### PR TITLE
fix(update): stop successful Windows updates reporting gateway failure

### DIFF
--- a/hermes_cli/update_cmd_windows.py
+++ b/hermes_cli/update_cmd_windows.py
@@ -933,7 +933,13 @@ def _cold_start_windows_gateway_after_update() -> bool:
         pid = gateway_windows._spawn_detached()
     if not pid:
         raise RuntimeError("Windows gateway cold-start did not return a process ID")
-    ready_pids = gateway_windows._wait_for_gateway_ready()
+    # Updating can leave the fresh process with a cold import/plugin cache, so
+    # use the same fleet-wide startup budget as the post-update relaunch path.
+    # The detached launcher PID is not necessarily the eventual gateway PID;
+    # canonical process discovery is the readiness authority.
+    ready_pids = gateway_windows._wait_for_gateway_ready(
+        timeout_s=30.0, all_profiles=True
+    )
     if not ready_pids:
         raise RuntimeError(f"Windows gateway cold-start PID {pid} did not become ready")
     print(f"\n✓ Gateway started via cold-start after update (PID: {', '.join(map(str, ready_pids))})")

--- a/tests/hermes_cli/test_update_cold_start_gateway_liveness.py
+++ b/tests/hermes_cli/test_update_cold_start_gateway_liveness.py
@@ -52,3 +52,34 @@ def test_cold_start_reports_success_when_process_survives(monkeypatch, capsys):
     out = _run_cold_start(monkeypatch, capsys, surviving_pids=[4242])
 
     assert "✓ Gateway started via cold-start after update" in out
+
+
+def test_cold_start_waits_for_the_live_gateway_fleet(monkeypatch, capsys):
+    """The detached launcher PID need not be the eventual gateway PID.
+
+    Cold startup after an update may also take longer than the interactive
+    gateway-start budget while fresh modules and plugins are imported.  The
+    updater must therefore use its fleet-wide 30-second verification budget
+    and report the PID that canonical gateway discovery actually observed.
+    """
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: True)
+    monkeypatch.setattr(main_install_repair, "_is_windows", lambda: True)
+    monkeypatch.setattr(
+        hermes_gateway, "find_gateway_pids", lambda all_profiles=False: []
+    )
+    monkeypatch.setattr(gateway_windows, "_spawn_detached", lambda: 21416)
+
+    wait_calls = []
+
+    def _wait_for_gateway_ready(*, timeout_s, all_profiles):
+        wait_calls.append((timeout_s, all_profiles))
+        return [44852]
+
+    monkeypatch.setattr(
+        gateway_windows, "_wait_for_gateway_ready", _wait_for_gateway_ready
+    )
+
+    update_cmd._cold_start_windows_gateway_after_update()
+
+    assert wait_calls == [(30.0, True)]
+    assert "PID: 44852" in capsys.readouterr().out


### PR DESCRIPTION
## What does this PR do?

Prevents `hermes update --yes` on Windows from reporting a failed update when a cold-started gateway needs more than the interactive six-second startup budget. The updater now uses the existing 30-second fleet-wide readiness check and reports the gateway PID discovered by the canonical process scan, which may legitimately differ from the detached launcher PID.

### Symptom

A successful update can end with `RuntimeError: Windows gateway cold-start PID <pid> did not become ready` even though the gateway becomes healthy shortly afterward.

### Impact

Affected Windows users receive a non-zero update result after code and dependencies were updated successfully, causing wrappers and automation to classify the completed update as failed.

### Bug Cause

**Trigger:** `hermes_cli/update_cmd_windows.py:_cold_start_windows_gateway_after_update` after `_spawn_detached()`.

**Causal chain:**
1. A Windows update cold-starts an installed gateway after applying the update.
2. The cold-start path uses `_wait_for_gateway_ready()` with its interactive six-second, current-profile defaults.
3. Fresh imports and plugin initialization can exceed that budget, so the updater fails before canonical discovery observes the healthy gateway.

**Why it is wrong:** Post-update startup has a colder and broader lifecycle than an interactive start, and the detached launcher PID is not guaranteed to be the eventual gateway PID.

**Working sibling / contrast:** The paused-gateway relaunch path already waits 30 seconds and scans all profiles before declaring the Windows restart incomplete.

**Ruled out:** Readiness failure is not made non-fatal; a gateway that never becomes stable still raises and keeps the update fail-closed.

### Fix

Use the established post-update 30-second, all-profile readiness policy for cold starts. Add a regression test where launcher PID `21416` produces live gateway PID `44852`, confirming that canonical discovery rather than PID identity determines success.

## Related Issue

Closes #102974

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd_windows.py` - apply the fleet-wide post-update readiness budget to Windows cold starts.
- `tests/hermes_cli/test_update_cold_start_gateway_liveness.py` - cover delayed fleet readiness and launcher/runtime PID divergence.

## How to Test

1. Run the focused Windows update and gateway readiness tests.
2. Confirm the cold-start regression reports the discovered gateway PID even when it differs from the launcher PID.
3. Confirm a gateway that never stabilizes still raises.

```bash
scripts/run_tests.sh tests/hermes_cli/test_update_cold_start_gateway_liveness.py tests/hermes_cli/test_gateway_start_attestation.py tests/hermes_cli/test_windows_update_restart_reconciliation.py -q
```

Result: 19 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repo test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested the focused suite on Windows 11

### Documentation & Housekeeping

- [x] Documentation updates are N/A
- [x] Config example updates are N/A
- [x] Architecture guide updates are N/A
- [x] I've considered cross-platform impact; the changed path is Windows-only
- [x] Tool description/schema updates are N/A

## Screenshots / Logs

N/A
