### PR TITLE
feat(telegram): add privacy-safe latency diagnostics

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3,6 +3,7 @@
 import asyncio
 import contextlib
 import dataclasses
+import hashlib
 import inspect
 import json
 import logging
@@ -30,6 +31,49 @@ def _redact_telegram_error_text(error: object) -> str:
         return redact_sensitive_text(text, force=True)
     except Exception:
         return "<telegram error redacted>"
+
+
+def _telegram_latency_diagnostics_enabled() -> bool:
+    """Return whether opt-in Telegram latency diagnostics are enabled."""
+    raw = os.getenv("HERMES_TELEGRAM_LATENCY_DIAGNOSTICS", "")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _telegram_chat_ref(chat_id: object) -> str:
+    """Return a stable, pseudonymous chat reference for correlation."""
+    value = str(chat_id or "").encode("utf-8", errors="replace")
+    return hashlib.blake2s(value, digest_size=6).hexdigest()
+
+
+def _telegram_message_age_ms(
+    timestamp: object,
+    *,
+    now: Optional[datetime] = None,
+) -> Optional[int]:
+    """Return non-negative Telegram message age in milliseconds.
+
+    Telegram timestamps are UTC.  Older fixtures and callers may provide a
+    naive datetime, so treat it as UTC rather than mixing aware/naive values.
+    Negative values caused by small host clock skew are clamped to zero.
+    """
+    if not isinstance(timestamp, datetime):
+        return None
+    observed_at = now or datetime.now(timezone.utc)
+    if observed_at.tzinfo is None:
+        observed_at = observed_at.replace(tzinfo=timezone.utc)
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    try:
+        age_ms = round(
+            (
+                observed_at.astimezone(timezone.utc)
+                - timestamp.astimezone(timezone.utc)
+            ).total_seconds()
+            * 1000
+        )
+    except (OverflowError, ValueError):
+        return None
+    return max(0, age_ms)
 
 
 def _scoped_gate_env(name: str, default: str = "") -> str:
@@ -421,6 +465,40 @@ class TelegramAdapter(BasePlatformAdapter):
     def message_len_fn(self):
         """Telegram measures message length in UTF-16 code units."""
         return utf16_len
+
+    def _log_inbound_latency(self, event: MessageEvent, *, stage: str) -> None:
+        """Emit opt-in, content-free ingress timing at adapter boundaries."""
+        if not _telegram_latency_diagnostics_enabled():
+            return
+
+        now_monotonic = time.monotonic()
+        received_monotonic = getattr(
+            event, "_telegram_latency_received_monotonic", None
+        )
+        if stage == "adapter_received":
+            received_monotonic = now_monotonic
+            setattr(event, "_telegram_latency_received_monotonic", received_monotonic)
+        adapter_queue_ms: Optional[int] = None
+        if isinstance(received_monotonic, (int, float)):
+            adapter_queue_ms = max(
+                0, round((now_monotonic - received_monotonic) * 1000)
+            )
+
+        logger.info(
+            "[TelegramLatency] stage=%s chat_ref=%s update_id=%s message_id=%s "
+            "platform_age_ms=%s adapter_queue_ms=%s",
+            stage,
+            _telegram_chat_ref(getattr(event.source, "chat_id", None)),
+            event.platform_update_id,
+            event.message_id,
+            _telegram_message_age_ms(event.timestamp),
+            adapter_queue_ms,
+        )
+
+    async def handle_message(self, event: MessageEvent) -> None:
+        """Record the Telegram-to-gateway boundary, then preserve base behavior."""
+        self._log_inbound_latency(event, stage="gateway_dispatch")
+        await super().handle_message(event)
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.TELEGRAM)
@@ -4842,30 +4920,88 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
         """Send typing indicator."""
-        if not self._bot or self._typing_in_cooldown(chat_id):
+        diagnostics_enabled = _telegram_latency_diagnostics_enabled()
+        chat_ref = _telegram_chat_ref(chat_id) if diagnostics_enabled else None
+        if not self._bot:
+            if diagnostics_enabled:
+                logger.info(
+                    "[TelegramLatency] operation=send_chat_action outcome=skipped "
+                    "reason=not_connected chat_ref=%s",
+                    chat_ref,
+                )
             return
+        if self._typing_in_cooldown(chat_id):
+            if diagnostics_enabled:
+                logger.info(
+                    "[TelegramLatency] operation=send_chat_action outcome=skipped "
+                    "reason=cooldown chat_ref=%s",
+                    chat_ref,
+                )
+            return
+
+        typing_started = time.monotonic() if diagnostics_enabled else None
+        if diagnostics_enabled:
+            logger.info(
+                "[TelegramLatency] operation=send_chat_action outcome=started chat_ref=%s",
+                chat_ref,
+            )
+
+        def _log_typing_result(outcome: str, error: object = None) -> None:
+            if typing_started is None:
+                return
+            duration_ms = max(0, round((time.monotonic() - typing_started) * 1000))
+            if error is None:
+                logger.info(
+                    "[TelegramLatency] operation=send_chat_action outcome=%s "
+                    "chat_ref=%s duration_ms=%d",
+                    outcome,
+                    chat_ref,
+                    duration_ms,
+                )
+            else:
+                logger.info(
+                    "[TelegramLatency] operation=send_chat_action outcome=%s "
+                    "chat_ref=%s duration_ms=%d error=%s",
+                    outcome,
+                    chat_ref,
+                    duration_ms,
+                    _redact_telegram_error_text(error),
+                )
+
         _is_dm_topic: bool = False
         message_thread_id: Optional[int] = None
 
         async def _action(**kw) -> None:
             await self._bot.send_chat_action(chat_id=normalize_telegram_chat_id(chat_id), action="typing", **kw)
             self._telegram_typing_cooldown_until.pop(str(chat_id), None)
+
         try:
             _is_dm_topic = self._dm_topic_fallback(metadata)
             message_thread_id = self._message_thread_id_for_typing(self._metadata_thread_id(metadata))
             await _action(message_thread_id=message_thread_id)
+            _log_typing_result("success")
+        except asyncio.CancelledError:
+            _log_typing_result("cancelled")
+            raise
         except Exception as e:
+            final_error = e
             # DM topic lanes: Telegram may reject message_thread_id — retry without it so the indicator at
             # least appears in the main DM view.
             if _is_dm_topic and message_thread_id is not None:
                 try:
                     await _action()
+                    _log_typing_result("fallback_success")
                     return
+                except asyncio.CancelledError:
+                    _log_typing_result("cancelled")
+                    raise
                 except Exception as fallback_exc:
+                    final_error = fallback_exc
                     if self._is_transient_typing_error(fallback_exc):
                         self._record_typing_cooldown(chat_id, fallback_exc)
             elif self._is_transient_typing_error(e):
                 self._record_typing_cooldown(chat_id, e)
+            _log_typing_result("failure", final_error)
             logger.debug("[%s] Failed to send Telegram typing indicator: %s", self.name, _redact_telegram_error_text(e), exc_info=True)
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
@@ -6282,12 +6418,14 @@ class TelegramAdapter(BasePlatformAdapter):
         reply_to_id, reply_to_text = self._reply_context(message)
         from gateway.platforms.base import resolve_channel_prompt  # per-channel/topic ephemeral prompt
         _chat_id_str = str(chat.id)
-        return MessageEvent(
+        event = MessageEvent(
             text=message.text or "", message_type=msg_type, source=source, raw_message=message,
             message_id=str(message.message_id), platform_update_id=update_id,
             reply_to_message_id=reply_to_id, reply_to_text=reply_to_text, auto_skill=topic_skill,
             channel_prompt=resolve_channel_prompt(self.config.extra, thread_id_str or _chat_id_str, _chat_id_str if thread_id_str else None),
             timestamp=message.date)
+        self._log_inbound_latency(event, stage="adapter_received")
+        return event
 
     # -- Message reactions (processing lifecycle) --
 

--- a/tests/gateway/test_telegram_latency_diagnostics.py
+++ b/tests/gateway/test_telegram_latency_diagnostics.py
@@ -1,0 +1,233 @@
+"""Opt-in Telegram ingress and typing latency diagnostics."""
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent
+from gateway.session import SessionSource
+from plugins.platforms.telegram import adapter as adapter_module
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+def _make_adapter() -> TelegramAdapter:
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = AsyncMock()
+    return adapter
+
+
+def _event(*, timestamp: datetime) -> MessageEvent:
+    return MessageEvent(
+        text="private message text",
+        timestamp=timestamp,
+        platform_update_id=77,
+        message_id="42",
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="123456789"),
+        metadata={},
+    )
+
+
+def test_message_age_ms_handles_naive_utc_and_clamps_clock_skew() -> None:
+    now = datetime(2026, 9, 4, 8, 0, 0, tzinfo=timezone.utc)
+
+    assert (
+        adapter_module._telegram_message_age_ms(
+            now.replace(tzinfo=None) - timedelta(seconds=1.25), now=now
+        )
+        == 1250
+    )
+    assert (
+        adapter_module._telegram_message_age_ms(now + timedelta(seconds=10), now=now)
+        == 0
+    )
+    assert adapter_module._telegram_message_age_ms(None, now=now) is None
+
+
+def test_chat_ref_is_stable_and_does_not_expose_raw_chat_id() -> None:
+    first = adapter_module._telegram_chat_ref("123456789")
+
+    assert first == adapter_module._telegram_chat_ref("123456789")
+    assert first != adapter_module._telegram_chat_ref("987654321")
+    assert "123456789" not in first
+
+
+def test_inbound_diagnostics_are_disabled_by_default(monkeypatch, caplog) -> None:
+    monkeypatch.delenv("HERMES_TELEGRAM_LATENCY_DIAGNOSTICS", raising=False)
+    adapter = _make_adapter()
+
+    with caplog.at_level(logging.INFO):
+        adapter._log_inbound_latency(
+            _event(timestamp=datetime.now(timezone.utc)), stage="adapter_received"
+        )
+
+    assert "TelegramLatency" not in caplog.text
+
+
+def test_inbound_diagnostics_log_correlatable_sanitized_age(
+    monkeypatch, caplog
+) -> None:
+    monkeypatch.setenv("HERMES_TELEGRAM_LATENCY_DIAGNOSTICS", "1")
+    adapter = _make_adapter()
+    event = _event(timestamp=datetime.now(timezone.utc) - timedelta(seconds=2))
+
+    with caplog.at_level(logging.INFO):
+        adapter._log_inbound_latency(event, stage="adapter_received")
+
+    assert "TelegramLatency" in caplog.text
+    assert "stage=adapter_received" in caplog.text
+    assert "update_id=77" in caplog.text
+    assert "message_id=42" in caplog.text
+    assert "platform_age_ms=" in caplog.text
+    assert "chat_ref=" in caplog.text
+    assert "123456789" not in caplog.text
+    assert event.text not in caplog.text
+    assert event.metadata == {}
+    assert hasattr(event, "_telegram_latency_received_monotonic")
+
+
+@pytest.mark.asyncio
+async def test_gateway_dispatch_diagnostic_preserves_base_behavior(
+    monkeypatch, caplog
+) -> None:
+    monkeypatch.setenv("HERMES_TELEGRAM_LATENCY_DIAGNOSTICS", "true")
+    adapter = _make_adapter()
+    event = _event(timestamp=datetime.now(timezone.utc) - timedelta(seconds=1))
+
+    adapter._log_inbound_latency(event, stage="adapter_received")
+    base_handle = AsyncMock()
+    with (
+        caplog.at_level(logging.INFO),
+        patch.object(BasePlatformAdapter, "handle_message", base_handle),
+    ):
+        await adapter.handle_message(event)
+
+    assert "stage=gateway_dispatch" in caplog.text
+    assert "adapter_queue_ms=" in caplog.text
+    base_handle.assert_awaited_once_with(event)
+
+
+@pytest.mark.asyncio
+async def test_typing_success_logs_duration_when_enabled(monkeypatch, caplog) -> None:
+    monkeypatch.setenv("HERMES_TELEGRAM_LATENCY_DIAGNOSTICS", "yes")
+    adapter = _make_adapter()
+
+    with caplog.at_level(logging.INFO):
+        await adapter.send_typing("123456789")
+
+    assert "TelegramLatency" in caplog.text
+    assert "operation=send_chat_action" in caplog.text
+    assert "outcome=success" in caplog.text
+    assert "duration_ms=" in caplog.text
+    assert "123456789" not in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("bot_connected", "cooldown", "reason"),
+    (
+        (False, False, "not_connected"),
+        (True, True, "cooldown"),
+    ),
+)
+async def test_typing_skip_reason_is_visible_when_enabled(
+    monkeypatch, caplog, bot_connected, cooldown, reason
+) -> None:
+    monkeypatch.setenv("HERMES_TELEGRAM_LATENCY_DIAGNOSTICS", "1")
+    adapter = _make_adapter()
+    if not bot_connected:
+        adapter._bot = None
+    monkeypatch.setattr(adapter, "_typing_in_cooldown", lambda _chat_id: cooldown)
+
+    with caplog.at_level(logging.INFO):
+        await adapter.send_typing("123456789")
+
+    assert "outcome=skipped" in caplog.text
+    assert f"reason={reason}" in caplog.text
+    assert "123456789" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_typing_failure_logs_redacted_error_when_enabled(
+    monkeypatch, caplog
+) -> None:
+    monkeypatch.setenv("HERMES_TELEGRAM_LATENCY_DIAGNOSTICS", "on")
+    adapter = _make_adapter()
+    secret = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi"
+    adapter._bot.send_chat_action = AsyncMock(
+        side_effect=RuntimeError(
+            f"request failed https://api.telegram.org/bot{secret}/sendChatAction"
+        )
+    )
+
+    with caplog.at_level(logging.INFO):
+        await adapter.send_typing("987654321")
+
+    assert "outcome=failure" in caplog.text
+    assert secret not in caplog.text
+    assert "987654321" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_typing_fallback_failure_logs_the_final_error(
+    monkeypatch, caplog
+) -> None:
+    monkeypatch.setenv("HERMES_TELEGRAM_LATENCY_DIAGNOSTICS", "1")
+    adapter = _make_adapter()
+    adapter._bot.send_chat_action = AsyncMock(
+        side_effect=(
+            ValueError("primary thread error"),
+            RuntimeError("fallback transport error"),
+        )
+    )
+
+    with caplog.at_level(logging.INFO):
+        await adapter.send_typing(
+            "987654321",
+            metadata={"thread_id": "99", "telegram_dm_topic_reply_fallback": True},
+        )
+
+    assert "outcome=failure" in caplog.text
+    assert "fallback transport error" in caplog.text
+    assert "primary thread error" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_typing_fallback_cancellation_is_logged_and_propagated(
+    monkeypatch, caplog
+) -> None:
+    monkeypatch.setenv("HERMES_TELEGRAM_LATENCY_DIAGNOSTICS", "1")
+    adapter = _make_adapter()
+    adapter._bot.send_chat_action = AsyncMock(
+        side_effect=(
+            ValueError("primary thread error"),
+            asyncio.CancelledError(),
+        )
+    )
+
+    with caplog.at_level(logging.INFO), pytest.raises(asyncio.CancelledError):
+        await adapter.send_typing(
+            "987654321",
+            metadata={"thread_id": "99", "telegram_dm_topic_reply_fallback": True},
+        )
+
+    assert "outcome=cancelled" in caplog.text
+    assert "duration_ms=" in caplog.text
+    assert "987654321" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_typing_cancellation_is_logged_and_propagated(
+    monkeypatch, caplog
+) -> None:
+    monkeypatch.setenv("HERMES_TELEGRAM_LATENCY_DIAGNOSTICS", "1")
+    adapter = _make_adapter()
+    adapter._bot.send_chat_action = AsyncMock(side_effect=asyncio.CancelledError())
+
+    with caplog.at_level(logging.INFO), pytest.raises(asyncio.CancelledError):
+        await adapter.send_typing("123456789")
+
+    assert "outcome=cancelled" in caplog.text


### PR DESCRIPTION
## Summary

- add opt-in Telegram ingress timing at `adapter_received` and `gateway_dispatch`
- log `sendChatAction(typing)` start, success, failure, cancellation, fallback success, and skipped outcomes with duration where applicable
- correlate records with a stable pseudonymous chat reference without logging message text, credentials, or raw chat IDs
- preserve normal Telegram behavior and keep diagnostics disabled by default

## Motivation

Intermittent Telegram messages can take 150–185 seconds before Hermes shows any visible acknowledgement. Existing logs cannot distinguish Telegram transport/polling delay, adapter batching/dispatch delay, and the typing API call. This adds the missing component-boundary evidence without changing retries, polling, batching, routing, or typing cadence.

## Enablement

Set:

```bash
HERMES_TELEGRAM_LATENCY_DIAGNOSTICS=1
```

Relevant log records use the `[TelegramLatency]` marker. Unset the variable to disable the instrumentation again.

## Safety and privacy

- disabled by default
- no message text or credentials logged
- raw chat IDs are replaced with a 48-bit BLAKE2s correlation reference
- Telegram transport errors pass through the existing forced secret redactor
- operation durations use monotonic time; platform-message age uses UTC
- diagnostic receive timestamps stay on private event attributes rather than forwarded metadata
- no changes to polling, retries, batching, routing, typing cadence, or response delivery

## Tests

- `scripts/run_tests.sh tests/gateway/test_telegram_latency_diagnostics.py` — 12 passed
- `scripts/run_tests.sh tests/gateway/test_telegram_*.py` — 659 passed, 2 skipped
- `ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_latency_diagnostics.py` — passed
- `ruff format --check tests/gateway/test_telegram_latency_diagnostics.py` — passed
- `python -m py_compile plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_latency_diagnostics.py` — passed
- `python scripts/check-windows-footguns.py plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_latency_diagnostics.py` — passed
- `git diff --check` — passed

The new fallback-cancellation regression test was proven by sabotage: it fails against the pre-fix behavior because only `outcome=started` is emitted, and passes after restoring the cancellation handler.

A full repository run was attempted locally but stopped at 26.7% after 22 non-Telegram test files had already failed in the local test environment. No full-suite success is claimed; GitHub CI is required for repository-wide verification.

## Relationship to existing work

- Closes #102761
- Alternative to #102779: this draft additionally segments `adapter_received → gateway_dispatch`, avoids raw chat IDs, and covers skipped typing calls plus primary/fallback cancellation and fallback-failure outcomes.
- Related to #102260 and #102383, which add aggregate healthy-but-deaf ingress watchdog telemetry rather than per-message latency segmentation.

## AI assistance disclosure

Implemented and reviewed with AI assistance under human-authorized repository scope.
