### PR TITLE
fix(cron): honour the configured media-send timeout on the standalone fallback

### DIFF
--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -1416,8 +1416,13 @@ def _standalone_send(
             try:
                 # A fresh thread does NOT inherit the profile ContextVars (home override + secret
                 # scope); run in the active context or the sender reads the default bot token.
+                # Media rides this fallback too, carrying the same attachments as the live lane,
+                # so a large one must get the same configurable budget (#88787 covered only
+                # _send_media_via_adapter). Text-only sends keep the short timeout so a hung
+                # text send still fails fast.
+                send_timeout = _script._get_media_send_timeout() if media_files else 30
                 return pool.submit(contextvars.copy_context().run, asyncio.run, _send()).result(
-                    timeout=30), None
+                    timeout=send_timeout), None
             finally:
                 pool.shutdown(wait=False)
         except Exception as e:

--- a/tests/cron/test_media_send_timeout.py
+++ b/tests/cron/test_media_send_timeout.py
@@ -12,10 +12,13 @@ Covers two salvaged fixes:
   HERMES_CRON_MEDIA_SEND_TIMEOUT → cron.media_send_timeout_seconds → 300s.
 """
 
+import dataclasses
+
 import pytest
 
 from cron.scheduler_script import _DEFAULT_MEDIA_SEND_TIMEOUT, _get_media_send_timeout
-from cron.scheduler_delivery import _send_media_via_adapter
+from cron.scheduler_delivery import (
+    _TargetDelivery, _send_media_via_adapter, _standalone_send)
 
 
 class TestMediaSendTimeoutResolution:
@@ -93,3 +96,80 @@ class TestEmptyReasonFallback:
     def test_exception_with_message_keeps_it(self, tmp_path, monkeypatch):
         err = self._run(tmp_path, monkeypatch, RuntimeError("bridge closed"))
         assert "bridge closed" in err
+
+
+class TestStandaloneFallbackTimeout:
+    """The standalone lane's RuntimeError fallback carries the same attachments.
+
+    #88787 made only ``_send_media_via_adapter`` configurable. ``_standalone_send``
+    retries in a thread when ``asyncio.run`` refuses inside a running loop, and that
+    retry passes ``media_files`` straight through — so a large attachment still hit a
+    hardcoded 30s there while the live lane honoured the configured budget.
+    """
+
+    @staticmethod
+    def _drive(monkeypatch, media_files, config):
+        """Force _standalone_send down its fallback; return the timeout it asked for."""
+        recorded = {}
+
+        class _Coro:
+            def close(self):
+                pass
+
+        def _fake_send_to_platform(*a, **kw):
+            return _Coro()
+
+        def _refuses(coro):
+            raise RuntimeError("asyncio.run() cannot be called from a running event loop")
+
+        class _Future:
+            def result(self, timeout=None):
+                recorded["timeout"] = timeout
+                return "sent"
+
+        class _Pool:
+            def __init__(self, *a, **kw):
+                pass
+
+            def submit(self, *a, **kw):
+                return _Future()
+
+            def shutdown(self, *a, **kw):
+                pass
+
+        monkeypatch.setattr("tools.send_message_tool._send_to_platform", _fake_send_to_platform)
+        monkeypatch.setattr("cron.scheduler_delivery.asyncio.run", _refuses)
+        monkeypatch.setattr("concurrent.futures.ThreadPoolExecutor", _Pool)
+        monkeypatch.setattr("cron.scheduler._interpreter_shutting_down", lambda *a: False)
+        monkeypatch.delenv("HERMES_CRON_MEDIA_SEND_TIMEOUT", raising=False)
+        monkeypatch.setattr("cron.scheduler.load_config", lambda: config)
+
+        # Build a real _TargetDelivery so ``where`` stays the dataclass property;
+        # fill every required field with None and set only what this lane reads.
+        t = _TargetDelivery(**{
+            f.name: None for f in dataclasses.fields(_TargetDelivery)
+            if f.default is dataclasses.MISSING and f.default_factory is dataclasses.MISSING
+        })
+        t.job = {"id": "job-x"}
+        t.platform_name = "matrix"
+        t.chat_id = "!room:example.org"
+        t.pconfig = {}
+        result, err = _standalone_send(t, "briefing", media_files)
+        assert (result, err) == ("sent", None)
+        return recorded["timeout"]
+
+    def test_media_uses_configured_timeout(self, monkeypatch):
+        got = self._drive(
+            monkeypatch, [("/tmp/briefing.mp3", True)],
+            {"cron": {"media_send_timeout_seconds": 900}},
+        )
+        assert got == 900
+
+    def test_media_uses_default_when_unconfigured(self, monkeypatch):
+        got = self._drive(monkeypatch, [("/tmp/briefing.mp3", True)], {})
+        assert got == _DEFAULT_MEDIA_SEND_TIMEOUT == 300
+
+    def test_text_only_keeps_short_timeout(self, monkeypatch):
+        # No attachment, no reason to wait five minutes on a hung text send.
+        got = self._drive(monkeypatch, [], {"cron": {"media_send_timeout_seconds": 900}})
+        assert got == 30


### PR DESCRIPTION
### What

`_standalone_send` (`cron/scheduler_delivery.py`) resolves its thread-fallback timeout through
`_get_media_send_timeout()` when the send carries attachments, instead of a hardcoded `30`.

### Why

#88787 made the per-attachment send timeout configurable —
`HERMES_CRON_MEDIA_SEND_TIMEOUT` → `cron.media_send_timeout_seconds` → 300s — but it changed
only `_send_media_via_adapter`, the **live-adapter** lane.

`_deliver_result` has a second lane. When the live adapter is not ready (or does not deliver),
it falls through to `_deliver_standalone` → `_standalone_send`, and that function has the same
shape as the one #88787 fixed:

```python
coro = _send()                       # carries media_files
try:
    return asyncio.run(coro), None
except RuntimeError as run_err:      # a loop is already running
    ...
    return pool.submit(contextvars.copy_context().run, asyncio.run, _send()).result(
        timeout=30), None            # <- not configurable
```

`_send()` passes `media_files` straight through, so the standalone lane ships the *same*
attachments as the live lane on a budget the operator cannot raise. Setting
`cron.media_send_timeout_seconds: 900` is silently ignored for any cron delivery that lands on
this path.

Worth being precise about the evidence: this is a **latent gap found by inspection**, not a
field failure we can point at a log for. What we can show is that the two lanes carry identical
payloads while only one honours the setting — the configuration does not mean what it says.

### The fix

```python
send_timeout = _script._get_media_send_timeout() if media_files else 30
```

Text-only sends deliberately keep 30s. There is no large payload to wait for, and raising the
budget there would let a wedged text send hold the delivery loop for five minutes — a
regression the media case does not have. If you would rather the two sites be unconditionally
identical, say so and I will drop the conditional.

### Tests

Three cases added to `tests/cron/test_media_send_timeout.py`, driving `_standalone_send` into
its `RuntimeError` fallback with a fake pool that records the timeout requested:

- configured value is honoured (`900`)
- default applies when unconfigured (`300`)
- text-only keeps `30`

The first two fail on `main` (`assert 30 == 900`, `assert 30 == 300`). Full run of the file:
13 passed. `tests/cron` as a whole is unchanged by this patch — 121 failed / 1031 passed before,
121 failed / 1034 passed after (+3 = the new cases); those 121 are pre-existing collection
failures from optional deps missing in my environment, not regressions.

### Provenance

We reported and carry the original of this bug. #87967 (mine) was closed unmerged and salvaged
as #88787, which fixed the primary path; we have carried a local patch for the remaining site
since, and rebased it across `v2026.8.19` → `v2026.8.27`. The site moved when `scheduler.py` was
split into `scheduler_delivery.py`, and the gap moved with it — this PR is against the current
`main` location, not the older `_deliver_result` one.
