### PR TITLE
fix(delegate): surface nonzero terminal exits in tool traces

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -601,6 +601,41 @@ class TestDelegateObservability(unittest.TestCase):
             self.assertEqual(trace[0]["status"], "ok")
             self.assertGreater(trace[0]["result_bytes"], 0)
 
+    def test_terminal_nonzero_exit_is_error_in_tool_trace(self):
+        """A terminal command can fail with empty output and ``error: null``;
+        its numeric exit code is the host-owned failure signal."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = {
+                "final_response": "Everything passed.",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [
+                    {"role": "assistant", "tool_calls": [
+                        {"id": "tc_1", "function": {"name": "terminal", "arguments": '{"command": "false"}'}},
+                        {"id": "tc_2", "function": {"name": "terminal", "arguments": '{"command": "true"}'}},
+                    ]},
+                    {"role": "tool", "tool_call_id": "tc_1",
+                     "content": '{"output":"","exit_code":1,"error":null}'},
+                    {"role": "tool", "tool_call_id": "tc_2",
+                     "content": '{"output":"","exit_code":0,"error":null}'},
+                ],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="Test terminal evidence", parent_agent=parent))
+            entry = result["results"][0]
+            trace = entry["tool_trace"]
+
+            self.assertEqual(entry["status"], "completed")
+            self.assertEqual([item["status"] for item in trace], ["error", "ok"])
+
     def test_parallel_tool_calls_paired_correctly(self):
         """Parallel tool calls should each get their own result via tool_call_id matching."""
         parent = _make_mock_parent(depth=0)

--- a/tools/delegate_tool_results.py
+++ b/tools/delegate_tool_results.py
@@ -30,8 +30,9 @@ def _stringify_tool_content(content: Any) -> str:
 
 def _looks_like_error_output(content: Any) -> bool:
     """Conservative error detector for tool-result previews: structured JSON with
-    an ``error`` key or an error/failed ``status``, or a first line starting with a
-    classic error marker. (Substring "error" alone painted normal output red.)"""
+    an ``error`` key, a non-zero numeric ``exit_code``, or an error/failed
+    ``status``; otherwise a first line starting with a classic error marker.
+    (Substring "error" alone painted normal output red.)"""
     content = _stringify_tool_content(content)
     if not content:
         return False
@@ -40,10 +41,14 @@ def _looks_like_error_output(content: Any) -> bool:
             parsed = json.loads(content)
         except Exception:
             parsed = None
-        if isinstance(parsed, dict) and (
-            parsed.get("error") or str(parsed.get("status") or "").strip().lower() in {"error", "failed", "failure", "timeout"}
-        ):
-            return True
+        if isinstance(parsed, dict):
+            exit_code = parsed.get("exit_code")
+            if (
+                parsed.get("error")
+                or (isinstance(exit_code, int) and not isinstance(exit_code, bool) and exit_code != 0)
+                or str(parsed.get("status") or "").strip().lower() in {"error", "failed", "failure", "timeout"}
+            ):
+                return True
     first = content.splitlines()[0].strip().lower() if content.splitlines() else ""
     return first.startswith(("error:", "failed:", "traceback ", "exception:"))
 


### PR DESCRIPTION
## What does this PR do?

Makes delegated tool traces honor Hermes's existing terminal failure contract.

Foreground terminal results normally encode command failure as a nonzero integer `exit_code` while leaving `error` as `null`. The delegate preview classifier previously checked only `error` and textual `status`, so a child could report "Everything passed" while the parent-owned trace labeled a failed command `ok`.

This change classifies nonzero integer exit codes as trace errors. It deliberately does not coerce strings or booleans, and it does not change the delegated task's overall status; it only makes the host-owned tool evidence truthful.

## Related Issue

Related to #16357 and its duplicate #102977. This is the narrow trace-classification defect, not a claim to solve structural side-effect verification.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Teach `tools/delegate_tool_results.py` to recognize nonzero numeric terminal exit codes.
- Add a behavioral regression test where a child's confident summary disagrees with one failed and one successful terminal call.

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_delegate.py`.
2. Confirm all 82 tests pass, including `test_terminal_nonzero_exit_is_error_in_tool_trace`.
3. Run `python -m ruff check tools/delegate_tool_results.py tests/tools/test_delegate.py`.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing issues and PRs for duplicates.
- [x] This PR contains only changes related to this fix.
- [ ] Full repository suite run locally; the focused 82-test delegate suite passes and CI can exercise the full matrix.
- [x] I've added a behavior-level regression test.
- [x] Tested on Windows 11.

### Documentation & Housekeeping

- [x] Documentation update: N/A; the existing tool contract is unchanged.
- [x] Config example update: N/A.
- [x] Contributing/AGENTS update: N/A.
- [x] Cross-platform impact considered: JSON result classification is platform-independent.
- [x] Tool schema update: N/A; no schema change.
