### PR TITLE
fix(cli): prevent false startup warnings

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1925,6 +1925,8 @@ def _read_raw_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
             return {}
 
         if not isinstance(data, dict):
+            _warn_config_parse_failure(
+                config_path, TypeError(f"top-level YAML must be a mapping, got {type(data).__name__}"))
             data = {}
         # The cache stores its own deepcopy. The readonly path returns THAT object (identity
         # invariant: later cache hits return the same dict); the mutable path returns the parse.

--- a/hermes_cli/plugins_discovery.py
+++ b/hermes_cli/plugins_discovery.py
@@ -77,11 +77,26 @@ def _classify_entrypoint_value_kind(value: str) -> str:
         return "standalone"
 
 
+def _plugin_gate_value(key: str) -> Any:
+    # Discovery runs before dotenv/secret loading. Resolve only the gate being
+    # read, not unrelated MCP/provider credentials elsewhere in config.yaml.
+    from hermes_cli.config import (
+        _deep_merge, _expand_env_vars, get_active_config_parse_failure, load_config, read_raw_config,
+    )
+    from hermes_cli.managed_scope import load_managed_config
+
+    config = read_raw_config()
+    if get_active_config_parse_failure() is not None:
+        # Preserve the runtime loader's last-known-good policy after a broken edit.
+        return cfg_get(load_config(), "plugins", key)
+    config = _deep_merge(config, load_managed_config())
+    return _expand_env_vars(cfg_get(config, "plugins", key))
+
+
 def _get_disabled_plugins() -> set:
     """Read ``plugins.disabled`` — a deny-list that wins over ``plugins.enabled``."""
     try:
-        from hermes_cli.config import load_config
-        disabled = cfg_get(load_config(), "plugins", "disabled", default=[])
+        disabled = _plugin_gate_value("disabled")
         return set(disabled) if isinstance(disabled, list) else set()
     except Exception:
         return set()
@@ -92,8 +107,7 @@ def _get_enabled_plugins() -> Optional[set]:
     enabled yet"; the first ``migrate_config`` run grandfathers installed user plugins); ``set()`` = explicitly
     empty; else the allow-list."""
     try:
-        from hermes_cli.config import load_config
-        enabled = cfg_get(load_config(), "plugins", "enabled")
+        enabled = _plugin_gate_value("enabled")
         return set(enabled) if isinstance(enabled, list) else None
     except Exception:
         return None

--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -81,7 +81,10 @@ def _receipt_looks_unfinished(receipt: dict) -> bool:
     """True when *receipt* is from an update that did not finish cleanly."""
     gateway_restart = receipt.get("gateway_restart")
     return bool(
-        receipt.get("stop_reason")
+        # Successful command-boundary receipts also carry a stop_reason.
+        (receipt.get("stop_reason")
+         and receipt.get("outcome") != "success"
+         and receipt.get("exit_code") != 0)
         or receipt.get("exit_code") not in (0, None)
         or receipt.get("outcome") in ("failed", "partial", "running")
         or (isinstance(gateway_restart, dict) and gateway_restart.get("incomplete"))

--- a/tests/hermes_cli/test_cli_startup_env_refs.py
+++ b/tests/hermes_cli/test_cli_startup_env_refs.py
@@ -1,0 +1,114 @@
+"""Startup discovery must not resolve unrelated config references before secrets load."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+import pytest
+
+from hermes_cli import __version__
+
+
+@pytest.mark.parametrize("argv", (["gateway", "restart", "--help"], ["--version"]))
+@pytest.mark.parametrize("named_profile", (False, True), ids=("default", "named"))
+@pytest.mark.parametrize("source", ("dotenv", pytest.param("command", marks=pytest.mark.linux_only)))
+def test_startup_leaves_config_refs_for_runtime(tmp_path, argv, named_profile, source):
+    home = tmp_path / ".hermes"
+    if named_profile:
+        home = home / "profiles" / "work"
+    home.mkdir(parents=True)
+    config = {"mcp_servers": {"foobar": {
+        "command": "example", "env": {"FOOBAR_API_KEY": "${env:FOOBAR_API_KEY}"},
+    }}}
+    if source == "dotenv":
+        (home / ".env").write_text("FOOBAR_API_KEY=test-key\n", encoding="utf-8")
+    else:
+        config["secrets"] = {"command": {
+            "enabled": True, "command": "printf 'FOOBAR_API_KEY=test-key\\n'",
+        }}
+    if argv == ["--version"]:
+        config.setdefault("secrets", {})["bitwarden"] = {"enabled": True}
+    (home / "config.yaml").write_text(json.dumps(config), encoding="utf-8")
+    (home / ".update_check").write_text(
+        json.dumps({"ts": time.time(), "behind": 0, "rev": None, "ver": __version__}),
+        encoding="utf-8",
+    )
+    repo = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env.update(HOME=str(tmp_path), HERMES_HOME=str(home), PYTHONPATH=str(repo))
+    env.pop("FOOBAR_API_KEY", None)
+    code = """
+import runpy
+import sys
+sys.argv[0] = 'hermes'
+try:
+    runpy.run_module('hermes_cli.main', run_name='__main__')
+except SystemExit as exc:
+    assert exc.code == 0
+if '--version' in sys.argv:
+    assert 'agent.secret_sources.bitwarden' not in sys.modules
+    assert 'hermes_cli.env_loader' not in sys.modules
+    assert 'dotenv' not in sys.modules
+else:
+    from hermes_cli.config import load_config
+    assert load_config()['mcp_servers']['foobar']['env']['FOOBAR_API_KEY'] == 'test-key'
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code, *argv], cwd=repo, env=env,
+        capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Config ref" not in result.stderr
+
+
+@pytest.mark.parametrize("managed_plugins, expected_enabled, expected_disabled", (
+    ({}, {"allowed"}, {"blocked"}),
+    ({"enabled": ["blocked"]}, {"blocked"}, {"blocked"}),
+    ({"disabled": ["${env:PLUGIN_NAME}"]}, {"allowed"}, {"allowed"}),
+    ({"enabled": []}, set(), {"blocked"}),
+    ({"enabled": None, "disabled": None}, None, set()),
+))
+@pytest.mark.parametrize("broken_config", (
+    pytest.param("plugins: [\n", id="syntax-error"),
+    pytest.param("- accidental-list-root\n", id="list-root"),
+    pytest.param("accidental-scalar-root\n", id="scalar-root"),
+))
+def test_plugin_gates_resolve_only_their_own_refs(
+    tmp_path, monkeypatch, caplog, managed_plugins, expected_enabled, expected_disabled,
+    broken_config,
+):
+    from hermes_cli.config import load_config
+    from hermes_cli.plugins_discovery import _get_disabled_plugins, _get_enabled_plugins
+
+    home = tmp_path / "home"
+    managed = tmp_path / "managed"
+    home.mkdir()
+    managed.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed))
+    monkeypatch.setenv("PLUGIN_NAME", "allowed")
+    monkeypatch.delenv("MISSING_PLUGIN_SECRET", raising=False)
+    (home / "config.yaml").write_text(json.dumps({"plugins": {
+        "enabled": ["${env:PLUGIN_NAME}"], "disabled": ["blocked"],
+        "example": {"api_key": "${env:MISSING_PLUGIN_SECRET}"},
+    }}), encoding="utf-8")
+    (managed / "config.yaml").write_text(
+        json.dumps({"plugins": managed_plugins, "model": {"api_key": "${env:MISSING_PLUGIN_SECRET}"}}),
+        encoding="utf-8",
+    )
+
+    assert _get_enabled_plugins() == expected_enabled
+    assert _get_disabled_plugins() == expected_disabled
+    assert "Config ref" not in caplog.text
+    assert load_config()["plugins"]["example"]["api_key"] == "${env:MISSING_PLUGIN_SECRET}"
+    assert "MISSING_PLUGIN_SECRET is not set" in caplog.text
+
+    # A broken edit must retain the policy cached by the runtime load above,
+    # including user denials of plugins on the managed allow-list.
+    (home / "config.yaml").write_text(broken_config, encoding="utf-8")
+    assert (_get_enabled_plugins(), _get_disabled_plugins()) == (
+        expected_enabled, expected_disabled,
+    )

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -210,6 +210,13 @@ def test_pending_needed_when_unfinished_receipt_runtime_sha_skews(monkeypatch):
     assert update_cmd._pending_fleet_restart_needed() is True
 
 
+def test_legacy_receipt_with_only_stop_reason_is_unfinished():
+    """Preserve the fallback for receipts written before terminal fields existed."""
+    assert update_cmd_fleet._receipt_looks_unfinished(
+        {"stop_reason": "KeyboardInterrupt: "}
+    ) is True
+
+
 def test_successful_receipt_with_pre_update_plan_shas_does_not_retrigger(
     monkeypatch,
 ):
@@ -246,6 +253,31 @@ def test_successful_receipt_with_pre_update_plan_shas_does_not_retrigger(
                     }
                 ],
                 "gateway_restart": {"incomplete": False},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert update_cmd._pending_fleet_restart_needed() is False
+
+
+def test_successful_boundary_receipt_without_fleet_does_not_retrigger(monkeypatch):
+    """A normal command-boundary reason does not make a successful receipt unfinished."""
+    disk_sha = "n" * 40
+    old_sha = "o" * 40
+    monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: disk_sha)
+    monkeypatch.setattr(update_cmd_fleet, "_current_checkout_sha", lambda: disk_sha)
+
+    receipt_dir = get_hermes_home() / "logs" / "update_receipts"
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / "latest.json").write_text(
+        json.dumps(
+            {
+                "exit_code": 0,
+                "outcome": "success",
+                "stop_reason": "completed at command boundary",
+                "fleet": [],
+                "plan": {"runtimes": [{"kind": "gateway", "code_sha": old_sha}]},
             }
         ),
         encoding="utf-8",


### PR DESCRIPTION
## What does this PR do?

Fixes two false startup warnings without moving modules or changing their callers.

- Plugin discovery expands the entire config before dotenv and external secrets load. It now resolves only the plugin allow/deny lists, leaving unrelated credential references for runtime.
- Successful update receipts can contain a stop reason. That field alone no longer triggers a warning about an unfinished update.

Real missing-reference warnings, plugin policy, and failed/incomplete update detection stay intact. `hermes --version` does not load dotenv or external secret backends.

## Related Issue

No linked issue.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Security fix
- [ ] Documentation update
- [x] Tests
- [ ] Refactor
- [ ] New skill

## Changes Made

- `hermes_cli/plugins_discovery.py`: resolve only plugin enablement settings, preserving managed overrides and cached policy after malformed config edits.
- `hermes_cli/config.py`: report non-mapping YAML roots as parse failures so the cached-policy fallback also handles them.
- `hermes_cli/update_cmd_fleet.py`: use terminal success fields before treating a stop reason as evidence of an unfinished update. Explicit failure flags still win.
- Two test files cover the warnings and the behavior that must remain unchanged.

Five files total. No module moves, compatibility changes, or caller migrations.

## How to Test

1. Run the focused regressions:
   ```bash
   scripts/run_tests.sh \
     tests/hermes_cli/test_cli_startup_env_refs.py \
     tests/hermes_cli/test_update_fleet_restart_pending.py
   ```
2. Compare the representative help command below on the pre-fix commit and this branch, using the same isolated fixture. Both exit 0. Only the pre-fix version prints the warnings.
3. The startup tests also cover `hermes --version`, default and named homes, dotenv and an external command source, managed plugin policy, malformed config, and genuinely missing references.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched open and closed PRs for duplicates
- [x] This PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for the changes
- [x] I've tested on Linux

### Documentation & Housekeeping

- [x] No documentation or compatibility-path changes needed
- [x] No config keys added or changed
- [x] No contributor workflow changes
- [x] Cross-platform impact considered; the command-source test is Linux-only because that backend requires a POSIX shell
- [x] No tool descriptions or schemas changed

## For New Skills

Not applicable.

## Screenshots / Logs

Actual output from `hermes gateway restart --help` on Linux, using isolated temporary homes with the same test fixture. These are fixture values, not production credentials or a live update receipt. No gateway was restarted.

The fixture has `FOOBAR_URL=https://foobar.example` and `FOOBAR_API_KEY=test-key` in `.env`, neither exported in the parent environment. `config.yaml` references both:

```yaml
mcp_servers:
  foobar:
    command: example
    env:
      FOOBAR_URL: ${env:FOOBAR_URL}
      FOOBAR_API_KEY: ${env:FOOBAR_API_KEY}
```

`logs/update_receipts/latest.json` contains a successful command-boundary receipt with an old gateway SHA in the pre-update plan:

```json
{
  "exit_code": 0,
  "outcome": "success",
  "stop_reason": "completed at command boundary",
  "fleet": [],
  "plan": {
    "runtimes": [
      {"kind": "gateway", "code_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
    ]
  }
}
```

**Before**, pre-fix commit `13e72fb205`:

```text
$ hermes gateway restart --help
Config ref '${env:FOOBAR_URL}': FOOBAR_URL is not set (check ~/.hermes/.env); keeping the literal placeholder
Config ref '${env:FOOBAR_API_KEY}': FOOBAR_API_KEY is not set (check ~/.hermes/.env); keeping the literal placeholder
⚠ A previous `hermes update` pulled new code but did not restart running gateways.
  Gateways may still be serving pre-update modules (mixed sys.modules).
  Run `hermes update` or `hermes gateway restart`.
usage: hermes gateway restart [-h] [--system] [--all]

options:
  -h, --help  show this help message and exit
  --system    Target the Linux system-level gateway service
  --all       Kill ALL gateway processes across all profiles before restarting
```

Exit status: `0`.

**After**, PR commit `ad0e171a69`:

```text
$ hermes gateway restart --help
usage: hermes gateway restart [-h] [--system] [--all]

options:
  -h, --help  show this help message and exit
  --system    Target the Linux system-level gateway service
  --all       Kill ALL gateway processes across all profiles before restarting
```

Exit status: `0`.

Validation of the reduced branch:

- Canonical relevant suite: **749 passed, 0 failed, 4 skipped** across 65 test files.
- Ruff and `git diff --check` pass.
- The full-suite attempt was stopped after three failures caused by the missing Anthropic SDK. All three reproduce on the unchanged base. This is not a full-suite pass.
- GitHub Actions is running for the rewritten branch. Both commits have verified GPG signatures.
