### PR TITLE
feat(providers): add generic runtime extension seams

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5873,6 +5873,7 @@ def _project_provider_profile(
     reasoning_extra: Dict[str, Any] = {}
     top_level: Dict[str, Any] = {}
     handles_reasoning = False
+    profile = None
     try:
         from providers import get_provider_profile
         from providers.base import ProviderProfile

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5862,6 +5862,7 @@ class _ProfileProjection(NamedTuple):
     reasoning_extra: Dict[str, Any]
     top_level: Dict[str, Any]
     handles_reasoning: bool
+    profile: Any | None
 
 
 def _project_provider_profile(
@@ -5892,7 +5893,7 @@ def _project_provider_profile(
             )
     except Exception as exc:
         logger.debug("_build_call_kwargs: provider profile projection failed for %s: %s", provider, exc)
-    return _ProfileProjection(body, reasoning_extra, top_level, handles_reasoning)
+    return _ProfileProjection(body, reasoning_extra, top_level, handles_reasoning, profile)
 
 
 def _merge_aux_extra_body(
@@ -5954,7 +5955,16 @@ def _build_call_kwargs(
     # ``extra_body.reasoning`` fallback.
     projection = _project_provider_profile(provider, provider_norm, model, effective_base, reasoning_config)
     kwargs.update(projection.top_level)
-    if merged_extra := _merge_aux_extra_body(extra_body, projection, reasoning_config, provider_norm):
+    merged_extra = _merge_aux_extra_body(extra_body, projection, reasoning_config, provider_norm)
+    normalize_extra_body = getattr(projection.profile, "normalize_auxiliary_extra_body", None)
+    if callable(normalize_extra_body):
+        merged_extra = normalize_extra_body(
+            merged_extra,
+            model=model,
+            base_url=effective_base,
+            reasoning_config=reasoning_config,
+        )
+    if merged_extra:
         kwargs["extra_body"] = merged_extra
     # Anthropic Messages adapters take reasoning via a private kwarg that plain OpenAI SDK clients
     # would reject; Portal Claude is dual-wire, so include it only when the catalog id selects

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2375,6 +2375,26 @@ def _build_partial_stream_stub(role, full_content, full_reasoning, model_name, u
     )
 
 
+def _normalize_streamed_tool_name(agent, wire_name: str, api_kwargs: dict) -> str:
+    """Restore a complete streamed tool name before display callbacks see it."""
+    if not isinstance(wire_name, str) or not wire_name:
+        return wire_name
+    try:
+        from agent.transports.chat_completions import _normalize_response_tool_name
+        from providers import get_provider_profile
+
+        transport = agent._get_transport("chat_completions")
+        return _normalize_response_tool_name(
+            wire_name,
+            profile=get_provider_profile(getattr(agent, "provider", "") or ""),
+            phase="stream_delta",
+            model=api_kwargs.get("model") or getattr(agent, "model", None),
+            request_wire_aliases=getattr(transport, "_last_wire_aliases", None),
+        )
+    except Exception:
+        return wire_name
+
+
 # SSE error events from proxies (OpenRouter's {"error":{"message":"Network
 # connection lost."}}) surface as SDK APIError without a status_code (unlike
 # APIStatusError). They mean the upstream stream died: retry with a fresh
@@ -3015,6 +3035,7 @@ class _StreamingCall:
                 for tc_delta in delta_tool_calls:
                     name = tool_calls.feed(tc_delta)
                     if name is not None:
+                        name = _normalize_streamed_tool_name(self.agent, name, self.api_kwargs)
                         self._emit_tool_started(name)
                         # Lets the stub-builder warn if streaming dies before the args
                         # complete instead of silently discarding the action.

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -5,7 +5,7 @@ provider-specific work lives in build_kwargs (max_tokens, reasoning, extra_body)
 """
 
 import json
-from typing import Any
+from typing import Any, Literal, Mapping
 from urllib.parse import urlparse
 
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
@@ -205,6 +205,34 @@ def _model_consumes_thought_signature(model: Any) -> bool:
     """
     m = str(model or "").lower()
     return "gemini" in m or "gemma" in m
+
+
+def _normalize_response_tool_name(
+    wire_name: str,
+    *,
+    profile: Any | None = None,
+    phase: Literal["stream_delta", "final_tool_call"] = "final_tool_call",
+    model: str | None = None,
+    request_wire_aliases: Mapping[str, str] | None = None,
+) -> str:
+    """Apply a provider profile's inbound tool-name normalization hook."""
+    if not isinstance(wire_name, str) or not wire_name:
+        return wire_name
+    normalizer = getattr(profile, "response_tool_name_normalizer", None)
+    if normalizer is None:
+        return wire_name
+
+    from providers.base import ToolNameNormalizeContext
+
+    return normalizer(
+        wire_name,
+        ToolNameNormalizeContext(
+            phase=phase,
+            provider=str(getattr(profile, "name", "") or ""),
+            model=model,
+            request_wire_aliases=request_wire_aliases,
+        ),
+    )
 
 
 def _attr_or_model_extra(obj: Any, name: str) -> Any:
@@ -481,8 +509,18 @@ class ChatCompletionsTransport(ProviderTransport):
                 extra_body = {k: v for k, v in extra_body.items() if k in ("thinking_config", "thinkingConfig")}
             if extra_body:
                 api_kwargs["extra_body"] = extra_body
-        return _finish_kwargs(
+        api_kwargs = _finish_kwargs(
             api_kwargs, sanitized, params, supports_prompt_cache_key=bool(getattr(profile, "supports_prompt_cache_key", False)),
+        )
+        finalize_api_kwargs = getattr(profile, "finalize_api_kwargs", None)
+        if not callable(finalize_api_kwargs):
+            return api_kwargs
+        return finalize_api_kwargs(
+            api_kwargs,
+            model=model,
+            base_url=params.get("base_url"),
+            reasoning_config=reasoning_config,
+            session_id=params.get("session_id"),
         )
 
     def normalize_response(self, response: Any, **kwargs) -> NormalizedResponse:
@@ -498,7 +536,22 @@ class ChatCompletionsTransport(ProviderTransport):
 
         tool_calls = None
         if getattr(msg, "tool_calls", None):
-            tool_calls = [tc for tc in (self._normalize_tool_call(tc) for tc in msg.tool_calls) if tc is not None]
+            tool_names_normalized = bool(getattr(response, "_tool_names_normalized", False))
+            normalized_tool_calls = []
+            for tc in msg.tool_calls:
+                normalized = self._normalize_tool_call(tc)
+                if normalized is None:
+                    continue
+                if not tool_names_normalized:
+                    normalized.name = _normalize_response_tool_name(
+                        normalized.name,
+                        profile=kwargs.get("provider_profile"),
+                        phase="final_tool_call",
+                        model=kwargs.get("model"),
+                        request_wire_aliases=self._last_wire_aliases,
+                    )
+                normalized_tool_calls.append(normalized)
+            tool_calls = normalized_tool_calls
 
         usage = Usage.from_openai(response.usage) if hasattr(response, "usage") and response.usage else None
 

--- a/agent/turn_truncation.py
+++ b/agent/turn_truncation.py
@@ -60,6 +60,18 @@ def normalize_response_for_agent(agent: Any, response: Any) -> Any:
         return agent._get_transport().normalize_response(
             response, strip_tool_prefix=agent._is_anthropic_oauth
         )
+    if agent.api_mode == "chat_completions":
+        try:
+            from providers import get_provider_profile
+
+            provider_profile = get_provider_profile(getattr(agent, "provider", "") or "")
+        except Exception:
+            provider_profile = None
+        return agent._get_transport().normalize_response(
+            response,
+            provider_profile=provider_profile,
+            model=getattr(agent, "model", None),
+        )
     return agent._get_transport().normalize_response(response)
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -268,7 +268,11 @@ def _register_plugin_provider(pp: Any) -> None:
     if pp.auth_type == "external_process":
         pconfig = ProviderConfig(
             pp.name, pp.display_name or pp.name, "external_process", inference_base_url=pp.base_url)
-    elif pp.auth_type == "api_key" and pp.env_vars and pp.name not in _REGISTRY_PLUGIN_SKIP:
+    elif (
+        pp.auth_type == "api_key"
+        and (pp.env_vars or getattr(pp, "keyless", False))
+        and pp.name not in _REGISTRY_PLUGIN_SKIP
+    ):
         is_url = lambda v: v.endswith("_BASE_URL") or v.endswith("_URL")  # noqa: E731
         pconfig = _api_key_provider(
             pp.name, pp.display_name or pp.name, pp.base_url,
@@ -1773,6 +1777,17 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     pconfig = PROVIDER_REGISTRY.get(provider_id)
     if not pconfig or pconfig.auth_type != "api_key":
         return {"configured": False}
+    # ProviderProfile is the source of truth for out-of-tree keyless gateways.
+    # Diagnostics must agree with runtime credential admission instead of
+    # demanding a secret that the provider explicitly does not use.
+    try:
+        from providers.base import keyless_provider_status_for_auth
+
+        keyless_status = keyless_provider_status_for_auth(provider_id, pconfig)
+        if keyless_status is not None:
+            return keyless_status
+    except Exception:
+        pass
     status = {
         "configured": True, "provider": provider_id, "name": pconfig.name, "key_source": "keyless",
         "base_url": pconfig.inference_base_url, "logged_in": True}
@@ -2005,6 +2020,15 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
             provider=provider_id, code="invalid_provider")
 
     api_key, key_source = _resolve_api_key_provider_secret(provider_id, pconfig)
+    # Provider profiles own keyless admission. This lets an out-of-tree
+    # gateway opt in without another provider-name branch in core.
+    try:
+        from providers.base import apply_keyless_api_key
+
+        api_key, key_source = apply_keyless_api_key(provider_id, api_key, key_source)
+    except Exception:
+        # Provider discovery must not make ordinary API-key auth unavailable.
+        pass
     # No-auth LM Studio: a placeholder so runtime / auxiliary_client see the local server as
     # configured. doctor still reports unconfigured because the status path uses the raw secret.
     if not api_key and provider_id == "lmstudio":

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -168,7 +168,16 @@ def _provider_supports_explicit_api_mode(provider: Optional[str], configured_pro
 def _configured_api_mode(provider: str, model_cfg: Dict[str, Any]) -> Optional[str]:
     """Persisted ``model.api_mode`` when valid and recorded for this provider, else None."""
     configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-    return configured_mode if configured_mode and _provider_supports_explicit_api_mode(provider, _cfg_provider(model_cfg)) else None
+    if not configured_mode or not _provider_supports_explicit_api_mode(provider, _cfg_provider(model_cfg)):
+        return None
+    try:
+        from providers import get_provider_profile
+
+        if getattr(get_provider_profile(provider), "ignore_configured_api_mode", False):
+            return None
+    except Exception:
+        pass
+    return configured_mode
 
 
 def _effective_model(model_cfg: Dict[str, Any], target_model: Optional[str]) -> str:

--- a/providers/README.md
+++ b/providers/README.md
@@ -41,7 +41,8 @@ layer reads from it:
 - `hermes_cli/config.py` injects every `env_var` into
   `OPTIONAL_ENV_VARS` so the setup wizard knows about it.
 - `hermes_cli/runtime_provider.py` reads `profile.api_mode` as a fallback
-  when URL detection finds nothing.
+  when URL detection finds nothing, and lets a profile-owned mode supersede a
+  stale persisted `model.api_mode`.
 - `agent/model_metadata.py` maps hostname → provider via
   `profile.get_hostname()`.
 - `agent/auxiliary_client.py` reads `profile.default_aux_model` first
@@ -69,8 +70,16 @@ under `$HERMES_HOME/plugins/model-providers/` for a private plugin).
 | `prepare_messages(msgs)` | Provider-specific message preprocessing (Qwen normalises to list-of-parts, injects `cache_control`). |
 | `build_extra_body(**ctx)` | Provider-specific `extra_body` (OpenRouter provider prefs, Gemini `thinking_config`). |
 | `build_api_kwargs_extras(**ctx)` | `(extra_body_additions, top_level_kwargs)` — Kimi puts reasoning_effort top-level, Qwen splits `enable_thinking`/`thinking_budget`. |
+| `normalize_auxiliary_extra_body(extra_body, **ctx)` | Final normalization for auxiliary request bodies after profile fields, generic reasoning, and caller overrides are merged. |
+| `finalize_api_kwargs(api_kwargs, **ctx)` | Final normalization for the main Chat Completions request after shared assembly and prompt-cache routing. |
 | `supported_reasoning_efforts(model)` | Declared per-model reasoning-effort vocabulary for gateways that 400 on unknown levels (Ramp Router reads its live catalog). `None` = defer to transport defaults, `()` = model takes no reasoning params, tuple = clamp target. Must be cache-only — called on the request hot path. |
 | `fetch_models(*, api_key)` | Live catalog fetch — default hits `{models_url or base_url}/models` with Bearer auth. Override for no-REST providers (Bedrock), OAuth catalogs (Anthropic), or public catalogs (OpenRouter). |
+
+Profiles that expose an OpenAI-compatible endpoint without credentials can set
+`keyless=True` and provide a non-secret `api_key_placeholder`; auth status and
+runtime resolution then agree without a provider-specific branch. A
+`response_tool_name_normalizer(name, context)` callback can similarly restore
+provider wire names for both streamed deltas and completed tool calls.
 
 ---
 

--- a/providers/base.py
+++ b/providers/base.py
@@ -12,13 +12,27 @@ Those stay on AIAgent.
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Callable, Literal, Mapping
 
 logger = logging.getLogger(__name__)
 
 # Sentinel for "omit temperature entirely" (Kimi: server manages it)
 OMIT_TEMPERATURE = object()
+
+
+@dataclass(frozen=True)
+class ToolNameNormalizeContext:
+    """Describe where an inbound provider wire tool name appeared."""
+
+    phase: Literal["stream_delta", "final_tool_call"]
+    provider: str
+    model: str | None = None
+    request_wire_aliases: Mapping[str, str] | None = None
+
+
+ResponseToolNameNormalizer = Callable[[str, ToolNameNormalizeContext], str]
 
 
 def _profile_user_agent() -> str:
@@ -77,6 +91,18 @@ class ProviderProfile:
     # is deliberately opt-in: many OpenAI-compatible endpoints reject unknown
     # top-level fields rather than ignoring them.
     supports_prompt_cache_key: bool = False
+
+    # A provider plugin may own the API mode even when the user's saved model
+    # block predates that plugin and contains a stale mode.
+    ignore_configured_api_mode: bool = False
+
+    # Keyless gateways still need a non-empty token for OpenAI-compatible
+    # clients. The placeholder is routing metadata, never a credential.
+    keyless: bool = False
+    api_key_placeholder: str = ""
+
+    # Optional provider-owned restoration of response tool names.
+    response_tool_name_normalizer: ResponseToolNameNormalizer | None = None
 
     # ── External-process providers (auth_type="external_process") ──
     # An agent CLI driven over stdio (ACP) rather than an HTTP endpoint. These
@@ -177,6 +203,38 @@ class ProviderProfile:
         Default: ({}, {}).
         """
         return {}, {}
+
+    def normalize_auxiliary_extra_body(
+        self,
+        extra_body: dict[str, Any],
+        *,
+        model: str | None = None,
+        **context: Any,
+    ) -> dict[str, Any]:
+        """Normalize the final ``extra_body`` for an auxiliary request.
+
+        Called after profile fields, generic reasoning fallbacks, and the
+        caller's extra body have been merged. Override this when an auxiliary
+        endpoint needs to remove or reshape a field without a provider branch
+        in the shared auxiliary client.
+        """
+        return extra_body
+
+    def finalize_api_kwargs(
+        self,
+        api_kwargs: dict[str, Any],
+        *,
+        model: str | None = None,
+        **context: Any,
+    ) -> dict[str, Any]:
+        """Normalize the final chat-completions request mapping.
+
+        Called after generic request assembly, profile extras, user request
+        overrides, and prompt-cache routing. Most providers should leave this
+        as a no-op; gateways with model-specific validation quirks can strip
+        or adjust unsupported fields here without a shared transport branch.
+        """
+        return api_kwargs
 
     def default_vision_model(self) -> str | None:
         """Return a default vision model id for this provider, or None.
@@ -330,3 +388,77 @@ class ProviderProfile:
         except Exception as exc:
             logger.debug("fetch_models(%s): %s", self.name, exc)
             return None
+
+
+def _provider_profile(provider_id: str) -> ProviderProfile | None:
+    """Best-effort profile lookup for shared auth helpers."""
+    try:
+        from providers import get_provider_profile
+
+        return get_provider_profile(provider_id)
+    except Exception:
+        return None
+
+
+def apply_keyless_api_key(provider_id: str, api_key: str, key_source: str) -> tuple[str, str]:
+    """Fill a profile-declared keyless gateway placeholder when no secret exists."""
+    if api_key:
+        return api_key, key_source
+    placeholder = keyless_api_key_placeholder(provider_id)
+    if placeholder:
+        return placeholder, key_source or "default"
+    return api_key, key_source
+
+
+def keyless_api_key_placeholder(provider_id: str) -> str | None:
+    """Return a keyless gateway's non-secret client placeholder, if declared."""
+    profile = _provider_profile(provider_id)
+    placeholder = getattr(profile, "api_key_placeholder", "") if profile is not None else ""
+    if (
+        profile is not None
+        and getattr(profile, "keyless", False)
+        and isinstance(placeholder, str)
+        and placeholder
+    ):
+        return placeholder
+    return None
+
+
+def keyless_provider_status_for_auth(provider_id: str, pconfig: Any) -> dict[str, Any] | None:
+    """Return an auth-status payload for a profile-declared keyless provider."""
+    return keyless_provider_status_payload(
+        provider_id,
+        default_name=getattr(pconfig, "name", provider_id),
+        default_base_url=getattr(pconfig, "inference_base_url", ""),
+    )
+
+
+def keyless_provider_status_payload(
+    provider_id: str,
+    *,
+    default_name: str,
+    default_base_url: str,
+) -> dict[str, Any] | None:
+    """Build a keyless provider status payload from its profile metadata."""
+    profile = _provider_profile(provider_id)
+    if profile is None or not getattr(profile, "keyless", False):
+        return None
+
+    env_url = ""
+    for env_var in getattr(profile, "env_vars", ()) or ():
+        if isinstance(env_var, str) and (
+            env_var.endswith("_BASE_URL") or env_var.endswith("_URL")
+        ):
+            env_url = os.getenv(env_var, "").strip()
+            if env_url:
+                break
+    profile_base_url = str(getattr(profile, "base_url", "") or "").strip()
+    base_url = (env_url or profile_base_url or str(default_base_url or "").strip()).rstrip("/")
+    return {
+        "configured": True,
+        "provider": provider_id,
+        "name": getattr(profile, "display_name", "") or default_name,
+        "key_source": "keyless",
+        "base_url": base_url,
+        "logged_in": True,
+    }

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2935,6 +2935,28 @@ class TestAnthropicAuxiliaryReasoningTranslation:
 class TestAuxiliaryProviderProfileReasoning:
     """Auxiliary calls must reuse provider-profile reasoning wire shapes."""
 
+    def test_profile_normalizes_final_auxiliary_extra_body(self, monkeypatch):
+        from providers.base import ProviderProfile
+
+        class NormalizingProfile(ProviderProfile):
+            def normalize_auxiliary_extra_body(self, extra_body, *, model=None, **context):
+                return {"profile_only": model, "incoming": extra_body.get("incoming")}
+
+        profile = NormalizingProfile(name="test-provider")
+        monkeypatch.setattr(
+            "providers.get_provider_profile",
+            lambda provider: profile if provider == "test-provider" else None,
+        )
+
+        kwargs = _build_call_kwargs(
+            "test-provider",
+            "test-model",
+            [{"role": "user", "content": "hi"}],
+            extra_body={"incoming": "value", "removed": True},
+        )
+
+        assert kwargs["extra_body"] == {"profile_only": "test-model", "incoming": "value"}
+
     def test_kimi_reasoning_uses_top_level_effort(self):
         kwargs = _build_call_kwargs(
             "kimi-coding",

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -83,6 +83,63 @@ class TestChatCompletionsBasic:
             "{}",
         ]
 
+    def test_profile_finalizer_runs_after_request_assembly(self, transport):
+        from providers.base import ProviderProfile
+
+        class FinalizingProfile(ProviderProfile):
+            def finalize_api_kwargs(self, api_kwargs, *, model=None, **context):
+                api_kwargs["profile_finalized"] = True
+                api_kwargs["extra_body"] = {**api_kwargs.get("extra_body", {}), "profile_marker": model}
+                return api_kwargs
+
+        kwargs = transport.build_kwargs(
+            model="test-model",
+            messages=[{"role": "user", "content": "Hi"}],
+            provider_profile=FinalizingProfile(name="test-provider"),
+            request_overrides={"profile_finalized": False},
+        )
+
+        assert kwargs["profile_finalized"] is True
+        assert kwargs["extra_body"]["profile_marker"] == "test-model"
+
+    def test_profile_normalizes_final_tool_name_with_context(self, transport):
+        from providers.base import ProviderProfile, ToolNameNormalizeContext
+
+        seen = []
+
+        def normalize(name, context):
+            seen.append(context)
+            return f"canonical_{name}"
+
+        profile = ProviderProfile(name="test-provider", response_tool_name_normalizer=normalize)
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content=None,
+                    tool_calls=[SimpleNamespace(
+                        id="call-1",
+                        function=SimpleNamespace(name="wire_tool", arguments="{}"),
+                    )],
+                ),
+                finish_reason="tool_calls",
+            )],
+            usage=None,
+        )
+
+        normalized = transport.normalize_response(
+            response,
+            provider_profile=profile,
+            model="test-model",
+        )
+
+        assert normalized.tool_calls[0].name == "canonical_wire_tool"
+        assert seen == [ToolNameNormalizeContext(
+            phase="final_tool_call",
+            provider="test-provider",
+            model="test-model",
+            request_wire_aliases=None,
+        )]
+
     @pytest.mark.parametrize("provider", ["nous", "openrouter"])
     def test_gpt56_ultra_uses_max_wire_effort(self, transport, provider):
         from providers import get_provider_profile

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -8,6 +8,97 @@ import pytest
 from hermes_cli import runtime_provider as rp
 
 
+def test_profile_owned_api_mode_ignores_stale_saved_mode(monkeypatch):
+    from providers.base import ProviderProfile
+
+    profile = ProviderProfile(
+        name="test-profile-owned-mode",
+        api_mode="anthropic_messages",
+        ignore_configured_api_mode=True,
+    )
+    monkeypatch.setattr(
+        "providers.get_provider_profile",
+        lambda provider: profile if provider == profile.name else None,
+    )
+
+    assert rp._configured_api_mode(profile.name, {
+        "provider": profile.name,
+        "api_mode": "chat_completions",
+    }) is None
+
+    # Providers without the opt-in keep the existing persisted-mode behavior.
+    assert rp._configured_api_mode("test-unowned-mode", {
+        "provider": "test-unowned-mode",
+        "api_mode": "chat_completions",
+    }) == "chat_completions"
+
+
+def test_keyless_profile_with_no_env_vars_is_registered_for_runtime(monkeypatch):
+    from hermes_cli import auth as auth_mod
+    from providers.base import ProviderProfile
+
+    provider_id = "test-keyless-no-env"
+    profile = ProviderProfile(
+        name=provider_id,
+        base_url="https://gateway.example/v1",
+        keyless=True,
+        api_key_placeholder="test-placeholder",
+    )
+    monkeypatch.setattr("providers.get_provider_profile", lambda _provider: profile)
+    previous = auth_mod.PROVIDER_REGISTRY.get(provider_id)
+    try:
+        auth_mod._register_plugin_provider(profile)
+
+        assert auth_mod.PROVIDER_REGISTRY[provider_id].auth_type == "api_key"
+        assert auth_mod.PROVIDER_REGISTRY[provider_id].api_key_env_vars == ()
+    finally:
+        if previous is None:
+            auth_mod.PROVIDER_REGISTRY.pop(provider_id, None)
+        else:
+            auth_mod.PROVIDER_REGISTRY[provider_id] = previous
+
+
+def test_auth_uses_profile_declared_keyless_credentials_and_status(monkeypatch):
+    from hermes_cli import auth as auth_mod
+    from providers import base as provider_base
+    from providers.base import ProviderProfile
+
+    provider_id = "test-keyless-auth"
+    profile = ProviderProfile(
+        name=provider_id,
+        display_name="Test Keyless Auth",
+        base_url="https://gateway.example/v1",
+        keyless=True,
+        api_key_placeholder="test-placeholder",
+    )
+    monkeypatch.setitem(
+        auth_mod.PROVIDER_REGISTRY,
+        provider_id,
+        auth_mod.ProviderConfig(
+            id=provider_id,
+            name="Registry fallback",
+            auth_type="api_key",
+            inference_base_url="https://registry.example/v1",
+        ),
+    )
+    monkeypatch.setattr(
+        provider_base,
+        "_provider_profile",
+        lambda current: profile if current == provider_id else None,
+    )
+    monkeypatch.setattr(auth_mod, "_resolve_api_key_provider_secret", lambda *_args: ("", ""))
+
+    assert auth_mod.get_api_key_provider_status(provider_id) == {
+        "configured": True,
+        "provider": provider_id,
+        "name": "Test Keyless Auth",
+        "key_source": "keyless",
+        "base_url": "https://gateway.example/v1",
+        "logged_in": True,
+    }
+    assert auth_mod.resolve_api_key_provider_credentials(provider_id)["api_key"] == "test-placeholder"
+
+
 def test_configured_api_key_provider_without_key_fails_closed(monkeypatch):
     """A saved provider must not resolve as another authenticated provider."""
     monkeypatch.setattr(
@@ -166,6 +257,7 @@ def test_qwen_oauth_auto_fallthrough_on_auth_failure(monkeypatch):
         lambda **kw: (_ for _ in ()).throw(AuthError("stale", provider="qwen-oauth", code="qwen_auth_missing")),
     )
     monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setattr(rp, "load_pool", lambda _provider: None)
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-or-key")
 
     # Should NOT raise — falls through to OpenRouter

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -11,6 +11,47 @@ class TestRegistry:
         assert p.name == "nvidia"
 
 
+class TestProviderProfileRuntimeSeams:
+    def test_keyless_helpers_use_profile_metadata(self, monkeypatch):
+        from providers import base
+
+        profile = ProviderProfile(
+            name="test-keyless",
+            display_name="Test Keyless",
+            base_url="https://gateway.example/v1",
+            env_vars=("TEST_GATEWAY_BASE_URL",),
+            keyless=True,
+            api_key_placeholder="profile-placeholder",
+        )
+        monkeypatch.setattr(
+            base, "_provider_profile", lambda provider_id: profile if provider_id == profile.name else None
+        )
+        monkeypatch.setenv("TEST_GATEWAY_BASE_URL", "https://override.example/v1/")
+
+        assert base.apply_keyless_api_key(profile.name, "", "") == ("profile-placeholder", "default")
+        assert base.apply_keyless_api_key(profile.name, "real-secret", "env") == ("real-secret", "env")
+        assert base.keyless_provider_status_payload(
+            profile.name,
+            default_name="Fallback",
+            default_base_url="https://fallback.example/v1",
+        ) == {
+            "configured": True,
+            "provider": "test-keyless",
+            "name": "Test Keyless",
+            "key_source": "keyless",
+            "base_url": "https://override.example/v1",
+            "logged_in": True,
+        }
+
+    def test_default_runtime_hooks_are_identity(self):
+        profile = ProviderProfile(name="test")
+        body = {"reasoning": {"effort": "low"}}
+        kwargs = {"model": "test-model"}
+
+        assert profile.normalize_auxiliary_extra_body(body, model="test-model") is body
+        assert profile.finalize_api_kwargs(kwargs, model="test-model") is kwargs
+
+
 
 
 

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -307,6 +307,46 @@ class TestStreamingAccumulator:
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_profile_normalizes_streamed_tool_start_name(self, mock_close, mock_create):
+        from providers.base import ProviderProfile
+        from run_agent import AIAgent
+
+        started = []
+        profile = ProviderProfile(
+            name="test-stream-profile",
+            response_tool_name_normalizer=lambda name, context: f"canonical_{name}",
+        )
+        chunks = [
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_123", name="terminal"),
+            ]),
+            _make_stream_chunk(finish_reason="tool_calls"),
+        ]
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://gateway.example/v1",
+            model="test/model",
+            provider="test-stream-profile",
+            tool_gen_callback=started.append,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        with patch("providers.get_provider_profile", return_value=profile):
+            response = agent._interruptible_streaming_api_call({})
+
+        assert started == ["canonical_terminal"]
+        assert response.choices[0].message.tool_calls[0].function.name == "terminal"
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
     def test_tool_argument_deltas_are_collected_without_concatenating_each_chunk(
         self, mock_close, mock_create
     ):


### PR DESCRIPTION
## Summary

- let out-of-tree ProviderProfile implementations own stale persisted API-mode precedence and keyless OpenAI-compatible auth
- add final auxiliary/body and chat-completions request normalization hooks
- add request-aware response tool-name normalization for streamed and completed tool calls
- preserve existing behavior unless a provider profile explicitly opts in

## Plugin examples

```python
profile = ProviderProfile(
    name="local-gateway",
    base_url="http://127.0.0.1:9000/v1",
    keyless=True,
    api_key_placeholder="local",
    ignore_configured_api_mode=True,
)
```

```python
class StrictGatewayProfile(ProviderProfile):
    def finalize_api_kwargs(self, api_kwargs, **context):
        api_kwargs.pop("unsupported_field", None)
        return api_kwargs
```

The response_tool_name_normalizer callback receives a ToolNameNormalizeContext containing the phase, provider, model, and request-local wire aliases, so profiles can restore provider-specific wire names without adding core provider branches.

## Verification

- Ruff on all changed Python files
- 389 focused provider/auth/runtime/transport/streaming tests
- rebased on current origin/main
- scope scan confirms no private providers, credentials, local deployment configuration, Poke/Guest, texture, LCM, billing, or support-package code

Screenshots are not applicable because this PR has no UI changes.