### PR TITLE
fix(desktop): do not double-speak auto-TTS replies

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.test.tsx
@@ -134,6 +134,7 @@ describe('useAutoSpeakReplies — Edge TTS fallback chain (#93515)', () => {
     $autoSpeakReplies.set(true)
 
     const $messages = atom<ChatMessage[]>([])
+
     const pendingReply = () => {
       const messages = $messages.get()
       const last = messages.findLast(m => m.role === 'assistant' && !m.hidden)

--- a/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.test.tsx
@@ -129,4 +129,56 @@ describe('useAutoSpeakReplies — Edge TTS fallback chain (#93515)', () => {
     expect($voicePlayback.get().status).toBe('idle')
     expect(playSpeechText).toHaveBeenCalledTimes(1)
   })
+
+  it('does not double-speak when $messages and idle fire for the same reply (#102960)', async () => {
+    $autoSpeakReplies.set(true)
+
+    const $messages = atom<ChatMessage[]>([])
+    const pendingReply = () => {
+      const messages = $messages.get()
+      const last = messages.findLast(m => m.role === 'assistant' && !m.hidden)
+      const spoken = resolveSpokenReply(SESSION_ID, messages)
+
+      if (!last || last.id === spoken?.id) {
+        return null
+      }
+
+      return { id: last.id, pending: Boolean(last.pending), text: chatMessageText(last) }
+    }
+
+    const markSpoken = () => {
+      const messages = $messages.get()
+      const last = messages.findLast(m => m.role === 'assistant' && !m.hidden)
+
+      if (last) {
+        markAssistantIdSpoken(SESSION_ID, messages, last.id)
+      }
+    }
+
+    vi.mocked(playSpeechText).mockResolvedValue(true)
+
+    renderHook(
+      () =>
+        useAutoSpeakReplies({
+          conversationActive: false,
+          failureLabel: 'read-aloud failed',
+          markSpoken,
+          pendingReply,
+          sessionId: SESSION_ID
+        }),
+      {
+        wrapper: ({ children }) => (
+          <ComposerScopeProvider value={{ ...MAIN_COMPOSER_SCOPE, $messages }}>{children}</ComposerScopeProvider>
+        )
+      }
+    )
+
+    act(() => {
+      $messages.set([assistantMessage('a1', 'hello there')])
+      setVoicePlaybackState({ ...IDLE_STATE })
+    })
+
+    await waitFor(() => expect(playSpeechText).toHaveBeenCalledTimes(1))
+    expect(playSpeechText).toHaveBeenCalledTimes(1)
+  })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.ts
@@ -48,6 +48,9 @@ export function useAutoSpeakReplies({
   latest.current = { conversationActive, failureLabel, markSpoken, pendingReply }
   const speakingId = useRef<string | null>(null)
 
+  // speakingId is a same-tick request token ($messages + playback-idle can
+  // both enter speakLatest before markSpoken runs), not an atom mirror.
+  // eslint-disable-next-line no-restricted-syntax -- in-flight token, not atom sync
   useEffect(() => {
     if (!enabled) {
       return undefined

--- a/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.ts
@@ -46,6 +46,7 @@ export function useAutoSpeakReplies({
   const { $messages } = useComposerScope()
   const latest = useRef({ conversationActive, failureLabel, markSpoken, pendingReply })
   latest.current = { conversationActive, failureLabel, markSpoken, pendingReply }
+  const speakingId = useRef<string | null>(null)
 
   useEffect(() => {
     if (!enabled) {
@@ -54,6 +55,7 @@ export function useAutoSpeakReplies({
 
     // Don't read whatever reply already sits at the bottom when the toggle flips
     // on (or a chat opens) — consume it so only later replies are spoken.
+    speakingId.current = null
     latest.current.markSpoken()
 
     const speakLatest = () => {
@@ -65,10 +67,11 @@ export function useAutoSpeakReplies({
 
       const reply = pendingReply()
 
-      if (!reply || reply.pending) {
+      if (!reply || reply.pending || speakingId.current === reply.id) {
         return
       }
 
+      speakingId.current = reply.id
       markSpoken()
       // Only one window voices a given reply when the same chat is open in
       // several (reply.id is the shared backend message id). markSpoken already


### PR DESCRIPTION
## What does this PR do?

With `voice.auto_tts`, `$messages.subscribe` and `$voicePlayback.listen` both call `speakLatest`. If a reply lands on the playback-idle edge, both listeners can pass the idle guard before `markSpoken()` runs and `playSpeechText` starts twice for the same `reply.id`.

A ref records the in-flight reply id synchronously so the second listener no-ops.

## Related Issue

Fixes #102960

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.ts` — `speakingId` ref
- `apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.test.tsx` — dual-listener regression

## How to Test

```
cd apps/desktop
npx vitest run src/app/chat/composer/hooks/use-auto-speak-replies.test.tsx
# 2 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
