### PR TITLE
feat(whatsapp): add bounded passive observations

### DIFF
--- a/gateway/config_loader.py
+++ b/gateway/config_loader.py
@@ -186,6 +186,7 @@ def _str_keyed(value: Any) -> Any:
 
 
 _TELEGRAM = frozenset({Platform.TELEGRAM})
+_TELEGRAM_WHATSAPP = frozenset({Platform.TELEGRAM, Platform.WHATSAPP})
 _DISCORD_SLACK = frozenset({Platform.DISCORD, Platform.SLACK})
 
 def _plain(*keys: str) -> tuple:
@@ -203,7 +204,7 @@ _SHARED_KEYS: tuple = (
     ("group_allowed_chats", _TELEGRAM, None),
     ("allowed_topics", _TELEGRAM, None),
     *_plain("free_response_channels", "mention_patterns", "exclusive_bot_mentions"),
-    ("observe_unmentioned_group_messages", _TELEGRAM, None),
+    ("observe_unmentioned_group_messages", _TELEGRAM_WHATSAPP, None),
     *_plain(
         "dm_policy", "allow_from", "allow_admin_from", "user_allowed_commands",
         "group_policy", "group_allow_from", "group_allow_admin_from", "group_user_allowed_commands",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1166,8 +1166,11 @@ def _build_gateway_agent_history(
         content = msg.get("content")
         if inject_timestamps and role == "user" and isinstance(content, str):
             content = _render_msg_ts(content, msg.get("timestamp"), tz=_msg_tz)
-        if separate_observed_context and msg.get("observed") and role == "user" and content:
-            observed_group_context.append(str(content).strip())
+        if msg.get("observed"):
+            if separate_observed_context and role == "user" and content:
+                observed_group_context.append(str(content).strip())
+            # Observations are never ordinary agent-history turns. Platforms
+            # without an explicit context-only marker keep them storage-only.
             continue
 
         # Rich tool_calls/tool-result rows pass through intact so the API sees valid assistant→tool sequences.

--- a/gateway/session_transcript.py
+++ b/gateway/session_transcript.py
@@ -405,11 +405,14 @@ class SessionTranscriptMixin:
             self._transcript_append_failures.pop(session_id, None)
 
     def has_platform_message_id(self, session_id: str, platform_message_id: str) -> bool:
-        """Whether a message with this platform_message_id is persisted (False without a DB).
-
-        Thin wrapper over SessionDB.has_platform_message_id(). Returns False when no DB is available
-        (in-memory sessions). Used by the gateway's transient-failure dedupe guard (#47237).
-        """
+        """Whether a platform message ID is persisted or queued for retry."""
+        with self._transcript_retry_lock:
+            for message in self._dirty_transcripts.get(session_id, ()):
+                pending_id = message.get("platform_message_id") or message.get(
+                    "message_id"
+                )
+                if pending_id == platform_message_id:
+                    return True
         db = self._db_for_session_id(session_id)
         if not db:
             return False

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -2,6 +2,7 @@
 client; messages are polled over a local HTTP API and responses are posted back through it."""
 
 import asyncio
+import json
 import logging
 import os
 import platform
@@ -673,6 +674,113 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 logger.debug("Could not get WhatsApp chat info for %s: %s", chat_id, e)
         return {"name": chat_id, "type": "dm"}
 
+    def _should_observe_unmentioned_group_message(self, data: Dict[str, Any]) -> bool:
+        """Admit an untriggered, text-only group message for silent observation."""
+        if self.config.extra.get("observe_unmentioned_group_messages") is not True:
+            return False
+        if (
+            data.get("isGroup") is not True
+            or data.get("fromMe") is not False
+            or data.get("hasMedia") is not False
+            or data.get("hasQuotedMessage") is not False
+            or data.get("isForwarded") is not False
+        ):
+            return False
+        if type(data.get("mentionedIds")) is not list or data["mentionedIds"]:
+            return False
+        if type(data.get("mediaType")) is not str or data["mediaType"]:
+            return False
+        body = data.get("body")
+        chat_id = data.get("chatId")
+        sender_id = data.get("senderId")
+        message_id = data.get("messageId")
+        timestamp = data.get("timestamp")
+        if not all(
+            type(value) is str and value.strip()
+            for value in (body, chat_id, sender_id, message_id)
+        ):
+            return False
+        if type(timestamp) is not int or timestamp <= 0:
+            return False
+        if not self._matches_whatsapp_allowlist(chat_id, self._group_allow_from):
+            return False
+        return self._is_sender_authorized(
+            sender_id,
+            chat_type="group",
+            chat_id=chat_id,
+        ) is True
+
+    def _observe_unmentioned_group_message(self, data: Dict[str, Any]) -> bool:
+        """Persist one admitted observation using the native session transcript."""
+        if not self._should_observe_unmentioned_group_message(data):
+            return False
+        store = getattr(self, "_session_store", None)
+        if store is None:
+            return False
+        source = self.build_source(
+            chat_id=data["chatId"],
+            chat_name=data.get("chatName"),
+            chat_type="group",
+            user_id=None,
+            user_name=None,
+        )
+        if source.profile is None:
+            source.profile = self._session_key_profile(source)
+        session_entry = store.get_or_create_session(source)
+        message_id = data["messageId"]
+        if store.has_platform_message_id(session_entry.session_id, message_id):
+            return True
+        sender_name = data.get("senderName")
+        if type(sender_name) is not str or not sender_name.strip():
+            sender_name = data["senderId"]
+        attribution = json.dumps(
+            {"name": sender_name.strip(), "id": data["senderId"]},
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        store.append_to_transcript(
+            session_entry.session_id,
+            {
+                "role": "user",
+                "content": (
+                    f"[WhatsApp observation sender] {attribution}\n{data['body']}"
+                ),
+                "timestamp": data["timestamp"],
+                "observed": True,
+                "message_id": message_id,
+            },
+        )
+        return True
+
+    async def _handle_polled_message(self, data: Dict[str, Any]) -> None:
+        """Route one bridge message to dispatch or silent observation."""
+        try:
+            active = self._should_process_message(data)
+        except Exception as exc:
+            print(f"[{self.name}] Error building event: {exc}")
+            return
+        if not active and self._should_observe_unmentioned_group_message(data):
+            try:
+                self._observe_unmentioned_group_message(data)
+            except Exception as exc:
+                logger.warning(
+                    "[%s] Failed to persist WhatsApp group observation: %s",
+                    self.name,
+                    type(exc).__name__,
+                )
+            return
+        if not active:
+            return
+        event = await self._build_message_event(data, _admitted=True)
+        if event is None:
+            return
+        # Fire-and-forget: a slow bridge /read must not delay dispatch.
+        asyncio.create_task(self._send_read_receipt(data))
+        if event.message_type == MessageType.TEXT:
+            self._enqueue_text_event(event)
+        else:
+            await self.handle_message(event)
+
     async def _report_bridge_exit(self) -> bool:
         bridge_exit = await self._check_managed_bridge_exit()
         if bridge_exit:
@@ -687,14 +795,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 async with self._bridge_req("get", "messages", 30) as resp:
                     if resp.status == 200:
                         for msg_data in await resp.json():
-                            event = await self._build_message_event(msg_data)
-                            if event:
-                                # Fire-and-forget: a slow bridge /read must not delay dispatch.
-                                asyncio.create_task(self._send_read_receipt(msg_data))
-                                if event.message_type == MessageType.TEXT:
-                                    self._enqueue_text_event(event)
-                                else:
-                                    await self.handle_message(event)
+                            await self._handle_polled_message(msg_data)
             except asyncio.CancelledError:
                 break
             except Exception as e:
@@ -784,10 +885,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 print(f"[{self.name}] Failed to read document text: {e}", flush=True)
         return body
 
-    async def _build_message_event(self, data: Dict[str, Any]) -> Optional[MessageEvent]:
+    async def _build_message_event(
+        self, data: Dict[str, Any], *, _admitted: bool = False
+    ) -> Optional[MessageEvent]:
         """Build a MessageEvent from bridge message data, downloading images to cache."""
         try:
-            if not self._should_process_message(data):
+            if not _admitted and not self._should_process_message(data):
                 return None
             msg_type = self._classify_bridge_message(data)
             source = self.build_source(chat_id=data.get("chatId", ""), chat_name=data.get("chatName"), chat_type="group" if data.get("isGroup", False) else "dm",

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -94,12 +94,13 @@ import {
         fromMe: false,
       },
       pushName: 'Tester',
-      messageTimestamp: 123,
+      messageTimestamp: { toString: () => '123' },
       message: {
         extendedTextMessage: {
           text: 'approved',
           contextInfo: {
             stanzaId: 'outbound-1',
+            isForwarded: true,
             participant: '15559998888@s.whatsapp.net',
             remoteJid: '15551234567@s.whatsapp.net',
             quotedMessage: { conversation: 'approve deploy?' },
@@ -125,6 +126,9 @@ import {
     fromMe: false,
   });
   assert.equal(event.hasQuotedMessage, true);
+  assert.equal(event.fromMe, false);
+  assert.equal(event.isForwarded, true);
+  assert.equal(event.timestamp, 123);
   assert.equal(event.body, 'approved');
   console.log('  ✓ inbound quoted metadata includes quoted text');
 }

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -461,6 +461,11 @@ export async function extractBridgeEvent({
     body = `[${mediaType} received]`;
   }
 
+  const rawTimestamp = Number(msg.messageTimestamp);
+  const timestamp = Number.isSafeInteger(rawTimestamp) && rawTimestamp > 0
+    ? rawTimestamp
+    : 0;
+
   return {
     messageId: msg.key.id,
     chatId,
@@ -468,6 +473,8 @@ export async function extractBridgeEvent({
     senderName: msg.pushName || senderNumber,
     chatName: isGroup ? (chatId.split('@')[0]) : (msg.pushName || senderNumber),
     isGroup,
+    fromMe: Boolean(msg.key.fromMe),
+    isForwarded: Boolean(contextInfo?.isForwarded || Number(contextInfo?.forwardingScore || 0) > 0),
     body,
     hasMedia,
     mediaType,
@@ -489,7 +496,7 @@ export async function extractBridgeEvent({
       participant: msg.key.participant || senderId,
       fromMe: Boolean(msg.key.fromMe),
     },
-    timestamp: msg.messageTimestamp,
+    timestamp,
   };
 }
 

--- a/tests/gateway/test_whatsapp_observation.py
+++ b/tests/gateway/test_whatsapp_observation.py
@@ -1,0 +1,364 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig, load_gateway_config
+from gateway.run import _build_gateway_agent_history
+from gateway.session import SessionStore
+from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+
+GROUP_ID = "120363001234567890@g.us"
+SENDER_ID = "15551234567@s.whatsapp.net"
+
+
+class FakeSessionStore:
+    def __init__(self):
+        self.sources = []
+        self.messages = []
+
+    def get_or_create_session(self, source):
+        self.sources.append(source)
+        return SimpleNamespace(session_id="whatsapp-group-session")
+
+    def append_to_transcript(self, session_id, message, skip_db=False):
+        self.messages.append((session_id, message, skip_db))
+
+    def has_platform_message_id(self, session_id, message_id):
+        return any(
+            stored_session == session_id and message.get("message_id") == message_id
+            for stored_session, message, _skip_db in self.messages
+        )
+
+
+def make_adapter(**extra):
+    config = {
+        "require_mention": True,
+        "group_policy": "allowlist",
+        "group_allow_from": [GROUP_ID],
+        "observe_unmentioned_group_messages": True,
+        **extra,
+    }
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra=config))
+    adapter._session_store = FakeSessionStore()
+    adapter._send_read_receipt = AsyncMock()
+    adapter._enqueue_text_event = Mock()
+    adapter._message_handler = AsyncMock()
+    adapter.set_authorization_check(
+        lambda user_id, chat_type, chat_id, **_kwargs: (
+            user_id == SENDER_ID
+            and chat_type == "group"
+            and chat_id == GROUP_ID
+        )
+    )
+    return adapter
+
+
+def untriggered_text(**overrides):
+    data = {
+        "isGroup": True,
+        "fromMe": False,
+        "hasMedia": False,
+        "hasQuotedMessage": False,
+        "isForwarded": False,
+        "body": "Relatório revisado, nenhuma decisão tomada.",
+        "chatId": GROUP_ID,
+        "chatName": "LAB",
+        "senderId": SENDER_ID,
+        "senderName": "Founder",
+        "messageId": "wamid-observe-1",
+        "timestamp": 1788468500,
+        "mediaType": "",
+        "mentionedIds": [],
+        "botIds": ["15550000000@s.whatsapp.net"],
+        "quotedParticipant": "",
+    }
+    data.update(overrides)
+    return data
+
+
+@pytest.mark.asyncio
+async def test_untriggered_authorized_group_text_is_observed_without_effects():
+    adapter = make_adapter()
+    adapter._build_message_event = AsyncMock(wraps=adapter._build_message_event)
+
+    await adapter._handle_polled_message(untriggered_text())
+
+    assert len(adapter._session_store.messages) == 1
+    session_id, message, skip_db = adapter._session_store.messages[0]
+    assert session_id == "whatsapp-group-session"
+    assert skip_db is False
+    assert message == {
+        "role": "user",
+        "content": '[WhatsApp observation sender] '
+        '{"name":"Founder","id":"15551234567@s.whatsapp.net"}\n'
+        "Relatório revisado, nenhuma decisão tomada.",
+        "timestamp": 1788468500,
+        "observed": True,
+        "message_id": "wamid-observe-1",
+    }
+    source = adapter._session_store.sources[0]
+    assert source.chat_id == GROUP_ID
+    assert source.chat_type == "group"
+    assert source.user_id is None
+    assert source.user_name is None
+    adapter._build_message_event.assert_not_awaited()
+    adapter._send_read_receipt.assert_not_awaited()
+    adapter._enqueue_text_event.assert_not_called()
+    adapter._message_handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_observation_persistence_failure_stays_silent_and_never_dispatches():
+    adapter = make_adapter()
+    adapter._session_store.append_to_transcript = Mock(
+        side_effect=RuntimeError("synthetic persistence failure")
+    )
+
+    await adapter._handle_polled_message(untriggered_text())
+
+    adapter._send_read_receipt.assert_not_awaited()
+    adapter._enqueue_text_event.assert_not_called()
+    adapter._message_handler.assert_not_awaited()
+
+
+def test_top_level_whatsapp_observation_config_is_bridged_as_exact_bool(
+    monkeypatch, tmp_path
+):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "whatsapp:\n"
+        "  enabled: true\n"
+        "  observe_unmentioned_group_messages: true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    config = load_gateway_config()
+
+    assert (
+        config.platforms[Platform.WHATSAPP].extra[
+            "observe_unmentioned_group_messages"
+        ]
+        is True
+    )
+
+
+@pytest.mark.asyncio
+async def test_replayed_platform_message_id_is_observed_once():
+    adapter = make_adapter()
+    data = untriggered_text()
+
+    await adapter._handle_polled_message(data)
+    await adapter._handle_polled_message(data)
+
+    assert len(adapter._session_store.messages) == 1
+    adapter._send_read_receipt.assert_not_awaited()
+    adapter._enqueue_text_event.assert_not_called()
+    adapter._message_handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("adapter_overrides", "message_overrides"),
+    [
+        ({"observe_unmentioned_group_messages": False}, {}),
+        ({}, {"isGroup": 1}),
+        ({}, {"fromMe": True}),
+        ({}, {"hasMedia": True, "mediaType": "image"}),
+        ({}, {"hasMedia": "false"}),
+        ({}, {"hasQuotedMessage": True}),
+        ({}, {"isForwarded": True}),
+        ({}, {"chatId": "120363009999999999@g.us"}),
+        ({}, {"senderId": "19999999999@s.whatsapp.net"}),
+        ({}, {"body": 123}),
+        ({}, {"body": ""}),
+        ({}, {"messageId": ""}),
+        ({}, {"messageId": 123}),
+        ({}, {"timestamp": None}),
+        ({}, {"timestamp": True}),
+        ({}, {"timestamp": -1}),
+    ],
+)
+async def test_ineligible_messages_create_no_observation_or_effects(
+    adapter_overrides, message_overrides
+):
+    adapter = make_adapter(**adapter_overrides)
+
+    await adapter._handle_polled_message(untriggered_text(**message_overrides))
+
+    assert adapter._session_store.messages == []
+    adapter._send_read_receipt.assert_not_awaited()
+    adapter._enqueue_text_event.assert_not_called()
+    adapter._message_handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_native_mention_keeps_existing_active_route_without_observation():
+    adapter = make_adapter()
+    data = untriggered_text(
+        body="@15550000000 status",
+        mentionedIds=["15550000000@s.whatsapp.net"],
+    )
+
+    await adapter._handle_polled_message(data)
+    await asyncio.sleep(0)
+
+    assert adapter._session_store.messages == []
+    event = adapter._enqueue_text_event.call_args.args[0]
+    assert event.source.user_id == SENDER_ID
+    assert event.source.chat_id == GROUP_ID
+    adapter._enqueue_text_event.assert_called_once()
+    adapter._send_read_receipt.assert_awaited_once_with(data)
+    adapter._message_handler.assert_not_awaited()
+
+
+
+@pytest.mark.asyncio
+async def test_observation_persists_in_native_session_store_sqlite(
+    monkeypatch, tmp_path
+):
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    adapter = make_adapter()
+    store = SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig())
+    adapter._session_store = store
+
+    await adapter._handle_polled_message(untriggered_text())
+
+    assert len(store._entries) == 1
+    session_id = next(iter(store._entries.values())).session_id
+    transcript = store.load_transcript(session_id)
+    assert len(transcript) == 1
+    assert transcript[0]["role"] == "user"
+    assert transcript[0]["content"] == (
+        '[WhatsApp observation sender] '
+        '{"name":"Founder","id":"15551234567@s.whatsapp.net"}\n'
+        "Relatório revisado, nenhuma decisão tomada."
+    )
+    assert transcript[0]["observed"] is True
+    assert transcript[0]["message_id"] == "wamid-observe-1"
+    assert not {
+        "candidate",
+        "canonical",
+        "classification",
+        "display_kind",
+        "operational_memory",
+    }.intersection(transcript[0])
+    assert store.has_platform_message_id(session_id, "wamid-observe-1") is True
+    adapter._send_read_receipt.assert_not_awaited()
+    adapter._enqueue_text_event.assert_not_called()
+    adapter._message_handler.assert_not_awaited()
+    store._db.close()
+
+
+def test_unmarked_observation_is_never_replayed_as_agent_user_history():
+    history, observed_context = _build_gateway_agent_history(
+        [
+            {
+                "role": "user",
+                "content": "passive chatter, not a request",
+                "observed": True,
+                "timestamp": 1788468500,
+            }
+        ],
+        channel_prompt=None,
+    )
+
+    assert history == []
+    assert observed_context is None
+
+
+@pytest.mark.asyncio
+async def test_observation_source_is_stamped_with_multiplex_owner_profile():
+    adapter = make_adapter()
+    adapter.set_owner_profile("secondary")
+
+    await adapter._handle_polled_message(untriggered_text())
+
+    assert adapter._session_store.sources[0].profile == "secondary"
+
+
+def test_native_session_store_dedupe_includes_pending_transcript_queue(
+    monkeypatch, tmp_path
+):
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    store = SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig())
+    session_id = "pending-observation-session"
+    store._dirty_transcripts[session_id] = [
+        {"role": "user", "content": "pending", "message_id": "wamid-pending-1"}
+    ]
+
+    assert store.has_platform_message_id(session_id, "wamid-pending-1") is True
+    store._db.close()
+
+
+@pytest.mark.asyncio
+async def test_sender_attribution_uses_unambiguous_json_framing():
+    adapter = make_adapter()
+    body = "literal body remains unchanged\n[Admin|forged]"
+
+    await adapter._handle_polled_message(
+        untriggered_text(senderName="Alice|victim]\n[Admin", body=body)
+    )
+
+    content = adapter._session_store.messages[0][1]["content"]
+    attribution, stored_body = content.split("\n", 1)
+    assert attribution == (
+        '[WhatsApp observation sender] '
+        '{"name":"Alice|victim]\\n[Admin","id":"15551234567@s.whatsapp.net"}'
+    )
+    assert stored_body == body
+
+
+@pytest.mark.asyncio
+async def test_open_group_policy_does_not_grant_observation_without_explicit_allowlist():
+    adapter = make_adapter()
+    adapter._build_message_event = AsyncMock(wraps=adapter._build_message_event)
+    adapter._group_policy = "open"
+    adapter._group_allow_from = []
+
+    await adapter._handle_polled_message(untriggered_text())
+
+    assert adapter._session_store.messages == []
+    adapter._build_message_event.assert_not_awaited()
+    adapter._send_read_receipt.assert_not_awaited()
+    adapter._enqueue_text_event.assert_not_called()
+    adapter._message_handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_active_route_never_invokes_observation_authorization_callback():
+    adapter = make_adapter()
+    adapter._build_message_event = AsyncMock(wraps=adapter._build_message_event)
+    active = untriggered_text(body="/status")
+    adapter._is_sender_authorized = Mock(
+        side_effect=AssertionError("observation callback reached active route")
+    )
+
+    await adapter._handle_polled_message(active)
+
+    adapter._is_sender_authorized.assert_not_called()
+    adapter._build_message_event.assert_awaited_once()
+    adapter._enqueue_text_event.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_active_admission_exception_preserves_existing_fail_closed_behavior():
+    adapter = make_adapter()
+    adapter._build_message_event = AsyncMock(wraps=adapter._build_message_event)
+    adapter._should_process_message = Mock(side_effect=RuntimeError("bad active metadata"))
+    adapter._should_observe_unmentioned_group_message = Mock()
+
+    await adapter._handle_polled_message(untriggered_text())
+
+    adapter._should_observe_unmentioned_group_message.assert_not_called()
+    adapter._build_message_event.assert_not_awaited()
+    adapter._send_read_receipt.assert_not_awaited()
+    adapter._enqueue_text_event.assert_not_called()


### PR DESCRIPTION
Summary

- Adds bounded passive WhatsApp group observation using the native SessionStore.
- Requires an explicit `group_allow_from` match even when `group_policy` is open, plus strict sender authorization.
- Admits only strictly typed, text-only, unforwarded, unquoted, unmentioned transport messages.
- Persists `observed=True` once with JSON-safe sender attribution and transport provenance, then returns before event construction or agent dispatch.
- Prevents observed rows from replaying as ordinary agent user turns, preserves multiplex profile ownership, and deduplicates persisted and pending transcript entries.
- Extends the bridge schema with transport-derived `fromMe`/`isForwarded` and safe timestamps.

Safety

- Active routing is decided first and does not call observation authorization; the active predicate is evaluated once on the polling path.
- Zero read receipt, enqueue, handler, dispatch, send, STT, canonicalization, candidate promotion, or operational-memory behavior on the passive route.
- Invalid, unknown, unauthorized, malformed, forwarded, quoted, media, or persistence-failure cases remain silent and fail closed.
- No runtime activation, deploy, restart, merge, or v17 work is included.

Validation

- 29 bounded tests passed.
- 324 relevant regression tests passed, 4 skipped.
- 22 native bridge tests passed.
- Strict boolean matrix: 7,776/7,776 combinations, exactly one admitted.
- Ruff, `node --check`, and `git diff --check` passed.
- Local bridge-to-adapter proof persisted one observation with zero builder/read-receipt/enqueue/handler calls.

Review custody

- Reviewed patch against `f1ccf436a27522c1bb5d36383a6f13b950676338`: 25,415 bytes.
- SHA-256: `056377bbf46909d5bafed3c019c03da06b5046085914d9c9ac5048e255840495`.
- Commit: `9b5b9d62683a63532906a3b4a80f08081ac2b755`.
- Independent exact-byte review: PASS, no concrete blockers.
- Current main later advanced by two disjoint commits touching no candidate files.

