### PR TITLE
fix(serve): serve the live session token so SSH remote adoption works

### DIFF
--- a/hermes_cli/web_server_dashboard.py
+++ b/hermes_cli/web_server_dashboard.py
@@ -102,7 +102,12 @@ def mount_spa(application: FastAPI):
     with a missing dist per-request (404 JSON / ``check_dir=False``), so a long-lived
     ``--skip-build`` process recovers the moment a build appears on disk — no restart.
     """
-    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, _SESSION_TOKEN, app
+    # Read the session token through the module, never as an import-time value: the SSH
+    # remote path (`hermes serve --ssh-session-token-file`) overrides the token via
+    # ``_apply_ssh_session_token`` after this module was imported, and a closure over the
+    # old value would hand the renderer a credential the auth middleware rejects (#103001).
+    from hermes_cli import web_server
+    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, app
 
     # `hermes serve` is the headless backend: it must NEVER serve the browser SPA, even if a
     # dist is lying around, so only the JSON-RPC/WS/API surface is reachable.
@@ -120,7 +125,7 @@ def mount_spa(application: FastAPI):
             if full_path == "" and not gated:
                 return HTMLResponse(
                     "<!doctype html><html><head><script>"
-                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(_SESSION_TOKEN)};"
+                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(web_server._SESSION_TOKEN)};"
                     "window.__HERMES_AUTH_REQUIRED__=false;"
                     f"</script></head><body>{_HEADLESS_MSG}</body></html>",
                     headers=_NO_STORE,
@@ -151,7 +156,11 @@ def mount_spa(application: FastAPI):
             return JSONResponse({"error": "Frontend not built. Run: cd web && npm run build"}, status_code=404)
         chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
         gated = bool(getattr(app.state, "auth_required", False))
-        token_js = "" if gated else f'window.__HERMES_SESSION_TOKEN__="{_SESSION_TOKEN}";'
+        token_js = (
+            ""
+            if gated
+            else f'window.__HERMES_SESSION_TOKEN__="{web_server._SESSION_TOKEN}";'
+        )
         bootstrap_script = (
             f"<script>{token_js}"
             f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5375,3 +5375,87 @@ def test_mount_spa_dynamic_web_dist_recheck(tmp_path, monkeypatch):
     res2 = client.get("/")
     assert res2.status_code == 200
     assert "Test" in res2.text
+
+
+# ---------------------------------------------------------------------------
+# SSH remote token adoption (#103001): the SPA handlers must serve the LIVE
+# module token, not the import-time closure copy.
+# ---------------------------------------------------------------------------
+
+
+class TestHeadlessServeTokenFollowsSshAdoption:
+    """``hermes serve --ssh-session-token-file`` adopts the file token via
+    ``_apply_ssh_session_token`` AFTER ``web_server_dashboard`` was imported.
+    The handshake page and the SPA index must reflect the adopted value, or the
+    renderer authenticates with a credential the auth middleware rejects and
+    every /api call 401s."""
+
+    @staticmethod
+    def _headless_client(monkeypatch, *, gated: bool):
+        from fastapi import FastAPI
+        from starlette.testclient import TestClient
+
+        monkeypatch.setenv("HERMES_SERVE_HEADLESS", "1")
+        spa_app = FastAPI()
+        spa_app.state.auth_required = gated
+        _web_server_dashboard.mount_spa(spa_app)
+        return TestClient(spa_app)
+
+    def test_handshake_page_serves_adopted_ssh_token(self, monkeypatch):
+        import re
+        import hermes_cli.web_server as ws
+
+        adopted = "a" * 64
+        before = ws._SESSION_TOKEN
+        assert adopted != before
+        client = self._headless_client(monkeypatch, gated=False)
+        try:
+            ws._apply_ssh_session_token(adopted)
+            resp = client.get("/")
+            assert resp.status_code == 200
+            match = re.search(
+                r'window\.__HERMES_SESSION_TOKEN__\s*=\s*("(?:\\.|[^"\\])*")',
+                resp.text,
+            )
+            assert match, resp.text
+            import json as _json
+
+            assert _json.loads(match.group(1)) == adopted
+        finally:
+            ws._apply_ssh_session_token(before)
+
+    def test_spa_index_serves_adopted_ssh_token(self, tmp_path, monkeypatch):
+        import re
+        import hermes_cli.web_server as ws
+
+        dist = tmp_path / "web_dist"
+        dist.mkdir()
+        (dist / "index.html").write_text(
+            "<html><head></head><body>SPA</body></html>", encoding="utf-8"
+        )
+        monkeypatch.setattr(ws, "WEB_DIST", dist)
+        monkeypatch.delenv("HERMES_SERVE_HEADLESS", raising=False)
+
+        from fastapi import FastAPI
+        from starlette.testclient import TestClient
+
+        adopted = "b" * 64
+        before = ws._SESSION_TOKEN
+        assert adopted != before
+        spa_app = FastAPI()
+        _web_server_dashboard.mount_spa(spa_app)
+        client = TestClient(spa_app)
+        try:
+            ws._apply_ssh_session_token(adopted)
+            resp = client.get("/chat")
+            assert resp.status_code == 200
+            match = re.search(
+                r'window\.__HERMES_SESSION_TOKEN__\s*=\s*("(?:\\.|[^"\\])*")',
+                resp.text,
+            )
+            assert match, resp.text
+            import json as _json
+
+            assert _json.loads(match.group(1)) == adopted
+        finally:
+            ws._apply_ssh_session_token(before)


### PR DESCRIPTION
## Problem

Desktop SSH remote mode (`hermes serve --isolated --ssh-session-token-file <path>`) boots, the tunnel and readiness checks pass, but every authenticated `/api/` call returns `401 {"detail":"Unauthorized"}` — the desktop then silently falls back to the local backend (#103001).

## Root cause

`hermes_cli/web_server.py` resolves `_SESSION_TOKEN` at import time (env var or a fresh `secrets.token_urlsafe(32)`). `mount_spa()` in `web_server_dashboard.py` imports that value as a **name** and closes over it, so both

- the headless handshake page (`window.__HERMES_SESSION_TOKEN__=...` at `/`), and
- the SPA `_serve_index` token injection

keep serving the import-time copy. `start_server(ssh_session_token=...)` later overrides the module global via `_apply_ssh_session_token()` — the value the auth middleware enforces — but the closures never see it. The renderer therefore adopts a stale credential that the middleware rejects.

Local desktop backends are unaffected because `HERMES_DASHBOARD_SESSION_TOKEN` is set before import, so both values coincide.

## Fix

Read the live module attribute at request time:

- `from hermes_cli import web_server` inside `mount_spa`
- `web_server._SESSION_TOKEN` in the handshake page and `_serve_index`

so the post-import adoption from `--ssh-session-token-file` is honored.

## Testing

- New `TestHeadlessServeTokenFollowsSshAdoption` in `tests/hermes_cli/test_web_server.py`: mounts the SPA, then applies an SSH session token, and asserts both the handshake page and the SPA index serve the adopted value (red on main, green with this patch).
- Existing `TestHeadlessServeTokenPage`, `TestServeIndexMissingIndex`, `TestHashedAssetCacheHeaders` — all pass unchanged.
- `ruff check` clean on both files; the new lines are stable under `ruff format` (pre-existing drift untouched).

Fixes #103001
