### PR TITLE
fix(moa): forward provider identity to pre_llm_call hooks

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -593,6 +593,11 @@ def _collect_pre_llm_call_context(
             conversation_history=list(messages),
             is_first_turn=(not bool(conversation_history)),
             model=agent.model,
+            # Virtual providers (MoA) put a PRESET name in agent.model, not a
+            # real model identity. A hook that classifies the host model by
+            # name cannot distinguish "MoA preset named default" from an
+            # ordinary model named "default" without knowing the provider.
+            provider=getattr(agent, "provider", None) or "",
             platform=getattr(agent, "platform", None) or "",
             parent_session_id=getattr(agent, "_parent_session_id", None) or "",
             sender_id=getattr(agent, "_user_id", None) or "",

--- a/tests/agent/test_pre_llm_call_provider_forwarding.py
+++ b/tests/agent/test_pre_llm_call_provider_forwarding.py
@@ -1,0 +1,106 @@
+"""``pre_llm_call`` must tell plugins which PROVIDER is acting.
+
+Under the MoA virtual provider ``agent.model`` holds a PRESET name (see
+``agent/agent_init.py``: "AI Agent initialized with MoA preset"), not a real
+model identity. A plugin that classifies the host model by name therefore sees
+something like ``default``, which matches no model family.
+
+The name alone cannot disambiguate -- a provider may legitimately ship a model
+called ``default`` -- so the dispatch must also forward ``provider``. Without
+it a cross-family review gate cannot tell "MoA preset" from "ordinary model"
+and silently mis-gates every MoA turn.
+
+These tests exercise the real ``_collect_pre_llm_call_context`` and assert on
+the kwargs the hook actually receives.
+"""
+
+from __future__ import annotations
+
+import types
+from unittest.mock import patch
+
+from agent.turn_context import _collect_pre_llm_call_context
+
+
+def _agent(model="claude-opus-5", provider="anthropic"):
+    return types.SimpleNamespace(
+        session_id="sess-1",
+        model=model,
+        provider=provider,
+        platform="cli",
+        _parent_session_id=None,
+        _user_id=None,
+    )
+
+
+def _collect(agent):
+    """Run the real collector, returning the kwargs the hook received."""
+    seen = {}
+
+    def fake_invoke_hook(name, **kwargs):
+        seen["name"] = name
+        seen["kwargs"] = kwargs
+        return []
+
+    lifecycle = types.ModuleType("hermes_cli.lifecycle")
+    lifecycle.invoke_hook = fake_invoke_hook  # type: ignore[attr-defined]
+
+    with patch.dict("sys.modules", {"hermes_cli.lifecycle": lifecycle}):
+        _collect_pre_llm_call_context(
+            agent,
+            effective_task_id="task-1",
+            turn_id="turn-1",
+            original_user_message="hello",
+            messages=[{"role": "user", "content": "hello"}],
+            conversation_history=None,
+        )
+    return seen
+
+
+def test_pre_llm_call_receives_the_host_provider():
+    seen = _collect(_agent())
+    assert seen["name"] == "pre_llm_call"
+    assert seen["kwargs"]["provider"] == "anthropic"
+    assert seen["kwargs"]["model"] == "claude-opus-5"
+
+
+def test_moa_turn_forwards_the_virtual_provider_with_the_preset_name():
+    """The pairing is what makes a MoA turn identifiable.
+
+    ``model`` is the preset and ``provider`` is ``moa``; a plugin needs BOTH
+    to resolve the preset to its acting aggregator.
+    """
+    seen = _collect(_agent(model="default", provider="moa"))
+    assert seen["kwargs"]["provider"] == "moa"
+    assert seen["kwargs"]["model"] == "default"
+
+
+def test_absent_provider_is_forwarded_as_an_empty_string():
+    """A provider-less agent must not raise or omit the key.
+
+    Hooks read ``kwargs["provider"]``; omitting it on some paths would make
+    the contract conditional and reintroduce the ambiguity for those callers.
+    """
+    agent = _agent()
+    del agent.provider
+    seen = _collect(agent)
+    assert seen["kwargs"]["provider"] == ""
+
+
+def test_provider_is_forwarded_alongside_the_preexisting_kwargs():
+    """Forwarding must be additive -- no existing hook input may be dropped."""
+    seen = _collect(_agent())
+    for key in (
+        "session_id",
+        "task_id",
+        "turn_id",
+        "user_message",
+        "conversation_history",
+        "is_first_turn",
+        "model",
+        "platform",
+        "parent_session_id",
+        "sender_id",
+        "provider",
+    ):
+        assert key in seen["kwargs"], f"pre_llm_call lost the {key!r} kwarg"


### PR DESCRIPTION
## Summary

Forward the active provider alongside the model in the generic `pre_llm_call` lifecycle hook.

For virtual providers such as MoA, `agent.model` holds a **preset name** rather than the acting model's identity (`agent/agent_init.py` prints `AI Agent initialized with MoA preset`). A hook that receives only `model="default"` cannot distinguish a MoA preset from an ordinary model legitimately named `default` — the name alone is ambiguous, so no amount of plugin-side logic can resolve it.

Forwarding `provider="moa"` gives plugins enough information to resolve the preset to its acting aggregator, without pushing provider- or plugin-specific logic into the hook layer.

### Why it matters

This ambiguity silently mis-gates cross-family peer review. A reviewer plugin that classifies the host model by name sees `default`, matches no known family, and falls back — inverting the gate whenever the MoA aggregator is itself from the reviewer's own family. The result is same-family review (a model reviewing its own output) while the correct cross-family reviewer is suppressed. Both failure modes are silent.

### Shape of the change

Purely additive:

- every pre-existing kwarg is unchanged;
- a provider-less agent yields `""` rather than the key being omitted, so hooks can read `kwargs["provider"]` unconditionally;
- no behavior change for non-MoA turns.

## Tests

`tests/agent/test_pre_llm_call_provider_forwarding.py` exercises the real `_collect_pre_llm_call_context` and asserts on the kwargs the hook actually receives:

- a MoA turn forwards `provider="moa"` with the preset name in `model`;
- ordinary providers are forwarded unchanged;
- an agent without a provider yields `""` instead of a missing key;
- every pre-existing kwarg survives (guards against a regression that drops one).

```
tests/agent/test_pre_llm_call_provider_forwarding.py tests/agent/test_turn_context.py
24 passed
```
