### PR TITLE
fix(update): skip transient SCM service states instead of aborting the update

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -781,6 +781,17 @@ def find_profile_gateway_processes(exclude_pids: set | None = None, *, strict: b
     return processes
 
 
+_TRANSIENT_SERVICE_STATES = frozenset(
+    {
+        "stop_pending",
+        "start_pending",
+        "continue_pending",
+        "pause_pending",
+        "paused",
+    }
+)
+
+
 def find_windows_gateway_services(
     *, psutil_module=None, profile_processes: list[ProfileGatewayProcess] | None = None
 ) -> list[WindowsGatewayService]:
@@ -816,6 +827,12 @@ def find_windows_gateway_services(
             if not service_name:
                 raise RuntimeError("SCM service has an empty name")
             if service_status == "stopped":
+                continue
+            if service_status in _TRANSIENT_SERVICE_STATES:
+                # A service mid-transition (e.g. BcastDVRUserService stuck in
+                # stop_pending) cannot be supervising a live gateway tree, and
+                # its PID is not yet meaningful. Skip it instead of aborting
+                # the whole update on an unrelated Windows service.
                 continue
             if service_status != "running":
                 if service_pid > 0:

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1227,6 +1227,47 @@ def test_find_windows_gateway_services_rejects_shared_service_host_pid(monkeypat
         )
 
 
+def test_find_windows_gateway_services_skips_transient_service_states(
+    monkeypatch,
+):
+    """A service mid-transition (stop_pending etc.) is skipped, not fatal."""
+    monkeypatch.setattr(gateway.sys, "platform", "win32")
+    profile = SimpleNamespace(profile="default", pid=300, create_time=300.0)
+
+    class TransientService:
+        def as_dict(self):
+            return {"name": "BcastDVRUserService_74d1b7", "pid": 0, "status": "stop_pending"}
+
+    class RunningService:
+        def as_dict(self):
+            return {"name": "HermesGateway", "pid": 100, "status": "running"}
+
+    class FakeProcess:
+        def __init__(self, pid):
+            self.pid = pid
+
+        def parents(self):
+            return [FakeProcess(100)]
+
+        def children(self, recursive=False):
+            return [FakeProcess(300)]
+
+        def create_time(self):
+            return float(self.pid)
+
+    fake_psutil = SimpleNamespace(
+        win_service_iter=lambda: [TransientService(), RunningService()],
+        Process=FakeProcess,
+    )
+
+    result = gateway.find_windows_gateway_services(
+        psutil_module=fake_psutil,
+        profile_processes=[profile],
+    )
+
+    assert [service.name for service in result] == ["HermesGateway"]
+
+
 def test_find_windows_gateway_services_fails_closed_on_service_access_error(
     monkeypatch,
 ):


### PR DESCRIPTION
## Problem

`hermes update` on Windows aborts with:

```
RuntimeError: Could not determine Windows gateway service ownership: SCM service enumeration failed
```

`find_windows_gateway_services()` treats any SCM service whose status is neither `running` nor `stopped` as fatal. Windows per-user services (e.g. `BcastDVRUserService_<sid>`) routinely sit in `stop_pending` for a long time, so the update fails before touching anything — every time, until the service happens to settle.

Reproduced on Windows 11: `psutil.win_service_iter()` returns `BcastDVRUserService_74d1b7` with status `stop_pending` (confirmed via `Get-Service` / `Win32_Service`), and the updater's exact loop raises on it.

## Fix

Skip services in transient states (`stop_pending`, `start_pending`, `continue_pending`, `pause_pending`, `paused`) the same way `stopped` is skipped: a service mid-transition cannot be supervising a live gateway tree, and its PID is not yet meaningful. Truly unknown states still fail closed.

## Tests

- New test `test_find_windows_gateway_services_skips_transient_service_states` covers the skip.
- Existing fail-closed tests (access error, indeterminate scan) still pass.
- Full `tests/hermes_cli/test_gateway.py`: 33 passed, 5 skipped.
- Verified against the live machine: the updater's discovery path now completes without the RuntimeError.