### PR TITLE
feat(audio): native audio input fast-path for multimodal models (Gemini, GPT-4o)

### DIFF
--- a/agent/audio_routing.py
+++ b/agent/audio_routing.py
@@ -1,0 +1,467 @@
+"""Routing helpers for inbound user-attached audio and voice notes.
+
+Two modes:
+
+  native  — attach audio directly as multimodal parts (OpenAI-style ``input_audio``
+            content parts, or Gemini inlineData) on the user turn without an
+            intermediate speech-to-text (STT) transcription step.
+
+  stt     — run the configured STT provider up-front and prepend the transcription
+            to the user's text. This is the fallback / classic flow for models
+            that do not accept native audio input.
+
+The decision is made once per message turn by :func:`decide_audio_input_mode`.
+It reads ``agent.audio_input_mode`` from config.yaml (``auto`` | ``native``
+| ``stt``, default ``auto``) and the active model's capability metadata.
+
+In ``auto`` mode:
+  - If the active model or provider reports native audio support (via
+    config override, models.dev metadata, or built-in model capability rules),
+    we attach natively.
+  - Otherwise (non-audio model), routes to the STT pipeline.
+  ``agent.audio_input_mode: native`` remains an explicit override.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import mimetypes
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_VALID_MODES = frozenset({"auto", "native", "stt"})
+
+_AUDIO_EXTS = (
+    ".oga", ".ogg", ".mp3", ".wav", ".m4a", ".aac", ".flac", ".webm", ".opus", ".wma",
+)
+_AUDIO_EXT_PATTERN = "|".join(e.lstrip(".") for e in _AUDIO_EXTS)
+
+_LOCAL_AUDIO_PATH_RE = re.compile(
+    r"(?<![/:\\w.])(?:~/|/)(?:[\w.\-]+/)*[\w.\-]+\.(?:" + _AUDIO_EXT_PATTERN + r")\b",
+    re.IGNORECASE,
+)
+
+_AUDIO_URL_RE = re.compile(
+    r"https?://[^\s<>\"']+?\.(?:" + _AUDIO_EXT_PATTERN + r")(?:\?[^\s<>\"']*)?",
+    re.IGNORECASE,
+)
+
+
+def _coerce_mode(raw: Any) -> str:
+    """Coerce arbitrary raw mode input to 'auto' | 'native' | 'stt'."""
+    if not isinstance(raw, str):
+        return "auto"
+    s = raw.strip().lower()
+    if s in ("native", "stt", "text", "auto"):
+        return "stt" if s == "text" else s
+    return "auto"
+
+
+def extract_audio_refs(text: str) -> Tuple[List[str], List[str]]:
+    """Scan free-form text for audio references the model should hear.
+
+    Returns ``(local_paths, urls)``.
+    """
+    if not isinstance(text, str) or not text:
+        return [], []
+
+    code_spans: list[tuple[int, int]] = []
+    for m in re.finditer(r"```[^\n]*\n.*?```", text, re.DOTALL):
+        code_spans.append((m.start(), m.end()))
+    for m in re.finditer(r"`[^`\n]+`", text):
+        code_spans.append((m.start(), m.end()))
+
+    def _in_code(pos: int) -> bool:
+        return any(s <= pos < e for s, e in code_spans)
+
+    local_paths: list[str] = []
+    seen_paths: set[str] = set()
+    for match in _LOCAL_AUDIO_PATH_RE.finditer(text):
+        if _in_code(match.start()):
+            continue
+        raw = match.group(0)
+        expanded = os.path.expanduser(raw)
+        try:
+            if not os.path.isfile(expanded):
+                continue
+        except OSError:
+            continue
+        if expanded in seen_paths:
+            continue
+        seen_paths.add(expanded)
+        local_paths.append(expanded)
+
+    urls: list[str] = []
+    seen_urls: set[str] = set()
+    for match in _AUDIO_URL_RE.finditer(text):
+        if _in_code(match.start()):
+            continue
+        url = match.group(0).rstrip(".,;:!?)]>")
+        if url in seen_urls:
+            continue
+        seen_urls.add(url)
+        urls.append(url)
+
+    return local_paths, urls
+
+
+_TRUE_TOKENS = frozenset({"true", "yes", "on", "1"})
+_FALSE_TOKENS = frozenset({"false", "no", "off", "0"})
+
+
+def _coerce_capability_bool(raw: Any) -> Optional[bool]:
+    """Return True/False for recognised boolean values, None otherwise."""
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, int):
+        if raw in (0, 1):
+            return bool(raw)
+        return None
+    if isinstance(raw, str):
+        s = raw.strip().lower()
+        if s in _TRUE_TOKENS:
+            return True
+        if s in _FALSE_TOKENS:
+            return False
+    return None
+
+
+def _supports_audio_override(
+    cfg: Optional[Dict[str, Any]],
+    provider: str,
+    model: str,
+    *,
+    requested_provider: str = "",
+) -> Optional[bool]:
+    """Resolve user-declared audio capability from config.yaml."""
+    if not isinstance(cfg, dict):
+        return None
+
+    # 1. Top-level shortcut under model
+    model_cfg_raw = cfg.get("model")
+    model_cfg: Dict[str, Any] = model_cfg_raw if isinstance(model_cfg_raw, dict) else {}
+    for key in ("supports_audio", "supports_audio_input", "audio"):
+        if key in model_cfg:
+            coerced = _coerce_capability_bool(model_cfg.get(key))
+            if coerced is not None:
+                return coerced
+
+    # 2. Per-provider, per-model
+    config_provider = str(model_cfg.get("provider") or "").strip()
+    provider_candidates: List[str] = []
+    for candidate in (requested_provider, provider, config_provider):
+        if not candidate:
+            continue
+        provider_candidates.append(candidate)
+        if candidate.startswith("custom:"):
+            stripped_candidate = candidate[len("custom:"):]
+            if stripped_candidate:
+                provider_candidates.append(stripped_candidate)
+    providers_raw = cfg.get("providers")
+    providers_cfg: Dict[str, Any] = providers_raw if isinstance(providers_raw, dict) else {}
+    for p in dict.fromkeys(provider_candidates):
+        entry_raw = providers_cfg.get(p)
+        entry: Dict[str, Any] = entry_raw if isinstance(entry_raw, dict) else {}
+        models_raw = entry.get("models")
+        models_cfg: Dict[str, Any] = models_raw if isinstance(models_raw, dict) else {}
+        per_model_raw = models_cfg.get(model)
+        per_model: Dict[str, Any] = per_model_raw if isinstance(per_model_raw, dict) else {}
+        for key in ("supports_audio", "supports_audio_input", "audio"):
+            if key in per_model:
+                coerced = _coerce_capability_bool(per_model.get(key))
+                if coerced is not None:
+                    return coerced
+
+    # 2b. Legacy list-style custom_providers
+    custom_providers = cfg.get("custom_providers")
+    if isinstance(custom_providers, list):
+        for candidate in dict.fromkeys(provider_candidates):
+            candidate_name = candidate.strip().lower()
+            for entry_raw in custom_providers:
+                if not isinstance(entry_raw, dict):
+                    continue
+                entry_name = str(entry_raw.get("name") or "").strip().lower()
+                if entry_name != candidate_name:
+                    continue
+                models_raw = entry_raw.get("models")
+                models_cfg = models_raw if isinstance(models_raw, dict) else {}
+                per_model_raw = models_cfg.get(model)
+                per_model = per_model_raw if isinstance(per_model_raw, dict) else {}
+                for key in ("supports_audio", "supports_audio_input", "audio"):
+                    if key in per_model:
+                        coerced = _coerce_capability_bool(per_model.get(key))
+                        if coerced is not None:
+                            return coerced
+
+    return None
+
+
+def _is_known_audio_model_or_provider(provider: str, model: str) -> bool:
+    """Heuristic check for known native-audio capable models and providers."""
+    prov = (provider or "").strip().lower()
+    mod = (model or "").strip().lower()
+
+    # Gemini family (Flash / Pro natively accept audio)
+    if prov in ("gemini", "google"):
+        return True
+    if "gemini" in mod:
+        return True
+
+    # OpenAI GPT-4o audio preview / realtime models
+    if "gpt-4o-audio" in mod or "gpt-4o-mini-audio" in mod or "gpt-4o-realtime" in mod:
+        return True
+
+    return False
+
+
+def _lookup_supports_audio(
+    provider: str,
+    model: str,
+    cfg: Optional[Dict[str, Any]] = None,
+    *,
+    requested_provider: str = "",
+) -> Optional[bool]:
+    """Check if the active model/provider supports native audio input."""
+    override = _supports_audio_override(
+        cfg,
+        provider,
+        model,
+        requested_provider=requested_provider,
+    )
+    if override is not None:
+        return override
+    if not provider and not model:
+        return None
+
+    # Try models.dev capabilities
+    try:
+        from agent.models_dev import get_model_capabilities
+
+        caps = get_model_capabilities(provider, model, allow_network=True)
+        if caps is not None and caps.supports_audio_input():
+            return True
+    except Exception as exc:
+        logger.debug("audio_routing: models.dev lookup failed for %s:%s — %s", provider, model, exc)
+
+    # Built-in heuristics for Gemini / GPT-4o Audio
+    if _is_known_audio_model_or_provider(provider, model):
+        return True
+
+    return None
+
+
+def decide_audio_input_mode(
+    provider: str,
+    model: str,
+    cfg: Optional[Dict[str, Any]],
+    *,
+    requested_provider: str = "",
+) -> str:
+    """Return "native" or "stt" for the given turn.
+
+    Args:
+      provider: active inference provider ID (e.g. "gemini", "openai").
+      model:    active model slug as it would be sent to the provider.
+      cfg:      loaded config.yaml dict, or None. When None, behaves as auto.
+      requested_provider: provider identity before runtime canonicalization.
+    """
+    mode_cfg = "auto"
+    if isinstance(cfg, dict):
+        agent_cfg = cfg.get("agent") or {}
+        if isinstance(agent_cfg, dict):
+            mode_cfg = _coerce_mode(agent_cfg.get("audio_input_mode"))
+        if mode_cfg == "auto" and "audio_input_mode" in cfg:
+            mode_cfg = _coerce_mode(cfg.get("audio_input_mode"))
+        if mode_cfg == "auto":
+            gw_cfg = cfg.get("gateway") or {}
+            if isinstance(gw_cfg, dict) and "audio_input_mode" in gw_cfg:
+                mode_cfg = _coerce_mode(gw_cfg.get("audio_input_mode"))
+
+    if mode_cfg == "native":
+        return "native"
+    if mode_cfg in ("stt", "text"):
+        return "stt"
+
+    if requested_provider:
+        supports = _lookup_supports_audio(
+            provider,
+            model,
+            cfg,
+            requested_provider=requested_provider,
+        )
+    else:
+        supports = _lookup_supports_audio(provider, model, cfg)
+
+    if supports is True:
+        return "native"
+    return "stt"
+
+
+def _sniff_audio_mime_from_bytes(raw: bytes) -> Optional[str]:
+    """Detect audio MIME from magic bytes. Returns None if unrecognised."""
+    if not raw:
+        return None
+    # WAV: RIFF....WAVE
+    if len(raw) >= 12 and raw[:4] == b"RIFF" and raw[8:12] == b"WAVE":
+        return "audio/wav"
+    # Ogg / Opus / OGA: OggS
+    if raw.startswith(b"OggS"):
+        return "audio/ogg"
+    # MP3: ID3 or frame sync
+    if raw.startswith(b"ID3"):
+        return "audio/mp3"
+    if len(raw) >= 2 and raw[0] == 0xFF and (raw[1] & 0xE0) == 0xE0:
+        return "audio/mp3"
+    # FLAC: fLaC
+    if raw.startswith(b"fLaC"):
+        return "audio/flac"
+    # M4A / MP4: bytes 4..8 == 'ftyp'
+    if len(raw) >= 12 and raw[4:8] == b"ftyp":
+        return "audio/m4a"
+    # WebM: \x1a\x45\xdf\xa3
+    if raw.startswith(b"\x1a\x45\xdf\xa3"):
+        return "audio/webm"
+    return None
+
+
+def _guess_audio_mime(path: Path, raw: Optional[bytes] = None) -> str:
+    """Return audio MIME type for path."""
+    if raw is not None:
+        sniffed = _sniff_audio_mime_from_bytes(raw)
+        if sniffed:
+            return sniffed
+    suffix = path.suffix.lower()
+    suffix_map = {
+        ".oga": "audio/ogg",
+        ".ogg": "audio/ogg",
+        ".opus": "audio/ogg",
+        ".mp3": "audio/mp3",
+        ".wav": "audio/wav",
+        ".m4a": "audio/m4a",
+        ".aac": "audio/aac",
+        ".flac": "audio/flac",
+        ".webm": "audio/webm",
+        ".wma": "audio/x-ms-wma",
+    }
+    if suffix in suffix_map:
+        return suffix_map[suffix]
+    mime, _ = mimetypes.guess_type(str(path))
+    if mime and mime.startswith("audio/"):
+        if mime in ("audio/x-wav", "audio/wave"):
+            return "audio/wav"
+        if mime in ("audio/mpeg", "audio/mpeg3"):
+            return "audio/mp3"
+        return mime
+    return "audio/ogg"
+
+
+def _mime_to_audio_format(mime: str, suffix: str = "") -> str:
+    """Normalize MIME or suffix to audio format identifier for input_audio."""
+    mime_clean = (mime or "").strip().lower()
+    if mime_clean in ("audio/wav", "audio/x-wav", "audio/wave"):
+        return "wav"
+    if mime_clean in ("audio/mp3", "audio/mpeg", "audio/mpeg3"):
+        return "mp3"
+    if mime_clean in ("audio/ogg", "audio/oga", "audio/opus", "application/ogg"):
+        return "ogg"
+    if mime_clean in ("audio/m4a", "audio/mp4", "audio/x-m4a"):
+        return "m4a"
+    if mime_clean in ("audio/aac", "audio/x-aac"):
+        return "aac"
+    if mime_clean in ("audio/flac", "audio/x-flac"):
+        return "flac"
+    if mime_clean in ("audio/webm",):
+        return "webm"
+    if suffix:
+        s = suffix.lower().lstrip(".")
+        if s in ("wav", "mp3", "ogg", "oga", "m4a", "aac", "flac", "webm", "opus"):
+            return "ogg" if s in ("oga", "opus") else s
+    return "ogg"
+
+
+def _file_to_audio_part(path: Path) -> Optional[Dict[str, Any]]:
+    """Encode local audio file as an input_audio multimodal part."""
+    try:
+        from agent.file_safety import raise_if_read_blocked
+
+        raise_if_read_blocked(str(path))
+    except ValueError as exc:
+        logger.warning("audio_routing: blocked local audio attachment %s -- %s", path, exc)
+        return None
+    except Exception:
+        pass
+
+    try:
+        raw = path.read_bytes()
+    except Exception as exc:
+        logger.warning("audio_routing: failed to read %s — %s", path, exc)
+        return None
+
+    if not raw:
+        logger.warning("audio_routing: audio file is empty: %s", path)
+        return None
+
+    mime = _guess_audio_mime(path, raw=raw)
+    fmt = _mime_to_audio_format(mime, path.suffix)
+    b64 = base64.b64encode(raw).decode("ascii")
+
+    return {
+        "type": "input_audio",
+        "input_audio": {
+            "data": b64,
+            "format": fmt,
+        },
+    }
+
+
+def build_native_audio_content_parts(
+    user_text: str,
+    audio_paths: List[str],
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """Build multimodal content parts for a user turn with audio attachments.
+
+    Returns ``(content_parts, skipped)``.
+    """
+    skipped: List[str] = []
+    audio_parts: List[Dict[str, Any]] = []
+    attached_paths: List[str] = []
+
+    for raw_path in audio_paths:
+        p = Path(raw_path)
+        if not p.exists() or not p.is_file():
+            skipped.append(str(raw_path))
+            continue
+        part = _file_to_audio_part(p)
+        if not part:
+            skipped.append(str(raw_path))
+            continue
+        audio_parts.append(part)
+        attached_paths.append(str(raw_path))
+
+    text = (user_text or "").strip()
+
+    if attached_paths:
+        base_text = text or "Listen to the attached audio and respond."
+        hint_lines: List[str] = []
+        hint_lines.extend(f"[Audio attached at: {p}]" for p in attached_paths)
+        combined_text = f"{base_text}\n\n" + "\n".join(hint_lines)
+        parts: List[Dict[str, Any]] = [{"type": "text", "text": combined_text}]
+        parts.extend(audio_parts)
+        return parts, skipped
+
+    parts = []
+    if text:
+        parts.append({"type": "text", "text": text})
+    return parts, skipped
+
+
+__all__ = [
+    "decide_audio_input_mode",
+    "build_native_audio_content_parts",
+    "extract_audio_refs",
+]

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -299,6 +299,63 @@ def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
                     }
                 }
             )
+        elif ptype in ("input_audio", "audio"):
+            audio_info = item.get("input_audio") or item.get("audio") or {}
+            b64_data = None
+            mime = None
+            if isinstance(audio_info, dict):
+                b64_data = audio_info.get("data")
+                fmt = audio_info.get("format") or audio_info.get("mime_type") or audio_info.get("mimeType")
+                if fmt:
+                    ext_mime = {
+                        "wav": "audio/wav",
+                        "mp3": "audio/mp3",
+                        "ogg": "audio/ogg",
+                        "oga": "audio/ogg",
+                        "m4a": "audio/m4a",
+                        "aac": "audio/aac",
+                        "flac": "audio/flac",
+                    }
+                    mime = ext_mime.get(str(fmt).lower(), f"audio/{fmt}" if "/" not in str(fmt) else str(fmt))
+            elif isinstance(item.get("data"), str):
+                b64_data = item.get("data")
+                fmt = item.get("format") or item.get("mime_type") or item.get("mimeType")
+                if fmt:
+                    mime = f"audio/{fmt}" if "/" not in str(fmt) else str(fmt)
+            if b64_data:
+                if not mime:
+                    mime = "audio/wav"
+                if mime == "audio/oga":
+                    mime = "audio/ogg"
+                parts.append(
+                    {
+                        "inlineData": {
+                            "mimeType": mime,
+                            "data": b64_data,
+                        }
+                    }
+                )
+        elif ptype == "audio_url":
+            url = ((item.get("audio_url") or {}).get("url") or "")
+            if isinstance(url, str) and url.startswith("data:"):
+                try:
+                    header, encoded = url.split(",", 1)
+                    mime = header.split(":", 1)[1].split(";", 1)[0]
+                    if mime == "audio/oga":
+                        mime = "audio/ogg"
+                    raw = base64.b64decode(encoded)
+                    parts.append(
+                        {
+                            "inlineData": {
+                                "mimeType": mime,
+                                "data": base64.b64encode(raw).decode("ascii"),
+                            }
+                        }
+                    )
+                except Exception:
+                    continue
+        elif "inlineData" in item:
+            parts.append(item)
     return parts
 
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1220,6 +1220,7 @@ class GatewayConfig:
                 else None
             )
 
+        raw_gateway = data.get("gateway")
         audio_input_mode = data.get("audio_input_mode")
         if audio_input_mode is None:
             raw_agent = data.get("agent")
@@ -1234,7 +1235,6 @@ class GatewayConfig:
         group_sessions_per_user = data.get("group_sessions_per_user")
         thread_sessions_per_user = data.get("thread_sessions_per_user")
         multiplex_profiles = data.get("multiplex_profiles")
-        raw_gateway = data.get("gateway")
         nested_gateway = raw_gateway if isinstance(raw_gateway, dict) else {}
         if "multiplex_profile_allowlist" in data:
             multiplex_profile_allowlist = data.get("multiplex_profile_allowlist")
@@ -1480,6 +1480,11 @@ def load_gateway_config() -> GatewayConfig:
                 gw_data["stt_echo_transcripts"] = yaml_cfg["stt_echo_transcripts"]
             elif isinstance(gateway_section, dict) and "stt_echo_transcripts" in gateway_section:
                 gw_data["stt_echo_transcripts"] = gateway_section["stt_echo_transcripts"]
+
+            if "audio_input_mode" in yaml_cfg:
+                gw_data["audio_input_mode"] = yaml_cfg["audio_input_mode"]
+            elif isinstance(gateway_section, dict) and "audio_input_mode" in gateway_section:
+                gw_data["audio_input_mode"] = gateway_section["audio_input_mode"]
 
             gateway_cfg = yaml_cfg.get("gateway")
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -967,6 +967,7 @@ class GatewayConfig:
     # STT settings
     stt_enabled: bool = True  # Whether to auto-transcribe inbound voice messages
     stt_echo_transcripts: bool = True  # Whether to echo raw STT transcripts back to the user
+    audio_input_mode: str = "auto"  # How inbound audio is routed: auto | native | stt
 
     # Session isolation in shared chats
     group_sessions_per_user: bool = True  # Isolate group/channel sessions per participant when user IDs are available
@@ -1149,6 +1150,7 @@ class GatewayConfig:
             "filter_silence_narration": self.filter_silence_narration,
             "stt_enabled": self.stt_enabled,
             "stt_echo_transcripts": self.stt_echo_transcripts,
+            "audio_input_mode": self.audio_input_mode,
             "group_sessions_per_user": self.group_sessions_per_user,
             "thread_sessions_per_user": self.thread_sessions_per_user,
             "max_concurrent_sessions": self.max_concurrent_sessions,
@@ -1217,6 +1219,17 @@ class GatewayConfig:
                 if isinstance(data.get("stt"), dict)
                 else None
             )
+
+        audio_input_mode = data.get("audio_input_mode")
+        if audio_input_mode is None:
+            raw_agent = data.get("agent")
+            if isinstance(raw_agent, dict):
+                audio_input_mode = raw_agent.get("audio_input_mode")
+        if audio_input_mode is None and isinstance(raw_gateway, dict):
+            audio_input_mode = raw_gateway.get("audio_input_mode")
+        if not isinstance(audio_input_mode, str) or not audio_input_mode.strip():
+            audio_input_mode = "auto"
+        audio_input_mode = audio_input_mode.strip().lower()
 
         group_sessions_per_user = data.get("group_sessions_per_user")
         thread_sessions_per_user = data.get("thread_sessions_per_user")
@@ -1334,6 +1347,7 @@ class GatewayConfig:
             ),
             stt_enabled=_coerce_bool(stt_enabled, True),
             stt_echo_transcripts=_coerce_bool(stt_echo_transcripts, True),
+            audio_input_mode=audio_input_mode,
             group_sessions_per_user=_coerce_bool(group_sessions_per_user, True),
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             multiplex_profiles=_coerce_bool(multiplex_profiles, False),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7061,12 +7061,51 @@ class TurnRunner:
         _approval_session_token = set_current_session_key(_approval_session_key)
         register_gateway_notify(_approval_session_key, _approval_notify_sync)
         try:
-            # If _prepare_inbound_message_text buffered image paths for native
+            # If _prepare_inbound_message_text buffered image/audio paths for native
             # attachment, wrap the user turn as an OpenAI-style multimodal
             # content list. Consume-and-clear so subsequent turns on the same
-            # runner instance don't re-attach stale images.
+            # runner instance don't re-attach stale media.
             _native_imgs = self._runner._consume_pending_native_image_paths(ctx.session_key)
-            if _native_imgs:
+            _native_audios = self._runner._consume_pending_native_audio_paths(ctx.session_key)
+            if _native_imgs and _native_audios:
+                try:
+                    from agent.image_routing import build_native_content_parts
+                    from agent.audio_routing import build_native_audio_content_parts
+                    _img_parts, _img_skipped = build_native_content_parts(
+                        ctx.message,
+                        _native_imgs,
+                    )
+                    _aud_parts, _aud_skipped = build_native_audio_content_parts(
+                        "",
+                        _native_audios,
+                    )
+                    _combined_parts: List[Dict[str, Any]] = []
+                    _text_pieces: List[str] = []
+                    for p in _img_parts:
+                        if p.get("type") == "text" and p.get("text"):
+                            _text_pieces.append(p["text"])
+                    for p in _aud_parts:
+                        if p.get("type") == "text" and p.get("text"):
+                            _text_pieces.append(p["text"])
+                    if _text_pieces:
+                        _combined_parts.append({"type": "text", "text": "\n\n".join(_text_pieces)})
+                    for p in _img_parts:
+                        if p.get("type") != "text":
+                            _combined_parts.append(p)
+                    for p in _aud_parts:
+                        if p.get("type") != "text":
+                            _combined_parts.append(p)
+                    if any(p.get("type") in ("image_url", "input_audio") for p in _combined_parts):
+                        _run_message: Any = _combined_parts
+                    else:
+                        _run_message = ctx.message
+                except Exception as _combo_exc:
+                    logger.warning(
+                        "Native multimodal attachment failed, falling back to text: %s",
+                        _combo_exc,
+                    )
+                    _run_message = ctx.message
+            elif _native_imgs:
                 try:
                     from agent.image_routing import build_native_content_parts
                     _parts, _skipped = build_native_content_parts(
@@ -7087,6 +7126,29 @@ class TurnRunner:
                     logger.warning(
                         "Native image attachment failed, falling back to text: %s",
                         _img_exc,
+                    )
+                    _run_message = ctx.message
+            elif _native_audios:
+                try:
+                    from agent.audio_routing import build_native_audio_content_parts
+                    _parts, _skipped = build_native_audio_content_parts(
+                        ctx.message,
+                        _native_audios,
+                    )
+                    if _skipped:
+                        logger.warning(
+                            "Native audio attachment: skipped %d unreadable path(s): %s",
+                            len(_skipped), _skipped,
+                        )
+                    if any(p.get("type") == "input_audio" for p in _parts):
+                        _run_message = _parts
+                    else:
+                        # All audio failed to read — fall back to plain text.
+                        _run_message = ctx.message
+                except Exception as _aud_exc:
+                    logger.warning(
+                        "Native audio attachment failed, falling back to text: %s",
+                        _aud_exc,
                     )
                     _run_message = ctx.message
             else:
@@ -7509,6 +7571,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     _pending_messages = legacy_dict_property("_pending_messages")
     _pending_native_image_paths_by_session = legacy_dict_property(
         "_pending_native_image_paths_by_session"
+    )
+    _pending_native_audio_paths_by_session = legacy_dict_property(
+        "_pending_native_audio_paths_by_session"
     )
     _session_ephemeral_pin = legacy_dict_property("_session_ephemeral_pin")
     _session_vc_last = legacy_dict_property("_session_vc_last")
@@ -20538,6 +20603,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Reset only this session's per-call buffer; other sessions may be
         # concurrently preparing multimodal turns on the same runner.
         self._consume_pending_native_image_paths(session_key)
+        self._consume_pending_native_audio_paths(session_key)
 
         _is_shared_multi_user = is_shared_multi_user_session(
             source,
@@ -20652,29 +20718,43 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         )
 
             if audio_paths:
-                message_text, _successful_transcripts = await self._enrich_message_with_transcription(
-                    message_text,
-                    audio_paths,
+                _audio_mode = await asyncio.to_thread(
+                    self._decide_audio_input_mode,
+                    source=source,
+                    session_key=session_key,
                 )
-                # Echo each successful transcript back to the user immediately
-                # when configured. Lets users verify STT quality in real-time,
-                # while allowing quiet STT for users who only want the agent to
-                # receive the transcription.
-                if _successful_transcripts and self._should_echo_stt_transcripts():
-                    _echo_adapter = self._adapter_for_source(source)
-                    _echo_meta = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
-                    if _echo_adapter:
-                        for _tx in _successful_transcripts:
-                            try:
-                                await _echo_adapter.send(
-                                    source.chat_id,
-                                    f'🎙️ "{_tx}"',
-                                    metadata=_echo_meta,
-                                )
-                            except Exception as _echo_exc:
-                                logger.debug(
-                                    "Transcript echo failed (non-fatal): %s", _echo_exc,
-                                )
+                if _audio_mode == "native":
+                    self._session_state(
+                        session_key
+                    ).persistent.native_audio_paths = list(audio_paths)
+                    logger.info(
+                        "Audio routing: native (model supports audio). %d audio file(s) will be attached inline.",
+                        len(audio_paths),
+                    )
+                else:
+                    message_text, _successful_transcripts = await self._enrich_message_with_transcription(
+                        message_text,
+                        audio_paths,
+                    )
+                    # Echo each successful transcript back to the user immediately
+                    # when configured. Lets users verify STT quality in real-time,
+                    # while allowing quiet STT for users who only want the agent to
+                    # receive the transcription.
+                    if _successful_transcripts and self._should_echo_stt_transcripts():
+                        _echo_adapter = self._adapter_for_source(source)
+                        _echo_meta = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
+                        if _echo_adapter:
+                            for _tx in _successful_transcripts:
+                                try:
+                                    await _echo_adapter.send(
+                                        source.chat_id,
+                                        f'🎙️ "{_tx}"',
+                                        metadata=_echo_meta,
+                                    )
+                                except Exception as _echo_exc:
+                                    logger.debug(
+                                        "Transcript echo failed (non-fatal): %s", _echo_exc,
+                                    )
                 # NOTE: Previously, when transcription failed (e.g. no STT
                 # provider configured), the gateway also emitted a hardcoded
                 # English notice via `_stt_adapter.send()`. That bypassed the
@@ -20969,6 +21049,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return []
         paths = list(state.persistent.native_image_paths)
         state.persistent.native_image_paths = []
+        return paths
+
+    def _consume_pending_native_audio_paths(self, session_key: str) -> List[str]:
+        state = self._peek_session_state(session_key)
+        if state is None or not state.persistent.native_audio_paths:
+            return []
+        paths = list(state.persistent.native_audio_paths)
+        state.persistent.native_audio_paths = []
         return paths
 
     def _cache_session_source(self, session_key: str, source) -> None:
@@ -27673,6 +27761,72 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 break
             worker.join(remaining)
         return sum(1 for worker in workers if worker.is_alive())
+
+    def _decide_audio_input_mode(
+        self,
+        *,
+        source: Optional[SessionSource] = None,
+        session_key: Optional[str] = None,
+        user_config: Optional[dict] = None,
+        provider: Optional[str] = None,
+        model: Optional[str] = None,
+    ) -> str:
+        """Resolve audio-input routing for the effective model this turn.
+
+        Returns ``"native"`` (attach raw audio parts on the user turn) or ``"stt"``
+        (pre-transcribe via STT pipeline). See agent/audio_routing.py for the full decision table.
+        """
+        try:
+            from agent.audio_routing import decide_audio_input_mode
+            from agent.auxiliary_client import _read_main_model, _read_main_provider
+            from hermes_cli.config import load_config
+
+            cfg = user_config if isinstance(user_config, dict) else load_config()
+            resolved_provider = (provider or "").strip()
+            resolved_model = (model or "").strip()
+            resolved_requested_provider = ""
+
+            needs_session_runtime = not resolved_provider or not resolved_model
+            has_session_identity = source is not None or session_key
+            if needs_session_runtime and has_session_identity:
+                try:
+                    turn_model, runtime_kwargs = self._resolve_session_agent_runtime(
+                        source=source,
+                        session_key=session_key,
+                        user_config=cfg,
+                    )
+                    if not resolved_model and isinstance(turn_model, str):
+                        resolved_model = turn_model.strip()
+                    runtime_provider = runtime_kwargs.get("provider") if isinstance(runtime_kwargs, dict) else None
+                    runtime_requested_provider = (
+                        runtime_kwargs.get("requested_provider")
+                        if isinstance(runtime_kwargs, dict)
+                        else None
+                    )
+                    if not resolved_provider and isinstance(runtime_provider, str):
+                        resolved_provider = runtime_provider.strip()
+                    if isinstance(runtime_requested_provider, str):
+                        resolved_requested_provider = runtime_requested_provider.strip()
+                except Exception as exc:
+                    logger.debug(
+                        "audio_routing: session runtime resolution failed, falling back to config — %s",
+                        exc,
+                    )
+
+            if not resolved_provider:
+                resolved_provider = _read_main_provider()
+            if not resolved_model:
+                resolved_model = _read_main_model()
+
+            return decide_audio_input_mode(
+                resolved_provider,
+                resolved_model,
+                cfg,
+                requested_provider=resolved_requested_provider,
+            )
+        except Exception as exc:
+            logger.debug("audio_routing: decision failed, falling back to stt — %s", exc)
+            return "stt"
 
     def _decide_image_input_mode(
         self,

--- a/gateway/session_state.py
+++ b/gateway/session_state.py
@@ -140,6 +140,8 @@ class PersistentState:
     update_prompt_pending: bool = False
     # Image paths staged for native (inline) attachment; consumed one-shot.
     native_image_paths: List[str] = field(default_factory=list)
+    # Audio paths staged for native (inline) attachment; consumed one-shot.
+    native_audio_paths: List[str] = field(default_factory=list)
     # Legacy runner-level pending message text (write-mostly; flushed to
     # disk on shutdown — see #72680).  NOTE: distinct from the adapter-level
     # ``_pending_messages`` (Dict[str, MessageEvent]) in gateway/base.py,
@@ -405,6 +407,9 @@ LEGACY_FIELD_SPECS: Dict[str, _FieldSpec] = {
     ),
     "_pending_native_image_paths_by_session": _FieldSpec(
         "persistent", "native_image_paths", list, _present_nonzero
+    ),
+    "_pending_native_audio_paths_by_session": _FieldSpec(
+        "persistent", "native_audio_paths", list, _present_nonzero
     ),
     "_pending_messages": _FieldSpec(
         "persistent", "pending_command_text", lambda: None, _present_not_none

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -372,6 +372,12 @@ DEFAULT_CONFIG = {
         # remains available as a tool regardless of this setting — the routing
         # only controls how inbound user images are presented.
         "image_input_mode": "auto",
+        # How user-attached voice notes and audio files are presented to the main model.
+        #   "auto"   — attach natively when the active model/provider supports audio
+        #              input (e.g. Gemini, GPT-4o Audio). Otherwise fall back to STT.
+        #   "native" — always attach natively as multimodal input_audio / inlineData parts.
+        #   "stt"    — always pre-transcribe via STT; model only sees transcription text.
+        "audio_input_mode": "auto",
         "disabled_toolsets": [],
 
         # Per-model reasoning effort overrides (spelling-tolerant).

--- a/tests/agent/test_audio_routing.py
+++ b/tests/agent/test_audio_routing.py
@@ -1,0 +1,279 @@
+"""Tests for agent/audio_routing.py — the per-turn audio input mode decision and parts builder."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from agent.audio_routing import (
+    _coerce_capability_bool,
+    _coerce_mode,
+    _guess_audio_mime,
+    _is_known_audio_model_or_provider,
+    _lookup_supports_audio,
+    _mime_to_audio_format,
+    _sniff_audio_mime_from_bytes,
+    _supports_audio_override,
+    build_native_audio_content_parts,
+    decide_audio_input_mode,
+    extract_audio_refs,
+)
+from agent.gemini_native_adapter import _extract_multimodal_parts
+
+
+class TestCoerceMode:
+    def test_case_insensitive(self):
+        assert _coerce_mode("NATIVE") == "native"
+        assert _coerce_mode("Auto") == "auto"
+        assert _coerce_mode("STT") == "stt"
+
+    def test_text_alias_maps_to_stt(self):
+        assert _coerce_mode("text") == "stt"
+
+    def test_invalid_falls_back_to_auto(self):
+        assert _coerce_mode("nonsense") == "auto"
+        assert _coerce_mode("") == "auto"
+        assert _coerce_mode(None) == "auto"
+        assert _coerce_mode(42) == "auto"
+
+
+class TestCoerceCapabilityBool:
+    def test_bool_literals(self):
+        assert _coerce_capability_bool(True) is True
+        assert _coerce_capability_bool(False) is False
+
+    def test_integer_flags(self):
+        assert _coerce_capability_bool(1) is True
+        assert _coerce_capability_bool(0) is False
+        assert _coerce_capability_bool(2) is None
+
+    def test_string_tokens(self):
+        for token in ("true", "TRUE", "yes", "on", "1"):
+            assert _coerce_capability_bool(token) is True
+        for token in ("false", "FALSE", "no", "off", "0"):
+            assert _coerce_capability_bool(token) is False
+
+    def test_invalid_tokens(self):
+        assert _coerce_capability_bool("maybe") is None
+        assert _coerce_capability_bool("") is None
+        assert _coerce_capability_bool({}) is None
+
+
+class TestDecideAudioInputMode:
+    def test_mode_native_override(self):
+        cfg = {"agent": {"audio_input_mode": "native"}}
+        assert decide_audio_input_mode("any-provider", "any-model", cfg) == "native"
+
+    def test_mode_stt_override(self):
+        cfg = {"agent": {"audio_input_mode": "stt"}}
+        assert decide_audio_input_mode("gemini", "gemini-2.5-flash", cfg) == "stt"
+
+    def test_mode_text_alias_override(self):
+        cfg = {"agent": {"audio_input_mode": "text"}}
+        assert decide_audio_input_mode("gemini", "gemini-2.5-flash", cfg) == "stt"
+
+    def test_auto_with_gemini_provider(self):
+        assert decide_audio_input_mode("gemini", "gemini-2.0-flash", {}) == "native"
+        assert decide_audio_input_mode("google", "gemini-pro", {}) == "native"
+
+    def test_auto_with_gemini_model_slug(self):
+        assert decide_audio_input_mode("openrouter", "google/gemini-2.5-flash", {}) == "native"
+        assert decide_audio_input_mode("custom", "gemini-1.5-pro", {}) == "native"
+
+    def test_auto_with_gpt4o_audio_model(self):
+        assert decide_audio_input_mode("openai", "gpt-4o-audio-preview", {}) == "native"
+        assert decide_audio_input_mode("openai", "gpt-4o-mini-audio-preview", {}) == "native"
+
+    def test_auto_with_text_only_model(self):
+        assert decide_audio_input_mode("anthropic", "claude-sonnet-4", {}) == "stt"
+        assert decide_audio_input_mode("openai", "gpt-4o", {}) == "stt"
+
+    def test_auto_with_models_dev_capability(self):
+        mock_cap = MagicMock()
+        mock_cap.supports_audio_input.return_value = True
+        with patch("agent.models_dev.get_model_capabilities", return_value=mock_cap):
+            assert decide_audio_input_mode("custom_provider", "some-multimodal-model", {}) == "native"
+
+    def test_config_model_supports_audio_override(self):
+        cfg = {"model": {"supports_audio": True}}
+        assert decide_audio_input_mode("custom", "any-text-model", cfg) == "native"
+
+        cfg_false = {"model": {"supports_audio": False}}
+        assert decide_audio_input_mode("gemini", "gemini-2.5-flash", cfg_false) == "stt"
+
+    def test_config_providers_model_override(self):
+        cfg = {
+            "providers": {
+                "my-vllm": {
+                    "models": {
+                        "whisper-llm": {"supports_audio": True}
+                    }
+                }
+            }
+        }
+        assert decide_audio_input_mode("my-vllm", "whisper-llm", cfg) == "native"
+
+
+class TestSniffAndGuessMime:
+    def test_sniff_audio_wav(self):
+        wav_header = b"RIFF\x24\x00\x00\x00WAVEfmt "
+        assert _sniff_audio_mime_from_bytes(wav_header) == "audio/wav"
+
+    def test_sniff_audio_ogg(self):
+        ogg_header = b"OggS\x00\x02\x00\x00\x00\x00\x00\x00"
+        assert _sniff_audio_mime_from_bytes(ogg_header) == "audio/ogg"
+
+    def test_sniff_audio_mp3_id3(self):
+        mp3_header = b"ID3\x04\x00\x00\x00\x00\x00"
+        assert _sniff_audio_mime_from_bytes(mp3_header) == "audio/mp3"
+
+    def test_sniff_audio_flac(self):
+        flac_header = b"fLaC\x00\x00\x00\x22"
+        assert _sniff_audio_mime_from_bytes(flac_header) == "audio/flac"
+
+    def test_guess_audio_mime_by_extension(self):
+        assert _guess_audio_mime(Path("voice.oga")) == "audio/ogg"
+        assert _guess_audio_mime(Path("note.ogg")) == "audio/ogg"
+        assert _guess_audio_mime(Path("clip.mp3")) in ("audio/mp3", "audio/mpeg")
+        assert _mime_to_audio_format(_guess_audio_mime(Path("clip.mp3"))) == "mp3"
+        assert _guess_audio_mime(Path("recording.wav")) == "audio/wav"
+        assert _guess_audio_mime(Path("voice.m4a")) == "audio/m4a"
+
+
+class TestMimeToAudioFormat:
+    def test_mime_formats(self):
+        assert _mime_to_audio_format("audio/wav") == "wav"
+        assert _mime_to_audio_format("audio/mp3") == "mp3"
+        assert _mime_to_audio_format("audio/ogg") == "ogg"
+        assert _mime_to_audio_format("audio/oga") == "ogg"
+        assert _mime_to_audio_format("audio/m4a") == "m4a"
+
+
+class TestBuildNativeAudioContentParts:
+    def test_build_parts_from_valid_audio(self, tmp_path):
+        audio_file = tmp_path / "test.wav"
+        raw_content = b"RIFF\x24\x00\x00\x00WAVEfmt \x10\x00\x00\x00\x01\x00\x01\x00"
+        audio_file.write_bytes(raw_content)
+
+        parts, skipped = build_native_audio_content_parts(
+            "Hello, listen to this:",
+            [str(audio_file)],
+        )
+
+        assert skipped == []
+        assert len(parts) == 2
+        assert parts[0]["type"] == "text"
+        assert "Hello, listen to this:" in parts[0]["text"]
+        assert f"[Audio attached at: {audio_file}]" in parts[0]["text"]
+
+        assert parts[1]["type"] == "input_audio"
+        assert parts[1]["input_audio"]["format"] == "wav"
+        assert parts[1]["input_audio"]["data"] == base64.b64encode(raw_content).decode("ascii")
+
+    def test_build_parts_empty_text_default_prompt(self, tmp_path):
+        audio_file = tmp_path / "voice.oga"
+        raw_content = b"OggS\x00\x02\x00\x00\x00\x00\x00\x00fakeopuspayload"
+        audio_file.write_bytes(raw_content)
+
+        parts, skipped = build_native_audio_content_parts(
+            "",
+            [str(audio_file)],
+        )
+
+        assert skipped == []
+        assert len(parts) == 2
+        assert "Listen to the attached audio" in parts[0]["text"]
+        assert f"[Audio attached at: {audio_file}]" in parts[0]["text"]
+        assert parts[1]["type"] == "input_audio"
+        assert parts[1]["input_audio"]["format"] == "ogg"
+
+    def test_build_parts_missing_file_skipped(self, tmp_path):
+        missing = tmp_path / "non_existent.mp3"
+        parts, skipped = build_native_audio_content_parts(
+            "Check audio",
+            [str(missing)],
+        )
+        assert skipped == [str(missing)]
+        assert parts == [{"type": "text", "text": "Check audio"}]
+
+
+class TestGeminiNativeAdapterAudioParts:
+    def test_extract_input_audio_part_to_gemini_inlinedata(self):
+        b64_data = base64.b64encode(b"fake-audio-bytes").decode("ascii")
+        content = [
+            {"type": "text", "text": "Listen to this voice clip"},
+            {
+                "type": "input_audio",
+                "input_audio": {
+                    "data": b64_data,
+                    "format": "ogg",
+                },
+            },
+        ]
+
+        parts = _extract_multimodal_parts(content)
+        assert len(parts) == 2
+        assert parts[0] == {"text": "Listen to this voice clip"}
+        assert parts[1] == {
+            "inlineData": {
+                "mimeType": "audio/ogg",
+                "data": b64_data,
+            }
+        }
+
+    def test_extract_input_audio_wav_to_gemini(self):
+        b64_data = base64.b64encode(b"RIFFwavefake").decode("ascii")
+        content = [
+            {
+                "type": "input_audio",
+                "input_audio": {
+                    "data": b64_data,
+                    "format": "wav",
+                },
+            }
+        ]
+
+        parts = _extract_multimodal_parts(content)
+        assert len(parts) == 1
+        assert parts[0]["inlineData"]["mimeType"] == "audio/wav"
+        assert parts[0]["inlineData"]["data"] == b64_data
+
+    def test_extract_audio_url_data_uri_to_gemini(self):
+        b64_data = base64.b64encode(b"fake-mp3").decode("ascii")
+        content = [
+            {
+                "type": "audio_url",
+                "audio_url": {
+                    "url": f"data:audio/mp3;base64,{b64_data}",
+                },
+            }
+        ]
+
+        parts = _extract_multimodal_parts(content)
+        assert len(parts) == 1
+        assert parts[0]["inlineData"]["mimeType"] == "audio/mp3"
+        assert parts[0]["inlineData"]["data"] == b64_data
+
+
+class TestExtractAudioRefs:
+    def test_extract_audio_paths(self, tmp_path):
+        f1 = tmp_path / "voice.oga"
+        f1.write_bytes(b"123")
+        f2 = tmp_path / "song.mp3"
+        f2.write_bytes(b"456")
+
+        text = f"Check {f1} and {f2} and https://example.com/audio.wav"
+        local_paths, urls = extract_audio_refs(text)
+
+        assert str(f1) in local_paths
+        assert str(f2) in local_paths
+        assert "https://example.com/audio.wav" in urls
+
+    def test_ignore_code_blocks(self, tmp_path):
+        f = tmp_path / "hidden.wav"
+        f.write_bytes(b"test")
+        text = f"Here is code:\n```\n{f}\n```\nand inline `{f}`"
+        local_paths, urls = extract_audio_refs(text)
+        assert local_paths == []
+        assert urls == []

--- a/tests/gateway/test_audio_input_routing_runtime.py
+++ b/tests/gateway/test_audio_input_routing_runtime.py
@@ -1,0 +1,182 @@
+"""Tests for gateway runtime audio input routing and session buffer handling."""
+
+import pytest
+from unittest.mock import AsyncMock
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_key
+
+
+def _make_runner() -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")}
+    )
+    runner.adapters = {}
+    runner._pending_native_image_paths_by_session = {}
+    runner._pending_native_audio_paths_by_session = {}
+    runner._session_model_overrides = {}
+    runner._session_reasoning_overrides = {}
+    return runner
+
+
+def _source(chat_id: str = "273403055") -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=chat_id,
+        chat_type="private",
+        user_id="42",
+        user_name=f"user-{chat_id}",
+    )
+
+
+def _voice_event(source: SessionSource, path: str = "/tmp/voice.oga") -> MessageEvent:
+    return MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=source,
+        media_urls=[path],
+        media_types=["audio/ogg"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_native_audio_routing_buffers_paths_when_model_supports_audio(monkeypatch):
+    runner = _make_runner()
+    source = _source()
+    event = _voice_event(source, "/tmp/voice_note.oga")
+
+    runner._decide_audio_input_mode = lambda **_: "native"
+
+    # Mock enrich with transcription to verify it is NOT called
+    mock_stt = AsyncMock(return_value=("enriched", []))
+    runner._enrich_message_with_transcription = mock_stt
+
+    text = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    # In native mode, STT is bypassed
+    assert mock_stt.await_count == 0
+    # Pending audio paths are buffered for the session
+    session_key = build_session_key(source)
+    buffered = runner._consume_pending_native_audio_paths(session_key)
+    assert buffered == ["/tmp/voice_note.oga"]
+
+
+@pytest.mark.asyncio
+async def test_stt_audio_routing_calls_transcription_when_model_is_text_only(monkeypatch):
+    runner = _make_runner()
+    source = _source()
+    event = _voice_event(source, "/tmp/voice_note.oga")
+
+    runner._decide_audio_input_mode = lambda **_: "stt"
+
+    mock_stt = AsyncMock(return_value=("[User spoke: Hello world]", ["Hello world"]))
+    runner._enrich_message_with_transcription = mock_stt
+    runner._should_echo_stt_transcripts = lambda: False
+
+    text = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert mock_stt.await_count == 1
+    assert "[User spoke: Hello world]" in text
+    session_key = build_session_key(source)
+    buffered = runner._consume_pending_native_audio_paths(session_key)
+    assert buffered == []
+
+
+@pytest.mark.asyncio
+async def test_native_audio_buffer_isolated_per_session():
+    runner = _make_runner()
+    runner._decide_audio_input_mode = lambda **_: "native"
+
+    source_a = _source("chat-a")
+    source_b = _source("chat-b")
+
+    await runner._prepare_inbound_message_text(
+        event=_voice_event(source_a, "/tmp/voice_a.oga"),
+        source=source_a,
+        history=[],
+    )
+    await runner._prepare_inbound_message_text(
+        event=_voice_event(source_b, "/tmp/voice_b.oga"),
+        source=source_b,
+        history=[],
+    )
+
+    session_key_a = build_session_key(source_a)
+    session_key_b = build_session_key(source_b)
+
+    assert runner._consume_pending_native_audio_paths(session_key_a) == ["/tmp/voice_a.oga"]
+    assert runner._consume_pending_native_audio_paths(session_key_b) == ["/tmp/voice_b.oga"]
+    # Consumed once, second consume is empty
+    assert runner._consume_pending_native_audio_paths(session_key_a) == []
+    assert runner._consume_pending_native_audio_paths(session_key_b) == []
+
+
+def test_decide_audio_input_mode_integration(monkeypatch):
+    runner = _make_runner()
+    cfg = {
+        "agent": {"audio_input_mode": "auto"},
+        "model": {"provider": "gemini", "default": "gemini-2.0-flash"},
+    }
+
+    monkeypatch.setattr(
+        runner,
+        "_resolve_session_agent_runtime",
+        lambda **_: ("gemini-2.0-flash", {"provider": "gemini"}),
+    )
+
+    assert runner._decide_audio_input_mode(
+        source=_source(),
+        user_config=cfg,
+    ) == "native"
+
+
+def test_multimodal_parts_turn_building_with_image_and_audio(tmp_path):
+    img_file = tmp_path / "test.png"
+    img_file.write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15c4")
+    aud_file = tmp_path / "voice.oga"
+    aud_file.write_bytes(b"OggS\x00\x02\x00\x00\x00\x00\x00\x00fakeopus")
+
+    from agent.image_routing import build_native_content_parts
+    from agent.audio_routing import build_native_audio_content_parts
+
+    img_parts, img_skipped = build_native_content_parts(
+        "Look and listen",
+        [str(img_file)],
+    )
+    aud_parts, aud_skipped = build_native_audio_content_parts(
+        "",
+        [str(aud_file)],
+    )
+
+    combined_parts = []
+    text_pieces = []
+    for p in img_parts:
+        if p.get("type") == "text" and p.get("text"):
+            text_pieces.append(p["text"])
+    for p in aud_parts:
+        if p.get("type") == "text" and p.get("text"):
+            text_pieces.append(p["text"])
+    if text_pieces:
+        combined_parts.append({"type": "text", "text": "\n\n".join(text_pieces)})
+    for p in img_parts:
+        if p.get("type") != "text":
+            combined_parts.append(p)
+    for p in aud_parts:
+        if p.get("type") != "text":
+            combined_parts.append(p)
+
+    assert any(p.get("type") == "image_url" for p in combined_parts)
+    assert any(p.get("type") == "input_audio" for p in combined_parts)
+    assert any(p.get("type") == "text" and "[Image attached at:" in p.get("text", "") and "[Audio attached at:" in p.get("text", "") for p in combined_parts)
+

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -240,6 +240,24 @@ class TestGatewayConfigRoundtrip:
             for record in caplog.records
         )
 
+    def test_from_dict_empty_uses_audio_input_default(self):
+        config = GatewayConfig.from_dict({})
+
+        assert config.audio_input_mode == "auto"
+
+    def test_from_dict_audio_input_mode_prefers_top_level_then_nested_sections(self):
+        assert GatewayConfig.from_dict({"agent": {"audio_input_mode": "stt"}}).audio_input_mode == "stt"
+        assert GatewayConfig.from_dict({"gateway": {"audio_input_mode": "native"}}).audio_input_mode == "native"
+        assert (
+            GatewayConfig.from_dict(
+                {
+                    "audio_input_mode": "native",
+                    "agent": {"audio_input_mode": "stt"},
+                    "gateway": {"audio_input_mode": "stt"},
+                }
+            ).audio_input_mode
+            == "native"
+        )
 
     def test_roundtrip_preserves_unauthorized_dm_behavior(self):
         config = GatewayConfig(
@@ -315,6 +333,31 @@ class TestLoadGatewayConfig:
 
         assert config.default_reset_policy.mode == "none"
 
+    def test_audio_input_mode_from_top_level_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "audio_input_mode: native\n", encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.audio_input_mode == "native"
+
+    def test_audio_input_mode_from_nested_gateway_config_yaml(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "gateway:\n  audio_input_mode: stt\n", encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.audio_input_mode == "stt"
 
     def test_explicit_session_reset_opt_in_is_honored(self, tmp_path, monkeypatch):
         """Users who explicitly opt in to auto-reset keep their policy."""


### PR DESCRIPTION
## Summary

Implements a native audio input fast-path for multimodal models (specifically Gemini family and GPT-4o audio models) to route inbound voice notes and audio attachments directly as multimodal message parts (`input_audio` / `inlineData`) without forcing an intermediate STT transcription step.

### Key Changes

1. **Audio Capability Detection & Routing (`agent/audio_routing.py`):**
   - Added `decide_audio_input_mode` supporting `auto | native | stt` (default `auto`).
   - Resolves capabilities from `model.supports_audio` (and custom providers config), `models.dev` metadata (`supports_audio_input`), and built-in heuristics (Gemini 1.5/2.0/2.5/3.x, GPT-4o audio preview/realtime).
   - Added `build_native_audio_content_parts` to package audio into multimodal turns with provenance hints (`[Audio attached at: ...]`).
   - Magic byte sniffing and MIME detection for `.oga`, `.ogg`, `.mp3`, `.wav`, `.m4a`, `.aac`, `.flac`, `.webm`.

2. **Session State & Gateway Pipeline (`gateway/session_state.py`, `gateway/run.py`):**
   - Added `native_audio_paths` to `PersistentState` and `LEGACY_FIELD_SPECS`.
   - Updated `_prepare_inbound_message_text` to detect audio capability: when `native`, audio paths are buffered in `native_audio_paths` and the STT pipeline is bypassed.
   - Updated turn construction at `run_conversation` call site to combine native image and audio parts.
   - Added `_decide_audio_input_mode` and `_consume_pending_native_audio_paths` to `GatewayRunner`.

3. **Gemini Native Adapter (`agent/gemini_native_adapter.py`):**
   - Extended `_extract_multimodal_parts` to translate `input_audio`, `audio`, and `audio_url` parts into Gemini's `inlineData` parts (`mimeType` and `data`).

4. **Configuration Defaults & Schemas (`gateway/config.py`, `hermes_cli/config_defaults.py`):**
   - Added `audio_input_mode: str = \"auto\"` across GatewayConfig and config defaults.

5. **Tests:**
   - Added `tests/agent/test_audio_routing.py` (31 tests covering decision modes, MIME sniffing, parts builder, Gemini translation, and ref extraction).
   - Added `tests/gateway/test_audio_input_routing_runtime.py` (unit and integration tests for gateway routing, buffer isolation, and multimodal turn construction).

Closes #102947