### PR TITLE
fix(tui-gateway): ignore activity heartbeats in sessions.changed fingerprint

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -127,28 +127,41 @@ function ChatHeader({
   onToggleSelectedPin,
   selectedSessionId
 }: ChatHeaderProps) {
-  const sessions = useStore($sessions)
   const pinnedSessionIds = useStore($pinnedSessionIds)
   const profiles = useStore($profiles)
 
-  const activeStoredSession =
-    (selectedSessionId && sessions.find(session => sessionMatchesStoredId(session, selectedSessionId))) || null
+  // Scalars only: `$sessions` is republished whenever any row's last_active
+  // moves. Returning the row object here remounts the title menu (and with it
+  // the perceived "whole chat flicker") on that tick.
+  const title = useStoreSelector($sessions, list => {
+    const row = selectedSessionId ? list.find(session => sessionMatchesStoredId(session, selectedSessionId)) : undefined
 
-  const title = activeStoredSession ? sessionTitle(activeStoredSession) : NEW_SESSION_TITLE
+    return row ? sessionTitle(row) : NEW_SESSION_TITLE
+  })
+  const sessionProfile = useStoreSelector($sessions, list => {
+    const row = selectedSessionId ? list.find(session => sessionMatchesStoredId(session, selectedSessionId)) : undefined
+
+    return row?.profile
+  })
+  const selectedPinId = useStoreSelector($sessions, list => {
+    const row = selectedSessionId ? list.find(session => sessionMatchesStoredId(session, selectedSessionId)) : undefined
+
+    if (row) {
+      return sessionPinId(row)
+    }
+
+    return selectedSessionId
+  })
 
   // Which agent/persona owns this chat — glanceable in the header once a
   // second profile exists, so the open session's ownership is never ambiguous
   // (#66003). Single-profile users see the unchanged header.
-  const showProfileTag = profiles.length > 1 && Boolean(activeStoredSession)
+  const showProfileTag = profiles.length > 1 && Boolean(selectedPinId)
 
   // Pins live on the durable lineage-root id, but selectedSessionId is the live
   // (tip) id — resolve through the loaded row so the menu reflects the pin
   // state after auto-compression rotates the id.
-  const selectedIsPinned = activeStoredSession
-    ? pinnedSessionIds.includes(sessionPinId(activeStoredSession))
-    : selectedSessionId
-      ? pinnedSessionIds.includes(selectedSessionId)
-      : false
+  const selectedIsPinned = selectedPinId ? pinnedSessionIds.includes(selectedPinId) : false
 
   // Secondary windows (new-session scratch, subagent watch, cmd-click pop-out)
   // are compact side panels — they drop the session-actions header + border
@@ -166,7 +179,7 @@ function ChatHeader({
             'calc(100vw - var(--titlebar-content-inset,0px) - var(--titlebar-tools-right) - var(--titlebar-tools-width) - 1.5rem)'
         }}
       >
-        {showProfileTag && <ProfileTag className="pointer-events-auto mr-1.5" profile={activeStoredSession?.profile} />}
+        {showProfileTag && <ProfileTag className="pointer-events-auto mr-1.5" profile={sessionProfile} />}
         <SessionActionsMenu
           align="start"
           onDelete={selectedSessionId ? onDeleteSelectedSession : undefined}
@@ -455,7 +468,6 @@ const ChatViewContent = memo(function ChatViewContent({
   const messagesEmpty = useStore(view.$messagesEmpty)
   const lastVisibleIsUser = useStore(view.$lastVisibleIsUser)
   const selectedSessionId = useStore(view.$storedId)
-  const sessions = useStore($sessions)
   const resumeExhaustedSessionId = useStore($resumeExhaustedSessionId)
 
   // Durable composer/queue scope (lineage root) so auto-compression tip rotation
@@ -464,13 +476,17 @@ const ChatViewContent = memo(function ChatViewContent({
   // latter can be momentarily null/stale mid-switch, which used to leak into
   // the composer's scope key (#59305). A tile has no route, so it always uses
   // its own selection directly.
-  const queueSessionKey = useMemo(() => {
+  //
+  // SCALAR over $sessions: a 10s sessions.changed list refresh republishes the
+  // whole array whenever any other row's last_active moved. Subscribing to the
+  // array remounts this shell (thread + composer) on that tick.
+  const queueSessionKey = useStoreSelector($sessions, list => {
     const effectiveSelectedSessionId = isPrimary
       ? primaryRouteSelectedSessionId(location.pathname, selectedSessionId)
       : selectedSessionId
 
-    return resolveComposerSessionKey(effectiveSelectedSessionId, sessions)
-  }, [isPrimary, location.pathname, selectedSessionId, sessions])
+    return resolveComposerSessionKey(effectiveSelectedSessionId, list)
+  })
 
   // When the tip row arrives after compression, migrate any tip-keyed stash onto
   // the durable lineage key before the composer remounts onto that key.
@@ -480,13 +496,13 @@ const ChatViewContent = memo(function ChatViewContent({
   // migrating on bare inequality would re-home A's queued prompts onto B and
   // auto-drain them into the wrong chat.
   useEffect(() => {
-    if (!shouldMigrateComposerScope(selectedSessionId, queueSessionKey, sessions)) {
+    if (!shouldMigrateComposerScope(selectedSessionId, queueSessionKey, $sessions.get())) {
       return
     }
 
     migrateSessionDraft(selectedSessionId, queueSessionKey)
     migrateQueuedPrompts(selectedSessionId, queueSessionKey)
-  }, [queueSessionKey, selectedSessionId, sessions])
+  }, [queueSessionKey, selectedSessionId])
 
   // Transcript-side stops (the streaming message's hover Stop, the runtime's
   // cancel) are explicit halts, same as the composer's Stop button: park any
@@ -507,7 +523,9 @@ const ChatViewContent = memo(function ChatViewContent({
   // direct nav). Derived in render so the swap reads instantly: the same frame
   // the id changes we drop the old transcript and show the loader, instead of
   // waiting for the resume effect (which paints a frame later) to clear them.
-  const routeSessionMismatch = isPrimary ? isRouteSessionMismatch(routedSessionId, selectedSessionId, sessions) : false
+  const routeSessionMismatch = useStoreSelector($sessions, list =>
+    isPrimary ? isRouteSessionMismatch(routedSessionId, selectedSessionId, list) : false
+  )
 
   // The compact new-session pop-out skips the wordmark/tagline intro — it's a
   // scratch window, not the full-height empty state. The Appearance toggle
@@ -537,9 +555,11 @@ const ChatViewContent = memo(function ChatViewContent({
   // session can't blank the current one.
   const resumeExhausted = isPrimary && isRoutedSessionView && resumeExhaustedSessionId === routedSessionId
 
-  const routedHasHistory = Boolean(
-    routedSessionId &&
-    sessions.some(session => sessionMatchesStoredId(session, routedSessionId) && sessionShouldHaveTranscript(session))
+  const routedHasHistory = useStoreSelector($sessions, list =>
+    Boolean(
+      routedSessionId &&
+        list.some(session => sessionMatchesStoredId(session, routedSessionId) && sessionShouldHaveTranscript(session))
+    )
   )
 
   const loadingSession = routedSessionIsLoading({

--- a/tests/tui_gateway/test_change_watcher.py
+++ b/tests/tui_gateway/test_change_watcher.py
@@ -8,11 +8,32 @@ and the pet signature only moves for a *renderable* pet.
 """
 
 import os
+import sqlite3
 import time
 
 import pytest
 
 from tui_gateway import server
+
+
+def _write_sessions_db(path, rows):
+    con = sqlite3.connect(path)
+    try:
+        con.execute(
+            "CREATE TABLE IF NOT EXISTS sessions ("
+            "id TEXT PRIMARY KEY, last_activity_at REAL, started_at REAL, ended_at REAL, "
+            "message_count INTEGER, title TEXT, pinned INTEGER DEFAULT 0, "
+            "archived INTEGER DEFAULT 0, hidden INTEGER DEFAULT 0)"
+        )
+        con.execute("DELETE FROM sessions")
+        con.executemany(
+            "INSERT INTO sessions(id, last_activity_at, started_at, ended_at, "
+            "message_count, title, pinned, archived, hidden) VALUES (?,?,?,?,?,?,?,?,?)",
+            rows,
+        )
+        con.commit()
+    finally:
+        con.close()
 
 
 @pytest.fixture()
@@ -26,6 +47,7 @@ def watcher_home(tmp_path, monkeypatch):
     monkeypatch.setattr(server, "_change_checked_at", {})
     monkeypatch.setattr(server, "_change_broadcast_at", {})
     monkeypatch.setattr(server, "_bot_relay_outbox_seen", 0)
+    monkeypatch.setattr(server, "_sessions_sql_cache", {}, raising=False)
 
     events = []
     monkeypatch.setattr(
@@ -62,6 +84,62 @@ def test_state_db_move_broadcasts_sessions_changed(watcher_home):
     server._broadcast_watched_changes(now=10.0)
 
     assert ("sessions.changed", {}) in events
+
+
+def test_activity_heartbeat_does_not_broadcast_sessions_changed(watcher_home):
+    """CLI/agent heartbeats rewrite last_activity_at in the same state.db.
+    That must not look like a new/changed conversation — Desktop remounts the
+    open composer on each sessions.changed tick."""
+    home, events = watcher_home
+    db = home / "state.db"
+    _write_sessions_db(
+        db,
+        [("s1", 1.0, 1.0, None, 11, "hello", 0, 0, 0)],
+    )
+    server._broadcast_watched_changes(now=0.0)
+
+    _write_sessions_db(
+        db,
+        [("s1", 99.0, 1.0, None, 11, "hello", 0, 0, 0)],
+    )
+    server._broadcast_watched_changes(now=10.0)
+
+    assert ("sessions.changed", {}) not in events
+
+
+def test_message_count_change_broadcasts_sessions_changed(watcher_home):
+    home, events = watcher_home
+    db = home / "state.db"
+    _write_sessions_db(
+        db,
+        [("s1", 1.0, 1.0, None, 11, "hello", 0, 0, 0)],
+    )
+    server._broadcast_watched_changes(now=0.0)
+
+    _write_sessions_db(
+        db,
+        [("s1", 1.0, 1.0, None, 12, "hello", 0, 0, 0)],
+    )
+    server._broadcast_watched_changes(now=10.0)
+
+    assert ("sessions.changed", {}) in events
+
+
+def test_sql_probe_stays_on_cache_when_db_is_busy(watcher_home):
+    """A locked/non-sqlite moment after a successful SQL probe must not flip
+    to mtime — that flip-flop storms sessions.changed every 2s."""
+    home, events = watcher_home
+    db = home / "state.db"
+    _write_sessions_db(
+        db,
+        [("s1", 1.0, 1.0, None, 1, "hello", 0, 0, 0)],
+    )
+    server._broadcast_watched_changes(now=0.0)
+
+    db.write_text("not-sqlite")
+    server._broadcast_watched_changes(now=10.0)
+
+    assert ("sessions.changed", {}) not in events
 
 
 def test_served_profile_store_move_broadcasts_sessions_changed(watcher_home, monkeypatch):

--- a/tui_gateway/change_watcher.py
+++ b/tui_gateway/change_watcher.py
@@ -115,18 +115,70 @@ def _pet_changed_payload() -> dict:
     return {"enabled": False}
 
 
-def _sessions_sig():
-    """Newest mtime across state.db + WAL: the one thing messaging-gateway turns and cron runs
-    all move. Served sibling profile homes are probed too, else a routed Bot Chat never refreshes.
+# Last successful SQL fingerprint per profile home. A locked/busy probe must
+# reuse this instead of falling back to mtime — sql↔mtime flip-flops look like
+# a session change and re-storm Desktop.
+_sessions_sql_cache: dict[str, tuple] = {}
 
-    signal. Messaging-gateway turns and cron runs are written by OTHER processes that never touch this
-    gateway's transports; the shared SQLite file is the one thing they all move (#58671). A backend serving
-    several profiles owns one store per profile, so every served sibling home is
+
+def _sessions_store_sig(root: Path):
+    """Session-table fingerprint for one profile home.
+
+    ``state.db`` mtime is the wrong signal: gateway heartbeats, FTS, leases,
+    and ``last_activity_at`` heartbeats rewrite the same file without a
+    conversation actually appearing/disappearing. Desktop then rebuilds the
+    open chat (including the composer) on each ``sessions.changed`` tick.
+    Ignore activity timestamps; only count/title/pin/archive/message-count
+    and start/end bounds. Fake/non-sqlite files (tests) return None so the
+    caller can fall back to mtime.
     """
-    return _newest_mtime_ns(
-        root / name
-        for root in (_watcher_home(), *_served_profile_homes)
-        for name in ("state.db", "state.db-wal"))
+    db = root / "state.db"
+    if not db.is_file():
+        return None
+    key = str(root)
+    try:
+        # Import here: bind_module rebinds this function onto server.py globals,
+        # which do not include change_watcher's module imports.
+        import sqlite3 as _sqlite3
+        con = _sqlite3.connect(f"file:{db}?mode=ro", uri=True, timeout=0.2)
+        try:
+            con.execute("PRAGMA query_only=ON")
+            row = con.execute(
+                "SELECT COUNT(*), COALESCE(SUM(message_count), 0), "
+                "MAX(started_at), MAX(ended_at), "
+                "COALESCE(SUM(LENGTH(COALESCE(title, ''))), 0), "
+                "COALESCE(SUM(pinned), 0), COALESCE(SUM(archived), 0), "
+                "COALESCE(SUM(hidden), 0) FROM sessions"
+            ).fetchone()
+        finally:
+            con.close()
+    except Exception:
+        return _sessions_sql_cache.get(key)
+    if row is None:
+        return _sessions_sql_cache.get(key)
+    sig = tuple(row)
+    _sessions_sql_cache[key] = sig
+    return sig
+
+
+def _sessions_sig():
+    """Per-home session fingerprint. Served sibling profile homes are probed too,
+    else a routed Bot Chat never refreshes (#99333).
+
+    Messaging-gateway turns and cron runs are written by OTHER processes that never
+    touch this gateway's transports; the shared SQLite file is the one thing they
+    all move (#58671). A backend serving several profiles owns one store per
+    profile. Heartbeats in the same file must not count as a session change.
+    """
+    parts = []
+    for root in (_watcher_home(), *_served_profile_homes):
+        sql_sig = _sessions_store_sig(root)
+        if sql_sig is not None:
+            parts.append((str(root), "sql", sql_sig))
+        else:
+            parts.append((str(root), "mtime", _newest_mtime_ns(
+                root / name for name in ("state.db", "state.db-wal"))))
+    return tuple(parts)
 
 
 def _pairing_sig():


### PR DESCRIPTION
## Bug Description

Desktop remounts the open chat (including the composer) on idle `sessions.changed` ticks. New Desktop-created sessions flicker every few seconds; older / CLI-projected sessions often do not.

Fixes #98005

Related: #98394, #95033. Complements (does not duplicate) open PR #98523, which still keys the signature on db/WAL mtime and would still fire on `last_activity_at` heartbeats.

## Root Cause

`_sessions_sig()` used `state.db` / WAL mtime. Anything that writes the shared store — `gateway_heartbeats`, FTS, leases, **and** CLI/agent `last_activity_at` stamps — looks like a session change.

The 2s broadcast floor then storms Desktop. `refreshSessions` republishes `$sessions` whenever any row's `last_active` moved; `ChatView` subscribed to the whole array, so the thread + composer remounted.

Issue #98005 proposed `MAX(last_activity_at)` as the fingerprint. That is still wrong: a live CLI turn rewrites `last_activity_at` continuously, so the broadcast never stops. Open PR #98523 returns `(mtime, content)` — mtime still changes the tuple on every heartbeat.

## Fix

- Fingerprint the `sessions` table on count, message-count, title length, pin/archive/hidden, start/end bounds. **Ignore `last_activity_at`.**
- Cache the last successful SQL probe so a busy/non-sqlite moment cannot flip back to mtime (that flip-flop storms every 2s).
- `ChatView` / header read scalars off `$sessions` instead of the array identity.

Gateway-only: restart the Desktop `serve` process. No Desktop rebuild required for the storm to stop.

## How to Verify

1. Open Desktop, create a new chat, send one message, leave it open.
2. Keep a CLI session writing (or wait for gateway heartbeats).
3. `grep sessions.changed ~/.hermes/logs/desktop.log` — idle ticks should stop; a real new message/title/pin still fires.
4. Composer no longer unmounts on the open Desktop chat.

## Test Plan

- [x] Added regression tests: activity heartbeat does **not** broadcast; message_count change **does**; SQL→mtime flip-flop does **not**
- [x] `pytest tests/tui_gateway/test_change_watcher.py` — 19 passed
- [x] Sabotage: restoring mtime `_sessions_sig` fails the two new negative tests
- [x] Manual: after restarting Desktop serve, idle 15s dropped from ~1 event/2s to 0–2 events (the remaining ones were this CLI session's own message writes)

## Risk Assessment

Low — watcher fingerprint + renderer subscription only. Cron/messaging/Bot Chat still refresh when a **row** actually appears/changes (count/title/pin/archive/message_count). A session whose only delta is `last_activity_at` no longer refreshes the sidebar timestamp until a real row change; liveness still comes from `session.active_list`.
