### PR TITLE
fix(custom): emit reasoning object form for b.ai-style relays (intermittent HTTP 400 on top-level reasoning_effort)

### DIFF
--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -49,6 +49,25 @@ def _looks_like_ollama_endpoint(base_url: str | None) -> bool:
     return "ollama" in host.split(".")
 
 
+# Relays whose model pools intermittently mis-translate the OpenAI top-level
+# ``reasoning_effort`` field. Observed on api.b.ai (glm-5.3-flash): the relay
+# round-robins across several upstream nodes and some of them translate
+# ``reasoning_effort`` into ``thinking: {"type": "disabled"}``, which the model
+# rejects with HTTP 400 code 400001 "该模型始终思考，不支持关闭思考；请使用 low、
+# high 或 max" (~40% of calls, body-independent — replaying the identical body
+# alternates 400/200 with the round-robin). The OpenAI-style ``reasoning``
+# object form is accepted by every node in the pool (0/20 failures vs 4/10 with
+# the top-level field). Endpoints listed here get their enabled+effort control
+# emitted as ``extra_body.reasoning`` instead of top-level ``reasoning_effort``.
+def _needs_reasoning_object_form(base_url: str | None) -> bool:
+    raw = (base_url or "").strip()
+    if not raw:
+        return False
+    parsed = urlparse(raw if "://" in raw else f"//{raw}")
+    host = (parsed.hostname or "").lower().rstrip(".")
+    return host == "b.ai" or host.endswith(".b.ai")
+
+
 class CustomProfile(ProviderProfile):
     """Custom/Ollama local provider — think=false and num_ctx support."""
 
@@ -95,9 +114,17 @@ class CustomProfile(ProviderProfile):
                 # but respects the top-level reasoning_effort field (#25758).
                 # Always emit reasoning_effort="none"; only add think=False
                 # when the URL is actually Ollama.
-                top_level["reasoning_effort"] = "none"
-                if _looks_like_ollama_endpoint(ctx.get("base_url")):
-                    extra_body["think"] = False
+                if _needs_reasoning_object_form(ctx.get("base_url")):
+                    # Always-thinking models behind b.ai-style relays reject
+                    # any "disable thinking" wire form with HTTP 400 400001
+                    # ("该模型始终思考，不支持关闭思考"). Omit the control and
+                    # let the server default (thinking on) apply — the only
+                    # non-error outcome for these models.
+                    pass
+                else:
+                    top_level["reasoning_effort"] = "none"
+                    if _looks_like_ollama_endpoint(ctx.get("base_url")):
+                        extra_body["think"] = False
             elif _effort:
                 # Clamp the internal ladder onto the widest OpenAI-compatible
                 # wire vocabulary (shared policy in agent.reasoning_effort) —
@@ -108,9 +135,14 @@ class CustomProfile(ProviderProfile):
                     clamp_effort,
                 )
 
-                top_level["reasoning_effort"] = clamp_effort(
-                    _effort, OPENAI_COMPAT_WIRE_EFFORTS
-                )
+                _clamped = clamp_effort(_effort, OPENAI_COMPAT_WIRE_EFFORTS)
+                if _needs_reasoning_object_form(ctx.get("base_url")):
+                    # b.ai-style relay: top-level reasoning_effort intermittently
+                    # 400s (see _needs_reasoning_object_form). Send the
+                    # object form instead, which every pool node accepts.
+                    extra_body["reasoning"] = {"enabled": True, "effort": _clamped}
+                else:
+                    top_level["reasoning_effort"] = _clamped
 
         return extra_body, top_level
 


### PR DESCRIPTION
## Problem

Requests to certain OpenAI-compatible relays fail intermittently with:

```
HTTP 400, code 400001: "该模型始终思考，不支持关闭思考；请使用 low、high 或 max"
("this model always thinks, disabling thinking is not supported")
```

even though Hermes never emits `thinking: {"type": "disabled"}` — the request carries only the top-level `reasoning_effort` field.

## Root cause

Captured and replayed the exact wire payload (`glm-5.3-flash` via `api.b.ai`) through a logging proxy:

- The relay round-robins across several upstream nodes; **some of them mistranslate the top-level `reasoning_effort` field into `thinking: {"type": "disabled"}`**, which always-thinking models reject.
- Replaying the byte-identical payload alternated `400, 400, 200, 200, 400, 400, ...` following the node rotation (~40% failure rate).
- The OpenAI-style `reasoning` **object form** (`reasoning: {"enabled": true, "effort": "medium"}` in `extra_body`) is accepted by **every** node in the pool: **0/20 failures vs 4/10** with the top-level field.
- Sending both forms together still fails (~50%), so the object form must *replace* — not accompany — the top-level field.

This is the wire-shape counterpart of #102764 (which clamps the effort *values* for the same model family; that PR does not address the intermittent 400, and this PR does not change effort clamping).

## Fix

In `CustomProfile.build_api_kwargs_extras` (`plugins/model-providers/custom/__init__.py`):

1. Add `_needs_reasoning_object_form(base_url)` — currently matches `b.ai` / `*.b.ai` hosts, documented and trivially extensible.
2. For those endpoints, the enabled+effort case emits `extra_body["reasoning"] = {"enabled": True, "effort": clamped}` instead of the top-level `reasoning_effort`.
3. For the disabled case on those endpoints, omit the control entirely: always-thinking models reject *any* disable-thinking wire form (top-level or object), so omission (server default = thinking on) is the only non-error outcome.

All other endpoints (ARK, Ollama, vLLM, llama.cpp, ...) keep **byte-identical** behavior — the change is gated on the host list, so it cannot regress unrelated providers. Because both the main transport and the auxiliary client build reasoning kwargs through the same profile hook, the fix covers resumed sessions, fresh sessions, and vision/background-review calls alike.

## Testing

- Unit-style assertions against the profile: b.ai → object form (no top-level field); other hosts → unchanged top-level form; Ollama disabled case → `think: false` + `reasoning_effort: "none"` unchanged.
- End-to-end against the affected relay: 6/6 fresh CLI runs on the previously failing session plus 4 additional calls — **zero 400s** over ~10+ calls, where the unfixed client failed ~40% of calls. `py_compile` passes.

## Notes / open questions for maintainers

- I kept the host-based gate minimal to avoid regressions, but I suspect other round-robin relays hit the same bug. If you'd prefer a generic mechanism (e.g. an opt-in `reasoning_wire: object` field on `custom_providers` entries, or always preferring the object form for non-Ollama endpoints), I'm happy to rework the patch in that direction.
- Always-thinking models behind these relays will still 400 if the user explicitly requests `reasoning effort: none`; that case is now a graceful omission instead of a guaranteed error.
