### PR TITLE
feat(gateway): route voice notes to native audio models

### DIFF
--- a/agent/audio_routing.py
+++ b/agent/audio_routing.py
@@ -1,0 +1,320 @@
+"""Native audio routing and inline payload construction for gateway voice notes."""
+
+from __future__ import annotations
+
+import base64
+import logging
+import mimetypes
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+
+from tools.audio_container import sniff_container
+
+logger = logging.getLogger(__name__)
+
+# Limit the encoded payload, not only the source file: Base64 expands data by
+# roughly one third and the encoded bytes are what enter the provider request.
+MAX_INLINE_AUDIO_BASE64_BYTES = 25 * 1024 * 1024
+
+AUDIO_FORMAT_TO_MIME: Dict[str, str] = {
+    "mp3": "audio/mpeg",
+    "mpeg": "audio/mpeg",
+    "mp4": "audio/mp4",
+    "m4a": "audio/m4a",
+    "ogg": "audio/ogg",
+    "oga": "audio/ogg",
+    "opus": "audio/ogg",
+    "wav": "audio/wav",
+    "wave": "audio/wav",
+    "flac": "audio/flac",
+    "aac": "audio/aac",
+    "webm": "audio/webm",
+}
+
+_OPENAI_AUDIO_FORMAT_PROVIDERS = {
+    "openai",
+    "azure",
+    "azure-foundry",
+    "azure-openai",
+}
+
+
+def _canonical_audio_format(value: str) -> str:
+    clean = (value or "").strip().lower().lstrip(".")
+    if "/" in clean:
+        clean = clean.rsplit("/", 1)[-1]
+    if clean in {"mpeg", "mp3"}:
+        return "mp3"
+    if clean in {"ogg", "oga", "opus"}:
+        return "ogg"
+    if clean in {"wav", "wave"}:
+        return "wav"
+    return clean if clean in AUDIO_FORMAT_TO_MIME else ""
+
+
+def normalize_audio_format(
+    path: Optional[Path] = None,
+    mime: str = "",
+    *,
+    header: bytes = b"",
+) -> str:
+    """Return a canonical provider format, preferring shared magic-byte detection."""
+    detected = sniff_container(header) if header else None
+    if detected is None and path and path.is_file():
+        try:
+            with path.open("rb") as source:
+                detected = sniff_container(source.read(32))
+        except OSError:
+            detected = None
+    if detected:
+        return _canonical_audio_format(detected)
+    if path and path.suffix:
+        suffix_format = _canonical_audio_format(path.suffix)
+        if suffix_format:
+            return suffix_format
+    return _canonical_audio_format(mime)
+
+
+def normalize_audio_mime(fmt_or_ext: str) -> str:
+    """Convert a supported audio format, extension, or MIME to a canonical MIME."""
+    clean = (fmt_or_ext or "").strip().lower().lstrip(".")
+    if clean.startswith("audio/"):
+        clean = clean.rsplit("/", 1)[-1]
+    canonical = _canonical_audio_format(clean)
+    return AUDIO_FORMAT_TO_MIME.get(canonical, "audio/mpeg")
+
+
+def supported_input_modalities(provider: str, model: str) -> Set[str]:
+    """Return known native input modalities; unknown models fail closed."""
+    try:
+        from agent.models_dev import get_model_info
+
+        info = get_model_info(provider, model, allow_network=True)
+        if info is None and (provider or "").strip().lower() == "openrouter" and "/" in model:
+            vendor, bare_model = model.split("/", 1)
+            info = get_model_info(vendor, bare_model, allow_network=True)
+        if info is None:
+            return set()
+        return {
+            str(modality).strip().lower()
+            for modality in (getattr(info, "input_modalities", ()) or ())
+            if modality
+        }
+    except Exception as exc:  # pragma: no cover - defensive catalog boundary
+        logger.debug(
+            "audio_routing: capability lookup failed for %s:%s: %s",
+            provider,
+            model,
+            exc,
+        )
+        return set()
+
+
+def decide_audio_input_mode(
+    provider: str,
+    model: str,
+    configured_mode: str = "auto",
+) -> str:
+    """Return ``native`` or ``stt`` for one resolved model turn."""
+    provider_norm = (provider or "").strip().lower()
+    model_norm = (model or "").strip().lower()
+    # api.meta.ai has rejected input_audio for models whose catalog metadata
+    # advertised it. Keep this as a hard safety rule, including explicit native.
+    if provider_norm in {"meta", "meta-ai"} or "muse-spark" in model_norm or "muse_spark" in model_norm:
+        return "stt"
+
+    mode = (configured_mode or "auto").strip().lower()
+    if mode == "stt":
+        return "stt"
+    if mode == "native":
+        return "native"
+    return "native" if "audio" in supported_input_modalities(provider, model) else "stt"
+
+
+def _encoded_size(raw_size: int) -> int:
+    return 4 * ((raw_size + 2) // 3)
+
+
+def _read_audio_bytes(path: Path, max_encoded_bytes: int) -> Optional[bytes]:
+    try:
+        from agent.file_safety import raise_if_read_blocked
+
+        raise_if_read_blocked(str(path))
+    except ValueError as exc:
+        logger.warning("audio_routing: blocked local voice attachment %s -- %s", path, exc)
+        return None
+    except Exception:
+        pass
+
+    try:
+        if not path.is_file():
+            return None
+        size = path.stat().st_size
+        if size <= 0 or _encoded_size(size) > max_encoded_bytes:
+            logger.warning(
+                "audio_routing: %s exceeds the %d-byte encoded inline limit or is empty",
+                path,
+                max_encoded_bytes,
+            )
+            return None
+        raw = path.read_bytes()
+        if not raw or _encoded_size(len(raw)) > max_encoded_bytes:
+            logger.warning(
+                "audio_routing: %s changed while reading and no longer fits the encoded inline limit",
+                path,
+            )
+            return None
+        return raw
+    except OSError as exc:
+        logger.warning("audio_routing: failed to read %s: %s", path, exc)
+        return None
+
+
+def transcode_audio_to_supported_format(
+    path: Path,
+    target_format: str = "mp3",
+) -> Optional[Tuple[bytes, str]]:
+    """Best-effort ffmpeg conversion for providers limited to MP3/WAV input."""
+    ffmpeg = shutil.which("ffmpeg")
+    target = _canonical_audio_format(target_format)
+    if not ffmpeg or not path.is_file() or target not in {"mp3", "wav"}:
+        return None
+
+    output_path: Optional[Path] = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=f".{target}", delete=False) as output:
+            output_path = Path(output.name)
+        result = subprocess.run(
+            [
+                ffmpeg,
+                "-y",
+                "-i",
+                str(path),
+                "-vn",
+                "-ar",
+                "24000",
+                "-ac",
+                "1",
+                str(output_path),
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=30,
+            check=False,
+        )
+        if result.returncode == 0 and output_path.is_file():
+            raw = output_path.read_bytes()
+            if raw:
+                return raw, target
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.debug("audio_routing: ffmpeg conversion failed for %s: %s", path, exc)
+    finally:
+        if output_path is not None:
+            try:
+                output_path.unlink(missing_ok=True)
+            except OSError:
+                logger.debug("audio_routing: could not remove temporary conversion output %s", output_path)
+    return None
+
+
+def _attachment_hint(path: str, size: int, mime: str) -> str:
+    try:
+        from tools.credential_files import to_agent_visible_cache_path
+
+        visible_path = to_agent_visible_cache_path(path)
+    except Exception:
+        visible_path = path
+    size_text = f"{size / 1024:.1f} KB" if size < 1024 * 1024 else f"{size / (1024 * 1024):.1f} MB"
+    return (
+        f"[Voice message ({size_text}, {mime}) attached natively at: {visible_path}. "
+        "Inspect the native audio directly.]"
+    )
+
+
+def build_native_audio_content_parts(
+    user_text: str,
+    attachments: Iterable[Dict[str, str]],
+    *,
+    target_provider: str = "",
+    max_encoded_bytes: int = MAX_INLINE_AUDIO_BASE64_BYTES,
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """Build OpenAI-style ``input_audio`` parts and report every rejected path."""
+    audio_parts: List[Dict[str, Any]] = []
+    hints: List[str] = []
+    skipped: List[str] = []
+    provider = (target_provider or "").strip().lower()
+
+    for item in attachments:
+        if isinstance(item, (str, Path)):
+            raw_path, declared_mime = str(item), ""
+        elif isinstance(item, dict):
+            raw_path = str(item.get("path") or "")
+            declared_mime = str(item.get("mime_type") or "")
+        else:
+            continue
+        if not raw_path:
+            continue
+
+        path = Path(raw_path)
+        raw = _read_audio_bytes(path, max_encoded_bytes)
+        if raw is None:
+            skipped.append(raw_path)
+            continue
+        audio_format = normalize_audio_format(path, declared_mime, header=raw[:32])
+        if not audio_format:
+            guessed_mime, _ = mimetypes.guess_type(str(path))
+            audio_format = _canonical_audio_format(guessed_mime or "")
+        if not audio_format:
+            logger.warning("audio_routing: unsupported voice container %s", path)
+            skipped.append(raw_path)
+            continue
+
+        if provider in _OPENAI_AUDIO_FORMAT_PROVIDERS and audio_format not in {"mp3", "wav"}:
+            converted = transcode_audio_to_supported_format(path, "mp3")
+            if converted is None:
+                logger.warning(
+                    "audio_routing: %s requires MP3/WAV and %s could not be converted",
+                    provider,
+                    path,
+                )
+                skipped.append(raw_path)
+                continue
+            raw, audio_format = converted
+            if _encoded_size(len(raw)) > max_encoded_bytes:
+                logger.warning("audio_routing: converted voice attachment %s exceeds the encoded limit", path)
+                skipped.append(raw_path)
+                continue
+
+        encoded = base64.b64encode(raw)
+        if len(encoded) > max_encoded_bytes:
+            skipped.append(raw_path)
+            continue
+        mime = AUDIO_FORMAT_TO_MIME[audio_format]
+        audio_parts.append(
+            {
+                "type": "input_audio",
+                "input_audio": {"data": encoded.decode("ascii"), "format": audio_format},
+            }
+        )
+        hints.append(_attachment_hint(raw_path, len(raw), mime))
+
+    text = (user_text or "").strip()
+    if not audio_parts:
+        return ([{"type": "text", "text": text}] if text else []), skipped
+    prompt = text or "Analyze the attached voice message."
+    return [{"type": "text", "text": f"{prompt}\n\n" + "\n".join(hints)}, *audio_parts], skipped
+
+
+__all__ = [
+    "AUDIO_FORMAT_TO_MIME",
+    "MAX_INLINE_AUDIO_BASE64_BYTES",
+    "build_native_audio_content_parts",
+    "decide_audio_input_mode",
+    "normalize_audio_format",
+    "normalize_audio_mime",
+    "supported_input_modalities",
+    "transcode_audio_to_supported_format",
+]

--- a/agent/audio_routing.py
+++ b/agent/audio_routing.py
@@ -36,6 +36,7 @@ AUDIO_FORMAT_TO_MIME: Dict[str, str] = {
 
 _OPENAI_AUDIO_FORMAT_PROVIDERS = {
     "openai",
+    "openai-api",
     "azure",
     "azure-foundry",
     "azure-openai",

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, Iterator, List, Optional
 
 import httpx
 
+from agent.audio_routing import normalize_audio_mime
 from agent.bounded_response import read_streaming_error_body
 from agent.gemini_schema import sanitize_gemini_tool_parameters
 
@@ -173,7 +174,27 @@ def _coerce_content_to_text(content: Any) -> str:
 
 
 def _inline_data_part(item: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    """``inlineData`` part for an ``image_url`` item carrying a ``data:`` URL; None otherwise."""
+    """Translate locally encoded OpenAI image/audio content to Gemini ``inlineData``.
+
+    Remote URLs are deliberately not fetched here: doing so would introduce an
+    SSRF boundary and they are not valid Gemini Files API identifiers.
+    """
+    if item.get("type") == "input_audio":
+        audio = item.get("input_audio") or {}
+        encoded = audio.get("data")
+        if not isinstance(encoded, str) or not encoded.strip():
+            return None
+        try:
+            data = base64.b64encode(base64.b64decode(encoded, validate=True)).decode("ascii")
+        except (ValueError, TypeError):
+            return None
+        return {
+            "inlineData": {
+                "mimeType": normalize_audio_mime(str(audio.get("format") or "")),
+                "data": data,
+            }
+        }
+
     url = (item.get("image_url") or {}).get("url") or ""
     if item.get("type") != "image_url" or not isinstance(url, str) or not url.startswith("data:"):
         return None

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -107,7 +107,7 @@ class ModelCapabilities:
 # Hermes provider names → models.dev provider IDs
 PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "openrouter": "openrouter", "novita": "novita-ai", "anthropic": "anthropic",
-    "openai": "openai", "openai-codex": "openai", "zai": "zai",
+    "openai": "openai", "openai-api": "openai", "openai-codex": "openai", "zai": "zai",
     "kimi": "kimi-for-coding", "kimi-coding": "kimi-for-coding",
     "moonshot": "kimi-for-coding", "stepfun": "stepfun",
     "kimi-coding-cn": "kimi-for-coding", "minimax": "minimax",

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1233,9 +1233,14 @@ agent:
   #     style: "terse"
 
 # =============================================================================
-# Gateway Lifecycle
+# Gateway
 # =============================================================================
 gateway:
+  # Route inbound voice notes. auto uses native audio only when the active model
+  # advertises audio input; native prefers inline audio; stt always transcribes.
+  # Payload-construction failures fall back to STT for only the rejected clips.
+  audio_mode: auto
+
   # Post-interrupt grace for running agents during an unexpected SIGTERM.
   # Adapter, bridge, and database teardown starts after this many seconds even
   # if an agent has not unwound. Keep it below the service-manager stop budget.

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -557,6 +557,7 @@ class GatewayConfig:
     filter_silence_narration: bool = True
     stt_enabled: bool = True  # Auto-transcribe inbound voice messages
     stt_echo_transcripts: bool = True  # Echo raw STT transcripts back to the user
+    audio_mode: str = "auto"  # auto, native, or stt for inbound voice notes
     group_sessions_per_user: bool = True  # Isolate group sessions per participant when user IDs exist
     thread_sessions_per_user: bool = False  # False = threads shared across participants
     max_concurrent_sessions: Optional[int] = None  # Positive int caps simultaneous active sessions
@@ -591,7 +592,7 @@ class GatewayConfig:
     # Scalar fields serialized verbatim by ``to_dict`` (in output order).
     _SCALAR_DICT_FIELDS = (
         "write_sessions_json", "always_log_local", "filter_silence_narration", "stt_enabled",
-        "stt_echo_transcripts", "group_sessions_per_user", "thread_sessions_per_user",
+        "stt_echo_transcripts", "audio_mode", "group_sessions_per_user", "thread_sessions_per_user",
         "max_concurrent_sessions", "multiplex_profiles", "multiplex_profile_allowlist",
         "room_link_url", "systemd_watchdog_seconds", "loop_watchdog",
         "loop_watchdog_probe_interval_s", "loop_watchdog_probe_timeout_s",
@@ -599,6 +600,7 @@ class GatewayConfig:
     )
 
     def __post_init__(self) -> None:
+        self.audio_mode = _normalize_choice(self.audio_mode, {"auto", "native", "stt"}, "auto")
         self.multiplex_profile_allowlist = _normalize_multiplex_profile_allowlist(self.multiplex_profile_allowlist)
         self.systemd_watchdog_seconds = coerce_systemd_watchdog_seconds(self.systemd_watchdog_seconds)
 
@@ -753,6 +755,7 @@ class GatewayConfig:
             **{name: _coerce_bool(data.get(name), default) for name, default in _TOPLEVEL_BOOL_DEFAULTS.items()},
             stt_enabled=_coerce_bool(stt_setting("stt_enabled", "enabled"), True),
             stt_echo_transcripts=_coerce_bool(stt_setting("stt_echo_transcripts", "echo_transcripts"), True),
+            audio_mode=_normalize_choice(pick("audio_mode"), {"auto", "native", "stt"}, "auto"),
             multiplex_profiles=_coerce_bool(multiplex_profiles, False),
             multiplex_profile_allowlist=pick("multiplex_profile_allowlist"),
             room_link_url=room_link_url if isinstance(room_link_url, str) else None,

--- a/gateway/config_loader.py
+++ b/gateway/config_loader.py
@@ -71,7 +71,7 @@ _TOPLEVEL_BRIDGE: tuple = (
     ("session_reset", "default_reset_policy", "presence", lambda v: bool(v) and isinstance(v, dict), None),
     ("quick_commands", "quick_commands", "none", _quick_commands_ok, None),
     ("stt", "stt", "presence", lambda v: isinstance(v, dict), None),
-    *_presence("stt_echo_transcripts", "group_sessions_per_user", "thread_sessions_per_user"),
+    *_presence("stt_echo_transcripts", "audio_mode", "group_sessions_per_user", "thread_sessions_per_user"),
     ("multiplex_profiles", "multiplex_profiles", "gwdata", None, None),
     *_presence("multiplex_profile_allowlist", "room_link_url"),
     ("profile_routes", "profile_routes", "none", lambda v: isinstance(v, list), None),

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -1333,12 +1333,12 @@ class GatewayInboundMixin:
     @staticmethod
     def _classify_inbound_media(
         event: MessageEvent, pending_stt_prepared: bool
-    ) -> Tuple[list, list, list, list]:
-        """Split ``event.media_urls`` into (image, STT-voice, audio-file, video) paths. Per-attachment
+    ) -> Tuple[list, list, list, list, list]:
+        """Split media into image, voice, native-voice metadata, audio-file, and video lists. Per-attachment
         MIME wins over the message-level type (a document sent alongside an image must not be routed
         as an image). MessageType.AUDIO / mixed DOCUMENT audio is a file attachment, never STT."""
         from gateway.run import _event_media_is_audio, _event_media_is_image, _event_media_is_stt_input
-        image_paths, audio_paths, audio_file_paths, video_paths = [], [], [], []
+        image_paths, audio_paths, audio_attachments, audio_file_paths, video_paths = [], [], [], [], []
         for i, path in enumerate(event.media_urls or []):
             mtype = event.media_types[i] if i < len(event.media_types) else ""
             if _event_media_is_image(event, i):
@@ -1348,9 +1348,10 @@ class GatewayInboundMixin:
                     audio_file_paths.append(path)
                 elif not pending_stt_prepared and _event_media_is_stt_input(event, i):
                     audio_paths.append(path)
+                    audio_attachments.append({"path": path, "mime_type": mtype})
             if mtype.startswith("video/") or (not mtype and event.message_type == MessageType.VIDEO):
                 video_paths.append(path)
-        return image_paths, audio_paths, audio_file_paths, video_paths
+        return image_paths, audio_paths, audio_attachments, audio_file_paths, video_paths
 
     async def _enrich_inbound_images(
         self, source: SessionSource, session_key: str, message_text: str, image_paths: list[str]
@@ -1413,6 +1414,45 @@ class GatewayInboundMixin:
                 _echo_meta = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
                 await self._echo_stt_transcripts(_echo_adapter, source, _successful_transcripts, metadata=_echo_meta)
         return message_text
+
+    async def _route_inbound_voice(
+        self, event: MessageEvent, source: SessionSource, session_key: str, message_text: str,
+        audio_paths: list[str], audio_attachments: list[Dict[str, str]],
+    ) -> str:
+        """Stage voice notes for native input, or preserve the established STT path."""
+        mode = await asyncio.to_thread(
+            self._decide_audio_input_mode, source=source, session_key=session_key,
+        )
+        if mode == "native":
+            self._session_state(session_key).persistent.native_audio_attachments = [
+                dict(item) for item in audio_attachments
+            ]
+            logger.info(
+                "Audio routing: native. %d voice attachment(s) will be sent inline.",
+                len(audio_attachments),
+            )
+            return message_text
+        logger.info("Audio routing: STT. Transcribing %d voice attachment(s).", len(audio_paths))
+        return await self._enrich_inbound_voice(event, source, message_text, audio_paths)
+
+    async def _transcribe_native_audio_fallback(
+        self, audio_paths: List[str], *, source: SessionSource,
+        reply_to_message_id: Optional[str] = None,
+    ) -> str:
+        """Transcribe only native voice clips rejected during final payload construction."""
+        fallback_text, transcripts = await self._enrich_message_with_transcription("", audio_paths)
+        if transcripts and self._should_echo_stt_transcripts():
+            adapter = self._adapter_for_source(source)
+            if adapter:
+                metadata = self._thread_metadata_for_source(source, reply_to_message_id)
+                await self._echo_stt_transcripts(
+                    adapter,
+                    source,
+                    transcripts,
+                    metadata=metadata,
+                    log_context="Native audio STT fallback",
+                )
+        return fallback_text
 
     @staticmethod
     def _inbound_attachment_display_name(path: str) -> Tuple[str, str]:
@@ -1605,15 +1645,20 @@ class GatewayInboundMixin:
         # Prefer the caller's resolved session key so this write key matches the consume key at the
         # run_conversation site; derive it here only for tests and legacy standalone callers.
         session_key = session_key or self._session_key_for_source(source)
-        # Reset only this session's per-call buffer; other sessions may be concurrently preparing.
+        # Reset only this session's per-call buffers; other sessions may be concurrently preparing.
         self._consume_pending_native_image_paths(session_key)
+        self._consume_pending_native_audio_attachments(session_key)
 
         message_text = self._prefix_inbound_sender_context(event, source, message_text)
-        image_paths, audio_paths, audio_file_paths, video_paths = self._classify_inbound_media(event, _pending_stt_prepared)
+        image_paths, audio_paths, audio_attachments, audio_file_paths, video_paths = self._classify_inbound_media(
+            event, _pending_stt_prepared,
+        )
         if image_paths:
             message_text = await self._enrich_inbound_images(source, session_key, message_text, image_paths)
         if audio_paths:
-            message_text = await self._enrich_inbound_voice(event, source, message_text, audio_paths)
+            message_text = await self._route_inbound_voice(
+                event, source, session_key, message_text, audio_paths, audio_attachments,
+            )
         message_text = self._prepend_inbound_media_file_notes(message_text, audio_file_paths, video_paths)
         message_text = self._prepend_inbound_document_notes(event, message_text)
         message_text = self._prepend_inbound_reply_context(event, source, message_text)
@@ -1646,6 +1691,14 @@ class GatewayInboundMixin:
         if paths:
             state.persistent.native_image_paths = []
         return paths
+
+    def _consume_pending_native_audio_attachments(self, session_key: str) -> List[Dict[str, str]]:
+        """Consume this session's one-shot native voice attachment buffer."""
+        state = self._peek_session_state(session_key)
+        attachments = list(state.persistent.native_audio_attachments or []) if state is not None else []
+        if attachments:
+            state.persistent.native_audio_attachments = []
+        return [dict(item) for item in attachments]
 
     async def _mark_durable_active_turn(self, event: "MessageEvent", session_key: str) -> bool:
         """Persist the exact resolved routing key for this running turn."""
@@ -1846,6 +1899,65 @@ class GatewayInboundMixin:
         except Exception as exc:
             logger.debug("image_routing: decision failed, falling back to text — %s", exc)
             return "text"
+
+    def _decide_audio_input_mode(
+        self, *, source: Optional[SessionSource] = None, session_key: Optional[str] = None,
+        user_config: Optional[dict] = None, provider: Optional[str] = None,
+        model: Optional[str] = None,
+    ) -> str:
+        """Resolve native/STT routing against the effective model for this session turn."""
+        try:
+            from agent.audio_routing import decide_audio_input_mode
+            from agent.auxiliary_client import _read_main_model, _read_main_provider
+            from gateway.run import _load_gateway_config
+            from hermes_cli.config import load_config
+
+            cfg = user_config if isinstance(user_config, dict) else load_config()
+            raw_cfg = user_config if isinstance(user_config, dict) else _load_gateway_config()
+            raw_gateway = raw_cfg.get("gateway") if isinstance(raw_cfg.get("gateway"), dict) else {}
+            if "audio_mode" in raw_cfg:
+                configured_mode = raw_cfg.get("audio_mode")
+            elif "audio_mode" in raw_gateway:
+                configured_mode = raw_gateway.get("audio_mode")
+            else:
+                configured_mode = getattr(getattr(self, "config", None), "audio_mode", "auto")
+
+            resolved_provider = (provider or "").strip()
+            resolved_model = (model or "").strip()
+            if (not resolved_provider or not resolved_model) and (source is not None or session_key):
+                try:
+                    turn_model, runtime_kwargs = self._resolve_session_agent_runtime(
+                        source=source, session_key=session_key, user_config=cfg,
+                    )
+                    runtime = runtime_kwargs if isinstance(runtime_kwargs, dict) else {}
+                    if not resolved_model and isinstance(turn_model, str):
+                        resolved_model = turn_model.strip()
+                    if not resolved_provider and isinstance(runtime.get("provider"), str):
+                        resolved_provider = runtime["provider"].strip()
+                except Exception as exc:
+                    logger.debug(
+                        "audio_routing: session runtime resolution failed, falling back to process runtime — %s",
+                        exc,
+                    )
+
+            resolved_provider = resolved_provider or _read_main_provider()
+            resolved_model = resolved_model or _read_main_model()
+            mode = decide_audio_input_mode(
+                resolved_provider,
+                resolved_model,
+                str(configured_mode or "auto"),
+            )
+            logger.info(
+                "Audio routing decision: mode=%s provider=%s model=%s configured=%s",
+                mode,
+                resolved_provider or "unknown",
+                resolved_model or "unknown",
+                configured_mode or "auto",
+            )
+            return mode
+        except Exception as exc:
+            logger.debug("audio_routing: decision failed, falling back to STT — %s", exc)
+            return "stt"
 
     async def _enrich_message_with_vision(self, user_text: str, image_paths: List[str]) -> str:
         """Auto-analyze user-attached images with the vision tool and prepend the descriptions.

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1389,17 +1389,95 @@ class TurnRunner:
             ctx.message = build_resume_recovery_note(resume_reason, "", interactive=self._resume_note_interactive())
         return persist_override, ctx.persist_user_timestamp
 
-    def _native_image_run_message(self):
+    @staticmethod
+    def _prepend_message_text(message: Any, prefix: str) -> Any:
+        """Prepend text without discarding native multimodal content parts."""
+        prefix = str(prefix or "").strip()
+        if not prefix:
+            return message
+        if isinstance(message, list):
+            updated = list(message)
+            for index, part in enumerate(updated):
+                if not isinstance(part, dict) or part.get("type") != "text":
+                    continue
+                current = part.get("text") if isinstance(part.get("text"), str) else ""
+                updated[index] = {**part, "text": f"{prefix}\n\n{current}" if current else prefix}
+                return updated
+            return [{"type": "text", "text": prefix}, *updated]
+        if isinstance(message, str) and message:
+            return f"{prefix}\n\n{message}"
+        return prefix
+
+    @staticmethod
+    def _message_text(message: Any) -> str:
+        if isinstance(message, str):
+            return message
+        if isinstance(message, list):
+            return "\n".join(
+                part["text"] for part in message
+                if isinstance(part, dict) and part.get("type") == "text" and isinstance(part.get("text"), str)
+            )
+        return ""
+
+    @staticmethod
+    def _native_audio_fallback_note(audio_paths: List[str]) -> str:
+        """Return a non-empty last-resort note when the STT bridge is unavailable."""
+        def visible_path(path: str) -> str:
+            try:
+                from tools.credential_files import to_agent_visible_cache_path
+
+                return to_agent_visible_cache_path(path)
+            except Exception:
+                return path
+
+        notes, seen = [], set()
+        for path in audio_paths:
+            raw_path = str(path or "")
+            if not raw_path or raw_path in seen:
+                continue
+            seen.add(raw_path)
+            notes.append(
+                "[voice message could not be transcribed automatically; "
+                f"the audio is available at: {visible_path(raw_path)}]"
+            )
+        return "\n\n".join(notes) or (
+            "[voice message could not be processed natively or transcribed automatically]"
+        )
+
+    def _transcribe_native_audio_fallback_sync(self, audio_paths: List[str]) -> str:
+        """Bridge rejected native audio back to the gateway's async STT path."""
+        if not audio_paths:
+            return self._native_audio_fallback_note([])
+        ctx = self._ctx
+        future = self._schedule(
+            self._runner._transcribe_native_audio_fallback(
+                audio_paths,
+                source=ctx.source,
+                reply_to_message_id=ctx.event_message_id,
+            ),
+            "Native audio STT fallback scheduling error",
+        )
+        if future is not None:
+            try:
+                fallback_text = future.result()
+                if isinstance(fallback_text, str) and fallback_text.strip():
+                    return fallback_text.strip()
+            except Exception as exc:
+                logger.warning("Native audio STT fallback failed: %s", exc)
+        return self._native_audio_fallback_note(audio_paths)
+
+    def _native_image_run_message(self, native_imgs: Optional[List[str]] = None):
         """Wrap the user turn as an OpenAI-style multimodal content list when
         _prepare_inbound_message_text buffered image paths; consume-and-clear so later turns on the
         same runner never re-attach stale images. Falls back to plain text when nothing is readable."""
         ctx = self._ctx
-        native_imgs = self._runner._consume_pending_native_image_paths(ctx.session_key)
+        if native_imgs is None:
+            native_imgs = self._runner._consume_pending_native_image_paths(ctx.session_key or "")
         if not native_imgs:
             return ctx.message
         try:
             from agent.image_routing import build_native_content_parts
-            parts, skipped = build_native_content_parts(ctx.message, native_imgs)
+            parts, skipped = build_native_content_parts(ctx.message or "", native_imgs)
             if skipped:
                 logger.warning("Native image attachment: skipped %d unreadable path(s): %s", len(skipped), skipped)
             if any(p.get("type") == "image_url" for p in parts):
@@ -1407,6 +1485,72 @@ class TurnRunner:
         except Exception as exc:
             logger.warning("Native image attachment failed, falling back to text: %s", exc)
         return ctx.message
+
+    def _native_media_run_message(self, agent, persist_user_message_override):
+        """Build one mixed image/audio turn, preserving clean text-only persistence."""
+        ctx = self._ctx
+        session_key = ctx.session_key or ""
+        native_imgs = self._runner._consume_pending_native_image_paths(session_key)
+        native_audio = self._runner._consume_pending_native_audio_attachments(session_key)
+        run_message = self._native_image_run_message(native_imgs) if native_imgs else ctx.message
+        if not native_audio:
+            return run_message, persist_user_message_override
+
+        audio_paths = [
+            str(item.get("path") or "") if isinstance(item, dict) else str(item or "")
+            for item in native_audio
+        ]
+        audio_paths = [path for path in audio_paths if path]
+        failed_audio_paths: List[str] = []
+        native_audio_count = 0
+        try:
+            from agent.audio_routing import build_native_audio_content_parts
+
+            existing_media = (
+                [part for part in run_message if isinstance(part, dict) and part.get("type") != "text"]
+                if isinstance(run_message, list) else []
+            )
+            audio_parts, skipped = build_native_audio_content_parts(
+                self._message_text(run_message),
+                native_audio,
+                target_provider=(
+                    getattr(agent, "provider", "")
+                    or getattr(agent, "requested_provider", "")
+                    or ""
+                ),
+            )
+            if skipped:
+                logger.warning(
+                    "Native audio attachment: skipped %d path(s): %s",
+                    len(skipped),
+                    skipped,
+                )
+            skipped_paths = {str(path) for path in skipped}
+            failed_audio_paths = [path for path in audio_paths if path in skipped_paths]
+            native_audio_parts = [part for part in audio_parts if part.get("type") == "input_audio"]
+            native_audio_count = len(native_audio_parts)
+            if native_audio_parts:
+                text_parts = [part for part in audio_parts if part.get("type") == "text"]
+                run_message = [*text_parts, *existing_media, *native_audio_parts]
+            elif not failed_audio_paths:
+                # A builder must either attach or explicitly reject each staged clip.
+                failed_audio_paths = list(audio_paths)
+        except Exception as exc:
+            logger.warning("Native audio attachment failed, falling back to STT: %s", exc)
+            failed_audio_paths = list(audio_paths)
+
+        fallback_text = ""
+        if failed_audio_paths:
+            fallback_text = self._transcribe_native_audio_fallback_sync(failed_audio_paths)
+            run_message = self._prepend_message_text(run_message, fallback_text)
+
+        # The request carries Base64, but session history only keeps text plus a compact marker.
+        persist_base = persist_user_message_override if persist_user_message_override is not None else ctx.message
+        if native_audio_count:
+            persist_base = self._prepend_message_text(persist_base, "[Voice message attached natively]")
+        if fallback_text:
+            persist_base = self._prepend_message_text(persist_base, fallback_text)
+        return run_message, persist_base
 
     def _run_conversation_with_approval(self, agent, agent_history, observed_group_context,
                                         persist_user_message_override, persist_user_timestamp_override):
@@ -1420,7 +1564,10 @@ class TurnRunner:
         token = set_current_session_key(session_key)
         register_gateway_notify(session_key, self._approval_notify_sync)
         try:
-            api_message = _wrap_current_message_with_observed_context(self._native_image_run_message(), observed_group_context)
+            run_message, persist_user_message_override = self._native_media_run_message(
+                agent, persist_user_message_override,
+            )
+            api_message = _wrap_current_message_with_observed_context(run_message, observed_group_context)
             kwargs = {"conversation_history": agent_history, "task_id": ctx.session_id}
             if persist_user_message_override is not None:
                 kwargs["persist_user_message"] = persist_user_message_override

--- a/gateway/session_state.py
+++ b/gateway/session_state.py
@@ -61,6 +61,8 @@ class PersistentState:
     approvals: Optional[Dict[str, Any]] = None  # {"command": ..., "pattern_key": ...}
     update_prompt_pending: bool = False  # /update prompt awaiting a reply
     native_image_paths: List[str] = field(default_factory=list)  # consumed one-shot
+    # Voice-note attachments staged for native input; consumed one-shot before the model call.
+    native_audio_attachments: List[Dict[str, str]] = field(default_factory=list)
     # Legacy runner-level pending text (flushed on shutdown); not the adapter-level one.
     pending_command_text: Optional[str] = None
     run_generation: int = 0  # monotonic; NEVER reset (stale-run detection depends on it)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1085,7 +1085,7 @@ _EXTRA_KNOWN_ROOT_KEYS = {
     "tool_gateway_declined_tools",  # per-tool Tool Gateway offer declines
     # Top-level forms read/bridged by gateway/config.py:
     "session_reset", "group_sessions_per_user", "thread_sessions_per_user",
-    "stt_echo_transcripts", "reset_triggers", "always_log_local", "filter_silence_narration",
+    "stt_echo_transcripts", "audio_mode", "reset_triggers", "always_log_local", "filter_silence_narration",
     "multiplex_profiles", "profile_routes", "platforms", "require_mention",
     "unauthorized_dm_behavior", "signal",
     "timeouts",          # unified timeout resolution section (agent/deadline.py)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1860,6 +1860,9 @@ DEFAULT_CONFIG = {
         "export": {"otlp": {"enabled": False, "endpoint": "", "headers_env": {}}},
     },
     "gateway": {  # Gateway settings (messaging platforms: Telegram, Discord, Slack, ...).
+        # Inbound voice notes: auto uses native audio only when the active model advertises it;
+        # native prefers inline audio; stt always transcribes before the model turn.
+        "audio_mode": "auto",
         # Named-profile allowlist for multiplex mode. None = serve all; [] = default only.
         "multiplex_profile_allowlist": None,
         # Seconds to let a SIGTERM-interrupted gateway agent unwind before adapter/database

--- a/tests/agent/test_audio_routing.py
+++ b/tests/agent/test_audio_routing.py
@@ -1,0 +1,52 @@
+"""Invariants for conservative native voice-note payload construction."""
+
+import base64
+
+
+def test_builder_sniffs_audio_and_enforces_the_encoded_ceiling(tmp_path):
+    from agent.audio_routing import build_native_audio_content_parts
+
+    voice = tmp_path / "voice.bin"
+    raw = b"OggS" + b"voice-bytes"
+    voice.write_bytes(raw)
+    attachment = {"path": str(voice), "mime_type": "audio/wav"}
+
+    parts, skipped = build_native_audio_content_parts("listen", [attachment])
+
+    assert skipped == []
+    audio = next(part["input_audio"] for part in parts if part["type"] == "input_audio")
+    assert audio["format"] == "ogg"
+    assert base64.b64decode(audio["data"]) == raw
+    assert "audio/ogg" in parts[0]["text"]
+
+    limited_parts, skipped = build_native_audio_content_parts(
+        "listen", [attachment], max_encoded_bytes=4,
+    )
+    assert limited_parts == [{"type": "text", "text": "listen"}]
+    assert skipped == [str(voice)]
+
+
+def test_routing_is_capability_driven_but_endpoint_denials_are_hard(monkeypatch):
+    import agent.audio_routing as audio_routing
+
+    assert audio_routing.normalize_audio_mime("m4a") == "audio/m4a"
+    monkeypatch.setattr(audio_routing, "supported_input_modalities", lambda *_: {"text", "audio"})
+    assert audio_routing.decide_audio_input_mode("openrouter", "google/gemini", "auto") == "native"
+    assert audio_routing.decide_audio_input_mode("openrouter", "unknown", "stt") == "stt"
+    assert audio_routing.decide_audio_input_mode("meta", "llama-audio", "native") == "stt"
+    assert audio_routing.decide_audio_input_mode("openrouter", "vendor/muse-spark", "native") == "stt"
+
+
+def test_openai_incompatible_container_is_rejected_when_conversion_fails(monkeypatch, tmp_path):
+    import agent.audio_routing as audio_routing
+
+    voice = tmp_path / "voice.ogg"
+    voice.write_bytes(b"OggSvoice-bytes")
+    monkeypatch.setattr(audio_routing, "transcode_audio_to_supported_format", lambda *_args: None)
+
+    parts, skipped = audio_routing.build_native_audio_content_parts(
+        "listen", [{"path": str(voice), "mime_type": "audio/ogg"}], target_provider="openai",
+    )
+
+    assert parts == [{"type": "text", "text": "listen"}]
+    assert skipped == [str(voice)]

--- a/tests/agent/test_audio_routing.py
+++ b/tests/agent/test_audio_routing.py
@@ -37,16 +37,17 @@ def test_routing_is_capability_driven_but_endpoint_denials_are_hard(monkeypatch)
     assert audio_routing.decide_audio_input_mode("openrouter", "vendor/muse-spark", "native") == "stt"
 
 
-def test_openai_incompatible_container_is_rejected_when_conversion_fails(monkeypatch, tmp_path):
+def test_direct_openai_aliases_reject_incompatible_container_when_conversion_fails(monkeypatch, tmp_path):
     import agent.audio_routing as audio_routing
 
     voice = tmp_path / "voice.ogg"
     voice.write_bytes(b"OggSvoice-bytes")
     monkeypatch.setattr(audio_routing, "transcode_audio_to_supported_format", lambda *_args: None)
 
-    parts, skipped = audio_routing.build_native_audio_content_parts(
-        "listen", [{"path": str(voice), "mime_type": "audio/ogg"}], target_provider="openai",
-    )
+    for provider in ("openai", "openai-api", "azure-foundry"):
+        parts, skipped = audio_routing.build_native_audio_content_parts(
+            "listen", [{"path": str(voice), "mime_type": "audio/ogg"}], target_provider=provider,
+        )
 
-    assert parts == [{"type": "text", "text": "listen"}]
-    assert skipped == [str(voice)]
+        assert parts == [{"type": "text", "text": "listen"}]
+        assert skipped == [str(voice)]

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 from types import SimpleNamespace
 
@@ -17,6 +18,21 @@ class DummyResponse:
 
     def json(self):
         return self._payload
+
+
+def test_input_audio_becomes_validated_gemini_inline_data():
+    from agent.gemini_native_adapter import _extract_multimodal_parts
+
+    encoded = base64.b64encode(b"OggSvoice").decode("ascii")
+    parts = _extract_multimodal_parts([
+        {"type": "text", "text": "listen"},
+        {"type": "input_audio", "input_audio": {"data": encoded, "format": "ogg"}},
+    ])
+
+    assert parts == [
+        {"text": "listen"},
+        {"inlineData": {"mimeType": "audio/ogg", "data": encoded}},
+    ]
 
 
 

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -103,6 +103,7 @@ class TestProviderMapping:
     def test_known_providers_mapped(self):
         assert PROVIDER_TO_MODELS_DEV["anthropic"] == "anthropic"
         assert PROVIDER_TO_MODELS_DEV["copilot"] == "github-copilot"
+        assert PROVIDER_TO_MODELS_DEV["openai-api"] == "openai"
         assert PROVIDER_TO_MODELS_DEV["stepfun"] == "stepfun"
         assert PROVIDER_TO_MODELS_DEV["kilocode"] == "kilo"
         assert PROVIDER_TO_MODELS_DEV["ai-gateway"] == "vercel"

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -209,6 +209,12 @@ class TestStreamingConfig:
 
 class TestGatewayConfigRoundtrip:
 
+    def test_audio_mode_accepts_nested_and_legacy_forms_with_safe_normalization(self):
+        assert GatewayConfig.from_dict({"gateway": {"audio_mode": "native"}}).audio_mode == "native"
+        assert GatewayConfig.from_dict({"audio_mode": "stt", "gateway": {"audio_mode": "native"}}).audio_mode == "stt"
+        assert GatewayConfig.from_dict({"gateway": {"audio_mode": "invalid"}}).audio_mode == "auto"
+        assert GatewayConfig(audio_mode="NATIVE").to_dict()["audio_mode"] == "native"
+
     def test_systemd_watchdog_from_dict_disables_invalid_values(self):
         invalid_values = [
             None,
@@ -489,6 +495,17 @@ class TestLoadGatewayConfig:
         config = load_gateway_config()
 
         assert config.stt_enabled is False
+
+    def test_audio_mode_from_nested_gateway_section(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "gateway:\n  audio_mode: native\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        assert load_gateway_config().audio_mode == "native"
 
 
     @staticmethod

--- a/tests/gateway/test_native_audio_routing.py
+++ b/tests/gateway/test_native_audio_routing.py
@@ -1,0 +1,164 @@
+"""Gateway invariants for session-aware native voice-note routing."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.run_turn_runner import TurnRunner
+from gateway.session import SessionSource, build_session_key
+from gateway.turn_context import TurnContext
+
+
+def _source() -> SessionSource:
+    return SessionSource(platform=Platform.TELEGRAM, chat_id="audio-chat", chat_type="dm")
+
+
+def _bare_gateway() -> GatewayRunner:
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner.adapters = {}
+    runner._model = "google/gemini-test"
+    runner._base_url = None
+    return runner
+
+
+def test_gateway_decision_honors_config_precedence_and_endpoint_denial(monkeypatch):
+    import agent.audio_routing as audio_routing
+
+    runner = _bare_gateway()
+    monkeypatch.setattr(audio_routing, "supported_input_modalities", lambda *_: set())
+
+    assert runner._decide_audio_input_mode(
+        provider="openrouter",
+        model="unknown",
+        user_config={"gateway": {"audio_mode": "native"}},
+    ) == "native"
+    assert runner._decide_audio_input_mode(
+        provider="openrouter",
+        model="unknown",
+        user_config={"audio_mode": "stt", "gateway": {"audio_mode": "native"}},
+    ) == "stt"
+    assert runner._decide_audio_input_mode(
+        provider="meta",
+        model="audio-model",
+        user_config={"gateway": {"audio_mode": "native"}},
+    ) == "stt"
+
+
+@pytest.mark.asyncio
+async def test_voice_note_is_staged_once_without_invoking_stt(tmp_path):
+    runner = _bare_gateway()
+    runner._decide_audio_input_mode = lambda **_: "native"
+    runner._enrich_message_with_transcription = lambda *_args: (_ for _ in ()).throw(
+        AssertionError("native voice routing must not invoke STT")
+    )
+    source = _source()
+    voice = tmp_path / "voice.ogg"
+    voice.write_bytes(b"OggSvoice-bytes")
+    event = MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=source,
+        media_urls=[str(voice)],
+        media_types=["audio/ogg"],
+    )
+
+    prepared = await runner._prepare_inbound_message_text(event=event, source=source, history=[])
+
+    session_key = build_session_key(source)
+    assert prepared == ""
+    assert runner._consume_pending_native_audio_attachments(session_key) == [
+        {"path": str(voice), "mime_type": "audio/ogg"}
+    ]
+    assert runner._consume_pending_native_audio_attachments(session_key) == []
+
+
+@pytest.mark.asyncio
+async def test_construction_fallback_reuses_stt_and_echoes_each_transcript_once():
+    runner = _bare_gateway()
+    adapter = SimpleNamespace(send=AsyncMock())
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._enrich_message_with_transcription = AsyncMock(
+        return_value=("[transcripts]", ["one", "two"]),
+    )
+    runner._thread_metadata_for_source = lambda *_args: {"thread_id": "topic"}
+
+    fallback = await runner._transcribe_native_audio_fallback(
+        ["one.ogg", "two.ogg"],
+        source=_source(),
+        reply_to_message_id="reply",
+    )
+
+    assert fallback == "[transcripts]"
+    runner._enrich_message_with_transcription.assert_awaited_once_with(
+        "", ["one.ogg", "two.ogg"],
+    )
+    assert adapter.send.await_count == 2
+
+
+def test_mixed_media_keeps_valid_parts_and_persists_no_audio_base64(tmp_path):
+    image = tmp_path / "photo.png"
+    image.write_bytes(b"\x89PNG\r\n\x1a\n" + b"pixels")
+    voice = tmp_path / "voice.mp3"
+    raw_audio = b"ID3native-voice"
+    voice.write_bytes(raw_audio)
+    missing = tmp_path / "missing.ogg"
+
+    class BufferRunner:
+        def __init__(self):
+            self.images = [str(image)]
+            self.audio = [
+                {"path": str(voice), "mime_type": "audio/mpeg"},
+                {"path": str(missing), "mime_type": "audio/ogg"},
+            ]
+
+        def _consume_pending_native_image_paths(self, _session_key):
+            paths, self.images = self.images, []
+            return paths
+
+        def _consume_pending_native_audio_attachments(self, _session_key):
+            attachments, self.audio = self.audio, []
+            return attachments
+
+        async def _transcribe_native_audio_fallback(self, *_args, **_kwargs):
+            raise AssertionError("the sync bridge is replaced in this test")
+
+    runner = BufferRunner()
+    ctx = TurnContext(message="look and listen", session_key="session", source=_source())
+    turn = TurnRunner(runner, ctx)
+    fallback_calls = []
+    turn._transcribe_native_audio_fallback_sync = lambda paths: (
+        fallback_calls.append(list(paths)) or "[transcript: recovered clip]"
+    )
+
+    captured = {}
+
+    class Agent:
+        provider = "openai"
+        requested_provider = "openai"
+
+        def run_conversation(self, message, **kwargs):
+            captured.update(message=message, kwargs=kwargs)
+            return {"final_response": "done"}
+
+    result = turn._run_conversation_with_approval(Agent(), [], None, None, None)
+
+    assert result == {"final_response": "done"}
+    message = captured["message"]
+    assert {part.get("type") for part in message} >= {"text", "image_url", "input_audio"}
+    assert fallback_calls == [[str(missing)]]
+    persisted = captured["kwargs"]["persist_user_message"]
+    assert persisted == (
+        "[transcript: recovered clip]\n\n[Voice message attached natively]\n\nlook and listen"
+    )
+    base64_payload = next(
+        part["input_audio"]["data"] for part in message if part.get("type") == "input_audio"
+    )
+    assert base64_payload
+    assert base64_payload not in persisted
+    assert runner.images == []
+    assert runner.audio == []

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2147,6 +2147,32 @@ Direct OpenAI API requests and custom proxy endpoints are unchanged.
 
 ## Speech-to-Text (STT)
 
+Gateway voice notes can be sent directly to models that declare native audio
+input, preserving information such as tone and prosody. This policy is separate
+from the STT provider configuration:
+
+```yaml
+gateway:
+  audio_mode: auto             # auto (default) | native | stt
+```
+
+- `auto` uses native audio only when the active session model advertises audio input; unknown capability data falls back to STT.
+- `native` prefers inline audio even without catalog metadata.
+- `stt` always transcribes voice notes before the model turn.
+
+The policy applies to voice notes, not regular audio-file attachments. Meta and
+Muse Spark routes remain on STT because those endpoints reject this native
+payload shape. Each inline clip is limited to 25 MiB after Base64 encoding.
+Direct OpenAI and Azure routes accept MP3/WAV; Hermes uses `ffmpeg` to convert
+other recognized voice containers and falls back to STT when conversion is not
+available.
+
+Unreadable, oversized, or unconvertible clips fall back through the configured
+STT path during request construction. Other valid audio and image attachments
+in the same turn remain native. A provider rejection after the request is sent
+is handled by the normal model error path and is not automatically replayed
+through STT.
+
 ```yaml
 stt:
   enabled: true                # Auto-transcribe inbound voice messages (default: true)


### PR DESCRIPTION
## What does this PR do?

Routes inbound gateway voice notes directly to models that support native audio while preserving the existing STT path as the conservative fallback. This is a clean rebuild of #100764 on the current decomposed gateway architecture.

The implementation resolves the effective per-session provider/model (including model switches), keeps regular audio files as file attachments, and never persists inline Base64 payloads in session history.

## Related Issue

Fixes #90206
Supersedes #100764

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Security fix
- [x] Documentation update
- [x] Tests
- [ ] Refactor
- [ ] New skill

## Changes Made

- Added gateway.audio_mode with auto, native, and stt policies, including legacy top-level config compatibility.
- Added bounded native audio payload construction using shared magic-byte container detection and the existing local-file read guard.
- Enforced a 25 MiB per-clip ceiling on the Base64-encoded payload.
- Added OpenAI-style input_audio payloads and Gemini inlineData translation without fetching remote URLs.
- Kept Meta and Muse Spark routes on STT because those endpoints reject this payload shape.
- Mapped the official openai-api provider to the OpenAI capability catalog and added MP3 conversion for direct OpenAI/Azure routes when a recognized voice container is not already MP3/WAV.
- Preserved valid image/audio parts when another clip fails construction; only rejected clips fall back through the existing STT and transcript-echo path.
- Kept provider-response failures on the normal model error path rather than replaying the user input through STT.
- Added focused routing, payload, mixed-media, config, and Gemini adapter tests and updated user configuration docs.

## How to Test

1. Run the focused canonical suite:
   scripts/run_tests.sh tests/agent/test_audio_routing.py tests/agent/test_gemini_native_adapter.py tests/agent/test_models_dev.py tests/gateway/test_native_audio_routing.py tests/gateway/test_config.py tests/gateway/test_mixed_attachment_routing.py tests/gateway/test_native_image_buffer_isolation.py tests/gateway/test_queued_native_image_session_key.py tests/gateway/test_stt_config.py tests/gateway/test_stt_transcript_echo_config.py tests/gateway/test_api_server_multimodal.py tests/gateway/test_api_server_media_data_urls.py tests/gateway/test_media_extraction.py tests/hermes_cli/test_config_validation.py -q
2. Run Ruff, ty on agent/audio_routing.py, and scripts/check-windows-footguns.py on the changed Python files.
3. Configure gateway.audio_mode as auto, native, or stt and send a voice note through a configured gateway.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing PRs and issues
- [x] This PR contains only related changes
- [ ] I ran the entire repository test suite (the 222-test focused canonical suite passed)
- [x] I added tests for these changes
- [x] I tested on Windows 11

### Documentation & Housekeeping

- [x] Updated the relevant user documentation
- [x] Updated cli-config.yaml.example
- [x] CONTRIBUTING.md / AGENTS.md changes are N/A
- [x] Considered cross-platform behavior and ran the Windows footgun checker
- [x] Tool description/schema changes are N/A

## Screenshots / Logs

Focused canonical suite: 222 passed, 0 failed across 14 files.

Additional checks passed: Ruff, Python bytecode compilation, ty for the new audio module, YAML/default parsing, git diff --check, and the Windows footgun checker. A local ffmpeg smoke test converted an OGG voice clip to the direct-OpenAI MP3 payload path.

No live model/provider request or paid API call was made.