### PR TITLE
feat: add one-shot TTS provider fallback

### DIFF
--- a/agent/mcp_run_context.py
+++ b/agent/mcp_run_context.py
@@ -10,6 +10,7 @@ import base64
 import binascii
 import copy
 import json
+import math
 from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Any, Iterator, Mapping, Optional
@@ -18,10 +19,17 @@ from typing import Any, Iterator, Mapping, Optional
 MCP_RUN_METADATA_HEADER = "X-Hermes-MCP-Metadata"
 MAX_MCP_RUN_METADATA_BYTES = 8 * 1024
 MAX_MCP_RUN_METADATA_DEPTH = 64
+_BASE64URL_ALPHABET = frozenset(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+)
 
 _mcp_run_metadata: ContextVar[Optional[dict[str, Any]]] = ContextVar(
     "mcp_run_metadata", default=None
 )
+
+
+def _reject_non_finite_json_constant(_constant: str) -> None:
+    raise ValueError("JSON constants must be finite")
 
 
 def _copy_validated_metadata(value: dict[str, Any]) -> dict[str, Any]:
@@ -37,6 +45,8 @@ def _copy_validated_metadata(value: dict[str, Any]) -> dict[str, Any]:
             if depth > MAX_MCP_RUN_METADATA_DEPTH:
                 raise ValueError("MCP metadata header is too deeply nested")
             pending.extend((child, depth + 1) for child in item)
+        elif isinstance(item, float) and not math.isfinite(item):
+            raise ValueError("MCP metadata header must contain finite numbers")
     try:
         return copy.deepcopy(value)
     except RecursionError as exc:
@@ -49,6 +59,8 @@ def decode_mcp_run_metadata_header(raw: str) -> dict[str, Any]:
         raise ValueError("MCP metadata header is empty")
     if len(raw) > ((MAX_MCP_RUN_METADATA_BYTES + 2) // 3) * 4:
         raise ValueError("MCP metadata header is too large")
+    if len(raw) % 4 == 1 or not all(char in _BASE64URL_ALPHABET for char in raw):
+        raise ValueError("MCP metadata header is not valid base64url")
 
     padded = raw + "=" * (-len(raw) % 4)
     try:
@@ -61,8 +73,11 @@ def decode_mcp_run_metadata_header(raw: str) -> dict[str, Any]:
     if len(payload) > MAX_MCP_RUN_METADATA_BYTES:
         raise ValueError("MCP metadata header is too large")
     try:
-        value = json.loads(payload.decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
+        value = json.loads(
+            payload.decode("utf-8"),
+            parse_constant=_reject_non_finite_json_constant,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError, ValueError) as exc:
         raise ValueError("MCP metadata header is not valid JSON") from exc
     if not isinstance(value, dict):
         raise ValueError("MCP metadata header must encode a JSON object")

--- a/agent/mcp_run_context.py
+++ b/agent/mcp_run_context.py
@@ -1,0 +1,98 @@
+"""Private, per-run metadata forwarded to opted-in MCP servers.
+
+The value lives in a ContextVar so concurrent API runs cannot overwrite one
+another. It is deliberately separate from model messages and tool arguments.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import copy
+import json
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any, Iterator, Mapping, Optional
+
+
+MCP_RUN_METADATA_HEADER = "X-Hermes-MCP-Metadata"
+MAX_MCP_RUN_METADATA_BYTES = 8 * 1024
+MAX_MCP_RUN_METADATA_DEPTH = 64
+
+_mcp_run_metadata: ContextVar[Optional[dict[str, Any]]] = ContextVar(
+    "mcp_run_metadata", default=None
+)
+
+
+def _copy_validated_metadata(value: dict[str, Any]) -> dict[str, Any]:
+    """Copy metadata after an iterative nesting-depth check."""
+    pending: list[tuple[Any, int]] = [(value, 1)]
+    while pending:
+        item, depth = pending.pop()
+        if isinstance(item, dict):
+            if depth > MAX_MCP_RUN_METADATA_DEPTH:
+                raise ValueError("MCP metadata header is too deeply nested")
+            pending.extend((child, depth + 1) for child in item.values())
+        elif isinstance(item, list):
+            if depth > MAX_MCP_RUN_METADATA_DEPTH:
+                raise ValueError("MCP metadata header is too deeply nested")
+            pending.extend((child, depth + 1) for child in item)
+    try:
+        return copy.deepcopy(value)
+    except RecursionError as exc:
+        raise ValueError("MCP metadata header is too deeply nested") from exc
+
+
+def decode_mcp_run_metadata_header(raw: str) -> dict[str, Any]:
+    """Decode an unpadded base64url JSON object from the API header."""
+    if not isinstance(raw, str) or not raw:
+        raise ValueError("MCP metadata header is empty")
+    if len(raw) > ((MAX_MCP_RUN_METADATA_BYTES + 2) // 3) * 4:
+        raise ValueError("MCP metadata header is too large")
+
+    padded = raw + "=" * (-len(raw) % 4)
+    try:
+        payload = base64.b64decode(
+            padded.encode("ascii"), altchars=b"-_", validate=True
+        )
+    except (UnicodeEncodeError, binascii.Error, ValueError) as exc:
+        raise ValueError("MCP metadata header is not valid base64url") from exc
+
+    if len(payload) > MAX_MCP_RUN_METADATA_BYTES:
+        raise ValueError("MCP metadata header is too large")
+    try:
+        value = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
+        raise ValueError("MCP metadata header is not valid JSON") from exc
+    if not isinstance(value, dict):
+        raise ValueError("MCP metadata header must encode a JSON object")
+    return _copy_validated_metadata(value)
+
+
+@contextmanager
+def mcp_run_metadata(
+    value: Optional[Mapping[str, Any]],
+) -> Iterator[None]:
+    """Bind a defensive copy of private MCP metadata for the current run."""
+    bound = _copy_validated_metadata(dict(value)) if value is not None else None
+    token = _mcp_run_metadata.set(bound)
+    try:
+        yield
+    finally:
+        _mcp_run_metadata.reset(token)
+
+
+def read_mcp_run_metadata() -> Optional[dict[str, Any]]:
+    """Return a defensive copy of the current run metadata, if any."""
+    value = _mcp_run_metadata.get()
+    return copy.deepcopy(value) if value is not None else None
+
+
+__all__ = [
+    "MAX_MCP_RUN_METADATA_BYTES",
+    "MAX_MCP_RUN_METADATA_DEPTH",
+    "MCP_RUN_METADATA_HEADER",
+    "decode_mcp_run_metadata_header",
+    "mcp_run_metadata",
+    "read_mcp_run_metadata",
+]

--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -172,6 +172,8 @@ ${modelContextLength ? `  context_length: ${modelContextLength}\n` : ''}provider
     models:
       mock-model: {}
     context_length: 4096
+approvals:
+  mode: off
 ${displaySection}${extraConfig ? `\n${extraConfig.trim()}\n` : ''}`
 
   fs.writeFileSync(configPath, config, 'utf8')

--- a/contributors/emails/a15975345678@gmail.com
+++ b/contributors/emails/a15975345678@gmail.com
@@ -1,0 +1,2 @@
+DOUIF
+# Authorship preserved from upstream PR #70768

--- a/contributors/emails/magic360.xyz@gmail.com
+++ b/contributors/emails/magic360.xyz@gmail.com
@@ -1,0 +1,2 @@
+isacstelian
+# Internal fork maintenance

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3005,13 +3005,8 @@ def run_job(
 
     agent = None
 
-    # Mark this as a cron session so the approval system can apply cron_mode.
-    # This env var is process-wide and persists for the lifetime of the
-    # scheduler process — every job this process runs is a cron job.
-    os.environ["HERMES_CRON_SESSION"] = "1"
-
-    # Use ContextVars for per-job session/delivery state so parallel jobs
-    # don't clobber each other's targets (os.environ is process-global).
+    # Use ContextVars for per-job session/delivery and approval state so
+    # parallel cron jobs cannot contaminate live gateway turns.
     from gateway.session_context import set_session_vars, clear_session_vars, _VAR_MAP
 
     # Cron execution is an internal scheduler context, not a live inbound
@@ -3066,6 +3061,9 @@ def run_job(
         # See declare_stateless_channel(). Upstream: #53027, #63142.
         async_delivery=False,
         cwd=_job_workdir or "",
+        # Cron approval state must be task-local; a process-global env flag
+        # contaminates later Telegram/API turns hosted by the same gateway.
+        cron_session=True,
     )
     _cron_delivery_vars = (
         "HERMES_CRON_AUTO_DELIVER_PLATFORM",

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1785,6 +1785,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 route_metadata = {
                     "direct_messages_topic_id": str(thread_id),
                     "job_id": job["id"],
+                    "source": "cron",
+                    "execution_id": job.get("execution_id"),
                 }
                 # Media metadata mirrors the text routing so attachments land in
                 # the same DM topic instead of the General lane (#22773).
@@ -1799,10 +1801,20 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # anchor, so the metadata key bypasses that check and lets the
                 # adapter route via a plain message_thread_id.
                 route_thread_id = str(thread_id) if thread_id is not None else None
-                route_metadata = {"job_id": job["id"]}
+                route_metadata = {
+                    "job_id": job["id"],
+                    "source": "cron",
+                    "execution_id": job.get("execution_id"),
+                }
                 if route_thread_id:
                     route_metadata["thread_id"] = route_thread_id
                 media_metadata = {"thread_id": thread_id} if thread_id else None
+
+            # Only a successful generated-text run can produce a confirmed
+            # delivery record. Plugins that add feedback controls must gate on
+            # this flag so failed-run summaries never show unusable buttons.
+            if emit_gateway_message_delivered:
+                route_metadata["routine_feedback_eligible"] = True
 
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content.

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1387,6 +1387,41 @@ def _confirm_adapter_delivery(send_result) -> bool:
     return bool(getattr(send_result, "success"))
 
 
+def _emit_gateway_message_delivered(
+    job: dict,
+    *,
+    platform: str,
+    chat_id: Any,
+    thread_id: Any,
+    message_id: Any,
+) -> None:
+    """Emit the confirmed Telegram cron-delivery observer, best-effort."""
+    platform = str(platform).lower()
+    if platform != "telegram" or message_id in (None, ""):
+        return
+    try:
+        from hermes_cli.plugins import has_hook, invoke_hook
+
+        if not has_hook("gateway_message_delivered"):
+            return
+        execution_id = job.get("execution_id")
+        job_id = job.get("id")
+        if not execution_id or not job_id or chat_id is None:
+            return
+        invoke_hook(
+            "gateway_message_delivered",
+            source="cron",
+            execution_id=str(execution_id),
+            job_id=str(job_id),
+            platform=platform,
+            chat_id=str(chat_id),
+            thread_id=str(thread_id) if thread_id is not None else None,
+            message_id=str(message_id),
+        )
+    except Exception:
+        logger.debug("gateway_message_delivered hook failed", exc_info=True)
+
+
 def _is_channel_dm_topic(
     runtime_adapter: Any,
     chat_id: Any,
@@ -1454,6 +1489,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
     Returns None on success, or an error string on failure.
     """
+    emit_gateway_message_delivered = bool(job.get("_gateway_message_delivered_hook"))
     targets = _resolve_delivery_targets(job)
     if not targets:
         deliver_value = _normalize_deliver_value(job.get("deliver", "local"))
@@ -1779,6 +1815,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 text_to_send = cleaned_delivery_content.strip()
                 adapter_ok = True
                 timed_out = False
+                delivered_message_id = None
+                delivered_thread_id = thread_id
                 if text_to_send:
                     from agent.async_utils import safe_schedule_threadsafe
 
@@ -1876,9 +1914,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                             if isinstance(send_result, dict):
                                 send_success = bool(send_result.get("success", False))
                                 send_raw_response = send_result.get("raw_response")
+                                delivered_message_id = send_result.get("message_id")
                             else:
                                 send_success = _confirm_adapter_delivery(send_result)
                                 send_raw_response = getattr(send_result, "raw_response", None)
+                                delivered_message_id = getattr(send_result, "message_id", None)
 
                             if not send_success:
                                 if isinstance(send_result, dict):
@@ -1909,12 +1949,19 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                 and send_raw_response.get("thread_fallback")
                             ):
                                 requested_thread_id = send_raw_response.get("requested_thread_id") or thread_id
+                                delivered_thread_id = None
                                 msg = (
                                     f"configured thread_id {requested_thread_id} for "
                                     f"{platform_name}:{chat_id} was not found; delivered without thread_id"
                                 )
                                 logger.warning("Job '%s': %s", job["id"], msg)
                                 delivery_errors.append(msg)
+                            elif isinstance(send_raw_response, dict):
+                                actual_thread_id = send_raw_response.get(
+                                    "requested_thread_id"
+                                )
+                                if actual_thread_id is not None:
+                                    delivered_thread_id = str(actual_thread_id)
 
                 # Send extracted media files as native attachments via the live
                 # adapter, using the same DM-topic-aware routing as the text send
@@ -1955,6 +2002,14 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 if adapter_ok:
                     logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)
                     delivered = True
+                    if emit_gateway_message_delivered and text_to_send:
+                        _emit_gateway_message_delivered(
+                            job,
+                            platform=platform_name,
+                            chat_id=chat_id,
+                            thread_id=delivered_thread_id,
+                            message_id=delivered_message_id,
+                        )
                     # Seed the thread session only now that delivery into it
                     # succeeded (deferred from thread-open above).
                     if opened_thread_id and not thread_seeded:
@@ -3853,6 +3908,8 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
     execution_id = job.get("execution_id")
     if not execution_id:
         execution_id = create_execution(job["id"], source="direct")["id"]
+    delivery_job = dict(job, execution_id=execution_id)
+    delivery_job.pop("_gateway_message_delivered_hook", None)
     try:
         # Pre-run dispatch claim (issue #38758): atomically commit a finite
         # one-shot's dispatch BEFORE its side effect runs, so a tick that dies
@@ -3963,7 +4020,15 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
 
             if should_deliver:
                 try:
-                    delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
+                    if success:
+                        from gateway.platforms.base import BasePlatformAdapter
+
+                        _, generated_text = BasePlatformAdapter.extract_media(deliver_content)
+                        if (generated_text or "").strip():
+                            delivery_job["_gateway_message_delivered_hook"] = True
+                    delivery_error = _deliver_result(
+                        delivery_job, deliver_content, adapters=adapters, loop=loop
+                    )
                 except Exception as de:
                     delivery_error = str(de)
                     logger.error("Delivery failed for job %s: %s", job["id"], de)

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -421,12 +421,58 @@ class GatewayAuthorizationMixin:
         # documented behavior matches reality
         # (website/docs/reference/environment-variables.md,
         # website/docs/user-guide/messaging/telegram.md).
+        telegram_trusted_adder_mode = False
         if source.chat_type in {"group", "forum", "channel"} and source.chat_id:
+            adapter = None
+            try:
+                adapter = self._adapter_for_source(source)
+            except Exception:
+                pass
+            if source.platform == Platform.TELEGRAM and adapter is not None:
+                adapter_extra = (
+                    getattr(getattr(adapter, "config", None), "extra", None) or {}
+                )
+                telegram_trusted_adder_mode = (
+                    adapter_extra.get("auto_allow_groups_from_trusted_adders") is True
+                )
+                trusted_adder_mode = getattr(
+                    adapter,
+                    "_telegram_auto_allow_groups_from_trusted_adders",
+                    None,
+                )
+                if callable(trusted_adder_mode):
+                    try:
+                        telegram_trusted_adder_mode = trusted_adder_mode() is True
+                    except Exception:
+                        # A configured strict profile must not fall back to a
+                        # process-global allowlist because its helper failed.
+                        pass
+
+                if telegram_trusted_adder_mode:
+                    effective_admission = getattr(
+                        adapter,
+                        "_telegram_group_admission_chats",
+                        None,
+                    )
+                    try:
+                        admitted_chats = (
+                            effective_admission()
+                            if callable(effective_admission)
+                            else set()
+                        )
+                    except Exception:
+                        admitted_chats = set()
+                    if source.chat_id not in admitted_chats:
+                        return False
+
             chat_allowlist_env = {
                 Platform.TELEGRAM: "TELEGRAM_GROUP_ALLOWED_CHATS",
                 Platform.QQBOT: "QQ_GROUP_ALLOWED_USERS",
             }.get(source.platform, "")
-            if chat_allowlist_env:
+            # Strict trusted-adder profiles must use their adapter-local effective
+            # allowlist. A process-global legacy env value may belong to another
+            # profile in the same multiplex gateway.
+            if chat_allowlist_env and not telegram_trusted_adder_mode:
                 raw_chat_allowlist = os.getenv(chat_allowlist_env, "").strip()
                 if raw_chat_allowlist:
                     allowed_group_ids = {
@@ -444,12 +490,27 @@ class GatewayAuthorizationMixin:
             # so the env-var-only check above misses config.yaml-configured
             # allowlists.  Read the live adapter's config.extra as a fallback.
             try:
-                adapter = self._adapter_for_source(source)
+                if adapter is None:
+                    adapter = self._adapter_for_source(source)
                 if adapter is not None:
                     extra = getattr(getattr(adapter, "config", None), "extra", None) or {}
-                    adapter_group_allowed = extra.get("group_allowed_chats")
+                    adapter_group_allowed = None
+                    if source.platform == Platform.TELEGRAM:
+                        effective_group_allowed = getattr(
+                            adapter,
+                            "_telegram_group_allowed_chats",
+                            None,
+                        )
+                        if callable(effective_group_allowed):
+                            adapter_group_allowed = effective_group_allowed()
+                    if adapter_group_allowed is None:
+                        adapter_group_allowed = extra.get("group_allowed_chats")
                     if adapter_group_allowed:
-                        allowed = _coerce_allow_set(adapter_group_allowed)
+                        allowed = (
+                            adapter_group_allowed
+                            if isinstance(adapter_group_allowed, set)
+                            else _coerce_allow_set(adapter_group_allowed)
+                        )
                         if "*" in allowed or source.chat_id in allowed:
                             return True
             except Exception:
@@ -574,7 +635,10 @@ class GatewayAuthorizationMixin:
         group_chat_allowlist = ""
         if source.chat_type in {"group", "forum"}:
             group_user_allowlist = _auth_env(platform_group_user_env_map.get(source.platform, ""))
-            group_chat_allowlist = _auth_env(platform_group_chat_env_map.get(source.platform, ""))
+            if not telegram_trusted_adder_mode:
+                group_chat_allowlist = _auth_env(
+                    platform_group_chat_env_map.get(source.platform, "")
+                )
         global_allowlist = _auth_env("GATEWAY_ALLOWED_USERS")
 
         if not platform_allowlist and not group_user_allowlist and not group_chat_allowlist and not global_allowlist:
@@ -659,6 +723,7 @@ class GatewayAuthorizationMixin:
         # TELEGRAM_GROUP_ALLOWED_CHATS.
         if (
             source.platform == Platform.TELEGRAM
+            and not telegram_trusted_adder_mode
             and group_user_allowlist
             and source.chat_type in {"group", "forum"}
             and source.chat_id

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1554,6 +1554,10 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["allowed_chats"] = platform_cfg["allowed_chats"]
                 if plat == Platform.TELEGRAM and "group_allowed_chats" in platform_cfg:
                     bridged["group_allowed_chats"] = platform_cfg["group_allowed_chats"]
+                if plat == Platform.TELEGRAM and "auto_allow_groups_from_trusted_adders" in platform_cfg:
+                    bridged["auto_allow_groups_from_trusted_adders"] = platform_cfg["auto_allow_groups_from_trusted_adders"]
+                if plat == Platform.TELEGRAM and "trusted_group_adders" in platform_cfg:
+                    bridged["trusted_group_adders"] = platform_cfg["trusted_group_adders"]
                 if plat == Platform.TELEGRAM and "allowed_topics" in platform_cfg:
                     bridged["allowed_topics"] = platform_cfg["allowed_topics"]
                 if "free_response_channels" in platform_cfg:

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -185,6 +185,46 @@ def _send_result_error_kind(result: Any) -> Optional[str]:
     return str(kind) if kind else None
 
 
+def _apply_gateway_message_before_send(
+    target: "DeliveryTarget",
+    content: str,
+    metadata: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Apply plugin-owned metadata to an outbound Telegram delivery.
+
+    The hook is deliberately narrow: plugins can provide only the neutral
+    ``telegram_inline_keyboard`` value consumed by the Telegram adapter. A
+    broken plugin or malformed directive leaves the normal delivery unchanged.
+    """
+    if target.platform != Platform.TELEGRAM:
+        return metadata
+    try:
+        from hermes_cli.plugins import has_hook, invoke_hook
+
+        if not has_hook("gateway_message_before_send"):
+            return metadata
+        results = invoke_hook(
+            "gateway_message_before_send",
+            source=metadata.get("source"),
+            execution_id=metadata.get("execution_id"),
+            job_id=metadata.get("job_id"),
+            routine_feedback_eligible=bool(metadata.get("routine_feedback_eligible")),
+            platform=target.platform.value,
+            chat_id=str(target.chat_id),
+            thread_id=metadata.get("thread_id") or target.thread_id,
+        )
+        for result in results:
+            if not isinstance(result, dict):
+                continue
+            keyboard = result.get("telegram_inline_keyboard")
+            if keyboard is not None:
+                metadata["telegram_inline_keyboard"] = keyboard
+                break
+    except Exception:
+        logger.debug("gateway_message_before_send hook failed", exc_info=True)
+    return metadata
+
+
 def _classify_dead_from_error_text(error_text: Optional[str]) -> Optional[str]:
     """Best-effort dead-target classification from a raised error's text.
 
@@ -603,6 +643,9 @@ class DeliveryRouter:
                 send_metadata["telegram_dm_topic_reply_fallback"] = True
             elif "thread_id" not in send_metadata and "message_thread_id" not in send_metadata and not has_explicit_direct_topic:
                 send_metadata["thread_id"] = target_thread_id
+        send_metadata = _apply_gateway_message_before_send(
+            target, content, send_metadata,
+        )
         result = await transport.send(
             target.platform,
             target.chat_id,
@@ -640,7 +683,6 @@ class DeliveryRouter:
             if _send_result_failed(result):
                 raise RuntimeError(_send_result_error(result) or f"{target.platform.value} delivery failed")
         return result
-
 
 
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6195,6 +6195,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
 
         session_id = provided_session_id or body_session_id or stored_session_id
+        continuation_session_id = provided_session_id
         route = self._resolve_route(body.get("model"))
         agent_overrides = _request_agent_overrides(body, virtual_model=self._model_name)
         selection_error = self._request_route_conflict_error(
@@ -6257,10 +6258,10 @@ class APIServerAdapter(BasePlatformAdapter):
             return cached_response
 
         response_session_id = session_id
-        if not conversation_history and session_id:
+        if not conversation_history and continuation_session_id:
             try:
                 conversation_history = await self._conversation_history_for_session(
-                    session_id,
+                    continuation_session_id,
                     fail_closed=True,
                 )
             except Exception:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6192,6 +6192,8 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response(_openai_error(selection_error), status=400)
 
         response_session_id = session_id
+        if not conversation_history and session_id:
+            conversation_history = await self._conversation_history_for_session(session_id)
         run_id = f"run_{uuid.uuid4().hex}"
         session_id = session_id or run_id
         # Approval queues gate host-side tool execution and must be isolated

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3062,7 +3062,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 raise RuntimeError("session_db_unavailable")
             return []
         try:
-            return await asyncio.to_thread(db.get_messages_as_conversation, session_id)
+            resolved_id = session_id
+            if hasattr(db, "resolve_resume_session_id"):
+                resolved_id = await asyncio.to_thread(db.resolve_resume_session_id, session_id)
+            return await asyncio.to_thread(db.get_messages_as_conversation, resolved_id)
         except Exception as exc:
             logger.warning("Failed to load session history for %s: %s", session_id, exc)
             if fail_closed:
@@ -6206,6 +6209,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         idempotency_key = request.headers.get("Idempotency-Key")
         idempotency_fingerprint = None
+        idempotency_storage_key = None
         if idempotency_key:
             if len(idempotency_key) > 256:
                 return web.json_response(
@@ -6216,18 +6220,21 @@ class APIServerAdapter(BasePlatformAdapter):
                     ),
                     status=400,
                 )
+            effective_profile = _api_request_profile.get() or ""
+            idempotency_storage_key = f"{effective_profile}:{idempotency_key}" if effective_profile else idempotency_key
             fingerprint_body = dict(body)
             fingerprint_body["_resolved_session_id"] = session_id
             fingerprint_body["_gateway_session_key"] = gateway_session_key
+            fingerprint_body["_request_profile"] = effective_profile
             idempotency_fingerprint = _make_request_fingerprint(
                 fingerprint_body,
                 keys=sorted(fingerprint_body),
             )
 
         def _cached_idempotency_response():
-            if not idempotency_key:
+            if not idempotency_storage_key:
                 return None
-            existing = self._run_idempotency.get(idempotency_key)
+            existing = self._run_idempotency.get(idempotency_storage_key)
             if not existing:
                 return None
             if existing["fingerprint"] != idempotency_fingerprint:
@@ -6578,8 +6585,8 @@ class APIServerAdapter(BasePlatformAdapter):
             "session_id": session_id,
             "status": "started",
         }
-        if idempotency_key and idempotency_fingerprint:
-            self._run_idempotency[idempotency_key] = {
+        if idempotency_storage_key and idempotency_fingerprint:
+            self._run_idempotency[idempotency_storage_key] = {
                 "fingerprint": idempotency_fingerprint,
                 "response": response_payload,
                 "headers": response_headers,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6191,6 +6191,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if selection_error:
             return web.json_response(_openai_error(selection_error), status=400)
 
+        response_session_id = session_id
         run_id = f"run_{uuid.uuid4().hex}"
         session_id = session_id or run_id
         # Approval queues gate host-side tool execution and must be isolated
@@ -6492,7 +6493,9 @@ class APIServerAdapter(BasePlatformAdapter):
         if hasattr(task, "add_done_callback"):
             task.add_done_callback(self._background_tasks.discard)
 
-        response_headers = {"X-Hermes-Session-Id": str(session_id)}
+        response_headers = {}
+        if response_session_id:
+            response_headers["X-Hermes-Session-Id"] = response_session_id
         if gateway_session_key:
             response_headers["X-Hermes-Session-Key"] = gateway_session_key
         return web.json_response(

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1248,6 +1248,10 @@ class APIServerAdapter(BasePlatformAdapter):
         self._stopping_run_ids: set[str] = set()
         # Pollable run status for dashboards and external control-plane UIs.
         self._run_statuses: Dict[str, Dict[str, Any]] = {}
+        # Original 202 response per Idempotency-Key. The run status owns the
+        # lifetime, so retries after a lost HTTP response cannot start a second
+        # agent run while the gateway process is still serving the first one.
+        self._run_idempotency: Dict[str, Dict[str, Any]] = {}
         # Active approval session key for each run_id.  The approval core
         # resolves requests by session key, while API clients address the
         # in-flight run by run_id.
@@ -6200,6 +6204,51 @@ class APIServerAdapter(BasePlatformAdapter):
         if selection_error:
             return web.json_response(_openai_error(selection_error), status=400)
 
+        idempotency_key = request.headers.get("Idempotency-Key")
+        idempotency_fingerprint = None
+        if idempotency_key:
+            if len(idempotency_key) > 256:
+                return web.json_response(
+                    _openai_error(
+                        "Idempotency-Key is too long",
+                        code="invalid_idempotency_key",
+                        param="Idempotency-Key",
+                    ),
+                    status=400,
+                )
+            fingerprint_body = dict(body)
+            fingerprint_body["_resolved_session_id"] = session_id
+            fingerprint_body["_gateway_session_key"] = gateway_session_key
+            idempotency_fingerprint = _make_request_fingerprint(
+                fingerprint_body,
+                keys=sorted(fingerprint_body),
+            )
+
+        def _cached_idempotency_response():
+            if not idempotency_key:
+                return None
+            existing = self._run_idempotency.get(idempotency_key)
+            if not existing:
+                return None
+            if existing["fingerprint"] != idempotency_fingerprint:
+                return web.json_response(
+                    _openai_error(
+                        "Idempotency-Key was already used with different input",
+                        code="idempotency_conflict",
+                        param="Idempotency-Key",
+                    ),
+                    status=409,
+                )
+            return web.json_response(
+                dict(existing["response"]),
+                status=202,
+                headers=dict(existing["headers"]),
+            )
+
+        cached_response = _cached_idempotency_response()
+        if cached_response is not None:
+            return cached_response
+
         response_session_id = session_id
         if not conversation_history and session_id:
             try:
@@ -6215,6 +6264,9 @@ class APIServerAdapter(BasePlatformAdapter):
                     ),
                     status=503,
                 )
+        cached_response = _cached_idempotency_response()
+        if cached_response is not None:
+            return cached_response
         run_id = f"run_{uuid.uuid4().hex}"
         session_id = session_id or run_id
         # Approval queues gate host-side tool execution and must be isolated
@@ -6521,8 +6573,19 @@ class APIServerAdapter(BasePlatformAdapter):
             response_headers["X-Hermes-Session-Id"] = response_session_id
         if gateway_session_key:
             response_headers["X-Hermes-Session-Key"] = gateway_session_key
+        response_payload = {
+            "run_id": run_id,
+            "session_id": session_id,
+            "status": "started",
+        }
+        if idempotency_key and idempotency_fingerprint:
+            self._run_idempotency[idempotency_key] = {
+                "fingerprint": idempotency_fingerprint,
+                "response": response_payload,
+                "headers": response_headers,
+            }
         return web.json_response(
-            {"run_id": run_id, "session_id": session_id, "status": "started"},
+            response_payload,
             status=202,
             headers=response_headers,
         )
@@ -6753,6 +6816,10 @@ class APIServerAdapter(BasePlatformAdapter):
         ]
         for run_id in stale_statuses:
             self._run_statuses.pop(run_id, None)
+        live_run_ids = set(self._run_statuses)
+        for key, entry in list(self._run_idempotency.items()):
+            if entry.get("response", {}).get("run_id") not in live_run_ids:
+                self._run_idempotency.pop(key, None)
 
     # ------------------------------------------------------------------
     # BasePlatformAdapter interface

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3046,14 +3046,23 @@ class APIServerAdapter(BasePlatformAdapter):
             return None, web.json_response(_openai_error(f"Session not found: {session_id}", code="session_not_found"), status=404)
         return session, None
 
-    async def _conversation_history_for_session(self, session_id: str) -> List[Dict[str, Any]]:
+    async def _conversation_history_for_session(
+        self,
+        session_id: str,
+        *,
+        fail_closed: bool = False,
+    ) -> List[Dict[str, Any]]:
         db = await self._ensure_session_db_async()
         if db is None:
+            if fail_closed:
+                raise RuntimeError("session_db_unavailable")
             return []
         try:
             return await asyncio.to_thread(db.get_messages_as_conversation, session_id)
         except Exception as exc:
             logger.warning("Failed to load session history for %s: %s", session_id, exc)
+            if fail_closed:
+                raise
             return []
 
     async def _handle_list_sessions(self, request: "web.Request") -> "web.Response":
@@ -6193,7 +6202,19 @@ class APIServerAdapter(BasePlatformAdapter):
 
         response_session_id = session_id
         if not conversation_history and session_id:
-            conversation_history = await self._conversation_history_for_session(session_id)
+            try:
+                conversation_history = await self._conversation_history_for_session(
+                    session_id,
+                    fail_closed=True,
+                )
+            except Exception:
+                return web.json_response(
+                    _openai_error(
+                        "Session history unavailable",
+                        code="session_history_unavailable",
+                    ),
+                    status=503,
+                )
         run_id = f"run_{uuid.uuid4().hex}"
         session_id = session_id or run_id
         # Approval queues gate host-side tool execution and must be isolated

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -121,7 +121,7 @@ def _hermes_version() -> str:
 
 
 def _profile_capability_attestation() -> tuple[str, Optional[str]]:
-    """Return the active profile and the exact capabilities.json digest."""
+    """Return the active profile and canonical capabilities.json digest."""
     try:
         from hermes_cli.profiles import get_active_profile_name
 
@@ -133,10 +133,26 @@ def _profile_capability_attestation() -> tuple[str, Optional[str]]:
         from hermes_constants import get_hermes_home
 
         capability_path = get_hermes_home() / "capabilities.json"
-        digest = hashlib.sha256(capability_path.read_bytes()).hexdigest()
-    except (OSError, TypeError):
+        with capability_path.open(encoding="utf-8") as capability_file:
+            capability_manifest = json.load(
+                capability_file,
+                parse_constant=_reject_non_finite_json_constant,
+            )
+        canonical_manifest = json.dumps(
+            capability_manifest,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+        digest = hashlib.sha256(canonical_manifest.encode("utf-8")).hexdigest()
+    except (OSError, TypeError, UnicodeDecodeError, ValueError):
         digest = None
     return profile, digest
+
+
+def _reject_non_finite_json_constant(_constant: str) -> None:
+    raise ValueError("JSON constants must be finite")
 
 
 # Default settings
@@ -1901,7 +1917,7 @@ class APIServerAdapter(BasePlatformAdapter):
             decode_mcp_run_metadata_header,
         )
 
-        raw = request.headers.get(MCP_RUN_METADATA_HEADER, "").strip()
+        raw = request.headers.get(MCP_RUN_METADATA_HEADER, "")
         if not raw:
             return None, None
         if not self._api_key:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1814,6 +1814,43 @@ class APIServerAdapter(BasePlatformAdapter):
     # that the sanitized form is safe to pass into Honcho / state.db.
     _MAX_SESSION_HEADER_LEN = 256
 
+    def _parse_session_id_header(
+        self, request: "web.Request"
+    ) -> tuple[Optional[str], Optional["web.Response"]]:
+        """Extract and validate the ``X-Hermes-Session-Id`` header."""
+        raw = request.headers.get("X-Hermes-Session-Id", "").strip()
+        if not raw:
+            return None, None
+
+        if not self._api_key:
+            logger.warning(
+                "Session continuation via X-Hermes-Session-Id rejected: "
+                "no API key configured.  Set API_SERVER_KEY to enable "
+                "session continuity."
+            )
+            return None, web.json_response(
+                _openai_error(
+                    "Session continuation requires API key authentication. "
+                    "Configure API_SERVER_KEY to enable this feature."
+                ),
+                status=403,
+            )
+
+        from gateway.session import _is_path_unsafe
+
+        if re.search(r'[\r\n\x00]', raw) or _is_path_unsafe(raw):
+            return None, web.json_response(
+                {"error": {"message": "Invalid session ID", "type": "invalid_request_error"}},
+                status=400,
+            )
+        if len(raw) > self._MAX_SESSION_HEADER_LEN:
+            return None, web.json_response(
+                {"error": {"message": "Session ID too long", "type": "invalid_request_error"}},
+                status=400,
+            )
+
+        return raw, None
+
     def _parse_session_key_header(
         self, request: "web.Request"
     ) -> tuple[Optional[str], Optional["web.Response"]]:
@@ -3724,37 +3761,10 @@ class APIServerAdapter(BasePlatformAdapter):
         # only allowed when the API key is configured and the request is
         # authenticated.  Without this gate, any unauthenticated client could
         # read arbitrary session history by guessing/enumerating session IDs.
-        provided_session_id = request.headers.get("X-Hermes-Session-Id", "").strip()
+        provided_session_id, session_id_err = self._parse_session_id_header(request)
+        if session_id_err is not None:
+            return session_id_err
         if provided_session_id:
-            if not self._api_key:
-                logger.warning(
-                    "Session continuation via X-Hermes-Session-Id rejected: "
-                    "no API key configured.  Set API_SERVER_KEY to enable "
-                    "session continuity."
-                )
-                return web.json_response(
-                    _openai_error(
-                        "Session continuation requires API key authentication. "
-                        "Configure API_SERVER_KEY to enable this feature."
-                    ),
-                    status=403,
-                )
-            # Sanitize: reject control characters that could enable header
-            # injection, and path-traversal-shaped IDs that would escape the
-            # sessions directory when interpolated into on-disk artifact
-            # filenames (session snapshots, request dumps). Mirrors the native
-            # gateway's entry-boundary guard (gateway.session._is_path_unsafe).
-            from gateway.session import _is_path_unsafe
-            if re.search(r'[\r\n\x00]', provided_session_id) or _is_path_unsafe(provided_session_id):
-                return web.json_response(
-                    {"error": {"message": "Invalid session ID", "type": "invalid_request_error"}},
-                    status=400,
-                )
-            if len(provided_session_id) > self._MAX_SESSION_HEADER_LEN:
-                return web.json_response(
-                    {"error": {"message": "Session ID too long", "type": "invalid_request_error"}},
-                    status=400,
-                )
             session_id = provided_session_id
             try:
                 db = await self._ensure_session_db_async()
@@ -6049,8 +6059,42 @@ class APIServerAdapter(BasePlatformAdapter):
         if not raw_input:
             return web.json_response(_openai_error("Missing 'input' field"), status=400)
 
-        user_message = raw_input if isinstance(raw_input, str) else (raw_input[-1].get("content", "") if isinstance(raw_input, list) else "")
-        if not user_message:
+        input_messages: List[Dict[str, Any]] = []
+        if isinstance(raw_input, str):
+            input_messages = [{"role": "user", "content": raw_input}]
+        elif isinstance(raw_input, list):
+            for idx, item in enumerate(raw_input):
+                if isinstance(item, str):
+                    input_messages.append({"role": "user", "content": item})
+                elif isinstance(item, dict):
+                    if "content" not in item:
+                        return web.json_response(
+                            _openai_error(
+                                "Input message objects must include a 'content' field",
+                                code="invalid_input_item",
+                                param=f"input[{idx}]",
+                            ),
+                            status=400,
+                        )
+                    try:
+                        content = _normalize_multimodal_content(item.get("content", ""))
+                    except ValueError as exc:
+                        return _multimodal_validation_error(exc, param=f"input[{idx}].content")
+                    input_messages.append({"role": item.get("role", "user"), "content": content})
+                else:
+                    return web.json_response(
+                        _openai_error(
+                            "Input array items must be strings or message objects",
+                            code="invalid_input_item",
+                            param=f"input[{idx}]",
+                        ),
+                        status=400,
+                    )
+        else:
+            return web.json_response(_openai_error("'input' must be a string or array"), status=400)
+
+        user_message: Any = input_messages[-1].get("content", "") if input_messages else ""
+        if not _content_has_visible_payload(user_message):
             return web.json_response(_openai_error("No user message found in input"), status=400)
 
         instructions = body.get("instructions")
@@ -6058,7 +6102,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Accept explicit conversation_history from the request body.
         # Precedence: explicit conversation_history > previous_response_id.
-        conversation_history: List[Dict[str, str]] = []
+        conversation_history: List[Dict[str, Any]] = []
         raw_history = body.get("conversation_history")
         if raw_history:
             if not isinstance(raw_history, list):
@@ -6072,7 +6116,11 @@ class APIServerAdapter(BasePlatformAdapter):
                         _openai_error(f"conversation_history[{i}] must have 'role' and 'content' fields"),
                         status=400,
                     )
-                conversation_history.append({"role": str(entry["role"]), "content": str(entry["content"])})
+                try:
+                    entry_content = _normalize_multimodal_content(entry["content"])
+                except ValueError as exc:
+                    return _multimodal_validation_error(exc, param=f"conversation_history[{i}].content")
+                conversation_history.append({"role": str(entry["role"]), "content": entry_content})
             if previous_response_id:
                 logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
 
@@ -6088,19 +6136,49 @@ class APIServerAdapter(BasePlatformAdapter):
         # When input is a multi-message array, extract all but the last
         # message as conversation history (the last becomes user_message).
         # Only fires when no explicit history was provided.
-        if not conversation_history and isinstance(raw_input, list) and len(raw_input) > 1:
-            for msg in raw_input[:-1]:
-                if isinstance(msg, dict) and msg.get("role") and msg.get("content"):
-                    content = msg["content"]
-                    if isinstance(content, list):
-                        # Flatten multi-part content blocks to text
-                        content = " ".join(
-                            part.get("text", "") for part in content
-                            if isinstance(part, dict) and part.get("type") == "text"
-                        )
-                    conversation_history.append({"role": msg["role"], "content": str(content)})
+        if not conversation_history and len(input_messages) > 1:
+            for msg in input_messages[:-1]:
+                if msg.get("role") and _content_has_visible_payload(msg.get("content")):
+                    conversation_history.append(msg)
 
-        session_id = body.get("session_id") or stored_session_id
+        provided_session_id, session_id_err = self._parse_session_id_header(request)
+        if session_id_err is not None:
+            return session_id_err
+        raw_body_session_id = body.get("session_id")
+        if raw_body_session_id is not None and not isinstance(raw_body_session_id, str):
+            return web.json_response(
+                _openai_error(
+                    "Body session_id must be a string",
+                    code="invalid_session_id",
+                    param="session_id",
+                ),
+                status=400,
+            )
+        body_session_id = raw_body_session_id.strip() if raw_body_session_id else None
+        if body_session_id:
+            from gateway.session import _is_path_unsafe
+
+            if (
+                re.search(r'[\r\n\x00]', body_session_id)
+                or _is_path_unsafe(body_session_id)
+                or len(body_session_id) > self._MAX_SESSION_HEADER_LEN
+            ):
+                return web.json_response(
+                    _openai_error("Invalid session ID", code="invalid_session_id"),
+                    status=400,
+                )
+        if provided_session_id and body_session_id:
+            if body_session_id != provided_session_id:
+                return web.json_response(
+                    _openai_error(
+                        "X-Hermes-Session-Id does not match body session_id",
+                        code="session_id_mismatch",
+                        param="session_id",
+                    ),
+                    status=400,
+                )
+
+        session_id = provided_session_id or body_session_id or stored_session_id
         route = self._resolve_route(body.get("model"))
         agent_overrides = _request_agent_overrides(body, virtual_model=self._model_name)
         selection_error = self._request_route_conflict_error(
@@ -6414,11 +6492,11 @@ class APIServerAdapter(BasePlatformAdapter):
         if hasattr(task, "add_done_callback"):
             task.add_done_callback(self._background_tasks.discard)
 
-        response_headers = (
-            {"X-Hermes-Session-Key": gateway_session_key} if gateway_session_key else {}
-        )
+        response_headers = {"X-Hermes-Session-Id": str(session_id)}
+        if gateway_session_key:
+            response_headers["X-Hermes-Session-Key"] = gateway_session_key
         return web.json_response(
-            {"run_id": run_id, "status": "started"},
+            {"run_id": run_id, "session_id": session_id, "status": "started"},
             status=202,
             headers=response_headers,
         )

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6233,9 +6233,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation_history.append({"role": str(entry["role"]), "content": entry_content})
             if previous_response_id:
                 logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
+            explicit_history_provided = bool(raw_history)
 
         stored_session_id = None
-        if not explicit_history_provided and previous_response_id:
+        # An empty history is a common client default, not an instruction to
+        # erase a chained transcript. Preserve previous_response_id/session
+        # continuation when callers send conversation_history: [].
+        if not conversation_history and previous_response_id:
             stored = self._response_store.get(previous_response_id)
             if stored:
                 conversation_history = list(stored.get("conversation_history", []))

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -119,11 +119,34 @@ def _hermes_version() -> str:
         return "dev"
 
 
+def _profile_capability_attestation() -> tuple[str, Optional[str]]:
+    """Return the active profile and the exact capabilities.json digest."""
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        profile = _api_request_profile.get() or get_active_profile_name() or "default"
+    except Exception:
+        profile = _api_request_profile.get() or "default"
+
+    try:
+        from hermes_constants import get_hermes_home
+
+        capability_path = get_hermes_home() / "capabilities.json"
+        digest = hashlib.sha256(capability_path.read_bytes()).hexdigest()
+    except (OSError, TypeError):
+        digest = None
+    return profile, digest
+
+
 # Default settings
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8642
 MAX_STORED_RESPONSES = 100
 MAX_REQUEST_BYTES = 10_000_000  # 10 MB — accommodates long agent conversations with tool calls
+# Base64url expands the 8 KiB decoded MCP metadata allowance to about 10.7
+# KiB. aiohttp defaults to an 8 KiB header field, so the server needs a modest
+# explicit ceiling above that contract.
+MAX_REQUEST_HEADER_FIELD_BYTES = 16 * 1024
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
@@ -810,7 +833,10 @@ class ResponseStore:
 
 _CORS_HEADERS = {
     "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
-    "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key",
+    "Access-Control-Allow-Headers": (
+        "Authorization, Content-Type, Idempotency-Key, X-Hermes-MCP-Metadata, "
+        "X-Hermes-Session-Id, X-Hermes-Session-Key"
+    ),
 }
 
 
@@ -942,14 +968,20 @@ def _admit_api_agent_request(handler):
         auth_err = self._check_auth(request)
         if auth_err:
             return auth_err
+        mcp_metadata, metadata_err = self._parse_mcp_run_metadata_header(request)
+        if metadata_err is not None:
+            return metadata_err
         draining = self._draining_response()
         if draining is not None:
             return draining
         reservation = {"active": True}
         token = _api_agent_request_reservation.set(reservation)
         self._pending_agent_requests += 1
+        from agent.mcp_run_context import mcp_run_metadata
+
         try:
-            return await handler(self, request, *args, **kwargs)
+            with mcp_run_metadata(mcp_metadata):
+                return await handler(self, request, *args, **kwargs)
         finally:
             if reservation["active"]:
                 reservation["active"] = False
@@ -1078,10 +1110,15 @@ class _IdempotencyCache:
 _idem_cache = _IdempotencyCache()
 
 
-def _make_request_fingerprint(body: Dict[str, Any], keys: List[str]) -> str:
+def _make_request_fingerprint(
+    body: Dict[str, Any],
+    keys: List[str],
+    *,
+    mcp_metadata: Optional[Dict[str, Any]] = None,
+) -> str:
     from hashlib import sha256
     subset = {k: body.get(k) for k in keys}
-    return sha256(repr(subset).encode("utf-8")).hexdigest()
+    return sha256(repr((subset, mcp_metadata)).encode("utf-8")).hexdigest()
 
 
 def _derive_chat_session_id(
@@ -1854,6 +1891,37 @@ class APIServerAdapter(BasePlatformAdapter):
             )
 
         return raw, None
+
+    def _parse_mcp_run_metadata_header(
+        self, request: "web.Request"
+    ) -> tuple[Optional[Dict[str, Any]], Optional["web.Response"]]:
+        """Decode private metadata for this run without exposing it to the model."""
+        from agent.mcp_run_context import (
+            MCP_RUN_METADATA_HEADER,
+            decode_mcp_run_metadata_header,
+        )
+
+        raw = request.headers.get(MCP_RUN_METADATA_HEADER, "").strip()
+        if not raw:
+            return None, None
+        if not self._api_key:
+            logger.warning(
+                "%s rejected: no API key configured", MCP_RUN_METADATA_HEADER
+            )
+            return None, web.json_response(
+                _openai_error(
+                    f"{MCP_RUN_METADATA_HEADER} requires API key authentication. "
+                    "Configure API_SERVER_KEY to enable this feature."
+                ),
+                status=403,
+            )
+        try:
+            return decode_mcp_run_metadata_header(raw), None
+        except ValueError as exc:
+            return None, web.json_response(
+                _openai_error(str(exc), code="invalid_mcp_metadata"),
+                status=400,
+            )
 
     def _parse_session_key_header(
         self, request: "web.Request"
@@ -2707,11 +2775,14 @@ class APIServerAdapter(BasePlatformAdapter):
             process_completion_queue_depth=process_depth,
             active_delegations=active_delegations,
         )
+        profile, capability_manifest_sha256 = _profile_capability_attestation()
         return web.json_response({
             "status": readiness["status"],
             "readiness": readiness,
             "platform": "hermes-agent",
             "version": _hermes_version(),
+            "profile": profile,
+            "capability_manifest_sha256": capability_manifest_sha256,
             "gateway_state": gw_state,
             "platforms": runtime.get("platforms", {}),
             "active_agents": gw_active,
@@ -2871,6 +2942,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "realtime_voice": False,
                 "session_continuity_header": "X-Hermes-Session-Id",
                 "session_key_header": "X-Hermes-Session-Key",
+                "mcp_run_metadata_header": "X-Hermes-MCP-Metadata",
                 "cors": bool(self._cors_origins),
             },
             "endpoints": {
@@ -3934,9 +4006,12 @@ class APIServerAdapter(BasePlatformAdapter):
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
+            from agent.mcp_run_context import read_mcp_run_metadata
+
             fp = _make_request_fingerprint(
                 body,
                 keys=["model", "provider", "model_options", "messages", "tools", "tool_choice", "stream"],
+                mcp_metadata=read_mcp_run_metadata(),
             )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
@@ -5056,6 +5131,8 @@ class APIServerAdapter(BasePlatformAdapter):
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
+            from agent.mcp_run_context import read_mcp_run_metadata
+
             fp = _make_request_fingerprint(
                 body,
                 keys=[
@@ -5068,6 +5145,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "model_options",
                     "tools",
                 ],
+                mcp_metadata=read_mcp_run_metadata(),
             )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_response)
@@ -5777,11 +5855,18 @@ class APIServerAdapter(BasePlatformAdapter):
         # run_in_executor threads, so the profile scope must be re-entered
         # inside _run() from this explicit value.
         request_profile = _api_request_profile.get()
+        from agent.mcp_run_context import read_mcp_run_metadata
+
+        request_mcp_metadata = read_mcp_run_metadata()
 
         def _run():
             from gateway.session_context import clear_session_vars
 
-            with self._profile_scope(request_profile):
+            from agent.mcp_run_context import mcp_run_metadata
+
+            with self._profile_scope(request_profile), mcp_run_metadata(
+                request_mcp_metadata
+            ):
                 tokens = self._bind_api_server_session(
                     chat_id=session_id or "",
                     session_key=gateway_session_key or session_id or "",
@@ -5943,7 +6028,6 @@ class APIServerAdapter(BasePlatformAdapter):
 
     _RUN_STREAM_TTL = 300  # seconds before orphaned runs are swept
     _RUN_STATUS_TTL = 3600  # seconds to retain terminal run status for polling
-
     def _set_run_status(self, run_id: str, status: str, **fields: Any) -> Dict[str, Any]:
         """Update pollable run status without exposing private agent objects."""
         now = time.time()
@@ -6055,21 +6139,35 @@ class APIServerAdapter(BasePlatformAdapter):
     @_admit_api_agent_request
     async def _handle_runs(self, request: "web.Request") -> "web.Response":
         """POST /v1/runs — start an agent run, return run_id immediately."""
+        provided_session_id, session_id_err = self._parse_session_id_header(request)
+        if session_id_err is not None:
+            return session_id_err
+
         # Long-term memory scope header (see chat_completions for details).
         gateway_session_key, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
 
-        # Enforce concurrency limit (shared across all agent-serving
-        # endpoints; configurable via gateway.api_server.max_concurrent_runs).
-        limited = self._concurrency_limited_response()
-        if limited is not None:
-            return limited
+        def _started_response(run_id: str) -> "web.Response":
+            response_headers = (
+                {"X-Hermes-Session-Key": gateway_session_key}
+                if gateway_session_key
+                else {}
+            )
+            return web.json_response(
+                {"run_id": run_id, "status": "started"},
+                status=202,
+                headers=response_headers,
+            )
 
         try:
             body = await request.json()
         except Exception:
             return web.json_response(_openai_error("Invalid JSON"), status=400)
+
+        from agent.mcp_run_context import read_mcp_run_metadata
+
+        request_mcp_metadata = read_mcp_run_metadata()
 
         raw_input = body.get("input")
         if not raw_input:
@@ -6119,8 +6217,9 @@ class APIServerAdapter(BasePlatformAdapter):
         # Accept explicit conversation_history from the request body.
         # Precedence: explicit conversation_history > previous_response_id.
         conversation_history: List[Dict[str, Any]] = []
+        explicit_history_provided = "conversation_history" in body
         raw_history = body.get("conversation_history")
-        if raw_history:
+        if explicit_history_provided:
             if not isinstance(raw_history, list):
                 return web.json_response(
                     _openai_error("'conversation_history' must be an array of message objects"),
@@ -6141,7 +6240,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
 
         stored_session_id = None
-        if not conversation_history and previous_response_id:
+        if not explicit_history_provided and previous_response_id:
             stored = self._response_store.get(previous_response_id)
             if stored:
                 conversation_history = list(stored.get("conversation_history", []))
@@ -6222,7 +6321,16 @@ class APIServerAdapter(BasePlatformAdapter):
                     status=400,
                 )
             effective_profile = _api_request_profile.get() or ""
-            idempotency_storage_key = f"{effective_profile}:{idempotency_key}" if effective_profile else idempotency_key
+            idempotency_scope = _make_request_fingerprint(
+                {
+                    "profile": effective_profile,
+                    "session_id": session_id,
+                    "session_key": gateway_session_key,
+                },
+                keys=["profile", "session_id", "session_key"],
+                mcp_metadata=request_mcp_metadata,
+            )
+            idempotency_storage_key = f"{effective_profile}:{idempotency_key}:{idempotency_scope}"
             fingerprint_body = dict(body)
             fingerprint_body["_resolved_session_id"] = session_id
             fingerprint_body["_gateway_session_key"] = gateway_session_key
@@ -6230,6 +6338,7 @@ class APIServerAdapter(BasePlatformAdapter):
             idempotency_fingerprint = _make_request_fingerprint(
                 fingerprint_body,
                 keys=sorted(fingerprint_body),
+                mcp_metadata=request_mcp_metadata,
             )
 
         def _cached_idempotency_response():
@@ -6275,6 +6384,9 @@ class APIServerAdapter(BasePlatformAdapter):
         cached_response = _cached_idempotency_response()
         if cached_response is not None:
             return cached_response
+        limited = self._concurrency_limited_response()
+        if limited is not None:
+            return limited
         run_id = f"run_{uuid.uuid4().hex}"
         session_id = session_id or run_id
         # Approval queues gate host-side tool execution and must be isolated
@@ -6325,7 +6437,6 @@ class APIServerAdapter(BasePlatformAdapter):
         # Background task outlives the HTTP response (and thus the middleware
         # profile scope). Capture now and re-enter inside the task/executor.
         request_profile = _api_request_profile.get()
-
         async def _run_and_close():
             try:
                 self._set_run_status(run_id, "running")
@@ -6385,6 +6496,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         pass
 
                 def _run_sync():
+                    from agent.mcp_run_context import mcp_run_metadata
                     from gateway.session_context import clear_session_vars
                     from tools.approval import (
                         register_gateway_notify,
@@ -6396,7 +6508,9 @@ class APIServerAdapter(BasePlatformAdapter):
                     effective_task_id = session_id or run_id
                     approval_token = None
                     session_tokens = []
-                    with self._profile_scope(request_profile):
+                    with self._profile_scope(request_profile), mcp_run_metadata(
+                        request_mcp_metadata
+                    ):
                         try:
                             # Bind approval/session identity for this API run via
                             # contextvars so concurrent runs do not share process
@@ -6421,6 +6535,27 @@ class APIServerAdapter(BasePlatformAdapter):
                                 conversation_history=conversation_history,
                                 task_id=effective_task_id,
                             )
+                            if (
+                                explicit_history_provided
+                                and isinstance(r, dict)
+                                and isinstance(r.get("messages"), list)
+                            ):
+                                result_session_id = r.get("session_id")
+                                if not isinstance(result_session_id, str) or not result_session_id:
+                                    agent_session_id = getattr(agent, "session_id", None)
+                                    result_session_id = (
+                                        agent_session_id
+                                        if isinstance(agent_session_id, str)
+                                        and agent_session_id
+                                        else session_id
+                                    )
+                                session_db = getattr(agent, "_session_db", None)
+                                if session_db is not None and result_session_id:
+                                    session_db.replace_messages(
+                                        result_session_id,
+                                        r["messages"],
+                                        active_only=True,
+                                    )
                         finally:
                             try:
                                 unregister_gateway_notify(approval_session_key)
@@ -6473,18 +6608,25 @@ class APIServerAdapter(BasePlatformAdapter):
                     )
                 else:
                     final_response = result.get("final_response", "") if isinstance(result, dict) else ""
+                    effective_session_id = session_id
+                    if isinstance(result, dict):
+                        result_session_id = result.get("session_id")
+                        if isinstance(result_session_id, str) and result_session_id:
+                            effective_session_id = result_session_id
                     _put_event_if_active({
                         "event": "run.completed",
                         "run_id": run_id,
                         "timestamp": time.time(),
                         "output": final_response,
                         "usage": usage,
+                        "session_id": effective_session_id,
                     })
                     self._set_run_status(
                         run_id,
                         "completed",
                         output=final_response,
                         usage=usage,
+                        session_id=effective_session_id,
                         last_event="run.completed",
                     )
             except asyncio.CancelledError:
@@ -6966,7 +7108,10 @@ class APIServerAdapter(BasePlatformAdapter):
                         self.name, self._host,
                     )
 
-            self._runner = web.AppRunner(self._app)
+            self._runner = web.AppRunner(
+                self._app,
+                max_field_size=MAX_REQUEST_HEADER_FIELD_BYTES,
+            )
             await self._runner.setup()
             # Bind directly instead of probing 127.0.0.1 first — the old
             # single-family pre-probe raced the real bind and reported a

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4975,7 +4975,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # Accept explicit conversation_history from the request body.
         # This lets stateless clients supply their own history instead of
         # relying on server-side response chaining via previous_response_id.
-        # Precedence: explicit conversation_history > previous_response_id.
+        # A non-empty explicit history takes precedence over continuation.
         conversation_history: List[Dict[str, Any]] = []
         raw_history = body.get("conversation_history")
         if raw_history:
@@ -6212,9 +6212,9 @@ class APIServerAdapter(BasePlatformAdapter):
         # Accept explicit conversation_history from the request body.
         # Precedence: explicit conversation_history > previous_response_id.
         conversation_history: List[Dict[str, Any]] = []
-        explicit_history_provided = "conversation_history" in body
+        explicit_history_is_authoritative = False
         raw_history = body.get("conversation_history")
-        if explicit_history_provided:
+        if "conversation_history" in body:
             if not isinstance(raw_history, list):
                 return web.json_response(
                     _openai_error("'conversation_history' must be an array of message objects"),
@@ -6233,12 +6233,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation_history.append({"role": str(entry["role"]), "content": entry_content})
             if previous_response_id:
                 logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
-            explicit_history_provided = bool(raw_history)
+            # An empty array is a common client default, not an instruction to
+            # replace an existing transcript. Only non-empty input overrides
+            # response/session continuation and receives explicit persistence.
+            explicit_history_is_authoritative = bool(raw_history)
 
         stored_session_id = None
-        # An empty history is a common client default, not an instruction to
-        # erase a chained transcript. Preserve previous_response_id/session
-        # continuation when callers send conversation_history: [].
+        # Preserve previous_response_id/session continuation when callers send
+        # conversation_history: [] as a client default.
         if not conversation_history and previous_response_id:
             stored = self._response_store.get(previous_response_id)
             if stored:
@@ -6249,9 +6251,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # When input is a multi-message array, extract all but the last
         # message as conversation history (the last becomes user_message).
-        # Only fires when no explicit history was provided.
+        # Only fires when no authoritative explicit history was provided.
         if (
-            not explicit_history_provided
+            not explicit_history_is_authoritative
             and not conversation_history
             and len(input_messages) > 1
         ):
@@ -6369,7 +6371,7 @@ class APIServerAdapter(BasePlatformAdapter):
             return cached_response
 
         if (
-            not explicit_history_provided
+            not explicit_history_is_authoritative
             and not conversation_history
             and continuation_session_id
         ):
@@ -6560,7 +6562,7 @@ class APIServerAdapter(BasePlatformAdapter):
                                 task_id=effective_task_id,
                             )
                             if (
-                                explicit_history_provided
+                                explicit_history_is_authoritative
                                 and isinstance(r, dict)
                                 and isinstance(r.get("messages"), list)
                             ):

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -42,6 +42,7 @@ Requires:
 import asyncio
 import errno
 import hashlib
+import inspect
 import hmac
 import json
 from contextlib import contextmanager, nullcontext
@@ -3126,6 +3127,7 @@ class APIServerAdapter(BasePlatformAdapter):
         session_id: str,
         *,
         fail_closed: bool = False,
+        resolve_compaction: bool = True,
     ) -> List[Dict[str, Any]]:
         db = await self._ensure_session_db_async()
         if db is None:
@@ -3133,7 +3135,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 raise RuntimeError("session_db_unavailable")
             return []
         try:
-            return await asyncio.to_thread(db.get_messages_as_conversation, session_id)
+            resolved_id = session_id
+            resolve_session = getattr(db, "resolve_resume_session_id", None)
+            if resolve_compaction and callable(resolve_session):
+                candidate = await asyncio.to_thread(resolve_session, session_id)
+                if isinstance(candidate, str) and candidate:
+                    resolved_id = candidate
+            return await asyncio.to_thread(db.get_messages_as_conversation, resolved_id)
         except Exception as exc:
             logger.warning("Failed to load session history for %s: %s", session_id, exc)
             if fail_closed:
@@ -6369,14 +6377,23 @@ class APIServerAdapter(BasePlatformAdapter):
                     )
                     if callable(resolve_session):
                         resolved_session_id = await asyncio.to_thread(
-                        resolve_session, continuation_session_id
+                            resolve_session, continuation_session_id
                         )
                         if isinstance(resolved_session_id, str) and resolved_session_id:
                             continuation_session_id = resolved_session_id
-                conversation_history = await self._conversation_history_for_session(
-                    continuation_session_id,
-                    fail_closed=True,
-                )
+                            session_id = resolved_session_id
+                history_loader = self._conversation_history_for_session
+                if inspect.ismethod(history_loader):
+                    conversation_history = await history_loader(
+                        continuation_session_id,
+                        fail_closed=True,
+                        resolve_compaction=False,
+                    )
+                else:
+                    conversation_history = await history_loader(
+                        continuation_session_id,
+                        fail_closed=True,
+                    )
             except Exception:
                 return web.json_response(
                     _openai_error(

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1876,7 +1876,6 @@ class APIServerAdapter(BasePlatformAdapter):
                 ),
                 status=403,
             )
-
         from gateway.session import _is_path_unsafe
 
         if re.search(r'[\r\n\x00]', raw) or _is_path_unsafe(raw):
@@ -1891,6 +1890,37 @@ class APIServerAdapter(BasePlatformAdapter):
             )
 
         return raw, None
+
+    def _parse_mcp_run_metadata_header(
+        self, request: "web.Request"
+    ) -> tuple[Optional[Dict[str, Any]], Optional["web.Response"]]:
+        """Decode private metadata for this run without exposing it to the model."""
+        from agent.mcp_run_context import (
+            MCP_RUN_METADATA_HEADER,
+            decode_mcp_run_metadata_header,
+        )
+
+        raw = request.headers.get(MCP_RUN_METADATA_HEADER, "").strip()
+        if not raw:
+            return None, None
+        if not self._api_key:
+            logger.warning(
+                "%s rejected: no API key configured", MCP_RUN_METADATA_HEADER
+            )
+            return None, web.json_response(
+                _openai_error(
+                    f"{MCP_RUN_METADATA_HEADER} requires API key authentication. "
+                    "Configure API_SERVER_KEY to enable this feature."
+                ),
+                status=403,
+            )
+        try:
+            return decode_mcp_run_metadata_header(raw), None
+        except ValueError as exc:
+            return None, web.json_response(
+                _openai_error(str(exc), code="invalid_mcp_metadata"),
+                status=400,
+            )
 
     def _parse_session_key_header(
         self, request: "web.Request"
@@ -3103,10 +3133,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 raise RuntimeError("session_db_unavailable")
             return []
         try:
-            resolved_id = session_id
-            if hasattr(db, "resolve_resume_session_id"):
-                resolved_id = await asyncio.to_thread(db.resolve_resume_session_id, session_id)
-            return await asyncio.to_thread(db.get_messages_as_conversation, resolved_id)
+            return await asyncio.to_thread(db.get_messages_as_conversation, session_id)
         except Exception as exc:
             logger.warning("Failed to load session history for %s: %s", session_id, exc)
             if fail_closed:
@@ -6177,6 +6204,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # Accept explicit conversation_history from the request body.
         # Precedence: explicit conversation_history > previous_response_id.
         conversation_history: List[Dict[str, Any]] = []
+        explicit_history_provided = "conversation_history" in body
         raw_history = body.get("conversation_history")
         if explicit_history_provided:
             if not isinstance(raw_history, list):
@@ -6210,7 +6238,11 @@ class APIServerAdapter(BasePlatformAdapter):
         # When input is a multi-message array, extract all but the last
         # message as conversation history (the last becomes user_message).
         # Only fires when no explicit history was provided.
-        if not conversation_history and len(input_messages) > 1:
+        if (
+            not explicit_history_provided
+            and not conversation_history
+            and len(input_messages) > 1
+        ):
             for msg in input_messages[:-1]:
                 if msg.get("role") and _content_has_visible_payload(msg.get("content")):
                     conversation_history.append(msg)
@@ -6253,6 +6285,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
 
         session_id = provided_session_id or body_session_id or stored_session_id
+        # Body session IDs identify/correlate the run but do not authorize
+        # loading prior conversation history.  Header IDs opt into resume.
         continuation_session_id = provided_session_id
         route = self._resolve_route(body.get("model"))
         agent_overrides = _request_agent_overrides(body, virtual_model=self._model_name)
@@ -6266,9 +6300,17 @@ class APIServerAdapter(BasePlatformAdapter):
         if selection_error:
             return web.json_response(_openai_error(selection_error), status=400)
 
+        from agent.mcp_run_context import read_mcp_run_metadata
+
+        request_mcp_metadata = read_mcp_run_metadata()
         idempotency_key = request.headers.get("Idempotency-Key")
         idempotency_fingerprint = None
-        idempotency_storage_key = None
+        effective_profile = _api_request_profile.get() or ""
+        idempotency_storage_key = (
+            f"{effective_profile}:{idempotency_key}"
+            if effective_profile and idempotency_key
+            else idempotency_key
+        )
         if idempotency_key:
             if len(idempotency_key) > 256:
                 return web.json_response(
@@ -6279,8 +6321,6 @@ class APIServerAdapter(BasePlatformAdapter):
                     ),
                     status=400,
                 )
-            effective_profile = _api_request_profile.get() or ""
-            idempotency_storage_key = f"{effective_profile}:{idempotency_key}" if effective_profile else idempotency_key
             fingerprint_body = dict(body)
             fingerprint_body["_resolved_session_id"] = session_id
             fingerprint_body["_gateway_session_key"] = gateway_session_key
@@ -6288,6 +6328,7 @@ class APIServerAdapter(BasePlatformAdapter):
             idempotency_fingerprint = _make_request_fingerprint(
                 fingerprint_body,
                 keys=sorted(fingerprint_body),
+                mcp_metadata=request_mcp_metadata,
             )
 
         def _cached_idempotency_response():
@@ -6315,9 +6356,23 @@ class APIServerAdapter(BasePlatformAdapter):
         if cached_response is not None:
             return cached_response
 
-        response_session_id = session_id
-        if not conversation_history and continuation_session_id:
+        if (
+            not explicit_history_provided
+            and not conversation_history
+            and continuation_session_id
+        ):
             try:
+                session_db = await self._ensure_session_db_async()
+                if session_db is not None:
+                    resolve_session = getattr(
+                        session_db, "resolve_resume_session_id", None
+                    )
+                    if callable(resolve_session):
+                        resolved_session_id = await asyncio.to_thread(
+                        resolve_session, continuation_session_id
+                        )
+                        if isinstance(resolved_session_id, str) and resolved_session_id:
+                            continuation_session_id = resolved_session_id
                 conversation_history = await self._conversation_history_for_session(
                     continuation_session_id,
                     fail_closed=True,
@@ -6330,6 +6385,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     ),
                     status=503,
                 )
+        response_session_id = session_id
         cached_response = _cached_idempotency_response()
         if cached_response is not None:
             return cached_response

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6297,6 +6297,9 @@ class APIServerAdapter(BasePlatformAdapter):
         if selection_error:
             return web.json_response(_openai_error(selection_error), status=400)
 
+        from agent.mcp_run_context import read_mcp_run_metadata
+
+        request_mcp_metadata = read_mcp_run_metadata()
         idempotency_key = request.headers.get("Idempotency-Key")
         idempotency_fingerprint = None
         if idempotency_key:
@@ -6315,6 +6318,7 @@ class APIServerAdapter(BasePlatformAdapter):
             idempotency_fingerprint = _make_request_fingerprint(
                 fingerprint_body,
                 keys=sorted(fingerprint_body),
+                mcp_metadata=request_mcp_metadata,
             )
 
         def _cached_idempotency_response():
@@ -6342,9 +6346,19 @@ class APIServerAdapter(BasePlatformAdapter):
         if cached_response is not None:
             return cached_response
 
-        response_session_id = session_id
-        if not conversation_history and session_id:
+        if not explicit_history_provided and not conversation_history and session_id:
             try:
+                session_db = await self._ensure_session_db_async()
+                if session_db is not None:
+                    resolve_session = getattr(
+                        session_db, "resolve_resume_session_id", None
+                    )
+                    if callable(resolve_session):
+                        resolved_session_id = await asyncio.to_thread(
+                            resolve_session, session_id
+                        )
+                        if isinstance(resolved_session_id, str) and resolved_session_id:
+                            session_id = resolved_session_id
                 conversation_history = await self._conversation_history_for_session(
                     session_id,
                     fail_closed=True,
@@ -6357,6 +6371,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     ),
                     status=503,
                 )
+        response_session_id = session_id
         cached_response = _cached_idempotency_response()
         if cached_response is not None:
             return cached_response
@@ -6410,9 +6425,6 @@ class APIServerAdapter(BasePlatformAdapter):
         # Background task outlives the HTTP response (and thus the middleware
         # profile scope). Capture now and re-enter inside the task/executor.
         request_profile = _api_request_profile.get()
-        from agent.mcp_run_context import read_mcp_run_metadata
-
-        request_mcp_metadata = read_mcp_run_metadata()
 
         async def _run_and_close():
             try:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -119,6 +119,25 @@ def _hermes_version() -> str:
         return "dev"
 
 
+def _profile_capability_attestation() -> tuple[str, Optional[str]]:
+    """Return the active profile and the exact capabilities.json digest."""
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        profile = _api_request_profile.get() or get_active_profile_name() or "default"
+    except Exception:
+        profile = _api_request_profile.get() or "default"
+
+    try:
+        from hermes_constants import get_hermes_home
+
+        capability_path = get_hermes_home() / "capabilities.json"
+        digest = hashlib.sha256(capability_path.read_bytes()).hexdigest()
+    except (OSError, TypeError):
+        digest = None
+    return profile, digest
+
+
 # Default settings
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8642
@@ -2755,11 +2774,14 @@ class APIServerAdapter(BasePlatformAdapter):
             process_completion_queue_depth=process_depth,
             active_delegations=active_delegations,
         )
+        profile, capability_manifest_sha256 = _profile_capability_attestation()
         return web.json_response({
             "status": readiness["status"],
             "readiness": readiness,
             "platform": "hermes-agent",
             "version": _hermes_version(),
+            "profile": profile,
+            "capability_manifest_sha256": capability_manifest_sha256,
             "gateway_state": gw_state,
             "platforms": runtime.get("platforms", {}),
             "active_agents": gw_active,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -124,6 +124,10 @@ DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8642
 MAX_STORED_RESPONSES = 100
 MAX_REQUEST_BYTES = 10_000_000  # 10 MB — accommodates long agent conversations with tool calls
+# Base64url expands the 8 KiB decoded MCP metadata allowance to about 10.7
+# KiB. aiohttp defaults to an 8 KiB header field, so the server needs a modest
+# explicit ceiling above that contract.
+MAX_REQUEST_HEADER_FIELD_BYTES = 16 * 1024
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
@@ -810,7 +814,10 @@ class ResponseStore:
 
 _CORS_HEADERS = {
     "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
-    "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key",
+    "Access-Control-Allow-Headers": (
+        "Authorization, Content-Type, Idempotency-Key, X-Hermes-MCP-Metadata, "
+        "X-Hermes-Session-Id, X-Hermes-Session-Key"
+    ),
 }
 
 
@@ -942,14 +949,20 @@ def _admit_api_agent_request(handler):
         auth_err = self._check_auth(request)
         if auth_err:
             return auth_err
+        mcp_metadata, metadata_err = self._parse_mcp_run_metadata_header(request)
+        if metadata_err is not None:
+            return metadata_err
         draining = self._draining_response()
         if draining is not None:
             return draining
         reservation = {"active": True}
         token = _api_agent_request_reservation.set(reservation)
         self._pending_agent_requests += 1
+        from agent.mcp_run_context import mcp_run_metadata
+
         try:
-            return await handler(self, request, *args, **kwargs)
+            with mcp_run_metadata(mcp_metadata):
+                return await handler(self, request, *args, **kwargs)
         finally:
             if reservation["active"]:
                 reservation["active"] = False
@@ -1078,10 +1091,15 @@ class _IdempotencyCache:
 _idem_cache = _IdempotencyCache()
 
 
-def _make_request_fingerprint(body: Dict[str, Any], keys: List[str]) -> str:
+def _make_request_fingerprint(
+    body: Dict[str, Any],
+    keys: List[str],
+    *,
+    mcp_metadata: Optional[Dict[str, Any]] = None,
+) -> str:
     from hashlib import sha256
     subset = {k: body.get(k) for k in keys}
-    return sha256(repr(subset).encode("utf-8")).hexdigest()
+    return sha256(repr((subset, mcp_metadata)).encode("utf-8")).hexdigest()
 
 
 def _derive_chat_session_id(
@@ -1839,7 +1857,6 @@ class APIServerAdapter(BasePlatformAdapter):
                 ),
                 status=403,
             )
-
         from gateway.session import _is_path_unsafe
 
         if re.search(r'[\r\n\x00]', raw) or _is_path_unsafe(raw):
@@ -1854,6 +1871,37 @@ class APIServerAdapter(BasePlatformAdapter):
             )
 
         return raw, None
+
+    def _parse_mcp_run_metadata_header(
+        self, request: "web.Request"
+    ) -> tuple[Optional[Dict[str, Any]], Optional["web.Response"]]:
+        """Decode private metadata for this run without exposing it to the model."""
+        from agent.mcp_run_context import (
+            MCP_RUN_METADATA_HEADER,
+            decode_mcp_run_metadata_header,
+        )
+
+        raw = request.headers.get(MCP_RUN_METADATA_HEADER, "").strip()
+        if not raw:
+            return None, None
+        if not self._api_key:
+            logger.warning(
+                "%s rejected: no API key configured", MCP_RUN_METADATA_HEADER
+            )
+            return None, web.json_response(
+                _openai_error(
+                    f"{MCP_RUN_METADATA_HEADER} requires API key authentication. "
+                    "Configure API_SERVER_KEY to enable this feature."
+                ),
+                status=403,
+            )
+        try:
+            return decode_mcp_run_metadata_header(raw), None
+        except ValueError as exc:
+            return None, web.json_response(
+                _openai_error(str(exc), code="invalid_mcp_metadata"),
+                status=400,
+            )
 
     def _parse_session_key_header(
         self, request: "web.Request"
@@ -2871,6 +2919,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "realtime_voice": False,
                 "session_continuity_header": "X-Hermes-Session-Id",
                 "session_key_header": "X-Hermes-Session-Key",
+                "mcp_run_metadata_header": "X-Hermes-MCP-Metadata",
                 "cors": bool(self._cors_origins),
             },
             "endpoints": {
@@ -3931,9 +3980,12 @@ class APIServerAdapter(BasePlatformAdapter):
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
+            from agent.mcp_run_context import read_mcp_run_metadata
+
             fp = _make_request_fingerprint(
                 body,
                 keys=["model", "provider", "model_options", "messages", "tools", "tool_choice", "stream"],
+                mcp_metadata=read_mcp_run_metadata(),
             )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
@@ -5053,6 +5105,8 @@ class APIServerAdapter(BasePlatformAdapter):
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
+            from agent.mcp_run_context import read_mcp_run_metadata
+
             fp = _make_request_fingerprint(
                 body,
                 keys=[
@@ -5065,6 +5119,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "model_options",
                     "tools",
                 ],
+                mcp_metadata=read_mcp_run_metadata(),
             )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_response)
@@ -5774,11 +5829,18 @@ class APIServerAdapter(BasePlatformAdapter):
         # run_in_executor threads, so the profile scope must be re-entered
         # inside _run() from this explicit value.
         request_profile = _api_request_profile.get()
+        from agent.mcp_run_context import read_mcp_run_metadata
+
+        request_mcp_metadata = read_mcp_run_metadata()
 
         def _run():
             from gateway.session_context import clear_session_vars
 
-            with self._profile_scope(request_profile):
+            from agent.mcp_run_context import mcp_run_metadata
+
+            with self._profile_scope(request_profile), mcp_run_metadata(
+                request_mcp_metadata
+            ):
                 tokens = self._bind_api_server_session(
                     chat_id=session_id or "",
                     session_key=gateway_session_key or session_id or "",
@@ -6052,6 +6114,10 @@ class APIServerAdapter(BasePlatformAdapter):
     @_admit_api_agent_request
     async def _handle_runs(self, request: "web.Request") -> "web.Response":
         """POST /v1/runs — start an agent run, return run_id immediately."""
+        provided_session_id, session_id_err = self._parse_session_id_header(request)
+        if session_id_err is not None:
+            return session_id_err
+
         # Long-term memory scope header (see chat_completions for details).
         gateway_session_key, key_err = self._parse_session_key_header(request)
         if key_err is not None:
@@ -6116,8 +6182,9 @@ class APIServerAdapter(BasePlatformAdapter):
         # Accept explicit conversation_history from the request body.
         # Precedence: explicit conversation_history > previous_response_id.
         conversation_history: List[Dict[str, Any]] = []
+        explicit_history_provided = "conversation_history" in body
         raw_history = body.get("conversation_history")
-        if raw_history:
+        if explicit_history_provided:
             if not isinstance(raw_history, list):
                 return web.json_response(
                     _openai_error("'conversation_history' must be an array of message objects"),
@@ -6138,7 +6205,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
 
         stored_session_id = None
-        if not conversation_history and previous_response_id:
+        if not explicit_history_provided and previous_response_id:
             stored = self._response_store.get(previous_response_id)
             if stored:
                 conversation_history = list(stored.get("conversation_history", []))
@@ -6149,7 +6216,11 @@ class APIServerAdapter(BasePlatformAdapter):
         # When input is a multi-message array, extract all but the last
         # message as conversation history (the last becomes user_message).
         # Only fires when no explicit history was provided.
-        if not conversation_history and len(input_messages) > 1:
+        if (
+            not explicit_history_provided
+            and not conversation_history
+            and len(input_messages) > 1
+        ):
             for msg in input_messages[:-1]:
                 if msg.get("role") and _content_has_visible_payload(msg.get("content")):
                     conversation_history.append(msg)
@@ -6317,6 +6388,9 @@ class APIServerAdapter(BasePlatformAdapter):
         # Background task outlives the HTTP response (and thus the middleware
         # profile scope). Capture now and re-enter inside the task/executor.
         request_profile = _api_request_profile.get()
+        from agent.mcp_run_context import read_mcp_run_metadata
+
+        request_mcp_metadata = read_mcp_run_metadata()
 
         async def _run_and_close():
             try:
@@ -6377,6 +6451,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         pass
 
                 def _run_sync():
+                    from agent.mcp_run_context import mcp_run_metadata
                     from gateway.session_context import clear_session_vars
                     from tools.approval import (
                         register_gateway_notify,
@@ -6388,7 +6463,9 @@ class APIServerAdapter(BasePlatformAdapter):
                     effective_task_id = session_id or run_id
                     approval_token = None
                     session_tokens = []
-                    with self._profile_scope(request_profile):
+                    with self._profile_scope(request_profile), mcp_run_metadata(
+                        request_mcp_metadata
+                    ):
                         try:
                             # Bind approval/session identity for this API run via
                             # contextvars so concurrent runs do not share process
@@ -6413,6 +6490,27 @@ class APIServerAdapter(BasePlatformAdapter):
                                 conversation_history=conversation_history,
                                 task_id=effective_task_id,
                             )
+                            if (
+                                explicit_history_provided
+                                and isinstance(r, dict)
+                                and isinstance(r.get("messages"), list)
+                            ):
+                                result_session_id = r.get("session_id")
+                                if not isinstance(result_session_id, str) or not result_session_id:
+                                    agent_session_id = getattr(agent, "session_id", None)
+                                    result_session_id = (
+                                        agent_session_id
+                                        if isinstance(agent_session_id, str)
+                                        and agent_session_id
+                                        else session_id
+                                    )
+                                session_db = getattr(agent, "_session_db", None)
+                                if session_db is not None and result_session_id:
+                                    session_db.replace_messages(
+                                        result_session_id,
+                                        r["messages"],
+                                        active_only=True,
+                                    )
                         finally:
                             try:
                                 unregister_gateway_notify(approval_session_key)
@@ -6465,18 +6563,25 @@ class APIServerAdapter(BasePlatformAdapter):
                     )
                 else:
                     final_response = result.get("final_response", "") if isinstance(result, dict) else ""
+                    effective_session_id = session_id
+                    if isinstance(result, dict):
+                        result_session_id = result.get("session_id")
+                        if isinstance(result_session_id, str) and result_session_id:
+                            effective_session_id = result_session_id
                     _put_event_if_active({
                         "event": "run.completed",
                         "run_id": run_id,
                         "timestamp": time.time(),
                         "output": final_response,
                         "usage": usage,
+                        "session_id": effective_session_id,
                     })
                     self._set_run_status(
                         run_id,
                         "completed",
                         output=final_response,
                         usage=usage,
+                        session_id=effective_session_id,
                         last_event="run.completed",
                     )
             except asyncio.CancelledError:
@@ -6958,7 +7063,10 @@ class APIServerAdapter(BasePlatformAdapter):
                         self.name, self._host,
                     )
 
-            self._runner = web.AppRunner(self._app)
+            self._runner = web.AppRunner(
+                self._app,
+                max_field_size=MAX_REQUEST_HEADER_FIELD_BYTES,
+            )
             await self._runner.setup()
             # Bind directly instead of probing 127.0.0.1 first — the old
             # single-family pre-probe raced the real bind and reported a

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -119,6 +119,7 @@ _SESSION_ASYNC_DELIVERY: ContextVar = ContextVar("HERMES_SESSION_ASYNC_DELIVERY"
 _CRON_AUTO_DELIVER_PLATFORM: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_PLATFORM", default=_UNSET)
 _CRON_AUTO_DELIVER_CHAT_ID: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_CHAT_ID", default=_UNSET)
 _CRON_AUTO_DELIVER_THREAD_ID: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_THREAD_ID", default=_UNSET)
+_CRON_SESSION: ContextVar = ContextVar("HERMES_CRON_SESSION", default=_UNSET)
 
 _VAR_MAP = {
     "HERMES_SESSION_PLATFORM": _SESSION_PLATFORM,
@@ -137,6 +138,7 @@ _VAR_MAP = {
     "HERMES_CRON_AUTO_DELIVER_PLATFORM": _CRON_AUTO_DELIVER_PLATFORM,
     "HERMES_CRON_AUTO_DELIVER_CHAT_ID": _CRON_AUTO_DELIVER_CHAT_ID,
     "HERMES_CRON_AUTO_DELIVER_THREAD_ID": _CRON_AUTO_DELIVER_THREAD_ID,
+    "HERMES_CRON_SESSION": _CRON_SESSION,
 }
 
 
@@ -171,6 +173,7 @@ def set_session_vars(
     cwd: str = "",
     async_delivery: bool = True,
     ui_session_id: str = "",
+    cron_session: bool = False,
 ) -> list:
     """Set all session context variables and return reset tokens.
 
@@ -207,6 +210,7 @@ def set_session_vars(
         _SESSION_MESSAGE_ID.set(message_id),
         _SESSION_PROFILE.set(profile),
         _SESSION_ASYNC_DELIVERY.set(bool(async_delivery)),
+        _CRON_SESSION.set("1" if cron_session else ""),
     ]
     try:
         from agent.runtime_cwd import set_session_cwd
@@ -242,6 +246,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_UI_SESSION_ID,
         _SESSION_MESSAGE_ID,
         _SESSION_PROFILE,
+        _CRON_SESSION,
     ):
         var.set("")
     # Reset async-delivery capability to the "never set" sentinel rather than a

--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -14,7 +14,7 @@ Provides subcommands for:
 import os
 import sys
 
-__version__ = "0.19.0"
+__version__ = "0.19.1"
 __release_date__ = "2026.7.20"
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2733,6 +2733,8 @@ DEFAULT_CONFIG = {
         "reactions": False,            # Add 👀/✅/❌ reactions to messages during processing
         "channel_prompts": {},         # Per-chat/topic ephemeral system prompts (topics inherit from parent group)
         "allowed_chats": "",           # If set, bot ONLY responds in these group/supergroup chat IDs (whitelist)
+        "auto_allow_groups_from_trusted_adders": False,  # Persist groups where a trusted actor promotes the bot to admin
+        "trusted_group_adders": [],     # Telegram user IDs permitted to auto-authorize groups
         "extra": {
             "rich_messages": False,     # Bot API 10.1 rich messages (tables/task lists/details/math) render natively; set True to opt in. Default stays legacy MarkdownV2 because rich messages can be hard to copy as plain text in Telegram clients.
             "rich_drafts": False,       # Experimental Bot API 10.1 rich draft previews during Telegram DM streaming. Default off because Telegram Desktop/macOS can visually overlay rich draft frames until the chat redraws.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2240,6 +2240,11 @@ DEFAULT_CONFIG = {
         # Set explicitly to pin a backend:
         # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "deepinfra" | "neutts" (local) | "kittentts" (local) | "piper" (local)
         "provider": "edge",
+        # Optional one-shot whole-message retry when the selected provider
+        # fails. Leave empty to preserve single-provider behaviour. A fallback
+        # must name a different built-in, command, or registered plugin provider
+        # (e.g. "openai").
+        "fallback_provider": "",
         "edge": {
             "voice": "en-US-AriaNeural",
             # Popular: AriaNeural, JennyNeural, AndrewNeural, BrianNeural, SoniaNeural

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -152,6 +152,15 @@ _DEFAULT_PAYLOADS = {
     "on_session_end": {"session_id": "test-session"},
     "on_session_finalize": {"session_id": "test-session"},
     "on_session_reset": {"session_id": "test-session"},
+    "gateway_message_delivered": {
+        "source": "cron",
+        "execution_id": "test-execution",
+        "job_id": "test-job",
+        "platform": "telegram",
+        "chat_id": "test-chat",
+        "thread_id": "test-thread",
+        "message_id": "test-message",
+    },
     "pre_api_request": {
         "session_id": "test-session",
         "task_id": "test-task",

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -161,6 +161,21 @@ _DEFAULT_PAYLOADS = {
         "thread_id": "test-thread",
         "message_id": "test-message",
     },
+    "gateway_message_before_send": {
+        "source": "cron",
+        "execution_id": "test-execution",
+        "job_id": "test-job",
+        "platform": "telegram",
+        "chat_id": "test-chat",
+        "thread_id": "test-thread",
+    },
+    "telegram_callback_query": {
+        "data": "rf:up:test-execution",
+        "chat_id": "test-chat",
+        "thread_id": "test-thread",
+        "message_id": "test-message",
+        "user_id": "test-user",
+    },
     "pre_api_request": {
         "session_id": "test-session",
         "task_id": "test-task",

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -171,6 +171,9 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # Confirmed outbound Telegram cron text delivery. Observers receive the
+    # execution and Telegram message identifiers, never message content.
+    "gateway_message_delivered",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs an approval decision -- fires for CLI-interactive prompts,
     # gateway/ACP approvals, and smart-mode auxiliary-LLM decisions.
@@ -1928,7 +1931,8 @@ class PluginManager:
         are reused.  All injected context is ephemeral — never
         persisted to session DB.
         """
-        kwargs.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
+        if hook_name != "gateway_message_delivered":
+            kwargs.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
         callbacks = self._hooks.get(hook_name, [])
         results: List[Any] = []
         for cb in callbacks:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -174,6 +174,12 @@ VALID_HOOKS: Set[str] = {
     # Confirmed outbound Telegram cron text delivery. Observers receive the
     # execution and Telegram message identifiers, never message content.
     "gateway_message_delivered",
+    # Outbound delivery customization. Plugins may return a neutral
+    # ``telegram_inline_keyboard`` value for Telegram sends.
+    "gateway_message_before_send",
+    # Unmatched Telegram callback queries. Plugins may return a handled
+    # directive with answer/edit instructions for their own callback prefix.
+    "telegram_callback_query",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs an approval decision -- fires for CLI-interactive prompts,
     # gateway/ACP approvals, and smart-mode auxiliary-LLM decisions.
@@ -289,6 +295,7 @@ class PluginManifest:
     description: str = ""
     author: str = ""
     requires_env: List[Union[str, Dict[str, Any]]] = field(default_factory=list)
+    requires_hooks: List[str] = field(default_factory=list)
     provides_tools: List[str] = field(default_factory=list)
     provides_hooks: List[str] = field(default_factory=list)
     source: str = ""        # "user", "project", or "entrypoint"
@@ -1194,6 +1201,10 @@ class PluginContext:
         self._manager._hooks.setdefault(hook_name, []).append(callback)
         logger.debug("Plugin %s registered hook: %s", self.manifest.name, hook_name)
 
+    def supports_hook(self, hook_name: str) -> bool:
+        """Return whether this Hermes core supports a plugin hook."""
+        return hook_name in VALID_HOOKS
+
     # -- middleware registration -------------------------------------------
 
     def register_middleware(self, kind: str, callback: Callable) -> None:
@@ -1660,6 +1671,11 @@ class PluginManager:
                 description=data.get("description", ""),
                 author=data.get("author", ""),
                 requires_env=data.get("requires_env", []),
+                requires_hooks=[
+                    str(hook)
+                    for hook in data.get("requires_hooks", [])
+                    if isinstance(hook, str)
+                ] if isinstance(data.get("requires_hooks", []), list) else [],
                 provides_tools=data.get("provides_tools", []),
                 provides_hooks=data.get("provides_hooks", []),
                 source=source,
@@ -1774,6 +1790,16 @@ class PluginManager:
             "Loading plugin '%s' (source=%s, kind=%s, path=%s)",
             manifest.key or manifest.name, manifest.source, manifest.kind, manifest.path,
         )
+
+        missing_hooks = sorted(set(manifest.requires_hooks) - VALID_HOOKS)
+        if missing_hooks:
+            loaded.error = "requires unsupported hook(s): " + ", ".join(missing_hooks)
+            logger.warning(
+                "Plugin '%s' requires unsupported hook(s): %s",
+                manifest.name, ", ".join(missing_hooks),
+            )
+            self._plugins[manifest.key or manifest.name] = loaded
+            return
 
         from tools.registry import registry as _registry
         _plugin_id = manifest.key or manifest.name

--- a/implementation-notes-trusted-group-adder.md
+++ b/implementation-notes-trusted-group-adder.md
@@ -1,0 +1,80 @@
+# Implementation Notes — Trusted Telegram Group Adder
+
+## Goal
+Allow a Telegram bot to auto-authorize a group only when Isac promotes the bot to administrator, while keeping mention/reply-only responses and full passive context observation.
+
+## Major Decisions I Made Because the Spec Was Missing Context
+
+### Require an administrator promotion, not mere membership
+I chose to enroll only when the bot transitions to Telegram `administrator` and the actor is an allowlisted trusted user. This matches Isac's actual workflow and avoids silently trusting groups where the bot was merely added.
+
+### Persist enrollment outside config.yaml
+I chose a profile-local state file written atomically with restrictive permissions so runtime enrollment does not rewrite config files or expose secrets. Removing/kicking the bot must revoke the saved enrollment so an untrusted user cannot re-add it later and inherit old access.
+
+### Fail closed
+If config is absent/invalid, the actor is not trusted, the chat is not a group, or state cannot be validated, do not enroll. When trusted-adder mode is enabled, I also made group admission strict even when every allowlist is empty. `group_allow_from` and `guest_mode` cannot admit an unknown group; either explicit chat allowlist can admit it, and normal mention/reply gating still runs afterward.
+
+### Expose dynamic enrollment without rewriting config
+I chose to have gateway authorization read the Telegram adapter's effective group allowlist helper. This makes persisted groups visible to anonymous/shared group sources without mutating or removing the operator's explicit `group_allowed_chats` config.
+
+### Revoke on every administrator demotion
+I chose to revoke persisted enrollment whenever the bot transitions from `administrator` to any other status, regardless of the actor. Only enrollment requires a trusted actor; revocation must fail safe.
+
+### Reconcile durable grants before using them
+I chose to treat the JSON file as a retryable candidate list, not an authorization source. Each adapter starts with an empty in-memory active set and post-connect housekeeping activates only entries for which `getChatMember(chat_id, bot_id)` reports the bot as `administrator`; unknown status and API errors stay inactive without deleting the candidate.
+
+### Persist before granting; revoke before persisting
+I chose asymmetric fail-closed ordering: promotion writes durable state before adding the live grant, while demotion removes the live grant before attempting durable removal. A failed disk write therefore cannot create a live-only grant or keep a revoked group live.
+
+### Move only dynamic grants during Telegram migration
+I chose to register PTB's migrate status handler on every application build and move an old basic-group durable grant to the new supergroup ID in one atomic state write. The new ID inherits live activation only if the old dynamic grant was already active; a merely persisted restart candidate stays inactive. Explicit config entries remain operator-owned and are never rewritten.
+
+### Reject unsafe state paths
+I chose a minimal `{"chat_ids": [...]}` schema containing only negative numeric strings, direct owner-only temp-file creation, `fsync`, and `os.replace`. Symlinked or non-regular state files/directories fail closed rather than being followed or overwritten.
+
+### Bind durable state to the adapter's construction-time profile
+I chose to capture `get_hermes_home()` in each real adapter during construction because multiplex dispatch later runs outside that profile scope. Narrow `object.__new__` test fixtures retain a safe dynamic fallback, but production adapters cannot drift into another profile's state after `HERMES_HOME` changes.
+
+### Emit only a validated per-event dynamic-group signal
+I chose to stamp `telegram_auto_authorized_group_active=True` only on Telegram group/forum events whose negative chat ID is in this adapter's active reconciled set while trusted-adder mode is enabled. Persisted-only candidates, explicit allowlists, DMs/channels, disabled mode, and malformed state never receive the key.
+
+### Keep trusted-adder behavior in config.yaml only
+I removed both trusted-adder environment-variable paths. The top-level Telegram keys still bridge into each adapter's `PlatformConfig.extra`, so multiplex profiles cannot contaminate one another through process-global environment mutation.
+
+### Serialize reconciliation with membership changes
+I chose to keep Bot API validation outside the lock, then perform the final durable-state recheck and live activation under the same reentrant lock as promotion, demotion, and migration. A process-local tombstone set now wins over stale durable state when revocation persistence fails; only a later trusted promotion whose durable-state update succeeds may clear that tombstone. Migration tombstones the old ID before persistence and clears the new ID only after the atomic move succeeds.
+
+### Keep strict profile allowlists profile-local
+I chose to ignore `TELEGRAM_ALLOWED_CHATS` and `TELEGRAM_GROUP_ALLOWED_CHATS` whenever trusted-adder mode is enabled and the corresponding adapter `config.extra` key is omitted. Legacy mode retains the environment fallback, but one multiplex profile can no longer leak its process-global group lists into another strict profile. The gateway authorization mixin resolves strict Telegram mode before any legacy chat or sender allowlist, rejects chats outside the adapter's effective admission set, and uses only the adapter's effective group allowlist for chat-wide authorization.
+
+### Treat membership metadata as an authorization proof
+I chose to enroll only an explicit transition from Telegram's recognized non-admin statuses (`member`, `restricted`, `left`, or `kicked`) to exactly `administrator`. Recognized non-admin outcomes revoke even when old/actor/target metadata is missing, and missing or unknown outcomes revoke any known dynamic grant conservatively.
+
+### Gate callbacks at the group boundary first
+I applied strict group admission before callback dispatch so model pickers, choice pickers, approvals, and clarify/session state cannot mutate in unknown or revoked groups. Negative chat IDs with missing or unknown chat type are denied as malformed group metadata; positive-ID DM behavior and admitted groups retain their existing paths.
+
+### Preserve atomic replacement on Windows
+I kept temporary-file fsync and `os.replace` on every platform, but skip POSIX-only chmod/fchmod and directory-fsync operations on Windows. POSIX permission assertions are likewise conditional.
+
+## Verification
+- TDD RED gate for the four review blockers: 7 targeted regressions failed for the expected missing behavior before implementation.
+- `uv run pytest -q tests/gateway/test_telegram_trusted_group_adder.py`: 57 passed.
+- `uv run pytest -q tests/gateway/test_telegram_group_gating.py`: 71 passed.
+- `uv run pytest -q tests/gateway/test_telegram_approval_buttons.py tests/gateway/test_telegram_clarify_buttons.py tests/gateway/test_telegram_callback_auth_fail_closed.py`: 45 passed.
+- `uv run pytest -q tests/gateway/test_telegram_model_picker.py tests/gateway/test_choice_picker.py`: 19 passed.
+- `uv run pytest -q tests/gateway/test_telegram_slash_confirm.py`: 3 passed.
+- `uv run pytest -q tests/gateway/test_telegram_auth_check.py`: 18 passed.
+- `uv run pytest -q tests/gateway/test_config_driven_access_policy.py`: 71 passed.
+- `uv run pytest -q tests/gateway/test_multiplex_profile_authz.py`: 13 passed.
+- `uv run pytest -q tests/gateway/test_auth_fallback.py`: 3 passed.
+- `uv run pytest -q tests/gateway/test_telegram_thread_fallback.py`: 51 passed (fake PTB fixture updated for the new membership handler import).
+- Production Python `/Users/magic/.hermes/hermes-agent/venv/bin/python3.11` (3.11.15) `-m py_compile` on all changed production Python files: passed.
+- `uv run ruff check` on all changed Python files: passed.
+- `python3 scripts/check-windows-footguns.py --diff isacstelian/main`: passed.
+- `git diff --check`: passed.
+
+## Follow-ups / Open Questions
+- `test_telegram_thread_fallback.py -k callback` still has its two pre-existing standalone fixture failures because that test imports the adapter with `ParseMode=None`; the same failures reproduce at the untouched `8d94c7ef0` baseline. This blocker-only change does not alter that unrelated harness.
+- After merge, enable the feature only on Telegram profiles with Isac's current Telegram user ID and restart those gateways.
+- Smoke-test first on one non-production bot/group before fleet rollout.
+- The active `scoped-telegram-access` plugins can consume the new internal per-event signal so validated Isac-enrolled groups follow their normal stakeholder-group path. Profile plugins were not edited in this branch.

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -27,6 +27,32 @@ from typing import Dict, List, Optional, Set, Any
 logger = logging.getLogger(__name__)
 
 
+def _build_inline_keyboard(value: Any) -> Any:
+    """Build a Telegram keyboard from the plugin-neutral metadata shape."""
+    if not isinstance(value, list) or not value:
+        return None
+    rows = []
+    for row in value:
+        if not isinstance(row, list) or not row:
+            return None
+        buttons = []
+        for button in row:
+            if not isinstance(button, dict):
+                return None
+            label = button.get("text")
+            callback_data = button.get("callback_data")
+            if label is None or callback_data is None:
+                return None
+            callback_data = str(callback_data)
+            if not callback_data or len(callback_data.encode("utf-8")) > 64:
+                return None
+            buttons.append(
+                InlineKeyboardButton(text=str(label), callback_data=callback_data)
+            )
+        rows.append(buttons)
+    return InlineKeyboardMarkup(rows)
+
+
 def _redact_telegram_error_text(error: object) -> str:
     """Redact secrets from Telegram transport errors before logging or returning them."""
     text = "" if error is None else str(error)
@@ -1647,6 +1673,9 @@ class TelegramAdapter(BasePlatformAdapter):
     ) -> bool:
         return bool(
             not (metadata or {}).get("expect_edits")
+            and _build_inline_keyboard(
+                (metadata or {}).get("telegram_inline_keyboard")
+            ) is None
             and self._rich_eligible(content)
         )
 
@@ -4304,6 +4333,10 @@ class TelegramAdapter(BasePlatformAdapter):
         # Skip whitespace-only text to prevent Telegram 400 empty-text errors.
         if not content or not content.strip():
             return SendResult(success=True, message_id=None)
+
+        reply_markup = _build_inline_keyboard(
+            (metadata or {}).get("telegram_inline_keyboard")
+        )
         
         try:
             # Bot API 10.1 rich fast-path: send the raw agent markdown via
@@ -4381,6 +4414,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 reply_to_source = reply_to or (
                     str(metadata_reply_to) if private_dm_topic_send and metadata_reply_to is not None else None
                 )
+                markup_kwargs = (
+                    {"reply_markup": reply_markup}
+                    if i == 0 and reply_markup is not None
+                    else {}
+                )
                 if private_dm_topic_send:
                     should_thread = (
                         reply_to_source is not None
@@ -4420,6 +4458,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 **thread_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
+                                **markup_kwargs,
                             )
                         except Exception as md_error:
                             # Markdown parsing failed, try plain text
@@ -4434,6 +4473,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     **thread_kwargs,
                                     **self._link_preview_kwargs(),
                                     **self._notification_kwargs(metadata),
+                                    **markup_kwargs,
                                 )
                             else:
                                 raise
@@ -6168,6 +6208,71 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception:
             pass
 
+    async def _handle_plugin_callback_query(
+        self,
+        query: Any,
+        data: str,
+        *,
+        chat_id: Any,
+        chat_type: Any,
+        thread_id: Any,
+        user_id: Any,
+    ) -> bool:
+        """Dispatch an authorized, otherwise-unmatched callback to plugins."""
+        try:
+            from hermes_cli.plugins import has_hook, invoke_hook
+
+            if not has_hook("telegram_callback_query"):
+                return False
+            if not self._is_callback_user_authorized(
+                str(user_id or ""),
+                chat_id=chat_id,
+                chat_type=str(chat_type) if chat_type is not None else None,
+                thread_id=thread_id,
+                user_name=getattr(query.from_user, "first_name", None),
+            ):
+                return False
+            results = invoke_hook(
+                "telegram_callback_query",
+                data=data,
+                chat_id=str(chat_id) if chat_id is not None else None,
+                thread_id=str(thread_id) if thread_id is not None else None,
+                message_id=(
+                    str(getattr(getattr(query, "message", None), "message_id"))
+                    if getattr(getattr(query, "message", None), "message_id", None)
+                    is not None
+                    else None
+                ),
+                user_id=str(user_id) if user_id is not None else None,
+            )
+            for result in results:
+                if not isinstance(result, dict) or result.get("handled") is not True:
+                    continue
+                answer_text = result.get("answer_text")
+                if answer_text:
+                    await query.answer(text=str(answer_text)[:200])
+                else:
+                    await query.answer()
+                if "edit_text" in result:
+                    await query.edit_message_text(
+                        text=str(result["edit_text"]),
+                        reply_markup=(
+                            _build_inline_keyboard(result["telegram_inline_keyboard"])
+                            if result.get("telegram_inline_keyboard") is not None
+                            else None
+                        ),
+                    )
+                elif result.get("clear_keyboard"):
+                    await query.edit_message_reply_markup(reply_markup=None)
+                elif result.get("telegram_inline_keyboard") is not None:
+                    markup = _build_inline_keyboard(result["telegram_inline_keyboard"])
+                    if markup is not None:
+                        await query.edit_message_reply_markup(reply_markup=markup)
+                return True
+        except Exception:
+            logger.debug("telegram_callback_query hook failed", exc_info=True)
+        return False
+
     async def _handle_callback_query(
         self, update: "Update", context: "ContextTypes.DEFAULT_TYPE"
     ) -> None:
@@ -6535,42 +6640,53 @@ class TelegramAdapter(BasePlatformAdapter):
             return
 
         # --- Update prompt callbacks ---
-        if not data.startswith("update_prompt:"):
+        if data.startswith("update_prompt:"):
+            answer = data.split(":", 1)[1]  # "y" or "n"
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(
+                caller_id,
+                chat_id=query_chat_id,
+                chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                user_name=query_user_name,
+            ):
+                await query.answer(text="⛔ You are not authorized to answer update prompts.")
+                return
+            await query.answer(text=f"Sent '{answer}' to the update process.")
+            # Edit the message to show the choice and remove buttons
+            label = "Yes" if answer == "y" else "No"
+            try:
+                await query.edit_message_text(
+                    text=self.format_message(f"⚕ Update prompt answered: *{label}*"),
+                    parse_mode=ParseMode.MARKDOWN_V2,
+                    reply_markup=None,
+                )
+            except Exception:
+                pass  # non-fatal if edit fails
+            # Write the response file
+            try:
+                from hermes_constants import get_hermes_home
+                home = get_hermes_home()
+                response_path = home / ".update_response"
+                tmp = response_path.with_suffix(".tmp")
+                tmp.write_text(answer, encoding="utf-8")
+                tmp.replace(response_path)
+                logger.info("Telegram update prompt answered '%s' by user %s",
+                            answer, getattr(query.from_user, "id", "unknown"))
+            except Exception as exc:
+                logger.error("Failed to write update response from callback: %s", exc)
             return
-        answer = data.split(":", 1)[1]  # "y" or "n"
-        caller_id = str(getattr(query.from_user, "id", ""))
-        if not self._is_callback_user_authorized(
-            caller_id,
+
+        # Native Hermes callbacks above always win. Plugins handle only an
+        # otherwise-unmatched callback after the same authorization checks.
+        await self._handle_plugin_callback_query(
+            query,
+            data,
             chat_id=query_chat_id,
-            chat_type=str(query_chat_type) if query_chat_type is not None else None,
-            thread_id=str(query_thread_id) if query_thread_id is not None else None,
-            user_name=query_user_name,
-        ):
-            await query.answer(text="⛔ You are not authorized to answer update prompts.")
-            return
-        await query.answer(text=f"Sent '{answer}' to the update process.")
-        # Edit the message to show the choice and remove buttons
-        label = "Yes" if answer == "y" else "No"
-        try:
-            await query.edit_message_text(
-                text=self.format_message(f"⚕ Update prompt answered: *{label}*"),
-                parse_mode=ParseMode.MARKDOWN_V2,
-                reply_markup=None,
-            )
-        except Exception:
-            pass  # non-fatal if edit fails
-        # Write the response file
-        try:
-            from hermes_constants import get_hermes_home
-            home = get_hermes_home()
-            response_path = home / ".update_response"
-            tmp = response_path.with_suffix(".tmp")
-            tmp.write_text(answer, encoding="utf-8")
-            tmp.replace(response_path)
-            logger.info("Telegram update prompt answered '%s' by user %s",
-                        answer, getattr(query.from_user, "id", "unknown"))
-        except Exception as exc:
-            logger.error("Failed to write update response from callback: %s", exc)
+            chat_type=query_chat_type,
+            thread_id=query_thread_id,
+            user_id=getattr(query.from_user, "id", None),
+        )
 
     # Maps `gt:<verb>` -> (script-name, extra-args, success-label, is_state).
     # Scripts live in ~/.hermes/scripts/gmail-triage/. `arg` from the callback

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -16,6 +16,8 @@ import logging
 import os
 import html as _html
 import re
+import stat
+import tempfile
 import threading
 import time
 from contextvars import ContextVar
@@ -226,6 +228,7 @@ try:
         Application,
         CommandHandler,
         CallbackQueryHandler,
+        ChatMemberHandler,
         MessageHandler as TelegramMessageHandler,
         ContextTypes,
         filters,
@@ -244,6 +247,7 @@ except ImportError:
     Application = Any
     CommandHandler = Any
     CallbackQueryHandler = Any
+    ChatMemberHandler = Any
     TelegramMessageHandler = Any
     HTTPXRequest = Any
     filters = None
@@ -262,6 +266,7 @@ sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
 from gateway.authz_mixin import _coerce_allow_set
 from gateway.config import Platform, PlatformConfig
+from hermes_constants import get_hermes_home
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -288,7 +293,7 @@ from plugins.platforms.telegram.telegram_network import (
     discover_fallback_ips,
     parse_fallback_ip_env,
 )
-from utils import atomic_replace, env_float, env_int
+from utils import env_float, env_int
 
 _TELEGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
 _TELEGRAM_IMAGE_MIME_TO_EXT = {
@@ -385,7 +390,7 @@ def check_telegram_requirements() -> bool:
     """
     global TELEGRAM_AVAILABLE, Update, Bot, Message, InlineKeyboardButton
     global InlineKeyboardMarkup, LinkPreviewOptions, Application
-    global CommandHandler, CallbackQueryHandler, TelegramMessageHandler
+    global CommandHandler, CallbackQueryHandler, ChatMemberHandler, TelegramMessageHandler
     global ContextTypes, filters, ParseMode, ChatType, HTTPXRequest
     if TELEGRAM_AVAILABLE:
         return True
@@ -404,6 +409,7 @@ def check_telegram_requirements() -> bool:
         from telegram.ext import (
             Application as _App, CommandHandler as _CH,
             CallbackQueryHandler as _CQH,
+            ChatMemberHandler as _CMH,
             MessageHandler as _MH,
             ContextTypes as _CT, filters as _filters,
         )
@@ -420,6 +426,7 @@ def check_telegram_requirements() -> bool:
     Application = _App
     CommandHandler = _CH
     CallbackQueryHandler = _CQH
+    ChatMemberHandler = _CMH
     TelegramMessageHandler = _MH
     ContextTypes = _CT
     filters = _filters
@@ -615,6 +622,8 @@ class TelegramAdapter(BasePlatformAdapter):
     _SPLIT_THRESHOLD = 4000
     MEDIA_GROUP_WAIT_SECONDS = 0.8
     _GENERAL_TOPIC_THREAD_ID = "1"
+    _AUTO_AUTHORIZED_GROUPS_FILENAME = "telegram-auto-authorized-groups.json"
+    _auto_authorized_groups_lock = threading.RLock()
 
     # Telegram's edit_message applies MarkdownV2 formatting only on the
     # finalize=True path.  Without this flag, stream_consumer._send_or_edit
@@ -677,8 +686,16 @@ class TelegramAdapter(BasePlatformAdapter):
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.TELEGRAM)
+        # Multiplex adapters are constructed inside their profile runtime scope
+        # but handle updates after that scope has exited.  Anchor durable state
+        # now so later ambient HERMES_HOME changes cannot cross profile bounds.
+        self._hermes_home: _Path = get_hermes_home()
         self._app: Optional[Application] = None
         self._bot: Optional[Bot] = None
+        # Durable grants are only candidates after restart. Bot API
+        # reconciliation repopulates this process-local validated set.
+        self._active_telegram_auto_authorized_groups: set[str] = set()
+        self._revoked_telegram_auto_authorized_groups: set[str] = set()
         self._webhook_mode: bool = False
         self._mention_patterns = self._compile_mention_patterns()
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
@@ -3501,6 +3518,8 @@ class TelegramAdapter(BasePlatformAdapter):
         DM topics — all off the connect path so a slow Bot API call cannot blow
         the gateway connect timeout (#46298). Every step is non-fatal."""
         try:
+            await self._reconcile_telegram_auto_authorized_groups()
+
             # Register bot commands so Telegram shows a hint menu when users type /
             # List is derived from the central COMMAND_REGISTRY — adding a new
             # gateway command there automatically adds it to the Telegram menu.
@@ -3771,25 +3790,7 @@ class TelegramAdapter(BasePlatformAdapter):
             self._app = builder.build()
             self._bot = self._app.bot
             
-            # Register handlers
-            self._app.add_handler(TelegramMessageHandler(
-                filters.TEXT & ~filters.COMMAND,
-                self._handle_text_message
-            ))
-            self._app.add_handler(TelegramMessageHandler(
-                filters.COMMAND,
-                self._handle_command
-            ))
-            self._app.add_handler(TelegramMessageHandler(
-                filters.LOCATION | getattr(filters, "VENUE", filters.LOCATION),
-                self._handle_location_message
-            ))
-            self._app.add_handler(TelegramMessageHandler(
-                filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
-                self._handle_media_message
-            ))
-            # Handle inline keyboard button callbacks (update prompts)
-            self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+            self._register_handlers(self._app)
             
             # Start polling — retry initialize() for transient TLS resets.
             # Each attempt is capped by _init_timeout so a single unreachable
@@ -3903,24 +3904,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         old_app = self._app
                         self._app = builder.build()
                         self._bot = self._app.bot
-                        # Re-register handlers on the new app
-                        self._app.add_handler(TelegramMessageHandler(
-                            filters.TEXT & ~filters.COMMAND,
-                            self._handle_text_message
-                        ))
-                        self._app.add_handler(TelegramMessageHandler(
-                            filters.COMMAND,
-                            self._handle_command
-                        ))
-                        self._app.add_handler(TelegramMessageHandler(
-                            filters.LOCATION | getattr(filters, "VENUE", filters.LOCATION),
-                            self._handle_location_message
-                        ))
-                        self._app.add_handler(TelegramMessageHandler(
-                            filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
-                            self._handle_media_message
-                        ))
-                        self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+                        self._register_handlers(self._app)
                         # Best-effort discard the old app's resources
                         try:
                             await _shutdown_abandoned_app(old_app)
@@ -6199,6 +6183,30 @@ class TelegramAdapter(BasePlatformAdapter):
         query_thread_id = getattr(query_message, "message_thread_id", None)
         query_user_name = getattr(query.from_user, "first_name", None)
 
+        # Inline buttons can mutate model, approval, clarify, and session state
+        # without passing through message admission. Apply the same strict chat
+        # boundary before dispatching any callback-specific behavior.
+        normalized_query_chat_type = str(query_chat_type or "").split(".")[-1].lower()
+        normalized_query_chat_id = str(query_chat_id or "").strip()
+        if self._telegram_auto_allow_groups_from_trusted_adders():
+            is_negative_chat_id = bool(
+                re.fullmatch(r"-\d+", normalized_query_chat_id)
+                and int(normalized_query_chat_id) < 0
+            )
+            if is_negative_chat_id and normalized_query_chat_type not in {
+                "group",
+                "supergroup",
+            }:
+                await query.answer(text="⛔ This group is not authorized.")
+                return
+        if normalized_query_chat_type in {"group", "supergroup"}:
+            if (
+                self._telegram_auto_allow_groups_from_trusted_adders()
+                and normalized_query_chat_id not in self._telegram_group_admission_chats()
+            ):
+                await query.answer(text="⛔ This group is not authorized.")
+                return
+
         # --- Model picker callbacks ---
         if data.startswith(("mp:", "mpg:", "mpv:", "mm:", "mc:", "mb", "mx", "mg:")):
             chat_id = str(query.message.chat_id) if query.message else None
@@ -7667,29 +7675,431 @@ class TelegramAdapter(BasePlatformAdapter):
         topic_id = str(thread_id) if thread_id is not None else self._GENERAL_TOPIC_THREAD_ID
         return f"{chat_id}:{topic_id}" in topics
 
+    def _register_handlers(self, app: Application) -> None:
+        """Register all Telegram update handlers on an Application instance."""
+        app.add_handler(TelegramMessageHandler(
+            filters.TEXT & ~filters.COMMAND,
+            self._handle_text_message,
+        ))
+        app.add_handler(TelegramMessageHandler(
+            filters.COMMAND,
+            self._handle_command,
+        ))
+        app.add_handler(TelegramMessageHandler(
+            filters.LOCATION | getattr(filters, "VENUE", filters.LOCATION),
+            self._handle_location_message,
+        ))
+        app.add_handler(TelegramMessageHandler(
+            filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE
+            | filters.Document.ALL | filters.Sticker.ALL,
+            self._handle_media_message,
+        ))
+        app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+        app.add_handler(TelegramMessageHandler(
+            filters.StatusUpdate.MIGRATE,
+            self._handle_chat_migration,
+        ))
+        app.add_handler(ChatMemberHandler(
+            self._handle_my_chat_member,
+            chat_member_types=ChatMemberHandler.MY_CHAT_MEMBER,
+        ))
+
+    @staticmethod
+    def _strict_telegram_user_ids(raw: object) -> set[int]:
+        """Parse trusted Telegram actor IDs, rejecting the whole malformed value."""
+        if not isinstance(raw, list):
+            return set()
+        parsed: set[int] = set()
+        for value in raw:
+            if isinstance(value, bool):
+                return set()
+            if isinstance(value, int):
+                user_id = value
+            elif isinstance(value, str) and value.strip().isdigit():
+                user_id = int(value.strip())
+            else:
+                return set()
+            if user_id <= 0:
+                return set()
+            parsed.add(user_id)
+        return parsed
+
+    def _telegram_auto_allow_groups_from_trusted_adders(self) -> bool:
+        """Return the strict opt-in flag; malformed values always disable it."""
+        configured = self.config.extra.get("auto_allow_groups_from_trusted_adders")
+        if isinstance(configured, bool):
+            return configured
+        if isinstance(configured, str):
+            normalized = configured.strip().lower()
+            if normalized in {"true", "1", "yes", "on"}:
+                return True
+            if normalized in {"false", "0", "no", "off", ""}:
+                return False
+        return False
+
+    def _telegram_trusted_group_adders(self) -> set[int]:
+        """Return trusted actor IDs from the config-only list."""
+        configured = self.config.extra.get("trusted_group_adders")
+        return self._strict_telegram_user_ids(configured)
+
+    def _telegram_auto_authorized_groups_path(self) -> _Path:
+        """Return the profile-local path used for non-secret enrollment state."""
+        # A few narrow unit fixtures instantiate with object.__new__; retaining
+        # dynamic resolution only for those incomplete objects keeps them safe
+        # without weakening real adapters' construction-time profile binding.
+        hermes_home = getattr(self, "_hermes_home", None)
+        if not isinstance(hermes_home, _Path):
+            hermes_home = get_hermes_home()
+        return hermes_home / "state" / self._AUTO_AUTHORIZED_GROUPS_FILENAME
+
+    @staticmethod
+    def _validated_auto_authorized_chat_ids(payload: object) -> Optional[set[str]]:
+        """Validate the complete persisted schema, returning None when malformed."""
+        if not isinstance(payload, dict) or set(payload) != {"chat_ids"}:
+            return None
+        raw_chat_ids = payload.get("chat_ids")
+        if not isinstance(raw_chat_ids, list):
+            return None
+        chat_ids: set[str] = set()
+        for value in raw_chat_ids:
+            if (
+                not isinstance(value, str)
+                or not re.fullmatch(r"-\d+", value)
+                or int(value) >= 0
+            ):
+                return None
+            chat_ids.add(value)
+        return chat_ids
+
+    def _load_telegram_auto_authorized_groups(self) -> tuple[set[str], bool]:
+        path = self._telegram_auto_authorized_groups_path()
+        try:
+            parent_stat = path.parent.lstat()
+        except FileNotFoundError:
+            return set(), True
+        except OSError:
+            return set(), False
+        if path.parent.is_symlink() or not stat.S_ISDIR(parent_stat.st_mode):
+            logger.warning("[%s] Ignoring unsafe Telegram group state directory", self.name)
+            return set(), False
+        try:
+            path_stat = path.lstat()
+        except FileNotFoundError:
+            return set(), True
+        except OSError:
+            return set(), False
+        if path.is_symlink() or not stat.S_ISREG(path_stat.st_mode):
+            logger.warning("[%s] Ignoring unsafe Telegram auto-authorized group state", self.name)
+            return set(), False
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, ValueError):
+            logger.warning("[%s] Ignoring invalid Telegram auto-authorized group state", self.name)
+            return set(), False
+        chat_ids = self._validated_auto_authorized_chat_ids(payload)
+        if chat_ids is None:
+            logger.warning("[%s] Ignoring invalid Telegram auto-authorized group state", self.name)
+            return set(), False
+        return chat_ids, True
+
+    def _telegram_auto_authorized_groups(self) -> set[str]:
+        """Read persisted grant candidates, failing closed to an empty set."""
+        groups, valid = self._load_telegram_auto_authorized_groups()
+        return groups if valid else set()
+
+    def _active_telegram_auto_authorized_group_ids(self) -> set[str]:
+        """Return this adapter's currently Bot-API-validated dynamic grants."""
+        active = getattr(self, "_active_telegram_auto_authorized_groups", None)
+        return active if isinstance(active, set) else set()
+
+    def _revoked_telegram_auto_authorized_group_ids(self) -> set[str]:
+        """Return process-local revocations that durable state cannot override."""
+        revoked = getattr(self, "_revoked_telegram_auto_authorized_groups", None)
+        if not isinstance(revoked, set):
+            revoked = set()
+            self._revoked_telegram_auto_authorized_groups = revoked
+        return revoked
+
+    def _telegram_auto_authorized_group_event_active(self, source: Any) -> bool:
+        """Fail-closed signal for plugins consuming a validated dynamic grant."""
+        if not self._telegram_auto_allow_groups_from_trusted_adders():
+            return False
+        if getattr(source, "chat_type", None) != "group":
+            return False
+        chat_id = getattr(source, "chat_id", None)
+        if not isinstance(chat_id, str) or not re.fullmatch(r"-\d+", chat_id):
+            return False
+        if int(chat_id) >= 0:
+            return False
+        return chat_id in self._active_telegram_auto_authorized_group_ids()
+
+    @staticmethod
+    def _supports_posix_group_state_security() -> bool:
+        """Return whether chmod and directory fsync semantics are available."""
+        return os.name != "nt"
+
+    def _write_telegram_auto_authorized_groups(self, chat_ids: set[str]) -> None:
+        """Atomically persist only validated chat IDs with owner-only permissions."""
+        if self._validated_auto_authorized_chat_ids({"chat_ids": sorted(chat_ids)}) is None:
+            raise ValueError("invalid Telegram auto-authorized group state")
+        path = self._telegram_auto_authorized_groups_path()
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        parent_stat = path.parent.lstat()
+        if path.parent.is_symlink() or not stat.S_ISDIR(parent_stat.st_mode):
+            raise OSError("unsafe Telegram group state directory")
+        use_posix_security = self._supports_posix_group_state_security()
+        if use_posix_security:
+            os.chmod(path.parent, 0o700)
+        try:
+            path_stat = path.lstat()
+        except FileNotFoundError:
+            pass
+        else:
+            if path.is_symlink() or not stat.S_ISREG(path_stat.st_mode):
+                raise OSError("unsafe Telegram auto-authorized group state")
+        fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                if use_posix_security:
+                    os.fchmod(handle.fileno(), 0o600)
+                json.dump({"chat_ids": sorted(chat_ids)}, handle, separators=(",", ":"))
+                handle.flush()
+                os.fsync(handle.fileno())
+            if not stat.S_ISREG(os.lstat(tmp_path).st_mode):
+                raise OSError("unsafe Telegram group state temporary file")
+            os.replace(tmp_path, path)
+            if use_posix_security:
+                directory_fd = os.open(path.parent, os.O_RDONLY)
+                try:
+                    os.fsync(directory_fd)
+                finally:
+                    os.close(directory_fd)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+    def _update_telegram_auto_authorized_group(self, chat_id: str, *, allowed: bool) -> bool:
+        with self._auto_authorized_groups_lock:
+            chat_ids, valid = self._load_telegram_auto_authorized_groups()
+            if not valid:
+                return False
+            updated = set(chat_ids)
+            if allowed:
+                updated.add(chat_id)
+            else:
+                updated.discard(chat_id)
+            if updated != chat_ids:
+                self._write_telegram_auto_authorized_groups(updated)
+            return True
+
+    async def _reconcile_telegram_auto_authorized_groups(self) -> None:
+        """Activate durable grants only while the bot is still an administrator."""
+        active = self._active_telegram_auto_authorized_group_ids()
+        with self._auto_authorized_groups_lock:
+            active.clear()
+            if not self._telegram_auto_allow_groups_from_trusted_adders():
+                return
+            chat_ids, valid = self._load_telegram_auto_authorized_groups()
+        bot = getattr(self, "_bot", None)
+        bot_id = getattr(bot, "id", None)
+        if not valid or isinstance(bot_id, bool) or not isinstance(bot_id, int):
+            return
+        for chat_id in sorted(chat_ids):
+            try:
+                member = await bot.get_chat_member(chat_id, bot_id)
+            except Exception as exc:
+                logger.warning(
+                    "[%s] Could not validate persisted Telegram group %s: %s",
+                    self.name,
+                    chat_id,
+                    _redact_telegram_error_text(exc),
+                )
+                continue
+            status = str(getattr(member, "status", "")).split(".")[-1].lower()
+            if status == "administrator":
+                # A demotion may have revoked the durable candidate while the
+                # Bot API check was in flight. Recheck and activate under the
+                # same lock as enrollment, revocation, and migration so the
+                # last operation always determines the live grant.
+                with self._auto_authorized_groups_lock:
+                    durable, durable_valid = self._load_telegram_auto_authorized_groups()
+                    revoked = self._revoked_telegram_auto_authorized_group_ids()
+                    if durable_valid and chat_id in durable and chat_id not in revoked:
+                        active.add(chat_id)
+
+    async def _handle_my_chat_member(
+        self,
+        update: Update,
+        context: ContextTypes.DEFAULT_TYPE,
+    ) -> None:
+        """Enroll or revoke a group from a validated MY_CHAT_MEMBER transition."""
+        del context
+        membership = getattr(update, "my_chat_member", None)
+        chat = getattr(membership, "chat", None)
+        chat_type = str(getattr(chat, "type", "")).split(".")[-1].lower()
+        if chat_type not in {"group", "supergroup"}:
+            return
+
+        chat_id = str(getattr(chat, "id", ""))
+        if not re.fullmatch(r"-\d+", chat_id):
+            return
+        old_member = getattr(membership, "old_chat_member", None)
+        new_member = getattr(membership, "new_chat_member", None)
+        old_status = str(getattr(old_member, "status", "")).split(".")[-1].lower()
+        new_status = str(getattr(new_member, "status", "")).split(".")[-1].lower()
+        non_admin_statuses = {"member", "restricted", "left", "kicked"}
+
+        should_revoke = False
+        try:
+            with self._auto_authorized_groups_lock:
+                active = self._active_telegram_auto_authorized_group_ids()
+                if new_status in non_admin_statuses:
+                    should_revoke = True
+                elif new_status != "administrator":
+                    durable, durable_valid = self._load_telegram_auto_authorized_groups()
+                    should_revoke = chat_id in active or (
+                        durable_valid and chat_id in durable
+                    )
+                if should_revoke:
+                    self._revoked_telegram_auto_authorized_group_ids().add(chat_id)
+                    active.discard(chat_id)
+                    self._update_telegram_auto_authorized_group(chat_id, allowed=False)
+        except Exception as exc:
+            logger.warning(
+                "[%s] Could not persist Telegram group revocation: %s",
+                self.name,
+                _redact_telegram_error_text(exc),
+            )
+        if should_revoke:
+            return
+        if old_status not in non_admin_statuses or new_status != "administrator":
+            return
+        bot_id = getattr(self._bot, "id", None)
+        target_id = getattr(getattr(new_member, "user", None), "id", None)
+        if isinstance(bot_id, bool) or not isinstance(bot_id, int) or target_id != bot_id:
+            return
+        if not self._telegram_auto_allow_groups_from_trusted_adders():
+            return
+
+        actor_id = getattr(getattr(membership, "from_user", None), "id", None)
+        if isinstance(actor_id, bool) or not isinstance(actor_id, int):
+            return
+        if actor_id not in self._telegram_trusted_group_adders():
+            return
+        try:
+            with self._auto_authorized_groups_lock:
+                persisted = self._update_telegram_auto_authorized_group(
+                    chat_id, allowed=True
+                )
+                if persisted:
+                    self._revoked_telegram_auto_authorized_group_ids().discard(chat_id)
+                    self._active_telegram_auto_authorized_group_ids().add(chat_id)
+        except Exception as exc:
+            logger.warning(
+                "[%s] Could not persist Telegram group enrollment: %s",
+                self.name,
+                _redact_telegram_error_text(exc),
+            )
+            return
+
+    async def _handle_chat_migration(
+        self,
+        update: Update,
+        context: ContextTypes.DEFAULT_TYPE,
+    ) -> None:
+        """Move only a durable dynamic grant when a basic group becomes a supergroup."""
+        del context
+        message = getattr(update, "effective_message", None)
+        chat = getattr(message, "chat", None)
+        chat_type = str(getattr(chat, "type", "")).split(".")[-1].lower()
+        old_chat_id = str(getattr(chat, "id", ""))
+        new_chat_id = str(getattr(message, "migrate_to_chat_id", ""))
+        if (
+            chat_type != "group"
+            or not re.fullmatch(r"-\d+", old_chat_id)
+            or not re.fullmatch(r"-\d+", new_chat_id)
+            or int(old_chat_id) >= 0
+            or int(new_chat_id) >= 0
+        ):
+            return
+
+        active = self._active_telegram_auto_authorized_group_ids()
+        try:
+            with self._auto_authorized_groups_lock:
+                was_active = old_chat_id in active
+                revoked = self._revoked_telegram_auto_authorized_group_ids()
+                revoked.add(old_chat_id)
+                active.discard(old_chat_id)
+                chat_ids, valid = self._load_telegram_auto_authorized_groups()
+                if not valid or old_chat_id not in chat_ids:
+                    return
+                migrated = set(chat_ids)
+                migrated.discard(old_chat_id)
+                migrated.add(new_chat_id)
+                self._write_telegram_auto_authorized_groups(migrated)
+                revoked.discard(new_chat_id)
+                if was_active:
+                    active.add(new_chat_id)
+        except Exception as exc:
+            logger.warning(
+                "[%s] Could not persist Telegram group migration: %s",
+                self.name,
+                _redact_telegram_error_text(exc),
+            )
+            return
+
     def _telegram_allowed_chats(self) -> set[str]:
         """Return the whitelist of group/supergroup chat IDs the bot will respond in.
 
         When non-empty, group messages from chats NOT in this set are
         silently ignored unless ``guest_mode`` is enabled and the bot is
         explicitly @mentioned.  DMs are never filtered.
-        Empty set means no restriction (fully backward compatible).
+        Empty set means no restriction unless trusted-adder mode is enabled;
+        that opt-in uses strict admission across both explicit chat lists and
+        persisted enrollments.
         """
         raw = self.config.extra.get("allowed_chats")
         if raw is None:
-            raw = os.getenv("TELEGRAM_ALLOWED_CHATS", "")
+            raw = (
+                ""
+                if self._telegram_auto_allow_groups_from_trusted_adders()
+                else os.getenv("TELEGRAM_ALLOWED_CHATS", "")
+            )
         if isinstance(raw, list):
-            return {str(part).strip() for part in raw if str(part).strip()}
-        return {part.strip() for part in str(raw).split(",") if part.strip()}
+            configured = {str(part).strip() for part in raw if str(part).strip()}
+        else:
+            configured = {part.strip() for part in str(raw).split(",") if part.strip()}
+        if self._telegram_auto_allow_groups_from_trusted_adders():
+            configured |= self._active_telegram_auto_authorized_group_ids()
+        return configured
 
     def _telegram_group_allowed_chats(self) -> set[str]:
         """Return Telegram chats authorized at group scope."""
         raw = self.config.extra.get("group_allowed_chats")
         if raw is None:
-            raw = os.getenv("TELEGRAM_GROUP_ALLOWED_CHATS", "")
+            raw = (
+                ""
+                if self._telegram_auto_allow_groups_from_trusted_adders()
+                else os.getenv("TELEGRAM_GROUP_ALLOWED_CHATS", "")
+            )
         if isinstance(raw, list):
-            return {str(part).strip() for part in raw if str(part).strip()}
-        return {part.strip() for part in str(raw).split(",") if part.strip()}
+            configured = {str(part).strip() for part in raw if str(part).strip()}
+        else:
+            configured = {part.strip() for part in str(raw).split(",") if part.strip()}
+        if self._telegram_auto_allow_groups_from_trusted_adders():
+            configured |= self._active_telegram_auto_authorized_group_ids()
+        return configured
+
+    def _telegram_group_admission_chats(self) -> set[str]:
+        """Return chats admitted while trusted-adder mode is enabled.
+
+        Either explicit chat allowlist is sufficient for backward-compatible
+        admission, and persisted administrator enrollment extends both.
+        """
+        return self._telegram_allowed_chats() | self._telegram_group_allowed_chats()
 
     def _telegram_observe_allowed_chats(self) -> set[str]:
         """Chats where observed group context may use a shared source.
@@ -8490,7 +8900,8 @@ class TelegramAdapter(BasePlatformAdapter):
         When ``allowed_chats`` is non-empty, it remains a hard gate except for
         the narrow ``guest_mode`` bypass: group/supergroup messages that
         explicitly @mention this bot. Replies and regex wake words do not bypass
-        ``allowed_chats``. When ``require_mention`` is enabled, slash commands are not given
+        ``allowed_chats``. Trusted-adder mode adds a stricter admission gate that
+        ``guest_mode`` cannot bypass. When ``require_mention`` is enabled, slash commands are not given
         special treatment — they must pass the same mention/reply checks
         as any other group message.  Users can still trigger commands via
         the Telegram bot menu (``/command@botname``) or by explicitly
@@ -8540,6 +8951,15 @@ class TelegramAdapter(BasePlatformAdapter):
         chat_id_str = str(getattr(getattr(message, "chat", None), "id", ""))
 
         if self._telegram_exclusive_bot_mentions() and self._explicit_bot_mentions_exclude_self(message):
+            return False
+
+        # Trusted-adder mode changes empty allowlist semantics from unrestricted
+        # to strict admission. This must run before guest_mode and sender gates:
+        # neither a direct mention nor an allowlisted sender can admit a new chat.
+        if (
+            self._telegram_auto_allow_groups_from_trusted_adders()
+            and chat_id_str not in self._telegram_group_admission_chats()
+        ):
             return False
 
         # Resolve guest-mode mention bypass once so _message_mentions_bot
@@ -9581,6 +10001,10 @@ class TelegramAdapter(BasePlatformAdapter):
             _chat_id_str if thread_id_str else None,
         )
 
+        metadata: Dict[str, Any] = {}
+        if self._telegram_auto_authorized_group_event_active(source):
+            metadata["telegram_auto_authorized_group_active"] = True
+
         return MessageEvent(
             text=message.text or "",
             message_type=msg_type,
@@ -9592,6 +10016,7 @@ class TelegramAdapter(BasePlatformAdapter):
             reply_to_text=reply_to_text,
             auto_skill=topic_skill,
             channel_prompt=_channel_prompt,
+            metadata=metadata,
             timestamp=message.date,
         )
 
@@ -9830,6 +10255,13 @@ def _apply_yaml_config(yaml_cfg: dict, telegram_cfg: dict) -> dict | None:
         if isinstance(ac, list):
             ac = ",".join(str(v) for v in ac)
         os.environ["TELEGRAM_ALLOWED_CHATS"] = str(ac)
+    if "auto_allow_groups_from_trusted_adders" in telegram_cfg:
+        extras.setdefault(
+            "auto_allow_groups_from_trusted_adders",
+            telegram_cfg["auto_allow_groups_from_trusted_adders"],
+        )
+    if "trusted_group_adders" in telegram_cfg:
+        extras.setdefault("trusted_group_adders", telegram_cfg["trusted_group_adders"])
     allowed_topics = telegram_cfg.get("allowed_topics")
     if allowed_topics is not None and not os.getenv("TELEGRAM_ALLOWED_TOPICS"):
         if isinstance(allowed_topics, list):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "hermes-agent"
-version = "0.19.0"
+version = "0.19.1"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 # Upper bound is load-bearing, not cosmetic. uv resolves the project's

--- a/tests/cron/test_gateway_message_delivered_hook.py
+++ b/tests/cron/test_gateway_message_delivered_hook.py
@@ -1,0 +1,228 @@
+from concurrent.futures import Future
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import asyncio
+
+import cron.scheduler as scheduler
+from cron.scheduler import _deliver_result, _emit_gateway_message_delivered
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+
+def _job(*, emit_hook=False):
+    job = {
+        "id": "daily-brief",
+        "execution_id": "exec-123",
+        "deliver": "origin",
+        "origin": {
+            "platform": "telegram",
+            "chat_id": "-1001",
+            "thread_id": "42",
+        },
+    }
+    if emit_hook:
+        job["_gateway_message_delivered_hook"] = True
+    return job
+
+
+def _run_coro(coro, _loop):
+    future = Future()
+    future.set_result(asyncio.run(coro))
+    return future
+
+
+def test_delivery_hook_uses_only_the_documented_payload():
+    job = _job()
+
+    with (
+        patch("hermes_cli.plugins.has_hook", return_value=True),
+        patch("hermes_cli.plugins.invoke_hook") as invoke,
+    ):
+        _emit_gateway_message_delivered(
+            job,
+            platform="telegram",
+            chat_id="-1001",
+            thread_id="42",
+            message_id="9001",
+        )
+
+    invoke.assert_called_once_with(
+        "gateway_message_delivered",
+        source="cron",
+        execution_id="exec-123",
+        job_id="daily-brief",
+        platform="telegram",
+        chat_id="-1001",
+        thread_id="42",
+        message_id="9001",
+    )
+
+
+def test_delivery_hook_does_nothing_without_a_subscriber():
+    job = MagicMock()
+
+    with (
+        patch("hermes_cli.plugins.has_hook", return_value=False),
+        patch("hermes_cli.plugins.invoke_hook") as invoke,
+    ):
+        _emit_gateway_message_delivered(
+            job,
+            platform="telegram",
+            chat_id="-1001",
+            thread_id="42",
+            message_id="9001",
+        )
+
+    invoke.assert_not_called()
+    job.get.assert_not_called()
+
+
+def test_delivery_hook_normalizes_the_platform_name():
+    with (
+        patch("hermes_cli.plugins.has_hook", return_value=True),
+        patch("hermes_cli.plugins.invoke_hook") as invoke,
+    ):
+        _emit_gateway_message_delivered(
+            _job(),
+            platform="Telegram",
+            chat_id="-1001",
+            thread_id=None,
+            message_id="9001",
+        )
+
+    assert invoke.call_args.kwargs["platform"] == "telegram"
+
+
+def test_live_telegram_delivery_uses_the_confirmed_message_id():
+    config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="token")}
+    )
+    adapter = AsyncMock()
+    adapter.send.return_value = MagicMock(
+        success=True, message_id="live-9002", raw_response=None
+    )
+    loop = MagicMock()
+    loop.is_running.return_value = True
+
+    with (
+        patch("gateway.config.load_gateway_config", return_value=config),
+        patch(
+            "cron.scheduler.load_config",
+            return_value={"cron": {"wrap_response": False}},
+        ),
+        patch("asyncio.run_coroutine_threadsafe", side_effect=_run_coro),
+        patch("hermes_cli.plugins.has_hook", return_value=True),
+        patch("hermes_cli.plugins.invoke_hook") as invoke,
+    ):
+        error = _deliver_result(
+            _job(emit_hook=True),
+            "Daily brief",
+            adapters={Platform.TELEGRAM: adapter},
+            loop=loop,
+        )
+
+    assert error is None
+    invoke.assert_called_once()
+    assert invoke.call_args.kwargs["message_id"] == "live-9002"
+
+
+def test_live_telegram_delivery_uses_the_resolved_topic_id():
+    config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="token")}
+    )
+    adapter = AsyncMock()
+    adapter.ensure_dm_topic.return_value = "38049"
+    adapter.send.return_value = MagicMock(
+        success=True,
+        message_id="live-9003",
+        raw_response={"requested_thread_id": 38049, "thread_fallback": False},
+    )
+    loop = MagicMock()
+    loop.is_running.return_value = True
+    job = _job(emit_hook=True)
+    job["origin"]["thread_id"] = "Feedback routine"
+
+    with (
+        patch("gateway.config.load_gateway_config", return_value=config),
+        patch(
+            "cron.scheduler.load_config",
+            return_value={"cron": {"wrap_response": False}},
+        ),
+        patch("asyncio.run_coroutine_threadsafe", side_effect=_run_coro),
+        patch("hermes_cli.plugins.has_hook", return_value=True),
+        patch("hermes_cli.plugins.invoke_hook") as invoke,
+    ):
+        error = _deliver_result(
+            job, "Daily brief", adapters={Platform.TELEGRAM: adapter}, loop=loop
+        )
+
+    assert error is None
+    assert invoke.call_args.kwargs["thread_id"] == "38049"
+
+
+def test_standalone_delivery_does_not_emit_the_hook():
+    config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="token")}
+    )
+
+    with (
+        patch("gateway.config.load_gateway_config", return_value=config),
+        patch(
+            "cron.scheduler.load_config",
+            return_value={"cron": {"wrap_response": False}},
+        ),
+        patch(
+            "tools.send_message_tool._send_to_platform",
+            new=AsyncMock(return_value={"success": True, "message_id": "9001"}),
+        ),
+        patch("hermes_cli.plugins.has_hook", return_value=True),
+        patch("hermes_cli.plugins.invoke_hook") as invoke,
+    ):
+        error = _deliver_result(_job(emit_hook=True), "Daily brief")
+
+    assert error is None
+    invoke.assert_not_called()
+
+
+def _delivery_flags(monkeypatch, result, job=None):
+    calls = []
+    monkeypatch.setattr(
+        scheduler, "create_execution", lambda *_a, **_kw: {"id": "exec-flag"}
+    )
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(scheduler, "mark_execution_running", lambda _execution_id: None)
+    monkeypatch.setattr(scheduler, "run_job", lambda *_a, **_kw: result)
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *_a, **_kw: "/tmp/out.txt")
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_result",
+        lambda job, _content, **_kwargs: (
+            calls.append(bool(job.get("_gateway_message_delivered_hook"))) or None
+        ),
+    )
+    monkeypatch.setattr(scheduler, "mark_job_run", lambda *_a, **_kw: True)
+    monkeypatch.setattr(scheduler, "finish_execution", lambda *_a, **_kw: None)
+
+    scheduler.run_one_job(job or {"id": "daily-brief", "deliver": "telegram"})
+    return calls
+
+
+def test_run_one_job_marks_only_successful_generated_text(monkeypatch, tmp_path):
+    assert _delivery_flags(monkeypatch, (True, "raw", "Daily brief", None)) == [True]
+
+    media = tmp_path / "report.pdf"
+    media.write_bytes(b"%PDF-1.4 test")
+    assert _delivery_flags(monkeypatch, (True, "raw", f"MEDIA:{media}", None)) == [
+        False
+    ]
+
+
+def test_run_one_job_removes_persisted_delivery_hook_flag_on_failure(monkeypatch):
+    assert _delivery_flags(
+        monkeypatch,
+        (False, "raw", "", "provider failed"),
+        {
+            "id": "daily-brief",
+            "deliver": "telegram",
+            "_gateway_message_delivered_hook": True,
+        },
+    ) == [False]

--- a/tests/cron/test_gateway_message_delivered_hook.py
+++ b/tests/cron/test_gateway_message_delivered_hook.py
@@ -34,7 +34,10 @@ def test_delivery_hook_uses_only_the_documented_payload():
     job = _job()
 
     with (
-        patch("hermes_cli.plugins.has_hook", return_value=True),
+        patch(
+            "hermes_cli.plugins.has_hook",
+            side_effect=lambda name: name == "gateway_message_delivered",
+        ),
         patch("hermes_cli.plugins.invoke_hook") as invoke,
     ):
         _emit_gateway_message_delivered(
@@ -110,7 +113,10 @@ def test_live_telegram_delivery_uses_the_confirmed_message_id():
             return_value={"cron": {"wrap_response": False}},
         ),
         patch("asyncio.run_coroutine_threadsafe", side_effect=_run_coro),
-        patch("hermes_cli.plugins.has_hook", return_value=True),
+        patch(
+            "hermes_cli.plugins.has_hook",
+            side_effect=lambda name: name == "gateway_message_delivered",
+        ),
         patch("hermes_cli.plugins.invoke_hook") as invoke,
     ):
         error = _deliver_result(

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1091,7 +1091,10 @@ class TestHealthDetailedEndpoint:
     async def test_health_detailed_attests_profile_and_capability_manifest(
         self, adapter, tmp_path
     ):
-        capability_bytes = b'{"profile":"magic-employee-support"}\n'
+        capability_bytes = (
+            b'{\n  "tools": ["magic_get_my_income_summary"],\n'
+            b'  "profile": "magic-employee-support"\n}\n'
+        )
         (tmp_path / "capabilities.json").write_bytes(capability_bytes)
         app = _create_app(adapter)
         with patch(
@@ -1110,8 +1113,31 @@ class TestHealthDetailedEndpoint:
 
         assert data["profile"] == "magic-employee-support"
         assert data["capability_manifest_sha256"] == hashlib.sha256(
-            capability_bytes
+            b'{"profile":"magic-employee-support","tools":["magic_get_my_income_summary"]}'
         ).hexdigest()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("value", ["NaN", "1e9999"])
+    async def test_health_detailed_rejects_non_finite_capability_manifest(
+        self, adapter, tmp_path, value
+    ):
+        (tmp_path / "capabilities.json").write_text(
+            f'{{"profile":"magic-employee-support","level":{value}}}',
+            encoding="utf-8",
+        )
+        app = _create_app(adapter)
+        with patch(
+            "gateway.status.read_runtime_status",
+            return_value={"gateway_state": "running"},
+        ), patch(
+            "hermes_constants.get_hermes_home", return_value=tmp_path
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/health/detailed")
+                assert resp.status == 200
+                data = await resp.json()
+
+        assert data["capability_manifest_sha256"] is None
 
     @pytest.mark.asyncio
     async def test_health_detailed_no_runtime_status(self, adapter):

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -13,6 +13,7 @@ Tests cover:
 """
 
 import asyncio
+import hashlib
 import json
 import os
 import stat
@@ -1085,6 +1086,32 @@ class TestHealthDetailedEndpoint:
                 assert data["gateway_drainable"] is True
                 assert isinstance(data["pid"], int)
                 assert "updated_at" in data
+
+    @pytest.mark.asyncio
+    async def test_health_detailed_attests_profile_and_capability_manifest(
+        self, adapter, tmp_path
+    ):
+        capability_bytes = b'{"profile":"magic-employee-support"}\n'
+        (tmp_path / "capabilities.json").write_bytes(capability_bytes)
+        app = _create_app(adapter)
+        with patch(
+            "gateway.status.read_runtime_status",
+            return_value={"gateway_state": "running"},
+        ), patch(
+            "gateway.run._resolve_gateway_model", return_value="test/model"
+        ), patch(
+            "hermes_cli.profiles.get_active_profile_name",
+            return_value="magic-employee-support",
+        ), patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/health/detailed")
+                assert resp.status == 200
+                data = await resp.json()
+
+        assert data["profile"] == "magic-employee-support"
+        assert data["capability_manifest_sha256"] == hashlib.sha256(
+            capability_bytes
+        ).hexdigest()
 
     @pytest.mark.asyncio
     async def test_health_detailed_no_runtime_status(self, adapter):

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -4562,6 +4562,37 @@ class TestConversationParameter:
                 assert len(history) > 0
 
     @pytest.mark.asyncio
+    async def test_empty_conversation_history_does_not_clear_previous_response_chain(self, adapter):
+        """Client default [] must preserve a previous_response_id transcript."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "First response", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                first = await cli.post("/v1/responses", json={"input": "first"})
+                assert first.status == 200
+                first_id = (await first.json())["id"]
+
+                mock_run.return_value = (
+                    {"final_response": "Second response", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                second = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "input": "second",
+                        "previous_response_id": first_id,
+                        "conversation_history": [],
+                    },
+                )
+                assert second.status == 200
+                history = mock_run.call_args_list[1].kwargs["conversation_history"]
+                assert history
+                assert history[0]["content"] == "first"
+
+    @pytest.mark.asyncio
     async def test_conversation_and_previous_response_id_conflict(self, adapter):
         """Cannot use both conversation and previous_response_id."""
         app = _create_app(adapter)

--- a/tests/gateway/test_api_server_mcp_metadata.py
+++ b/tests/gateway/test_api_server_mcp_metadata.py
@@ -58,6 +58,88 @@ def test_metadata_nesting_limit_is_explicit_and_stable():
         decode_mcp_run_metadata_header(_encode_metadata(too_deep))
 
 
+@pytest.mark.parametrize(
+    "invalid_json",
+    [
+        b'{"value":NaN}',
+        b'{"value":Infinity}',
+        b'{"value":-Infinity}',
+    ],
+)
+def test_metadata_rejects_non_finite_json_constants(invalid_json):
+    encoded = base64.urlsafe_b64encode(invalid_json).rstrip(b"=").decode()
+
+    with pytest.raises(ValueError, match="not valid JSON"):
+        decode_mcp_run_metadata_header(encoded)
+
+
+def test_metadata_rejects_numeric_overflow():
+    encoded = base64.urlsafe_b64encode(b'{"value":1e9999}').rstrip(b"=").decode()
+
+    with pytest.raises(ValueError, match="finite numbers"):
+        decode_mcp_run_metadata_header(encoded)
+
+
+@pytest.mark.asyncio
+async def test_api_rejects_metadata_numeric_overflow():
+    adapter = _adapter()
+    encoded = base64.urlsafe_b64encode(b'{"value":1e9999}').rstrip(b"=").decode()
+
+    with patch.object(adapter, "_create_agent") as create_agent:
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/v1/runs",
+                json={"input": "programul meu"},
+                headers={
+                    "Authorization": "Bearer sk-test-secret",
+                    "X-Hermes-MCP-Metadata": encoded,
+                },
+            )
+
+    assert response.status == 400
+    create_agent.assert_not_called()
+
+
+def test_metadata_rejects_standard_base64_alphabet():
+    encoded = base64.b64encode('{"x":"\u083e"}'.encode("utf-8")).rstrip(b"=").decode()
+    assert "+" in encoded
+
+    with pytest.raises(ValueError, match="not valid base64url"):
+        decode_mcp_run_metadata_header(encoded)
+
+
+@pytest.mark.parametrize("wrapper", [" {encoded} ", "\t{encoded}", "{encoded}="])
+def test_metadata_rejects_whitespace_and_padding(wrapper):
+    encoded = _encode_metadata({"magic.employee": {"binding": "signed-binding"}})
+
+    with pytest.raises(ValueError, match="not valid base64url"):
+        decode_mcp_run_metadata_header(wrapper.format(encoded=encoded))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "header_template",
+    [" {encoded} ", "{encoded}="],
+)
+async def test_api_rejects_metadata_header_whitespace_and_padding(header_template):
+    adapter = _adapter()
+    encoded = _encode_metadata({"magic.employee": {"binding": "signed-binding"}})
+
+    with patch.object(adapter, "_create_agent") as create_agent:
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/v1/runs",
+                json={"input": "programul meu"},
+                headers={
+                    "Authorization": "Bearer sk-test-secret",
+                    "X-Hermes-MCP-Metadata": header_template.format(encoded=encoded),
+                },
+            )
+
+    assert response.status == 400
+    create_agent.assert_not_called()
+
+
 async def _wait_for_run(adapter: APIServerAdapter, run_id: str) -> None:
     for _ in range(100):
         status = adapter._run_statuses.get(run_id, {})

--- a/tests/gateway/test_api_server_mcp_metadata.py
+++ b/tests/gateway/test_api_server_mcp_metadata.py
@@ -1,0 +1,529 @@
+import asyncio
+import base64
+import json
+import threading
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from agent.mcp_run_context import (
+    MAX_MCP_RUN_METADATA_BYTES,
+    MAX_MCP_RUN_METADATA_DEPTH,
+    decode_mcp_run_metadata_header,
+    read_mcp_run_metadata,
+)
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter, cors_middleware
+
+
+def _encode_metadata(value: dict) -> str:
+    raw = json.dumps(value, separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def _adapter(api_key: str = "sk-test-secret") -> APIServerAdapter:
+    return APIServerAdapter(
+        PlatformConfig(enabled=True, extra={"key": api_key} if api_key else {})
+    )
+
+
+def _app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application()
+    app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
+    app.router.add_post("/v1/responses", adapter._handle_responses)
+    app.router.add_post("/v1/runs", adapter._handle_runs)
+    return app
+
+
+def test_decoded_metadata_limit_is_enforced():
+    json_overhead = len(b'{"value":""}')
+    allowed = {"value": "a" * (MAX_MCP_RUN_METADATA_BYTES - json_overhead)}
+    assert decode_mcp_run_metadata_header(_encode_metadata(allowed)) == allowed
+
+    too_large = {"value": allowed["value"] + "a"}
+    with pytest.raises(ValueError, match="too large"):
+        decode_mcp_run_metadata_header(_encode_metadata(too_large))
+
+
+def test_metadata_nesting_limit_is_explicit_and_stable():
+    allowed = "leaf"
+    for _ in range(MAX_MCP_RUN_METADATA_DEPTH):
+        allowed = {"nested": allowed}
+    assert decode_mcp_run_metadata_header(_encode_metadata(allowed)) == allowed
+
+    too_deep = {"nested": allowed}
+    with pytest.raises(ValueError, match="too deeply nested"):
+        decode_mcp_run_metadata_header(_encode_metadata(too_deep))
+
+
+async def _wait_for_run(adapter: APIServerAdapter, run_id: str) -> None:
+    for _ in range(100):
+        status = adapter._run_statuses.get(run_id, {})
+        if status.get("status") in {"completed", "failed", "cancelled"}:
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("run did not finish")
+
+
+@pytest.mark.asyncio
+async def test_run_header_reaches_only_private_context_not_model_inputs():
+    adapter = _adapter()
+    metadata = {"magic.employee": {"binding": "signed-binding"}}
+    observed = {}
+
+    mock_agent = MagicMock()
+
+    def _run_conversation(user_message, conversation_history, task_id):
+        observed["metadata"] = read_mcp_run_metadata()
+        observed["user_message"] = user_message
+        observed["history"] = conversation_history
+        return {"final_response": "done"}
+
+    mock_agent.run_conversation.side_effect = _run_conversation
+    mock_agent.session_prompt_tokens = 0
+    mock_agent.session_completion_tokens = 0
+    mock_agent.session_total_tokens = 0
+
+    def _create_agent(**kwargs):
+        observed["system_prompt"] = kwargs.get("ephemeral_system_prompt")
+        return mock_agent
+
+    with patch.object(adapter, "_create_agent", side_effect=_create_agent):
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/v1/runs",
+                json={"input": "programul meu", "instructions": "Răspunde scurt"},
+                headers={
+                    "Authorization": "Bearer sk-test-secret",
+                    "X-Hermes-MCP-Metadata": _encode_metadata(metadata),
+                },
+            )
+            assert response.status == 202
+            run_id = (await response.json())["run_id"]
+            await _wait_for_run(adapter, run_id)
+
+    assert observed == {
+        "metadata": metadata,
+        "user_message": "programul meu",
+        "history": [],
+        "system_prompt": "Răspunde scurt",
+    }
+    assert "signed-binding" not in observed["user_message"]
+    assert "signed-binding" not in json.dumps(observed["history"])
+    assert "signed-binding" not in observed["system_prompt"]
+    assert read_mcp_run_metadata() is None
+
+
+@pytest.mark.asyncio
+async def test_two_concurrent_api_runs_keep_private_metadata_isolated():
+    adapter = _adapter()
+    barrier = threading.Barrier(2)
+    observed = {}
+
+    class _Agent:
+        session_prompt_tokens = 0
+        session_completion_tokens = 0
+        session_total_tokens = 0
+
+        def run_conversation(self, user_message, conversation_history, task_id):
+            first = read_mcp_run_metadata()
+            barrier.wait(timeout=5)
+            second = read_mcp_run_metadata()
+            observed[user_message] = (first, second)
+            return {"final_response": "done"}
+
+    with patch.object(adapter, "_create_agent", side_effect=lambda **_kwargs: _Agent()):
+        async with TestClient(TestServer(_app(adapter))) as client:
+            async def _start(key: str):
+                response = await client.post(
+                    "/v1/runs",
+                    json={"input": key},
+                    headers={
+                        "Authorization": "Bearer sk-test-secret",
+                        "X-Hermes-MCP-Metadata": _encode_metadata({"request": key}),
+                    },
+                )
+                assert response.status == 202
+                return (await response.json())["run_id"]
+
+            run_a, run_b = await asyncio.gather(_start("a"), _start("b"))
+            await asyncio.gather(
+                _wait_for_run(adapter, run_a),
+                _wait_for_run(adapter, run_b),
+            )
+
+    assert observed == {
+        "a": ({"request": "a"}, {"request": "a"}),
+        "b": ({"request": "b"}, {"request": "b"}),
+    }
+    assert read_mcp_run_metadata() is None
+
+
+@pytest.mark.asyncio
+async def test_runs_preserve_two_employee_transcripts_without_cross_session_leak():
+    adapter = _adapter()
+    histories = {}
+    observed = []
+
+    class _SessionDB:
+        def get_messages_as_conversation(self, session_id):
+            return list(histories.get(session_id, []))
+
+    class _Agent:
+        session_prompt_tokens = 0
+        session_completion_tokens = 0
+        session_total_tokens = 0
+
+        def __init__(self, session_id):
+            self.session_id = session_id
+
+        def run_conversation(self, user_message, conversation_history, task_id):
+            metadata = read_mcp_run_metadata()
+            observed.append(
+                {
+                    "session_id": self.session_id,
+                    "employee": metadata["employee"],
+                    "history": list(conversation_history),
+                    "message": user_message,
+                }
+            )
+            response = f"reply-{metadata['employee']}-{user_message}"
+            histories[self.session_id] = [
+                *conversation_history,
+                {"role": "user", "content": user_message},
+                {"role": "assistant", "content": response},
+            ]
+            return {"final_response": response}
+
+    def _create_agent(**kwargs):
+        return _Agent(kwargs["session_id"])
+
+    async def _start(client, employee, message, *, use_header):
+        session_id = f"employee-session-{employee}"
+        response = await client.post(
+            "/v1/runs",
+            json={
+                "input": message,
+                **({} if use_header else {"session_id": session_id}),
+            },
+            headers={
+                "Authorization": "Bearer sk-test-secret",
+                "X-Hermes-MCP-Metadata": _encode_metadata(
+                    {"employee": employee}
+                ),
+                **(
+                    {"X-Hermes-Session-Id": session_id}
+                    if use_header
+                    else {}
+                ),
+            },
+        )
+        assert response.status == 202
+        run_id = (await response.json())["run_id"]
+        await _wait_for_run(adapter, run_id)
+
+    with patch.object(
+        adapter, "_ensure_session_db_async", new_callable=AsyncMock
+    ) as session_db, patch.object(
+        adapter, "_create_agent", side_effect=_create_agent
+    ):
+        session_db.return_value = _SessionDB()
+        async with TestClient(TestServer(_app(adapter))) as client:
+            await _start(client, "a", "first-a", use_header=True)
+            await _start(client, "b", "first-b", use_header=True)
+            await _start(client, "a", "second-a", use_header=True)
+            await _start(client, "b", "second-b", use_header=True)
+            await _start(client, "bridge", "first-bridge", use_header=False)
+            await _start(client, "bridge", "second-bridge", use_header=False)
+
+    assert observed[0]["history"] == []
+    assert observed[1]["history"] == []
+    assert observed[2]["history"] == [
+        {"role": "user", "content": "first-a"},
+        {"role": "assistant", "content": "reply-a-first-a"},
+    ]
+    assert observed[3]["history"] == [
+        {"role": "user", "content": "first-b"},
+        {"role": "assistant", "content": "reply-b-first-b"},
+    ]
+    assert observed[4]["history"] == []
+    assert observed[5]["history"] == [
+        {"role": "user", "content": "first-bridge"},
+        {"role": "assistant", "content": "reply-bridge-first-bridge"},
+    ]
+    assert read_mcp_run_metadata() is None
+
+
+@pytest.mark.asyncio
+async def test_runs_follow_compression_tip_and_publish_rotated_session_id():
+    adapter = _adapter()
+    observed = {}
+
+    class _SessionDB:
+        def resolve_resume_session_id(self, session_id):
+            observed["resolved_from"] = session_id
+            return "session-child"
+
+        def get_messages_as_conversation(self, session_id):
+            observed["loaded_from"] = session_id
+            return [{"role": "user", "content": "compressed history"}]
+
+    mock_agent = MagicMock()
+    mock_agent.run_conversation.return_value = {
+        "final_response": "done",
+        "messages": [],
+        "session_id": "session-grandchild",
+    }
+    mock_agent.session_prompt_tokens = 0
+    mock_agent.session_completion_tokens = 0
+    mock_agent.session_total_tokens = 0
+
+    with patch.object(
+        adapter, "_ensure_session_db_async", new_callable=AsyncMock
+    ) as session_db, patch.object(
+        adapter, "_create_agent", return_value=mock_agent
+    ) as create_agent:
+        session_db.return_value = _SessionDB()
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/v1/runs",
+                json={"input": "next", "session_id": "session-old"},
+                headers={"Authorization": "Bearer sk-test-secret"},
+            )
+            assert response.status == 202
+            run_id = (await response.json())["run_id"]
+            await _wait_for_run(adapter, run_id)
+
+    assert observed == {
+        "resolved_from": "session-old",
+        "loaded_from": "session-child",
+    }
+    assert create_agent.call_args.kwargs["session_id"] == "session-child"
+    assert mock_agent.run_conversation.call_args.kwargs["conversation_history"] == [
+        {"role": "user", "content": "compressed history"}
+    ]
+    assert adapter._run_statuses[run_id]["session_id"] == "session-grandchild"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "explicit_history",
+    [
+        [],
+        [{"role": "user", "content": "explicit history"}],
+    ],
+)
+async def test_explicit_run_history_is_authoritative_and_persisted(
+    explicit_history,
+):
+    adapter = _adapter()
+    session_db = MagicMock()
+    returned_messages = [
+        *explicit_history,
+        {"role": "user", "content": "fresh turn"},
+        {"role": "assistant", "content": "done"},
+    ]
+    mock_agent = MagicMock()
+    mock_agent.session_id = "explicit-session"
+    mock_agent._session_db = session_db
+    mock_agent.run_conversation.return_value = {
+        "final_response": "done",
+        "messages": returned_messages,
+        "session_id": "explicit-session",
+    }
+    mock_agent.session_prompt_tokens = 0
+    mock_agent.session_completion_tokens = 0
+    mock_agent.session_total_tokens = 0
+
+    with patch.object(adapter, "_ensure_session_db_async") as load_db, patch.object(
+        adapter, "_create_agent", return_value=mock_agent
+    ):
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/v1/runs",
+                json={
+                    "input": "fresh turn",
+                    "session_id": "explicit-session",
+                    "conversation_history": explicit_history,
+                },
+                headers={"Authorization": "Bearer sk-test-secret"},
+            )
+            assert response.status == 202
+            run_id = (await response.json())["run_id"]
+            await _wait_for_run(adapter, run_id)
+
+    load_db.assert_not_called()
+    assert mock_agent.run_conversation.call_args.kwargs["conversation_history"] == (
+        explicit_history
+    )
+    session_db.replace_messages.assert_called_once_with(
+        "explicit-session",
+        returned_messages,
+        active_only=True,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invalid_history", [None, {}, "", False, 0])
+async def test_falsy_non_array_run_history_is_rejected(invalid_history):
+    adapter = _adapter()
+    with patch.object(adapter, "_create_agent") as create_agent:
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/v1/runs",
+                json={
+                    "input": "hello",
+                    "conversation_history": invalid_history,
+                },
+                headers={"Authorization": "Bearer sk-test-secret"},
+            )
+
+    assert response.status == 400
+    create_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_browser_preflight_allows_session_and_mcp_headers():
+    adapter = APIServerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "key": "sk-test-secret",
+                "cors_origins": ["https://magic-team.example"],
+            },
+        )
+    )
+    app = web.Application(middlewares=[cors_middleware])
+    app["api_server_adapter"] = adapter
+    app.router.add_post("/v1/runs", adapter._handle_runs)
+
+    async with TestClient(TestServer(app)) as client:
+        response = await client.options(
+            "/v1/runs",
+            headers={
+                "Origin": "https://magic-team.example",
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Headers": (
+                    "X-Hermes-Session-Id, X-Hermes-Session-Key, "
+                    "X-Hermes-MCP-Metadata"
+                ),
+            },
+        )
+
+    assert response.status == 200
+    allowed = response.headers["Access-Control-Allow-Headers"]
+    assert "X-Hermes-Session-Id" in allowed
+    assert "X-Hermes-Session-Key" in allowed
+    assert "X-Hermes-MCP-Metadata" in allowed
+
+
+@pytest.mark.asyncio
+async def test_invalid_metadata_header_is_rejected_before_agent_creation():
+    adapter = _adapter()
+    with patch.object(adapter, "_create_agent") as create_agent:
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/v1/runs",
+                json={"input": "hello"},
+                headers={
+                    "Authorization": "Bearer sk-test-secret",
+                    "X-Hermes-MCP-Metadata": "not-base64!",
+                },
+            )
+
+    assert response.status == 400
+    create_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_deeply_nested_metadata_is_rejected_before_agent_creation():
+    adapter = _adapter()
+    raw = (b'{"nested":' * 500) + b"null" + (b"}" * 500)
+    encoded = base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+    with patch.object(adapter, "_create_agent") as create_agent:
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/v1/runs",
+                json={"input": "hello"},
+                headers={
+                    "Authorization": "Bearer sk-test-secret",
+                    "X-Hermes-MCP-Metadata": encoded,
+                },
+            )
+            payload = await response.json()
+
+    assert response.status == 400
+    assert payload["error"]["code"] == "invalid_mcp_metadata"
+    create_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_metadata_header_requires_api_key_authentication():
+    adapter = _adapter(api_key="")
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/v1/runs",
+            json={"input": "hello"},
+            headers={"X-Hermes-MCP-Metadata": _encode_metadata({"private": "value"})},
+        )
+
+    assert response.status == 403
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("path", "body", "extract_text"),
+    [
+        (
+            "/v1/chat/completions",
+            {"model": "hermes-agent", "messages": [{"role": "user", "content": "hello"}]},
+            lambda payload: payload["choices"][0]["message"]["content"],
+        ),
+        (
+            "/v1/responses",
+            {"model": "hermes-agent", "input": "hello"},
+            lambda payload: payload["output"][0]["content"][0]["text"],
+        ),
+    ],
+)
+async def test_idempotency_cache_is_scoped_by_private_mcp_metadata(
+    path, body, extract_text
+):
+    adapter = _adapter()
+
+    async def _run_agent(**_kwargs):
+        employee = read_mcp_run_metadata()["employee"]
+        return (
+            {
+                "final_response": f"data-for-{employee}",
+                "messages": [],
+                "api_calls": 1,
+            },
+            {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+        )
+
+    with patch.object(
+        adapter, "_run_agent", new_callable=AsyncMock, side_effect=_run_agent
+    ) as run_agent:
+        async with TestClient(TestServer(_app(adapter))) as client:
+            responses = []
+            for employee in ("a", "b"):
+                response = await client.post(
+                    path,
+                    json=body,
+                    headers={
+                        "Authorization": "Bearer sk-test-secret",
+                        "Idempotency-Key": f"mcp-metadata-{path}",
+                        "X-Hermes-MCP-Metadata": _encode_metadata(
+                            {"employee": employee}
+                        ),
+                    },
+                )
+                assert response.status == 200
+                responses.append(extract_text(await response.json()))
+
+    assert responses == ["data-for-a", "data-for-b"]
+    assert run_agent.await_count == 2

--- a/tests/gateway/test_api_server_mcp_metadata.py
+++ b/tests/gateway/test_api_server_mcp_metadata.py
@@ -311,17 +311,59 @@ async def test_runs_follow_compression_tip_and_publish_rotated_session_id():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "explicit_history",
-    [
-        [],
-        [{"role": "user", "content": "explicit history"}],
-    ],
-)
-async def test_explicit_run_history_is_authoritative_and_persisted(
-    explicit_history,
-):
+async def test_empty_run_history_resumes_session_without_replacing_transcript():
     adapter = _adapter()
+    stored_history = [{"role": "user", "content": "stored history"}]
+    session_db = MagicMock()
+    session_db.resolve_resume_session_id.return_value = "explicit-session"
+    session_db.get_messages_as_conversation.return_value = stored_history
+    mock_agent = MagicMock()
+    mock_agent.session_id = "explicit-session"
+    mock_agent._session_db = session_db
+    mock_agent.run_conversation.return_value = {
+        "final_response": "done",
+        "messages": [
+            *stored_history,
+            {"role": "user", "content": "fresh turn"},
+            {"role": "assistant", "content": "done"},
+        ],
+        "session_id": "explicit-session",
+    }
+    mock_agent.session_prompt_tokens = 0
+    mock_agent.session_completion_tokens = 0
+    mock_agent.session_total_tokens = 0
+
+    with patch.object(
+        adapter, "_ensure_session_db_async", new_callable=AsyncMock
+    ) as load_db, patch.object(adapter, "_create_agent", return_value=mock_agent):
+        load_db.return_value = session_db
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/v1/runs",
+                json={
+                    "input": "fresh turn",
+                    "session_id": "explicit-session",
+                    "conversation_history": [],
+                },
+                headers={
+                    "Authorization": "Bearer sk-test-secret",
+                    "X-Hermes-Session-Id": "explicit-session",
+                },
+            )
+            assert response.status == 202
+            run_id = (await response.json())["run_id"]
+            await _wait_for_run(adapter, run_id)
+
+    assert mock_agent.run_conversation.call_args.kwargs["conversation_history"] == (
+        stored_history
+    )
+    session_db.replace_messages.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_nonempty_run_history_is_authoritative_and_persisted():
+    adapter = _adapter()
+    explicit_history = [{"role": "user", "content": "explicit history"}]
     session_db = MagicMock()
     returned_messages = [
         *explicit_history,

--- a/tests/gateway/test_api_server_mcp_metadata.py
+++ b/tests/gateway/test_api_server_mcp_metadata.py
@@ -235,8 +235,8 @@ async def test_runs_preserve_two_employee_transcripts_without_cross_session_leak
             await _start(client, "b", "first-b", use_header=True)
             await _start(client, "a", "second-a", use_header=True)
             await _start(client, "b", "second-b", use_header=True)
-            await _start(client, "bridge", "first-bridge", use_header=False)
-            await _start(client, "bridge", "second-bridge", use_header=False)
+            await _start(client, "bridge", "first-bridge", use_header=True)
+            await _start(client, "bridge", "second-bridge", use_header=True)
 
     assert observed[0]["history"] == []
     assert observed[1]["history"] == []
@@ -290,7 +290,10 @@ async def test_runs_follow_compression_tip_and_publish_rotated_session_id():
             response = await client.post(
                 "/v1/runs",
                 json={"input": "next", "session_id": "session-old"},
-                headers={"Authorization": "Bearer sk-test-secret"},
+                headers={
+                    "Authorization": "Bearer sk-test-secret",
+                    "X-Hermes-Session-Id": "session-old",
+                },
             )
             assert response.status == 202
             run_id = (await response.json())["run_id"]

--- a/tests/gateway/test_api_server_mcp_metadata.py
+++ b/tests/gateway/test_api_server_mcp_metadata.py
@@ -1,0 +1,570 @@
+import asyncio
+import base64
+import json
+import threading
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from agent.mcp_run_context import (
+    MAX_MCP_RUN_METADATA_BYTES,
+    MAX_MCP_RUN_METADATA_DEPTH,
+    decode_mcp_run_metadata_header,
+    read_mcp_run_metadata,
+)
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter, cors_middleware
+
+
+def _encode_metadata(value: dict) -> str:
+    raw = json.dumps(value, separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def _adapter(api_key: str = "sk-test-secret") -> APIServerAdapter:
+    return APIServerAdapter(
+        PlatformConfig(enabled=True, extra={"key": api_key} if api_key else {})
+    )
+
+
+def _app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application()
+    app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
+    app.router.add_post("/v1/responses", adapter._handle_responses)
+    app.router.add_post("/v1/runs", adapter._handle_runs)
+    return app
+
+
+def test_decoded_metadata_limit_is_enforced():
+    json_overhead = len(b'{"value":""}')
+    allowed = {"value": "a" * (MAX_MCP_RUN_METADATA_BYTES - json_overhead)}
+    assert decode_mcp_run_metadata_header(_encode_metadata(allowed)) == allowed
+
+    too_large = {"value": allowed["value"] + "a"}
+    with pytest.raises(ValueError, match="too large"):
+        decode_mcp_run_metadata_header(_encode_metadata(too_large))
+
+
+def test_metadata_nesting_limit_is_explicit_and_stable():
+    allowed = "leaf"
+    for _ in range(MAX_MCP_RUN_METADATA_DEPTH):
+        allowed = {"nested": allowed}
+    assert decode_mcp_run_metadata_header(_encode_metadata(allowed)) == allowed
+
+    too_deep = {"nested": allowed}
+    with pytest.raises(ValueError, match="too deeply nested"):
+        decode_mcp_run_metadata_header(_encode_metadata(too_deep))
+
+
+async def _wait_for_run(adapter: APIServerAdapter, run_id: str) -> None:
+    for _ in range(100):
+        status = adapter._run_statuses.get(run_id, {})
+        if status.get("status") in {"completed", "failed", "cancelled"}:
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("run did not finish")
+
+
+@pytest.mark.asyncio
+async def test_run_header_reaches_only_private_context_not_model_inputs():
+    adapter = _adapter()
+    metadata = {"magic.employee": {"binding": "signed-binding"}}
+    observed = {}
+
+    mock_agent = MagicMock()
+
+    def _run_conversation(user_message, conversation_history, task_id):
+        observed["metadata"] = read_mcp_run_metadata()
+        observed["user_message"] = user_message
+        observed["history"] = conversation_history
+        return {"final_response": "done"}
+
+    mock_agent.run_conversation.side_effect = _run_conversation
+    mock_agent.session_prompt_tokens = 0
+    mock_agent.session_completion_tokens = 0
+    mock_agent.session_total_tokens = 0
+
+    def _create_agent(**kwargs):
+        observed["system_prompt"] = kwargs.get("ephemeral_system_prompt")
+        return mock_agent
+
+    with patch.object(adapter, "_create_agent", side_effect=_create_agent):
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/v1/runs",
+                json={"input": "programul meu", "instructions": "Răspunde scurt"},
+                headers={
+                    "Authorization": "Bearer sk-test-secret",
+                    "X-Hermes-MCP-Metadata": _encode_metadata(metadata),
+                },
+            )
+            assert response.status == 202
+            run_id = (await response.json())["run_id"]
+            await _wait_for_run(adapter, run_id)
+
+    assert observed == {
+        "metadata": metadata,
+        "user_message": "programul meu",
+        "history": [],
+        "system_prompt": "Răspunde scurt",
+    }
+    assert "signed-binding" not in observed["user_message"]
+    assert "signed-binding" not in json.dumps(observed["history"])
+    assert "signed-binding" not in observed["system_prompt"]
+    assert read_mcp_run_metadata() is None
+
+
+@pytest.mark.asyncio
+async def test_two_concurrent_api_runs_keep_private_metadata_isolated():
+    adapter = _adapter()
+    barrier = threading.Barrier(2)
+    observed = {}
+
+    class _Agent:
+        session_prompt_tokens = 0
+        session_completion_tokens = 0
+        session_total_tokens = 0
+
+        def run_conversation(self, user_message, conversation_history, task_id):
+            first = read_mcp_run_metadata()
+            barrier.wait(timeout=5)
+            second = read_mcp_run_metadata()
+            observed[user_message] = (first, second)
+            return {"final_response": "done"}
+
+    with patch.object(adapter, "_create_agent", side_effect=lambda **_kwargs: _Agent()):
+        async with TestClient(TestServer(_app(adapter))) as client:
+            async def _start(key: str):
+                response = await client.post(
+                    "/v1/runs",
+                    json={"input": key},
+                    headers={
+                        "Authorization": "Bearer sk-test-secret",
+                        "X-Hermes-MCP-Metadata": _encode_metadata({"request": key}),
+                    },
+                )
+                assert response.status == 202
+                return (await response.json())["run_id"]
+
+            run_a, run_b = await asyncio.gather(_start("a"), _start("b"))
+            await asyncio.gather(
+                _wait_for_run(adapter, run_a),
+                _wait_for_run(adapter, run_b),
+            )
+
+    assert observed == {
+        "a": ({"request": "a"}, {"request": "a"}),
+        "b": ({"request": "b"}, {"request": "b"}),
+    }
+    assert read_mcp_run_metadata() is None
+
+
+@pytest.mark.asyncio
+async def test_run_idempotency_never_reuses_a_different_employee_binding():
+    adapter = _adapter()
+    observed = []
+
+    class _Agent:
+        session_prompt_tokens = 0
+        session_completion_tokens = 0
+        session_total_tokens = 0
+
+        def run_conversation(self, user_message, conversation_history, task_id):
+            observed.append(read_mcp_run_metadata())
+            return {"final_response": "done"}
+
+    with patch.object(adapter, "_create_agent", side_effect=lambda **_kwargs: _Agent()):
+        async with TestClient(TestServer(_app(adapter))) as client:
+            run_ids = []
+            for employee in ("a", "b"):
+                response = await client.post(
+                    "/v1/runs",
+                    json={"input": "same message"},
+                    headers={
+                        "Authorization": "Bearer sk-test-secret",
+                        "Idempotency-Key": "same-key",
+                        "X-Hermes-MCP-Metadata": _encode_metadata(
+                            {"employee": employee}
+                        ),
+                    },
+                )
+                assert response.status == 202
+                run_id = (await response.json())["run_id"]
+                run_ids.append(run_id)
+                await _wait_for_run(adapter, run_id)
+
+    assert run_ids[0] != run_ids[1]
+    assert observed == [{"employee": "a"}, {"employee": "b"}]
+
+
+@pytest.mark.asyncio
+async def test_runs_preserve_two_employee_transcripts_without_cross_session_leak():
+    adapter = _adapter()
+    histories = {}
+    observed = []
+
+    class _SessionDB:
+        def get_messages_as_conversation(self, session_id):
+            return list(histories.get(session_id, []))
+
+    class _Agent:
+        session_prompt_tokens = 0
+        session_completion_tokens = 0
+        session_total_tokens = 0
+
+        def __init__(self, session_id):
+            self.session_id = session_id
+
+        def run_conversation(self, user_message, conversation_history, task_id):
+            metadata = read_mcp_run_metadata()
+            observed.append(
+                {
+                    "session_id": self.session_id,
+                    "employee": metadata["employee"],
+                    "history": list(conversation_history),
+                    "message": user_message,
+                }
+            )
+            response = f"reply-{metadata['employee']}-{user_message}"
+            histories[self.session_id] = [
+                *conversation_history,
+                {"role": "user", "content": user_message},
+                {"role": "assistant", "content": response},
+            ]
+            return {"final_response": response}
+
+    def _create_agent(**kwargs):
+        return _Agent(kwargs["session_id"])
+
+    async def _start(client, employee, message, *, use_header):
+        session_id = f"employee-session-{employee}"
+        response = await client.post(
+            "/v1/runs",
+            json={
+                "input": message,
+                **({} if use_header else {"session_id": session_id}),
+            },
+            headers={
+                "Authorization": "Bearer sk-test-secret",
+                "X-Hermes-MCP-Metadata": _encode_metadata(
+                    {"employee": employee}
+                ),
+                **(
+                    {"X-Hermes-Session-Id": session_id}
+                    if use_header
+                    else {}
+                ),
+            },
+        )
+        assert response.status == 202
+        run_id = (await response.json())["run_id"]
+        await _wait_for_run(adapter, run_id)
+
+    with patch.object(
+        adapter, "_ensure_session_db_async", new_callable=AsyncMock
+    ) as session_db, patch.object(
+        adapter, "_create_agent", side_effect=_create_agent
+    ):
+        session_db.return_value = _SessionDB()
+        async with TestClient(TestServer(_app(adapter))) as client:
+            await _start(client, "a", "first-a", use_header=True)
+            await _start(client, "b", "first-b", use_header=True)
+            await _start(client, "a", "second-a", use_header=True)
+            await _start(client, "b", "second-b", use_header=True)
+            await _start(client, "bridge", "first-bridge", use_header=True)
+            await _start(client, "bridge", "second-bridge", use_header=True)
+
+    assert observed[0]["history"] == []
+    assert observed[1]["history"] == []
+    assert observed[2]["history"] == [
+        {"role": "user", "content": "first-a"},
+        {"role": "assistant", "content": "reply-a-first-a"},
+    ]
+    assert observed[3]["history"] == [
+        {"role": "user", "content": "first-b"},
+        {"role": "assistant", "content": "reply-b-first-b"},
+    ]
+    assert observed[4]["history"] == []
+    assert observed[5]["history"] == [
+        {"role": "user", "content": "first-bridge"},
+        {"role": "assistant", "content": "reply-bridge-first-bridge"},
+    ]
+    assert read_mcp_run_metadata() is None
+
+
+@pytest.mark.asyncio
+async def test_runs_follow_compression_tip_and_publish_rotated_session_id():
+    adapter = _adapter()
+    observed = {}
+
+    class _SessionDB:
+        def resolve_resume_session_id(self, session_id):
+            observed["resolved_from"] = session_id
+            return "session-child"
+
+        def get_messages_as_conversation(self, session_id):
+            observed["loaded_from"] = session_id
+            return [{"role": "user", "content": "compressed history"}]
+
+    mock_agent = MagicMock()
+    mock_agent.run_conversation.return_value = {
+        "final_response": "done",
+        "messages": [],
+        "session_id": "session-grandchild",
+    }
+    mock_agent.session_prompt_tokens = 0
+    mock_agent.session_completion_tokens = 0
+    mock_agent.session_total_tokens = 0
+
+    with patch.object(
+        adapter, "_ensure_session_db_async", new_callable=AsyncMock
+    ) as session_db, patch.object(
+        adapter, "_create_agent", return_value=mock_agent
+    ) as create_agent:
+        session_db.return_value = _SessionDB()
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/v1/runs",
+                json={"input": "next", "session_id": "session-old"},
+                headers={
+                    "Authorization": "Bearer sk-test-secret",
+                    "X-Hermes-Session-Id": "session-old",
+                },
+            )
+            assert response.status == 202
+            run_id = (await response.json())["run_id"]
+            await _wait_for_run(adapter, run_id)
+
+    assert observed == {
+        "resolved_from": "session-old",
+        "loaded_from": "session-child",
+    }
+    assert create_agent.call_args.kwargs["session_id"] == "session-old"
+    assert mock_agent.run_conversation.call_args.kwargs["conversation_history"] == [
+        {"role": "user", "content": "compressed history"}
+    ]
+    assert adapter._run_statuses[run_id]["session_id"] == "session-grandchild"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "explicit_history",
+    [
+        [],
+        [{"role": "user", "content": "explicit history"}],
+    ],
+)
+async def test_explicit_run_history_is_authoritative_and_persisted(
+    explicit_history,
+):
+    adapter = _adapter()
+    session_db = MagicMock()
+    returned_messages = [
+        *explicit_history,
+        {"role": "user", "content": "fresh turn"},
+        {"role": "assistant", "content": "done"},
+    ]
+    mock_agent = MagicMock()
+    mock_agent.session_id = "explicit-session"
+    mock_agent._session_db = session_db
+    mock_agent.run_conversation.return_value = {
+        "final_response": "done",
+        "messages": returned_messages,
+        "session_id": "explicit-session",
+    }
+    mock_agent.session_prompt_tokens = 0
+    mock_agent.session_completion_tokens = 0
+    mock_agent.session_total_tokens = 0
+
+    with patch.object(adapter, "_ensure_session_db_async") as load_db, patch.object(
+        adapter, "_create_agent", return_value=mock_agent
+    ):
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/v1/runs",
+                json={
+                    "input": "fresh turn",
+                    "session_id": "explicit-session",
+                    "conversation_history": explicit_history,
+                },
+                headers={"Authorization": "Bearer sk-test-secret"},
+            )
+            assert response.status == 202
+            run_id = (await response.json())["run_id"]
+            await _wait_for_run(adapter, run_id)
+
+    load_db.assert_not_called()
+    assert mock_agent.run_conversation.call_args.kwargs["conversation_history"] == (
+        explicit_history
+    )
+    session_db.replace_messages.assert_called_once_with(
+        "explicit-session",
+        returned_messages,
+        active_only=True,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invalid_history", [None, {}, "", False, 0])
+async def test_falsy_non_array_run_history_is_rejected(invalid_history):
+    adapter = _adapter()
+    with patch.object(adapter, "_create_agent") as create_agent:
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/v1/runs",
+                json={
+                    "input": "hello",
+                    "conversation_history": invalid_history,
+                },
+                headers={"Authorization": "Bearer sk-test-secret"},
+            )
+
+    assert response.status == 400
+    create_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_browser_preflight_allows_session_and_mcp_headers():
+    adapter = APIServerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "key": "sk-test-secret",
+                "cors_origins": ["https://magic-team.example"],
+            },
+        )
+    )
+    app = web.Application(middlewares=[cors_middleware])
+    app["api_server_adapter"] = adapter
+    app.router.add_post("/v1/runs", adapter._handle_runs)
+
+    async with TestClient(TestServer(app)) as client:
+        response = await client.options(
+            "/v1/runs",
+            headers={
+                "Origin": "https://magic-team.example",
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Headers": (
+                    "X-Hermes-Session-Id, X-Hermes-Session-Key, "
+                    "X-Hermes-MCP-Metadata"
+                ),
+            },
+        )
+
+    assert response.status == 200
+    allowed = response.headers["Access-Control-Allow-Headers"]
+    assert "X-Hermes-Session-Id" in allowed
+    assert "X-Hermes-Session-Key" in allowed
+    assert "X-Hermes-MCP-Metadata" in allowed
+
+
+@pytest.mark.asyncio
+async def test_invalid_metadata_header_is_rejected_before_agent_creation():
+    adapter = _adapter()
+    with patch.object(adapter, "_create_agent") as create_agent:
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/v1/runs",
+                json={"input": "hello"},
+                headers={
+                    "Authorization": "Bearer sk-test-secret",
+                    "X-Hermes-MCP-Metadata": "not-base64!",
+                },
+            )
+
+    assert response.status == 400
+    create_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_deeply_nested_metadata_is_rejected_before_agent_creation():
+    adapter = _adapter()
+    raw = (b'{"nested":' * 500) + b"null" + (b"}" * 500)
+    encoded = base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+    with patch.object(adapter, "_create_agent") as create_agent:
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/v1/runs",
+                json={"input": "hello"},
+                headers={
+                    "Authorization": "Bearer sk-test-secret",
+                    "X-Hermes-MCP-Metadata": encoded,
+                },
+            )
+            payload = await response.json()
+
+    assert response.status == 400
+    assert payload["error"]["code"] == "invalid_mcp_metadata"
+    create_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_metadata_header_requires_api_key_authentication():
+    adapter = _adapter(api_key="")
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/v1/runs",
+            json={"input": "hello"},
+            headers={"X-Hermes-MCP-Metadata": _encode_metadata({"private": "value"})},
+        )
+
+    assert response.status == 403
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("path", "body", "extract_text"),
+    [
+        (
+            "/v1/chat/completions",
+            {"model": "hermes-agent", "messages": [{"role": "user", "content": "hello"}]},
+            lambda payload: payload["choices"][0]["message"]["content"],
+        ),
+        (
+            "/v1/responses",
+            {"model": "hermes-agent", "input": "hello"},
+            lambda payload: payload["output"][0]["content"][0]["text"],
+        ),
+    ],
+)
+async def test_idempotency_cache_is_scoped_by_private_mcp_metadata(
+    path, body, extract_text
+):
+    adapter = _adapter()
+
+    async def _run_agent(**_kwargs):
+        employee = read_mcp_run_metadata()["employee"]
+        return (
+            {
+                "final_response": f"data-for-{employee}",
+                "messages": [],
+                "api_calls": 1,
+            },
+            {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+        )
+
+    with patch.object(
+        adapter, "_run_agent", new_callable=AsyncMock, side_effect=_run_agent
+    ) as run_agent:
+        async with TestClient(TestServer(_app(adapter))) as client:
+            responses = []
+            for employee in ("a", "b"):
+                response = await client.post(
+                    path,
+                    json=body,
+                    headers={
+                        "Authorization": "Bearer sk-test-secret",
+                        "Idempotency-Key": f"mcp-metadata-{path}",
+                        "X-Hermes-MCP-Metadata": _encode_metadata(
+                            {"employee": employee}
+                        ),
+                    },
+                )
+                assert response.status == 200
+                responses.append(extract_text(await response.json()))
+
+    assert responses == ["data-for-a", "data-for-b"]
+    assert run_agent.await_count == 2

--- a/tests/gateway/test_api_server_mcp_metadata.py
+++ b/tests/gateway/test_api_server_mcp_metadata.py
@@ -527,3 +527,52 @@ async def test_idempotency_cache_is_scoped_by_private_mcp_metadata(
 
     assert responses == ["data-for-a", "data-for-b"]
     assert run_agent.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_run_idempotency_key_cannot_cross_private_mcp_metadata():
+    adapter = _adapter()
+    observed = []
+    mock_agent = MagicMock()
+
+    def _run_conversation(**_kwargs):
+        observed.append(read_mcp_run_metadata()["employee"])
+        return {"final_response": "done", "messages": []}
+
+    mock_agent.run_conversation.side_effect = _run_conversation
+    mock_agent.session_prompt_tokens = 0
+    mock_agent.session_completion_tokens = 0
+    mock_agent.session_total_tokens = 0
+
+    with patch.object(adapter, "_create_agent", return_value=mock_agent):
+        async with TestClient(TestServer(_app(adapter))) as client:
+            first = await client.post(
+                "/v1/runs",
+                json={"input": "hello"},
+                headers={
+                    "Authorization": "Bearer sk-test-secret",
+                    "Idempotency-Key": "same-run-key",
+                    "X-Hermes-MCP-Metadata": _encode_metadata(
+                        {"employee": "a"}
+                    ),
+                },
+            )
+            assert first.status == 202
+            first_run_id = (await first.json())["run_id"]
+
+            second = await client.post(
+                "/v1/runs",
+                json={"input": "hello"},
+                headers={
+                    "Authorization": "Bearer sk-test-secret",
+                    "Idempotency-Key": "same-run-key",
+                    "X-Hermes-MCP-Metadata": _encode_metadata(
+                        {"employee": "b"}
+                    ),
+                },
+            )
+            assert second.status == 409
+            assert (await second.json())["error"]["code"] == "idempotency_conflict"
+            await _wait_for_run(adapter, first_run_id)
+
+    assert observed == ["a"]

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -246,10 +246,40 @@ class TestStartRun:
                     await asyncio.sleep(0.05)
 
         assert mock_history.await_args_list == [
-            call("crisp-session"),
-            call("crisp-session"),
+            call("crisp-session", fail_closed=True),
+            call("crisp-session", fail_closed=True),
         ]
         assert captured_histories == [[], stored_history]
+
+    @pytest.mark.asyncio
+    async def test_start_fails_closed_when_session_history_cannot_be_read(
+        self, adapter
+    ):
+        app = _create_runs_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(
+                    adapter,
+                    "_conversation_history_for_session",
+                    new_callable=AsyncMock,
+                    side_effect=OSError("database unavailable"),
+                ) as mock_history,
+                patch.object(adapter, "_create_agent") as mock_create,
+            ):
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "second", "session_id": "crisp-session"},
+                )
+                payload = await resp.json()
+
+        assert resp.status == 503
+        assert payload["error"]["code"] == "session_history_unavailable"
+        mock_history.assert_awaited_once_with(
+            "crisp-session",
+            fail_closed=True,
+        )
+        mock_create.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_start_forwards_inline_image_and_remains_stoppable(self, auth_adapter):

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -11,7 +11,7 @@ Covers:
 import asyncio
 import threading
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from aiohttp import web
@@ -196,6 +196,60 @@ class TestStartRun:
             {"role": "user", "content": "prior question"},
             {"role": "assistant", "content": "prior answer"},
         ]
+
+    @pytest.mark.asyncio
+    async def test_start_reloads_session_history_for_repeated_session(self, adapter):
+        app = _create_runs_app(adapter)
+        captured_histories = []
+        stored_history = [
+            {"role": "user", "content": "prior question"},
+            {"role": "assistant", "content": "prior answer"},
+        ]
+
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(
+                    adapter,
+                    "_conversation_history_for_session",
+                    new_callable=AsyncMock,
+                ) as mock_history,
+                patch.object(adapter, "_create_agent") as mock_create,
+            ):
+                mock_history.side_effect = [[], stored_history]
+                mock_agent = MagicMock()
+
+                def _capture_run(user_message=None, conversation_history=None, task_id=None):
+                    captured_histories.append(list(conversation_history))
+                    return {"final_response": "done"}
+
+                mock_agent.run_conversation.side_effect = _capture_run
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                first_resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "first", "session_id": "crisp-session"},
+                )
+                second_resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "second", "session_id": "crisp-session"},
+                )
+
+                assert first_resp.status == 202
+                assert second_resp.status == 202
+
+                for _ in range(40):
+                    if len(captured_histories) == 2:
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert mock_history.await_args_list == [
+            call("crisp-session"),
+            call("crisp-session"),
+        ]
+        assert captured_histories == [[], stored_history]
 
     @pytest.mark.asyncio
     async def test_start_forwards_inline_image_and_remains_stoppable(self, auth_adapter):

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -282,6 +282,96 @@ class TestStartRun:
         mock_create.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_start_reuses_run_for_the_same_idempotency_key(self, adapter):
+        app = _create_runs_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+                headers = {"Idempotency-Key": "crisp-event-123"}
+                async def delayed_history(*_args, **_kwargs):
+                    await asyncio.sleep(0.05)
+                    return []
+
+                with patch.object(
+                    adapter,
+                    "_conversation_history_for_session",
+                    side_effect=delayed_history,
+                ):
+                    first, second = await asyncio.gather(
+                        cli.post(
+                            "/v1/runs",
+                            json={"input": "hello", "session_id": "crisp-session"},
+                            headers=headers,
+                        ),
+                        cli.post(
+                            "/v1/runs",
+                            json={"input": "hello", "session_id": "crisp-session"},
+                            headers=headers,
+                        ),
+                    )
+                first_payload = await first.json()
+                second_payload = await second.json()
+                with patch.object(
+                    adapter,
+                    "_conversation_history_for_session",
+                    side_effect=RuntimeError("session db unavailable"),
+                ):
+                    replay = await cli.post(
+                        "/v1/runs",
+                        json={"input": "hello", "session_id": "crisp-session"},
+                        headers=headers,
+                    )
+                replay_payload = await replay.json()
+                for _ in range(40):
+                    if mock_create.call_count == 1:
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert first.status == 202
+        assert second.status == 202
+        assert replay.status == 202
+        assert second_payload == first_payload
+        assert replay_payload == first_payload
+        assert mock_create.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_start_rejects_idempotency_key_reuse_for_different_input(
+        self, adapter
+    ):
+        app = _create_runs_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+                headers = {"Idempotency-Key": "crisp-event-123"}
+                first = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "crisp-session"},
+                    headers=headers,
+                )
+                conflict = await cli.post(
+                    "/v1/runs",
+                    json={"input": "different", "session_id": "crisp-session"},
+                    headers=headers,
+                )
+                payload = await conflict.json()
+
+        assert first.status == 202
+        assert conflict.status == 409
+        assert payload["error"]["code"] == "idempotency_conflict"
+
+    @pytest.mark.asyncio
     async def test_start_forwards_inline_image_and_remains_stoppable(self, auth_adapter):
         app = _create_runs_app(auth_adapter)
         image_data_url = "data:image/png;base64,iVBORw0KGgo="

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -137,6 +137,7 @@ class TestStartRun:
                 data = await resp.json()
                 assert data["status"] == "started"
                 assert data["run_id"].startswith("run_")
+                assert "X-Hermes-Session-Id" not in resp.headers
 
                 status_resp = await cli.get(f"/v1/runs/{data['run_id']}")
                 assert status_resp.status == 200

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -121,6 +121,19 @@ def auth_adapter():
 
 class TestStartRun:
     @pytest.mark.asyncio
+    async def test_session_history_resolves_compacted_descendant(self, adapter):
+        db = MagicMock()
+        db.resolve_resume_session_id.return_value = "child-session"
+        db.get_messages_as_conversation.return_value = [{"role": "user", "content": "prior"}]
+        adapter._ensure_session_db_async = AsyncMock(return_value=db)
+
+        history = await adapter._conversation_history_for_session("parent-session")
+
+        assert history == [{"role": "user", "content": "prior"}]
+        db.resolve_resume_session_id.assert_called_once_with("parent-session")
+        db.get_messages_as_conversation.assert_called_once_with("child-session")
+
+    @pytest.mark.asyncio
     async def test_start_returns_202(self, adapter):
         app = _create_runs_app(adapter)
         async with TestClient(TestServer(app)) as cli:
@@ -370,6 +383,43 @@ class TestStartRun:
         assert first.status == 202
         assert conflict.status == 409
         assert payload["error"]["code"] == "idempotency_conflict"
+
+    @pytest.mark.asyncio
+    async def test_idempotency_keys_are_scoped_by_profile(self, adapter):
+        app = _create_runs_app(adapter)
+        app.middlewares.insert(0, adapter._make_profile_prefix_middleware())
+        app.router.add_post("/p/{profile}/v1/runs", adapter._handle_runs)
+
+        with patch.object(
+            adapter,
+            "_resolve_request_profile",
+            side_effect=lambda request: request.match_info.get("profile"),
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                with patch.object(adapter, "_create_agent") as mock_create:
+                    mock_agent = MagicMock()
+                    mock_agent.run_conversation.return_value = {"final_response": "done"}
+                    mock_agent.session_prompt_tokens = 0
+                    mock_agent.session_completion_tokens = 0
+                    mock_agent.session_total_tokens = 0
+                    mock_create.return_value = mock_agent
+                    headers = {"Idempotency-Key": "shared-key"}
+                    first = await cli.post(
+                        "/p/customer-support/v1/runs",
+                        json={"input": "hello"},
+                        headers=headers,
+                    )
+                    second = await cli.post(
+                        "/p/customer-support-specialist/v1/runs",
+                        json={"input": "hello"},
+                        headers=headers,
+                    )
+                    first_payload = await first.json()
+                    second_payload = await second.json()
+
+        assert first.status == 202
+        assert second.status == 202
+        assert first_payload["run_id"] != second_payload["run_id"]
 
     @pytest.mark.asyncio
     async def test_start_forwards_inline_image_and_remains_stoppable(self, auth_adapter):

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -211,8 +211,10 @@ class TestStartRun:
         ]
 
     @pytest.mark.asyncio
-    async def test_start_reloads_session_history_for_repeated_session(self, adapter):
-        app = _create_runs_app(adapter)
+    async def test_start_reloads_session_history_for_repeated_header_session(
+        self, auth_adapter
+    ):
+        app = _create_runs_app(auth_adapter)
         captured_histories = []
         stored_history = [
             {"role": "user", "content": "prior question"},
@@ -222,11 +224,11 @@ class TestStartRun:
         async with TestClient(TestServer(app)) as cli:
             with (
                 patch.object(
-                    adapter,
+                    auth_adapter,
                     "_conversation_history_for_session",
                     new_callable=AsyncMock,
                 ) as mock_history,
-                patch.object(adapter, "_create_agent") as mock_create,
+                patch.object(auth_adapter, "_create_agent") as mock_create,
             ):
                 mock_history.side_effect = [[], stored_history]
                 mock_agent = MagicMock()
@@ -244,10 +246,18 @@ class TestStartRun:
                 first_resp = await cli.post(
                     "/v1/runs",
                     json={"input": "first", "session_id": "crisp-session"},
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-Session-Id": "crisp-session",
+                    },
                 )
                 second_resp = await cli.post(
                     "/v1/runs",
                     json={"input": "second", "session_id": "crisp-session"},
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-Session-Id": "crisp-session",
+                    },
                 )
 
                 assert first_resp.status == 202
@@ -266,23 +276,27 @@ class TestStartRun:
 
     @pytest.mark.asyncio
     async def test_start_fails_closed_when_session_history_cannot_be_read(
-        self, adapter
+        self, auth_adapter
     ):
-        app = _create_runs_app(adapter)
+        app = _create_runs_app(auth_adapter)
 
         async with TestClient(TestServer(app)) as cli:
             with (
                 patch.object(
-                    adapter,
+                    auth_adapter,
                     "_conversation_history_for_session",
                     new_callable=AsyncMock,
                     side_effect=OSError("database unavailable"),
                 ) as mock_history,
-                patch.object(adapter, "_create_agent") as mock_create,
+                patch.object(auth_adapter, "_create_agent") as mock_create,
             ):
                 resp = await cli.post(
                     "/v1/runs",
                     json={"input": "second", "session_id": "crisp-session"},
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-Session-Id": "crisp-session",
+                    },
                 )
                 payload = await resp.json()
 
@@ -295,24 +309,59 @@ class TestStartRun:
         mock_create.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_start_reuses_run_for_the_same_idempotency_key(self, adapter):
+    async def test_body_session_id_remains_correlation_only(self, adapter):
         app = _create_runs_app(adapter)
 
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_create_agent") as mock_create:
+            with (
+                patch.object(
+                    adapter,
+                    "_conversation_history_for_session",
+                    new_callable=AsyncMock,
+                    side_effect=OSError("database unavailable"),
+                ) as mock_history,
+                patch.object(adapter, "_create_agent") as mock_create,
+            ):
                 mock_agent = MagicMock()
                 mock_agent.run_conversation.return_value = {"final_response": "done"}
                 mock_agent.session_prompt_tokens = 0
                 mock_agent.session_completion_tokens = 0
                 mock_agent.session_total_tokens = 0
                 mock_create.return_value = mock_agent
-                headers = {"Idempotency-Key": "crisp-event-123"}
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "legacy-session"},
+                )
+                payload = await resp.json()
+
+        assert resp.status == 202
+        assert payload["session_id"] == "legacy-session"
+        mock_history.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_start_reuses_run_for_the_same_idempotency_key(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+                headers = {
+                    "Authorization": "Bearer sk-secret",
+                    "Idempotency-Key": "crisp-event-123",
+                    "X-Hermes-Session-Id": "crisp-session",
+                }
                 async def delayed_history(*_args, **_kwargs):
                     await asyncio.sleep(0.05)
                     return []
 
                 with patch.object(
-                    adapter,
+                    auth_adapter,
                     "_conversation_history_for_session",
                     side_effect=delayed_history,
                 ):
@@ -331,7 +380,7 @@ class TestStartRun:
                 first_payload = await first.json()
                 second_payload = await second.json()
                 with patch.object(
-                    adapter,
+                    auth_adapter,
                     "_conversation_history_for_session",
                     side_effect=RuntimeError("session db unavailable"),
                 ):

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -146,6 +146,279 @@ class TestStartRun:
                 assert status["object"] == "hermes.run"
 
     @pytest.mark.asyncio
+    async def test_start_normalizes_text_parts_without_changing_history(self, adapter):
+        app = _create_runs_app(adapter)
+        captured = {}
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+
+                def _capture_run(user_message=None, conversation_history=None, task_id=None):
+                    captured.update(
+                        user_message=user_message,
+                        conversation_history=conversation_history,
+                    )
+                    return {"final_response": "done"}
+
+                mock_agent.run_conversation.side_effect = _capture_run
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "text", "text": "hello"},
+                                    {"type": "text", "text": "there"},
+                                ],
+                            }
+                        ],
+                        "conversation_history": [
+                            {"role": "user", "content": "prior question"},
+                            {"role": "assistant", "content": "prior answer"},
+                        ],
+                    },
+                )
+                assert resp.status == 202
+                for _ in range(40):
+                    if captured:
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert captured["user_message"] == "hello\nthere"
+        assert captured["conversation_history"] == [
+            {"role": "user", "content": "prior question"},
+            {"role": "assistant", "content": "prior answer"},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_start_forwards_inline_image_and_remains_stoppable(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        image_data_url = "data:image/png;base64,iVBORw0KGgo="
+        image_input = [
+            {"type": "text", "text": "Ce arata captura?"},
+            {
+                "type": "image_url",
+                "image_url": {"url": image_data_url, "detail": "high"},
+            },
+        ]
+        captured = {}
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent") as mock_create:
+                mock_agent, agent_ready, _ = _make_slow_agent()
+
+                def _capture_run(user_message=None, conversation_history=None, task_id=None):
+                    captured.update(
+                        user_message=user_message,
+                        conversation_history=conversation_history,
+                        task_id=task_id,
+                    )
+                    return _original_slow_run(
+                        user_message=user_message,
+                        conversation_history=conversation_history,
+                        task_id=task_id,
+                    )
+
+                _original_slow_run = mock_agent.run_conversation.side_effect
+                mock_agent.run_conversation.side_effect = _capture_run
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-Session-Id": " crisp-session ",
+                    },
+                    json={
+                        "input": [{"role": "user", "content": image_input}],
+                        "session_id": "crisp-session",
+                    },
+                )
+                data = await resp.json()
+
+                assert resp.status == 202
+                assert data["session_id"] == "crisp-session"
+                assert resp.headers["X-Hermes-Session-Id"] == "crisp-session"
+                run_id = data["run_id"]
+                assert agent_ready.wait(timeout=3.0)
+
+                request_headers = {
+                    "Authorization": "Bearer sk-secret",
+                    "X-Hermes-Session-Id": "crisp-session",
+                }
+                status_resp = await cli.get(
+                    f"/v1/runs/{run_id}", headers=request_headers
+                )
+                status = await status_resp.json()
+                assert status["session_id"] == "crisp-session"
+
+                stop_resp = await cli.post(
+                    f"/v1/runs/{run_id}/stop", headers=request_headers
+                )
+                assert stop_resp.status == 200
+
+        assert captured == {
+            "user_message": image_input,
+            "conversation_history": [],
+            "task_id": "crisp-session",
+        }
+        mock_agent.interrupt.assert_called_once_with("Stop requested via API")
+
+    @pytest.mark.asyncio
+    async def test_start_rejects_non_image_data_url(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "text", "text": "read this"},
+                                    {
+                                        "type": "image_url",
+                                        "image_url": {
+                                            "url": "data:text/plain;base64,aGVsbG8="
+                                        },
+                                    },
+                                ],
+                            }
+                        ]
+                    },
+                )
+                payload = await resp.json()
+
+        assert resp.status == 400
+        assert payload["error"]["code"] == "unsupported_content_type"
+        assert payload["error"]["param"] == "input[0].content"
+        assert adapter._run_streams == {}
+        assert adapter._run_statuses == {}
+        mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("invalid_item", [42, {"role": "user"}])
+    async def test_start_rejects_invalid_input_array_items(self, adapter, invalid_item):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": [
+                            {"role": "user", "content": "valid first message"},
+                            invalid_item,
+                        ]
+                    },
+                )
+                payload = await resp.json()
+
+        assert resp.status == 400
+        assert payload["error"]["code"] == "invalid_input_item"
+        assert payload["error"]["param"] == "input[1]"
+        assert adapter._run_streams == {}
+        assert adapter._run_statuses == {}
+        mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_start_rejects_session_header_body_mismatch(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent") as mock_create:
+                resp = await cli.post(
+                    "/v1/runs",
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-Session-Id": "header-session",
+                    },
+                    json={"input": "hello", "session_id": "body-session"},
+                )
+                payload = await resp.json()
+
+        assert resp.status == 400
+        assert payload["error"]["code"] == "session_id_mismatch"
+        assert auth_adapter._run_streams == {}
+        assert auth_adapter._run_statuses == {}
+        mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_start_rejects_unsafe_session_header(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent") as mock_create:
+                resp = await cli.post(
+                    "/v1/runs",
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-Session-Id": "../../other-session",
+                    },
+                    json={"input": "hello"},
+                )
+
+        assert resp.status == 400
+        assert auth_adapter._run_streams == {}
+        assert auth_adapter._run_statuses == {}
+        mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_start_rejects_unsafe_body_session_id(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "../../other-session"},
+                )
+                payload = await resp.json()
+
+        assert resp.status == 400
+        assert payload["error"]["code"] == "invalid_session_id"
+        assert adapter._run_streams == {}
+        assert adapter._run_statuses == {}
+        mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_start_rejects_non_string_body_session_id(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": 123},
+                )
+                payload = await resp.json()
+
+        assert resp.status == 400
+        assert payload["error"]["code"] == "invalid_session_id"
+        assert payload["error"]["param"] == "session_id"
+        assert adapter._run_streams == {}
+        assert adapter._run_statuses == {}
+        mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_start_session_header_requires_api_key_configuration(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                resp = await cli.post(
+                    "/v1/runs",
+                    headers={"X-Hermes-Session-Id": "crisp-session"},
+                    json={"input": "hello"},
+                )
+
+        assert resp.status == 403
+        assert adapter._run_streams == {}
+        assert adapter._run_statuses == {}
+        mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_start_binds_chat_id_for_delegation_wake_target(self, adapter):
         """/v1/runs must bind the raw session id as the api_server chat_id
         (like every other agent-entry route does via _run_agent): the async
@@ -374,7 +647,9 @@ class TestRunStatus:
                     "/v1/runs",
                     json={"input": "hello", "session_id": "space-session"},
                 )
+                assert resp.headers["X-Hermes-Session-Id"] == "space-session"
                 data = await resp.json()
+                assert data["session_id"] == "space-session"
                 run_id = data["run_id"]
 
                 for _ in range(20):

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -20,6 +20,7 @@ from aiohttp.test_utils import TestClient, TestServer
 from gateway.config import PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
+    _api_request_profile,
     _approval_event_choices,
     cors_middleware,
     security_headers_middleware,
@@ -401,6 +402,47 @@ class TestStartRun:
         assert second_payload == first_payload
         assert replay_payload == first_payload
         assert mock_create.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_idempotent_retry_bypasses_concurrency_limit(self, auth_adapter):
+        auth_adapter._max_concurrent_runs = 1
+        app = _create_runs_app(auth_adapter)
+        headers = {
+            "Authorization": "Bearer sk-secret",
+            "Idempotency-Key": "crisp-event-123",
+            "X-Hermes-Session-Id": "crisp-session",
+        }
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent") as mock_create:
+                mock_agent, agent_ready, _ = _make_slow_agent()
+                mock_create.return_value = mock_agent
+
+                first = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "crisp-session"},
+                    headers=headers,
+                )
+                first_payload = await first.json()
+                assert first.status == 202
+                assert agent_ready.wait(timeout=3.0)
+
+                retry = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "crisp-session"},
+                    headers=headers,
+                )
+                retry_payload = await retry.json()
+
+                assert retry.status == 202
+                assert retry_payload == first_payload
+                assert mock_create.call_count == 1
+
+                mock_agent.interrupt("finish test")
+                for _ in range(40):
+                    if not auth_adapter._active_run_tasks:
+                        break
+                    await asyncio.sleep(0.05)
 
     @pytest.mark.asyncio
     async def test_start_rejects_idempotency_key_reuse_for_different_input(

--- a/tests/gateway/test_delivery.py
+++ b/tests/gateway/test_delivery.py
@@ -449,6 +449,53 @@ async def test_explicit_telegram_group_thread_does_not_mark_dm_fallback(tmp_path
     assert adapter.calls[0]["metadata"] == {"thread_id": "42"}
 
 
+@pytest.mark.asyncio
+async def test_gateway_message_before_send_adds_plugin_keyboard(tmp_path, monkeypatch):
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    adapter = RecordingAdapter()
+    router = DeliveryRouter(GatewayConfig(), adapters={Platform.TELEGRAM: adapter})
+    target = DeliveryTarget.parse("telegram:-100123:42")
+    calls = []
+
+    monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: name == "gateway_message_before_send")
+    monkeypatch.setattr(
+        "hermes_cli.plugins.invoke_hook",
+        lambda name, **kwargs: calls.append((name, kwargs)) or [
+            {
+                "telegram_inline_keyboard": [[
+                    {"text": "👍", "callback_data": "rf:up:exec-1"},
+                    {"text": "👎", "callback_data": "rf:down:exec-1"},
+                ]]
+            }
+        ],
+    )
+
+    await router._deliver_to_platform(
+        target,
+        "hello",
+        metadata={
+            "source": "cron",
+            "execution_id": "exec-1",
+            "job_id": "job-1",
+            "routine_feedback_eligible": True,
+        },
+    )
+
+    assert calls == [(
+        "gateway_message_before_send",
+        {
+            "source": "cron",
+            "execution_id": "exec-1",
+            "job_id": "job-1",
+            "routine_feedback_eligible": True,
+            "platform": "telegram",
+            "chat_id": "-100123",
+            "thread_id": "42",
+        },
+    )]
+    assert adapter.calls[0]["metadata"]["telegram_inline_keyboard"][0][0]["text"] == "👍"
+
+
 class FailingAdapter:
     async def send(self, chat_id, content, metadata=None):
         return SendResult(success=False, error="route failed", retryable=False)
@@ -600,5 +647,3 @@ async def test_save_failure_during_truncation_raises_for_non_chunking_adapter(tm
     # retry (footer needs the path) re-raises.
     with pytest.raises(OSError, match="No space left on device"):
         await router._deliver_to_platform(target, long_content, metadata={"job_id": "job7"})
-
-

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -7,6 +7,7 @@ Mirrors test_telegram_approval_buttons.py for the new ``send_clarify`` and
 import os
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -521,3 +522,133 @@ class TestBaseAdapterClarifyFallback:
         assert "Free form?" in adapter.sent[0]
         # No numbered list — choices were empty
         assert "1." not in adapter.sent[0]
+
+
+@pytest.mark.asyncio
+async def test_send_uses_plugin_keyboard_metadata():
+    adapter = _make_adapter()
+    message = MagicMock(message_id=100)
+    adapter._bot.send_message = AsyncMock(return_value=message)
+    adapter._should_attempt_rich = MagicMock(return_value=False)
+
+    result = await adapter.send(
+        "12345",
+        "Routine result",
+        metadata={
+            "telegram_inline_keyboard": [[
+                {"text": "👍", "callback_data": "rf:up:exec-1"},
+                {"text": "👎", "callback_data": "rf:down:exec-1"},
+            ]]
+        },
+    )
+
+    assert result.success is True
+    assert result.message_id == "100"
+    assert adapter._bot.send_message.call_args.kwargs["reply_markup"] is not None
+
+
+def test_malformed_plugin_keyboard_does_not_disable_rich_delivery():
+    adapter = _make_adapter()
+    adapter._rich_eligible = MagicMock(return_value=True)
+
+    assert adapter._should_attempt_rich(
+        "Routine result", metadata={"telegram_inline_keyboard": "invalid"}
+    ) is True
+    assert adapter._should_attempt_rich(
+        "Routine result",
+        metadata={"telegram_inline_keyboard": [[{"text": "OK", "callback_data": "ok"}]]},
+    ) is False
+
+
+@pytest.mark.asyncio
+async def test_unmatched_callback_is_dispatched_to_plugin(monkeypatch):
+    adapter = _make_adapter()
+    adapter._is_callback_user_authorized = MagicMock(return_value=True)
+    monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: name == "telegram_callback_query")
+    monkeypatch.setattr(
+        "hermes_cli.plugins.invoke_hook",
+        lambda name, **kwargs: [{
+            "handled": True,
+            "answer_text": "Mulțumesc",
+            "clear_keyboard": True,
+        }],
+    )
+    query = SimpleNamespace(
+        data="rf:up:exec-1",
+        from_user=SimpleNamespace(id=7, first_name="Isac"),
+        message=SimpleNamespace(
+            chat_id="12345",
+            chat=SimpleNamespace(type="private"),
+            message_thread_id=None,
+            message_id=100,
+        ),
+        answer=AsyncMock(),
+        edit_message_reply_markup=AsyncMock(),
+    )
+
+    await adapter._handle_callback_query(
+        SimpleNamespace(callback_query=query),
+        SimpleNamespace(),
+    )
+
+    query.answer.assert_awaited_once_with(text="Mulțumesc")
+    query.edit_message_reply_markup.assert_awaited_once_with(reply_markup=None)
+
+
+@pytest.mark.asyncio
+async def test_unmatched_callback_does_not_reach_plugin_when_unauthorized(monkeypatch):
+    adapter = _make_adapter()
+    adapter._is_callback_user_authorized = MagicMock(return_value=False)
+    invoke = MagicMock()
+    monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: name == "telegram_callback_query")
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", invoke)
+    query = SimpleNamespace(
+        data="rf:up:exec-1",
+        from_user=SimpleNamespace(id=7, first_name="Other"),
+        message=SimpleNamespace(
+            chat_id="12345",
+            chat=SimpleNamespace(type="private"),
+            message_thread_id=None,
+            message_id=100,
+        ),
+        answer=AsyncMock(),
+    )
+
+    await adapter._handle_callback_query(
+        SimpleNamespace(callback_query=query),
+        SimpleNamespace(),
+    )
+
+    invoke.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_native_update_prompt_is_not_dispatched_to_plugin(monkeypatch, tmp_path):
+    adapter = _make_adapter()
+    invoke = MagicMock(return_value=[{"handled": True}])
+    monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: name == "telegram_callback_query")
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", invoke)
+    query = SimpleNamespace(
+        data="update_prompt:y",
+        from_user=SimpleNamespace(id=7, first_name="Isac"),
+        message=SimpleNamespace(
+            chat_id="12345",
+            chat=SimpleNamespace(type="private"),
+            message_thread_id=None,
+            message_id=100,
+        ),
+        answer=AsyncMock(),
+        edit_message_text=AsyncMock(),
+    )
+
+    with (
+        patch("hermes_constants.get_hermes_home", return_value=tmp_path),
+        patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}),
+    ):
+        await adapter._handle_callback_query(
+            SimpleNamespace(callback_query=query),
+            SimpleNamespace(),
+        )
+
+    invoke.assert_not_called()
+    assert (tmp_path / ".update_response").read_text() == "y"

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -21,6 +21,7 @@ def _make_adapter(
     allowed_chats=None,
     group_allowed_chats=None,
     guest_mode=None,
+    auto_allow_groups_from_trusted_adders=None,
     observe_unmentioned_group_messages=None,
     bot_username="hermes_bot",
 ):
@@ -63,6 +64,8 @@ def _make_adapter(
         extra["group_allowed_chats"] = []
     if guest_mode is not None:
         extra["guest_mode"] = guest_mode
+    if auto_allow_groups_from_trusted_adders is not None:
+        extra["auto_allow_groups_from_trusted_adders"] = auto_allow_groups_from_trusted_adders
     if observe_unmentioned_group_messages is not None:
         extra["observe_unmentioned_group_messages"] = observe_unmentioned_group_messages
 
@@ -70,6 +73,7 @@ def _make_adapter(
     adapter.platform = Platform.TELEGRAM
     adapter.config = PlatformConfig(enabled=True, token="***", extra=extra)
     adapter._bot = SimpleNamespace(id=999, username=bot_username)
+    adapter._active_telegram_auto_authorized_groups = set()
     adapter._message_handler = AsyncMock()
     adapter._pending_text_batches = {}
     adapter._pending_text_batch_tasks = {}
@@ -473,6 +477,74 @@ def test_group_messages_can_require_direct_trigger_via_config():
     # And commands still pass unconditionally when require_mention is disabled
     adapter_no_mention = _make_adapter(require_mention=False)
     assert adapter_no_mention._should_process_message(_group_message("/status"), is_command=True) is True
+
+
+def test_trusted_group_admission_denies_unregistered_group_for_allowed_sender():
+    adapter = _make_adapter(
+        require_mention=False,
+        group_allow_from=["111"],
+        auto_allow_groups_from_trusted_adders=True,
+    )
+    message = _group_message("hello")
+
+    assert adapter._is_user_authorized_from_message(message) is True
+    assert adapter._should_process_message(message) is False
+
+
+def test_trusted_group_admission_denies_guest_mention_from_unregistered_group():
+    text = "hello @hermes_bot"
+    adapter = _make_adapter(
+        require_mention=True,
+        guest_mode=True,
+        auto_allow_groups_from_trusted_adders=True,
+    )
+
+    assert adapter._should_process_message(
+        _group_message(text, entities=[_mention_entity(text)])
+    ) is False
+
+
+def test_explicit_group_admission_still_applies_mention_and_reply_gating():
+    text = "hello @hermes_bot"
+
+    for explicit_allowlist in (
+        {"allowed_chats": ["-100"]},
+        {"group_allowed_chats": ["-100"]},
+    ):
+        adapter = _make_adapter(
+            require_mention=True,
+            auto_allow_groups_from_trusted_adders=True,
+            **explicit_allowlist,
+        )
+
+        assert adapter._should_process_message(_group_message("hello")) is False
+        assert adapter._should_process_message(
+            _group_message(text, entities=[_mention_entity(text)])
+        ) is True
+        assert adapter._should_process_message(_group_message("reply", reply_to_bot=True)) is True
+
+
+def test_validated_dynamic_group_admission_still_applies_mention_gating(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    (state_dir / "telegram-auto-authorized-groups.json").write_text(
+        json.dumps({"chat_ids": ["-100"]}),
+        encoding="utf-8",
+    )
+    adapter = _make_adapter(
+        require_mention=True,
+        auto_allow_groups_from_trusted_adders=True,
+    )
+    adapter._active_telegram_auto_authorized_groups.add("-100")
+    text = "hello @hermes_bot"
+
+    assert adapter._should_process_message(_group_message("hello")) is False
+    assert adapter._should_process_message(
+        _group_message(text, entities=[_mention_entity(text)])
+    ) is True
 
 
 def test_explicit_multi_bot_mentions_route_only_to_named_bots():

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -99,6 +99,7 @@ _fake_telegram_ext = types.ModuleType("telegram.ext")
 _fake_telegram_ext.Application = object
 _fake_telegram_ext.CommandHandler = object
 _fake_telegram_ext.CallbackQueryHandler = object
+_fake_telegram_ext.ChatMemberHandler = object
 _fake_telegram_ext.MessageHandler = object
 _fake_telegram_ext.TypeHandler = object
 _fake_telegram_ext.ContextTypes = SimpleNamespace(DEFAULT_TYPE=object)

--- a/tests/gateway/test_telegram_trusted_group_adder.py
+++ b/tests/gateway/test_telegram_trusted_group_adder.py
@@ -1,0 +1,909 @@
+import asyncio
+import json
+import os
+import stat
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, Mock, call
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig, load_gateway_config
+from gateway.platforms.base import MessageType
+
+
+def _adapter(*, enabled: object = True, trusted=None, extra=None):
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    settings = dict(extra or {})
+    if enabled is not None:
+        settings["auto_allow_groups_from_trusted_adders"] = enabled
+    if trusted is not None:
+        settings["trusted_group_adders"] = trusted
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(enabled=True, token="not-written", extra=settings)
+    adapter._bot = SimpleNamespace(id=999, token="not-written")
+    adapter._active_telegram_auto_authorized_groups = set()
+    return adapter
+
+
+def _membership_update(
+    *,
+    chat_id=-100123,
+    chat_type="supergroup",
+    actor_id=111,
+    old_status="member",
+    new_status="administrator",
+    member_user_id=999,
+):
+    member = SimpleNamespace(
+        chat=SimpleNamespace(id=chat_id, type=chat_type, title="Private team content"),
+        from_user=SimpleNamespace(id=actor_id, username="secret-operator"),
+        old_chat_member=SimpleNamespace(
+            status=old_status,
+            user=SimpleNamespace(id=member_user_id),
+        ),
+        new_chat_member=SimpleNamespace(
+            status=new_status,
+            user=SimpleNamespace(id=member_user_id),
+        ),
+    )
+    return SimpleNamespace(my_chat_member=member)
+
+
+def _message(*, chat_id=-100123, chat_type="group", is_forum=False):
+    return SimpleNamespace(
+        chat=SimpleNamespace(
+            id=chat_id,
+            type=chat_type,
+            title="Private team content",
+            full_name=None,
+            is_forum=is_forum,
+        ),
+        from_user=SimpleNamespace(
+            id=111,
+            full_name="Trusted stakeholder",
+            is_bot=False,
+        ),
+        text="hello",
+        message_id=42,
+        message_thread_id=7 if is_forum else None,
+        is_topic_message=is_forum,
+        reply_to_message=None,
+        date=None,
+        forum_topic_created=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_trusted_admin_promotion_persists_and_extends_effective_allowlists(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _adapter(trusted=[111], extra={
+        "allowed_chats": ["-200"],
+        "group_allowed_chats": ["-300"],
+    })
+
+    await adapter._handle_my_chat_member(_membership_update(), None)
+
+    assert adapter._telegram_allowed_chats() == {"-200", "-100123"}
+    assert adapter._telegram_group_allowed_chats() == {"-300", "-100123"}
+
+    state_path = tmp_path / "state" / "telegram-auto-authorized-groups.json"
+    assert json.loads(state_path.read_text(encoding="utf-8")) == {
+        "chat_ids": ["-100123"]
+    }
+    if os.name != "nt":
+        assert stat.S_IMODE(state_path.parent.stat().st_mode) == 0o700
+        assert stat.S_IMODE(state_path.stat().st_mode) == 0o600
+    raw = state_path.read_text(encoding="utf-8")
+    assert "not-written" not in raw
+    assert "Private team content" not in raw
+    assert "secret-operator" not in raw
+
+
+def test_adapter_captures_profile_home_for_durable_group_state(monkeypatch, tmp_path):
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    first_home = tmp_path / "first-profile"
+    second_home = tmp_path / "second-profile"
+    unrelated_home = tmp_path / "later-runtime-scope"
+    config = PlatformConfig(
+        enabled=True,
+        token="not-written",
+        extra={"auto_allow_groups_from_trusted_adders": True},
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(first_home))
+    first = TelegramAdapter(config)
+    monkeypatch.setenv("HERMES_HOME", str(second_home))
+    second = TelegramAdapter(config)
+
+    # Multiplex dispatch runs after the construction-time profile scope exits.
+    monkeypatch.setenv("HERMES_HOME", str(unrelated_home))
+    first._write_telegram_auto_authorized_groups({"-100"})
+    second._write_telegram_auto_authorized_groups({"-200"})
+
+    assert first._telegram_auto_authorized_groups() == {"-100"}
+    assert second._telegram_auto_authorized_groups() == {"-200"}
+    assert json.loads(
+        (first_home / "state" / "telegram-auto-authorized-groups.json").read_text(
+            encoding="utf-8"
+        )
+    ) == {"chat_ids": ["-100"]}
+    assert json.loads(
+        (second_home / "state" / "telegram-auto-authorized-groups.json").read_text(
+            encoding="utf-8"
+        )
+    ) == {"chat_ids": ["-200"]}
+    assert not (unrelated_home / "state" / "telegram-auto-authorized-groups.json").exists()
+
+
+@pytest.mark.parametrize(
+    ("chat_type", "is_forum"),
+    [("group", False), ("supergroup", True)],
+)
+def test_message_event_marks_only_active_dynamic_groups(chat_type, is_forum):
+    adapter = _adapter(trusted=[111])
+    adapter._active_telegram_auto_authorized_groups.add("-100123")
+
+    event = adapter._build_message_event(
+        _message(chat_type=chat_type, is_forum=is_forum),
+        MessageType.TEXT,
+    )
+
+    assert event.metadata == {"telegram_auto_authorized_group_active": True}
+
+
+def test_message_event_does_not_mark_unreconciled_persisted_candidate(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    (state_dir / "telegram-auto-authorized-groups.json").write_text(
+        json.dumps({"chat_ids": ["-100123"]}),
+        encoding="utf-8",
+    )
+    adapter = _adapter(trusted=[111])
+
+    assert adapter._telegram_auto_authorized_groups() == {"-100123"}
+    event = adapter._build_message_event(_message(), MessageType.TEXT)
+
+    assert "telegram_auto_authorized_group_active" not in event.metadata
+
+
+@pytest.mark.parametrize(
+    ("message", "active", "enabled", "explicit"),
+    [
+        (_message(), set(), True, ["-100123"]),
+        (_message(), {"-100123"}, False, []),
+        (_message(chat_id=111, chat_type="private"), {"111"}, True, []),
+        (_message(chat_type="channel"), {"-100123"}, True, []),
+        (_message(), None, True, []),
+        (_message(), ["-100123"], True, []),
+        (_message(chat_id="malformed"), {"malformed"}, True, []),
+    ],
+)
+def test_message_event_dynamic_group_signal_fails_closed(
+    message, active, enabled, explicit
+):
+    adapter = _adapter(
+        enabled=enabled,
+        trusted=[111],
+        extra={"group_allowed_chats": explicit},
+    )
+    adapter._active_telegram_auto_authorized_groups = active
+
+    event = adapter._build_message_event(message, MessageType.TEXT)
+
+    assert "telegram_auto_authorized_group_active" not in event.metadata
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "update,adapter",
+    [
+        (_membership_update(actor_id=222), _adapter(trusted=[111])),
+        (_membership_update(new_status="member"), _adapter(trusted=[111])),
+        (_membership_update(chat_type="channel"), _adapter(trusted=[111])),
+        (_membership_update(chat_type="private", chat_id=123), _adapter(trusted=[111])),
+        (_membership_update(member_user_id=12345), _adapter(trusted=[111])),
+        (_membership_update(), _adapter(enabled=False, trusted=[111])),
+        (_membership_update(), _adapter(trusted="111")),
+        (_membership_update(), _adapter(trusted=[True, "not-an-id"])),
+        (_membership_update(), _adapter(enabled="sometimes", trusted=[111])),
+    ],
+)
+async def test_untrusted_or_malformed_updates_fail_closed(
+    monkeypatch, tmp_path, update, adapter
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    await adapter._handle_my_chat_member(update, None)
+
+    assert adapter._telegram_auto_authorized_groups() == set()
+    assert not (tmp_path / "state" / "telegram-auto-authorized-groups.json").exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("removed_status", ["member", "restricted", "left", "kicked"])
+async def test_transition_away_from_administrator_revokes_regardless_of_actor(
+    monkeypatch, tmp_path, removed_status
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _adapter(trusted=[111])
+    await adapter._handle_my_chat_member(_membership_update(), None)
+
+    await adapter._handle_my_chat_member(
+        _membership_update(
+            actor_id=222,
+            old_status="administrator",
+            new_status=removed_status,
+        ),
+        None,
+    )
+
+    assert adapter._telegram_auto_authorized_groups() == set()
+    assert adapter._telegram_allowed_chats() == set()
+    assert adapter._telegram_group_allowed_chats() == set()
+
+
+@pytest.mark.asyncio
+async def test_malformed_demotion_without_target_user_still_revokes_known_chat(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _adapter(trusted=[111])
+    await adapter._handle_my_chat_member(_membership_update(), None)
+
+    await adapter._handle_my_chat_member(
+        _membership_update(
+            actor_id=222,
+            old_status="administrator",
+            new_status="member",
+            member_user_id=None,
+        ),
+        None,
+    )
+
+    assert adapter._telegram_auto_authorized_groups() == set()
+    assert adapter._active_telegram_auto_authorized_group_ids() == set()
+
+
+@pytest.mark.asyncio
+async def test_gateway_authz_uses_only_reconciled_persisted_group_admission(
+    monkeypatch, tmp_path
+):
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    (state_dir / "telegram-auto-authorized-groups.json").write_text(
+        json.dumps({"chat_ids": ["-100123"]}),
+        encoding="utf-8",
+    )
+    adapter = _adapter(trusted=[111], extra={"group_allowed_chats": ["-200"]})
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-100123",
+        chat_type="group",
+        user_id=None,
+        user_name=None,
+    )
+
+    assert runner._is_user_authorized(source) is False
+
+    adapter._bot = SimpleNamespace(
+        id=999,
+        get_chat_member=AsyncMock(
+            return_value=SimpleNamespace(status="administrator")
+        ),
+    )
+    await adapter._reconcile_telegram_auto_authorized_groups()
+
+    assert runner._is_user_authorized(source) is True
+    assert adapter.config.extra["group_allowed_chats"] == ["-200"]
+
+
+def test_gateway_authz_strict_profile_ignores_legacy_group_environment(monkeypatch):
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+
+    monkeypatch.setenv("TELEGRAM_GROUP_ALLOWED_CHATS", "-100123")
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "42")
+    adapter = _adapter(trusted=[111])
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-100123",
+        chat_type="group",
+        user_id="42",
+        user_name=None,
+    )
+
+    assert adapter._telegram_group_allowed_chats() == set()
+    assert runner._is_user_authorized(source) is False
+
+
+@pytest.mark.asyncio
+async def test_restart_reconciliation_activates_only_current_administrators(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    (state_dir / "telegram-auto-authorized-groups.json").write_text(
+        json.dumps({"chat_ids": ["-100", "-200", "-300"]}),
+        encoding="utf-8",
+    )
+    adapter = _adapter(trusted=[111])
+
+    async def get_chat_member(chat_id, bot_id):
+        assert bot_id == 999
+        if chat_id == "-100":
+            return SimpleNamespace(status="administrator")
+        if chat_id == "-200":
+            return SimpleNamespace(status="member")
+        raise RuntimeError("Bot API unavailable")
+
+    adapter._bot = SimpleNamespace(id=999, get_chat_member=get_chat_member)
+
+    assert adapter._telegram_allowed_chats() == set()
+    await adapter._reconcile_telegram_auto_authorized_groups()
+
+    assert adapter._telegram_allowed_chats() == {"-100"}
+    assert adapter._telegram_group_allowed_chats() == {"-100"}
+    assert adapter._telegram_auto_authorized_groups() == {"-100", "-200", "-300"}
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_cannot_resurrect_group_after_concurrent_demotion(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    (state_dir / "telegram-auto-authorized-groups.json").write_text(
+        json.dumps({"chat_ids": ["-100123"]}),
+        encoding="utf-8",
+    )
+    validation_started = asyncio.Event()
+    finish_validation = asyncio.Event()
+
+    async def get_chat_member(chat_id, bot_id):
+        assert (chat_id, bot_id) == ("-100123", 999)
+        validation_started.set()
+        await finish_validation.wait()
+        return SimpleNamespace(status="administrator")
+
+    adapter = _adapter(trusted=[111])
+    adapter._bot = SimpleNamespace(id=999, get_chat_member=get_chat_member)
+
+    reconciliation = asyncio.create_task(
+        adapter._reconcile_telegram_auto_authorized_groups()
+    )
+    await validation_started.wait()
+    await adapter._handle_my_chat_member(
+        _membership_update(
+            actor_id=222,
+            old_status="administrator",
+            new_status="member",
+        ),
+        None,
+    )
+    finish_validation.set()
+    await reconciliation
+
+    assert adapter._telegram_auto_authorized_groups() == set()
+    assert adapter._active_telegram_auto_authorized_group_ids() == set()
+
+
+@pytest.mark.asyncio
+async def test_failed_durable_revocation_tombstones_against_inflight_reconciliation(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    state_path = state_dir / "telegram-auto-authorized-groups.json"
+    state_path.write_text(
+        json.dumps({"chat_ids": ["-100123"]}),
+        encoding="utf-8",
+    )
+    validation_started = asyncio.Event()
+    finish_validation = asyncio.Event()
+
+    async def get_chat_member(chat_id, bot_id):
+        assert (chat_id, bot_id) == ("-100123", 999)
+        validation_started.set()
+        await finish_validation.wait()
+        return SimpleNamespace(status="administrator")
+
+    adapter = _adapter(trusted=[111])
+    adapter._active_telegram_auto_authorized_groups.add("-100123")
+    adapter._bot = SimpleNamespace(id=999, get_chat_member=get_chat_member)
+    reconciliation = asyncio.create_task(
+        adapter._reconcile_telegram_auto_authorized_groups()
+    )
+    await validation_started.wait()
+
+    monkeypatch.setattr(
+        adapter,
+        "_write_telegram_auto_authorized_groups",
+        Mock(side_effect=OSError("disk full")),
+    )
+    await adapter._handle_my_chat_member(
+        _membership_update(old_status="administrator", new_status="member"),
+        None,
+    )
+    finish_validation.set()
+    await reconciliation
+
+    assert json.loads(state_path.read_text(encoding="utf-8")) == {
+        "chat_ids": ["-100123"]
+    }
+    assert adapter._active_telegram_auto_authorized_group_ids() == set()
+
+
+@pytest.mark.asyncio
+async def test_persistence_failure_never_creates_or_keeps_a_live_grant(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _adapter(trusted=[111])
+
+    def fail_write(_chat_ids):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(adapter, "_write_telegram_auto_authorized_groups", fail_write)
+
+    await adapter._handle_my_chat_member(_membership_update(), None)
+    assert adapter._telegram_allowed_chats() == set()
+
+    adapter._active_telegram_auto_authorized_groups.add("-100123")
+    await adapter._handle_my_chat_member(
+        _membership_update(
+            actor_id=222,
+            old_status="administrator",
+            new_status="member",
+        ),
+        None,
+    )
+    assert adapter._telegram_allowed_chats() == set()
+
+
+def test_strict_profile_allowlists_do_not_inherit_process_environment(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_ALLOWED_CHATS", "-100")
+    monkeypatch.setenv("TELEGRAM_GROUP_ALLOWED_CHATS", "-200")
+
+    profile_a_legacy = _adapter(enabled=False)
+    profile_b_strict = _adapter(enabled=True)
+
+    assert profile_a_legacy._telegram_allowed_chats() == {"-100"}
+    assert profile_a_legacy._telegram_group_allowed_chats() == {"-200"}
+    assert profile_b_strict._telegram_allowed_chats() == set()
+    assert profile_b_strict._telegram_group_allowed_chats() == set()
+
+
+@pytest.mark.asyncio
+async def test_promotion_with_missing_old_status_is_denied(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _adapter(trusted=[111])
+
+    await adapter._handle_my_chat_member(
+        _membership_update(old_status=None, new_status="administrator"),
+        None,
+    )
+
+    assert adapter._telegram_auto_authorized_groups() == set()
+    assert adapter._active_telegram_auto_authorized_group_ids() == set()
+
+
+@pytest.mark.asyncio
+async def test_recognized_non_admin_status_revokes_with_missing_old_status(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _adapter(trusted=[111])
+    await adapter._handle_my_chat_member(_membership_update(), None)
+
+    await adapter._handle_my_chat_member(
+        _membership_update(
+            actor_id=None,
+            old_status=None,
+            new_status="member",
+            member_user_id=None,
+        ),
+        None,
+    )
+
+    assert adapter._telegram_auto_authorized_groups() == set()
+    assert adapter._active_telegram_auto_authorized_group_ids() == set()
+
+
+@pytest.mark.asyncio
+async def test_unknown_new_status_revokes_known_dynamic_group(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _adapter(trusted=[111])
+    await adapter._handle_my_chat_member(_membership_update(), None)
+
+    await adapter._handle_my_chat_member(
+        _membership_update(old_status=None, new_status=None, member_user_id=None),
+        None,
+    )
+
+    assert adapter._telegram_auto_authorized_groups() == set()
+    assert adapter._active_telegram_auto_authorized_group_ids() == set()
+
+
+@pytest.mark.asyncio
+async def test_malformed_state_fails_closed_without_being_overwritten(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(mode=0o700)
+    state_path = state_dir / "telegram-auto-authorized-groups.json"
+    state_path.write_text('{"chat_ids": "-100123"}', encoding="utf-8")
+    adapter = _adapter(trusted=[111])
+
+    await adapter._handle_my_chat_member(_membership_update(), None)
+
+    assert adapter._telegram_auto_authorized_groups() == set()
+    assert state_path.read_text(encoding="utf-8") == '{"chat_ids": "-100123"}'
+
+
+@pytest.mark.asyncio
+async def test_symlinked_or_non_regular_state_is_rejected(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    external = tmp_path / "external.json"
+    external.write_text(json.dumps({"chat_ids": ["-100123"]}), encoding="utf-8")
+    state_path = state_dir / "telegram-auto-authorized-groups.json"
+    state_path.symlink_to(external)
+    adapter = _adapter(trusted=[111])
+
+    assert adapter._telegram_auto_authorized_groups() == set()
+    await adapter._handle_my_chat_member(_membership_update(), None)
+    assert state_path.is_symlink()
+    assert json.loads(external.read_text(encoding="utf-8")) == {
+        "chat_ids": ["-100123"]
+    }
+
+    state_path.unlink()
+    state_path.mkdir()
+    assert adapter._telegram_auto_authorized_groups() == set()
+
+
+@pytest.mark.parametrize("chat_id", ["0", "-0", "100", 100, True, "group"])
+def test_persisted_schema_accepts_only_negative_numeric_chat_id_strings(chat_id):
+    adapter = _adapter(trusted=[111])
+
+    assert adapter._validated_auto_authorized_chat_ids({"chat_ids": [chat_id]}) is None
+
+
+def test_trusted_adder_settings_bridge_from_profile_config(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "profile-home"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "telegram:\n"
+        "  auto_allow_groups_from_trusted_adders: true\n"
+        "  trusted_group_adders:\n"
+        "    - 111\n"
+        "    - \"222\"\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    config = load_gateway_config()
+    telegram_config = config.platforms[Platform.TELEGRAM]
+    adapter = _adapter(extra=telegram_config.extra)
+
+    assert telegram_config.extra["auto_allow_groups_from_trusted_adders"] is True
+    assert telegram_config.extra["trusted_group_adders"] == [111, "222"]
+    assert adapter._telegram_auto_allow_groups_from_trusted_adders() is True
+    assert adapter._telegram_trusted_group_adders() == {111, 222}
+
+
+def test_windows_state_write_keeps_atomic_replace_without_posix_operations(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _adapter(trusted=[111])
+    monkeypatch.setattr(adapter, "_supports_posix_group_state_security", lambda: False)
+    monkeypatch.setattr(os, "chmod", Mock(side_effect=AssertionError("POSIX chmod")))
+    monkeypatch.setattr(os, "fchmod", Mock(side_effect=AssertionError("POSIX fchmod")))
+    real_fsync = os.fsync
+    fsync_calls = []
+
+    def track_file_fsync(fd):
+        fsync_calls.append(fd)
+        return real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", track_file_fsync)
+
+    adapter._write_telegram_auto_authorized_groups({"-100123"})
+
+    state_path = tmp_path / "state" / "telegram-auto-authorized-groups.json"
+    assert json.loads(state_path.read_text(encoding="utf-8")) == {
+        "chat_ids": ["-100123"]
+    }
+    assert len(fsync_calls) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("chat_type", ["group", "supergroup"])
+async def test_strict_admission_rejects_group_callback_before_any_state_mutation(
+    monkeypatch, chat_type
+):
+    adapter = _adapter(trusted=[111])
+    adapter._approval_state = {7: "session-key"}
+    adapter._clarify_state = {"cid": "session-key"}
+    adapter._model_picker_state = {"-100123": {"page": 1}}
+    model_handler = AsyncMock()
+    choice_handler = AsyncMock()
+    monkeypatch.setattr(adapter, "_handle_model_picker_callback", model_handler)
+    monkeypatch.setattr(adapter, "_handle_choice_picker_callback", choice_handler)
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "111")
+
+    for data in ("mp:provider", "cp:reasoning", "ea:once:7", "cl:cid:0"):
+        query = SimpleNamespace(
+            data=data,
+            message=SimpleNamespace(
+                chat_id=-100123,
+                chat=SimpleNamespace(type=chat_type),
+                message_thread_id=8 if chat_type == "supergroup" else None,
+            ),
+            from_user=SimpleNamespace(id=111, first_name="Trusted"),
+            answer=AsyncMock(),
+        )
+        await adapter._handle_callback_query(
+            SimpleNamespace(callback_query=query), SimpleNamespace()
+        )
+        assert "not authorized" in query.answer.call_args.kwargs["text"].lower()
+
+    model_handler.assert_not_awaited()
+    choice_handler.assert_not_awaited()
+    assert adapter._approval_state == {7: "session-key"}
+    assert adapter._clarify_state == {"cid": "session-key"}
+    assert adapter._model_picker_state == {"-100123": {"page": 1}}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("chat_type", [None, "unknown"])
+async def test_strict_admission_rejects_negative_callback_with_malformed_chat_type(
+    monkeypatch, chat_type
+):
+    adapter = _adapter(trusted=[111])
+    adapter._approval_state = {7: "session-key"}
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "111")
+    query = SimpleNamespace(
+        data="ea:once:7",
+        message=SimpleNamespace(
+            chat_id=-100123,
+            chat=SimpleNamespace(type=chat_type),
+            message_thread_id=None,
+        ),
+        from_user=SimpleNamespace(id=111, first_name="Trusted"),
+        answer=AsyncMock(),
+    )
+
+    await adapter._handle_callback_query(
+        SimpleNamespace(callback_query=query), SimpleNamespace()
+    )
+
+    assert adapter._approval_state == {7: "session-key"}
+    assert "not authorized" in query.answer.call_args.kwargs["text"].lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("admission", ["explicit", "active"])
+async def test_admitted_group_callback_retains_existing_callback_auth(
+    monkeypatch, admission
+):
+    from tools import approval
+
+    extra = {"allowed_chats": ["-100123"]} if admission == "explicit" else {}
+    adapter = _adapter(trusted=[111], extra=extra)
+    if admission == "active":
+        adapter._active_telegram_auto_authorized_groups.add("-100123")
+    adapter._approval_state = {7: "session-key"}
+    resolved = Mock(return_value=0)
+    monkeypatch.setattr(approval, "resolve_gateway_approval", resolved)
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "111")
+    query = SimpleNamespace(
+        data="ea:once:7",
+        message=SimpleNamespace(
+            chat_id=-100123,
+            chat=SimpleNamespace(type="supergroup"),
+            message_thread_id=8,
+        ),
+        from_user=SimpleNamespace(id=111, first_name="Trusted"),
+        answer=AsyncMock(),
+        edit_message_text=AsyncMock(),
+    )
+
+    await adapter._handle_callback_query(
+        SimpleNamespace(callback_query=query), SimpleNamespace()
+    )
+
+    resolved.assert_called_once_with("session-key", "once")
+    assert adapter._approval_state == {}
+
+
+@pytest.mark.asyncio
+async def test_revoked_group_callback_is_denied_before_dispatch(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "111")
+    adapter = _adapter(trusted=[111])
+    await adapter._handle_my_chat_member(_membership_update(), None)
+    await adapter._handle_my_chat_member(
+        _membership_update(old_status="administrator", new_status="member"),
+        None,
+    )
+    adapter._handle_choice_picker_callback = AsyncMock()
+    query = SimpleNamespace(
+        data="cp:reasoning",
+        message=SimpleNamespace(
+            chat_id=-100123,
+            chat=SimpleNamespace(type="supergroup"),
+            message_thread_id=8,
+        ),
+        from_user=SimpleNamespace(id=111, first_name="Trusted"),
+        answer=AsyncMock(),
+    )
+
+    await adapter._handle_callback_query(
+        SimpleNamespace(callback_query=query), SimpleNamespace()
+    )
+
+    adapter._handle_choice_picker_callback.assert_not_awaited()
+    assert "not authorized" in query.answer.call_args.kwargs["text"].lower()
+
+
+def test_my_chat_member_handler_is_registered_on_each_application(monkeypatch):
+    import plugins.platforms.telegram.adapter as telegram_module
+
+    callbacks = []
+
+    class FakeChatMemberHandler:
+        MY_CHAT_MEMBER = "my-chat-member"
+
+        def __init__(self, callback, chat_member_types=None):
+            callbacks.append((callback, chat_member_types))
+
+    monkeypatch.setattr(telegram_module, "ChatMemberHandler", FakeChatMemberHandler, raising=False)
+    monkeypatch.setattr(telegram_module, "TelegramMessageHandler", Mock())
+    monkeypatch.setattr(telegram_module, "CallbackQueryHandler", Mock())
+    monkeypatch.setattr(
+        telegram_module,
+        "filters",
+        SimpleNamespace(
+            TEXT=MagicMock(),
+            COMMAND=MagicMock(),
+            LOCATION=MagicMock(),
+            VENUE=MagicMock(),
+            PHOTO=MagicMock(),
+            VIDEO=MagicMock(),
+            AUDIO=MagicMock(),
+            VOICE=MagicMock(),
+            Document=SimpleNamespace(ALL=MagicMock()),
+            Sticker=SimpleNamespace(ALL=MagicMock()),
+            StatusUpdate=SimpleNamespace(MIGRATE=MagicMock()),
+        ),
+    )
+    adapter = _adapter(trusted=[111])
+    first_app = SimpleNamespace(add_handler=Mock())
+    rebuilt_app = SimpleNamespace(add_handler=Mock())
+
+    adapter._register_handlers(first_app)
+    adapter._register_handlers(rebuilt_app)
+
+    assert callbacks == [
+        (adapter._handle_my_chat_member, FakeChatMemberHandler.MY_CHAT_MEMBER),
+        (adapter._handle_my_chat_member, FakeChatMemberHandler.MY_CHAT_MEMBER),
+    ]
+    assert telegram_module.TelegramMessageHandler.call_args_list.count(
+        call(telegram_module.filters.StatusUpdate.MIGRATE, adapter._handle_chat_migration)
+    ) == 2
+    assert first_app.add_handler.call_count == 7
+    assert rebuilt_app.add_handler.call_count == 7
+
+
+@pytest.mark.asyncio
+async def test_basic_group_migration_atomically_moves_active_dynamic_grant(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _adapter(
+        trusted=[111],
+        extra={"allowed_chats": ["-999"], "group_allowed_chats": ["-998"]},
+    )
+    await adapter._handle_my_chat_member(
+        _membership_update(chat_id=-100, chat_type="group"), None
+    )
+    update = SimpleNamespace(
+        effective_message=SimpleNamespace(
+            chat=SimpleNamespace(id=-100, type="group"),
+            migrate_to_chat_id=-1000000000100,
+        )
+    )
+
+    await adapter._handle_chat_migration(update, None)
+
+    assert adapter._telegram_auto_authorized_groups() == {"-1000000000100"}
+    assert "-100" not in adapter._telegram_allowed_chats()
+    assert "-1000000000100" in adapter._telegram_allowed_chats()
+    assert adapter.config.extra["allowed_chats"] == ["-999"]
+    assert adapter.config.extra["group_allowed_chats"] == ["-998"]
+
+
+@pytest.mark.asyncio
+async def test_migration_does_not_copy_explicit_or_unvalidated_persisted_grants(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    state_path = state_dir / "telegram-auto-authorized-groups.json"
+    state_path.write_text(json.dumps({"chat_ids": ["-200"]}), encoding="utf-8")
+    adapter = _adapter(extra={"allowed_chats": ["-100"]})
+
+    explicit_update = SimpleNamespace(
+        effective_message=SimpleNamespace(
+            chat=SimpleNamespace(id=-100, type="group"),
+            migrate_to_chat_id=-1000000000100,
+        )
+    )
+    await adapter._handle_chat_migration(explicit_update, None)
+    assert adapter._telegram_auto_authorized_groups() == {"-200"}
+    assert "-1000000000100" not in adapter._telegram_allowed_chats()
+
+    persisted_update = SimpleNamespace(
+        effective_message=SimpleNamespace(
+            chat=SimpleNamespace(id=-200, type="group"),
+            migrate_to_chat_id=-1000000000200,
+        )
+    )
+    await adapter._handle_chat_migration(persisted_update, None)
+    assert adapter._telegram_auto_authorized_groups() == {"-1000000000200"}
+    assert "-1000000000200" not in adapter._telegram_allowed_chats()
+
+
+@pytest.mark.asyncio
+async def test_migration_persistence_failure_revokes_old_without_activating_new(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _adapter(trusted=[111])
+    await adapter._handle_my_chat_member(
+        _membership_update(chat_id=-100, chat_type="group"), None
+    )
+    state_path = tmp_path / "state" / "telegram-auto-authorized-groups.json"
+
+    def fail_write(_chat_ids):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(adapter, "_write_telegram_auto_authorized_groups", fail_write)
+    update = SimpleNamespace(
+        effective_message=SimpleNamespace(
+            chat=SimpleNamespace(id=-100, type="group"),
+            migrate_to_chat_id=-1000000000100,
+        )
+    )
+
+    await adapter._handle_chat_migration(update, None)
+
+    assert adapter._telegram_allowed_chats() == set()
+    assert json.loads(state_path.read_text(encoding="utf-8")) == {
+        "chat_ids": ["-100"]
+    }

--- a/tests/hermes_cli/test_gateway_message_delivered_hook.py
+++ b/tests/hermes_cli/test_gateway_message_delivered_hook.py
@@ -1,0 +1,18 @@
+from hermes_cli.plugins import PluginManager, VALID_HOOKS
+
+
+def test_gateway_message_delivered_is_a_valid_hook_with_an_exact_payload():
+    payload = {
+        "source": "cron",
+        "execution_id": "exec-1",
+        "job_id": "job-1",
+        "platform": "telegram",
+        "chat_id": "123",
+        "thread_id": None,
+        "message_id": "456",
+    }
+    manager = PluginManager()
+    manager._hooks["gateway_message_delivered"] = [lambda **kwargs: kwargs]
+
+    assert "gateway_message_delivered" in VALID_HOOKS
+    assert manager.invoke_hook("gateway_message_delivered", **payload) == [payload]

--- a/tests/hermes_cli/test_hooks_cli.py
+++ b/tests/hermes_cli/test_hooks_cli.py
@@ -80,6 +80,41 @@ class TestHooksList:
 
 
 class TestHooksTest:
+    def test_gateway_message_delivered_uses_its_documented_synthetic_payload(self):
+        assert hooks_cli._DEFAULT_PAYLOADS["gateway_message_delivered"] == {
+            "source": "cron",
+            "execution_id": "test-execution",
+            "job_id": "test-job",
+            "platform": "telegram",
+            "chat_id": "test-chat",
+            "thread_id": "test-thread",
+            "message_id": "test-message",
+        }
+
+    def test_gateway_message_delivered_test_command_serializes_its_payload(self, tmp_path):
+        capture = tmp_path / "captured.json"
+        script = _hook_script(
+            tmp_path,
+            f"#!/usr/bin/env bash\ncat - > {capture}\nprintf '{{}}\\n'\n",
+        )
+        cfg = {"hooks": {"gateway_message_delivered": [{"command": str(script)}]}}
+
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            _run(SimpleNamespace(
+                hooks_action="test", event="gateway_message_delivered",
+                for_tool=None, payload_file=None,
+            ))
+
+        assert json.loads(capture.read_text())["extra"] == {
+            "source": "cron",
+            "execution_id": "test-execution",
+            "job_id": "test-job",
+            "platform": "telegram",
+            "chat_id": "test-chat",
+            "thread_id": "test-thread",
+            "message_id": "test-message",
+        }
+
     def test_synthetic_payload_matches_production_shape(self, tmp_path):
         """`hermes hooks test` must feed the script stdin in the same
         shape invoke_hook() would at runtime.  Prior to this fix,

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -70,6 +70,7 @@ class TestFetchOpenRouterModels:
                 return b'{"data":[{"id":"anthropic/claude-opus-4.8","pricing":{"prompt":"0.000015","completion":"0.000075"}},{"id":"qwen/qwen3.7-max","pricing":{"prompt":"0.000000325","completion":"0.00000195"}},{"id":"nvidia/nemotron-3-super-120b-a12b:free","pricing":{"prompt":"0","completion":"0"}}]}'
 
         monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        monkeypatch.setattr("hermes_cli.model_catalog.get_curated_openrouter_models", lambda: None)
         with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()):
             models = fetch_openrouter_models(force_refresh=True)
 
@@ -167,6 +168,7 @@ class TestFetchOpenRouterModels:
                 )
 
         monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        monkeypatch.setattr("hermes_cli.model_catalog.get_curated_openrouter_models", lambda: None)
         with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()):
             models = fetch_openrouter_models(force_refresh=True)
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -104,6 +104,22 @@ class TestPluginDiscovery:
         assert "hello_plugin" in mgr._plugins
         assert mgr._plugins["hello_plugin"].enabled
 
+    def test_plugin_requires_supported_hooks(self, tmp_path, monkeypatch):
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "future_plugin",
+            manifest_extra={"requires_hooks": ["future_hook"]},
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        plugin = mgr._plugins["future_plugin"]
+        assert plugin.enabled is False
+        assert plugin.error == "requires unsupported hook(s): future_hook"
+
     def test_plugin_can_register_and_invoke_middleware(self, tmp_path, monkeypatch):
         plugins_dir = tmp_path / "hermes_test" / "plugins"
         _make_plugin_dir(
@@ -634,6 +650,16 @@ class TestPluginHooks:
 
     def test_valid_hooks_include_pre_gateway_dispatch(self):
         assert "pre_gateway_dispatch" in VALID_HOOKS
+
+    def test_valid_hooks_include_telegram_feedback_hooks(self):
+        assert "gateway_message_before_send" in VALID_HOOKS
+        assert "telegram_callback_query" in VALID_HOOKS
+
+    def test_context_reports_hook_support(self):
+        ctx = PluginContext(PluginManifest(name="test"), PluginManager())
+
+        assert ctx.supports_hook("telegram_callback_query") is True
+        assert ctx.supports_hook("future_hook") is False
 
     def test_pre_gateway_dispatch_collects_action_dicts(self, tmp_path, monkeypatch):
         """pre_gateway_dispatch callbacks return action dicts (skip/rewrite/allow)."""

--- a/tests/tools/test_cron_approval_mode.py
+++ b/tests/tools/test_cron_approval_mode.py
@@ -380,7 +380,7 @@ class TestCronWithGatewayOrigin:
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
 
         from gateway.session_context import set_session_vars, clear_session_vars
-        tokens = set_session_vars(platform="telegram", chat_id="123")
+        tokens = set_session_vars(platform="telegram", chat_id="123", cron_session=True)
         try:
             from unittest.mock import patch as mock_patch
             with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):
@@ -402,7 +402,7 @@ class TestCronWithGatewayOrigin:
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
 
         from gateway.session_context import set_session_vars, clear_session_vars
-        tokens = set_session_vars(platform="discord", chat_id="456")
+        tokens = set_session_vars(platform="discord", chat_id="456", cron_session=True)
         try:
             from unittest.mock import patch as mock_patch
             with mock_patch("tools.approval._get_cron_approval_mode", return_value="approve"):
@@ -422,7 +422,7 @@ class TestCronWithGatewayOrigin:
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
 
         from gateway.session_context import set_session_vars, clear_session_vars
-        tokens = set_session_vars(platform="telegram", chat_id="789")
+        tokens = set_session_vars(platform="telegram", chat_id="789", cron_session=True)
         try:
             from unittest.mock import patch as mock_patch
             with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):

--- a/tests/tools/test_cron_context_isolation.py
+++ b/tests/tools/test_cron_context_isolation.py
@@ -1,0 +1,30 @@
+"""Regression tests for cron approval state isolation in long-lived gateways."""
+
+from gateway.session_context import clear_session_vars, reset_session_vars, set_session_vars
+from tools.approval import _is_cron_session, _is_gateway_approval_context
+
+
+def test_gateway_context_masks_stale_process_cron_flag(monkeypatch):
+    """A cron run must not make later Telegram turns look non-interactive."""
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+    tokens = set_session_vars(platform="telegram", cron_session=False)
+    try:
+        assert _is_cron_session() is False
+        assert _is_gateway_approval_context() is True
+    finally:
+        clear_session_vars(tokens)
+        reset_session_vars()
+
+
+def test_cron_context_is_task_local_without_process_env(monkeypatch):
+    """Cron approval mode works without mutating process-global os.environ."""
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+    tokens = set_session_vars(platform="", cron_session=True)
+    try:
+        assert _is_cron_session() is True
+        assert _is_gateway_approval_context() is False
+    finally:
+        clear_session_vars(tokens)
+        reset_session_vars()

--- a/tests/tools/test_cron_context_isolation.py
+++ b/tests/tools/test_cron_context_isolation.py
@@ -1,5 +1,7 @@
 """Regression tests for cron approval state isolation in long-lived gateways."""
 
+import threading
+
 from gateway.session_context import clear_session_vars, reset_session_vars, set_session_vars
 from tools.approval import _is_cron_session, _is_gateway_approval_context
 
@@ -7,7 +9,7 @@ from tools.approval import _is_cron_session, _is_gateway_approval_context
 def test_gateway_context_masks_stale_process_cron_flag(monkeypatch):
     """A cron run must not make later Telegram turns look non-interactive."""
     monkeypatch.setenv("HERMES_CRON_SESSION", "1")
-    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
     tokens = set_session_vars(platform="telegram", cron_session=False)
     try:
         assert _is_cron_session() is False
@@ -28,3 +30,37 @@ def test_cron_context_is_task_local_without_process_env(monkeypatch):
     finally:
         clear_session_vars(tokens)
         reset_session_vars()
+
+
+def test_concurrent_gateway_and_cron_contexts_do_not_bleed(monkeypatch):
+    """Overlapping gateway and cron turns keep independent approval policy."""
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    barrier = threading.Barrier(2)
+    results = {}
+
+    def inspect(name, *, platform, cron_session):
+        tokens = set_session_vars(platform=platform, cron_session=cron_session)
+        try:
+            barrier.wait(timeout=5)
+            results[name] = (_is_cron_session(), _is_gateway_approval_context())
+        finally:
+            clear_session_vars(tokens)
+            reset_session_vars()
+
+    gateway = threading.Thread(
+        target=inspect,
+        kwargs={"name": "gateway", "platform": "telegram", "cron_session": False},
+    )
+    cron = threading.Thread(
+        target=inspect,
+        kwargs={"name": "cron", "platform": "", "cron_session": True},
+    )
+    gateway.start()
+    cron.start()
+    gateway.join(timeout=10)
+    cron.join(timeout=10)
+
+    assert not gateway.is_alive()
+    assert not cron.is_alive()
+    assert results == {"gateway": (False, True), "cron": (True, False)}

--- a/tests/tools/test_cron_context_isolation.py
+++ b/tests/tools/test_cron_context_isolation.py
@@ -2,6 +2,8 @@
 
 import threading
 
+import pytest
+
 from gateway.session_context import clear_session_vars, reset_session_vars, set_session_vars
 from tools.approval import _is_cron_session, _is_gateway_approval_context
 
@@ -64,3 +66,16 @@ def test_concurrent_gateway_and_cron_contexts_do_not_bleed(monkeypatch):
     assert not gateway.is_alive()
     assert not cron.is_alive()
     assert results == {"gateway": (False, True), "cron": (True, False)}
+
+
+def test_cron_context_reader_does_not_hide_runtime_errors(monkeypatch):
+    """Unexpected context failures must not silently fall back to global state."""
+    import gateway.session_context as session_context
+
+    def fail_context_read(*_args, **_kwargs):
+        raise RuntimeError("broken context reader")
+
+    monkeypatch.setattr(session_context, "get_session_env", fail_context_read)
+
+    with pytest.raises(RuntimeError, match="broken context reader"):
+        _is_cron_session()

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -17,6 +17,7 @@ import types
 import unittest
 from unittest.mock import MagicMock, patch
 
+from agent.mcp_run_context import mcp_run_metadata, read_mcp_run_metadata
 from tools.delegate_tool import (
     DELEGATE_BLOCKED_TOOLS,
     DELEGATE_TASK_SCHEMA,
@@ -351,6 +352,35 @@ class TestDelegateTask(unittest.TestCase):
         self.assertEqual(result["results"][0]["summary"], "Result A")
         self.assertEqual(result["results"][1]["summary"], "Result B")
         self.assertIn("total_duration_seconds", result)
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_batch_workers_inherit_private_mcp_metadata(self, mock_run):
+        metadata = {"employee": "employee-42"}
+        observed = []
+
+        def _run(*_args, **kwargs):
+            observed.append(read_mcp_run_metadata())
+            return {
+                "task_index": kwargs["task_index"],
+                "status": "completed",
+                "summary": "Done",
+                "api_calls": 1,
+                "duration_seconds": 0,
+            }
+
+        mock_run.side_effect = _run
+        parent = _make_mock_parent()
+        with mcp_run_metadata(metadata):
+            result = json.loads(
+                delegate_task(
+                    tasks=[{"goal": "A"}, {"goal": "B"}],
+                    parent_agent=parent,
+                )
+            )
+
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(observed, [metadata, metadata])
+        self.assertIsNone(read_mcp_run_metadata())
 
     @patch("tools.delegate_tool._run_single_child")
     def test_batch_mode_accepts_json_string_tasks(self, mock_run):
@@ -2103,6 +2133,37 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
 
 
 class TestChildCredentialLeasing(unittest.TestCase):
+    def test_single_child_worker_inherits_private_mcp_metadata(self):
+        from tools.delegate_tool import _run_single_child
+
+        metadata = {"employee": "employee-42"}
+        observed = []
+        child = MagicMock()
+        child._credential_pool = None
+        child._subagent_id = None
+        child.tool_progress_callback = None
+        child.run_conversation.side_effect = lambda **_kwargs: (
+            observed.append(read_mcp_run_metadata())
+            or {
+                "final_response": "done",
+                "completed": True,
+                "api_calls": 1,
+                "messages": [],
+            }
+        )
+
+        with mcp_run_metadata(metadata):
+            result = _run_single_child(
+                task_index=0,
+                goal="Read employee schedule",
+                child=child,
+                parent_agent=_make_mock_parent(),
+            )
+
+        self.assertEqual(result["status"], "completed")
+        self.assertEqual(observed, [metadata])
+        self.assertIsNone(read_mcp_run_metadata())
+
     def test_run_single_child_acquires_and_releases_lease(self):
         from tools.delegate_tool import _run_single_child
 

--- a/tests/tools/test_mcp_run_metadata.py
+++ b/tests/tools/test_mcp_run_metadata.py
@@ -107,6 +107,24 @@ def test_server_without_opt_in_receives_no_run_metadata():
     )
 
 
+def test_string_opt_in_does_not_forward_run_metadata():
+    session = SimpleNamespace(
+        call_tool=AsyncMock(return_value=_ToolResult("ok")),
+    )
+    server = _server(session, forward="true")
+
+    with patch.dict(mcp_tool._servers, {"regular": server}, clear=False), patch(
+        "tools.mcp_tool._run_on_mcp_loop", side_effect=_run_direct
+    ), mcp_run_metadata({"private": "must-not-leak"}):
+        handler = mcp_tool._make_tool_handler("regular", "lookup", 30)
+        handler({"query": "public"})
+
+    session.call_tool.assert_awaited_once_with(
+        "lookup",
+        arguments={"query": "public"},
+    )
+
+
 def test_mcp_loop_propagates_metadata_without_leaking_after_scope():
     mcp_tool._ensure_mcp_loop()
     try:

--- a/tests/tools/test_mcp_run_metadata.py
+++ b/tests/tools/test_mcp_run_metadata.py
@@ -1,0 +1,149 @@
+import asyncio
+import json
+import threading
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from agent.mcp_run_context import mcp_run_metadata, read_mcp_run_metadata
+from tools import mcp_tool
+
+
+class _TextBlock:
+    type = "text"
+
+    def __init__(self, text: str):
+        self.text = text
+
+
+class _ToolResult:
+    isError = False
+    structuredContent = None
+
+    def __init__(self, text: str):
+        self.content = [_TextBlock(text)]
+
+
+def _run_direct(coro_or_factory, timeout=30):
+    coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+
+    async def _with_lock():
+        for server in mcp_tool._servers.values():
+            if getattr(server, "_rpc_lock", None) is None:
+                server._rpc_lock = asyncio.Lock()
+        return await coro
+
+    return asyncio.run(_with_lock())
+
+
+def _server(session, *, forward: bool):
+    return SimpleNamespace(
+        session=session,
+        _rpc_lock=None,
+        _config={"forward_run_metadata": forward},
+        _pending_call_context=None,
+    )
+
+
+def test_opted_in_server_receives_metadata_outside_model_arguments():
+    metadata = {
+        "magic.employee": {
+            "binding": "signed-secret-binding",
+            "crisp_session_id": "session-1",
+        }
+    }
+    session = SimpleNamespace(
+        call_tool=AsyncMock(return_value=_ToolResult("ok")),
+    )
+    server = _server(session, forward=True)
+
+    with patch.dict(mcp_tool._servers, {"employee": server}, clear=False), patch(
+        "tools.mcp_tool._run_on_mcp_loop", side_effect=_run_direct
+    ), mcp_run_metadata(metadata):
+        handler = mcp_tool._make_tool_handler("employee", "schedule", 30)
+        assert json.loads(handler({"visible": "value"})) == {"result": "ok"}
+
+    session.call_tool.assert_awaited_once_with(
+        "schedule",
+        arguments={"visible": "value"},
+        meta=metadata,
+    )
+    assert "signed-secret-binding" not in json.dumps({"visible": "value"})
+
+
+def test_metadata_never_changes_the_model_facing_tool_schema():
+    metadata = {"private": "schema-secret"}
+    listed_tool = SimpleNamespace(
+        name="schedule",
+        description="Read the schedule",
+        inputSchema={
+            "type": "object",
+            "properties": {"day": {"type": "string"}},
+            "required": ["day"],
+        },
+    )
+
+    with mcp_run_metadata(metadata):
+        schema = mcp_tool._convert_mcp_schema("employee", listed_tool)
+
+    assert schema["parameters"] == listed_tool.inputSchema
+    assert "schema-secret" not in json.dumps(schema)
+
+
+def test_server_without_opt_in_receives_no_run_metadata():
+    session = SimpleNamespace(
+        call_tool=AsyncMock(return_value=_ToolResult("ok")),
+    )
+    server = _server(session, forward=False)
+
+    with patch.dict(mcp_tool._servers, {"regular": server}, clear=False), patch(
+        "tools.mcp_tool._run_on_mcp_loop", side_effect=_run_direct
+    ), mcp_run_metadata({"private": "must-not-leak"}):
+        handler = mcp_tool._make_tool_handler("regular", "lookup", 30)
+        handler({"query": "public"})
+
+    session.call_tool.assert_awaited_once_with(
+        "lookup",
+        arguments={"query": "public"},
+    )
+
+
+def test_mcp_loop_propagates_metadata_without_leaking_after_scope():
+    mcp_tool._ensure_mcp_loop()
+    try:
+        async def _read():
+            return read_mcp_run_metadata()
+
+        with mcp_run_metadata({"request": "one"}):
+            assert mcp_tool._run_on_mcp_loop(_read, timeout=10) == {"request": "one"}
+        assert mcp_tool._run_on_mcp_loop(_read, timeout=10) is None
+    finally:
+        mcp_tool._stop_mcp_loop()
+
+
+def test_two_concurrent_runs_keep_metadata_isolated():
+    mcp_tool._ensure_mcp_loop()
+    barrier = threading.Barrier(2)
+    results = {}
+
+    async def _read_after_peer_started():
+        await asyncio.sleep(0.05)
+        return read_mcp_run_metadata()
+
+    def _run(key: str):
+        with mcp_run_metadata({"request": key}):
+            barrier.wait(timeout=5)
+            results[key] = mcp_tool._run_on_mcp_loop(_read_after_peer_started, timeout=10)
+
+    threads = [threading.Thread(target=_run, args=(key,)) for key in ("a", "b")]
+    try:
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=15)
+    finally:
+        mcp_tool._stop_mcp_loop()
+
+    assert results == {
+        "a": {"request": "a"},
+        "b": {"request": "b"},
+    }

--- a/tests/tools/test_request_tool_approval.py
+++ b/tests/tools/test_request_tool_approval.py
@@ -103,8 +103,7 @@ class TestRequestToolApproval:
     def test_cron_deny_mode_blocks(self, monkeypatch):
         monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
         monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
-        monkeypatch.setattr(approval, "env_var_enabled",
-                            lambda v: v == "HERMES_CRON_SESSION")
+        monkeypatch.setattr(approval, "_is_cron_session", lambda: True)
         monkeypatch.setattr(approval, "_get_cron_approval_mode", lambda: "deny")
         res = request_tool_approval("terminal", "smtp send")
         assert res["approved"] is False
@@ -113,8 +112,7 @@ class TestRequestToolApproval:
     def test_cron_approve_mode_allows(self, monkeypatch):
         monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
         monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
-        monkeypatch.setattr(approval, "env_var_enabled",
-                            lambda v: v == "HERMES_CRON_SESSION")
+        monkeypatch.setattr(approval, "_is_cron_session", lambda: True)
         monkeypatch.setattr(approval, "_get_cron_approval_mode", lambda: "approve")
         res = request_tool_approval("terminal", "smtp send")
         assert res["approved"] is True

--- a/tests/tools/test_snapshot_session_id_leak.py
+++ b/tests/tools/test_snapshot_session_id_leak.py
@@ -11,7 +11,7 @@ stale value and its ``echo $HERMES_SESSION_ID`` reported a FOREIGN session's id
 ``_inject_session_context_env``.
 
 The fix strips the per-session bridged vars (HERMES_SESSION_* / UI /
-CRON_AUTO_DELIVER_) from the snapshot at both dump sites in
+CRON_SESSION / CRON_AUTO_DELIVER_) from the snapshot at both dump sites in
 ``tools/environments/base.py``; they are re-injected fresh on every command.
 """
 
@@ -62,6 +62,7 @@ def test_export_snippet_shape():
     assert "${!HERMES_SESSION_*}" in snippet
     assert "${!HERMES_CRON_AUTO_DELIVER_*}" in snippet
     assert "HERMES_UI_SESSION_ID" in snippet
+    assert "HERMES_CRON_SESSION" in snippet
     assert "grep -vE" not in snippet
     assert "/tmp/snap.tmp.$BASHPID" in snippet
     # The redirection must be attached to a brace group wrapping the dump,

--- a/tests/tools/test_tts_provider_fallback.py
+++ b/tests/tools/test_tts_provider_fallback.py
@@ -1,0 +1,316 @@
+"""Regression coverage for opt-in TTS provider fallback.
+
+All synthesis functions are mocked: these tests prove routing and artifact
+atomicity without credentials, network requests, or real audio generation.
+"""
+
+import json
+import shlex
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from agent import tts_registry
+from hermes_cli import plugins
+from tools import tts_tool
+
+
+def _write_audio(_text: str, output_path: str, _config: dict) -> str:
+    Path(output_path).write_bytes(b"fallback-audio")
+    return output_path
+
+
+def _fallback_config() -> dict:
+    return {"provider": "elevenlabs", "fallback_provider": "openai"}
+
+
+def test_no_fallback_preserves_primary_dependency_error(tmp_path, monkeypatch):
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "elevenlabs"})
+    monkeypatch.setattr(tts_tool, "_import_elevenlabs", lambda: (_ for _ in ()).throw(ImportError()))
+
+    result = json.loads(tts_tool.text_to_speech_tool("hello", str(tmp_path / "out.mp3")))
+
+    assert result["success"] is False
+    assert result["error"] == (
+        "ElevenLabs provider selected but 'elevenlabs' package not installed. "
+        "Run: pip install elevenlabs"
+    )
+
+
+def test_normal_primary_path_uses_shared_dispatch_without_fallback(tmp_path, monkeypatch):
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "openai"})
+    monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_openai_tts", _write_audio)
+
+    output = tmp_path / "out.mp3"
+    result = json.loads(tts_tool.text_to_speech_tool("hello", str(output)))
+
+    assert result["success"] is True
+    assert result["provider"] == "openai"
+    assert "fallback_from" not in result
+    assert output.read_bytes() == b"fallback-audio"
+
+
+def test_missing_primary_sdk_uses_openai_fallback(tmp_path, monkeypatch):
+    monkeypatch.setattr(tts_tool, "_load_tts_config", _fallback_config)
+    monkeypatch.setattr(tts_tool, "_import_elevenlabs", lambda: (_ for _ in ()).throw(ImportError()))
+    monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_openai_tts", _write_audio)
+
+    result = json.loads(tts_tool.text_to_speech_tool("whole reply", str(tmp_path / "out.mp3")))
+
+    assert result["success"] is True
+    assert result["provider"] == "openai"
+    assert result["fallback_from"] == "elevenlabs"
+    assert "elevenlabs" in result["fallback_error"].lower()
+    assert (tmp_path / "out.mp3").read_bytes() == b"fallback-audio"
+
+
+def test_primary_runtime_failure_retries_complete_text_with_fallback(tmp_path, monkeypatch):
+    captured: list[str] = []
+
+    def fail_primary(text: str, output_path: str, _config: dict) -> str:
+        Path(output_path).write_bytes(b"partial-primary")
+        raise RuntimeError("quota exceeded")
+
+    def fallback(text: str, output_path: str, _config: dict) -> str:
+        captured.append(text)
+        Path(output_path).write_bytes(b"whole-fallback")
+        return output_path
+
+    monkeypatch.setattr(tts_tool, "_load_tts_config", _fallback_config)
+    monkeypatch.setattr(tts_tool, "_import_elevenlabs", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_elevenlabs", fail_primary)
+    monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_openai_tts", fallback)
+
+    whole_text = "first chunk. second chunk. third chunk."
+    output = tmp_path / "out.mp3"
+    result = json.loads(tts_tool.text_to_speech_tool(whole_text, str(output)))
+
+    assert result["success"] is True
+    assert captured == [whole_text]
+    assert output.read_bytes() == b"whole-fallback"
+    assert not list(tmp_path.glob(".*.primary.*"))
+    assert not list(tmp_path.glob(".*.fallback.*"))
+
+
+def test_primary_keeps_its_input_cap_and_fallback_uses_its_own_cap(tmp_path, monkeypatch, caplog):
+    primary_texts: list[str] = []
+    fallback_texts: list[str] = []
+
+    def fail_primary(text: str, _output_path: str, _config: dict) -> str:
+        primary_texts.append(text)
+        raise RuntimeError("quota exceeded")
+
+    def fallback(text: str, output_path: str, _config: dict) -> str:
+        fallback_texts.append(text)
+        Path(output_path).write_bytes(b"fallback-audio")
+        return output_path
+
+    monkeypatch.setattr(tts_tool, "_load_tts_config", _fallback_config)
+    monkeypatch.setattr(tts_tool, "_import_elevenlabs", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_elevenlabs", fail_primary)
+    monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_openai_tts", fallback)
+
+    text = "A" * 5000  # valid for ElevenLabs' default cap, over OpenAI's 4096
+    result = json.loads(tts_tool.text_to_speech_tool(text, str(tmp_path / "out.mp3")))
+
+    expected_primary = text[:5000]
+    expected_fallback = text[:4096]
+    assert result["success"] is True
+    assert primary_texts == [expected_primary]
+    assert fallback_texts == [expected_fallback]
+    assert result["text_truncated"] is True
+    assert result["original_text_length"] == 5000
+    assert result["synthesized_text_length"] == 4096
+    assert "fallback-ul openai" in result["warning"]
+    assert any("fallback text too long" in record.message for record in caplog.records)
+
+
+def test_primary_success_does_not_use_fallback_cap_or_emit_truncation_warning(tmp_path, monkeypatch):
+    captured: list[str] = []
+
+    def primary(text: str, output_path: str, _config: dict) -> str:
+        captured.append(text)
+        Path(output_path).write_bytes(b"primary-audio")
+        return output_path
+
+    monkeypatch.setattr(tts_tool, "_load_tts_config", _fallback_config)
+    monkeypatch.setattr(tts_tool, "_import_elevenlabs", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_elevenlabs", primary)
+    monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: object())
+
+    text = "A" * 5000
+    result = json.loads(tts_tool.text_to_speech_tool(text, str(tmp_path / "out.mp3")))
+
+    assert result["success"] is True
+    assert result["provider"] == "elevenlabs"
+    assert captured == [text]
+    assert "warning" not in result
+    assert "text_truncated" not in result
+
+
+@pytest.mark.parametrize("fallback", ["ELEVENLABS", "not-a-provider"])
+def test_invalid_or_self_referential_fallback_is_skipped(tmp_path, monkeypatch, fallback):
+    calls: list[str] = []
+
+    def fail_primary(*_args, **_kwargs):
+        calls.append("primary")
+        raise RuntimeError("quota exceeded")
+
+    config = {"provider": "elevenlabs", "fallback_provider": fallback}
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: config)
+    monkeypatch.setattr(tts_tool, "_import_elevenlabs", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_elevenlabs", fail_primary)
+
+    result = json.loads(tts_tool.text_to_speech_tool("hello", str(tmp_path / "out.mp3")))
+
+    assert result["success"] is False
+    assert calls == ["primary"]
+    assert "quota exceeded" in result["error"]
+
+
+def test_both_provider_failures_are_reported_without_secrets(tmp_path, monkeypatch):
+    secret = "do-not-leak-this-key"
+
+    monkeypatch.setattr(tts_tool, "_load_tts_config", _fallback_config)
+    monkeypatch.setattr(tts_tool, "_import_elevenlabs", lambda: object())
+    monkeypatch.setattr(
+        tts_tool, "_generate_elevenlabs",
+        lambda *_args: (_ for _ in ()).throw(
+            RuntimeError(f"quota failed Authorization: Token {secret}")
+        ),
+    )
+    monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: object())
+    monkeypatch.setattr(
+        tts_tool, "_generate_openai_tts",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("OpenAI billing disabled")),
+    )
+    monkeypatch.setattr(
+        tts_tool, "get_env_value",
+        lambda name, default=None: secret if name == "OPENAI_API_KEY" else default,
+    )
+
+    result = json.loads(tts_tool.text_to_speech_tool("hello", str(tmp_path / "out.mp3")))
+
+    assert result["success"] is False
+    assert "quota failed" in result["error"]
+    assert "OpenAI billing disabled" in result["error"]
+    assert secret not in result["error"]
+
+
+def test_preflight_uses_valid_fallback_when_primary_is_unavailable(monkeypatch):
+    monkeypatch.setattr(tts_tool, "_load_tts_config", _fallback_config)
+    monkeypatch.setattr(tts_tool, "_import_elevenlabs", lambda: (_ for _ in ()).throw(ImportError()))
+    monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: object())
+    monkeypatch.setattr(tts_tool, "_has_openai_audio_backend", lambda: True)
+
+    assert tts_tool.check_tts_requirements() is True
+
+
+def test_registered_plugin_is_a_valid_fallback_without_synthesizing(tmp_path, monkeypatch):
+    class PluginProvider:
+        voice_compatible = False
+
+        def __init__(self):
+            self.synthesize_calls = 0
+
+        def is_available(self):
+            return True
+
+        def synthesize(self, text, output_path, **_kwargs):
+            self.synthesize_calls += 1
+            Path(output_path).write_bytes(b"plugin-audio")
+            return output_path
+
+    plugin = PluginProvider()
+    monkeypatch.setattr(plugins, "_ensure_plugins_discovered", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        tts_registry, "get_provider", lambda name: plugin if name == "mock-plugin" else None,
+    )
+
+    assert tts_tool._get_tts_fallback_provider("elevenlabs", {
+        "provider": "elevenlabs", "fallback_provider": "mock-plugin",
+    }) == "mock-plugin"
+    assert plugin.synthesize_calls == 0
+
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {
+        "provider": "elevenlabs", "fallback_provider": "mock-plugin",
+    })
+    monkeypatch.setattr(tts_tool, "_import_elevenlabs", lambda: (_ for _ in ()).throw(ImportError()))
+    assert tts_tool.check_tts_requirements() is True
+
+    result = json.loads(tts_tool.text_to_speech_tool("whole reply", str(tmp_path / "out.mp3")))
+    assert result["success"] is True
+    assert result["provider"] == "mock-plugin"
+    assert plugin.synthesize_calls == 1
+
+
+def test_command_stderr_secret_never_reaches_fallback_metadata(tmp_path, monkeypatch):
+    secret = "nonstandard-command-secret"
+    config = {
+        "provider": "private-command",
+        "fallback_provider": "openai",
+        "providers": {
+            "private-command": {"type": "command", "command": "not-run"},
+        },
+    }
+
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: config)
+    monkeypatch.setattr(
+        tts_tool,
+        "_run_command_tts",
+        lambda *_args: (_ for _ in ()).throw(
+            subprocess.CalledProcessError(23, "not-run", stderr=secret)
+        ),
+    )
+    monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_openai_tts", _write_audio)
+
+    result = json.loads(tts_tool.text_to_speech_tool("hello", str(tmp_path / "out.mp3")))
+
+    assert result["success"] is True
+    assert "exited with code 23" in result["fallback_error"]
+    assert secret not in result["fallback_error"]
+
+
+def test_command_fallback_uses_its_configured_output_format(tmp_path, monkeypatch):
+    rendered_paths: list[Path] = []
+    config = {
+        "provider": "elevenlabs",
+        "fallback_provider": "wav-command",
+        "providers": {
+            "wav-command": {
+                "type": "command",
+                "command": "render {output_path}",
+                "output_format": "wav",
+            },
+        },
+    }
+
+    def fail_primary(*_args, **_kwargs):
+        raise RuntimeError("quota exceeded")
+
+    def render_command(command: str, _timeout: float):
+        output = Path(shlex.split(command)[1])
+        rendered_paths.append(output)
+        output.write_bytes(b"wav-audio")
+
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: config)
+    monkeypatch.setattr(tts_tool, "_import_elevenlabs", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_elevenlabs", fail_primary)
+    monkeypatch.setattr(tts_tool, "_run_command_tts", render_command)
+
+    requested = tmp_path / "requested.mp3"
+    result = json.loads(tts_tool.text_to_speech_tool("hello", str(requested)))
+
+    expected = tmp_path / "requested.wav"
+    assert result["success"] is True
+    assert result["provider"] == "wav-command"
+    assert result["file_path"] == str(expected)
+    assert rendered_paths and rendered_paths[0].suffix == ".wav"
+    assert expected.read_bytes() == b"wav-audio"
+    assert not requested.exists()

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -224,6 +224,17 @@ def _get_session_platform() -> str:
         return os.getenv("HERMES_SESSION_PLATFORM", "") or ""
 
 
+def _is_cron_session() -> bool:
+    """Return task-local cron state, falling back to env for legacy entrypoints."""
+    try:
+        from gateway.session_context import get_session_env
+
+        value = get_session_env("HERMES_CRON_SESSION", "")
+        return str(value).lower() in {"1", "true", "yes", "on"}
+    except Exception:
+        return env_var_enabled("HERMES_CRON_SESSION")
+
+
 def _is_gateway_approval_context() -> bool:
     """True when this call is inside a gateway/API session.
 
@@ -238,7 +249,7 @@ def _is_gateway_approval_context() -> bool:
     fall through to the gateway branch would submit a pending approval
     with no listener and block the job indefinitely.
     """
-    if env_var_enabled("HERMES_CRON_SESSION"):
+    if _is_cron_session():
         return False
     if env_var_enabled("HERMES_GATEWAY_SESSION"):
         return True
@@ -2869,7 +2880,7 @@ def _run_approval_gate(
 
     if not is_cli and not is_gateway:
         # Cron sessions: respect cron_mode config
-        if env_var_enabled("HERMES_CRON_SESSION"):
+        if _is_cron_session():
             if _get_cron_approval_mode() == "deny":
                 return {
                     "approved": False,
@@ -3397,7 +3408,7 @@ def check_all_command_guards(command: str, env_type: str,
     # flows, we do not block on approvals and we skip external guard work.
     if not is_cli and not is_gateway and not is_ask:
         # Cron sessions: respect cron_mode config
-        if env_var_enabled("HERMES_CRON_SESSION"):
+        if _is_cron_session():
             if _get_cron_approval_mode() == "deny":
                 # Run detection to get a description for the block message
                 is_dangerous, _pk, description = detect_dangerous_command(command)
@@ -3848,7 +3859,7 @@ def check_execute_code_guard(code: str, env_type: str,
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
 
     # Cron: no user is present to approve arbitrary code.
-    if env_var_enabled("HERMES_CRON_SESSION"):
+    if _is_cron_session():
         if _get_cron_approval_mode() == "deny":
             return {
                 "approved": False,

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -228,11 +228,11 @@ def _is_cron_session() -> bool:
     """Return task-local cron state, falling back to env for legacy entrypoints."""
     try:
         from gateway.session_context import get_session_env
-
-        value = get_session_env("HERMES_CRON_SESSION", "")
-        return str(value).lower() in {"1", "true", "yes", "on"}
-    except Exception:
+    except ImportError:
         return env_var_enabled("HERMES_CRON_SESSION")
+
+    value = get_session_env("HERMES_CRON_SESSION", "")
+    return str(value).lower() in {"1", "true", "yes", "on"}
 
 
 def _is_gateway_approval_context() -> bool:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -20,6 +20,7 @@ never the child's intermediate tool calls or reasoning.
 import enum
 import json
 import logging
+from contextvars import copy_context
 
 logger = logging.getLogger(__name__)
 import os
@@ -2183,7 +2184,10 @@ def _run_single_child(
                     stream_callback=_relay_child_text,
                 )
 
-        _child_future = _timeout_executor.submit(_run_with_thread_capture)
+        child_context = copy_context()
+        _child_future = _timeout_executor.submit(
+            child_context.run, _run_with_thread_capture
+        )
         try:
             result = _child_future.result(timeout=child_timeout)
         except Exception as _timeout_exc:
@@ -2984,7 +2988,9 @@ def delegate_task(
             with DaemonThreadPoolExecutor(max_workers=max_children) as executor:
                 futures = {}
                 for i, t, child in children:
+                    child_context = copy_context()
                     future = executor.submit(
+                        child_context.run,
                         _run_single_child,
                         task_index=i,
                         goal=t["goal"],

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -401,7 +401,8 @@ def _cwd_marker(session_id: str) -> str:
 # as the Python-side contract for the exclusion set; the dump path unsets by
 # name/prefix instead of grepping declare lines (see below / issue #71296).
 _SNAPSHOT_EXCLUDED_ENV_REGEX = (
-    "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_AUTO_DELIVER_)"
+    "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_SESSION|"
+    "HERMES_CRON_AUTO_DELIVER_)"
 )
 
 
@@ -431,7 +432,7 @@ def _export_dump_excluding_session_vars(tmp_path: str) -> str:
     return (
         "{ ( "
         "unset ${!HERMES_SESSION_*} ${!HERMES_CRON_AUTO_DELIVER_*} "
-        "HERMES_UI_SESSION_ID 2>/dev/null; "
+        "HERMES_UI_SESSION_ID HERMES_CRON_SESSION 2>/dev/null; "
         "export -p; "
         ") || true; } "
         f"> {tmp_path}"

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4639,11 +4639,9 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 # it and detect the gateway platform / session for routing.
                 server._pending_call_context = contextvars.copy_context()
                 try:
-                    forward_run_metadata = _parse_boolish(
-                        getattr(server, "_config", {}).get(
-                            "forward_run_metadata", False
-                        ),
-                        default=False,
+                    forward_run_metadata = (
+                        getattr(server, "_config", {}).get("forward_run_metadata")
+                        is True
                     )
                     if forward_run_metadata:
                         from agent.mcp_run_context import read_mcp_run_metadata

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4283,6 +4283,24 @@ def _wrap_with_dashboard_oauth_flow(coro):
     return _scoped()
 
 
+def _wrap_with_mcp_run_metadata(coro):
+    """Propagate private per-run MCP metadata onto the MCP loop task."""
+    try:
+        from agent.mcp_run_context import mcp_run_metadata, read_mcp_run_metadata
+
+        metadata = read_mcp_run_metadata()
+    except Exception:
+        return coro
+    if metadata is None:
+        return coro
+
+    async def _scoped():
+        with mcp_run_metadata(metadata):
+            return await coro
+
+    return _scoped()
+
+
 def _run_on_mcp_loop(coro_or_factory, timeout: float = 30):
     """Schedule a coroutine on the MCP event loop and block until done.
 
@@ -4318,6 +4336,7 @@ def _run_on_mcp_loop(coro_or_factory, timeout: float = 30):
     # scopes don't interfere). No-op when no override is active.
     coro = _wrap_with_home_override(coro)
     coro = _wrap_with_dashboard_oauth_flow(coro)
+    coro = _wrap_with_mcp_run_metadata(coro)
 
     future = safe_schedule_threadsafe(
         coro, loop,
@@ -4620,7 +4639,28 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 # it and detect the gateway platform / session for routing.
                 server._pending_call_context = contextvars.copy_context()
                 try:
-                    result = await server.session.call_tool(tool_name, arguments=args)
+                    forward_run_metadata = _parse_boolish(
+                        getattr(server, "_config", {}).get(
+                            "forward_run_metadata", False
+                        ),
+                        default=False,
+                    )
+                    if forward_run_metadata:
+                        from agent.mcp_run_context import read_mcp_run_metadata
+
+                        run_metadata = read_mcp_run_metadata()
+                    else:
+                        run_metadata = None
+                    if run_metadata is None:
+                        result = await server.session.call_tool(
+                            tool_name, arguments=args
+                        )
+                    else:
+                        result = await server.session.call_tool(
+                            tool_name,
+                            arguments=args,
+                            meta=run_metadata,
+                        )
                 finally:
                     server._pending_call_context = None
             # The RPC round-trip completed — the session is demonstrably

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -876,15 +876,8 @@ def _generate_command_tts(
                 f"TTS provider '{provider_name}' timed out after {timeout:g}s"
             ) from exc
         except subprocess.CalledProcessError as exc:
-            detail_parts = []
-            if exc.stderr:
-                detail_parts.append(f"stderr: {exc.stderr.strip()}")
-            if exc.stdout:
-                detail_parts.append(f"stdout: {exc.stdout.strip()}")
-            detail = "; ".join(detail_parts) or "no command output"
             raise RuntimeError(
-                f"TTS provider '{provider_name}' exited with code "
-                f"{exc.returncode}: {detail}"
+                f"TTS provider '{provider_name}' exited with code {exc.returncode}"
             ) from exc
 
     if not output.exists() or output.stat().st_size <= 0:
@@ -2288,6 +2281,225 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
 # ===========================================================================
 # Main tool function
 # ===========================================================================
+def _is_known_tts_provider(provider: str, tts_config: Dict[str, Any]) -> bool:
+    """Return whether *provider* names a built-in, command, or plugin backend.
+
+    Unknown primary providers retain the historical Edge fallback.  An unknown
+    fallback, however, must not silently become Edge: a fallback is an
+    explicit reliability contract and a typo must leave the primary error
+    intact rather than route audio somewhere unexpected.
+    """
+    if provider in BUILTIN_TTS_PROVIDERS:
+        return True
+    if _resolve_command_provider_config(provider, tts_config) is not None:
+        return True
+    try:
+        from agent.tts_registry import get_provider
+        from hermes_cli.plugins import _ensure_plugins_discovered
+
+        _ensure_plugins_discovered()
+        return get_provider(provider) is not None
+    except Exception:
+        return False
+
+
+def _get_tts_fallback_provider(
+    primary_provider: str,
+    tts_config: Dict[str, Any],
+) -> Optional[str]:
+    """Resolve the opt-in fallback provider, rejecting invalid/self loops."""
+    raw = tts_config.get("fallback_provider") if isinstance(tts_config, dict) else None
+    if not isinstance(raw, str):
+        return None
+    fallback = raw.lower().strip()
+    if not fallback or fallback == primary_provider.lower().strip():
+        return None
+    return fallback if _is_known_tts_provider(fallback, tts_config) else None
+
+
+def _safe_tts_error(exc: BaseException) -> str:
+    """Return concise provider evidence without leaking configured secrets."""
+    message = str(exc).strip() or exc.__class__.__name__
+    # Exception messages from HTTP libraries occasionally echo request headers.
+    # Remove values from the supported credential environment variables first,
+    # then redact common token-shaped header fragments as a second line of
+    # defense.  This evidence is returned to the tool caller and logged.
+    for env_name in (
+        "ELEVENLABS_API_KEY", "OPENAI_API_KEY", "VOICE_TOOLS_OPENAI_KEY",
+        "MINIMAX_API_KEY", "MISTRAL_API_KEY", "GEMINI_API_KEY",
+        "GOOGLE_API_KEY", "XAI_API_KEY", "DEEPINFRA_API_KEY",
+    ):
+        secret = get_env_value(env_name)
+        if secret:
+            message = message.replace(str(secret), "[REDACTED]")
+    message = re.sub(
+        r"(?i)(authorization\s*[:=]\s*)[^\r\n,;]+",
+        r"\1[REDACTED]",
+        message,
+    )
+    message = re.sub(
+        r"(?i)(bearer\s+|api[_ -]?key\s*[:=]\s*)([^\s,;]+)",
+        r"\1[REDACTED]",
+        message,
+    )
+    return message[:500]
+
+
+def _ensure_tts_output(path: str, provider: str) -> None:
+    """Raise when a provider returned without producing usable audio."""
+    if not os.path.exists(path) or os.path.getsize(path) == 0:
+        raise RuntimeError(f"TTS generation produced no output (provider: {provider})")
+
+
+def _tts_attempt_path(destination: str, attempt: str) -> str:
+    """Return an isolated sibling path so failed providers cannot leak audio."""
+    path = Path(destination)
+    suffix = path.suffix or ".mp3"
+    return str(path.with_name(f".{path.stem}.{attempt}.{uuid.uuid4().hex}{suffix}"))
+
+
+class _TTSProviderUnavailableError(RuntimeError):
+    """A configured provider cannot start; preserve its established tool error."""
+
+
+def _generate_tts_with_provider(
+    text: str,
+    output_path: str,
+    provider: str,
+    tts_config: Dict[str, Any],
+) -> tuple[str, str]:
+    """Generate one complete artifact and return ``(path, effective_provider)``.
+
+    This deliberately performs no fallback itself.  The caller can therefore
+    discard a failed primary artifact and retry the entire text with a single
+    fallback provider, never returning a mixed-provider audio file.
+    """
+    command_provider_config = _resolve_command_provider_config(provider, tts_config)
+    if command_provider_config is not None:
+        logger.info("Generating speech with command TTS provider '%s'...", provider)
+        return (
+            _generate_command_tts(
+                text, output_path, provider, command_provider_config, tts_config,
+            ),
+            provider,
+        )
+
+    if provider not in BUILTIN_TTS_PROVIDERS:
+        plugin_path = _dispatch_to_plugin_provider(text, output_path, provider, tts_config)
+        if plugin_path is not None:
+            return plugin_path, provider
+
+    if provider == "elevenlabs":
+        try:
+            _import_elevenlabs()
+        except ImportError as exc:
+            raise _TTSProviderUnavailableError(
+                "ElevenLabs provider selected but 'elevenlabs' package not installed. "
+                "Run: pip install elevenlabs"
+            ) from exc
+        logger.info("Generating speech with ElevenLabs...")
+        return _generate_elevenlabs(text, output_path, tts_config), provider
+
+    if provider == "openai":
+        try:
+            _import_openai_client()
+        except ImportError as exc:
+            raise _TTSProviderUnavailableError(
+                "OpenAI provider selected but 'openai' package not installed."
+            ) from exc
+        logger.info("Generating speech with OpenAI TTS...")
+        return _generate_openai_tts(text, output_path, tts_config), provider
+
+    if provider == "deepinfra":
+        try:
+            _import_openai_client()
+        except ImportError as exc:
+            raise _TTSProviderUnavailableError(
+                "DeepInfra TTS uses the 'openai' SDK but it isn't installed."
+            ) from exc
+        logger.info("Generating speech with DeepInfra TTS...")
+        return _generate_deepinfra_tts(text, output_path, tts_config), provider
+
+    if provider == "minimax":
+        logger.info("Generating speech with MiniMax TTS...")
+        return _generate_minimax_tts(text, output_path, tts_config), provider
+
+    if provider == "xai":
+        logger.info("Generating speech with xAI TTS...")
+        return _generate_xai_tts(text, output_path, tts_config), provider
+
+    if provider == "mistral":
+        try:
+            _import_mistral_client()
+        except ImportError as exc:
+            raise _TTSProviderUnavailableError(
+                "Mistral provider selected but 'mistralai' package not installed. "
+                "Run `hermes setup` to install Mistral support."
+            ) from exc
+        logger.info("Generating speech with Mistral Voxtral TTS...")
+        return _generate_mistral_tts(text, output_path, tts_config), provider
+
+    if provider == "gemini":
+        logger.info("Generating speech with Google Gemini TTS...")
+        return _generate_gemini_tts(text, output_path, tts_config), provider
+
+    if provider == "neutts":
+        if not _check_neutts_available():
+            raise _TTSProviderUnavailableError(
+                "NeuTTS provider selected but neutts is not installed. Run hermes setup "
+                "and choose NeuTTS, or install espeak-ng and run python -m pip install -U neutts[all]."
+            )
+        logger.info("Generating speech with NeuTTS (local)...")
+        return _generate_neutts(text, output_path, tts_config), provider
+
+    if provider == "kittentts":
+        try:
+            _import_kittentts()
+        except ImportError as exc:
+            raise _TTSProviderUnavailableError(
+                "KittenTTS provider selected but 'kittentts' package not installed. "
+                "Run 'hermes setup tts' and choose KittenTTS, or install manually: "
+                "pip install https://github.com/KittenML/KittenTTS/releases/download/0.8.1/"
+                "kittentts-0.8.1-py3-none-any.whl"
+            ) from exc
+        logger.info("Generating speech with KittenTTS (local, ~25MB)...")
+        return _generate_kittentts(text, output_path, tts_config), provider
+
+    if provider == "piper":
+        try:
+            _import_piper()
+        except ImportError as exc:
+            raise _TTSProviderUnavailableError(
+                "Piper provider selected but 'piper-tts' package not installed. "
+                "Run 'hermes tools' and select Piper under TTS, or install manually: pip install piper-tts"
+            ) from exc
+        logger.info("Generating speech with Piper (local)...")
+        return _generate_piper_tts(text, output_path, tts_config), provider
+
+    # Historical default: unknown provider names use Edge, then local NeuTTS.
+    try:
+        _import_edge_tts()
+    except ImportError:
+        if _check_neutts_available():
+            logger.info("Edge TTS not available, falling back to NeuTTS (local)...")
+            return _generate_neutts(text, output_path, tts_config), "neutts"
+        raise _TTSProviderUnavailableError(
+            "No TTS provider available. Install edge-tts (pip install edge-tts) "
+            "or set up NeuTTS for local synthesis."
+        )
+
+    logger.info("Generating speech with Edge TTS...")
+    try:
+        import concurrent.futures
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            pool.submit(
+                lambda: asyncio.run(_generate_edge_tts(text, output_path, tts_config))
+            ).result(timeout=60)
+    except RuntimeError:
+        asyncio.run(_generate_edge_tts(text, output_path, tts_config))
+    return output_path, provider
+
+
 def text_to_speech_tool(
     text: str,
     output_path: Optional[str] = None,
@@ -2314,6 +2526,7 @@ def text_to_speech_tool(
 
     tts_config = _load_tts_config()
     provider = _get_provider(tts_config)
+    fallback_provider = _get_tts_fallback_provider(provider, tts_config)
 
     # User-declared command provider (type: command under tts.providers.<name>)
     # resolves BEFORE the built-in dispatch. Built-in names short-circuit here
@@ -2321,13 +2534,19 @@ def text_to_speech_tool(
     # OpenAI handler.
     command_provider_config = _resolve_command_provider_config(provider, tts_config)
 
-    # Truncate very long text with a warning. The cap is per-provider
-    # (OpenAI 4096, xAI 15k, MiniMax 10k, ElevenLabs model-aware, etc.).
+    # Keep the primary provider's full supported input. If it fails, the
+    # fallback may have a smaller cap and will be shortened only for that
+    # second attempt.
+    original_text_length = len(text)
+    truncation_warnings: list[str] = []
     max_len = _resolve_max_text_length(provider, tts_config)
     if len(text) > max_len:
         logger.warning(
             "TTS text too long for provider %s (%d chars), truncating to %d",
             provider, len(text), max_len,
+        )
+        truncation_warnings.append(
+            f"Textul a fost scurtat pentru {provider}, de la {len(text)} la {max_len} caractere."
         )
         text = text[:max_len]
 
@@ -2384,153 +2603,93 @@ def text_to_speech_tool(
     # Ensure parent directory exists
     file_path.parent.mkdir(parents=True, exist_ok=True)
     file_str = str(file_path)
+    fallback_used = False
+    primary_error: Optional[str] = None
+    fallback_text = text
+    fallback_truncation_warning: Optional[str] = None
 
     try:
-        # Generate audio with the configured provider
-        if command_provider_config is not None:
-            logger.info(
-                "Generating speech with command TTS provider '%s'...", provider,
+        if fallback_provider is not None:
+            # Render each whole message into a private sibling first.  A
+            # provider that starts yielding audio then fails cannot leave a
+            # partial primary artifact for the fallback to append to.
+            primary_destination = file_str
+            fallback_command_config = _resolve_command_provider_config(
+                fallback_provider, tts_config,
             )
-            file_str = _generate_command_tts(
-                text, file_str, provider, command_provider_config, tts_config,
+            fallback_destination = (
+                str(_configured_command_tts_output_path(
+                    Path(primary_destination), fallback_command_config,
+                ))
+                if fallback_command_config is not None
+                else primary_destination
             )
+            fallback_max_len = _resolve_max_text_length(fallback_provider, tts_config)
+            if len(fallback_text) > fallback_max_len:
+                logger.warning(
+                    "TTS fallback text too long for provider %s (%d chars), truncating to %d",
+                    fallback_provider, len(fallback_text), fallback_max_len,
+                )
+                fallback_truncation_warning = (
+                    f"Textul a fost scurtat pentru fallback-ul {fallback_provider}, "
+                    f"de la {len(fallback_text)} la {fallback_max_len} caractere."
+                )
+                fallback_text = fallback_text[:fallback_max_len]
+            primary_attempt = _tts_attempt_path(primary_destination, "primary")
+            fallback_attempt = _tts_attempt_path(fallback_destination, "fallback")
+            try:
+                try:
+                    generated_path, effective_provider = _generate_tts_with_provider(
+                        text, primary_attempt, provider, tts_config,
+                    )
+                    _ensure_tts_output(generated_path, effective_provider)
+                except Exception as exc:
+                    primary_error = _safe_tts_error(exc)
+                    logger.warning(
+                        "TTS primary provider %s failed; retrying complete message with %s: %s",
+                        provider, fallback_provider, primary_error,
+                    )
+                    try:
+                        if os.path.exists(primary_attempt):
+                            os.unlink(primary_attempt)
+                    except OSError:
+                        logger.warning(
+                            "Could not remove failed primary TTS artifact: %s", primary_attempt,
+                        )
+                    try:
+                        generated_path, effective_provider = _generate_tts_with_provider(
+                            fallback_text, fallback_attempt, fallback_provider, tts_config,
+                        )
+                        _ensure_tts_output(generated_path, effective_provider)
+                    except Exception as fallback_exc:
+                        fallback_error = _safe_tts_error(fallback_exc)
+                        error_msg = (
+                            f"TTS generation failed ({provider}; fallback {fallback_provider}): "
+                            f"primary: {primary_error}; fallback: {fallback_error}"
+                        )
+                        logger.error("%s", error_msg)
+                        return tool_error(error_msg, success=False)
+                    fallback_used = True
+                    if fallback_truncation_warning:
+                        truncation_warnings.append(fallback_truncation_warning)
 
-        # Plugin-registered TTS backend (issue #30398). Fires when the
-        # configured provider is neither a built-in nor a command-type
-        # entry, AND a plugin is registered under that name. The walrus
-        # binds `_plugin_path` only when the dispatcher returns a path
-        # (i.e. a plugin was actually found); a None return falls
-        # through to the built-in elif chain so unknown names hit the
-        # Edge TTS default at the bottom. The dispatcher itself enforces
-        # built-ins-always-win + command-wins-over-plugin defensively.
-        elif provider not in BUILTIN_TTS_PROVIDERS and (
-            _plugin_path := _dispatch_to_plugin_provider(
+                destination = fallback_destination if fallback_used else primary_destination
+                os.replace(generated_path, destination)
+                file_str = destination
+                provider = effective_provider
+                command_provider_config = _resolve_command_provider_config(provider, tts_config)
+            finally:
+                for attempt_path in (primary_attempt, fallback_attempt):
+                    try:
+                        if os.path.exists(attempt_path):
+                            os.unlink(attempt_path)
+                    except OSError:
+                        logger.warning("Could not remove temporary TTS artifact: %s", attempt_path)
+        else:
+            file_str, provider = _generate_tts_with_provider(
                 text, file_str, provider, tts_config,
             )
-        ) is not None:
-            file_str = _plugin_path
-
-        elif provider == "elevenlabs":
-            try:
-                _import_elevenlabs()
-            except ImportError:
-                return json.dumps({
-                    "success": False,
-                    "error": "ElevenLabs provider selected but 'elevenlabs' package not installed. Run: pip install elevenlabs"
-                }, ensure_ascii=False)
-            logger.info("Generating speech with ElevenLabs...")
-            _generate_elevenlabs(text, file_str, tts_config)
-
-        elif provider == "openai":
-            try:
-                _import_openai_client()
-            except ImportError:
-                return json.dumps({
-                    "success": False,
-                    "error": "OpenAI provider selected but 'openai' package not installed."
-                }, ensure_ascii=False)
-            logger.info("Generating speech with OpenAI TTS...")
-            _generate_openai_tts(text, file_str, tts_config)
-
-        elif provider == "deepinfra":
-            try:
-                _import_openai_client()
-            except ImportError:
-                return json.dumps({
-                    "success": False,
-                    "error": "DeepInfra TTS uses the 'openai' SDK but it isn't installed."
-                }, ensure_ascii=False)
-            logger.info("Generating speech with DeepInfra TTS...")
-            _generate_deepinfra_tts(text, file_str, tts_config)
-
-        elif provider == "minimax":
-            logger.info("Generating speech with MiniMax TTS...")
-            _generate_minimax_tts(text, file_str, tts_config)
-
-        elif provider == "xai":
-            logger.info("Generating speech with xAI TTS...")
-            _generate_xai_tts(text, file_str, tts_config)
-
-        elif provider == "mistral":
-            try:
-                _import_mistral_client()
-            except ImportError:
-                return json.dumps({
-                    "success": False,
-                    "error": "Mistral provider selected but 'mistralai' package not installed. "
-                             "Run `hermes setup` to install Mistral support."
-                }, ensure_ascii=False)
-            logger.info("Generating speech with Mistral Voxtral TTS...")
-            _generate_mistral_tts(text, file_str, tts_config)
-
-        elif provider == "gemini":
-            logger.info("Generating speech with Google Gemini TTS...")
-            _generate_gemini_tts(text, file_str, tts_config)
-
-        elif provider == "neutts":
-            if not _check_neutts_available():
-                return json.dumps({
-                    "success": False,
-                    "error": "NeuTTS provider selected but neutts is not installed. "
-                             "Run hermes setup and choose NeuTTS, or install espeak-ng and run python -m pip install -U neutts[all]."
-                }, ensure_ascii=False)
-            logger.info("Generating speech with NeuTTS (local)...")
-            _generate_neutts(text, file_str, tts_config)
-
-        elif provider == "kittentts":
-            try:
-                _import_kittentts()
-            except ImportError:
-                return json.dumps({
-                    "success": False,
-                    "error": "KittenTTS provider selected but 'kittentts' package not installed. "
-                             "Run 'hermes setup tts' and choose KittenTTS, or install manually: "
-                             "pip install https://github.com/KittenML/KittenTTS/releases/download/0.8.1/kittentts-0.8.1-py3-none-any.whl"
-                }, ensure_ascii=False)
-            logger.info("Generating speech with KittenTTS (local, ~25MB)...")
-            _generate_kittentts(text, file_str, tts_config)
-
-        elif provider == "piper":
-            try:
-                _import_piper()
-            except ImportError:
-                return json.dumps({
-                    "success": False,
-                    "error": "Piper provider selected but 'piper-tts' package not installed. "
-                             "Run 'hermes tools' and select Piper under TTS, or install manually: "
-                             "pip install piper-tts",
-                }, ensure_ascii=False)
-            logger.info("Generating speech with Piper (local)...")
-            _generate_piper_tts(text, file_str, tts_config)
-
-        else:
-            # Default: Edge TTS (free), with NeuTTS as local fallback
-            edge_available = True
-            try:
-                _import_edge_tts()
-            except ImportError:
-                edge_available = False
-
-            if edge_available:
-                logger.info("Generating speech with Edge TTS...")
-                try:
-                    import concurrent.futures
-                    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                        pool.submit(
-                            lambda: asyncio.run(_generate_edge_tts(text, file_str, tts_config))
-                        ).result(timeout=60)
-                except RuntimeError:
-                    asyncio.run(_generate_edge_tts(text, file_str, tts_config))
-            elif _check_neutts_available():
-                logger.info("Edge TTS not available, falling back to NeuTTS (local)...")
-                provider = "neutts"
-                _generate_neutts(text, file_str, tts_config)
-            else:
-                return json.dumps({
-                    "success": False,
-                    "error": "No TTS provider available. Install edge-tts (pip install edge-tts) "
-                             "or set up NeuTTS for local synthesis."
-                }, ensure_ascii=False)
+            command_provider_config = _resolve_command_provider_config(provider, tts_config)
 
         # Check the file was actually created
         if not os.path.exists(file_str) or os.path.getsize(file_str) == 0:
@@ -2586,14 +2745,25 @@ def text_to_speech_tool(
         if voice_compatible:
             media_tag = f"[[audio_as_voice]]\n{media_tag}"
 
-        return json.dumps({
+        result = {
             "success": True,
             "file_path": file_str,
             "media_tag": media_tag,
             "provider": provider,
             "voice_compatible": voice_compatible,
-        }, ensure_ascii=False)
+        }
+        if fallback_used:
+            result["fallback_from"] = _get_provider(tts_config)
+            result["fallback_error"] = primary_error
+        if truncation_warnings:
+            result["text_truncated"] = True
+            result["original_text_length"] = original_text_length
+            result["synthesized_text_length"] = len(fallback_text if fallback_used else text)
+            result["warning"] = " ".join(truncation_warnings)
+        return json.dumps(result, ensure_ascii=False)
 
+    except _TTSProviderUnavailableError as e:
+        return json.dumps({"success": False, "error": str(e)}, ensure_ascii=False)
     except ValueError as e:
         # Configuration errors (missing API keys, etc.)
         error_msg = f"TTS configuration error ({provider}): {e}"
@@ -2611,18 +2781,16 @@ def text_to_speech_tool(
         return tool_error(error_msg, success=False)
 
 
+
+
 # ===========================================================================
 # Requirements check
 # ===========================================================================
-def check_tts_requirements() -> bool:
-    """Return whether the explicitly resolved TTS provider can run.
-
-    Availability must mirror :func:`text_to_speech_tool` dispatch. Unrelated
-    cloud credentials do not make the default Edge backend usable, and an
-    explicitly selected backend is checked on its own requirements.
-    """
-    tts_config = _load_tts_config()
-    provider = _get_provider(tts_config)
+def _check_tts_provider_requirements(
+    provider: str,
+    tts_config: Dict[str, Any],
+) -> bool:
+    """Return whether one already-resolved provider can run."""
     command_config = _resolve_command_provider_config(provider, tts_config)
     if command_config is not None:
         return True
@@ -2684,6 +2852,25 @@ def check_tts_requirements() -> bool:
         return bool(plugin and plugin.is_available())
     except Exception:
         return False
+
+
+def check_tts_requirements() -> bool:
+    """Return whether the primary or its valid configured fallback can run.
+
+    The fallback is considered only after the primary is unavailable.  This
+    keeps it opt-in and avoids making unrelated credentials expose the TTS
+    tool, while allowing an ElevenLabs package/key outage to leave OpenAI TTS
+    available to the agent.
+    """
+    tts_config = _load_tts_config()
+    primary_provider = _get_provider(tts_config)
+    if _check_tts_provider_requirements(primary_provider, tts_config):
+        return True
+    fallback_provider = _get_tts_fallback_provider(primary_provider, tts_config)
+    return bool(
+        fallback_provider
+        and _check_tts_provider_requirements(fallback_provider, tts_config)
+    )
 
 
 def _resolve_openai_audio_client_config() -> tuple[str, str, bool]:

--- a/uv.lock
+++ b/uv.lock
@@ -1518,7 +1518,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.19.0"
+version = "0.19.1"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -34,6 +34,7 @@ mcp_servers:
     timeout: 120
     connect_timeout: 60
     supports_parallel_tool_calls: false
+    forward_run_metadata: false
     tools:
       include: []
       exclude: []
@@ -57,10 +58,36 @@ mcp_servers:
 | `timeout` | number | both | Tool call timeout in seconds (default: `300`) |
 | `connect_timeout` | number | both | Initial connection timeout in seconds (default: `60`) |
 | `supports_parallel_tool_calls` | bool | both | Allow tools from this server to run concurrently |
+| `forward_run_metadata` | bool | both | Forward private API run metadata as MCP `tools/call.params._meta` (default: `false`) |
 | `skip_preflight` | bool | HTTP | Bypass the fail-fast content-type probe for valid Streamable HTTP endpoints whose HEAD/GET answers a non-MCP content type (default: `false`) |
 | `tools` | mapping | both | Filtering and utility-tool policy |
 | `auth` | string | HTTP | Authentication method. Set to `oauth` to enable OAuth 2.1 with PKCE |
 | `sampling` | mapping | both | Server-initiated LLM request policy (see MCP guide) |
+
+## Private metadata per API run
+
+An authenticated API client can attach private metadata to one agent run with
+the `X-Hermes-MCP-Metadata` header. The value is an unpadded base64url-encoded
+JSON object, with a decoded limit of 8 KiB and a maximum nesting depth of 64.
+
+Hermes forwards this object only to servers that explicitly opt in:
+
+```yaml
+mcp_servers:
+  employee:
+    url: "https://example.internal/mcp"
+    headers:
+      Authorization: "Bearer ${EMPLOYEE_MCP_TOKEN}"
+    forward_run_metadata: true
+```
+
+The object is sent in MCP `tools/call.params._meta`. It is not appended to the
+user message, system prompt, tool arguments, or model-facing tool schema. The
+same private context is propagated to delegated child agents. For non-streaming
+API requests, its value also contributes to the idempotency fingerprint so a
+cached response cannot be reused across different bindings; the raw object is
+not stored in the idempotency cache. The MCP server remains responsible for
+validating signatures, expiry, and scope.
 
 ## `tools` policy keys
 

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -34,6 +34,7 @@ mcp_servers:
     timeout: 120
     connect_timeout: 60
     supports_parallel_tool_calls: false
+    forward_run_metadata: false
     tools:
       include: []
       exclude: []
@@ -57,10 +58,36 @@ mcp_servers:
 | `timeout` | number | both | Tool call timeout in seconds (default: `300`) |
 | `connect_timeout` | number | both | Initial connection timeout in seconds (default: `60`) |
 | `supports_parallel_tool_calls` | bool | both | Allow tools from this server to run concurrently |
+| `forward_run_metadata` | bool | both | Forward private API run metadata as MCP `tools/call.params._meta` (default: `false`) |
 | `skip_preflight` | bool | HTTP | Bypass the fail-fast content-type probe for valid Streamable HTTP endpoints whose HEAD/GET answers a non-MCP content type (default: `false`) |
 | `tools` | mapping | both | Filtering and utility-tool policy |
 | `auth` | string | HTTP | Authentication method. Set to `oauth` to enable OAuth 2.1 with PKCE |
 | `sampling` | mapping | both | Server-initiated LLM request policy (see MCP guide) |
+
+## Private metadata per API run
+
+An authenticated API client can attach private metadata to one agent run with
+the `X-Hermes-MCP-Metadata` header. The value is an unpadded base64url-encoded
+JSON object, with a decoded limit of 8 KiB and a maximum nesting depth of 64.
+
+Hermes forwards this object only to servers that explicitly opt in:
+
+```yaml
+mcp_servers:
+  employee:
+    url: "https://example.internal/mcp"
+    headers:
+      Authorization: "Bearer ${EMPLOYEE_MCP_TOKEN}"
+    forward_run_metadata: true
+```
+
+The object is sent in MCP `tools/call.params._meta`. It is not appended to the
+user message, system prompt, tool arguments, or model-facing tool schema. The
+same private context is propagated to delegated child agents. Its value also
+contributes to API idempotency fingerprints, including `/v1/runs` start
+deduplication, so a response or run cannot be reused across different bindings;
+the raw object is not stored in the idempotency cache. The MCP server remains
+responsible for validating signatures, expiry, and scope.
 
 ## `tools` policy keys
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1475,6 +1475,7 @@ This mirrors Claude Code's per-session WebSearch and subagent caps (v2.1.212), w
 ```yaml
 tts:
   provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "neutts"
+  fallback_provider: "openai"   # Optional: retry the whole reply once if the primary fails
   speed: 1.0                    # Global speed multiplier (fallback for all providers)
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
@@ -1514,6 +1515,8 @@ tts:
 This controls both the `text_to_speech` tool and spoken replies in voice mode (`/voice tts` in the CLI or messaging gateway).
 
 **Speed fallback hierarchy:** provider-specific speed (e.g. `tts.edge.speed`) → global `tts.speed` → `1.0` default. Set the global `tts.speed` to apply a uniform speed across all providers, or override per-provider for fine-grained control.
+
+**Provider fallback:** set `tts.fallback_provider` to a different built-in, command, or registered plugin provider, such as `openai` for an ElevenLabs primary. Hermes retries the complete reply once after a primary failure, with no retry loop and no mixed-provider audio. If their input limits differ, it uses the lower limit for the shared script. The default empty value keeps single-provider behavior.
 
 ## Display Settings
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -363,9 +363,10 @@ model, disk space, gateway/platform state, active API runs, pending process
 completions, and active delegations. The response exposes status and counts,
 not config values, credentials, paths, commands, queue payloads, or raw errors.
 It also returns the active `profile` and the SHA-256 digest of that profile's
-exact `capabilities.json` bytes as `capability_manifest_sha256`. The digest is
-`null` when the profile has no manifest, so a control plane can fail closed on
-a missing or unexpected capability set.
+canonical JSON `capabilities.json` content as `capability_manifest_sha256`.
+Whitespace and key order do not change the digest. The digest is `null` when
+the profile has no valid JSON manifest, so a control plane can fail closed on a
+missing or unexpected capability set.
 
 The public `/health` route remains a cheap liveness probe and does not run
 readiness checks. A degraded readiness result still uses HTTP 200; inspect the

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -356,11 +356,13 @@ Runs accept a simple `input` string or an OpenAI-style message array. Message
 content can contain `text` and inline `image_url` parts, including
 `data:image/...` URLs. Uploaded files and non-image data URLs are rejected.
 
-Pass the transcript ID in `X-Hermes-Session-Id`, in the optional body
-`session_id`, or in both with the same value. Hermes returns the resolved ID in
-the 202 JSON body, the `X-Hermes-Session-Id` response header, and subsequent run
-status. `instructions`, `conversation_history`, and `previous_response_id` remain
-optional.
+Pass `X-Hermes-Session-Id` to continue an existing transcript. Session
+continuation requires API key authentication. The optional body `session_id`
+remains a correlation ID for existing callers and does not load stored history
+on its own. When both are present they must match. Hermes returns the resolved
+ID in the 202 JSON body, the `X-Hermes-Session-Id` response header, and
+subsequent run status. `instructions`, `conversation_history`, and
+`previous_response_id` remain optional.
 
 ### GET /v1/runs/\{run_id\}
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -347,11 +347,20 @@ Create a new agent run. Returns a `run_id` that can be used to subscribe to prog
 ```json
 {
   "run_id": "run_abc123",
+  "session_id": "space-session",
   "status": "started"
 }
 ```
 
-Runs accept a simple `input` string and optional `session_id`, `instructions`, `conversation_history`, or `previous_response_id`. When `session_id` is provided, Hermes surfaces it in the run status so external UIs can correlate runs with their own conversation IDs.
+Runs accept a simple `input` string or an OpenAI-style message array. Message
+content can contain `text` and inline `image_url` parts, including
+`data:image/...` URLs. Uploaded files and non-image data URLs are rejected.
+
+Pass the transcript ID in `X-Hermes-Session-Id`, in the optional body
+`session_id`, or in both with the same value. Hermes returns the resolved ID in
+the 202 JSON body, the `X-Hermes-Session-Id` response header, and subsequent run
+status. `instructions`, `conversation_history`, and `previous_response_id` remain
+optional.
 
 ### GET /v1/runs/\{run_id\}
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -53,6 +53,37 @@ curl http://localhost:8642/v1/chat/completions \
 
 Or connect Open WebUI, LobeChat, or any other frontend — see the [Open WebUI integration guide](/user-guide/messaging/open-webui) for step-by-step instructions.
 
+## Private MCP metadata
+
+Server-to-server clients can attach private context to one agent run with:
+
+```text
+X-Hermes-MCP-Metadata: <unpadded-base64url-json-object>
+```
+
+The header requires API key authentication and is limited to 8 KiB after
+decoding, with a maximum nesting depth of 64. Hermes keeps the decoded object
+outside model messages and tool schemas. It is forwarded as MCP
+`tools/call.params._meta` only to an MCP server configured with
+`forward_run_metadata: true`. Delegated child agents inherit the same private
+context. API idempotency fingerprints include it without storing the raw object
+in the idempotency cache. This includes `/v1/runs` start deduplication, so
+different employee bindings cannot share a cached response or run.
+
+For example, the decoded JSON can contain an opaque, signed binding:
+
+```json
+{
+  "acme.employee": {
+    "binding": "<opaque-signed-binding>",
+    "expires_at": "2026-09-02T12:00:00Z"
+  }
+}
+```
+
+Hermes transports this metadata but does not treat it as identity. The target
+MCP server must validate its signature, expiry, and authorization scope.
+
 ## Endpoints
 
 ### POST /v1/chat/completions
@@ -331,6 +362,10 @@ bounded status for the active profile's config, state database, configured
 model, disk space, gateway/platform state, active API runs, pending process
 completions, and active delegations. The response exposes status and counts,
 not config values, credentials, paths, commands, queue payloads, or raw errors.
+It also returns the active `profile` and the SHA-256 digest of that profile's
+exact `capabilities.json` bytes as `capability_manifest_sha256`. The digest is
+`null` when the profile has no manifest, so a control plane can fail closed on
+a missing or unexpected capability set.
 
 The public `/health` route remains a cheap liveness probe and does not run
 readiness checks. A degraded readiness result still uses HTTP 200; inspect the
@@ -581,7 +616,7 @@ API_SERVER_CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 When CORS is enabled:
 - **Preflight responses** include `Access-Control-Max-Age: 600` (10 minute cache)
 - **SSE streaming responses** include CORS headers so browser EventSource clients work correctly
-- **`Idempotency-Key`** is an allowed request header — clients can send it for deduplication (responses are cached by key for 5 minutes)
+- **`Idempotency-Key`** is an allowed request header — clients can send it for deduplication (`/v1/runs` starts are retained by key for one hour)
 
 Most documented frontends such as Open WebUI connect server-to-server and do not need CORS at all.
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -53,6 +53,37 @@ curl http://localhost:8642/v1/chat/completions \
 
 Or connect Open WebUI, LobeChat, or any other frontend — see the [Open WebUI integration guide](/user-guide/messaging/open-webui) for step-by-step instructions.
 
+## Private MCP metadata
+
+Server-to-server clients can attach private context to one agent run with:
+
+```text
+X-Hermes-MCP-Metadata: <unpadded-base64url-json-object>
+```
+
+The header requires API key authentication and is limited to 8 KiB after
+decoding, with a maximum nesting depth of 64. Hermes keeps the decoded object
+outside model messages and tool schemas. It is forwarded as MCP
+`tools/call.params._meta` only to an MCP server configured with
+`forward_run_metadata: true`. Delegated child agents inherit the same private
+context. Non-streaming idempotency fingerprints include it, without storing the
+raw object in the idempotency cache, so different employee bindings cannot
+share a cached response.
+
+For example, the decoded JSON can contain an opaque, signed binding:
+
+```json
+{
+  "acme.employee": {
+    "binding": "<opaque-signed-binding>",
+    "expires_at": "2026-09-02T12:00:00Z"
+  }
+}
+```
+
+Hermes transports this metadata but does not treat it as identity. The target
+MCP server must validate its signature, expiry, and authorization scope.
+
 ## Endpoints
 
 ### POST /v1/chat/completions
@@ -359,8 +390,16 @@ content can contain `text` and inline `image_url` parts, including
 Pass the transcript ID in `X-Hermes-Session-Id`, in the optional body
 `session_id`, or in both with the same value. Hermes returns the resolved ID in
 the 202 JSON body, the `X-Hermes-Session-Id` response header, and subsequent run
-status. `instructions`, `conversation_history`, and `previous_response_id` remain
-optional.
+status. When the same session ID is reused without explicit history or
+`previous_response_id`, Hermes loads that transcript from the session database
+before starting the new run. Hermes follows any
+compression-created child session and publishes the current session ID in the
+completed run status.
+
+An explicit `conversation_history` takes precedence even when it is an empty
+array. Hermes persists the resulting transcript as the active history for that
+session. This lets an API client replace stale stored context without it
+reappearing on the next turn.
 
 ### GET /v1/runs/\{run_id\}
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -392,6 +392,7 @@ def register(ctx):
 | [`subagent_start`](#subagent_start) | A `delegate_task` child has been constructed and is about to run | ignored |
 | [`subagent_stop`](#subagent_stop) | A `delegate_task` child has exited | ignored |
 | [`pre_gateway_dispatch`](#pre_gateway_dispatch) | Gateway received a user message, before auth + dispatch | `{"action": "skip" \| "rewrite" \| "allow", ...}` to influence flow |
+| [`gateway_message_delivered`](#gateway_message_delivered) | A live Telegram cron text message is confirmed delivered | ignored |
 | [`pre_approval_request`](#pre_approval_request) | An approval decision is requested, including smart-mode auto decisions | ignored |
 | [`post_approval_response`](#post_approval_response) | An approval decision is made (or a prompt times out) | ignored |
 | [`transform_tool_result`](#transform_tool_result) | After any tool returns, before the result is handed back to the model | `str` to replace the result, `None` to leave unchanged |
@@ -1058,6 +1059,24 @@ def buffer_or_rewrite(event, **kwargs):
 def register(ctx):
     ctx.register_hook("pre_gateway_dispatch", buffer_or_rewrite)
 ```
+
+---
+
+### `gateway_message_delivered`
+
+Fires after the live Telegram adapter confirms a successful generated cron text message. It does not fire for standalone sends, media-only responses, failed runs, or non-Telegram delivery.
+
+```python
+def on_cron_delivery(source, execution_id, job_id, platform, chat_id,
+                     thread_id, message_id, **kwargs):
+    assert source == "cron"
+    print(execution_id, chat_id, message_id)
+
+def register(ctx):
+    ctx.register_hook("gateway_message_delivered", on_cron_delivery)
+```
+
+The payload contains `source`, `execution_id`, `job_id`, `platform`, `chat_id`, `thread_id`, and the Telegram-confirmed `message_id`. It has no message text or Telegram client object. Callback failures do not affect delivery.
 
 ---
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -373,7 +373,7 @@ def register(ctx):
 
 - Callbacks receive **keyword arguments**. Always accept `**kwargs` for forward compatibility — new parameters may be added in future versions without breaking your plugin.
 - If a callback **crashes**, it's logged and skipped. Other hooks and the agent continue normally. A misbehaving plugin can never break the agent.
-- Two hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, and [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call. All other hooks are fire-and-forget observers.
+- Four hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call, [`gateway_message_before_send`](#gateway_message_before_send) can add an outbound Telegram keyboard, and [`telegram_callback_query`](#telegram_callback_query) can handle an otherwise-unmatched Telegram button. All other hooks are fire-and-forget observers.
 - Observer callbacks receive `telemetry_schema_version` automatically. When present, `turn_id`, `api_request_id`, `task_id`, `session_id`, and `api_call_count` are separate correlation fields. Treat `api_request_id` as an opaque identifier; do not parse its string format.
 
 ### Quick reference
@@ -393,6 +393,8 @@ def register(ctx):
 | [`subagent_stop`](#subagent_stop) | A `delegate_task` child has exited | ignored |
 | [`pre_gateway_dispatch`](#pre_gateway_dispatch) | Gateway received a user message, before auth + dispatch | `{"action": "skip" \| "rewrite" \| "allow", ...}` to influence flow |
 | [`gateway_message_delivered`](#gateway_message_delivered) | A live Telegram cron text message is confirmed delivered | ignored |
+| [`gateway_message_before_send`](#gateway_message_before_send) | Before a live Telegram delivery is sent | `{"telegram_inline_keyboard": ...}` to add a keyboard |
+| [`telegram_callback_query`](#telegram_callback_query) | Authorized unmatched Telegram button callback | `{"handled": true, ...}` to acknowledge/edit it |
 | [`pre_approval_request`](#pre_approval_request) | An approval decision is requested, including smart-mode auto decisions | ignored |
 | [`post_approval_response`](#post_approval_response) | An approval decision is made (or a prompt times out) | ignored |
 | [`transform_tool_result`](#transform_tool_result) | After any tool returns, before the result is handed back to the model | `str` to replace the result, `None` to leave unchanged |
@@ -1077,6 +1079,66 @@ def register(ctx):
 ```
 
 The payload contains `source`, `execution_id`, `job_id`, `platform`, `chat_id`, `thread_id`, and the Telegram-confirmed `message_id`. It has no message text or Telegram client object. Callback failures do not affect delivery.
+
+### `gateway_message_before_send`
+
+Fires before an outbound Telegram message is sent. It is intended for plugins
+that add a small amount of Telegram-native presentation without taking control
+of the adapter. A callback may return a neutral keyboard shape:
+
+```python
+def add_feedback_buttons(source, execution_id, job_id, platform, chat_id,
+                         routine_feedback_eligible,
+                         thread_id, **kwargs):
+    if not routine_feedback_eligible:
+        return None
+    return {"telegram_inline_keyboard": [[
+        {"text": "👍", "callback_data": f"rf:up:{execution_id}"},
+        {"text": "👎", "callback_data": f"rf:down:{execution_id}"},
+    ]]}
+
+def register(ctx):
+    ctx.register_hook("gateway_message_before_send", add_feedback_buttons)
+```
+
+The hook receives routing and execution identifiers, but never message content,
+the bot token, or the adapter object. `routine_feedback_eligible` is true only
+for a generated successful cron result that Hermes records after confirmed live
+Telegram delivery. Feedback plugins must require it before adding controls.
+Invalid or failing plugin directives are ignored and delivery continues normally.
+The keyboard is attached only to the first Telegram chunk when a message is split.
+
+Plugins can add `requires_hooks` to `plugin.yaml` to refuse loading on an older
+Hermes core that does not support a required hook:
+
+```yaml
+requires_hooks:
+  - gateway_message_before_send
+  - telegram_callback_query
+```
+
+### `telegram_callback_query`
+
+Fires for an otherwise-unmatched Telegram inline-button callback after native
+callback handlers, the adapter's chat boundary, and callback-user authorization
+checks. Plugins should ignore callback prefixes they do not own. Returning
+`{"handled": True}` lets a plugin acknowledge the tap and optionally edit the
+message:
+
+```python
+def on_feedback(data, chat_id, thread_id, message_id, user_id, **kwargs):
+    if not data.startswith("rf:"):
+        return None
+    return {"handled": True, "answer_text": "Mulțumesc", "clear_keyboard": True}
+
+def register(ctx):
+    ctx.register_hook("telegram_callback_query", on_feedback)
+```
+
+Supported directive fields are `answer_text`, `clear_keyboard`,
+`telegram_inline_keyboard`, and `edit_text`. The callback payload contains only
+the callback data and Telegram message/user identifiers, not the raw Telegram
+objects. Plugin failures are fail-open.
 
 ---
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -44,6 +44,7 @@ Convert text to speech with ten providers:
 # In ~/.hermes/config.yaml
 tts:
   provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "neutts" | "kittentts" | "piper"
+  fallback_provider: "openai"   # Optional: retry the whole reply once if the primary fails
   speed: 1.0                    # Global speed multiplier (provider-specific settings override this)
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
@@ -98,6 +99,8 @@ tts:
 ```
 
 **Speed control**: The global `tts.speed` value applies to all providers by default. Each provider can override it with its own `speed` setting (e.g., `tts.openai.speed: 1.5`). Provider-specific speed takes precedence over the global value. Default is `1.0` (normal speed).
+
+**Provider fallback**: Set `tts.fallback_provider` to a different built-in, command, or registered plugin provider, for example `openai` when `provider: elevenlabs`. Hermes retries the complete reply once only after the primary fails; it never loops back to the primary and never mixes partial audio from two providers. When the providers have different input limits, Hermes uses the lower limit for the shared script. Leave it empty (the default) for single-provider behavior.
 
 ### Gemini Persona Prompts
 

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -1030,6 +1030,31 @@ Behavior:
 - Use `*` in any of these to allow any sender/chat.
 - This layers on top of existing mention/pattern triggers and on top of `group_topics` + `ignored_threads`.
 
+### Trusted administrator group enrollment
+
+Hermes can persistently admit a Telegram group when a trusted Telegram user promotes the bot to **administrator**:
+
+```yaml
+telegram:
+  auto_allow_groups_from_trusted_adders: true
+  trusted_group_adders:
+    - "123456789"
+  require_mention: true
+```
+
+This mode is intentionally strict:
+
+- Enrollment occurs only on a transition to Telegram `administrator`, only when the actor who performed the promotion is in `trusted_group_adders`. Merely adding the bot as a member does not enroll the group.
+- While the mode is enabled, a group must be present in `allowed_chats`, `group_allowed_chats`, or the active validated enrollment set. An empty set no longer means “all groups.” Sender allowlists and `guest_mode` mentions cannot bypass this admission gate.
+- Persisted enrollments are only restart candidates: post-connect housekeeping checks each one with Telegram `getChatMember` and activates it only when the bot is currently an administrator. Member status, unknown status, and API errors remain inactive (the durable candidate is retained for a later retry).
+- Once a group is admitted, normal mention, reply, topic, sender, and command gates still apply. Enrollment does not make the bot answer every message.
+- Inline button callbacks in groups/forums use the same admission boundary before model selection, choices, approvals, or session state can change. Explicitly configured and currently active enrolled groups retain normal callback authorization.
+- Any transition away from `administrator` revokes the live grant immediately, regardless of who changed the bot's role, and removes the durable grant. A persistence failure never creates a live-only enrollment or keeps a revoked live grant. Leaving or being kicked also revokes it.
+- When Telegram migrates a dynamically enrolled basic group to a supergroup, Hermes atomically moves the durable grant to the new negative chat ID and denies the old dynamic grant immediately. Explicit `allowed_chats` / `group_allowed_chats` entries are never rewritten or copied.
+- State is stored under the active Hermes profile at `$HERMES_HOME/state/telegram-auto-authorized-groups.json` (normally `~/.hermes/state/telegram-auto-authorized-groups.json`). Hermes stores only negative numeric chat IDs, writes with atomic replacement, restricts the state directory/file to owner-only permissions (`0700`/`0600`) on POSIX systems, and rejects symlinked or non-regular state paths. Treat the profile state directory as security-sensitive and do not share or hand-edit this file while the gateway is running.
+
+Both settings default to disabled/empty. Invalid booleans or malformed trusted-user lists fail closed and do not enroll a group.
+
 ### Migration from before PR #17686
 
 Prior to this split, `TELEGRAM_GROUP_ALLOWED_USERS` was the only knob and users put **chat IDs** in it. For backward compatibility, chat-ID-shaped values (starting with `-`) in `TELEGRAM_GROUP_ALLOWED_USERS` are still honored as chat IDs and a deprecation warning is logged once. Migration:

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/api-server.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/api-server.md
@@ -386,7 +386,7 @@ API_SERVER_CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 启用 CORS 后：
 - **预检响应**包含 `Access-Control-Max-Age: 600`（10 分钟缓存）
 - **SSE 流式响应**包含 CORS 头，使浏览器 EventSource 客户端能够正常工作
-- **`Idempotency-Key`** 是允许的请求头——客户端可发送它用于去重（响应按 key 缓存 5 分钟）
+- **`Idempotency-Key`** 是允许的请求头——客户端可发送它用于去重（`/v1/runs` 启动请求按 key 保留 1 小时）
 
 大多数已记录的前端（如 Open WebUI）采用服务器到服务器连接，完全不需要 CORS。
 


### PR DESCRIPTION
## Summary

- Add opt-in `tts.fallback_provider` for a single complete-message retry after a provider failure.
- Keep artifacts atomic, preserve the primary error safely, and never mix primary and fallback audio.
- Support built-in, command, and registered-plugin fallbacks.

## Verification

- `uv run --with pytest pytest -q tests/tools/test_tts_provider_fallback.py tests/tools/test_tts_command_providers.py tests/tools/test_tts_opus_routing.py`
  - `66 passed`
- `python3 -m py_compile tools/tts_tool.py hermes_cli/config.py`
- `git diff --check`
- Independent post-fix review passed the command-fallback output-format regression.

## Risk

Fallback is opt-in, so existing single-provider behavior is unchanged. The fallback uses the smaller provider input limit and requires valid fallback credentials. A broad bare `tests/tools` collection did not start in this temporary environment because optional MCP and messaging dependencies were absent; focused coverage passed.

## Migration

None.

## Deployment

No runtime configuration changes in this PR. Merge before the dependent BOARD configuration release, then verify a private Telegram E2E before any BOARD rollout.

## Autonomy requested

Review-only.