### PR TITLE
fix(gemini): parse thoughtsTokenCount into usage reasoning_tokens on the native path

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -439,6 +439,7 @@ def _usage_from_metadata(usage_meta: Dict[str, Any]) -> SimpleNamespace:
     return SimpleNamespace(
         prompt_tokens=count("promptTokenCount"), completion_tokens=count("candidatesTokenCount"),
         total_tokens=count("totalTokenCount"), prompt_tokens_details=SimpleNamespace(cached_tokens=count("cachedContentTokenCount")),
+        completion_tokens_details=SimpleNamespace(reasoning_tokens=count("thoughtsTokenCount")),
     )
 
 

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -273,6 +273,55 @@ def test_translate_native_response_surfaces_reasoning_and_tool_calls():
     assert json.loads(choice.message.tool_calls[0].function.arguments) == {"q": "hermes"}
 
 
+def test_translate_native_response_counts_thought_tokens_as_reasoning():
+    from agent.gemini_native_adapter import translate_gemini_response
+
+    payload = {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "hello"}]},
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 10,
+            "candidatesTokenCount": 20,
+            "totalTokenCount": 30,
+            "thoughtsTokenCount": 12,
+        },
+    }
+
+    response = translate_gemini_response(payload, model="gemini-3-flash")
+    assert response.usage.completion_tokens == 20
+    assert response.usage.prompt_tokens_details.cached_tokens == 0
+    assert response.usage.completion_tokens_details.reasoning_tokens == 12
+
+
+def test_translate_stream_event_counts_thought_tokens_as_reasoning():
+    from agent.gemini_native_adapter import translate_stream_event
+
+    event = {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "hello"}]},
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 10,
+            "candidatesTokenCount": 20,
+            "totalTokenCount": 30,
+            "thoughtsTokenCount": 12,
+        },
+    }
+
+    chunks = translate_stream_event(event, model="gemini-3-flash", tool_call_indices={})
+    finish_chunks = [c for c in chunks if getattr(c.choices[0], "finish_reason", None)]
+    assert finish_chunks, "expected a finish chunk carrying usage"
+    assert finish_chunks[-1].usage.completion_tokens_details.reasoning_tokens == 12
+    assert finish_chunks[-1].usage.completion_tokens == 20
+
+
 def test_native_client_uses_x_goog_api_key_and_native_models_endpoint(monkeypatch):
     from agent.gemini_native_adapter import GeminiNativeClient
 


### PR DESCRIPTION
## What does this PR do?

On the `gemini_native` REST path, Gemini's `usageMetadata` carries `thoughtsTokenCount` for hidden thinking, but `_usage_from_metadata` never read it, so every thought token was silently accounted as ordinary output: `reasoning_tokens` stayed 0 while `completion_tokens` included the thoughts (#102996 reports sessions with `reasoning_tokens = 0` against `output_tokens = 18967`, and non-Gemini providers on the same install populate `reasoning` at a normal rate).

This maps `thoughtsTokenCount` to `completion_tokens_details.reasoning_tokens` — the OpenAI Chat Completions usage shape that `canonicalize_usage` (`agent/usage_pricing.py`) already deep-reads via `_first_nonzero(u, ("output_tokens_details", "reasoning_tokens"), ("completion_tokens_details", "reasoning_tokens"))`. The existing accounting pipeline (session counters, insights, cost estimates) then records thought tokens as reasoning with no further changes. Both the non-stream response path and the stream finish-chunk path go through `_usage_from_metadata`, so one line covers both.

Scope note: this fixes the usage-accounting item of #102996 ("thoughtsTokenCount is never parsed anywhere"). The request-side `includeThoughts` decoupling is already carried by #64036 for #64035, and the unmarked-planning-part leak needs a maintainer decision between the options the reporter listed (`thought_tag_marker` vs. first-part heuristic) — this PR deliberately does not guess between them.

## Related Issue

Fixes #102996

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/gemini_native_adapter.py` — `_usage_from_metadata` now also returns `completion_tokens_details=SimpleNamespace(reasoning_tokens=count("thoughtsTokenCount"))`, matching the OpenAI usage shape consumed downstream
- `tests/agent/test_gemini_native_adapter.py` — two regression tests: non-stream `translate_gemini_response` and stream `translate_stream_event` finish chunk both surface `thoughtsTokenCount` as `reasoning_tokens` while keeping the existing counters intact

## How to Test

1. `pytest tests/agent/test_gemini_native_adapter.py -q` — 31 passed (including the two new tests)
2. `pytest tests/agent/test_usage_pricing.py -q` — 48 passed (the canonicalization layer that consumes the new field)
3. Observed result: with a `usageMetadata` of `{"promptTokenCount": 10, "candidatesTokenCount": 20, "totalTokenCount": 30, "thoughtsTokenCount": 12}`, the translated usage now reports `completion_tokens=20` and `completion_tokens_details.reasoning_tokens=12`; before the change the reasoning count was always 0

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
