### PR TITLE
fix(approval): truthful block reasons for interpreter exec flags; gate cmd /c wrapper bypass

### DIFF
--- a/tests/tools/test_execution_flag_detection.py
+++ b/tests/tools/test_execution_flag_detection.py
@@ -367,7 +367,26 @@ def test_powershell_file_bypass_via_cmd_wrapper_is_gated():
         "cmd /k pwsh -f x.ps1",
         # git-bash/MSYS (the reporter's shell) escapes to //c.
         "cmd //c powershell -File x.ps1",
+        # options/markers before the verb must not hide the payload.
+        "cmd /u /c powershell -File x.ps1",
+        # whole-payload quoted (the canonical `cmd /c "..."` idiom).
+        'cmd /c "powershell -File x.ps1"',
+        'cmd.exe /c "powershell -NoProfile -ExecutionPolicy Bypass -File C:/x/repro.ps1"',
     ]:
         dangerous, key, description = detect_dangerous_command(command)
         assert dangerous is True, f"bypass via wrapper: {command!r}"
         assert description == "script execution via -File/-f flag (PowerShell)", (command, description)
+
+
+def test_cmd_wrapper_does_not_gate_benign_payloads():
+    """cmd /c <benign> must NOT gain approval just because it is a wrapper."""
+    for command in [
+        "cmd /c echo hello",
+        "cmd /c dir",
+        "cmd /c npm install",
+        "cmd /c git status",
+        "cmd /?",
+        "cmd /u",
+        'cmd /c "echo hello"',
+    ]:
+        assert detect_dangerous_command(command) == (False, None, None), command

--- a/tests/tools/test_execution_flag_detection.py
+++ b/tests/tools/test_execution_flag_detection.py
@@ -357,6 +357,29 @@ def test_powershell_file_legacy_approval_key_compatibility():
     assert "script execution via -e/-c flag" in aliases
 
 
+def test_powershell_file_historical_regex_approval_authorizes_new_findings():
+    """A persisted pre-migration approval stored under the exact historical
+    regex-derived key must still authorize a new `-File` finding through the
+    real consumer (`is_approved`), not just the intermediate alias set. The
+    alias map stores sets per key with no graph closure, so the -File key must
+    include the regex key directly (review feedback on #102955)."""
+    from tools.approval import is_approved, load_permanent
+    from tools.approval_detection import _approval_key_aliases
+
+    historical_regex_key = r"(python[23]?|perl|ruby|node)\s+-[ec]\s+"
+    aliases = _approval_key_aliases("script execution via -File/-f flag (PowerShell)")
+    assert historical_regex_key in aliases
+
+    load_permanent({historical_regex_key})
+    try:
+        assert is_approved("session", "script execution via -File/-f flag (PowerShell)")
+    finally:
+        from tools import approval as _approval
+
+        with _approval._lock:
+            _approval._permanent_approved.discard(historical_regex_key)
+
+
 def test_powershell_file_bypass_via_cmd_wrapper_is_gated():
     """`cmd /c powershell -File ...` ran with no gate at all (#102847) — a silent
     bypass of the approval the direct form triggers. The cmd /c payload is itself
@@ -388,5 +411,11 @@ def test_cmd_wrapper_does_not_gate_benign_payloads():
         "cmd /?",
         "cmd /u",
         'cmd /c "echo hello"',
+        # The FIRST /c|/k owns the whole remainder; a later /c is payload
+        # DATA. `cmd /c echo /c powershell -File x.ps1` just prints text —
+        # gating it was a false positive (review feedback on #102955).
+        "cmd /c echo /c powershell -File x.ps1",
+        "cmd /c echo /k powershell -File x.ps1",
+        "cmd /c printf '%s' //c powershell -File x.ps1",
     ]:
         assert detect_dangerous_command(command) == (False, None, None), command

--- a/tests/tools/test_execution_flag_detection.py
+++ b/tests/tools/test_execution_flag_detection.py
@@ -295,3 +295,79 @@ def test_max_accepted_separator_free_input_is_fast():
     # Loose bound: catches the O(n^2)/backtracking regression class without
     # flaking on CI scheduler stalls (see comment above).
     assert elapsed < 2.0, f"max accepted token took {elapsed:.3f}s"
+
+
+# ---- Interpreter exec-flag descriptions must name the actual flag (#102847) ------------
+# The block reason is the agent's only signal for what tripped the gate. When
+# `powershell -File script.ps1` reports "script execution via -e/-c flag" the
+# command contains no -e/-c at all, so the agent burns iterations hunting for a
+# nonexistent flag instead of routing around a deliberate approval gate.
+
+
+@pytest.mark.parametrize(
+    ("command", "flag"),
+    [
+        ("powershell -NoProfile -ExecutionPolicy Bypass -File C:/Users/Administrator/Desktop/x/repro.ps1", "-File"),
+        ("pwsh -f helper.ps1", "-f"),
+        ("python3 -c 'print(1)'", "-c"),
+        ("node -e 'console.log(1)'", "-e"),
+    ],
+)
+def test_exec_flag_block_reason_names_the_matched_flag(command, flag):
+    dangerous, _, description = detect_dangerous_command(command)
+    assert dangerous is True
+    assert flag in description, f"block reason {description!r} does not name the matched flag {flag!r}"
+
+
+def test_powershell_file_block_reason_does_not_claim_e_or_c():
+    """The reporter's exact repro: -File invocation flagged as `-e/-c` (#102847)."""
+    dangerous, key, description = detect_dangerous_command(
+        "powershell -NoProfile -ExecutionPolicy Bypass -File"
+        " C:/Users/Administrator/Desktop/hermes_issue/repro_hello.ps1"
+    )
+    assert dangerous is True
+    assert description == "script execution via -File/-f flag (PowerShell)"
+    assert key == description
+    assert "-e/-c" not in description
+
+
+def test_inline_code_flags_keep_the_legacy_e_or_c_reason():
+    """python -c / node -e / powershell -Command keep one legacy key so approvals
+    stored under it (and its legacy regex alias) still match."""
+    for command, expected in [
+        ("python -c 'print(1)'", "script execution via -e/-c flag"),
+        ("node -e '1'", "script execution via -e/-c flag"),
+        ("pwsh -Command 'Get-Process'", "script execution via -e/-c flag"),
+    ]:
+        dangerous, key, description = detect_dangerous_command(command)
+        assert dangerous is True
+        assert (key, description) == (expected, expected), (command, key, description)
+        # The legacy shared key resolves to the same approval set: an approval
+        # saved before the split keeps authorizing inline-code runs.
+        from tools.approval_detection import _approval_key_aliases
+
+        assert expected in _approval_key_aliases(description)
+
+
+def test_powershell_file_legacy_approval_key_compatibility():
+    """Approvals saved under the old shared key keep covering -File runs."""
+    from tools.approval_detection import _approval_key_aliases
+
+    aliases = _approval_key_aliases("script execution via -File/-f flag (PowerShell)")
+    assert "script execution via -e/-c flag" in aliases
+
+
+def test_powershell_file_bypass_via_cmd_wrapper_is_gated():
+    """`cmd /c powershell -File ...` ran with no gate at all (#102847) — a silent
+    bypass of the approval the direct form triggers. The cmd /c payload is itself
+    a top-level shell segment for the *inner* interpreter scan."""
+    for command in [
+        "cmd /c powershell -NoProfile -ExecutionPolicy Bypass -File C:/Users/Administrator/Desktop/x/repro.ps1",
+        "cmd.exe /c powershell -File x.ps1",
+        "cmd /k pwsh -f x.ps1",
+        # git-bash/MSYS (the reporter's shell) escapes to //c.
+        "cmd //c powershell -File x.ps1",
+    ]:
+        dangerous, key, description = detect_dangerous_command(command)
+        assert dangerous is True, f"bypass via wrapper: {command!r}"
+        assert description == "script execution via -File/-f flag (PowerShell)", (command, description)

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -863,6 +863,23 @@ def _execution_flag_findings(command: str):
                     finding = _read_tool_exec_flag(executable_name, args)
                     if finding:
                         yield (f"arbitrary program execution via {executable_name} {finding[0]}", finding[1])
+                # `cmd /c|/k` (and the git-bash //c //k spellings) hands the
+                # rest of the line to an arbitrary payload. Without this,
+                # `cmd /c powershell -File x.ps1` reached no gate at all while
+                # the direct form required approval — the trivial bypass
+                # reported in #102847. Options may precede the verb
+                # (`cmd /u /c ...` — /u is a modifier, not the payload), and
+                # the payload may be a single quoted string
+                # (`cmd /c "powershell -File x.ps1"`). Tokenize the whole tail
+                # with shlex so quoted payloads surface, find the LAST /c|/k,
+                # and scan the remaining tokens as a nested command.
+                if executable_name in {"cmd", "cmd.exe"}:
+                    verb_index = None
+                    for index in range(1, len(tokens)):
+                        if tokens[index].lower() in {"/c", "/k", "//c", "//k"}:
+                            verb_index = index
+                    if verb_index is not None:
+                        yield from _execution_flag_findings(" ".join(tokens[verb_index + 1 :]))
 
 
 def _skip_shell_whitespace(command: str, pos: int) -> int:
@@ -1070,19 +1087,6 @@ def _iter_shell_command_word_spans(command: str):
             yield (word_start, word_end, word)
             if lower_word in _COMMAND_WRAPPER_WORDS:
                 skip_wrapper_options = lower_word in {"sudo", "env"}
-            elif lower_word in {"cmd", "cmd.exe"}:
-                # `cmd /c|/k` hands the rest of the line to the payload
-                # interpreter. Without this, `cmd /c powershell -File x.ps1`
-                # reached no gate at all while the direct form required
-                # approval — the trivial bypass reported in #102847. /c and
-                # /k are cmd's "run the payload" verbs, not sudo-style
-                # options; git-bash spells them //c //k (MSYS path escapes).
-                # Options before the verb (`cmd /u /c ...`) stop the scan.
-                next_start, _, next_word = _read_shell_word(command, pos)
-                if next_word.lower() in {"/c", "/k", "//c", "//k"}:
-                    pos = next_start + len(next_word)
-                else:
-                    break
             elif _ENV_ASSIGNMENT_RE.fullmatch(deobfuscated):
                 skip_wrapper_options = False
             else:

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -398,10 +398,32 @@ DANGEROUS_PATTERNS = [
 
 DANGEROUS_PATTERNS_COMPILED = [(re.compile(p, _RE_FLAGS), d) for p, d in DANGEROUS_PATTERNS]
 
-# Preserve approvals stored under the removed interpreter regex rules.
+# Block reason for interpreter exec flags. One shared key for every inline-code
+# flag: the reason names the matched flag so an agent reading the block knows
+# what actually tripped the gate (#102847) — `powershell -File x.ps1` reported
+# "via -e/-c flag" while the command contained no -e/-c at all, burning agent
+# iterations hunting for a flag that did not exist.
+_EXEC_FLAG_LEGACY_KEY = "script execution via -e/-c flag"
+# -File/-f run a script from disk, not inline code. Still approval-worthy
+# (a .ps1 is arbitrary code) but its own description so the reason is truthful.
+_EXEC_FLAG_FILE_KEY = "script execution via -File/-f flag (PowerShell)"
+_POWERSHELL_FILE_FLAGS = {"-file", "-f"}
+
+
+def _interpreter_exec_flag_description(family: str, flag: str) -> str:
+    """Map the matched exec flag to its block reason (approval key)."""
+    if family == "powershell" and flag in _POWERSHELL_FILE_FLAGS:
+        return _EXEC_FLAG_FILE_KEY
+    return _EXEC_FLAG_LEGACY_KEY
+
+
+# Legacy approval keys keep resolving after the -File split: an approval saved
+# under the shared `-e/-c` key (or its older regex-derived key) still covers
+# -File runs, and vice versa.
 _REMOVED_PATTERN_KEY_ALIASES = {
-    "script execution via -e/-c flag": "(python[23]?|perl|ruby|node)\\s+-[ec]\\s+",
-    "script execution via heredoc": "(python[23]?|perl|ruby|node)\\s+<<",
+    _EXEC_FLAG_LEGACY_KEY: r"(python[23]?|perl|ruby|node)\s+-[ec]\s+",
+    _EXEC_FLAG_FILE_KEY: _EXEC_FLAG_LEGACY_KEY,
+    "script execution via heredoc": r"(python[23]?|perl|ruby|node)\s+<<",
 }
 # description <-> legacy regex-derived key (the old approval key, kept for backwards compatibility
 # with stored allowlist/session entries), both ways.
@@ -827,8 +849,9 @@ def _execution_flag_findings(command: str):
             if not tokens:
                 continue
             args = tokens[1:]
-            if family and _interpreter_exec_flag(family, args):
-                yield ("script execution via -e/-c flag", None)
+            exec_flag = _interpreter_exec_flag(family, args) if family else None
+            if exec_flag:
+                yield (_interpreter_exec_flag_description(family, exec_flag), None)
             elif family and any(token.startswith("<<") for token in args):
                 yield ("script execution via heredoc", None)
             else:
@@ -1047,6 +1070,19 @@ def _iter_shell_command_word_spans(command: str):
             yield (word_start, word_end, word)
             if lower_word in _COMMAND_WRAPPER_WORDS:
                 skip_wrapper_options = lower_word in {"sudo", "env"}
+            elif lower_word in {"cmd", "cmd.exe"}:
+                # `cmd /c|/k` hands the rest of the line to the payload
+                # interpreter. Without this, `cmd /c powershell -File x.ps1`
+                # reached no gate at all while the direct form required
+                # approval — the trivial bypass reported in #102847. /c and
+                # /k are cmd's "run the payload" verbs, not sudo-style
+                # options; git-bash spells them //c //k (MSYS path escapes).
+                # Options before the verb (`cmd /u /c ...`) stop the scan.
+                next_start, _, next_word = _read_shell_word(command, pos)
+                if next_word.lower() in {"/c", "/k", "//c", "//k"}:
+                    pos = next_start + len(next_word)
+                else:
+                    break
             elif _ENV_ASSIGNMENT_RE.fullmatch(deobfuscated):
                 skip_wrapper_options = False
             else:

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -419,18 +419,27 @@ def _interpreter_exec_flag_description(family: str, flag: str) -> str:
 
 # Legacy approval keys keep resolving after the -File split: an approval saved
 # under the shared `-e/-c` key (or its older regex-derived key) still covers
-# -File runs, and vice versa.
+# -File runs, and vice versa. The -File key pairs with BOTH the shared
+# description and the historical regex-derived key: `_approval_key_aliases()`
+# returns only the stored set (no graph closure), so pairing through a single
+# intermediate would leave one of the two pre-migration spellings unable to
+# authorize a new `-File` finding (review feedback on #102955).
+_EXEC_FLAG_LEGACY_REGEX_KEY = r"(python[23]?|perl|ruby|node)\s+-[ec]\s+"
 _REMOVED_PATTERN_KEY_ALIASES = {
-    _EXEC_FLAG_LEGACY_KEY: r"(python[23]?|perl|ruby|node)\s+-[ec]\s+",
+    _EXEC_FLAG_LEGACY_KEY: _EXEC_FLAG_LEGACY_REGEX_KEY,
     _EXEC_FLAG_FILE_KEY: _EXEC_FLAG_LEGACY_KEY,
     "script execution via heredoc": r"(python[23]?|perl|ruby|node)\s+<<",
 }
+_REMOVED_PATTERN_KEY_ALIAS_PAIRS = [
+    (_EXEC_FLAG_FILE_KEY, _EXEC_FLAG_LEGACY_KEY),
+    (_EXEC_FLAG_FILE_KEY, _EXEC_FLAG_LEGACY_REGEX_KEY),
+]
 # description <-> legacy regex-derived key (the old approval key, kept for backwards compatibility
 # with stored allowlist/session entries), both ways.
 _PATTERN_KEY_ALIASES: dict[str, set[str]] = {}
 for _canonical_key, _legacy_key in [
     (d, p.split(r'\b')[1] if r'\b' in p else p[:20]) for p, d in DANGEROUS_PATTERNS
-] + list(_REMOVED_PATTERN_KEY_ALIASES.items()):
+] + list(_REMOVED_PATTERN_KEY_ALIASES.items()) + _REMOVED_PATTERN_KEY_ALIAS_PAIRS:
     _PATTERN_KEY_ALIASES.setdefault(_canonical_key, set()).update({_canonical_key, _legacy_key})
     _PATTERN_KEY_ALIASES.setdefault(_legacy_key, set()).update({_legacy_key, _canonical_key})
 
@@ -871,13 +880,21 @@ def _execution_flag_findings(command: str):
                 # (`cmd /u /c ...` — /u is a modifier, not the payload), and
                 # the payload may be a single quoted string
                 # (`cmd /c "powershell -File x.ps1"`). Tokenize the whole tail
-                # with shlex so quoted payloads surface, find the LAST /c|/k,
-                # and scan the remaining tokens as a nested command.
+                # with shlex so quoted payloads surface, then hand everything
+                # after the FIRST /c|/k to the nested scan. cmd semantics: the
+                # first control verb owns the entire remainder, so a `/c` in
+                # the payload (`cmd /c echo /c powershell -File x.ps1`) is
+                # payload DATA — taking the last verb would gate benign echo
+                # lines that merely print the text (review feedback on #102955).
                 if executable_name in {"cmd", "cmd.exe"}:
-                    verb_index = None
-                    for index in range(1, len(tokens)):
-                        if tokens[index].lower() in {"/c", "/k", "//c", "//k"}:
-                            verb_index = index
+                    verb_index = next(
+                        (
+                            index
+                            for index in range(1, len(tokens))
+                            if tokens[index].lower() in {"/c", "/k", "//c", "//k"}
+                        ),
+                        None,
+                    )
                     if verb_index is not None:
                         yield from _execution_flag_findings(" ".join(tokens[verb_index + 1 :]))
 


### PR DESCRIPTION
Refs #102847 (partial: truthful block reasons + the `cmd /c` wrapper bypass; the report's ungating proposal is deliberately not taken — see Approach)

## Problem

The interpreter exec-flag approval gate emitted one fixed reason for every flagged invocation:

```
powershell -NoProfile -ExecutionPolicy Bypass -File C:/Users/Administrator/Desktop/hermes_issue/repro_hello.ps1
→ BLOCKED: Command flagged as dangerous (script execution via -e/-c flag...)
```

`-File` runs a script from disk; the command contains no `-e`/`-c` at all. The block reason is the agent's only signal for what tripped the gate, so it hunts for a nonexistent flag and burns its iteration budget working around the gate (the reporter measured 10 API calls on a task a baseline tool finished in 3 steps). Worse, the gate was trivially bypassed: `cmd /c powershell ... -File ...` reached **no gate** — so the approval the direct form triggered protected nothing.

Verified on current `main` (`f1ccf436a2`, post-simplification: the logic lives in `tools/approval_detection.py`), and confirmed natively on a Windows 11 host (Python 3.13.13).

| Command | Before | After |
|---|---|---|
| `powershell ... -File repro.ps1` | blocked, reason `via -e/-c flag` (lie) | blocked, reason `via -File/-f flag (PowerShell)` (truthful) |
| `cmd /c powershell ... -File repro.ps1` | **no gate** | gated, same truthful reason |
| `cmd /u /c powershell -File x.ps1` (modifier before verb) | no gate | gated |
| `cmd /c "powershell -File x.ps1"` (quoted payload) | no gate | gated |
| `cmd //c powershell -File x.ps1` (git-bash/MSYS) | no gate | gated |
| `python -c` / `node -e` / `pwsh -Command` | `via -e/-c flag` | unchanged (legacy key preserved) |
| `cmd /c echo hello` / `cmd /c dir` / `cmd /c npm install` | no gate | still no gate |

## Approach

**Keep the gate, make it tell the truth, and make it actually apply.**

1. **Truthful reason.** `powershell`'s `-File`/`-f` (script-from-disk) now produce their own approval key, `script execution via -File/-f flag (PowerShell)`. Inline-code flags (`-Command`/`-c`, python `-c`, node `-e`, …) keep the legacy `script execution via -e/-c flag` key.
2. **Back-compat.** The new key is wired into `_REMOVED_PATTERN_KEY_ALIASES`, so approvals already saved under the shared legacy key (or its older regex-derived key) still cover `-File` runs — no silently-lost allowlist coverage.
3. **Close the bypass.** `_execution_flag_findings` now treats `cmd`/`cmd.exe` + `/c|/k` (and git-bash's `//c` `//k`) as a carrier: it tokenizes the segment, takes everything after the *last* `/c|/k`, and scans it as a nested command. shlex tokenization already splits quoted payloads, so modifiers (`/u`), quoted-payload idioms, and the `//c` spelling no longer hide the interpreter. Termination is bounded by payload length (each level strips `cmd /c`).
4. **Deliberately NOT taken:** removing `-File` from the exec-flag set (the report's suggested fix). Gating `-File` is intentional design — b90dbac1d6 asserts `powershell -File …` stays approval-worthy (a `.ps1` is arbitrary code), mirrored by `python -c`/`node -e`. The reporter's actual pain — the lying reason and the zero-cost `cmd /c` bypass — is what this fixes. (PR #102899 takes the removal route and leaves the bypass open.)

## How to Test

```bash
python3 - <<'EOF'
from tools.approval import detect_dangerous_command as d
print(d("powershell -NoProfile -ExecutionPolicy Bypass -File C:/x/repro.ps1"))
# (True, 'script execution via -File/-f flag (PowerShell)', 'script execution via -File/-f flag (PowerShell)')
print(d("cmd /c powershell -NoProfile -ExecutionPolicy Bypass -File C:/x/repro.ps1"))
# (True, 'script execution via -File/-f flag (PowerShell)', ...)  — was (False, None, None)
print(d("cmd /c \"powershell -File x.ps1\""))  # quoted payload → True
print(d("cmd /c echo hello"))                  # (False, None, None)
print(d("python -c 'print(1)'"))               # unchanged legacy key
EOF
```

Suite: `test_execution_flag_detection.py` + `test_approval*` + hardline/smart-approval/deny — **553 passed, 1 skipped**. Sabotage runs confirmed every new regression test fails with its half of the fix reverted. Platform-verified natively on Windows 11.

## Tests

- `test_exec_flag_block_reason_names_the_matched_flag` — reason names the matched flag (`-File`, `-f`, `-c`, `-e`)
- `test_powershell_file_block_reason_does_not_claim_e_or_c` — the reporter's exact repro
- `test_inline_code_flags_keep_the_legacy_e_or_c_reason` — inline flags unchanged + alias resolution
- `test_powershell_file_legacy_approval_key_compatibility` — old keys keep covering `-File`
- `test_powershell_file_bypass_via_cmd_wrapper_is_gated` — `cmd /c`, `cmd.exe /c`, `cmd /k`, `//c`, `/u /c`, quoted payload
- `test_cmd_wrapper_does_not_gate_benign_payloads` — `echo`/`dir`/`npm install`/`git status`/`/?` stay ungated

## Risk

- Approval-key split: mitigated by the alias chain (verified by test); worst case a user re-approves once.
- Carrier scan is additive and additive-and-idempotent: `cmd` followed by `/c|/k` only; other `cmd` invocations behave exactly as before; benign payloads stay ungated; recursion terminates by length.
- Deliberately not extended (pre-existing, out of scope): full backslash path `C:\Windows\System32\powershell.exe -File …` (backslash-normalization gap affects *all* interpreters, not introduced here), and `start`/`wscript`/`cscript`/`mshta` wrappers — a separate wrapper family the issue doesn't mention. Noted for follow-up.