### PR TITLE
fix(local): reserve discrete host RAM headroom for spill planning

### DIFF
--- a/hermes_cli/local_runtime/context_policy.py
+++ b/hermes_cli/local_runtime/context_policy.py
@@ -64,7 +64,9 @@ def initial_window(profile: ModelProfile, budget: HardwareBudget, *, flash_atten
     everywhere, capped at native. ``overhead_bytes`` is runtime cost beyond weights+KV; zero keeps
     this pure physics for decision-table tests, production callers pass it.
     """
-    refusal = physics_check(profile, budget, FLOOR, flash_attention=flash_attention)
+    refusal = physics_check(
+        profile, budget, FLOOR, flash_attention=flash_attention,
+        overhead_bytes=overhead_bytes)
     if refusal:
         return refusal
 

--- a/hermes_cli/local_runtime/estimator.py
+++ b/hermes_cli/local_runtime/estimator.py
@@ -123,7 +123,7 @@ def ctx_bytes(profile: ModelProfile, window: int, *, flash_attention: bool = Tru
 
 @dataclass
 class PhysicsRefusal:
-    """The only true refusal: weights + floor-KV + state exceed VRAM + RAM. The remedy is a
+    """The only true refusal: weights + floor-KV + overhead exceed VRAM + RAM. The remedy is a
     smaller quant, never a smaller window."""
 
     needed_bytes: int
@@ -132,10 +132,12 @@ class PhysicsRefusal:
 
 
 def physics_check(profile: ModelProfile, budget: HardwareBudget,
-                  floor: int, *, flash_attention: bool = True) -> PhysicsRefusal | None:
+                  floor: int, *, flash_attention: bool = True,
+                  overhead_bytes: int = 0) -> PhysicsRefusal | None:
     needed = (profile.weights_bytes
               + ctx_bytes(profile, min(floor, profile.n_ctx_train or floor),
-                          flash_attention=flash_attention))
+                          flash_attention=flash_attention)
+              + max(0, int(overhead_bytes)))
     available = budget.usable_vram_bytes + budget.ram_available_bytes
     if needed <= available:
         return None

--- a/hermes_cli/local_runtime/hardware.py
+++ b/hermes_cli/local_runtime/hardware.py
@@ -33,6 +33,14 @@ _MARGIN_FRACTION = 0.09
 # UMA headroom: on unified-memory machines the model shares physical memory with the OS and every
 # app, so budget from RAM minus this fraction.
 _UMA_HEADROOM_FRACTION = 0.20
+# Discrete spill room: spilled weights live in host RAM alongside the OS and desktop. Planning
+# against ram_total with no headroom lets a ~21 GiB MoE "fit" a 30 GiB laptop and thrash-freeze
+# the session (#102865). UMA already discounts its pool by 20%; discrete host needs a larger
+# cut because the desktop cannot move off host RAM the way a model can share a UMA pool.
+# Live probes still use OS-available (already net of pressure). Floor covers compositor +
+# Electron + a browser tab on small boxes.
+_DISCRETE_RAM_HEADROOM_FRACTION = 0.40
+_DISCRETE_RAM_HEADROOM_FLOOR = 4 << 30
 
 # Engine-fallback gates for the unified-pool quirk — BOTH must hold, and no discrete card can
 # meet either: (1) the allocator's pool exceeds the smi report by well past rounding/ECC slack
@@ -250,6 +258,21 @@ def _uma_budget(base: int, total: int) -> HardwareBudget:
                           ram_available_bytes=0, uma=True)
 
 
+def _discrete_host_ram_bytes(ram_total: int, ram_avail: int, *, planning: bool) -> int:
+    """Host RAM the spill path may budget against.
+
+    Planning uses capacity minus desktop/OS headroom (mirrors VRAM margin + UMA headroom).
+    Live uses OS-available, which already reflects pressure.
+    """
+    if not planning:
+        return max(0, ram_avail)
+    headroom = max(
+        _DISCRETE_RAM_HEADROOM_FLOOR,
+        int(ram_total * _DISCRETE_RAM_HEADROOM_FRACTION),
+    )
+    return max(0, ram_total - headroom)
+
+
 def probe_budget(*, planning: bool = False) -> HardwareBudget:
     """Construct the budget per the source rules above.
 
@@ -292,5 +315,6 @@ def probe_budget(*, planning: bool = False) -> HardwareBudget:
     margin = max(_MARGIN_FLOOR, int(total * _MARGIN_FRACTION))
     return HardwareBudget(usable_vram_bytes=max(0, (total if planning else free) - margin),
                           total_device_bytes=total,
-                          ram_available_bytes=ram_total if planning else ram_avail,
+                          ram_available_bytes=_discrete_host_ram_bytes(
+                              ram_total, ram_avail, planning=planning),
                           uma=False)

--- a/tests/hermes_cli/test_context_policy.py
+++ b/tests/hermes_cli/test_context_policy.py
@@ -177,6 +177,16 @@ def test_physics_check_prices_at_floor_not_native():
     assert physics_check(p, card(24, ram_gib=8), FLOOR) is None
 
 
+def test_physics_check_includes_overhead_bytes():
+    """Preset/catalog callers price mmproj + runtime; refusal must too."""
+    p = dense(weights_gib=20)
+    budget = card(8, ram_gib=8)  # 16 GiB total
+    assert physics_check(p, budget, FLOOR) is None
+    refused = physics_check(p, budget, FLOOR, overhead_bytes=int(4 * GIB))
+    assert isinstance(refused, PhysicsRefusal)
+    assert refused.needed_bytes > refused.available_bytes
+
+
 # ── ladder + initial window ──────────────────────────────────
 
 

--- a/tests/hermes_cli/test_local_recommendation.py
+++ b/tests/hermes_cli/test_local_recommendation.py
@@ -14,9 +14,9 @@ human approved, exactly like a golden file. When a cell flips on
 purpose, update it in the same commit and say why. When one flips by
 surprise, that is the test doing its job.
 
-Budgets mirror hardware.probe_budget's planning-mode shapes (margins,
-UMA headroom) so the cells match what a real machine of that class
-resolves.
+Budgets mirror hardware.probe_budget's planning-mode shapes (VRAM
+margins, UMA headroom, discrete host RAM headroom) so the cells match
+what a real machine of that class resolves.
 """
 
 from __future__ import annotations
@@ -38,9 +38,12 @@ _GIB = 1 << 30
 def _discrete(size_gb: int) -> HardwareBudget:
     total = size_gb * _GIB
     margin = max(2 * _GIB, int(total * 0.09))
+    # Mirror probe_budget(planning=True) discrete host headroom (40%, floor 4 GiB).
+    ram_total = 64 * _GIB
+    headroom = max(4 * _GIB, int(ram_total * 0.40))
     return HardwareBudget(usable_vram_bytes=max(0, total - margin),
                           total_device_bytes=total,
-                          ram_available_bytes=64 * _GIB, uma=False)
+                          ram_available_bytes=ram_total - headroom, uma=False)
 
 
 def _unified(size_gb: int) -> HardwareBudget:
@@ -167,3 +170,29 @@ def test_quality_decides_where_speed_permits():
         if (c := select_variant(e, budget)) is not None and c.zero_spill
     ]
     assert pick == max(resident, key=lambda e: e.quality).id
+
+
+def test_discrete_30gib_laptop_does_not_recommend_thrash_spill():
+    """#102865: 8 GiB VRAM + ~30 GiB RAM must not auto-pick a ~21 GiB MoE.
+
+    Planning used to budget full ram_total for spill room; the 35B-A3B then
+    looked like the least-painful spilled pick and freeze-thrashed the
+    desktop on load. Host headroom must refuse that pick and land on a
+    smaller spilled alternative (or None if the catalog has nothing left).
+    """
+    vram_total = 8 * _GIB
+    ram_total = int(30.6 * _GIB)
+    margin = max(2 * _GIB, int(vram_total * 0.09))
+    headroom = max(4 * _GIB, int(ram_total * 0.40))
+    budget = HardwareBudget(
+        usable_vram_bytes=vram_total - margin,
+        total_device_bytes=vram_total,
+        ram_available_bytes=ram_total - headroom,
+        uma=False,
+    )
+    entry_35b = next(e for e in CATALOG if e.id == "qwen3.6-35b-a3b")
+    assert select_variant(entry_35b, budget) is None
+    picked = recommended_entry(budget)
+    assert picked is not None
+    assert picked[0].id != "qwen3.6-35b-a3b"
+    assert picked[1] == "least-painful-spilled"

--- a/tests/hermes_cli/test_unified_pool_quirk.py
+++ b/tests/hermes_cli/test_unified_pool_quirk.py
@@ -141,22 +141,45 @@ def test_budget_unified_no_smi_still_classifies(monkeypatch):
     assert live.usable_vram_bytes == int(32 * GIB * (1 - hw._UMA_HEADROOM_FRACTION))
 
 
+def _expected_discrete_planning_ram(ram_total: int) -> int:
+    headroom = max(
+        hw._DISCRETE_RAM_HEADROOM_FLOOR,
+        int(ram_total * hw._DISCRETE_RAM_HEADROOM_FRACTION),
+    )
+    return max(0, ram_total - headroom)
+
+
 def test_budget_discrete_unchanged_when_probe_says_discrete(monkeypatch):
-    """integrated=False keeps the existing discrete path bit-for-bit."""
+    """integrated=False keeps the discrete VRAM path; host RAM reserves desktop headroom."""
     _uma_machine(monkeypatch, view=(UMA_POOL, False))
     b = hw.probe_budget(planning=True)
     assert b.uma is False
     assert b.total_device_bytes == UMA_SMI_TOTAL
     margin = max(hw._MARGIN_FLOOR, int(UMA_SMI_TOTAL * hw._MARGIN_FRACTION))
     assert b.usable_vram_bytes == UMA_SMI_TOTAL - margin
-    assert b.ram_available_bytes == UMA_RAM
+    assert b.ram_available_bytes == _expected_discrete_planning_ram(UMA_RAM)
 
 
 def test_budget_discrete_unchanged_when_probe_unavailable(monkeypatch):
     _uma_machine(monkeypatch, view=None)
     b = hw.probe_budget(planning=True)
     assert b.uma is False
-    assert b.ram_available_bytes == UMA_RAM
+    assert b.ram_available_bytes == _expected_discrete_planning_ram(UMA_RAM)
+
+
+def test_discrete_planning_reserves_host_headroom(monkeypatch):
+    """Planning must not budget the entire host for spill (#102865)."""
+    _no_cache(monkeypatch)
+    ram_total = 30 * GIB
+    monkeypatch.setattr(hw, "_nvidia_vram", lambda: (8 * GIB, 7 * GIB))
+    monkeypatch.setattr(hw, "_ram_bytes", lambda: (ram_total, 20 * GIB))
+    monkeypatch.setattr(hw, "_device_pool_view", lambda: (8 * GIB, False))
+    planning = hw.probe_budget(planning=True)
+    assert planning.uma is False
+    assert planning.ram_available_bytes == _expected_discrete_planning_ram(ram_total)
+    assert planning.ram_available_bytes < ram_total
+    live = hw.probe_budget(planning=False)
+    assert live.ram_available_bytes == 20 * GIB
 
 
 def test_engine_fallback_without_smi_stays_conservative(monkeypatch):


### PR DESCRIPTION
## Summary

- Discrete `probe_budget(planning=True)` previously budgeted **full** `ram_total` for spill room (VRAM and UMA already take margins/headroom). That let catalog auto-pick a ~21 GiB MoE on an 8 GiB VRAM + ~30 GiB RAM laptop; load then thrash-froze the desktop (#102865).
- Reserve **40%** of host RAM (floor 4 GiB) in discrete planning budgets; live probes still use OS-available.
- Include `overhead_bytes` in `physics_check` so refusals match what presets actually price (mmproj + runtime + logits).

On the reporter shape, recommendation moves from `qwen3.6-35b-a3b` → `qwen3.8-27b` (still spilled). The 64 GiB decision table is unchanged.

Fixes #102865

## Test plan

- [x] `tests/hermes_cli/test_unified_pool_quirk.py` — planning reserves headroom; live uses OS-available
- [x] `tests/hermes_cli/test_local_recommendation.py` — 8 GiB + 30.6 GiB refuses 35B thrash spill; decision table still green
- [x] `tests/hermes_cli/test_context_policy.py` — `physics_check` includes overhead
- [ ] Manual: Local Models “Set up for me” on ≤32 GiB RAM + 8 GiB discrete should not recommend the 35B-A3B spill

