### PR TITLE
fix(kanban): support triage human-gate repair

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -213,7 +213,7 @@ def _profile_author() -> str:
 _DELEGATED_CHILD_DENIED_ACTIONS: frozenset[str] = frozenset({
     "init", "create", "swarm", "assign", "reclaim", "reassign", "link", "unlink",
     "claim", "comment", "attach", "attach-rm", "complete", "edit", "block",
-    "schedule", "unblock", "promote", "archive", "dispatch", "daemon", "repair",
+    "schedule", "unblock", "promote", "triage-gate", "archive", "dispatch", "daemon", "repair",
     "heartbeat", "notify-subscribe", "notify-unsubscribe", "specify", "decompose",
     "gc",
 })
@@ -1027,6 +1027,30 @@ def _cmd_promote(args: argparse.Namespace) -> int:
     return 0 if not failed else 1
 
 
+def _cmd_triage_gate(args: argparse.Namespace) -> int:
+    reason = " ".join(args.reason).strip()
+    as_json = getattr(args, "json", False)
+    with kbc.connect_closing() as conn:
+        ok, error = kb.route_triage_to_human_gate(
+            conn, args.task_id, actor=_profile_author(), reason=reason,
+            dry_run=bool(getattr(args, "dry_run", False)),
+        )
+    result = {
+        "task_id": args.task_id, "routed": ok,
+        "dry_run": bool(getattr(args, "dry_run", False)),
+        "source_status": "triage", "target_status": "blocked",
+        "block_kind": "needs_input", "reason": reason, "error": error,
+    }
+    if as_json:
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+    elif ok:
+        verb = "Would route" if result["dry_run"] else "Routed"
+        print(f"{verb} {args.task_id}: triage -> blocked (needs_input)")
+    else:
+        print(f"cannot route {args.task_id}: {error}", file=sys.stderr)
+    return 0 if ok else 1
+
+
 def _cmd_archive(args: argparse.Namespace) -> int:
     ids = list(args.task_ids or [])
     purge_ids = list(getattr(args, "purge_ids", None) or [])
@@ -1229,6 +1253,7 @@ _HANDLERS = {
     "schedule": _cmd_schedule, "unblock": _cmd_unblock,
     "request-review": _cmd_request_review, "request-changes": _cmd_request_changes,
     "reopen-review": _cmd_reopen_review, "promote": _cmd_promote,
+    "triage-gate": _cmd_triage_gate,
     "archive": _cmd_archive, "tail": _cmd_tail, "dispatch": _cmd_dispatch,
     "daemon": _cmd_daemon, "watch": _cmd_watch, "stats": _cmd_stats,
     "log": _cmd_log, "runs": _cmd_runs, "heartbeat": _cmd_heartbeat,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1975,10 +1975,11 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     """
     row = conn.execute(
         "SELECT kind FROM task_events "
-        "WHERE task_id = ? AND kind IN ('blocked', 'unblocked') "
+        "WHERE task_id = ? AND kind IN "
+        "('blocked', 'triage_human_gate', 'unblocked') "
         "ORDER BY id DESC LIMIT 1", (task_id,),
     ).fetchone()
-    return bool(row) and row["kind"] == "blocked"
+    return bool(row) and row["kind"] in {"blocked", "triage_human_gate"}
 
 
 def _latest_event(
@@ -3221,6 +3222,70 @@ def promote_task(
             conn, task_id, "promoted_manual", {"actor": actor, "reason": reason, "forced": force},
         )
 
+    return True, None
+
+
+def route_triage_to_human_gate(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    actor: str,
+    reason: str,
+    expected_status: str = "triage",
+    dry_run: bool = False,
+) -> tuple[bool, Optional[str]]:
+    """Move a triage task to the human ``blocked`` gate.
+
+    This narrow compare-and-set transition preserves the task payload, graph,
+    assignee, and retry history. Its audit event records inverse status and
+    block kind for durable rollback evidence.
+    """
+    reason = str(reason or "").strip()
+    if expected_status != "triage":
+        return False, "expected_status must be 'triage'"
+    if not reason:
+        return False, "reason is required"
+    row = conn.execute(
+        "SELECT status, block_kind FROM tasks WHERE id = ?", (task_id,)
+    ).fetchone()
+    if row is None:
+        return False, f"task {task_id} not found"
+    if row["status"] != expected_status:
+        return False, (
+            f"task {task_id} is {row['status']!r}; expected {expected_status!r}"
+        )
+    if dry_run:
+        return True, None
+
+    prior_kind = row["block_kind"]
+    with write_txn(conn):
+        cur = conn.execute(
+            """
+            UPDATE tasks
+               SET status = 'blocked', block_kind = ?,
+                   claim_lock = NULL, claim_expires = NULL,
+                   worker_pid = NULL, current_run_id = NULL
+             WHERE id = ? AND status = ?
+            """,
+            ("needs_input", task_id, expected_status),
+        )
+        if cur.rowcount != 1:
+            return False, f"task {task_id} status changed during human-gate repair"
+        _append_event(
+            conn, task_id, "triage_human_gate",
+            {
+                "actor": actor,
+                "reason": reason,
+                "source_status": expected_status,
+                "target_status": "blocked",
+                "target_block_kind": "needs_input",
+                "rollback": {
+                    "status": expected_status,
+                    "block_kind": prior_kind,
+                    "expected_status": "blocked",
+                },
+            },
+        )
     return True, None
 
 

--- a/hermes_cli/kanban_parser.py
+++ b/hermes_cli/kanban_parser.py
@@ -330,6 +330,12 @@ _SPECS = [
         _arg("--dry-run", action="store_true", help="Validate the promotion without mutating state"),
         _arg("--json", dest="json", action="store_true", help="Emit machine-readable JSON result"),
     ], help="Manually move one or more todo/blocked tasks to ready (recovery path)"),
+    _cmd("triage-gate", [
+        _TASK_ID,
+        _arg("reason", nargs="+", help="Human-gate reason (recorded in the audit event)"),
+        _arg("--dry-run", action="store_true", help="Validate the expected triage state without mutating it"),
+        _arg("--json", dest="json", action="store_true", help="Emit machine-readable JSON result"),
+    ], help="Move a triage task to the blocked human-input gate"),
     _cmd("archive", [
         _arg("task_ids", nargs="*", help="Task ids to archive (default mode)"),
         _arg("--rm", dest="purge_ids", nargs="+",

--- a/tests/hermes_cli/test_kanban_triage_gate.py
+++ b/tests/hermes_cli/test_kanban_triage_gate.py
@@ -1,0 +1,63 @@
+"""Regression tests for the supported triage human-gate repair."""
+
+from pathlib import Path
+
+from hermes_cli import kanban_db as kb
+
+
+def _home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.discard(str(kb.kanban_db_path(board="default").resolve()))
+    kb.init_db()
+
+
+def test_triage_gate_preserves_payload_history_and_records_rollback(tmp_path, monkeypatch):
+    _home(tmp_path, monkeypatch)
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="approval", body="keep this", assignee="elon")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status='triage', block_recurrences=3 WHERE id=?",
+                (tid,),
+            )
+        before = kb.get_task(conn, tid)
+        ok, error = kb.route_triage_to_human_gate(
+            conn, tid, actor="operator", reason="SoLo approval required"
+        )
+        after = kb.get_task(conn, tid)
+        assert (ok, error) == (True, None)
+        assert after.status == "blocked"
+        assert after.block_kind == "needs_input"
+        assert after.title == before.title
+        assert after.body == before.body
+        assert after.assignee == before.assignee == "elon"
+        assert after.block_recurrences == before.block_recurrences == 3
+        event = [e for e in kb.list_events(conn, tid) if e.kind == "triage_human_gate"][-1]
+        assert event.payload["rollback"] == {
+            "status": "triage",
+            "block_kind": None,
+            "expected_status": "blocked",
+        }
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, tid).status == "blocked"
+
+
+def test_triage_gate_is_compare_and_set_and_dry_run_is_non_mutating(tmp_path, monkeypatch):
+    _home(tmp_path, monkeypatch)
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="approval")
+        ok, error = kb.route_triage_to_human_gate(
+            conn, tid, actor="operator", reason="approval", dry_run=True
+        )
+        assert (ok, error) == (False, f"task {tid} is 'ready'; expected 'triage'")
+        assert kb.get_task(conn, tid).status == "ready"
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='triage' WHERE id=?", (tid,))
+        ok, error = kb.route_triage_to_human_gate(
+            conn, tid, actor="operator", reason="approval", dry_run=True
+        )
+        assert (ok, error) == (True, None)
+        assert kb.get_task(conn, tid).status == "triage"


### PR DESCRIPTION
## Summary
- add an expected-state triage-to-blocked(needs_input) lifecycle repair
- preserve task payload/graph/retry history and record rollback metadata
- prevent recompute_ready from auto-promoting triage human-gate repairs
- add CLI and regression coverage

## Verification
HERMES_PYTHON=/home/solo/.hermes/hermes-agent/venv/bin/python bash scripts/run_tests.sh tests/hermes_cli/test_kanban_triage_gate.py tests/hermes_cli/test_kanban_promote.py tests/hermes_cli/test_kanban_block_kinds.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban.py

37 passed, 1 skipped (Linux-only suite marker).