### PR TITLE
fix(gemini-native): disambiguate parallel same-name tool calls by id

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -923,9 +923,29 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
             except (TypeError, ValueError):
                 args_str = "{}"
             thought_signature = part.get("thoughtSignature") if isinstance(part.get("thoughtSignature"), str) else ""
+            fc_id = str(fc["id"]) if isinstance(fc.get("id"), str) and fc.get("id") else None
+            # Correlate streamed functionCall parts across SSE chunks.
+            #
+            # Gemini 3+ stamps each distinct function call with a stable,
+            # unique `id` (gemini_requires_tool_call_ids()) -- use THAT to
+            # key the slot when present, since it uniquely identifies the
+            # call regardless of tool name.
+            #
+            # Older Gemini (2.x) omits `id`, so fall back to the
+            # (part_index, name, thought_signature) heuristic. That
+            # heuristic is unsafe on its own for models that DO support
+            # parallel tool calls: `part_index` is the position within the
+            # CURRENT chunk's parts[] (which resets to 0 for a chunk that
+            # carries a single part), so two DIFFERENT calls to the SAME
+            # tool name (e.g. several `ha_call_service` calls in one turn)
+            # collide onto one slot and their JSON `arguments` get
+            # concatenated into one unparseable blob. Only reachable when
+            # fc_id is unavailable, i.e. pre-Gemini-3 models that don't
+            # advertise parallel-call ids in the first place.
             call_key = json.dumps(
                 {
-                    "part_index": part_index,
+                    "id": fc_id,
+                    "part_index": part_index if fc_id is None else None,
                     "name": name,
                     "thought_signature": thought_signature,
                 },
@@ -935,11 +955,7 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
             if slot is None:
                 slot = {
                     "index": len(tool_call_indices),
-                    "id": (
-                        str(fc["id"])
-                        if isinstance(fc.get("id"), str) and fc.get("id")
-                        else f"call_{uuid.uuid4().hex[:12]}"
-                    ),
+                    "id": fc_id or f"call_{uuid.uuid4().hex[:12]}",
                     "last_arguments": "",
                 }
                 tool_call_indices[call_key] = slot

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -400,6 +400,56 @@ def test_stream_event_translation_emits_tool_call_delta_with_stable_index():
     assert first[-1].choices[0].finish_reason == "tool_calls"
 
 
+def test_stream_event_translation_disambiguates_parallel_same_name_calls_by_id():
+    """Gemini 3+ stamps each distinct function call with a stable, unique
+    ``id`` (see ``gemini_requires_tool_call_ids``). Several DIFFERENT calls
+    to the SAME tool name arriving in separate SSE chunks (each chunk
+    carrying a single part, so ``part_index`` is always 0 within that
+    chunk) must not collide onto one slot and have their JSON arguments
+    concatenated -- regression test for that exact failure mode."""
+    from agent.gemini_native_adapter import translate_stream_event
+
+    tool_call_indices = {}
+    calls = [
+        ("call_aaa", {"entity_id": "input_number.phosphate_po4", "value": 0.03}),
+        ("call_bbb", {"entity_id": "input_number.aquarium_kh_carbonate_hardness", "value": 9.0}),
+        ("call_ccc", {"entity_id": "input_number.nitrate_no3", "value": 12.0}),
+    ]
+
+    chunks = []
+    for call_id, args in calls:
+        event = {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {"functionCall": {"id": call_id, "name": "ha_call_service", "args": args}}
+                        ]
+                    },
+                }
+            ]
+        }
+        chunks.extend(
+            translate_stream_event(event, model="gemini-3.1-flash-lite", tool_call_indices=tool_call_indices)
+        )
+
+    deltas = [c.choices[0].delta.tool_calls[0] for c in chunks if c.choices[0].delta.tool_calls]
+
+    # Each call gets its own index and its own id -- no collision.
+    assert {d.index for d in deltas} == {0, 1, 2}
+    assert {d.id for d in deltas} == {"call_aaa", "call_bbb", "call_ccc"}
+
+    # Each delta's arguments are independently valid JSON, not a
+    # concatenation of multiple calls' JSON payloads.
+    by_index: dict = {}
+    for d in deltas:
+        by_index.setdefault(d.index, "")
+        by_index[d.index] += d.function.arguments
+    assert len(by_index) == 3
+    for argstr in by_index.values():
+        json.loads(argstr)  # raises if this is a concatenated blob
+
+
 def test_build_gemini_request_preserves_explicit_max_tokens_without_thinking():
     from agent.gemini_native_adapter import build_gemini_request
 


### PR DESCRIPTION
## Problem

`translate_stream_event()` in `agent/gemini_native_adapter.py` correlates
streamed `functionCall` parts across SSE chunks using a `call_key` of
`(part_index, name, thought_signature)`.

`part_index` is the position within the **current chunk's** `parts[]`
array, which is `0` whenever a chunk carries a single part — the common
case when Gemini streams several tool calls, each arriving in its own
chunk. When a model turn contains multiple *different* calls to the
*same* tool name (e.g. several `ha_call_service` calls in one turn, one
per Home-Assistant entity being updated), every call collides onto the
identical `call_key` and gets treated as the same call growing
incrementally.

The `startswith`-based diffing then fails to reconcile unrelated JSON
payloads and falls through to re-emitting the full `args` each time,
which the downstream OpenAI-style delta accumulator appends (`+=`) onto
the same slot — concatenating multiple complete, individually-valid JSON
objects into one unparseable `arguments` string.

Observed symptom in production (Discord platform, `gemini-3.1-flash-lite`):

```
Unrepairable tool_call arguments for ha_call_service — replaced with empty object
(was: {"data": "...", "entity_id": "input_number.a", ...}{"data": "...", "entity_id": "input_number.b", ...}...)
Response truncated (finish_reason='length') - model hit max output tokens
```

...repeating across 4 retries, ending in "Response truncated due to
output length limit" — even though the model was behaving correctly and
sending well-formed, complete tool calls.

## Fix

Gemini 3+ already stamps each distinct function call with a stable,
unique `id` (see `gemini_requires_tool_call_ids()`) — the adapter already
read `fc["id"]`, but only to seed the outgoing tool-call id, never to
correlate calls across streaming chunks.

`call_key` now prefers `fc["id"]` when present, falling back to the
previous `(part_index, name, thought_signature)` heuristic only when
`id` is absent (Gemini 2.x, which doesn't advertise per-call ids and
isn't exercised for parallel same-name calls in practice — no behavior
change there).

## Testing

- Added `test_stream_event_translation_disambiguates_parallel_same_name_calls_by_id`,
  replicating the exact collision: three distinct calls to the same tool
  name, each in its own chunk, each with a Gemini-3-style per-call `id`.
  Confirms each call now lands in its own slot with independently valid
  (non-concatenated) JSON arguments.
- Confirmed the existing `test_stream_event_translation_emits_tool_call_delta_with_stable_index`
  (same call resent twice, no `id`, Gemini 2.x path) still passes
  unchanged.
- `pytest tests/agent/test_gemini_native_adapter.py` — 30 passed.

## Notes

Found and fixed while diagnosing a real-world failure where a Discord
user reported several aquarium water-parameter readings at once and the
agent tried to batch the corresponding `input_number.set_value` calls
(via `parallel_tool_call_guidance`) into a single turn.
