### PR TITLE
fix(web): late-bind Desktop SSH session token

### DIFF
--- a/hermes_cli/web_server_dashboard.py
+++ b/hermes_cli/web_server_dashboard.py
@@ -102,7 +102,7 @@ def mount_spa(application: FastAPI):
     with a missing dist per-request (404 JSON / ``check_dir=False``), so a long-lived
     ``--skip-build`` process recovers the moment a build appears on disk — no restart.
     """
-    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, _SESSION_TOKEN, app
+    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, app
 
     # `hermes serve` is the headless backend: it must NEVER serve the browser SPA, even if a
     # dist is lying around, so only the JSON-RPC/WS/API surface is reachable.
@@ -118,6 +118,11 @@ def mount_spa(application: FastAPI):
             # See #94227, #95575.
             gated = bool(getattr(application.state, "auth_required", False))
             if full_path == "" and not gated:
+                # SSH Desktop applies its per-connection token after the SPA routes are
+                # mounted. Read the facade state at request time so the handshake page
+                # advertises the same token the auth middleware currently validates.
+                from hermes_cli.web_server import _SESSION_TOKEN
+
                 return HTMLResponse(
                     "<!doctype html><html><head><script>"
                     f"window.__HERMES_SESSION_TOKEN__={json.dumps(_SESSION_TOKEN)};"
@@ -151,6 +156,9 @@ def mount_spa(application: FastAPI):
             return JSONResponse({"error": "Frontend not built. Run: cd web && npm run build"}, status_code=404)
         chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
         gated = bool(getattr(app.state, "auth_required", False))
+        # Keep this late-bound for the same SSH Desktop lifecycle as the headless root.
+        from hermes_cli.web_server import _SESSION_TOKEN
+
         token_js = "" if gated else f'window.__HERMES_SESSION_TOKEN__="{_SESSION_TOKEN}";'
         bootstrap_script = (
             f"<script>{token_js}"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5065,6 +5065,26 @@ class TestServeIndexMissingIndex:
         assert resp.status_code == 200
         assert "SPA-rebuilt" in resp.text
 
+    def test_index_uses_session_token_applied_after_spa_mount(
+        self, tmp_path, monkeypatch
+    ):
+        client, _dist = self._client_with_dist(
+            tmp_path, monkeypatch, write_index=True
+        )
+        import hermes_cli.web_server as ws
+
+        original_token = ws._SESSION_TOKEN
+        try:
+            ws._apply_ssh_session_token("ssh-token-applied-after-mount")
+            resp = client.get("/")
+            assert resp.status_code == 200
+            assert (
+                'window.__HERMES_SESSION_TOKEN__="ssh-token-applied-after-mount"'
+                in resp.text
+            )
+        finally:
+            ws._apply_ssh_session_token(original_token)
+
 
 class TestHeadlessServeTokenPage:
     """Headless `hermes serve` must serve the Desktop token handshake page
@@ -5109,6 +5129,24 @@ class TestHeadlessServeTokenPage:
 
         assert _json.loads(match.group(1)) == ws._SESSION_TOKEN
         assert "window.__HERMES_AUTH_REQUIRED__=false" in resp.text
+
+    def test_root_uses_session_token_applied_after_spa_mount(self, monkeypatch):
+        import json as _json
+        import re
+
+        client, ws = self._headless_client(monkeypatch, gated=False)
+        original_token = ws._SESSION_TOKEN
+        try:
+            ws._apply_ssh_session_token("ssh-token-applied-after-mount")
+            resp = client.get("/")
+            match = re.search(
+                r'window\.__HERMES_SESSION_TOKEN__\s*=\s*("(?:\\.|[^"\\])*")',
+                resp.text,
+            )
+            assert match, resp.text
+            assert _json.loads(match.group(1)) == "ssh-token-applied-after-mount"
+        finally:
+            ws._apply_ssh_session_token(original_token)
 
     def test_root_stays_404_json_when_auth_gated(self, monkeypatch):
         client, ws = self._headless_client(monkeypatch, gated=True)


### PR DESCRIPTION
## What

Read the dashboard session token at request time in both SPA response paths instead of capturing it when `mount_spa()` registers the routes.

## Root cause

`mount_spa()` imported `_SESSION_TOKEN` before `start_server()` applied the per-connection SSH token. The rendered root page therefore advertised the earlier token while the auth middleware validated the updated token. Desktop could pass the public readiness probes and then receive `401 Unauthorized` from protected endpoints such as `/api/profiles`.

The fix keeps the facade import function-local, matching the repository late-binding convention, and covers both the regular SPA and headless Desktop handshake page.

## Regression proof

On the previous code, the two new behavior tests failed after applying an SSH token after SPA mount. With this change:

- focused regression tests: 2 passed
- full `tests/hermes_cli/test_web_server.py`: 188 passed
- `scripts/check_compat_pointers.py`: passed
- `py_compile` and `git diff --check`: passed

A live SSH Desktop reproduction showed `/`, `/api/status`, and `/api/health` returning 200 while the token advertised by `/` received 401 from `/api/profiles`.