### PR TITLE
cron: normalize script path on Windows to prevent separator issues

### DIFF
--- a/cron/scheduler_script.py
+++ b/cron/scheduler_script.py
@@ -331,6 +331,12 @@ def _run_job_script(
     path, err = _resolve_script_path(script_path)
     if path is None:
         return False, err
+
+    # Windows: normalize path for subprocess execution to avoid separator issues
+    # on non-default profiles where HERMES_HOME override may produce mixed separators.
+    if sys.platform == "win32":
+        path = Path(os.path.normpath(str(path)))
+
     script_timeout = _get_script_timeout()
     argv, env_overlay, err = _script_argv(path)
     if argv is None:


### PR DESCRIPTION
Fixes #102958

## Problem

On Windows with non-default profiles, the cron scheduler could produce
malformed script paths when string concatenation drops path separators,
causing "No such file or directory" errors (exit code 127) when bash
tries to execute the script.

The issue occurred on Windows with non-default profiles where the
HERMES_HOME override could produce paths with mixed separators
(forward/backslashes) that bash couldn't resolve.

## Fix

Added `os.path.normpath` normalization for the resolved script path on
Windows before passing to subprocesses. This normalizes mixed separators
(forward/backslashes) and removes redundant separators that could cause
"No such file or directory" errors when passed to subprocesses on
Windows with non-default profiles.

The fix applies `os.path.normpath` to the resolved script path on
Windows, which normalizes mixed separators (forward/backslashes) and
removes redundant separators.

## Testing

Existing cron script tests pass. The fix is a defensive normalization
that only applies on Windows.