### PR TITLE
fix(desktop): gate review pane repo cwd on workspace ownership

### DIFF
--- a/apps/desktop/src/store/review.test.ts
+++ b/apps/desktop/src/store/review.test.ts
@@ -39,7 +39,7 @@ import {
   toggleReviewTreeMode,
   unstageReviewFile
 } from './review'
-import { $currentCwd } from './session'
+import { $currentCwd, $selectedStoredSessionId, $workspaceCwdOwner, releaseWorkspaceCwdOwner } from './session'
 
 // requestOneShot is the only cross-module dependency that must be faked (it
 // reaches the gateway); everything else routes through window.hermesDesktop.git,
@@ -101,6 +101,8 @@ beforeEach(() => {
   $reviewScopeCwd.set(null)
   $reviewScopeTarget.set('main')
   $currentCwd.set('/repo')
+  $selectedStoredSessionId.set(null)
+  $workspaceCwdOwner.set(null)
 })
 
 afterEach(() => {
@@ -177,6 +179,83 @@ describe('refreshReview', () => {
     expect($reviewFiles.get()).toEqual([])
     expect($reviewIsRepo.get()).toBe(true)
     expect($reviewLoading.get()).toBe(false)
+  })
+
+  it('ignores a leftover cwd the selected conversation does not own (switch window / bare new chat)', async () => {
+    const review = stubReview({ list: vi.fn(async () => ({ files: [file('previous-chat.ts')] })) })
+    $reviewOpen.set(true)
+    $currentCwd.set('/previous-conversation-repo')
+    $selectedStoredSessionId.set('session-b')
+    $workspaceCwdOwner.set('session-a')
+
+    await refreshReview()
+
+    expect(review.list).not.toHaveBeenCalled()
+    expect($reviewFiles.get()).toEqual([])
+    expect($reviewIsRepo.get()).toBe(false)
+    expect($reviewLoading.get()).toBe(false)
+  })
+
+  it('reads the cwd once the resume settles and ownership matches the selection', async () => {
+    const review = stubReview({ list: vi.fn(async () => ({ files: [file('mine.ts')] })) })
+    $reviewOpen.set(true)
+    $currentCwd.set('/my-repo')
+    $selectedStoredSessionId.set('session-b')
+    $workspaceCwdOwner.set('session-b')
+
+    await refreshReview()
+
+    expect(review.list).toHaveBeenCalledWith('/my-repo', 'uncommitted', null)
+    expect($reviewFiles.get().map(f => f.path)).toEqual(['mine.ts'])
+    expect($reviewIsRepo.get()).toBe(true)
+  })
+
+  it('keeps reading a pinned tile scope regardless of cwd ownership', async () => {
+    const review = stubReview({ list: vi.fn(async () => ({ files: [file('tile.ts')] })) })
+    $reviewOpen.set(true)
+    $reviewScopeCwd.set('/tile-worktree')
+    $selectedStoredSessionId.set('session-b')
+    $workspaceCwdOwner.set('session-a')
+
+    await refreshReview()
+
+    expect(review.list).toHaveBeenCalledWith('/tile-worktree', 'uncommitted', null)
+    expect($reviewFiles.get().map(f => f.path)).toEqual(['tile.ts'])
+  })
+
+  it('re-evaluates an open pane when cwd ownership flips without the path moving', async () => {
+    vi.useFakeTimers()
+    const review = stubReview({ list: vi.fn(async () => ({ files: [file('mine.ts')] })) })
+    $reviewOpen.set(true)
+    $currentCwd.set('/my-repo')
+    $selectedStoredSessionId.set('session-b')
+    $workspaceCwdOwner.set('session-b')
+    await refreshReview()
+    expect($reviewFiles.get().map(f => f.path)).toEqual(['mine.ts'])
+
+    // Switch away: selection moves to session-a, the path is released to the
+    // previous conversation — without the cwd itself changing.
+    $selectedStoredSessionId.set('session-a')
+    releaseWorkspaceCwdOwner()
+
+    // The ownership subscriber clears + schedules a debounced refresh; flush it.
+    await vi.advanceTimersByTimeAsync(150)
+
+    expect($reviewFiles.get()).toEqual([])
+    expect($reviewIsRepo.get()).toBe(false)
+    expect(review.list).toHaveBeenCalledTimes(1)
+
+    // Switch back in: the resume settles and adopts the same path for session-a.
+    review.list.mockResolvedValue({ files: [file('adopted.ts')] })
+    $workspaceCwdOwner.set('session-a')
+    await vi.advanceTimersByTimeAsync(150)
+
+    expect(review.list).toHaveBeenCalledTimes(2)
+    expect(review.list).toHaveBeenLastCalledWith('/my-repo', 'uncommitted', null)
+    expect($reviewFiles.get().map(f => f.path)).toEqual(['adopted.ts'])
+    expect($reviewIsRepo.get()).toBe(true)
+
+    vi.useRealTimers()
   })
 })
 

--- a/apps/desktop/src/store/review.ts
+++ b/apps/desktop/src/store/review.ts
@@ -12,7 +12,14 @@ import { Codecs, persistentAtom } from '@/lib/persisted'
 
 import { refreshRepoStatus, repoStatusForCwd } from './coding-status'
 import { stampSessionPrBranch } from './pull-requests'
-import { $busy, $currentCwd, $selectedStoredSessionId, $sessions } from './session'
+import {
+  $busy,
+  $currentCwd,
+  $selectedStoredSessionId,
+  $sessions,
+  $workspaceCwdOwner,
+  workspaceCwdBelongsToSelectedSession
+} from './session'
 import { $workspaceChangeTick } from './workspace-events'
 
 // State for the review pane: the working-tree changed-file list, the selected
@@ -96,8 +103,20 @@ export const $reviewScopeCwd = atom<null | string>(null)
 export const $reviewScopeTarget = atom('main')
 
 /** The repo the pane is reading right now: its pinned scope, else the active
- *  session's cwd. Exported for pane helpers that join repo-relative paths. */
-export const reviewRepoCwd = (): null | string => $reviewScopeCwd.get()?.trim() || $currentCwd.get()?.trim() || null
+ *  session's cwd. Exported for pane helpers that join repo-relative paths.
+ *
+ *  The fallback is guarded like every other workspace-derived surface
+ *  (coding rail, right-sidebar tree): during a switch — or under a bare new
+ *  chat — `$currentCwd` still holds the PREVIOUS conversation's path until the
+ *  new session reports its own workspace, and `$workspaceCwdOwner` marks it as
+ *  not the selected conversation's. Reading it raw diffs another conversation's
+ *  uncommitted changes (and, in remote mode, hits a different gateway's
+ *  backend), so an unowned path yields null and the pane falls to its
+ *  "not a repo" state instead. */
+export const reviewRepoCwd = (): null | string =>
+  $reviewScopeCwd.get()?.trim() ||
+  (workspaceCwdBelongsToSelectedSession() ? $currentCwd.get()?.trim() : null) ||
+  null
 
 const repoCwd = reviewRepoCwd
 
@@ -613,6 +632,17 @@ let prevScopeCwd = $reviewScopeCwd.get()
 $reviewScopeCwd.subscribe(scope => {
   if (scope !== prevScopeCwd) {
     prevScopeCwd = scope
+    onReviewRepoMoved()
+  }
+})
+
+// Ownership of `$currentCwd` flipped without the path itself moving: a switch
+// released it to the previous conversation (untrusted now) or a resume settled
+// and adopted it for the selected one (trusted again). The `$currentCwd`
+// subscriber above can't fire here — the path didn't change — so this is the
+// only edge that re-evaluates an already-open pane on it.
+$workspaceCwdOwner.subscribe(() => {
+  if (!$reviewScopeCwd.get()) {
     onReviewRepoMoved()
   }
 })


### PR DESCRIPTION
## Summary

`reviewRepoCwd()` read `$currentCwd` raw, so during a conversation switch — or under a bare workspace-less new chat — the review pane diffed the **previous** conversation's uncommitted changes (and in remote mode could issue `/api/git/*` against a different gateway's backend). This is the same leak class #71254 fixed for the coding rail and the right-sidebar tree; the review pane never got the ownership guard.

## Changes

- **`reviewRepoCwd()`** now gates the `$currentCwd` fallback behind `workspaceCwdBelongsToSelectedSession()`, mirroring `coding-status.ts`: an unowned path yields `null`, and `refreshReview()` lands the pane on its existing "not a repo" empty state instead of another conversation's diffs. `$reviewScopeCwd` stays exempt — a tile-pinned scope is explicitly chosen and survives switches.
- **New `$workspaceCwdOwner` subscription**: ownership can flip without the path moving (selection switched → path released; resume settled → path adopted), so the `$currentCwd` subscriber alone left an already-open pane stranded on the stale diff. The new edge routes through the existing `onReviewRepoMoved()` (clear list + selection, debounce-refresh), and is a no-op while a tile scope is pinned.

## Tests

Four store-level regression tests in `review.test.ts`:
- unowned leftover cwd → no bridge call, `not a repo` state (the switch window / detached new chat from the report);
- ownership matching the selection → repo read normally;
- pinned tile scope unaffected by ownership;
- an open pane re-evaluates when ownership flips without the cwd changing (clears, then re-reads once the resume adopts the path).

Verified locally: `vitest run src/store/review.test.ts --project ui` — 44/44 green; `tsc --build tsconfig.electron.json` and `tsc -p . --noEmit` clean; eslint clean on both files.

Fixes #102981
