### PR TITLE
fix(cli): interrupting a clarify prompt cancels neutrally instead of telling the model to proceed

### DIFF
--- a/hermes_cli/cli_modal_mixin.py
+++ b/hermes_cli/cli_modal_mixin.py
@@ -894,7 +894,9 @@ class CLIModalMixin:
             _put(self._approval_state, "deny")
             self._approval_state = None
         if self._clarify_state:
-            _put(self._clarify_state, "The user cancelled. Use your best judgement to proceed.")
+            # Neutral cancel — same as sudo/secret overlays and the TUI's clarify interrupt.
+            # An interrupt must not read as "use your best judgement and proceed" (#103009).
+            _put(self._clarify_state, "")
             self._clarify_state = None
             self._clarify_freetext = False
             self._clarify_multi_base = None

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -550,7 +550,7 @@ class TestClearOverlaysForInterrupt:
 
         # Each blocked thread would have received a terminal value.
         assert approval_q.get_nowait() == "deny"
-        assert clarify_q.get_nowait()  # cancellation sentinel string
+        assert clarify_q.get_nowait() == ""  # neutral cancel, same as sudo/secret
         assert sudo_q.get_nowait() == ""
         assert secret_q.get_nowait() == ""
 
@@ -572,7 +572,25 @@ class TestClearOverlaysForInterrupt:
 
         assert cli._approval_state is None  # cleared despite dead queue
         assert cli._clarify_state is None
-        assert clarify_q.get_nowait()
+        assert clarify_q.get_nowait() == ""
+
+    def test_interrupt_cancels_clarify_neutrally(self):
+        """#103009 — interrupting a pending clarify must put the neutral cancel
+        value (""), matching the sudo/secret overlays and the TUI's clarify
+        interrupt. It must NOT push an instruction like "use your best
+        judgement to proceed", which turns a Ctrl+C into an implicit go-ahead."""
+        cli = self._make_cli()
+        clarify_q = queue.Queue()
+        cli._clarify_state = {"response_queue": clarify_q}
+
+        cli._clear_active_overlays_for_interrupt()
+
+        value = clarify_q.get_nowait()
+        assert value == ""
+        # Guard against the fail-open prose sneaking back in any spelling.
+        lowered = value.lower()
+        assert "judgement" not in lowered and "judgment" not in lowered
+        assert "proceed" not in lowered
 
     def test_interrupt_unblocks_thread_blocked_on_approval(self):
         """End-to-end: a worker blocked on the approval queue unblocks when the


### PR DESCRIPTION
## What does this PR do?

Cancelling a `clarify` prompt with Ctrl+C (or `/stop`) in the CLI pushed `"The user cancelled. Use your best judgement to proceed."` onto the response queue, so the `clarify` tool returned instruction prose to the agent — an implicit go-ahead. The same keystroke on an approval prompt denies it, so one cancel gesture produced opposite outcomes six lines apart in the same function. Since `clarify` is the tool an agent reaches for before consequential actions ("shall I change this globally / delete this?"), a cancellation that reads as "you decide, and proceed" is the wrong failure direction.

This PR makes the CLI's clarify interrupt put the neutral empty string, which is already the established cancel value everywhere else:

- the sudo and secret overlays in the same `_clear_active_overlays_for_interrupt` helper both push `""`;
- the TUI returns `""` for an interrupted clarify (`tui_gateway/server.py`);
- the gateway returns `""` when no adapter is attached;
- the helper's own docstring says "Push a safe value onto each queue (approval -> 'deny', others -> cancel)".

The CLI clarify overlay was the lone fail-open outlier. An interrupted clarify now reads as cancelled, not as the user delegating the decision.

Scope note: the issue also raises the clarify *timeout* reply wording and the oneshot `chat -q` path. Those are separate surfaces with distinct semantics (a timeout genuinely has no user gesture, and oneshot cannot block on a user); this PR only fixes the interrupt/cancel path where the user explicitly cancelled.

## Related Issue

Fixes #103009

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/cli_modal_mixin.py` — `_clear_active_overlays_for_interrupt` now puts `""` on the clarify response queue instead of "The user cancelled. Use your best judgement to proceed.", matching the sudo/secret overlays in the same helper.
- `tests/cli/test_cli_approval_ui.py` — tightened the two existing interrupt assertions from truthy to `== ""`, and added `test_interrupt_cancels_clarify_neutrally`, which asserts the neutral value and guards against any fail-open "judgement"/"proceed" prose returning in any spelling.

## How to Test

1. `.venv/bin/python -m pytest tests/cli/test_cli_approval_ui.py -q` — 17 passed, including the new regression test.
2. `.venv/bin/python -m pytest tests/tools/test_clarify_tool.py -q` — 47 passed (consumer side of the clarify response is unaffected by the empty-string cancel).
3. `grep -rn "user cancelled. Use your best judgement" --include='*.py' .` — zero remaining references; no other test asserted the old prose.

Observed result: the interrupted clarify queue receives `""` (neutral cancel), identical to the sudo/secret overlays, and no path instructs the model to proceed on the user's behalf.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted: `tests/cli/test_cli_approval_ui.py` 17 passed, `tests/tools/test_clarify_tool.py` 47 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-ability) — N/A (queue value only, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
