### PR TITLE
fix(cli): default Nous portal picker to skip not flagship

### DIFF
--- a/hermes_cli/auth_model_picker.py
+++ b/hermes_cli/auth_model_picker.py
@@ -219,10 +219,13 @@ def _prompt_model_selection(
             model_search_labels.append(label if haystack == mid else f"{label} {haystack}")
         model_search_labels += [_CUSTOM_LABEL, _SKIP_LABEL]
 
+        # Current model is reordered to index 0. With no current match, default
+        # to Skip — a stray Enter must not silently adopt the paid flagship (#102943).
+        default_idx = 0 if (current_model and current_model in model_ids) else n + 1
         idx = curses_radiolist(
             "Select default model:",
             choices,
-            selected=0,  # cursor on the current model (index 0 if it was reordered to top)
+            selected=default_idx,
             cancel_returns=-1,
             description="\n".join(desc_lines) if desc_lines else None,
             searchable=True,

--- a/hermes_cli/auth_nous.py
+++ b/hermes_cli/auth_nous.py
@@ -1316,6 +1316,21 @@ def step_up_nous_billing_scope(
     return isinstance(granted, str) and NOUS_BILLING_MANAGE_SCOPE in granted.split()
 
 
+def _config_default_model() -> str:
+    """Current ``model.default`` from config, or empty when unset/unreadable."""
+    try:
+        from hermes_cli.config import load_config
+        model = (load_config() or {}).get("model")
+        if isinstance(model, dict):
+            default = model.get("default")
+            return str(default).strip() if default else ""
+        if isinstance(model, str):
+            return model.strip()
+    except Exception:
+        return ""
+    return ""
+
+
 def _pick_nous_model_after_login(
     auth_state: Dict[str, Any], inference_base_url: str) -> Optional[str]:
     """Fetch the curated Nous model list (tier/policy-filtered) and run the interactive picker.
@@ -1374,8 +1389,10 @@ def _pick_nous_model_after_login(
         print(
             f"Showing {len(model_ids)} curated models — "
             "use \"Enter custom model name\" for others.")
+        current_model = _config_default_model()
         return _prompt_model_selection(
-            model_ids, pricing=pricing, unavailable_models=unavailable_models, portal_url=_portal,
+            model_ids, current_model=current_model, pricing=pricing,
+            unavailable_models=unavailable_models, portal_url=_portal,
             unavailable_message=unavailable_message, confirm_provider="nous",
             confirm_base_url=inference_base_url, confirm_api_key=runtime_key)
     if unavailable_models:

--- a/tests/hermes_cli/test_auth_model_picker_skip_default.py
+++ b/tests/hermes_cli/test_auth_model_picker_skip_default.py
@@ -1,0 +1,48 @@
+"""Portal login picker must not treat bare Enter as the paid flagship (#102943)."""
+
+from hermes_cli.auth_model_picker import _CUSTOM_LABEL, _SKIP_LABEL, _prompt_model_selection
+
+
+def test_curses_picker_defaults_to_skip_when_current_model_is_absent(monkeypatch):
+    captured = {}
+
+    def fake_radio(title, items, selected=0, **kwargs):
+        captured["selected"] = selected
+        captured["items"] = items
+        return selected
+
+    monkeypatch.setattr("hermes_cli.curses_ui.curses_radiolist", fake_radio)
+    monkeypatch.setattr(
+        "hermes_cli.auth_model_picker._confirm_selection_guards",
+        lambda *a, **k: True,
+    )
+
+    models = ["anthropic/claude-fable-5.1", "xiaomi/mimo-v2-pro"]
+    result = _prompt_model_selection(models)
+
+    assert captured["items"][-1] == _SKIP_LABEL
+    assert captured["items"][-2] == _CUSTOM_LABEL
+    assert captured["selected"] == len(models) + 1
+    assert result is None
+
+
+def test_curses_picker_defaults_to_current_model_when_listed(monkeypatch):
+    captured = {}
+
+    def fake_radio(title, items, selected=0, **kwargs):
+        captured["selected"] = selected
+        return 0
+
+    monkeypatch.setattr("hermes_cli.curses_ui.curses_radiolist", fake_radio)
+    monkeypatch.setattr(
+        "hermes_cli.auth_model_picker._confirm_selection_guards",
+        lambda *a, **k: True,
+    )
+
+    result = _prompt_model_selection(
+        ["anthropic/claude-fable-5.1", "xiaomi/mimo-v2-pro"],
+        current_model="xiaomi/mimo-v2-pro",
+    )
+
+    assert captured["selected"] == 0
+    assert result == "xiaomi/mimo-v2-pro"


### PR DESCRIPTION
## What does this PR do?

`hermes portal login` ran the model picker without `current_model`, so the curses list defaulted to index 0 (the paid flagship). A stray Enter then wrote `model.provider=nous` plus that flagship into config.yaml.

The picker now defaults to Skip when the current model is not in the Nous list, and the login path passes `model.default` through so a matching current row still sits on top.

## Related Issue

Fixes #102943

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/auth_nous.py` — pass `current_model` from config into the picker
- `hermes_cli/auth_model_picker.py` — default cursor is Skip unless current is listed
- `tests/hermes_cli/test_auth_model_picker_skip_default.py`

## How to Test

```
uv run --extra dev python -m pytest tests/hermes_cli/test_auth_model_picker_skip_default.py tests/hermes_cli/test_auth_nous_provider.py -q
# 32 passed
```

Not runtime-tested against a live Nous device-code login.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
