### PR TITLE
fix(config): preserve opaque IDs as strings

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3185,6 +3185,74 @@ def _default_value_for_key(dotted_key: str):
     return None if isinstance(node, dict) else node
 
 
+_SCALAR_MESSAGING_ID_LEAVES = frozenset({
+    "chat_id", "guild_id", "thread_id", "user_id", "scope_id",
+})
+_MESSAGING_PLATFORM_KEYS = frozenset({
+    "discord", "telegram", "slack", "mattermost", "matrix", "whatsapp", "signal",
+    "feishu", "wecom", "weixin", "bluebubbles", "qqbot", "yuanbao", "email", "sms",
+    "dingtalk",
+})
+
+
+def _is_identifier_config_key(dotted_key: str) -> bool:
+    """Whether a schema-known messaging/routing leaf is an opaque identifier."""
+    path = tuple(part.lower() for part in _split_key_path(dotted_key))
+    if not path or path[-1] not in _SCALAR_MESSAGING_ID_LEAVES:
+        return False
+    if "profile_routes" in path[:-1]:
+        return True
+    if len(path) < 3 or path[-2] != "home_channel":
+        return False
+    platform = path[-3]
+    return platform in _MESSAGING_PLATFORM_KEYS
+
+
+_PLATFORM_ID_LIST_KEYS: Dict[str, frozenset[str]] = {
+    "discord": frozenset({
+        "free_response_channels", "allowed_channels", "ignored_channels", "no_thread_channels",
+    }),
+    "slack": frozenset({
+        "free_response_channels", "allowed_channels", "require_mention_channels", "ignored_channels",
+    }),
+    "mattermost": frozenset({"free_response_channels", "allowed_channels"}),
+    "matrix": frozenset({"free_response_rooms", "allowed_rooms"}),
+    "telegram": frozenset({"allowed_chats", "group_allowed_chats", "allowed_topics"}),
+}
+
+
+def _is_platform_id_list_path(path: Tuple[str, ...]) -> bool:
+    """Whether *path* is a schema-known messaging-platform ID collection."""
+    if len(path) < 2:
+        return False
+    platform, leaf = path[-2].lower(), path[-1].lower()
+    return leaf in _PLATFORM_ID_LIST_KEYS.get(platform, ())
+
+
+def _stringify_integer_identifier_leaves(
+    value: Any, path: Tuple[str, ...] = (),
+) -> Any:
+    """Copy a config tree, converting integer IDs to JSON-safe strings."""
+    if isinstance(value, dict):
+        return {
+            child_key: _stringify_integer_identifier_leaves(
+                child, (*path, str(child_key)),
+            )
+            for child_key, child in value.items()
+        }
+    if isinstance(value, list):
+        stringify_items = _is_platform_id_list_path(path)
+        return [
+            str(child) if stringify_items and isinstance(child, int) and not isinstance(child, bool)
+            else _stringify_integer_identifier_leaves(child, path)
+            for child in value
+        ]
+    dotted_key = ".".join(path)
+    if _is_identifier_config_key(dotted_key) and isinstance(value, int) and not isinstance(value, bool):
+        return str(value)
+    return value
+
+
 # Top-level keys that accept arbitrary user-supplied child keys (schema declares the dict, the
 # user populates it): any path below is accepted without deep checking.
 _OPEN_DICT_TOP_LEVEL_KEYS = frozenset({
@@ -3329,7 +3397,7 @@ def _coerce_config_set_value(key: str, value: str) -> Any:
     String-typed settings (per ``DEFAULT_CONFIG``) are preserved verbatim so enum members such as
     ``approvals.mode="off"`` never become booleans. List/mapping literals are parsed so
     isinstance-gated readers see real structures; the trigger is conservative."""
-    if isinstance(_default_value_for_key(key), str):
+    if isinstance(_default_value_for_key(key), str) or _is_identifier_config_key(key):
         return value
     stripped = value.strip()
     lower = stripped.lower()

--- a/hermes_cli/web_server_config.py
+++ b/hermes_cli/web_server_config.py
@@ -480,7 +480,12 @@ def _normalize_config_for_web(config: Dict[str, Any]) -> Dict[str, Any]:
     """Flatten a dict-form ``model`` to its string form (the schema is built from
     DEFAULT_CONFIG where ``model`` is a string) and surface ``model_context_length``
     as a top-level field (0 = auto-detect)."""
-    config = dict(config)
+    # JSON numbers are parsed as IEEE-754 doubles by browsers. Opaque numeric
+    # IDs (notably Discord snowflakes) can exceed Number.MAX_SAFE_INTEGER, so
+    # put them on the wire as strings before JavaScript can round them.
+    from hermes_cli.config import _stringify_integer_identifier_leaves
+
+    config = _stringify_integer_identifier_leaves(config)
     model_val = config.get("model")
     if isinstance(model_val, dict):
         ctx_len = model_val.get("context_length", 0)

--- a/tests/hermes_cli/test_config_set_coercion.py
+++ b/tests/hermes_cli/test_config_set_coercion.py
@@ -54,6 +54,43 @@ class TestNumericCoercion:
         assert saved == client_id
         assert isinstance(saved, str)
 
+    @pytest.mark.parametrize(
+        "key,path",
+        [
+            (
+                "platforms.discord.home_channel.chat_id",
+                ("platforms", "discord", "home_channel", "chat_id"),
+            ),
+            (
+                "discord.home_channel.scope_id",
+                ("discord", "home_channel", "scope_id"),
+            ),
+        ],
+    )
+    def test_integer_identifier_leaves_stay_strings(
+        self, tmp_path, monkeypatch, key, path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        snowflake = "1484510452825456722"
+
+        cfg.set_config_value(key, snowflake)
+
+        saved = _read(tmp_path, *path)
+        assert saved == snowflake
+        assert isinstance(saved, str)
+
+    @pytest.mark.parametrize("key", ["plugins.example.chain_id", "mcp_servers.example.id"])
+    def test_arbitrary_identifier_named_leaves_remain_numeric(
+        self, tmp_path, monkeypatch, key
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        cfg.set_config_value(key, "42")
+
+        saved = _read(tmp_path, *key.split("."))
+        assert saved == 42
+        assert isinstance(saved, int)
+
 
 class TestNullCoercion:
     @pytest.mark.parametrize("token", ["null", "none", "None", "~"])

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2551,6 +2551,79 @@ class TestConfigRoundTrip:
             "Shallow-merge regression: agent.x_dashboard_invisible_test_key " \
             "was wiped when the frontend sent a partial agent dict."
 
+    def test_round_trip_stringifies_integer_identifier_leaves(self):
+        """Config identifiers must cross JSON as strings so JavaScript cannot
+        round Discord snowflakes above Number.MAX_SAFE_INTEGER."""
+        from hermes_cli.config import read_raw_config, save_config
+
+        snowflake = 1484510452825456722
+        save_config({
+            "platforms": {
+                "discord": {
+                    "home_channel": {
+                        "platform": "discord",
+                        "chat_id": snowflake,
+                        "name": "Home",
+                    }
+                }
+            },
+            "profile_routes": [{
+                "platform": "discord",
+                "profile": "default",
+                "guild_id": snowflake,
+                "thread_id": snowflake,
+                "chat_id": snowflake,
+                "user_id": snowflake,
+                "scope_id": snowflake,
+            }],
+            "discord": {
+                "free_response_channels": [snowflake],
+                "allowed_channels": [snowflake],
+            },
+            "matrix": {"free_response_rooms": [snowflake]},
+            "custom_metrics": {
+                "event_count": snowflake,
+                "sample_values": [snowflake],
+                "chain_id": snowflake,
+                "id": snowflake,
+            },
+        })
+
+        web_config = self.client.get("/api/config").json()
+        assert web_config["platforms"]["discord"]["home_channel"]["chat_id"] \
+            == str(snowflake)
+        assert web_config["profile_routes"][0]["guild_id"] == str(snowflake)
+        assert web_config["profile_routes"][0]["thread_id"] == str(snowflake)
+        assert web_config["profile_routes"][0]["chat_id"] == str(snowflake)
+        assert web_config["profile_routes"][0]["user_id"] == str(snowflake)
+        assert web_config["profile_routes"][0]["scope_id"] == str(snowflake)
+        assert web_config["discord"]["free_response_channels"] == [str(snowflake)]
+        assert web_config["discord"]["allowed_channels"] == [str(snowflake)]
+        assert web_config["matrix"]["free_response_rooms"] == [str(snowflake)]
+        assert web_config["custom_metrics"]["event_count"] == snowflake
+        assert web_config["custom_metrics"]["sample_values"] == [snowflake]
+        assert web_config["custom_metrics"]["chain_id"] == snowflake
+        assert web_config["custom_metrics"]["id"] == snowflake
+
+        response = self.client.put("/api/config", json={"config": web_config})
+        assert response.status_code == 200
+
+        on_disk = read_raw_config()
+        home = on_disk["platforms"]["discord"]["home_channel"]
+        assert home["chat_id"] == str(snowflake)
+        assert on_disk["profile_routes"][0]["guild_id"] == str(snowflake)
+        assert on_disk["profile_routes"][0]["thread_id"] == str(snowflake)
+        assert on_disk["profile_routes"][0]["chat_id"] == str(snowflake)
+        assert on_disk["profile_routes"][0]["user_id"] == str(snowflake)
+        assert on_disk["profile_routes"][0]["scope_id"] == str(snowflake)
+        assert on_disk["discord"]["free_response_channels"] == [str(snowflake)]
+        assert on_disk["discord"]["allowed_channels"] == [str(snowflake)]
+        assert on_disk["matrix"]["free_response_rooms"] == [str(snowflake)]
+        assert on_disk["custom_metrics"]["event_count"] == snowflake
+        assert on_disk["custom_metrics"]["sample_values"] == [snowflake]
+        assert on_disk["custom_metrics"]["chain_id"] == snowflake
+        assert on_disk["custom_metrics"]["id"] == snowflake
+
     def test_schema_types_match_config_values(self):
         """Every schema field should have a matching-type value in the config."""
         config = self.client.get("/api/config").json()


### PR DESCRIPTION
## What does this PR do?
Preserves messaging-platform identifiers as exact strings when Hermes configuration passes through the CLI or Web API.
Discord snowflakes and similar identifiers can exceed JavaScript's `Number.MAX_SAFE_INTEGER`. If such an identifier is stored as a YAML integer, `GET /api/config` currently serializes it as a JSON number. The browser parses that value as an IEEE-754 `Number`, silently rounds it, and may write the corrupted identifier back through `PUT /api/config`.
For example:
```text
1484510452825456722 → 1484510452825456600
```
This caused a configured Discord home channel to become invalid and made the gateway report `404 Not Found (error code: 10003): Unknown Channel`.
The change normalizes known messaging and routing identifiers to strings before they reach JavaScript. It also prevents `hermes config set` from coercing known scalar messaging IDs to integers.
The implementation is deliberately schema-oriented rather than converting every field named `id` or `*_id`. Unrelated numeric values such as plugin `chain_id` fields, custom metric IDs, counters, and ordinary numeric lists retain their original numeric types.
This overlaps with #65420, which addresses unsafe integers in the Desktop configuration round trip. This PR additionally covers CLI coercion and limits normalization to known messaging/routing identifier fields and collections.
## Related Issue
No issue was opened for this locally reproduced bug.
Related PR: #65420
## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)
## Changes Made
- Updated `hermes_cli/config.py`
  - preserve known scalar messaging and routing IDs as strings during `hermes config set`
  - recursively normalize known messaging ID fields before Web serialization
  - normalize explicit channel, room, chat, and topic ID collections
  - leave unrelated numeric `id`, `chain_id`, counter, and list values unchanged
- Updated `hermes_cli/web_server_config.py`
  - normalize messaging identifiers before returning configuration as JSON
- Updated `tests/hermes_cli/test_config_set_coercion.py`
  - cover scalar messaging-ID coercion
  - verify arbitrary plugin and MCP numeric IDs remain integers
- Updated `tests/hermes_cli/test_web_server.py`
  - reproduce the complete `GET /api/config` → unchanged `PUT /api/config` precision-loss path
  - cover the exact Discord snowflake that triggered the bug
  - verify known channel/room collections are preserved as strings
  - verify unrelated numeric configuration remains numeric
## How to Test
1. Run the CLI coercion tests:
   ```bash
   pytest tests/hermes_cli/test_config_set_coercion.py -q -o 'addopts='
   ```
   Expected result:
   ```text
   17 passed
   ```
2. Run the focused Web configuration round-trip tests:
   ```bash
   pytest tests/hermes_cli/test_web_server.py \
     -q -o 'addopts=' \
     -k 'ConfigRoundTrip or identifier or snowflake'
   ```
   Expected result:
   ```text
   4 passed, 183 deselected
   ```
3. Seed a configuration with an unquoted Discord snowflake:
   ```yaml
   discord:
     free_response_channels:
       - 1484510452825456722
   ```
   Fetch `/api/config`, submit the returned record unchanged through `PUT /api/config`, and reload the YAML. The identifier must remain exactly:
   ```text
   1484510452825456722
   ```
   It must be represented as a string in the Web payload and persisted without precision loss.
## Checklist
### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - Found overlapping PR #65420; the relationship and additional CLI/scope behavior are documented above.
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - Focused and adjacent configuration suites pass. The broader local run encountered two unrelated SPA-mount baseline/environment failures.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian GNU/Linux 13 (trixie), x86_64, Python 3.11.15
### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
  - N/A: no user-facing configuration keys or behavior were added.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
  - N/A: no configuration keys were added or changed.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
  - N/A: no contributor workflow or architecture was changed.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - The fix operates on platform-independent Python mappings and JSON/YAML values; it does not use OS-specific APIs.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
  - N/A: no model tool or tool schema was changed.
## Screenshots / Logs
Observed before the fix:
```text
discord.errors.NotFound: 404 Not Found (error code: 10003): Unknown Channel
Home-channel startup notification failed for discord:1484510452825456600
```
Original configured channel ID:
```text
1484510452825456722
```
JavaScript reproduction:
```javascript
Number("1484510452825456722")
// 1484510452825456600
```
Verification after storing and preserving the ID as a string:
```text
Sent home-channel startup notification to discord:1484510452825456722
```
Focused verification:
```text
17 passed
4 passed, 183 deselected
All checks passed!  # Ruff
```
