### PR TITLE
fix(desktop): label remote local-models hardware as backend

### DIFF
--- a/apps/desktop/src/app/settings/local-models-settings.test.tsx
+++ b/apps/desktop/src/app/settings/local-models-settings.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { I18nProvider } from '@/i18n'
 import { $localRuntimeJobs } from '@/store/local-runtime-jobs'
+import { $connection } from '@/store/session'
 import type { LocalCatalogModel, LocalHardware, LocalModelsStatus, LocalRuntimeJob } from '@/types/hermes'
 
 import { LocalModelsSettings } from './local-models-settings'
@@ -134,9 +135,24 @@ beforeEach(() => {
 afterEach(() => {
   cleanup()
   vi.clearAllMocks()
+  $connection.set(null)
 })
 
 describe('LocalModelsSettings', () => {
+  it('labels hardware as the backend host on a remote gateway', async () => {
+    $connection.set({ baseUrl: 'https://gw', mode: 'remote', token: 't' } as never)
+    mocked.getLocalModelsStatus.mockResolvedValue({ ...BASE_STATUS, runtime_installed: true })
+    await renderFullPane()
+    expect(await screen.findByText('Backend server')).toBeTruthy()
+  })
+
+  it('labels hardware as this machine on a local gateway', async () => {
+    $connection.set({ mode: 'local' } as never)
+    mocked.getLocalModelsStatus.mockResolvedValue({ ...BASE_STATUS, runtime_installed: true })
+    await renderFullPane()
+    expect(await screen.findByText('This machine', { exact: true })).toBeTruthy()
+  })
+
   it('offers the runtime install with a plain-language explanation', async () => {
     await renderFullPane()
 

--- a/apps/desktop/src/app/settings/local-models-settings.tsx
+++ b/apps/desktop/src/app/settings/local-models-settings.tsx
@@ -47,6 +47,7 @@ import {
   watchLocalRuntimeJobs
 } from '@/store/local-runtime-jobs'
 import { notify, notifyError } from '@/store/notifications'
+import { $connection } from '@/store/session'
 import type { LocalCatalogModel, LocalHardware, LocalModelsStatus } from '@/types/hermes'
 
 import { ListRow, Pill, SettingsContent, SettingsSection, SettingsSkeleton } from './primitives'
@@ -88,6 +89,8 @@ function fitRank(model: LocalCatalogModel): number {
 export function LocalModelsSettings() {
   const { t } = useI18n()
   const copy = t.settings.localModels
+  const connection = useStore($connection)
+  const remoteBackend = connection?.mode === 'remote'
   const [status, setStatus] = useState<LocalModelsStatus | null>(null)
   const [hardware, setHardware] = useState<LocalHardware | null>(null)
   const [catalog, setCatalog] = useState<LocalCatalogModel[] | null>(null)
@@ -519,8 +522,8 @@ export function LocalModelsSettings() {
         {lastError?.kind === 'runtime-install' && <p className="text-[0.75rem] text-destructive">{lastError.error}</p>}
       </SettingsSection>
 
-      {/* ── This machine ── */}
-      <SettingsSection icon={Monitor} title={copy.hardwareTitle}>
+      {/* ── This machine (or the remote backend host) ── */}
+      <SettingsSection icon={Monitor} title={remoteBackend ? copy.hardwareTitleRemote : copy.hardwareTitle}>
         {hardware ? (
           <div className="flex flex-wrap items-center gap-x-5 gap-y-1 py-1 text-[length:var(--conversation-caption-font-size)] text-muted-foreground">
             {hardware.gpu_name && (

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1140,6 +1140,7 @@ export const en: Translations = {
       installing: 'Installing runtime…',
       installFailed: 'Runtime install failed',
       hardwareTitle: 'This machine',
+      hardwareTitleRemote: 'Backend server',
       hardwareLoading: 'Checking your hardware…',
       vram: label => `${label} GPU memory`,
       ram: label => `${label} RAM`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1046,6 +1046,7 @@ export const ja = defineLocale({
       installing: 'ランタイムをインストール中…',
       installFailed: 'ランタイムのインストールに失敗しました',
       hardwareTitle: 'このマシン',
+      hardwareTitleRemote: 'バックエンドサーバー',
       hardwareLoading: 'ハードウェアを確認中…',
       vram: label => `GPU メモリ ${label}`,
       ram: label => `RAM ${label}`,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -985,6 +985,7 @@ export interface Translations {
       installing: string
       installFailed: string
       hardwareTitle: string
+      hardwareTitleRemote: string
       hardwareLoading: string
       vram: (label: string) => string
       ram: (label: string) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1006,6 +1006,7 @@ export const zhHant = defineLocale({
       installing: '正在安裝執行環境…',
       installFailed: '執行環境安裝失敗',
       hardwareTitle: '本機配置',
+      hardwareTitleRemote: '後端伺服器',
       hardwareLoading: '正在檢測硬體…',
       vram: label => `${label} 顯示記憶體`,
       ram: label => `${label} 記憶體`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1341,6 +1341,7 @@ export const zh: Translations = {
       quickstartStageModel: '模型',
       quickstartStageFinish: '完成',
       hardwareTitle: '本机配置',
+      hardwareTitleRemote: '后端服务器',
       hardwareLoading: '正在检测硬件…',
       vram: label => `${label} 显存`,
       ram: label => `${label} 内存`,


### PR DESCRIPTION
## What does this PR do?

Local Models Settings always titled `/api/local-models/hardware` as "This machine". That endpoint runs on the connected backend, so an SSH/remote session showed the Pi's RAM/VRAM under a label that reads as the laptop.

When the desktop connection mode is `remote`, the section title is now "Backend server". Local mode keeps "This machine".

## Related Issue

Fixes #102850

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/settings/local-models-settings.tsx` — title from `$connection.mode`
- `apps/desktop/src/i18n/{types,en,zh,zh-hant,ja}.ts` — `hardwareTitleRemote`
- `apps/desktop/src/app/settings/local-models-settings.test.tsx`

## How to Test

```
cd apps/desktop
npx vitest run src/app/settings/local-models-settings.test.tsx
# 18 passed
npx tsc --noEmit -p tsconfig.json
# clean
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
