### PR TITLE
fix(web): serve the live session token on the headless handshake page

### DIFF
--- a/hermes_cli/web_server_dashboard.py
+++ b/hermes_cli/web_server_dashboard.py
@@ -102,7 +102,7 @@ def mount_spa(application: FastAPI):
     with a missing dist per-request (404 JSON / ``check_dir=False``), so a long-lived
     ``--skip-build`` process recovers the moment a build appears on disk — no restart.
     """
-    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, _SESSION_TOKEN, app
+    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, app
 
     # `hermes serve` is the headless backend: it must NEVER serve the browser SPA, even if a
     # dist is lying around, so only the JSON-RPC/WS/API surface is reachable.
@@ -118,6 +118,7 @@ def mount_spa(application: FastAPI):
             # See #94227, #95575.
             gated = bool(getattr(application.state, "auth_required", False))
             if full_path == "" and not gated:
+                from hermes_cli.web_server import _SESSION_TOKEN
                 return HTMLResponse(
                     "<!doctype html><html><head><script>"
                     f"window.__HERMES_SESSION_TOKEN__={json.dumps(_SESSION_TOKEN)};"
@@ -151,6 +152,7 @@ def mount_spa(application: FastAPI):
             return JSONResponse({"error": "Frontend not built. Run: cd web && npm run build"}, status_code=404)
         chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
         gated = bool(getattr(app.state, "auth_required", False))
+        from hermes_cli.web_server import _SESSION_TOKEN
         token_js = "" if gated else f'window.__HERMES_SESSION_TOKEN__="{_SESSION_TOKEN}";'
         bootstrap_script = (
             f"<script>{token_js}"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5110,6 +5110,28 @@ class TestHeadlessServeTokenPage:
         assert _json.loads(match.group(1)) == ws._SESSION_TOKEN
         assert "window.__HERMES_AUTH_REQUIRED__=false" in resp.text
 
+    def test_root_serves_updated_token_after_apply_ssh_session_token(self, monkeypatch):
+        import re
+        import json as _json
+
+        client, ws = self._headless_client(monkeypatch, gated=False)
+        updated_token = "updated_token_" + "a" * 50
+        original_token = ws._SESSION_TOKEN
+        try:
+            ws._apply_ssh_session_token(updated_token)
+            resp = client.get("/")
+            assert resp.status_code == 200
+            match = re.search(
+                r'window\.__HERMES_SESSION_TOKEN__\s*=\s*(\"(?:\\.|[^\"\\])*\")',
+                resp.text,
+            )
+            assert match
+            assert _json.loads(match.group(1)) == updated_token
+        finally:
+            # _apply_ssh_session_token rebinds the module global; restore it so
+            # later by-value importers in this file keep seeing a valid token.
+            ws._apply_ssh_session_token(original_token)
+
     def test_root_stays_404_json_when_auth_gated(self, monkeypatch):
         client, ws = self._headless_client(monkeypatch, gated=True)
         resp = client.get("/")


### PR DESCRIPTION
## Summary

- `web_server_dashboard.py` captured `_SESSION_TOKEN` **by value** in `mount_spa()`'s module-level import; after `start_server() -> _apply_ssh_session_token()` rebinds the module global, both injection sites (the `HERMES_SERVE_HEADLESS` root handshake page and `_serve_index()`'s `token_js`) kept serving the stale mount-time token. Read it inside the request handlers instead.
- Adds a regression test that fails on the pre-fix base and restores the module global afterwards, so sibling by-value importers in the same test file keep seeing a valid token.

Closes #102930
Related: #102931 — also see the parallel fixes #102948 and #102954 (same root cause; this PR is independently derived and carries the production reproduction below).

## Root cause (line-level)

The #102117 decomposition moved the SPA mount out of `web_server.py` and, in doing so, hoisted `_SESSION_TOKEN` into the mount-time import:

```python
# hermes_cli/web_server_dashboard.py:105 (pre-fix)
from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, _SESSION_TOKEN, app
```

`_SESSION_TOKEN` is a module global that `_apply_ssh_session_token()` (`web_server.py:305-308`, called from `start_server()` at line 1351) **rebinds** when the Electron shell bootstraps a remote `hermes serve` over SSH. A by-value import cannot see the rebinding, so from that moment:

- `_has_valid_session_token()` / `_ws_auth_reason()` (live module global) expect the **new** token,
- the served HTML keeps injecting the **old** mount-time token.

The desktop's drift recovery (`apps/desktop/electron/dashboard-token.ts`) fetches `/` and prefers the served token, so it adopts the stale value → `/api/ws` rejects with `token_mismatch` → HTTP 403 `dial failed` → the window can't connect at all.

## Reproduction (real fleet, not a mock)

Hit on a production setup after upgrading to v0.21.0: desktop app (macOS) → SSH backend at 10.0.0.5 running `hermes serve --isolated --ssh-session-token-file ...`, three profiles (`default`, `cun`, `li`). Every profile failed with `token_mismatch`/`dial failed`; `lsof` showed the SSH tunnel ESTABLISHED but every WS dial was 403'd. After this fix (applied to the remote tree and the stale `serve` processes cleaned up), all three profiles reconnect with the correct 64-char session token and `dial failed` disappears from `~/.hermes/logs/desktop.log`.

## Fix

Late-import the token inside each request handler (`no_frontend`, `_serve_index`) — the repo's established seam pattern for facade-owned mutable state (siblings late-import the facade so the live binding is read where production reads it). No behavior change for the non-SSH paths: the token is normally set once before the first request.

Also audited the rest of the bug class: every other `_SESSION_TOKEN` consumer either already late-imports inside the function (`web_server_chat.py` WS auth at ~L222, sidecar URL builder at ~L395) or goes through `web_deps` property access (dynamic by construction). These two injection sites were the only stale captures.

## Test plan

- [x] New regression test proven **red on the pre-fix base** (stash-verified: `1 failed` without the fix, passes with it)
- [x] `TestHeadlessServeTokenPage` 4/4 green on the exact PR tree (`uv run --with pytest --with pytest-asyncio pytest tests/hermes_cli/test_web_server.py -k TestHeadlessServeTokenPage`)
- [x] Full `tests/hermes_cli/test_web_server.py`: 185 passed; the 2 remaining failures (`TestThemeBootstrapCSS::test_serve_index_injects_bootstrap_for_user_theme`, `test_mount_spa_dynamic_web_dist_recheck`) reproduce identically on the unmodified base — pre-existing, unrelated to this change
- [x] `ruff check` clean on both touched files
- [ ] CI