### PR TITLE
fix(desktop): tool-pane tab click opens its toggle store so a stranded terminal mounts

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -1618,9 +1618,21 @@ export function mergeTreeZones(groupIds: string[], paneId: string | readonly str
 export function activateTreePane(groupId: string, paneId: string) {
   const tree = $layoutTree.get()
 
-  if (tree) {
-    commit(setActivePaneOp(tree, groupId, paneId))
+  if (!tree) {
+    return
   }
+
+  // A collapse-marked tool pane (terminal/logs) mounts its workspace ONLY
+  // while its owning toggle store is open (PersistentTerminal). Fronting such
+  // a tab without the store leaves an empty surface — no shell, no PTY — and
+  // the next toggle press then reads the fronted pane as "on screen" and folds
+  // the zone instead of opening it. A tab click on a tool pane is a reveal:
+  // open its store with the front (the opener is a no-op when already open).
+  if (isCollapsePane(paneId)) {
+    paneOpeners[paneId]?.()
+  }
+
+  commit(setActivePaneOp(tree, groupId, paneId))
 }
 
 /** Reorder a tab block (multi-tab selection, or a single tab) within its
@@ -1684,7 +1696,18 @@ export function setPaneCollapsed(paneId: string, collapsed: boolean) {
           activateTreePane(group.id, group.panes[at - 1] ?? group.panes[at + 1])
         }
       } else {
-        setTreeGroupMinimized(group.id, true) // pure tool zone folds as a unit
+        // A shared zone with NO uncloseable member folds as a unit only when
+        // every member is a tool pane ([terminal, logs]). A tool pane active
+        // among hide-style panes (the terminal dragged into the sessions
+        // column) must hand the slot to a non-tool sibling instead — folding
+        // the group would collapse the sessions list along with the terminal.
+        const peer = group.panes.find(id => id !== paneId && !isCollapsePane(id))
+
+        if (peer) {
+          activateTreePane(group.id, peer)
+        } else {
+          setTreeGroupMinimized(group.id, true) // pure tool zone folds as a unit
+        }
       }
     } else if (!collapsed) {
       revealTreePane(paneId)

--- a/apps/desktop/src/components/pane-shell/tree/tool-pane-stranded-tab.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/tool-pane-stranded-tab.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { $terminalTakeover, setTerminalTakeover } from '@/app/right-sidebar/store'
+import { registry } from '@/contrib/registry'
+
+import { allPaneIds, group, split } from './model'
+import {
+  $dismissedPanes,
+  $hiddenTreePanes,
+  $layoutTree,
+  activateTreePane,
+  bindToolPaneCollapse,
+  isPaneVisible,
+  togglePaneVisible
+} from './store'
+
+// Ground truth for the reported bug: the bottom tool pane (terminal) ended up
+// stacked as a tab inside the left hide-style sessions column (a user drag —
+// `userPlacedPanes: ["terminal"]`), with the terminal's toggle store persisted
+// as OFF. Persisted evidence from the field: layoutTree put terminal in
+// `grp-sessions` next to `sessions`, `terminalTakeover` stayed false, and the
+// ⌃`/⌘K/statusbar toggle appeared to do nothing — no pane, no shell, no tab.
+// Recovery was only possible by resetting the layout state.
+
+const disposers: (() => void)[] = []
+
+/** Bind through the REAL production function (controller.tsx wiring). */
+function bindTerminalToggle() {
+  bindToolPaneCollapse(
+    'terminal',
+    $terminalTakeover,
+    () => setTerminalTakeover(false),
+    () => setTerminalTakeover(true)
+  )
+}
+
+beforeEach(() => {
+  window.localStorage.clear()
+  $dismissedPanes.set(new Set())
+  $hiddenTreePanes.set(new Set())
+  setTerminalTakeover(false)
+
+  for (const [id, data] of [
+    ['workspace', { placement: 'main', uncloseable: true }],
+    ['sessions', { placement: 'left', hideOnly: true, collapsible: true }],
+    ['terminal', { placement: 'bottom' }]
+  ] as const) {
+    disposers.push(registry.register({ area: 'panes', data, id, render: () => null, title: id }))
+  }
+})
+
+afterEach(() => {
+  disposers.splice(0).forEach(dispose => dispose())
+})
+
+/** The field layout: terminal dragged into the sessions column, sessions active. */
+function sessionsColumnWithTerminal() {
+  $layoutTree.set(
+    split('row', [
+      group(['sessions', 'terminal'], { active: 'sessions', id: 'grp-sessions' }),
+      group(['workspace'], { active: 'workspace', id: 'grp-main' })
+    ])
+  )
+}
+
+describe('a bottom tool pane stranded in the sessions column (field layout)', () => {
+  it('fronting its tab via activate opens its toggle store, so the shell can mount', () => {
+    sessionsColumnWithTerminal()
+    bindTerminalToggle()
+
+    // Persisted state after the reported bug: takeover is OFF while the pane
+    // still sits in the tree (un-minimized). Clicking the terminal's tab only
+    // runs activateTreePane — PersistentTerminal mounts its workspace ONLY
+    // while the takeover store is true, so a bare front leaves an EMPTY pane:
+    // no shell is ever spawned and the pane reads as "not showing".
+    expect($terminalTakeover.get()).toBe(false)
+    expect(isPaneVisible('terminal')).toBe(false)
+
+    activateTreePane('grp-sessions', 'terminal')
+
+    expect(isPaneVisible('terminal')).toBe(true)
+    // THE regression: the store must open with the front, or the pane is an
+    // unmountable shell (empty surface, no PTY spawn, dead toggle afterwards).
+    expect($terminalTakeover.get()).toBe(true)
+  })
+
+  it('⌃` / the statusbar toggle surfaces the terminal from the sessions column and keeps it open', () => {
+    sessionsColumnWithTerminal()
+    bindTerminalToggle()
+
+    togglePaneVisible('terminal')
+
+    expect(isPaneVisible('terminal')).toBe(true)
+    expect($terminalTakeover.get()).toBe(true)
+
+    // A second press collapses it again (plain toggle round-trip).
+    togglePaneVisible('terminal')
+    expect(isPaneVisible('terminal')).toBe(false)
+  })
+
+  it('closing the stranded terminal hands the slot to sessions instead of folding the whole column', () => {
+    sessionsColumnWithTerminal()
+    bindTerminalToggle()
+
+    togglePaneVisible('terminal')
+    expect(isPaneVisible('terminal')).toBe(true)
+
+    // THE second half of the field bug: with the terminal active in the
+    // sessions column, a closing ⌃` used to minimize the WHOLE group — the
+    // sessions list collapsed along with the terminal it was stacked in.
+    togglePaneVisible('terminal')
+
+    expect(isPaneVisible('terminal')).toBe(false)
+    expect($terminalTakeover.get()).toBe(false)
+    // The column survives; sessions takes back the slot.
+    const tree = $layoutTree.get()!
+    const column = tree.type === 'split' ? tree.children[0] : null
+    expect(column).toMatchObject({ type: 'group', id: 'grp-sessions', active: 'sessions' })
+    expect(column?.type === 'group' && column.minimized).not.toBe(true)
+    expect(isPaneVisible('sessions')).toBe(true)
+  })
+
+  it('the terminal tab remains clickable and mountable after a simulated restart', () => {
+    sessionsColumnWithTerminal()
+    bindTerminalToggle()
+
+    // ── restart: tree + takeover atom are both persisted ──
+    // Terminal is a tab in the sessions column again; takeover is OFF.
+    expect($terminalTakeover.get()).toBe(false)
+
+    activateTreePane('grp-sessions', 'terminal')
+
+    expect(isPaneVisible('terminal')).toBe(true)
+    expect($terminalTakeover.get()).toBe(true)
+    // The pane must stay in the tree (no dismissal from fronting a tab).
+    expect(allPaneIds($layoutTree.get()!)).toContain('terminal')
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Fixes the "dead" in-app terminal pane that results when the bottom tool pane (terminal) is stacked as a tab inside the left hide-style sessions column (a user drag — `userPlacedPanes: ["terminal"]`).

**Problem.** Tool panes (terminal/logs) are bound via `bindToolPaneCollapse` to an owning toggle store, and `PersistentTerminal` mounts its workspace **only while that store is `true`**. A group-strip tab click only runs `activateTreePane()` (`restoreTreePane` is used just when the group is minimized). So with the terminal in a non-minimized group whose toggle store is `false` — exactly what a drag into the sessions column leaves behind:

1. Clicking the terminal's tab fronts an **empty surface**: no shell, no PTY, nothing in `desktop.log`.
2. The next ⌃` press sees the fronted pane as "on screen" and routes to the collapse path, which (no uncloseable member in the group) **minimizes the whole sessions column** with the terminal in it.

Only a layout/pane-state reset recovered (field report: #102991).

**Fix.** Two small changes in `components/pane-shell/tree/store.ts`:

- `activateTreePane()` runs the pane's registered opener for collapse-marked panes before fronting (no-op when already open), so a fronted tool pane always mounts its workspace/shell.
- The shared-zone close branch of `setPaneCollapsed()` hands the active slot to a **non-tool sibling** when one exists, and only minimizes when the group is a pure tool zone — so closing a stranded terminal no longer folds the sessions column it sits in.

## Related Issue

Fixes #102991

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/pane-shell/tree/store.ts` — `activateTreePane`: open a collapse-marked pane's toggle store on front.
- `apps/desktop/src/components/pane-shell/tree/store.ts` — `setPaneCollapsed`: hand a mixed group's active slot to a non-tool sibling instead of folding the group.
- `apps/desktop/src/components/pane-shell/tree/tool-pane-stranded-tab.test.ts` — new regression suite reproducing the field layout (terminal as a tab in `grp-sessions` with `sessions` active, toggle store `false`): tab-click mounts, ⌃` round-trip, close does not fold the column, restart stays clickable.

## How to Test

1. Unit (deterministic repro of the field state):
   `cd apps/desktop && npx vitest run src/components/pane-shell/tree/tool-pane-stranded-tab.test.ts`
   — all 4 pass with the fix; the tab-activation tests fail on `main`.
2. Existing suites unchanged:
   `npx vitest run src/components/pane-shell/tree src/store/panes.test.ts src/store/layout.test.ts` → 170 passed.
3. Full suite: `npx vitest run` → 9276 passed / 1 failed — the failure is `electron/managed-ssh-update.test.ts`, pre-existing on macOS (its launcher script calls `setsid`, which does not exist on macOS → exit 127; unrelated to this renderer-store change).
4. Manual (macOS packaged build): drag the terminal tab into the sessions column, restart, click its tab → shell mounts; ⌃` opens/closes without folding the sessions list.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(desktop): tool-pane tab click opens its toggle store so a stranded terminal mounts`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (renderer change; vitest suite run instead, see above)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6.2 (packaged build repro + fix verified by the reporter)

### Documentation & Housekeeping

- [x] Documentation — N/A
- [x] Config keys — N/A
- [x] CONTRIBUTING/AGENTS — N/A
- [x] Cross-platform — the fix is platform-agnostic store logic; exercised the macOS path end-to-end
- [x] Tool schemas — N/A

## Screenshots / Logs

Repro → fix verification (unit):

```
# main (before): tab activation fronts an empty pane
expect($terminalTakeover.get()).toBe(true)  →  received false   [FAIL]

# fix branch: 30 files / 170 tests pass in pane-shell tree + panes/layout; new suite green
Test Files  30 passed (30)
Tests       170 passed (170)
```
