### PR TITLE
fix(desktop): pass the electron-builder staging override as direct argv

### DIFF
--- a/hermes_cli/main_desktop.py
+++ b/hermes_cli/main_desktop.py
@@ -19,7 +19,7 @@ import time as _time_mod
 
 from pathlib import Path
 from typing import Optional
-from hermes_cli.main_tui_launch import _npm_lifecycle_env
+from hermes_cli.main_tui_launch import _npm_lifecycle_env, _tui_node_bin
 from hermes_cli.main_web_build import (
     _hash_source_tree, _nixos_build_env, _stamp_is_current, _write_build_stamp)
 
@@ -1263,8 +1263,15 @@ def _install_desktop_workspace_deps(npm: str, env: dict) -> None:
               "the Electron fetch itself.")
 
 
+# Mirrors the `builder` script in apps/desktop/package.json (cross-env
+# NODE_OPTIONS=--) so the direct electron-builder invocation keeps the same
+# heap headroom npm's lifecycle used to provide.
+_BUILDER_NODE_OPTIONS = "--max-old-space-size=16384"
+
+
 def _run_desktop_pack_with_recovery(
-    desktop_dir: Path, build_cmd: list[str], npm_build_env: dict, env: dict, staging_dir: Optional[Path]
+    desktop_dir: Path, build_cmd: list[str], builder_steps: Optional[list[list[str]]], npm_build_env: dict,
+    env: dict, staging_dir: Optional[Path]
 ) -> subprocess.CompletedProcess:
     """Run the desktop build; a packaged build with NO staged exe retries after an Electron re-download, then via mirror.
 
@@ -1277,7 +1284,15 @@ def _run_desktop_pack_with_recovery(
         return _desktop_packaged_executable_in(staging_dir) if staging_dir else None
 
     def _pack(run_env: dict) -> subprocess.CompletedProcess:
-        return subprocess.run(build_cmd, cwd=desktop_dir, env=run_env, check=False)
+        result = subprocess.run(build_cmd, cwd=desktop_dir, env=run_env, check=False)
+        if result.returncode != 0 or not builder_steps:
+            return result
+        builder_env = {**run_env, "NODE_OPTIONS": _BUILDER_NODE_OPTIONS}
+        for step in builder_steps:
+            result = subprocess.run(step, cwd=desktop_dir, env=builder_env, check=False)
+            if result.returncode != 0:
+                return result
+        return result
 
     build_result = _pack(npm_build_env)
     if build_result.returncode != 0 and staging_dir is not None and _staged_exe() is None:
@@ -1361,17 +1376,36 @@ def _build_desktop_app(desktop_dir: Path, *, source_mode: bool, npm: str, env: d
     # only replaced — by rename — after the staged result verifies.
     # See #86443.
     staging_dir: Optional[Path] = None
-    build_cmd = [npm, "run", build_script]
+    # The packaged flow splits `npm run pack` (= `build && builder -- --dir
+    # --publish never`) into its two phases: the vite build below, then the
+    # direct electron-builder invocation in *builder_steps*. `build_script`
+    # stays "pack" only for the manual-retry hint above.
+    build_cmd = [npm, "run", "build"]
+    builder_steps: Optional[list[list[str]]] = None
     if not source_mode:
         staging_dir = _desktop_staging_dir(desktop_dir)
-        build_cmd += ["--", f"-c.directories.output={staging_dir}"]
+        # npm run pack -- -c.directories.output=<path> forwards the override
+        # through npm's cmd.exe script chain (pack is a `&&` composite), where
+        # Windows profile-path characters such as the apostrophe in
+        # C:\Users\r'y'z get stripped and electron-builder then fails on the
+        # mangled path (#103010). Keep `npm run build` argument-free and hand
+        # electron-builder its override directly: the wrapper script's argv
+        # never crosses a shell, so the staging path arrives verbatim.
+        node = _tui_node_bin("node")
+        builder_steps = [
+            # npm's `prebuilder` hook (no-op off darwin; idempotent on it).
+            [node, str(desktop_dir / "scripts" / "patch-electron-builder-mac-binary.mjs")],
+            [node, str(desktop_dir / "scripts" / "run-electron-builder.mjs"),
+             "--dir", f"-c.directories.output={staging_dir}"],
+        ]
         # A running desktop instance holds Hermes.exe locked on Windows, so the
         # pack can't replace it ("Access is denied"). Stop it first.
         stopped = _stop_desktop_processes_locking_build(desktop_dir)
         if stopped:
             print(f"  ⚠ Stopped running desktop app to free the build output (pid {', '.join(map(str, stopped))})")
 
-    build_result = _run_desktop_pack_with_recovery(desktop_dir, build_cmd, npm_build_env, env, staging_dir)
+    build_result = _run_desktop_pack_with_recovery(
+        desktop_dir, build_cmd, builder_steps, npm_build_env, env, staging_dir)
     if build_result.returncode != 0:
         print("✗ Desktop GUI build failed")
         if staging_dir is not None:

--- a/tests/hermes_cli/test_desktop_exe_integrity.py
+++ b/tests/hermes_cli/test_desktop_exe_integrity.py
@@ -303,9 +303,11 @@ def test_build_only_fails_when_pack_produces_corrupt_exe(tmp_path, monkeypatch, 
 
     def pack_into_staging(cmd, *args, **kwargs):
         # electron-builder honours -c.directories.output=<staging>; emulate a
-        # pack that "succeeds" but writes a truncated exe there.
+        # pack that "succeeds" but writes a truncated exe there. The vite build
+        # and the prebuilder patch carry no override and just succeed.
         out_flag = next((a for a in cmd if str(a).startswith("-c.directories.output=")), None)
-        assert out_flag is not None, "pack must be redirected into a staging dir"
+        if out_flag is None:
+            return subprocess.CompletedProcess(list(cmd), 0)
         staging = Path(str(out_flag).split("=", 1)[1])
         make_pe(staging / "win-unpacked" / "Hermes.exe", PE_AMD64, truncate_to=0x300)
         return subprocess.CompletedProcess(list(cmd), 0)
@@ -319,6 +321,7 @@ def test_build_only_fails_when_pack_produces_corrupt_exe(tmp_path, monkeypatch, 
          patch("hermes_cli.main_desktop._desktop_stamp_path", return_value=tmp_path / "stamp.json"), \
          patch("hermes_cli.main_desktop._write_desktop_build_stamp") as mock_stamp, \
          patch("hermes_cli.main_desktop._windows_native_machine", return_value="AMD64"), \
+         patch("hermes_cli.main_desktop._tui_node_bin", return_value="C:\\Program Files\\nodejs\\node.exe"), \
          patch("hermes_cli.main_desktop.subprocess.run", side_effect=pack_into_staging), \
          pytest.raises(SystemExit) as exc:
         cli_main.cmd_gui(_ns())

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -104,7 +104,7 @@ def _make_packaged_executable(root: Path, monkeypatch) -> Path:
 
 def _staging_dir_from(cmd) -> Path:
     """Extract the ``-c.directories.output=<dir>`` electron-builder override
-    ``cmd_gui`` appends to ``npm run pack`` (stage-and-swap, #86443)."""
+    ``cmd_gui`` passes to the pack wrapper (stage-and-swap, #86443)."""
     for arg in cmd:
         if isinstance(arg, str) and arg.startswith("-c.directories.output="):
             return Path(arg.split("=", 1)[1])
@@ -121,12 +121,13 @@ def _packaged_exe_rel() -> Path:
 
 
 def _pack_into_staging(root: Path, content: str = "", returncode: int = 0):
-    """``subprocess.run`` side effect mimicking a real ``npm run pack``: lays
-    the packaged app down inside the STAGING dir named on the command line
-    (never in release/), then returns *returncode*. Non-pack commands (the
-    launch) return success."""
+    """``subprocess.run`` side effect mimicking the direct electron-builder
+    invocation: lays the packaged app down inside the STAGING dir named on the
+    command line (never in release/), then returns *returncode*. Other
+    commands (the vite build, the prebuilder patch, the launch) return
+    success."""
     def _run(cmd, **kwargs):
-        if len(cmd) >= 3 and cmd[1:3] == ["run", "pack"]:
+        if any("run-electron-builder.mjs" in str(part) for part in cmd):
             exe = _staging_dir_from(cmd) / _packaged_exe_rel()
             exe.parent.mkdir(parents=True, exist_ok=True)
             exe.write_text(content, encoding="utf-8")
@@ -154,6 +155,7 @@ def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):
          patch("hermes_cli.main_desktop._desktop_macos_relaunchable_fixup"), \
          patch("hermes_cli.main_desktop._desktop_linux_sandbox_fixup", return_value=True), \
          patch("hermes_cli.main_desktop._register_linux_desktop_entry"), \
+         patch("hermes_cli.main_desktop._tui_node_bin", return_value="/usr/bin/node"), \
          patch("hermes_cli.main.subprocess.run", side_effect=_pack_into_staging(root)) as mock_run, \
          pytest.raises(SystemExit) as exc:
         cli_main.cmd_gui(_ns())
@@ -166,20 +168,34 @@ def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):
     assert mock_install.call_args.kwargs["capture_output"] is False
     install_env = mock_install.call_args.kwargs["env"]
     assert install_env is not None and "PATH" in install_env
-    pack_cmd = mock_run.call_args_list[0].args[0]
-    assert pack_cmd[:4] == ["/usr/bin/npm", "run", "pack", "--"]
+    commands = [call.args[0] for call in mock_run.call_args_list]
+    # Phase 1 is a plain `npm run build`: the packaged flow must never forward
+    # the staging override through `npm run pack -- <arg>`, whose cmd.exe
+    # script chain mangles Windows profile paths (#103010).
+    assert commands[0][:3] == ["/usr/bin/npm", "run", "build"]
+    assert "--" not in commands[0]
+    assert all(cmd[1:3] != ["run", "pack"] for cmd in commands)
+    # Phase 2 runs electron-builder's wrapper directly, so the override rides a
+    # plain argv element and no shell ever re-parses it.
+    builder_cmd = commands[2]
+    assert "run-electron-builder.mjs" in builder_cmd[1]
+    assert builder_cmd[2] == "--dir"
+    # npm's `prebuilder` hook still runs ahead of the builder step.
+    assert "patch-electron-builder-mac-binary.mjs" in commands[1][1]
     # Stage-and-swap (#86443): the pack targets a staging dir beside release/,
     # never release/ itself.
-    staging = _staging_dir_from(pack_cmd)
+    staging = _staging_dir_from(builder_cmd)
     assert staging.parent == desktop_dir and staging.name.startswith(".staging-")
     assert not staging.exists()  # swapped into release/ and cleaned up
+    builder_env = mock_run.call_args_list[2].kwargs["env"]
+    assert builder_env["NODE_OPTIONS"] == "--max-old-space-size=16384"
     assert mock_run.call_args_list[0].kwargs["cwd"] == desktop_dir
-    launched = mock_run.call_args_list[1].args[0]
+    launched = mock_run.call_args_list[3].args[0]
     if sys.platform.startswith("linux"):
         assert launched == [str(packaged_exe), "--disable-setuid-sandbox"]
     else:
         assert launched == [str(packaged_exe)]
-    assert mock_run.call_args_list[1].kwargs["cwd"] == desktop_dir
+    assert mock_run.call_args_list[3].kwargs["cwd"] == desktop_dir
 
 
 def test_gui_install_env_prepends_managed_node_on_bare_path(tmp_path, monkeypatch):
@@ -317,6 +333,7 @@ def test_gui_does_not_retry_after_packaged_executable_exists(tmp_path, monkeypat
          patch("hermes_cli.main_desktop._desktop_macos_relaunchable_fixup"), \
          patch("hermes_cli.main_desktop._purge_electron_build_cache", return_value=[Path("/c/electron.zip")]) as mock_purge, \
          patch("hermes_cli.main_desktop._redownload_electron_dist", return_value=True) as mock_dl, \
+         patch("hermes_cli.main_desktop._tui_node_bin", return_value="/usr/bin/node"), \
          patch("hermes_cli.main.subprocess.run", side_effect=pack_fail) as mock_run, \
          pytest.raises(SystemExit) as exc:
         cli_main.cmd_gui(_ns())
@@ -325,10 +342,11 @@ def test_gui_does_not_retry_after_packaged_executable_exists(tmp_path, monkeypat
     # The live app was never touched by the failed pack (#86443).
     assert live_exe.read_text(encoding="utf-8") == "good build"
     assert not list((root / "apps" / "desktop").glob(".staging-*"))
-    # Neither destructive recovery runs, and there is exactly ONE pack attempt.
+    # Neither destructive recovery runs, and there is exactly ONE builder
+    # attempt (preceded by the vite build and the prebuilder patch).
     mock_purge.assert_not_called()
     mock_dl.assert_not_called()
-    assert mock_run.call_count == 1
+    assert mock_run.call_count == 3
     assert "Desktop GUI build failed" in capsys.readouterr().out
 
 
@@ -1088,6 +1106,49 @@ def test_desktop_launch_options_normalizes_ozone_hint(raw, expected):
     assert hint == expected
 
 
+def test_desktop_pack_staging_override_bypasses_npm_arg_chain(tmp_path, monkeypatch):
+    r"""Regression (#103010): ``npm run pack -- -c.directories.output=<path>``
+    forwarded the staging override through npm's cmd.exe script chain (pack is
+    a ``&&`` composite), which strips Windows profile-path characters such as
+    the apostrophe in ``C:\Users\r'y'z`` — electron-builder then died on the
+    mangled path. The override now rides a direct argv element to the wrapper
+    script, so no shell ever re-parses it and the profile dir arrives verbatim.
+    """
+    root = _make_desktop_tree(tmp_path / "r'y'z")
+    desktop_dir = root / "apps" / "desktop"
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    _make_packaged_executable(root, monkeypatch)
+
+    install_ok = subprocess.CompletedProcess(["npm", "ci"], 0)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main_web_build._run_npm_install_deterministic", return_value=install_ok), \
+         patch("hermes_cli.main_desktop._desktop_build_needed", return_value=True), \
+         patch("hermes_cli.main_desktop._write_desktop_build_stamp"), \
+         patch("hermes_cli.main_desktop._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main_desktop._desktop_linux_sandbox_fixup", return_value=True), \
+         patch("hermes_cli.main_desktop._register_linux_desktop_entry"), \
+         patch("hermes_cli.main_desktop._tui_node_bin", return_value="/usr/bin/node"), \
+         patch("hermes_cli.main.subprocess.run", side_effect=_pack_into_staging(root)) as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns())
+
+    assert exc.value.code == 0
+    commands = [call.args[0] for call in mock_run.call_args_list]
+    # Nothing hands a path-bearing argument to `npm run <script> --` anymore.
+    assert all(cmd[1:3] != ["run", "pack"] for cmd in commands)
+    builder_cmds = [c for c in commands if "run-electron-builder.mjs" in " ".join(map(str, c))]
+    assert len(builder_cmds) == 1
+    override = next(a for a in builder_cmds[0] if str(a).startswith("-c.directories.output="))
+    staging = Path(str(override).split("=", 1)[1])
+    # The apostrophe survives the whole Python -> node chain: the override
+    # names the staging dir under the profile dir verbatim, never a mangled
+    # ``ryz``-style path.
+    assert "r'y'z" in str(staging)
+    assert staging.parent == desktop_dir
+    assert staging.name.startswith(".staging-")
+
+
 def test_desktop_launch_options_ozone_hint_defaults_auto():
     with patch("hermes_cli.config.load_config", return_value={}):
         assert main_desktop._desktop_launch_options()[3] == "auto"
@@ -1111,11 +1172,12 @@ def test_gui_bridges_ozone_hint_to_launch_env(tmp_path, monkeypatch):
          patch("hermes_cli.main_desktop._desktop_linux_sandbox_fixup", return_value=True), \
          patch("hermes_cli.config.load_config", return_value=cfg), \
          patch("hermes_cli.linux_desktop_entry.install_desktop_entry", return_value=None), \
+         patch("hermes_cli.main_desktop._tui_node_bin", return_value="/usr/bin/node"), \
          patch("hermes_cli.main.subprocess.run", side_effect=_pack_into_staging(root)) as mock_run, \
          pytest.raises(SystemExit):
         cli_main.cmd_gui(_ns())
 
-    launch_env = mock_run.call_args_list[1].kwargs["env"]
+    launch_env = mock_run.call_args_list[3].kwargs["env"]
     assert launch_env.get("ELECTRON_OZONE_PLATFORM_HINT") == "x11"
 
     monkeypatch.setenv("ELECTRON_OZONE_PLATFORM_HINT", "wayland")
@@ -1127,11 +1189,12 @@ def test_gui_bridges_ozone_hint_to_launch_env(tmp_path, monkeypatch):
          patch("hermes_cli.main_desktop._desktop_linux_sandbox_fixup", return_value=True), \
          patch("hermes_cli.config.load_config", return_value=cfg), \
          patch("hermes_cli.linux_desktop_entry.install_desktop_entry", return_value=None), \
+         patch("hermes_cli.main_desktop._tui_node_bin", return_value="/usr/bin/node"), \
          patch("hermes_cli.main.subprocess.run", side_effect=_pack_into_staging(root)) as mock_run2, \
          pytest.raises(SystemExit):
         cli_main.cmd_gui(_ns())
 
-    launch_env = mock_run2.call_args_list[1].kwargs["env"]
+    launch_env = mock_run2.call_args_list[3].kwargs["env"]
     assert launch_env.get("ELECTRON_OZONE_PLATFORM_HINT") == "wayland"
 
 
@@ -1344,6 +1407,7 @@ def _gui_build_patches(root: Path, run_side_effect):
         patch("hermes_cli.main_desktop._stop_desktop_processes_locking_build", return_value=[]),
         patch("hermes_cli.main_desktop._purge_electron_build_cache", return_value=[]),
         patch("hermes_cli.main_desktop._redownload_electron_dist", return_value=False),
+        patch("hermes_cli.main_desktop._tui_node_bin", return_value="/usr/bin/node"),
         patch("hermes_cli.main.subprocess.run", side_effect=run_side_effect),
     ]
 
@@ -1419,6 +1483,10 @@ def test_gui_failed_pack_leaves_previous_app_untouched(tmp_path, monkeypatch, ca
     monkeypatch.setenv("ELECTRON_MIRROR", "https://example.test/electron/")
 
     def failing_pack(cmd, **kwargs):
+        # The vite build phase succeeds; the failure below belongs to the
+        # electron-builder step that carries the staging override.
+        if next((a for a in cmd if str(a).startswith("-c.directories.output=")), None) is None:
+            return subprocess.CompletedProcess(cmd, 0)
         # Mimic before-pack.mjs wiping appOutDir inside the OUTPUT dir it was
         # given, then dying (corrupt Electron zip → ENOENT on rename).
         out = _staging_dir_from(cmd) / _packaged_exe_rel().parts[0]
@@ -1473,6 +1541,8 @@ def test_gui_zero_exit_pack_without_artifact_keeps_previous_app(tmp_path, monkey
     live_exe.write_text("good build", encoding="utf-8")
 
     def empty_pack(cmd, **kwargs):
+        if next((a for a in cmd if str(a).startswith("-c.directories.output=")), None) is None:
+            return subprocess.CompletedProcess(cmd, 0)
         _staging_dir_from(cmd).mkdir(parents=True, exist_ok=True)
         return subprocess.CompletedProcess(cmd, 0)
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Windows desktop rebuild failure when the user's profile path contains an apostrophe (e.g. `C:\Users\r'y'z`). The reporter's five-probe RCA in the issue localised the mangling to the npm argument-forwarding chain: `npm run pack -- -c.directories.output=<path>` appends the override to the `pack` script — a `build && builder -- --dir --publish never` composite — which npm then executes through `cmd /d /s /c`, and the apostrophe is stripped somewhere in that handoff. electron-builder receives `C:\Users\ryz`, tries to `mkdir` under `C:\Users`, and dies with `EPERM`.

The fix splits the packaged flow into the two phases `npm run pack` was chaining:

1. a plain, argument-free `npm run build` (its `prebuild`/`postbuild` lifecycle hooks are untouched), and
2. electron-builder invoked directly via `node scripts/run-electron-builder.mjs --dir -c.directories.output=<staging>`, where the override rides a single argv element from `subprocess.run` → node → `spawnSync` and never crosses a shell, so the path arrives verbatim.

Two npm lifecycle details the direct invocation would otherwise lose are preserved explicitly: the `prebuilder` hook (`patch-electron-builder-mac-binary.mjs`, self-guarded to darwin and idempotent) runs ahead of the builder step, and the `builder` script's `cross-env NODE_OPTIONS=--max-old-space-size=16384` is applied to the builder step's env. The corrupt-download/mirror recovery in `_run_desktop_pack_with_recovery` now retries the whole two-phase sequence, which is idempotent.

## Related Issue

Fixes #103010

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main_desktop.py`: `_build_desktop_app` no longer appends `-c.directories.output=<staging>` to `npm run pack`; it keeps phase 1 as `npm run build` and hands the override to a new `builder_steps` sequence (prebuilder patch + wrapper script) invoked by `_run_desktop_pack_with_recovery`.
- `hermes_cli/main_desktop.py`: `_run_desktop_pack_with_recovery` takes the extra `builder_steps` argument, runs them after a successful build phase with the builder env (`NODE_OPTIONS` mirrors the `builder` script), and returns on the first failing step so the existing recovery gates keep working unchanged.
- `tests/hermes_cli/test_gui_command.py`: the subprocess fakes now key on the direct wrapper invocation instead of `npm run pack`; assertions cover the new command sequence, the builder env, and a regression test that a profile dir containing an apostrophe (`r'y'z`) arrives verbatim in the override argv.
- `tests/hermes_cli/test_desktop_exe_integrity.py`: the pack side effect lets the argument-free build/patch commands succeed and only simulates the electron-builder step.

## How to Test

1. `pytest tests/hermes_cli/test_gui_command.py tests/hermes_cli/test_desktop_exe_integrity.py -q` — should pass (`49 passed, 8 skipped` and `1 passed, 4 skipped` on macOS; the skipped ones are `windows_only` lanes).
2. New regression test `test_desktop_pack_staging_override_bypasses_npm_arg_chain` builds under a `r'y'z` profile dir and asserts: no `npm run pack --` call exists in the sequence, exactly one direct wrapper invocation carries the override, and the apostrophe survives into the staging path verbatim.
3. On Windows with an apostrophe-bearing username, `hermes desktop --build-only` (Observed result: packaging proceeds with `appOutDir=C:\Users\r'y'z\...` instead of failing with `EPERM mkdir C:\Users\ryz`; the issue's probe A/B already proved electron-builder keeps the apostrophe when invoked directly).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64); Windows behaviour covered by the `windows_only` integrity test lane and the argv-level regression test

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — not a skill.

## Screenshots / Logs

Test run on macOS:

```
$ pytest tests/hermes_cli/test_gui_command.py -q
49 passed, 8 skipped in 0.81s
$ pytest tests/hermes_cli/test_desktop_exe_integrity.py -q
1 passed, 4 skipped in 0.19s
```
