### PR TITLE
fix(telegram): bind a clarify to its prompt message before a callback can resolve it

### DIFF
--- a/contributors/emails/elm@Emanuels-MacBook-Pro.local
+++ b/contributors/emails/elm@Emanuels-MacBook-Pro.local
@@ -1,0 +1,2 @@
+thelonewander3r
+# PR #103000 (telegram: bind clarify to its prompt message)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -365,6 +365,28 @@ class _PollingLifecycleAbort(RuntimeError):
     """Internal control flow for polling startup fenced by teardown."""
 
 
+def _callback_identity(value: Any) -> Optional[str]:
+    """Normalize a Telegram id for comparison (int on the wire, str in config/state)."""
+    return None if value is None else str(value)
+
+
+@dataclasses.dataclass(frozen=True)
+class _ClarifyPrompt:
+    """A pending clarify's session key plus the identity of the message that rendered its buttons.
+
+    Telegram message ids are unique within a chat, so ``(chat_id, message_id)`` names this exact
+    prompt.  A ``cl:`` callback carrying a matching clarify id but arriving on some *other* message
+    cannot be a deliberate tap on this one and must not resolve it (#102957).  ``thread_id`` is
+    recorded for the audit line only: it is implied by the message, so gating on it would add false
+    rejects (Telegram omits it for a forum's General topic) without narrowing anything.
+    """
+
+    session_key: str
+    chat_id: Optional[str] = None
+    message_id: Optional[str] = None
+    thread_id: Optional[str] = None
+
+
 class TelegramAdapter(BasePlatformAdapter):
     """Telegram bot adapter: users/groups, MarkdownV2 replies, forum topics, media."""
 
@@ -514,7 +536,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self._choice_picker_state: Dict[str, dict] = {}
         self._approval_state: Dict[int, str] = {}  # message_id → session_key
         self._slash_confirm_state: Dict[str, str] = {}  # confirm_id → session_key
-        self._clarify_state: Dict[str, str] = {}  # clarify_id → session_key
+        self._clarify_state: Dict[str, "_ClarifyPrompt"] = {}  # clarify_id → prompt binding (#102957)
         # "important" (default): only final responses, approvals and slash confirmations notify;
         # "all": every message notifies (display.platforms.telegram.notifications).
         self._notifications_mode: str = "important"
@@ -3829,7 +3851,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 rows = [[InlineKeyboardButton(str(idx + 1), callback_data=f"cl:{clarify_id}:{idx}")] for idx in range(len(choices))]
                 rows.append([InlineKeyboardButton("✏️ Other (type answer)", callback_data=f"cl:{clarify_id}:other")])
                 keyboard = InlineKeyboardMarkup(rows)
-            return text, keyboard, lambda msg: self._clarify_state.__setitem__(clarify_id, session_key)
+            return text, keyboard, lambda msg: self._bind_clarify_prompt(clarify_id, session_key, msg)
         return await self._send_prompt(
             "send_clarify", chat_id, metadata, build, parse_mode=ParseMode.HTML, thread_id=self._metadata_thread_id(metadata))
 
@@ -4342,6 +4364,43 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.error("[%s] slash-confirm callback failed: %s", self.name, exc, exc_info=True)
 
+    def _bind_clarify_prompt(self, clarify_id: str, session_key: str, msg: Any) -> None:
+        """Register a pending clarify against the message that carries its buttons (#102957)."""
+        self._clarify_state[clarify_id] = _ClarifyPrompt(
+            session_key=session_key, chat_id=_callback_identity(getattr(msg, "chat_id", None)),
+            message_id=_callback_identity(getattr(msg, "message_id", None)),
+            thread_id=_callback_identity(getattr(msg, "message_thread_id", None)))
+
+    async def _clarify_callback_matches_prompt(self, query, clarify_id: str, prompt: "_ClarifyPrompt") -> bool:
+        """Fail closed unless the tap came from the message that rendered this clarify (#102957).
+
+        The allowlist gate upstream of this proves only that the caller may answer *some* prompt here — it
+        cannot tell a deliberate tap from a callback that arrived on another message.  On a mismatch the
+        entry is left pending so the real prompt stays answerable, and the rejection is logged with enough
+        non-secret provenance (callback-query id, immutable caller id, both message identities) to tell a
+        stale tap from a mismatched one after the fact.
+        """
+        if prompt.message_id is None:
+            # Nothing to match against: the send path reported no message id.  Only a Bot API response can
+            # reach this branch — no caller-controlled input does — so treat it as unverifiable, not hostile.
+            logger.warning(
+                "[%s] Telegram clarify callback unverifiable — no prompt message bound (id=%s)", self.name, clarify_id)
+            return True
+        message = getattr(query, "message", None)
+        actual_chat_id = _callback_identity(getattr(message, "chat_id", None))
+        actual_message_id = _callback_identity(getattr(message, "message_id", None))
+        if actual_chat_id == prompt.chat_id and actual_message_id == prompt.message_id:
+            return True
+        logger.warning(
+            "[%s] Telegram clarify callback rejected — prompt binding mismatch (id=%s, expected chat=%s message=%s "
+            "thread=%s, got chat=%s message=%s thread=%s, callback_query=%s, caller_id=%s)",
+            self.name, clarify_id, prompt.chat_id, prompt.message_id, prompt.thread_id, actual_chat_id,
+            actual_message_id, _callback_identity(getattr(message, "message_thread_id", None)),
+            getattr(query, "id", None), _callback_identity(getattr(query.from_user, "id", None)))
+        with contextlib.suppress(Exception):
+            await query.answer(text="⛔ This button belongs to a different prompt.")
+        return False
+
     async def _handle_clarify_callback(self, query, data: str, cb: Dict[str, Any]) -> None:
         """``cl:<clarify_id>:<idx|other>`` — resolve a clarify prompt or flip to text capture."""
         parts = data.split(":", 2)
@@ -4349,10 +4408,12 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         clarify_id = parts[1]
         choice_token = parts[2]
-        session_key = await self._claim_callback_state(
+        prompt = await self._claim_callback_state(
             query, cb, self._clarify_state, clarify_id, "⛔ You are not authorized to answer this prompt.",
             "This prompt has already been resolved.", pop=False)
-        if not session_key:
+        if not prompt:
+            return
+        if not await self._clarify_callback_matches_prompt(query, clarify_id, prompt):
             return
         user_display = getattr(query.from_user, "first_name", "User")
         if choice_token == "other":
@@ -4401,7 +4462,11 @@ class TelegramAdapter(BasePlatformAdapter):
             await query.answer(text=f"✓ {resolved_text[:60]}")
             await self._edit_html_quiet(
                 query, f"❓ {_html.escape(query.message.text or '')}\n\n<b>{_html.escape(user_display)}:</b> {_html.escape(resolved_text)}")
-            logger.info("Telegram clarify button resolved (id=%s, choice=%r, user=%s)", clarify_id, resolved_text, user_display)
+            logger.info(
+                "Telegram clarify button resolved (id=%s, choice=%r, user=%s, caller_id=%s, callback_query=%s, "
+                "chat=%s, message=%s)", clarify_id, resolved_text, user_display,
+                _callback_identity(getattr(query.from_user, "id", None)), getattr(query, "id", None),
+                prompt.chat_id, prompt.message_id)
         else:
             # Entry evicted / gateway restarted between ask and tap.
             await self._notify_clarify_expired(query, user_display)

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -23,7 +23,7 @@ if _repo not in sys.path:
 # Minimal Telegram mock so TelegramAdapter can be imported (mirrors
 # test_telegram_approval_buttons.py)
 # ---------------------------------------------------------------------------
-from plugins.platforms.telegram.adapter import TelegramAdapter
+from plugins.platforms.telegram.adapter import TelegramAdapter, _ClarifyPrompt
 from gateway.config import PlatformConfig
 
 
@@ -58,6 +58,8 @@ class TestTelegramSendClarify:
         adapter = _make_adapter()
         mock_msg = MagicMock()
         mock_msg.message_id = 100
+        mock_msg.chat_id = 12345
+        mock_msg.message_thread_id = None
         adapter._bot.send_message = AsyncMock(return_value=mock_msg)
 
         result = await adapter.send_clarify(
@@ -84,7 +86,10 @@ class TestTelegramSendClarify:
         # Mocked InlineKeyboardMarkup — just verify it was constructed
         # with rows.  We check state instead of poking the mock structure.
         assert "cid1" in adapter._clarify_state
-        assert adapter._clarify_state["cid1"] == "sk1"
+        # State carries the session key *and* the identity of the message that rendered the
+        # buttons, so a callback can be matched against it (#102957).
+        assert adapter._clarify_state["cid1"] == _ClarifyPrompt(
+            session_key="sk1", chat_id="12345", message_id="100", thread_id=None)
 
 
         # The button label should be short ("1"), not the long choice
@@ -128,12 +133,15 @@ class TestTelegramClarifyCallback:
         adapter = _make_adapter()
         # Pre-register a clarify entry so the callback can look up the choice text
         cm.register("cidA", "sk-cb", "Pick", ["red", "green", "blue"])
-        adapter._clarify_state["cidA"] = "sk-cb"
+        adapter._clarify_state["cidA"] = _ClarifyPrompt(
+            session_key="sk-cb", chat_id="12345", message_id="100", thread_id=None)
 
         query = AsyncMock()
         query.data = "cl:cidA:1"  # green
         query.message = MagicMock()
         query.message.chat_id = 12345
+        query.message.message_id = 100
+        query.message.message_thread_id = None
         query.message.text = "Pick"
         query.from_user = MagicMock()
         query.from_user.id = "777"
@@ -170,7 +178,8 @@ class TestTelegramClarifyCallback:
 
         adapter = _make_adapter()
         cm.register("cidC", "sk-auth", "Pick", ["a", "b"])
-        adapter._clarify_state["cidC"] = "sk-auth"
+        adapter._clarify_state["cidC"] = _ClarifyPrompt(
+            session_key="sk-auth", chat_id="12345", message_id="100", thread_id=None)
 
         # Hook up a runner that says NOT authorized
         class _DenyRunner:
@@ -207,7 +216,137 @@ class TestTelegramClarifyCallback:
         query.answer.assert_called_once()
         assert "not authorized" in query.answer.call_args[1]["text"].lower()
         # State preserved
-        assert adapter._clarify_state["cidC"] == "sk-auth"
+        assert adapter._clarify_state["cidC"].session_key == "sk-auth"
+
+
+# ===========================================================================
+# Prompt binding — a callback may only resolve the clarify it was rendered on
+# ===========================================================================
+
+class TestTelegramClarifyPromptBinding:
+    """#102957 — chat-level authorization cannot tell a deliberate tap from a callback
+    that arrived on some other message, so the clarify is bound to its prompt message."""
+
+    ASK_CHAT_ID = 12345
+    ASK_MESSAGE_ID = 100
+
+    def setup_method(self):
+        _clear_clarify_state()
+
+    def _ask(self, adapter, clarify_id="cid-bind", session_key="sk-bind"):
+        """Register a pending clarify bound to (ASK_CHAT_ID, ASK_MESSAGE_ID)."""
+        from tools import clarify_gateway as cm
+        cm.register(clarify_id, session_key, "Recover the worker?", ["keep running", "stop the worker"])
+        adapter._clarify_state[clarify_id] = _ClarifyPrompt(
+            session_key=session_key, chat_id=str(self.ASK_CHAT_ID),
+            message_id=str(self.ASK_MESSAGE_ID), thread_id=None)
+
+    def _tap(self, chat_id, message_id, *, clarify_id="cid-bind", token="1"):
+        query = AsyncMock()
+        query.id = "cbq-1"
+        query.data = f"cl:{clarify_id}:{token}"
+        query.message = MagicMock()
+        query.message.chat_id = chat_id
+        query.message.message_id = message_id
+        query.message.message_thread_id = None
+        query.message.chat.type = "private"
+        query.message.text = "Recover the worker?"
+        query.from_user = MagicMock()
+        query.from_user.id = "777"
+        query.from_user.first_name = "Owner"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+        update = MagicMock()
+        update.callback_query = query
+        return update, query
+
+    async def _deliver(self, adapter, update):
+        # The caller is allowed to answer prompts — authorization is not what is under test.
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            await adapter._handle_callback_query(update, MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_callback_from_another_message_does_not_resolve(self):
+        from tools import clarify_gateway as cm
+
+        adapter = _make_adapter()
+        self._ask(adapter)
+        update, query = self._tap(self.ASK_CHAT_ID, 999)
+
+        await self._deliver(adapter, update)
+
+        with cm._lock:
+            entry = cm._entries.get("cid-bind")
+        assert not entry.event.is_set()
+        assert entry.response is None
+        # The real prompt stays answerable.
+        assert "cid-bind" in adapter._clarify_state
+        query.edit_message_text.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_callback_from_another_chat_does_not_resolve(self):
+        from tools import clarify_gateway as cm
+
+        adapter = _make_adapter()
+        self._ask(adapter)
+        update, query = self._tap(67890, 555)
+
+        await self._deliver(adapter, update)
+
+        with cm._lock:
+            entry = cm._entries.get("cid-bind")
+        assert not entry.event.is_set()
+        assert "cid-bind" in adapter._clarify_state
+
+    @pytest.mark.asyncio
+    async def test_mismatched_callback_does_not_flip_to_text_capture(self):
+        """The "Other" branch mutates state too, so it fails closed on the same check."""
+        from tools import clarify_gateway as cm
+
+        adapter = _make_adapter()
+        self._ask(adapter)
+        update, query = self._tap(self.ASK_CHAT_ID, 999, token="other")
+
+        await self._deliver(adapter, update)
+
+        with cm._lock:
+            entry = cm._entries.get("cid-bind")
+        assert entry.awaiting_text is False
+        assert "cid-bind" in adapter._clarify_state
+
+    @pytest.mark.asyncio
+    async def test_genuine_tap_on_the_prompt_still_resolves(self):
+        from tools import clarify_gateway as cm
+
+        adapter = _make_adapter()
+        self._ask(adapter)
+        update, query = self._tap(self.ASK_CHAT_ID, self.ASK_MESSAGE_ID)
+
+        await self._deliver(adapter, update)
+
+        with cm._lock:
+            entry = cm._entries.get("cid-bind")
+        assert entry.event.is_set()
+        assert entry.response == "stop the worker"
+        assert "cid-bind" not in adapter._clarify_state
+
+    @pytest.mark.asyncio
+    async def test_prompt_without_a_bound_message_stays_answerable(self):
+        """A send that reported no message id leaves nothing to match — resolve rather than
+        strand the prompt, since no caller-controlled input can reach that state."""
+        from tools import clarify_gateway as cm
+
+        adapter = _make_adapter()
+        cm.register("cid-unbound", "sk-unbound", "Pick", ["a", "b"])
+        adapter._clarify_state["cid-unbound"] = _ClarifyPrompt(session_key="sk-unbound")
+        update, query = self._tap(self.ASK_CHAT_ID, self.ASK_MESSAGE_ID, clarify_id="cid-unbound", token="0")
+
+        await self._deliver(adapter, update)
+
+        with cm._lock:
+            entry = cm._entries.get("cid-unbound")
+        assert entry.event.is_set()
+        assert entry.response == "a"
 
 
 # ===========================================================================


### PR DESCRIPTION
Fixes #102957

## The gap

A `cl:` callback resolved a pending clarify on the strength of the chat-level allowlist alone. `send_clarify` stored only `clarify_id -> session_key` and discarded the message it had just sent, so `_handle_clarify_callback` had nothing to check the callback against: any callback carrying a matching clarify id resolved the prompt no matter which message it arrived on. The allowlist proves the caller may answer *some* prompt in that chat — it cannot tell a deliberate tap from a callback that landed elsewhere.

## Reproduced first

Against unmodified `f1ccf436a2`, a clarify asked in chat `12345` on message `100`:

```
[A] same chat, different message  -> resolved=True  response='stop the worker'   <- fail-open
[B] different chat entirely       -> resolved=True  response='stop the worker'   <- fail-open
[C] genuine tap on the prompt     -> resolved=True  response='stop the worker'   <- control
```

With this PR applied, A and B reject and C still resolves. All three are now permanent tests.

## What this does and does not claim

This closes a validation gap and makes a future incident attributable. It does **not** prove it caused the reported incident, and I would rather say so than overclaim: `clarify_id` is a `uuid.uuid4().hex[:10]` slice (`gateway/run_turn_runner.py:1181`), that `callback_data` exists only on the buttons of the one message, `_send_message_with_thread_fallback` retries only when the first send actually failed, and Telegram strips callback buttons on forward. I could not identify an in-the-wild vector that puts those buttons on a second message.

So the case here is fail-closed hardening plus the provenance the reporter actually needs — the issue makes the same point when it says the missing binding "leaves the incident unverifiable". The old audit line (`id`, choice text, display name) could not distinguish a real tap from a stale or mismatched event; the new one can.

## The fix

- `_ClarifyPrompt` (frozen dataclass) replaces the bare session-key value, recording the session key plus the identity of the message that rendered the buttons — captured from the message `send_clarify` actually landed, so a thread fallback is reflected rather than the requested route.
- `_clarify_callback_matches_prompt` fails closed when `(chat_id, message_id)` does not match, leaving the entry pending so the real prompt stays answerable. Both branches go through it — the numeric choice *and* the `"Other"` text-capture flip, which mutates state too.
- The resolve line gains the callback-query id and the immutable caller id alongside the message identity. Rejections log the expected and the observed identity together.

### Two deliberate deviations from the issue's proposal

- **No `thread_id` gating.** Telegram message ids are unique within a chat, so `(chat_id, message_id)` already names the message exactly and the thread is implied by it. Gating on the thread narrows nothing and adds false rejects when Telegram omits it for a forum's General topic. It is recorded for the audit line.
- **No principal binding.** `send_clarify` cannot know who will answer, and pinning a single user at send time would break group prompts where any authorized owner may answer. Authorization stays chat-level; the caller id goes to the log instead.

## Tests

`tests/gateway/test_telegram_clarify_buttons.py` gains `TestTelegramClarifyPromptBinding` (5 tests): callback from another message, callback from another chat, a mismatched callback not flipping to text capture, the genuine tap still resolving, and a prompt with no bound message staying answerable rather than stranded.

Three existing assertions pinned the bare-string state shape and were updated to the new one.

Full `tests/gateway/` + `tests/tools/test_clarify_gateway.py`:

| | passed | failed |
|---|---|---|
| this PR | 7667 | 13 |
| pristine `f1ccf436a2` | 7662 | 13 |

The same 13 fail either way (discord send, teams wiring, systemd notify, scale-to-zero, shutdown forensics and friends — all pre-existing in this sandbox, none clarify-related). The `+5` is this PR's new tests. No regressions.

## Out of scope, but noted

`_approval_state` and `_slash_confirm_state` have the same shape and the same missing check. I left them alone to keep this scoped to what #102957 reports, but exec approvals are the higher-stakes surface and may deserve their own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
