### PR TITLE
feat: complete Hermes smart router runtime integration

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2702,6 +2702,27 @@ def _fallback_reason_text(reason: "FailoverReason | None") -> str:
     return str(value or reason or "provider failure").replace("_", " ")
 
 
+_ROUTER_STREAM_FAILOVER_REASONS = frozenset(
+    {
+        FailoverReason.rate_limit,
+        FailoverReason.upstream_rate_limit,
+        FailoverReason.overloaded,
+        FailoverReason.server_error,
+        FailoverReason.timeout,
+        FailoverReason.unknown,
+    }
+)
+
+
+def router_stream_fallback_allowed(
+    entry: dict, reason: "FailoverReason | None"
+) -> bool:
+    """Router-owned alternates are infrastructure-failure retries only."""
+    if not entry.get("_router_retryable_only"):
+        return True
+    return reason in _ROUTER_STREAM_FAILOVER_REASONS
+
+
 def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool:
     """Switch to the next fallback model/provider in the chain.
 
@@ -2714,6 +2735,11 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     auth resolution and client construction — no duplicated provider→key
     mappings.
     """
+    pending_reason = getattr(agent, "_fallback_activation_reason", None)
+    agent._fallback_activation_reason = None
+    if reason is None and pending_reason is not None:
+        reason = pending_reason
+
     if reason in {FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit}:
         # Only start cooldown when leaving the primary provider.  If we're
         # already on a fallback and chain-switching, the primary wasn't the
@@ -2755,6 +2781,25 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         return False
     fb = agent._fallback_chain[agent._fallback_index]
     agent._fallback_index += 1
+    if not router_stream_fallback_allowed(fb, reason):
+        logger.debug(
+            "Router stream fallback skip: failure reason %s is not retryable infrastructure",
+            getattr(reason, "value", reason),
+        )
+        return agent._try_activate_fallback(reason)
+    if fb.get("_router_retryable_only"):
+        health = getattr(agent, "_router_health_store", None)
+        if health is not None:
+            try:
+                if not health.claim_dispatch(
+                    str(fb.get("provider") or ""),
+                    str(fb.get("model") or ""),
+                ):
+                    logger.debug("Router stream fallback circuit unavailable")
+                    return agent._try_activate_fallback(reason)
+            except Exception:
+                # Health is advisory and deliberately fails open.
+                pass
     fb_key = _fallback_entry_key(fb)
     unavailable = getattr(agent, "_unavailable_fallback_keys", None)
     if unavailable is None:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3357,7 +3357,7 @@ def run_conversation(
                             f"⏳ {_nous_msg} Trying fallback..."
                         )
                         agent._buffer_status(f"⏳ {_nous_msg}")
-                        if agent._try_activate_fallback():
+                        if agent._try_activate_fallback(FailoverReason.rate_limit):
                             active_system_prompt = _sync_failover_system_message(
                                 agent, api_messages, active_system_prompt)
                             retry_count = 0
@@ -3848,7 +3848,7 @@ def run_conversation(
                     # rather than retrying with extended backoff.
                     if agent._fallback_index < len(agent._fallback_chain):
                         agent._buffer_status("⚠️ Empty/malformed response — switching to fallback...")
-                    if agent._try_activate_fallback():
+                    if agent._try_activate_fallback(FailoverReason.server_error):
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
                         retry_count = 0
@@ -3922,7 +3922,7 @@ def run_conversation(
                         # Try fallback before giving up
                         if agent._has_pending_fallback():
                             agent._buffer_status(f"⚠️ Max retries ({max_retries}) for invalid responses — trying fallback...")
-                        if agent._try_activate_fallback():
+                        if agent._try_activate_fallback(FailoverReason.server_error):
                             active_system_prompt = _sync_failover_system_message(
                                 agent, api_messages, active_system_prompt)
                             retry_count = 0
@@ -4100,6 +4100,9 @@ def run_conversation(
                         agent._buffer_status(
                             "⚠️ Model declined to respond (safety refusal) — trying fallback..."
                         )
+                    agent._fallback_activation_reason = (
+                        FailoverReason.content_policy_blocked
+                    )
                     if agent._try_activate_fallback():
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
@@ -4323,6 +4326,9 @@ def run_conversation(
                             )
                             agent._emit_status(
                                 "Content filter terminated stream; switching to fallback..."
+                            )
+                            agent._fallback_activation_reason = (
+                                FailoverReason.content_policy_blocked
                             )
                             if agent._try_activate_fallback():
                                 # Roll the partial content (if any was already
@@ -6821,7 +6827,7 @@ def run_conversation(
                             agent._buffer_status("⚠️ TLS certificate verification failed — trying fallback...")
                         else:
                             agent._buffer_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
-                    if agent._try_activate_fallback():
+                    if agent._try_activate_fallback(classified.reason):
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
                         retry_count = 0
@@ -7035,7 +7041,7 @@ def run_conversation(
                     # Try fallback before giving up entirely
                     if agent._has_pending_fallback():
                         agent._buffer_status(f"⚠️ Max retries ({max_retries}) exhausted — trying fallback...")
-                    if agent._try_activate_fallback():
+                    if agent._try_activate_fallback(classified.reason):
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
                         retry_count = 0
@@ -7451,6 +7457,13 @@ def run_conversation(
                     assistant_message.content = "\n".join(parts)
                 else:
                     assistant_message.content = str(raw)
+
+            # A valid normalized response closes/reset the selected model's
+            # health circuit. This callback is a no-op outside routed gateway
+            # agents and carries no response or prompt content.
+            health_success = getattr(agent, "_record_router_health_success", None)
+            if health_success is not None:
+                health_success()
 
             # ── Agent-as-provider projection ──────────────────────────────
             # A provider that IS an agent ran its own tools inside its own
@@ -8692,7 +8705,7 @@ def run_conversation(
                             "⚠️ Model returning empty responses — "
                             "switching to fallback provider..."
                         )
-                        if agent._try_activate_fallback():
+                        if agent._try_activate_fallback(FailoverReason.server_error):
                             active_system_prompt = _sync_failover_system_message(
                                 agent, api_messages, active_system_prompt)
                             agent._empty_content_retries = 0

--- a/agent/model_router.py
+++ b/agent/model_router.py
@@ -46,13 +46,19 @@ _REASON_RE = re.compile(r"\b(why|prove|tradeoff|architecture|分析|推导|证�
 _COMPLEX_RE = re.compile(r"\b(complex|large|multi[- ]file|production|安全|复杂|多文件|生产|系统)\b", re.I)
 
 
-def extract_features(message: str, *, has_images: bool = False, context_tokens: int = 0) -> Features:
+def _contains_image(message: object) -> bool:
+    if isinstance(message, list):
+        return any(isinstance(part, dict) and part.get("type") in {"image", "image_url"} for part in message)
+    return False
+
+
+def extract_features(message: str | list[object], *, has_images: bool = False, context_tokens: int = 0) -> Features:
     """Extract stable routing signals without an LLM or network lookup."""
     text = str(message or "")
     coding = bool(_CODE_RE.search(text))
     reasoning = bool(_REASON_RE.search(text)) or bool(_COMPLEX_RE.search(text))
     complexity = min(1.0, (0.35 if reasoning else 0.0) + (0.35 if _COMPLEX_RE.search(text) else 0.0) + min(len(text) / 4000, 0.3))
-    return Features(coding=coding, reasoning=reasoning, vision=bool(has_images), context_tokens=max(0, int(context_tokens)), complexity=complexity)
+    return Features(coding=coding, reasoning=reasoning, vision=bool(has_images or _contains_image(message)), context_tokens=max(0, int(context_tokens)), complexity=complexity)
 
 
 def _eligible(candidate: Candidate, features: Features) -> tuple[bool, str]:
@@ -76,7 +82,7 @@ def _score(candidate: Candidate, features: Features) -> float:
     return score
 
 
-def route_turn(message: str, candidates: Iterable[Candidate], *, current_model: str, mode: str = "off", has_images: bool = False, context_tokens: int = 0) -> RouteDecision:
+def route_turn(message: str | list[object], candidates: Iterable[Candidate], *, current_model: str, mode: str = "off", has_images: bool = False, context_tokens: int = 0) -> RouteDecision:
     """Choose at most one model for a turn; modes are off, suggest, and auto."""
     if mode not in {"off", "suggest", "auto"}:
         mode = "off"

--- a/agent/model_router.py
+++ b/agent/model_router.py
@@ -1,0 +1,99 @@
+"""Deterministic, turn-boundary model routing.
+
+This module is intentionally pure: it never discovers credentials, performs
+network calls, or mutates an agent. Callers resolve authenticated candidates
+before passing them here and keep the returned choice for the whole turn.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import re
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class Candidate:
+    model: str
+    provider: str = ""
+    context_window: int = 0
+    reasoning: bool = False
+    vision: bool = False
+    quality: float = 0.5
+    cost: float = 0.5
+
+
+@dataclass(frozen=True)
+class Features:
+    coding: bool = False
+    reasoning: bool = False
+    vision: bool = False
+    context_tokens: int = 0
+    complexity: float = 0.0
+
+
+@dataclass(frozen=True)
+class RouteDecision:
+    selected_model: str
+    reason: str
+    explanation: str
+    features: Features
+    suggestion: str = ""
+    rejected: tuple[str, ...] = field(default_factory=tuple)
+
+
+_CODE_RE = re.compile(r"\b(code|coding|debug|traceback|python|javascript|typescript|sql|api|implement|refactor|test|代码|调试|报错|脚本|编程)\b", re.I)
+_REASON_RE = re.compile(r"\b(why|prove|tradeoff|architecture|分析|推导|证明|原因|权衡|架构|设计)\b", re.I)
+_COMPLEX_RE = re.compile(r"\b(complex|large|multi[- ]file|production|安全|复杂|多文件|生产|系统)\b", re.I)
+
+
+def extract_features(message: str, *, has_images: bool = False, context_tokens: int = 0) -> Features:
+    """Extract stable routing signals without an LLM or network lookup."""
+    text = str(message or "")
+    coding = bool(_CODE_RE.search(text))
+    reasoning = bool(_REASON_RE.search(text)) or bool(_COMPLEX_RE.search(text))
+    complexity = min(1.0, (0.35 if reasoning else 0.0) + (0.35 if _COMPLEX_RE.search(text) else 0.0) + min(len(text) / 4000, 0.3))
+    return Features(coding=coding, reasoning=reasoning, vision=bool(has_images), context_tokens=max(0, int(context_tokens)), complexity=complexity)
+
+
+def _eligible(candidate: Candidate, features: Features) -> tuple[bool, str]:
+    if features.vision and not candidate.vision:
+        return False, "requires vision"
+    if features.reasoning and not candidate.reasoning:
+        return False, "requires reasoning"
+    if features.context_tokens and candidate.context_window and candidate.context_window < features.context_tokens:
+        return False, "context window too small"
+    return True, ""
+
+
+def _score(candidate: Candidate, features: Features) -> float:
+    score = candidate.quality * 3.0 - candidate.cost * (0.8 if features.complexity < 0.4 else 0.2)
+    if features.coding and ("code" in candidate.model.lower() or "kimi" in candidate.model.lower()):
+        score += 0.35
+    if features.reasoning and candidate.reasoning:
+        score += 0.5
+    if features.vision and candidate.vision:
+        score += 0.5
+    return score
+
+
+def route_turn(message: str, candidates: Iterable[Candidate], *, current_model: str, mode: str = "off", has_images: bool = False, context_tokens: int = 0) -> RouteDecision:
+    """Choose at most one model for a turn; modes are off, suggest, and auto."""
+    if mode not in {"off", "suggest", "auto"}:
+        mode = "off"
+    features = extract_features(message, has_images=has_images, context_tokens=context_tokens)
+    pool = sorted(tuple(candidates), key=lambda c: c.model)
+    eligible, rejected = [], []
+    for candidate in pool:
+        ok, why = _eligible(candidate, features)
+        if ok:
+            eligible.append(candidate)
+        else:
+            rejected.append(f"{candidate.model}: {why}")
+    best = sorted(eligible, key=lambda c: (-_score(c, features), c.model))[0] if eligible else None
+    if mode == "off":
+        return RouteDecision(current_model, "disabled", "routing disabled", features, rejected=tuple(rejected))
+    if best is None:
+        return RouteDecision(current_model, "fallback", "no candidate satisfies capability constraints", features, rejected=tuple(rejected))
+    if mode == "suggest":
+        return RouteDecision(current_model, "suggestion", f"suggested {best.model}; current model retained", features, suggestion=best.model, rejected=tuple(rejected))
+    return RouteDecision(best.model, "routed", f"selected {best.model} for {'vision, ' if features.vision else ''}{'reasoning, ' if features.reasoning else ''}this turn", features, rejected=tuple(rejected))

--- a/agent/model_router/__init__.py
+++ b/agent/model_router/__init__.py
@@ -1,0 +1,77 @@
+"""Hermes model router — staged, cache-aware, turn-boundary routing.
+
+Public API:
+
+- Legacy deterministic router (unchanged behavior): ``Candidate``, ``Features``,
+  ``RouteDecision``, ``extract_features``, ``route_turn``.
+- Staged pipeline ported from pi-smart-router: ``RouterPipeline``,
+  ``RoutingRequest``, ``RoutingDecision``, ``ModelProfile``,
+  ``pipeline_from_config``.
+
+Invariants: routing decides once per turn, before agent construction; pure by
+default (no network unless ``local_zero`` is explicitly enabled); explicit
+candidates only; any failure falls back to the current model; deterministic
+tie-breaks.
+"""
+from __future__ import annotations
+
+# Legacy API — preserved verbatim for existing callers and tests.
+from .legacy import (
+    Candidate,
+    Features,
+    RouteDecision,
+    extract_features,
+    route_turn,
+)
+
+# Staged pipeline API.
+from .types import (
+    CandidateScore,
+    Message,
+    ModelProfile,
+    RoutingDecision,
+    RoutingRequest,
+    SessionPin,
+    TIER_ECONOMICAL,
+    TIER_FRONTIER,
+    TIER_LOCAL,
+    normalize_tier,
+)
+from .pipeline import (
+    MODE_AUTO,
+    MODE_OFF,
+    MODE_SUGGEST,
+    RouterConfig,
+    RouterPipeline,
+    pipeline_from_config,
+    profile_from_config,
+    router_config_from_dict,
+)
+
+__all__ = [
+    # legacy
+    "Candidate",
+    "Features",
+    "RouteDecision",
+    "extract_features",
+    "route_turn",
+    # pipeline
+    "CandidateScore",
+    "Message",
+    "ModelProfile",
+    "RoutingDecision",
+    "RoutingRequest",
+    "SessionPin",
+    "RouterConfig",
+    "RouterPipeline",
+    "pipeline_from_config",
+    "profile_from_config",
+    "router_config_from_dict",
+    "normalize_tier",
+    "TIER_LOCAL",
+    "TIER_ECONOMICAL",
+    "TIER_FRONTIER",
+    "MODE_OFF",
+    "MODE_SUGGEST",
+    "MODE_AUTO",
+]

--- a/agent/model_router/__init__.py
+++ b/agent/model_router/__init__.py
@@ -37,6 +37,14 @@ from .types import (
     TIER_LOCAL,
     normalize_tier,
 )
+from .health import (
+    HealthConfig,
+    HealthOutcome,
+    HealthSnapshot,
+    RouterHealthStore,
+    bind_agent_health,
+    classify_health_outcome,
+)
 from .pipeline import (
     MODE_AUTO,
     MODE_OFF,
@@ -62,6 +70,12 @@ __all__ = [
     "RoutingDecision",
     "RoutingRequest",
     "SessionPin",
+    "HealthConfig",
+    "HealthOutcome",
+    "HealthSnapshot",
+    "RouterHealthStore",
+    "bind_agent_health",
+    "classify_health_outcome",
     "RouterConfig",
     "RouterPipeline",
     "pipeline_from_config",

--- a/agent/model_router/context_fit.py
+++ b/agent/model_router/context_fit.py
@@ -1,0 +1,126 @@
+"""Context-fit gate and overflow fallback — port of routing/context-fit.ts.
+
+Filters fleet models whose context window cannot accommodate the estimated
+input token count (with a configurable safety margin), and resolves a
+structured fallback when economical tiers cannot fit.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .types import (
+    CandidateScore,
+    ModelProfile,
+    RoutingRequest,
+    TIER_FRONTIER,
+)
+
+CONTEXT_FIT_EXCEEDED = "context_fit_exceeded"
+CONTEXT_OVERFLOW_SAME_PROVIDER_FALLBACK = "context_overflow_same_provider_fallback"
+CONTEXT_OVERFLOW_FRONTIER_FALLBACK = "context_overflow_frontier_fallback"
+CONTEXT_OVERFLOW_NO_FIT = "context_overflow_no_fit"
+
+DEFAULT_SAFETY_MARGIN = 0.9
+
+
+@dataclass(frozen=True)
+class ContextFitFilterResult:
+    effective_fleet: tuple
+    rejected: tuple
+
+
+@dataclass(frozen=True)
+class ContextOverflowResult:
+    kind: str  # "selected" | "no_fit"
+    model: Optional[ModelProfile]
+    reason_code: str
+
+
+def model_fits_context(profile: ModelProfile, estimated_input_tokens: int, safety_margin: float = DEFAULT_SAFETY_MARGIN) -> bool:
+    if not profile.context_window:
+        return True  # unknown window → retained
+    effective_limit = int(profile.context_window * safety_margin)
+    return estimated_input_tokens <= effective_limit
+
+
+def select_largest_window_model(candidates) -> Optional[ModelProfile]:
+    """Select the healthy model with the largest declared context window."""
+    best = None
+    best_window = -1
+    for model in candidates:
+        if not model.healthy:
+            continue
+        window = model.context_window if model.context_window else 1 << 62
+        if window > best_window:
+            best_window = window
+            best = model
+    return best
+
+
+def select_lowest_cost_model(candidates) -> Optional[ModelProfile]:
+    """Select the lowest-cost healthy model (ties broken by model id)."""
+    healthy = [m for m in candidates if m.healthy]
+    if not healthy:
+        return None
+    return sorted(healthy, key=lambda m: (m.cost, m.id))[0]
+
+
+def resolve_context_overflow_fallback(
+    fleet,
+    estimated_input_tokens: int,
+    preferred_provider: Optional[str] = None,
+    safety_margin: float = DEFAULT_SAFETY_MARGIN,
+) -> ContextOverflowResult:
+    """Escalate when economical/pinned models cannot fit context.
+
+    1. Same-provider largest-fit model
+    2. Cheapest frontier model that fits
+    3. Structured no-fit (never dispatch undersized)
+    """
+    fits = lambda m: model_fits_context(m, estimated_input_tokens, safety_margin)
+
+    if preferred_provider:
+        same_provider = [m for m in fleet if m.provider == preferred_provider and fits(m)]
+        model = select_largest_window_model(same_provider)
+        if model:
+            return ContextOverflowResult("selected", model, CONTEXT_OVERFLOW_SAME_PROVIDER_FALLBACK)
+
+    frontier = [m for m in fleet if m.tier == TIER_FRONTIER and fits(m)]
+    model = select_lowest_cost_model(frontier)
+    if model:
+        return ContextOverflowResult("selected", model, CONTEXT_OVERFLOW_FRONTIER_FALLBACK)
+
+    return ContextOverflowResult("no_fit", None, CONTEXT_OVERFLOW_NO_FIT)
+
+
+def filter_fleet_by_context_fit(
+    fleet,
+    request: RoutingRequest,
+    safety_margin: float = DEFAULT_SAFETY_MARGIN,
+) -> ContextFitFilterResult:
+    """Remove fleet entries whose window cannot fit the estimated input.
+
+    Honors ``force_model_id`` by leaving the fleet unchanged. Models without
+    declared limits are retained (unknown window).
+    """
+    if request.force_model_id:
+        return ContextFitFilterResult(tuple(fleet), ())
+
+    estimated = request.estimated_tokens()
+    effective = []
+    rejected = []
+    for profile in fleet:
+        if model_fits_context(profile, estimated, safety_margin):
+            effective.append(profile)
+            continue
+        effective_limit = int(profile.context_window * safety_margin)
+        rejected.append(
+            CandidateScore(
+                model_id=profile.id,
+                score=0.0,
+                shortfall=float(estimated - effective_limit),
+                rejected_reason=CONTEXT_FIT_EXCEEDED,
+            )
+        )
+    return ContextFitFilterResult(tuple(effective), tuple(rejected))

--- a/agent/model_router/context_fit.py
+++ b/agent/model_router/context_fit.py
@@ -17,11 +17,16 @@ from .types import (
 )
 
 CONTEXT_FIT_EXCEEDED = "context_fit_exceeded"
+OUTPUT_HEADROOM_EXCEEDED = "output_headroom_exceeded"
 CONTEXT_OVERFLOW_SAME_PROVIDER_FALLBACK = "context_overflow_same_provider_fallback"
 CONTEXT_OVERFLOW_FRONTIER_FALLBACK = "context_overflow_frontier_fallback"
 CONTEXT_OVERFLOW_NO_FIT = "context_overflow_no_fit"
 
 DEFAULT_SAFETY_MARGIN = 0.9
+# Pi's delegation floor is intentionally small: it prevents a candidate whose
+# input exactly fills the context window from being selected without reserving
+# a large, provider-specific generation budget.
+DEFAULT_MIN_OUTPUT_TOKENS = 256
 
 
 @dataclass(frozen=True)
@@ -37,11 +42,21 @@ class ContextOverflowResult:
     reason_code: str
 
 
-def model_fits_context(profile: ModelProfile, estimated_input_tokens: int, safety_margin: float = DEFAULT_SAFETY_MARGIN) -> bool:
+def model_fits_context(
+    profile: ModelProfile,
+    estimated_input_tokens: int,
+    safety_margin: float = DEFAULT_SAFETY_MARGIN,
+    min_output_tokens: int = 0,
+) -> bool:
+    """Whether input plus the requested output floor fits the safe window.
+
+    ``min_output_tokens=0`` preserves the historical context-only predicate
+    for callers outside the router pipeline. Unknown windows remain eligible.
+    """
     if not profile.context_window:
         return True  # unknown window → retained
     effective_limit = int(profile.context_window * safety_margin)
-    return estimated_input_tokens <= effective_limit
+    return estimated_input_tokens + max(0, int(min_output_tokens)) <= effective_limit
 
 
 def select_largest_window_model(candidates) -> Optional[ModelProfile]:
@@ -71,6 +86,7 @@ def resolve_context_overflow_fallback(
     estimated_input_tokens: int,
     preferred_provider: Optional[str] = None,
     safety_margin: float = DEFAULT_SAFETY_MARGIN,
+    min_output_tokens: int = 0,
 ) -> ContextOverflowResult:
     """Escalate when economical/pinned models cannot fit context.
 
@@ -78,7 +94,9 @@ def resolve_context_overflow_fallback(
     2. Cheapest frontier model that fits
     3. Structured no-fit (never dispatch undersized)
     """
-    fits = lambda m: model_fits_context(m, estimated_input_tokens, safety_margin)
+    fits = lambda m: model_fits_context(
+        m, estimated_input_tokens, safety_margin, min_output_tokens
+    )
 
     if preferred_provider:
         same_provider = [m for m in fleet if m.provider == preferred_provider and fits(m)]
@@ -98,6 +116,7 @@ def filter_fleet_by_context_fit(
     fleet,
     request: RoutingRequest,
     safety_margin: float = DEFAULT_SAFETY_MARGIN,
+    min_output_tokens: int = 0,
 ) -> ContextFitFilterResult:
     """Remove fleet entries whose window cannot fit the estimated input.
 
@@ -110,17 +129,22 @@ def filter_fleet_by_context_fit(
     estimated = request.estimated_tokens()
     effective = []
     rejected = []
+    output_floor = max(0, int(min_output_tokens))
     for profile in fleet:
-        if model_fits_context(profile, estimated, safety_margin):
+        if model_fits_context(profile, estimated, safety_margin, output_floor):
             effective.append(profile)
             continue
         effective_limit = int(profile.context_window * safety_margin)
+        input_fits = estimated <= effective_limit
+        required = estimated + output_floor
         rejected.append(
             CandidateScore(
                 model_id=profile.id,
                 score=0.0,
-                shortfall=float(estimated - effective_limit),
-                rejected_reason=CONTEXT_FIT_EXCEEDED,
+                shortfall=float(max(0, required - effective_limit)),
+                rejected_reason=(
+                    OUTPUT_HEADROOM_EXCEEDED if input_fits else CONTEXT_FIT_EXCEEDED
+                ),
             )
         )
     return ContextFitFilterResult(tuple(effective), tuple(rejected))

--- a/agent/model_router/envelope.py
+++ b/agent/model_router/envelope.py
@@ -1,0 +1,76 @@
+"""Turn-envelope classifier — port of pi-smart-router triage/turn-envelope.ts.
+
+Derives turn_type from the message envelope using deterministic heuristics
+(no neural inference). Classification priority (first match wins):
+
+  1. tool_result — last message is role=tool
+  2. planning    — planning/architecture signals in recent content
+  3. subagent    — subagent/exploration context markers
+  4. main_loop   — default agent loop turn (messages present)
+  5. unknown     — no messages or empty envelope
+"""
+from __future__ import annotations
+
+import re
+
+from .types import (
+    Message,
+    TURN_MAIN_LOOP,
+    TURN_PLANNING,
+    TURN_SUBAGENT,
+    TURN_TOOL_RESULT,
+    TURN_UNKNOWN,
+)
+
+TOOL_RESULT_SIZE_THRESHOLD = 50_000
+
+PLANNING_PATTERNS = tuple(
+    re.compile(p, re.I | re.M)
+    for p in (
+        r"\b(?:plan|planning|architect(?:ure)?|design|refactor|migration)\b",
+        r"\b(?:step\s*\d|phase\s*\d|breakdown|strategy|trade-?off)\b",
+        r"^#+\s*(?:plan|design|architecture)",
+        # Repo-hygiene / destructive-intent (SP-176) — escalate off main_loop
+        r"\b(?:clean\s*up(?:\s+the)?\s+repo|repo\s+cleanup|cleanup\s+the\s+repo)\b",
+        r"\b(?:clean\s*up|cleanup|mistakenly\s+added|accidentally\s+added|accidental\s+add)\b",
+        r"\b(?:unstage|git\s+rm|rm\s+-rf|force\s+push|git\s+reset\s+--hard|destructive)\b",
+    )
+)
+
+SUBAGENT_PATTERNS = tuple(
+    re.compile(p, re.I)
+    for p in (
+        r"\b(?:subagent|sub-agent|exploration|explore|search|investigate)\b",
+        r"\b(?:spawned|delegat(?:e|ed|ing)|parallel\s+agent)\b",
+        r"\b(?:Task|Agent)\.(?:create|spawn|launch)\b",
+    )
+)
+
+
+def classify_turn_envelope(messages) -> str:
+    if not messages:
+        return TURN_UNKNOWN
+    last = messages[-1]
+    if _is_tool_result(last):
+        return TURN_TOOL_RESULT
+    window = messages[-3:]
+    if _matches_any(window, PLANNING_PATTERNS):
+        return TURN_PLANNING
+    if _matches_any(window, SUBAGENT_PATTERNS):
+        return TURN_SUBAGENT
+    return TURN_MAIN_LOOP
+
+
+def _is_tool_result(message: Message) -> bool:
+    if getattr(message, "role", None) != "tool":
+        return False
+    return len(getattr(message, "content", "") or "") <= TOOL_RESULT_SIZE_THRESHOLD
+
+
+def _matches_any(messages, patterns) -> bool:
+    for msg in messages:
+        content = getattr(msg, "content", "") or ""
+        for pattern in patterns:
+            if pattern.search(content):
+                return True
+    return False

--- a/agent/model_router/escalation.py
+++ b/agent/model_router/escalation.py
@@ -1,0 +1,196 @@
+"""Loop escalation — port of pinning/loop-escalation.ts.
+
+Detects bounded repeated tool failures and signals session escalation to a
+frontier-capable tier. Escalation fires once per session (no tier
+oscillation). Economical pins count consecutive failures of ANY signature
+(a session failing with varied errors is just as stuck); other pins count
+identical failure signatures only (FR-014).
+
+Pure evaluation: the caller persists pin state via the state store.
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, replace
+from typing import Optional
+
+from .types import (
+    ModelProfile,
+    PIN_REASON_LOOP_ESCALATION,
+    RoutingRequest,
+    SessionPin,
+    TIER_ECONOMICAL,
+    TIER_FRONTIER,
+    TIER_LOCAL,
+    TURN_TOOL_RESULT,
+)
+
+_FAILURE_PATTERNS = (
+    "error", "fail", "exception", "timed out", "timeout",
+    "econnrefused", "enotfound", "econnreset", "epipe",
+)
+_RATE_LIMIT_PATTERNS = ("rate limit", "429", "too many requests", "quota exceeded")
+_AUTH_DENIED_PATTERNS = ("permission denied", "access denied")
+_UNSUPPORTED_TOOL_PATTERNS = (
+    "unknown tool", "unsupported tool", "tool not found", "no such tool",
+    "unrecognized tool", "is not a valid tool", "tool does not exist",
+    "not a known tool",
+)
+
+ZERO_TIER_TOOL_CHURN_SIGNATURE = "zt:tool_churn"
+
+
+@dataclass(frozen=True)
+class LoopEscalationResult:
+    should_escalate: bool
+    updated_pin: Optional[SessionPin]
+    escalation_target: Optional[ModelProfile]
+    reason: str
+
+
+def _last_tool_message(request: RoutingRequest):
+    messages = request.messages
+    if not messages:
+        return None
+    last = messages[-1]
+    return last if getattr(last, "role", None) == "tool" else None
+
+
+def _looks_like_failure(content: str) -> bool:
+    lower = content.lower()
+    if "no error" in lower or "no errors" in lower or "no failure" in lower or "no failures" in lower:
+        return False
+    if "without error" in lower or "without an error" in lower or "without failure" in lower or "without a failure" in lower:
+        return False
+    return any(p in lower for p in _FAILURE_PATTERNS + _RATE_LIMIT_PATTERNS + _AUTH_DENIED_PATTERNS)
+
+
+def _is_tool_failure(msg) -> bool:
+    if getattr(msg, "is_error", None) is True:
+        return True
+    if getattr(msg, "is_error", None) is False:
+        return False
+    status = getattr(msg, "status", None)
+    if status is not None:
+        return status >= 400
+    return _looks_like_failure(getattr(msg, "content", "") or "")
+
+
+def _compute_signature(content: str) -> str:
+    """Deterministic djb2 hash of normalised error content."""
+    normalized = content.strip()[:256].lower()
+    h = 5381
+    for ch in normalized:
+        h = ((h << 5) + h + ord(ch)) & 0xFFFFFFFF
+    return f"tf:{h:x}"
+
+
+def extract_tool_failure_signature(request: RoutingRequest) -> Optional[str]:
+    """Extract a tool-failure signature, or None when no failure is present."""
+    msg = _last_tool_message(request)
+    if msg is None:
+        return None
+    if _is_tool_failure(msg):
+        return _compute_signature(getattr(msg, "content", "") or "")
+    return None
+
+
+def is_unsupported_or_unknown_tool_result(request: RoutingRequest) -> bool:
+    msg = _last_tool_message(request)
+    if msg is None:
+        return False
+    lower = (getattr(msg, "content", "") or "").lower()
+    return any(p in lower for p in _UNSUPPORTED_TOOL_PATTERNS)
+
+
+def _select_escalation_target(fleet, current_model_id: str) -> Optional[ModelProfile]:
+    """Best healthy frontier model that differs from the current pin."""
+    frontier = [
+        m for m in fleet
+        if m.tier == TIER_FRONTIER and m.id != current_model_id and m.healthy
+    ]
+    if not frontier:
+        return None
+    return sorted(frontier, key=lambda m: (-m.quality, m.id))[0]
+
+
+def _pinned_tier(pin: SessionPin, fleet) -> Optional[str]:
+    for m in fleet:
+        if m.id == pin.pinned_model_id:
+            return m.tier
+    return None
+
+
+def _no_escalation(reason: str) -> LoopEscalationResult:
+    return LoopEscalationResult(False, None, None, reason)
+
+
+def _try_escalate(pin: SessionPin, fleet, updated: SessionPin, reason: str) -> LoopEscalationResult:
+    target = _select_escalation_target(fleet, pin.pinned_model_id)
+    if target:
+        return LoopEscalationResult(True, updated, target, reason)
+    return LoopEscalationResult(False, updated, None, "no_frontier_available")
+
+
+def evaluate_loop_escalation(
+    pin: Optional[SessionPin],
+    request: RoutingRequest,
+    fleet,
+    threshold: int = 3,
+) -> LoopEscalationResult:
+    """Evaluate whether the session should escalate to a higher tier."""
+    if pin is None:
+        return _no_escalation("no_pin")
+    if pin.pin_reason == PIN_REASON_LOOP_ESCALATION:
+        return _no_escalation("already_escalated")
+    if request.turn_type != TURN_TOOL_RESULT:
+        return _no_escalation("not_tool_result")
+
+    now = time.time()
+
+    # Local (zero-tier) pin: unsupported tool → immediate escalate; else count
+    # every tool_result turn as observational churn.
+    if _pinned_tier(pin, fleet) == TIER_LOCAL:
+        if is_unsupported_or_unknown_tool_result(request):
+            updated = replace(
+                pin,
+                consecutive_tool_failures=max(pin.consecutive_tool_failures, 1),
+                last_tool_failure_signature="zt:unsupported_tool",
+                updated_at=now,
+            )
+            return _try_escalate(pin, fleet, updated, "zero_tier_unsupported_tool")
+        is_churn = pin.last_tool_failure_signature == ZERO_TIER_TOOL_CHURN_SIGNATURE
+        new_count = pin.consecutive_tool_failures + 1 if is_churn else 1
+        updated = replace(
+            pin,
+            consecutive_tool_failures=new_count,
+            last_tool_failure_signature=ZERO_TIER_TOOL_CHURN_SIGNATURE,
+            updated_at=now,
+        )
+        if new_count >= threshold:
+            return _try_escalate(pin, fleet, updated, "zero_tier_tool_churn")
+        return LoopEscalationResult(False, updated, None, "zero_tier_below_threshold")
+
+    signature = extract_tool_failure_signature(request)
+    if not signature:
+        if pin.consecutive_tool_failures > 0:
+            return LoopEscalationResult(
+                False,
+                replace(pin, consecutive_tool_failures=0, last_tool_failure_signature=None, updated_at=now),
+                None,
+                "success_reset",
+            )
+        return _no_escalation("no_failure")
+
+    is_economical = _pinned_tier(pin, fleet) == TIER_ECONOMICAL
+    is_identical = pin.last_tool_failure_signature == signature
+    new_count = pin.consecutive_tool_failures + 1 if (is_economical or is_identical) else 1
+    updated = replace(
+        pin,
+        consecutive_tool_failures=new_count,
+        last_tool_failure_signature=signature,
+        updated_at=now,
+    )
+    if new_count >= threshold:
+        return _try_escalate(pin, fleet, updated, "threshold_exceeded")
+    return LoopEscalationResult(False, updated, None, "below_threshold")

--- a/agent/model_router/health.py
+++ b/agent/model_router/health.py
@@ -1,0 +1,465 @@
+"""Bounded provider/model health state for Hermes model routing.
+
+The store shares the router SQLite database, is profile-safe through the
+caller's db path, and serializes state transitions per database in-process.
+Only retryable provider/infrastructure failures affect circuits; request 4xx,
+auth, billing, safety, and local payload/context errors never poison health.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+HEALTH_CLOSED = "closed"
+HEALTH_OPEN = "open"
+HEALTH_HALF_OPEN = "half_open"
+
+OUTCOME_SUCCESS = "success"
+OUTCOME_RETRYABLE_INFRASTRUCTURE = "retryable_infrastructure"
+OUTCOME_NON_RETRYABLE = "non_retryable"
+OUTCOME_IGNORED = "ignored"
+
+DEFAULT_FAILURE_THRESHOLD = 3
+DEFAULT_RESET_TIMEOUT_SECONDS = 30.0
+DEFAULT_HALF_OPEN_SUCCESSES = 2
+DEFAULT_MAX_ENTRIES = 256
+
+_RETRYABLE_REASONS = frozenset(
+    {
+        "timeout",
+        "rate_limit",
+        "upstream_rate_limit",
+        "overloaded",
+        "server_error",
+        "unknown",
+    }
+)
+_NON_RETRYABLE_REASONS = frozenset(
+    {
+        "auth",
+        "auth_permanent",
+        "billing",
+        "model_not_found",
+        "provider_policy_blocked",
+        "content_policy_blocked",
+        "format_error",
+        "ssl_cert_verification",
+    }
+)
+_IGNORED_REASONS = frozenset(
+    {
+        "context_overflow",
+        "payload_too_large",
+        "image_too_large",
+        "image_corrupt",
+        "invalid_encrypted_content",
+        "multimodal_tool_content_unsupported",
+        "reasoning_mandatory",
+        "thinking_signature",
+        "long_context_tier",
+        "oauth_long_context_beta_forbidden",
+        "llama_cpp_grammar_pattern",
+    }
+)
+_TRANSIENT_ERROR_TYPES = frozenset(
+    {
+        "APIConnectionError",
+        "APITimeoutError",
+        "ConnectError",
+        "ConnectTimeout",
+        "ConnectionError",
+        "ConnectionResetError",
+        "NetworkError",
+        "PoolTimeout",
+        "ReadError",
+        "ReadTimeout",
+        "RemoteProtocolError",
+        "TimeoutError",
+        "WriteError",
+        "WriteTimeout",
+    }
+)
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS router_health (
+    endpoint_key TEXT PRIMARY KEY,
+    provider TEXT NOT NULL DEFAULT '',
+    model_id TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'closed',
+    consecutive_failures INTEGER NOT NULL DEFAULT 0,
+    consecutive_successes INTEGER NOT NULL DEFAULT 0,
+    last_failure_at REAL,
+    last_state_change_at REAL NOT NULL,
+    probe_in_flight INTEGER NOT NULL DEFAULT 0,
+    last_touched_at REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_router_health_touched
+ON router_health(last_touched_at);
+"""
+
+_DB_LOCKS: dict[str, threading.RLock] = {}
+_DB_LOCKS_GUARD = threading.Lock()
+
+
+def _db_lock(path: str) -> threading.RLock:
+    with _DB_LOCKS_GUARD:
+        lock = _DB_LOCKS.get(path)
+        if lock is None:
+            lock = threading.RLock()
+            _DB_LOCKS[path] = lock
+        return lock
+
+
+def endpoint_key(provider: str, model_id: str) -> str:
+    """Stable provider/model key; no URL or credential material is persisted."""
+    return f"{str(provider or '').strip().lower()}\x1f{str(model_id or '').strip()}"
+
+
+@dataclass(frozen=True)
+class HealthConfig:
+    enabled: bool = True
+    failure_threshold: int = DEFAULT_FAILURE_THRESHOLD
+    reset_timeout_seconds: float = DEFAULT_RESET_TIMEOUT_SECONDS
+    half_open_successes: int = DEFAULT_HALF_OPEN_SUCCESSES
+    max_entries: int = DEFAULT_MAX_ENTRIES
+
+
+@dataclass(frozen=True)
+class HealthSnapshot:
+    provider: str
+    model_id: str
+    state: str = HEALTH_CLOSED
+    consecutive_failures: int = 0
+    consecutive_successes: int = 0
+    last_failure_at: Optional[float] = None
+    last_state_change_at: float = 0.0
+    probe_in_flight: bool = False
+
+
+@dataclass(frozen=True)
+class HealthOutcome:
+    category: str
+    retryable_infrastructure: bool
+
+
+def classify_health_outcome(
+    *,
+    success: bool = False,
+    status_code: Optional[int] = None,
+    retryable: Optional[bool] = None,
+    reason: Optional[str] = None,
+    error_type: Optional[str] = None,
+) -> HealthOutcome:
+    """Classify an API outcome without retaining an error body or prompt.
+
+    Structured Hermes classifier fields win. HTTP 429/5xx and known transport
+    exceptions are infrastructure failures. Other 4xx and safety/auth reasons
+    are explicitly non-retryable; context/payload recovery is ignored.
+    """
+    if success:
+        return HealthOutcome(OUTCOME_SUCCESS, False)
+
+    normalized_reason = str(reason or "").strip().lower()
+    if normalized_reason in _IGNORED_REASONS:
+        return HealthOutcome(OUTCOME_IGNORED, False)
+    if normalized_reason in _NON_RETRYABLE_REASONS:
+        return HealthOutcome(OUTCOME_NON_RETRYABLE, False)
+    if normalized_reason in _RETRYABLE_REASONS:
+        return HealthOutcome(OUTCOME_RETRYABLE_INFRASTRUCTURE, True)
+
+    try:
+        status = int(status_code) if status_code is not None else None
+    except (TypeError, ValueError):
+        status = None
+    if status == 429 or (status is not None and status >= 500):
+        return HealthOutcome(OUTCOME_RETRYABLE_INFRASTRUCTURE, True)
+    if status is not None and 400 <= status < 500:
+        return HealthOutcome(OUTCOME_NON_RETRYABLE, False)
+    if str(error_type or "").strip() in _TRANSIENT_ERROR_TYPES:
+        return HealthOutcome(OUTCOME_RETRYABLE_INFRASTRUCTURE, True)
+    if retryable is True:
+        return HealthOutcome(OUTCOME_RETRYABLE_INFRASTRUCTURE, True)
+    if retryable is False:
+        return HealthOutcome(OUTCOME_NON_RETRYABLE, False)
+    return HealthOutcome(OUTCOME_IGNORED, False)
+
+
+def bind_agent_health(agent, store: Optional["RouterHealthStore"]) -> None:
+    """Attach a privacy-safe health outcome adapter to a Hermes AIAgent."""
+    if agent is None:
+        return
+    if store is None or not store.available:
+        agent._router_health_callback = None
+        agent._router_health_store = None
+        return
+    agent._router_health_store = store
+
+    def record(**outcome) -> None:
+        store.record_outcome(
+            str(outcome.get("provider") or ""),
+            str(outcome.get("model") or ""),
+            success=bool(outcome.get("success", False)),
+            status_code=outcome.get("status_code"),
+            retryable=outcome.get("retryable"),
+            reason=outcome.get("reason"),
+            error_type=outcome.get("error_type"),
+        )
+
+    agent._router_health_callback = record
+
+
+class RouterHealthStore:
+    """SQLite-backed deterministic CLOSED/OPEN/HALF_OPEN circuit state."""
+
+    def __init__(
+        self,
+        db_path,
+        config: HealthConfig = HealthConfig(),
+        *,
+        clock=None,
+        read_only: bool = False,
+    ):
+        self._db_path = str(Path(db_path))
+        self._config = config
+        self._clock = clock or time.time
+        self._read_only = bool(read_only)
+        self._lock = _db_lock(self._db_path)
+        self._available = bool(config.enabled)
+        if not self._available:
+            return
+        if self._read_only:
+            self._available = Path(self._db_path).is_file()
+            return
+        try:
+            Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
+            with self._lock, self._connect() as conn:
+                conn.executescript(_SCHEMA)
+            os.chmod(self._db_path, 0o600)
+        except Exception:
+            self._available = False
+
+    @property
+    def available(self) -> bool:
+        return self._available
+
+    def _connect(self) -> sqlite3.Connection:
+        if self._read_only:
+            uri = Path(self._db_path).resolve().as_uri() + "?mode=ro"
+            return sqlite3.connect(uri, uri=True, timeout=5)
+        conn = sqlite3.connect(self._db_path, timeout=5)
+        conn.execute("PRAGMA journal_mode=WAL")
+        return conn
+
+    def _read(self, conn: sqlite3.Connection, provider: str, model_id: str):
+        return conn.execute(
+            "SELECT provider, model_id, state, consecutive_failures,"
+            " consecutive_successes, last_failure_at, last_state_change_at,"
+            " probe_in_flight FROM router_health WHERE endpoint_key = ?",
+            (endpoint_key(provider, model_id),),
+        ).fetchone()
+
+    @staticmethod
+    def _snapshot(row, provider: str, model_id: str) -> HealthSnapshot:
+        if row is None:
+            return HealthSnapshot(provider=str(provider or ""), model_id=model_id)
+        return HealthSnapshot(
+            provider=row[0],
+            model_id=row[1],
+            state=row[2],
+            consecutive_failures=int(row[3]),
+            consecutive_successes=int(row[4]),
+            last_failure_at=float(row[5]) if row[5] is not None else None,
+            last_state_change_at=float(row[6]),
+            probe_in_flight=bool(row[7]),
+        )
+
+    def snapshot(self, provider: str, model_id: str) -> HealthSnapshot:
+        if not self._available:
+            return HealthSnapshot(str(provider or ""), model_id)
+        try:
+            with self._lock, self._connect() as conn:
+                return self._snapshot(self._read(conn, provider, model_id), provider, model_id)
+        except Exception:
+            return HealthSnapshot(str(provider or ""), model_id)
+
+    def is_available(self, provider: str, model_id: str) -> bool:
+        """Non-mutating eligibility check used while scoring candidates."""
+        snap = self.snapshot(provider, model_id)
+        if snap.state == HEALTH_CLOSED:
+            return True
+        if snap.state == HEALTH_HALF_OPEN:
+            return (
+                not snap.probe_in_flight
+                or (self._clock() - snap.last_state_change_at)
+                >= self._config.reset_timeout_seconds
+            )
+        return (self._clock() - snap.last_state_change_at) >= self._config.reset_timeout_seconds
+
+    def claim_dispatch(self, provider: str, model_id: str) -> bool:
+        """Atomically claim a dispatch, allowing only one HALF_OPEN probe."""
+        if not self._available or self._read_only:
+            return self.is_available(provider, model_id)
+        now = float(self._clock())
+        try:
+            with self._lock, self._connect() as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                row = self._read(conn, provider, model_id)
+                if row is None or row[2] == HEALTH_CLOSED:
+                    return True
+                if row[2] == HEALTH_OPEN:
+                    if now - float(row[6]) < self._config.reset_timeout_seconds:
+                        return False
+                    conn.execute(
+                        "UPDATE router_health SET state=?, consecutive_successes=0,"
+                        " probe_in_flight=1, last_state_change_at=?, last_touched_at=?"
+                        " WHERE endpoint_key=?",
+                        (HEALTH_HALF_OPEN, now, now, endpoint_key(provider, model_id)),
+                    )
+                    return True
+                if (
+                    bool(row[7])
+                    and now - float(row[6]) < self._config.reset_timeout_seconds
+                ):
+                    return False
+                # Reclaim a stale probe lease after the reset timeout so a
+                # crashed/cancelled dispatch cannot wedge a durable circuit.
+                conn.execute(
+                    "UPDATE router_health SET probe_in_flight=1,"
+                    " last_state_change_at=?, last_touched_at=? WHERE endpoint_key=?",
+                    (now, now, endpoint_key(provider, model_id)),
+                )
+                return True
+        except Exception:
+            return True  # health is advisory; never block all inference on I/O failure
+
+    def record_outcome(
+        self,
+        provider: str,
+        model_id: str,
+        *,
+        success: bool = False,
+        status_code: Optional[int] = None,
+        retryable: Optional[bool] = None,
+        reason: Optional[str] = None,
+        error_type: Optional[str] = None,
+    ) -> HealthOutcome:
+        outcome = classify_health_outcome(
+            success=success,
+            status_code=status_code,
+            retryable=retryable,
+            reason=reason,
+            error_type=error_type,
+        )
+        if not self._available or self._read_only or not model_id:
+            return outcome
+        if outcome.category == OUTCOME_SUCCESS:
+            self.record_success(provider, model_id)
+        elif outcome.retryable_infrastructure:
+            self.record_failure(provider, model_id)
+        return outcome
+
+    def record_failure(self, provider: str, model_id: str) -> None:
+        if self._read_only:
+            return
+        now = float(self._clock())
+        key = endpoint_key(provider, model_id)
+        try:
+            with self._lock, self._connect() as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                row = self._read(conn, provider, model_id)
+                failures = (int(row[3]) if row else 0) + 1
+                old_state = row[2] if row else HEALTH_CLOSED
+                new_state = old_state
+                changed_at = float(row[6]) if row else now
+                if old_state == HEALTH_HALF_OPEN or failures >= self._config.failure_threshold:
+                    new_state = HEALTH_OPEN
+                    changed_at = now
+                conn.execute(
+                    "INSERT INTO router_health (endpoint_key, provider, model_id, state,"
+                    " consecutive_failures, consecutive_successes, last_failure_at,"
+                    " last_state_change_at, probe_in_flight, last_touched_at)"
+                    " VALUES (?, ?, ?, ?, ?, 0, ?, ?, 0, ?)"
+                    " ON CONFLICT(endpoint_key) DO UPDATE SET state=excluded.state,"
+                    " consecutive_failures=excluded.consecutive_failures,"
+                    " consecutive_successes=0, last_failure_at=excluded.last_failure_at,"
+                    " last_state_change_at=excluded.last_state_change_at,"
+                    " probe_in_flight=0, last_touched_at=excluded.last_touched_at",
+                    (key, str(provider or ""), model_id, new_state, failures, now, changed_at, now),
+                )
+                self._prune(conn)
+        except Exception:
+            return
+
+    def record_success(self, provider: str, model_id: str) -> None:
+        if self._read_only:
+            return
+        now = float(self._clock())
+        key = endpoint_key(provider, model_id)
+        try:
+            with self._lock, self._connect() as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                row = self._read(conn, provider, model_id)
+                if row is None:
+                    return
+                state = row[2]
+                successes = int(row[4])
+                if state == HEALTH_HALF_OPEN:
+                    successes += 1
+                    if successes >= self._config.half_open_successes:
+                        conn.execute("DELETE FROM router_health WHERE endpoint_key=?", (key,))
+                    else:
+                        conn.execute(
+                            "UPDATE router_health SET consecutive_failures=0,"
+                            " consecutive_successes=?, probe_in_flight=0, last_touched_at=?"
+                            " WHERE endpoint_key=?",
+                            (successes, now, key),
+                        )
+                elif state == HEALTH_OPEN:
+                    # A request may run through the fail-open current-model safety net.
+                    conn.execute("DELETE FROM router_health WHERE endpoint_key=?", (key,))
+                else:
+                    conn.execute("DELETE FROM router_health WHERE endpoint_key=?", (key,))
+        except Exception:
+            return
+
+    def _prune(self, conn: sqlite3.Connection) -> None:
+        limit = max(1, int(self._config.max_entries))
+        conn.execute(
+            "DELETE FROM router_health WHERE endpoint_key IN ("
+            " SELECT endpoint_key FROM router_health ORDER BY last_touched_at DESC"
+            " LIMIT -1 OFFSET ?)",
+            (limit,),
+        )
+
+    def list_snapshots(self, *, limit: int = 100) -> list[dict]:
+        if not self._available:
+            return []
+        try:
+            with self._lock, self._connect() as conn:
+                rows = conn.execute(
+                    "SELECT provider, model_id, state, consecutive_failures,"
+                    " consecutive_successes, last_failure_at, last_state_change_at,"
+                    " probe_in_flight FROM router_health"
+                    " ORDER BY last_touched_at DESC LIMIT ?",
+                    (max(1, min(int(limit), self._config.max_entries)),),
+                ).fetchall()
+        except Exception:
+            return []
+        return [
+            {
+                "provider": row[0],
+                "model": row[1],
+                "state": row[2],
+                "consecutive_failures": int(row[3]),
+                "consecutive_successes": int(row[4]),
+                "last_failure_at": row[5],
+                "last_state_change_at": row[6],
+                "probe_in_flight": bool(row[7]),
+            }
+            for row in rows
+        ]

--- a/agent/model_router/hydra.py
+++ b/agent/model_router/hydra.py
@@ -1,0 +1,147 @@
+"""HyDRA-style requirement/capability matcher (deterministic port).
+
+pi-smart-router's HyDRA matcher projects a prompt embedding into a 3D
+requirement space (reasoning, code_gen, tool_use) and scores models by
+capability shortfall with a multi-objective re-rank. The neural encoder is an
+optional artifact there; the structure — requirement vector, shortfall gate,
+multi-objective selection — is what this module ports.
+
+Hermes default is fully deterministic: the requirement vector is derived from
+triage signals, the turn envelope, and structural prompt features. If
+``hydra.embeddings: true`` is configured, a semantic-similarity backend may be
+layered on later; the deterministic vector remains the fallback and the gate.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from .low_intensity import compute_code_block_ratio
+from .scoring import FrugalityWeights, MultiObjectiveResult, score_multi_objective
+from .triage import CYCLOMATIC_THRESHOLD, TriageResult
+from .types import CandidateScore, ModelProfile, RoutingRequest, TURN_PLANNING, TURN_TOOL_RESULT
+
+# Hard-gate thresholds: requirements above these demand declared capabilities.
+REASONING_REQUIREMENT_GATE = 0.6
+SHORTFALL_TOLERANCE = 0.25
+
+_CODE_RE = re.compile(
+    r"\b(code|coding|debug|traceback|python|javascript|typescript|sql|api|implement|refactor|test|"
+    r"代码|调试|报错|脚本|编程|函数|接口)\b",
+    re.I,
+)
+_REASON_RE = re.compile(
+    r"\b(why|prove|tradeoff|architecture|分析|推导|证明|原因|权衡|架构|设计)\b",
+    re.I,
+)
+_TOOL_CUE_PATTERNS = tuple(
+    re.compile(p, re.I)
+    for p in (
+        r"\b(run|execute|shell|terminal|command|bash)\b",
+        r"\b(read|write|edit|patch|create)\s+(the\s+)?(file|config|code)\b",
+        r"\b(search|fetch|browse|scrape|download)\b",
+        r"\b(git|docker|ssh|curl)\b",
+        r"\b(deploy|install|build|test)\b",
+    )
+)
+
+
+@dataclass(frozen=True)
+class RequirementVector:
+    reasoning: float
+    code_gen: float
+    tool_use: float
+
+    @property
+    def magnitude(self) -> float:
+        return max(self.reasoning, self.code_gen, self.tool_use)
+
+
+def _clamp01(value: float) -> float:
+    return 0.0 if value <= 0 else (1.0 if value >= 1 else value)
+
+
+def build_requirement_vector(request: RoutingRequest, triage_result: TriageResult) -> RequirementVector:
+    """Derive a 3D requirement vector without neural inference."""
+    text = request.prompt_text or ""
+    turn_type = request.turn_type or "unknown"
+
+    reasoning = _clamp01(
+        0.35 * (1.0 if _REASON_RE.search(text) else 0.0)
+        + 0.30 * min(triage_result.complex_hits / 3.0, 1.0)
+        + 0.20 * (1.0 if triage_result.cyclomatic_score >= CYCLOMATIC_THRESHOLD else 0.0)
+        + 0.15 * (1.0 if turn_type == TURN_PLANNING else 0.0)
+    )
+    code_gen = _clamp01(
+        0.40 * (1.0 if _CODE_RE.search(text) else 0.0)
+        + 0.35 * compute_code_block_ratio(text)
+        + 0.25 * min(triage_result.cyclomatic_score / CYCLOMATIC_THRESHOLD, 1.0)
+    )
+    cue_hits = sum(1 for p in _TOOL_CUE_PATTERNS if p.search(text))
+    tool_use = _clamp01(
+        0.50 * (1.0 if turn_type == TURN_TOOL_RESULT or any(getattr(m, "role", None) == "tool" for m in request.messages or ()) else 0.0)
+        + 0.50 * min(cue_hits / 3.0, 1.0)
+    )
+    return RequirementVector(reasoning, code_gen, tool_use)
+
+
+def _capability_scores(profile: ModelProfile):
+    """(reasoning_cap, code_cap, tool_cap) in 0..1 from declared capabilities."""
+    reasoning_cap = 1.0 if profile.reasoning else 0.3 + 0.4 * profile.quality
+    code_cap = 0.5 + 0.5 * profile.quality
+    name = profile.id.lower()
+    if "code" in name or "kimi" in name or "codex" in name:
+        code_cap = min(1.0, code_cap + 0.15)
+    tool_cap = 0.4 + 0.6 * profile.quality
+    return reasoning_cap, code_cap, tool_cap
+
+
+def score_fleet(
+    fleet,
+    requirements: RequirementVector,
+    request: RoutingRequest,
+) -> tuple:
+    """Capability-score every candidate with a shortfall gate.
+
+    Hard gates: vision required, reasoning required above the gate, unhealthy.
+    Soft shortfall: capability gaps beyond tolerance reject the candidate.
+    """
+    scores = []
+    for profile in fleet:
+        if not profile.healthy:
+            scores.append(CandidateScore(profile.id, 0.0, rejected_reason="unhealthy"))
+            continue
+        if request.has_images and not profile.vision:
+            scores.append(CandidateScore(profile.id, 0.0, rejected_reason="requires_vision"))
+            continue
+        if requirements.reasoning >= REASONING_REQUIREMENT_GATE and not profile.reasoning:
+            scores.append(CandidateScore(profile.id, 0.0, rejected_reason="requires_reasoning"))
+            continue
+
+        reasoning_cap, code_cap, tool_cap = _capability_scores(profile)
+        short_r = max(0.0, requirements.reasoning - reasoning_cap)
+        short_c = max(0.0, requirements.code_gen - code_cap)
+        short_t = max(0.0, requirements.tool_use - tool_cap)
+        shortfall = short_r + short_c + short_t
+        if shortfall > SHORTFALL_TOLERANCE * 3:
+            scores.append(
+                CandidateScore(profile.id, 0.0, shortfall=shortfall, rejected_reason="capability_shortfall")
+            )
+            continue
+
+        capability = profile.quality - 0.6 * short_r - 0.5 * short_c - 0.4 * short_t
+        if request.has_images and profile.vision:
+            capability += 0.1
+        scores.append(CandidateScore(profile.id, capability, shortfall=shortfall))
+    return tuple(scores)
+
+
+def hydra_match(
+    fleet,
+    requirements: RequirementVector,
+    request: RoutingRequest,
+    weights: FrugalityWeights = FrugalityWeights(),
+) -> MultiObjectiveResult:
+    """Full deterministic HyDRA-style match: capability gate + multi-objective."""
+    capability_scores = score_fleet(fleet, requirements, request)
+    return score_multi_objective(capability_scores, fleet, weights)

--- a/agent/model_router/legacy.py
+++ b/agent/model_router/legacy.py
@@ -1,4 +1,8 @@
-"""Deterministic, turn-boundary model routing.
+"""Legacy deterministic, turn-boundary model routing.
+
+Preserved verbatim from the original ``agent/model_router.py`` so the public
+API (``Candidate``, ``Features``, ``RouteDecision``, ``extract_features``,
+``route_turn``) keeps its exact behavior for existing callers and tests.
 
 This module is intentionally pure: it never discovers credentials, performs
 network calls, or mutates an agent. Callers resolve authenticated candidates
@@ -38,7 +42,7 @@ class RouteDecision:
     explanation: str
     features: Features
     suggestion: str = ""
-    rejected: tuple[str, ...] = field(default_factory=tuple)
+    rejected: tuple = field(default_factory=tuple)
 
 
 _CODE_RE = re.compile(r"\b(code|coding|debug|traceback|python|javascript|typescript|sql|api|implement|refactor|test|代码|调试|报错|脚本|编程)\b", re.I)
@@ -52,7 +56,7 @@ def _contains_image(message: object) -> bool:
     return False
 
 
-def extract_features(message: str | list[object], *, has_images: bool = False, context_tokens: int = 0) -> Features:
+def extract_features(message, *, has_images: bool = False, context_tokens: int = 0) -> Features:
     """Extract stable routing signals without an LLM or network lookup."""
     text = str(message or "")
     coding = bool(_CODE_RE.search(text))
@@ -61,7 +65,7 @@ def extract_features(message: str | list[object], *, has_images: bool = False, c
     return Features(coding=coding, reasoning=reasoning, vision=bool(has_images or _contains_image(message)), context_tokens=max(0, int(context_tokens)), complexity=complexity)
 
 
-def _eligible(candidate: Candidate, features: Features) -> tuple[bool, str]:
+def _eligible(candidate: Candidate, features: Features):
     if features.vision and not candidate.vision:
         return False, "requires vision"
     if features.reasoning and not candidate.reasoning:
@@ -82,7 +86,7 @@ def _score(candidate: Candidate, features: Features) -> float:
     return score
 
 
-def route_turn(message: str | list[object], candidates: Iterable[Candidate], *, current_model: str, mode: str = "off", has_images: bool = False, context_tokens: int = 0) -> RouteDecision:
+def route_turn(message, candidates: Iterable[Candidate], *, current_model: str, mode: str = "off", has_images: bool = False, context_tokens: int = 0) -> RouteDecision:
     """Choose at most one model for a turn; modes are off, suggest, and auto."""
     if mode not in {"off", "suggest", "auto"}:
         mode = "off"

--- a/agent/model_router/local_zero.py
+++ b/agent/model_router/local_zero.py
@@ -1,0 +1,37 @@
+"""Optional local zero-tier — port of local/local-zero-tier.ts.
+
+Strictly opt-in (``model_router.local_zero.enabled: true``). When enabled,
+configured local inference endpoints (LM Studio / Ollama) are probed with a
+short-timeout HTTP GET; trivial / low-intensity turns may then route to the
+configured local model. Every failure mode (network down, timeout, import
+error) degrades to "not decided" — this stage never breaks routing.
+"""
+from __future__ import annotations
+
+import socket
+import urllib.request
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LocalZeroConfig:
+    enabled: bool = False
+    endpoints: tuple = ()
+    model: str = ""
+    timeout_ms: int = 1500
+
+
+def ping_local_services(config: LocalZeroConfig) -> bool:
+    """True when any configured endpoint answers within the timeout."""
+    if not config.enabled or not config.endpoints:
+        return False
+    timeout = max(0.1, config.timeout_ms / 1000.0)
+    for endpoint in config.endpoints:
+        try:
+            request = urllib.request.Request(str(endpoint), method="GET")
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                if response.status < 500:
+                    return True
+        except Exception:
+            continue
+    return False

--- a/agent/model_router/low_intensity.py
+++ b/agent/model_router/low_intensity.py
@@ -1,0 +1,112 @@
+"""Low-intensity tier gate — port of routing/tier-features.ts.
+
+Aggregates structural and envelope signals into a pure feature vector and a
+low-intensity score. High scores let the pipeline decide the cheapest adequate
+economical model immediately; low scores fall through to deeper stages.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from .triage import CYCLOMATIC_THRESHOLD, TriageResult
+from .types import RoutingRequest, TURN_TOOL_RESULT
+
+PROMPT_LENGTH_NORM = 8_000
+TOKEN_NORM = 2_000
+MESSAGE_COUNT_NORM = 20
+MAX_KEYWORD_HITS = 3
+
+DEFAULT_HIGH_THRESHOLD = 0.65
+DEFAULT_LOW_THRESHOLD = 0.35
+
+# Weights ported from DEFAULT_LOW_INTENSITY_WEIGHTS (cluster signal folded into
+# requirement_low weight — Hermes has no cluster matcher by default).
+WEIGHTS = {
+    "prompt_shortness": 0.06,
+    "token_shortness": 0.05,
+    "cyclomatic_low": 0.08,
+    "trivial_signal": 0.10,
+    "complex_inverse": 0.14,
+    "triage_verdict": 0.18,
+    "turn_type": 0.18,
+    "no_tool_context": 0.05,
+    "message_shallow": 0.03,
+    "prose_ratio": 0.03,
+    "requirement_low": 0.20,  # 0.12 requirement + 0.08 cluster neutral
+}
+
+_TRIAGE_LOW = {"trivial": 1.0, "ambiguous": 0.55, "complex": 0.0}
+_TURN_LOW = {
+    "planning": 0.0,
+    "tool_result": 0.25,
+    "subagent": 0.35,
+    "main_loop": 0.55,
+    "unknown": 0.5,
+}
+
+_RE_CODE_FENCE = re.compile(r"```[\s\S]*?```")
+
+
+def _clamp01(value: float) -> float:
+    return 0.0 if value <= 0 else (1.0 if value >= 1 else value)
+
+
+def compute_code_block_ratio(prompt_text: str) -> float:
+    """Ratio of fenced code block characters to total prompt length (0..1)."""
+    if not prompt_text:
+        return 0.0
+    code_chars = sum(len(m.group(0)) for m in _RE_CODE_FENCE.finditer(prompt_text))
+    return _clamp01(code_chars / len(prompt_text))
+
+
+def _has_tool_context(request: RoutingRequest) -> bool:
+    if request.turn_type == TURN_TOOL_RESULT:
+        return True
+    return any(getattr(m, "role", None) == "tool" for m in request.messages or ())
+
+
+@dataclass(frozen=True)
+class LowIntensityResult:
+    score: float
+    is_low: bool
+    is_high: bool
+
+
+def score_low_intensity(
+    request: RoutingRequest,
+    triage_result: TriageResult,
+    requirement_magnitude: float = 0.0,
+    *,
+    high_threshold: float = DEFAULT_HIGH_THRESHOLD,
+    low_threshold: float = DEFAULT_LOW_THRESHOLD,
+) -> LowIntensityResult:
+    """Weighted combination of normalized signals; 1 = strongly low-intensity."""
+    prompt_shortness = 1 - _clamp01(len(request.prompt_text) / PROMPT_LENGTH_NORM)
+    token_shortness = 1 - _clamp01(request.estimated_tokens() / TOKEN_NORM)
+    cyclomatic_low = 1 - _clamp01(triage_result.cyclomatic_score / CYCLOMATIC_THRESHOLD)
+    trivial_signal = _clamp01(triage_result.trivial_hits / MAX_KEYWORD_HITS)
+    complex_inverse = 1 - _clamp01(triage_result.complex_hits / MAX_KEYWORD_HITS)
+    triage_signal = _TRIAGE_LOW.get(triage_result.verdict, 0.55)
+    turn_signal = _TURN_LOW.get(request.turn_type or "unknown", 0.5)
+    no_tool_context = 0.0 if _has_tool_context(request) else 1.0
+    message_shallow = 1 - _clamp01(len(request.messages or ()) / MESSAGE_COUNT_NORM)
+    prose_ratio = 1 - compute_code_block_ratio(request.prompt_text)
+    requirement_low = 1 - _clamp01(requirement_magnitude)
+
+    weighted = (
+        WEIGHTS["prompt_shortness"] * prompt_shortness
+        + WEIGHTS["token_shortness"] * token_shortness
+        + WEIGHTS["cyclomatic_low"] * cyclomatic_low
+        + WEIGHTS["trivial_signal"] * trivial_signal
+        + WEIGHTS["complex_inverse"] * complex_inverse
+        + WEIGHTS["triage_verdict"] * triage_signal
+        + WEIGHTS["turn_type"] * turn_signal
+        + WEIGHTS["no_tool_context"] * no_tool_context
+        + WEIGHTS["message_shallow"] * message_shallow
+        + WEIGHTS["prose_ratio"] * prose_ratio
+        + WEIGHTS["requirement_low"] * requirement_low
+    )
+    total = sum(WEIGHTS.values())
+    score = _clamp01(weighted / total) if total > 0 else 0.5
+    return LowIntensityResult(score, score <= low_threshold, score >= high_threshold)

--- a/agent/model_router/pinning.py
+++ b/agent/model_router/pinning.py
@@ -1,0 +1,210 @@
+"""Session pinning, flip-flop guard, and cache-breakeven economics.
+
+Ports of pi-smart-router pinning/session-pinner.ts (core hold/break logic),
+pinning/flip-flop-guard.ts, and pinning/cache-breakeven.ts.
+
+A session pin preserves provider prefix-cache economics: once a session is
+routed to a model, subsequent turns stay on it unless an explicit break
+condition fires (compaction, context overflow, loop escalation, or a
+voluntary switch that clears the cache-breakeven / score-margin gate).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .types import ModelProfile, SessionPin
+
+# ─── Flip-flop guard (port of flip-flop-guard.ts) ─────────────────────────────
+
+FLIP_FLOP_PIN_THRESHOLD = 3
+
+
+@dataclass(frozen=True)
+class FlipFlopObservation:
+    tier_flip_detected: bool
+    consecutive_tier_flips: int
+    tier_pinned: Optional[str]
+
+
+class FlipFlopGuard:
+    """Tracks consecutive per-turn tier flips within a session.
+
+    When the shadow routing tier flips ``threshold`` times in a row, the
+    session tier is pinned for the remainder of the process lifetime to stop
+    adversarial paraphrase / suffix oscillation. In-memory (matches the Pi
+    implementation); the durable pin lives in the state store.
+    """
+
+    def __init__(self, threshold: int = FLIP_FLOP_PIN_THRESHOLD):
+        self._threshold = max(1, int(threshold))
+        self._sessions = {}
+
+    def is_tier_pinned(self, session_id: str) -> Optional[str]:
+        state = self._sessions.get(session_id)
+        return state[2] if state else None
+
+    def observe_tier(self, session_id: str, observed_tier: str) -> FlipFlopObservation:
+        if not session_id:
+            return FlipFlopObservation(False, 0, None)
+        current = self._sessions.get(session_id)
+        if current is None:
+            self._sessions[session_id] = (observed_tier, 0, None)
+            return FlipFlopObservation(False, 0, None)
+
+        last_tier, consecutive, tier_pinned = current
+        if tier_pinned is not None:
+            return FlipFlopObservation(False, consecutive, tier_pinned)
+        if last_tier == observed_tier:
+            self._sessions[session_id] = (observed_tier, 0, None)
+            return FlipFlopObservation(False, 0, None)
+
+        consecutive += 1
+        if consecutive >= self._threshold:
+            self._sessions[session_id] = (observed_tier, consecutive, observed_tier)
+            return FlipFlopObservation(True, consecutive, observed_tier)
+        self._sessions[session_id] = (observed_tier, consecutive, None)
+        return FlipFlopObservation(True, consecutive, None)
+
+    def clear_session(self, session_id: str) -> None:
+        self._sessions.pop(session_id, None)
+
+
+# ─── Cache breakeven economics (port of cache-breakeven.ts) ──────────────────
+
+DEFAULT_PREFIX_CACHE_WEIGHT = 0.2
+DEFAULT_PREFIX_CACHE_DISCOUNT = 0.9
+_TOKENS_PER_M = 1_000_000
+
+
+@dataclass(frozen=True)
+class CacheBreakevenResult:
+    should_switch: bool
+    marginal_savings: float
+    future_cache_value: float
+    cache_reprime_cost: float
+    total_benefit: float
+    reason: str
+
+
+def compute_future_cache_value(
+    warm_prefix_tokens: float,
+    pinned_cost_per_1m: float,
+    prefix_cache_weight: float = DEFAULT_PREFIX_CACHE_WEIGHT,
+    prefix_cache_discount: float = DEFAULT_PREFIX_CACHE_DISCOUNT,
+) -> float:
+    """Estimate the retained value of a warm prefix cache."""
+    if warm_prefix_tokens <= 0 or pinned_cost_per_1m < 0:
+        return 0.0
+    prefix_cost = (warm_prefix_tokens / _TOKENS_PER_M) * pinned_cost_per_1m
+    return prefix_cost * prefix_cache_discount * prefix_cache_weight
+
+
+def compute_cache_reprime_cost(warm_prefix_tokens: float, candidate_cost_per_1m: float) -> float:
+    """Cost to re-transmit a cold prefix on the candidate after a switch."""
+    if warm_prefix_tokens <= 0 or candidate_cost_per_1m < 0:
+        return 0.0
+    return (warm_prefix_tokens / _TOKENS_PER_M) * candidate_cost_per_1m
+
+
+def compute_marginal_switch_savings(
+    pinned: ModelProfile,
+    candidate: ModelProfile,
+    estimated_input_tokens: int,
+) -> Optional[float]:
+    """Per-turn savings from switching, or None when pricing is undeclared."""
+    if pinned.cost_per_1m is None or candidate.cost_per_1m is None:
+        return None
+    return max(0.0, (pinned.cost_per_1m - candidate.cost_per_1m)) * (estimated_input_tokens / _TOKENS_PER_M)
+
+
+def evaluate_cache_breakeven_for_prefix(
+    marginal_savings: float,
+    warm_prefix_tokens: float,
+    pinned_cost_per_1m: float,
+    candidate_cost_per_1m: float,
+    prefix_cache_weight: float = DEFAULT_PREFIX_CACHE_WEIGHT,
+    prefix_cache_discount: float = DEFAULT_PREFIX_CACHE_DISCOUNT,
+) -> CacheBreakevenResult:
+    """Switch only when marginal_savings + future_cache_value > reprime cost."""
+    components = (marginal_savings, warm_prefix_tokens, pinned_cost_per_1m, candidate_cost_per_1m)
+    if any(not isinstance(v, (int, float)) or v < 0 for v in components):
+        return CacheBreakevenResult(False, marginal_savings, 0.0, 0.0, marginal_savings, "invalid_input")
+
+    future_value = compute_future_cache_value(
+        warm_prefix_tokens, pinned_cost_per_1m, prefix_cache_weight, prefix_cache_discount
+    )
+    reprime_cost = compute_cache_reprime_cost(warm_prefix_tokens, candidate_cost_per_1m)
+    total_benefit = marginal_savings + future_value
+
+    if total_benefit <= reprime_cost:
+        return CacheBreakevenResult(False, marginal_savings, future_value, reprime_cost, total_benefit, "breakeven_not_met")
+    return CacheBreakevenResult(True, marginal_savings, future_value, reprime_cost, total_benefit, "breakeven_pass")
+
+
+# ─── Pin hold / break evaluation ──────────────────────────────────────────────
+
+PIN_HOLD = "hold"
+PIN_BREAK_COMPACTION = "break_compaction"
+PIN_BREAK_OVERFLOW = "break_context_overflow"
+PIN_BREAK_BREAKEVEN = "break_breakeven"
+PIN_BREAK_SCORE_MARGIN = "break_score_margin"
+PIN_BREAK_STALE = "break_stale"
+
+
+@dataclass(frozen=True)
+class PinEvaluation:
+    hold: bool
+    reason: str
+    switch_to: Optional[ModelProfile] = None
+
+
+def evaluate_pin(
+    pin: SessionPin,
+    pinned_model: Optional[ModelProfile],
+    best_alternative: Optional[ModelProfile],
+    *,
+    compaction_flag: bool = False,
+    pinned_fits_context: bool = True,
+    dwell_turns: int = 3,
+    switch_margin: float = 0.25,
+    pinned_score: float = 0.0,
+    alternative_score: float = 0.0,
+    estimated_input_tokens: int = 0,
+    warm_prefix_tokens: int = 0,
+) -> PinEvaluation:
+    """Decide whether a session pin holds for this turn.
+
+    Break conditions (first match wins):
+      1. compaction — the conversation was compacted; prefix cache is gone
+      2. context overflow — pinned model can no longer fit the request
+      3. voluntary switch past the dwell guard that clears the economics gate:
+         cache-breakeven when both models declare ``cost_per_1m``, otherwise a
+         composite-score margin (``switch_margin``)
+    """
+    if compaction_flag:
+        return PinEvaluation(False, PIN_BREAK_COMPACTION, best_alternative)
+    if pinned_model is None or not pinned_model.healthy:
+        return PinEvaluation(False, PIN_BREAK_STALE, best_alternative)
+    if not pinned_fits_context:
+        return PinEvaluation(False, PIN_BREAK_OVERFLOW, best_alternative)
+    if best_alternative is None or best_alternative.id == pin.pinned_model_id:
+        return PinEvaluation(True, PIN_HOLD)
+    if pin.turns_held < max(0, dwell_turns):
+        return PinEvaluation(True, PIN_HOLD)
+
+    savings = compute_marginal_switch_savings(pinned_model, best_alternative, estimated_input_tokens)
+    if savings is not None:
+        result = evaluate_cache_breakeven_for_prefix(
+            savings,
+            warm_prefix_tokens,
+            pinned_model.cost_per_1m or 0.0,
+            best_alternative.cost_per_1m or 0.0,
+        )
+        if result.should_switch:
+            return PinEvaluation(False, PIN_BREAK_BREAKEVEN, best_alternative)
+        return PinEvaluation(True, PIN_HOLD)
+
+    if alternative_score - pinned_score > switch_margin:
+        return PinEvaluation(False, PIN_BREAK_SCORE_MARGIN, best_alternative)
+    return PinEvaluation(True, PIN_HOLD)

--- a/agent/model_router/pipeline.py
+++ b/agent/model_router/pipeline.py
@@ -22,6 +22,7 @@ probe, speculative prewarm, planning delegate — are explicit non-goals):
 """
 from __future__ import annotations
 
+import logging
 import time
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -29,14 +30,15 @@ from typing import Optional
 
 from . import hydra
 from .context_fit import (
+    DEFAULT_MIN_OUTPUT_TOKENS,
     DEFAULT_SAFETY_MARGIN,
     filter_fleet_by_context_fit,
-    model_fits_context,
     resolve_context_overflow_fallback,
     select_lowest_cost_model,
 )
 from .envelope import classify_turn_envelope
 from .escalation import evaluate_loop_escalation
+from .health import HealthConfig
 from .local_zero import LocalZeroConfig, ping_local_services
 from .low_intensity import DEFAULT_HIGH_THRESHOLD, DEFAULT_LOW_THRESHOLD, score_low_intensity
 from .pinning import FlipFlopGuard, PIN_BREAK_OVERFLOW, evaluate_pin
@@ -46,6 +48,7 @@ from .triage import VERDICT_COMPLEX, VERDICT_TRIVIAL, triage
 from .types import (
     PIN_REASON_AUTO,
     PIN_REASON_LOOP_ESCALATION,
+    CandidateScore,
     ModelProfile,
     RoutingDecision,
     RoutingRequest,
@@ -59,6 +62,8 @@ from .types import (
 MODE_OFF = "off"
 MODE_SUGGEST = "suggest"
 MODE_AUTO = "auto"
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -75,6 +80,10 @@ class RouterConfig:
     local_zero: LocalZeroConfig = LocalZeroConfig()
     hydra_enabled: bool = True
     flip_flop_threshold: int = 3
+    min_output_tokens: int = DEFAULT_MIN_OUTPUT_TOKENS
+    health: HealthConfig = HealthConfig()
+    stream_failover_enabled: bool = True
+    stream_failover_max_alternates: int = 1
 
 
 def _redact_error(error: BaseException, prompt_text: str) -> str:
@@ -88,21 +97,44 @@ def _redact_error(error: BaseException, prompt_text: str) -> str:
 class RouterPipeline:
     """Ordered early-exit routing pipeline over an explicit candidate fleet."""
 
-    def __init__(self, fleet, config: RouterConfig = RouterConfig(), state=None, telemetry=None):
+    def __init__(
+        self,
+        fleet,
+        config: RouterConfig = RouterConfig(),
+        state=None,
+        telemetry=None,
+        health=None,
+    ):
         self._fleet = tuple(fleet)
         self._config = config
         self._state = state
         self._telemetry = telemetry
+        self._health = health
         self._flip_flop = FlipFlopGuard(config.flip_flop_threshold)
 
     @property
     def fleet(self):
         return self._fleet
 
+    @property
+    def health(self):
+        return self._health
+
     # ─── Public entry ────────────────────────────────────────────────────────
 
-    def route(self, request: RoutingRequest, *, current_model: str, mode: str = MODE_OFF) -> RoutingDecision:
-        """Choose at most one model for a turn. Modes: off, suggest, auto."""
+    def route(
+        self,
+        request: RoutingRequest,
+        *,
+        current_model: str,
+        mode: str = MODE_OFF,
+        dry_run: bool = False,
+    ) -> RoutingDecision:
+        """Choose at most one model for a turn. Modes: off, suggest, auto.
+
+        ``dry_run`` executes the same stages while suppressing pin, health,
+        flip-flop, and telemetry writes; it powers ``hermes router explain``.
+        """
         if mode not in {MODE_OFF, MODE_SUGGEST, MODE_AUTO}:
             mode = MODE_OFF
         start = time.monotonic()
@@ -111,7 +143,38 @@ class RouterPipeline:
             return RoutingDecision(current_model, "disabled", "routing_disabled", explanation="routing disabled")
 
         try:
-            decision = self._run_pipeline(request, current_model)
+            health_excluded: set[str] = set()
+            while True:
+                decision = self._run_pipeline(
+                    request,
+                    current_model,
+                    health_excluded=health_excluded,
+                    mutate_state=not dry_run,
+                )
+                if (
+                    dry_run
+                    or mode != MODE_AUTO
+                    or self._health is None
+                    or decision.stage in {"fallback", "pipeline_error", "force_model"}
+                ):
+                    break
+                selected = next(
+                    (model for model in self._fleet if model.id == decision.selected_model),
+                    None,
+                )
+                if selected is None or self._health.claim_dispatch(
+                    selected.provider, selected.id
+                ):
+                    break
+                health_excluded.add(selected.id)
+                if len(health_excluded) >= len(self._fleet):
+                    decision = self._decide_named(
+                        current_model,
+                        "fallback",
+                        "health_probe_busy",
+                        request,
+                    )
+                    break
         except Exception as exc:  # belt-and-braces; stages already guard
             decision = self._fallback_decision(
                 request, current_model, "pipeline_error", _redact_error(exc, request.prompt_text)
@@ -134,41 +197,126 @@ class RouterPipeline:
 
         # Pin bookkeeping only applies to turns that will actually run on the
         # selected model (auto mode).
-        if mode == MODE_AUTO and self._state is not None and self._config.pin_enabled:
+        if (
+            not dry_run
+            and mode == MODE_AUTO
+            and self._state is not None
+            and self._config.pin_enabled
+        ):
             self._update_pin(request, decision)
 
-        if self._telemetry is not None:
-            self._telemetry.record(request, decision, mode=mode, session_id=request.session_id)
+        if not dry_run and self._telemetry is not None:
+            try:
+                self._telemetry.record(
+                    request,
+                    decision,
+                    mode=mode,
+                    session_id=request.session_id,
+                )
+            except Exception as exc:
+                # Telemetry is never a routing gate. Avoid logging the exception
+                # message because third-party recorders may include prompt text.
+                logger.warning(
+                    "Model router telemetry write failed: mode=%s stage=%s error_type=%s",
+                    mode,
+                    decision.stage,
+                    type(exc).__name__,
+                )
         return decision
 
     # ─── Pipeline ────────────────────────────────────────────────────────────
 
-    def _run_pipeline(self, request: RoutingRequest, current_model: str) -> RoutingDecision:
+    def _run_pipeline(
+        self,
+        request: RoutingRequest,
+        current_model: str,
+        *,
+        health_excluded: set[str] | None = None,
+        mutate_state: bool = True,
+    ) -> RoutingDecision:
         turn_type = request.turn_type or (
             classify_turn_envelope(request.messages) if request.messages else "main_loop"
         )
         request = replace(request, turn_type=turn_type)
         cfg = self._config
+        basic_features = {
+            "estimated_input_tokens": request.estimated_tokens(),
+            "min_output_tokens": cfg.min_output_tokens,
+            "has_images": bool(request.has_images),
+        }
 
-        # 1. force_model — explicit override short-circuits routing.
+        # 1. force_model — explicit operator override short-circuits gates.
         if request.force_model_id:
             for model in self._fleet:
                 if model.id == request.force_model_id:
-                    return self._decide(model, "force_model", "operator_override", request)
-            # Forced model outside the fleet: retain current, never guess.
-            return self._decide_named(current_model, "force_model", "forced_model_not_in_fleet", request)
+                    return self._decide(
+                        model,
+                        "force_model",
+                        "operator_override",
+                        request,
+                        features=basic_features,
+                    )
+            return self._decide_named(
+                current_model,
+                "force_model",
+                "forced_model_not_in_fleet",
+                request,
+                features=basic_features,
+            )
 
-        pin = self._state.load_pin(request.session_id) if (self._state and cfg.pin_enabled) else None
+        # Compute candidate eligibility before an early escalation decision so
+        # every automatic target (including a frontier escalation) reserves
+        # context plus output headroom and respects an open health circuit.
+        fit = filter_fleet_by_context_fit(
+            self._fleet,
+            request,
+            cfg.context_safety_margin,
+            cfg.min_output_tokens,
+        )
+        excluded = health_excluded or set()
+        health_rejected = []
+        eligible = []
+        for profile in fit.effective_fleet:
+            unavailable = profile.id in excluded
+            if not unavailable and self._health is not None:
+                unavailable = not self._health.is_available(profile.provider, profile.id)
+            if unavailable:
+                health_rejected.append(
+                    CandidateScore(profile.id, rejected_reason="health_circuit_open")
+                )
+            else:
+                eligible.append(profile)
+        fleet = tuple(eligible)
+        all_rejected = tuple(fit.rejected) + tuple(health_rejected)
+        rejected_notes = tuple(
+            f"{candidate.model_id}: {candidate.rejected_reason}"
+            for candidate in all_rejected
+        )
 
-        # 2. loop_escalation — repeated tool failures escalate to frontier.
+        pin = self._state.load_pin(request.session_id) if (
+            self._state and cfg.pin_enabled
+        ) else None
+
+        # 2. loop_escalation — repeated tool failures escalate to an eligible frontier.
         if pin is not None:
-            result = self._stage("loop_escalation", evaluate_loop_escalation, pin, request, self._fleet, cfg.loop_escalation_threshold)
+            result = self._stage(
+                "loop_escalation",
+                evaluate_loop_escalation,
+                pin,
+                request,
+                fleet,
+                cfg.loop_escalation_threshold,
+            )
             if result is not None:
-                if result.updated_pin is not None and self._state is not None:
+                if (
+                    mutate_state
+                    and result.updated_pin is not None
+                    and self._state is not None
+                ):
                     self._state.save_pin(result.updated_pin)
                     pin = result.updated_pin
                 if result.should_escalate and result.escalation_target is not None:
-                    if self._state is not None:
+                    if mutate_state and self._state is not None:
                         self._state.save_pin(replace(
                             pin,
                             pinned_model_id=result.escalation_target.id,
@@ -176,54 +324,91 @@ class RouterPipeline:
                             turns_held=0,
                             updated_at=time.time(),
                         ))
-                    return self._decide(result.escalation_target, "loop_escalation", result.reason, request, pinned=True)
+                    return self._decide(
+                        result.escalation_target,
+                        "loop_escalation",
+                        result.reason,
+                        request,
+                        pinned=True,
+                        rejected=rejected_notes,
+                        features=basic_features,
+                    )
 
-        # 3. context_fit — narrow the fleet (never decides).
-        fit = filter_fleet_by_context_fit(self._fleet, request, cfg.context_safety_margin)
-        fleet = fit.effective_fleet or self._fleet if not request.force_model_id else self._fleet
-        rejected_notes = tuple(f"{c.model_id}: {c.rejected_reason}" for c in fit.rejected)
-
-        # Flip-flop guard: a tier-pinned session stays on its pinned tier when possible.
+        # 3. context_fit and health have narrowed ``fleet`` but never decide.
         guard_tier = self._flip_flop.is_tier_pinned(request.session_id)
         if guard_tier:
-            tier_fleet = tuple(m for m in fleet if m.tier == guard_tier)
+            tier_fleet = tuple(model for model in fleet if model.tier == guard_tier)
             if tier_fleet:
                 fleet = tier_fleet
 
-        # Shared analysis for downstream stages.
         triage_result = triage(request.prompt_text)
         requirements = hydra.build_requirement_vector(request, triage_result)
-
-        def hydra_pick(candidates):
-            result = hydra.hydra_match(candidates, requirements, request, cfg.frugality)
-            return result
+        low = score_low_intensity(
+            request,
+            triage_result,
+            requirements.magnitude,
+            high_threshold=cfg.low_intensity_high,
+            low_threshold=cfg.low_intensity_low,
+        )
+        features = {
+            **basic_features,
+            "low_intensity_score": low.score,
+            "triage": {
+                "verdict": triage_result.verdict,
+                "reason": triage_result.reason_code,
+            },
+            "requirements": {
+                "reasoning": requirements.reasoning,
+                "code_gen": requirements.code_gen,
+                "tool_use": requirements.tool_use,
+            },
+        }
+        mo = hydra.hydra_match(fleet, requirements, request, cfg.frugality)
+        candidates = mo.candidates + tuple(
+            # Keep eligibility rejections visible beside scored candidates.
+            # Multi-objective candidates already include unhealthy/capability rejects.
+            CandidateScore(
+                candidate.model_id,
+                rejected_reason=candidate.rejected_reason,
+                shortfall=candidate.shortfall,
+            )
+            for candidate in all_rejected
+        )
 
         # 4. low_intensity — cheap adequate pick for low-intensity turns.
-        low = score_low_intensity(
-            request, triage_result, requirements.magnitude,
-            high_threshold=cfg.low_intensity_high, low_threshold=cfg.low_intensity_low,
-        )
         if low.is_high:
-            economical = [m for m in fleet if m.tier == TIER_ECONOMICAL]
+            economical = [model for model in fleet if model.tier == TIER_ECONOMICAL]
             pick = select_lowest_cost_model(economical)
             if pick is not None:
-                return self._decide(pick, "low_intensity", "low_intensity_gate", request, rejected=rejected_notes,
-                                    features={"low_intensity_score": low.score})
+                return self._decide(
+                    pick,
+                    "low_intensity",
+                    "low_intensity_gate",
+                    request,
+                    rejected=rejected_notes,
+                    candidates=candidates,
+                    features=features,
+                )
 
         # 5. session_pin — valid pin holds unless a break condition fires.
         if pin is not None:
-            pinned_model = next((m for m in self._fleet if m.id == pin.pinned_model_id), None)
-            active_pinned = next((m for m in fleet if m.id == pin.pinned_model_id), None)
-            mo = hydra_pick(fleet)
-            best_alt = None
-            best_alt_score = 0.0
-            pinned_score = 0.0
-            if mo.selected is not None:
-                best_alt = next((m for m in fleet if m.id == mo.selected.model_id), None)
-                best_alt_score = mo.selected.composite_score
-            for scored in mo.candidates:
-                if scored.model_id == pin.pinned_model_id:
-                    pinned_score = scored.composite_score
+            active_pinned = next(
+                (model for model in fleet if model.id == pin.pinned_model_id),
+                None,
+            )
+            best_alt = next(
+                (model for model in fleet if mo.selected and model.id == mo.selected.model_id),
+                None,
+            )
+            best_alt_score = mo.selected.composite_score if mo.selected else 0.0
+            pinned_score = next(
+                (
+                    scored.composite_score
+                    for scored in mo.candidates
+                    if scored.model_id == pin.pinned_model_id
+                ),
+                0.0,
+            )
             evaluation = evaluate_pin(
                 pin,
                 active_pinned,
@@ -238,62 +423,220 @@ class RouterPipeline:
                 warm_prefix_tokens=request.estimated_tokens(),
             )
             if evaluation.hold and active_pinned is not None:
-                return self._decide(active_pinned, "session_pin", "pin_hold", request, pinned=True, rejected=rejected_notes)
+                return self._decide(
+                    active_pinned,
+                    "session_pin",
+                    "pin_hold",
+                    request,
+                    pinned=True,
+                    rejected=rejected_notes,
+                    candidates=candidates,
+                    features=features,
+                )
             if evaluation.switch_to is not None and evaluation.reason != PIN_BREAK_OVERFLOW:
-                return self._decide(evaluation.switch_to, "session_pin", evaluation.reason, request, rejected=rejected_notes)
-            # Overflow break: fall through to the overflow stage below with the pin cleared.
-            if self._state is not None:
+                return self._decide(
+                    evaluation.switch_to,
+                    "session_pin",
+                    evaluation.reason,
+                    request,
+                    rejected=rejected_notes,
+                    candidates=candidates,
+                    features=features,
+                )
+            if mutate_state and self._state is not None:
                 self._state.clear_pin(request.session_id)
             pin = None
 
         # 6. triage — fast paths.
         if triage_result.verdict == VERDICT_COMPLEX:
-            frontier = [m for m in fleet if m.tier == TIER_FRONTIER and m.healthy]
+            frontier = [
+                model for model in fleet
+                if model.tier == TIER_FRONTIER and model.healthy
+            ]
             if frontier:
-                pick = sorted(frontier, key=lambda m: (-m.quality, m.id))[0]
-                return self._decide(pick, "triage", triage_result.reason_code, request, rejected=rejected_notes)
+                pick = sorted(frontier, key=lambda model: (-model.quality, model.id))[0]
+                return self._decide(
+                    pick,
+                    "triage",
+                    triage_result.reason_code,
+                    request,
+                    rejected=rejected_notes,
+                    candidates=candidates,
+                    features=features,
+                )
 
         # 7. local_zero — opt-in local inference for trivial/low-intensity turns.
-        if cfg.local_zero.enabled and (triage_result.verdict == VERDICT_TRIVIAL or low.is_high):
+        if cfg.local_zero.enabled and (
+            triage_result.verdict == VERDICT_TRIVIAL or low.is_high
+        ):
             local_model = next(
-                (m for m in fleet if m.tier == TIER_LOCAL and m.healthy and (not cfg.local_zero.model or m.id == cfg.local_zero.model)),
+                (
+                    model for model in fleet
+                    if model.tier == TIER_LOCAL
+                    and model.healthy
+                    and (not cfg.local_zero.model or model.id == cfg.local_zero.model)
+                ),
                 None,
             )
-            if local_model is not None and self._stage("local_zero_ping", ping_local_services, cfg.local_zero):
-                return self._decide(local_model, "local_zero", "local_ready", request, rejected=rejected_notes)
+            if local_model is not None and self._stage(
+                "local_zero_ping", ping_local_services, cfg.local_zero
+            ):
+                return self._decide(
+                    local_model,
+                    "local_zero",
+                    "local_ready",
+                    request,
+                    rejected=rejected_notes,
+                    candidates=candidates,
+                    features=features,
+                )
 
         # 8. triage_cloud_fallback — trivial turns not claimed locally.
         if triage_result.verdict == VERDICT_TRIVIAL:
-            economical = [m for m in fleet if m.tier == TIER_ECONOMICAL]
+            economical = [model for model in fleet if model.tier == TIER_ECONOMICAL]
             pick = select_lowest_cost_model(economical)
             if pick is not None:
-                return self._decide(pick, "triage_cloud_fallback", triage_result.reason_code, request, rejected=rejected_notes)
+                return self._decide(
+                    pick,
+                    "triage_cloud_fallback",
+                    triage_result.reason_code,
+                    request,
+                    rejected=rejected_notes,
+                    candidates=candidates,
+                    features=features,
+                )
 
         # 9. hydra_match — requirement vector + multi-objective selection.
-        if cfg.hydra_enabled:
-            mo = hydra_pick(fleet)
-            if mo.selected is not None:
-                pick = next(m for m in fleet if m.id == mo.selected.model_id)
-                decision = self._decide(pick, "hydra_match", "multi_objective", request, rejected=rejected_notes,
-                                        candidates=mo.candidates)
+        if cfg.hydra_enabled and mo.selected is not None:
+            pick = next(model for model in fleet if model.id == mo.selected.model_id)
+            decision = self._decide(
+                pick,
+                "hydra_match",
+                "multi_objective",
+                request,
+                rejected=rejected_notes,
+                candidates=candidates,
+                features=features,
+            )
+            if mutate_state:
                 self._flip_flop.observe_tier(request.session_id, pick.tier)
-                return decision
+            return decision
 
-        # 10. safe_default — first healthy safe-tier model (context-fit aware).
-        pick = safe_default(fleet, request, safe_tier=cfg.safe_tier, safety_margin=cfg.context_safety_margin)
+        # 10. safe_default — context, headroom, and health aware.
+        pick = safe_default(
+            fleet,
+            request,
+            safe_tier=cfg.safe_tier,
+            safety_margin=cfg.context_safety_margin,
+            min_output_tokens=cfg.min_output_tokens,
+        )
         if pick is not None:
-            return self._decide(pick, "safe_default", "safe_tier_default", request, rejected=rejected_notes)
+            return self._decide(
+                pick,
+                "safe_default",
+                "safe_tier_default",
+                request,
+                rejected=rejected_notes,
+                candidates=candidates,
+                features=features,
+            )
 
-        # 11. context_overflow — largest-fit model when nothing else decided.
+        # 11. context_overflow — try a larger healthy circuit without ever
+        # dispatching a model that still lacks the required output floor.
         if fit.rejected:
+            overflow_fleet = tuple(
+                model for model in self._fleet
+                if model.id not in excluded
+                and (
+                    self._health is None
+                    or self._health.is_available(model.provider, model.id)
+                )
+            )
             overflow = resolve_context_overflow_fallback(
-                self._fleet, request.estimated_tokens(),
-                preferred_provider=None, safety_margin=cfg.context_safety_margin,
+                overflow_fleet,
+                request.estimated_tokens(),
+                preferred_provider=None,
+                safety_margin=cfg.context_safety_margin,
+                min_output_tokens=cfg.min_output_tokens,
             )
             if overflow.kind == "selected" and overflow.model is not None:
-                return self._decide(overflow.model, "context_overflow", overflow.reason_code, request, rejected=rejected_notes)
+                return self._decide(
+                    overflow.model,
+                    "context_overflow",
+                    overflow.reason_code,
+                    request,
+                    rejected=rejected_notes,
+                    candidates=candidates,
+                    features=features,
+                )
 
-        return self._decide_named(current_model, "fallback", "no_candidate_eligible", request, rejected=rejected_notes)
+        return self._decide_named(
+            current_model,
+            "fallback",
+            "no_candidate_eligible",
+            request,
+            rejected=rejected_notes,
+            candidates=candidates,
+            features=features,
+        )
+
+    def failover_candidates(
+        self,
+        request: RoutingRequest,
+        selected_model: str,
+        *,
+        limit: int | None = None,
+    ) -> tuple[ModelProfile, ...]:
+        """Return deterministic, currently eligible stream-failover targets.
+
+        This is selection only: it performs no health probe claim and no state,
+        telemetry, pin, or network mutation. The gateway passes these targets
+        to Hermes' existing provider-failure retry loop.
+        """
+        if not self._config.stream_failover_enabled:
+            return ()
+        cap = self._config.stream_failover_max_alternates if limit is None else limit
+        cap = max(0, int(cap))
+        if cap == 0:
+            return ()
+        fit = filter_fleet_by_context_fit(
+            self._fleet,
+            request,
+            self._config.context_safety_margin,
+            self._config.min_output_tokens,
+        )
+        fleet = tuple(
+            model for model in fit.effective_fleet
+            if model.id != selected_model
+            and model.healthy
+            and (
+                self._health is None
+                or self._health.is_available(model.provider, model.id)
+            )
+        )
+        triage_result = triage(request.prompt_text)
+        requirements = hydra.build_requirement_vector(request, triage_result)
+        scored = hydra.hydra_match(
+            fleet, requirements, request, self._config.frugality
+        )
+        score_by_id = {
+            candidate.model_id: candidate.composite_score
+            for candidate in scored.candidates
+            if candidate.rejected_reason is None
+        }
+        selected = next(
+            (model for model in self._fleet if model.id == selected_model),
+            None,
+        )
+        viable = [model for model in fleet if model.id in score_by_id]
+        viable.sort(
+            key=lambda model: (
+                0 if selected is not None and model.tier == selected.tier else 1,
+                -score_by_id[model.id],
+                model.id,
+            )
+        )
+        return tuple(viable[:cap])
 
     # ─── Stage guard ─────────────────────────────────────────────────────────
 
@@ -320,20 +663,43 @@ class RouterPipeline:
             features=features or {},
         )
 
-    def _decide_named(self, model_id: str, stage: str, reason: str, request: RoutingRequest, *, rejected: tuple = ()) -> RoutingDecision:
+    def _decide_named(
+        self,
+        model_id: str,
+        stage: str,
+        reason: str,
+        request: RoutingRequest,
+        *,
+        rejected: tuple = (),
+        candidates: tuple = (),
+        features: dict | None = None,
+    ) -> RoutingDecision:
         return RoutingDecision(
             selected_model=model_id,
             stage=stage,
             reason_code=reason,
             explanation=f"stage={stage} reason={reason}",
             rejected=rejected,
+            candidates=candidates,
             turn_type=request.turn_type or "unknown",
+            features=features or {},
         )
 
     def _fallback_decision(self, request: RoutingRequest, current_model: str, stage: str, error: str) -> RoutingDecision:
         pick = None
         try:
-            pick = safe_default(self._fleet, request, safe_tier=self._config.safe_tier)
+            eligible = tuple(
+                model for model in self._fleet
+                if self._health is None
+                or self._health.is_available(model.provider, model.id)
+            )
+            pick = safe_default(
+                eligible,
+                request,
+                safe_tier=self._config.safe_tier,
+                safety_margin=self._config.context_safety_margin,
+                min_output_tokens=self._config.min_output_tokens,
+            )
         except Exception:
             pick = None
         selected = pick.id if pick is not None else current_model
@@ -409,6 +775,9 @@ def router_config_from_dict(cfg: dict) -> RouterConfig:
     pin = cfg.get("session_pin") or {}
     local = cfg.get("local_zero") or {}
     hydra_cfg = cfg.get("hydra") or {}
+    headroom = cfg.get("output_headroom") or {}
+    health = cfg.get("health") or {}
+    stream_failover = cfg.get("stream_failover") or {}
     return RouterConfig(
         frugality=FrugalityWeights(
             lambda_cost=float(frugality.get("lambda_cost", 0.5)),
@@ -420,6 +789,9 @@ def router_config_from_dict(cfg: dict) -> RouterConfig:
         dwell_turns=max(0, int(pin.get("dwell_turns", 3))),
         switch_margin=float(pin.get("switch_margin", 0.25)),
         safe_tier=normalize_tier(cfg.get("safe_tier"), default=TIER_ECONOMICAL),
+        context_safety_margin=max(
+            0.0, min(1.0, float(cfg.get("context_safety_margin", DEFAULT_SAFETY_MARGIN)))
+        ),
         local_zero=LocalZeroConfig(
             enabled=bool(local.get("enabled", False)),
             endpoints=tuple(local.get("endpoints") or ()),
@@ -427,6 +799,22 @@ def router_config_from_dict(cfg: dict) -> RouterConfig:
             timeout_ms=int(local.get("timeout_ms", 1500)),
         ),
         hydra_enabled=bool(hydra_cfg.get("enabled", True)),
+        min_output_tokens=max(
+            0, int(headroom.get("min_output_tokens", DEFAULT_MIN_OUTPUT_TOKENS))
+        ),
+        health=HealthConfig(
+            enabled=bool(health.get("enabled", True)),
+            failure_threshold=max(1, int(health.get("failure_threshold", 3))),
+            reset_timeout_seconds=max(
+                0.0, float(health.get("reset_timeout_seconds", 30.0))
+            ),
+            half_open_successes=max(1, int(health.get("half_open_successes", 2))),
+            max_entries=max(1, min(4096, int(health.get("max_entries", 256)))),
+        ),
+        stream_failover_enabled=bool(stream_failover.get("enabled", True)),
+        stream_failover_max_alternates=max(
+            0, min(8, int(stream_failover.get("max_alternates", 1)))
+        ),
     )
 
 
@@ -441,7 +829,12 @@ def default_db_path(hermes_home=None) -> Path:
     return Path(hermes_home) / "state" / "model_router" / "router.db"
 
 
-def pipeline_from_config(router_cfg: dict, *, hermes_home=None) -> Optional["RouterPipeline"]:
+def pipeline_from_config(
+    router_cfg: dict,
+    *,
+    hermes_home=None,
+    read_only: bool = False,
+) -> Optional["RouterPipeline"]:
     """Build a pipeline from the model_router config section.
 
     Returns None when no usable candidates exist. State and telemetry are
@@ -463,19 +856,35 @@ def pipeline_from_config(router_cfg: dict, *, hermes_home=None) -> Optional["Rou
 
     state = None
     telemetry = None
+    health = None
     if config.pin_enabled:
         try:
             from .state import RouterStateStore
-            store = RouterStateStore(db_path)
+            store = RouterStateStore(db_path, read_only=read_only)
             state = store if store.available else None
         except Exception:
             state = None
-    if bool(telemetry_cfg.get("enabled", True)):
+    if not read_only and bool(telemetry_cfg.get("enabled", True)):
         try:
             from .telemetry import RouterTelemetry
             recorder = RouterTelemetry(db_path)
             telemetry = recorder if recorder.available else None
         except Exception:
             telemetry = None
+    if config.health.enabled:
+        try:
+            from .health import RouterHealthStore
+            health_store = RouterHealthStore(
+                db_path, config.health, read_only=read_only
+            )
+            health = health_store if health_store.available else None
+        except Exception:
+            health = None
 
-    return RouterPipeline(profiles, config, state=state, telemetry=telemetry)
+    return RouterPipeline(
+        profiles,
+        config,
+        state=state,
+        telemetry=telemetry,
+        health=health,
+    )

--- a/agent/model_router/pipeline.py
+++ b/agent/model_router/pipeline.py
@@ -1,0 +1,481 @@
+"""Staged routing pipeline — port of pipeline/router-pipeline.ts control flow.
+
+Ordered stages with early exit: the moment any stage reaches a routing
+decision, subsequent stages are skipped. Any stage exception produces a
+fallback decision (safe default, else current model) with the prompt redacted
+from the error — routing never raises into the gateway.
+
+Stage order (adapted from PIPELINE_STAGE_ORDER; Pi-only stages — hardware
+probe, speculative prewarm, planning delegate — are explicit non-goals):
+
+  1. force_model            — explicit operator override short-circuit
+  2. loop_escalation        — repeated tool failures escalate to frontier
+  3. context_fit            — filter fleet by context window (never decides)
+  4. low_intensity          — low-intensity turns pick cheapest adequate model
+  5. session_pin            — valid pin holds; break conditions evaluated
+  6. triage                 — trivial/complex fast paths
+  7. local_zero             — opt-in local inference (default disabled)
+  8. triage_cloud_fallback  — trivial turns not claimed locally → economical
+  9. hydra_match            — requirement vector + multi-objective selection
+ 10. safe_default           — first healthy safe-tier model
+ 11. context_overflow       — largest-fit model when economical cannot fit
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Optional
+
+from . import hydra
+from .context_fit import (
+    DEFAULT_SAFETY_MARGIN,
+    filter_fleet_by_context_fit,
+    model_fits_context,
+    resolve_context_overflow_fallback,
+    select_lowest_cost_model,
+)
+from .envelope import classify_turn_envelope
+from .escalation import evaluate_loop_escalation
+from .local_zero import LocalZeroConfig, ping_local_services
+from .low_intensity import DEFAULT_HIGH_THRESHOLD, DEFAULT_LOW_THRESHOLD, score_low_intensity
+from .pinning import FlipFlopGuard, PIN_BREAK_OVERFLOW, evaluate_pin
+from .safe_default import safe_default
+from .scoring import FrugalityWeights
+from .triage import VERDICT_COMPLEX, VERDICT_TRIVIAL, triage
+from .types import (
+    PIN_REASON_AUTO,
+    PIN_REASON_LOOP_ESCALATION,
+    ModelProfile,
+    RoutingDecision,
+    RoutingRequest,
+    SessionPin,
+    TIER_ECONOMICAL,
+    TIER_FRONTIER,
+    TIER_LOCAL,
+    normalize_tier,
+)
+
+MODE_OFF = "off"
+MODE_SUGGEST = "suggest"
+MODE_AUTO = "auto"
+
+
+@dataclass(frozen=True)
+class RouterConfig:
+    frugality: FrugalityWeights = FrugalityWeights()
+    loop_escalation_threshold: int = 3
+    pin_enabled: bool = True
+    dwell_turns: int = 3
+    switch_margin: float = 0.25
+    safe_tier: str = TIER_ECONOMICAL
+    context_safety_margin: float = DEFAULT_SAFETY_MARGIN
+    low_intensity_high: float = DEFAULT_HIGH_THRESHOLD
+    low_intensity_low: float = DEFAULT_LOW_THRESHOLD
+    local_zero: LocalZeroConfig = LocalZeroConfig()
+    hydra_enabled: bool = True
+    flip_flop_threshold: int = 3
+
+
+def _redact_error(error: BaseException, prompt_text: str) -> str:
+    """Error string with prompt content removed (port of redactPromptFromError)."""
+    message = str(error) or type(error).__name__
+    if prompt_text:
+        message = message.replace(prompt_text[:200], "<redacted>")
+    return message[:300]
+
+
+class RouterPipeline:
+    """Ordered early-exit routing pipeline over an explicit candidate fleet."""
+
+    def __init__(self, fleet, config: RouterConfig = RouterConfig(), state=None, telemetry=None):
+        self._fleet = tuple(fleet)
+        self._config = config
+        self._state = state
+        self._telemetry = telemetry
+        self._flip_flop = FlipFlopGuard(config.flip_flop_threshold)
+
+    @property
+    def fleet(self):
+        return self._fleet
+
+    # ─── Public entry ────────────────────────────────────────────────────────
+
+    def route(self, request: RoutingRequest, *, current_model: str, mode: str = MODE_OFF) -> RoutingDecision:
+        """Choose at most one model for a turn. Modes: off, suggest, auto."""
+        if mode not in {MODE_OFF, MODE_SUGGEST, MODE_AUTO}:
+            mode = MODE_OFF
+        start = time.monotonic()
+
+        if mode == MODE_OFF:
+            return RoutingDecision(current_model, "disabled", "routing_disabled", explanation="routing disabled")
+
+        try:
+            decision = self._run_pipeline(request, current_model)
+        except Exception as exc:  # belt-and-braces; stages already guard
+            decision = self._fallback_decision(
+                request, current_model, "pipeline_error", _redact_error(exc, request.prompt_text)
+            )
+
+        latency_ms = (time.monotonic() - start) * 1000.0
+        decision = replace(decision, routing_latency_ms=round(latency_ms, 3))
+
+        # Mode semantics: suggest computes and records but retains the model.
+        if mode == MODE_SUGGEST and decision.selected_model != current_model:
+            decision = replace(
+                decision,
+                selected_model=current_model,
+                suggestion=decision.selected_model,
+                pinned=False,
+                explanation=f"{decision.explanation}; suggestion only — current model retained",
+            )
+        elif mode == MODE_SUGGEST:
+            decision = replace(decision, pinned=False)
+
+        # Pin bookkeeping only applies to turns that will actually run on the
+        # selected model (auto mode).
+        if mode == MODE_AUTO and self._state is not None and self._config.pin_enabled:
+            self._update_pin(request, decision)
+
+        if self._telemetry is not None:
+            self._telemetry.record(request, decision, mode=mode, session_id=request.session_id)
+        return decision
+
+    # ─── Pipeline ────────────────────────────────────────────────────────────
+
+    def _run_pipeline(self, request: RoutingRequest, current_model: str) -> RoutingDecision:
+        turn_type = request.turn_type or (
+            classify_turn_envelope(request.messages) if request.messages else "main_loop"
+        )
+        request = replace(request, turn_type=turn_type)
+        cfg = self._config
+
+        # 1. force_model — explicit override short-circuits routing.
+        if request.force_model_id:
+            for model in self._fleet:
+                if model.id == request.force_model_id:
+                    return self._decide(model, "force_model", "operator_override", request)
+            # Forced model outside the fleet: retain current, never guess.
+            return self._decide_named(current_model, "force_model", "forced_model_not_in_fleet", request)
+
+        pin = self._state.load_pin(request.session_id) if (self._state and cfg.pin_enabled) else None
+
+        # 2. loop_escalation — repeated tool failures escalate to frontier.
+        if pin is not None:
+            result = self._stage("loop_escalation", evaluate_loop_escalation, pin, request, self._fleet, cfg.loop_escalation_threshold)
+            if result is not None:
+                if result.updated_pin is not None and self._state is not None:
+                    self._state.save_pin(result.updated_pin)
+                    pin = result.updated_pin
+                if result.should_escalate and result.escalation_target is not None:
+                    if self._state is not None:
+                        self._state.save_pin(replace(
+                            pin,
+                            pinned_model_id=result.escalation_target.id,
+                            pin_reason=PIN_REASON_LOOP_ESCALATION,
+                            turns_held=0,
+                            updated_at=time.time(),
+                        ))
+                    return self._decide(result.escalation_target, "loop_escalation", result.reason, request, pinned=True)
+
+        # 3. context_fit — narrow the fleet (never decides).
+        fit = filter_fleet_by_context_fit(self._fleet, request, cfg.context_safety_margin)
+        fleet = fit.effective_fleet or self._fleet if not request.force_model_id else self._fleet
+        rejected_notes = tuple(f"{c.model_id}: {c.rejected_reason}" for c in fit.rejected)
+
+        # Flip-flop guard: a tier-pinned session stays on its pinned tier when possible.
+        guard_tier = self._flip_flop.is_tier_pinned(request.session_id)
+        if guard_tier:
+            tier_fleet = tuple(m for m in fleet if m.tier == guard_tier)
+            if tier_fleet:
+                fleet = tier_fleet
+
+        # Shared analysis for downstream stages.
+        triage_result = triage(request.prompt_text)
+        requirements = hydra.build_requirement_vector(request, triage_result)
+
+        def hydra_pick(candidates):
+            result = hydra.hydra_match(candidates, requirements, request, cfg.frugality)
+            return result
+
+        # 4. low_intensity — cheap adequate pick for low-intensity turns.
+        low = score_low_intensity(
+            request, triage_result, requirements.magnitude,
+            high_threshold=cfg.low_intensity_high, low_threshold=cfg.low_intensity_low,
+        )
+        if low.is_high:
+            economical = [m for m in fleet if m.tier == TIER_ECONOMICAL]
+            pick = select_lowest_cost_model(economical)
+            if pick is not None:
+                return self._decide(pick, "low_intensity", "low_intensity_gate", request, rejected=rejected_notes,
+                                    features={"low_intensity_score": low.score})
+
+        # 5. session_pin — valid pin holds unless a break condition fires.
+        if pin is not None:
+            pinned_model = next((m for m in self._fleet if m.id == pin.pinned_model_id), None)
+            active_pinned = next((m for m in fleet if m.id == pin.pinned_model_id), None)
+            mo = hydra_pick(fleet)
+            best_alt = None
+            best_alt_score = 0.0
+            pinned_score = 0.0
+            if mo.selected is not None:
+                best_alt = next((m for m in fleet if m.id == mo.selected.model_id), None)
+                best_alt_score = mo.selected.composite_score
+            for scored in mo.candidates:
+                if scored.model_id == pin.pinned_model_id:
+                    pinned_score = scored.composite_score
+            evaluation = evaluate_pin(
+                pin,
+                active_pinned,
+                best_alt,
+                compaction_flag=request.compaction_flag,
+                pinned_fits_context=active_pinned is not None,
+                dwell_turns=cfg.dwell_turns,
+                switch_margin=cfg.switch_margin,
+                pinned_score=pinned_score,
+                alternative_score=best_alt_score,
+                estimated_input_tokens=request.estimated_tokens(),
+                warm_prefix_tokens=request.estimated_tokens(),
+            )
+            if evaluation.hold and active_pinned is not None:
+                return self._decide(active_pinned, "session_pin", "pin_hold", request, pinned=True, rejected=rejected_notes)
+            if evaluation.switch_to is not None and evaluation.reason != PIN_BREAK_OVERFLOW:
+                return self._decide(evaluation.switch_to, "session_pin", evaluation.reason, request, rejected=rejected_notes)
+            # Overflow break: fall through to the overflow stage below with the pin cleared.
+            if self._state is not None:
+                self._state.clear_pin(request.session_id)
+            pin = None
+
+        # 6. triage — fast paths.
+        if triage_result.verdict == VERDICT_COMPLEX:
+            frontier = [m for m in fleet if m.tier == TIER_FRONTIER and m.healthy]
+            if frontier:
+                pick = sorted(frontier, key=lambda m: (-m.quality, m.id))[0]
+                return self._decide(pick, "triage", triage_result.reason_code, request, rejected=rejected_notes)
+
+        # 7. local_zero — opt-in local inference for trivial/low-intensity turns.
+        if cfg.local_zero.enabled and (triage_result.verdict == VERDICT_TRIVIAL or low.is_high):
+            local_model = next(
+                (m for m in fleet if m.tier == TIER_LOCAL and m.healthy and (not cfg.local_zero.model or m.id == cfg.local_zero.model)),
+                None,
+            )
+            if local_model is not None and self._stage("local_zero_ping", ping_local_services, cfg.local_zero):
+                return self._decide(local_model, "local_zero", "local_ready", request, rejected=rejected_notes)
+
+        # 8. triage_cloud_fallback — trivial turns not claimed locally.
+        if triage_result.verdict == VERDICT_TRIVIAL:
+            economical = [m for m in fleet if m.tier == TIER_ECONOMICAL]
+            pick = select_lowest_cost_model(economical)
+            if pick is not None:
+                return self._decide(pick, "triage_cloud_fallback", triage_result.reason_code, request, rejected=rejected_notes)
+
+        # 9. hydra_match — requirement vector + multi-objective selection.
+        if cfg.hydra_enabled:
+            mo = hydra_pick(fleet)
+            if mo.selected is not None:
+                pick = next(m for m in fleet if m.id == mo.selected.model_id)
+                decision = self._decide(pick, "hydra_match", "multi_objective", request, rejected=rejected_notes,
+                                        candidates=mo.candidates)
+                self._flip_flop.observe_tier(request.session_id, pick.tier)
+                return decision
+
+        # 10. safe_default — first healthy safe-tier model (context-fit aware).
+        pick = safe_default(fleet, request, safe_tier=cfg.safe_tier, safety_margin=cfg.context_safety_margin)
+        if pick is not None:
+            return self._decide(pick, "safe_default", "safe_tier_default", request, rejected=rejected_notes)
+
+        # 11. context_overflow — largest-fit model when nothing else decided.
+        if fit.rejected:
+            overflow = resolve_context_overflow_fallback(
+                self._fleet, request.estimated_tokens(),
+                preferred_provider=None, safety_margin=cfg.context_safety_margin,
+            )
+            if overflow.kind == "selected" and overflow.model is not None:
+                return self._decide(overflow.model, "context_overflow", overflow.reason_code, request, rejected=rejected_notes)
+
+        return self._decide_named(current_model, "fallback", "no_candidate_eligible", request, rejected=rejected_notes)
+
+    # ─── Stage guard ─────────────────────────────────────────────────────────
+
+    def _stage(self, name: str, fn, *args):
+        """Run a pure stage function; exceptions degrade to None (no decision)."""
+        try:
+            return fn(*args)
+        except Exception:
+            return None
+
+    # ─── Decision builders ───────────────────────────────────────────────────
+
+    def _decide(self, model: ModelProfile, stage: str, reason: str, request: RoutingRequest,
+                *, pinned: bool = False, rejected: tuple = (), candidates: tuple = (), features: dict = None) -> RoutingDecision:
+        return RoutingDecision(
+            selected_model=model.id,
+            stage=stage,
+            reason_code=reason,
+            explanation=f"stage={stage} reason={reason} tier={model.tier} provider={model.provider or 'default'}",
+            rejected=rejected,
+            candidates=candidates,
+            turn_type=request.turn_type or "unknown",
+            pinned=pinned,
+            features=features or {},
+        )
+
+    def _decide_named(self, model_id: str, stage: str, reason: str, request: RoutingRequest, *, rejected: tuple = ()) -> RoutingDecision:
+        return RoutingDecision(
+            selected_model=model_id,
+            stage=stage,
+            reason_code=reason,
+            explanation=f"stage={stage} reason={reason}",
+            rejected=rejected,
+            turn_type=request.turn_type or "unknown",
+        )
+
+    def _fallback_decision(self, request: RoutingRequest, current_model: str, stage: str, error: str) -> RoutingDecision:
+        pick = None
+        try:
+            pick = safe_default(self._fleet, request, safe_tier=self._config.safe_tier)
+        except Exception:
+            pick = None
+        selected = pick.id if pick is not None else current_model
+        return RoutingDecision(
+            selected_model=selected,
+            stage=stage,
+            reason_code="stage_error",
+            explanation=f"routing stage failed ({error}); fell back to {selected}",
+            turn_type=request.turn_type or "unknown",
+        )
+
+    # ─── Pin bookkeeping ─────────────────────────────────────────────────────
+
+    def _update_pin(self, request: RoutingRequest, decision: RoutingDecision) -> None:
+        """Create/refresh the session pin after an auto-mode decision."""
+        if not request.session_id or self._state is None:
+            return
+        try:
+            existing = self._state.load_pin(request.session_id)
+            if decision.stage in {"fallback", "disabled"}:
+                return
+            if existing and existing.pinned_model_id == decision.selected_model:
+                self._state.save_pin(replace(existing, turns_held=existing.turns_held + 1, updated_at=time.time()))
+            else:
+                reason = existing.pin_reason if existing and decision.pinned else PIN_REASON_AUTO
+                self._state.save_pin(SessionPin(
+                    session_id=request.session_id,
+                    pinned_model_id=decision.selected_model,
+                    pin_reason=reason,
+                    turns_held=1,
+                    updated_at=time.time(),
+                ))
+        except Exception:
+            pass
+
+
+# ─── Config factory ───────────────────────────────────────────────────────────
+
+
+def profile_from_config(item: dict) -> Optional[ModelProfile]:
+    """Build a ModelProfile from one config candidate entry (tolerant)."""
+    if not isinstance(item, dict):
+        return None
+    model = item.get("model")
+    if not isinstance(model, str) or not model.strip():
+        return None
+    quality = float(item.get("quality", 0.5) or 0.5)
+    tier = item.get("tier")
+    if tier is None:
+        tier = TIER_FRONTIER if quality >= 0.9 else TIER_ECONOMICAL
+    cost_per_1m = item.get("cost_per_1m")
+    return ModelProfile(
+        id=model.strip(),
+        provider=str(item.get("provider", "") or ""),
+        tier=normalize_tier(tier),
+        context_window=int(item.get("context_window", 0) or 0),
+        reasoning=bool(item.get("reasoning", False)),
+        vision=bool(item.get("vision", False)),
+        quality=quality,
+        cost=float(item.get("cost", 0.5) or 0.5),
+        cost_per_1m=float(cost_per_1m) if cost_per_1m is not None else None,
+        est_latency_ms=float(item.get("est_latency_ms", 0.0) or 0.0),
+        verbosity=float(item.get("verbosity", 1.0) or 1.0),
+        healthy=bool(item.get("healthy", True)),
+    )
+
+
+def router_config_from_dict(cfg: dict) -> RouterConfig:
+    """Parse the extended model_router config sections (all optional)."""
+    cfg = cfg if isinstance(cfg, dict) else {}
+    frugality = cfg.get("frugality") or {}
+    escalation = cfg.get("loop_escalation") or {}
+    pin = cfg.get("session_pin") or {}
+    local = cfg.get("local_zero") or {}
+    hydra_cfg = cfg.get("hydra") or {}
+    return RouterConfig(
+        frugality=FrugalityWeights(
+            lambda_cost=float(frugality.get("lambda_cost", 0.5)),
+            lambda_latency=float(frugality.get("lambda_latency", 0.1)),
+            lambda_verbosity=float(frugality.get("lambda_verbosity", 0.15)),
+        ),
+        loop_escalation_threshold=max(1, int(escalation.get("threshold", 3))),
+        pin_enabled=bool(pin.get("enabled", True)),
+        dwell_turns=max(0, int(pin.get("dwell_turns", 3))),
+        switch_margin=float(pin.get("switch_margin", 0.25)),
+        safe_tier=normalize_tier(cfg.get("safe_tier"), default=TIER_ECONOMICAL),
+        local_zero=LocalZeroConfig(
+            enabled=bool(local.get("enabled", False)),
+            endpoints=tuple(local.get("endpoints") or ()),
+            model=str(local.get("model") or ""),
+            timeout_ms=int(local.get("timeout_ms", 1500)),
+        ),
+        hydra_enabled=bool(hydra_cfg.get("enabled", True)),
+    )
+
+
+def default_db_path(hermes_home=None) -> Path:
+    """Resolve the router state/telemetry DB path under $HERMES_HOME."""
+    if hermes_home is None:
+        try:
+            from hermes_cli.config import get_hermes_home
+            hermes_home = get_hermes_home()
+        except Exception:
+            hermes_home = Path.home() / ".hermes"
+    return Path(hermes_home) / "state" / "model_router" / "router.db"
+
+
+def pipeline_from_config(router_cfg: dict, *, hermes_home=None) -> Optional["RouterPipeline"]:
+    """Build a pipeline from the model_router config section.
+
+    Returns None when no usable candidates exist. State and telemetry are
+    created best-effort; their failure never blocks routing.
+    """
+    if not isinstance(router_cfg, dict):
+        return None
+    raw_candidates = router_cfg.get("candidates")
+    if not isinstance(raw_candidates, list) or not raw_candidates:
+        return None
+
+    profiles = [p for p in (profile_from_config(item) for item in raw_candidates) if p is not None]
+    if not profiles:
+        return None
+
+    config = router_config_from_dict(router_cfg)
+    telemetry_cfg = router_cfg.get("telemetry") or {}
+    db_path = telemetry_cfg.get("db_path") or default_db_path(hermes_home)
+
+    state = None
+    telemetry = None
+    if config.pin_enabled:
+        try:
+            from .state import RouterStateStore
+            store = RouterStateStore(db_path)
+            state = store if store.available else None
+        except Exception:
+            state = None
+    if bool(telemetry_cfg.get("enabled", True)):
+        try:
+            from .telemetry import RouterTelemetry
+            recorder = RouterTelemetry(db_path)
+            telemetry = recorder if recorder.available else None
+        except Exception:
+            telemetry = None
+
+    return RouterPipeline(profiles, config, state=state, telemetry=telemetry)

--- a/agent/model_router/safe_default.py
+++ b/agent/model_router/safe_default.py
@@ -1,0 +1,43 @@
+"""Safe default selector — port of pipeline/safe-default.ts.
+
+Selects the first healthy model of the configured safe tier (default
+economical), falling back to frontier only when no safe-tier model is
+available. Context-fit aware when a request is provided. Never throws.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from .context_fit import DEFAULT_SAFETY_MARGIN, model_fits_context
+from .types import ModelProfile, RoutingRequest, TIER_ECONOMICAL, TIER_FRONTIER
+
+
+def safe_default(
+    models,
+    request: Optional[RoutingRequest] = None,
+    *,
+    safe_tier: str = TIER_ECONOMICAL,
+    safety_margin: float = DEFAULT_SAFETY_MARGIN,
+) -> Optional[ModelProfile]:
+    """Pick the deterministic safe model, or None when nothing is viable."""
+    estimated = request.estimated_tokens() if request else 0
+
+    def fits(model: ModelProfile) -> bool:
+        if not model.healthy:
+            return False
+        if not request:
+            return True
+        return model_fits_context(model, estimated, safety_margin)
+
+    ordered = sorted(models, key=lambda m: m.id)
+    for model in ordered:
+        if model.tier == safe_tier and fits(model):
+            return model
+    if safe_tier != TIER_FRONTIER:
+        for model in ordered:
+            if model.tier == TIER_FRONTIER and fits(model):
+                return model
+    for model in ordered:
+        if fits(model):
+            return model
+    return None

--- a/agent/model_router/safe_default.py
+++ b/agent/model_router/safe_default.py
@@ -18,6 +18,7 @@ def safe_default(
     *,
     safe_tier: str = TIER_ECONOMICAL,
     safety_margin: float = DEFAULT_SAFETY_MARGIN,
+    min_output_tokens: int = 0,
 ) -> Optional[ModelProfile]:
     """Pick the deterministic safe model, or None when nothing is viable."""
     estimated = request.estimated_tokens() if request else 0
@@ -27,7 +28,9 @@ def safe_default(
             return False
         if not request:
             return True
-        return model_fits_context(model, estimated, safety_margin)
+        return model_fits_context(
+            model, estimated, safety_margin, min_output_tokens
+        )
 
     ordered = sorted(models, key=lambda m: m.id)
     for model in ordered:

--- a/agent/model_router/scoring.py
+++ b/agent/model_router/scoring.py
@@ -1,0 +1,110 @@
+"""Multi-objective scoring — port of scoring/multi-objective.ts.
+
+Re-ranks candidates using operator-configured frugality weights. At quality
+parity (the capability gate has already run), the scorer penalizes cost,
+latency, and verbosity to prefer cheaper/faster/leaner models:
+
+    score = capability_score
+          - lambda_cost      * norm_cost
+          - lambda_latency   * norm_latency
+          - lambda_verbosity * norm_verbosity
+
+Normalization is min-max across the viable candidate set so penalties are
+scale-invariant. Ties break deterministically by model id.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .types import CandidateScore, ModelProfile
+
+
+@dataclass(frozen=True)
+class FrugalityWeights:
+    lambda_cost: float = 0.5
+    lambda_latency: float = 0.1
+    lambda_verbosity: float = 0.15
+
+
+@dataclass(frozen=True)
+class ScoredCandidate:
+    model_id: str
+    capability_score: float
+    cost_penalty: float
+    latency_penalty: float
+    verbosity_penalty: float
+    composite_score: float
+    rejected_reason: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class MultiObjectiveResult:
+    selected: Optional[ScoredCandidate]
+    candidates: tuple
+
+
+_MIDPOINT = 0.5
+
+
+def _range(values):
+    values = list(values)
+    if not values:
+        return 0.0, 0.0
+    return min(values), max(values)
+
+
+def _normalize(value: float, lo: float, hi: float) -> float:
+    if hi == lo:
+        return _MIDPOINT
+    return (value - lo) / (hi - lo)
+
+
+def score_multi_objective(
+    capability_scores,
+    fleet,
+    weights: FrugalityWeights = FrugalityWeights(),
+) -> MultiObjectiveResult:
+    """Score and re-rank candidates with cost/latency/verbosity penalties."""
+    profile_map = {m.id: m for m in fleet}
+    viable = [c for c in capability_scores if c.rejected_reason is None]
+    rejected = [c for c in capability_scores if c.rejected_reason is not None]
+
+    scored_rejected = tuple(
+        ScoredCandidate(c.model_id, c.score, 0.0, 0.0, 0.0, 0.0, c.rejected_reason)
+        for c in rejected
+    )
+    if not viable:
+        return MultiObjectiveResult(None, scored_rejected)
+
+    def metrics(c: CandidateScore):
+        profile: Optional[ModelProfile] = profile_map.get(c.model_id)
+        if profile is None:
+            return 0.0, 0.0, 1.0
+        cost = profile.cost_per_1m if profile.cost_per_1m is not None else profile.cost
+        return cost, profile.est_latency_ms, profile.verbosity
+
+    raw = [metrics(c) for c in viable]
+    cost_lo, cost_hi = _range(m[0] for m in raw)
+    lat_lo, lat_hi = _range(m[1] for m in raw)
+    verb_lo, verb_hi = _range(m[2] for m in raw)
+
+    scored = []
+    for candidate, (cost, latency, verbosity) in zip(viable, raw):
+        cost_penalty = weights.lambda_cost * _normalize(cost, cost_lo, cost_hi)
+        latency_penalty = weights.lambda_latency * _normalize(latency, lat_lo, lat_hi)
+        verbosity_penalty = weights.lambda_verbosity * _normalize(verbosity, verb_lo, verb_hi)
+        composite = candidate.score - cost_penalty - latency_penalty - verbosity_penalty
+        scored.append(
+            ScoredCandidate(
+                candidate.model_id,
+                candidate.score,
+                cost_penalty,
+                latency_penalty,
+                verbosity_penalty,
+                composite,
+            )
+        )
+
+    scored.sort(key=lambda s: (-s.composite_score, s.model_id))
+    return MultiObjectiveResult(scored[0], tuple(scored) + scored_rejected)

--- a/agent/model_router/state.py
+++ b/agent/model_router/state.py
@@ -31,10 +31,14 @@ CREATE TABLE IF NOT EXISTS session_pins (
 class RouterStateStore:
     """SQLite-backed session pin store. Thread-safe, failure-safe."""
 
-    def __init__(self, db_path):
+    def __init__(self, db_path, *, read_only: bool = False):
         self._db_path = str(db_path)
+        self._read_only = bool(read_only)
         self._lock = threading.Lock()
         self._available = True
+        if self._read_only:
+            self._available = Path(self._db_path).is_file()
+            return
         try:
             Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
             with self._connect() as conn:
@@ -48,6 +52,9 @@ class RouterStateStore:
         return self._available
 
     def _connect(self) -> sqlite3.Connection:
+        if self._read_only:
+            uri = Path(self._db_path).resolve().as_uri() + "?mode=ro"
+            return sqlite3.connect(uri, uri=True, timeout=5)
         conn = sqlite3.connect(self._db_path, timeout=5)
         conn.execute("PRAGMA journal_mode=WAL")
         return conn
@@ -78,7 +85,7 @@ class RouterStateStore:
         )
 
     def save_pin(self, pin: SessionPin) -> None:
-        if not self._available or not pin.session_id:
+        if self._read_only or not self._available or not pin.session_id:
             return
         try:
             with self._lock, self._connect() as conn:
@@ -107,7 +114,7 @@ class RouterStateStore:
             pass
 
     def clear_pin(self, session_id: str) -> None:
-        if not self._available or not session_id:
+        if self._read_only or not self._available or not session_id:
             return
         try:
             with self._lock, self._connect() as conn:

--- a/agent/model_router/state.py
+++ b/agent/model_router/state.py
@@ -1,0 +1,138 @@
+"""Per-session router state: pins and loop-escalation counters (SQLite).
+
+State survives gateway restarts so a session's pin (and its cache economics)
+is durable. All operations are failure-safe: a broken database degrades to
+"no state", never to a routing error. Owner-only file permissions.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+from .types import SessionPin
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS session_pins (
+    session_id TEXT PRIMARY KEY,
+    pinned_model_id TEXT NOT NULL,
+    pin_reason TEXT NOT NULL DEFAULT 'auto',
+    turns_held INTEGER NOT NULL DEFAULT 0,
+    consecutive_tool_failures INTEGER NOT NULL DEFAULT 0,
+    last_tool_failure_signature TEXT,
+    updated_at REAL NOT NULL
+);
+"""
+
+
+class RouterStateStore:
+    """SQLite-backed session pin store. Thread-safe, failure-safe."""
+
+    def __init__(self, db_path):
+        self._db_path = str(db_path)
+        self._lock = threading.Lock()
+        self._available = True
+        try:
+            Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
+            with self._connect() as conn:
+                conn.executescript(_SCHEMA)
+            os.chmod(self._db_path, 0o600)
+        except Exception:
+            self._available = False
+
+    @property
+    def available(self) -> bool:
+        return self._available
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._db_path, timeout=5)
+        conn.execute("PRAGMA journal_mode=WAL")
+        return conn
+
+    def load_pin(self, session_id: str) -> Optional[SessionPin]:
+        if not self._available or not session_id:
+            return None
+        try:
+            with self._lock, self._connect() as conn:
+                row = conn.execute(
+                    "SELECT session_id, pinned_model_id, pin_reason, turns_held,"
+                    " consecutive_tool_failures, last_tool_failure_signature, updated_at"
+                    " FROM session_pins WHERE session_id = ?",
+                    (session_id,),
+                ).fetchone()
+        except Exception:
+            return None
+        if not row:
+            return None
+        return SessionPin(
+            session_id=row[0],
+            pinned_model_id=row[1],
+            pin_reason=row[2],
+            turns_held=int(row[3]),
+            consecutive_tool_failures=int(row[4]),
+            last_tool_failure_signature=row[5],
+            updated_at=float(row[6]),
+        )
+
+    def save_pin(self, pin: SessionPin) -> None:
+        if not self._available or not pin.session_id:
+            return
+        try:
+            with self._lock, self._connect() as conn:
+                conn.execute(
+                    "INSERT INTO session_pins (session_id, pinned_model_id, pin_reason,"
+                    " turns_held, consecutive_tool_failures, last_tool_failure_signature, updated_at)"
+                    " VALUES (?, ?, ?, ?, ?, ?, ?)"
+                    " ON CONFLICT(session_id) DO UPDATE SET"
+                    " pinned_model_id=excluded.pinned_model_id,"
+                    " pin_reason=excluded.pin_reason,"
+                    " turns_held=excluded.turns_held,"
+                    " consecutive_tool_failures=excluded.consecutive_tool_failures,"
+                    " last_tool_failure_signature=excluded.last_tool_failure_signature,"
+                    " updated_at=excluded.updated_at",
+                    (
+                        pin.session_id,
+                        pin.pinned_model_id,
+                        pin.pin_reason,
+                        pin.turns_held,
+                        pin.consecutive_tool_failures,
+                        pin.last_tool_failure_signature,
+                        pin.updated_at or time.time(),
+                    ),
+                )
+        except Exception:
+            pass
+
+    def clear_pin(self, session_id: str) -> None:
+        if not self._available or not session_id:
+            return
+        try:
+            with self._lock, self._connect() as conn:
+                conn.execute("DELETE FROM session_pins WHERE session_id = ?", (session_id,))
+        except Exception:
+            pass
+
+    def list_pins(self) -> list:
+        if not self._available:
+            return []
+        try:
+            with self._lock, self._connect() as conn:
+                rows = conn.execute(
+                    "SELECT session_id, pinned_model_id, pin_reason, turns_held, updated_at"
+                    " FROM session_pins ORDER BY updated_at DESC LIMIT 100"
+                ).fetchall()
+        except Exception:
+            return []
+        return [
+            {
+                "session_id": r[0],
+                "pinned_model_id": r[1],
+                "pin_reason": r[2],
+                "turns_held": r[3],
+                "updated_at": r[4],
+            }
+            for r in rows
+        ]

--- a/agent/model_router/telemetry.py
+++ b/agent/model_router/telemetry.py
@@ -8,6 +8,7 @@ Bounded to the newest ~10k rows. Failure-safe: telemetry never breaks routing.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sqlite3
 import threading
@@ -17,6 +18,8 @@ from pathlib import Path
 from .types import RoutingDecision, RoutingRequest
 
 MAX_ROWS = 10_000
+
+logger = logging.getLogger(__name__)
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS routing_history (
@@ -49,6 +52,13 @@ def prompt_hash(text: str) -> str:
     return f"{h:x}"
 
 
+def _candidate_score(candidate) -> float:
+    """Return the final score for either pipeline candidate representation."""
+    if hasattr(candidate, "composite_score"):
+        return candidate.composite_score
+    return candidate.score
+
+
 class RouterTelemetry:
     """SQLite-backed routing decision log. Thread-safe, failure-safe."""
 
@@ -61,8 +71,13 @@ class RouterTelemetry:
             with self._connect() as conn:
                 conn.executescript(_SCHEMA)
             os.chmod(self._db_path, 0o600)
-        except Exception:
+        except Exception as exc:
             self._available = False
+            logger.warning(
+                "Model router telemetry initialization failed: db=%s error_type=%s",
+                self._db_path,
+                type(exc).__name__,
+            )
 
     @property
     def available(self) -> bool:
@@ -78,8 +93,12 @@ class RouterTelemetry:
             return
         try:
             candidates = [
-                {"model": c.model_id, "score": round(c.score, 4), "rejected": c.rejected_reason}
-                for c in decision.candidates
+                {
+                    "model": candidate.model_id,
+                    "score": round(_candidate_score(candidate), 4),
+                    "rejected": candidate.rejected_reason,
+                }
+                for candidate in decision.candidates
             ]
             with self._lock, self._connect() as conn:
                 conn.execute(
@@ -109,8 +128,15 @@ class RouterTelemetry:
                     " (SELECT id FROM routing_history ORDER BY id DESC LIMIT ?)",
                     (MAX_ROWS,),
                 )
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning(
+                "Model router telemetry write failed: db=%s mode=%s stage=%s "
+                "error_type=%s",
+                self._db_path,
+                mode,
+                decision.stage,
+                type(exc).__name__,
+            )
 
     def history(self, *, limit: int = 20, session_id: str = "") -> list:
         if not self._available:

--- a/agent/model_router/telemetry.py
+++ b/agent/model_router/telemetry.py
@@ -1,0 +1,172 @@
+"""Routing telemetry — SQLite history of every pipeline decision.
+
+Records mode, stage, turn type, selected/suggested model, candidate scores,
+and routing latency for observability (``hermes router history/stats``).
+Privacy: prompts are never stored — only a djb2 hash and a bounded length.
+Bounded to the newest ~10k rows. Failure-safe: telemetry never breaks routing.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
+from .types import RoutingDecision, RoutingRequest
+
+MAX_ROWS = 10_000
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS routing_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts REAL NOT NULL,
+    session_id TEXT NOT NULL DEFAULT '',
+    mode TEXT NOT NULL,
+    stage TEXT NOT NULL,
+    turn_type TEXT NOT NULL DEFAULT 'unknown',
+    selected_model TEXT NOT NULL,
+    suggestion TEXT NOT NULL DEFAULT '',
+    reason_code TEXT NOT NULL DEFAULT '',
+    pinned INTEGER NOT NULL DEFAULT 0,
+    candidates_json TEXT NOT NULL DEFAULT '[]',
+    rejected_json TEXT NOT NULL DEFAULT '[]',
+    latency_ms REAL NOT NULL DEFAULT 0,
+    prompt_hash TEXT NOT NULL DEFAULT '',
+    prompt_chars INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_routing_history_ts ON routing_history(ts DESC);
+CREATE INDEX IF NOT EXISTS idx_routing_history_session ON routing_history(session_id, ts DESC);
+"""
+
+
+def prompt_hash(text: str) -> str:
+    """Deterministic djb2 hash — identifies repeat prompts without storing them."""
+    h = 5381
+    for ch in (text or "")[:256]:
+        h = ((h << 5) + h + ord(ch)) & 0xFFFFFFFF
+    return f"{h:x}"
+
+
+class RouterTelemetry:
+    """SQLite-backed routing decision log. Thread-safe, failure-safe."""
+
+    def __init__(self, db_path):
+        self._db_path = str(db_path)
+        self._lock = threading.Lock()
+        self._available = True
+        try:
+            Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
+            with self._connect() as conn:
+                conn.executescript(_SCHEMA)
+            os.chmod(self._db_path, 0o600)
+        except Exception:
+            self._available = False
+
+    @property
+    def available(self) -> bool:
+        return self._available
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._db_path, timeout=5)
+        conn.execute("PRAGMA journal_mode=WAL")
+        return conn
+
+    def record(self, request: RoutingRequest, decision: RoutingDecision, *, mode: str, session_id: str = "") -> None:
+        if not self._available:
+            return
+        try:
+            candidates = [
+                {"model": c.model_id, "score": round(c.score, 4), "rejected": c.rejected_reason}
+                for c in decision.candidates
+            ]
+            with self._lock, self._connect() as conn:
+                conn.execute(
+                    "INSERT INTO routing_history (ts, session_id, mode, stage, turn_type,"
+                    " selected_model, suggestion, reason_code, pinned, candidates_json,"
+                    " rejected_json, latency_ms, prompt_hash, prompt_chars)"
+                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        time.time(),
+                        session_id or request.session_id or "",
+                        mode,
+                        decision.stage,
+                        decision.turn_type,
+                        decision.selected_model,
+                        decision.suggestion,
+                        decision.reason_code,
+                        1 if decision.pinned else 0,
+                        json.dumps(candidates),
+                        json.dumps(list(decision.rejected)),
+                        decision.routing_latency_ms,
+                        prompt_hash(request.prompt_text),
+                        len(request.prompt_text or ""),
+                    ),
+                )
+                conn.execute(
+                    "DELETE FROM routing_history WHERE id NOT IN"
+                    " (SELECT id FROM routing_history ORDER BY id DESC LIMIT ?)",
+                    (MAX_ROWS,),
+                )
+        except Exception:
+            pass
+
+    def history(self, *, limit: int = 20, session_id: str = "") -> list:
+        if not self._available:
+            return []
+        try:
+            with self._lock, self._connect() as conn:
+                if session_id:
+                    rows = conn.execute(
+                        "SELECT ts, session_id, mode, stage, turn_type, selected_model,"
+                        " suggestion, reason_code, pinned, latency_ms FROM routing_history"
+                        " WHERE session_id = ? ORDER BY id DESC LIMIT ?",
+                        (session_id, limit),
+                    ).fetchall()
+                else:
+                    rows = conn.execute(
+                        "SELECT ts, session_id, mode, stage, turn_type, selected_model,"
+                        " suggestion, reason_code, pinned, latency_ms FROM routing_history"
+                        " ORDER BY id DESC LIMIT ?",
+                        (limit,),
+                    ).fetchall()
+        except Exception:
+            return []
+        return [
+            {
+                "ts": r[0], "session_id": r[1], "mode": r[2], "stage": r[3],
+                "turn_type": r[4], "selected_model": r[5], "suggestion": r[6],
+                "reason_code": r[7], "pinned": bool(r[8]), "latency_ms": r[9],
+            }
+            for r in rows
+        ]
+
+    def stats(self) -> dict:
+        if not self._available:
+            return {}
+        try:
+            with self._lock, self._connect() as conn:
+                total = conn.execute("SELECT COUNT(*) FROM routing_history").fetchone()[0]
+                by_stage = dict(
+                    conn.execute(
+                        "SELECT stage, COUNT(*) FROM routing_history GROUP BY stage ORDER BY 2 DESC"
+                    ).fetchall()
+                )
+                by_model = dict(
+                    conn.execute(
+                        "SELECT selected_model, COUNT(*) FROM routing_history"
+                        " GROUP BY selected_model ORDER BY 2 DESC"
+                    ).fetchall()
+                )
+                avg_latency = conn.execute(
+                    "SELECT AVG(latency_ms) FROM routing_history"
+                ).fetchone()[0]
+        except Exception:
+            return {}
+        return {
+            "total": total,
+            "by_stage": by_stage,
+            "by_model": by_model,
+            "avg_latency_ms": round(avg_latency or 0.0, 3),
+        }

--- a/agent/model_router/triage.py
+++ b/agent/model_router/triage.py
@@ -1,0 +1,367 @@
+"""Deterministic triage engine — port of pi-smart-router triage/.
+
+Pipeline: sanitize (adversarial-inflation stripping) → entropy tail check →
+Aho-Corasick keyword scan → cyclomatic scan → verdict.
+
+Verdicts: obvious-trivial → economical fast path, obvious-complex → frontier
+fast path, otherwise ambiguous for deeper pipeline stages.
+"""
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+
+VERDICT_TRIVIAL = "trivial"
+VERDICT_COMPLEX = "complex"
+VERDICT_AMBIGUOUS = "ambiguous"
+
+CYCLOMATIC_THRESHOLD = 15
+
+
+@dataclass(frozen=True)
+class TriageResult:
+    verdict: str
+    reason_code: str
+    trivial_hits: int = 0
+    complex_hits: int = 0
+    cyclomatic_score: int = 0
+    sanitized_length_delta: int = 0
+    entropy_score: float = 0.0
+    entropy_tail_delta: float = 0.0
+    entropy_tail_stripped_length: int = 0
+
+
+# ─── Adversarial sanitization ─────────────────────────────────────────────────
+
+_RE_BASE64_BLOCK = re.compile(r"[A-Za-z0-9+/=]{64,}")
+_RE_HEX_BLOCK = re.compile(r"(?:0x)?[0-9a-fA-F]{32,}")
+_RE_HTML_TAGS = re.compile(r"</?[a-z][^>]*>", re.I)
+_RE_HTML_COMMENT = re.compile(r"<!--[\s\S]*?-->")
+_RE_URL_ENCODED = re.compile(r"%[0-9A-Fa-f]{2}")
+_RE_REPEATED_CHARS = re.compile(r"(.)\1{4,}")
+_RE_MULTI_HSPACE = re.compile(r"[^\S\r\n]{2,}")
+_RE_MULTI_NEWLINE = re.compile(r"\n{3,}")
+
+
+def sanitize(raw: str) -> str:
+    """Strip adversarial complexity-inflation patterns from prompt text."""
+    text = raw.replace("\r\n", "\n").replace("\r", "\n")
+    text = _RE_BASE64_BLOCK.sub(" ", text)
+    text = _RE_HEX_BLOCK.sub(" ", text)
+    text = _RE_HTML_COMMENT.sub(" ", text)
+    text = _RE_HTML_TAGS.sub(" ", text)
+    text = _RE_URL_ENCODED.sub("", text)
+    text = _RE_REPEATED_CHARS.sub(r"\1\1", text)
+    text = _RE_MULTI_HSPACE.sub(" ", text)
+    text = _RE_MULTI_NEWLINE.sub("\n\n", text)
+    return text.strip()
+
+
+# ─── Entropy tail check (port of triage/entropy-check.ts) ────────────────────
+
+DEFAULT_TAIL_WINDOW_TOKENS = 32
+MIN_TAIL_TOKENS = 8
+ENTROPY_DELTA_THRESHOLD = 0.35
+ABSOLUTE_TAIL_ENTROPY_THRESHOLD = 0.55
+GIBBERISH_TAIL_RATIO_THRESHOLD = 0.45
+MIN_PREFIX_TOKENS = 4
+MIN_PROMPT_TOKENS = MIN_PREFIX_TOKENS + MIN_TAIL_TOKENS
+
+_COMMON_SHORT_TOKENS = frozenset(
+    "a i an as at be by do go if in is it me my no of on or so to up us we".split()
+)
+_RE_DIGIT = re.compile(r"\d")
+_RE_SYMBOL_ONLY = re.compile(r"^[^\w]+$", re.U)
+
+
+def _tokenize(text: str) -> list:
+    return text.split()
+
+
+def _normalized_entropy(tokens) -> float:
+    n = len(tokens)
+    if n <= 1:
+        return 0.0
+    counts = {}
+    for tok in tokens:
+        counts[tok] = counts.get(tok, 0) + 1
+    entropy = 0.0
+    for count in counts.values():
+        p = count / n
+        entropy -= p * math.log2(p)
+    max_entropy = math.log2(n)
+    if max_entropy <= 0:
+        return 0.0
+    return min(1.0, entropy / max_entropy)
+
+
+def _gibberish_ratio(tokens) -> float:
+    if not tokens:
+        return 0.0
+    gibberish = 0
+    for token in tokens:
+        if _RE_DIGIT.search(token):
+            gibberish += 1
+        elif _RE_SYMBOL_ONLY.match(token):
+            gibberish += 1
+        elif len(token) <= 2 and token.lower() not in _COMMON_SHORT_TOKENS:
+            gibberish += 1
+    return gibberish / len(tokens)
+
+
+def _segment_anomaly(tokens) -> float:
+    if not tokens:
+        return 0.0
+    return _normalized_entropy(tokens) * 0.5 + _gibberish_ratio(tokens) * 0.5
+
+
+def _find_tail_strip_index(text: str, strip_token_count: int) -> int:
+    if strip_token_count <= 0:
+        return len(text)
+    remaining = strip_token_count
+    i = len(text)
+    while i > 0 and remaining > 0:
+        while i > 0 and text[i - 1].isspace():
+            i -= 1
+        if i == 0:
+            break
+        while i > 0 and not text[i - 1].isspace():
+            i -= 1
+        remaining -= 1
+    while i > 0 and text[i - 1].isspace():
+        i -= 1
+    return i
+
+
+@dataclass(frozen=True)
+class EntropyResult:
+    text: str
+    entropy_score: float = 0.0
+    tail_delta: float = 0.0
+    anomaly_detected: bool = False
+    tail_stripped_length: int = 0
+
+
+def check_entropy_tail(text: str, *, tail_window: int = DEFAULT_TAIL_WINDOW_TOKENS, strip: bool = True) -> EntropyResult:
+    """Detect and optionally strip high-entropy adversarial suffixes (R2A-style)."""
+    tokens = _tokenize(text)
+    if len(tokens) < MIN_PROMPT_TOKENS:
+        return EntropyResult(text)
+
+    max_tail = len(tokens) - MIN_PREFIX_TOKENS
+    if max_tail < MIN_TAIL_TOKENS:
+        return EntropyResult(text)
+
+    tail_size = min(tail_window, max_tail)
+    tail_tokens = tokens[len(tokens) - tail_size:]
+    prefix_tokens = tokens[: len(tokens) - tail_size]
+
+    tail_entropy = _normalized_entropy(tail_tokens)
+    tail_score = _segment_anomaly(tail_tokens)
+    prefix_score = _segment_anomaly(prefix_tokens)
+    tail_delta = tail_score - prefix_score
+    tail_gibberish = _gibberish_ratio(tail_tokens)
+
+    anomaly = (
+        len(tail_tokens) >= MIN_TAIL_TOKENS
+        and tail_delta >= ENTROPY_DELTA_THRESHOLD
+        and tail_score >= ABSOLUTE_TAIL_ENTROPY_THRESHOLD
+        and tail_gibberish >= GIBBERISH_TAIL_RATIO_THRESHOLD
+    )
+    if not anomaly or not strip:
+        return EntropyResult(text, tail_entropy, tail_delta, anomaly, 0)
+
+    strip_index = _find_tail_strip_index(text, len(tail_tokens))
+    stripped = text[:strip_index].rstrip()
+    return EntropyResult(stripped, tail_entropy, tail_delta, True, len(text) - len(stripped))
+
+
+# ─── Aho-Corasick multi-pattern matcher ───────────────────────────────────────
+
+_WORD_CHAR = re.compile(r"[0-9A-Za-z_]")
+
+
+class AhoCorasick:
+    """Aho-Corasick automaton for simultaneous multi-pattern matching.
+
+    Word-boundary checks prevent substring false positives
+    (e.g. "format" inside "information").
+    """
+
+    def __init__(self, patterns):
+        # patterns: iterable of (text, set_name)
+        self._states = [{"children": {}, "fail": 0, "outputs": []}]
+        for text, set_name in patterns:
+            self._insert(text.lower(), set_name)
+        self._build_failure()
+
+    def _insert(self, text: str, set_name: str) -> None:
+        current = 0
+        for ch in text:
+            nxt = self._states[current]["children"].get(ch)
+            if nxt is None:
+                nxt = len(self._states)
+                self._states.append({"children": {}, "fail": 0, "outputs": []})
+                self._states[current]["children"][ch] = nxt
+            current = nxt
+        self._states[current]["outputs"].append((len(text), set_name))
+
+    def _build_failure(self) -> None:
+        queue = []
+        for child in self._states[0]["children"].values():
+            self._states[child]["fail"] = 0
+            queue.append(child)
+        head = 0
+        while head < len(queue):
+            r = queue[head]
+            head += 1
+            for ch, s in self._states[r]["children"].items():
+                queue.append(s)
+                f = self._states[r]["fail"]
+                while f != 0 and ch not in self._states[f]["children"]:
+                    f = self._states[f]["fail"]
+                target = self._states[f]["children"].get(ch)
+                fail_target = target if target is not None and target != s else 0
+                self._states[s]["fail"] = fail_target
+                if self._states[fail_target]["outputs"]:
+                    self._states[s]["outputs"].extend(self._states[fail_target]["outputs"])
+
+    def search(self, text: str):
+        """Return (trivial_hits, complex_hits) with word-boundary checks."""
+        lower = text.lower()
+        current = 0
+        trivial_hits = 0
+        complex_hits = 0
+        seen = set()
+        n = len(lower)
+        for i, ch in enumerate(lower):
+            while current != 0 and ch not in self._states[current]["children"]:
+                current = self._states[current]["fail"]
+            current = self._states[current]["children"].get(ch, 0)
+            for length, set_name in self._states[current]["outputs"]:
+                start = i - length + 1
+                if start > 0 and _WORD_CHAR.match(lower[start - 1]):
+                    continue
+                if i < n - 1 and _WORD_CHAR.match(lower[i + 1]):
+                    continue
+                key = (start, length)
+                if key in seen:
+                    continue
+                seen.add(key)
+                if set_name == VERDICT_TRIVIAL:
+                    trivial_hits += 1
+                else:
+                    complex_hits += 1
+        return trivial_hits, complex_hits
+
+
+# ─── Keyword dictionaries ─────────────────────────────────────────────────────
+
+TRIVIAL_KEYWORDS = (
+    "format", "formatting", "lint", "linting", "rename", "indent", "indentation",
+    "prettier", "eslint", "semicolon", "whitespace", "spacing", "typo",
+    "boilerplate", "template", "uncomment", "sort imports", "fix import",
+    "fix imports", "add export", "remove unused", "unused import",
+    "unused variable", "fix spacing", "fix whitespace", "simple test", "move file",
+)
+
+COMPLEX_KEYWORDS = (
+    "architect", "architecture", "refactor", "refactoring", "debug", "debugging",
+    "distributed", "microservice", "microservices", "concurrency", "concurrent",
+    "deadlock", "race condition", "migration", "migrate", "scalability",
+    "infrastructure", "optimize", "optimization", "performance tuning",
+    "security audit", "vulnerability", "exploit", "algorithm", "algorithmic",
+    "system design", "design pattern", "design patterns", "memory leak",
+    "memory management", "state machine", "error handling strategy", "api design",
+    "schema design",
+    # Repo-hygiene / destructive-intent (SP-176) — never cheap-route on turn 1
+    "clean up the repo", "cleanup the repo", "repo cleanup", "clean up", "cleanup",
+    "mistakenly added", "accidentally added", "accidental add", "unstage",
+    "git rm", "rm -rf", "force push", "git reset --hard", "destructive",
+)
+
+_MATCHER = AhoCorasick(
+    [(kw, VERDICT_TRIVIAL) for kw in TRIVIAL_KEYWORDS]
+    + [(kw, VERDICT_COMPLEX) for kw in COMPLEX_KEYWORDS]
+)
+
+
+# ─── Cyclomatic scan ──────────────────────────────────────────────────────────
+
+_RE_CODE_FENCE = re.compile(r"```\w*\n([\s\S]*?)```")
+_RE_INDENTED_BLOCK = re.compile(r"(?:^|\n)((?:(?: {4}|\t).+(?:\n|$))+)")
+_DECISION_PATTERNS = tuple(
+    re.compile(p)
+    for p in (r"\bif\b", r"\belif\b", r"\bfor\b", r"\bwhile\b", r"\bcase\b", r"\bcatch\b", r"&&", r"\|\|", r"\?\?")
+)
+
+
+def _extract_code(text: str) -> str:
+    blocks = _RE_CODE_FENCE.findall(text)
+    if not blocks:
+        blocks = _RE_INDENTED_BLOCK.findall(text)
+    return "\n".join(blocks)
+
+
+def cyclomatic_scan(text: str) -> int:
+    """Estimate cyclomatic complexity of code embedded in the prompt."""
+    code = _extract_code(text)
+    if not code:
+        return 1
+    score = 1
+    for pattern in _DECISION_PATTERNS:
+        score += len(pattern.findall(code))
+    return score
+
+
+# ─── Triage entry point ───────────────────────────────────────────────────────
+
+
+def triage(prompt_text: str) -> TriageResult:
+    """Classify a prompt as trivial, complex, or ambiguous for fast-path routing."""
+    if not prompt_text or not prompt_text.strip():
+        return TriageResult(VERDICT_AMBIGUOUS, "empty_prompt")
+
+    sanitized = sanitize(prompt_text)
+    entropy = check_entropy_tail(sanitized)
+    scored_text = entropy.text
+    delta = len(prompt_text) - len(scored_text)
+
+    if not scored_text or not scored_text.strip():
+        return TriageResult(
+            VERDICT_AMBIGUOUS,
+            "empty_prompt",
+            sanitized_length_delta=delta,
+            entropy_score=entropy.entropy_score,
+            entropy_tail_delta=entropy.tail_delta,
+            entropy_tail_stripped_length=entropy.tail_stripped_length,
+        )
+
+    trivial_hits, complex_hits = _MATCHER.search(scored_text)
+    cyclomatic = cyclomatic_scan(scored_text)
+
+    if cyclomatic >= CYCLOMATIC_THRESHOLD:
+        verdict, reason = VERDICT_COMPLEX, "cyclomatic_high"
+    elif complex_hits > 0 and trivial_hits == 0:
+        verdict, reason = VERDICT_COMPLEX, "keyword_frontier"
+    elif trivial_hits > 0 and complex_hits == 0:
+        verdict, reason = VERDICT_TRIVIAL, "keyword_economical"
+    elif complex_hits > trivial_hits:
+        verdict, reason = VERDICT_COMPLEX, "keyword_frontier"
+    elif trivial_hits > complex_hits:
+        verdict, reason = VERDICT_TRIVIAL, "keyword_economical"
+    else:
+        verdict, reason = VERDICT_AMBIGUOUS, "no_fast_path"
+
+    return TriageResult(
+        verdict,
+        reason,
+        trivial_hits=trivial_hits,
+        complex_hits=complex_hits,
+        cyclomatic_score=cyclomatic,
+        sanitized_length_delta=delta,
+        entropy_score=entropy.entropy_score,
+        entropy_tail_delta=entropy.tail_delta,
+        entropy_tail_stripped_length=entropy.tail_stripped_length,
+    )

--- a/agent/model_router/types.py
+++ b/agent/model_router/types.py
@@ -1,0 +1,144 @@
+"""Core types for the staged model-routing pipeline.
+
+Ported from pi-smart-router (domain/types) and adapted to Hermes: the router
+stays pure by default — no credential discovery, no network unless a stage is
+explicitly enabled — and every decision is made once at the turn boundary.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+# ─── Tiers ────────────────────────────────────────────────────────────────────
+
+TIER_LOCAL = "local"
+TIER_ECONOMICAL = "economical"
+TIER_FRONTIER = "frontier"
+
+_TIER_ALIASES = {
+    "local": TIER_LOCAL,
+    "zero-tier": TIER_LOCAL,
+    "economical": TIER_ECONOMICAL,
+    "economical-cloud": TIER_ECONOMICAL,
+    "frontier": TIER_FRONTIER,
+    "frontier-cloud": TIER_FRONTIER,
+}
+
+
+def normalize_tier(value: object, *, default: str = TIER_ECONOMICAL) -> str:
+    """Map config tier names (Hermes or pi-smart-router style) to Hermes tiers."""
+    if isinstance(value, str):
+        tier = _TIER_ALIASES.get(value.strip().lower())
+        if tier:
+            return tier
+    return default
+
+
+# ─── Turn types ───────────────────────────────────────────────────────────────
+
+TURN_TOOL_RESULT = "tool_result"
+TURN_PLANNING = "planning"
+TURN_SUBAGENT = "subagent"
+TURN_MAIN_LOOP = "main_loop"
+TURN_UNKNOWN = "unknown"
+TURN_TYPES = (TURN_TOOL_RESULT, TURN_PLANNING, TURN_SUBAGENT, TURN_MAIN_LOOP, TURN_UNKNOWN)
+
+
+@dataclass(frozen=True)
+class Message:
+    """Minimal message envelope used by routing classifiers."""
+
+    role: str
+    content: str = ""
+    is_error: Optional[bool] = None
+    status: Optional[int] = None
+
+
+# ─── Fleet ────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ModelProfile:
+    """Rich candidate profile. Superset of the legacy ``Candidate``."""
+
+    id: str
+    provider: str = ""
+    tier: str = TIER_ECONOMICAL
+    context_window: int = 0  # 0 = unknown window → treated as fitting
+    reasoning: bool = False
+    vision: bool = False
+    quality: float = 0.5  # relative routing score, not a benchmark claim
+    cost: float = 0.5  # relative routing score 0..1, not billing data
+    cost_per_1m: Optional[float] = None  # USD per 1M input tokens (breakeven gate)
+    est_latency_ms: float = 0.0
+    verbosity: float = 1.0
+    healthy: bool = True
+
+
+@dataclass(frozen=True)
+class CandidateScore:
+    model_id: str
+    score: float = 0.0
+    shortfall: float = 0.0
+    rejected_reason: Optional[str] = None
+
+
+# ─── Request / decision ───────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class RoutingRequest:
+    prompt_text: str
+    session_id: str = ""
+    messages: tuple = ()
+    turn_type: Optional[str] = None  # classified when None
+    has_images: bool = False
+    estimated_input_tokens: Optional[int] = None
+    compaction_flag: bool = False
+    force_model_id: Optional[str] = None
+
+    def estimated_tokens(self) -> int:
+        if self.estimated_input_tokens is not None:
+            return max(0, int(self.estimated_input_tokens))
+        if not self.prompt_text:
+            return 0
+        return max(1, -(-len(self.prompt_text) // 4))  # ceil(len/4)
+
+
+@dataclass(frozen=True)
+class RoutingDecision:
+    selected_model: str
+    stage: str
+    reason_code: str
+    explanation: str = ""
+    suggestion: str = ""
+    rejected: tuple = ()
+    candidates: tuple = ()
+    turn_type: str = TURN_UNKNOWN
+    routing_latency_ms: float = 0.0
+    pinned: bool = False
+    features: dict = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class StageResult:
+    decided: bool
+    decision: Optional[RoutingDecision] = None
+
+
+# ─── Session pin ──────────────────────────────────────────────────────────────
+
+PIN_REASON_AUTO = "auto"
+PIN_REASON_LOOP_ESCALATION = "loop_escalation"
+PIN_REASON_FLIP_FLOP = "flip_flop"
+
+
+@dataclass(frozen=True)
+class SessionPin:
+    session_id: str
+    pinned_model_id: str
+    pin_reason: str = PIN_REASON_AUTO
+    turns_held: int = 0
+    consecutive_tool_failures: int = 0
+    last_tool_failure_signature: Optional[str] = None
+    updated_at: float = 0.0

--- a/docs/model-router.md
+++ b/docs/model-router.md
@@ -1,36 +1,114 @@
-# Deterministic model router
+# Hermes staged model router
 
-Hermes has an opt-in, turn-boundary model router. It is disabled by default.
-The router never changes the model during a tool loop, and it does not perform
-credential discovery or network probes.
+Hermes includes an opt-in, turn-boundary router ported from the architecture of
+[`pi-smart-router`](https://github.com/beettlle/pi-smart-router). It keeps the
+existing `Candidate`/`route_turn` API and adds a staged `RouterPipeline`.
 
-Example configuration:
+## Safety invariants
+
+- `off` is the default and preserves the configured model.
+- `suggest` computes and records a recommendation but retains the current model.
+- `auto` selects once before `AIAgent` construction; it never changes the model
+  during the tool loop, preserving prompt-cache and tool-history stability.
+- Candidates are explicit declarations. Provider resolution stays in the
+  gateway; failures and stage exceptions fall back safely.
+- No network, credentials, embedding download, or filesystem probe is used by
+  default. Local routing is explicitly opt-in.
+- Telemetry stores no prompt text, only a bounded djb2 hash and prompt length.
+
+## Pipeline
+
+The adapted pipeline is sequential with early exit:
+
+1. `force_model` — explicit override
+2. `loop_escalation` — repeated tool failures can escalate a pinned session
+3. `context_fit` — remove models whose declared window cannot fit the request
+4. `low_intensity` — cheap adequate selection for low-intensity turns
+5. `session_pin` — hold a warm session pin; break on compaction, overflow, or
+   cache-breakeven / score-margin conditions
+6. `triage` — deterministic trivial/complex/ambiguous classification with
+   adversarial sanitization and cyclomatic scan
+7. `local_zero` — optional LM Studio/Ollama health probe
+8. `triage_cloud_fallback` — trivial turns use the economical tier
+9. `hydra_match` — deterministic requirement vector, capability shortfall gate,
+   and multi-objective scoring
+10. `safe_default` — healthy configured safe tier
+11. `context_overflow` — largest fitting fallback, otherwise current model
+
+Pi-only subsystems are deliberately not copied: hardware/battery probe,
+speculative prewarm, adaptive reasoning effort, workload heat, isotonic
+calibration, price fetching, planning delegate, Gemini history guard, and
+provider stream failover.
+
+## Configuration
+
+Use the normal configuration writer, not manual edits:
+
+```bash
+hermes config set model_router.mode suggest
+```
+
+Example:
 
 ```yaml
 model_router:
-  mode: auto # off, suggest, or auto
+  mode: suggest                 # off | suggest | auto
   candidates:
-    - model: gpt-5-mini
+    - model: gpt-5.6-luna
       provider: openai-codex
+      tier: economical
       reasoning: true
       vision: true
-      context_window: 400000
-      quality: 0.8
-      cost: 0.3
-    - model: kimi-k3
-      provider: kimi-coding
+      context_window: 272000
+      quality: 0.90
+      cost: 0.20
+      cost_per_1m: 0.20          # optional; only for cache economics
+      est_latency_ms: 500
+      verbosity: 1.0
+    - model: gpt-5.6-sol
+      provider: openai-codex
+      tier: frontier
       reasoning: true
       vision: true
-      context_window: 1048576
-      quality: 1.0
-      cost: 0.8
+      context_window: 272000
+      quality: 1.00
+      cost: 0.70
+  frugality:
+    lambda_cost: 0.5
+    lambda_latency: 0.1
+    lambda_verbosity: 0.15
+  loop_escalation: {threshold: 3}
+  session_pin: {enabled: true, dwell_turns: 3, switch_margin: 0.25}
+  safe_tier: economical
+  local_zero: {enabled: false, endpoints: [], model: null, timeout_ms: 1500}
+  hydra: {enabled: true, embeddings: false}
+  telemetry: {enabled: true, db_path: null}
 ```
 
-`off` preserves the configured model. `suggest` keeps the configured model and
-records the best candidate in the route metadata. `auto` selects the best
-eligible candidate once before constructing `AIAgent`; provider resolution
-failures and capability mismatches fall back to the current model.
+Tier aliases `zero-tier`, `economical-cloud`, and `frontier-cloud` are accepted
+for compatibility with Pi. `quality` and `cost` are routing heuristics, not
+billing guarantees. Keep the pool small and verify exact provider/model IDs
+before switching from `suggest` to `auto`.
 
-Candidates are explicit declarations. Their provider must already be
-configured and authenticated; the router does not infer availability from a
-model name.
+## Inspection
+
+```bash
+hermes router status
+hermes router history --limit 20
+hermes router history --session SESSION_ID
+hermes router stats
+```
+
+The default database is `$HERMES_HOME/state/model_router/router.db`; it is
+SQLite WAL mode, owner-only, and pruned to roughly 10,000 routing rows.
+Telemetry and state failures are non-fatal.
+
+## Development
+
+The compatibility tests remain in `tests/agent/test_model_router.py`. Staged
+pipeline tests belong under `tests/agent/model_router/`. Run the legacy gate
+and package smoke tests with:
+
+```bash
+pytest tests/agent/test_model_router.py tests/agent/model_router -q
+```

--- a/docs/model-router.md
+++ b/docs/model-router.md
@@ -1,0 +1,36 @@
+# Deterministic model router
+
+Hermes has an opt-in, turn-boundary model router. It is disabled by default.
+The router never changes the model during a tool loop, and it does not perform
+credential discovery or network probes.
+
+Example configuration:
+
+```yaml
+model_router:
+  mode: auto # off, suggest, or auto
+  candidates:
+    - model: gpt-5-mini
+      provider: openai-codex
+      reasoning: true
+      vision: true
+      context_window: 400000
+      quality: 0.8
+      cost: 0.3
+    - model: kimi-k3
+      provider: kimi-coding
+      reasoning: true
+      vision: true
+      context_window: 1048576
+      quality: 1.0
+      cost: 0.8
+```
+
+`off` preserves the configured model. `suggest` keeps the configured model and
+records the best candidate in the route metadata. `auto` selects the best
+eligible candidate once before constructing `AIAgent`; provider resolution
+failures and capability mismatches fall back to the current model.
+
+Candidates are explicit declarations. Their provider must already be
+configured and authenticated; the router does not infer availability from a
+model name.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9145,6 +9145,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         for key in ("api_key", "base_url", "provider", "requested_provider", "api_mode", "command", "args", "credential_pool", "max_tokens", "capabilities")
                         if key in selected_runtime
                     })
+                    base_request_overrides = dict(selected_runtime.get("request_overrides") or {})
                     # The cache key must describe the selected model/runtime,
                     # not the pre-routing model, otherwise a routed turn can
                     # accidentally reuse an agent built for another backend.
@@ -9172,8 +9173,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         try:
             overrides = resolve_fast_mode_overrides(
                 route["model"],
-                provider=runtime["provider"],
-                base_url=runtime["base_url"],
+                provider=route["runtime"]["provider"],
+                base_url=route["runtime"]["base_url"],
             )
         except Exception:
             overrides = None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6102,7 +6102,12 @@ class TurnRunner:
                 log_message="interim_assistant_callback scheduling error",
             )
 
-        turn_route = self._runner._resolve_turn_agent_config(ctx.message, model, runtime_kwargs)
+        turn_route = self._runner._resolve_turn_agent_config(
+            ctx.message,
+            model,
+            runtime_kwargs,
+            session_id=ctx.session_key or ctx.session_id or "",
+        )
 
         # Per-platform skip_context_files — messaging platforms can opt out
         # of filesystem-heavy context-file discovery (SOUL.md, AGENTS.md,
@@ -9044,7 +9049,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         return model, runtime_kwargs
 
-    def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:
+    def _resolve_turn_agent_config(
+        self,
+        user_message: str,
+        model: str,
+        runtime_kwargs: dict,
+        *,
+        session_id: str = "",
+    ) -> dict:
         """Build the effective model/runtime config for a single turn.
 
         Always uses the session's primary model/provider.  If `/fast` is
@@ -9108,7 +9120,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         raw_candidates = router_cfg.get("candidates", []) if isinstance(router_cfg, dict) else []
         if mode in {"suggest", "auto"} and isinstance(raw_candidates, list) and raw_candidates:
             try:
-                from agent.model_router import Candidate, route_turn
+                from agent.model_router import (
+                    Candidate,
+                    RoutingRequest,
+                    RouterPipeline,
+                    profile_from_config,
+                    router_config_from_dict,
+                    route_turn,
+                )
 
                 candidates = []
                 runtimes = {}
@@ -9138,16 +9157,44 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         cost=float(item.get("cost", 0.5)),
                     ))
                     runtimes[candidate_model.strip()] = candidate_runtime
-                decision = route_turn(user_message, candidates, current_model=model, mode=mode)
+                # Prefer the staged pi-smart-router-compatible pipeline. Keep
+                # the legacy scorer as a last-resort compatibility path so a
+                # malformed new section never disables the old router.
+                profiles = [
+                    profile_from_config(item)
+                    for item in raw_candidates
+                    if isinstance(item, dict)
+                ]
+                profiles = [profile for profile in profiles if profile is not None]
+                if profiles:
+                    staged = RouterPipeline(
+                        profiles,
+                        router_config_from_dict(router_cfg),
+                    )
+                    decision = staged.route(
+                        RoutingRequest(
+                            prompt_text=user_message,
+                            session_id=session_id,
+                            estimated_input_tokens=max(0, len(str(user_message or "")) // 4),
+                        ),
+                        current_model=model,
+                        mode=mode,
+                    )
+                else:
+                    decision = route_turn(user_message, candidates, current_model=model, mode=mode)
                 route["model_router"] = {
-                    "reason": decision.reason,
+                    "reason": getattr(decision, "reason_code", None) or getattr(decision, "reason", "unknown"),
                     "explanation": decision.explanation,
                     "suggestion": decision.suggestion,
                     "rejected": list(decision.rejected),
+                    "stage": getattr(decision, "stage", "legacy"),
+                    "turn_type": getattr(decision, "turn_type", "unknown"),
+                    "routing_latency_ms": getattr(decision, "routing_latency_ms", 0.0),
                 }
                 logger.info(
                     "Model router decision: mode=%s current=%s selected=%s reason=%s",
-                    mode, model, decision.selected_model, decision.reason,
+                    mode, model, decision.selected_model,
+                    getattr(decision, "reason_code", getattr(decision, "reason", "unknown")),
                 )
                 if mode == "auto" and decision.selected_model in runtimes:
                     selected_runtime = runtimes[decision.selected_model]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9087,11 +9087,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             ),
         }
 
+        def _load_model_router_config() -> dict:
+            """Load model-router settings from the canonical config source."""
+            try:
+                from hermes_cli.config import load_config_readonly
+                live_config = load_config_readonly() or {}
+                router = live_config.get("model_router", {}) if isinstance(live_config, dict) else {}
+                return router if isinstance(router, dict) else {}
+            except Exception:
+                return {}
+
         # Model routing happens once while constructing the turn route. It is
         # deliberately before AIAgent creation and is never consulted from
         # the tool loop, preserving the frozen prompt/tool cache for a turn.
-        router_cfg = getattr(self, "config", None)
-        router_cfg = router_cfg.get("model_router", {}) if isinstance(router_cfg, dict) else {}
+        # GatewayConfig is a typed runtime object and does not expose arbitrary
+        # config.yaml keys. The helper reads the canonical readonly config
+        # source; treating GatewayConfig as a dict makes routing silently skip.
+        router_cfg = _load_model_router_config()
         mode = router_cfg.get("mode", "off") if isinstance(router_cfg, dict) else "off"
         raw_candidates = router_cfg.get("candidates", []) if isinstance(router_cfg, dict) else []
         if mode in {"suggest", "auto"} and isinstance(raw_candidates, list) and raw_candidates:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9123,9 +9123,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 from agent.model_router import (
                     Candidate,
                     RoutingRequest,
-                    RouterPipeline,
-                    profile_from_config,
-                    router_config_from_dict,
+                    pipeline_from_config,
                     route_turn,
                 )
 
@@ -9160,17 +9158,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Prefer the staged pi-smart-router-compatible pipeline. Keep
                 # the legacy scorer as a last-resort compatibility path so a
                 # malformed new section never disables the old router.
-                profiles = [
-                    profile_from_config(item)
-                    for item in raw_candidates
+                # Only route across candidates whose provider runtime resolved
+                # successfully above. Build through pipeline_from_config so
+                # gateway turns use the durable state/telemetry stores too.
+                resolved_items = [
+                    item for item in raw_candidates
                     if isinstance(item, dict)
+                    and isinstance(item.get("model"), str)
+                    and item.get("model", "").strip() in runtimes
                 ]
-                profiles = [profile for profile in profiles if profile is not None]
-                if profiles:
-                    staged = RouterPipeline(
-                        profiles,
-                        router_config_from_dict(router_cfg),
-                    )
+                staged_cfg = dict(router_cfg)
+                staged_cfg["candidates"] = resolved_items
+                staged = pipeline_from_config(staged_cfg)
+                if staged is not None:
                     decision = staged.route(
                         RoutingRequest(
                             prompt_text=user_message,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6306,18 +6306,6 @@ class TurnRunner:
                         logger.debug("Reusing cached agent for session %s", ctx.session_key)
                         reused_cached_agent = True
 
-        # Lock released — refresh the fallback chain from disk for the
-        # reused agent OUTSIDE the cache lock (config.yaml read is disk
-        # I/O; the idle-sweep watcher contends on this lock and stalls
-        # Discord heartbeats — same reasoning as #52197).  A chain
-        # configured after this agent was cached (or after gateway start)
-        # must reach the next turn (#60955).  Per-session turn
-        # serialization (_running_agents) keeps this safe post-lock.
-        if reused_cached_agent and agent is not None:
-            self._runner._apply_fallback_chain_to_agent(
-                agent, self._runner._refresh_fallback_model(),
-            )
-
         # Lock released — now schedule cleanup of any cross-process-evicted
         # agent on a daemon thread so memory-provider shutdown / socket
         # teardown never blocks the gateway event loop or the cache lock
@@ -6371,7 +6359,8 @@ class TurnRunner:
                 thread_id=ctx.source.thread_id,
                 gateway_session_key=ctx.session_key,
                 session_db=getattr(self._runner._session_db, "_db", self._runner._session_db),
-                # Reload from disk — do not reuse the startup snapshot (#60955).
+                # Preserve the load-bearing per-turn config reload. Router
+                # alternates are merged immediately after construction.
                 fallback_model=self._runner._refresh_fallback_model(),
                 skip_context_files=skip_context_files,
                 # Keep the persona even with minimal context: soul identity is
@@ -6390,6 +6379,26 @@ class TurnRunner:
                     )
                     self._runner._enforce_agent_cache_cap()
             logger.debug("Created new agent for session %s (sig=%s)", ctx.session_key, _sig)
+
+        # Apply router-selected alternates after construction while retaining
+        # the existing cooldown guard for cached agents and live fallbacks.
+        self._runner._apply_fallback_chain_to_agent(
+            agent,
+            self._runner._merge_turn_fallback_chain(
+                turn_route.get("_model_router_failover_chain"),
+                self._runner._refresh_fallback_model(),
+            ),
+        )
+
+        # Bind provider/model health at the actual API outcome boundary. The
+        # callbacks receive classifier metadata only (never prompt/error text).
+        try:
+            from agent.model_router.health import bind_agent_health
+
+            bind_agent_health(agent, turn_route.get("_model_router_health"))
+        except Exception:
+            agent._router_health_callback = None
+            agent._router_health_store = None
 
         # Per-message state — callbacks and reasoning config change every
         # turn and must not be baked into the cached agent constructor.
@@ -9170,13 +9179,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 staged_cfg = dict(router_cfg)
                 staged_cfg["candidates"] = resolved_items
                 staged = pipeline_from_config(staged_cfg)
+                routing_request = RoutingRequest(
+                    prompt_text=user_message,
+                    session_id=session_id,
+                    estimated_input_tokens=max(
+                        0, -(-len(str(user_message or "")) // 4)
+                    ),
+                )
                 if staged is not None:
                     decision = staged.route(
-                        RoutingRequest(
-                            prompt_text=user_message,
-                            session_id=session_id,
-                            estimated_input_tokens=max(0, len(str(user_message or "")) // 4),
-                        ),
+                        routing_request,
                         current_model=model,
                         mode=mode,
                     )
@@ -9190,7 +9202,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "stage": getattr(decision, "stage", "legacy"),
                     "turn_type": getattr(decision, "turn_type", "unknown"),
                     "routing_latency_ms": getattr(decision, "routing_latency_ms", 0.0),
+                    "features": dict(getattr(decision, "features", {}) or {}),
                 }
+                if staged is not None:
+                    # Internal-only boundary adapter. The health object and
+                    # failover entries never enter logs/telemetry/user output.
+                    route["_model_router_health"] = staged.health
+                    if mode == "auto":
+                        failovers = staged.failover_candidates(
+                            routing_request,
+                            decision.selected_model,
+                        )
+                        router_chain = []
+                        for profile in failovers:
+                            candidate_runtime = runtimes.get(profile.id) or {}
+                            entry = {
+                                "provider": str(
+                                    candidate_runtime.get("provider")
+                                    or profile.provider
+                                ),
+                                "model": profile.id,
+                                "_router_retryable_only": True,
+                            }
+                            if candidate_runtime.get("base_url"):
+                                entry["base_url"] = candidate_runtime["base_url"]
+                            if candidate_runtime.get("api_mode"):
+                                entry["api_mode"] = candidate_runtime["api_mode"]
+                            router_chain.append(entry)
+                        route["_model_router_failover_chain"] = router_chain
                 logger.info(
                     "Model router decision: mode=%s current=%s selected=%s reason=%s",
                     mode, model, decision.selected_model,
@@ -11093,6 +11132,49 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return self._fallback_model
         self._fallback_model = get_fallback_chain(cfg) or None
         return self._fallback_model
+
+    @staticmethod
+    def _merge_turn_fallback_chain(
+        router_chain: list | None,
+        configured_chain: list | None,
+    ) -> list | None:
+        """Combine bounded router alternates with the user's fallback policy.
+
+        Router entries carry an internal retryable-only marker. Existing user
+        fallback behavior remains unchanged and duplicate provider/model pairs
+        are removed without retaining credentials in router-owned metadata.
+        """
+        configured = [
+            entry for entry in list(configured_chain or [])
+            if isinstance(entry, dict)
+        ]
+        configured_keys = {
+            (
+                str(entry.get("provider") or "").strip().lower(),
+                str(entry.get("model") or "").strip(),
+            )
+            for entry in configured
+        }
+        # If a router alternate duplicates a user entry, retain the user's
+        # unmarked policy (including its established broader failover rules).
+        ordered = [
+            entry for entry in list(router_chain or [])
+            if isinstance(entry, dict)
+            and (
+                str(entry.get("provider") or "").strip().lower(),
+                str(entry.get("model") or "").strip(),
+            ) not in configured_keys
+        ] + configured
+        merged = []
+        seen = set()
+        for entry in ordered:
+            provider = str(entry.get("provider") or "").strip().lower()
+            model = str(entry.get("model") or "").strip()
+            if not provider or not model or (provider, model) in seen:
+                continue
+            seen.add((provider, model))
+            merged.append(dict(entry))
+        return merged or None
 
     @staticmethod
     def _apply_fallback_chain_to_agent(agent: Any, chain: list | None) -> None:
@@ -25669,7 +25751,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             self._reasoning_config = reasoning_config
             self._service_tier = self._resolve_session_service_tier(source=source)
-            turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+            turn_route = self._resolve_turn_agent_config(
+                prompt, model, runtime_kwargs, session_id=task_id
+            )
 
             # Enrich the prompt with image descriptions so the background
             # agent can see user-attached images (same as the main flow).
@@ -25717,9 +25801,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     chat_type=source.chat_type,
                     thread_id=source.thread_id,
                     session_db=getattr(self._session_db, "_db", self._session_db),
-                    # Reload from disk — do not reuse the startup snapshot (#60955).
                     fallback_model=self._refresh_fallback_model(),
                 )
+                self._apply_fallback_chain_to_agent(
+                    agent,
+                    self._merge_turn_fallback_chain(
+                        turn_route.get("_model_router_failover_chain"),
+                        self._refresh_fallback_model(),
+                    ),
+                )
+                try:
+                    from agent.model_router.health import bind_agent_health
+
+                    bind_agent_health(
+                        agent, turn_route.get("_model_router_health")
+                    )
+                except Exception:
+                    agent._router_health_callback = None
+                    agent._router_health_store = None
                 try:
                     return agent.run_conversation(
                         user_message=enriched_prompt,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9087,6 +9087,76 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             ),
         }
 
+        # Model routing happens once while constructing the turn route. It is
+        # deliberately before AIAgent creation and is never consulted from
+        # the tool loop, preserving the frozen prompt/tool cache for a turn.
+        router_cfg = getattr(self, "config", None)
+        router_cfg = router_cfg.get("model_router", {}) if isinstance(router_cfg, dict) else {}
+        mode = router_cfg.get("mode", "off") if isinstance(router_cfg, dict) else "off"
+        raw_candidates = router_cfg.get("candidates", []) if isinstance(router_cfg, dict) else []
+        if mode in {"suggest", "auto"} and isinstance(raw_candidates, list) and raw_candidates:
+            try:
+                from agent.model_router import Candidate, route_turn
+
+                candidates = []
+                runtimes = {}
+                for item in raw_candidates:
+                    if not isinstance(item, dict):
+                        continue
+                    candidate_model = item.get("model")
+                    candidate_provider = item.get("provider", "")
+                    if not isinstance(candidate_model, str) or not candidate_model.strip():
+                        continue
+                    if candidate_model == model and candidate_provider in {"", runtime["provider"]}:
+                        candidate_runtime = runtime
+                    else:
+                        try:
+                            candidate_runtime = _resolve_runtime_agent_kwargs_for_provider(candidate_provider) if candidate_provider else {}
+                        except Exception:
+                            continue
+                    if candidate_provider and candidate_runtime.get("provider") != candidate_provider:
+                        continue
+                    candidates.append(Candidate(
+                        model=candidate_model.strip(),
+                        provider=str(candidate_runtime.get("provider") or candidate_provider),
+                        context_window=int(item.get("context_window", 0) or 0),
+                        reasoning=bool(item.get("reasoning", False)),
+                        vision=bool(item.get("vision", False)),
+                        quality=float(item.get("quality", 0.5)),
+                        cost=float(item.get("cost", 0.5)),
+                    ))
+                    runtimes[candidate_model.strip()] = candidate_runtime
+                decision = route_turn(user_message, candidates, current_model=model, mode=mode)
+                route["model_router"] = {
+                    "reason": decision.reason,
+                    "explanation": decision.explanation,
+                    "suggestion": decision.suggestion,
+                    "rejected": list(decision.rejected),
+                }
+                logger.info(
+                    "Model router decision: mode=%s current=%s selected=%s reason=%s",
+                    mode, model, decision.selected_model, decision.reason,
+                )
+                if mode == "auto" and decision.selected_model in runtimes:
+                    selected_runtime = runtimes[decision.selected_model]
+                    route["model"] = decision.selected_model
+                    route["runtime"].update({
+                        key: selected_runtime.get(key)
+                        for key in ("api_key", "base_url", "provider", "requested_provider", "api_mode", "command", "args", "credential_pool", "max_tokens", "capabilities")
+                        if key in selected_runtime
+                    })
+                    # The cache key must describe the selected model/runtime,
+                    # not the pre-routing model, otherwise a routed turn can
+                    # accidentally reuse an agent built for another backend.
+                    route["signature"] = (
+                        route["model"], route["runtime"]["provider"],
+                        route["runtime"]["requested_provider"], route["runtime"]["base_url"],
+                        route["runtime"]["api_mode"], route["runtime"]["command"],
+                        tuple(route["runtime"]["args"]),
+                    )
+            except Exception:
+                logger.debug("Model router unavailable; retaining current turn model", exc_info=True)
+
         # Provider-level request_overrides (e.g. a custom_providers extra_body)
         # resolved upstream by resolve_runtime_provider().  These were being
         # dropped by the runtime whitelist above, so a custom provider's

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -13,6 +13,19 @@ DEFAULT_CONFIG = {
     "model_router": {
         "mode": "off",  # "off", "suggest", or "auto"
         "candidates": [],
+        # Staged pi-smart-router-compatible controls. All are conservative:
+        # no local/network probes or semantic model downloads by default.
+        "frugality": {
+            "lambda_cost": 0.5,
+            "lambda_latency": 0.1,
+            "lambda_verbosity": 0.15,
+        },
+        "loop_escalation": {"threshold": 3},
+        "session_pin": {"enabled": True, "dwell_turns": 3, "switch_margin": 0.25},
+        "safe_tier": "economical",
+        "local_zero": {"enabled": False, "endpoints": [], "model": None, "timeout_ms": 1500},
+        "hydra": {"enabled": True, "embeddings": False},
+        "telemetry": {"enabled": True, "db_path": None},
     },
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -23,6 +23,21 @@ DEFAULT_CONFIG = {
         "loop_escalation": {"threshold": 3},
         "session_pin": {"enabled": True, "dwell_turns": 3, "switch_margin": 0.25},
         "safe_tier": "economical",
+        # Reserve a small generation floor inside the existing context safety
+        # margin so routing never selects an input-only fit with no answer room.
+        "output_headroom": {"min_output_tokens": 256},
+        # Provider/model circuits count retryable infrastructure failures only.
+        # State is bounded and stored beside router telemetry under HERMES_HOME.
+        "health": {
+            "enabled": True,
+            "failure_threshold": 3,
+            "reset_timeout_seconds": 30,
+            "half_open_successes": 2,
+            "max_entries": 256,
+        },
+        # Auto-mode gateway turns may use Hermes' existing provider retry loop
+        # for a bounded eligible alternate. Off/suggest never add alternates.
+        "stream_failover": {"enabled": True, "max_alternates": 1},
         "local_zero": {"enabled": False, "endpoints": [], "model": None, "timeout_ms": 1500},
         "hydra": {"enabled": True, "embeddings": False},
         "telemetry": {"enabled": True, "db_path": None},

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -8,6 +8,12 @@ DEFAULT_CONFIG = {
     "model": "",
     "providers": {},
     "fallback_providers": [],
+    # Deterministic model routing is opt-in. Candidates must be explicitly
+    # configured so routing never guesses credentials or provider capability.
+    "model_router": {
+        "mode": "off",  # "off", "suggest", or "auto"
+        "candidates": [],
+    },
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
     # SQLite journal mode used by every Hermes database opener. WAL is the

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13664,6 +13664,21 @@ def main():
     history_parser.add_argument("--limit", type=int, default=20)
     history_parser.add_argument("--session", default="")
     router_subparsers.add_parser("stats", help="Show routing counts and average latency")
+    explain_parser = router_subparsers.add_parser(
+        "explain",
+        help="Explain a routing decision without calling a model",
+    )
+    explain_parser.add_argument("prompt", nargs="?", default="")
+    explain_parser.add_argument("--current-model", default="")
+    explain_parser.add_argument("--session", default="")
+    explain_parser.add_argument("--estimated-input-tokens", type=int, default=None)
+    explain_parser.add_argument("--has-images", action="store_true")
+    explain_parser.add_argument(
+        "--turn-type",
+        choices=("tool_result", "planning", "subagent", "main_loop", "unknown"),
+        default=None,
+    )
+    explain_parser.add_argument("--force-model", default=None)
     router_parser.set_defaults(func=cmd_router, router_action="status")
 
     # =========================================================================

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13650,6 +13650,23 @@ def main():
     fallback_parser.set_defaults(func=cmd_fallback)
 
     # =========================================================================
+    # router command — inspect staged model-router decisions
+    # =========================================================================
+    from hermes_cli.router_cmd import cmd_router
+
+    router_parser = subparsers.add_parser(
+        "router",
+        help="Inspect the staged model-router state and telemetry",
+    )
+    router_subparsers = router_parser.add_subparsers(dest="router_action")
+    router_subparsers.add_parser("status", help="Show router mode, fleet, pins, and database")
+    history_parser = router_subparsers.add_parser("history", help="Show recent routing decisions")
+    history_parser.add_argument("--limit", type=int, default=20)
+    history_parser.add_argument("--session", default="")
+    router_subparsers.add_parser("stats", help="Show routing counts and average latency")
+    router_parser.set_defaults(func=cmd_router, router_action="status")
+
+    # =========================================================================
     # worktree command — audit/reclaim accumulated git worktrees + branches
     # =========================================================================
     worktree_parser = subparsers.add_parser(

--- a/hermes_cli/router_cmd.py
+++ b/hermes_cli/router_cmd.py
@@ -1,0 +1,50 @@
+"""Read-only model-router inspection commands."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def _router_db_path():
+    from agent.model_router.pipeline import default_db_path
+    return default_db_path()
+
+
+def _load_cfg():
+    try:
+        from hermes_cli.config import load_config_readonly
+        cfg = load_config_readonly() or {}
+        return cfg.get("model_router", {}) if isinstance(cfg, dict) else {}
+    except Exception:
+        return {}
+
+
+def cmd_router(args):
+    from agent.model_router.state import RouterStateStore
+    from agent.model_router.telemetry import RouterTelemetry
+
+    action = getattr(args, "router_action", None) or "status"
+    cfg = _load_cfg()
+    db_path = _router_db_path()
+    telemetry = RouterTelemetry(db_path)
+    state = RouterStateStore(db_path)
+
+    if action == "status":
+        payload = {
+            "mode": cfg.get("mode", "off"),
+            "candidate_count": len(cfg.get("candidates", [])) if isinstance(cfg.get("candidates", []), list) else 0,
+            "pinned_sessions": len(state.list_pins()),
+            "db_path": str(db_path),
+            "db_size": db_path.stat().st_size if db_path.exists() else 0,
+        }
+    elif action == "history":
+        payload = telemetry.history(
+            limit=max(1, min(1000, int(getattr(args, "limit", 20)))),
+            session_id=getattr(args, "session", "") or "",
+        )
+    elif action == "stats":
+        payload = telemetry.stats()
+    else:
+        raise ValueError(f"unknown router action: {action}")
+
+    print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))

--- a/hermes_cli/router_cmd.py
+++ b/hermes_cli/router_cmd.py
@@ -10,13 +10,123 @@ def _router_db_path():
     return default_db_path()
 
 
-def _load_cfg():
+def _load_full_cfg():
     try:
         from hermes_cli.config import load_config_readonly
+
         cfg = load_config_readonly() or {}
-        return cfg.get("model_router", {}) if isinstance(cfg, dict) else {}
+        return cfg if isinstance(cfg, dict) else {}
     except Exception:
         return {}
+
+
+def _load_cfg():
+    cfg = _load_full_cfg()
+    router = cfg.get("model_router", {})
+    return router if isinstance(router, dict) else {}
+
+
+def _score_value(candidate) -> float:
+    return float(
+        getattr(candidate, "composite_score", getattr(candidate, "score", 0.0))
+    )
+
+
+def _rejected_payload(decision) -> list[dict]:
+    rejected = {}
+    for note in decision.rejected:
+        model, separator, reason = str(note).partition(":")
+        rejected[model.strip()] = reason.strip() if separator else "rejected"
+    for candidate in decision.candidates:
+        reason = getattr(candidate, "rejected_reason", None)
+        if reason:
+            rejected[str(candidate.model_id)] = str(reason)
+    return [
+        {"model": model, "reason": rejected[model]}
+        for model in sorted(rejected)
+    ]
+
+
+def explain_router(
+    router_cfg: dict,
+    *,
+    prompt: str,
+    current_model: str,
+    session_id: str = "",
+    estimated_input_tokens=None,
+    has_images: bool = False,
+    turn_type=None,
+    force_model_id=None,
+):
+    """Run the production pipeline without inference or mutable side effects."""
+    from agent.model_router import RoutingRequest, pipeline_from_config
+
+    pipeline = pipeline_from_config(router_cfg, read_only=True)
+    mode = str(router_cfg.get("mode", "off") or "off")
+    if pipeline is None:
+        return {
+            "mode": mode,
+            "stage": "fallback",
+            "reason": "no_configured_candidates",
+            "selected_model": current_model,
+            "suggested_model": None,
+            "rejected_candidates": [],
+            "features": {},
+            "scores": [],
+            "pin": None,
+            "fallback_reason": "no_configured_candidates",
+        }
+
+    request = RoutingRequest(
+        prompt_text=prompt,
+        session_id=session_id,
+        estimated_input_tokens=estimated_input_tokens,
+        has_images=has_images,
+        turn_type=turn_type,
+        force_model_id=force_model_id,
+    )
+    pin = pipeline._state.load_pin(session_id) if (
+        session_id and pipeline._state is not None
+    ) else None
+    decision = pipeline.route(
+        request,
+        current_model=current_model,
+        mode=mode,
+        dry_run=True,
+    )
+    scores = [
+        {
+            "model": str(candidate.model_id),
+            "score": round(_score_value(candidate), 6),
+            "rejected_reason": getattr(candidate, "rejected_reason", None),
+        }
+        for candidate in decision.candidates
+    ]
+    fallback_reason = (
+        decision.reason_code
+        if decision.stage in {"fallback", "pipeline_error", "context_overflow"}
+        else None
+    )
+    return {
+        "mode": mode,
+        "stage": decision.stage,
+        "reason": decision.reason_code,
+        "selected_model": decision.selected_model,
+        "suggested_model": decision.suggestion or None,
+        "rejected_candidates": _rejected_payload(decision),
+        "features": decision.features,
+        "scores": scores,
+        "pin": (
+            {
+                "model": pin.pinned_model_id,
+                "reason": pin.pin_reason,
+                "turns_held": pin.turns_held,
+            }
+            if pin is not None
+            else None
+        ),
+        "fallback_reason": fallback_reason,
+    }
 
 
 def cmd_router(args):
@@ -26,10 +136,9 @@ def cmd_router(args):
     action = getattr(args, "router_action", None) or "status"
     cfg = _load_cfg()
     db_path = _router_db_path()
-    telemetry = RouterTelemetry(db_path)
-    state = RouterStateStore(db_path)
 
     if action == "status":
+        state = RouterStateStore(db_path)
         payload = {
             "mode": cfg.get("mode", "off"),
             "candidate_count": len(cfg.get("candidates", [])) if isinstance(cfg.get("candidates", []), list) else 0,
@@ -38,12 +147,43 @@ def cmd_router(args):
             "db_size": db_path.stat().st_size if db_path.exists() else 0,
         }
     elif action == "history":
+        telemetry = RouterTelemetry(db_path)
         payload = telemetry.history(
             limit=max(1, min(1000, int(getattr(args, "limit", 20)))),
             session_id=getattr(args, "session", "") or "",
         )
     elif action == "stats":
+        telemetry = RouterTelemetry(db_path)
         payload = telemetry.stats()
+    elif action == "explain":
+        full_cfg = _load_full_cfg()
+        configured_model = full_cfg.get("model", "")
+        if isinstance(configured_model, dict):
+            configured_model = configured_model.get("model", "")
+        raw_candidates = cfg.get("candidates") or []
+        first_model = next(
+            (
+                item.get("model")
+                for item in raw_candidates
+                if isinstance(item, dict) and item.get("model")
+            ),
+            "",
+        )
+        current_model = (
+            getattr(args, "current_model", "")
+            or str(configured_model or "")
+            or str(first_model or "")
+        )
+        payload = explain_router(
+            cfg,
+            prompt=str(getattr(args, "prompt", "") or ""),
+            current_model=current_model,
+            session_id=str(getattr(args, "session", "") or ""),
+            estimated_input_tokens=getattr(args, "estimated_input_tokens", None),
+            has_images=bool(getattr(args, "has_images", False)),
+            turn_type=getattr(args, "turn_type", None),
+            force_model_id=getattr(args, "force_model", None),
+        )
     else:
         raise ValueError(f"unknown router action: {action}")
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -3322,6 +3322,20 @@ class AIAgent:
             }
         )
 
+    def _record_router_health_success(self) -> None:
+        """Notify the gateway's optional router-health adapter of API success."""
+        callback = getattr(self, "_router_health_callback", None)
+        if callback is None:
+            return
+        try:
+            callback(
+                success=True,
+                provider=self.provider,
+                model=self.model,
+            )
+        except Exception:
+            pass
+
     def _invoke_api_request_error_hook(
         self,
         *,
@@ -3339,6 +3353,24 @@ class AIAgent:
         retryable: Optional[bool] = None,
         reason: Optional[str] = None,
     ) -> None:
+        # The gateway adapter consumes classifier metadata only. Deliberately
+        # omit ``error_message`` and request data so health state stays
+        # privacy-safe even when a provider body echoes prompt content.
+        health_callback = getattr(self, "_router_health_callback", None)
+        if health_callback is not None:
+            try:
+                health_callback(
+                    success=False,
+                    provider=self.provider,
+                    model=self.model,
+                    status_code=status_code,
+                    retryable=retryable,
+                    reason=reason,
+                    error_type=error_type,
+                )
+            except Exception:
+                pass
+
         # Lazy module import (not from-import) so tests can replace lifecycle
         # dispatch at this call site. After first call the import is a
         # ``sys.modules`` dict lookup, so retries don't repay any real cost.

--- a/tests/agent/test_model_router.py
+++ b/tests/agent/test_model_router.py
@@ -20,6 +20,11 @@ def test_features_detect_coding_reasoning_and_images():
     assert features.vision is True
 
 
+def test_features_detect_image_content_blocks():
+    features = extract_features([{"type": "text", "text": "inspect"}, {"type": "image_url", "image_url": {"url": "x"}}])
+    assert features.vision is True
+
+
 def test_off_preserves_current_model():
     decision = route_turn("simple question", candidates(), current_model="current", mode="off")
     assert decision.selected_model == "current"

--- a/tests/agent/test_model_router.py
+++ b/tests/agent/test_model_router.py
@@ -1,0 +1,55 @@
+from agent.model_router import (
+    Candidate,
+    extract_features,
+    route_turn,
+)
+
+
+def candidates():
+    return [
+        Candidate("fast", "openai", context_window=128_000, reasoning=False, vision=False, quality=0.4, cost=0.1),
+        Candidate("think", "kimi-coding", context_window=1_000_000, reasoning=True, vision=True, quality=1.0, cost=0.8),
+        Candidate("vision", "openrouter", context_window=200_000, reasoning=True, vision=True, quality=0.7, cost=0.5),
+    ]
+
+
+def test_features_detect_coding_reasoning_and_images():
+    features = extract_features("请 debug this Python traceback and explain why it fails", has_images=True)
+    assert features.coding is True
+    assert features.reasoning is True
+    assert features.vision is True
+
+
+def test_off_preserves_current_model():
+    decision = route_turn("simple question", candidates(), current_model="current", mode="off")
+    assert decision.selected_model == "current"
+    assert decision.reason == "disabled"
+
+
+def test_suggest_never_changes_model_but_explains_choice():
+    decision = route_turn("implement a complex algorithm", candidates(), current_model="fast", mode="suggest")
+    assert decision.selected_model == "fast"
+    assert decision.suggestion == "think"
+    assert decision.reason == "suggestion"
+
+
+def test_auto_filters_vision_and_selects_once():
+    decision = route_turn("analyze this screenshot", candidates(), current_model="fast", mode="auto", has_images=True)
+    assert decision.selected_model == "think"
+    assert decision.features.vision is True
+    assert "vision" in decision.explanation
+
+
+def test_auto_falls_back_when_no_candidate_meets_constraints():
+    decision = route_turn("review this image", [candidates()[0]], current_model="fast", mode="auto", has_images=True)
+    assert decision.selected_model == "fast"
+    assert decision.reason == "fallback"
+    assert decision.rejected[0].startswith("fast:")
+
+
+def test_scoring_is_deterministic_on_ties():
+    pool = [
+        Candidate("b", "p", context_window=1000, quality=0.5, cost=0.5),
+        Candidate("a", "p", context_window=1000, quality=0.5, cost=0.5),
+    ]
+    assert route_turn("hello", pool, current_model="x", mode="auto").selected_model == "a"

--- a/tests/agent/test_model_router_resilience.py
+++ b/tests/agent/test_model_router_resilience.py
@@ -1,0 +1,467 @@
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+from agent.error_classifier import FailoverReason
+from agent.model_router import ModelProfile, RouterPipeline, RoutingRequest
+from agent.model_router.context_fit import (
+    OUTPUT_HEADROOM_EXCEEDED,
+    filter_fleet_by_context_fit,
+)
+from agent.model_router.health import (
+    HEALTH_CLOSED,
+    HEALTH_HALF_OPEN,
+    HEALTH_OPEN,
+    OUTCOME_IGNORED,
+    OUTCOME_NON_RETRYABLE,
+    OUTCOME_RETRYABLE_INFRASTRUCTURE,
+    HealthConfig,
+    RouterHealthStore,
+    bind_agent_health,
+    classify_health_outcome,
+)
+from agent.model_router.pipeline import router_config_from_dict
+from agent.model_router.state import RouterStateStore
+from agent.model_router.telemetry import RouterTelemetry
+from agent.model_router.types import SessionPin
+from hermes_cli.router_cmd import cmd_router
+
+
+def _models():
+    return [
+        ModelProfile(
+            "small", provider="provider-a", tier="economical",
+            context_window=1_000, quality=0.7, cost=0.1, reasoning=True,
+        ),
+        ModelProfile(
+            "large", provider="provider-b", tier="economical",
+            context_window=4_000, quality=0.8, cost=0.2, reasoning=True,
+        ),
+        ModelProfile(
+            "frontier", provider="provider-c", tier="frontier",
+            context_window=8_000, quality=1.0, cost=0.8, reasoning=True,
+        ),
+    ]
+
+
+def test_output_headroom_rejects_input_only_fit_and_default_is_explicit():
+    request = RoutingRequest("x", estimated_input_tokens=700)
+    result = filter_fleet_by_context_fit(
+        [_models()[0]], request, safety_margin=1.0, min_output_tokens=350
+    )
+
+    assert result.effective_fleet == ()
+    assert result.rejected[0].rejected_reason == OUTPUT_HEADROOM_EXCEEDED
+    assert result.rejected[0].shortfall == 50
+    assert router_config_from_dict({}).min_output_tokens == 256
+
+
+def test_headroom_pipeline_escalates_or_fails_open_to_current():
+    request = RoutingRequest("hello", estimated_input_tokens=800)
+    pipeline = RouterPipeline(
+        _models()[:2],
+        router_config_from_dict(
+            {
+                "output_headroom": {"min_output_tokens": 300},
+                "session_pin": {"enabled": False},
+            }
+        ),
+    )
+    decision = pipeline.route(
+        request, current_model="current", mode="auto", dry_run=True
+    )
+    assert decision.selected_model == "large"
+    assert "small: output_headroom_exceeded" in decision.rejected
+
+    no_fit = RouterPipeline(
+        _models()[:1],
+        router_config_from_dict(
+            {
+                "output_headroom": {"min_output_tokens": 300},
+                "session_pin": {"enabled": False},
+            }
+        ),
+    ).route(request, current_model="current", mode="auto", dry_run=True)
+    assert no_fit.selected_model == "current"
+    assert no_fit.stage == "fallback"
+    assert no_fit.reason_code == "no_candidate_eligible"
+
+
+def test_health_classifier_separates_infrastructure_from_4xx_and_context():
+    assert classify_health_outcome(status_code=503).category == OUTCOME_RETRYABLE_INFRASTRUCTURE
+    assert classify_health_outcome(status_code=429).retryable_infrastructure is True
+    assert classify_health_outcome(
+        reason="timeout", retryable=True
+    ).category == OUTCOME_RETRYABLE_INFRASTRUCTURE
+    assert classify_health_outcome(
+        status_code=400, reason="content_policy_blocked", retryable=False
+    ).category == OUTCOME_NON_RETRYABLE
+    assert classify_health_outcome(
+        reason="context_overflow", retryable=True
+    ).category == OUTCOME_IGNORED
+
+
+def test_circuit_breaker_open_half_open_is_bounded_and_single_probe(tmp_path):
+    now = [100.0]
+    store = RouterHealthStore(
+        tmp_path / "router.db",
+        HealthConfig(
+            failure_threshold=2,
+            reset_timeout_seconds=10,
+            half_open_successes=2,
+            max_entries=2,
+        ),
+        clock=lambda: now[0],
+    )
+    store.record_outcome("p", "m", status_code=500)
+    store.record_outcome("p", "m", error_type="ConnectError")
+    assert store.snapshot("p", "m").state == HEALTH_OPEN
+    assert store.is_available("p", "m") is False
+
+    # A safety rejection is observable classification, but does not deepen it.
+    store.record_outcome(
+        "p", "m", status_code=400, reason="content_policy_blocked", retryable=False
+    )
+    assert store.snapshot("p", "m").consecutive_failures == 2
+
+    now[0] += 11
+    results = []
+    barrier = threading.Barrier(3)
+
+    def claim():
+        barrier.wait()
+        results.append(store.claim_dispatch("p", "m"))
+
+    threads = [threading.Thread(target=claim) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    barrier.wait()
+    for thread in threads:
+        thread.join()
+
+    assert sorted(results) == [False, True]
+    assert store.snapshot("p", "m").state == HEALTH_HALF_OPEN
+    now[0] += 11
+    assert store.is_available("p", "m") is True
+    assert store.claim_dispatch("p", "m") is True  # stale probe lease recovered
+    store.record_outcome("p", "m", success=True)
+    assert store.claim_dispatch("p", "m") is True
+    store.record_outcome("p", "m", success=True)
+    assert store.snapshot("p", "m").state == HEALTH_CLOSED
+
+    # The durable table is bounded by least-recently-touched endpoint.
+    for model in ("one", "two", "three"):
+        store.record_outcome("p", model, status_code=500)
+    assert len(store.list_snapshots(limit=10)) <= 2
+
+
+def test_pipeline_filters_open_circuit_and_fails_open_if_all_open(tmp_path):
+    store = RouterHealthStore(
+        tmp_path / "router.db",
+        HealthConfig(failure_threshold=1, reset_timeout_seconds=60),
+    )
+    store.record_failure("provider-a", "small")
+    pipeline = RouterPipeline(
+        _models()[:2],
+        router_config_from_dict({"session_pin": {"enabled": False}}),
+        health=store,
+    )
+    decision = pipeline.route(
+        RoutingRequest("hello", estimated_input_tokens=10),
+        current_model="small",
+        mode="auto",
+        dry_run=True,
+    )
+    assert decision.selected_model == "large"
+    assert "small: health_circuit_open" in decision.rejected
+
+    store.record_failure("provider-b", "large")
+    fallback = pipeline.route(
+        RoutingRequest("hello", estimated_input_tokens=10),
+        current_model="small",
+        mode="auto",
+        dry_run=True,
+    )
+    assert fallback.selected_model == "small"
+    assert fallback.stage == "fallback"
+
+
+def test_gateway_health_adapter_records_only_metadata(tmp_path):
+    store = RouterHealthStore(
+        tmp_path / "router.db", HealthConfig(failure_threshold=1)
+    )
+    agent = SimpleNamespace(provider="provider-a", model="small")
+    bind_agent_health(agent, store)
+
+    # Exercise the actual AIAgent hook methods without constructing a provider.
+    from run_agent import AIAgent
+
+    AIAgent._invoke_api_request_error_hook(
+        agent,
+        task_id="task",
+        turn_id="turn",
+        api_request_id="request",
+        api_call_count=0,
+        api_start_time=0,
+        api_kwargs={"messages": [{"content": "private prompt"}]},
+        error_type="ConnectError",
+        error_message="private prompt echoed by provider",
+        status_code=503,
+        retryable=True,
+        reason="server_error",
+    )
+    assert store.snapshot("provider-a", "small").state == HEALTH_OPEN
+    AIAgent._record_router_health_success(agent)
+    assert store.snapshot("provider-a", "small").state == HEALTH_CLOSED
+    assert "private prompt" not in Path(tmp_path / "router.db").read_bytes().decode(
+        "utf-8", errors="ignore"
+    )
+
+
+def test_stream_failover_candidates_are_bounded_eligible_and_retryable_only(tmp_path):
+    from agent.chat_completion_helpers import router_stream_fallback_allowed
+
+    store = RouterHealthStore(
+        tmp_path / "router.db", HealthConfig(failure_threshold=1)
+    )
+    store.record_failure("provider-c", "frontier")
+    pipeline = RouterPipeline(
+        _models(),
+        router_config_from_dict(
+            {
+                "output_headroom": {"min_output_tokens": 300},
+                "stream_failover": {"enabled": True, "max_alternates": 1},
+            }
+        ),
+        health=store,
+    )
+    candidates = pipeline.failover_candidates(
+        RoutingRequest("debug why architecture fails", estimated_input_tokens=800),
+        "large",
+    )
+    assert candidates == ()  # small lacks headroom; frontier circuit is open
+
+    entry = {"provider": "p", "model": "m", "_router_retryable_only": True}
+    assert router_stream_fallback_allowed(entry, FailoverReason.timeout) is True
+    assert router_stream_fallback_allowed(entry, FailoverReason.server_error) is True
+    assert router_stream_fallback_allowed(
+        entry, FailoverReason.content_policy_blocked
+    ) is False
+    assert router_stream_fallback_allowed(entry, FailoverReason.format_error) is False
+
+    # The production activation seam consumes (skips) a marked entry instead
+    # of switching on a non-infrastructure failure.
+    from agent.chat_completion_helpers import try_activate_fallback
+
+    agent = SimpleNamespace(
+        _fallback_chain=[entry],
+        _fallback_index=0,
+        _fallback_activated=False,
+        _rate_limited_until=0,
+        _unavailable_fallback_keys=set(),
+    )
+    agent._try_activate_fallback = lambda reason=None: try_activate_fallback(
+        agent, reason
+    )
+    assert agent._try_activate_fallback(FailoverReason.format_error) is False
+    assert agent._fallback_index == 1
+
+
+def test_gateway_auto_builds_bounded_marked_chain_but_suggest_does_not(
+    tmp_path, monkeypatch
+):
+    from gateway.run import GatewayRunner
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    def runtime(provider):
+        return {
+            "api_key": None,
+            "base_url": None,
+            "provider": provider,
+            "requested_provider": provider,
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+            "capabilities": {},
+        }
+
+    monkeypatch.setattr(
+        "gateway.run._resolve_runtime_agent_kwargs_for_provider", runtime
+    )
+    config = """\
+model_router:
+  mode: auto
+  candidates:
+    - model: small
+      provider: provider-a
+      tier: economical
+      context_window: 4000
+      reasoning: true
+      quality: 0.7
+      cost: 0.1
+    - model: large
+      provider: provider-b
+      tier: economical
+      context_window: 8000
+      reasoning: true
+      quality: 0.8
+      cost: 0.2
+  session_pin:
+    enabled: false
+  stream_failover:
+    enabled: true
+    max_alternates: 1
+"""
+    (home / "config.yaml").write_text(config, encoding="utf-8")
+    runner = SimpleNamespace(_service_tier=None)
+    route = GatewayRunner._resolve_turn_agent_config(
+        runner, "hello", "small", runtime("provider-a"), session_id="s"
+    )
+    chain = route["_model_router_failover_chain"]
+    assert len(chain) == 1
+    assert chain[0] == {
+        "provider": "provider-b",
+        "model": "large",
+        "_router_retryable_only": True,
+        "api_mode": "chat_completions",
+    }
+
+    (home / "config.yaml").write_text(
+        config.replace("mode: auto", "mode: suggest"), encoding="utf-8"
+    )
+    suggest = GatewayRunner._resolve_turn_agent_config(
+        runner, "hello", "small", runtime("provider-a"), session_id="s"
+    )
+    assert suggest["model"] == "small"
+    assert "_model_router_failover_chain" not in suggest
+
+
+def test_gateway_merges_router_alternate_without_changing_user_fallback():
+    from gateway.run import GatewayRunner
+
+    router = [{
+        "provider": "provider-b",
+        "model": "large",
+        "_router_retryable_only": True,
+    }]
+    user = [
+        {"provider": "provider-b", "model": "large", "api_key": "not-read"},
+        {"provider": "provider-c", "model": "frontier"},
+    ]
+    merged = GatewayRunner._merge_turn_fallback_chain(router, user)
+    assert merged == user
+    assert "_router_retryable_only" not in merged[0]
+
+
+def test_router_explain_does_not_create_state_database(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "clean-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    (home / "config.yaml").write_text(
+        """\
+model: small
+model_router:
+  mode: auto
+  candidates:
+    - model: small
+      provider: provider-a
+      context_window: 4000
+      quality: 0.7
+      cost: 0.1
+""",
+        encoding="utf-8",
+    )
+    cmd_router(
+        SimpleNamespace(
+            router_action="explain",
+            prompt="private",
+            current_model="small",
+            session="",
+            estimated_input_tokens=10,
+            has_images=False,
+            turn_type=None,
+            force_model=None,
+        )
+    )
+    assert json.loads(capsys.readouterr().out)["selected_model"] == "small"
+    assert not (home / "state" / "model_router" / "router.db").exists()
+
+
+def test_router_explain_is_structured_private_and_read_only(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    prompt = "private debug architecture prompt " * 40
+    (home / "config.yaml").write_text(
+        """\
+model: current
+model_router:
+  mode: suggest
+  candidates:
+    - model: current
+      provider: provider-a
+      tier: economical
+      context_window: 1000
+      reasoning: true
+      quality: 0.6
+      cost: 0.1
+    - model: frontier
+      provider: provider-b
+      tier: frontier
+      context_window: 8000
+      reasoning: true
+      quality: 1.0
+      cost: 0.8
+  output_headroom:
+    min_output_tokens: 256
+  session_pin:
+    enabled: true
+  telemetry:
+    enabled: true
+""",
+        encoding="utf-8",
+    )
+    db_path = home / "state" / "model_router" / "router.db"
+    state = RouterStateStore(db_path)
+    state.save_pin(SessionPin("session-1", "frontier", turns_held=2))
+
+    cmd_router(
+        SimpleNamespace(
+            router_action="explain",
+            prompt=prompt,
+            current_model="current",
+            session="session-1",
+            estimated_input_tokens=900,
+            has_images=False,
+            turn_type="main_loop",
+            force_model=None,
+        )
+    )
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+
+    assert prompt not in output
+    assert set(payload) == {
+        "fallback_reason", "features", "mode", "pin", "reason",
+        "rejected_candidates", "scores", "selected_model", "stage",
+        "suggested_model",
+    }
+    assert payload["mode"] == "suggest"
+    assert payload["selected_model"] == "current"
+    assert payload["pin"] == {
+        "model": "frontier", "reason": "auto", "turns_held": 2
+    }
+    assert payload["features"]["estimated_input_tokens"] == 900
+    assert any(
+        item["model"] == "current" and item["reason"] == "output_headroom_exceeded"
+        for item in payload["rejected_candidates"]
+    )
+    assert RouterTelemetry(db_path).stats()["total"] == 0
+    assert state.load_pin("session-1").turns_held == 2

--- a/tests/agent/test_model_router_telemetry.py
+++ b/tests/agent/test_model_router_telemetry.py
@@ -1,0 +1,149 @@
+import json
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+
+from agent.model_router import ModelProfile, RouterPipeline, RoutingRequest
+from agent.model_router.pipeline import default_db_path
+from agent.model_router.telemetry import RouterTelemetry
+from gateway.run import GatewayRunner
+from hermes_cli.router_cmd import cmd_router
+
+
+_HYDRA_PROMPT = "run a shell command, read the file, and search the output. " * 50
+_SESSION_KEY = "gateway:test-platform:chat-42"
+
+
+def _runtime(provider="test-provider"):
+    return {
+        "api_key": None,
+        "base_url": None,
+        "provider": provider,
+        "requested_provider": provider,
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+        "capabilities": {},
+    }
+
+
+def test_gateway_hydra_decision_is_visible_to_router_cli(tmp_path, monkeypatch, capsys):
+    """The real gateway seam and CLI must share one durable telemetry DB."""
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    (hermes_home / "config.yaml").write_text(
+        """\
+model_router:
+  mode: suggest
+  candidates:
+    - model: current
+      provider: test-provider
+      tier: economical
+      reasoning: true
+      quality: 0.9
+      cost: 0.2
+  session_pin:
+    enabled: false
+  telemetry:
+    enabled: true
+""",
+        encoding="utf-8",
+    )
+
+    runner = SimpleNamespace(_service_tier=None)
+    route = GatewayRunner._resolve_turn_agent_config(
+        runner,
+        _HYDRA_PROMPT,
+        "current",
+        _runtime(),
+        session_id=_SESSION_KEY,
+    )
+
+    assert route["model"] == "current"  # suggest mode never changes runtime behavior
+    assert route["model_router"]["stage"] == "hydra_match"
+    assert route["model_router"]["reason"] == "multi_objective"
+    assert default_db_path() == hermes_home / "state" / "model_router" / "router.db"
+
+    cmd_router(SimpleNamespace(router_action="stats"))
+    stats = json.loads(capsys.readouterr().out)
+    assert stats["total"] == 1
+    assert stats["by_stage"] == {"hydra_match": 1}
+
+    cmd_router(
+        SimpleNamespace(router_action="history", limit=20, session=_SESSION_KEY)
+    )
+    history = json.loads(capsys.readouterr().out)
+    assert len(history) == 1
+    assert history[0]["session_id"] == _SESSION_KEY
+    assert history[0]["mode"] == "suggest"
+    assert history[0]["stage"] == "hydra_match"
+    assert history[0]["selected_model"] == "current"
+
+    # Candidate telemetry is metadata only; prompt content is never persisted.
+    import sqlite3
+
+    with sqlite3.connect(default_db_path()) as conn:
+        candidates_json, prompt_chars = conn.execute(
+            "SELECT candidates_json, prompt_chars FROM routing_history"
+        ).fetchone()
+    candidates = json.loads(candidates_json)
+    assert len(candidates) == 1
+    assert candidates[0]["model"] == "current"
+    assert isinstance(candidates[0]["score"], float)
+    assert candidates[0]["rejected"] is None
+    assert prompt_chars == len(_HYDRA_PROMPT)
+    assert _HYDRA_PROMPT not in Path(default_db_path()).read_bytes().decode(
+        "utf-8", errors="ignore"
+    )
+
+
+def test_sqlite_write_failure_is_observable_but_does_not_break_routing(
+    tmp_path, monkeypatch, caplog
+):
+    telemetry = RouterTelemetry(tmp_path / "router.db")
+
+    def fail_connect():
+        raise OSError("simulated telemetry failure")
+
+    monkeypatch.setattr(telemetry, "_connect", fail_connect)
+    pipeline = RouterPipeline(
+        [ModelProfile("current", tier="economical", reasoning=True)],
+        telemetry=telemetry,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="agent.model_router.telemetry"):
+        decision = pipeline.route(
+            RoutingRequest(_HYDRA_PROMPT, session_id=_SESSION_KEY),
+            current_model="current",
+            mode="suggest",
+        )
+
+    assert decision.selected_model == "current"
+    assert decision.stage == "hydra_match"
+    assert "Model router telemetry write failed" in caplog.text
+    assert _HYDRA_PROMPT not in caplog.text
+
+
+def test_unexpected_recorder_failure_is_fail_closed(caplog):
+    class BrokenTelemetry:
+        def record(self, request, decision, *, mode, session_id):
+            raise OSError("simulated telemetry failure")
+
+    pipeline = RouterPipeline(
+        [ModelProfile("current", tier="economical", reasoning=True)],
+        telemetry=BrokenTelemetry(),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="agent.model_router.pipeline"):
+        decision = pipeline.route(
+            RoutingRequest(_HYDRA_PROMPT, session_id=_SESSION_KEY),
+            current_model="current",
+            mode="suggest",
+        )
+
+    assert decision.selected_model == "current"
+    assert decision.stage == "hydra_match"
+    assert "Model router telemetry write failed" in caplog.text
+    assert _HYDRA_PROMPT not in caplog.text


### PR DESCRIPTION
## Summary

- Extend the Hermes model-router port with output-headroom context gating.
- Add bounded, thread-safe provider/model health state with CLOSED/OPEN/HALF_OPEN circuit behavior.
- Integrate router-selected, retryable-only stream failover with the existing Hermes fallback loop.
- Add privacy-safe `hermes router explain` dry-run inspection.
- Fix telemetry candidate score compatibility and make telemetry failures observable without breaking routing.
- Preserve `off`/`suggest`/`auto` semantics, prompt-cache stability, and turn-boundary selection.

## Validation

- Hermes independently ran the focused integration suite: **148 passed, 0 failed**.
- `python -m compileall`: exit 0.
- `git diff --check`: exit 0.
- Gateway restart and real SQLite telemetry readback verified on a Telegram session.

## Explicit boundaries

- Planning delegate spawn/observation injection is not included in this PR.
- ONNX embedding HyDRA remains optional and disabled; deterministic matching remains the default.
- Stream failover retries an alternate provider request; it does not resume a partially emitted stream at token level.
- No live upstream model failure was injected during validation.

## Notes

The implementation uses Hermes-native provider, gateway, session, and fallback paths and does not add Pi as a runtime dependency.
