### PR TITLE
fix(desktop): stop queue-stuck toast on leftover composer queues

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
@@ -10,6 +10,9 @@ import {
   MAX_AUTO_DRAIN_ATTEMPTS,
   parkQueuedPrompts
 } from '@/store/composer-queue'
+import { $notifications, clearNotifications } from '@/store/notifications'
+import { $sessions, setSessions, setSessionsLoading } from '@/store/session'
+import { makeSessionInfo } from '@/test/session-info'
 
 import type { QueueEditState } from '../composer-utils'
 import type { ChatBarProps } from '../types'
@@ -58,6 +61,9 @@ describe('useComposerQueue park integration', () => {
     window.localStorage.clear()
     $queuedPromptsBySession.set({})
     $parkedQueueSessions.set({})
+    $sessions.set([])
+    setSessionsLoading(false)
+    clearNotifications()
   })
 
   afterEach(() => {
@@ -65,6 +71,9 @@ describe('useComposerQueue park integration', () => {
     vi.restoreAllMocks()
     $queuedPromptsBySession.set({})
     $parkedQueueSessions.set({})
+    $sessions.set([])
+    setSessionsLoading(true)
+    clearNotifications()
   })
 
   it('reschedules rejected foreground drains to a bounded stop and keeps manual recovery', async () => {
@@ -72,6 +81,7 @@ describe('useComposerQueue park integration', () => {
 
     try {
       const entry = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'recoverable' })!
+      setSessions([makeSessionInfo({ id: SESSION_KEY })])
       const { hook, onSubmit } = renderQueueHook({ busy: true })
       onSubmit.mockResolvedValue(false)
       hook.rerender({ busy: false })
@@ -252,5 +262,63 @@ describe('useComposerQueue park integration', () => {
 
     expect(isQueueParked(SESSION_KEY)).toBe(false)
     expect(getQueuedPrompts(SESSION_KEY)).toHaveLength(1)
+  })
+
+  it('does not auto-drain restored queues while the session list is still loading', async () => {
+    setSessionsLoading(true)
+    enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'wait for session list' })
+
+    const { onSubmit } = renderQueueHook()
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(getQueuedPrompts(SESSION_KEY)).toHaveLength(1)
+  })
+
+  it('auto-drains a restored queue once the session list finishes loading', async () => {
+    setSessionsLoading(true)
+    enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'send after load' })
+
+    const { hook, onSubmit } = renderQueueHook()
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(onSubmit).not.toHaveBeenCalled()
+
+    setSessionsLoading(false)
+    hook.rerender({ busy: false })
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1))
+    expect(getQueuedPrompts(SESSION_KEY)).toHaveLength(0)
+  })
+
+  it('drops an unlisted leftover queue after bounded failures instead of toasting', async () => {
+    vi.useFakeTimers()
+
+    try {
+      enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'orphaned leftover' })
+      const { hook, onSubmit } = renderQueueHook({ busy: true })
+      onSubmit.mockResolvedValue(false)
+      hook.rerender({ busy: false })
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      for (let attempt = 1; attempt < MAX_AUTO_DRAIN_ATTEMPTS; attempt++) {
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(30_000)
+        })
+      }
+
+      expect(onSubmit).toHaveBeenCalledTimes(MAX_AUTO_DRAIN_ATTEMPTS)
+      expect(getQueuedPrompts(SESSION_KEY)).toHaveLength(0)
+      expect($notifications.get().some(item => item.id === 'composer-queue-stuck')).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -9,6 +9,7 @@ import { resetBrowseState } from '@/store/composer-input-history'
 import {
   $parkedQueueSessions,
   $queuedPromptsBySession,
+  clearQueuedPrompts,
   enqueueQueuedPrompt,
   getQueuedPrompts,
   isSteerableEntry,
@@ -22,6 +23,7 @@ import {
   updateQueuedPrompt
 } from '@/store/composer-queue'
 import { notify } from '@/store/notifications'
+import { $sessionsLoading, ownerLookupSessionRows, sessionRowsIncludeId } from '@/store/session'
 
 import { cloneAttachments, type QueueEditState } from '../composer-utils'
 import { useComposerScope } from '../scope'
@@ -80,6 +82,7 @@ export function useComposerQueue({
   // is fine; the auto-drain effect below reads it as a gate.
   const parkedSessions = useStore($parkedQueueSessions)
   const queueParked = Boolean(activeQueueSessionKey && parkedSessions[activeQueueSessionKey])
+  const sessionsLoading = useStore($sessionsLoading)
 
   const [queueEdit, setQueueEdit] = useState<QueueEditState | null>(null)
   queueEditRef.current = queueEdit
@@ -345,6 +348,8 @@ export function useComposerQueue({
     let cancelled = false
     let retryTimer: ReturnType<typeof setTimeout> | undefined
 
+    const drainQueueSessionKey = activeQueueSessionKey
+
     const onFail = () => {
       if (cancelled) {
         return
@@ -353,16 +358,24 @@ export function useComposerQueue({
       const fails = (drainFailuresRef.current.get(entry.id) ?? 0) + 1
       drainFailuresRef.current.set(entry.id, fails)
 
-      if (fails >= MAX_AUTO_DRAIN_ATTEMPTS) {
-        notify({
-          id: 'composer-queue-stuck',
-          kind: 'error',
-          title: t.composer.queueStuckTitle,
-          message: t.composer.queueStuckBody
-        })
-      } else {
+      if (fails < MAX_AUTO_DRAIN_ATTEMPTS) {
         retryTimer = setTimeout(() => setDrainRetryTick(tick => tick + 1), 750 * fails)
+
+        return
       }
+
+      if (!sessionRowsIncludeId(ownerLookupSessionRows(), drainQueueSessionKey)) {
+        clearQueuedPrompts(drainQueueSessionKey)
+
+        return
+      }
+
+      notify({
+        id: 'composer-queue-stuck',
+        kind: 'error',
+        title: t.composer.queueStuckTitle,
+        message: t.composer.queueStuckBody
+      })
     }
 
     void runDrain(() => entry)
@@ -402,10 +415,18 @@ export function useComposerQueue({
   // strand them. A park (explicit Stop/Esc) is the one gate: those entries wait
   // for the user. To cancel queued turns, the user deletes them from the panel.
   useEffect(() => {
+    // Same gate as the background drainer: while the session list is
+    // unavailable, a restored localStorage entry has no resumable runtime to
+    // target, so draining only burns its retry budget and toasts. Covers app
+    // boot, a gateway/profile switch, and any refresh over an empty list.
+    if (sessionsLoading) {
+      return
+    }
+
     if (shouldAutoDrain({ isBusy: busy, parked: queueParked, queueLength: queuedPrompts.length })) {
       return autoDrainNext()
     }
-  }, [autoDrainNext, busy, drainRetryTick, queueParked, queuedPrompts.length])
+  }, [autoDrainNext, busy, drainRetryTick, queueParked, queuedPrompts.length, sessionsLoading])
 
   // Queue-edit cleanup: on session swap the scope effect already stashed the
   // edit snapshot; only restore into the composer when still on the same scope.

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.test.tsx
@@ -8,9 +8,11 @@ import {
   $queuedPromptsBySession,
   enqueueQueuedPrompt,
   getQueuedPrompts,
+  MAX_AUTO_DRAIN_ATTEMPTS,
   parkQueuedPrompts
 } from '@/store/composer-queue'
-import { $sessions, setSessions } from '@/store/session'
+import { $notifications, clearNotifications } from '@/store/notifications'
+import { $sessions, setSessions, setSessionsLoading } from '@/store/session'
 import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
 import type { SessionInfo } from '@/types/hermes'
 
@@ -62,6 +64,9 @@ describe('useBackgroundQueueDrain', () => {
   beforeEach(() => {
     vi.useRealTimers()
     clearAllSessionStates()
+    // Production drain waits for the sidebar list. Tests that assert drain
+    // behavior are post-load unless they opt into the loading gate.
+    setSessionsLoading(false)
   })
 
   afterEach(() => {
@@ -71,6 +76,8 @@ describe('useBackgroundQueueDrain', () => {
     $queuedPromptsBySession.set({})
     $parkedQueueSessions.set({})
     $sessions.set([])
+    setSessionsLoading(true)
+    clearNotifications()
     clearAllSessionStates()
   })
 
@@ -221,5 +228,106 @@ describe('useBackgroundQueueDrain', () => {
 
     expect(submitText).toHaveBeenCalledTimes(2)
     expect(getQueuedPrompts('stored-session-a')).toHaveLength(0)
+  })
+
+  it('does not drain restored queues while the session list is still loading', async () => {
+    vi.useFakeTimers()
+    setSessionsLoading(true)
+
+    const runtimeMap = { current: new Map([['stored-session-a', 'rt-session-a']]) }
+    const submitText = vi.fn(async () => true)
+
+    enqueueQueuedPrompt('stored-session-a', { text: 'wait for session list', attachments: [] })
+
+    render(<Harness runtimeMap={runtimeMap} submitText={submitText} />)
+
+    // Four 750ms retries is what used to burn the drain budget and toast on boot.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(750 * 4)
+      await Promise.resolve()
+    })
+
+    expect(submitText).not.toHaveBeenCalled()
+    expect(getQueuedPrompts('stored-session-a')).toHaveLength(1)
+  })
+
+  it('drains a restored background queue once the session list finishes loading', async () => {
+    setSessionsLoading(true)
+
+    const runtimeMap = { current: new Map([['stored-session-a', 'rt-session-a']]) }
+    const submitText = vi.fn(async () => true)
+
+    enqueueQueuedPrompt('stored-session-a', { text: 'send after load', attachments: [] })
+
+    render(<Harness runtimeMap={runtimeMap} submitText={submitText} />)
+
+    await new Promise(resolve => window.setTimeout(resolve, 0))
+    expect(submitText).not.toHaveBeenCalled()
+
+    setSessionsLoading(false)
+
+    await waitFor(() => {
+      expect(submitText).toHaveBeenCalledWith('send after load', {
+        attachments: [],
+        fromQueue: true,
+        sessionId: 'rt-session-a',
+        storedSessionId: 'stored-session-a'
+      })
+    })
+
+    await waitFor(() => expect(getQueuedPrompts('stored-session-a')).toHaveLength(0))
+  })
+
+  it('drops an unlisted leftover queue after bounded failures instead of toasting', async () => {
+    vi.useFakeTimers()
+
+    const runtimeMap = { current: new Map<string, string>() }
+    const submitText = vi.fn(async () => false)
+
+    enqueueQueuedPrompt('ghost-session', { text: 'orphaned leftover', attachments: [] })
+
+    render(<Harness runtimeMap={runtimeMap} submitText={submitText} />)
+
+    for (let attempt = 1; attempt < MAX_AUTO_DRAIN_ATTEMPTS; attempt++) {
+      await act(async () => {
+        await Promise.resolve()
+        await vi.advanceTimersByTimeAsync(750)
+      })
+    }
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(submitText).toHaveBeenCalledTimes(MAX_AUTO_DRAIN_ATTEMPTS)
+    expect(getQueuedPrompts('ghost-session')).toHaveLength(0)
+    expect($notifications.get().some(item => item.id.startsWith('composer-background-queue-stuck'))).toBe(false)
+  })
+
+  it('toasts a listed session queue that keeps failing, and leaves it for manual send', async () => {
+    vi.useFakeTimers()
+
+    const runtimeMap = { current: new Map([['stored-session-a', 'rt-session-a']]) }
+    const submitText = vi.fn(async () => false)
+
+    setSessions([lineageSession({ id: 'stored-session-a' })])
+    enqueueQueuedPrompt('stored-session-a', { text: 'still recoverable', attachments: [] })
+
+    render(<Harness runtimeMap={runtimeMap} submitText={submitText} />)
+
+    for (let attempt = 1; attempt < MAX_AUTO_DRAIN_ATTEMPTS; attempt++) {
+      await act(async () => {
+        await Promise.resolve()
+        await vi.advanceTimersByTimeAsync(750)
+      })
+    }
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(submitText).toHaveBeenCalledTimes(MAX_AUTO_DRAIN_ATTEMPTS)
+    expect(getQueuedPrompts('stored-session-a')).toHaveLength(1)
+    expect($notifications.get().some(item => item.id === 'composer-background-queue-stuck-stored-session-a')).toBe(true)
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
@@ -6,6 +6,7 @@ import { resetBrowseState } from '@/store/composer-input-history'
 import {
   $parkedQueueSessions,
   $queuedPromptsBySession,
+  clearQueuedPrompts,
   getQueuedPrompts,
   MAX_AUTO_DRAIN_ATTEMPTS,
   type QueuedPromptEntry,
@@ -13,7 +14,13 @@ import {
   shouldAutoDrain
 } from '@/store/composer-queue'
 import { notify } from '@/store/notifications'
-import { $sessions, idsShareLineage } from '@/store/session'
+import {
+  $sessions,
+  $sessionsLoading,
+  idsShareLineage,
+  ownerLookupSessionRows,
+  sessionRowsIncludeId
+} from '@/store/session'
 import { $workingSessionIds } from '@/store/session-states'
 
 import type { SubmitTextOptions } from './use-prompt-actions/utils'
@@ -46,6 +53,7 @@ export function useBackgroundQueueDrain({
   const { t } = useI18n()
   const queuedPromptsBySession = useStore($queuedPromptsBySession)
   const parkedQueueSessions = useStore($parkedQueueSessions)
+  const sessionsLoading = useStore($sessionsLoading)
   const workingSessionIds = useStore($workingSessionIds)
   const submitTextRef = useRef(submitText)
   const drainingSessionIdsRef = useRef(new Set<string>())
@@ -94,18 +102,27 @@ export function useBackgroundQueueDrain({
         const failures = (drainFailuresRef.current.get(entry.id) ?? 0) + 1
         drainFailuresRef.current.set(entry.id, failures)
 
-        if (failures >= MAX_AUTO_DRAIN_ATTEMPTS) {
-          notify({
-            id: `composer-background-queue-stuck-${sessionKey}`,
-            kind: 'error',
-            title: t.composer.queueStuckTitle,
-            message: t.composer.queueStuckBody
-          })
+        if (failures < MAX_AUTO_DRAIN_ATTEMPTS) {
+          scheduleRetry()
 
           return
         }
 
-        scheduleRetry()
+        // A leftover localStorage key whose conversation is not in the loaded
+        // list cannot resume (deleted / ghost / other HERMES_HOME). Drop it
+        // instead of toasting — the toast is for a chat the user can still open.
+        if (!sessionRowsIncludeId(ownerLookupSessionRows(), sessionKey)) {
+          clearQueuedPrompts(sessionKey)
+
+          return
+        }
+
+        notify({
+          id: `composer-background-queue-stuck-${sessionKey}`,
+          kind: 'error',
+          title: t.composer.queueStuckTitle,
+          message: t.composer.queueStuckBody
+        })
       }
 
       void Promise.resolve()
@@ -151,13 +168,25 @@ export function useBackgroundQueueDrain({
   )
 
   useEffect(() => {
-    if (!enabled) {
+    // While the session list is unavailable, a queue restored from
+    // localStorage has no resumable runtime to target: every attempt is
+    // rejected against a reaped runtime, and four of them exhaust the entry's
+    // budget and toast "queued message not sent" before the user has done
+    // anything. Covers app boot, a gateway/profile switch, and any refresh
+    // over an empty list. Once the list lands, submitText resumes by stored id.
+    if (!enabled || sessionsLoading) {
       return
     }
 
     // Queue keys prefer the lineage root (resolveComposerSessionKey) while
     // $workingSessionIds / selection may hold the compression tip. Strict
     // equality then mis-classifies a busy or selected chat as idle/offscreen.
+    //
+    // Boot/reconnect: the composer queue survives in localStorage, but session
+    // runtimes are reaped. Draining before the sidebar list has loaded burns
+    // MAX_AUTO_DRAIN_ATTEMPTS against a backend that cannot resume yet, then
+    // toasts "Queued message not sent" on every launch even when the user has
+    // no visible queue (#98015).
     const sessions = $sessions.get()
     const working = [...workingSessionIds]
 
@@ -194,6 +223,7 @@ export function useBackgroundQueueDrain({
     queuedPromptsBySession,
     retryTick,
     selectedStoredSessionId,
+    sessionsLoading,
     workingSessionIds
   ])
 }

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -53,6 +53,7 @@ import {
   sessionMatchesStoredId,
   sessionOwnerRouteFromRow,
   sessionPinId,
+  sessionRowsIncludeId,
   setComposerSelectionOwner,
   setConnection,
   setCurrentCwd,
@@ -377,6 +378,8 @@ describe('lineageAliases across a deep compression chain', () => {
     expect(lineageAliases('mid', rows).sort()).toEqual(['mid', 'root', 'tip'])
     expect(lineageAliases('tip', rows).sort()).toEqual(['mid', 'root', 'tip'])
     expect(sessionMatchesStoredId(rows[0], 'mid')).toBe(true)
+    expect(sessionRowsIncludeId(rows, 'mid')).toBe(true)
+    expect(sessionRowsIncludeId(rows, 'ghost')).toBe(false)
   })
 })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -367,6 +367,24 @@ export const sessionMatchesStoredId = (
   session._lineage_root_id === storedSessionId ||
   Boolean(session._lineage_ids?.includes(storedSessionId))
 
+/** True when `storedId` names a conversation already in the loaded rows.
+ *
+ *  Composer-queue keys persist in localStorage across launches. After the
+ *  sidebar list has loaded, a leftover key that is not in those rows cannot
+ *  be resumed — auto-drain must drop it rather than toast "queued message
+ *  not sent". A key that IS listed still retries and toasts: that chat is
+ *  one the user can still open. Off-page / hidden chats are not in this
+ *  list; they still try resume-by-stored-id first, and only this predicate
+ *  decides toast-vs-drop after the send has already failed. */
+export function sessionRowsIncludeId(
+  sessions: readonly Pick<SessionInfo, '_lineage_ids' | '_lineage_root_id' | 'id'>[],
+  storedId: string
+): boolean {
+  const id = storedId.trim()
+
+  return Boolean(id) && sessions.some(session => sessionMatchesStoredId(session, id))
+}
+
 // Alias lookup, memoized per sessions-list reference. `lineageAliases` runs
 // per cached session state per status projection per message delta — an
 // O(sessions) scan there multiplies out to states × sessions × ~30Hz per busy


### PR DESCRIPTION
## Summary

Opening Desktop could show **Queued message not sent** with no visible queue and no running turn. The composer queue is restored from `localStorage`. Session runtimes are reaped on launch, so auto-drain retries fail, exhaust `MAX_AUTO_DRAIN_ATTEMPTS`, and toast even when the leftover session id is gone.

Waiting for `$sessionsLoading` alone is not enough: after the list lands, a ghost / deleted id still fails four times and toasts. This PR:

- Still waits for `$sessionsLoading` so boot / gateway-switch / empty-list refresh does not burn the retry budget.
- After bounded drain failures, **drops** a leftover queue whose id is **not** in the loaded session rows, with **no toast**.
- Keeps retry + toast for queues whose session **is** listed, so a real stuck send stays recoverable by a manual send.

Off-page / hidden chats still try resume-by-stored-id first. The listed-vs-drop check only runs after the send has already failed.

## Test plan

- [x] `npx vitest run src/app/session/hooks/use-background-queue-drain.test.tsx src/app/chat/composer/hooks/use-composer-queue.test.tsx` from `apps/desktop` → 25/25 pass
- [x] Unlisted leftover queue: four failed drains drop the entry and do not toast
- [x] Listed session: four failed drains toast and leave the entry for manual send
- [x] `npx eslint` on the touched sources → clean