### PR TITLE
fix(cron): survive deleted cwd during bot-chat delivery

### DIFF
--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -641,6 +641,27 @@ def _get_bot_chat_delivery_timeout() -> int:
         return 600
 
 
+def _bot_chat_delivery_cwd() -> str:
+    """Stable existing directory for the bot-chat delivery subprocess.
+
+    Must not inherit the caller's cwd: kanban/cron workers often sit in a scratch
+    workspace that completion cleanup has already removed. Spawning into a
+    deleted cwd crashes CLI startup in ``ensure_project_root_on_path`` (#102941).
+    Prefer the active profile home; fall back to the system temp dir.
+    """
+    import tempfile
+
+    try:
+        from hermes_constants import get_hermes_home
+
+        home = str(get_hermes_home())
+        if home and os.path.isdir(home):
+            return home
+    except Exception:
+        pass
+    return tempfile.gettempdir()
+
+
 def _deliver_to_bot_chat(job: dict, content: str, profile: str) -> Optional[str]:
     """Deliver job output into a profile's canonical Bot Chat as a real inbound user turn, via
     ``hermes [-p <profile>] chat --in ~ -c "Bot Chat" --create-if-missing -Q --query-file`` — the
@@ -693,6 +714,7 @@ def _deliver_to_bot_chat(job: dict, content: str, profile: str) -> Optional[str]
         ]
         result = subprocess.run(
             argv, capture_output=True, text=True, timeout=_get_bot_chat_delivery_timeout(), env=env,
+            cwd=_bot_chat_delivery_cwd(),
             creationflags=windows_hide_flags())
         if result.returncode != 0:
             tail = (result.stderr or result.stdout or "").strip()[-500:]

--- a/hermes_cli/_startup_fast.py
+++ b/hermes_cli/_startup_fast.py
@@ -34,12 +34,31 @@ def project_root_str() -> str:
     return os.path.realpath(os.path.join(os.path.dirname(__file__), os.pardir))
 
 
+def _sys_path_entry_matches_root(entry: str, normalized_root: str) -> bool:
+    """True when *entry* realpath-equals the project root.
+
+    ``os.path.realpath`` of a relative/cwd-derived entry needs a live cwd. Cron
+    bot-chat delivery (and other short-lived children) can inherit a deleted
+    worker scratch directory — realpath then raises FileNotFoundError/ENOENT
+    via getcwd() and would crash CLI startup before argv is parsed (#102941).
+    Unresolvable entries are treated as non-matches so they stay on sys.path.
+    """
+    if not entry:
+        return False
+    try:
+        return os.path.normcase(os.path.realpath(entry)) == normalized_root
+    except OSError:
+        return False
+
+
 def ensure_project_root_on_path() -> None:
     """Put the project root at sys.path[0], deduping realpath-equivalents."""
     project_root = project_root_str()
     normalized_root = os.path.normcase(os.path.realpath(project_root))
-    sys.path[:] = [entry for entry in sys.path
-                   if not entry or os.path.normcase(os.path.realpath(entry)) != normalized_root]
+    sys.path[:] = [
+        entry for entry in sys.path
+        if not _sys_path_entry_matches_root(entry, normalized_root)
+    ]
     sys.path.insert(0, project_root)
 
 

--- a/tests/cron/test_cron_bot_chat_delivery.py
+++ b/tests/cron/test_cron_bot_chat_delivery.py
@@ -6,6 +6,7 @@ preflight exemption, create-time validation, the subprocess delivery lane,
 and the delivery-targets listing used by UI pickers.
 """
 
+import os
 import subprocess
 from unittest import mock
 
@@ -143,6 +144,29 @@ def test_deliver_runs_canonical_bot_chat_lane():
     assert "--query-file" in argv
     # Message rides a temp file, never inline argv (quote/expansion safety).
     assert not any("the output" in str(a) for a in argv)
+    # Never inherit a possibly-deleted worker cwd (#102941).
+    assert "cwd" in calls["kwargs"]
+    assert calls["kwargs"]["cwd"]
+    assert os.path.isdir(calls["kwargs"]["cwd"])
+
+
+def test_deliver_uses_stable_cwd_not_caller_cwd(tmp_path, monkeypatch):
+    """Bot-chat spawn must pin cwd to an existing directory (profile home)."""
+    home = tmp_path / "profile-home"
+    home.mkdir()
+    calls = {}
+
+    def fake_run(argv, **kwargs):
+        calls["kwargs"] = kwargs
+        return _completed()
+
+    monkeypatch.setattr(sched_delivery, "_bot_chat_delivery_cwd", lambda: str(home))
+    with mock.patch.object(sched.subprocess, "run", side_effect=fake_run), \
+         mock.patch.object(sched_delivery.shutil, "which", return_value="/usr/bin/hermes"):
+        err = _deliver_to_bot_chat({"id": "j1", "name": "n"}, "out", "")
+
+    assert err is None
+    assert calls["kwargs"]["cwd"] == str(home)
 
 
 def test_deliver_named_profile_uses_p_flag_and_clears_home():

--- a/tests/hermes_cli/test_startup_fast_guards.py
+++ b/tests/hermes_cli/test_startup_fast_guards.py
@@ -104,3 +104,49 @@ def test_fast_version_reports_install_method_stamp(tmp_path):
     result = _run_version({"HERMES_HOME": str(home), "TERMUX_VERSION": ""})
     assert result.returncode == 0, result.stderr
     assert "Install method: git" in result.stdout
+
+
+def test_ensure_project_root_tolerates_unresolvable_sys_path_entries(monkeypatch):
+    """Relative/cwd-derived sys.path entries must not crash when realpath fails.
+
+    Cron bot-chat delivery can spawn into a deleted worker cwd; realpath then
+    raises FileNotFoundError via getcwd() (#102941).
+    """
+    import hermes_cli._startup_fast as startup_fast
+
+    real_realpath = os.path.realpath
+    boom = FileNotFoundError(2, "Unable to get the current working directory")
+
+    def fake_realpath(path):
+        if path in (".", "relative-entry"):
+            raise boom
+        return real_realpath(path)
+
+    monkeypatch.setattr(os.path, "realpath", fake_realpath)
+    monkeypatch.setattr(
+        sys,
+        "path",
+        [".", "relative-entry", startup_fast.project_root_str(), "/unrelated"],
+        raising=False,
+    )
+
+    startup_fast.ensure_project_root_on_path()
+
+    assert sys.path[0] == startup_fast.project_root_str()
+    assert "." in sys.path
+    assert "relative-entry" in sys.path
+    assert "/unrelated" in sys.path
+    # The absolute project-root duplicate was dropped once.
+    assert sys.path.count(startup_fast.project_root_str()) == 1
+
+
+def test_sys_path_entry_match_treats_oserror_as_non_match(monkeypatch):
+    from hermes_cli._startup_fast import _sys_path_entry_matches_root
+
+    assert _sys_path_entry_matches_root("", "/any") is False
+
+    def boom(_path):
+        raise FileNotFoundError(2, "Unable to get the current working directory")
+
+    monkeypatch.setattr(os.path, "realpath", boom)
+    assert _sys_path_entry_matches_root(".", "/root") is False


### PR DESCRIPTION
## Summary
- Cron bot-chat delivery spawned `hermes` without `cwd=`, so the child inherited a worker scratch directory that kanban/cron cleanup may already have deleted.
- CLI startup then crashed in `ensure_project_root_on_path` when `realpath` hit ENOENT via `getcwd()`, recording `delivery_failed` for jobs that had already finished.
- Pin the delivery subprocess to the profile home (tempdir fallback), and treat unresolvable `sys.path` entries as non-duplicates so startup stays up.

## Test plan
- [ ] `scripts/run_tests.sh tests/cron/test_cron_bot_chat_delivery.py tests/hermes_cli/test_startup_fast_guards.py -q`
- [ ] From a deleted cwd (`mkdir /tmp/gone && cd /tmp/gone && rmdir /tmp/gone` from another shell), confirm `hermes --version` no longer crashes at `_startup_fast.py`
- [ ] Trigger a `deliver: bot-chat` cron job from a worker whose scratch workspace was removed; delivery should succeed

Fixes #102941
