### PR TITLE
fix(backup): skip update rollback bundles and worktrees

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -45,6 +45,8 @@ _EXCLUDED_DIRS = {
     ".git",             # nested git dirs (profiles shouldn't have these, but safety)
     "node_modules",     # js deps — reinstalled on demand
     "backups",          # prior auto-backups — don't nest backups exponentially
+    "update-backups",   # hermes update rollback bundles — same nest reason as backups/
+    "worktrees",        # disposable source checkouts (hermes update / hermes -w)
     _QUICK_SNAPSHOTS_DIR,  # each holds a full state.db copy — same reason as ``backups``
     "checkpoints",      # session-hash-keyed trajectory caches — regenerated, don't port
     # Live CDP browser profiles: Chromium holds their SQLite DBs exclusively locked while running

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -133,6 +133,14 @@ class TestShouldExclude:
         from hermes_cli.backup import _should_exclude
         assert _should_exclude(Path("backups/pre-update-2026-04-27-063400.zip"))
 
+    def test_excludes_update_backups_and_worktrees(self):
+        """Rollback bundles and disposable source trees must not nest inside a full backup."""
+        from hermes_cli.backup import _should_exclude
+        assert _should_exclude(Path("update-backups/20260723-141712-0600/base.bundle"))
+        assert _should_exclude(Path("worktrees/hermes-update-abc/cli.py"))
+        assert _should_exclude(Path("profiles/coder/worktrees/hermes-update-abc/cli.py"))
+        assert not _should_exclude(Path("config.yaml"))
+
     def test_excludes_state_snapshots_dir(self):
         """state-snapshots/ is excluded for the same reason as backups/: every
         quick / pre-update snapshot holds its own copy of state.db, so zipping


### PR DESCRIPTION
## What does this PR do?

`hermes backup` in full mode walked `update-backups/` (rollback git bundles) and `worktrees/` (disposable source checkouts). Those directories are the same class as `backups/`: nesting them inside a new archive balloons the zip and stores one backup inside another.

This adds both names to the shared exclude set so a full backup no longer ships update rollback bundles or `hermes-update-*` trees.

## Related Issue

Fixes #102951

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/backup.py` — exclude `update-backups` and `worktrees`
- `tests/hermes_cli/test_backup.py` — `_should_exclude` coverage for both

## How to Test

```
uv run --extra dev python -m pytest tests/hermes_cli/test_backup.py::TestShouldExclude -q
# 8 passed
```

Not runtime-tested by taking a multi-GB live `hermes backup` of a machine that already has `update-backups/`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
