### PR TITLE
fix(413): strip retained vision payloads before spending a compaction attempt

### DIFF
--- a/agent/turn_overflow.py
+++ b/agent/turn_overflow.py
@@ -222,6 +222,22 @@ def _recover_payload_too_large(st: _Recovery, _retry: TurnRetryState) -> Overflo
     from agent.model_metadata import estimate_messages_tokens_rough
 
     agent = st.agent
+
+    # Vision payloads first: a 413 is a byte-size rejection and text
+    # summarization cannot shrink base64, so a compaction pass spent while
+    # screenshots still ride the request reduces neither the message count nor
+    # the payload — the session then re-fires 413 -> compress -> 413 until the
+    # attempt cap is burned. Stripping is instant and targets exactly the bytes
+    # the provider rejected, so it runs BEFORE count_attempt(). Text-only 413s
+    # fall through unchanged. remember_model=False: this body was too large,
+    # which is not evidence the model rejects list-type tool content in general.
+    if agent._try_strip_image_parts_from_tool_messages(st.api_messages, remember_model=False):
+        agent._buffer_status(
+            "🖼️  Request payload too large (413) — dropped retained vision "
+            "payloads and retrying before compressing..."
+        )
+        return st.done("continue")
+
     exhausted = st.count_attempt(payload_too_large=True)
     if exhausted is not None:
         return exhausted
@@ -260,12 +276,11 @@ def _recover_payload_too_large(st: _Recovery, _retry: TurnRetryState) -> Overflo
         _retry.restart_with_compressed_messages = True
         return st.done("break")
 
-    if agent._try_strip_image_parts_from_tool_messages(st.api_messages, remember_model=False):
-        agent._buffer_status(
-            "📐 Compression could not reduce the request further — "
-            "removed retained vision payloads and retrying..."
-        )
-        return st.done("continue")
+    # NOTE: the post-compression vision strip that used to live here is gone —
+    # it is unreachable now that the same call runs before count_attempt()
+    # above. Reaching this point means that earlier call already returned False
+    # (no image parts in any tool message), so a second identical call cannot
+    # succeed.
 
     return st.fail_turn(
         "Request payload too large (413). Cannot compress further.",

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -186,12 +186,14 @@ class TestHTTP413Compression:
 
 
     def test_413_strips_vision_payloads_when_compression_cannot_reduce_messages(self, agent):
-        """If compression leaves image payloads behind, strip them and retry.
+        """A 413 must evict image payloads BEFORE spending a compaction pass.
 
-        Browser vision tool results can contain base64 image parts. A 413 can
-        persist even after summarisation when the remaining recent tool result
-        still carries binary data; Hermes should evict the image payload and
-        keep the text/placeholder context instead of failing immediately.
+        Browser vision tool results can contain base64 image parts, which are
+        usually the bulk of an oversized request body. Text summarisation
+        cannot shrink base64, so the recovery path strips the vision payload
+        first and retries immediately -- keeping the text/placeholder context
+        and never burning a (slow) compaction attempt that could not have
+        reduced the payload anyway.
         """
         err_413 = _make_413_error()
         ok_resp = _mock_response(content="Recovered after image eviction", finish_reason="stop")
@@ -244,7 +246,9 @@ class TestHTTP413Compression:
             mock_compress.side_effect = lambda msgs, *_a, **_k: (msgs, "compressed prompt")
             result = agent.run_conversation("continue", conversation_history=prefill)
 
-        mock_compress.assert_called_once()
+        # The vision strip is the FIRST recovery move, so no compaction pass
+        # is spent: text summarisation cannot shrink base64 anyway.
+        mock_compress.assert_not_called()
         assert result["completed"] is True
         assert result["final_response"] == "Recovered after image eviction"
         assert len(request_payloads) == 2


### PR DESCRIPTION
## The bug

A 413 is a **byte-size** rejection, and text summarization cannot shrink base64.

`_recover_payload_too_large` in `agent/turn_overflow.py` already strips retained vision payloads — but only as a **last resort**, after a full compaction pass has been spent and scored. That ordering is backwards for the image-dominated case.

When screenshots still ride the request, the compaction pass reduces neither the message count nor the payload. The byte-scored progress check from #88960 correctly reports no progress — and `count_attempt()` has already consumed the attempt. The session re-fires `413 -> compress -> 413` until `max_compression_attempts` is exhausted and the turn is lost.

Observed as `messages=48 -> 48` with no progress, every attempt burned, turn dead.

## Relationship to #88960

#88960 fixed the *scoring* of those attempts — it stopped the compressor from mis-reading a multi-MB image reduction as "no progress" because the token estimate is deliberately byte-blind to images.

This fixes the attempts being **spent at all**. The compactor is being asked to shrink bytes it structurally cannot touch; scoring that pass accurately doesn't make it worth running first.

## The fix

Move the existing `_try_strip_image_parts_from_tool_messages(...)` call ahead of `count_attempt()`. It's instant, free, and targets exactly the bytes the provider rejected. Text-only 413s fall through to compression completely unchanged.

The post-compression strip is now **unreachable** — reaching it means the earlier identical call already returned `False` (no image parts in any tool message), so a second call on the same `st.api_messages` cannot succeed. Removed rather than left as dead code.

`remember_model=False` is preserved: a 413 means *this request body* was too large, not that the provider/model rejects list-type tool content in general. Pinning the model would needlessly disable native vision for the rest of the session. The #27344 `multimodal_tool_content_unsupported` path — which *does* mean that — keeps the default `remember_model=True`.

## Interaction with the preemptive evictor

No overlap with `evict_stale_outbound_tool_images` (#89286/#89296). That keeps the newest N image-bearing tool results (`_MAX_KEEP_TOOL_IMAGES = 3`) on every call; this handles the case where those retained images are *themselves* enough to trip the limit. A 413 is proof the keep-window didn't fit, and at that point the surviving screenshots are the thing to drop. Preemptive eviction reduces how often we reach this branch; it doesn't make the recovery ordering correct.

## Test

`test_413_strips_vision_payloads_when_compression_cannot_reduce_messages` already covered the recovery outcome but asserted `mock_compress.assert_called_once()` — encoding the wasted pass as expected behavior. Flipped to `assert_not_called()`: the retry now has to succeed off the strip alone, and the existing payload assertions still pin that the text survives (`"Screenshot of the dashboard"` present, `data:image` gone) and that `_no_list_tool_content_models` stays empty.

Behavioral, not source-string: it asserts what happens to the outbound request, not what the file says.

- **Fails on `main`** without the `turn_overflow.py` hunk.
- **Passes** with it.
- Suites run: 413 byte-scoring (`test_413_image_payload_recovery`), 413 compression, outbound stale vision, multimodal tool content recovery, compression budget refund, compression lock defer, overflow overhead-aware tokens — **77 passed**.

The neighboring `test_413_image_payload_recovery.py` source-contract test still passes: the byte-scoring expressions it pins are untouched, since this change sits above them.

## Not verified

- Only exercised against the mocked 413 path, not a live provider rejection.
- No measurement of how often the preemptive evictor already prevents reaching this branch in practice — this is the belt to its braces.
