### PR TITLE
fix(cron): allow prompts after create options

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3259,6 +3259,29 @@ def _build_cli_parser():
     return parser, subparsers
 
 
+def _parse_args_with_trailing_cron_prompt(parser, argv):
+    """Accept cron create's optional prompt after its option/value pairs.
+
+    ``argparse`` does not return to a ``nargs='?'`` positional after parsing
+    subparser options, so the documented trailing prompt otherwise lands in
+    ``unknown``. Keep the exception narrow so misspelled flags and additional
+    positional arguments retain argparse's normal strict failure.
+    """
+    args, unknown = parser.parse_known_args(argv)
+    if not unknown:
+        return args
+    if (
+        getattr(args, "command", None) == "cron"
+        and getattr(args, "cron_command", None) in {"create", "add"}
+        and getattr(args, "prompt", None) is None
+        and len(unknown) == 1
+        and not unknown[0].startswith("-")
+    ):
+        args.prompt = unknown[0]
+        return args
+    return parser.parse_args(argv)
+
+
 def _parse_cli_args(parser, subparsers, argv):
     """Parse ``argv`` with the bpo-9338 subparser-routing workaround.
 
@@ -3279,13 +3302,13 @@ def _parse_cli_args(parser, subparsers, argv):
     )
     if not _has_cmd_token:
         subparsers.required = False
-        return parser.parse_args(_processed_argv)
+        return _parse_args_with_trailing_cron_prompt(parser, _processed_argv)
 
     subparsers.required = True
     _saved_stderr = sys.stderr
     try:
         sys.stderr = _io.StringIO()
-        args = parser.parse_args(_processed_argv)
+        args = _parse_args_with_trailing_cron_prompt(parser, _processed_argv)
         sys.stderr = _saved_stderr
     except SystemExit as exc:
         sys.stderr = _saved_stderr
@@ -3293,7 +3316,7 @@ def _parse_cli_args(parser, subparsers, argv):
             raise
         # Subcommand consumed as a flag value (e.g. -c model): normal parse.
         subparsers.required = False
-        args = parser.parse_args(_processed_argv)
+        args = _parse_args_with_trailing_cron_prompt(parser, _processed_argv)
     return args
 
 

--- a/tests/hermes_cli/test_cron_parser_builder.py
+++ b/tests/hermes_cli/test_cron_parser_builder.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 
 import argparse
 
+import pytest
+
+from hermes_cli.main import _build_cli_parser, _parse_cli_args
 from hermes_cli.subcommands.cron import build_cron_parser
 
 
@@ -48,3 +51,36 @@ def test_cron_accept_hooks_flag_on_run_and_tick():
     assert ns.accept_hooks is True
     ns2 = parser.parse_args(["cron", "tick", "--accept-hooks"])
     assert ns2.accept_hooks is True
+
+
+@pytest.mark.parametrize(
+    ("options", "prompt"),
+    [
+        (["--name", "test-prompt-job"], "Single-word-prompt"),
+        (
+            ["--name", "test-prompt-job", "--deliver", "local"],
+            "Test prompt to see if positionals work",
+        ),
+    ],
+)
+def test_cron_create_accepts_prompt_after_options(options, prompt):
+    parser, subparsers = _build_cli_parser()
+
+    ns = _parse_cli_args(
+        parser,
+        subparsers,
+        ["cron", "create", "0 3 * * *", *options, prompt],
+    )
+
+    assert ns.prompt == prompt
+
+
+def test_cron_create_still_rejects_unknown_options():
+    parser, subparsers = _build_cli_parser()
+
+    with pytest.raises(SystemExit):
+        _parse_cli_args(
+            parser,
+            subparsers,
+            ["cron", "create", "30m", "--unknown", "value"],
+        )


### PR DESCRIPTION
## What does this PR do?

Allows `hermes cron create` and its `add` alias to accept the documented optional prompt after named options. Without this fix, valid jobs that place the prompt last fail before creation with `unrecognized arguments`.

### Symptom

Commands such as `hermes cron create "0 3 * * *" --name test-prompt-job --deliver local "Test prompt to see if positionals work"` fail with a top-level argparse error.

### Impact

CLI users cannot create an agent-backed cron job with the documented trailing prompt when create options appear before it. They must reorder arguments or use another interface.

### Bug Cause

**Trigger:** `hermes_cli/main.py:3262` / `_parse_cli_args`

**Causal chain:**
1. `cron create` declares `prompt` as an optional `nargs="?"` positional.
2. After argparse starts consuming create options, it does not revisit that optional positional for a final prompt token.
3. Strict top-level parsing receives the prompt as unknown and exits with `unrecognized arguments`.

**Why it is wrong:** The parser rejects an argument order documented by the command usage even though the cron subcommand has an available prompt field.

**Working sibling / contrast:** A prompt placed immediately after the schedule parses successfully, and script-only jobs without a prompt are unaffected.

**Ruled out:** Session-name argument coalescing leaves these argv forms unchanged; a direct parser regression test reproduces the failure before dispatch or cron storage is involved.

### Fix

Parse known arguments first, then accept exactly one non-option unknown token only when it fills an empty prompt for `cron create` or `cron add`. All other unknown options and extra positionals still use argparse's strict failure path.

## Related Issue

Closes #102983

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py` - narrowly recover the trailing cron create prompt while preserving strict parsing elsewhere.
- `tests/hermes_cli/test_cron_parser_builder.py` - cover the reported single-word and quoted multi-word forms plus unknown-option rejection.

## How to Test

1. Parse a cron create command with `--name`, `--deliver`, and a final multi-word prompt.
2. Parse the single-word prompt form and confirm the exact prompt value is retained.
3. Run:

```bash
scripts/run_tests.sh tests/hermes_cli/test_cron_parser_builder.py -q
```

Result: 6 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - parser behavior is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A
