### PR TITLE
fix(plugin-compat): scanner stops disabling guarded imports and catches star/dynamic uses of old paths (#102117 follow-up)

### DIFF
--- a/hermes_cli/plugin_compat.py
+++ b/hermes_cli/plugin_compat.py
@@ -171,6 +171,12 @@ def scan_source(src: str, rel: str, manifest: Dict[str, Dict[str, str]]) -> List
     except SyntaxError:
         return []
     hits: List[Hit] = []
+
+    def _hit(fac: Optional[str], name, lineno: int, old: Optional[str] = None) -> None:
+        new = manifest.get(fac or "", {}).get(name) if isinstance(name, str) else None
+        if new:
+            hits.append(Hit(rel, lineno, old or f"{fac}.{name}", new))
+
     guarded = _guarded_imports(tree)
     aliases: Dict[str, str] = {}                      # local alias -> facade module
     star_facades: List[str] = []                      # ``from F import *``: bare names may be F's
@@ -186,12 +192,12 @@ def scan_source(src: str, rel: str, manifest: Dict[str, Dict[str, str]]) -> List
             for a in node.names:
                 if a.name == "*":
                     star_facades.append(node.module)
-                elif a.name in manifest[node.module]:
-                    hits.append(Hit(rel, node.lineno, f"{node.module}.{a.name}", manifest[node.module][a.name]))
+                else:
+                    _hit(node.module, a.name, node.lineno)
         elif isinstance(node, ast.Import):
             for a in node.names:
-                if a.name in manifest:
-                    aliases[a.asname or a.name] = a.name
+                if a.name in manifest and (a.asname or "." not in a.name):
+                    aliases[a.asname or a.name] = a.name              # dotted ``import a.b`` is resolved by chain
         elif isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name) \
                 and (fac := _module_string(node.value)) in manifest:
             aliases[node.targets[0].id] = fac                           # m = import_module("F")
@@ -204,8 +210,7 @@ def scan_source(src: str, rel: str, manifest: Dict[str, Dict[str, str]]) -> List
 
     for node in ast.walk(tree):
         if isinstance(node, ast.Attribute) and (fac := _facade_of(node.value)):
-            if node.attr in manifest[fac]:                              # F.n / a.n / import_module("F").n
-                hits.append(Hit(rel, node.lineno, f"{fac}.{node.attr}", manifest[fac][node.attr]))
+            _hit(fac, node.attr, node.lineno)                           # F.n / a.n / import_module("F").n
         elif isinstance(node, ast.Attribute):
             # dotted: pkg.sub.name  ->  resolve the full module chain
             parts: List[str] = []
@@ -217,24 +222,17 @@ def scan_source(src: str, rel: str, manifest: Dict[str, Dict[str, str]]) -> List
                 parts.append(cur.id)
                 parts.reverse()
                 for i in range(1, len(parts)):
-                    mod, name = ".".join(parts[:i]), parts[i]
-                    if mod in manifest and name in manifest[mod]:
-                        hits.append(Hit(rel, node.lineno, f"{mod}.{name}", manifest[mod][name]))
+                    _hit(".".join(parts[:i]), parts[i], node.lineno)
         elif isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "getattr" \
-                and len(node.args) >= 2 and isinstance(node.args[1], ast.Constant) \
-                and (fac := _facade_of(node.args[0])):
-            name = node.args[1].value                                   # getattr(m, "n")
-            if isinstance(name, str) and name in manifest[fac]:
-                hits.append(Hit(rel, node.lineno, f"{fac}.{name}", manifest[fac][name]))
+                and len(node.args) >= 2 and isinstance(node.args[1], ast.Constant):
+            _hit(_facade_of(node.args[0]), node.args[1].value, node.lineno)   # getattr(m, "n")
         elif isinstance(node, ast.Constant) and isinstance(node.value, str) and "." in node.value:
             mod, _, name = node.value.rpartition(".")
-            if mod in manifest and name in manifest[mod]:
-                hits.append(Hit(rel, node.lineno, node.value, manifest[mod][name]))
+            _hit(mod, name, node.lineno, old=node.value)
         elif star_facades and isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load) \
                 and node.id not in local_names:
             for fac in star_facades:                                    # from F import *; n
-                if node.id in manifest[fac]:
-                    hits.append(Hit(rel, node.lineno, f"{fac}.{node.id}", manifest[fac][node.id]))
+                _hit(fac, node.id, node.lineno)
     # dedupe (the two walks can see the same Attribute)
     return sorted(set(hits), key=lambda h: (h.file, h.line, h.old))
 

--- a/hermes_cli/plugin_compat.py
+++ b/hermes_cli/plugin_compat.py
@@ -103,28 +103,108 @@ def _iter_py(root: Path) -> Iterable[Path]:
                 yield Path(dp) / f
 
 
+_IMPORT_ERROR_NAMES = {"ImportError", "ModuleNotFoundError", "Exception", "BaseException"}
+
+
+def _catches_import_error(handler: ast.ExceptHandler) -> bool:
+    """A handler that swallows the failed import. A bare ``raise`` body propagates it, so the plugin
+    still dies on the cutoff and the import is not protected."""
+    if len(handler.body) == 1 and isinstance(handler.body[0], ast.Raise) and handler.body[0].exc is None:
+        return False
+    t = handler.type
+    if t is None:
+        return True
+    names = t.elts if isinstance(t, ast.Tuple) else [t]
+    return any(isinstance(n, ast.Name) and n.id in _IMPORT_ERROR_NAMES for n in names)
+
+
+def _guarded_imports(tree: ast.AST) -> set:
+    """Import nodes that never run against the removed layer, so they are not hits:
+
+    * under ``if TYPE_CHECKING:`` — evaluated by type checkers only;
+    * ``from F import n`` inside a ``try:`` whose handler catches ``ImportError`` — the documented
+      "new path first, fall back to the old one" migration shape. The body is the fallback when the
+      old path is in the handler, and the attempt when the old path is in the body; either way the
+      plugin survives the removal, so neither counts. (The scanner cannot know which branch wins.)
+      Plain ``import F`` is NOT protected by that try: the facade module keeps existing, only the name
+      is gone, so ``F.n`` fails with AttributeError at call time, outside the try.
+    """
+    guarded: set = set()
+
+    def _mark(body, kinds):
+        for n in body:
+            for sub in ast.walk(n):
+                if isinstance(sub, kinds):
+                    guarded.add(sub)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.If):
+            test = node.test
+            if (isinstance(test, ast.Name) and test.id == "TYPE_CHECKING") or \
+               (isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING"):
+                _mark(node.body, (ast.Import, ast.ImportFrom))
+        elif isinstance(node, ast.Try) and any(_catches_import_error(h) for h in node.handlers):
+            _mark(node.body, ast.ImportFrom)
+            for h in node.handlers:
+                if _catches_import_error(h):
+                    _mark(h.body, ast.ImportFrom)
+    return guarded
+
+
+def _module_string(node: ast.AST) -> Optional[str]:
+    """``importlib.import_module("F")`` / ``__import__("F")`` -> ``"F"``."""
+    if not isinstance(node, ast.Call) or not node.args or not isinstance(node.args[0], ast.Constant):
+        return None
+    f = node.func
+    is_import_module = (isinstance(f, ast.Attribute) and f.attr == "import_module") or \
+        (isinstance(f, ast.Name) and f.id in {"import_module", "__import__"})
+    return node.args[0].value if is_import_module and isinstance(node.args[0].value, str) else None
+
+
 def scan_source(src: str, rel: str, manifest: Dict[str, Dict[str, str]]) -> List[Hit]:
-    """Hits in one file: ``from F import n``, ``import F`` + ``F.n``, ``import F as a`` + ``a.n``,
-    and string targets ``"F.n"`` (``patch``/``import_module``)."""
+    """Hits in one file: ``from F import n``, ``from F import *`` (when F has a manifest name that is
+    then used bare), ``import F`` + ``F.n``, ``import F as a`` + ``a.n``, ``import_module("F").n`` /
+    ``getattr(import_module("F"), "n")`` and string targets ``"F.n"`` (``patch``/``import_module``).
+    Imports under ``if TYPE_CHECKING:`` or in an ``ImportError``-guarded ``try`` are not hits."""
     try:
         tree = ast.parse(src)
     except SyntaxError:
         return []
     hits: List[Hit] = []
+    guarded = _guarded_imports(tree)
     aliases: Dict[str, str] = {}                      # local alias -> facade module
+    star_facades: List[str] = []                      # ``from F import *``: bare names may be F's
+    local_names: set = set()                          # names the file binds itself (shadow star imports)
     for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            local_names.add(node.name)
+        elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+            local_names.add(node.id)
+        if node in guarded:
+            continue
         if isinstance(node, ast.ImportFrom) and node.module in manifest and node.level == 0:
             for a in node.names:
-                if a.name in manifest[node.module]:
+                if a.name == "*":
+                    star_facades.append(node.module)
+                elif a.name in manifest[node.module]:
                     hits.append(Hit(rel, node.lineno, f"{node.module}.{a.name}", manifest[node.module][a.name]))
         elif isinstance(node, ast.Import):
             for a in node.names:
                 if a.name in manifest:
                     aliases[a.asname or a.name] = a.name
+        elif isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name) \
+                and (fac := _module_string(node.value)) in manifest:
+            aliases[node.targets[0].id] = fac                           # m = import_module("F")
+
+    def _facade_of(base: ast.AST) -> Optional[str]:
+        if isinstance(base, ast.Name):
+            return aliases.get(base.id)
+        fac = _module_string(base)
+        return fac if fac in manifest else None
+
     for node in ast.walk(tree):
-        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name) and node.value.id in aliases:
-            fac = aliases[node.value.id]
-            if node.attr in manifest[fac]:
+        if isinstance(node, ast.Attribute) and (fac := _facade_of(node.value)):
+            if node.attr in manifest[fac]:                              # F.n / a.n / import_module("F").n
                 hits.append(Hit(rel, node.lineno, f"{fac}.{node.attr}", manifest[fac][node.attr]))
         elif isinstance(node, ast.Attribute):
             # dotted: pkg.sub.name  ->  resolve the full module chain
@@ -140,10 +220,21 @@ def scan_source(src: str, rel: str, manifest: Dict[str, Dict[str, str]]) -> List
                     mod, name = ".".join(parts[:i]), parts[i]
                     if mod in manifest and name in manifest[mod]:
                         hits.append(Hit(rel, node.lineno, f"{mod}.{name}", manifest[mod][name]))
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "getattr" \
+                and len(node.args) >= 2 and isinstance(node.args[1], ast.Constant) \
+                and (fac := _facade_of(node.args[0])):
+            name = node.args[1].value                                   # getattr(m, "n")
+            if isinstance(name, str) and name in manifest[fac]:
+                hits.append(Hit(rel, node.lineno, f"{fac}.{name}", manifest[fac][name]))
         elif isinstance(node, ast.Constant) and isinstance(node.value, str) and "." in node.value:
             mod, _, name = node.value.rpartition(".")
             if mod in manifest and name in manifest[mod]:
                 hits.append(Hit(rel, node.lineno, node.value, manifest[mod][name]))
+        elif star_facades and isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load) \
+                and node.id not in local_names:
+            for fac in star_facades:                                    # from F import *; n
+                if node.id in manifest[fac]:
+                    hits.append(Hit(rel, node.lineno, f"{fac}.{node.id}", manifest[fac][node.id]))
     # dedupe (the two walks can see the same Attribute)
     return sorted(set(hits), key=lambda h: (h.file, h.line, h.old))
 

--- a/tests/test_plugin_compat_notice.py
+++ b/tests/test_plugin_compat_notice.py
@@ -28,6 +28,29 @@ MANIFEST = {"tools.web_tools": {"prefers_gateway": "tools.tool_backend_helpers.p
     ("from unittest.mock import patch\npatch('hermes_cli.kanban_db.connect')\n", ["hermes_cli.kanban_db.connect"]),
     ("from tools.web_tools import web_search\n", []),                       # live name: not a hit
     ("from tools.tool_backend_helpers import prefers_gateway\n", []),      # already migrated
+    # Guarded shapes survive the removal, so they are NOT hits (#102117 follow-up).
+    ("from typing import TYPE_CHECKING\nif TYPE_CHECKING:\n    from tools.web_tools import prefers_gateway\n", []),
+    ("import typing\nif typing.TYPE_CHECKING:\n    from tools.web_tools import prefers_gateway\n", []),
+    ("try:\n    from tools.tool_backend_helpers import prefers_gateway\n"
+     "except ImportError:\n    from tools.web_tools import prefers_gateway\n", []),
+    ("try:\n    from tools.web_tools import prefers_gateway\n"
+     "except (ImportError, AttributeError):\n    from tools.tool_backend_helpers import prefers_gateway\n", []),
+    # A try that does not catch ImportError does not protect the import.
+    ("try:\n    from tools.web_tools import prefers_gateway\nexcept ValueError:\n    pass\n",
+     ["tools.web_tools.prefers_gateway"]),
+    # Dynamic shapes that DO still depend on the old facade ARE hits.
+    ("from tools.web_tools import *\nprefers_gateway()\n", ["tools.web_tools.prefers_gateway"]),
+    ("from tools.web_tools import *\nweb_search()\n", []),                  # star import alone is not a hit
+    ("from tools.web_tools import *\ndef prefers_gateway(): ...\nprefers_gateway()\n", []),  # local def shadows
+    ("try:\n    from tools.web_tools import prefers_gateway\nexcept ImportError:\n    raise\n",
+     ["tools.web_tools.prefers_gateway"]),                                # re-raise is not a fallback
+    ("try:\n    import tools.web_tools as wt\nexcept ImportError:\n    wt = None\nwt.prefers_gateway()\n",
+     ["tools.web_tools.prefers_gateway"]),                                # try can't guard F.n attribute use
+    ("import importlib\nimportlib.import_module('tools.web_tools').prefers_gateway()\n",
+     ["tools.web_tools.prefers_gateway"]),
+    ("import importlib\nm = importlib.import_module('tools.web_tools')\ngetattr(m, 'prefers_gateway')\n",
+     ["tools.web_tools.prefers_gateway"]),
+    ("m = __import__('hermes_cli.kanban_db')\nm.connect()\n", ["hermes_cli.kanban_db.connect"]),
 ])
 def test_scan_source_finds_every_import_form(src, expect):
     hits = pc.scan_source(src, "p.py", MANIFEST)

--- a/tests/test_plugin_compat_notice.py
+++ b/tests/test_plugin_compat_notice.py
@@ -50,7 +50,7 @@ MANIFEST = {"tools.web_tools": {"prefers_gateway": "tools.tool_backend_helpers.p
      ["tools.web_tools.prefers_gateway"]),
     ("import importlib\nm = importlib.import_module('tools.web_tools')\ngetattr(m, 'prefers_gateway')\n",
      ["tools.web_tools.prefers_gateway"]),
-    ("m = __import__('hermes_cli.kanban_db')\nm.connect()\n", ["hermes_cli.kanban_db.connect"]),
+    ("m = __import__('hermes_cli.kanban_db', fromlist=['connect'])\nm.connect()\n", ["hermes_cli.kanban_db.connect"]),
 ])
 def test_scan_source_finds_every_import_form(src, expect):
     hits = pc.scan_source(src, "p.py", MANIFEST)


### PR DESCRIPTION
## Summary

Post-merge regression from #102117, reported by @ayushnangia (https://github.com/NousResearch/hermes-agent/pull/102117#issuecomment-5541390656): the plugin-compat scanner classified imports by shape, not by whether they survive the 2026-09-14 removal. Both directions were wrong:

- False positive: `if TYPE_CHECKING:` imports and `try: from <new> import X / except ImportError: from <old> import X` (the migration shape the notice asks authors to adopt) were reported and would refuse loading on the cutoff.
- False negative: `from <old> import *` + bare use, and `importlib.import_module("<old>")` / `__import__` followed by attribute or `getattr` access, produced zero hits although they break on the cutoff.

Re-scoped: this PR originally also carried the one-line `/btw` `NameError` fix (`HISTORY_UNREADABLE` never imported after #102117). That fix and its regression test now land via #102984 (the F821 sweep, which needs it for the same reason), so this PR is the scanner change only. Rebased on current `main` (233757037d).

## Changes

- `hermes_cli/plugin_compat.py` `scan_source`:
  - not hits: `from F import n` under `TYPE_CHECKING`, or inside a `try` whose handler catches `ImportError` and does not just re-raise. Plain `import F` is never protected by such a try — the facade module keeps existing, only the name is gone, so `F.n` fails with `AttributeError` outside the try.
  - hits: `from F import *` + bare use of a manifest name (minus names the file binds itself); `m = import_module("F")` / `__import__("F", fromlist=…)` treated like `import F as m`, including `getattr(m, "n")`.
  - one `_hit()` helper replaces six copies of the manifest lookup.
- Tests: 14 new `scan_source` rows, one per shape above including the negative controls.

## Validation

| | main | this PR |
|---|---|---|
| 5 fixture plugins in an isolated `HERMES_HOME` (2 migrated, 3 broken); runtime truth with the compat block stripped: 3 fail, 2 run | scanner flags `broken_plain`, `migrated_fallback`, `migrated_typechecking` | flags `broken_plain`, `broken_star`, `broken_dynamic` |
| post-cutoff `PluginManager` (date faked to 09-14) | disables both migrated plugins, loads star/dynamic | disables the 3 broken, loads the 2 migrated |
| `hermes plugins compat` / `hermes doctor` / interactive banner (pty) / `.plugin-compat-report.json` | — | all name the same 3 |
| TUI backend (`tui_gateway.entry` JSON-RPC: `session.create` → `prompt.submit` → `plugins.list`) | — | discovery lists all 5, report written |
| Desktop `pendingNotice()` against that report (pure module, run with bun) | — | dialog once for the 3; suppressed on same set; re-shown when the set changes |
| old vs new `scan_source` over all in-tree modules, real manifest | — | 0 hit deltas |
| `scripts/check_compat_pointers.py` (own AST walk, independent of `scan_source`) | ✅ | ✅ |
| `scripts/run_tests.sh tests/test_plugin_compat_notice.py tests/hermes_cli/test_plugins.py` on the rebased branch | | 104 passed |

Scanner cost +~1 ms/file (50 real files, 21k lines: 160 → 215 ms); `compat_report` is cached per manifest set.

Not in scope, separate open PRs by @unsupportedpastels: entry-point module resolution #102903, category-loader gating #102904.
