### PR TITLE
feat(langfuse): default environment to the active profile name

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -201,6 +201,33 @@ def _get_langfuse() -> Optional[Langfuse]:
     return None if _LANGFUSE_CLIENT is _INIT_FAILED else _LANGFUSE_CLIENT
 
 
+def _default_environment() -> str:
+    """Fall back to the active Hermes profile name as the Langfuse environment.
+
+    Without this every profile exports under Langfuse's default environment, so
+    traces from different profiles are indistinguishable in the UI and cannot be
+    compared. The profile name is already derivable at runtime, so requiring
+    HERMES_LANGFUSE_ENV to be set per profile stores a second copy of something
+    the process already knows — and that copy goes stale: ``hermes profile
+    create --clone-from`` copies the source profile's .env verbatim, so a cloned
+    profile silently reports under the name of the profile it was cloned from.
+
+    An explicit HERMES_LANGFUSE_ENV / LANGFUSE_ENV still takes precedence.
+    Returns "" when the profile cannot be determined, leaving ``environment``
+    unset exactly as before.
+    """
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        name = (get_active_profile_name() or "").strip()
+    except Exception:  # pragma: no cover - fail-open, tracing must never break
+        return ""
+    # "custom" is what get_active_profile_name() returns for an unrecognized
+    # HERMES_HOME. It carries no information, so prefer leaving the environment
+    # unset over bucketing traces under a placeholder.
+    return "" if name == "custom" else name
+
+
 def _build_client() -> Optional[Langfuse]:
     """Construct the SDK client from env, or None (with one warning) when it can't be."""
     if Langfuse is None:
@@ -232,7 +259,8 @@ def _build_client() -> Optional[Langfuse]:
         return None
 
     kwargs: Dict[str, Any] = {"public_key": public_key, "secret_key": secret_key}
-    for key, name, default in (("base_url", "BASE_URL", "https://cloud.langfuse.com"), ("environment", "ENV", ""),
+    for key, name, default in (("base_url", "BASE_URL", "https://cloud.langfuse.com"),
+                               ("environment", "ENV", _default_environment()),
                                ("release", "RELEASE", "")):
         value = _env(f"HERMES_LANGFUSE_{name}") or _env(f"LANGFUSE_{name}") or default
         if value:

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -2387,3 +2387,55 @@ class TestCanonicalCostExport:
         # explicit zeros are treated as authoritative by Langfuse and block
         # its own model-based estimation (#43129).
         assert response_cost == {}
+
+
+class TestDefaultEnvironmentFromProfile:
+    """`environment` falls back to the active profile name.
+
+    Without this every profile exports under Langfuse's default environment, so
+    traces from different profiles cannot be told apart or compared in the UI.
+    """
+
+    @staticmethod
+    def _mod():
+        sys.modules.pop("plugins.observability.langfuse", None)
+        import importlib
+        return importlib.import_module("plugins.observability.langfuse")
+
+    def test_defaults_to_active_profile_name(self, monkeypatch):
+        import hermes_cli.profiles as profiles
+        monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "research")
+        assert self._mod()._default_environment() == "research"
+
+    def test_default_profile_reports_as_default(self, monkeypatch):
+        import hermes_cli.profiles as profiles
+        monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+        assert self._mod()._default_environment() == "default"
+
+    def test_unrecognized_home_leaves_environment_unset(self, monkeypatch):
+        # "custom" carries no information; leaving it unset preserves the prior
+        # behaviour rather than bucketing traces under a placeholder.
+        import hermes_cli.profiles as profiles
+        monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "custom")
+        assert self._mod()._default_environment() == ""
+
+    def test_fails_open_when_profile_lookup_raises(self, monkeypatch):
+        def boom():
+            raise RuntimeError("profile subsystem unavailable")
+
+        import hermes_cli.profiles as profiles
+        monkeypatch.setattr(profiles, "get_active_profile_name", boom)
+        # Tracing must never break the agent loop, so this returns "" instead.
+        assert self._mod()._default_environment() == ""
+
+    def test_explicit_env_var_takes_precedence(self, monkeypatch):
+        import hermes_cli.profiles as profiles
+        monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "research")
+        monkeypatch.setenv("HERMES_LANGFUSE_ENV", "production")
+        mod = self._mod()
+        resolved = (
+            mod._env("HERMES_LANGFUSE_ENV")
+            or mod._env("LANGFUSE_ENV")
+            or mod._default_environment()
+        )
+        assert resolved == "production"


### PR DESCRIPTION
## What does this PR do?

Defaults the Langfuse `environment` to the active Hermes profile name when it is not explicitly configured.

Today `environment` comes only from `HERMES_LANGFUSE_ENV` / `LANGFUSE_ENV`, and nothing sets those — so every profile exports under Langfuse's default environment and traces from different profiles are indistinguishable in the UI. On the install this came from, that meant **17,174 traces in a single bucket across five profiles**, with no way to compare one profile against another.

The profile name is already derivable at runtime via `get_active_profile_name()`, so this uses it as the fallback.

**Why a fallback rather than documenting the env var.** Requiring it per profile stores a second copy of something the process already knows, and that copy goes stale in a way that is worse than being absent: `hermes profile create --clone-from <src>` copies the source profile's `.env` verbatim, so a cloned profile silently reports under **the name of the profile it was cloned from**. Misattributed traces are more damaging than untagged ones, because nothing looks wrong — a per-profile comparison would quietly attribute one profile's calls to another.

## Behaviour

- Explicit `HERMES_LANGFUSE_ENV` / `LANGFUSE_ENV` still takes precedence, so several profiles can deliberately report as one environment (e.g. `production`).
- When the profile cannot be determined the helper returns `""`, leaving `environment` unset exactly as before — no behaviour change for anyone who does not use profiles.
- `"custom"` (what `get_active_profile_name()` returns for an unrecognized `HERMES_HOME`) is treated as undeterminable rather than used as a value; bucketing traces under a placeholder is worse than leaving them unset.
- Fail-open: a raising profile lookup is swallowed and tracing continues, in keeping with the plugin's existing "never break the agent loop" contract.

No prompts, messages, tool arguments/results, credentials, or local paths are added. The profile name is a user-chosen label already visible in the CLI.

## Duplication check

I searched open and closed PRs before writing this. The nearest neighbours are adjacent but do not overlap:

| PR | What it does | Overlap |
|----|--------------|---------|
| #102755 | adds `platform:` and `trigger:` **tags** to root traces | Different field and dimension. Complementary — tags vs `environment`. |
| #58264 | sets the OpenTelemetry **`service.name`** identity | Service identity, not environment. |
| #32416 | traces **auxiliary** LLM calls | Different call surface entirely. |

No PR mentions `HERMES_LANGFUSE_ENV`, and none sets `environment`. Searches run: `langfuse in:title`, `langfuse environment`, `langfuse profile`, `HERMES_LANGFUSE_ENV`.

If maintainers would rather fold this into #102755 as a fourth dimension (`environment` alongside `platform`/`trigger`), that is a reasonable call and I am happy to close this in favour of it.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add `_default_environment()`, deriving the Langfuse environment from the active profile, fail-open and returning `""` when undeterminable
- use it as the last fallback in the existing `environment` resolution chain
- cover the profile default, the `default` profile, the `custom` case, fail-open on a raising lookup, and explicit-env precedence

## How to Test

1. `scripts/run_tests.sh tests/plugins/test_langfuse_plugin.py -q` — 94 pass (89 existing + 5 new).
2. With Langfuse enabled and no `HERMES_LANGFUSE_ENV` set, run one turn under the default profile and one under `hermes -p <name>`; the two root traces land under different environments in the UI.
3. Set `HERMES_LANGFUSE_ENV=production` and repeat — both report `production`.
4. Ruff clean on both changed files.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (see the Duplication check section above)
