### PR TITLE
fix(desktop): honor backup policy in WAL-safe update preflight

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -290,6 +290,7 @@ import {
 import { createPoolStopper } from './pool-stop'
 import { poolTouchKeys } from './pool-touch-scope'
 import { createKeepAwake } from './power-save'
+import { resolvePreUpdateBackupPolicy } from './pre-update-backup-policy'
 import { capturePreviewContents } from './preview-capture'
 import { PreviewReachRegistry } from './preview-reach'
 import {
@@ -357,10 +358,10 @@ import {
   SESSION_WINDOW_MIN_WIDTH
 } from './session-windows'
 import { ensureLoginShellPath } from './shell-path'
-import { createVerifiedSqliteBackup } from './sqlite-backup'
 import { createBootstrapCoordinator, sshConfigFingerprint } from './ssh-bootstrap-coordinator'
 import { collectSshConfigHosts, parseSshGOutput } from './ssh-config'
 import { createSshProbeConnection, pickLocalPort, redactSecrets, SshConnection } from './ssh-connection'
+import { runStateDbUpdatePreflight } from './state-db-update-preflight'
 import { createStreamThrottle } from './stream-throttle'
 import { registerTerminalIpc } from './terminal-ipc'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
@@ -384,7 +385,7 @@ import {
   resolveCommitLogSelection,
   shouldCountCommits
 } from './update-count'
-import { waitForUpdateClearance } from './update-gate'
+import { ExclusiveUpdateFlight, runPreflightThenHandoff, waitForUpdateClearance } from './update-gate'
 import { readLiveUpdateMarker, updateHandoffConflict, writeUpdateMarker } from './update-marker'
 import { isOfficialSshRemote, OFFICIAL_REPO_HTTPS_URL } from './update-remote'
 import {
@@ -2236,9 +2237,11 @@ const UPDATE_WAIT_POLL_MS = 1000
 // updater's own progress window appears. (#50419)
 const UPDATE_HANDOFF_DWELL_MS = 2500
 
+const updateFlight = new ExclusiveUpdateFlight()
+
 // Gate deps shared by the primary-window boot path and the pool-backend
 // spawn path. Consulting BOTH the on-disk marker and the in-process
-// updateInFlight flag is load-bearing (#73822): applyUpdates kills its own
+// update-flight lease is load-bearing (#73822): applyUpdates kills its own
 // backend BEFORE the Windows venv-blocker scan but only writes the marker
 // AFTER it, so a marker-only gate lets the renderer's ~1s reconnect respawn
 // a backend inside the update's own critical section — which the scan then
@@ -2246,7 +2249,7 @@ const UPDATE_HANDOFF_DWELL_MS = 2500
 function updateGateDeps() {
   return {
     hasLiveMarker: () => Boolean(readLiveUpdateMarker(HERMES_HOME)),
-    isUpdateInFlight: () => updateInFlight
+    isUpdateInFlight: () => updateFlight.active
   }
 }
 
@@ -2571,13 +2574,7 @@ function isHermesSourceRoot(root) {
   return directoryExists(root) && fileExists(path.join(root, 'hermes_cli', 'main.py'))
 }
 
-function findPythonForRoot(root) {
-  const override = process.env.HERMES_DESKTOP_PYTHON
-
-  if (override && fileExists(override)) {
-    return override
-  }
-
+function findManagedPythonForRoot(root) {
   const relativePaths = IS_WINDOWS
     ? [path.join('.venv', 'Scripts', 'python.exe'), path.join('venv', 'Scripts', 'python.exe')]
     : [path.join('.venv', 'bin', 'python'), path.join('venv', 'bin', 'python')]
@@ -2585,12 +2582,18 @@ function findPythonForRoot(root) {
   for (const relativePath of relativePaths) {
     const candidate = path.join(root, relativePath)
 
-    if (fileExists(candidate)) {
-      return candidate
-    }
+    if (fileExists(candidate)) {return candidate}
   }
 
-  return findSystemPython()
+  return null
+}
+
+function findPythonForRoot(root) {
+  const override = process.env.HERMES_DESKTOP_PYTHON
+
+  if (override && fileExists(override)) {return override}
+
+  return findManagedPythonForRoot(root) ?? findSystemPython()
 }
 
 function findSystemPython() {
@@ -3287,8 +3290,6 @@ async function readCommitLog(cwd, branch, isShallow) {
     })
 }
 
-let updateInFlight = false
-
 // Set to true when the desktop is about to quit so a detached swap/install/
 // uninstall script can take over. On macOS, app.quit() closes windows but
 // window-all-closed deliberately keeps the process alive (standard Electron
@@ -3871,13 +3872,13 @@ async function releaseBackendLock(updateRoot, tag) {
 // Detection (checkUpdates / commit changelog / "N behind") stays in the UI;
 // only this apply action changed.
 async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
-  if (updateInFlight) {
-    throw new Error('An update is already in progress.')
+  if (updateFlight.active) {
+    emitUpdateProgress({ stage: 'already-running', message: 'An update is already in progress.', percent: null })
+
+    return { ok: false, error: 'already-running' }
   }
 
-  updateInFlight = true
-
-  try {
+  return updateFlight.run(async () => {
     const updater = resolveUpdaterBinary()
 
     if (!updater && !IS_WINDOWS) {
@@ -3970,16 +3971,14 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
 
     const venvBin = path.join(updateRoot, 'venv', IS_WINDOWS ? 'Scripts' : 'bin')
 
-    // ── Pre-flight state.db integrity guard (#68474) ─────────────────
-    // Emergency backup and header verification before the update touches
-    // anything.  Runs while the backend is still alive.
-    await preflightStateDb(HERMES_HOME, rememberLog)
-
-    // Stop our own backend(s) and wait for the venv shim to unlock BEFORE we
-    // spawn the updater. Without this the updater races a still-locked
-    // hermes.exe (held by the backend child / its grandchildren) and the update
-    // bricks. See releaseBackendLockForUpdate for the full failure analysis.
-    const lock = await releaseBackendLockForUpdate(updateRoot)
+    // Stop our own backend(s) and wait for the venv shim to unlock only after
+    // the policy-aware state.db preflight has settled. Without this the updater
+    // races a still-locked hermes.exe (held by the backend child / its
+    // grandchildren) and the update bricks.
+    const lock = await runPreflightThenHandoff(
+      () => preflightStateDb(HERMES_HOME, updateRoot, rememberLog),
+      () => releaseBackendLockForUpdate(updateRoot)
+    )
 
     if (!lock.unlocked) {
       // Something OUTSIDE this app holds the venv (a second window, a user
@@ -4209,9 +4208,7 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
     )
 
     return { ok: true, handedOff: true, updater }
-  } finally {
-    updateInFlight = false
-  }
+  })
 }
 
 async function handOffWindowsBootstrapRecovery(reason) {
@@ -4341,90 +4338,33 @@ function runningAppBundle() {
 }
 
 // ── Pre-flight state.db integrity guard (#68474) ─────────────────────
-// Take an emergency snapshot of state.db and verify the live copy is
-// intact before any update process mutates the install.  Runs in the
+// Validate the live database and, when the canonical Python policy enables it,
+// publish one WAL-consistent recovery point before any backend is stopped. Runs in the
 // desktop Electron process itself, before the backend is killed and
 // before the updater is spawned — a separate safety net from the
 // Python-level pre-update snapshot inside `hermes update`.
-async function preflightStateDb(hermesHome, rememberLog) {
-  const stateDbPath = path.join(hermesHome, 'state.db')
-
-  if (!fileExists(stateDbPath)) {
-    rememberLog('[updates] state.db pre-flight: not found (fresh install?)')
-
-    return
-  }
-
+async function preflightStateDb(hermesHome, updateRoot, rememberLog) {
   try {
-    const stat = fs.statSync(stateDbPath)
+    await runStateDbUpdatePreflight({
+      hermesHome,
+      policy: async () => {
+        const pythonPath = findManagedPythonForRoot(updateRoot)
 
-    if (stat.size <= 100) {
-      throw new Error(`state.db is too small (${stat.size} bytes) to snapshot safely`)
-    }
+        if (!pythonPath) {
+          throw new Error('could not resolve the update root venv Python for the backup policy')
+        }
 
-    const fd = fs.openSync(stateDbPath, 'r')
-    const header = Buffer.alloc(16)
-
-    try {
-      fs.readSync(fd, header, 0, 16, 0)
-    } finally {
-      fs.closeSync(fd)
-    }
-
-    const expectedHeader = Buffer.from('SQLite format 3\0')
-    const headerOk = header.equals(expectedHeader)
-
-    rememberLog(
-      `[updates] state.db pre-flight: size=${stat.size}, ` +
-        `headerOk=${headerOk}, headerHex=${header.toString('hex')}`
-    )
-
-    if (!headerOk) {
-      throw new Error('state.db has an invalid SQLite header before update')
-    }
-
-    const homeDir = fs.readdirSync(hermesHome)
-
-    for (const stalePartial of homeDir.filter(
-      f => f.startsWith('state.db.pre-update-emergency-') && f.endsWith('.bak.partial')
-    )) {
-      try {
-        fs.rmSync(path.join(hermesHome, stalePartial), { force: true })
-      } catch (error) {
-        rememberLog(`[updates] could not remove stale emergency backup partial ${stalePartial}: ${error.message}`)
-      }
-    }
-
-    // Emergency timestamped backup, separate from the Python-level snapshot.
-    const ts = new Date().toISOString().replace(/[:.]/g, '-')
-    const emergencyPath = path.join(hermesHome, `state.db.pre-update-emergency-${ts}.bak`)
-    const backupResult = await createVerifiedSqliteBackup(stateDbPath, emergencyPath)
-
-    rememberLog(
-      `[updates] emergency state.db backup: ${emergencyPath} (${backupResult.size} bytes, ` +
-        `${backupResult.verification}, ${backupResult.durationMs}ms)`
-    )
-
-    // Prune to the 2 most recent emergency backups.
-    const backups = homeDir
-      .filter(
-        f =>
-          f.startsWith('state.db.pre-update-emergency-') &&
-          f.endsWith('.bak') &&
-          f !== path.basename(emergencyPath)
-      )
-      .sort()
-      .reverse()
-
-    for (const old of backups.slice(1)) {
-      try {
-        fs.unlinkSync(path.join(hermesHome, old))
-      } catch {
-        void 0
-      }
-    }
+        return resolvePreUpdateBackupPolicy({
+          hermesHome,
+          pythonPath,
+          updateRoot
+        })
+      },
+      rememberLog
+    })
   } catch (error) {
-    const message = `Update aborted: could not create a verified emergency state.db backup: ${error.message}`
+    const detail = error instanceof Error ? error.message : String(error)
+    const message = `Update aborted: state.db pre-flight failed before backend shutdown: ${detail}`
 
     rememberLog(`[updates] ${message}`)
     emitUpdateProgress({ stage: 'error', message, percent: null })
@@ -4458,9 +4398,6 @@ async function applyUpdatesPosixHandoff(opts: any) {
 
     return { ok: false, error: 'update-already-running', message: handoffConflict.message }
   }
-
-  // ── Pre-flight state.db integrity guard (#68474) ──
-  await preflightStateDb(HERMES_HOME, rememberLog)
 
   // Branch-pin so a non-main checkout doesn't get switched to main (and
   // self-heal to main when the pinned branch no longer exists on origin).
@@ -4506,17 +4443,23 @@ async function applyUpdatesPosixHandoff(opts: any) {
     }
   }
 
-  const child = spawnUpdaterProcess(handoff.command, args, {
-    cwd: HERMES_HOME,
-    env: {
-      ...process.env,
-      HERMES_HOME,
-      HERMES_UPDATE_STARTED_AT: String(updateStartedAt),
-      PATH: pathWithHermesManagedNode(path.join(updateRoot, 'venv', 'bin'))
-    },
-    detached: true,
-    stdio: 'ignore'
-  })
+  // The detached script cannot start until the policy-aware database preflight
+  // has settled; a rejection leaves the Desktop and backend running.
+  const child = await runPreflightThenHandoff(
+    () => preflightStateDb(HERMES_HOME, updateRoot, rememberLog),
+    async () =>
+      spawnUpdaterProcess(handoff.command, args, {
+        cwd: HERMES_HOME,
+        env: {
+          ...process.env,
+          HERMES_HOME,
+          HERMES_UPDATE_STARTED_AT: String(updateStartedAt),
+          PATH: pathWithHermesManagedNode(path.join(updateRoot, 'venv', 'bin'))
+        },
+        detached: true,
+        stdio: 'ignore'
+      })
+  )
 
   // Bridge marker (same contract as the Windows hand-off): cover the gap
   // until the script claims the marker with its own pid as step 0. If the

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -357,6 +357,7 @@ import {
   SESSION_WINDOW_MIN_WIDTH
 } from './session-windows'
 import { ensureLoginShellPath } from './shell-path'
+import { createVerifiedSqliteBackup } from './sqlite-backup'
 import { createBootstrapCoordinator, sshConfigFingerprint } from './ssh-bootstrap-coordinator'
 import { collectSshConfigHosts, parseSshGOutput } from './ssh-config'
 import { createSshProbeConnection, pickLocalPort, redactSecrets, SshConnection } from './ssh-connection'
@@ -3972,7 +3973,7 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
     // ── Pre-flight state.db integrity guard (#68474) ─────────────────
     // Emergency backup and header verification before the update touches
     // anything.  Runs while the backend is still alive.
-    preflightStateDb(HERMES_HOME, rememberLog)
+    await preflightStateDb(HERMES_HOME, rememberLog)
 
     // Stop our own backend(s) and wait for the venv shim to unlock BEFORE we
     // spawn the updater. Without this the updater races a still-locked
@@ -4345,7 +4346,7 @@ function runningAppBundle() {
 // desktop Electron process itself, before the backend is killed and
 // before the updater is spawned — a separate safety net from the
 // Python-level pre-update snapshot inside `hermes update`.
-function preflightStateDb(hermesHome, rememberLog) {
+async function preflightStateDb(hermesHome, rememberLog) {
   const stateDbPath = path.join(hermesHome, 'state.db')
 
   if (!fileExists(stateDbPath)) {
@@ -4385,7 +4386,7 @@ function preflightStateDb(hermesHome, rememberLog) {
       const emergencyPath = path.join(hermesHome, `state.db.pre-update-emergency-${ts}.bak`)
 
       try {
-        fs.copyFileSync(stateDbPath, emergencyPath)
+        await createVerifiedSqliteBackup(stateDbPath, emergencyPath)
         const emergStat = fs.statSync(emergencyPath)
 
         rememberLog(`[updates] emergency state.db backup: ${emergencyPath} ` + `(${emergStat.size} bytes)`)
@@ -4453,7 +4454,7 @@ async function applyUpdatesPosixHandoff(opts: any) {
   }
 
   // ── Pre-flight state.db integrity guard (#68474) ──
-  preflightStateDb(HERMES_HOME, rememberLog)
+  await preflightStateDb(HERMES_HOME, rememberLog)
 
   // Branch-pin so a non-main checkout doesn't get switched to main (and
   // self-heal to main when the pinned branch no longer exists on origin).

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -4358,71 +4358,77 @@ async function preflightStateDb(hermesHome, rememberLog) {
   try {
     const stat = fs.statSync(stateDbPath)
 
-    if (stat.size > 100) {
-      const fd = fs.openSync(stateDbPath, 'r')
-      const header = Buffer.alloc(16)
-
-      fs.readSync(fd, header, 0, 16, 0)
-      fs.closeSync(fd)
-
-      const expectedHeader = Buffer.from('SQLite format 3\0')
-      const headerOk = header.equals(expectedHeader)
-
-      rememberLog(
-        `[updates] state.db pre-flight: size=${stat.size}, ` +
-          `headerOk=${headerOk}, headerHex=${header.toString('hex')}`
-      )
-
-      if (!headerOk) {
-        rememberLog(
-          '[updates] state.db header is INVALID before update — ' +
-            'this indicates pre-existing corruption or a concurrent write issue'
-        )
-      }
-
-      // Emergency timestamped backup, separate from the Python-level snapshot.
-      const ts = new Date().toISOString().replace(/[:.]/g, '-')
-
-      const emergencyPath = path.join(hermesHome, `state.db.pre-update-emergency-${ts}.bak`)
-
-      try {
-        await createVerifiedSqliteBackup(stateDbPath, emergencyPath)
-        const emergStat = fs.statSync(emergencyPath)
-
-        rememberLog(`[updates] emergency state.db backup: ${emergencyPath} ` + `(${emergStat.size} bytes)`)
-
-        // Prune to the 2 most recent emergency backups.
-        try {
-          const homeDir = fs.readdirSync(hermesHome)
-
-          const backups = homeDir
-            .filter(
-              f =>
-                f.startsWith('state.db.pre-update-emergency-') &&
-                f.endsWith('.bak') &&
-                f !== path.basename(emergencyPath)
-            )
-            .sort()
-            .reverse()
-
-          for (const old of backups.slice(2)) {
-            try {
-              fs.unlinkSync(path.join(hermesHome, old))
-            } catch {
-              void 0
-            }
-          }
-        } catch {
-          void 0
-        }
-      } catch (copyErr) {
-        rememberLog(`[updates] emergency state.db backup failed: ${copyErr.message}`)
-      }
-    } else {
-      rememberLog(`[updates] state.db too small (${stat.size} bytes) for a valid SQLite database`)
+    if (stat.size <= 100) {
+      throw new Error(`state.db is too small (${stat.size} bytes) to snapshot safely`)
     }
-  } catch (statErr) {
-    rememberLog(`[updates] could not stat state.db before update: ${statErr.message}`)
+
+    const fd = fs.openSync(stateDbPath, 'r')
+    const header = Buffer.alloc(16)
+
+    try {
+      fs.readSync(fd, header, 0, 16, 0)
+    } finally {
+      fs.closeSync(fd)
+    }
+
+    const expectedHeader = Buffer.from('SQLite format 3\0')
+    const headerOk = header.equals(expectedHeader)
+
+    rememberLog(
+      `[updates] state.db pre-flight: size=${stat.size}, ` +
+        `headerOk=${headerOk}, headerHex=${header.toString('hex')}`
+    )
+
+    if (!headerOk) {
+      throw new Error('state.db has an invalid SQLite header before update')
+    }
+
+    const homeDir = fs.readdirSync(hermesHome)
+
+    for (const stalePartial of homeDir.filter(
+      f => f.startsWith('state.db.pre-update-emergency-') && f.endsWith('.bak.partial')
+    )) {
+      try {
+        fs.rmSync(path.join(hermesHome, stalePartial), { force: true })
+      } catch (error) {
+        rememberLog(`[updates] could not remove stale emergency backup partial ${stalePartial}: ${error.message}`)
+      }
+    }
+
+    // Emergency timestamped backup, separate from the Python-level snapshot.
+    const ts = new Date().toISOString().replace(/[:.]/g, '-')
+    const emergencyPath = path.join(hermesHome, `state.db.pre-update-emergency-${ts}.bak`)
+    const backupResult = await createVerifiedSqliteBackup(stateDbPath, emergencyPath)
+
+    rememberLog(
+      `[updates] emergency state.db backup: ${emergencyPath} (${backupResult.size} bytes, ` +
+        `${backupResult.verification}, ${backupResult.durationMs}ms)`
+    )
+
+    // Prune to the 2 most recent emergency backups.
+    const backups = homeDir
+      .filter(
+        f =>
+          f.startsWith('state.db.pre-update-emergency-') &&
+          f.endsWith('.bak') &&
+          f !== path.basename(emergencyPath)
+      )
+      .sort()
+      .reverse()
+
+    for (const old of backups.slice(1)) {
+      try {
+        fs.unlinkSync(path.join(hermesHome, old))
+      } catch {
+        void 0
+      }
+    }
+  } catch (error) {
+    const message = `Update aborted: could not create a verified emergency state.db backup: ${error.message}`
+
+    rememberLog(`[updates] ${message}`)
+    emitUpdateProgress({ stage: 'error', message, percent: null })
+    throw new Error(message, { cause: error })
   }
 }
 

--- a/apps/desktop/electron/pre-update-backup-policy.test.ts
+++ b/apps/desktop/electron/pre-update-backup-policy.test.ts
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict'
+
+import { describe, test } from 'vitest'
+
+import {
+  parsePreUpdateBackupPolicy,
+  resolvePreUpdateBackupPolicy,
+  type RunPolicyProcess,
+  type RunPolicyProcessOptions
+} from './pre-update-backup-policy'
+
+const VALID = JSON.stringify({
+  backup_keep: 3,
+  mode: 'full',
+  quick_keep: 1,
+  quick_max_file_size: 1024
+})
+
+describe('parsePreUpdateBackupPolicy', () => {
+  test('accepts the strict producer schema', () => {
+    assert.deepEqual(parsePreUpdateBackupPolicy(`${VALID}\n`), {
+      backupKeep: 3,
+      mode: 'full',
+      quickKeep: 1,
+      quickMaxFileSize: 1024
+    })
+  })
+
+  test.each(['', 'not-json\n', `${VALID}\nnoise\n`, `noise\n${VALID}\n`, '{}\n'])(
+    'rejects empty, noisy, or malformed output',
+    stdout => {
+      assert.throws(() => parsePreUpdateBackupPolicy(stdout), /policy/)
+    }
+  )
+
+  test.each([
+    { ...JSON.parse(VALID), mode: 'maybe' },
+    { ...JSON.parse(VALID), backup_keep: 0 },
+    { ...JSON.parse(VALID), quick_keep: 0 },
+    { ...JSON.parse(VALID), quick_max_file_size: 0 },
+    { ...JSON.parse(VALID), extra: true }
+  ])('rejects values the strict Python producer must never emit', payload => {
+    assert.throws(() => parsePreUpdateBackupPolicy(`${JSON.stringify(payload)}\n`), /policy/)
+  })
+})
+
+describe('resolvePreUpdateBackupPolicy', () => {
+  test('uses one bounded no-shell Python invocation with explicit cwd and HERMES_HOME', async () => {
+    const calls: Array<{ args: string[]; command: string; options: RunPolicyProcessOptions }> = []
+
+    const runProcess: RunPolicyProcess = async (command, args, options) => {
+      calls.push({ args, command, options })
+
+      return { stderr: '', stdout: `${VALID}\n` }
+    }
+
+    const policy = await resolvePreUpdateBackupPolicy(
+      {
+        hermesHome: 'C:\\Hermes Home',
+        pythonPath: 'C:\\Python\\python.exe',
+        updateRoot: 'C:\\Hermes Source'
+      },
+      runProcess
+    )
+
+    assert.equal(policy.mode, 'full')
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0].command, 'C:\\Python\\python.exe')
+    assert.deepEqual(calls[0].args, ['-m', 'hermes_cli.update_preflight_policy'])
+    assert.equal(calls[0].options.cwd, 'C:\\Hermes Source')
+    assert.equal(calls[0].options.shell, false)
+    assert.equal(calls[0].options.timeout, 15_000)
+    assert.equal((calls[0].options.env as NodeJS.ProcessEnv).HERMES_HOME, 'C:\\Hermes Home')
+    assert.equal((calls[0].options.env as NodeJS.ProcessEnv).PYTHONUTF8, '1')
+  })
+
+  test.each([
+    Object.assign(new Error('exit 2'), { code: 2 }),
+    Object.assign(new Error('timed out'), { code: 'ETIMEDOUT' })
+  ])('fails closed when the producer process rejects', async error => {
+    const runProcess: RunPolicyProcess = async () => {
+      throw error
+    }
+
+    await assert.rejects(
+      resolvePreUpdateBackupPolicy({ hermesHome: 'home', pythonPath: 'python', updateRoot: 'root' }, runProcess),
+      /could not resolve pre-update backup policy/
+    )
+  })
+
+  test('fails closed when a successful process emits malformed JSON', async () => {
+    const runProcess: RunPolicyProcess = async () => ({ stderr: '', stdout: '{bad}\n' })
+
+    await assert.rejects(
+      resolvePreUpdateBackupPolicy({ hermesHome: 'home', pythonPath: 'python', updateRoot: 'root' }, runProcess),
+      /policy/
+    )
+  })
+
+  test('fails closed on noisy stderr even when stdout is valid', async () => {
+    const runProcess: RunPolicyProcess = async () => ({ stderr: 'unexpected warning\n', stdout: VALID })
+
+    await assert.rejects(
+      resolvePreUpdateBackupPolicy({ hermesHome: 'home', pythonPath: 'python', updateRoot: 'root' }, runProcess),
+      /unexpected stderr/
+    )
+  })
+})

--- a/apps/desktop/electron/pre-update-backup-policy.ts
+++ b/apps/desktop/electron/pre-update-backup-policy.ts
@@ -1,0 +1,124 @@
+import { execFile } from 'node:child_process'
+
+export type PreUpdateBackupMode = 'full' | 'off' | 'quick'
+
+export interface PreUpdateBackupPolicy {
+  backupKeep: number
+  mode: PreUpdateBackupMode
+  quickKeep: number
+  quickMaxFileSize: number
+}
+
+export interface RunPolicyProcessOptions {
+  cwd: string
+  env: NodeJS.ProcessEnv
+  maxBuffer: number
+  shell: false
+  timeout: number
+  windowsHide: true
+}
+
+export type RunPolicyProcess = (
+  command: string,
+  args: string[],
+  options: RunPolicyProcessOptions
+) => Promise<{ stderr: string; stdout: string }>
+
+const POLICY_TIMEOUT_MS = 15_000
+const POLICY_MAX_OUTPUT_BYTES = 64 * 1024
+const POLICY_KEYS = ['backup_keep', 'mode', 'quick_keep', 'quick_max_file_size']
+
+function positiveSafeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && Number(value) > 0
+}
+
+export function parsePreUpdateBackupPolicy(stdout: string): PreUpdateBackupPolicy {
+  const lines = stdout.split(/\r?\n/).filter(line => line.length > 0)
+
+  if (lines.length !== 1) {
+    throw new Error('pre-update backup policy output must contain exactly one JSON line')
+  }
+
+  let payload: unknown
+
+  try {
+    payload = JSON.parse(lines[0])
+  } catch (error) {
+    throw new Error('pre-update backup policy output is not valid JSON', { cause: error })
+  }
+
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new Error('pre-update backup policy payload must be an object')
+  }
+
+  const record = payload as Record<string, unknown>
+  const keys = Object.keys(record).sort()
+
+  if (keys.length !== POLICY_KEYS.length || keys.some((key, index) => key !== POLICY_KEYS[index])) {
+    throw new Error('pre-update backup policy payload has an unexpected schema')
+  }
+
+  if (record.mode !== 'off' && record.mode !== 'quick' && record.mode !== 'full') {
+    throw new Error('pre-update backup policy contains an invalid mode')
+  }
+
+  if (
+    !positiveSafeInteger(record.backup_keep) ||
+    !positiveSafeInteger(record.quick_keep) ||
+    !positiveSafeInteger(record.quick_max_file_size)
+  ) {
+    throw new Error('pre-update backup policy contains an invalid positive integer')
+  }
+
+  return {
+    backupKeep: record.backup_keep,
+    mode: record.mode,
+    quickKeep: record.quick_keep,
+    quickMaxFileSize: record.quick_max_file_size
+  }
+}
+
+const runPolicyProcess: RunPolicyProcess = (command, args, options) =>
+  new Promise((resolve, reject) => {
+    execFile(command, args, { ...options, encoding: 'utf8' }, (error, stdout, stderr) => {
+      if (error) {
+        reject(error)
+
+        return
+      }
+
+      resolve({ stderr, stdout })
+    })
+  })
+
+export async function resolvePreUpdateBackupPolicy(
+  paths: { hermesHome: string; pythonPath: string; updateRoot: string },
+  runProcess: RunPolicyProcess = runPolicyProcess
+): Promise<PreUpdateBackupPolicy> {
+  let output: { stderr: string; stdout: string }
+
+  try {
+    output = await runProcess(paths.pythonPath, ['-m', 'hermes_cli.update_preflight_policy'], {
+      cwd: paths.updateRoot,
+      env: {
+        ...process.env,
+        HERMES_HOME: paths.hermesHome,
+        PYTHONUTF8: '1'
+      },
+      maxBuffer: POLICY_MAX_OUTPUT_BYTES,
+      shell: false,
+      timeout: POLICY_TIMEOUT_MS,
+      windowsHide: true
+    })
+  } catch (error) {
+    throw new Error('could not resolve pre-update backup policy with the managed Python runtime', {
+      cause: error
+    })
+  }
+
+  if (output.stderr.trim()) {
+    throw new Error('pre-update backup policy process wrote unexpected stderr output')
+  }
+
+  return parsePreUpdateBackupPolicy(output.stdout)
+}

--- a/apps/desktop/electron/sqlite-backup.test.ts
+++ b/apps/desktop/electron/sqlite-backup.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+
+import { afterEach, test } from 'vitest'
+
+import { createVerifiedSqliteBackup } from './sqlite-backup'
+
+const tempDirs: string[] = []
+
+function tempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-sqlite-backup-'))
+
+  tempDirs.push(dir)
+
+  return dir
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('includes committed WAL transactions in the verified snapshot', async () => {
+  const dir = tempDir()
+  const sourcePath = path.join(dir, 'state.db')
+  const destinationPath = path.join(dir, 'state.db.bak')
+  const source = new DatabaseSync(sourcePath)
+
+  source.exec('PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; CREATE TABLE sessions (id TEXT PRIMARY KEY);')
+  source.prepare('INSERT INTO sessions (id) VALUES (?)').run('wal-only-session')
+
+  assert.ok(fs.existsSync(`${sourcePath}-wal`))
+  await createVerifiedSqliteBackup(sourcePath, destinationPath)
+
+  const snapshot = new DatabaseSync(destinationPath, { readOnly: true })
+
+  try {
+    const sessionRows = snapshot.prepare('SELECT id FROM sessions').all() as Array<{ id: string }>
+    const integrityRows = snapshot.prepare('PRAGMA integrity_check').all() as Array<{ integrity_check: string }>
+
+    assert.deepEqual(sessionRows.map(row => row.id), ['wal-only-session'])
+    assert.deepEqual(integrityRows.map(row => row.integrity_check), ['ok'])
+  } finally {
+    snapshot.close()
+    source.close()
+  }
+})

--- a/apps/desktop/electron/sqlite-backup.test.ts
+++ b/apps/desktop/electron/sqlite-backup.test.ts
@@ -7,7 +7,8 @@ import { Worker } from 'node:worker_threads'
 
 import { afterEach, test } from 'vitest'
 
-import { createVerifiedSqliteBackup, sqliteVerificationMode } from './sqlite-backup'
+import { createVerifiedSqliteBackup, inspectSqliteFootprint, sqliteVerificationMode } from './sqlite-backup'
+import { planEmergencyStateDbBackup } from './state-db-update-preflight'
 
 const tempDirs: string[] = []
 
@@ -58,8 +59,14 @@ test('includes committed WAL transactions and publishes only the verified snapsh
     const sessionRows = snapshot.prepare('SELECT id FROM sessions').all() as Array<{ id: string }>
     const integrityRows = snapshot.prepare('PRAGMA integrity_check').all() as Array<{ integrity_check: string }>
 
-    assert.deepEqual(sessionRows.map(row => row.id), ['wal-only-session'])
-    assert.deepEqual(integrityRows.map(row => row.integrity_check), ['ok'])
+    assert.deepEqual(
+      sessionRows.map(row => row.id),
+      ['wal-only-session']
+    )
+    assert.deepEqual(
+      integrityRows.map(row => row.integrity_check),
+      ['ok']
+    )
   } finally {
     snapshot.close()
     source.close()
@@ -114,16 +121,25 @@ test('reaches a bounded outcome while another connection continuously writes', a
   source.prepare('INSERT INTO payload (value) VALUES (?)').run(Buffer.alloc(4 * 1024 * 1024))
   source.close()
 
+  const counter = new Int32Array(new SharedArrayBuffer(4))
+
   const writer = new Worker(
     `
       const { parentPort, workerData } = require('node:worker_threads')
       const { DatabaseSync } = require('node:sqlite')
-      const database = new DatabaseSync(workerData)
+      const database = new DatabaseSync(workerData.sourcePath)
       const insert = database.prepare('INSERT INTO writes (value) VALUES (?)')
-      parentPort.postMessage('ready')
-      setInterval(() => insert.run(String(Date.now())), 0)
+      let ready = false
+      setInterval(() => {
+        insert.run(String(Date.now()))
+        Atomics.add(new Int32Array(workerData.counter), 0, 1)
+        if (!ready) {
+          ready = true
+          parentPort.postMessage('ready')
+        }
+      }, 0)
     `,
-    { eval: true, workerData: sourcePath }
+    { eval: true, workerData: { counter: counter.buffer, sourcePath } }
   )
 
   try {
@@ -132,16 +148,18 @@ test('reaches a bounded outcome while another connection continuously writes', a
       writer.once('error', reject)
     })
 
+    const writesBefore = Atomics.load(counter, 0)
     const startedAt = Date.now()
     let completed = false
 
     try {
       await createVerifiedSqliteBackup(sourcePath, destinationPath, { deadlineMs: 100 })
       completed = true
-    } catch {
-      // A timeout is also a valid bounded outcome under sustained writes.
+    } catch (error) {
+      assert.match(String(error), /emergency backup exceeded 100ms deadline/)
     }
 
+    assert.ok(Atomics.load(counter, 0) > writesBefore)
     assert.ok(Date.now() - startedAt < 5_000)
     assert.equal(fs.existsSync(`${destinationPath}.partial`), false)
 
@@ -151,7 +169,10 @@ test('reaches a bounded outcome while another connection continuously writes', a
       try {
         const rows = snapshot.prepare('PRAGMA integrity_check').all() as Array<{ integrity_check: string }>
 
-        assert.deepEqual(rows.map(row => row.integrity_check), ['ok'])
+        assert.deepEqual(
+          rows.map(row => row.integrity_check),
+          ['ok']
+        )
       } finally {
         snapshot.close()
       }
@@ -204,5 +225,165 @@ test('rejects a corrupt snapshot and removes both publication paths', async () =
 
   await assert.rejects(createVerifiedSqliteBackup(sourcePath, destinationPath), /integrity_check|malformed/)
   assert.equal(fs.existsSync(destinationPath), false)
+  assert.equal(fs.existsSync(`${destinationPath}.partial`), false)
+})
+
+test('estimates the online snapshot from logical pages and the committed WAL footprint', () => {
+  const dir = tempDir()
+  const sourcePath = path.join(dir, 'state.db')
+  const source = createPopulatedDatabase(sourcePath)
+
+  try {
+    source.exec('CREATE TABLE payload (value BLOB)')
+    source.prepare('INSERT INTO payload (value) VALUES (?)').run(Buffer.alloc(1024 * 1024))
+    const footprint = inspectSqliteFootprint(sourcePath)
+
+    assert.ok(footprint.walBytes > 0)
+    assert.ok(footprint.logicalBytes > 0)
+    assert.ok(footprint.estimatedBackupBytes >= footprint.logicalBytes)
+    assert.ok(footprint.estimatedBackupBytes >= footprint.mainBytes + footprint.walBytes)
+    assert.deepEqual(
+      planEmergencyStateDbBackup(
+        { backupKeep: 5, mode: 'quick', quickKeep: 1, quickMaxFileSize: footprint.mainBytes },
+        footprint.estimatedBackupBytes
+      ),
+      { reason: 'quick-size-cap', status: 'skipped' }
+    )
+  } finally {
+    source.close()
+  }
+})
+
+test('keeps the final name absent until verification has completed', async () => {
+  const dir = tempDir()
+  const sourcePath = path.join(dir, 'state.db')
+  const destinationPath = path.join(dir, 'state.db.bak')
+  const source = createPopulatedDatabase(sourcePath)
+  const phases: string[] = []
+
+  try {
+    await createVerifiedSqliteBackup(sourcePath, destinationPath, {
+      onPhase: phase => {
+        phases.push(phase)
+
+        if (phase !== 'published') {
+          assert.equal(fs.existsSync(destinationPath), false)
+          assert.equal(fs.existsSync(`${destinationPath}.partial`), true)
+        }
+      }
+    })
+
+    assert.deepEqual(phases, ['backup-complete', 'verified', 'published'])
+    assert.equal(fs.existsSync(destinationPath), true)
+  } finally {
+    source.close()
+  }
+})
+
+test('uses the bounded structural worker probe above the configured deep-check boundary', async () => {
+  const dir = tempDir()
+  const sourcePath = path.join(dir, 'state.db')
+  const destinationPath = path.join(dir, 'state.db.bak')
+  const source = createPopulatedDatabase(sourcePath)
+
+  try {
+    const result = await createVerifiedSqliteBackup(sourcePath, destinationPath, {
+      integrityCheckMaxBytes: 1,
+      verificationDeadlineMs: 5_000
+    })
+
+    assert.equal(result.verification, 'schema-probe')
+    assert.equal(fs.existsSync(destinationPath), true)
+    assert.equal(fs.existsSync(`${destinationPath}.partial`), false)
+  } finally {
+    source.close()
+  }
+})
+
+test('preserves a pre-existing final byte-for-byte when publication cannot claim the name', async () => {
+  const dir = tempDir()
+  const sourcePath = path.join(dir, 'state.db')
+  const destinationPath = path.join(dir, 'state.db.bak')
+  const source = createPopulatedDatabase(sourcePath)
+  const sentinel = Buffer.from('existing recovery point')
+  fs.writeFileSync(destinationPath, sentinel)
+
+  try {
+    await assert.rejects(createVerifiedSqliteBackup(sourcePath, destinationPath), /already exists/)
+    assert.deepEqual(fs.readFileSync(destinationPath), sentinel)
+    assert.equal(fs.existsSync(`${destinationPath}.partial`), false)
+  } finally {
+    source.close()
+  }
+})
+
+test('preserves a final that appears after verification instead of overwriting it', async () => {
+  const dir = tempDir()
+  const sourcePath = path.join(dir, 'state.db')
+  const destinationPath = path.join(dir, 'state.db.bak')
+  const source = createPopulatedDatabase(sourcePath)
+  const sentinel = Buffer.from('racing recovery point')
+
+  try {
+    await assert.rejects(
+      createVerifiedSqliteBackup(sourcePath, destinationPath, {
+        onPhase: phase => {
+          if (phase === 'verified') {
+            fs.writeFileSync(destinationPath, sentinel)
+          }
+        }
+      }),
+      /already exists/
+    )
+    assert.deepEqual(fs.readFileSync(destinationPath), sentinel)
+    assert.equal(fs.existsSync(`${destinationPath}.partial`), false)
+  } finally {
+    source.close()
+  }
+})
+
+test('a forced worker termination leaves no final and the next attempt replaces its stale partial', async () => {
+  const dir = tempDir()
+  const sourcePath = path.join(dir, 'state.db')
+  const destinationPath = path.join(dir, 'state.db.bak')
+  const source = new DatabaseSync(sourcePath)
+  source.exec('CREATE TABLE payload (value BLOB)')
+  const insert = source.prepare('INSERT INTO payload (value) VALUES (?)')
+
+  for (let index = 0; index < 16; index += 1) {
+    insert.run(Buffer.alloc(1024 * 1024, index))
+  }
+
+  source.close()
+
+  const worker = new Worker(
+    `
+      const { parentPort, workerData } = require('node:worker_threads')
+      const { backup, DatabaseSync } = require('node:sqlite')
+      const source = new DatabaseSync(workerData.source)
+      const wait = new Int32Array(new SharedArrayBuffer(4))
+      backup(source, workerData.partial, {
+        rate: 1,
+        progress() {
+          parentPort.postMessage('partial-created')
+          Atomics.wait(wait, 0, 0, 10000)
+        }
+      }).catch(error => parentPort.postMessage(String(error)))
+    `,
+    { eval: true, workerData: { partial: `${destinationPath}.partial`, source: sourcePath } }
+  )
+
+  await new Promise<void>((resolve, reject) => {
+    worker.once('message', () => resolve())
+    worker.once('error', reject)
+  })
+  await worker.terminate()
+
+  assert.equal(fs.existsSync(destinationPath), false)
+  assert.equal(fs.existsSync(`${destinationPath}.partial`), true)
+
+  const result = await createVerifiedSqliteBackup(sourcePath, destinationPath)
+  assert.ok(result.size > 0)
+  assert.equal(fs.existsSync(destinationPath), true)
   assert.equal(fs.existsSync(`${destinationPath}.partial`), false)
 })

--- a/apps/desktop/electron/sqlite-backup.test.ts
+++ b/apps/desktop/electron/sqlite-backup.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
+import { Worker } from 'node:worker_threads'
 
 import { afterEach, test } from 'vitest'
 
@@ -18,23 +19,33 @@ function tempDir(): string {
   return dir
 }
 
+function createPopulatedDatabase(sourcePath: string): DatabaseSync {
+  const source = new DatabaseSync(sourcePath)
+
+  source.exec('PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; CREATE TABLE sessions (id TEXT PRIMARY KEY);')
+  source.prepare('INSERT INTO sessions (id) VALUES (?)').run('wal-only-session')
+
+  return source
+}
+
 afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
 
-test('includes committed WAL transactions in the verified snapshot', async () => {
+test('includes committed WAL transactions and publishes only the verified snapshot', async () => {
   const dir = tempDir()
   const sourcePath = path.join(dir, 'state.db')
   const destinationPath = path.join(dir, 'state.db.bak')
-  const source = new DatabaseSync(sourcePath)
-
-  source.exec('PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; CREATE TABLE sessions (id TEXT PRIMARY KEY);')
-  source.prepare('INSERT INTO sessions (id) VALUES (?)').run('wal-only-session')
+  const source = createPopulatedDatabase(sourcePath)
 
   assert.ok(fs.existsSync(`${sourcePath}-wal`))
-  await createVerifiedSqliteBackup(sourcePath, destinationPath)
+  const result = await createVerifiedSqliteBackup(sourcePath, destinationPath)
+
+  assert.equal(result.verification, 'integrity-check')
+  assert.ok(result.size > 0)
+  assert.equal(fs.existsSync(`${destinationPath}.partial`), false)
 
   const snapshot = new DatabaseSync(destinationPath, { readOnly: true })
 
@@ -48,4 +59,125 @@ test('includes committed WAL transactions in the verified snapshot', async () =>
     snapshot.close()
     source.close()
   }
+})
+
+test('uses the bounded structural probe above the deep-check size limit', async () => {
+  const dir = tempDir()
+  const sourcePath = path.join(dir, 'state.db')
+  const destinationPath = path.join(dir, 'state.db.bak')
+  const source = createPopulatedDatabase(sourcePath)
+
+  try {
+    const result = await createVerifiedSqliteBackup(sourcePath, destinationPath, { integrityCheckMaxBytes: 1 })
+
+    assert.equal(result.verification, 'schema-probe')
+    assert.ok(fs.existsSync(destinationPath))
+  } finally {
+    source.close()
+  }
+})
+
+test('aborts within the backup deadline without publishing a partial snapshot', async () => {
+  const dir = tempDir()
+  const sourcePath = path.join(dir, 'state.db')
+  const destinationPath = path.join(dir, 'state.db.bak')
+  const source = createPopulatedDatabase(sourcePath)
+
+  try {
+    source.exec('CREATE TABLE payload (value BLOB)')
+    source.prepare('INSERT INTO payload (value) VALUES (?)').run(Buffer.alloc(2 * 1024 * 1024))
+    fs.writeFileSync(`${destinationPath}.partial`, 'stale partial')
+
+    await assert.rejects(
+      createVerifiedSqliteBackup(sourcePath, destinationPath, { deadlineMs: 0 }),
+      /emergency backup exceeded 0ms deadline/
+    )
+    assert.equal(fs.existsSync(destinationPath), false)
+    assert.equal(fs.existsSync(`${destinationPath}.partial`), false)
+  } finally {
+    source.close()
+  }
+})
+
+test('reaches a bounded outcome while another connection continuously writes', async () => {
+  const dir = tempDir()
+  const sourcePath = path.join(dir, 'state.db')
+  const destinationPath = path.join(dir, 'state.db.bak')
+  const source = createPopulatedDatabase(sourcePath)
+
+  source.exec('CREATE TABLE writes (value TEXT); CREATE TABLE payload (value BLOB)')
+  source.prepare('INSERT INTO payload (value) VALUES (?)').run(Buffer.alloc(4 * 1024 * 1024))
+  source.close()
+
+  const writer = new Worker(
+    `
+      const { parentPort, workerData } = require('node:worker_threads')
+      const { DatabaseSync } = require('node:sqlite')
+      const database = new DatabaseSync(workerData)
+      const insert = database.prepare('INSERT INTO writes (value) VALUES (?)')
+      parentPort.postMessage('ready')
+      setInterval(() => insert.run(String(Date.now())), 0)
+    `,
+    { eval: true, workerData: sourcePath }
+  )
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      writer.once('message', () => resolve())
+      writer.once('error', reject)
+    })
+
+    const startedAt = Date.now()
+
+    await assert.rejects(createVerifiedSqliteBackup(sourcePath, destinationPath, { deadlineMs: 100 }))
+    assert.ok(Date.now() - startedAt < 5_000)
+    assert.equal(fs.existsSync(destinationPath), false)
+    assert.equal(fs.existsSync(`${destinationPath}.partial`), false)
+  } finally {
+    await writer.terminate()
+  }
+})
+
+test('removes a partial when the backup operation rejects', async () => {
+  const dir = tempDir()
+  const sourcePath = path.join(dir, 'state.db')
+  const destinationPath = path.join(dir, 'missing', 'state.db.bak')
+  const partialPath = `${destinationPath}.partial`
+  const source = createPopulatedDatabase(sourcePath)
+
+  try {
+    await assert.rejects(createVerifiedSqliteBackup(sourcePath, destinationPath))
+    assert.equal(fs.existsSync(destinationPath), false)
+    assert.equal(fs.existsSync(partialPath), false)
+  } finally {
+    source.close()
+  }
+})
+
+test('rejects a corrupt snapshot and removes both publication paths', async () => {
+  const dir = tempDir()
+  const sourcePath = path.join(dir, 'state.db')
+  const destinationPath = path.join(dir, 'state.db.bak')
+  const source = new DatabaseSync(sourcePath)
+
+  source.exec('CREATE TABLE payload (value BLOB)')
+  const insert = source.prepare('INSERT INTO payload (value) VALUES (?)')
+
+  for (let index = 0; index < 50; index += 1) {
+    insert.run(Buffer.alloc(4096, index))
+  }
+
+  source.close()
+
+  const fd = fs.openSync(sourcePath, 'r+')
+
+  try {
+    fs.writeSync(fd, Buffer.alloc(4096, 0xff), 0, 4096, 2 * 4096)
+  } finally {
+    fs.closeSync(fd)
+  }
+
+  await assert.rejects(createVerifiedSqliteBackup(sourcePath, destinationPath), /integrity_check|malformed/)
+  assert.equal(fs.existsSync(destinationPath), false)
+  assert.equal(fs.existsSync(`${destinationPath}.partial`), false)
 })

--- a/apps/desktop/electron/sqlite-backup.test.ts
+++ b/apps/desktop/electron/sqlite-backup.test.ts
@@ -133,11 +133,31 @@ test('reaches a bounded outcome while another connection continuously writes', a
     })
 
     const startedAt = Date.now()
+    let completed = false
 
-    await assert.rejects(createVerifiedSqliteBackup(sourcePath, destinationPath, { deadlineMs: 100 }))
+    try {
+      await createVerifiedSqliteBackup(sourcePath, destinationPath, { deadlineMs: 100 })
+      completed = true
+    } catch {
+      // A timeout is also a valid bounded outcome under sustained writes.
+    }
+
     assert.ok(Date.now() - startedAt < 5_000)
-    assert.equal(fs.existsSync(destinationPath), false)
     assert.equal(fs.existsSync(`${destinationPath}.partial`), false)
+
+    if (completed) {
+      const snapshot = new DatabaseSync(destinationPath, { readOnly: true })
+
+      try {
+        const rows = snapshot.prepare('PRAGMA integrity_check').all() as Array<{ integrity_check: string }>
+
+        assert.deepEqual(rows.map(row => row.integrity_check), ['ok'])
+      } finally {
+        snapshot.close()
+      }
+    } else {
+      assert.equal(fs.existsSync(destinationPath), false)
+    }
   } finally {
     await writer.terminate()
   }

--- a/apps/desktop/electron/sqlite-backup.test.ts
+++ b/apps/desktop/electron/sqlite-backup.test.ts
@@ -7,7 +7,7 @@ import { Worker } from 'node:worker_threads'
 
 import { afterEach, test } from 'vitest'
 
-import { createVerifiedSqliteBackup } from './sqlite-backup'
+import { createVerifiedSqliteBackup, sqliteVerificationMode } from './sqlite-backup'
 
 const tempDirs: string[] = []
 
@@ -32,6 +32,11 @@ afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true })
   }
+})
+
+test('uses the default 2 GiB boundary for deep verification', () => {
+  assert.equal(sqliteVerificationMode(2 * 1024 * 1024 * 1024), 'integrity-check')
+  assert.equal(sqliteVerificationMode(2 * 1024 * 1024 * 1024 + 1), 'schema-probe')
 })
 
 test('includes committed WAL transactions and publishes only the verified snapshot', async () => {

--- a/apps/desktop/electron/sqlite-backup.ts
+++ b/apps/desktop/electron/sqlite-backup.ts
@@ -1,0 +1,41 @@
+import fs from 'node:fs'
+import { backup, DatabaseSync } from 'node:sqlite'
+
+export async function createVerifiedSqliteBackup(sourcePath: string, destinationPath: string): Promise<void> {
+  const source = new DatabaseSync(sourcePath, { readOnly: true })
+
+  try {
+    await backup(source, destinationPath)
+  } catch (error) {
+    removePartialBackup(destinationPath)
+    throw error
+  } finally {
+    source.close()
+  }
+
+  let snapshot: DatabaseSync | null = null
+
+  try {
+    snapshot = new DatabaseSync(destinationPath, { readOnly: true })
+    const rows = snapshot.prepare('PRAGMA integrity_check').all() as Array<Record<string, unknown>>
+
+    if (rows.length !== 1 || Object.values(rows[0])[0] !== 'ok') {
+      throw new Error('SQLite integrity_check failed for emergency backup')
+    }
+  } catch (error) {
+    snapshot?.close()
+    snapshot = null
+    removePartialBackup(destinationPath)
+    throw error
+  } finally {
+    snapshot?.close()
+  }
+}
+
+function removePartialBackup(destinationPath: string): void {
+  try {
+    fs.unlinkSync(destinationPath)
+  } catch {
+    // Nothing to clean up, or another process already removed the partial file.
+  }
+}

--- a/apps/desktop/electron/sqlite-backup.ts
+++ b/apps/desktop/electron/sqlite-backup.ts
@@ -1,9 +1,55 @@
 import fs from 'node:fs'
-import { backup, DatabaseSync } from 'node:sqlite'
+import { DatabaseSync } from 'node:sqlite'
+import { Worker } from 'node:worker_threads'
 
 const DEFAULT_BACKUP_DEADLINE_MS = 30_000
+const DEFAULT_VERIFICATION_DEADLINE_MS = 30_000
 const DEFAULT_INTEGRITY_CHECK_MAX_BYTES = 2 * 1024 * 1024 * 1024
 const BACKUP_RATE_PAGES = 100
+
+const BACKUP_WORKER_SOURCE = `
+  const { parentPort, workerData } = require('node:worker_threads')
+  const { backup, DatabaseSync } = require('node:sqlite')
+  let source
+  ;(async () => {
+    try {
+      source = new DatabaseSync(workerData.sourcePath)
+      source.exec('PRAGMA busy_timeout = 1000')
+      source.prepare('SELECT count(*) FROM sqlite_master').get()
+      await backup(source, workerData.partialPath, { rate: workerData.rate })
+      parentPort.postMessage({ ok: true })
+    } catch (error) {
+      parentPort.postMessage({ error: error instanceof Error ? error.message : String(error), ok: false })
+    } finally {
+      try { source?.close() } catch {}
+    }
+  })()
+`
+
+const VERIFY_WORKER_SOURCE = `
+  const { parentPort, workerData } = require('node:worker_threads')
+  const { DatabaseSync } = require('node:sqlite')
+  let snapshot
+  try {
+    snapshot = new DatabaseSync(workerData.snapshotPath, { readOnly: true })
+    if (workerData.verification === 'schema-probe') {
+      snapshot.prepare('PRAGMA schema_version').get()
+      snapshot.prepare('SELECT count(*) FROM sqlite_master').get()
+    } else {
+      const rows = snapshot.prepare('PRAGMA integrity_check').all()
+      if (rows.length !== 1 || Object.values(rows[0])[0] !== 'ok') {
+        throw new Error('SQLite integrity_check failed for emergency backup')
+      }
+    }
+    parentPort.postMessage({ ok: true })
+  } catch (error) {
+    parentPort.postMessage({ error: error instanceof Error ? error.message : String(error), ok: false })
+  } finally {
+    try { snapshot?.close() } catch {}
+  }
+`
+
+export type SqliteBackupPhase = 'backup-complete' | 'published' | 'verified'
 
 export interface SqliteBackupResult {
   durationMs: number
@@ -11,9 +57,18 @@ export interface SqliteBackupResult {
   verification: 'integrity-check' | 'schema-probe'
 }
 
+export interface SqliteFootprint {
+  estimatedBackupBytes: number
+  logicalBytes: number
+  mainBytes: number
+  walBytes: number
+}
+
 interface SqliteBackupOptions {
   deadlineMs?: number
   integrityCheckMaxBytes?: number
+  onPhase?: (phase: SqliteBackupPhase) => void
+  verificationDeadlineMs?: number
 }
 
 export function sqliteVerificationMode(
@@ -21,6 +76,44 @@ export function sqliteVerificationMode(
   integrityCheckMaxBytes = DEFAULT_INTEGRITY_CHECK_MAX_BYTES
 ): SqliteBackupResult['verification'] {
   return integrityCheckMaxBytes > 0 && size > integrityCheckMaxBytes ? 'schema-probe' : 'integrity-check'
+}
+
+function fileSizeOrZero(filePath: string): number {
+  try {
+    return fs.statSync(filePath).size
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {return 0}
+    throw error
+  }
+}
+
+/** Conservative destination estimate including logical pages and WAL bytes. */
+export function inspectSqliteFootprint(sourcePath: string): SqliteFootprint {
+  const mainBytes = fs.statSync(sourcePath).size
+  const walBytes = fileSizeOrZero(`${sourcePath}-wal`)
+  const source = new DatabaseSync(sourcePath, { readOnly: true })
+
+  try {
+    source.exec('PRAGMA busy_timeout = 1000')
+    const pageCountRow = source.prepare('PRAGMA page_count').get() as Record<string, number | bigint>
+    const pageSizeRow = source.prepare('PRAGMA page_size').get() as Record<string, number | bigint>
+    const pageCount = Number(Object.values(pageCountRow)[0])
+    const pageSize = Number(Object.values(pageSizeRow)[0])
+    const logicalBytes = pageCount * pageSize
+
+    if (!Number.isSafeInteger(logicalBytes) || logicalBytes <= 0) {
+      throw new Error(`SQLite reported an invalid logical size (${logicalBytes})`)
+    }
+
+    return {
+      estimatedBackupBytes: Math.max(logicalBytes, mainBytes + walBytes),
+      logicalBytes,
+      mainBytes,
+      walBytes
+    }
+  } finally {
+    source.close()
+  }
 }
 
 export async function createVerifiedSqliteBackup(
@@ -31,74 +124,91 @@ export async function createVerifiedSqliteBackup(
   const startedAt = Date.now()
   const deadlineMs = options.deadlineMs ?? DEFAULT_BACKUP_DEADLINE_MS
   const partialPath = `${destinationPath}.partial`
-  let source: DatabaseSync | null = null
 
   fs.statSync(sourcePath)
+  assertDestinationAbsent(destinationPath)
   removeFile(partialPath)
 
   try {
-    source = new DatabaseSync(sourcePath)
-    source.exec('PRAGMA busy_timeout = 1000')
-    source.prepare('SELECT count(*) FROM sqlite_master').get()
-
-    await backup(source, partialPath, {
-      rate: BACKUP_RATE_PAGES,
-      progress: () => {
-        if (Date.now() - startedAt >= deadlineMs) {
-          throw new Error(`SQLite emergency backup exceeded ${deadlineMs}ms deadline`)
-        }
-      }
-    })
+    await runBoundedWorker(
+      BACKUP_WORKER_SOURCE,
+      { partialPath, rate: BACKUP_RATE_PAGES, sourcePath },
+      deadlineMs,
+      'SQLite emergency backup'
+    )
+    options.onPhase?.('backup-complete')
 
     const size = fs.statSync(partialPath).size
 
-    if (size <= 100) {
-      throw new Error(`SQLite emergency backup is too small (${size} bytes)`)
-    }
+    if (size <= 100) {throw new Error(`SQLite emergency backup is too small (${size} bytes)`)}
 
-    const verification = verifySqliteSnapshot(
-      partialPath,
+    const verification = sqliteVerificationMode(
       size,
       options.integrityCheckMaxBytes ?? DEFAULT_INTEGRITY_CHECK_MAX_BYTES
     )
 
-    fs.renameSync(partialPath, destinationPath)
+    await runBoundedWorker(
+      VERIFY_WORKER_SOURCE,
+      { snapshotPath: partialPath, verification },
+      options.verificationDeadlineMs ?? Math.max(DEFAULT_VERIFICATION_DEADLINE_MS, deadlineMs),
+      'SQLite emergency backup verification'
+    )
+    options.onPhase?.('verified')
+
+    assertDestinationAbsent(destinationPath)
+    // Hard-link publication is atomic and no-replace on Windows and POSIX.
+    fs.linkSync(partialPath, destinationPath)
+    fs.unlinkSync(partialPath)
+    options.onPhase?.('published')
 
     return { durationMs: Date.now() - startedAt, size, verification }
   } catch (error) {
     removeFile(partialPath)
     throw error
-  } finally {
-    source?.close()
   }
 }
 
-function verifySqliteSnapshot(
-  snapshotPath: string,
-  size: number,
-  integrityCheckMaxBytes: number
-): SqliteBackupResult['verification'] {
-  const snapshot = new DatabaseSync(snapshotPath, { readOnly: true })
+function assertDestinationAbsent(destinationPath: string): void {
+  if (fs.existsSync(destinationPath)) {
+    throw new Error(`SQLite emergency backup destination already exists: ${destinationPath}`)
+  }
+}
+
+async function runBoundedWorker(
+  source: string,
+  workerData: Record<string, unknown>,
+  timeoutMs: number,
+  label: string
+): Promise<void> {
+  const worker = new Worker(source, { eval: true, workerData })
+  let timer: NodeJS.Timeout | undefined
 
   try {
-    const verification = sqliteVerificationMode(size, integrityCheckMaxBytes)
+    await new Promise<void>((resolve, reject) => {
+      let settled = false
 
-    if (verification === 'schema-probe') {
-      snapshot.prepare('PRAGMA schema_version').get()
-      snapshot.prepare('SELECT count(*) FROM sqlite_master').get()
+      const finish = (error?: Error) => {
+        if (settled) {return}
+        settled = true
 
-      return verification
-    }
+        if (error) {reject(error)}
+        else {resolve()}
+      }
 
-    const rows = snapshot.prepare('PRAGMA integrity_check').all() as Array<Record<string, unknown>>
-
-    if (rows.length !== 1 || Object.values(rows[0])[0] !== 'ok') {
-      throw new Error('SQLite integrity_check failed for emergency backup')
-    }
-
-    return verification
+      timer = setTimeout(() => finish(new Error(`${label} exceeded ${timeoutMs}ms deadline`)), timeoutMs)
+      timer.unref?.()
+      worker.once('message', message => {
+        if (message?.ok) {finish()}
+        else {finish(new Error(message?.error || `${label} failed`))}
+      })
+      worker.once('error', error => finish(error))
+      worker.once('exit', code => {
+        if (!settled) {finish(new Error(`${label} worker exited ${code} before reporting completion`))}
+      })
+    })
   } finally {
-    snapshot.close()
+    if (timer) {clearTimeout(timer)}
+    await worker.terminate()
   }
 }
 
@@ -106,8 +216,6 @@ function removeFile(filePath: string): void {
   try {
     fs.unlinkSync(filePath)
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-      throw error
-    }
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {throw error}
   }
 }

--- a/apps/desktop/electron/sqlite-backup.ts
+++ b/apps/desktop/electron/sqlite-backup.ts
@@ -1,41 +1,104 @@
 import fs from 'node:fs'
 import { backup, DatabaseSync } from 'node:sqlite'
 
-export async function createVerifiedSqliteBackup(sourcePath: string, destinationPath: string): Promise<void> {
-  const source = new DatabaseSync(sourcePath, { readOnly: true })
+const DEFAULT_BACKUP_DEADLINE_MS = 30_000
+const DEFAULT_INTEGRITY_CHECK_MAX_BYTES = 2 << 30
+const BACKUP_RATE_PAGES = 100
+
+export interface SqliteBackupResult {
+  durationMs: number
+  size: number
+  verification: 'integrity-check' | 'schema-probe'
+}
+
+interface SqliteBackupOptions {
+  deadlineMs?: number
+  integrityCheckMaxBytes?: number
+}
+
+export async function createVerifiedSqliteBackup(
+  sourcePath: string,
+  destinationPath: string,
+  options: SqliteBackupOptions = {}
+): Promise<SqliteBackupResult> {
+  const startedAt = Date.now()
+  const deadlineMs = options.deadlineMs ?? DEFAULT_BACKUP_DEADLINE_MS
+  const partialPath = `${destinationPath}.partial`
+  let source: DatabaseSync | null = null
+
+  fs.statSync(sourcePath)
+  removeFile(partialPath)
 
   try {
-    await backup(source, destinationPath)
+    source = new DatabaseSync(sourcePath)
+    source.exec('PRAGMA busy_timeout = 1000')
+    source.prepare('SELECT count(*) FROM sqlite_master').get()
+
+    await backup(source, partialPath, {
+      rate: BACKUP_RATE_PAGES,
+      progress: () => {
+        if (Date.now() - startedAt >= deadlineMs) {
+          throw new Error(`SQLite emergency backup exceeded ${deadlineMs}ms deadline`)
+        }
+      }
+    })
+
+    const size = fs.statSync(partialPath).size
+
+    if (size <= 100) {
+      throw new Error(`SQLite emergency backup is too small (${size} bytes)`)
+    }
+
+    const verification = verifySqliteSnapshot(
+      partialPath,
+      size,
+      options.integrityCheckMaxBytes ?? DEFAULT_INTEGRITY_CHECK_MAX_BYTES
+    )
+
+    fs.renameSync(partialPath, destinationPath)
+
+    return { durationMs: Date.now() - startedAt, size, verification }
   } catch (error) {
-    removePartialBackup(destinationPath)
+    removeFile(partialPath)
     throw error
   } finally {
-    source.close()
+    source?.close()
   }
+}
 
-  let snapshot: DatabaseSync | null = null
+function verifySqliteSnapshot(
+  snapshotPath: string,
+  size: number,
+  integrityCheckMaxBytes: number
+): SqliteBackupResult['verification'] {
+  const snapshot = new DatabaseSync(snapshotPath, { readOnly: true })
 
   try {
-    snapshot = new DatabaseSync(destinationPath, { readOnly: true })
+    if (integrityCheckMaxBytes > 0 && size > integrityCheckMaxBytes) {
+      snapshot.prepare('PRAGMA schema_version').get()
+      snapshot.prepare('SELECT count(*) FROM sqlite_master').get()
+
+      return 'schema-probe'
+    }
+
     const rows = snapshot.prepare('PRAGMA integrity_check').all() as Array<Record<string, unknown>>
 
     if (rows.length !== 1 || Object.values(rows[0])[0] !== 'ok') {
       throw new Error('SQLite integrity_check failed for emergency backup')
     }
-  } catch (error) {
-    snapshot?.close()
-    snapshot = null
-    removePartialBackup(destinationPath)
-    throw error
+
+    return 'integrity-check'
   } finally {
-    snapshot?.close()
+    snapshot.close()
   }
 }
 
-function removePartialBackup(destinationPath: string): void {
+function removeFile(filePath: string): void {
   try {
-    fs.unlinkSync(destinationPath)
-  } catch {
-    // Nothing to clean up, or another process already removed the partial file.
+    fs.unlinkSync(filePath)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error
+    }
   }
 }

--- a/apps/desktop/electron/sqlite-backup.ts
+++ b/apps/desktop/electron/sqlite-backup.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import { backup, DatabaseSync } from 'node:sqlite'
 
 const DEFAULT_BACKUP_DEADLINE_MS = 30_000
-const DEFAULT_INTEGRITY_CHECK_MAX_BYTES = 2 << 30
+const DEFAULT_INTEGRITY_CHECK_MAX_BYTES = 2 * 1024 * 1024 * 1024
 const BACKUP_RATE_PAGES = 100
 
 export interface SqliteBackupResult {
@@ -14,6 +14,13 @@ export interface SqliteBackupResult {
 interface SqliteBackupOptions {
   deadlineMs?: number
   integrityCheckMaxBytes?: number
+}
+
+export function sqliteVerificationMode(
+  size: number,
+  integrityCheckMaxBytes = DEFAULT_INTEGRITY_CHECK_MAX_BYTES
+): SqliteBackupResult['verification'] {
+  return integrityCheckMaxBytes > 0 && size > integrityCheckMaxBytes ? 'schema-probe' : 'integrity-check'
 }
 
 export async function createVerifiedSqliteBackup(
@@ -74,11 +81,13 @@ function verifySqliteSnapshot(
   const snapshot = new DatabaseSync(snapshotPath, { readOnly: true })
 
   try {
-    if (integrityCheckMaxBytes > 0 && size > integrityCheckMaxBytes) {
+    const verification = sqliteVerificationMode(size, integrityCheckMaxBytes)
+
+    if (verification === 'schema-probe') {
       snapshot.prepare('PRAGMA schema_version').get()
       snapshot.prepare('SELECT count(*) FROM sqlite_master').get()
 
-      return 'schema-probe'
+      return verification
     }
 
     const rows = snapshot.prepare('PRAGMA integrity_check').all() as Array<Record<string, unknown>>
@@ -87,7 +96,7 @@ function verifySqliteSnapshot(
       throw new Error('SQLite integrity_check failed for emergency backup')
     }
 
-    return 'integrity-check'
+    return verification
   } finally {
     snapshot.close()
   }

--- a/apps/desktop/electron/state-db-update-preflight.test.ts
+++ b/apps/desktop/electron/state-db-update-preflight.test.ts
@@ -1,0 +1,453 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, describe, test, vi } from 'vitest'
+
+import type { PreUpdateBackupPolicy } from './pre-update-backup-policy'
+import {
+  backupDeadlineMs,
+  inspectStateDbHeader,
+  planEmergencyStateDbBackup,
+  requiredFreeBytes,
+  runStateDbUpdatePreflight,
+  selectEmergencyBackupPrune,
+  type StateDbPreflightDeps
+} from './state-db-update-preflight'
+
+const tempDirs: string[] = []
+
+const QUICK_POLICY: PreUpdateBackupPolicy = {
+  backupKeep: 5,
+  mode: 'quick',
+  quickKeep: 1,
+  quickMaxFileSize: 1024
+}
+
+function tempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-state-preflight-'))
+  tempDirs.push(dir)
+
+  return dir
+}
+
+function validHeaderFile(filePath: string, size = 101): void {
+  const content = Buffer.alloc(size)
+  Buffer.from('SQLite format 3\0').copy(content)
+  fs.writeFileSync(filePath, content)
+}
+
+function validInspection(size = 101) {
+  return { headerHex: Buffer.from('SQLite format 3\0').toString('hex'), size, status: 'valid' as const }
+}
+
+function successfulDeps(overrides: Partial<StateDbPreflightDeps> = {}): StateDbPreflightDeps {
+  return {
+    availableBytes: () => 10_000_000_000n,
+    createBackup: async (_source, destination) => {
+      fs.writeFileSync(destination, 'snapshot')
+
+      return { durationMs: 5, size: 8, verification: 'integrity-check' }
+    },
+    inspectFootprint: () => ({ estimatedBackupBytes: 512, logicalBytes: 512, mainBytes: 101, walBytes: 0 }),
+    inspectHeader: () => validInspection(),
+    listFiles: directory => fs.readdirSync(directory),
+    nonce: () => 'nonce',
+    now: () => new Date('2026-09-03T12:00:00.000Z'),
+    removeFile: filePath => fs.rmSync(filePath, { force: true }),
+    ...overrides
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { force: true, recursive: true })
+  }
+})
+
+describe('inspectStateDbHeader', () => {
+  test('allows only ENOENT as a missing database', () => {
+    assert.deepEqual(inspectStateDbHeader(path.join(tempDir(), 'missing.db')), { status: 'missing' })
+  })
+
+  test('requires a regular file, sufficient size, and an exact 16-byte header', () => {
+    const dir = tempDir()
+    const valid = path.join(dir, 'valid.db')
+    validHeaderFile(valid)
+
+    assert.equal(inspectStateDbHeader(valid).status, 'valid')
+    assert.throws(() => inspectStateDbHeader(dir), /regular file/)
+
+    const short = path.join(dir, 'short.db')
+    fs.writeFileSync(short, 'SQLite format 3\0')
+    assert.throws(() => inspectStateDbHeader(short), /too small/)
+
+    const wrong = path.join(dir, 'wrong.db')
+    fs.writeFileSync(wrong, Buffer.alloc(101, 0xff))
+    assert.throws(() => inspectStateDbHeader(wrong), /invalid SQLite header/)
+  })
+
+  test('fails closed on stat and open errors other than ENOENT', () => {
+    const source = path.join(tempDir(), 'state.db')
+    validHeaderFile(source)
+    const denied = Object.assign(new Error('denied'), { code: 'EACCES' })
+
+    vi.spyOn(fs, 'statSync').mockImplementationOnce(() => {
+      throw denied
+    })
+    assert.throws(() => inspectStateDbHeader(source), /denied/)
+
+    vi.spyOn(fs, 'openSync').mockImplementationOnce(() => {
+      throw denied
+    })
+    assert.throws(() => inspectStateDbHeader(source), /denied/)
+  })
+
+  test('rejects a short read and always closes the descriptor after read failure', () => {
+    const source = path.join(tempDir(), 'state.db')
+    validHeaderFile(source)
+
+    vi.spyOn(fs, 'readSync').mockReturnValueOnce(15)
+    assert.throws(() => inspectStateDbHeader(source), /header read was short/)
+
+    const close = vi.spyOn(fs, 'closeSync')
+    vi.spyOn(fs, 'readSync').mockImplementationOnce(() => {
+      throw new Error('read failed')
+    })
+    assert.throws(() => inspectStateDbHeader(source), /read failed/)
+    assert.equal(close.mock.calls.length, 1)
+  })
+})
+
+describe('backup planning', () => {
+  test('off always skips before an artifact plan exists', () => {
+    assert.deepEqual(planEmergencyStateDbBackup({ ...QUICK_POLICY, mode: 'off' }, 99_999), {
+      reason: 'config-disabled',
+      status: 'skipped'
+    })
+  })
+
+  test('quick backs up at the canonical boundary and skips boundary plus one', () => {
+    assert.deepEqual(planEmergencyStateDbBackup(QUICK_POLICY, 1024), {
+      keep: 1,
+      status: 'backup'
+    })
+    assert.deepEqual(planEmergencyStateDbBackup(QUICK_POLICY, 1025), {
+      reason: 'quick-size-cap',
+      status: 'skipped'
+    })
+  })
+
+  test('full uses the normalized configured retention above the quick boundary', () => {
+    assert.deepEqual(planEmergencyStateDbBackup({ ...QUICK_POLICY, backupKeep: 4, mode: 'full' }, 10_000), {
+      keep: 4,
+      status: 'backup'
+    })
+  })
+
+  test('free-space bound and deadline are conservative and bounded', () => {
+    assert.equal(requiredFreeBytes(100n), 1024n * 1024n * 1024n + 100n)
+    assert.equal(requiredFreeBytes(20n * 1024n * 1024n * 1024n), 22n * 1024n * 1024n * 1024n)
+    assert.equal(backupDeadlineMs(1), 120_000)
+    assert.equal(backupDeadlineMs(40 * 1024 * 1024 * 1024), 30 * 60_000)
+  })
+
+  test('retention counts the newly published artifact', () => {
+    const current = 'state.db.pre-update-emergency-2026-09-03T12-00-00-000Z-nonce.bak'
+
+    const files = [
+      current,
+      'state.db.pre-update-emergency-2026-09-02T12-00-00-000Z-a.bak',
+      'state.db.pre-update-emergency-2026-09-01T12-00-00-000Z-b.bak',
+      'state.db.pre-update-emergency-2026-08-31T12-00-00-000Z-c.bak',
+      'state.db.pre-update-emergency-junk.bak.partial',
+      'state.db'
+    ]
+
+    assert.deepEqual(selectEmergencyBackupPrune(files, current, 1), files.slice(1, 4))
+    assert.deepEqual(selectEmergencyBackupPrune(files, current, 3), [files[3]])
+  })
+})
+
+describe('runStateDbUpdatePreflight', () => {
+  test('missing state.db exits before policy/Python discovery or any artifact work', async () => {
+    const calls: string[] = []
+
+    const deps = successfulDeps({
+      inspectHeader: () => ({ status: 'missing' })
+    })
+
+    const result = await runStateDbUpdatePreflight(
+      {
+        hermesHome: tempDir(),
+        policy: async () => {
+          calls.push('policy')
+          throw new Error('must not run')
+        },
+        rememberLog: () => {}
+      },
+      deps
+    )
+
+    assert.deepEqual(result, { status: 'missing' })
+    assert.deepEqual(calls, [])
+  })
+
+  test('config off with an oversized database performs no footprint, space, enumeration, write, or delete', async () => {
+    const calls: string[] = []
+
+    const deps = successfulDeps({
+      availableBytes: () => {
+        calls.push('space')
+
+        return 0n
+      },
+      createBackup: async () => {
+        calls.push('backup')
+        throw new Error('must not run')
+      },
+      inspectFootprint: () => {
+        calls.push('footprint')
+        throw new Error('must not run')
+      },
+      inspectHeader: () => validInspection(16 * 1024 * 1024 * 1024),
+      listFiles: () => {
+        calls.push('list')
+
+        return []
+      },
+      removeFile: () => calls.push('delete')
+    })
+
+    const logs: string[] = []
+
+    const result = await runStateDbUpdatePreflight(
+      { hermesHome: tempDir(), policy: { ...QUICK_POLICY, mode: 'off' }, rememberLog: line => logs.push(line) },
+      deps
+    )
+
+    assert.deepEqual(result, { reason: 'config-disabled', status: 'skipped' })
+    assert.deepEqual(calls, [])
+    assert.ok(logs.some(line => line.includes('disabled by updates.pre_update_backup')))
+  })
+
+  test('validates the header before resolving policy and fails closed on resolver errors', async () => {
+    const calls: string[] = []
+
+    const deps = successfulDeps({
+      availableBytes: () => {
+        calls.push('space')
+
+        return 0n
+      },
+      inspectFootprint: () => {
+        calls.push('footprint')
+        throw new Error('must not run')
+      }
+    })
+
+    await assert.rejects(
+      runStateDbUpdatePreflight(
+        {
+          hermesHome: tempDir(),
+          policy: async () => {
+            calls.push('policy')
+            throw new Error('policy process timed out')
+          },
+          rememberLog: () => {}
+        },
+        deps
+      ),
+      /policy process timed out/
+    )
+
+    assert.deepEqual(calls, ['policy'])
+  })
+
+  test('does not resolve policy when the existing database header is invalid', async () => {
+    let policyCalls = 0
+
+    const deps = successfulDeps({
+      inspectHeader: () => {
+        throw new Error('invalid SQLite header')
+      }
+    })
+
+    await assert.rejects(
+      runStateDbUpdatePreflight(
+        {
+          hermesHome: tempDir(),
+          policy: async () => {
+            policyCalls += 1
+
+            return QUICK_POLICY
+          },
+          rememberLog: () => {}
+        },
+        deps
+      ),
+      /invalid SQLite header/
+    )
+    assert.equal(policyCalls, 0)
+  })
+
+  test('quick skips a large logical/WAL footprint before free-space or artifact work', async () => {
+    const calls: string[] = []
+
+    const deps = successfulDeps({
+      availableBytes: () => {
+        calls.push('space')
+
+        return 0n
+      },
+      createBackup: async () => {
+        calls.push('backup')
+        throw new Error('must not run')
+      },
+      inspectFootprint: () => ({ estimatedBackupBytes: 1025, logicalBytes: 1000, mainBytes: 101, walBytes: 1024 }),
+      listFiles: () => {
+        calls.push('list')
+
+        return []
+      }
+    })
+
+    const result = await runStateDbUpdatePreflight(
+      { hermesHome: tempDir(), policy: QUICK_POLICY, rememberLog: () => {} },
+      deps
+    )
+
+    assert.deepEqual(result, { reason: 'quick-size-cap', status: 'skipped' })
+    assert.deepEqual(calls, [])
+  })
+
+  test('insufficient or unmeasurable free space aborts before enumeration, writes, or deletes', async () => {
+    for (const availableBytes of [
+      () => 0n,
+      () => {
+        throw new Error('probe failed')
+      }
+    ]) {
+      const calls: string[] = []
+
+      const deps = successfulDeps({
+        availableBytes,
+        createBackup: async () => {
+          calls.push('backup')
+          throw new Error('must not run')
+        },
+        listFiles: () => {
+          calls.push('list')
+
+          return []
+        },
+        removeFile: () => calls.push('delete')
+      })
+
+      await assert.rejects(
+        runStateDbUpdatePreflight(
+          { hermesHome: tempDir(), policy: { ...QUICK_POLICY, mode: 'full' }, rememberLog: () => {} },
+          deps
+        ),
+        /free space/
+      )
+      assert.deepEqual(calls, [])
+    }
+  })
+
+  test('free-space boundary rejects one byte below and allows the exact required amount', async () => {
+    const required = requiredFreeBytes(512n)
+    let backupCalls = 0
+
+    await assert.rejects(
+      runStateDbUpdatePreflight(
+        { hermesHome: tempDir(), policy: { ...QUICK_POLICY, mode: 'full' }, rememberLog: () => {} },
+        successfulDeps({
+          availableBytes: () => required - 1n,
+          createBackup: async () => {
+            backupCalls += 1
+            throw new Error('must not run')
+          }
+        })
+      ),
+      /insufficient free space/
+    )
+    assert.equal(backupCalls, 0)
+
+    const result = await runStateDbUpdatePreflight(
+      { hermesHome: tempDir(), policy: { ...QUICK_POLICY, mode: 'full' }, rememberLog: () => {} },
+      successfulDeps({ availableBytes: () => required })
+    )
+
+    assert.equal(result.status, 'backed-up')
+  })
+
+  test('cleans stale partials only after the space gate, publishes, then applies total-count retention', async () => {
+    const home = tempDir()
+    const old = 'state.db.pre-update-emergency-2026-09-01T00-00-00-000Z-old.bak'
+    const stale = 'state.db.pre-update-emergency-2026-09-02T00-00-00-000Z-stale.bak.partial'
+    fs.writeFileSync(path.join(home, old), 'old')
+    fs.writeFileSync(path.join(home, stale), 'partial')
+    const events: string[] = []
+
+    const deps = successfulDeps({
+      availableBytes: () => {
+        events.push('space')
+
+        return 10_000_000_000n
+      },
+      createBackup: async (_source, destination) => {
+        events.push('backup')
+        assert.equal(fs.existsSync(path.join(home, stale)), false)
+        fs.writeFileSync(destination, 'snapshot')
+
+        return { durationMs: 5, size: 8, verification: 'integrity-check' }
+      },
+      removeFile: filePath => {
+        events.push(`delete:${path.basename(filePath)}`)
+        fs.rmSync(filePath, { force: true })
+      }
+    })
+
+    const result = await runStateDbUpdatePreflight(
+      { hermesHome: home, policy: QUICK_POLICY, rememberLog: () => {} },
+      deps
+    )
+
+    assert.equal(result.status, 'backed-up')
+    assert.equal(events[0], 'space')
+    assert.equal(events[1], `delete:${stale}`)
+    assert.equal(events[2], 'backup')
+    assert.ok(events.includes(`delete:${old}`))
+  })
+
+  test('backup or verification failure performs no published-backup retention', async () => {
+    const home = tempDir()
+    const old = 'state.db.pre-update-emergency-2026-09-01T00-00-00-000Z-old.bak'
+    fs.writeFileSync(path.join(home, old), 'preserve me')
+    const deleted: string[] = []
+
+    const deps = successfulDeps({
+      createBackup: async () => {
+        throw new Error('verification failed')
+      },
+      removeFile: filePath => {
+        deleted.push(path.basename(filePath))
+        fs.rmSync(filePath, { force: true })
+      }
+    })
+
+    await assert.rejects(
+      runStateDbUpdatePreflight(
+        { hermesHome: home, policy: { ...QUICK_POLICY, mode: 'full' }, rememberLog: () => {} },
+        deps
+      ),
+      /verification failed/
+    )
+    assert.equal(fs.readFileSync(path.join(home, old), 'utf8'), 'preserve me')
+    assert.deepEqual(deleted, [])
+  })
+})

--- a/apps/desktop/electron/state-db-update-preflight.ts
+++ b/apps/desktop/electron/state-db-update-preflight.ts
@@ -1,0 +1,237 @@
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import type { PreUpdateBackupPolicy } from './pre-update-backup-policy'
+import {
+  createVerifiedSqliteBackup,
+  inspectSqliteFootprint,
+  type SqliteBackupResult,
+  type SqliteFootprint
+} from './sqlite-backup'
+
+const SQLITE_HEADER = Buffer.from('SQLite format 3\0')
+const MIN_SQLITE_BYTES = 101
+const GIB = 1024n * 1024n * 1024n
+const MAX_BACKUP_DEADLINE_MS = 30 * 60_000
+const MIN_BACKUP_DEADLINE_MS = 2 * 60_000
+
+export type StateDbHeaderInspection = { status: 'missing' } | { headerHex: string; size: number; status: 'valid' }
+
+export interface StateDbPreflightDeps {
+  availableBytes: (directory: string) => bigint
+  createBackup: (
+    sourcePath: string,
+    destinationPath: string,
+    options: { deadlineMs: number; integrityCheckMaxBytes: number; verificationDeadlineMs: number }
+  ) => Promise<SqliteBackupResult>
+  inspectFootprint: (sourcePath: string) => SqliteFootprint
+  inspectHeader: (sourcePath: string) => StateDbHeaderInspection
+  listFiles: (directory: string) => string[]
+  nonce: () => string
+  now: () => Date
+  removeFile: (filePath: string) => void
+}
+
+export interface StateDbPreflightOptions {
+  hermesHome: string
+  policy: PreUpdateBackupPolicy | (() => Promise<PreUpdateBackupPolicy>)
+  rememberLog: (message: string) => void
+}
+
+export type StateDbPreflightResult =
+  | { status: 'missing' }
+  | { reason: 'config-disabled' | 'quick-size-cap'; status: 'skipped' }
+  | { backup: SqliteBackupResult; path: string; status: 'backed-up' }
+
+export function inspectStateDbHeader(sourcePath: string): StateDbHeaderInspection {
+  let stat: fs.Stats
+
+  try {
+    stat = fs.statSync(sourcePath)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { status: 'missing' }
+    }
+
+    throw error
+  }
+
+  if (!stat.isFile()) {
+    throw new Error('state.db is not a regular file')
+  }
+
+  if (stat.size < MIN_SQLITE_BYTES) {
+    throw new Error(`state.db is too small (${stat.size} bytes) for a valid SQLite database`)
+  }
+
+  const descriptor = fs.openSync(sourcePath, 'r')
+  const header = Buffer.alloc(SQLITE_HEADER.length)
+  let bytesRead = 0
+
+  try {
+    bytesRead = fs.readSync(descriptor, header, 0, header.length, 0)
+  } finally {
+    fs.closeSync(descriptor)
+  }
+
+  if (bytesRead !== SQLITE_HEADER.length) {
+    throw new Error(`state.db header read was short (${bytesRead}/${SQLITE_HEADER.length} bytes)`)
+  }
+
+  if (!header.equals(SQLITE_HEADER)) {
+    throw new Error(`state.db has an invalid SQLite header (${header.toString('hex')})`)
+  }
+
+  return { headerHex: header.toString('hex'), size: stat.size, status: 'valid' }
+}
+
+export function planEmergencyStateDbBackup(
+  policy: PreUpdateBackupPolicy,
+  estimatedBackupBytes: number
+): { reason: 'config-disabled' | 'quick-size-cap'; status: 'skipped' } | { keep: number; status: 'backup' } {
+  if (policy.mode === 'off') {
+    return { reason: 'config-disabled', status: 'skipped' }
+  }
+
+  if (policy.mode === 'quick' && estimatedBackupBytes > policy.quickMaxFileSize) {
+    return { reason: 'quick-size-cap', status: 'skipped' }
+  }
+
+  return { keep: policy.mode === 'quick' ? policy.quickKeep : policy.backupKeep, status: 'backup' }
+}
+
+export function requiredFreeBytes(estimatedBackupBytes: bigint): bigint {
+  const proportionalHeadroom = estimatedBackupBytes / 10n
+  const headroom = proportionalHeadroom > GIB ? proportionalHeadroom : GIB
+
+  return estimatedBackupBytes + headroom
+}
+
+export function backupDeadlineMs(estimatedBackupBytes: number): number {
+  const gibibytes = Math.max(1, Math.ceil(estimatedBackupBytes / Number(GIB)))
+
+  return Math.min(MAX_BACKUP_DEADLINE_MS, Math.max(MIN_BACKUP_DEADLINE_MS, gibibytes * 60_000))
+}
+
+export function selectEmergencyBackupPrune(files: string[], current: string, keep: number): string[] {
+  const previous = files
+    .filter(file => file !== current && file.startsWith('state.db.pre-update-emergency-') && file.endsWith('.bak'))
+    .sort()
+    .reverse()
+
+  return previous.slice(Math.max(0, keep - 1))
+}
+
+function defaultAvailableBytes(directory: string): bigint {
+  const stats = fs.statfsSync(directory, { bigint: true })
+
+  return stats.bavail * stats.bsize
+}
+
+const DEFAULT_DEPS: StateDbPreflightDeps = {
+  availableBytes: defaultAvailableBytes,
+  createBackup: createVerifiedSqliteBackup,
+  inspectFootprint: inspectSqliteFootprint,
+  inspectHeader: inspectStateDbHeader,
+  listFiles: directory => fs.readdirSync(directory),
+  nonce: () => crypto.randomUUID(),
+  now: () => new Date(),
+  removeFile: filePath => fs.rmSync(filePath, { force: true })
+}
+
+function emergencyBackupName(now: Date, nonce: string): string {
+  const timestamp = now.toISOString().replace(/[:.]/g, '-')
+
+  return `state.db.pre-update-emergency-${timestamp}-${nonce}.bak`
+}
+
+export async function runStateDbUpdatePreflight(
+  options: StateDbPreflightOptions,
+  deps: StateDbPreflightDeps = DEFAULT_DEPS
+): Promise<StateDbPreflightResult> {
+  const stateDbPath = path.join(options.hermesHome, 'state.db')
+  const header = deps.inspectHeader(stateDbPath)
+
+  if (header.status === 'missing') {
+    options.rememberLog('[updates] state.db pre-flight: not found (fresh install?)')
+
+    return { status: 'missing' }
+  }
+
+  options.rememberLog(
+    `[updates] state.db pre-flight: size=${header.size}, headerOk=true, headerHex=${header.headerHex}`
+  )
+
+  const policy = typeof options.policy === 'function' ? await options.policy() : options.policy
+
+  if (policy.mode === 'off') {
+    options.rememberLog('[updates] emergency state.db backup disabled by updates.pre_update_backup')
+
+    return { reason: 'config-disabled', status: 'skipped' }
+  }
+
+  const footprint = deps.inspectFootprint(stateDbPath)
+  const plan = planEmergencyStateDbBackup(policy, footprint.estimatedBackupBytes)
+
+  if (plan.status === 'skipped') {
+    options.rememberLog(
+      `[updates] emergency state.db backup skipped: estimated ${footprint.estimatedBackupBytes} bytes exceeds ` +
+        `quick-mode cap ${policy.quickMaxFileSize}`
+    )
+
+    return plan
+  }
+
+  const estimatedBytes = BigInt(footprint.estimatedBackupBytes)
+  const requiredBytes = requiredFreeBytes(estimatedBytes)
+  let availableBytes: bigint
+
+  try {
+    availableBytes = deps.availableBytes(options.hermesHome)
+  } catch (error) {
+    throw new Error('could not measure free space for the emergency state.db backup', { cause: error })
+  }
+
+  if (availableBytes < requiredBytes) {
+    throw new Error(
+      `insufficient free space for the emergency state.db backup: ` +
+        `available=${availableBytes} required=${requiredBytes} estimated_snapshot=${estimatedBytes}`
+    )
+  }
+
+  const filesBefore = deps.listFiles(options.hermesHome)
+
+  for (const stalePartial of filesBefore.filter(
+    file => file.startsWith('state.db.pre-update-emergency-') && file.endsWith('.bak.partial')
+  )) {
+    deps.removeFile(path.join(options.hermesHome, stalePartial))
+  }
+
+  const fileName = emergencyBackupName(deps.now(), deps.nonce())
+  const destinationPath = path.join(options.hermesHome, fileName)
+  const deadlineMs = backupDeadlineMs(footprint.estimatedBackupBytes)
+
+  const backup = await deps.createBackup(stateDbPath, destinationPath, {
+    deadlineMs,
+    integrityCheckMaxBytes: policy.quickMaxFileSize,
+    verificationDeadlineMs: deadlineMs
+  })
+
+  options.rememberLog(
+    `[updates] emergency state.db backup: ${destinationPath} (${backup.size} bytes, ` +
+      `${backup.verification}, ${backup.durationMs}ms)`
+  )
+
+  const filesAfter = deps.listFiles(options.hermesHome)
+
+  for (const old of selectEmergencyBackupPrune(filesAfter, fileName, plan.keep)) {
+    try {
+      deps.removeFile(path.join(options.hermesHome, old))
+    } catch (error) {
+      options.rememberLog(`[updates] could not prune old emergency state.db backup ${old}: ${String(error)}`)
+    }
+  }
+
+  return { backup, path: destinationPath, status: 'backed-up' }
+}

--- a/apps/desktop/electron/update-gate.test.ts
+++ b/apps/desktop/electron/update-gate.test.ts
@@ -14,7 +14,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { updateGateReason, waitForUpdateClearance } from './update-gate'
+import { ExclusiveUpdateFlight, runPreflightThenHandoff, updateGateReason, waitForUpdateClearance } from './update-gate'
 
 function deps(marker: boolean, inFlight: boolean) {
   return {
@@ -111,7 +111,7 @@ test('parks across the flag→marker handoff without a gap', async () => {
         }
 
         if (ticks === 3) {
-          inFlight = false // …then the flag clears; marker still holds the gate
+          inFlight = false // …then the lease releases; marker still holds the gate
         }
 
         if (ticks === 5) {
@@ -141,4 +141,75 @@ test('returns timeout when the gate never opens', async () => {
   })
 
   assert.equal(outcome, 'timeout')
+})
+
+// ---------------------------------------------------------------------------
+// Update transaction ordering / release
+// ---------------------------------------------------------------------------
+
+test('exclusive update flight clears after a preflight rejection and permits retry', async () => {
+  const flight = new ExclusiveUpdateFlight()
+  let downstreamCalls = 0
+
+  await assert.rejects(
+    flight.run(() =>
+      runPreflightThenHandoff(
+        async () => {
+          throw new Error('policy resolution failed')
+        },
+        async () => {
+          downstreamCalls += 1
+
+          return 'unreachable'
+        }
+      )
+    ),
+    /policy resolution failed/
+  )
+
+  assert.equal(downstreamCalls, 0)
+  assert.equal(flight.active, false)
+  assert.equal(await flight.run(async () => 'retry-ok'), 'retry-ok')
+  assert.equal(flight.active, false)
+})
+
+test.each(['windows', 'posix'])('%s handoff settles preflight before any downstream action', async platform => {
+  const events: string[] = []
+
+  const result = await runPreflightThenHandoff(
+    async () => {
+      events.push(`${platform}:preflight:start`)
+      await Promise.resolve()
+      events.push(`${platform}:preflight:end`)
+    },
+    async () => {
+      events.push(`${platform}:handoff`)
+
+      return platform
+    }
+  )
+
+  assert.equal(result, platform)
+  assert.deepEqual(events, [`${platform}:preflight:start`, `${platform}:preflight:end`, `${platform}:handoff`])
+})
+
+test('exclusive update flight rejects overlap without running a second operation', async () => {
+  const flight = new ExclusiveUpdateFlight()
+  let releaseFirst: (() => void) | undefined
+
+  const first = flight.run(
+    () =>
+      new Promise<void>(resolve => {
+        releaseFirst = resolve
+      })
+  )
+
+  assert.equal(flight.active, true)
+  await assert.rejects(
+    flight.run(async () => {}),
+    /already in progress/
+  )
+  releaseFirst?.()
+  await first
+  assert.equal(flight.active, false)
 })

--- a/apps/desktop/electron/update-gate.ts
+++ b/apps/desktop/electron/update-gate.ts
@@ -10,7 +10,7 @@
  *
  *  - the on-disk marker (`HERMES_HOME/.hermes-update-in-progress`), written
  *    by the updater — and by the desktop itself just before hand-off — and
- *  - the in-process `updateInFlight` flag, true for the whole
+ *  - the in-process `ExclusiveUpdateFlight` lease, active for the whole
  *    `applyUpdates()` critical section.
  *
  * The marker alone is NOT enough (#73822): `applyUpdates` kills its own
@@ -19,9 +19,9 @@
  * WebSocket, the renderer reconnects within ~1s, and a marker-only gate
  * happily spawns a fresh backend inside the update's own critical section —
  * which `scanVenvBlockers` then reports as a blocker, aborting every update
- * attempt forever. Consulting the flag closes that window. On the success
- * path the marker is written BEFORE the flag clears in `applyUpdates`'
- * `finally`, so there is no instant where both signals are false and a
+ * attempt forever. Consulting the lease closes that window. On the success
+ * path the marker is written BEFORE the lease releases, so there is no instant
+ * where both signals are false and a
  * waiter could slip through mid-update.
  */
 
@@ -92,4 +92,44 @@ export async function waitForUpdateClearance(
   }
 
   return reason ? 'timeout' : 'finished'
+}
+
+/**
+ * Owns the in-process update lease and always releases it, including when the
+ * preflight or handoff rejects.  Keeping the lifecycle here makes the retry
+ * invariant executable instead of relying on duplicated try/finally blocks.
+ */
+export class ExclusiveUpdateFlight {
+  #active = false
+
+  get active(): boolean {
+    return this.#active
+  }
+
+  async run<T>(operation: () => Promise<T>): Promise<T> {
+    if (this.#active) {
+      throw new Error('An update is already in progress.')
+    }
+
+    this.#active = true
+
+    try {
+      return await operation()
+    } finally {
+      this.#active = false
+    }
+  }
+}
+
+/**
+ * Await the database preflight to settlement before any destructive handoff
+ * work is allowed to start. Both Windows and POSIX update paths use this seam.
+ */
+export async function runPreflightThenHandoff<T>(
+  preflight: () => Promise<void>,
+  handoff: () => Promise<T>
+): Promise<T> {
+  await preflight()
+
+  return await handoff()
 }

--- a/hermes_cli/update_backup_policy.py
+++ b/hermes_cli/update_backup_policy.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import re
+from typing import Any
+
+import yaml
+
+from hermes_cli import managed_scope
+from hermes_cli.config_defaults import DEFAULT_CONFIG
+from hermes_constants import get_hermes_home
+
+
+PRE_UPDATE_SNAPSHOT_KEEP = 1
+PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE = 1 << 30
+_ENV_REF = re.compile(r"\${([^}]+)}")
+
+
+def normalize_pre_update_backup_mode(raw: Any) -> str:
+    if raw is None:
+        raise ValueError("updates.pre_update_backup must not be null")
+    if isinstance(raw, bool):
+        return "full" if raw else "off"
+
+    value = str(raw).strip().lower()
+    if value in {"off", "false", "none", "disabled"}:
+        return "off"
+    if value in {"full", "zip", "true"}:
+        return "full"
+    if value == "quick":
+        return "quick"
+    raise ValueError("unknown updates.pre_update_backup value")
+
+
+def normalize_pre_update_backup_keep(raw: Any) -> int:
+    return max(1, int(raw))
+
+
+def _read_yaml_mapping(path: Path, label: str) -> dict[str, Any]:
+    try:
+        with open(path, encoding="utf-8") as config_file:
+            parsed = yaml.safe_load(config_file) or {}
+    except FileNotFoundError:
+        return {}
+    if not isinstance(parsed, dict):
+        raise ValueError(f"{label} root must be a mapping")
+    return parsed
+
+
+def _updates_mapping(config: dict[str, Any], label: str) -> dict[str, Any]:
+    updates = config.get("updates", {})
+    if updates is None:
+        return {}
+    if not isinstance(updates, dict):
+        raise ValueError(f"{label} updates must be a mapping")
+    return updates
+
+
+def _expand_update_scalar(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+
+    def replace(match: re.Match[str]) -> str:
+        reference = match.group(1).strip()
+        if reference.startswith("env:"):
+            reference = reference[4:].strip()
+        elif ":" in reference and re.match(r"^[a-z][a-z0-9_-]*:", reference):
+            return match.group(0)
+        return os.environ.get(reference, match.group(0))
+
+    return _ENV_REF.sub(replace, value)
+
+
+def resolve_pre_update_backup_policy_strict() -> dict[str, int | str]:
+    """Read the canonical update policy without mutating ``HERMES_HOME``."""
+    defaults = dict(DEFAULT_CONFIG.get("updates", {}))
+    home = get_hermes_home()
+    user = _updates_mapping(
+        _read_yaml_mapping(home / "config.yaml", "config"), "config"
+    )
+
+    managed: dict[str, Any] = {}
+    managed_dir = managed_scope.get_managed_dir()
+    if managed_dir is not None:
+        managed = _updates_mapping(
+            _read_yaml_mapping(managed_dir / "config.yaml", "managed config"),
+            "managed config",
+        )
+
+    merged = {**defaults, **user, **managed}
+    raw_mode = _expand_update_scalar(merged.get("pre_update_backup", "quick"))
+    raw_keep = _expand_update_scalar(merged.get("backup_keep", 5))
+
+    return {
+        "mode": normalize_pre_update_backup_mode(raw_mode),
+        "backup_keep": normalize_pre_update_backup_keep(raw_keep),
+        "quick_keep": PRE_UPDATE_SNAPSHOT_KEEP,
+        "quick_max_file_size": PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE,
+    }

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -37,6 +37,13 @@ from pathlib import Path
 from typing import Optional
 
 from hermes_cli.config import get_hermes_home
+from hermes_cli.update_backup_policy import (
+    PRE_UPDATE_SNAPSHOT_KEEP as _PRE_UPDATE_SNAPSHOT_KEEP,
+    PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE as _PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE,
+    normalize_pre_update_backup_keep as _canonical_pre_update_backup_keep,
+    normalize_pre_update_backup_mode as _canonical_pre_update_backup_mode,
+    resolve_pre_update_backup_policy_strict as _strict_pre_update_backup_policy,
+)
 from hermes_constants import get_default_hermes_root, venv_python_path
 
 logger = logging.getLogger(__name__)
@@ -4918,19 +4925,37 @@ def _ensure_acp_launcher() -> None:
             continue
         print(f"  ✓ Installed hermes-acp launcher → {acp_cmd}")
 
-_PRE_UPDATE_SNAPSHOT_KEEP = 1
 # Sibling-profile snapshot ids from the current run's pre-update backup
 # ({profile: snapshot_id}) — consumed by the post-update per-profile
 # cron-jobs safety net (#66140). Module-level because the snapshot and the
 # restore run in the same process but far apart in _cmd_update_impl.
 _LAST_SIBLING_SNAPSHOTS: dict = {}
 
-# Per-file size cap for the pre-update quick snapshot. Anything larger is
-# skipped with a warning: the snapshot exists to protect small, hard-to-
-# regenerate state (pairing JSONs, cron jobs, config, auth) — not to copy a
-# multi-GB state.db on every update (observed: a 24 GB state.db added ~60s
-# of wall time and silently ate 24 GB of disk per update).
-_PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE = 1 << 30  # 1 GiB
+def _normalize_pre_update_backup_mode(raw, *, strict: bool = False) -> str:
+    """Preserve the CLI's legacy unknown-value fallback around the strict core."""
+    if raw is None and not strict:
+        return "off"
+
+    try:
+        return _canonical_pre_update_backup_mode(raw)
+    except ValueError:
+        if strict:
+            raise
+        logging.getLogger(__name__).warning(
+            "Unknown updates.pre_update_backup value %r — using 'quick'", raw
+        )
+        return "quick"
+
+
+def _normalize_pre_update_backup_keep(raw) -> int:
+    """Return the retention count accepted by the backup implementation."""
+    return _canonical_pre_update_backup_keep(raw)
+
+
+def resolve_pre_update_backup_policy_strict() -> dict:
+    """Compatibility export for the side-effect-free strict policy resolver."""
+    return _strict_pre_update_backup_policy()
+
 
 def _resolve_pre_update_backup_mode(args) -> str:
     """Resolve the pre-update backup mode: ``"off"``, ``"quick"``, or ``"full"``.
@@ -4960,21 +4985,7 @@ def _resolve_pre_update_backup_mode(args) -> str:
     updates_cfg = cfg.get("updates", {}) if isinstance(cfg, dict) else {}
     raw = updates_cfg.get("pre_update_backup", "quick")
 
-    if raw is True:
-        return "full"
-    if raw is False:
-        return "off"
-    mode = str(raw).strip().lower()
-    if mode in ("off", "false", "none", "disabled"):
-        return "off"
-    if mode in ("full", "zip", "true"):
-        return "full"
-    if mode == "quick":
-        return "quick"
-    logging.getLogger(__name__).warning(
-        "Unknown updates.pre_update_backup value %r — using 'quick'", raw
-    )
-    return "quick"
+    return _normalize_pre_update_backup_mode(raw)
 
 def _run_pre_update_backup(args) -> Optional[str]:
     """Run the pre-update safety backup and return the quick-snapshot id.
@@ -5135,7 +5146,9 @@ def _run_pre_update_backup(args) -> Optional[str]:
     print("◆ Creating pre-update backup...")
     t0 = _time.monotonic()
     try:
-        out_path = create_pre_update_backup(keep=int(_keep))
+        out_path = create_pre_update_backup(
+            keep=_normalize_pre_update_backup_keep(_keep)
+        )
     except Exception as exc:  # defensive — helper already swallows, but just in case
         print(f"  ⚠ Backup failed: {exc}")
         print("  Continuing with update.")

--- a/hermes_cli/update_preflight_policy.py
+++ b/hermes_cli/update_preflight_policy.py
@@ -1,0 +1,26 @@
+"""Strict JSON bridge for the Desktop's pre-teardown backup policy."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from hermes_cli.update_backup_policy import resolve_pre_update_backup_policy_strict
+
+
+def main() -> int:
+    try:
+        policy = resolve_pre_update_backup_policy_strict()
+    except Exception as exc:
+        print(
+            f"pre-update policy resolution failed: {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(json.dumps(policy, separators=(",", ":"), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/hermes_cli/test_update_preflight_policy.py
+++ b/tests/hermes_cli/test_update_preflight_policy.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_policy(
+    tmp_path: Path, yaml_text: str | None = None
+) -> subprocess.CompletedProcess[str]:
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    if yaml_text is not None:
+        (hermes_home / "config.yaml").write_text(
+            textwrap.dedent(yaml_text).lstrip(), encoding="utf-8"
+        )
+
+    return _run_policy_home(hermes_home)
+
+
+def _run_policy_home(hermes_home: Path) -> subprocess.CompletedProcess[str]:
+
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_home)
+    return subprocess.run(
+        [sys.executable, "-m", "hermes_cli.update_preflight_policy"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+
+
+def _payload(result: subprocess.CompletedProcess[str]) -> dict[str, object]:
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ""
+    assert result.stdout.count("\n") == 1
+    return json.loads(result.stdout)
+
+
+def test_policy_process_is_zero_write_with_missing_or_existing_config(tmp_path: Path):
+    missing_home = tmp_path / "missing-home"
+    missing_home.mkdir()
+    assert _payload(_run_policy_home(missing_home))["mode"] == "quick"
+    assert list(missing_home.iterdir()) == []
+
+    existing_home = tmp_path / "existing-home"
+    existing_home.mkdir()
+    config_path = existing_home / "config.yaml"
+    config_path.write_text(
+        "updates:\n  pre_update_backup: false\n  backup_keep: 1\n",
+        encoding="utf-8",
+    )
+    before = (config_path.read_bytes(), config_path.stat().st_mtime_ns)
+    assert _payload(_run_policy_home(existing_home))["mode"] == "off"
+    assert [path.name for path in existing_home.iterdir()] == ["config.yaml"]
+    assert (config_path.read_bytes(), config_path.stat().st_mtime_ns) == before
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        ("off", "off"),
+        ("quick", "quick"),
+        ("full", "full"),
+        ("false", "off"),
+        ("true", "full"),
+    ],
+)
+def test_policy_process_resolves_modes_and_legacy_booleans(
+    tmp_path: Path, configured: str, expected: str
+):
+    result = _run_policy(
+        tmp_path,
+        f"""
+        updates:
+          pre_update_backup: {configured}
+          backup_keep: 7
+        """,
+    )
+
+    assert _payload(result) == {
+        "mode": expected,
+        "backup_keep": 7,
+        "quick_keep": 1,
+        "quick_max_file_size": 1 << 30,
+    }
+
+
+def test_policy_process_uses_canonical_defaults_when_keys_are_missing(tmp_path: Path):
+    result = _run_policy(tmp_path, "updates: {}\n")
+
+    assert _payload(result) == {
+        "mode": "quick",
+        "backup_keep": 5,
+        "quick_keep": 1,
+        "quick_max_file_size": 1 << 30,
+    }
+
+
+@pytest.mark.parametrize("configured", [0, -5])
+def test_policy_process_floors_backup_keep_to_one(tmp_path: Path, configured: int):
+    result = _run_policy(
+        tmp_path,
+        f"""
+        updates:
+          pre_update_backup: full
+          backup_keep: {configured}
+        """,
+    )
+
+    assert _payload(result)["backup_keep"] == 1
+
+
+@pytest.mark.parametrize(
+    "yaml_text",
+    [
+        """
+        updates:
+          pre_update_backup: sometimes
+          backup_keep: 5
+        """,
+        """
+        updates:
+          pre_update_backup: full
+          backup_keep: many
+        """,
+        """
+        updates:
+          pre_update_backup: null
+          backup_keep: 5
+        """,
+        "updates: []\n",
+    ],
+)
+def test_policy_process_fails_closed_on_ambiguous_or_malformed_config(
+    tmp_path: Path, yaml_text: str
+):
+    result = _run_policy(tmp_path, yaml_text)
+
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert "pre-update policy resolution failed" in result.stderr
+
+
+def test_cli_resolver_preserves_the_legacy_unknown_value_fallback(monkeypatch, caplog):
+    from argparse import Namespace
+
+    import hermes_cli.config as config_module
+    from hermes_cli.update_cmd import (
+        _normalize_pre_update_backup_keep,
+        _resolve_pre_update_backup_mode,
+    )
+
+    monkeypatch.setattr(
+        config_module,
+        "load_config",
+        lambda: {"updates": {"pre_update_backup": "surprise"}},
+    )
+
+    assert (
+        _resolve_pre_update_backup_mode(Namespace(no_backup=False, backup=False))
+        == "quick"
+    )
+    assert "using 'quick'" in caplog.text
+    assert _normalize_pre_update_backup_keep(0) == 1
+    with pytest.raises(ValueError):
+        _normalize_pre_update_backup_keep("many")


### PR DESCRIPTION
## Summary

- make the Desktop pre-teardown state database guard honor the canonical Python `updates.pre_update_backup` / `backup_keep` policy
- replace the live `copyFileSync` snapshot with a bounded, WAL-consistent `node:sqlite` backup that is verified before no-replace publication
- fail closed before backend teardown on policy, header, free-space, backup, verification, or publication errors
- preserve the documented zero-write path for `off` and the 1 GiB skip for oversized `quick` snapshots
- keep update-flight and preflight ordering testable for both Windows and POSIX handoffs

## Context and provenance

This addresses the independent Electron backup path reported in #88252 and #91636 while preserving the pre-teardown recovery intent of #68474. The WAL-safe backup implementation carries forward the work from #91662 with its commits cherry-picked for attribution, then adds canonical policy resolution, no-write config probing, disk/retention guards, a hard worker deadline, and no-replace publication.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_update_preflight_policy.py -q`
- `scripts/run_tests.sh tests/hermes_cli/test_backup.py -q -k TestRunPreUpdateBackup`
- `npm --prefix apps/desktop run test:desktop:platforms -- electron/pre-update-backup-policy.test.ts electron/state-db-update-preflight.test.ts electron/sqlite-backup.test.ts electron/update-gate.test.ts`
- `npm --prefix apps/desktop run check:lint`
- `npm --prefix apps/desktop run build`
- real Python-to-Electron temporary-home probes for `off` (zero artifacts) and `quick` with committed WAL data

The complete Desktop platform suite still has existing Windows-only failures around 8.3 temp-path normalization, POSIX shell assumptions, and POSIX mode-bit assertions; every changed/new test passes locally. CI is the exact-SHA cross-platform gate.
