### PR TITLE
fix(cron): spawn bot-chat delivery from a live cwd

### DIFF
--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -693,6 +693,7 @@ def _deliver_to_bot_chat(job: dict, content: str, profile: str) -> Optional[str]
         ]
         result = subprocess.run(
             argv, capture_output=True, text=True, timeout=_get_bot_chat_delivery_timeout(), env=env,
+            cwd=os.path.expanduser("~") or None,
             creationflags=windows_hide_flags())
         if result.returncode != 0:
             tail = (result.stderr or result.stdout or "").strip()[-500:]

--- a/hermes_cli/_startup_fast.py
+++ b/hermes_cli/_startup_fast.py
@@ -34,12 +34,20 @@ def project_root_str() -> str:
     return os.path.realpath(os.path.join(os.path.dirname(__file__), os.pardir))
 
 
+def _realpath_or_self(path: str) -> str:
+    """``os.path.realpath`` without raising when the process cwd is gone (#102941)."""
+    try:
+        return os.path.realpath(path)
+    except OSError:
+        return path
+
+
 def ensure_project_root_on_path() -> None:
     """Put the project root at sys.path[0], deduping realpath-equivalents."""
     project_root = project_root_str()
-    normalized_root = os.path.normcase(os.path.realpath(project_root))
+    normalized_root = os.path.normcase(_realpath_or_self(project_root))
     sys.path[:] = [entry for entry in sys.path
-                   if not entry or os.path.normcase(os.path.realpath(entry)) != normalized_root]
+                   if not entry or os.path.normcase(_realpath_or_self(entry)) != normalized_root]
     sys.path.insert(0, project_root)
 
 

--- a/tests/cron/test_cron_bot_chat_delivery.py
+++ b/tests/cron/test_cron_bot_chat_delivery.py
@@ -143,6 +143,8 @@ def test_deliver_runs_canonical_bot_chat_lane():
     assert "--query-file" in argv
     # Message rides a temp file, never inline argv (quote/expansion safety).
     assert not any("the output" in str(a) for a in argv)
+    # Inherit a live cwd: the worker may have been left in a deleted scratch dir.
+    assert calls["kwargs"].get("cwd")
 
 
 def test_deliver_named_profile_uses_p_flag_and_clears_home():

--- a/tests/hermes_cli/test_startup_fast_guards.py
+++ b/tests/hermes_cli/test_startup_fast_guards.py
@@ -22,6 +22,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 # Modules that must NEVER be imported by the fast path. Each one either
@@ -37,6 +39,22 @@ _FORBIDDEN_MODULES = (
     "httpx",
     "openai",
 )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX: rmdir of cwd then realpath")
+def test_ensure_project_root_on_path_survives_deleted_cwd(tmp_path):
+    """``os.path.realpath('.')`` raises FileNotFoundError when cwd is gone (#102941)."""
+    import hermes_cli._startup_fast as fast
+
+    gone = tmp_path / "scratch"
+    gone.mkdir()
+    previous = os.getcwd()
+    os.chdir(gone)
+    gone.rmdir()
+    try:
+        fast.ensure_project_root_on_path()
+    finally:
+        os.chdir(previous)
 
 
 def test_startup_fast_import_weight():


### PR DESCRIPTION
## What does this PR do?

Cron bot-chat delivery spawned `hermes chat` without `cwd=`, so the child inherited a worker directory that kanban cleanup may already have deleted. `ensure_project_root_on_path()` then called `os.path.realpath` on `sys.path` entries and crashed with `FileNotFoundError` before the delivery could run.

The delivery subprocess now starts in `$HOME`, and the startup helper treats a missing cwd as non-fatal.

## Related Issue

Fixes #102941

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `cron/scheduler_delivery.py` — `subprocess.run(..., cwd=expanduser("~"))`
- `hermes_cli/_startup_fast.py` — `realpath` no longer raises when cwd is gone
- `tests/cron/test_cron_bot_chat_delivery.py` — assert a live cwd is passed
- `tests/hermes_cli/test_startup_fast_guards.py` — deleted-cwd regression

## How to Test

```
uv run --extra dev python -m pytest tests/cron/test_cron_bot_chat_delivery.py tests/hermes_cli/test_startup_fast_guards.py -q
# 22 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
