### PR TITLE
fix(models): add claude-fable-5-1 to the curated Anthropic picker list

### DIFF
--- a/hermes_cli/models_catalog_static.py
+++ b/hermes_cli/models_catalog_static.py
@@ -193,7 +193,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "minimax-oauth": ["MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"],
     "minimax-cn": list(_MINIMAX_MODELS),
     "anthropic": [
-        "claude-fable-5", "claude-sonnet-5", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6",
+        "claude-fable-5-1", "claude-fable-5", "claude-sonnet-5", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6",
         "claude-sonnet-4-6", "claude-opus-4-5-20251101", "claude-sonnet-4-5-20250929",
         "claude-opus-4-20250514", "claude-sonnet-4-20250514", "claude-haiku-4-5-20251001",
     ],


### PR DESCRIPTION
Anthropic's /v1/models lags freshly-routed aliases, and the picker only surfaces a model the live catalog omits when it is in the curated list. Family-keyed tables (context length, output cap, mandatory thinking, reasoning timeouts) already match the claude-fable prefix.
