### PR TITLE
fix(dashboard): late-bind served SSH session token

### DIFF
--- a/hermes_cli/web_server_dashboard.py
+++ b/hermes_cli/web_server_dashboard.py
@@ -102,7 +102,8 @@ def mount_spa(application: FastAPI):
     with a missing dist per-request (404 JSON / ``check_dir=False``), so a long-lived
     ``--skip-build`` process recovers the moment a build appears on disk — no restart.
     """
-    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, _SESSION_TOKEN, app
+    from hermes_cli.web_deps import get_session_token
+    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, app
 
     # `hermes serve` is the headless backend: it must NEVER serve the browser SPA, even if a
     # dist is lying around, so only the JSON-RPC/WS/API surface is reachable.
@@ -120,7 +121,7 @@ def mount_spa(application: FastAPI):
             if full_path == "" and not gated:
                 return HTMLResponse(
                     "<!doctype html><html><head><script>"
-                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(_SESSION_TOKEN)};"
+                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(get_session_token())};"
                     "window.__HERMES_AUTH_REQUIRED__=false;"
                     f"</script></head><body>{_HEADLESS_MSG}</body></html>",
                     headers=_NO_STORE,
@@ -151,7 +152,7 @@ def mount_spa(application: FastAPI):
             return JSONResponse({"error": "Frontend not built. Run: cd web && npm run build"}, status_code=404)
         chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
         gated = bool(getattr(app.state, "auth_required", False))
-        token_js = "" if gated else f'window.__HERMES_SESSION_TOKEN__="{_SESSION_TOKEN}";'
+        token_js = "" if gated else f'window.__HERMES_SESSION_TOKEN__="{get_session_token()}";'
         bootstrap_script = (
             f"<script>{token_js}"
             f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5065,6 +5065,20 @@ class TestServeIndexMissingIndex:
         assert resp.status_code == 200
         assert "SPA-rebuilt" in resp.text
 
+    def test_index_uses_session_token_applied_after_mount(self, tmp_path, monkeypatch):
+        import hermes_cli.web_server as ws
+
+        client, _dist = self._client_with_dist(tmp_path, monkeypatch, write_index=True)
+        mounted_token = ws._SESSION_TOKEN
+        monkeypatch.setattr(ws, "_SESSION_TOKEN", mounted_token)
+        ssh_token = "s" * 64
+
+        ws._apply_ssh_session_token(ssh_token)
+        resp = client.get("/chat")
+
+        assert resp.status_code == 200
+        assert f'window.__HERMES_SESSION_TOKEN__="{ssh_token}"' in resp.text
+
 
 class TestHeadlessServeTokenPage:
     """Headless `hermes serve` must serve the Desktop token handshake page
@@ -5109,6 +5123,25 @@ class TestHeadlessServeTokenPage:
 
         assert _json.loads(match.group(1)) == ws._SESSION_TOKEN
         assert "window.__HERMES_AUTH_REQUIRED__=false" in resp.text
+
+    def test_root_uses_session_token_applied_after_mount(self, monkeypatch):
+        import json as _json
+        import re
+
+        client, ws = self._headless_client(monkeypatch, gated=False)
+        mounted_token = ws._SESSION_TOKEN
+        monkeypatch.setattr(ws, "_SESSION_TOKEN", mounted_token)
+        ssh_token = "s" * 64
+
+        ws._apply_ssh_session_token(ssh_token)
+        resp = client.get("/")
+
+        match = re.search(
+            r'window\.__HERMES_SESSION_TOKEN__\s*=\s*("(?:\\.|[^"\\])*")',
+            resp.text,
+        )
+        assert match, resp.text
+        assert _json.loads(match.group(1)) == ssh_token
 
     def test_root_stays_404_json_when_auth_gated(self, monkeypatch):
         client, ws = self._headless_client(monkeypatch, gated=True)


### PR DESCRIPTION
## Summary

- resolve the dashboard session token at request time instead of capturing its import-time value
- keep both the headless Desktop handshake page and the browser SPA aligned with the token used by API authentication
- add regression coverage for tokens applied after SPA routes are mounted

## Root Cause

`mount_spa()` captured `_SESSION_TOKEN` before `start_server()` replaced it with the token read from `--ssh-session-token-file`. The HTML routes kept serving that stale snapshot while API middleware validated against the updated module global.

## Testing

- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py -k 'test_root_uses_session_token_applied_after_mount or test_index_uses_session_token_applied_after_mount' -q`
- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py -q` (183 passed, 5 skipped)

Closes #102930
Related: #102931
