### PR TITLE
desktop: fix auto_tts double-read race in useAutoSpeakReplies

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.ts
@@ -46,6 +46,9 @@ export function useAutoSpeakReplies({
   const { $messages } = useComposerScope()
   const latest = useRef({ conversationActive, failureLabel, markSpoken, pendingReply })
   latest.current = { conversationActive, failureLabel, markSpoken, pendingReply }
+  // Track which reply is currently being spoken to prevent the $messages + $voicePlayback
+  // race where both listeners call speakLatest concurrently for the same reply.id.
+  const speakingRef = useRef<string | null>(null)
 
   useEffect(() => {
     if (!enabled) {
@@ -69,6 +72,13 @@ export function useAutoSpeakReplies({
         return
       }
 
+      // Prevent concurrent invocations for the same reply.id (race between
+      // $messages.subscribe and $voicePlayback.listen).
+      if (speakingRef.current === reply.id) {
+        return
+      }
+      speakingRef.current = reply.id
+
       markSpoken()
       // Only one window voices a given reply when the same chat is open in
       // several (reply.id is the shared backend message id). markSpoken already
@@ -78,6 +88,11 @@ export function useAutoSpeakReplies({
           void playSpeechText(reply.text, { messageId: reply.id, source: 'read-aloud' }).catch(error =>
             notifyError(error, failureLabel)
           )
+        }
+      }).finally(() => {
+        // Clear the speaking ref so the next reply can be spoken.
+        if (speakingRef.current === reply.id) {
+          speakingRef.current = null
         }
       })
     }


### PR DESCRIPTION
Fixes #102960

## Problem

Desktop `voice.auto_tts` spoke each completed assistant reply **twice in succession** — a first full playback, then an immediate second playback of the same text — before stopping normally.

## Root Cause

The hook `useAutoSpeakReplies` registered two listeners that both called `speakLatest`:

1. `$messages.subscribe` — fires when a new message arrives/completes
2. `$voicePlayback.listen` — fires when playback state transitions to `idle`

**Race condition**: If a new reply arrived at the exact moment the prior playback ended (or the timing overlapped), both listeners saw `$voicePlayback.get().status !== 'idle'` as false, both called `speakLatest`, both passed the guard, and both invoked `playSpeechText` for the same `reply.id`.

The `markSpoken()` dedupe was called *inside* `speakLatest` — so it didn't prevent the second concurrent invocation, because the first hadn't run it yet.

## Fix

Track the `reply.id` currently being spoken in a ref, skip `speakLatest` if already processing that ID, and clear the ref in a `finally` block.

```typescript
const speakingRef = useRef<string | null>(null)

const speakLatest = () => {
  // ...
  if (speakingRef.current === reply.id) return
  speakingRef.current = reply.id
  // ... 
  .finally(() => {
    if (speakingRef.current === reply.id) speakingRef.current = null
  })
}
```

This ensures only one `speakLatest` call per `reply.id` can proceed at a time.