### PR TITLE
fix(process): canonicalize completion bookkeeping after prefix lookup

### DIFF
--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -271,6 +271,45 @@ class TestCompletionConsumed:
             assert registry.is_completion_consumed(sid)
         assert registry.drain_notifications() == []
 
+    def test_prefix_actions_dedupe_canonical_cli_completions(self, registry):
+        """A short process ID must consume/observe the canonical completion."""
+        cases = (
+            ("proc_a1b2c3d4", "a1b2", "poll"),
+            ("proc_b2c3d4e5", "b2c3", "wait"),
+            ("proc_c3d4e5f6", "c3d4", "log"),
+            ("proc_d4e5f6a7", "d4e5", "kill_exited"),
+            ("proc_e5f6a7b8", "e5f6", "kill_running"),
+        )
+        actions = {
+            "poll": registry.poll,
+            "wait": lambda prefix: registry.wait(prefix, timeout=1),
+            "log": registry.read_log,
+            "kill_exited": registry.kill_process,
+            "kill_running": registry.kill_process,
+        }
+        with patch.object(registry, "_write_checkpoint"):
+            for sid, prefix, action in cases:
+                running = action == "kill_running"
+                session = _make_session(
+                    sid=sid, notify_on_complete=True, output="done",
+                    exited=not running, exit_code=None if running else 0,
+                )
+                if running:
+                    session._pty = MagicMock()
+                registry._running[sid] = session
+                if not running:
+                    registry._move_to_finished(session)
+                result = actions[action](prefix)
+                assert result["status"] in {"exited", "already_exited", "killed"}
+
+        assert cases[0][0] in registry._poll_observed
+        assert all(sid in registry._completion_consumed for sid, _prefix, _action in cases[1:])
+        assert all(
+            prefix not in registry._poll_observed | registry._completion_consumed
+            for _sid, prefix, _action in cases
+        )
+        assert registry.drain_notifications() == []
+
 
 # ---------------------------------------------------------------------------
 # Silent-background-process hint

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1472,7 +1472,7 @@ class ProcessRegistry:
             # Read-only: record in _poll_observed (CLI inline dedup) but NOT in
             # _completion_consumed, or a status check would suppress the watcher's
             # autonomous delivery turn. See __init__.
-            self._poll_observed.add(session_id)
+            self._poll_observed.add(session.id)
         if session.detached:
             result.update(detached=True, note="Process recovered after restart -- output history unavailable")
         return result
@@ -1505,7 +1505,7 @@ class ProcessRegistry:
             **self._status_head(session), "output": "\n".join(selected),
             "total_lines": total_lines, "showing": f"{len(selected)} lines"}
         if session.exited and observed_completion_output:
-            self._completion_consumed.add(session_id)
+            self._completion_consumed.add(session.id)
         return result
 
     def wait(self, session_id: str, timeout: int = None) -> dict:
@@ -1538,7 +1538,7 @@ class ProcessRegistry:
             self._reconcile_local_exit(session)  # orphaned-pipe reader guard
             result = None
             if session.exited:
-                self._completion_consumed.add(session_id)
+                self._completion_consumed.add(session.id)
                 result = self._exit_snapshot(session, "exited")
             elif _is_interrupted():
                 result = {
@@ -1602,10 +1602,10 @@ class ProcessRegistry:
             # Only suppress the autonomous turn after its output is present in
             # the explicit kill result, matching wait/log consumption.
             if consume_output:
-                self._completion_consumed.add(session_id)
+                self._completion_consumed.add(session.id)
             return result
         try:
-            early = self._signal_kill(session, session_id, consume_output)
+            early = self._signal_kill(session, consume_output)
             if early is not None:
                 return early
             # Additive to the PID kill: stopping the scope reaps double-forked
@@ -1617,7 +1617,7 @@ class ProcessRegistry:
             with session._lock:
                 output = _output_tail(session, 2000)
                 if consume_output:
-                    self._completion_consumed.add(session_id)
+                    self._completion_consumed.add(session.id)
                 session.exited = True
                 session.exit_code = -15  # SIGTERM
                 session.completion_reason = "killed"
@@ -1630,7 +1630,7 @@ class ProcessRegistry:
         except Exception as e:
             return {"status": "error", "error": str(e)}
 
-    def _signal_kill(self, session: ProcessSession, session_id: str, consume_output: bool) -> Optional[dict]:
+    def _signal_kill(self, session: ProcessSession, consume_output: bool) -> Optional[dict]:
         """Deliver the kill via PTY, local Popen tree, sandbox exec or recovered host
         PID. Returns a final result dict when the kill cannot proceed (recycled/dead
         recovered PID, or no runtime handle), else None."""
@@ -1661,7 +1661,7 @@ class ProcessRegistry:
                     session.exit_code = None
                     output = _output_tail(session, 2000)
                 if consume_output:
-                    self._completion_consumed.add(session_id)
+                    self._completion_consumed.add(session.id)
                 self._move_to_finished(session)
                 return {"status": "already_exited", "exit_code": session.exit_code, "output": output}
             self._terminate_host_pid(session.pid, session.host_start_time)


### PR DESCRIPTION
## What does this PR do?

Prevents duplicate background-process completion delivery when a process is observed through a supported short ID.

`ProcessRegistry.get()` resolves a short prefix to a canonical `session.id`, but poll/log/wait/kill bookkeeping stored the caller's raw alias. Completion events are keyed by the canonical ID, so the notification drain failed to recognize that the completion had already been observed or consumed and could deliver it again.

This change records the resolved `session.id` in every post-lookup consumption path and removes the raw ID parameter from `_signal_kill`, making the invariant harder to regress.

## Related Issue

Related to the prefix support from #80793 and completion deduplication from #8228. Adjacent #94465 adds explicit poll acknowledgement; that path should likewise key any consumption by the resolved canonical ID.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Canonicalize `_poll_observed` and `_completion_consumed` keys after prefix resolution.
- Cover poll, wait, full log read, already-exited kill, and running PTY kill with one invariant test.

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_notify_on_complete.py` (20 passed).
2. Run `scripts/run_tests.sh tests/tools/test_process_registry.py -k TestGetByPrefix` (9 passed on Windows; Linux-only cases are skipped by the runner).
3. Run `python -m ruff check tools/process_registry.py tests/tools/test_notify_on_complete.py`.

Before the patch, polling a finished process by prefix stored the prefix and `drain_notifications()` returned one duplicate event. After the patch, it stores the canonical ID and drains zero duplicates.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing issues and PRs for duplicates.
- [x] This PR contains only changes related to this fix.
- [ ] Full repository suite run locally; focused notification and prefix suites pass and CI can exercise the full matrix.
- [x] I've added a behavior-level regression test.
- [x] Tested on Windows 11.

### Documentation & Housekeeping

- [x] Documentation update: N/A; supported short-ID behavior is unchanged.
- [x] Config example update: N/A.
- [x] Contributing/AGENTS update: N/A.
- [x] Cross-platform impact considered: canonical ID bookkeeping is platform-independent; POSIX-only tests remain in CI.
- [x] Tool schema update: N/A; no schema change.
