### PR TITLE
fix(local-models): point _assign_default's late-bound assignment at web_server_config

### DIFF
--- a/hermes_cli/web_routers/local_models.py
+++ b/hermes_cli/web_routers/local_models.py
@@ -270,7 +270,7 @@ def _ensure_server(job: Dict[str, Any], config: dict, model_id: str, *, fail_det
 def _assign_default(job: Dict[str, Any], model_id: str) -> None:
     """Make ``model_id`` the main model via the same machinery as /api/model/set (late-bound: tests stub web_deps.late)."""
     _step(job, "setting-default", "Making it your default")
-    web_deps.late("_apply_model_assignment_sync")("main", "llamacpp", model_id, "", "", "")
+    web_deps.late("_apply_model_assignment_sync", "hermes_cli.web_server_config")("main", "llamacpp", model_id, "", "", "")
 
 
 # ── downloads: ranged parallel streams ───────────────────────

--- a/tests/hermes_cli/test_local_quickstart.py
+++ b/tests/hermes_cli/test_local_quickstart.py
@@ -84,7 +84,7 @@ def test_quickstart_runs_all_three_legs(client, monkeypatch, tmp_path):
 
     monkeypatch.setattr(
         web_deps, "late",
-        lambda name: (lambda *a, **k: calls.append("assign")))
+        lambda name, module="hermes_cli.web_server": (lambda *a, **k: calls.append("assign")))
 
     r = client.post("/api/local-models/quickstart", json={})
     assert r.status_code == 200
@@ -137,7 +137,7 @@ def test_quickstart_skips_satisfied_legs(client, monkeypatch):
 
     monkeypatch.setattr(
         web_deps, "late",
-        lambda name: (lambda *a, **k: calls.append("assign")))
+        lambda name, module="hermes_cli.web_server": (lambda *a, **k: calls.append("assign")))
 
     r = client.post("/api/local-models/quickstart", json={})
     assert r.status_code == 200

--- a/tests/hermes_cli/test_local_quickstart.py
+++ b/tests/hermes_cli/test_local_quickstart.py
@@ -55,7 +55,7 @@ def test_quickstart_refuses_when_nothing_fits(client, monkeypatch):
 def test_quickstart_runs_all_three_legs(client, monkeypatch, tmp_path):
     """Fresh machine: install runtime -> download recommended -> activate.
     Each leg is asserted by its observable call, in order."""
-    calls: list[str] = []
+    calls: list = []
 
     # Leg 1: no runtime installed yet; install is the stubbed binaries call.
     monkeypatch.setattr(
@@ -84,7 +84,8 @@ def test_quickstart_runs_all_three_legs(client, monkeypatch, tmp_path):
 
     monkeypatch.setattr(
         web_deps, "late",
-        lambda name, module="hermes_cli.web_server": (lambda *a, **k: calls.append("assign")))
+        lambda name, module="hermes_cli.web_server": (
+            calls.append((name, module)) or (lambda *a, **k: calls.append("assign"))))
 
     r = client.post("/api/local-models/quickstart", json={})
     assert r.status_code == 200
@@ -100,6 +101,8 @@ def test_quickstart_runs_all_three_legs(client, monkeypatch, tmp_path):
     assert calls[0] == "install"
     assert "download" in calls
     assert calls.index("install") < calls.index("download") < calls.index("assign")
+    # _assign_default binds the defining module, not the web_server facade.
+    assert ("_apply_model_assignment_sync", "hermes_cli.web_server_config") in calls
 
     # Durable effect: the runtime is enabled in config.
     from hermes_cli.config import load_config
@@ -110,7 +113,7 @@ def test_quickstart_runs_all_three_legs(client, monkeypatch, tmp_path):
 def test_quickstart_skips_satisfied_legs(client, monkeypatch):
     """Runtime present and model already staged: the response says so and
     the job goes straight to activation."""
-    calls: list[str] = []
+    calls: list = []
 
     monkeypatch.setattr(
         "hermes_cli.local_runtime.binaries.installed_tags", lambda: ["b10362"])
@@ -137,7 +140,8 @@ def test_quickstart_skips_satisfied_legs(client, monkeypatch):
 
     monkeypatch.setattr(
         web_deps, "late",
-        lambda name, module="hermes_cli.web_server": (lambda *a, **k: calls.append("assign")))
+        lambda name, module="hermes_cli.web_server": (
+            calls.append((name, module)) or (lambda *a, **k: calls.append("assign"))))
 
     r = client.post("/api/local-models/quickstart", json={})
     assert r.status_code == 200
@@ -150,6 +154,8 @@ def test_quickstart_skips_satisfied_legs(client, monkeypatch):
     assert job["status"] == "done", job["error"]
     assert "install" not in calls and "download" not in calls
     assert calls == ["assign"] or calls[-1] == "assign"
+    # _assign_default binds the defining module, not the web_server facade.
+    assert ("_apply_model_assignment_sync", "hermes_cli.web_server_config") in calls
 
 
 @pytest.fixture

--- a/tests/hermes_cli/test_local_quickstart.py
+++ b/tests/hermes_cli/test_local_quickstart.py
@@ -185,3 +185,25 @@ def test_quickstart_is_single_flight(client, quickstart_ready, monkeypatch):
         assert "already running" in r.json()["detail"].lower()
     finally:
         lm._QUICKSTART_LOCK.release()
+
+
+def test_assign_default_resolves_against_defining_module(monkeypatch):
+    """_assign_default must bind _apply_model_assignment_sync to the module
+    that defines it (web_server_config), not the web_server facade it was
+    extracted from. Without the explicit module the late() proxy defaults to
+    web_server and the quickstart's 'making it your default' step fails with
+    AttributeError (regression from the god-file decomposition)."""
+    import hermes_cli.web_routers.local_models as lm
+    from hermes_cli import web_deps
+
+    seen: dict = {}
+
+    def _fake_late(name, module=None):
+        seen["name"] = name
+        seen["module"] = module
+        return lambda *a, **k: None
+
+    monkeypatch.setattr(web_deps, "late", _fake_late)
+    lm._assign_default({}, "some-model")
+    assert seen["name"] == "_apply_model_assignment_sync"
+    assert seen["module"] == "hermes_cli.web_server_config"


### PR DESCRIPTION
## Summary
Fixes the local-model quickstart's final "making it your default" step, which fails on current main with:
```
module 'hermes_cli.web_server' has no attribute '_apply_model_assignment_sync'
```

## Root cause
The whole-codebase refactor (god-file decomposition) moved `_apply_model_assignment_sync` from the `hermes_cli.web_server` facade into `hermes_cli.web_server_config` (commit `5233cbf50f`). Most callers were repointed, but `_assign_default` in `hermes_cli/web_routers/local_models.py` still resolves it through `web_deps.late("...")`, which defaults its module to `web_server` — a facade that no longer carries the symbol. The sibling `models.py` router was correctly updated to import from `web_server_config`; this fix brings `local_models.py` in line.

## Changes made
- `hermes_cli/web_routers/local_models.py`: pass the defining module (`hermes_cli.web_server_config`) explicitly to `web_deps.late()`, matching the real `late(name, module=...)` signature.
- `tests/hermes_cli/test_local_quickstart.py`: update the two `web_deps.late` stubs to accept the module argument the production call now passes.

## How to test
1. Install a local model runtime (or run the quickstart route).
2. Without the fix, the job ends with the `AttributeError` above on the `setting-default` step.
3. With the fix, the quickstart completes and assigns the model.

## Checklist
- [x] `scripts/run_tests.sh` on the affected test files passes (test_local_quickstart.py: 5/5; plus 29 related local-runtime/assignment tests)
- [x] Import from the defining module (no compat pointer used)
- [x] Conventional commit
- [x] Smallest footprint: 1 source line + 2 test-stub signatures