### PR TITLE
fix(bluebubbles): harden delivery and reaction lifecycles

### DIFF
--- a/gateway/config_loader.py
+++ b/gateway/config_loader.py
@@ -187,6 +187,7 @@ def _str_keyed(value: Any) -> Any:
 
 _TELEGRAM = frozenset({Platform.TELEGRAM})
 _DISCORD_SLACK = frozenset({Platform.DISCORD, Platform.SLACK})
+_BLUEBUBBLES = frozenset({Platform.BLUEBUBBLES})
 
 def _plain(*keys: str) -> tuple:
     """Keys copied verbatim into ``extra`` for every platform."""
@@ -203,6 +204,7 @@ _SHARED_KEYS: tuple = (
     ("group_allowed_chats", _TELEGRAM, None),
     ("allowed_topics", _TELEGRAM, None),
     *_plain("free_response_channels", "mention_patterns", "exclusive_bot_mentions"),
+    ("participant_names", _BLUEBUBBLES, _str_keyed),
     ("observe_unmentioned_group_messages", _TELEGRAM, None),
     *_plain(
         "dm_policy", "allow_from", "allow_admin_from", "user_allowed_commands",

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -158,6 +158,12 @@ def _reply_anchor_for_event(event) -> str | None:
         return getattr(event, "message_id", None) or getattr(event, "reply_to_message_id", None)
     if platform == "feishu" and thread_id and getattr(event, "reply_to_message_id", None):
         return getattr(event, "reply_to_message_id", None)
+    if platform == "bluebubbles" and getattr(source, "chat_type", None) == "group":
+        # A normal addressed message in an iMessage group should receive a
+        # top-level group response, not a private-looking inline reply to the
+        # sender. Preserve native threading only when the user explicitly sent
+        # their request as an inline reply to an existing message.
+        return getattr(event, "reply_to_message_id", None)
     return getattr(event, "message_id", None)
 
 

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -1,77 +1,191 @@
-"""BlueBubbles iMessage platform adapter: local BlueBubbles macOS server for outbound REST sends and
-inbound webhooks (text, media attachments, typing indicators, read receipts)."""
+"""BlueBubbles iMessage platform adapter.
+
+Uses the local BlueBubbles macOS server for outbound REST sends and inbound
+webhooks.  Supports text messaging, media attachments (images, voice, video,
+documents), tapback reactions, typing indicators, and read receipts.
+
+Architecture based on PR #5869 (benjaminsehl) with inbound attachment
+downloading from PR #4588 (YuhangLin).
+"""
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
 import re
 import uuid
 from collections import OrderedDict
-from contextlib import suppress
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
-from urllib.parse import parse_qs, quote
+from urllib.parse import quote
 
 import httpx
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms._shared import get_scoped_secret as _get_scoped_secret
+from gateway.reactions import (
+    TapbackAction,
+    TapbackDirection,
+    TapbackOperation,
+    TapbackStatus,
+    TapbackType,
+    TapbackValidationError,
+)
 from gateway.platforms.base import (
-    BasePlatformAdapter, MessageEvent, MessageType, SendResult,
-    cache_image_from_bytes_async, cache_audio_from_bytes_async, cache_document_from_bytes_async)
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+    cache_image_from_bytes_async,
+    cache_audio_from_bytes_async,
+    cache_document_from_bytes_async,
+)
 from .media_cache import ext_for_mime
+from .bluebubbles_attachments import (
+    AttachmentReadiness,
+    materialize_attachments,
+    schedule_pending_attachment_retry,
+)
 from gateway.platforms.helpers import compile_mention_patterns, strip_markdown
-from utils import TRUTHY_STRINGS
 
-# Historical BlueBubbles mime→ext maps, preserved verbatim as overrides for the shared dispatch in
-# gateway.platforms.media_cache. Both maps are CLOSED: unlisted mimes fall back to .jpg / .mp3.
+
+# Historical BlueBubbles mime→ext maps, preserved verbatim as overrides for
+# the shared dispatch in gateway.platforms.media_cache. Both maps are
+# CLOSED: unlisted mimes fall back to .jpg / .mp3 (never mimetypes).
 _BLUEBUBBLES_IMAGE_EXT_OVERRIDES = {
-    "image/jpeg": ".jpg", "image/png": ".png", "image/gif": ".gif", "image/webp": ".webp",
-    "image/heic": ".jpg", "image/heif": ".jpg", "image/tiff": ".jpg",  # historical mapping
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+    "image/heic": ".jpg",  # preserves historical bluebubbles mapping
+    "image/heif": ".jpg",  # preserves historical bluebubbles mapping
+    "image/tiff": ".jpg",  # preserves historical bluebubbles mapping
 }
 _BLUEBUBBLES_AUDIO_EXT_OVERRIDES = {
-    "audio/mp3": ".mp3", "audio/mpeg": ".mp3", "audio/ogg": ".ogg", "audio/wav": ".wav",
-    "audio/x-caf": ".mp3", "audio/mp4": ".m4a",
-    "audio/aac": ".m4a",  # historical mapping (shared table says .aac)
+    "audio/mp3": ".mp3",
+    "audio/mpeg": ".mp3",
+    "audio/ogg": ".ogg",
+    "audio/wav": ".wav",
+    "audio/x-caf": ".mp3",  # preserves historical bluebubbles mapping
+    "audio/mp4": ".m4a",
+    "audio/aac": ".m4a",  # preserves historical bluebubbles mapping (shared table says .aac)
 }
+
+from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
+from agent.secret_scope import get_secret as _scoped_get_secret
+
+
+def _get_scoped_secret(name, default=None):
+    """Scope-aware credential read with the default-profile startup fallback.
+
+    Secondary profiles construct their adapters under a profile secret
+    scope -- the scope is authoritative and a scoped miss returns ``default``
+    (no cross-profile borrow from ``os.environ``, which may hold another
+    profile's value). The DEFAULT profile's adapter constructs and sends
+    *unscoped* under multiplexing, where a bare ``get_secret`` would raise
+    ``UnscopedSecretError`` and crash this path; there ``os.environ`` is that
+    profile's own value, so fall back to it. Same pattern as the Slack
+    ``SLACK_APP_TOKEN`` read (#59739) and
+    ``gateway/platforms/whatsapp_common.py::_get_wsecret``.
+    """
+    try:
+        val = _scoped_get_secret(name, default)
+    except _UnscopedSecretError:
+        val = os.getenv(name)
+    return val if val is not None else default
+
 
 logger = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
 DEFAULT_WEBHOOK_HOST = "127.0.0.1"
-# Webhook events are small JSON/form payloads (attachments come through the REST API); 1 MiB keeps
-# oversized/chunked bodies from buffering unbounded.
+# BlueBubbles webhook events are small JSON/form payloads; attachments come
+# through the REST API, not the webhook. 1 MiB is generous headroom while
+# keeping oversized/chunked bodies from being buffered unbounded.
 _WEBHOOK_MAX_BODY_BYTES = 1_048_576
 DEFAULT_WEBHOOK_PORT = 8645
 DEFAULT_WEBHOOK_PATH = "/bluebubbles-webhook"
 MAX_TEXT_LENGTH = 4000
 
-# iMessage has no stable bot mention identity (unlike <@U...>/@botname/MXID), so
-# `require_mention: true` without custom aliases uses Hermes wake words.
-DEFAULT_MENTION_PATTERNS = [r"(?<![\w@])@?hermes\s+agent\b[,:\-]?", r"(?<![\w@])@?hermes\b[,:\-]?"]
+# BlueBubbles/iMessage does not expose a stable bot mention identity like
+# Slack (<@U...>), Telegram (@botname), or Matrix (MXID). When users opt into
+# group mention gating without custom aliases, use conservative Hermes wake
+# words so `require_mention: true` is a one-line enablement path.
+DEFAULT_MENTION_PATTERNS = [
+    r"(?<![\w@])@?hermes\s+agent\b[,:\-]?",
+    r"(?<![\w@])@?hermes\b[,:\-]?",
+]
 
-# Tapback associatedMessageType codes: 2000-2005 added, 3000-3005 removed (love, like, dislike, ...).
-_TAPBACK_CODES = {*range(2000, 2006), *range(3000, 3006)}
-_MESSAGE_EVENTS = {"new-message", "message", "updated-message"}  # webhook event types carrying user messages
+# Tapback reaction codes (BlueBubbles associatedMessageType values)
+_TAPBACK_ADDED = {
+    2000: "love", 2001: "like", 2002: "dislike",
+    2003: "laugh", 2004: "emphasize", 2005: "question",
+}
+_TAPBACK_REMOVED = {
+    3000: "love", 3001: "like", 3002: "dislike",
+    3003: "laugh", 3004: "emphasize", 3005: "question",
+}
+_TAPBACK_REACTIONS = frozenset(_TAPBACK_ADDED.values())
+_TAPBACK_EMOJI = {
+    "❤️": "love",
+    "👍": "like",
+    "👎": "dislike",
+    "😂": "laugh",
+    "‼️": "emphasize",
+    "❓": "question",
+}
 
+# Webhook event types that carry user messages
+_MESSAGE_EVENTS = {"new-message", "message", "updated-message"}
+_MESSAGE_DEDUP_SIZE = 2048  # LRU cap for completed message identity caches
+_MESSAGE_REVISION_WAIT_SECONDS = 1.0
+_MESSAGE_CHAT_LOOKUP_TIMEOUT_SECONDS = 1.0
+_PROVISIONAL_MESSAGE_WAIT_SECONDS = 1.0
+_STOP_TYPING_HELPER_REFRESH_SECONDS = 0.25
+_HELPER_NEGATIVE_REFRESH_TTL_SECONDS = 1.0
+_READ_RECEIPT_RETRY_SECONDS = 1.0
+_ATTACHMENT_RETRY_DELAY_SECONDS = 0.25
+_ATTACHMENT_RETRY_ATTEMPTS = 5
+_REFERENCED_MESSAGE_LOOKUP_LIMIT = 100
+_REPLY_ATTACHMENT_LIMIT = 8
+_BLUEBUBBLES_MESSAGE_QUERY_LIMIT = 1_000
+
+_InboundMessageKey = tuple[str, str, str]
+_ProvisionalMessageKey = tuple[str, str, str]
+_RevisionMediaContext = tuple[List[str], List[str], MessageType, Dict[str, Any], int]
+
+
+def _is_phone_handle(target: str) -> bool:
+    """Return true only for a complete international-style phone handle."""
+    value = target.strip()
+    return "@" not in value and bool(re.fullmatch(r"\+[1-9]\d{6,14}", value))
+
+# Log redaction patterns
 _PHONE_RE = re.compile(r"\+?\d{7,15}")
 _EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.]+")
-_PAGINATION_SUFFIX_RE = re.compile(r"\s*\(\d+/\d+\)$")
-_ADDRESS_RE = re.compile(r"^\+\d+")
 
 _GUID_CACHE_SIZE = 500  # LRU cap for resolved chat-GUID lookups
-_LOCAL_HOSTS = {"0.0.0.0", "127.0.0.1", "localhost", "::"}
 
 
 def _redact(text: str) -> str:
     """Redact phone numbers and emails from log output."""
-    return _EMAIL_RE.sub("[REDACTED]", _PHONE_RE.sub("[REDACTED]", text))
+    text = _PHONE_RE.sub("[REDACTED]", text)
+    text = _EMAIL_RE.sub("[REDACTED]", text)
+    return text
 
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 def check_bluebubbles_requirements() -> bool:
     try:
         import aiohttp  # noqa: F401
+        import httpx  # noqa: F401
     except ImportError:
         return False
     return True
@@ -79,31 +193,19 @@ def check_bluebubbles_requirements() -> bool:
 
 def _normalize_server_url(raw: str) -> str:
     value = (raw or "").strip()
-    if value and not re.match(r"^https?://", value, flags=re.I):
+    if not value:
+        return ""
+    if not re.match(r"^https?://", value, flags=re.I):
         value = f"http://{value}"
     return value.rstrip("/")
 
 
-def _closed_ext(mime: str, overrides: Dict[str, str], fallback: str) -> str:
-    """Historical maps were closed: unlisted mimes fall back without consulting mimetypes."""
-    return ext_for_mime(mime, overrides=overrides, use_defaults=False, use_mimetypes=False,
-                        fallback=fallback) or fallback
 
 
-def _setting(extra: Dict[str, Any], key: str, env: str, default: str = "") -> Any:
-    """Config ``extra[key]`` wins over env var ``env`` (falsy values fall through)."""
-    return extra.get(key) or os.getenv(env, default)
 
-
-def _temp_guid() -> str:
-    return f"temp-{datetime.utcnow().timestamp()}"
-
-
-def _ok():
-    """Plain ``ok`` acknowledgement for webhook events we accept but don't process."""
-    from aiohttp import web
-    return web.Response(text="ok")
-
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
 
 class BlueBubblesAdapter(BasePlatformAdapter):
     platform = Platform.BLUEBUBBLES
@@ -114,92 +216,244 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.BLUEBUBBLES)
         extra = config.extra or {}
-        self.server_url = _normalize_server_url(_setting(extra, "server_url", "BLUEBUBBLES_SERVER_URL"))
+        self.server_url = _normalize_server_url(
+            extra.get("server_url") or os.getenv("BLUEBUBBLES_SERVER_URL", "")
+        )
         self.password = extra.get("password") or _get_scoped_secret("BLUEBUBBLES_PASSWORD", "")
-        self.webhook_host = _setting(extra, "webhook_host", "BLUEBUBBLES_WEBHOOK_HOST", DEFAULT_WEBHOOK_HOST)
-        self.webhook_port = int(_setting(extra, "webhook_port", "BLUEBUBBLES_WEBHOOK_PORT", str(DEFAULT_WEBHOOK_PORT)))
-        path = str(_setting(extra, "webhook_path", "BLUEBUBBLES_WEBHOOK_PATH", DEFAULT_WEBHOOK_PATH))
-        self.webhook_path = path if path.startswith("/") else f"/{path}"
+        self.webhook_host = (
+            extra.get("webhook_host")
+            or os.getenv("BLUEBUBBLES_WEBHOOK_HOST", DEFAULT_WEBHOOK_HOST)
+        )
+        self.webhook_port = int(
+            extra.get("webhook_port")
+            or os.getenv("BLUEBUBBLES_WEBHOOK_PORT", str(DEFAULT_WEBHOOK_PORT))
+        )
+        self.webhook_path = (
+            extra.get("webhook_path")
+            or os.getenv("BLUEBUBBLES_WEBHOOK_PATH", DEFAULT_WEBHOOK_PATH)
+        )
+        if not str(self.webhook_path).startswith("/"):
+            self.webhook_path = f"/{self.webhook_path}"
         self.send_read_receipts = bool(extra.get("send_read_receipts", True))
         _require_mention = extra.get("require_mention")
         if _require_mention is None:
             _require_mention = os.getenv("BLUEBUBBLES_REQUIRE_MENTION")
-        self.require_mention = str(_require_mention).strip().lower() in TRUTHY_STRINGS
+        self.require_mention = str(_require_mention).strip().lower() in {"true", "1", "yes", "on"}
         self._mention_patterns = self._compile_mention_patterns(
-            extra["mention_patterns"] if "mention_patterns" in extra else os.getenv("BLUEBUBBLES_MENTION_PATTERNS"))
+            extra["mention_patterns"]
+            if "mention_patterns" in extra
+            else os.getenv("BLUEBUBBLES_MENTION_PATTERNS")
+        )
+        raw_participant_names = extra.get("participant_names")
+        self._participant_names = {
+            handle: name.strip()
+            for handle, name in raw_participant_names.items()
+            if isinstance(handle, str)
+            and isinstance(name, str)
+            and name.strip()
+        } if isinstance(raw_participant_names, dict) else {}
         self.client: Optional[httpx.AsyncClient] = None
         self._runner = None
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
-        self._guid_cache: OrderedDict[str, str] = OrderedDict()
+        self._helper_last_refresh_at: float = 0.0
 
-    # --- API helpers ---
+        self._guid_cache: OrderedDict[str, str] = OrderedDict()
+        self._seen_message_guids: OrderedDict[str, None] = OrderedDict()
+        self._terminal_message_identities: OrderedDict[str, None] = OrderedDict()
+        self._pending_message_identities: set[str] = set()
+        self._active_message_dispatches: Dict[
+            _InboundMessageKey, tuple[int, Optional[str], asyncio.Task]
+        ] = {}
+        self._tapback_event_states: OrderedDict[
+            tuple[str, str, str, int, str, str], tuple[TapbackOperation, int]
+        ] = OrderedDict()
+        self._tapback_event_serial = 0
+        self._pending_message_revisions: Dict[
+            _InboundMessageKey,
+            tuple[MessageEvent, Optional[str], int, tuple[str, ...]],
+        ] = {}
+        self._pending_message_revision_tasks: Dict[_InboundMessageKey, asyncio.Task] = {}
+        self._provisional_messages: OrderedDict[
+            _ProvisionalMessageKey, tuple[Dict[str, Any], Dict[str, Any]]
+        ] = OrderedDict()
+        self._provisional_message_tasks: Dict[
+            _ProvisionalMessageKey, asyncio.Task
+        ] = {}
+        self._active_attachment_revisions: Dict[_InboundMessageKey, int] = {}
+        self._active_attachment_leases: set[tuple[_InboundMessageKey, int]] = set()
+        self._active_attachment_identity_leases: Dict[
+            tuple[_InboundMessageKey, int], str
+        ] = {}
+        self._pending_attachment_tasks: Dict[_InboundMessageKey, asyncio.Task] = {}
+        self._message_revision_serials: OrderedDict[
+            _InboundMessageKey, int
+        ] = OrderedDict()
+        self._message_revision_orders: OrderedDict[
+            str, tuple[int, Optional[float]]
+        ] = OrderedDict()
+        self._message_revision_text: OrderedDict[_InboundMessageKey, str] = OrderedDict()
+        self._message_revision_media: OrderedDict[
+            _InboundMessageKey, _RevisionMediaContext
+        ] = OrderedDict()
+        self._accepted_group_captions: OrderedDict[
+            _InboundMessageKey, str
+        ] = OrderedDict()
+        self._sent_message_keys: OrderedDict[str, str] = OrderedDict()
+        self._pending_read_receipts: Dict[str, set[str]] = {}
+        self._read_receipt_tasks: Dict[str, asyncio.Task] = {}
+        self._sent_read_receipts: OrderedDict[tuple[str, str], None] = OrderedDict()
+        self._read_receipts_closed = False
+        self._helper_refresh_lock = asyncio.Lock()
+        self._typing_transition_locks: Dict[str, asyncio.Lock] = {}
+        self._typing_started: set[str] = set()
+        self._typing_pending_stops: set[str] = set()
+        self._typing_stopped: OrderedDict[str, None] = OrderedDict()
+        self._typing_stop_tasks: Dict[str, asyncio.Task] = {}
+        self._typing_shutdown = False
+        self._inbound_dedup_lock = asyncio.Lock()
+        self._outbound_dedup_lock = asyncio.Lock()
+        self._read_receipt_lock = asyncio.Lock()
+
+        try:
+            self._message_revision_wait_seconds = max(
+                0.0,
+                float(
+                    extra.get(
+                        "message_revision_wait_seconds",
+                        _MESSAGE_REVISION_WAIT_SECONDS,
+                    )
+                ),
+            )
+        except (TypeError, ValueError):
+            self._message_revision_wait_seconds = _MESSAGE_REVISION_WAIT_SECONDS
+        try:
+            self._attachment_retry_delay_seconds = max(
+                0.0,
+                float(
+                    extra.get(
+                        "attachment_retry_delay_seconds",
+                        _ATTACHMENT_RETRY_DELAY_SECONDS,
+                    )
+                ),
+            )
+        except (TypeError, ValueError):
+            self._attachment_retry_delay_seconds = _ATTACHMENT_RETRY_DELAY_SECONDS
+        try:
+            self._message_retry_max_attempts = max(
+                1, int(extra.get("message_retry_max_attempts", 3))
+            )
+        except (TypeError, ValueError):
+            self._message_retry_max_attempts = 3
+        try:
+            self._message_retry_base_delay_seconds = max(
+                0.0, float(extra.get("message_retry_base_delay_seconds", 0.5))
+            )
+        except (TypeError, ValueError):
+            self._message_retry_base_delay_seconds = 0.5
+
+    # ------------------------------------------------------------------
+    # API helpers
+    # ------------------------------------------------------------------
 
     def _api_url(self, path: str) -> str:
-        return f"{self.server_url}{path}{'&' if '?' in path else '?'}password={quote(self.password, safe='')}"
+        sep = "&" if "?" in path else "?"
+        return f"{self.server_url}{path}{sep}password={quote(self.password, safe='')}"
+
 
     @staticmethod
     def _compile_mention_patterns(raw: Any) -> List[re.Pattern]:
-        """Compile group-mention wake words; ``raw`` is a list, a raw env string (JSON list or
-        comma/newline-separated), or None (Hermes defaults)."""
-        return compile_mention_patterns(raw, log_prefix="bluebubbles", defaults=DEFAULT_MENTION_PATTERNS,
-                                        logger_=logger)
+        """Compile group-mention wake words from config/env.
+
+        ``raw`` is a list (from config or env JSON), a string (raw env var:
+        JSON list, or comma/newline-separated), or None (use Hermes defaults).
+        """
+        return compile_mention_patterns(
+            raw,
+            log_prefix="bluebubbles",
+            defaults=DEFAULT_MENTION_PATTERNS,
+            logger_=logger,
+        )
 
     def _message_matches_mention_patterns(self, text: str) -> bool:
-        return bool(text) and any(pattern.search(text) for pattern in self._mention_patterns)
+        if not text or not self._mention_patterns:
+            return False
+        return any(pattern.search(text) for pattern in self._mention_patterns)
 
     def _clean_mention_text(self, text: str) -> str:
-        """Strip a leading wake word only — patterns are regexes, so stripping anywhere later in the
-        prompt could delete ordinary words."""
-        stripped = (text or "").lstrip()
+        """Strip a leading BlueBubbles wake word before dispatch.
+
+        Custom mention patterns are regular expressions, so stripping only a
+        leading match avoids deleting ordinary words later in the prompt.
+        """
+        if not text:
+            return text
         for pattern in self._mention_patterns:
-            if match := pattern.match(stripped):
-                return stripped[match.end():].lstrip(" ,:-") or text
+            match = pattern.match(text.lstrip())
+            if match:
+                cleaned = text.lstrip()[match.end():].lstrip(" ,:-")
+                return cleaned or text
         return text
 
-    async def _api_json(self, method: str, path: str, **kwargs) -> Dict[str, Any]:
-        """Authenticated request to the BlueBubbles REST API; raises on HTTP errors, returns decoded JSON."""
+    async def _api_get(self, path: str) -> Dict[str, Any]:
         assert self.client is not None
-        res = await getattr(self.client, method)(self._api_url(path), **kwargs)
+        res = await self.client.get(self._api_url(path))
         res.raise_for_status()
         return res.json()
 
-    async def _api_get(self, path: str) -> Dict[str, Any]:
-        return await self._api_json("get", path)
-
     async def _api_post(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
-        return await self._api_json("post", path, json=payload)
+        assert self.client is not None
+        res = await self.client.post(self._api_url(path), json=payload)
+        res.raise_for_status()
+        return res.json()
 
-    async def _post_message(self, path: str, payload: Dict[str, Any]) -> SendResult:
-        """POST a message payload and wrap the outcome as a SendResult."""
-        try:
-            res = await self._api_post(path, payload)
-            data = res.get("data") or {}
-            msg_id = str(data.get("guid") or data.get("messageGuid") or "ok")
-            return SendResult(success=True, message_id=msg_id, raw_response=res)
-        except Exception as exc:
-            return SendResult(success=False, error=str(exc) or type(exc).__name__)
-
-    async def _private_api_chat_call(self, chat_id: str, action: str, method: str) -> bool:
-        """Fire a private-API chat action (typing/read); True only if the call was made."""
-        if not self._private_api_enabled or not self._helper_connected or not self.client:
+    async def _refresh_helper_state(self) -> bool:
+        """Refresh stale Private API/helper reachability from the live server."""
+        if self._private_api_enabled and self._helper_connected:
+            return True
+        if not self.client:
             return False
-        with suppress(Exception):
-            if guid := await self._resolve_chat_guid(chat_id):
-                url = self._api_url(f"/api/v1/chat/{quote(guid, safe='')}/{action}")
-                await getattr(self.client, method)(url, timeout=5)
+        async with self._helper_refresh_lock:
+            if self._private_api_enabled and self._helper_connected:
                 return True
-        return False
+            loop = asyncio.get_running_loop()
+            if (
+                self._helper_last_refresh_at > 0
+                and loop.time() - self._helper_last_refresh_at
+                < _HELPER_NEGATIVE_REFRESH_TTL_SECONDS
+            ):
+                return False
+            try:
+                info = await self._api_get("/api/v1/server/info")
+                server_data = (info or {}).get("data", {})
+                self._private_api_enabled = bool(server_data.get("private_api"))
+                self._helper_connected = bool(server_data.get("helper_connected"))
+            except Exception as exc:
+                logger.debug("[bluebubbles] helper state refresh failed: %s", exc)
+                self._helper_last_refresh_at = loop.time()
+                return False
+            self._helper_last_refresh_at = loop.time()
+            return bool(self._private_api_enabled and self._helper_connected)
 
-    # --- Lifecycle ---
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
 
-    async def connect(self, *, is_reconnect: bool = False) -> bool:
+    async def connect_outbound(self) -> bool:
+        """Open only the REST client needed for outbound delivery.
+
+        Standalone senders (cron and send_message outside the live gateway) must
+        not bind, register, or unregister the gateway's inbound webhook.
+        """
+        self._typing_shutdown = False
+        self._read_receipts_closed = False
         if not self.server_url or not self.password:
-            logger.error("[bluebubbles] BLUEBUBBLES_SERVER_URL and BLUEBUBBLES_PASSWORD are required")
+            logger.error(
+                "[bluebubbles] BLUEBUBBLES_SERVER_URL and BLUEBUBBLES_PASSWORD are required"
+            )
             return False
-        from aiohttp import web
-        # Tighter keepalive so idle CLOSE_WAIT drains promptly.
-        # See #18451.
+
+        # Tighter keepalive so idle CLOSE_WAIT drains promptly (#18451).
         from gateway.platforms._http_client_limits import platform_httpx_limits
         self.client = httpx.AsyncClient(timeout=30.0, limits=platform_httpx_limits())
         try:
@@ -208,397 +462,2602 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             server_data = (info or {}).get("data", {})
             self._private_api_enabled = bool(server_data.get("private_api"))
             self._helper_connected = bool(server_data.get("helper_connected"))
-            logger.info("[bluebubbles] connected to %s (private_api=%s, helper=%s)",
-                        self.server_url, self._private_api_enabled, self._helper_connected)
+            logger.info(
+                "[bluebubbles] connected to %s (private_api=%s, helper=%s)",
+                self.server_url,
+                self._private_api_enabled,
+                self._helper_connected,
+            )
+            return True
         except Exception as exc:
-            logger.error("[bluebubbles] cannot reach server at %s: %s", self.server_url, exc)
-            await self._close_client()
+            logger.error(
+                "[bluebubbles] cannot reach server at %s: %s", self.server_url, exc
+            )
+            await self.disconnect_outbound()
             return False
-        # client_max_size makes aiohttp enforce the cap on every read path, incl. chunked requests
-        # with no Content-Length.
-        # Explicit body cap: BlueBubbles webhook events are small JSON (or form-encoded) payloads.
-        # client_max_size makes aiohttp enforce the cap on every read path — including chunked requests that
-        # carry no Content-Length (same pattern as webhook.py / raft, #58536/#58902).
+
+    async def disconnect_outbound(self) -> None:
+        """Close an outbound-only REST client without touching webhooks."""
+        self._typing_shutdown = True
+        await self._reconcile_typing_stops()
+        await self._cancel_read_receipts()
+        if self.client:
+            await self.client.aclose()
+            self.client = None
+        self._clear_typing_lifecycle_state()
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        if not await self.connect_outbound():
+            return False
+        from aiohttp import web
+
+        # Explicit body cap: BlueBubbles webhook events are small JSON (or
+        # form-encoded) payloads. client_max_size makes aiohttp enforce the
+        # cap on every read path — including chunked requests that carry no
+        # Content-Length (same pattern as webhook.py / raft, #58536/#58902).
         app = web.Application(client_max_size=_WEBHOOK_MAX_BODY_BYTES)
         app.router.add_get("/health", lambda _: web.Response(text="ok"))
         app.router.add_post(self.webhook_path, self._handle_webhook)
-        # The webhook auth value rides in the query string (BlueBubbles cannot send custom headers)
-        # — keep it out of aiohttp access logs.
+        # The webhook auth value is carried in the query string because the
+        # BlueBubbles webhook API cannot send custom headers. Do not let
+        # aiohttp access logs write that request target to agent.log.
         self._runner = web.AppRunner(app, access_log=None)
         await self._runner.setup()
         site = web.TCPSite(self._runner, self.webhook_host, self.webhook_port)
         await site.start()
         self._mark_connected()
-        logger.info("[bluebubbles] webhook listening on http://%s:%s%s", self.webhook_host, self.webhook_port,
-                    self.webhook_path)
-        await self._register_webhook()  # the server only sends events to webhooks registered via its API
+        logger.info(
+            "[bluebubbles] webhook listening on http://%s:%s%s",
+            self.webhook_host,
+            self.webhook_port,
+            self.webhook_path,
+        )
+
+        # Register webhook with BlueBubbles server
+        # This is required for the server to know where to send events
+        await self._register_webhook()
+
         # Plugin-registered native handlers (ctx.register_platform_handler).
         self._wire_plugin_handlers(None)
         return True
 
-    async def _close_client(self) -> None:
-        if self.client:
-            await self.client.aclose()
-            self.client = None
-
     async def disconnect(self) -> None:
+        self._typing_shutdown = True
+        await self._reconcile_typing_stops()
+        # Unregister webhook before cleaning up
         await self._unregister_webhook()
-        await self._close_client()
+
+        await self.disconnect_outbound()
         if self._runner:
             await self._runner.cleanup()
             self._runner = None
+        self._clear_typing_lifecycle_state()
         self._mark_disconnected()
+
+    async def cancel_background_tasks(self) -> None:
+        self._typing_shutdown = True
+        await super().cancel_background_tasks()
+        await self._cancel_read_receipts()
+        await self._reconcile_typing_stops()
+        self._clear_typing_lifecycle_state()
+        async with self._inbound_dedup_lock:
+            self._pending_message_revisions.clear()
+            self._pending_message_revision_tasks.clear()
+            self._provisional_messages.clear()
+            self._provisional_message_tasks.clear()
+            self._pending_message_identities.clear()
+            self._active_message_dispatches.clear()
+            self._active_attachment_revisions.clear()
+            self._active_attachment_leases.clear()
+            self._active_attachment_identity_leases.clear()
+            self._pending_attachment_tasks.clear()
+            self._message_revision_media.clear()
 
     @property
     def _webhook_url(self) -> str:
-        """External webhook URL for BlueBubbles registration (local binds → localhost)."""
-        host = "localhost" if self.webhook_host in _LOCAL_HOSTS else self.webhook_host
+        """Compute the external webhook URL for BlueBubbles registration."""
+        host = self.webhook_host
+        if host in {"0.0.0.0", "127.0.0.1", "localhost", "::"}:
+            host = "localhost"
         return f"http://{host}:{self.webhook_port}{self.webhook_path}"
-
-    def _webhook_register_url_with(self, password_param: str) -> str:
-        return f"{self._webhook_url}?password={password_param}" if self.password else self._webhook_url
 
     @property
     def _webhook_register_url(self) -> str:
-        """Registered webhook URL with the password as a query param: BlueBubbles posts to the exact
-        registered URL and cannot set custom headers, so this is the only way to authenticate inbound
-        webhooks without disabling auth."""
-        return self._webhook_register_url_with(quote(self.password, safe=""))
+        """Webhook URL registered with BlueBubbles, including the password as
+        a query param so inbound webhook POSTs carry credentials.
+
+        BlueBubbles posts events to the exact URL registered via
+        ``/api/v1/webhook``. Its webhook registration API does not support
+        custom headers, so embedding the password in the URL is the only
+        way to authenticate inbound webhooks without disabling auth.
+        """
+        base = self._webhook_url
+        if self.password:
+            return f"{base}?password={quote(self.password, safe='')}"
+        return base
 
     @property
     def _webhook_register_url_for_log(self) -> str:
-        return self._webhook_register_url_with("***")
+        """Webhook registration URL safe for logs."""
+        base = self._webhook_url
+        if self.password:
+            return f"{base}?password=***"
+        return base
 
     async def _find_registered_webhooks(self, url: str) -> list:
         """Return list of BB webhook entries matching *url*."""
-        with suppress(Exception):
-            data = (await self._api_get("/api/v1/webhook")).get("data")
+        try:
+            res = await self._api_get("/api/v1/webhook")
+            data = res.get("data")
             if isinstance(data, list):
                 return [wh for wh in data if wh.get("url") == url]
+        except Exception:
+            pass
         return []
 
     async def _register_webhook(self) -> bool:
-        """Register this webhook URL, reusing an existing registration if present (crash resilience —
-        avoids duplicates after an unclean shutdown)."""
+        """Register this webhook URL with the BlueBubbles server.
+
+        BlueBubbles requires webhooks to be registered via API before
+        it will send events.  Checks for an existing registration first
+        to avoid duplicates (e.g. after a crash without clean shutdown).
+        """
         if not self.client:
             return False
-        webhook_url, log_url = self._webhook_register_url, self._webhook_register_url_for_log
-        if await self._find_registered_webhooks(webhook_url):
-            logger.info("[bluebubbles] webhook already registered: %s", log_url)
+
+        webhook_url = self._webhook_register_url
+
+        # Crash resilience — reuse an existing registration if present
+        existing = await self._find_registered_webhooks(webhook_url)
+        if existing:
+            logger.info(
+                "[bluebubbles] webhook already registered: %s",
+                self._webhook_register_url_for_log,
+            )
             return True
+
+        payload = {
+            "url": webhook_url,
+            "events": ["new-message", "updated-message"],
+        }
+
         try:
-            res = await self._api_post("/api/v1/webhook",
-                                       {"url": webhook_url, "events": ["new-message", "updated-message"]})
+            res = await self._api_post("/api/v1/webhook", payload)
             status = res.get("status", 0)
             if 200 <= status < 300:
-                logger.info("[bluebubbles] webhook registered with server: %s", log_url)
+                logger.info(
+                    "[bluebubbles] webhook registered with server: %s",
+                    self._webhook_register_url_for_log,
+                )
                 return True
-            logger.warning("[bluebubbles] webhook registration returned status %s: %s", status, res.get("message"))
-            return False
+            else:
+                logger.warning(
+                    "[bluebubbles] webhook registration returned status %s: %s",
+                    status,
+                    res.get("message"),
+                )
+                return False
         except Exception as exc:
-            logger.warning("[bluebubbles] failed to register webhook with server: %s", exc)
+            logger.warning(
+                "[bluebubbles] failed to register webhook with server: %s",
+                exc,
+            )
             return False
 
     async def _unregister_webhook(self) -> bool:
-        """Remove *all* registrations matching our URL (cleans up crash duplicates)."""
+        """Unregister this webhook URL from the BlueBubbles server.
+
+        Removes *all* matching registrations to clean up any duplicates
+        left by prior crashes.
+        """
         if not self.client:
             return False
+
+        webhook_url = self._webhook_register_url
         removed = False
+
         try:
-            for wh in await self._find_registered_webhooks(self._webhook_register_url):
-                if wh_id := wh.get("id"):
-                    (await self.client.delete(self._api_url(f"/api/v1/webhook/{wh_id}"))).raise_for_status()
+            for wh in await self._find_registered_webhooks(webhook_url):
+                wh_id = wh.get("id")
+                if wh_id:
+                    res = await self.client.delete(
+                        self._api_url(f"/api/v1/webhook/{wh_id}")
+                    )
+                    res.raise_for_status()
                     removed = True
             if removed:
-                logger.info("[bluebubbles] webhook unregistered: %s", self._webhook_register_url_for_log)
+                logger.info(
+                    "[bluebubbles] webhook unregistered: %s",
+                    self._webhook_register_url_for_log,
+                )
         except Exception as exc:
-            logger.debug("[bluebubbles] failed to unregister webhook (non-critical): %s", exc)
+            logger.debug(
+                "[bluebubbles] failed to unregister webhook (non-critical): %s",
+                exc,
+            )
         return removed
 
-    # --- Chat GUID resolution ---
+    # ------------------------------------------------------------------
+    # Chat GUID resolution
+    # ------------------------------------------------------------------
 
     async def _resolve_chat_guid(self, target: str) -> Optional[str]:
-        """Resolve an email/phone to a chat GUID (raw ``a;-;b`` GUIDs pass through). Matches strictly on
-        ``chatIdentifier`` / ``identifier``; participant membership is intentionally NOT a fallback —
-        the same contact appears in a 1:1 DM and any number of groups, so a participant match could
-        leak a DM reply into a group thread. ``None`` lets the caller create a fresh DM.
+        """Resolve an email/phone to a BlueBubbles chat GUID.
 
-        See #24157.
+        If *target* already contains a semicolon (raw GUID format like
+        ``iMessage;-;user@example.com``), it is returned as-is.  Otherwise
+        the adapter queries the BlueBubbles chat list and matches strictly
+        on ``chatIdentifier`` / ``identifier``.
+
+        Participant membership is intentionally NOT used as a fallback:
+        the same contact can appear in a 1:1 DM and in any number of group
+        chats, so a participant match would let an outbound DM reply leak
+        into a group thread (see #24157). When no exact chat identity
+        matches, return ``None`` and let the caller create a fresh DM
+        explicitly via ``_create_chat_for_handle``.
         """
         target = (target or "").strip()
-        if not target or ";" in target:
-            return target or None
+        if not target:
+            return None
+        # Already a raw GUID
+        if ";" in target:
+            return target
         if target in self._guid_cache:
             self._guid_cache.move_to_end(target)
             return self._guid_cache[target]
-        with suppress(Exception):
-            payload = await self._api_post("/api/v1/chat/query", {"limit": 100, "offset": 0})
+        try:
+            payload = await self._api_post(
+                "/api/v1/chat/query",
+                {"limit": 100, "offset": 0},
+            )
             for chat in payload.get("data", []) or []:
-                if (chat.get("chatIdentifier") or chat.get("identifier")) != target:
-                    continue
-                if guid := chat.get("guid") or chat.get("chatGuid"):
-                    self._guid_cache[target] = guid
-                    while len(self._guid_cache) > _GUID_CACHE_SIZE:
-                        self._guid_cache.popitem(last=False)
-                return guid
+                guid = chat.get("guid") or chat.get("chatGuid")
+                identifier = chat.get("chatIdentifier") or chat.get("identifier")
+                if identifier == target:
+                    if guid:
+                        self._guid_cache[target] = guid
+                        while len(self._guid_cache) > _GUID_CACHE_SIZE:
+                            self._guid_cache.popitem(last=False)
+                    return guid
+        except Exception:
+            pass
         return None
 
-    async def _create_chat_for_handle(self, address: str, message: str) -> SendResult:
+    async def _create_chat_for_handle(
+        self,
+        address: str,
+        message: str,
+        temp_guid: Optional[str] = None,
+    ) -> SendResult:
         """Create a new chat by sending the first message to *address*."""
-        return await self._post_message(
-            "/api/v1/chat/new", {"addresses": [address], "message": message, "tempGuid": _temp_guid()})
+        payload = {
+            "addresses": [address],
+            "message": message,
+            "tempGuid": temp_guid or f"temp-{uuid.uuid4().hex}",
+        }
+        try:
+            res = await self._api_post("/api/v1/chat/new", payload)
+            data = res.get("data") or {}
+            msg_id = data.get("guid") or data.get("messageGuid") or "ok"
+            return SendResult(success=True, message_id=str(msg_id), raw_response=res)
+        except Exception as exc:
+            return SendResult(success=False, error=str(exc) or type(exc).__name__)
 
-    # --- Text sending ---
+    # ------------------------------------------------------------------
+    # Text sending
+    # ------------------------------------------------------------------
 
     @staticmethod
     def truncate_message(content: str, max_length: int = MAX_TEXT_LENGTH) -> List[str]:
-        # Base splitter minus "(1/3)" pagination suffixes — iMessage bubbles flow naturally.
-        return [_PAGINATION_SUFFIX_RE.sub("", c) for c in BasePlatformAdapter.truncate_message(content, max_length)]
+        # Use the base splitter but skip pagination indicators — iMessage
+        # bubbles flow naturally without "(1/3)" suffixes.
+        chunks = BasePlatformAdapter.truncate_message(content, max_length)
+        return [re.sub(r"\s*\(\d+/\d+\)$", "", c) for c in chunks]
 
-    async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None,
-                   metadata: Optional[Dict[str, Any]] = None) -> SendResult:
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
         text = self.format_message(content)
         if not text:
             return SendResult(success=False, error="BlueBubbles send requires text")
-        # Each paragraph becomes its own iMessage bubble; truncate any still too long.
-        paragraphs = [p.strip() for p in re.split(r'\n\s*\n', text) if p.strip()] or [text]
-        chunks = [c for para in paragraphs for c in (
-            [para] if len(para) <= self.MAX_MESSAGE_LENGTH else self.truncate_message(para, self.MAX_MESSAGE_LENGTH))]
+        origin_id = reply_to or (
+            metadata.get("reply_to_message_id") if metadata else None
+        )
+        internal_notice = bool(metadata and metadata.get("internal_notice") is True)
+        if not origin_id:
+            return await self._send_formatted_text(
+                chat_id, text, reply_to, internal_notice=internal_notice
+            )
+
+        content_hash = hashlib.sha256(text.encode("utf-8")).hexdigest()
+        dedup_key = f"{chat_id}\0{origin_id}\0{content_hash}"
+        async with self._outbound_dedup_lock:
+            prior_message_id = self._sent_message_keys.get(dedup_key)
+            if prior_message_id is not None:
+                self._sent_message_keys.move_to_end(dedup_key)
+                logger.debug("[bluebubbles] suppressing duplicate outbound reply")
+                return SendResult(
+                    success=True,
+                    message_id=prior_message_id,
+                    raw_response={"deduplicated": True},
+                )
+            result = await self._send_formatted_text(
+                chat_id,
+                text,
+                reply_to,
+                internal_notice=internal_notice,
+                dedup_key=dedup_key,
+            )
+            if result.success and result.message_id:
+                self._sent_message_keys[dedup_key] = result.message_id
+                self._sent_message_keys.move_to_end(dedup_key)
+                while len(self._sent_message_keys) > _MESSAGE_DEDUP_SIZE:
+                    self._sent_message_keys.popitem(last=False)
+            return result
+
+    async def _send_formatted_text(
+        self,
+        chat_id: str,
+        text: str,
+        reply_to: Optional[str],
+        *,
+        internal_notice: bool,
+        dedup_key: Optional[str] = None,
+    ) -> SendResult:
+        # Keep a complete reply in one iMessage bubble whenever it fits. Only
+        # split when the platform's message-length limit requires it.
+        chunks = (
+            [text]
+            if len(text) <= self.MAX_MESSAGE_LENGTH
+            else self.truncate_message(text, max_length=self.MAX_MESSAGE_LENGTH)
+        )
+        private_reply_available = bool(
+            reply_to and await self._refresh_helper_state()
+        )
         last = SendResult(success=True)
-        for chunk in chunks:
+        for chunk_index, chunk in enumerate(chunks):
+            if dedup_key:
+                temp_guid = "temp-" + hashlib.sha256(
+                    f"{dedup_key}\0{chunk_index}".encode("utf-8")
+                ).hexdigest()
+            else:
+                temp_guid = f"temp-{uuid.uuid4().hex}"
             guid = await self._resolve_chat_guid(chat_id)
             if not guid:
-                if self._private_api_enabled and ("@" in chat_id or _ADDRESS_RE.match(chat_id)):  # address → new chat
-                    return await self._create_chat_for_handle(chat_id, chunk)
-                return SendResult(success=False, error=f"BlueBubbles chat not found for target: {chat_id}")
-            payload: Dict[str, Any] = {"chatGuid": guid, "tempGuid": _temp_guid(), "message": chunk}
-            if reply_to and self._private_api_enabled and self._helper_connected:
-                payload.update(method="private-api", selectedMessageGuid=reply_to, partIndex=0)
-            if not (last := await self._post_message("/api/v1/message/text", payload)).success:
-                return last
+                if internal_notice and _is_phone_handle(chat_id):
+                    logger.info(
+                        "[bluebubbles] suppressed internal notice to unresolved phone target"
+                    )
+                    return SendResult(
+                        success=True,
+                        raw_response={"suppressed": "internal_sms_notice"},
+                    )
+                # If the target looks like an address, try creating a new chat
+                if self._private_api_enabled and (
+                    "@" in chat_id or _is_phone_handle(chat_id)
+                ):
+                    created = await self._create_chat_for_handle(
+                        chat_id, chunk, temp_guid=temp_guid
+                    )
+                    if not created.success:
+                        return created
+                    last = created
+                    if chunk_index == len(chunks) - 1:
+                        return created
+                    continue
+                return SendResult(
+                    success=False,
+                    error=f"BlueBubbles chat not found for target: {chat_id}",
+                )
+            if guid.lower().startswith("sms;") and internal_notice:
+                logger.info("[bluebubbles] suppressed internal notice over SMS")
+                return SendResult(
+                    success=True,
+                    raw_response={"suppressed": "internal_sms_notice"},
+                )
+            payload: Dict[str, Any] = {
+                "chatGuid": guid,
+                "tempGuid": temp_guid,
+                "message": chunk,
+            }
+            if reply_to and private_reply_available:
+                payload["method"] = "private-api"
+                payload["selectedMessageGuid"] = reply_to
+                payload["partIndex"] = 0
+            try:
+                res = await self._api_post("/api/v1/message/text", payload)
+                data = res.get("data") or {}
+                msg_id = data.get("guid") or data.get("messageGuid") or "ok"
+                last = SendResult(
+                    success=True, message_id=str(msg_id), raw_response=res
+                )
+            except Exception as exc:
+                return SendResult(success=False, error=str(exc) or type(exc).__name__)
         return last
 
-    # --- Media sending (outbound) ---
+    # ------------------------------------------------------------------
+    # Media sending (outbound)
+    # ------------------------------------------------------------------
 
-    async def _send_attachment(self, chat_id: str, file_path: str, filename: Optional[str] = None,
-                               caption: Optional[str] = None, is_audio_message: bool = False) -> SendResult:
+    async def _send_attachment(
+        self,
+        chat_id: str,
+        file_path: str,
+        filename: Optional[str] = None,
+        caption: Optional[str] = None,
+        is_audio_message: bool = False,
+    ) -> SendResult:
         """Send a file attachment via BlueBubbles multipart upload."""
         if not self.client:
             return SendResult(success=False, error="Not connected")
         if not await asyncio.to_thread(os.path.isfile, file_path):
             return SendResult(success=False, error=f"File not found: {file_path}")
+
         guid = await self._resolve_chat_guid(chat_id)
         if not guid:
             return SendResult(success=False, error=f"Chat not found: {chat_id}")
+
         fname = filename or os.path.basename(file_path)
         try:
-            # httpx's async multipart iterator reads file objects through a sync chunk generator —
-            # read the bytes off the event-loop thread first.
+            # httpx's async multipart iterator reads file-like objects through
+            # a synchronous chunk generator. Read the file off the event-loop
+            # thread before handing bytes to the client.
             payload = await asyncio.to_thread(Path(file_path).read_bytes)
-            data: Dict[str, str] = {"chatGuid": guid, "name": fname, "tempGuid": uuid.uuid4().hex}
+            files = {"attachment": (fname, payload, "application/octet-stream")}
+            data: Dict[str, str] = {
+                "chatGuid": guid,
+                "name": fname,
+                "tempGuid": uuid.uuid4().hex,
+            }
             if is_audio_message:
                 data["isAudioMessage"] = "true"
-            res = await self.client.post(self._api_url("/api/v1/message/attachment"), data=data, timeout=120,
-                                         files={"attachment": (fname, payload, "application/octet-stream")})
+            res = await self.client.post(
+                self._api_url("/api/v1/message/attachment"),
+                files=files,
+                data=data,
+                timeout=120,
+            )
             res.raise_for_status()
             result = res.json()
+
             if caption:
                 await self.send(chat_id, caption)
+
             if result.get("status") == 200:
                 rdata = result.get("data") or {}
-                return SendResult(success=True, message_id=rdata.get("guid") if isinstance(rdata, dict) else None,
-                                  raw_response=result)
-            return SendResult(success=False, error=result.get("message", "Attachment upload failed"))
+                msg_id = rdata.get("guid") if isinstance(rdata, dict) else None
+                return SendResult(
+                    success=True, message_id=msg_id, raw_response=result
+                )
+            return SendResult(
+                success=False,
+                error=result.get("message", "Attachment upload failed"),
+            )
         except Exception as e:
             return SendResult(success=False, error=str(e))
 
-    async def send_image(self, chat_id: str, image_url: str, caption: Optional[str] = None,
-                         reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
         try:
             from gateway.platforms.base import cache_image_from_url
-            return await self._send_attachment(chat_id, await cache_image_from_url(image_url), caption=caption)
+
+            local_path = await cache_image_from_url(image_url)
+            return await self._send_attachment(chat_id, local_path, caption=caption)
         except Exception:
             return await super().send_image(chat_id, image_url, caption, reply_to)
 
-    async def send_image_file(self, chat_id, image_path, caption=None, reply_to=None, **kw) -> SendResult:
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
         return await self._send_attachment(chat_id, image_path, caption=caption)
 
-    async def send_voice(self, chat_id, audio_path, caption=None, reply_to=None, **kw) -> SendResult:
-        return await self._send_attachment(chat_id, audio_path, caption=caption, is_audio_message=True)
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._send_attachment(
+            chat_id, audio_path, caption=caption, is_audio_message=True
+        )
 
-    async def send_video(self, chat_id, video_path, caption=None, reply_to=None, **kw) -> SendResult:
+    async def send_video(
+        self,
+        chat_id: str,
+        video_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
         return await self._send_attachment(chat_id, video_path, caption=caption)
 
-    async def send_document(self, chat_id, file_path, caption=None, file_name=None, reply_to=None, **kw) -> SendResult:
-        return await self._send_attachment(chat_id, file_path, filename=file_name, caption=caption)
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._send_attachment(
+            chat_id, file_path, filename=file_name, caption=caption
+        )
 
-    async def send_animation(self, chat_id, animation_url, caption=None, reply_to=None, metadata=None) -> SendResult:
-        return await self.send_image(chat_id, animation_url, caption, reply_to, metadata)
+    async def send_animation(
+        self,
+        chat_id: str,
+        animation_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        return await self.send_image(
+            chat_id, animation_url, caption, reply_to, metadata
+        )
 
-    # --- Typing indicators / read receipts (private API only) ---
+    # ------------------------------------------------------------------
+    # Typing indicators
+    # ------------------------------------------------------------------
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
-        await self._private_api_chat_call(chat_id, "typing", "post")
+        key = str(chat_id)
+        if self._typing_shutdown:
+            return
+
+        self._typing_pending_stops.discard(key)
+        self._typing_stopped.pop(key, None)
+        retry_task = self._typing_stop_tasks.pop(key, None)
+        if retry_task is not None and retry_task is not asyncio.current_task():
+            retry_task.cancel()
+
+        lock = self._typing_transition_locks.setdefault(key, asyncio.Lock())
+        async with lock:
+            # A stop request can arrive while helper discovery or GUID lookup
+            # is in flight. Re-check at each process boundary so cancellation
+            # cannot resurrect typing after cleanup has begun.
+            if self._typing_shutdown or key in self._typing_pending_stops:
+                return
+            if not await self._refresh_helper_state():
+                return
+            if self._typing_shutdown or key in self._typing_pending_stops:
+                return
+            try:
+                guid = await self._resolve_chat_guid(chat_id)
+                if not guid or self._typing_shutdown or key in self._typing_pending_stops:
+                    return
+                encoded = quote(guid, safe="")
+                # Once the request crosses this boundary its delivery is
+                # uncertain even if our task is cancelled. Track it before the
+                # await so a later stop always reconciles the remote state.
+                self._typing_started.add(key)
+                await self.client.post(
+                    self._api_url(f"/api/v1/chat/{encoded}/typing"), timeout=5
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                pass
 
     async def stop_typing(self, chat_id: str) -> None:
-        await self._private_api_chat_call(chat_id, "typing", "delete")
+        key = str(chat_id)
+        if key in self._typing_stopped and key not in self._typing_started:
+            return
+        self._typing_pending_stops.add(key)
+        await self._apply_typing_stop(chat_id, schedule_retry=not self._typing_shutdown)
+
+    async def _apply_typing_stop(
+        self,
+        chat_id: str,
+        *,
+        schedule_retry: bool,
+    ) -> None:
+        """Serialize one remote stop after any in-flight typing start."""
+        key = str(chat_id)
+        lock = self._typing_transition_locks.setdefault(key, asyncio.Lock())
+        async with lock:
+            if key not in self._typing_pending_stops:
+                return
+            if key in self._typing_stopped and key not in self._typing_started:
+                self._typing_pending_stops.discard(key)
+                return
+            helper_available = False
+            try:
+                helper_available = await asyncio.wait_for(
+                    self._refresh_helper_state(),
+                    timeout=_STOP_TYPING_HELPER_REFRESH_SECONDS,
+                )
+            except TimeoutError:
+                pass
+            except asyncio.CancelledError:
+                raise
+            if not helper_available:
+                if key not in self._typing_started:
+                    # No start request crossed the helper boundary, so there
+                    # is no remote state to reconcile and no reason to retain
+                    # a retry worker for an idle chat.
+                    self._typing_pending_stops.discard(key)
+                elif schedule_retry:
+                    self._schedule_typing_stop_retry(chat_id)
+                return
+            try:
+                guid = await self._resolve_chat_guid(chat_id)
+                if not guid:
+                    if schedule_retry:
+                        self._schedule_typing_stop_retry(chat_id)
+                    return
+                client = self.client
+                if client is None:
+                    return
+                encoded = quote(guid, safe="")
+                await client.delete(
+                    self._api_url(f"/api/v1/chat/{encoded}/typing"), timeout=5
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                if schedule_retry:
+                    self._schedule_typing_stop_retry(chat_id)
+                return
+            self._typing_started.discard(key)
+            self._typing_pending_stops.discard(key)
+            self._typing_stopped[key] = None
+            self._typing_stopped.move_to_end(key)
+            while len(self._typing_stopped) > _MESSAGE_DEDUP_SIZE:
+                self._typing_stopped.popitem(last=False)
+
+    def _schedule_typing_stop_retry(self, chat_id: str) -> None:
+        """Keep one retry worker per chat until the cold helper is reachable."""
+        key = str(chat_id)
+        if self._typing_shutdown or not self.client:
+            return
+        existing = self._typing_stop_tasks.get(key)
+        if existing is not None and not existing.done():
+            return
+
+        async def retry() -> None:
+            current = asyncio.current_task()
+            try:
+                while (
+                    not self._typing_shutdown
+                    and self.client is not None
+                    and key in self._typing_pending_stops
+                ):
+                    await asyncio.sleep(_HELPER_NEGATIVE_REFRESH_TTL_SECONDS)
+                    await self._apply_typing_stop(chat_id, schedule_retry=False)
+            except asyncio.CancelledError:
+                pass
+            finally:
+                if self._typing_stop_tasks.get(key) is current:
+                    self._typing_stop_tasks.pop(key, None)
+
+        task = asyncio.create_task(retry())
+        self._typing_stop_tasks[key] = task
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
+    async def _reconcile_typing_stops(self) -> None:
+        """Issue one final stop for every locally active or pending chat."""
+        chats = set(self._typing_started) | set(self._typing_pending_stops)
+        for chat_id in chats:
+            self._typing_pending_stops.add(chat_id)
+            try:
+                await self._apply_typing_stop(chat_id, schedule_retry=False)
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                pass
+
+    def _clear_typing_lifecycle_state(self) -> None:
+        for task in self._typing_stop_tasks.values():
+            if not task.done():
+                task.cancel()
+        self._typing_stop_tasks.clear()
+        self._typing_transition_locks.clear()
+        self._typing_started.clear()
+        self._typing_pending_stops.clear()
+        self._typing_stopped.clear()
+
+    # ------------------------------------------------------------------
+    # Read receipts
+    # ------------------------------------------------------------------
+
+    def _read_receipt_allowed(
+        self,
+        chat_id: str,
+        *,
+        is_group: Optional[bool] = None,
+        admitted: bool = False,
+    ) -> bool:
+        """Apply receipt privacy policy at the final delivery boundary."""
+        if not self.send_read_receipts or self._read_receipts_closed or not chat_id:
+            return False
+        group = bool(is_group) or ";+;" in chat_id
+        return not group or admitted
 
     async def mark_read(self, chat_id: str) -> bool:
-        return await self._private_api_chat_call(chat_id, "read", "post")
+        """Mark a direct conversation read; group callers must use admission."""
+        return await self._deliver_read_receipt(
+            chat_id,
+            is_group=None,
+            admitted=False,
+        )
 
-    # --- Chat info ---
+    async def _deliver_read_receipt(
+        self,
+        chat_id: str,
+        *,
+        is_group: Optional[bool] = None,
+        admitted: bool = False,
+    ) -> bool:
+        if not self._read_receipt_allowed(
+            chat_id,
+            is_group=is_group,
+            admitted=admitted,
+        ):
+            return False
+        if not await self._refresh_helper_state():
+            return False
+        if self._read_receipts_closed:
+            return False
+        try:
+            guid = await self._resolve_chat_guid(chat_id)
+            if guid:
+                if self._read_receipts_closed:
+                    return False
+                encoded = quote(guid, safe="")
+                await self.client.post(
+                    self._api_url(f"/api/v1/chat/{encoded}/read"), timeout=5
+                )
+                return True
+        except Exception:
+            pass
+        return False
+
+    async def _queue_read_receipt(
+        self,
+        chat_id: str,
+        message_id: str,
+        *,
+        is_group: bool,
+        admitted: bool,
+    ) -> bool:
+        """Queue one admitted receipt until the Private API helper is ready."""
+        if not self._read_receipt_allowed(
+            chat_id,
+            is_group=is_group,
+            admitted=admitted,
+        ):
+            return False
+        message_id = (message_id or "").strip()
+        if not message_id:
+            return False
+        receipt_key = (chat_id, message_id)
+        async with self._read_receipt_lock:
+            if self._read_receipts_closed or receipt_key in self._sent_read_receipts:
+                return False
+            pending = self._pending_read_receipts.setdefault(chat_id, set())
+            if message_id in pending:
+                return False
+            pending.add(message_id)
+            task = self._read_receipt_tasks.get(chat_id)
+            if task is None or task.done():
+                task = asyncio.create_task(
+                    self._run_read_receipt_worker(chat_id, is_group=is_group)
+                )
+                self._read_receipt_tasks[chat_id] = task
+                self._background_tasks.add(task)
+                task.add_done_callback(self._background_tasks.discard)
+        return True
+
+    async def _run_read_receipt_worker(self, chat_id: str, *, is_group: bool) -> None:
+        current_task = asyncio.current_task()
+        try:
+            while True:
+                async with self._read_receipt_lock:
+                    if self._read_receipts_closed:
+                        self._pending_read_receipts.pop(chat_id, None)
+                        return
+                    pending = self._pending_read_receipts.get(chat_id)
+                    if not pending:
+                        return
+                    attempt_ids = tuple(pending)
+
+                if await self._deliver_read_receipt(
+                    chat_id,
+                    is_group=is_group,
+                    admitted=True,
+                ):
+                    async with self._read_receipt_lock:
+                        pending = self._pending_read_receipts.get(chat_id)
+                        if pending is not None:
+                            for message_id in attempt_ids:
+                                pending.discard(message_id)
+                                key = (chat_id, message_id)
+                                self._sent_read_receipts[key] = None
+                                self._sent_read_receipts.move_to_end(key)
+                            while len(self._sent_read_receipts) > _MESSAGE_DEDUP_SIZE:
+                                self._sent_read_receipts.popitem(last=False)
+                            if not pending:
+                                self._pending_read_receipts.pop(chat_id, None)
+                                if self._read_receipt_tasks.get(chat_id) is current_task:
+                                    self._read_receipt_tasks.pop(chat_id, None)
+                                return
+                    continue
+                await asyncio.sleep(_READ_RECEIPT_RETRY_SECONDS)
+        except asyncio.CancelledError:
+            async with self._read_receipt_lock:
+                self._pending_read_receipts.pop(chat_id, None)
+            raise
+        finally:
+            async with self._read_receipt_lock:
+                if self._read_receipt_tasks.get(chat_id) is current_task:
+                    self._read_receipt_tasks.pop(chat_id, None)
+
+    async def _cancel_read_receipts(self) -> None:
+        """Cancel queued receipt work and prevent post-teardown sends."""
+        self._read_receipts_closed = True
+        async with self._read_receipt_lock:
+            tasks = [task for task in self._read_receipt_tasks.values() if not task.done()]
+            for task in tasks:
+                task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        async with self._read_receipt_lock:
+            self._pending_read_receipts.clear()
+            self._read_receipt_tasks.clear()
+            self._sent_read_receipts.clear()
+
+    # ------------------------------------------------------------------
+    # Tapback reactions
+    # ------------------------------------------------------------------
+
+    async def on_processing_start(self, event: MessageEvent) -> None:
+        """Never generate an outbound Tapback from inbound processing state."""
+        return
+
+    async def add_reaction(
+        self,
+        chat_id: str,
+        emoji: str,
+        message_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Send one explicitly approved native Tapback to an exact target."""
+        reaction = _TAPBACK_EMOJI.get((emoji or "").strip())
+        if not reaction or not message_id:
+            return {"success": False, "error": "Exact native Tapback and message_id required"}
+        result = await self.send_reaction(
+            chat_id,
+            message_id,
+            reaction,
+            source_event_id=f"outbound:add:{chat_id}:{message_id}:{reaction}",
+        )
+        return {
+            "success": result.success,
+            "message_id": result.message_id,
+            **({"error": result.error} if result.error else {}),
+        }
+
+    async def remove_reaction(
+        self,
+        chat_id: str,
+        emoji: str,
+        message_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Remove the same exact native Tapback identity from its exact target."""
+        reaction = _TAPBACK_EMOJI.get((emoji or "").strip())
+        if not reaction or not message_id:
+            return {"success": False, "error": "Exact native Tapback and message_id required"}
+        result = await self.send_reaction(
+            chat_id,
+            message_id,
+            f"-{reaction}",
+            source_event_id=f"outbound:remove:{chat_id}:{message_id}:{reaction}",
+        )
+        return {
+            "success": result.success,
+            "message_id": result.message_id,
+            **({"error": result.error} if result.error else {}),
+        }
+
+    async def send_reaction(
+        self,
+        chat_id: str,
+        message_guid: str,
+        reaction: str,
+        part_index: int = 0,
+        *,
+        source_event_id: Optional[str] = None,
+    ) -> SendResult:
+        """Add or remove a native Tapback on an exact message and chat."""
+        normalized = (reaction or "").strip().lower()
+        base_reaction = normalized.removeprefix("-")
+        if base_reaction not in _TAPBACK_REACTIONS or normalized.startswith("--"):
+            return SendResult(
+                success=False,
+                error=f"Unsupported BlueBubbles reaction: {reaction}",
+            )
+        message_guid = (message_guid or "").strip()
+        if not message_guid:
+            return SendResult(success=False, error="BlueBubbles reaction requires message GUID")
+        if isinstance(part_index, bool) or not isinstance(part_index, int) or part_index < 0:
+            return SendResult(
+                success=False,
+                error="BlueBubbles reaction part index must be a non-negative integer",
+            )
+        if not self.client:
+            return SendResult(success=False, error="BlueBubbles is not connected")
+        if not await self._refresh_helper_state():
+            return SendResult(success=False, error="Private API helper not connected")
+        guid = await self._resolve_chat_guid(chat_id)
+        if not guid:
+            return SendResult(success=False, error=f"Chat not found: {chat_id}")
+        try:
+            operation = TapbackOperation(
+                platform="bluebubbles",
+                chat_id=guid,
+                target_message_id=message_guid,
+                sender_id="self",
+                reaction=TapbackType(base_reaction),
+                action=(
+                    TapbackAction.REMOVE
+                    if normalized.startswith("-")
+                    else TapbackAction.ADD
+                ),
+                direction=TapbackDirection.OUTBOUND,
+                source_event_id=source_event_id or message_guid,
+                part_index=part_index,
+            ).transition_to(TapbackStatus.VALIDATED)
+            target = await self._query_exact_message(guid, message_guid)
+            if target is None:
+                return SendResult(
+                    success=False,
+                    error=f"Message {message_guid} does not belong to chat {guid}",
+                )
+            res = await self._api_post(
+                "/api/v1/message/react",
+                {
+                    "chatGuid": operation.chat_id,
+                    "selectedMessageGuid": operation.target_message_id,
+                    "reaction": (
+                        f"-{operation.reaction.value}"
+                        if operation.action is TapbackAction.REMOVE
+                        else operation.reaction.value
+                    ),
+                    "partIndex": operation.part_index,
+                },
+            )
+            data = res.get("data") or {}
+            message_id = data.get("guid") or data.get("messageGuid")
+            return SendResult(
+                success=True,
+                message_id=str(message_id) if message_id else None,
+                raw_response=res,
+            )
+        except Exception as exc:
+            return SendResult(success=False, error=str(exc))
+
+    # ------------------------------------------------------------------
+    # Chat info
+    # ------------------------------------------------------------------
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         is_group = ";+;" in (chat_id or "")
-        info: Dict[str, Any] = {"name": chat_id, "type": "group" if is_group else "dm"}
-        with suppress(Exception):
-            if guid := await self._resolve_chat_guid(chat_id):
-                res = await self._api_get(f"/api/v1/chat/{quote(guid, safe='')}?with=participants")
+        info: Dict[str, Any] = {
+            "name": chat_id,
+            "type": "group" if is_group else "dm",
+        }
+        try:
+            guid = await self._resolve_chat_guid(chat_id)
+            if guid:
+                encoded = quote(guid, safe="")
+                res = await self._api_get(
+                    f"/api/v1/chat/{encoded}?with=participants"
+                )
                 data = (res or {}).get("data", {})
-                info["name"] = data.get("displayName") or data.get("chatIdentifier") or chat_id
-                participants = [addr for p in data.get("participants", []) or []
-                                if (addr := (p.get("address") or "").strip())]
+                display_name = (
+                    data.get("displayName")
+                    or data.get("chatIdentifier")
+                    or chat_id
+                )
+                participants = []
+                for p in data.get("participants", []) or []:
+                    addr = (p.get("address") or "").strip()
+                    if addr:
+                        participants.append(addr)
+                info["name"] = display_name
                 if participants:
                     info["participants"] = participants
+        except Exception:
+            pass
         return info
 
     def format_message(self, content: str) -> str:
         return strip_markdown(content)
 
-    # --- Inbound attachment downloading ---
+    # ------------------------------------------------------------------
+    # Inbound attachment downloading (from #4588)
+    # ------------------------------------------------------------------
 
-    async def _download_attachment(self, att_guid: str, att_meta: Dict[str, Any]) -> Optional[str]:
-        """Download an attachment and cache it locally; local path or None on failure."""
+    async def _download_attachment(
+        self, att_guid: str, att_meta: Dict[str, Any]
+    ) -> Optional[str]:
+        """Download an attachment from BlueBubbles and cache it locally.
+
+        Returns the local file path on success, None on failure.
+        """
         if not self.client:
             return None
+
         try:
-            resp = await self.client.get(self._api_url(f"/api/v1/attachment/{quote(att_guid, safe='')}/download"),
-                                         timeout=60, follow_redirects=True)
+            encoded = quote(att_guid, safe="")
+            resp = await self.client.get(
+                self._api_url(f"/api/v1/attachment/{encoded}/download"),
+                timeout=60,
+                follow_redirects=True,
+            )
             resp.raise_for_status()
             data = resp.content
+
             mime = (att_meta.get("mimeType") or "").lower()
+            transfer_name = att_meta.get("transferName", "")
+
             if mime.startswith("image/"):
-                return await cache_image_from_bytes_async(data, _closed_ext(mime, _BLUEBUBBLES_IMAGE_EXT_OVERRIDES, ".jpg"))
+                ext = ext_for_mime(
+                    mime,
+                    overrides=_BLUEBUBBLES_IMAGE_EXT_OVERRIDES,
+                    # Historical map was closed: any unlisted image mime
+                    # fell back to .jpg without consulting mimetypes.
+                    use_defaults=False,
+                    use_mimetypes=False,
+                    fallback=".jpg",
+                ) or ".jpg"
+                return await cache_image_from_bytes_async(data, ext)
+
             if mime.startswith("audio/"):
-                return await cache_audio_from_bytes_async(data, _closed_ext(mime, _BLUEBUBBLES_AUDIO_EXT_OVERRIDES, ".mp3"))
+                ext = ext_for_mime(
+                    mime,
+                    overrides=_BLUEBUBBLES_AUDIO_EXT_OVERRIDES,
+                    # Historical map was closed: any unlisted audio mime
+                    # fell back to .mp3 without consulting mimetypes.
+                    use_defaults=False,
+                    use_mimetypes=False,
+                    fallback=".mp3",
+                ) or ".mp3"
+                return await cache_audio_from_bytes_async(data, ext)
+
             # Videos, documents, and everything else
-            return await cache_document_from_bytes_async(data, att_meta.get("transferName", "") or f"file_{uuid.uuid4().hex[:8]}")
+            filename = transfer_name or f"file_{uuid.uuid4().hex[:8]}"
+            return await cache_document_from_bytes_async(data, filename)
+
         except Exception as exc:
-            logger.warning("[bluebubbles] failed to download attachment %s: %s", _redact(att_guid), exc)
+            logger.warning(
+                "[bluebubbles] failed to download attachment %s: %s",
+                _redact(att_guid),
+                exc,
+            )
             return None
 
-    # --- Webhook handling ---
+    async def _query_exact_message(
+        self,
+        chat_guid: str,
+        message_guid: str,
+        *,
+        include_attachments: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        """Return one exact message only when it belongs to the requested chat."""
+        if not chat_guid or not message_guid:
+            return None
+        with_relations = ["chats"]
+        if include_attachments:
+            with_relations.insert(0, "attachments")
+        encoded_guid = quote(message_guid, safe="")
+        encoded_with = quote(",".join(with_relations), safe="")
+        record: Any = None
+        try:
+            payload = await self._api_get(
+                f"/api/v1/message/{encoded_guid}?with={encoded_with}"
+            )
+            record = payload.get("data")
+            if isinstance(record, list):
+                record = record[0] if len(record) == 1 else None
+        except Exception:
+            # Older/custom BlueBubbles-compatible servers may lack the find
+            # route. Keep the exact chat-scoped query as a compatibility fallback.
+            payload = await self._api_post(
+                "/api/v1/message/query",
+                {
+                    "limit": 1,
+                    "offset": 0,
+                    "chatGuid": chat_guid,
+                    "with": with_relations,
+                    "where": [
+                        {
+                            "statement": "message.guid = :guid",
+                            "args": {"guid": message_guid},
+                        }
+                    ],
+                },
+            )
+            records = payload.get("data") or []
+            record = records[0] if isinstance(records, list) and records else None
+        if not isinstance(record, dict) or record.get("guid") != message_guid:
+            return None
+        chat_guids = {
+            guid
+            for chat in (record.get("chats") or [])
+            if isinstance(chat, dict)
+            for guid in [self._value(chat.get("guid"), chat.get("chatGuid"))]
+            if guid
+        }
+        if chat_guids != {chat_guid}:
+            return None
+        return record
 
-    def _extract_payload_record(self, payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    async def _lookup_referenced_message(
+        self,
+        chat_guid: str,
+        message_guid: str,
+        *,
+        include_attachments: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        """Resolve one reference from the bounded current-chat message window."""
+        if (
+            not isinstance(chat_guid, str)
+            or not chat_guid
+            or chat_guid != chat_guid.strip()
+            or not isinstance(message_guid, str)
+            or not message_guid
+            or message_guid != message_guid.strip()
+        ):
+            return None
+        with_relations = ["chats"]
+        if include_attachments:
+            with_relations.insert(0, "attachments")
+        try:
+            payload = await asyncio.wait_for(
+                self._api_post(
+                    "/api/v1/message/query",
+                    {
+                        "limit": _REFERENCED_MESSAGE_LOOKUP_LIMIT,
+                        "offset": 0,
+                        "chatGuid": chat_guid,
+                        "with": with_relations,
+                    },
+                ),
+                timeout=_MESSAGE_CHAT_LOOKUP_TIMEOUT_SECONDS,
+            )
+        except Exception:
+            return None
+        records = payload.get("data") if isinstance(payload, dict) else None
+        if (
+            not isinstance(records, list)
+            or len(records) > _REFERENCED_MESSAGE_LOOKUP_LIMIT
+        ):
+            return None
+        matches = [
+            record
+            for record in records
+            if isinstance(record, dict) and record.get("guid") == message_guid
+        ]
+        if len(matches) != 1:
+            return None
+        record = matches[0]
+        chat_guids = {
+            guid
+            for chat in (record.get("chats") or [])
+            if isinstance(chat, dict)
+            for guid in [self._value(chat.get("guid"), chat.get("chatGuid"))]
+            if guid
+        }
+        return record if chat_guids == {chat_guid} else None
+
+    async def _verify_inbound_message_membership(
+        self,
+        message_guid: str,
+        candidate_chat_guid: Optional[str],
+    ) -> Optional[str]:
+        """Resolve exact server-side membership, never trusting webhook chat fields."""
+        if not message_guid:
+            return None
+        if not candidate_chat_guid:
+            return await self._resolve_exact_message_chat_guid(message_guid)
+        try:
+            record = await asyncio.wait_for(
+                self._query_exact_message(candidate_chat_guid, message_guid),
+                timeout=_MESSAGE_CHAT_LOOKUP_TIMEOUT_SECONDS,
+            )
+        except Exception:
+            return None
+        return candidate_chat_guid if record is not None else None
+
+    async def _resolve_exact_message_chat_guid(
+        self, message_guid: str
+    ) -> Optional[str]:
+        """Resolve one message GUID to exactly one authoritative chat."""
+        if not self.client or not message_guid:
+            return None
+        encoded_guid = quote(message_guid, safe="")
+        try:
+            payload = await asyncio.wait_for(
+                self._api_get(f"/api/v1/message/{encoded_guid}?with=chats"),
+                timeout=_MESSAGE_CHAT_LOOKUP_TIMEOUT_SECONDS,
+            )
+        except Exception:
+            return None
+        record: Any = payload.get("data") if isinstance(payload, dict) else None
+        if isinstance(record, list):
+            record = record[0] if len(record) == 1 else None
+        if not isinstance(record, dict) or self._value(record.get("guid")) != message_guid:
+            return None
+        chat_guids = {
+            guid
+            for chat in (record.get("chats") or [])
+            if isinstance(chat, dict)
+            for guid in [self._value(chat.get("guid"), chat.get("chatGuid"))]
+            if guid
+        }
+        if len(chat_guids) != 1:
+            return None
+        return next(iter(chat_guids))
+
+    async def _expire_provisional_message(
+        self, provisional_key: _ProvisionalMessageKey
+    ) -> None:
+        """Retry exact membership once, then fail closed."""
+        current_task = asyncio.current_task()
+        try:
+            await asyncio.sleep(_PROVISIONAL_MESSAGE_WAIT_SECONDS)
+            async with self._inbound_dedup_lock:
+                if self._provisional_message_tasks.get(provisional_key) is not current_task:
+                    return
+                pending = self._provisional_messages.get(provisional_key)
+            if not pending:
+                return
+            candidate_chat_guid = provisional_key[2] or None
+            chat_guid = await self._verify_inbound_message_membership(
+                provisional_key[0], candidate_chat_guid
+            )
+            if not chat_guid:
+                async with self._inbound_dedup_lock:
+                    if self._provisional_message_tasks.get(provisional_key) is current_task:
+                        self._provisional_messages.pop(provisional_key, None)
+                return
+            async with self._inbound_dedup_lock:
+                if self._provisional_message_tasks.get(provisional_key) is not current_task:
+                    return
+                pending = self._provisional_messages.get(provisional_key)
+            if not pending:
+                return
+            payload, record = pending
+            resolved_record = {
+                **record,
+                "chatGuid": chat_guid,
+                "chats": [{"guid": chat_guid}],
+            }
+            resolved_payload = dict(payload)
+            if isinstance(resolved_payload.get("data"), dict):
+                resolved_payload["data"] = resolved_record
+            elif isinstance(resolved_payload.get("message"), dict):
+                resolved_payload["message"] = resolved_record
+            else:
+                resolved_payload.update(resolved_record)
+            await self._handle_webhook(
+                None,
+                _trusted_payload=resolved_payload,
+                _authoritative_chat_guid=chat_guid,
+            )
+        finally:
+            async with self._inbound_dedup_lock:
+                if self._provisional_message_tasks.get(provisional_key) is current_task:
+                    self._provisional_messages.pop(provisional_key, None)
+                    self._provisional_message_tasks.pop(provisional_key, None)
+
+    async def _queue_provisional_message(
+        self,
+        provisional_key: _ProvisionalMessageKey,
+        payload: Dict[str, Any],
+        record: Dict[str, Any],
+    ) -> None:
+        """Hold one ambiguous revision without assigning it to the sender's DM."""
+        async with self._inbound_dedup_lock:
+            self._provisional_messages[provisional_key] = (
+                dict(payload),
+                dict(record),
+            )
+            self._provisional_messages.move_to_end(provisional_key)
+            while len(self._provisional_messages) > _MESSAGE_DEDUP_SIZE:
+                evicted_key, _ = self._provisional_messages.popitem(last=False)
+                evicted_task = self._provisional_message_tasks.pop(evicted_key, None)
+                if evicted_task and not evicted_task.done():
+                    evicted_task.cancel()
+
+    async def _schedule_provisional_retry(
+        self, provisional_key: _ProvisionalMessageKey
+    ) -> None:
+        async with self._inbound_dedup_lock:
+            if provisional_key not in self._provisional_messages:
+                return
+            prior_task = self._provisional_message_tasks.get(provisional_key)
+            if prior_task and not prior_task.done():
+                return
+            task = asyncio.create_task(self._expire_provisional_message(provisional_key))
+            self._provisional_message_tasks[provisional_key] = task
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
+
+    async def _take_provisional_message(
+        self,
+        provisional_key: _ProvisionalMessageKey,
+        *,
+        allow_unclaimed_chat: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        async with self._inbound_dedup_lock:
+            if provisional_key not in self._provisional_messages and allow_unclaimed_chat:
+                unclaimed_key = (provisional_key[0], provisional_key[1], "")
+                if unclaimed_key in self._provisional_messages:
+                    provisional_key = unclaimed_key
+            pending = self._provisional_messages.pop(provisional_key, None)
+            task = self._provisional_message_tasks.pop(provisional_key, None)
+            if task and task is not asyncio.current_task() and not task.done():
+                task.cancel()
+            return pending[1] if pending else None
+
+    @staticmethod
+    def _merge_provisional_record(
+        authoritative: Dict[str, Any], provisional: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Fill content gaps without replacing authoritative chat membership."""
+        merged = dict(authoritative)
+        for field in (
+            "text",
+            "message",
+            "body",
+            "handle",
+            "sender",
+            "from",
+            "address",
+            "threadOriginatorGuid",
+            "associatedMessageGuid",
+        ):
+            if not merged.get(field) and provisional.get(field):
+                merged[field] = provisional[field]
+        attachments: List[Dict[str, Any]] = []
+        attachment_indexes: Dict[str, int] = {}
+        for candidate in (
+            provisional.get("attachments") or [],
+            authoritative.get("attachments") or [],
+        ):
+            for attachment in candidate:
+                if not isinstance(attachment, dict):
+                    continue
+                attachment_guid = BlueBubblesAdapter._value(attachment.get("guid"))
+                if attachment_guid in attachment_indexes:
+                    index = attachment_indexes[attachment_guid]
+                    attachments[index] = {**attachments[index], **attachment}
+                else:
+                    if attachment_guid:
+                        attachment_indexes[attachment_guid] = len(attachments)
+                    attachments.append(dict(attachment))
+        if attachments:
+            merged["attachments"] = attachments
+        return merged
+
+    async def _lookup_reply_context(
+        self, chat_guid: str, message_guid: str
+    ) -> tuple[Optional[str], bool, List[str], List[str]]:
+        """Hydrate one exact replied-to message, failing closed on locality."""
+        if not chat_guid or not message_guid:
+            return None, False, [], []
+        try:
+            record = await self._lookup_referenced_message(
+                chat_guid, message_guid, include_attachments=True
+            )
+            if record is None:
+                return None, False, [], []
+
+            paths: List[str] = []
+            types: List[str] = []
+            attachments = record.get("attachments") or []
+            for attachment in attachments[:_REPLY_ATTACHMENT_LIMIT]:
+                if not isinstance(attachment, dict):
+                    continue
+                attachment_guid = self._value(attachment.get("guid"))
+                if not attachment_guid:
+                    continue
+                cached = await self._download_attachment(
+                    attachment_guid, attachment
+                )
+                if cached:
+                    paths.append(cached)
+                    types.append((attachment.get("mimeType") or "").lower())
+            return (
+                self._value(record.get("text")),
+                bool(record.get("isFromMe")),
+                paths,
+                types,
+            )
+        except Exception as exc:
+            logger.debug("[bluebubbles] reply context lookup failed: %s", exc)
+            return None, False, [], []
+
+
+    # ------------------------------------------------------------------
+    # Webhook handling
+    # ------------------------------------------------------------------
+
+    def _extract_payload_record(
+        self, payload: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
         data = payload.get("data")
         if isinstance(data, dict):
             return data
-        if isinstance(data, list) and (first := next((i for i in data if isinstance(i, dict)), None)):
-            return first
+        if isinstance(data, list):
+            for item in data:
+                if isinstance(item, dict):
+                    return item
         if isinstance(payload.get("message"), dict):
             return payload.get("message")
         return payload if isinstance(payload, dict) else None
 
     @staticmethod
     def _value(*candidates: Any) -> Optional[str]:
-        return next((c.strip() for c in candidates if isinstance(c, str) and c.strip()), None)
+        for candidate in candidates:
+            if isinstance(candidate, str) and candidate.strip():
+                return candidate.strip()
+        return None
 
     @staticmethod
-    def _parse_webhook_body(raw: bytes) -> Any:
-        """Decode a webhook body: JSON, else form-encoded with a JSON field."""
-        body = raw.decode("utf-8", errors="replace")
-        try:
-            return json.loads(body)
-        except Exception:
-            form = parse_qs(body)
-            payload_str = (form.get("payload") or form.get("data") or form.get("message") or [""])[0]
-            return json.loads(payload_str) if payload_str else {}
+    def _tapback_target(raw_guid: Any) -> tuple[Optional[str], int]:
+        """Return the exact target GUID and part index from an associated GUID."""
+        if not isinstance(raw_guid, str) or not raw_guid.strip():
+            return None, 0
+        value = raw_guid.strip()
+        match = re.fullmatch(r"p:(\d+)/(.+)", value)
+        if match:
+            return match.group(2), int(match.group(1))
+        if value.startswith("bp:") and value[3:]:
+            return value[3:], 0
+        return value, 0
 
-    async def _collect_attachments(self, record: Dict[str, Any]):
-        """Download inbound attachments; returns (media_urls, media_types, msg_type)."""
-        media_urls: List[str] = []
-        media_types: List[str] = []
-        msg_type = MessageType.TEXT
-        for att in record.get("attachments") or []:
-            att_guid = att.get("guid", "")
-            cached = await self._download_attachment(att_guid, att) if att_guid else None
-            if not cached:
+    @classmethod
+    def _reply_target(cls, *candidates: Any) -> tuple[Optional[str], int]:
+        """Parse a quoted-message reference without normalizing malformed IDs."""
+        for candidate in candidates:
+            if candidate is None or candidate == "":
                 continue
-            mime = (att.get("mimeType") or "").lower()
-            media_urls.append(cached)
-            media_types.append(mime)
-            is_voice = mime.startswith("audio/") or (att.get("uti") or "").endswith("caf")
-            msg_type = (MessageType.PHOTO if mime.startswith("image/") else MessageType.VOICE if is_voice
-                        else MessageType.VIDEO if mime.startswith("video/") else MessageType.DOCUMENT)
-        if len(media_urls) > 1 and any(m.split("/")[0] == "image" for m in media_types):  # any image → PHOTO
-            msg_type = MessageType.PHOTO
-        return media_urls, media_types, msg_type
+            if not isinstance(candidate, str) or candidate != candidate.strip():
+                return None, 0
+            target, part_index = cls._tapback_target(candidate)
+            if not target or target != target.strip():
+                return None, 0
+            return target, part_index
+        return None, 0
 
-    def _webhook_token(self, request) -> Optional[str]:
-        return (request.query.get("password") or request.query.get("guid") or request.headers.get("x-password")
-                or request.headers.get("x-guid") or request.headers.get("x-bluebubbles-guid"))
+    async def _dispatch_inbound_tapback(
+        self,
+        *,
+        payload: Dict[str, Any],
+        tapback: tuple[str, str],
+        target_guid: str,
+        part_index: int,
+        session_chat_id: str,
+        chat_identifier: Optional[str],
+        sender: str,
+        is_group: bool,
+        message_guid: Optional[str],
+    ) -> None:
+        """Publish one already-authorized, exact-chat Tapback."""
+        if not message_guid:
+            logger.debug("[bluebubbles] rejected Tapback without source event ID")
+            return
+        source = self.build_source(
+            chat_id=session_chat_id,
+            chat_name=chat_identifier or sender,
+            chat_type="group" if is_group else "dm",
+            user_id=sender,
+            user_name=self._participant_names.get(sender, sender),
+            chat_id_alt=chat_identifier,
+        )
+        platform_handler = getattr(self, "_platform_event_handler", None)
+        if platform_handler is None:
+            return
 
-    def _resolve_chat_and_sender(self, payload: Dict[str, Any], record: Dict[str, Any]):
-        """Returns ``(chat_guid, chat_identifier, sender)`` from the many BlueBubbles payload shapes."""
-        chat_guid = self._value(record.get("chatGuid"), payload.get("chatGuid"), record.get("chat_guid"),
-                                payload.get("chat_guid"), payload.get("guid"))
-        # BlueBubbles v1.9+ payloads omit top-level chatGuid; it's nested under data.chats[0].guid.
-        _chats = record.get("chats") or []
-        if not chat_guid and _chats and isinstance(_chats[0], dict):
-            chat_guid = _chats[0].get("guid") or _chats[0].get("chatGuid")
-        chat_identifier = self._value(record.get("chatIdentifier"), record.get("identifier"),
-                                      payload.get("chatIdentifier"), payload.get("identifier"))
-        handle = record.get("handle")
-        sender = (self._value(handle.get("address") if isinstance(handle, dict) else None, record.get("sender"),
-                              record.get("from"), record.get("address")) or chat_identifier or chat_guid)
-        if not (chat_guid or chat_identifier) and sender:
-            chat_identifier = sender
-        return chat_guid, chat_identifier, sender
+        action, reaction = tapback
+        try:
+            operation = TapbackOperation(
+                platform="bluebubbles",
+                chat_id=session_chat_id,
+                target_message_id=target_guid,
+                sender_id=sender,
+                reaction=TapbackType(reaction),
+                action=TapbackAction(action),
+                direction=TapbackDirection.INBOUND,
+                source_event_id=message_guid,
+                part_index=part_index,
+            )
+            operation = operation.transition_to(TapbackStatus.VALIDATED)
+            operation = operation.transition_to(TapbackStatus.PENDING)
+            operation = operation.transition_to(TapbackStatus.PROCESSING)
+        except (TapbackValidationError, ValueError):
+            logger.debug("[bluebubbles] rejected malformed Tapback", exc_info=True)
+            return
+        state_key = operation.state_key
+        async with self._inbound_dedup_lock:
+            prior_state = self._tapback_event_states.get(state_key)
+            if (
+                prior_state
+                and prior_state[0].action is operation.action
+                and prior_state[0].reaction is operation.reaction
+            ):
+                self._tapback_event_states.move_to_end(state_key)
+                return
+            self._tapback_event_serial += 1
+            state_serial = self._tapback_event_serial
+            self._tapback_event_states[state_key] = (operation, state_serial)
+            self._tapback_event_states.move_to_end(state_key)
+            while len(self._tapback_event_states) > _MESSAGE_DEDUP_SIZE:
+                self._tapback_event_states.popitem(last=False)
+        event_payload = {
+            "platform": "bluebubbles",
+            "event_type": "reaction",
+            "payload": {
+                **operation.to_platform_payload(),
+                "raw_event": payload,
+            },
+        }
+        try:
+            await platform_handler(event_payload, source)
+            async with self._inbound_dedup_lock:
+                current_state = self._tapback_event_states.get(state_key)
+                if current_state and current_state[1] == state_serial:
+                    self._tapback_event_states[state_key] = (
+                        operation.transition_to(TapbackStatus.APPLIED),
+                        state_serial,
+                    )
+                    self._tapback_event_states.move_to_end(state_key)
+        except Exception:
+            async with self._inbound_dedup_lock:
+                current_state = self._tapback_event_states.get(state_key)
+                if current_state and current_state[1] == state_serial:
+                    if prior_state is None:
+                        self._tapback_event_states.pop(state_key, None)
+                    else:
+                        self._tapback_event_states[state_key] = prior_state
+                        self._tapback_event_states.move_to_end(state_key)
+            logger.debug(
+                "[bluebubbles] platform event dispatch failed",
+                exc_info=True,
+            )
 
-    async def _handle_webhook(self, request):
+    @staticmethod
+    def _is_retryable_inbound_error(exc: BaseException) -> bool:
+        """Classify failures that are safe to retry before dispatch commits."""
+        return bool(
+            getattr(exc, "retryable", False)
+            or isinstance(
+                exc,
+                (
+                    ConnectionError,
+                    TimeoutError,
+                    httpx.ConnectError,
+                    httpx.RemoteProtocolError,
+                ),
+            )
+        )
+
+    def _remember_terminal_identities_locked(
+        self, identities: tuple[str, ...]
+    ) -> None:
+        for identity in identities:
+            self._terminal_message_identities[identity] = None
+            self._terminal_message_identities.move_to_end(identity)
+        while len(self._terminal_message_identities) > _MESSAGE_DEDUP_SIZE:
+            self._terminal_message_identities.popitem(last=False)
+
+    async def _handle_reserved_message(
+        self,
+        event: MessageEvent,
+        message_identity: Optional[str],
+        coalesced_identities: tuple[str, ...] = (),
+        message_key: Optional[_InboundMessageKey] = None,
+        revision_serial: int = 0,
+    ) -> None:
+        """Run one revision with supersession-safe cancellation and retries.
+
+        A stable message identity stays reserved for the entire bounded retry
+        sequence. Newer revisions cancel only an older task for the same exact
+        chat/sender/GUID key. Success is recorded only after the operation and
+        a final latest-revision check; permanent or exhausted failures use a
+        separate terminal cache so they cannot masquerade as completed work.
+        """
+        identities = tuple(
+            dict.fromkeys(
+                identity
+                for identity in (message_identity, *coalesced_identities)
+                if identity
+            )
+        )
+        current_task = asyncio.current_task()
+        join_task: Optional[asyncio.Task] = None
+        cancel_task: Optional[asyncio.Task] = None
+        if message_key and current_task is not None:
+            async with self._inbound_dedup_lock:
+                if any(
+                    identity in self._terminal_message_identities
+                    for identity in identities
+                ):
+                    self._pending_message_identities.difference_update(identities)
+                    return
+                active = self._active_message_dispatches.get(message_key)
+                if active and not active[2].done():
+                    if active[0] == revision_serial and active[1] == message_identity:
+                        join_task = active[2]
+                    elif active[0] < revision_serial:
+                        cancel_task = active[2]
+                if join_task is None:
+                    self._active_message_dispatches[message_key] = (
+                        revision_serial,
+                        message_identity,
+                        current_task,
+                    )
+
+        if join_task is not None:
+            try:
+                await asyncio.shield(join_task)
+            except asyncio.CancelledError:
+                pass
+            return
+        if cancel_task is not None:
+            cancel_task.cancel()
+            try:
+                await asyncio.shield(cancel_task)
+            except asyncio.CancelledError:
+                pass
+
+        try:
+            for attempt in range(1, self._message_retry_max_attempts + 1):
+                if message_key:
+                    async with self._inbound_dedup_lock:
+                        if self._message_revision_serials.get(message_key, 0) > revision_serial:
+                            self._pending_message_identities.difference_update(identities)
+                            return
+                try:
+                    await self.handle_message(event)
+                except asyncio.CancelledError:
+                    if identities:
+                        async with self._inbound_dedup_lock:
+                            self._pending_message_identities.difference_update(identities)
+                    if (
+                        message_key
+                        and self._message_revision_serials.get(message_key, 0)
+                        > revision_serial
+                    ):
+                        return
+                    raise
+                except Exception as exc:
+                    retryable = self._is_retryable_inbound_error(exc)
+                    if retryable and attempt < self._message_retry_max_attempts:
+                        delay = self._message_retry_base_delay_seconds * (
+                            2 ** (attempt - 1)
+                        )
+                        logger.warning(
+                            "[bluebubbles] transient inbound dispatch failure "
+                            "(attempt %d/%d, retrying in %.1fs): %s",
+                            attempt,
+                            self._message_retry_max_attempts,
+                            delay,
+                            exc,
+                        )
+                        try:
+                            await asyncio.sleep(delay)
+                        except asyncio.CancelledError:
+                            async with self._inbound_dedup_lock:
+                                self._pending_message_identities.difference_update(
+                                    identities
+                                )
+                                superseded = bool(
+                                    message_key
+                                    and self._message_revision_serials.get(
+                                        message_key, 0
+                                    )
+                                    > revision_serial
+                                )
+                            if superseded:
+                                return
+                            raise
+                        continue
+                    async with self._inbound_dedup_lock:
+                        self._pending_message_identities.difference_update(identities)
+                        self._remember_terminal_identities_locked(identities)
+                    logger.exception(
+                        "[bluebubbles] inbound dispatch failed permanently "
+                        "after %d attempt(s)",
+                        attempt,
+                    )
+                    return
+                break
+
+            async with self._inbound_dedup_lock:
+                if (
+                    message_key
+                    and self._message_revision_serials.get(message_key, 0)
+                    > revision_serial
+                ):
+                    self._pending_message_identities.difference_update(identities)
+                    return
+                self._pending_message_identities.difference_update(identities)
+                for identity in identities:
+                    self._seen_message_guids[identity] = None
+                    self._seen_message_guids.move_to_end(identity)
+                while len(self._seen_message_guids) > _MESSAGE_DEDUP_SIZE:
+                    self._seen_message_guids.popitem(last=False)
+                if message_key is not None:
+                    media_context = self._message_revision_media.get(message_key)
+                    if media_context and media_context[4] <= revision_serial:
+                        self._message_revision_media.pop(message_key, None)
+        finally:
+            if message_key and current_task is not None:
+                async with self._inbound_dedup_lock:
+                    active = self._active_message_dispatches.get(message_key)
+                    if active and active[2] is current_task:
+                        self._active_message_dispatches.pop(message_key, None)
+
+    async def _flush_message_revision(self, message_key: _InboundMessageKey) -> None:
+        """Dispatch the latest completed webhook revision for one iMessage GUID."""
+        current_task = asyncio.current_task()
+        pending: Optional[
+            tuple[MessageEvent, Optional[str], int, tuple[str, ...]]
+        ] = None
+        try:
+            while True:
+                await asyncio.sleep(self._message_revision_wait_seconds)
+                async with self._inbound_dedup_lock:
+                    if self._pending_message_revision_tasks.get(message_key) is not current_task:
+                        return
+                    if self._active_attachment_revisions.get(message_key, 0) > 0:
+                        continue
+                    pending = self._pending_message_revisions.pop(message_key, None)
+                    # Once dispatch starts this task is no longer a debounce timer.
+                    # A late revision may queue a follow-up, but must not cancel an
+                    # already-running agent turn.
+                    self._pending_message_revision_tasks.pop(message_key, None)
+                    break
+            if pending:
+                await self._handle_reserved_message(
+                    pending[0],
+                    pending[1],
+                    pending[3],
+                    message_key,
+                    pending[2],
+                )
+        finally:
+            async with self._inbound_dedup_lock:
+                if self._pending_message_revision_tasks.get(message_key) is current_task:
+                    self._pending_message_revision_tasks.pop(message_key, None)
+
+    @staticmethod
+    def _merge_revision_media(
+        event: MessageEvent,
+        media_urls: List[str],
+        media_types: List[str],
+        message_type: MessageType,
+        metadata: Dict[str, Any],
+    ) -> None:
+        """Add richer revision fields without replacing the recipient's text."""
+        if len(media_urls) <= len(event.media_urls):
+            return
+        event.media_urls = list(media_urls)
+        event.media_types = list(media_types)
+        event.message_type = message_type
+        event.metadata = {**metadata, **event.metadata}
+
+    def _remember_revision_media_locked(
+        self,
+        message_key: _InboundMessageKey,
+        event: MessageEvent,
+        revision_serial: int,
+    ) -> None:
+        if not event.media_urls:
+            return
+        self._message_revision_media[message_key] = (
+            list(event.media_urls),
+            list(event.media_types),
+            event.message_type,
+            dict(event.metadata),
+            revision_serial,
+        )
+        self._message_revision_media.move_to_end(message_key)
+        while len(self._message_revision_media) > _MESSAGE_DEDUP_SIZE:
+            self._message_revision_media.popitem(last=False)
+
+    async def _queue_message_revision(
+        self,
+        message_key: _InboundMessageKey,
+        event: MessageEvent,
+        message_identity: Optional[str],
+        revision_serial: int,
+        *,
+        attachment_revision: bool,
+    ) -> None:
+        """Debounce BlueBubbles revisions without losing richer prior fields."""
+        async with self._inbound_dedup_lock:
+            if attachment_revision:
+                self._release_attachment_revision_locked(
+                    message_key,
+                    revision_serial,
+                    preserve_identity=True,
+                )
+
+            prior = self._pending_message_revisions.get(message_key)
+            if prior and prior[2] > revision_serial:
+                prior_event = prior[0]
+                if len(event.media_urls) > len(prior_event.media_urls):
+                    self._merge_revision_media(
+                        prior_event,
+                        event.media_urls,
+                        event.media_types,
+                        event.message_type,
+                        event.metadata,
+                    )
+                    self._remember_revision_media_locked(
+                        message_key, event, revision_serial
+                    )
+                    identities = tuple(
+                        dict.fromkeys(
+                            identity
+                            for identity in (*prior[3], message_identity)
+                            if identity
+                        )
+                    )
+                    self._pending_message_revisions[message_key] = (
+                        prior_event,
+                        prior[1],
+                        prior[2],
+                        identities,
+                    )
+                elif message_identity:
+                    self._pending_message_identities.discard(message_identity)
+                    self._seen_message_guids[message_identity] = None
+                    self._seen_message_guids.move_to_end(message_identity)
+                    while len(self._seen_message_guids) > _MESSAGE_DEDUP_SIZE:
+                        self._seen_message_guids.popitem(last=False)
+                return
+
+            coalesced_identities: tuple[str, ...] = ()
+            same_context = bool(
+                prior
+                and prior[0].source.user_id == event.source.user_id
+                and prior[0].source.chat_id == event.source.chat_id
+            )
+            if same_context and prior and len(prior[0].media_urls) > len(event.media_urls):
+                prior_event = prior[0]
+                self._merge_revision_media(
+                    event,
+                    prior_event.media_urls,
+                    prior_event.media_types,
+                    prior_event.message_type,
+                    prior_event.metadata,
+                )
+                coalesced_identities = tuple(
+                    dict.fromkeys(
+                        identity
+                        for identity in (prior[1], *prior[3])
+                        if identity
+                    )
+                )
+            else:
+                media_context = self._message_revision_media.get(message_key)
+                if media_context:
+                    self._merge_revision_media(event, *media_context[:4])
+                    self._message_revision_media.move_to_end(message_key)
+
+            if event.media_urls and event.text == "(attachment)":
+                prior_text = ""
+                if prior:
+                    prior_event = prior[0]
+                    if (
+                        prior_event.source.user_id == event.source.user_id
+                        and prior_event.source.chat_id == event.source.chat_id
+                    ):
+                        prior_text = prior_event.text
+                if not prior_text:
+                    prior_text = self._message_revision_text.get(message_key, "")
+                if prior_text and prior_text != "(attachment)":
+                    event.text = prior_text
+
+            if event.text and event.text != "(attachment)":
+                self._message_revision_text[message_key] = event.text
+                self._message_revision_text.move_to_end(message_key)
+                while len(self._message_revision_text) > _MESSAGE_DEDUP_SIZE:
+                    self._message_revision_text.popitem(last=False)
+
+            self._remember_revision_media_locked(
+                message_key, event, revision_serial
+            )
+
+            superseded_identities = ()
+            if prior and not coalesced_identities:
+                superseded_identities = tuple(
+                    identity
+                    for identity in (prior[1], *prior[3])
+                    if identity and identity != message_identity
+                )
+            for superseded_identity in superseded_identities:
+                self._pending_message_identities.discard(superseded_identity)
+                self._seen_message_guids[superseded_identity] = None
+                self._seen_message_guids.move_to_end(superseded_identity)
+            if superseded_identities:
+                while len(self._seen_message_guids) > _MESSAGE_DEDUP_SIZE:
+                    self._seen_message_guids.popitem(last=False)
+            self._pending_message_revisions[message_key] = (
+                event,
+                message_identity,
+                revision_serial,
+                coalesced_identities,
+            )
+            prior_task = self._pending_message_revision_tasks.get(message_key)
+            if prior_task and not prior_task.done():
+                prior_task.cancel()
+            task = asyncio.create_task(self._flush_message_revision(message_key))
+            self._pending_message_revision_tasks[message_key] = task
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
+
+    def _release_attachment_revision_now(
+        self,
+        message_key: _InboundMessageKey,
+        revision_serial: int,
+        *,
+        preserve_identity: bool = False,
+    ) -> None:
+        lease = (message_key, revision_serial)
+        if lease not in self._active_attachment_leases:
+            return
+        self._active_attachment_leases.discard(lease)
+        leased_identity = self._active_attachment_identity_leases.pop(lease, None)
+        if leased_identity and not preserve_identity:
+            self._pending_message_identities.discard(leased_identity)
+        active = self._active_attachment_revisions.get(message_key, 0)
+        if active <= 1:
+            self._active_attachment_revisions.pop(message_key, None)
+        else:
+            self._active_attachment_revisions[message_key] = active - 1
+
+    def _release_attachment_revision_locked(
+        self,
+        message_key: _InboundMessageKey,
+        revision_serial: int,
+        *,
+        preserve_identity: bool = False,
+    ) -> None:
+        self._release_attachment_revision_now(
+            message_key,
+            revision_serial,
+            preserve_identity=preserve_identity,
+        )
+
+    async def _release_attachment_revision(
+        self,
+        message_key: Optional[_InboundMessageKey],
+        revision_serial: int,
+        *,
+        preserve_identity: bool = False,
+    ) -> None:
+        if not message_key:
+            return
+        async with self._inbound_dedup_lock:
+            self._release_attachment_revision_locked(
+                message_key,
+                revision_serial,
+                preserve_identity=preserve_identity,
+            )
+
+    async def _handle_webhook(
+        self,
+        request,
+        *,
+        _trusted_payload=None,
+        _authoritative_chat_guid: Optional[str] = None,
+    ):
         from aiohttp import web
 
-        if self._webhook_token(request) != self.password:
-            return web.json_response({"error": "unauthorized"}, status=401)
-        try:
-            payload = self._parse_webhook_body(await request.read())
-        except Exception as exc:
-            logger.error("[bluebubbles] webhook parse error: %s", exc)
-            return web.json_response({"error": "invalid payload"}, status=400)
+        if _trusted_payload is None:
+            token = (
+                request.query.get("password")
+                or request.query.get("guid")
+                or request.headers.get("x-password")
+                or request.headers.get("x-guid")
+                or request.headers.get("x-bluebubbles-guid")
+            )
+            if token != self.password:
+                return web.json_response({"error": "unauthorized"}, status=401)
+            try:
+                raw = await request.read()
+                body = raw.decode("utf-8", errors="replace")
+                try:
+                    payload = json.loads(body)
+                except Exception:
+                    from urllib.parse import parse_qs
+
+                    form = parse_qs(body)
+                    payload_str = (
+                        form.get("payload")
+                        or form.get("data")
+                        or form.get("message")
+                        or [""]
+                    )[0]
+                    payload = json.loads(payload_str) if payload_str else {}
+            except Exception as exc:
+                logger.error("[bluebubbles] webhook parse error: %s", exc)
+                return web.json_response({"error": "invalid payload"}, status=400)
+        else:
+            payload = _trusted_payload
+
         event_type = self._value(payload.get("type"), payload.get("event")) or ""
-        if event_type and event_type not in _MESSAGE_EVENTS:  # ack non-message events silently
-            return _ok()
+        # Only process message events; silently acknowledge everything else
+        if event_type and event_type not in _MESSAGE_EVENTS:
+            return web.Response(text="ok")
+
         record = self._extract_payload_record(payload) or {}
-        if record.get("isFromMe") or record.get("fromMe") or record.get("is_from_me"):
-            return _ok()
+        is_from_me = bool(
+            record.get("isFromMe")
+            or record.get("fromMe")
+            or record.get("is_from_me")
+        )
+        if is_from_me:
+            return web.Response(text="ok")
+
+        # Classify Tapbacks now, but publish them only after the webhook's
+        # source/chat admission fields have been validated below.
         assoc_type = record.get("associatedMessageType")
-        if isinstance(assoc_type, int) and assoc_type in _TAPBACK_CODES:  # tapback reactions delivered as messages
-            return _ok()
-        text = self._value(record.get("text"), record.get("message"), record.get("body")) or ""
-        media_urls, media_types, msg_type = await self._collect_attachments(record)
+        tapback: Optional[tuple[str, str]] = None
+        assoc_code: Optional[int] = None
+        if isinstance(assoc_type, int) and not isinstance(assoc_type, bool):
+            assoc_code = assoc_type
+        elif isinstance(assoc_type, str) and assoc_type.strip().isdigit():
+            assoc_code = int(assoc_type.strip())
+        if assoc_code is not None:
+            if assoc_code in _TAPBACK_ADDED:
+                tapback = ("added", _TAPBACK_ADDED[assoc_code])
+            elif assoc_code in _TAPBACK_REMOVED:
+                tapback = ("removed", _TAPBACK_REMOVED[assoc_code])
+        if assoc_type is not None and assoc_code != 0 and tapback is None:
+            # A provider payload that explicitly claims an association type is
+            # not safe to reinterpret as conversational text. Unknown future
+            # reactions and malformed values must not wake the agent (and thus
+            # cannot trigger an acknowledgement Tapback or automated reply).
+            logger.debug(
+                "[bluebubbles] ignoring unsupported associated message type: %r",
+                assoc_type,
+            )
+            return web.Response(text="ok")
+
+        message_guid = self._value(
+            record.get("guid"),
+            record.get("messageGuid"),
+            record.get("id"),
+        )
+        text = (
+            self._value(
+                record.get("text"), record.get("message"), record.get("body")
+            )
+            or ""
+        )
+
+        # Resolve the exact message-to-chat membership before authorization or
+        # any other inbound side effect. Webhook chat fields are candidates only.
+        candidate_chat_guids = {
+            guid
+            for candidate in (
+                record.get("chatGuid"),
+                payload.get("chatGuid"),
+                record.get("chat_guid"),
+                payload.get("chat_guid"),
+                *(
+                    nested_candidate
+                    for chat in (
+                        *(record.get("chats") or []),
+                        *(payload.get("chats") or []),
+                    )
+                    if isinstance(chat, dict)
+                    for nested_candidate in (chat.get("guid"), chat.get("chatGuid"))
+                ),
+            )
+            for guid in [self._value(candidate)]
+            if guid
+        }
+        if len(candidate_chat_guids) > 1:
+            return web.Response(text="ok")
+        candidate_chat_guid = (
+            next(iter(candidate_chat_guids)) if candidate_chat_guids else None
+        )
+        preauth_chat_identifier = self._value(
+            record.get("chatIdentifier"),
+            record.get("identifier"),
+            payload.get("chatIdentifier"),
+            payload.get("identifier"),
+        )
+        preauth_sender = self._value(
+            record.get("handle", {}).get("address")
+            if isinstance(record.get("handle"), dict)
+            else None,
+            record.get("sender"),
+            record.get("from"),
+            record.get("address"),
+        )
+        if not message_guid:
+            return web.Response(text="ok")
+
+        provisional_key = None
+        if preauth_sender:
+            provisional_key = (
+                message_guid,
+                str(preauth_sender),
+                candidate_chat_guid or "",
+            )
+        provisional_record: Optional[Dict[str, Any]] = None
+
+        if _authoritative_chat_guid is not None:
+            if candidate_chat_guid != _authoritative_chat_guid:
+                return web.Response(text="ok")
+            preauth_chat_guid = _authoritative_chat_guid
+        elif candidate_chat_guid is None:
+            if not provisional_key:
+                return web.Response(text="ok")
+            await self._queue_provisional_message(
+                provisional_key,
+                payload,
+                record,
+            )
+            try:
+                preauth_chat_guid = await self._verify_inbound_message_membership(
+                    message_guid,
+                    None,
+                )
+            except BaseException:
+                await self._take_provisional_message(provisional_key)
+                raise
+            if not preauth_chat_guid:
+                await self._schedule_provisional_retry(provisional_key)
+                return web.Response(text="ok")
+            provisional_record = await self._take_provisional_message(provisional_key)
+            if provisional_record is None:
+                return web.Response(text="ok")
+        else:
+            preauth_chat_guid = await self._verify_inbound_message_membership(
+                message_guid,
+                candidate_chat_guid,
+            )
+            if not preauth_chat_guid:
+                if provisional_key:
+                    await self._queue_provisional_message(
+                        provisional_key,
+                        payload,
+                        record,
+                    )
+                    await self._schedule_provisional_retry(provisional_key)
+                return web.Response(text="ok")
+
+        if not provisional_key:
+            return web.Response(text="ok")
+        if candidate_chat_guid and provisional_record is None:
+            provisional_record = await self._take_provisional_message(
+                provisional_key,
+                allow_unclaimed_chat=True,
+            )
+        elif provisional_record is None:
+            provisional_record = await self._take_provisional_message(provisional_key)
+        if provisional_record:
+            record = self._merge_provisional_record(record, provisional_record)
+            preauth_sender = (
+                self._value(
+                    record.get("handle", {}).get("address")
+                    if isinstance(record.get("handle"), dict)
+                    else None,
+                    record.get("sender"),
+                    record.get("from"),
+                    record.get("address"),
+                )
+                or preauth_sender
+            )
+            text = (
+                self._value(
+                    record.get("text"),
+                    record.get("message"),
+                    record.get("body"),
+                )
+                or ""
+            )
+        preauth_chat_id = preauth_chat_guid or preauth_chat_identifier
+        preauth_is_group = bool(record.get("isGroup")) or (
+            ";+;" in (preauth_chat_guid or "")
+        )
+        authorized = self._is_sender_authorized(
+            preauth_sender,
+            "group" if preauth_is_group else "dm",
+            preauth_chat_id,
+        )
+        if (tapback and authorized is not True) or (
+            not tapback
+            and self._authorization_check is not None
+            and authorized is not True
+        ):
+            return web.Response(text="ok")
+
+        if tapback:
+            if not preauth_sender or not preauth_chat_id:
+                return web.json_response({"error": "missing message fields"}, status=400)
+            target_guid, part_index = self._tapback_target(
+                record.get("associatedMessageGuid")
+            )
+            if not target_guid:
+                return web.Response(text="ok")
+            target = await self._query_exact_message(
+                str(preauth_chat_id), target_guid
+            )
+            if target is None:
+                return web.Response(text="ok")
+            await self._dispatch_inbound_tapback(
+                payload=payload,
+                tapback=tapback,
+                target_guid=target_guid,
+                part_index=part_index,
+                session_chat_id=str(preauth_chat_id),
+                chat_identifier=preauth_chat_identifier,
+                sender=str(preauth_sender),
+                is_group=preauth_is_group,
+                message_guid=message_guid,
+            )
+            return web.Response(text="ok")
+
+        # BlueBubbles does not provide a monotonic revision number on every
+        # webhook shape. The stable message GUID is therefore the canonical
+        # logical identity. An update is newer than the corresponding create
+        # event even when webhooks arrive out of order. When both updates carry
+        # dateEdited, that provider timestamp orders them; otherwise same-kind
+        # events retain arrival order and content-based idempotency below.
+        event_rank = 1 if event_type == "updated-message" else 0
+        raw_edit_time = record.get("dateEdited")
+        edit_time: Optional[float] = None
+        if isinstance(raw_edit_time, (int, float)) and not isinstance(
+            raw_edit_time, bool
+        ):
+            edit_time = float(raw_edit_time)
+        elif isinstance(raw_edit_time, str):
+            try:
+                edit_time = float(raw_edit_time.strip())
+            except ValueError:
+                pass
+        async with self._inbound_dedup_lock:
+            prior_order = self._message_revision_orders.get(message_guid)
+            if prior_order is not None:
+                prior_rank, prior_edit_time = prior_order
+                if event_rank < prior_rank or (
+                    event_rank == prior_rank == 1
+                    and edit_time is not None
+                    and prior_edit_time is not None
+                    and edit_time < prior_edit_time
+                ):
+                    self._message_revision_orders.move_to_end(message_guid)
+                    return web.Response(text="ok")
+                if event_rank == prior_rank and edit_time is None:
+                    edit_time = prior_edit_time
+            self._message_revision_orders[message_guid] = (event_rank, edit_time)
+            self._message_revision_orders.move_to_end(message_guid)
+            while len(self._message_revision_orders) > _MESSAGE_DEDUP_SIZE:
+                self._message_revision_orders.popitem(last=False)
+
+        message_key: Optional[_InboundMessageKey] = None
+        revision_chat_id = preauth_chat_guid
+        if not revision_chat_id and preauth_chat_identifier:
+            revision_chat_id = (
+                f"iMessage;-;{preauth_chat_identifier}"
+                if not preauth_is_group
+                else preauth_chat_identifier
+            )
+        if message_guid and revision_chat_id and preauth_sender:
+            message_key = (
+                str(revision_chat_id),
+                str(preauth_sender),
+                message_guid,
+            )
+
+        revision_serial = 0
+        if message_key:
+            async with self._inbound_dedup_lock:
+                pending_attachment_task = self._pending_attachment_tasks.get(message_key)
+                if (
+                    pending_attachment_task
+                    and pending_attachment_task is not asyncio.current_task()
+                    and not pending_attachment_task.done()
+                ):
+                    pending_attachment_task.cancel()
+                    self._pending_attachment_tasks.pop(message_key, None)
+                revision_serial = self._message_revision_serials.get(message_key, 0) + 1
+                self._message_revision_serials[message_key] = revision_serial
+                self._message_revision_serials.move_to_end(message_key)
+                while len(self._message_revision_serials) > _MESSAGE_DEDUP_SIZE:
+                    evicted = False
+                    for candidate in list(self._message_revision_serials):
+                        if (
+                            candidate not in self._pending_message_revisions
+                            and candidate not in self._active_attachment_revisions
+                        ):
+                            self._message_revision_serials.pop(candidate, None)
+                            evicted = True
+                            break
+                    if not evicted:
+                        break
+
+        # --- Inbound attachment handling ---
+        attachments = record.get("attachments") or []
+        media_urls: List[str] = []
+        media_types: List[str] = []
+        downloaded_attachment_guids: set[str] = set()
+        msg_type = MessageType.TEXT
+        attachment_revision = bool(message_key and attachments)
+        if attachment_revision and message_key:
+            async with self._inbound_dedup_lock:
+                self._active_attachment_revisions[message_key] = (
+                    self._active_attachment_revisions.get(message_key, 0) + 1
+                )
+                self._active_attachment_leases.add((message_key, revision_serial))
+            request_task = asyncio.current_task()
+            if request_task is not None:
+                request_task.add_done_callback(
+                    lambda _task, key=message_key, serial=revision_serial: (
+                        self._release_attachment_revision_now(key, serial)
+                    )
+                )
+
+        try:
+            materialized = await materialize_attachments(
+                attachments,
+                self._download_attachment,
+            )
+        except BaseException:
+            if attachment_revision:
+                await self._release_attachment_revision(message_key, revision_serial)
+            raise
+        if materialized.readiness is AttachmentReadiness.TERMINAL_FAILURE:
+            if attachment_revision:
+                await self._release_attachment_revision(message_key, revision_serial)
+            logger.warning(
+                "[bluebubbles] terminal attachment failure for %s",
+                _redact(materialized.failed_guid or message_guid or "unknown"),
+            )
+            return web.Response(text="ok")
+        if materialized.readiness is AttachmentReadiness.PENDING:
+            if attachment_revision:
+                await self._release_attachment_revision(message_key, revision_serial)
+            if message_key and preauth_chat_guid:
+                await schedule_pending_attachment_retry(
+                    self,
+                    message_key,
+                    revision_serial,
+                    payload,
+                    record,
+                    preauth_chat_guid,
+                    attempts=_ATTACHMENT_RETRY_ATTEMPTS,
+                )
+            return web.Response(text="ok")
+
+        media_urls.extend(materialized.paths)
+        media_types.extend(materialized.mime_types)
+        downloaded_attachment_guids.update(
+            str(att.get("guid"))
+            for att in attachments
+            if isinstance(att, dict) and att.get("guid")
+        )
+        for att, mime in zip(attachments, media_types):
+            if mime.startswith("image/"):
+                msg_type = MessageType.PHOTO
+            elif mime.startswith("audio/") or (
+                isinstance(att, dict) and (att.get("uti") or "").endswith("caf")
+            ):
+                msg_type = MessageType.VOICE
+            elif mime.startswith("video/"):
+                msg_type = MessageType.VIDEO
+            else:
+                msg_type = MessageType.DOCUMENT
+
+        # With multiple attachments, prefer PHOTO if any images present
+        if len(media_urls) > 1:
+            mime_prefixes = {(m or "").split("/")[0] for m in media_types}
+            if "image" in mime_prefixes:
+                msg_type = MessageType.PHOTO
+
         if not text and media_urls:
             text = "(attachment)"
-        chat_guid, chat_identifier, sender = self._resolve_chat_and_sender(payload, record)
-        if not sender or not (chat_guid or chat_identifier) or not text:
+        # --- End attachment handling ---
+
+        chat_guid = preauth_chat_guid
+        chat_identifier = preauth_chat_identifier
+        sender = preauth_sender
+        if not sender or not (chat_guid or chat_identifier) or (not text and not tapback):
+            if attachment_revision:
+                await self._release_attachment_revision(message_key, revision_serial)
             return web.json_response({"error": "missing message fields"}, status=400)
+
         session_chat_id = chat_guid or chat_identifier
-        is_group = bool(record.get("isGroup")) or (";+;" in (chat_guid or ""))
+        is_group = preauth_is_group
         if is_group and self.require_mention:
-            if not self._message_matches_mention_patterns(text):
-                logger.debug("[bluebubbles] ignoring group message (require_mention=true, no mention pattern matched)")
-                return _ok()
-            text = self._clean_mention_text(text)
-        source = self.build_source(chat_id=session_chat_id, chat_name=chat_identifier or sender,
-                                   chat_type="group" if is_group else "dm", user_id=sender, user_name=sender,
-                                   chat_id_alt=chat_identifier)
+            if self._message_matches_mention_patterns(text):
+                text = self._clean_mention_text(text)
+                if message_key:
+                    async with self._inbound_dedup_lock:
+                        self._accepted_group_captions[message_key] = text
+                        self._accepted_group_captions.move_to_end(message_key)
+                        while len(self._accepted_group_captions) > _MESSAGE_DEDUP_SIZE:
+                            self._accepted_group_captions.popitem(last=False)
+            else:
+                inherited_text = ""
+                if message_key and media_urls:
+                    async with self._inbound_dedup_lock:
+                        accepted = self._accepted_group_captions.get(message_key)
+                        if accepted:
+                            inherited_text = accepted
+                            self._accepted_group_captions.move_to_end(message_key)
+                        else:
+                            pending = self._pending_message_revisions.get(message_key)
+                            if pending:
+                                pending_event = pending[0]
+                                if (
+                                    pending_event.source.user_id == sender
+                                    and pending_event.source.chat_id == session_chat_id
+                                ):
+                                    inherited_text = pending_event.text
+                if not inherited_text:
+                    logger.debug(
+                        "[bluebubbles] ignoring group message (require_mention=true, no mention pattern matched)"
+                    )
+                    if attachment_revision:
+                        await self._release_attachment_revision(message_key, revision_serial)
+                    return web.Response(text="ok")
+                text = inherited_text
+        message_identity: Optional[str] = None
+        if message_key:
+            # Keep revision identity independent of delivery bookkeeping and
+            # mutable webhook timestamps. Attachment GUID plus stable visible
+            # descriptors identify the logical media; readiness is included so
+            # a successful retry is not hidden by an earlier failed download.
+            attachment_identity = [
+                {
+                    "guid": att.get("guid"),
+                    "id": att.get("id"),
+                    "mimeType": att.get("mimeType"),
+                    "uti": att.get("uti"),
+                    "transferName": att.get("transferName"),
+                    "totalBytes": att.get("totalBytes"),
+                    "__hermes_downloaded": att.get("guid")
+                    in downloaded_attachment_guids,
+                }
+                for att in attachments
+                if isinstance(att, dict)
+            ]
+            revision_payload = json.dumps(
+                {"text": text, "attachments": attachment_identity},
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            revision_hash = hashlib.sha256(revision_payload.encode("utf-8")).hexdigest()
+            message_identity = "\0".join((*message_key, revision_hash))
+            async with self._inbound_dedup_lock:
+                if message_identity in self._pending_message_identities:
+                    if attachment_revision:
+                        self._release_attachment_revision_locked(message_key, revision_serial)
+                    return web.Response(text="ok")
+                if message_identity in self._seen_message_guids:
+                    self._seen_message_guids.move_to_end(message_identity)
+                    if attachment_revision:
+                        self._release_attachment_revision_locked(message_key, revision_serial)
+                    return web.Response(text="ok")
+                self._pending_message_identities.add(message_identity)
+                if attachment_revision:
+                    self._active_attachment_identity_leases[
+                        (message_key, revision_serial)
+                    ] = message_identity
+        source = self.build_source(
+            chat_id=session_chat_id,
+            chat_name=chat_identifier or sender,
+            chat_type="group" if is_group else "dm",
+            user_id=sender,
+            user_name=self._participant_names.get(sender, sender),
+            chat_id_alt=chat_identifier,
+        )
+        reply_to_message_id, _reply_part_index = self._reply_target(
+            record.get("threadOriginatorGuid"),
+            record.get("associatedMessageGuid"),
+        )
+        reply_to_text: Optional[str] = None
+        reply_to_is_own_message = False
+        reply_attachment_count = 0
+        if reply_to_message_id:
+            try:
+                (
+                    reply_to_text,
+                    reply_to_is_own_message,
+                    reply_paths,
+                    reply_types,
+                ) = await self._lookup_reply_context(
+                    str(session_chat_id), reply_to_message_id
+                )
+            except BaseException:
+                if attachment_revision:
+                    await self._release_attachment_revision(
+                        message_key, revision_serial
+                    )
+                elif message_identity:
+                    async with self._inbound_dedup_lock:
+                        self._pending_message_identities.discard(message_identity)
+                raise
+            if reply_paths:
+                media_urls.extend(reply_paths)
+                media_types.extend(reply_types)
+                reply_attachment_count = len(reply_paths)
         event = MessageEvent(
-            text=text, message_type=msg_type, source=source, raw_message=payload,
-            message_id=self._value(record.get("guid"), record.get("messageGuid"), record.get("id")),
-            reply_to_message_id=self._value(record.get("threadOriginatorGuid"), record.get("associatedMessageGuid")),
-            media_urls=media_urls, media_types=media_types)
-        task = asyncio.create_task(self.handle_message(event))
-        self._background_tasks.add(task)
-        task.add_done_callback(self._background_tasks.discard)
-        if self.send_read_receipts and session_chat_id:  # fire-and-forget read receipt
-            asyncio.create_task(self.mark_read(session_chat_id))
-        return _ok()
+            text=text,
+            message_type=msg_type,
+            source=source,
+            raw_message=payload,
+            message_id=message_guid,
+            reply_to_message_id=reply_to_message_id,
+            reply_to_text=reply_to_text,
+            reply_to_is_own_message=reply_to_is_own_message,
+            media_urls=media_urls,
+            media_types=media_types,
+            metadata=(
+                {"bluebubbles_reply_attachment_count": reply_attachment_count}
+                if reply_attachment_count
+                else {}
+            ),
+        )
+        if message_key and self._message_revision_wait_seconds > 0:
+            await self._queue_message_revision(
+                message_key,
+                event,
+                message_identity,
+                revision_serial,
+                attachment_revision=attachment_revision,
+            )
+        else:
+            if attachment_revision:
+                await self._release_attachment_revision(
+                    message_key,
+                    revision_serial,
+                    preserve_identity=True,
+                )
+            task = asyncio.create_task(
+                self._handle_reserved_message(event, message_identity)
+            )
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
+
+        # Queue only after authorization and group mention admission. The queue
+        # retries helper cold boots while retaining the same message identity.
+        await self._queue_read_receipt(
+            str(session_chat_id),
+            message_guid,
+            is_group=is_group,
+            admitted=True,
+        )
+
+        return web.Response(text="ok")

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -1223,9 +1223,10 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 if self._read_receipts_closed:
                     return False
                 encoded = quote(guid, safe="")
-                await self.client.post(
+                response = await self.client.post(
                     self._api_url(f"/api/v1/chat/{encoded}/read"), timeout=5
                 )
+                response.raise_for_status()
                 return True
         except Exception:
             pass
@@ -2013,8 +2014,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             state_serial = self._tapback_event_serial
             self._tapback_event_states[state_key] = (operation, state_serial)
             self._tapback_event_states.move_to_end(state_key)
-            while len(self._tapback_event_states) > _MESSAGE_DEDUP_SIZE:
-                self._tapback_event_states.popitem(last=False)
+            self._prune_tapback_event_states_locked()
         event_payload = {
             "platform": "bluebubbles",
             "event_type": "reaction",
@@ -2033,6 +2033,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                         state_serial,
                     )
                     self._tapback_event_states.move_to_end(state_key)
+                    self._prune_tapback_event_states_locked()
         except Exception:
             async with self._inbound_dedup_lock:
                 current_state = self._tapback_event_states.get(state_key)
@@ -2042,10 +2043,24 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                     else:
                         self._tapback_event_states[state_key] = prior_state
                         self._tapback_event_states.move_to_end(state_key)
+                    self._prune_tapback_event_states_locked()
             logger.debug(
                 "[bluebubbles] platform event dispatch failed",
                 exc_info=True,
             )
+
+    def _prune_tapback_event_states_locked(self) -> None:
+        """Bound terminal Tapback history without evicting in-flight work."""
+        if len(self._tapback_event_states) <= _MESSAGE_DEDUP_SIZE:
+            return
+        for state_key, (operation, _serial) in list(
+            self._tapback_event_states.items()
+        ):
+            if operation.status is TapbackStatus.PROCESSING:
+                continue
+            self._tapback_event_states.pop(state_key, None)
+            if len(self._tapback_event_states) <= _MESSAGE_DEDUP_SIZE:
+                return
 
     @staticmethod
     def _is_retryable_inbound_error(exc: BaseException) -> bool:

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -2470,6 +2470,21 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 preserve_identity=preserve_identity,
             )
 
+    async def _rollback_uncommitted_revision(
+        self,
+        message_key: Optional[_InboundMessageKey],
+        revision_serial: int,
+    ) -> None:
+        """Release a cancelled webhook lease without superseding prior work."""
+        if not message_key:
+            return
+        async with self._inbound_dedup_lock:
+            self._release_attachment_revision_locked(message_key, revision_serial)
+            if self._message_revision_serials.get(message_key) == revision_serial:
+                self._message_revision_serials[message_key] = max(
+                    0, revision_serial - 1
+                )
+
     async def _handle_webhook(
         self,
         request,
@@ -2835,7 +2850,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             )
         except BaseException:
             if attachment_revision:
-                await self._release_attachment_revision(message_key, revision_serial)
+                await self._rollback_uncommitted_revision(
+                    message_key, revision_serial
+                )
             raise
         if materialized.readiness is AttachmentReadiness.TERMINAL_FAILURE:
             if attachment_revision:
@@ -2962,11 +2979,24 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             message_identity = "\0".join((*message_key, revision_hash))
             async with self._inbound_dedup_lock:
                 if message_identity in self._pending_message_identities:
+                    # Identity is computed only after attachment materialization,
+                    # but reserving a revision serial happens before that work so
+                    # an actual newer revision can supersede it. A duplicate must
+                    # not leave that provisional serial behind: doing so makes the
+                    # already-queued owner look stale and suppresses its dispatch.
+                    if self._message_revision_serials.get(message_key) == revision_serial:
+                        self._message_revision_serials[message_key] = max(
+                            0, revision_serial - 1
+                        )
                     if attachment_revision:
                         self._release_attachment_revision_locked(message_key, revision_serial)
                     return web.Response(text="ok")
                 if message_identity in self._seen_message_guids:
                     self._seen_message_guids.move_to_end(message_identity)
+                    if self._message_revision_serials.get(message_key) == revision_serial:
+                        self._message_revision_serials[message_key] = max(
+                            0, revision_serial - 1
+                        )
                     if attachment_revision:
                         self._release_attachment_revision_locked(message_key, revision_serial)
                     return web.Response(text="ok")
@@ -3031,13 +3061,30 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             ),
         )
         if message_key and self._message_revision_wait_seconds > 0:
-            await self._queue_message_revision(
-                message_key,
-                event,
-                message_identity,
-                revision_serial,
-                attachment_revision=attachment_revision,
-            )
+            try:
+                await self._queue_message_revision(
+                    message_key,
+                    event,
+                    message_identity,
+                    revision_serial,
+                    attachment_revision=attachment_revision,
+                )
+            except BaseException:
+                if attachment_revision:
+                    await self._rollback_uncommitted_revision(
+                        message_key, revision_serial
+                    )
+                elif message_identity:
+                    async with self._inbound_dedup_lock:
+                        self._pending_message_identities.discard(message_identity)
+                        if (
+                            self._message_revision_serials.get(message_key)
+                            == revision_serial
+                        ):
+                            self._message_revision_serials[message_key] = max(
+                                0, revision_serial - 1
+                            )
+                raise
         else:
             if attachment_revision:
                 await self._release_attachment_revision(

--- a/gateway/platforms/bluebubbles_attachments.py
+++ b/gateway/platforms/bluebubbles_attachments.py
@@ -1,0 +1,193 @@
+"""Attachment readiness outcomes for BlueBubbles webhook revisions."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Awaitable, Callable, Mapping, Sequence
+
+
+class AttachmentReadiness(str, Enum):
+    READY = "ready"
+    PENDING = "pending"
+    TERMINAL_FAILURE = "terminal_failure"
+
+
+@dataclass(frozen=True)
+class MaterializedAttachments:
+    readiness: AttachmentReadiness
+    paths: tuple[str, ...] = ()
+    mime_types: tuple[str, ...] = ()
+    failed_guid: str | None = None
+
+
+DownloadAttachment = Callable[[str, dict[str, Any]], Awaitable[str | None]]
+logger = logging.getLogger(__name__)
+
+
+def metadata_readiness(attachment: Mapping[str, Any]) -> AttachmentReadiness:
+    """Classify provider metadata before attempting to read attachment bytes.
+
+    BlueBubbles documents transferState=5 as complete. Notification webhooks may
+    omit transferState, so an absent state remains eligible for an immediate
+    materialization attempt. Explicit provider errors are terminal; incomplete
+    transfer states are pending rather than failures.
+    """
+    if attachment.get("isCorrupt") is True:
+        return AttachmentReadiness.TERMINAL_FAILURE
+    error = attachment.get("error")
+    if error not in (None, 0, "", False):
+        return AttachmentReadiness.TERMINAL_FAILURE
+    transfer_state = attachment.get("transferState")
+    if transfer_state is not None and transfer_state != 5:
+        return AttachmentReadiness.PENDING
+    return AttachmentReadiness.READY
+
+
+async def materialize_attachments(
+    attachments: Sequence[Any],
+    download: DownloadAttachment,
+) -> MaterializedAttachments:
+    """Materialize a whole revision atomically; never return partial media."""
+    paths: list[str] = []
+    mime_types: list[str] = []
+    pending_guid: str | None = None
+
+    for raw in attachments:
+        if not isinstance(raw, Mapping):
+            return MaterializedAttachments(AttachmentReadiness.TERMINAL_FAILURE)
+        attachment = dict(raw)
+        guid = attachment.get("guid")
+        if not isinstance(guid, str) or not guid.strip():
+            return MaterializedAttachments(
+                AttachmentReadiness.TERMINAL_FAILURE,
+                failed_guid=None,
+            )
+        guid = guid.strip()
+        readiness = metadata_readiness(attachment)
+        if readiness is AttachmentReadiness.TERMINAL_FAILURE:
+            return MaterializedAttachments(readiness, failed_guid=guid)
+        if readiness is AttachmentReadiness.PENDING:
+            pending_guid = pending_guid or guid
+            continue
+
+        cached = await download(guid, attachment)
+        if not cached:
+            pending_guid = pending_guid or guid
+            continue
+        paths.append(cached)
+        mime_types.append(str(attachment.get("mimeType") or "").lower())
+
+    if pending_guid is not None:
+        return MaterializedAttachments(
+            AttachmentReadiness.PENDING,
+            failed_guid=pending_guid,
+        )
+    return MaterializedAttachments(
+        AttachmentReadiness.READY,
+        paths=tuple(paths),
+        mime_types=tuple(mime_types),
+    )
+
+
+async def _retry_pending_attachments(
+    adapter: Any,
+    message_key: tuple[str, str, str],
+    revision_serial: int,
+    payload: dict[str, Any],
+    record: dict[str, Any],
+    chat_guid: str,
+    attempts: int,
+) -> None:
+    """Poll the authoritative message and replay only its current attachment set."""
+    current_task = asyncio.current_task()
+    try:
+        for attempt in range(attempts):
+            delay = adapter._attachment_retry_delay_seconds * min(2**attempt, 8)
+            await asyncio.sleep(delay)
+            async with adapter._inbound_dedup_lock:
+                if (
+                    adapter._pending_attachment_tasks.get(message_key) is not current_task
+                    or adapter._message_revision_serials.get(message_key) != revision_serial
+                ):
+                    return
+            try:
+                refreshed = await adapter._query_exact_message(
+                    chat_guid,
+                    message_key[2],
+                    include_attachments=True,
+                )
+            except Exception:
+                continue
+            if refreshed is None:
+                continue
+            current_attachments = refreshed.get("attachments") or []
+            readiness = [
+                metadata_readiness(attachment)
+                for attachment in current_attachments
+                if isinstance(attachment, Mapping)
+            ]
+            if any(
+                state is AttachmentReadiness.TERMINAL_FAILURE
+                for state in readiness
+            ):
+                logger.warning("BlueBubbles attachment materialization failed terminally")
+                return
+            if any(state is AttachmentReadiness.PENDING for state in readiness):
+                continue
+
+            refreshed_record = {**record, **refreshed}
+            # The exact lookup is authoritative for removals as well as
+            # additions; never merge stale webhook attachments back in.
+            refreshed_record["attachments"] = list(current_attachments)
+            refreshed_payload = dict(payload)
+            if isinstance(refreshed_payload.get("data"), dict):
+                refreshed_payload["data"] = refreshed_record
+            elif isinstance(refreshed_payload.get("message"), dict):
+                refreshed_payload["message"] = refreshed_record
+            else:
+                refreshed_payload.update(refreshed_record)
+            await adapter._handle_webhook(
+                None,
+                _trusted_payload=refreshed_payload,
+                _authoritative_chat_guid=chat_guid,
+            )
+            return
+        logger.warning("BlueBubbles attachment materialization retries exhausted")
+    finally:
+        async with adapter._inbound_dedup_lock:
+            if adapter._pending_attachment_tasks.get(message_key) is current_task:
+                adapter._pending_attachment_tasks.pop(message_key, None)
+
+
+async def schedule_pending_attachment_retry(
+    adapter: Any,
+    message_key: tuple[str, str, str],
+    revision_serial: int,
+    payload: dict[str, Any],
+    record: dict[str, Any],
+    chat_guid: str,
+    *,
+    attempts: int,
+) -> None:
+    """Keep exactly one current attachment-readiness worker per logical message."""
+    async with adapter._inbound_dedup_lock:
+        prior = adapter._pending_attachment_tasks.get(message_key)
+        if prior and prior is not asyncio.current_task() and not prior.done():
+            prior.cancel()
+        task = asyncio.create_task(
+            _retry_pending_attachments(
+                adapter,
+                message_key,
+                revision_serial,
+                dict(payload),
+                dict(record),
+                chat_guid,
+                attempts,
+            )
+        )
+        adapter._pending_attachment_tasks[message_key] = task
+        adapter._background_tasks.add(task)
+        task.add_done_callback(adapter._background_tasks.discard)

--- a/gateway/reactions.py
+++ b/gateway/reactions.py
@@ -1,0 +1,200 @@
+"""Shared, fail-closed identity and lifecycle rules for message Tapbacks.
+
+A Tapback operation carries only exact routing identifiers.  It deliberately has
+no message-text, participant-list, chat-alias, or fallback fields: callers must
+resolve one authoritative chat and one target message before constructing it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, replace
+from enum import StrEnum
+from typing import Any
+
+
+class TapbackValidationError(ValueError):
+    """A Tapback cannot be represented as one unambiguous operation."""
+
+
+class TapbackType(StrEnum):
+    """Native iMessage Tapbacks supported by BlueBubbles."""
+
+    LOVE = "love"
+    LIKE = "like"
+    DISLIKE = "dislike"
+    LAUGH = "laugh"
+    EMPHASIZE = "emphasize"
+    QUESTION = "question"
+
+
+class TapbackAction(StrEnum):
+    """Whether the sender adds or removes the named Tapback."""
+
+    ADD = "added"
+    REMOVE = "removed"
+
+
+class TapbackDirection(StrEnum):
+    """The transport direction of the operation."""
+
+    INBOUND = "inbound"
+    OUTBOUND = "outbound"
+
+
+class TapbackStatus(StrEnum):
+    """Processing lifecycle for an immutable Tapback operation."""
+
+    RECEIVED = "received"
+    VALIDATED = "validated"
+    PENDING = "pending"
+    PROCESSING = "processing"
+    APPLIED = "applied"
+    REJECTED = "rejected"
+    FAILED = "failed"
+
+
+_ALLOWED_STATUS_TRANSITIONS: dict[TapbackStatus, frozenset[TapbackStatus]] = {
+    TapbackStatus.RECEIVED: frozenset(
+        {TapbackStatus.VALIDATED, TapbackStatus.REJECTED}
+    ),
+    TapbackStatus.VALIDATED: frozenset(
+        {TapbackStatus.PENDING, TapbackStatus.REJECTED}
+    ),
+    TapbackStatus.PENDING: frozenset(
+        {TapbackStatus.PROCESSING, TapbackStatus.REJECTED}
+    ),
+    TapbackStatus.PROCESSING: frozenset(
+        {TapbackStatus.APPLIED, TapbackStatus.FAILED}
+    ),
+    # A failed provider or handler attempt is retryable with the same identity.
+    TapbackStatus.FAILED: frozenset(
+        {TapbackStatus.PENDING, TapbackStatus.REJECTED}
+    ),
+    TapbackStatus.APPLIED: frozenset(),
+    TapbackStatus.REJECTED: frozenset(),
+}
+
+
+def _require_exact_identifier(name: str, value: Any) -> str:
+    """Accept one nonempty scalar identifier and reject ambiguous targets."""
+    if not isinstance(value, str):
+        raise TapbackValidationError(f"{name} must be one exact string identifier")
+    normalized = value.strip()
+    if not normalized:
+        raise TapbackValidationError(f"{name} is required")
+    if "\x00" in normalized:
+        raise TapbackValidationError(f"{name} contains an invalid separator")
+    return normalized
+
+
+@dataclass(frozen=True, slots=True)
+class TapbackOperation:
+    """One exact inbound or outbound Tapback operation.
+
+    ``deduplication_key`` identifies a full source event, including add/remove.
+    ``state_key`` identifies the current reaction slot, intentionally excluding
+    action and source-event identity.  A state ledger can therefore suppress an
+    adjacent replay while still accepting add -> remove -> add, even when a
+    provider reuses the same source event GUID for those updates.
+    """
+
+    platform: str
+    chat_id: str
+    target_message_id: str
+    sender_id: str
+    reaction: TapbackType
+    action: TapbackAction
+    direction: TapbackDirection
+    source_event_id: str
+    part_index: int = 0
+    status: TapbackStatus = TapbackStatus.RECEIVED
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "platform",
+            "chat_id",
+            "target_message_id",
+            "sender_id",
+            "source_event_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_exact_identifier(field_name, getattr(self, field_name)),
+            )
+        if not isinstance(self.reaction, TapbackType):
+            raise TapbackValidationError("reaction must be a supported TapbackType")
+        if not isinstance(self.action, TapbackAction):
+            raise TapbackValidationError("action must be a TapbackAction")
+        if not isinstance(self.direction, TapbackDirection):
+            raise TapbackValidationError("direction must be a TapbackDirection")
+        if not isinstance(self.status, TapbackStatus):
+            raise TapbackValidationError("status must be a TapbackStatus")
+        if (
+            isinstance(self.part_index, bool)
+            or not isinstance(self.part_index, int)
+            or self.part_index < 0
+        ):
+            raise TapbackValidationError(
+                "part_index must be a non-negative integer"
+            )
+
+    @property
+    def state_key(self) -> tuple[str, str, str, int, str, str]:
+        """Return the exact reaction slot, isolated by chat and sender."""
+        return (
+            self.platform,
+            self.chat_id,
+            self.target_message_id,
+            self.part_index,
+            self.sender_id,
+            self.direction.value,
+        )
+
+    @property
+    def deduplication_key(self) -> str:
+        """Return a deterministic, transport-safe identity for this event."""
+        canonical = json.dumps(
+            {
+                "action": self.action.value,
+                "chat_id": self.chat_id,
+                "direction": self.direction.value,
+                "part_index": self.part_index,
+                "platform": self.platform,
+                "reaction": self.reaction.value,
+                "sender_id": self.sender_id,
+                "source_event_id": self.source_event_id,
+                "target_message_id": self.target_message_id,
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+    def transition_to(self, status: TapbackStatus) -> TapbackOperation:
+        """Return the operation at an allowed next processing status."""
+        if not isinstance(status, TapbackStatus):
+            raise ValueError("Tapback status transitions require TapbackStatus")
+        if status not in _ALLOWED_STATUS_TRANSITIONS[self.status]:
+            raise ValueError(
+                f"Tapback cannot transition from {self.status.value} to {status.value}"
+            )
+        return replace(self, status=status)
+
+    def to_platform_payload(self) -> dict[str, Any]:
+        """Serialize the exact, text-free reaction boundary payload."""
+        return {
+            "action": self.action.value,
+            "reaction": self.reaction.value,
+            "message_id": self.target_message_id,
+            "reaction_message_id": self.source_event_id,
+            "part_index": self.part_index,
+            "chat_id": self.chat_id,
+            "user_id": self.sender_id,
+            "direction": self.direction.value,
+            "status": self.status.value,
+            "deduplication_key": self.deduplication_key,
+        }

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -471,6 +471,15 @@ def _interim_metadata(metadata: Optional[Dict[str, Any]] = None) -> Dict[str, An
     return merged
 
 
+def _internal_notice_metadata(
+    metadata: Optional[Dict[str, Any]] = None, *, platform: Any = None
+) -> Dict[str, Any]:
+    """Mark suppressible operational notices without hiding user prompts."""
+    merged = _interim_metadata(_non_conversational_metadata(metadata, platform=platform))
+    merged["internal_notice"] = True
+    return merged
+
+
 def _seed_hygiene_system_prompt(agent: Any, session_row: Optional[Dict[str, Any]]) -> bool:
     """Keep gateway hygiene from rebuilding a live session's system prompt.
 
@@ -706,6 +715,8 @@ async def _send_or_update_status_coro(adapter, chat_id, status_key, content, met
 
     See #30045.
     """
+    metadata = dict(metadata or {})
+    metadata["internal_notice"] = True
     sender = getattr(adapter, "send_or_update_status", None)
     if callable(sender):
         return await sender(chat_id, status_key, content, metadata=metadata)

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -72,8 +72,8 @@ class GatewayNotificationsMixin:
         platform: Any
 
         def send_metadata(self):
-            from gateway.run import _non_conversational_metadata
-            return _non_conversational_metadata(self.metadata, platform=self.platform)
+            from gateway.run import _internal_notice_metadata
+            return _internal_notice_metadata(self.metadata, platform=self.platform)
 
         async def send(self, text: str):
             return await self.adapter.send(self.chat_id, text, metadata=self.send_metadata())
@@ -535,7 +535,6 @@ class GatewayNotificationsMixin:
 
         False while the update is still running (caller may retry); True after a definitive send/skip.
         """
-        from gateway.run import _non_conversational_metadata
         paths = self._update_paths()
         if not paths.any_pending():
             return False
@@ -586,7 +585,8 @@ class GatewayNotificationsMixin:
                         "✅ Hermes update finished successfully." if exit_code == 0 else
                         "❌ Hermes update failed. Check the gateway logs or run `hermes update` manually for details."
                     )
-                await adapter.send(chat_id, msg, metadata=_non_conversational_metadata(metadata, platform=platform))
+                from gateway.run import _internal_notice_metadata
+                await adapter.send(chat_id, msg, metadata=_internal_notice_metadata(metadata, platform=platform))
                 logger.info("Sent post-update notification to %s:%s (exit=%s)", platform_str, chat_id, exit_code)
         except Exception as e:
             logger.warning("Post-update notification failed: %s", e)
@@ -599,7 +599,7 @@ class GatewayNotificationsMixin:
     async def _send_restart_notification(self) -> Optional[tuple[str, str, Optional[str]]]:
         """Notify the chat that initiated /restart that the gateway is back."""
         from gateway.delivery import resolve_delivery_transport
-        from gateway.run import _hermes_home, _non_conversational_metadata
+        from gateway.run import _hermes_home, _internal_notice_metadata
         notify_path = _hermes_home / ".restart_notify.json"
         if not notify_path.exists():
             return None
@@ -629,7 +629,7 @@ class GatewayNotificationsMixin:
                         metadata[field] = str(data[field])
             result = await transport.send(
                 platform, str(chat_id), "♻ Gateway restarted successfully. Your session continues.",
-                metadata=_non_conversational_metadata(metadata, platform=platform),
+                metadata=_internal_notice_metadata(metadata, platform=platform),
             )
             # adapter.send() catches provider errors (e.g. "Chat not found") and returns
             # SendResult(success=False) rather than raising, so inspect the result before claiming success.
@@ -660,7 +660,7 @@ class GatewayNotificationsMixin:
 
     async def _send_home_channel_message(self, platform, home, transport, message: str, failure_fmt: str) -> bool:
         """Best-effort send to one home channel; True on success, failures logged with ``failure_fmt``."""
-        from gateway.run import _non_conversational_metadata
+        from gateway.run import _internal_notice_metadata
         try:
             metadata = self._thread_metadata_for_target(platform, home.chat_id, home.thread_id, adapter=transport.adapter)
             if transport.is_relay:
@@ -669,7 +669,7 @@ class GatewayNotificationsMixin:
                     metadata["user_id"] = home.user_id
                 if home.scope_id:
                     metadata["scope_id"] = home.scope_id
-            send_metadata = _non_conversational_metadata(metadata, platform=platform)
+            send_metadata = _internal_notice_metadata(metadata, platform=platform)
             if send_metadata is not None or transport.is_relay:
                 result = await transport.send(platform, str(home.chat_id), message, metadata=send_metadata)
             else:
@@ -1391,13 +1391,13 @@ class GatewayNotificationsMixin:
         return new_output
 
     async def _send_watcher_message(self, platform_name: str, chat_id, thread_id, message_text: str) -> None:
-        from gateway.run import _non_conversational_metadata
+        from gateway.run import _internal_notice_metadata
         adapter = self._adapter_by_platform_value(platform_name)
         if adapter and chat_id:
             with _log_suppressed(logging.ERROR, "Watcher delivery error: %s"):
                 send_meta = {"thread_id": thread_id} if thread_id else None
                 await adapter.send(
-                    chat_id, message_text, metadata=_non_conversational_metadata(send_meta, platform=platform_name),
+                    chat_id, message_text, metadata=_internal_notice_metadata(send_meta, platform=platform_name),
                 )
 
     @staticmethod

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2768,7 +2768,7 @@ class GatewayTurnMixin:
         for status / approval / stream sends (Feishu topics need the triggering message id via the
         reply API, so carry it as a fallback). Slack and Buzz honour the user's reply_in_thread
         opt-out: never synthesise a thread for progress, or every later reply inherits it."""
-        from gateway.run import _non_conversational_metadata, _resolve_progress_thread_id
+        from gateway.run import _internal_notice_metadata, _resolve_progress_thread_id
         is_buzz = str(getattr(source.platform, "value", source.platform) or "").lower() == "buzz"
         _progress_reply_in_thread = True
         _adapter = self._adapter_for_source(source) if source.platform == Platform.SLACK or is_buzz else None
@@ -2796,7 +2796,7 @@ class GatewayTurnMixin:
             and not source.thread_id
             else None
         )
-        _progress_metadata = _non_conversational_metadata(
+        _progress_metadata = _internal_notice_metadata(
             self._thread_metadata_for_progress(
                 source, event_message_id, _progress_thread_id, _relay_prospective_thread_id,
             ),
@@ -3711,7 +3711,7 @@ class GatewayTurnMixin:
 
         Interval: agent.gateway_notify_interval / HERMES_AGENT_NOTIFY_INTERVAL (default 180s; 0 or
         long_running_notifications=off disables)."""
-        from gateway.run import _float_env, _interim_metadata, _non_conversational_metadata
+        from gateway.run import _float_env, _internal_notice_metadata
         _notify_start = time.time()
         _NOTIFY_INTERVAL = _float_env("HERMES_AGENT_NOTIFY_INTERVAL", 180)
         _long_running_mode = disp._display_surface_mode("long_running_notifications", default=True, allow_generic=True)
@@ -3762,7 +3762,7 @@ class GatewayTurnMixin:
                 if not (_notify_res and getattr(_notify_res, "success", False)):
                     _notify_res = await _notify_adapter.send(
                         source.chat_id, _heartbeat_text,
-                        metadata=_interim_metadata(_non_conversational_metadata(_status_thread_metadata, platform=source.platform)),
+                        metadata=_internal_notice_metadata(_status_thread_metadata, platform=source.platform),
                     )
                     if getattr(_notify_res, "success", False) and getattr(_notify_res, "message_id", None):
                         _heartbeat_msg_id = str(_notify_res.message_id)

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1035,7 +1035,7 @@ class TurnRunner:
     def _make_bg_review_callbacks(self):
         """(send, release): background-review messages ("💾 Memory updated") are held until the
         adapter's post-delivery hook releases them after the main response lands."""
-        from gateway.run import _interim_metadata, _non_conversational_metadata
+        from gateway.run import _internal_notice_metadata
         ctx = self._ctx
         release_evt = threading.Event()
         pending: list[str] = []
@@ -1045,7 +1045,7 @@ class TurnRunner:
             if self._status_live():
                 self._send_status_text(
                     message,
-                    _interim_metadata(_non_conversational_metadata(ctx._status_thread_metadata, platform=ctx.source.platform)),
+                    _internal_notice_metadata(ctx._status_thread_metadata, platform=ctx.source.platform),
                     "background_review_callback scheduling error",
                 )
 

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -1275,8 +1275,15 @@ class PhotonAdapter(BasePlatformAdapter):
             return {"success": False, "error": "reaction failed (see gateway debug log)"}
         return {"success": True, "message_id": target}
 
-    async def remove_reaction(self, chat_id: str, message_id: Optional[str] = None) -> Dict[str, Any]:
-        """Retract our tapback from a message (best-effort)."""
+    async def remove_reaction(
+        self, chat_id: str, emoji: Optional[str] = None, message_id: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Retract our exact tapback slot from an explicitly named message.
+
+        Spectrum stores one reaction handle per sender/message, so ``emoji`` is
+        identity/audit context while the provider removal primitive addresses
+        that single slot by message id.
+        """
         target = message_id or self._last_inbound_by_chat.get(self._normalize_chat_key(chat_id))
         if not target:
             return {"success": False, "error": "no message to unreact — pass message_id"}

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -1284,9 +1284,9 @@ class PhotonAdapter(BasePlatformAdapter):
         identity/audit context while the provider removal primitive addresses
         that single slot by message id.
         """
-        target = message_id or self._last_inbound_by_chat.get(self._normalize_chat_key(chat_id))
+        target = (message_id or "").strip()
         if not target:
-            return {"success": False, "error": "no message to unreact — pass message_id"}
+            return {"success": False, "error": "exact message_id is required to unreact"}
         if not await self._remove_reaction(chat_id, target):
             return {"success": False, "error": "unreact failed (see gateway debug log)"}
         return {"success": True, "message_id": target}

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -1260,9 +1260,14 @@ class TestBlueBubblesHelperState:
         adapter._helper_connected = False
         posts = []
 
+        class SuccessfulResponse:
+            def raise_for_status(self):
+                return None
+
         class FakeClient:
             async def post(self, url, timeout):
                 posts.append((url, timeout))
+                return SuccessfulResponse()
 
         async def fake_api_get(path):
             assert path == "/api/v1/server/info"
@@ -5041,4 +5046,3 @@ class TestBlueBubblesTimeoutErrorNormalization:
 
         assert not result.success
         assert "500 Internal Server Error" in (result.error or "")
-

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -3530,17 +3530,21 @@ class TestBlueBubblesMentionGating:
         assert sorted(event.text for event in handled) == ["one", "two"]
 
     @pytest.mark.asyncio
-    async def test_failed_text_edit_dispatch_releases_richer_revision_for_retry(
+    async def test_transient_text_edit_retry_keeps_merged_media(
         self, monkeypatch
     ):
-        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        adapter = _make_adapter(
+            monkeypatch,
+            send_read_receipts=False,
+            message_retry_base_delay_seconds=0,
+        )
         adapter._message_revision_wait_seconds = 0.01
         handled = []
 
         async def flaky_handle_message(event):
             handled.append(event)
             if len(handled) == 1:
-                raise RuntimeError("retry merged revision")
+                raise ConnectionError("retry merged revision")
 
         async def fake_download_attachment(att_guid, att_meta):
             return f"/tmp/{att_guid}"
@@ -3571,8 +3575,6 @@ class TestBlueBubblesMentionGating:
             "data": {**base, "text": "Edited caption"},
         }))
         await asyncio.sleep(0.03)
-        await adapter._handle_webhook(_FakeBlueBubblesRequest(richer_payload))
-        await asyncio.sleep(0.03)
 
         assert len(handled) == 2
         assert handled[0].text == "Edited caption"
@@ -3580,15 +3582,19 @@ class TestBlueBubblesMentionGating:
         assert handled[1].media_urls == ["/tmp/retry-photo"]
 
     @pytest.mark.asyncio
-    async def test_failed_rich_dispatch_sparse_retry_restores_media(self, monkeypatch):
-        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+    async def test_transient_sparse_dispatch_retry_restores_media(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            send_read_receipts=False,
+            message_retry_base_delay_seconds=0,
+        )
         adapter._message_revision_wait_seconds = 0.01
         handled = []
 
         async def flaky_handle_message(event):
             handled.append(event)
             if len(handled) == 1:
-                raise RuntimeError("retry sparse revision")
+                raise ConnectionError("retry sparse revision")
 
         async def fake_download_attachment(att_guid, att_meta):
             return f"/tmp/{att_guid}"
@@ -3617,8 +3623,6 @@ class TestBlueBubblesMentionGating:
                 ],
             },
         }))
-        await adapter._handle_webhook(_FakeBlueBubblesRequest(sparse_payload))
-        await asyncio.sleep(0.03)
         await adapter._handle_webhook(_FakeBlueBubblesRequest(sparse_payload))
         await asyncio.sleep(0.03)
 
@@ -3823,6 +3827,7 @@ class TestBlueBubblesMentionGating:
                 "type": "updated-message",
                 "data": {
                     **base,
+                    "dateEdited": 100,
                     "attachments": [
                         {"guid": "older-photo", "mimeType": "image/png"}
                     ],
@@ -3834,6 +3839,7 @@ class TestBlueBubblesMentionGating:
             "type": "updated-message",
             "data": {
                 **base,
+                "dateEdited": 200,
                 "attachments": [
                     {"guid": "newer-photo", "mimeType": "image/png"}
                 ],
@@ -3845,6 +3851,7 @@ class TestBlueBubblesMentionGating:
             "type": "updated-message",
             "data": {
                 **base,
+                "dateEdited": 100,
                 "attachments": [
                     {"guid": "older-photo", "mimeType": "image/png"}
                 ],
@@ -4099,7 +4106,7 @@ class TestBlueBubblesMentionGating:
         assert handled[0].media_urls == []
 
     @pytest.mark.asyncio
-    async def test_late_revision_does_not_cancel_in_flight_dispatch(self, monkeypatch):
+    async def test_late_revision_cancels_in_flight_dispatch_before_commit(self, monkeypatch):
         adapter = _make_adapter(monkeypatch, send_read_receipts=False)
         adapter._message_revision_wait_seconds = 0.01
         started = asyncio.Event()
@@ -4140,7 +4147,7 @@ class TestBlueBubblesMentionGating:
         release.set()
         await asyncio.sleep(0)
 
-        assert cancelled is False
+        assert cancelled is True
         assert handled == ["first revision", "late revision"]
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -6,7 +6,7 @@ import httpx
 import pytest
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import BasePlatformAdapter
+from gateway.platforms.base import BasePlatformAdapter, MessageType
 
 
 def _make_adapter(monkeypatch, **extra):
@@ -19,10 +19,23 @@ def _make_adapter(monkeypatch, **extra):
         extra={
             "server_url": "http://localhost:1234",
             "password": "secret",
+            "message_revision_wait_seconds": 0,
             **extra,
         },
     )
-    return BlueBubblesAdapter(cfg)
+    adapter = BlueBubblesAdapter(cfg)
+
+    async def verified_test_membership(message_guid, candidate_chat_guid):
+        if candidate_chat_guid:
+            return candidate_chat_guid
+        return await adapter._resolve_exact_message_chat_guid(message_guid)
+
+    monkeypatch.setattr(
+        adapter,
+        "_verify_inbound_message_membership",
+        verified_test_membership,
+    )
+    return adapter
 
 
 class TestBlueBubblesConfigLoading:
@@ -46,7 +59,77 @@ class TestBlueBubblesConfigLoading:
         assert bc.extra["mention_patterns"] == ["(?i)^amos\\b"]
 
 
+    def test_top_level_participant_names_are_bridged_to_adapter_extra(
+        self, monkeypatch, tmp_path
+    ):
+        (tmp_path / "config.yaml").write_text(
+            """
+platforms:
+  bluebubbles:
+    enabled: true
+    participant_names:
+      "+15550000100": "Mark"
+""".strip(),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("gateway.config.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setenv("BLUEBUBBLES_SERVER_URL", "http://localhost:1234")
+        monkeypatch.setenv("BLUEBUBBLES_PASSWORD", "secret")
+
+        from gateway.config import load_gateway_config
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.BLUEBUBBLES].extra["participant_names"] == {
+            "+15550000100": "Mark"
+        }
+
+
 class TestBlueBubblesHelpers:
+    def test_group_reply_anchor_is_top_level_unless_user_used_inline_reply(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch)
+        from gateway.platforms.base import MessageEvent, _reply_anchor_for_event
+
+        source = adapter.build_source(
+            chat_id="iMessage;+;family-group",
+            chat_name="family",
+            chat_type="group",
+            user_id="user@example.com",
+        )
+        top_level = MessageEvent(
+            text="ducky, answer this",
+            source=source,
+            message_id="current-message-guid",
+        )
+        inline = MessageEvent(
+            text="ducky, follow up",
+            source=source,
+            message_id="current-reply-guid",
+            reply_to_message_id="original-thread-guid",
+        )
+
+        assert _reply_anchor_for_event(top_level) is None
+        assert _reply_anchor_for_event(inline) == "original-thread-guid"
+
+    def test_dm_reply_anchor_keeps_current_message(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        from gateway.platforms.base import MessageEvent, _reply_anchor_for_event
+
+        event = MessageEvent(
+            text="hello",
+            source=adapter.build_source(
+                chat_id="iMessage;-;user@example.com",
+                chat_name="user@example.com",
+                chat_type="dm",
+                user_id="user@example.com",
+            ),
+            message_id="current-message-guid",
+        )
+
+        assert _reply_anchor_for_event(event) == "current-message-guid"
+
     def test_check_requirements(self, monkeypatch):
         monkeypatch.setenv("BLUEBUBBLES_SERVER_URL", "http://localhost:1234")
         monkeypatch.setenv("BLUEBUBBLES_PASSWORD", "secret")
@@ -54,6 +137,252 @@ class TestBlueBubblesHelpers:
 
         assert check_bluebubbles_requirements() is True
 
+    def test_supports_message_editing_is_false(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        assert adapter.SUPPORTS_MESSAGE_EDITING is False
+
+    def test_truncate_message_omits_pagination_suffixes(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        chunks = adapter.truncate_message("abcdefghij", max_length=6)
+        assert len(chunks) > 1
+        assert "".join(chunks) == "abcdefghij"
+        assert all("(" not in chunk for chunk in chunks)
+
+    @pytest.mark.asyncio
+    async def test_send_keeps_paragraphs_in_one_bubble_when_under_limit(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        sent = []
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "iMessage;-;user@example.com"
+
+        async def fake_api_post(path, payload):
+            sent.append(payload["message"])
+            return {"data": {"guid": f"msg-{len(sent)}"}}
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+
+        content = "first thought\n\nsecond thought"
+        result = await adapter.send("user@example.com", content)
+
+        assert result.success is True
+        assert sent == [content]
+
+    @pytest.mark.asyncio
+    async def test_send_deduplicates_concurrent_content_for_same_origin(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        sent = []
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "iMessage;-;user@example.com"
+
+        async def fake_api_post(path, payload):
+            sent.append(payload)
+            await asyncio.sleep(0.01)
+            return {"data": {"guid": "assistant-message-guid"}}
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        metadata = {"reply_to_message_id": "origin-message-guid"}
+
+        first, second = await asyncio.gather(
+            adapter.send("user@example.com", "same answer", metadata=metadata),
+            adapter.send("user@example.com", "same answer", metadata=metadata),
+        )
+
+        assert first.success is True
+        assert second.success is True
+        assert [payload["message"] for payload in sent] == ["same answer"]
+        assert {first.raw_response.get("deduplicated"), second.raw_response.get("deduplicated")} == {None, True}
+
+    @pytest.mark.asyncio
+    async def test_send_without_origin_does_not_deduplicate_legitimate_repeats(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        sent = []
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "iMessage;-;user@example.com"
+
+        async def fake_api_post(path, payload):
+            sent.append(payload["message"])
+            return {"data": {"guid": f"message-{len(sent)}"}}
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+
+        await adapter.send("user@example.com", "legitimate repeat")
+        await adapter.send("user@example.com", "legitimate repeat")
+
+        assert sent == ["legitimate repeat", "legitimate repeat"]
+
+    @pytest.mark.asyncio
+    async def test_send_reuses_idempotency_key_after_ambiguous_failure(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        payloads = []
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "iMessage;-;user@example.com"
+
+        async def fake_api_post(path, payload):
+            payloads.append(payload)
+            if len(payloads) == 1:
+                raise TimeoutError("response lost")
+            return {"data": {"guid": "assistant-message-guid"}}
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        metadata = {"reply_to_message_id": "origin-message-guid"}
+
+        first = await adapter.send("user@example.com", "same answer", metadata=metadata)
+        second = await adapter.send("user@example.com", "same answer", metadata=metadata)
+
+        assert first.success is False
+        assert second.success is True
+        assert payloads[0]["tempGuid"] == payloads[1]["tempGuid"]
+
+    @pytest.mark.asyncio
+    async def test_send_suppresses_only_structured_internal_notice_over_sms(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        api_calls = []
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "SMS;-;+155****0100"
+
+        async def fake_api_post(path, payload):
+            api_calls.append((path, payload))
+            return {"data": {"guid": "sent-message"}}
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        text = "Gateway shutting down for maintenance"
+
+        legitimate = await adapter.send("+155****0100", text)
+        suppressed = await adapter.send(
+            "+155****0100",
+            text,
+            metadata={"internal_notice": True},
+        )
+
+        assert legitimate.success is True
+        assert suppressed.success is True
+        assert suppressed.raw_response == {"suppressed": "internal_sms_notice"}
+        assert [payload["message"] for _, payload in api_calls] == [text]
+
+    @pytest.mark.asyncio
+    async def test_internal_notice_does_not_create_unresolved_phone_chat(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        create_calls = []
+
+        async def fake_resolve_chat_guid(chat_id):
+            return None
+
+        async def fake_create_chat(address, message, temp_guid=None):
+            create_calls.append((address, message, temp_guid))
+            raise AssertionError("internal notice must not create an unresolved phone chat")
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_create_chat_for_handle", fake_create_chat)
+
+        result = await adapter.send(
+            "+15555550100",
+            "Gateway restarting",
+            metadata={"internal_notice": True},
+        )
+
+        assert result.success is True
+        assert result.raw_response == {"suppressed": "internal_sms_notice"}
+        assert create_calls == []
+
+    @pytest.mark.asyncio
+    async def test_internal_notice_allows_plus_prefixed_email_handle(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        payloads = []
+
+        async def fake_resolve_chat_guid(chat_id):
+            return None
+
+        async def fake_api_post(path, payload):
+            payloads.append((path, payload))
+            return {"data": {"guid": "new-chat-message"}}
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+
+        result = await adapter.send(
+            "+15555550100@example.com",
+            "Internal iMessage notice",
+            metadata={"internal_notice": True},
+        )
+
+        assert result.success is True
+        assert [path for path, _ in payloads] == ["/api/v1/chat/new"]
+
+    @pytest.mark.asyncio
+    async def test_new_chat_retry_reuses_idempotency_key(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        payloads = []
+
+        async def fake_resolve_chat_guid(chat_id):
+            return None
+
+        async def fake_api_post(path, payload):
+            assert path == "/api/v1/chat/new"
+            payloads.append(payload)
+            if len(payloads) == 1:
+                raise TimeoutError("response lost")
+            return {"data": {"guid": "new-chat-message"}}
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        metadata = {"reply_to_message_id": "origin-message-guid"}
+
+        first = await adapter.send("user@example.com", "hello", metadata=metadata)
+        second = await adapter.send("user@example.com", "hello", metadata=metadata)
+
+        assert first.success is False
+        assert second.success is True
+        assert payloads[0]["tempGuid"] == payloads[1]["tempGuid"]
+
+    @pytest.mark.asyncio
+    async def test_new_chat_sends_remaining_chunks_after_creation(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        resolve_calls = 0
+        payloads = []
+
+        async def fake_resolve_chat_guid(chat_id):
+            nonlocal resolve_calls
+            resolve_calls += 1
+            return None if resolve_calls == 1 else "iMessage;-;user@example.com"
+
+        async def fake_api_post(path, payload):
+            payloads.append((path, payload))
+            return {"data": {"guid": f"message-{len(payloads)}"}}
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        text = "x" * (adapter.MAX_MESSAGE_LENGTH + 1)
+
+        result = await adapter.send(
+            "user@example.com",
+            text,
+            metadata={"reply_to_message_id": "origin-message-guid"},
+        )
+
+        assert result.success is True
+        assert [path for path, _ in payloads] == [
+            "/api/v1/chat/new",
+            "/api/v1/message/text",
+        ]
+        assert "".join(payload["message"] for _, payload in payloads) == text
+
+    def test_format_message_strips_markdown(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        assert adapter.format_message("**Hello** `world`") == "Hello world"
 
     def test_format_message_preserves_underscores_in_identifiers(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
@@ -75,6 +404,911 @@ class TestBlueBubblesHelpers:
         assert adapter.server_url == "http://localhost:1234"
 
 
+class TestBlueBubblesReactions:
+    @pytest.mark.asyncio
+    async def test_processing_start_never_generates_automatic_tapback(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, ack_reaction="like")
+        from gateway.platforms.base import MessageEvent
+
+        calls = []
+
+        async def fake_send_reaction(chat_id, message_guid, reaction, part_index=0):
+            calls.append((chat_id, message_guid, reaction, part_index))
+
+        monkeypatch.setattr(adapter, "send_reaction", fake_send_reaction)
+        adapter.set_authorization_check(lambda user_id, chat_type, chat_id: True)
+        event = MessageEvent(
+            text="check this",
+            source=adapter.build_source(
+                chat_id="iMessage;+;exact-family-guid",
+                chat_name="family-group",
+                chat_type="group",
+                user_id="+155****0100",
+            ),
+            message_id="inbound-message-guid",
+        )
+
+        await adapter.on_processing_start(event)
+
+        assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_processing_start_sends_no_ack_without_positive_authorization(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, ack_reaction="like")
+        from gateway.platforms.base import MessageEvent
+
+        calls = []
+
+        async def fake_send_reaction(*args, **kwargs):
+            calls.append((args, kwargs))
+
+        monkeypatch.setattr(adapter, "send_reaction", fake_send_reaction)
+        adapter.set_authorization_check(lambda user_id, chat_type, chat_id: False)
+        event = MessageEvent(
+            text="check this",
+            source=adapter.build_source(
+                chat_id="iMessage;+;exact-family-guid",
+                chat_name="family-group",
+                chat_type="group",
+                user_id="+155****0100",
+            ),
+            message_id="inbound-message-guid",
+        )
+
+        await adapter.on_processing_start(event)
+
+        assert calls == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "reaction",
+        [
+            "love",
+            "like",
+            "dislike",
+            "laugh",
+            "emphasize",
+            "question",
+            "-love",
+            "-like",
+            "-dislike",
+            "-laugh",
+            "-emphasize",
+            "-question",
+        ],
+    )
+    async def test_send_reaction_posts_supported_tapbacks_to_exact_chat(
+        self, monkeypatch, reaction
+    ):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = True
+        adapter.client = object()
+        calls = []
+
+        async def fake_resolve_chat_guid(chat_id):
+            assert chat_id == "family-group"
+            return "iMessage;+;exact-family-guid"
+
+        async def fake_api_post(path, payload):
+            calls.append((path, payload))
+            if path == "/api/v1/message/query":
+                return {
+                    "data": [
+                        {
+                            "guid": "target-message-guid",
+                            "chats": [{"guid": "iMessage;+;exact-family-guid"}],
+                        }
+                    ]
+                }
+            assert path == "/api/v1/message/react"
+            return {"status": 200, "data": {"guid": "reaction-guid"}}
+
+        async def fake_refresh_helper_state():
+            return True
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        monkeypatch.setattr(adapter, "_refresh_helper_state", fake_refresh_helper_state)
+
+        result = await adapter.send_reaction(
+            "family-group", "target-message-guid", reaction, part_index=2
+        )
+
+        assert result.success is True
+        assert result.message_id == "reaction-guid"
+        assert calls == [
+            (
+                "/api/v1/message/query",
+                {
+                    "limit": 1,
+                    "offset": 0,
+                    "chatGuid": "iMessage;+;exact-family-guid",
+                    "with": ["chats"],
+                    "where": [
+                        {
+                            "statement": "message.guid = :guid",
+                            "args": {"guid": "target-message-guid"},
+                        }
+                    ],
+                },
+            ),
+            (
+                "/api/v1/message/react",
+                {
+                    "chatGuid": "iMessage;+;exact-family-guid",
+                    "selectedMessageGuid": "target-message-guid",
+                    "reaction": reaction,
+                    "partIndex": 2,
+                },
+            )
+        ]
+
+    @pytest.mark.asyncio
+    async def test_send_reaction_fails_explicitly_without_live_private_helper(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = True
+        adapter.client = None
+
+        result = await adapter.send_reaction(
+            "iMessage;-;user@example.com", "target-message-guid", "like"
+        )
+
+        assert result.success is False
+        assert result.error == "BlueBubbles is not connected"
+
+    @pytest.mark.asyncio
+    async def test_send_reaction_refreshes_stale_private_helper_gate(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = False
+        adapter.client = object()
+        posts = []
+
+        async def fake_api_get(path):
+            assert path == "/api/v1/server/info"
+            return {"data": {"private_api": True, "helper_connected": True}}
+
+        async def fake_api_post(path, payload):
+            posts.append((path, payload))
+            if path == "/api/v1/message/query":
+                return {
+                    "data": [
+                        {
+                            "guid": "target-message-guid",
+                            "chats": [{"guid": "iMessage;-;user@example.com"}],
+                        }
+                    ]
+                }
+            return {"data": {"guid": "reaction-guid"}}
+
+        monkeypatch.setattr(adapter, "_api_get", fake_api_get)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+
+        result = await adapter.send_reaction(
+            "iMessage;-;user@example.com", "target-message-guid", "love"
+        )
+
+        assert result.success is True
+        assert [path for path, _ in posts] == [
+            "/api/v1/message/query",
+            "/api/v1/message/react",
+        ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("message_guid", "reaction", "part_index", "error_fragment"),
+        [
+            ("target-message-guid", "party", 0, "Unsupported"),
+            ("", "like", 0, "requires message GUID"),
+            ("target-message-guid", "like", -1, "part index"),
+        ],
+    )
+    async def test_send_reaction_rejects_unsafe_request_before_io(
+        self,
+        monkeypatch,
+        message_guid,
+        reaction,
+        part_index,
+        error_fragment,
+    ):
+        adapter = _make_adapter(monkeypatch)
+        adapter.client = object()
+
+        async def fail_refresh():
+            raise AssertionError("invalid reaction must fail before helper I/O")
+
+        monkeypatch.setattr(adapter, "_refresh_helper_state", fail_refresh)
+
+        result = await adapter.send_reaction(
+            "iMessage;-;user@example.com",
+            message_guid,
+            reaction,
+            part_index=part_index,
+        )
+
+        assert result.success is False
+        assert error_fragment in result.error
+
+    @pytest.mark.asyncio
+    async def test_send_reaction_rejects_message_from_a_different_chat(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = True
+        adapter.client = object()
+        calls = []
+
+        async def fake_api_post(path, payload):
+            calls.append((path, payload))
+            if path == "/api/v1/message/query":
+                return {
+                    "data": [
+                        {
+                            "guid": "target-message-guid",
+                            "chats": [{"guid": "iMessage;+;other-family-guid"}],
+                        }
+                    ]
+                }
+            raise AssertionError("cross-chat reaction must fail before mutation")
+
+        async def fake_refresh_helper_state():
+            return True
+
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        monkeypatch.setattr(adapter, "_refresh_helper_state", fake_refresh_helper_state)
+
+        result = await adapter.send_reaction(
+            "iMessage;+;exact-family-guid", "target-message-guid", "like"
+        )
+
+        assert result.success is False
+        assert "does not belong to chat" in (result.error or "")
+        assert [path for path, _ in calls] == ["/api/v1/message/query"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("authorization", [None, False])
+    async def test_unauthorized_tapback_with_attachment_has_no_side_effects(
+        self, monkeypatch, authorization
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        downloads = []
+        platform_events = []
+
+        if authorization is not None:
+            adapter.set_authorization_check(
+                lambda user_id, chat_type, chat_id: authorization
+            )
+
+        async def capture_download(att_guid, att_meta):
+            downloads.append((att_guid, att_meta))
+            return f"/tmp/{att_guid}"
+
+        async def capture_platform_event(event, source):
+            platform_events.append((event, source))
+
+        monkeypatch.setattr(adapter, "_download_attachment", capture_download)
+        adapter.set_platform_event_handler(capture_platform_event)
+
+        response = await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "new-message",
+                    "data": {
+                        "guid": "unauthorized-tapback-guid",
+                        "text": "",
+                        "associatedMessageType": 2001,
+                        "associatedMessageGuid": "p:0/target-message-guid",
+                        "handle": {"address": "+15555550100"},
+                        "isFromMe": False,
+                        "chatGuid": "iMessage;-;+15555550100",
+                        "attachments": [
+                            {"guid": "must-not-download", "mimeType": "image/png"}
+                        ],
+                    },
+                }
+            )
+        )
+
+        assert response.status == 200
+        assert downloads == []
+        assert platform_events == []
+        assert adapter._message_revision_serials == {}
+        assert adapter._pending_message_identities == set()
+        assert adapter._active_attachment_revisions == {}
+        assert adapter._active_attachment_leases == set()
+
+    @pytest.mark.asyncio
+    async def test_inbound_tapback_rejects_target_outside_exact_chat(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        adapter.set_authorization_check(lambda user_id, chat_type, chat_id: True)
+        downloads = []
+        platform_events = []
+        exact_queries = []
+
+        async def return_cross_chat_target(path):
+            exact_queries.append(path)
+            return {
+                "data": {
+                    "guid": "other-chat-target-guid",
+                    "chats": [{"guid": "iMessage;+;other-family-guid"}],
+                }
+            }
+
+        async def capture_platform_event(event, source):
+            platform_events.append((event, source))
+
+        async def capture_download(att_guid, att_meta):
+            downloads.append((att_guid, att_meta))
+            return f"/tmp/{att_guid}"
+
+        monkeypatch.setattr(adapter, "_api_get", return_cross_chat_target)
+        monkeypatch.setattr(adapter, "_download_attachment", capture_download)
+        adapter.set_platform_event_handler(capture_platform_event)
+
+        response = await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "new-message",
+                    "data": {
+                        "guid": "cross-chat-tapback-guid",
+                        "text": "",
+                        "associatedMessageType": 2001,
+                        "associatedMessageGuid": "p:0/other-chat-target-guid",
+                        "handle": {"address": "+15555550100"},
+                        "isFromMe": False,
+                        "chatGuid": "iMessage;+;exact-family-guid",
+                        "chatIdentifier": "family-group",
+                        "attachments": [
+                            {
+                                "guid": "cross-chat-must-not-download",
+                                "mimeType": "image/png",
+                            }
+                        ],
+                    },
+                }
+            )
+        )
+
+        assert response.status == 200
+        assert exact_queries == [
+            "/api/v1/message/other-chat-target-guid?with=chats"
+        ]
+        assert downloads == []
+        assert platform_events == []
+        assert adapter._message_revision_serials == {}
+        assert adapter._pending_message_revisions == {}
+        assert adapter._pending_message_identities == set()
+        assert adapter._seen_message_guids == {}
+        assert adapter._active_attachment_revisions == {}
+        assert adapter._active_attachment_leases == set()
+        assert adapter._active_attachment_identity_leases == {}
+        assert adapter._message_revision_text == {}
+        assert adapter._tapback_event_states == {}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("associated_type", "action", "reaction"),
+        [
+            (2001, "added", "like"),
+            ("2001", "added", "like"),
+            (3005, "removed", "question"),
+            ("3005", "removed", "question"),
+        ],
+    )
+    async def test_inbound_tapback_uses_authorized_platform_event_boundary_once(
+        self, monkeypatch, associated_type, action, reaction
+    ):
+        adapter = _make_adapter(
+            monkeypatch,
+            require_mention=True,
+            send_read_receipts=False,
+        )
+        platform_events = []
+        normal_messages = []
+
+        async def capture_platform_event(event, source):
+            platform_events.append((event, source))
+
+        async def capture_normal_message(event):
+            normal_messages.append(event)
+
+        async def exact_target(chat_guid, message_guid, **kwargs):
+            return {
+                "guid": message_guid,
+                "chats": [{"guid": chat_guid}],
+            }
+
+        adapter.set_authorization_check(lambda user_id, chat_type, chat_id: True)
+        adapter.set_platform_event_handler(capture_platform_event)
+        monkeypatch.setattr(adapter, "handle_message", capture_normal_message)
+        monkeypatch.setattr(adapter, "_query_exact_message", exact_target)
+
+        response = await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "new-message",
+                    "data": {
+                        "guid": "tapback-event-guid",
+                        "text": "",
+                        "associatedMessageType": associated_type,
+                        "associatedMessageGuid": "p:0/target-message-guid",
+                        "handle": {"address": "+15555550100"},
+                        "isFromMe": False,
+                        "isGroup": True,
+                        "chatGuid": "iMessage;+;exact-family-guid",
+                        "chatIdentifier": "family-group",
+                    },
+                }
+            )
+        )
+        await asyncio.sleep(0)
+
+        assert response.status == 200
+        assert normal_messages == []
+        assert len(platform_events) == 1
+        event, source = platform_events[0]
+        assert event["event_type"] == "reaction"
+        assert event["payload"]["action"] == action
+        assert event["payload"]["reaction"] == reaction
+        assert event["payload"]["message_id"] == "target-message-guid"
+        assert event["payload"]["reaction_message_id"] == "tapback-event-guid"
+        assert source.chat_id == "iMessage;+;exact-family-guid"
+        assert source.chat_type == "group"
+        assert source.user_id == event["payload"]["user_id"]
+
+    @pytest.mark.asyncio
+    async def test_duplicate_inbound_tapback_webhooks_emit_one_platform_event(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        platform_events = []
+
+        async def capture_platform_event(event, source):
+            platform_events.append((event, source))
+
+        async def exact_target(chat_guid, message_guid, **kwargs):
+            return {
+                "guid": message_guid,
+                "chats": [{"guid": chat_guid}],
+            }
+
+        adapter.set_authorization_check(lambda user_id, chat_type, chat_id: True)
+        adapter.set_platform_event_handler(capture_platform_event)
+        monkeypatch.setattr(adapter, "_query_exact_message", exact_target)
+        payload = {
+            "type": "updated-message",
+            "data": {
+                "guid": "tapback-event-guid",
+                "text": "",
+                "associatedMessageType": 2001,
+                "associatedMessageGuid": "p:0/target-message-guid",
+                "handle": {"address": "+155****0100"},
+                "isFromMe": False,
+                "isGroup": True,
+                "chatGuid": "iMessage;+;exact-family-guid",
+                "chatIdentifier": "family-group",
+            },
+        }
+
+        first = await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        second = await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+
+        assert first.status == 200
+        assert second.status == 200
+        assert len(platform_events) == 1
+
+    @pytest.mark.asyncio
+    async def test_tapback_dedup_preserves_add_remove_add_with_reused_guid(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        adapter.set_authorization_check(lambda user_id, chat_type, chat_id: True)
+        platform_events = []
+
+        async def exact_target(chat_guid, message_guid, **kwargs):
+            return {
+                "guid": message_guid,
+                "chats": [{"guid": chat_guid}],
+            }
+
+        async def capture_platform_event(event, source):
+            platform_events.append((event, source))
+
+        monkeypatch.setattr(adapter, "_query_exact_message", exact_target)
+        adapter.set_platform_event_handler(capture_platform_event)
+        base = {
+            "guid": "reused-tapback-guid",
+            "text": "",
+            "associatedMessageGuid": "p:2/target-message-guid",
+            "handle": {"address": "+15555550100"},
+            "isFromMe": False,
+            "isGroup": True,
+            "chatGuid": "iMessage;+;exact-family-guid",
+            "chatIdentifier": "family-group",
+        }
+
+        for associated_type in (2001, 2001, 3001, 2001):
+            await adapter._handle_webhook(
+                _FakeBlueBubblesRequest(
+                    {
+                        "type": "updated-message",
+                        "data": {
+                            **base,
+                            "associatedMessageType": associated_type,
+                        },
+                    }
+                )
+            )
+
+        assert [
+            (event["payload"]["action"], event["payload"]["reaction"])
+            for event, _source in platform_events
+        ] == [
+            ("added", "like"),
+            ("removed", "like"),
+            ("added", "like"),
+        ]
+
+
+class TestBlueBubblesHelperState:
+    @pytest.mark.asyncio
+    async def test_helper_state_does_not_poll_when_live_state_is_already_true(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = True
+        adapter.client = object()
+
+        async def fail_api_get(path):
+            raise AssertionError(f"live helper state should not repoll {path}")
+
+        monkeypatch.setattr(adapter, "_api_get", fail_api_get)
+
+        assert await adapter._refresh_helper_state() is True
+
+    @pytest.mark.asyncio
+    async def test_concurrent_stale_helper_refreshes_share_one_server_info_request(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = False
+        adapter._helper_connected = False
+        adapter.client = object()
+        calls = 0
+        release = asyncio.Event()
+
+        async def fake_api_get(path):
+            nonlocal calls
+            calls += 1
+            await release.wait()
+            return {"data": {"private_api": True, "helper_connected": True}}
+
+        monkeypatch.setattr(adapter, "_api_get", fake_api_get)
+        first = asyncio.create_task(adapter._refresh_helper_state())
+        second = asyncio.create_task(adapter._refresh_helper_state())
+        await asyncio.sleep(0)
+        release.set()
+
+        assert await asyncio.gather(first, second) == [True, True]
+        assert calls == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("raises", [False, True])
+    async def test_concurrent_negative_helper_refreshes_share_result_and_retry_after_ttl(
+        self, monkeypatch, raises
+    ):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = False
+        adapter._helper_connected = False
+        adapter.client = object()
+        calls = 0
+        release = asyncio.Event()
+
+        async def fake_api_get(path):
+            nonlocal calls
+            calls += 1
+            await release.wait()
+            if raises:
+                raise RuntimeError("server info unavailable")
+            return {"data": {"private_api": True, "helper_connected": False}}
+
+        monkeypatch.setattr(adapter, "_api_get", fake_api_get)
+        first = asyncio.create_task(adapter._refresh_helper_state())
+        second = asyncio.create_task(adapter._refresh_helper_state())
+        third = asyncio.create_task(adapter._refresh_helper_state())
+        await asyncio.sleep(0)
+        release.set()
+
+        assert await asyncio.gather(first, second, third) == [False, False, False]
+        assert calls == 1
+
+        adapter._helper_last_refresh_at = 0.0
+        assert await adapter._refresh_helper_state() is False
+        assert calls == 2
+
+    @pytest.mark.asyncio
+    async def test_send_typing_refreshes_stale_helper_state(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = False
+        posts = []
+
+        class FakeClient:
+            async def post(self, url, timeout):
+                posts.append((url, timeout))
+
+        async def fake_api_get(path):
+            assert path == "/api/v1/server/info"
+            return {"data": {"private_api": True, "helper_connected": True}}
+
+        adapter.client = FakeClient()
+        monkeypatch.setattr(adapter, "_api_get", fake_api_get)
+
+        await adapter.send_typing("iMessage;-;user@example.com")
+
+        assert len(posts) == 1
+        assert "/api/v1/chat/iMessage%3B-%3Buser%40example.com/typing" in posts[0][0]
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_refreshes_cold_boot_helper_state(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = None
+        adapter._helper_connected = False
+        deletes = []
+        info_calls = []
+
+        class FakeClient:
+            async def delete(self, url, timeout):
+                deletes.append((url, timeout))
+
+        async def fake_api_get(path):
+            info_calls.append(path)
+            return {
+                "data": {
+                    "private_api": True,
+                    "helper_connected": True,
+                }
+            }
+
+        adapter.client = FakeClient()
+        monkeypatch.setattr(adapter, "_api_get", fake_api_get)
+
+        await adapter.stop_typing("iMessage;-;user@example.com")
+
+        assert info_calls == ["/api/v1/server/info"]
+        assert len(deletes) == 1
+        assert "/api/v1/chat/iMessage%3B-%3Buser%40example.com/typing" in deletes[0][0]
+        assert deletes[0][1] == 5
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_bounds_cold_helper_refresh(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter.client = object()
+        adapter._private_api_enabled = False
+        adapter._helper_connected = False
+        refresh_cancelled = asyncio.Event()
+
+        async def hanging_refresh():
+            try:
+                await asyncio.Event().wait()
+            finally:
+                refresh_cancelled.set()
+
+        monkeypatch.setattr(adapter, "_refresh_helper_state", hanging_refresh)
+        monkeypatch.setattr(
+            "gateway.platforms.bluebubbles._STOP_TYPING_HELPER_REFRESH_SECONDS",
+            0.01,
+        )
+
+        await asyncio.wait_for(adapter.stop_typing("unavailable-chat"), timeout=0.1)
+        await asyncio.wait_for(adapter.stop_typing("unavailable-chat"), timeout=0.1)
+
+        assert refresh_cancelled.is_set()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_typing_start_is_reconciled_after_late_delivery(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = True
+        post_started = asyncio.Event()
+        release_post = asyncio.Event()
+        events = []
+
+        class FakeClient:
+            async def post(self, url, timeout):
+                post_started.set()
+                try:
+                    await release_post.wait()
+                except asyncio.CancelledError:
+                    # Model an HTTP stack where cancellation arrives after the
+                    # request has already crossed the process boundary.
+                    await release_post.wait()
+                events.append("start")
+
+            async def delete(self, url, timeout):
+                events.append("stop")
+
+        adapter.client = FakeClient()
+
+        start_task = asyncio.create_task(
+            adapter.send_typing("iMessage;-;user@example.com")
+        )
+        await post_started.wait()
+        start_task.cancel()
+        stop_task = asyncio.create_task(
+            adapter.stop_typing("iMessage;-;user@example.com")
+        )
+        await asyncio.sleep(0)
+        release_post.set()
+        await asyncio.gather(start_task, stop_task)
+
+        assert events == ["start", "stop"]
+
+    @pytest.mark.asyncio
+    async def test_repeated_stop_typing_emits_one_transition(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = True
+        events = []
+
+        class FakeClient:
+            async def post(self, url, timeout):
+                events.append("start")
+
+            async def delete(self, url, timeout):
+                events.append("stop")
+
+        adapter.client = FakeClient()
+
+        await adapter.send_typing("iMessage;-;user@example.com")
+        await adapter.stop_typing("iMessage;-;user@example.com")
+        await adapter.stop_typing("iMessage;-;user@example.com")
+
+        assert events == ["start", "stop"]
+
+    @pytest.mark.asyncio
+    async def test_background_cleanup_stops_active_typing_once(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = True
+        events = []
+
+        class FakeClient:
+            async def post(self, url, timeout):
+                events.append("start")
+
+            async def delete(self, url, timeout):
+                events.append("stop")
+
+        adapter.client = FakeClient()
+
+        await adapter.send_typing("iMessage;-;user@example.com")
+        await adapter.cancel_background_tasks()
+        await adapter.cancel_background_tasks()
+        await adapter.send_typing("iMessage;-;user@example.com")
+
+        assert events == ["start", "stop"]
+        assert adapter._typing_transition_locks == {}
+        assert adapter._typing_pending_stops == set()
+        assert adapter._typing_stop_tasks == {}
+
+    @pytest.mark.asyncio
+    async def test_pending_stop_retries_after_helper_cold_boot(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = True
+        events = []
+        info_calls = 0
+
+        class FakeClient:
+            async def post(self, url, timeout):
+                events.append("start")
+
+            async def delete(self, url, timeout):
+                events.append("stop")
+
+        async def fake_api_get(path):
+            nonlocal info_calls
+            info_calls += 1
+            helper_connected = info_calls > 1
+            return {
+                "data": {
+                    "private_api": True,
+                    "helper_connected": helper_connected,
+                }
+            }
+
+        adapter.client = FakeClient()
+        await adapter.send_typing("iMessage;-;user@example.com")
+        adapter._helper_connected = False
+        adapter._helper_last_refresh_at = 0.0
+        monkeypatch.setattr(adapter, "_api_get", fake_api_get)
+        monkeypatch.setattr(
+            "gateway.platforms.bluebubbles._HELPER_NEGATIVE_REFRESH_TTL_SECONDS",
+            0.01,
+        )
+
+        await adapter.stop_typing("iMessage;-;user@example.com")
+        assert events == ["start"]
+        assert len(adapter._typing_stop_tasks) == 1
+
+        for _ in range(20):
+            if events == ["start", "stop"]:
+                break
+            await asyncio.sleep(0.01)
+
+        assert events == ["start", "stop"]
+        assert info_calls >= 2
+        assert adapter._typing_pending_stops == set()
+
+    @pytest.mark.asyncio
+    async def test_mark_read_refreshes_stale_helper_state(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = False
+        posts = []
+
+        class FakeClient:
+            async def post(self, url, timeout):
+                posts.append((url, timeout))
+
+        async def fake_api_get(path):
+            assert path == "/api/v1/server/info"
+            return {"data": {"private_api": True, "helper_connected": True}}
+
+        adapter.client = FakeClient()
+        monkeypatch.setattr(adapter, "_api_get", fake_api_get)
+
+        result = await adapter.mark_read("iMessage;-;user@example.com")
+
+        assert result is True
+        assert len(posts) == 1
+        assert "/api/v1/chat/iMessage%3B-%3Buser%40example.com/read" in posts[0][0]
+
+    @pytest.mark.asyncio
+    async def test_threaded_reply_refreshes_stale_helper_state(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = False
+        adapter.client = object()
+        payloads = []
+
+        async def fake_api_get(path):
+            assert path == "/api/v1/server/info"
+            return {"data": {"private_api": True, "helper_connected": True}}
+
+        async def fake_api_post(path, payload):
+            assert path == "/api/v1/message/text"
+            payloads.append(payload)
+            return {"data": {"guid": "threaded-reply-guid"}}
+
+        monkeypatch.setattr(adapter, "_api_get", fake_api_get)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+
+        result = await adapter.send(
+            "iMessage;-;user@example.com",
+            "native reply",
+            reply_to="origin-message-guid",
+        )
+
+        assert result.success is True
+        assert payloads[0]["method"] == "private-api"
+        assert payloads[0]["selectedMessageGuid"] == "origin-message-guid"
+        assert payloads[0]["partIndex"] == 0
+
+
 class _FakeBlueBubblesRequest:
     def __init__(self, payload, password="secret"):
         self.query = {"password": password}
@@ -86,11 +1320,638 @@ class _FakeBlueBubblesRequest:
 
 
 class TestBlueBubblesMentionGating:
+    @pytest.mark.parametrize(
+        ("raw_reference", "expected"),
+        [
+            ("message-guid", ("message-guid", 0)),
+            ("p:2/message-guid", ("message-guid", 2)),
+            ("bp:message-guid", ("message-guid", 0)),
+            (" message-guid", (None, 0)),
+            ("message-guid ", (None, 0)),
+            ("p:2/ message-guid", (None, 0)),
+            (7, (None, 0)),
+        ],
+    )
+    def test_reply_target_preserves_valid_forms_and_rejects_malformed_ids(
+        self, monkeypatch, raw_reference, expected
+    ):
+        adapter = _make_adapter(monkeypatch)
+        assert adapter._reply_target(raw_reference) == expected
+
     @pytest.mark.asyncio
-    async def test_group_message_without_mention_is_acknowledged_and_skipped(self, monkeypatch):
+    async def test_exact_message_lookup_is_bounded_to_current_chat(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        calls = []
+        records = [
+            {
+                "guid": f"earlier-{index}",
+                "chats": [{"guid": "iMessage;+;exact-family-guid"}],
+            }
+            for index in range(99)
+        ]
+        records.append(
+            {
+                "guid": "target/message-guid",
+                "chats": [{"guid": "iMessage;+;exact-family-guid"}],
+            }
+        )
+
+        async def fail_api_get(path):
+            raise AssertionError("referenced-message lookup must not use a global endpoint")
+
+        async def fake_api_post(path, payload):
+            calls.append((path, payload))
+            return {"data": records[: payload["limit"]]}
+
+        monkeypatch.setattr(adapter, "_api_get", fail_api_get)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+
+        record = await adapter._lookup_referenced_message(
+            "iMessage;+;exact-family-guid",
+            "target/message-guid",
+            include_attachments=True,
+        )
+
+        assert record is not None
+        assert calls == [
+            (
+                "/api/v1/message/query",
+                {
+                    "limit": 100,
+                    "offset": 0,
+                    "chatGuid": "iMessage;+;exact-family-guid",
+                    "with": ["attachments", "chats"],
+                },
+            )
+        ]
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_group_sender_is_dropped_before_background_processing(
+        self, monkeypatch
+    ):
         adapter = _make_adapter(
             monkeypatch,
             require_mention=True,
+            mention_patterns=["ducky"],
+            send_read_receipts=False,
+        )
+        handled = []
+        reply_lookups = []
+
+        async def capture_message(event):
+            handled.append(event)
+
+        async def capture_reply_lookup(chat_id, message_id):
+            reply_lookups.append((chat_id, message_id))
+            return None, False, [], []
+
+        adapter.set_authorization_check(lambda user_id, chat_type, chat_id: False)
+        monkeypatch.setattr(adapter, "handle_message", capture_message)
+        monkeypatch.setattr(adapter, "_lookup_reply_context", capture_reply_lookup)
+
+        response = await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "new-message",
+                    "data": {
+                        "guid": "unauthorized-message-guid",
+                        "text": "ducky, inspect this",
+                        "threadOriginatorGuid": "quoted-message-guid",
+                        "handle": {"address": "+155****0102"},
+                        "isFromMe": False,
+                        "isGroup": True,
+                        "chatGuid": "iMessage;+;exact-family-guid",
+                        "chatIdentifier": "family-group",
+                    },
+                }
+            )
+        )
+
+        assert response.status == 200
+        assert handled == []
+        assert reply_lookups == []
+
+    @pytest.mark.asyncio
+    async def test_cancelled_reply_lookup_releases_identity_for_retry(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        lookup_started = asyncio.Event()
+        handled = []
+
+        async def blocking_reply_lookup(chat_id, message_id):
+            lookup_started.set()
+            await asyncio.Event().wait()
+
+        async def completed_reply_lookup(chat_id, message_id):
+            return "quoted text", False, [], []
+
+        async def capture_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "_lookup_reply_context", blocking_reply_lookup)
+        monkeypatch.setattr(adapter, "handle_message", capture_message)
+        payload = {
+            "type": "new-message",
+            "data": {
+                "guid": "cancelled-reply-lookup-guid",
+                "text": "please retry me",
+                "threadOriginatorGuid": "quoted-message-guid",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chatGuid": "iMessage;-;user@example.com",
+                "chatIdentifier": "user@example.com",
+            },
+        }
+
+        first = asyncio.create_task(
+            adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        )
+        await lookup_started.wait()
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+
+        assert adapter._pending_message_identities == set()
+
+        monkeypatch.setattr(adapter, "_lookup_reply_context", completed_reply_lookup)
+        retry = await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        await asyncio.sleep(0)
+
+        assert retry.status == 200
+        assert [event.text for event in handled] == ["please retry me"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "reply_field", ["threadOriginatorGuid", "associatedMessageGuid"]
+    )
+    async def test_reply_context_lookup_is_bounded_exact_chat_and_stages_attachments(
+        self, monkeypatch, reply_field
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+        queries = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_api_post(path, payload):
+            queries.append((path, payload))
+            return {
+                "data": [
+                    {
+                        "guid": "replied-message-guid",
+                        "text": "the exact earlier message",
+                        "isFromMe": True,
+                        "chats": [{"guid": "iMessage;+;exact-family-guid"}],
+                        "attachments": [
+                            {
+                                "guid": "replied-photo-guid",
+                                "mimeType": "image/png",
+                                "transferName": "photo.png",
+                            },
+                            {
+                                "guid": "replied-document-guid",
+                                "mimeType": "application/pdf",
+                                "transferName": "details.pdf",
+                            },
+                        ],
+                    }
+                ]
+            }
+
+        async def fake_download_attachment(att_guid, att_meta):
+            return {
+                "replied-photo-guid": "/tmp/exact-replied-photo.png",
+                "replied-document-guid": "/tmp/exact-details.pdf",
+            }[att_guid]
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download_attachment)
+
+        response = await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "new-message",
+                    "data": {
+                        "guid": "new-message-guid",
+                        "text": "what is in this?",
+                        reply_field: "replied-message-guid",
+                        "handle": {"address": "+15555550100"},
+                        "isFromMe": False,
+                        "isGroup": True,
+                        "chatGuid": "iMessage;+;exact-family-guid",
+                        "chatIdentifier": "family-group",
+                    },
+                }
+            )
+        )
+        await asyncio.sleep(0)
+
+        assert response.status == 200
+        assert len(handled) == 1
+        event = handled[0]
+        assert event.reply_to_message_id == "replied-message-guid"
+        assert event.reply_to_text == "the exact earlier message"
+        assert event.reply_to_is_own_message is True
+        assert event.media_urls == [
+            "/tmp/exact-replied-photo.png",
+            "/tmp/exact-details.pdf",
+        ]
+        assert event.media_types == ["image/png", "application/pdf"]
+        assert event.metadata["bluebubbles_reply_attachment_count"] == 2
+        assert queries == [
+            (
+                "/api/v1/message/query",
+                {
+                    "limit": 100,
+                    "offset": 0,
+                    "chatGuid": "iMessage;+;exact-family-guid",
+                    "with": ["attachments", "chats"],
+                },
+            )
+        ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("mode", ["missing", "ambiguous", "cross-chat", "over-bound"])
+    async def test_referenced_message_lookup_rejects_unresolved_results(
+        self, monkeypatch, mode
+    ):
+        adapter = _make_adapter(monkeypatch)
+        target = {
+            "guid": "target-guid",
+            "text": "private text",
+            "chats": [{"guid": "iMessage;+;current-chat"}],
+        }
+        records = {
+            "missing": [],
+            "ambiguous": [target, dict(target)],
+            "cross-chat": [
+                {
+                    **target,
+                    "chats": [{"guid": "iMessage;+;other-chat"}],
+                }
+            ],
+            "over-bound": [target] + [
+                {
+                    "guid": f"filler-{index}",
+                    "chats": [{"guid": "iMessage;+;current-chat"}],
+                }
+                for index in range(100)
+            ],
+        }[mode]
+
+        async def fake_api_post(path, payload):
+            return {"data": records}
+
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+
+        assert (
+            await adapter._lookup_referenced_message(
+                "iMessage;+;current-chat", "target-guid"
+            )
+            is None
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("chat_guid", "message_guid"),
+        [("", "target-guid"), (" current-chat", "target-guid"), ("current-chat", 7)],
+    )
+    async def test_referenced_message_lookup_rejects_malformed_input_without_io(
+        self, monkeypatch, chat_guid, message_guid
+    ):
+        adapter = _make_adapter(monkeypatch)
+
+        async def fail_api_post(path, payload):
+            raise AssertionError("malformed references must fail before I/O")
+
+        monkeypatch.setattr(adapter, "_api_post", fail_api_post)
+
+        assert await adapter._lookup_referenced_message(chat_guid, message_guid) is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("mode", ["foreign", "missing", "error"])
+    async def test_reply_context_missing_or_cross_chat_fails_closed(
+        self, monkeypatch, mode
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+        downloads = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_api_post(path, payload):
+            if mode == "error":
+                raise RuntimeError("query failed")
+            if mode == "missing":
+                return {"data": []}
+            return {
+                "data": [
+                    {
+                        "guid": "replied-message-guid",
+                        "text": "foreign private context",
+                        "chats": [{"guid": "iMessage;+;other-group"}],
+                        "attachments": [{"guid": "foreign-attachment"}],
+                    }
+                ]
+            }
+
+        async def fake_download_attachment(att_guid, att_meta):
+            downloads.append(att_guid)
+            return "/tmp/should-not-stage"
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download_attachment)
+
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "new-message",
+                    "data": {
+                        "guid": "new-message-guid",
+                        "text": "ordinary reply",
+                        "associatedMessageGuid": "replied-message-guid",
+                        "handle": {"address": "user@example.com"},
+                        "isFromMe": False,
+                        "chatGuid": "iMessage;-;user@example.com",
+                        "chatIdentifier": "user@example.com",
+                    },
+                }
+            )
+        )
+        await asyncio.sleep(0)
+
+        assert len(handled) == 1
+        assert handled[0].reply_to_message_id == "replied-message-guid"
+        assert handled[0].reply_to_text is None
+        assert handled[0].media_urls == []
+        assert downloads == []
+
+    @pytest.mark.asyncio
+    async def test_malformed_reply_reference_exposes_no_attachment_context(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+        downloads = []
+
+        async def fake_api_post(path, payload):
+            return {
+                "data": [
+                    {
+                        "guid": "replied-message-guid",
+                        "text": "private quoted caption",
+                        "isFromMe": True,
+                        "chats": [{"guid": "iMessage;-;user@example.com"}],
+                        "attachments": [
+                            {
+                                "guid": "private-attachment-guid",
+                                "mimeType": "image/png",
+                                "transferName": "private-photo.png",
+                            }
+                        ],
+                    }
+                ]
+            }
+
+        async def fake_download_attachment(att_guid, att_meta):
+            downloads.append((att_guid, att_meta))
+            return "/tmp/private-photo.png"
+
+        async def capture_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", capture_message)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download_attachment)
+
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "new-message",
+                    "data": {
+                        "guid": "new-message-guid",
+                        "text": "ordinary reply",
+                        "associatedMessageGuid": " replied-message-guid",
+                        "handle": {"address": "user@example.com"},
+                        "isFromMe": False,
+                        "chatGuid": "iMessage;-;user@example.com",
+                        "chatIdentifier": "user@example.com",
+                    },
+                }
+            )
+        )
+        await asyncio.sleep(0)
+
+        assert len(handled) == 1
+        assert handled[0].reply_to_text is None
+        assert handled[0].reply_to_is_own_message is False
+        assert handled[0].media_urls == []
+        assert handled[0].media_types == []
+        assert handled[0].metadata == {}
+        assert downloads == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("record_count", "expected_quote"),
+        [(100, "boundary quote"), (101, None)],
+    )
+    async def test_reply_hydration_enforces_lookup_boundary_without_partial_leakage(
+        self, monkeypatch, record_count, expected_quote
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+        downloads = []
+        records = [
+            {
+                "guid": f"filler-{index}",
+                "chats": [{"guid": "iMessage;+;family-group"}],
+            }
+            for index in range(record_count - 1)
+        ]
+        records.append(
+            {
+                "guid": "boundary-target",
+                "text": "boundary quote",
+                "isFromMe": True,
+                "chats": [{"guid": "iMessage;+;family-group"}],
+                "attachments": [
+                    {
+                        "guid": "boundary-attachment",
+                        "mimeType": "image/png",
+                        "transferName": "private.png",
+                    }
+                ],
+            }
+        )
+
+        async def fake_api_post(path, payload):
+            assert payload["limit"] == 100
+            return {"data": records}
+
+        async def fake_download_attachment(att_guid, att_meta):
+            downloads.append((att_guid, att_meta))
+            return "/tmp/boundary-attachment.png"
+
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download_attachment)
+        monkeypatch.setattr(adapter, "handle_message", handled.append)
+
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "new-message",
+                    "data": {
+                        "guid": f"boundary-inbound-{record_count}",
+                        "text": "keep the inbound text",
+                        "threadOriginatorGuid": "boundary-target",
+                        "handle": {"address": "+155****0100"},
+                        "isFromMe": False,
+                        "isGroup": True,
+                        "chatGuid": "iMessage;+;family-group",
+                        "chatIdentifier": "family-group",
+                    },
+                }
+            )
+        )
+        await asyncio.sleep(0)
+
+        assert len(handled) == 1
+        event = handled[0]
+        assert event.text == "keep the inbound text"
+        assert event.reply_to_message_id == "boundary-target"
+        assert event.reply_to_text == expected_quote
+        if expected_quote is not None:
+            assert event.reply_to_is_own_message is True
+            assert event.media_urls == ["/tmp/boundary-attachment.png"]
+            assert event.media_types == ["image/png"]
+            assert event.metadata == {"bluebubbles_reply_attachment_count": 1}
+            assert len(downloads) == 1
+        else:
+            assert event.reply_to_is_own_message is False
+            assert event.media_urls == []
+            assert event.media_types == []
+            assert event.metadata == {}
+            assert downloads == []
+
+    @pytest.mark.asyncio
+    async def test_colliding_cross_chat_reply_identifier_fails_closed(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+        downloads = []
+
+        async def fake_api_post(path, payload):
+            return {
+                "data": [
+                    {
+                        "guid": "colliding-guid",
+                        "text": "same-chat text must not partially win",
+                        "isFromMe": True,
+                        "chats": [{"guid": "iMessage;+;family-group"}],
+                        "attachments": [{"guid": "same-chat-private-file"}],
+                    },
+                    {
+                        "guid": "colliding-guid",
+                        "text": "foreign private text",
+                        "isFromMe": True,
+                        "chats": [{"guid": "iMessage;+;other-group"}],
+                        "attachments": [{"guid": "foreign-private-file"}],
+                    },
+                ]
+            }
+
+        async def fake_download_attachment(att_guid, att_meta):
+            downloads.append((att_guid, att_meta))
+            return "/tmp/must-not-leak"
+
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download_attachment)
+        monkeypatch.setattr(adapter, "handle_message", handled.append)
+
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "new-message",
+                    "data": {
+                        "guid": "collision-inbound",
+                        "text": "ordinary reply survives",
+                        "associatedMessageGuid": "colliding-guid",
+                        "handle": {"address": "+155****0100"},
+                        "isFromMe": False,
+                        "isGroup": True,
+                        "chatGuid": "iMessage;+;family-group",
+                        "chatIdentifier": "family-group",
+                    },
+                }
+            )
+        )
+        await asyncio.sleep(0)
+
+        assert len(handled) == 1
+        event = handled[0]
+        assert event.text == "ordinary reply survives"
+        assert event.reply_to_message_id == "colliding-guid"
+        assert event.reply_to_text is None
+        assert event.reply_to_is_own_message is False
+        assert event.media_urls == []
+        assert event.media_types == []
+        assert event.metadata == {}
+        assert downloads == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("reference", "expected_reply_id", "expected_queries"),
+        [(None, None, 0), ("", None, 0), (" malformed", None, 0), (7, None, 0), ("missing-guid", "missing-guid", 1)],
+    )
+    async def test_unquoted_missing_and_malformed_references_leave_message_unchanged(
+        self, monkeypatch, reference, expected_reply_id, expected_queries
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+        queries = []
+
+        async def fake_api_post(path, payload):
+            queries.append((path, payload))
+            return {"data": []}
+
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        monkeypatch.setattr(adapter, "handle_message", handled.append)
+        data = {
+            "guid": f"ordinary-{reference!r}",
+            "text": "ordinary message text",
+            "handle": {"address": "user@example.com"},
+            "isFromMe": False,
+            "chatGuid": "iMessage;-;user@example.com",
+            "chatIdentifier": "user@example.com",
+        }
+        if reference is not None:
+            data["threadOriginatorGuid"] = reference
+
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest({"type": "new-message", "data": data})
+        )
+        await asyncio.sleep(0)
+
+        assert len(handled) == 1
+        event = handled[0]
+        assert event.text == "ordinary message text"
+        assert event.reply_to_message_id == expected_reply_id
+        assert event.reply_to_text is None
+        assert event.reply_to_is_own_message is False
+        assert event.media_urls == []
+        assert event.media_types == []
+        assert event.metadata == {}
+        assert len(queries) == expected_queries
+
+    @pytest.mark.asyncio
+    async def test_participant_names_preserve_canonical_identity_across_dm_and_group(self, monkeypatch):
+        known = "+15555550100"
+        unknown = "+15555550101"
+        adapter = _make_adapter(
+            monkeypatch,
+            participant_names={known: "Mark", unknown: "", 7: "ignored"},
             send_read_receipts=False,
         )
         handled = []
@@ -99,6 +1960,81 @@ class TestBlueBubblesMentionGating:
             handled.append(event)
 
         monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+
+        async def dispatch(guid, sender, *, group=False):
+            data = {
+                "guid": guid,
+                "text": "hello",
+                "handle": {"address": sender},
+                "isFromMe": False,
+                "chatGuid": (
+                    "iMessage;+;family-group"
+                    if group
+                    else f"iMessage;-;{sender}"
+                ),
+                "chatIdentifier": "family-group" if group else sender,
+                "isGroup": group,
+            }
+            response = await adapter._handle_webhook(
+                _FakeBlueBubblesRequest({"type": "new-message", "data": data})
+            )
+            await asyncio.sleep(0)
+            assert response.status == 200
+
+        await dispatch("participant-known-dm", known)
+        await dispatch("participant-known-group", known, group=True)
+        await dispatch("participant-unknown", unknown)
+
+        malformed = _make_adapter(
+            monkeypatch,
+            participant_names=[{known: "not-a-map"}],
+            send_read_receipts=False,
+        )
+        monkeypatch.setattr(malformed, "handle_message", fake_handle_message)
+        response = await malformed._handle_webhook(
+            _FakeBlueBubblesRequest({
+                "type": "new-message",
+                "data": {
+                    "guid": "participant-malformed",
+                    "text": "hello",
+                    "handle": {"address": known},
+                    "isFromMe": False,
+                    "chatGuid": f"iMessage;-;{known}",
+                    "chatIdentifier": known,
+                },
+            })
+        )
+        await asyncio.sleep(0)
+        assert response.status == 200
+
+        assert [
+            (event.source.user_id, event.source.user_name, event.source.chat_type)
+            for event in handled
+        ] == [
+            (known, "Mark", "dm"),
+            (known, "Mark", "group"),
+            (unknown, unknown, "dm"),
+            (known, known, "dm"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_group_message_without_mention_is_acknowledged_and_skipped(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            require_mention=True,
+            send_read_receipts=False,
+        )
+        handled = []
+        reactions = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_send_reaction(*args, **kwargs):
+            reactions.append((args, kwargs))
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "send_reaction", fake_send_reaction)
         response = await adapter._handle_webhook(_FakeBlueBubblesRequest({
             "type": "new-message",
             "data": {
@@ -114,49 +2050,2319 @@ class TestBlueBubblesMentionGating:
 
         assert response.status == 200
         assert handled == []
+        assert reactions == []
+
+    @pytest.mark.asyncio
+    async def test_group_message_with_default_mention_is_dispatched_cleaned(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            require_mention=True,
+            send_read_receipts=False,
+        )
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        response = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "msg-2",
+                "text": "Hermes, summarize this",
+                "handle": {"address": "+15555550100"},
+                "isFromMe": False,
+                "isGroup": True,
+                "chats": [{"guid": "iMessage;+;group-chat"}],
+            },
+        }))
+        await asyncio.sleep(0)
+
+        assert response.status == 200
+        assert [event.text for event in handled] == ["summarize this"]
+
+    @pytest.mark.asyncio
+    async def test_dm_message_does_not_require_mention(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            require_mention=True,
+            send_read_receipts=False,
+        )
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        response = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "msg-3",
+                "text": "hello from a dm",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chatGuid": "iMessage;-;user@example.com",
+                "chatIdentifier": "user@example.com",
+            },
+        }))
+        await asyncio.sleep(0)
+
+        assert response.status == 200
+        assert [event.text for event in handled] == ["hello from a dm"]
+
+    @pytest.mark.asyncio
+    async def test_duplicate_new_and_updated_events_are_handled_once(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        message = {
+            "guid": "same-message-guid",
+            "text": "hello once",
+            "handle": {"address": "user@example.com"},
+            "isFromMe": False,
+            "chatIdentifier": "user@example.com",
+        }
+
+        first, second = await asyncio.gather(
+            adapter._handle_webhook(_FakeBlueBubblesRequest({
+                "type": "new-message",
+                "data": {**message, "chatGuid": "iMessage;-;user@example.com"},
+            })),
+            adapter._handle_webhook(_FakeBlueBubblesRequest({
+                "type": "updated-message",
+                "data": message,
+            })),
+        )
+        await asyncio.sleep(0)
+
+        assert first.status == 200
+        assert second.status == 200
+        assert [event.text for event in handled] == ["hello once"]
+
+    @pytest.mark.asyncio
+    async def test_incomplete_first_group_second_dispatches_one_group_turn(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        base = {
+            "guid": "ambiguous-then-group-guid",
+            "text": "family request",
+            "handle": {"address": "+15555550100"},
+            "isFromMe": False,
+            "chatIdentifier": "+15555550100",
+        }
+
+        first = await adapter._handle_webhook(
+            _FakeBlueBubblesRequest({"type": "new-message", "data": base})
+        )
+        await asyncio.sleep(0)
+        second = await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "updated-message",
+                    "data": {
+                        **base,
+                        "chatGuid": "iMessage;+;family-group",
+                        "chatIdentifier": "family-group",
+                        "isGroup": True,
+                    },
+                }
+            )
+        )
+        await asyncio.sleep(0)
+
+        assert first.status == 200
+        assert second.status == 200
+        assert [event.source.chat_id for event in handled] == [
+            "iMessage;+;family-group"
+        ]
+        assert [event.source.chat_type for event in handled] == ["group"]
+
+    @pytest.mark.asyncio
+    async def test_authoritative_revision_wins_while_ambiguous_lookup_is_in_flight(
+        self, monkeypatch
+    ):
+        import gateway.platforms.bluebubbles as bluebubbles_module
+
+        monkeypatch.setattr(
+            bluebubbles_module,
+            "_PROVISIONAL_MESSAGE_WAIT_SECONDS",
+            0.01,
+        )
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        lookup_started = asyncio.Event()
+        release_lookup = asyncio.Event()
+        handled = []
+        lookup_count = 0
+
+        async def delayed_lookup(message_guid):
+            nonlocal lookup_count
+            lookup_count += 1
+            if lookup_count == 1:
+                lookup_started.set()
+                await release_lookup.wait()
+                return None
+            return "iMessage;+;family-group"
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(
+            adapter,
+            "_resolve_exact_message_chat_guid",
+            delayed_lookup,
+        )
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        first = asyncio.create_task(
+            adapter._handle_webhook(
+                _FakeBlueBubblesRequest(
+                    {
+                        "type": "new-message",
+                        "data": {
+                            "guid": "in-flight-lookup-guid",
+                            "text": "ambiguous text",
+                            "handle": {"address": "+15555550100"},
+                            "isFromMe": False,
+                            "chatIdentifier": "+15555550100",
+                        },
+                    }
+                )
+            )
+        )
+        await lookup_started.wait()
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "updated-message",
+                    "data": {
+                        "guid": "in-flight-lookup-guid",
+                        "text": "authoritative text",
+                        "handle": {"address": "+15555550100"},
+                        "isFromMe": False,
+                        "chatGuid": "iMessage;+;family-group",
+                        "chatIdentifier": "family-group",
+                        "isGroup": True,
+                    },
+                }
+            )
+        )
+        await asyncio.sleep(0)
+        release_lookup.set()
+        await first
+        await asyncio.sleep(0.03)
+
+        assert [
+            (event.source.chat_id, event.text) for event in handled
+        ] == [("iMessage;+;family-group", "authoritative text")]
+        assert lookup_count == 1
+
+    @pytest.mark.asyncio
+    async def test_authoritative_revision_merges_provisional_message_text(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        first = {
+            "guid": "provisional-text-guid",
+            "text": "text only present in first revision",
+            "handle": {"address": "+15555550100"},
+            "isFromMe": False,
+            "chatIdentifier": "+15555550100",
+        }
+
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest({"type": "new-message", "data": first})
+        )
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "updated-message",
+                    "data": {
+                        **first,
+                        "text": "",
+                        "chatGuid": "iMessage;+;family-group",
+                        "chatIdentifier": "family-group",
+                        "isGroup": True,
+                    },
+                }
+            )
+        )
+        await asyncio.sleep(0)
+
+        assert [
+            (event.source.chat_id, event.text) for event in handled
+        ] == [
+            (
+                "iMessage;+;family-group",
+                "text only present in first revision",
+            )
+        ]
+
+    @pytest.mark.asyncio
+    async def test_sparse_authoritative_revision_does_not_consume_provisional(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+        lookup_count = 0
+
+        async def resolve_on_retry(message_guid):
+            nonlocal lookup_count
+            lookup_count += 1
+            return None
+
+        async def exact_membership(chat_guid, message_guid, **kwargs):
+            return {
+                "guid": message_guid,
+                "chats": [{"guid": chat_guid}],
+            }
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(
+            adapter,
+            "_resolve_exact_message_chat_guid",
+            resolve_on_retry,
+        )
+        monkeypatch.setattr(adapter, "_query_exact_message", exact_membership)
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "new-message",
+                    "data": {
+                        "guid": "sparse-authoritative-guid",
+                        "text": "ambiguous text",
+                        "handle": {"address": "+15555550100"},
+                        "isFromMe": False,
+                        "chatIdentifier": "+15555550100",
+                    },
+                }
+            )
+        )
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "updated-message",
+                    "data": {
+                        "guid": "sparse-authoritative-guid",
+                        "text": "authoritative text",
+                        "isFromMe": False,
+                        "chatGuid": "iMessage;+;family-group",
+                        "chatIdentifier": "family-group",
+                        "isGroup": True,
+                    },
+                }
+            )
+        )
+        await asyncio.sleep(0)
+
+        assert lookup_count == 1
+        assert handled == []
+
+    @pytest.mark.asyncio
+    async def test_forged_chat_guid_is_rejected_against_rest_membership(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        membership_lookups = []
+        authorization_calls = []
+        handled = []
+
+        async def exact_membership(chat_guid, message_guid, **kwargs):
+            membership_lookups.append((chat_guid, message_guid))
+            return None
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.delattr(adapter, "_verify_inbound_message_membership")
+        monkeypatch.setattr(adapter, "_query_exact_message", exact_membership)
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        adapter.set_authorization_check(
+            lambda *args: authorization_calls.append(args) or True
+        )
+
+        response = await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "new-message",
+                    "data": {
+                        "guid": "forged-chat-guid-message",
+                        "text": "do not route to forged chat",
+                        "handle": {"address": "user@example.com"},
+                        "isFromMe": False,
+                        "chatGuid": "iMessage;+;forged-chat",
+                        "chatIdentifier": "forged-chat",
+                        "isGroup": True,
+                    },
+                }
+            )
+        )
+
+        assert response.status == 200
+        assert membership_lookups == [
+            ("iMessage;+;forged-chat", "forged-chat-guid-message")
+        ]
+        assert authorization_calls == []
+        assert handled == []
+
+    @pytest.mark.asyncio
+    async def test_conflicting_scalar_chat_guids_fail_before_membership_lookup(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        membership_lookups = []
+        handled = []
+
+        async def membership(chat_guid, message_guid, **kwargs):
+            membership_lookups.append((chat_guid, message_guid))
+            return chat_guid
+
+        monkeypatch.delattr(adapter, "_verify_inbound_message_membership")
+        monkeypatch.setattr(adapter, "_query_exact_message", membership)
+        monkeypatch.setattr(adapter, "handle_message", handled.append)
+
+        response = await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "new-message",
+                    "chatGuid": "iMessage;+;top-level-chat",
+                    "data": {
+                        "guid": "conflicting-chat-fields-guid",
+                        "text": "do not choose either chat",
+                        "handle": {"address": "user@example.com"},
+                        "isFromMe": False,
+                        "chatGuid": "iMessage;+;record-chat",
+                        "isGroup": True,
+                    },
+                }
+            )
+        )
+
+        assert response.status == 200
+        assert membership_lookups == []
+        assert handled == []
+
+    @pytest.mark.asyncio
+    async def test_conflicting_nested_chat_guids_fail_before_membership_lookup(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        membership_lookups = []
+        handled = []
+
+        async def membership(chat_guid, message_guid, **kwargs):
+            membership_lookups.append((chat_guid, message_guid))
+            return chat_guid
+
+        monkeypatch.delattr(adapter, "_verify_inbound_message_membership")
+        monkeypatch.setattr(adapter, "_query_exact_message", membership)
+        monkeypatch.setattr(adapter, "handle_message", handled.append)
+
+        response = await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "new-message",
+                    "data": {
+                        "guid": "conflicting-nested-chat-guid",
+                        "text": "do not choose nested chat",
+                        "handle": {"address": "user@example.com"},
+                        "isFromMe": False,
+                        "chats": [
+                            {
+                                "guid": "iMessage;+;nested-a",
+                                "chatGuid": "iMessage;+;nested-b",
+                            }
+                        ],
+                        "isGroup": True,
+                    },
+                }
+            )
+        )
+
+        assert response.status == 200
+        assert membership_lookups == []
+        assert handled == []
+
+    @pytest.mark.asyncio
+    async def test_transient_candidate_membership_lookup_has_no_side_effects(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=True)
+        side_effects = []
+
+        async def unavailable_membership(chat_guid, message_guid, **kwargs):
+            raise TimeoutError("BlueBubbles lookup unavailable")
+
+        async def capture(name, *args, **kwargs):
+            side_effects.append((name, args, kwargs))
+
+        monkeypatch.delattr(adapter, "_verify_inbound_message_membership")
+        monkeypatch.setattr(adapter, "_query_exact_message", unavailable_membership)
+        monkeypatch.setattr(
+            adapter,
+            "_download_attachment",
+            lambda *args, **kwargs: capture("download", *args, **kwargs),
+        )
+        monkeypatch.setattr(
+            adapter,
+            "handle_message",
+            lambda *args, **kwargs: capture("handle", *args, **kwargs),
+        )
+        monkeypatch.setattr(
+            adapter,
+            "mark_read",
+            lambda *args, **kwargs: capture("read", *args, **kwargs),
+        )
+        adapter.set_authorization_check(
+            lambda *args: side_effects.append(("authorize", args, {})) or True
+        )
+
+        response = await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "new-message",
+                    "data": {
+                        "guid": "transient-membership-guid",
+                        "text": "hold until verified",
+                        "handle": {"address": "user@example.com"},
+                        "isFromMe": False,
+                        "chatGuid": "iMessage;-;user@example.com",
+                        "chatIdentifier": "user@example.com",
+                        "attachments": [
+                            {"guid": "private-photo", "mimeType": "image/png"}
+                        ],
+                    },
+                }
+            )
+        )
+
+        assert response.status == 200
+        assert side_effects == []
+
+    @pytest.mark.asyncio
+    async def test_provisional_chat_a_cannot_leak_into_authoritative_chat_b(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+        downloads = []
+
+        async def exact_membership(chat_guid, message_guid, **kwargs):
+            if chat_guid == "iMessage;+;chat-a":
+                return None
+            return {
+                "guid": message_guid,
+                "chats": [{"guid": "iMessage;+;chat-b"}],
+            }
+
+        async def fake_download(att_guid, att_meta):
+            downloads.append(att_guid)
+            return f"/tmp/{att_guid}"
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.delattr(adapter, "_verify_inbound_message_membership")
+        monkeypatch.setattr(adapter, "_query_exact_message", exact_membership)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download)
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        message_guid = "cross-chat-provisional-guid"
+        sender = {"address": "same-sender@example.com"}
+
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "new-message",
+                    "data": {
+                        "guid": message_guid,
+                        "text": "chat A secret",
+                        "handle": sender,
+                        "isFromMe": False,
+                        "chatGuid": "iMessage;+;chat-a",
+                        "chatIdentifier": "chat-a",
+                        "isGroup": True,
+                        "attachments": [
+                            {"guid": "chat-a-private", "mimeType": "image/png"}
+                        ],
+                    },
+                }
+            )
+        )
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "updated-message",
+                    "data": {
+                        "guid": message_guid,
+                        "text": "chat B public",
+                        "handle": sender,
+                        "isFromMe": False,
+                        "chatGuid": "iMessage;+;chat-b",
+                        "chatIdentifier": "chat-b",
+                        "isGroup": True,
+                    },
+                }
+            )
+        )
+        await asyncio.sleep(0)
+
+        assert downloads == []
+        assert [(event.source.chat_id, event.text) for event in handled] == [
+            ("iMessage;+;chat-b", "chat B public")
+        ]
+
+    @pytest.mark.asyncio
+    async def test_authoritative_revision_merges_provisional_attachments_after_resolution(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+        downloads = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_download_attachment(att_guid, att_meta):
+            downloads.append(att_guid)
+            return f"/tmp/{att_guid}"
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download_attachment)
+        first = {
+            "guid": "provisional-attachments-guid",
+            "text": "inspect both",
+            "handle": {"address": "+15555550100"},
+            "isFromMe": False,
+            "chatIdentifier": "+15555550100",
+            "attachments": [
+                {"guid": "first-photo", "mimeType": "image/png"},
+            ],
+        }
+
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest({"type": "new-message", "data": first})
+        )
+        assert downloads == []
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "updated-message",
+                    "data": {
+                        **first,
+                        "chatGuid": "iMessage;+;family-group",
+                        "chatIdentifier": "family-group",
+                        "isGroup": True,
+                        "attachments": [
+                            {"guid": "second-photo", "mimeType": "image/png"},
+                        ],
+                    },
+                }
+            )
+        )
+        await asyncio.sleep(0)
+
+        assert downloads == ["first-photo", "second-photo"]
+        assert [event.media_urls for event in handled] == [
+            ["/tmp/first-photo", "/tmp/second-photo"]
+        ]
+
+    @pytest.mark.asyncio
+    async def test_provisional_retry_resolves_authoritative_true_dm(
+        self, monkeypatch
+    ):
+        import gateway.platforms.bluebubbles as bluebubbles_module
+
+        monkeypatch.setattr(
+            bluebubbles_module,
+            "_PROVISIONAL_MESSAGE_WAIT_SECONDS",
+            0.01,
+        )
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+        lookups = []
+
+        async def resolve_on_retry(message_guid):
+            lookups.append(message_guid)
+            if len(lookups) == 1:
+                return None
+            return "iMessage;-;user@example.com"
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(
+            adapter,
+            "_resolve_exact_message_chat_guid",
+            resolve_on_retry,
+        )
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+
+        response = await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "new-message",
+                    "data": {
+                        "guid": "true-dm-provisional-guid",
+                        "text": "private request",
+                        "handle": {"address": "user@example.com"},
+                        "isFromMe": False,
+                        "chatIdentifier": "user@example.com",
+                    },
+                }
+            )
+        )
+        await asyncio.sleep(0.03)
+
+        assert response.status == 200
+        assert lookups == [
+            "true-dm-provisional-guid",
+            "true-dm-provisional-guid",
+        ]
+        assert [
+            (event.source.chat_id, event.source.chat_type, event.text)
+            for event in handled
+        ] == [
+            (
+                "iMessage;-;user@example.com",
+                "dm",
+                "private request",
+            )
+        ]
+
+    @pytest.mark.asyncio
+    async def test_newer_provisional_revision_wins_while_retry_lookup_is_in_flight(
+        self, monkeypatch
+    ):
+        import gateway.platforms.bluebubbles as bluebubbles_module
+
+        monkeypatch.setattr(
+            bluebubbles_module,
+            "_PROVISIONAL_MESSAGE_WAIT_SECONDS",
+            0.01,
+        )
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        retry_started = asyncio.Event()
+        release_retry = asyncio.Event()
+        handled = []
+        lookup_count = 0
+
+        async def resolve_during_retry(message_guid):
+            nonlocal lookup_count
+            lookup_count += 1
+            if lookup_count == 1:
+                return None
+            if lookup_count == 2:
+                retry_started.set()
+                await release_retry.wait()
+                return "iMessage;-;user@example.com"
+            return None
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(
+            adapter,
+            "_resolve_exact_message_chat_guid",
+            resolve_during_retry,
+        )
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        base = {
+            "guid": "edited-during-retry-guid",
+            "handle": {"address": "user@example.com"},
+            "isFromMe": False,
+            "chatIdentifier": "user@example.com",
+        }
+
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {"type": "new-message", "data": {**base, "text": "old text"}}
+            )
+        )
+        await retry_started.wait()
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "updated-message",
+                    "data": {**base, "text": "new text"},
+                }
+            )
+        )
+        release_retry.set()
+        await asyncio.sleep(0.03)
+
+        assert lookup_count == 3
+        assert [event.text for event in handled] == ["new text"]
+
+    @pytest.mark.asyncio
+    async def test_unresolved_message_has_no_delivery_side_effects(self, monkeypatch):
+        import gateway.platforms.bluebubbles as bluebubbles_module
+
+        monkeypatch.setattr(
+            bluebubbles_module,
+            "_PROVISIONAL_MESSAGE_WAIT_SECONDS",
+            0.01,
+        )
+        adapter = _make_adapter(
+            monkeypatch,
+            ack_reaction="like",
+            send_read_receipts=True,
+        )
+        side_effects = []
+        lookups = []
+
+        async def unresolved_lookup(message_guid):
+            lookups.append(message_guid)
+            return None
+
+        async def capture(name, *args, **kwargs):
+            side_effects.append((name, args, kwargs))
+
+        monkeypatch.setattr(
+            adapter,
+            "_resolve_exact_message_chat_guid",
+            unresolved_lookup,
+        )
+        monkeypatch.setattr(
+            adapter,
+            "_download_attachment",
+            lambda *args, **kwargs: capture("download", *args, **kwargs),
+        )
+        monkeypatch.setattr(
+            adapter,
+            "handle_message",
+            lambda *args, **kwargs: capture("handle", *args, **kwargs),
+        )
+        monkeypatch.setattr(
+            adapter,
+            "mark_read",
+            lambda *args, **kwargs: capture("read", *args, **kwargs),
+        )
+        monkeypatch.setattr(
+            adapter,
+            "send_typing",
+            lambda *args, **kwargs: capture("typing", *args, **kwargs),
+        )
+        monkeypatch.setattr(
+            adapter,
+            "send_reaction",
+            lambda *args, **kwargs: capture("reaction", *args, **kwargs),
+        )
+        adapter.set_authorization_check(
+            lambda *args: side_effects.append(("authorize", args, {})) or True
+        )
+
+        response = await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "new-message",
+                    "data": {
+                        "guid": "never-resolved-guid",
+                        "text": "do not leak",
+                        "handle": {"address": "+15555550100"},
+                        "isFromMe": False,
+                        "chatIdentifier": "+15555550100",
+                        "attachments": [
+                            {"guid": "private-photo", "mimeType": "image/png"},
+                        ],
+                    },
+                }
+            )
+        )
+        await asyncio.sleep(0.03)
+
+        assert response.status == 200
+        assert lookups == ["never-resolved-guid", "never-resolved-guid"]
+        assert side_effects == []
+        assert adapter._provisional_messages == {}
+        assert adapter._provisional_message_tasks == {}
+        assert adapter._message_revision_serials == {}
+
+    @pytest.mark.asyncio
+    async def test_multi_chat_webhook_membership_is_not_treated_as_authoritative(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+        authorization_calls = []
+
+        async def unresolved_lookup(message_guid):
+            return None
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(
+            adapter,
+            "_resolve_exact_message_chat_guid",
+            unresolved_lookup,
+        )
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        adapter.set_authorization_check(
+            lambda *args: authorization_calls.append(args) or True
+        )
+
+        response = await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "new-message",
+                    "data": {
+                        "guid": "ambiguous-membership-guid",
+                        "text": "must not choose first chat",
+                        "handle": {"address": "+15555550100"},
+                        "isFromMe": False,
+                        "chats": [
+                            {"guid": "iMessage;-;+15555550100"},
+                            {"guid": "iMessage;+;family-group"},
+                        ],
+                    },
+                }
+            )
+        )
+
+        assert response.status == 200
+        assert authorization_calls == []
+        assert handled == []
+
+    @pytest.mark.asyncio
+    async def test_cancelled_membership_lookup_releases_provisional_for_retry(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        lookup_started = asyncio.Event()
+        handled = []
+
+        async def blocking_lookup(message_guid):
+            lookup_started.set()
+            await asyncio.Event().wait()
+
+        async def resolved_lookup(message_guid):
+            return "iMessage;-;user@example.com"
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(
+            adapter,
+            "_resolve_exact_message_chat_guid",
+            blocking_lookup,
+        )
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        payload = {
+            "type": "new-message",
+            "data": {
+                "guid": "cancelled-membership-guid",
+                "text": "retry after cancellation",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chatIdentifier": "user@example.com",
+            },
+        }
+
+        first = asyncio.create_task(
+            adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        )
+        await lookup_started.wait()
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+
+        assert adapter._provisional_messages == {}
+        assert adapter._provisional_message_tasks == {}
+
+        monkeypatch.setattr(
+            adapter,
+            "_resolve_exact_message_chat_guid",
+            resolved_lookup,
+        )
+        retry = await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        await asyncio.sleep(0)
+
+        assert retry.status == 200
+        assert [event.text for event in handled] == ["retry after cancellation"]
+
+    @pytest.mark.asyncio
+    async def test_shutdown_clears_provisional_and_same_webhook_remains_retryable(
+        self, monkeypatch
+    ):
+        import gateway.platforms.bluebubbles as bluebubbles_module
+
+        monkeypatch.setattr(
+            bluebubbles_module,
+            "_PROVISIONAL_MESSAGE_WAIT_SECONDS",
+            60,
+        )
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def unresolved_lookup(message_guid):
+            return None
+
+        async def resolved_lookup(message_guid):
+            return "iMessage;-;user@example.com"
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(
+            adapter,
+            "_resolve_exact_message_chat_guid",
+            unresolved_lookup,
+        )
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        payload = {
+            "type": "new-message",
+            "data": {
+                "guid": "shutdown-provisional-guid",
+                "text": "retry after shutdown",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chatIdentifier": "user@example.com",
+            },
+        }
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        assert len(adapter._provisional_messages) == 1
+        assert len(adapter._provisional_message_tasks) == 1
+
+        await adapter.cancel_background_tasks()
+
+        assert adapter._provisional_messages == {}
+        assert adapter._provisional_message_tasks == {}
+        monkeypatch.setattr(
+            adapter,
+            "_resolve_exact_message_chat_guid",
+            resolved_lookup,
+        )
+        retry = await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        await asyncio.sleep(0)
+
+        assert retry.status == 200
+        assert [event.text for event in handled] == ["retry after shutdown"]
+
+    @pytest.mark.asyncio
+    async def test_lookup_resolved_group_authorizes_with_authoritative_chat(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        authorization_calls = []
+        handled = []
+
+        async def resolve_group(message_guid):
+            assert message_guid == "lookup-group-guid"
+            return "iMessage;+;authoritative-group"
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        def authorize(user_id, chat_type, chat_id):
+            authorization_calls.append((user_id, chat_type, chat_id))
+            return True
+
+        monkeypatch.setattr(
+            adapter,
+            "_resolve_exact_message_chat_guid",
+            resolve_group,
+        )
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        adapter.set_authorization_check(authorize)
+
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "new-message",
+                    "data": {
+                        "guid": "lookup-group-guid",
+                        "text": "group request",
+                        "handle": {"address": "+15555550100"},
+                        "isFromMe": False,
+                        "chatIdentifier": "+15555550100",
+                    },
+                }
+            )
+        )
+        await asyncio.sleep(0)
+
+        assert authorization_calls == [
+            (
+                "+15555550100",
+                "group",
+                "iMessage;+;authoritative-group",
+            )
+        ]
+        assert [
+            (event.source.chat_id, event.source.chat_type) for event in handled
+        ] == [("iMessage;+;authoritative-group", "group")]
+
+    @pytest.mark.asyncio
+    async def test_same_guid_in_two_authoritative_chats_remains_isolated(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+
+        for chat_guid in ("iMessage;+;group-a", "iMessage;+;group-b"):
+            await adapter._handle_webhook(
+                _FakeBlueBubblesRequest(
+                    {
+                        "type": "new-message",
+                        "data": {
+                            "guid": "provider-collision-guid",
+                            "text": "same provider identity",
+                            "handle": {"address": "+15555550100"},
+                            "isFromMe": False,
+                            "chatGuid": chat_guid,
+                            "chatIdentifier": chat_guid.rsplit(";", 1)[-1],
+                            "isGroup": True,
+                        },
+                    }
+                )
+            )
+            await asyncio.sleep(0)
+
+        assert [event.source.chat_id for event in handled] == [
+            "iMessage;+;group-a",
+            "iMessage;+;group-b",
+        ]
+        assert {
+            key[0] for key in adapter._message_revision_serials
+        } == {
+            "iMessage;+;group-a",
+            "iMessage;+;group-b",
+        }
+
+    @pytest.mark.asyncio
+    async def test_meaningful_text_revision_with_same_guid_is_processed(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        base = {
+            "guid": "edited-message-guid",
+            "handle": {"address": "user@example.com"},
+            "isFromMe": False,
+            "chatGuid": "iMessage;-;user@example.com",
+            "chatIdentifier": "user@example.com",
+        }
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {**base, "text": "original text"},
+        }))
+        await asyncio.sleep(0)
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {**base, "text": "edited text"},
+        }))
+        await asyncio.sleep(0)
+
+        assert [event.text for event in handled] == ["original text", "edited text"]
+
+    @pytest.mark.asyncio
+    async def test_update_before_new_keeps_the_updated_revision(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        adapter._message_revision_wait_seconds = 0.02
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        base = {
+            "guid": "update-before-new-guid",
+            "handle": {"address": "user@example.com"},
+            "isFromMe": False,
+            "chatGuid": "iMessage;-;user@example.com",
+            "chatIdentifier": "user@example.com",
+        }
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {**base, "text": "edited text", "dateEdited": 200},
+        }))
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {**base, "text": "original text", "dateCreated": 100},
+        }))
+        await asyncio.sleep(0.05)
+
+        assert [event.text for event in handled] == ["edited text"]
+
+    @pytest.mark.asyncio
+    async def test_older_dated_update_cannot_replace_a_newer_update(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        adapter._message_revision_wait_seconds = 0.02
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        base = {
+            "guid": "out-of-order-updates-guid",
+            "handle": {"address": "user@example.com"},
+            "isFromMe": False,
+            "chatGuid": "iMessage;-;user@example.com",
+            "chatIdentifier": "user@example.com",
+        }
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {**base, "text": "newest text", "dateEdited": 300},
+        }))
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {**base, "text": "stale text", "dateEdited": 200},
+        }))
+        await asyncio.sleep(0.05)
+
+        assert [event.text for event in handled] == ["newest text"]
+
+    @pytest.mark.asyncio
+    async def test_attachment_revision_with_same_guid_is_processed(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_download_attachment(att_guid, att_meta):
+            return f"/tmp/{att_guid}"
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download_attachment)
+        base = {
+            "guid": "attachment-revision-guid",
+            "text": "",
+            "handle": {"address": "user@example.com"},
+            "isFromMe": False,
+            "chatGuid": "iMessage;-;user@example.com",
+            "chatIdentifier": "user@example.com",
+        }
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                **base,
+                "attachments": [
+                    {
+                        "guid": "same-attachment",
+                        "mimeType": "application/octet-stream",
+                        "uti": "public.data",
+                    }
+                ],
+            },
+        }))
+        await asyncio.sleep(0)
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {
+                **base,
+                "attachments": [
+                    {
+                        "guid": "same-attachment",
+                        "mimeType": "application/octet-stream",
+                        "uti": "public.caf",
+                    }
+                ],
+            },
+        }))
+        await asyncio.sleep(0)
+
+        assert [event.media_urls for event in handled] == [
+            ["/tmp/same-attachment"],
+            ["/tmp/same-attachment"],
+        ]
+
+    @pytest.mark.asyncio
+    async def test_duplicate_attachment_revision_ignores_mutable_delivery_metadata(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_download_attachment(att_guid, att_meta):
+            return f"/tmp/{att_guid}"
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download_attachment)
+        base = {
+            "guid": "stable-attachment-identity-guid",
+            "text": "same caption",
+            "handle": {"address": "user@example.com"},
+            "isFromMe": False,
+            "chatGuid": "iMessage;-;user@example.com",
+            "chatIdentifier": "user@example.com",
+        }
+
+        for delivered_at in (100, 200):
+            await adapter._handle_webhook(_FakeBlueBubblesRequest({
+                "type": "updated-message",
+                "deliveryId": f"delivery-{delivered_at}",
+                "data": {
+                    **base,
+                    "attachments": [
+                        {
+                            "guid": "stable-photo-guid",
+                            "mimeType": "image/png",
+                            "transferName": "photo.png",
+                            "totalBytes": 1234,
+                            "updatedAt": delivered_at,
+                        }
+                    ],
+                },
+            }))
+            await asyncio.sleep(0)
+
+        assert len(handled) == 1
+        assert handled[0].media_urls == ["/tmp/stable-photo-guid"]
+
+    @pytest.mark.asyncio
+    async def test_text_and_attachment_revisions_with_same_guid_are_coalesced(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        adapter._message_revision_wait_seconds = 0.02
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_download_attachment(att_guid, att_meta):
+            return f"/tmp/{att_guid}"
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download_attachment)
+        base = {
+            "guid": "split-composition-guid",
+            "text": "What size is this part?",
+            "handle": {"address": "user@example.com"},
+            "isFromMe": False,
+            "chatGuid": "iMessage;-;user@example.com",
+            "chatIdentifier": "user@example.com",
+        }
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": base,
+        }))
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {
+                **base,
+                "text": "",
+                "attachments": [
+                    {"guid": "part-photo", "mimeType": "image/png"}
+                ],
+            },
+        }))
+        await asyncio.sleep(0.05)
+
+        assert len(handled) == 1
+        assert handled[0].text == "What size is this part?"
+        assert handled[0].media_urls == ["/tmp/part-photo"]
+        assert handled[0].message_id == "split-composition-guid"
+
+    @pytest.mark.asyncio
+    async def test_text_edit_preserves_pending_attachment_revision(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        adapter._message_revision_wait_seconds = 0.02
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_download_attachment(att_guid, att_meta):
+            return f"/tmp/{att_guid}"
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download_attachment)
+        base = {
+            "guid": "attachment-then-edit-guid",
+            "handle": {"address": "user@example.com"},
+            "isFromMe": False,
+            "chatGuid": "iMessage;-;user@example.com",
+            "chatIdentifier": "user@example.com",
+        }
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {
+                **base,
+                "text": "Original caption",
+                "attachments": [
+                    {"guid": "pending-photo", "mimeType": "image/png"}
+                ],
+            },
+        }))
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {**base, "text": "Edited caption"},
+        }))
+        await asyncio.sleep(0.05)
+
+        assert len(handled) == 1
+        assert handled[0].text == "Edited caption"
+        assert handled[0].media_urls == ["/tmp/pending-photo"]
+        assert handled[0].media_types == ["image/png"]
+        assert handled[0].message_type is MessageType.PHOTO
+
+    @pytest.mark.asyncio
+    async def test_same_guid_isolated_by_exact_chat_and_sender(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        adapter._message_revision_wait_seconds = 0.01
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_download_attachment(att_guid, att_meta):
+            return f"/tmp/{att_guid}"
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download_attachment)
+        guid = "provider-collision-guid"
+        payloads = [
+            {
+                "guid": guid,
+                "text": "dm media",
+                "handle": {"address": "same@example.com"},
+                "isFromMe": False,
+                "chatGuid": "iMessage;-;same@example.com",
+                "chatIdentifier": "same@example.com",
+                "attachments": [{"guid": "dm-photo", "mimeType": "image/png"}],
+            },
+            {
+                "guid": guid,
+                "text": "group from same sender",
+                "handle": {"address": "same@example.com"},
+                "isFromMe": False,
+                "isGroup": True,
+                "chatGuid": "iMessage;+;shared-group",
+                "chatIdentifier": "shared-group",
+            },
+            {
+                "guid": guid,
+                "text": "group from other sender",
+                "handle": {"address": "other@example.com"},
+                "isFromMe": False,
+                "isGroup": True,
+                "chatGuid": "iMessage;+;shared-group",
+                "chatIdentifier": "shared-group",
+            },
+        ]
+
+        await asyncio.gather(*(
+            adapter._handle_webhook(_FakeBlueBubblesRequest({
+                "type": "updated-message",
+                "data": payload,
+            }))
+            for payload in payloads
+        ))
+        await asyncio.sleep(0.04)
+
+        assert sorted(event.text for event in handled) == sorted(
+            payload["text"] for payload in payloads
+        )
+        assert all(event.message_id == guid for event in handled)
+        assert {event.text: event.media_urls for event in handled} == {
+            "dm media": ["/tmp/dm-photo"],
+            "group from same sender": [],
+            "group from other sender": [],
+        }
+
+    @pytest.mark.asyncio
+    async def test_same_identifier_different_chat_guids_do_not_coalesce(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        adapter._message_revision_wait_seconds = 0.01
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        base = {
+            "guid": "shared-provider-guid",
+            "handle": {"address": "same@example.com"},
+            "isFromMe": False,
+            "isGroup": True,
+            "chatIdentifier": "shared-display-name",
+        }
+
+        await asyncio.gather(
+            adapter._handle_webhook(_FakeBlueBubblesRequest({
+                "type": "updated-message",
+                "data": {**base, "chatGuid": "iMessage;+;group-one", "text": "one"},
+            })),
+            adapter._handle_webhook(_FakeBlueBubblesRequest({
+                "type": "updated-message",
+                "data": {**base, "chatGuid": "iMessage;+;group-two", "text": "two"},
+            })),
+        )
+        await asyncio.sleep(0.04)
+
+        assert sorted(event.text for event in handled) == ["one", "two"]
+
+    @pytest.mark.asyncio
+    async def test_failed_text_edit_dispatch_releases_richer_revision_for_retry(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        adapter._message_revision_wait_seconds = 0.01
+        handled = []
+
+        async def flaky_handle_message(event):
+            handled.append(event)
+            if len(handled) == 1:
+                raise RuntimeError("retry merged revision")
+
+        async def fake_download_attachment(att_guid, att_meta):
+            return f"/tmp/{att_guid}"
+
+        monkeypatch.setattr(adapter, "handle_message", flaky_handle_message)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download_attachment)
+        base = {
+            "guid": "failed-attachment-edit-guid",
+            "handle": {"address": "user@example.com"},
+            "isFromMe": False,
+            "chatGuid": "iMessage;-;user@example.com",
+            "chatIdentifier": "user@example.com",
+        }
+        richer_payload = {
+            "type": "updated-message",
+            "data": {
+                **base,
+                "text": "Original caption",
+                "attachments": [
+                    {"guid": "retry-photo", "mimeType": "image/png"}
+                ],
+            },
+        }
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest(richer_payload))
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {**base, "text": "Edited caption"},
+        }))
+        await asyncio.sleep(0.03)
+        await adapter._handle_webhook(_FakeBlueBubblesRequest(richer_payload))
+        await asyncio.sleep(0.03)
+
+        assert len(handled) == 2
+        assert handled[0].text == "Edited caption"
+        assert handled[0].media_urls == ["/tmp/retry-photo"]
+        assert handled[1].media_urls == ["/tmp/retry-photo"]
+
+    @pytest.mark.asyncio
+    async def test_failed_rich_dispatch_sparse_retry_restores_media(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        adapter._message_revision_wait_seconds = 0.01
+        handled = []
+
+        async def flaky_handle_message(event):
+            handled.append(event)
+            if len(handled) == 1:
+                raise RuntimeError("retry sparse revision")
+
+        async def fake_download_attachment(att_guid, att_meta):
+            return f"/tmp/{att_guid}"
+
+        monkeypatch.setattr(adapter, "handle_message", flaky_handle_message)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download_attachment)
+        base = {
+            "guid": "failed-rich-sparse-retry-guid",
+            "handle": {"address": "user@example.com"},
+            "isFromMe": False,
+            "chatGuid": "iMessage;-;user@example.com",
+            "chatIdentifier": "user@example.com",
+        }
+        sparse_payload = {
+            "type": "updated-message",
+            "data": {**base, "text": "Newest caption"},
+        }
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {
+                **base,
+                "text": "Older caption",
+                "attachments": [
+                    {"guid": "retry-from-context-photo", "mimeType": "image/png"}
+                ],
+            },
+        }))
+        await adapter._handle_webhook(_FakeBlueBubblesRequest(sparse_payload))
+        await asyncio.sleep(0.03)
+        await adapter._handle_webhook(_FakeBlueBubblesRequest(sparse_payload))
+        await asyncio.sleep(0.03)
+
+        assert [event.text for event in handled] == ["Newest caption", "Newest caption"]
+        assert [event.media_urls for event in handled] == [
+            ["/tmp/retry-from-context-photo"],
+            ["/tmp/retry-from-context-photo"],
+        ]
+        assert adapter._message_revision_media == {}
+
+    @pytest.mark.asyncio
+    async def test_in_progress_attachment_download_extends_coalesce_window(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        adapter._message_revision_wait_seconds = 0.01
+        download_started = asyncio.Event()
+        release_download = asyncio.Event()
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_download_attachment(att_guid, att_meta):
+            download_started.set()
+            await release_download.wait()
+            return f"/tmp/{att_guid}"
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download_attachment)
+        base = {
+            "guid": "slow-attachment-guid",
+            "text": "Please inspect this",
+            "handle": {"address": "user@example.com"},
+            "isFromMe": False,
+            "chatGuid": "iMessage;-;user@example.com",
+            "chatIdentifier": "user@example.com",
+        }
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": base,
+        }))
+        updated_task = asyncio.create_task(
+            adapter._handle_webhook(_FakeBlueBubblesRequest({
+                "type": "updated-message",
+                "data": {
+                    **base,
+                    "attachments": [
+                        {"guid": "slow-photo", "mimeType": "image/png"}
+                    ],
+                },
+            }))
+        )
+        await download_started.wait()
+        await asyncio.sleep(0.03)
+        assert handled == []
+
+        release_download.set()
+        await updated_task
+        await asyncio.sleep(0.03)
+
+        assert len(handled) == 1
+        assert handled[0].media_urls == ["/tmp/slow-photo"]
+
+    @pytest.mark.asyncio
+    async def test_cancelled_attachment_download_releases_coalesce_hold(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        adapter._message_revision_wait_seconds = 0.01
+        download_started = asyncio.Event()
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_download_attachment(att_guid, att_meta):
+            download_started.set()
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download_attachment)
+        base = {
+            "guid": "cancelled-download-guid",
+            "text": "Keep this caption",
+            "handle": {"address": "user@example.com"},
+            "isFromMe": False,
+            "chatGuid": "iMessage;-;user@example.com",
+            "chatIdentifier": "user@example.com",
+        }
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": base,
+        }))
+        updated_task = asyncio.create_task(
+            adapter._handle_webhook(_FakeBlueBubblesRequest({
+                "type": "updated-message",
+                "data": {
+                    **base,
+                    "attachments": [
+                        {"guid": "cancelled-photo", "mimeType": "image/png"}
+                    ],
+                },
+            }))
+        )
+        await download_started.wait()
+        updated_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await updated_task
+        await asyncio.sleep(0.03)
+
+        assert [event.text for event in handled] == ["Keep this caption"]
+        assert adapter._active_attachment_revisions == {}
+
+    @pytest.mark.asyncio
+    async def test_cancellation_after_download_releases_coalesce_hold(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        adapter._message_revision_wait_seconds = 0.01
+        queue_started = asyncio.Event()
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_download_attachment(att_guid, att_meta):
+            return f"/tmp/{att_guid}"
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download_attachment)
+        base = {
+            "guid": "cancelled-after-download-guid",
+            "text": "Keep this caption",
+            "handle": {"address": "user@example.com"},
+            "isFromMe": False,
+            "chatGuid": "iMessage;-;user@example.com",
+            "chatIdentifier": "user@example.com",
+        }
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": base,
+        }))
+
+        async def blocking_queue(*args, **kwargs):
+            queue_started.set()
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(adapter, "_queue_message_revision", blocking_queue)
+        updated_task = asyncio.create_task(
+            adapter._handle_webhook(_FakeBlueBubblesRequest({
+                "type": "updated-message",
+                "data": {
+                    **base,
+                    "attachments": [
+                        {"guid": "downloaded-photo", "mimeType": "image/png"}
+                    ],
+                },
+            }))
+        )
+        await queue_started.wait()
+        updated_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await updated_task
+        await asyncio.sleep(0.03)
+
+        assert [event.text for event in handled] == ["Keep this caption"]
+        assert adapter._active_attachment_revisions == {}
+        assert adapter._pending_message_identities == set()
+
+    @pytest.mark.asyncio
+    async def test_slow_older_attachment_revision_cannot_replace_newer(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        adapter._message_revision_wait_seconds = 0.01
+        slow_started = asyncio.Event()
+        release_slow = asyncio.Event()
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_download_attachment(att_guid, att_meta):
+            if att_guid == "older-photo":
+                slow_started.set()
+                await release_slow.wait()
+            return f"/tmp/{att_guid}"
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download_attachment)
+        base = {
+            "guid": "out-of-order-guid",
+            "text": "Inspect the latest photo",
+            "handle": {"address": "user@example.com"},
+            "isFromMe": False,
+            "chatGuid": "iMessage;-;user@example.com",
+            "chatIdentifier": "user@example.com",
+        }
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": base,
+        }))
+        older_task = asyncio.create_task(
+            adapter._handle_webhook(_FakeBlueBubblesRequest({
+                "type": "updated-message",
+                "data": {
+                    **base,
+                    "attachments": [
+                        {"guid": "older-photo", "mimeType": "image/png"}
+                    ],
+                },
+            }))
+        )
+        await slow_started.wait()
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {
+                **base,
+                "attachments": [
+                    {"guid": "newer-photo", "mimeType": "image/png"}
+                ],
+            },
+        }))
+        release_slow.set()
+        await older_task
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {
+                **base,
+                "attachments": [
+                    {"guid": "older-photo", "mimeType": "image/png"}
+                ],
+            },
+        }))
+        await asyncio.sleep(0.03)
+
+        assert len(handled) == 1
+        assert handled[0].media_urls == ["/tmp/newer-photo"]
+
+    @pytest.mark.asyncio
+    async def test_slow_older_rich_revision_merges_into_newer_sparse_text(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        adapter._message_revision_wait_seconds = 0.01
+        slow_started = asyncio.Event()
+        release_slow = asyncio.Event()
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_download_attachment(att_guid, att_meta):
+            slow_started.set()
+            await release_slow.wait()
+            return f"/tmp/{att_guid}"
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download_attachment)
+        base = {
+            "guid": "older-rich-newer-sparse-guid",
+            "handle": {"address": "user@example.com"},
+            "isFromMe": False,
+            "chatGuid": "iMessage;-;user@example.com",
+            "chatIdentifier": "user@example.com",
+        }
+
+        older_task = asyncio.create_task(
+            adapter._handle_webhook(_FakeBlueBubblesRequest({
+                "type": "updated-message",
+                "data": {
+                    **base,
+                    "text": "Older caption",
+                    "attachments": [
+                        {"guid": "slow-rich-photo", "mimeType": "image/png"}
+                    ],
+                },
+            }))
+        )
+        await slow_started.wait()
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {**base, "text": "Newest caption"},
+        }))
+        release_slow.set()
+        await older_task
+        await asyncio.sleep(0.03)
+
+        assert len(handled) == 1
+        assert handled[0].text == "Newest caption"
+        assert handled[0].media_urls == ["/tmp/slow-rich-photo"]
+        assert handled[0].message_id == base["guid"]
+
+    @pytest.mark.asyncio
+    async def test_retry_of_superseded_revision_cannot_replace_richer_revision(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        adapter._message_revision_wait_seconds = 0.02
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_download_attachment(att_guid, att_meta):
+            return f"/tmp/{att_guid}"
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download_attachment)
+        base = {
+            "guid": "superseded-retry-guid",
+            "text": "Inspect this image",
+            "handle": {"address": "user@example.com"},
+            "isFromMe": False,
+            "chatGuid": "iMessage;-;user@example.com",
+            "chatIdentifier": "user@example.com",
+        }
+        text_payload = {"type": "new-message", "data": base}
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest(text_payload))
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {
+                **base,
+                "attachments": [
+                    {"guid": "richer-photo", "mimeType": "image/png"}
+                ],
+            },
+        }))
+        await adapter._handle_webhook(_FakeBlueBubblesRequest(text_payload))
+        await asyncio.sleep(0.05)
+
+        assert len(handled) == 1
+        assert handled[0].media_urls == ["/tmp/richer-photo"]
+
+    @pytest.mark.asyncio
+    async def test_group_attachment_revision_inherits_accepted_caption(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            require_mention=True,
+            send_read_receipts=False,
+        )
+        adapter._message_revision_wait_seconds = 0.02
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_download_attachment(att_guid, att_meta):
+            return f"/tmp/{att_guid}"
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download_attachment)
+        base = {
+            "guid": "group-split-guid",
+            "handle": {"address": "user@example.com"},
+            "isFromMe": False,
+            "isGroup": True,
+            "chatGuid": "iMessage;+;family-group",
+            "chatIdentifier": "family-group",
+        }
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {**base, "text": "Hermes, what is this?"},
+        }))
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {
+                **base,
+                "text": "",
+                "attachments": [
+                    {"guid": "group-photo", "mimeType": "image/png"}
+                ],
+            },
+        }))
+        await asyncio.sleep(0.05)
+
+        assert len(handled) == 1
+        assert handled[0].text == "what is this?"
+        assert handled[0].media_urls == ["/tmp/group-photo"]
+
+    @pytest.mark.asyncio
+    async def test_late_group_attachment_revision_keeps_accepted_caption(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            require_mention=True,
+            send_read_receipts=False,
+        )
+        adapter._message_revision_wait_seconds = 0.01
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_download_attachment(att_guid, att_meta):
+            return f"/tmp/{att_guid}"
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download_attachment)
+        base = {
+            "guid": "late-group-split-guid",
+            "handle": {"address": "user@example.com"},
+            "isFromMe": False,
+            "isGroup": True,
+            "chatGuid": "iMessage;+;family-group",
+            "chatIdentifier": "family-group",
+        }
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {**base, "text": "Hermes, identify this"},
+        }))
+        await asyncio.sleep(0.03)
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {
+                **base,
+                "text": "",
+                "attachments": [
+                    {"guid": "late-group-photo", "mimeType": "image/png"}
+                ],
+            },
+        }))
+        await asyncio.sleep(0.03)
+
+        assert [event.text for event in handled] == [
+            "identify this",
+            "identify this",
+        ]
+        assert handled[-1].media_urls == ["/tmp/late-group-photo"]
+
+    @pytest.mark.asyncio
+    async def test_group_caption_is_not_inherited_across_sender_or_chat(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            require_mention=True,
+            send_read_receipts=False,
+        )
+        adapter._message_revision_wait_seconds = 0.02
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_download_attachment(att_guid, att_meta):
+            return f"/tmp/{att_guid}"
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download_attachment)
+        guid = "defensive-collision-guid"
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": guid,
+                "text": "Hermes, private caption",
+                "handle": {"address": "first@example.com"},
+                "isFromMe": False,
+                "isGroup": True,
+                "chatGuid": "iMessage;+;first-group",
+                "chatIdentifier": "first-group",
+            },
+        }))
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {
+                "guid": guid,
+                "text": "",
+                "handle": {"address": "second@example.com"},
+                "isFromMe": False,
+                "isGroup": True,
+                "chatGuid": "iMessage;+;second-group",
+                "chatIdentifier": "second-group",
+                "attachments": [
+                    {"guid": "unrelated-photo", "mimeType": "image/png"}
+                ],
+            },
+        }))
+        await asyncio.sleep(0.05)
+
+        assert [event.text for event in handled] == ["private caption"]
+        assert handled[0].media_urls == []
+
+    @pytest.mark.asyncio
+    async def test_late_revision_does_not_cancel_in_flight_dispatch(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        adapter._message_revision_wait_seconds = 0.01
+        started = asyncio.Event()
+        release = asyncio.Event()
+        cancelled = False
+        handled = []
+
+        async def fake_handle_message(event):
+            nonlocal cancelled
+            handled.append(event.text)
+            if len(handled) == 1:
+                started.set()
+                try:
+                    await release.wait()
+                except asyncio.CancelledError:
+                    cancelled = True
+                    raise
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        base = {
+            "guid": "late-revision-guid",
+            "handle": {"address": "user@example.com"},
+            "isFromMe": False,
+            "chatGuid": "iMessage;-;user@example.com",
+            "chatIdentifier": "user@example.com",
+        }
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {**base, "text": "first revision"},
+        }))
+        await started.wait()
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {**base, "text": "late revision"},
+        }))
+        await asyncio.sleep(0.03)
+        release.set()
+        await asyncio.sleep(0)
+
+        assert cancelled is False
+        assert handled == ["first revision", "late revision"]
+
+    @pytest.mark.asyncio
+    async def test_shutdown_clears_pending_revision_state(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        adapter._message_revision_wait_seconds = 60
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "shutdown-pending-guid",
+                "text": "held during shutdown",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chatGuid": "iMessage;-;user@example.com",
+                "chatIdentifier": "user@example.com",
+            },
+        }))
+
+        await adapter.cancel_background_tasks()
+
+        assert handled == []
+        assert adapter._pending_message_revisions == {}
+        assert adapter._pending_message_revision_tasks == {}
+        assert adapter._pending_message_identities == set()
+
+    @pytest.mark.asyncio
+    async def test_attachment_readiness_transition_is_processed(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        adapter._message_revision_wait_seconds = 0.02
+        handled = []
+        downloads = 0
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_download_attachment(att_guid, att_meta):
+            nonlocal downloads
+            downloads += 1
+            return None if downloads == 1 else f"/tmp/{att_guid}"
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download_attachment)
+        payload = {
+            "type": "updated-message",
+            "data": {
+                "guid": "attachment-ready-guid",
+                "text": "caption",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chatGuid": "iMessage;-;user@example.com",
+                "chatIdentifier": "user@example.com",
+                "attachments": [{"guid": "same-attachment", "mimeType": "image/png"}],
+            },
+        }
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        await asyncio.sleep(0)
+        await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        await asyncio.sleep(0.05)
+
+        assert [event.media_urls for event in handled] == [
+            ["/tmp/same-attachment"],
+        ]
+
+    @pytest.mark.asyncio
+    async def test_failed_dispatch_releases_guid_for_retry(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        attempts = 0
+        handled = []
+
+        async def fake_handle_message(event):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise RuntimeError("transient dispatch failure")
+            handled.append(event.text)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        payload = {
+            "type": "new-message",
+            "data": {
+                "guid": "retryable-message-guid",
+                "text": "retry me",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chatGuid": "iMessage;-;user@example.com",
+                "chatIdentifier": "user@example.com",
+            },
+        }
+
+        first = await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        await asyncio.sleep(0)
+        second = await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        await asyncio.sleep(0)
+
+        assert first.status == 200
+        assert second.status == 200
+        assert attempts == 2
+        assert handled == ["retry me"]
+
+    @pytest.mark.asyncio
+    async def test_cancelled_dispatch_releases_identity_for_retry(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        attempts = 0
+        handled = []
+
+        async def fake_handle_message(event):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise asyncio.CancelledError()
+            handled.append(event.text)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        payload = {
+            "type": "new-message",
+            "data": {
+                "guid": "cancelled-message-guid",
+                "text": "retry cancellation",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chatGuid": "iMessage;-;user@example.com",
+                "chatIdentifier": "user@example.com",
+            },
+        }
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        await asyncio.sleep(0)
+        await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        await asyncio.sleep(0)
+
+        assert attempts == 2
+        assert handled == ["retry cancellation"]
+
+    @pytest.mark.asyncio
+    async def test_pending_identity_is_not_evicted_by_completed_lru(self, monkeypatch):
+        import gateway.platforms.bluebubbles as bluebubbles_module
+
+        monkeypatch.setattr(bluebubbles_module, "_MESSAGE_DEDUP_SIZE", 1)
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        started = asyncio.Event()
+        release = asyncio.Event()
+        attempts = {"pending-guid": 0, "completed-guid": 0}
+
+        async def fake_handle_message(event):
+            attempts[event.message_id] += 1
+            if event.message_id == "pending-guid":
+                started.set()
+                await release.wait()
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+
+        def payload(guid, text):
+            return {
+                "type": "new-message",
+                "data": {
+                    "guid": guid,
+                    "text": text,
+                    "handle": {"address": "user@example.com"},
+                    "isFromMe": False,
+                    "chatGuid": "iMessage;-;user@example.com",
+                    "chatIdentifier": "user@example.com",
+                },
+            }
+
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(payload("pending-guid", "still running"))
+        )
+        await started.wait()
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(payload("completed-guid", "done"))
+        )
+        await asyncio.sleep(0)
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(payload("pending-guid", "still running"))
+        )
+        await asyncio.sleep(0)
+        pending_attempts = attempts["pending-guid"]
+        release.set()
+        await asyncio.sleep(0)
+
+        assert pending_attempts == 1
 
 
 class TestBlueBubblesWebhookParsing:
 
-    def test_webhook_can_fall_back_to_sender_when_chat_fields_missing(self, monkeypatch):
-        adapter = _make_adapter(monkeypatch)
-        payload = {
-            "data": {
-                "guid": "MESSAGE-GUID",
-                "text": "hello",
-                "handle": {"address": "user@example.com"},
-                "isFromMe": False,
-            }
-        }
-        record = adapter._extract_payload_record(payload) or {}
-        chat_guid = adapter._value(
-            record.get("chatGuid"),
-            payload.get("chatGuid"),
-            record.get("chat_guid"),
-            payload.get("chat_guid"),
-            payload.get("guid"),
-        )
-        chat_identifier = adapter._value(
-            record.get("chatIdentifier"),
-            record.get("identifier"),
-            payload.get("chatIdentifier"),
-            payload.get("identifier"),
-        )
-        sender = (
-            adapter._value(
-                record.get("handle", {}).get("address")
-                if isinstance(record.get("handle"), dict)
-                else None,
-                record.get("sender"),
-                record.get("from"),
-                record.get("address"),
+    @pytest.mark.asyncio
+    async def test_unresolved_inbound_event_never_routes_to_sender_dm(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def unresolved(message_guid):
+            return None
+
+        monkeypatch.setattr(adapter, "_resolve_exact_message_chat_guid", unresolved)
+        monkeypatch.setattr(adapter, "handle_message", handled.append)
+
+        response = await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "new-message",
+                    "data": {
+                        "guid": "unresolved-sender-guid",
+                        "text": "must remain unresolved",
+                        "handle": {"address": "user@example.com"},
+                        "isFromMe": False,
+                    },
+                }
             )
-            or chat_identifier
-            or chat_guid
         )
-        if not (chat_guid or chat_identifier) and sender:
-            chat_identifier = sender
-        assert chat_identifier == "user@example.com"
+        await asyncio.sleep(0)
+
+        assert response.status == 200
+        assert handled == []
 
 
     def test_extract_payload_record_accepts_list_data(self, monkeypatch):
@@ -176,6 +4382,45 @@ class TestBlueBubblesWebhookParsing:
 
 
 class TestBlueBubblesGuidResolution:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("data", "expected"),
+        [
+            (
+                {
+                    "guid": "message/guid",
+                    "chats": [{"guid": "iMessage;-;user@example.com"}],
+                },
+                "iMessage;-;user@example.com",
+            ),
+            ({"guid": "other-guid", "chats": [{"guid": "chat-a"}]}, None),
+            ({"guid": "message/guid", "chats": []}, None),
+            (
+                {
+                    "guid": "message/guid",
+                    "chats": [{"guid": "chat-a"}, {"guid": "chat-b"}],
+                },
+                None,
+            ),
+            ({"guid": "message/guid", "chats": [None, {}]}, None),
+        ],
+    )
+    async def test_exact_message_chat_resolution_requires_one_membership(
+        self, monkeypatch, data, expected
+    ):
+        adapter = _make_adapter(monkeypatch)
+        adapter.client = object()
+        requests = []
+
+        async def fake_api_get(path):
+            requests.append(path)
+            return {"data": data}
+
+        monkeypatch.setattr(adapter, "_api_get", fake_api_get)
+
+        assert await adapter._resolve_exact_message_chat_guid("message/guid") == expected
+        assert requests == ["/api/v1/message/message%2Fguid?with=chats"]
+
 
 
     @pytest.mark.asyncio
@@ -234,6 +4479,231 @@ class TestBlueBubblesGuidResolution:
         monkeypatch.setattr(adapter, "_api_post", fake_api_post)
         await adapter._resolve_chat_guid("user@example.com")
         assert "user@example.com" not in adapter._guid_cache
+
+
+class TestBlueBubblesAttachmentReadiness:
+    @staticmethod
+    def _payload(*, attachments=None, text="inspect this"):
+        data = {
+            "guid": "attachment-readiness-guid",
+            "text": text,
+            "handle": {"address": "user@example.com"},
+            "isFromMe": False,
+            "chatGuid": "iMessage;-;user@example.com",
+            "chatIdentifier": "user@example.com",
+        }
+        if attachments is not None:
+            data["attachments"] = attachments
+        return {"type": "updated-message", "data": data}
+
+    @pytest.mark.asyncio
+    async def test_message_without_attachments_dispatches_immediately(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+        monkeypatch.setattr(adapter, "handle_message", handled.append)
+
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(self._payload(attachments=None))
+        )
+        await asyncio.sleep(0)
+
+        assert [event.media_urls for event in handled] == [[]]
+
+    @pytest.mark.asyncio
+    async def test_immediately_ready_attachments_dispatch_together(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+        monkeypatch.setattr(adapter, "handle_message", handled.append)
+        monkeypatch.setattr(
+            adapter,
+            "_download_attachment",
+            lambda guid, _meta: asyncio.sleep(0, result=f"/tmp/{guid}"),
+        )
+
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                self._payload(
+                    attachments=[
+                        {"guid": "ready-a", "mimeType": "image/png"},
+                        {"guid": "ready-b", "mimeType": "image/jpeg"},
+                    ]
+                )
+            )
+        )
+        await asyncio.sleep(0)
+
+        assert [event.media_urls for event in handled] == [
+            ["/tmp/ready-a", "/tmp/ready-b"]
+        ]
+
+    @pytest.mark.asyncio
+    async def test_delayed_attachment_readiness_defers_and_retries_once(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(
+            monkeypatch,
+            send_read_receipts=False,
+            attachment_retry_delay_seconds=0.01,
+        )
+        handled = []
+        downloads = 0
+
+        async def download(guid, _meta):
+            nonlocal downloads
+            downloads += 1
+            return None if downloads == 1 else f"/tmp/{guid}"
+
+        async def refreshed(_chat_guid, _message_guid, **_kwargs):
+            return self._payload(
+                attachments=[
+                    {
+                        "guid": "delayed-photo",
+                        "mimeType": "image/png",
+                        "transferState": 5,
+                    }
+                ]
+            )["data"]
+
+        monkeypatch.setattr(adapter, "handle_message", handled.append)
+        monkeypatch.setattr(adapter, "_download_attachment", download)
+        monkeypatch.setattr(adapter, "_query_exact_message", refreshed)
+
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                self._payload(
+                    attachments=[
+                        {"guid": "delayed-photo", "mimeType": "image/png"}
+                    ]
+                )
+            )
+        )
+        assert handled == []
+        await asyncio.sleep(0.05)
+
+        assert [event.media_urls for event in handled] == [["/tmp/delayed-photo"]]
+        assert downloads == 2
+
+    @pytest.mark.asyncio
+    async def test_mixed_attachment_readiness_never_emits_partial_media(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(
+            monkeypatch,
+            send_read_receipts=False,
+            attachment_retry_delay_seconds=0.01,
+        )
+        handled = []
+        attempts = {}
+
+        async def download(guid, _meta):
+            attempts[guid] = attempts.get(guid, 0) + 1
+            if guid == "pending-b" and attempts[guid] == 1:
+                return None
+            return f"/tmp/{guid}"
+
+        async def refreshed(_chat_guid, _message_guid, **_kwargs):
+            return self._payload(
+                attachments=[
+                    {"guid": "ready-a", "mimeType": "image/png", "transferState": 5},
+                    {"guid": "pending-b", "mimeType": "image/jpeg", "transferState": 5},
+                ]
+            )["data"]
+
+        monkeypatch.setattr(adapter, "handle_message", handled.append)
+        monkeypatch.setattr(adapter, "_download_attachment", download)
+        monkeypatch.setattr(adapter, "_query_exact_message", refreshed)
+
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                self._payload(
+                    attachments=[
+                        {"guid": "ready-a", "mimeType": "image/png"},
+                        {"guid": "pending-b", "mimeType": "image/jpeg"},
+                    ]
+                )
+            )
+        )
+        assert handled == []
+        await asyncio.sleep(0.05)
+
+        assert [event.media_urls for event in handled] == [
+            ["/tmp/ready-a", "/tmp/pending-b"]
+        ]
+
+    @pytest.mark.asyncio
+    async def test_newer_revision_removing_attachment_cancels_pending_materialization(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(
+            monkeypatch,
+            send_read_receipts=False,
+            attachment_retry_delay_seconds=0.01,
+        )
+        handled = []
+        monkeypatch.setattr(adapter, "handle_message", handled.append)
+        monkeypatch.setattr(
+            adapter,
+            "_download_attachment",
+            lambda *_args: asyncio.sleep(0, result=None),
+        )
+
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                self._payload(
+                    attachments=[
+                        {"guid": "removed-photo", "mimeType": "image/png"}
+                    ],
+                    text="old revision",
+                )
+            )
+        )
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                self._payload(attachments=[], text="new revision without photo")
+            )
+        )
+        await asyncio.sleep(0.05)
+
+        assert [(event.text, event.media_urls) for event in handled] == [
+            ("new revision without photo", [])
+        ]
+
+    @pytest.mark.asyncio
+    async def test_terminal_attachment_failure_drops_revision_without_dispatch(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+        downloads = []
+
+        async def download(guid, _meta):
+            downloads.append(guid)
+            return f"/tmp/{guid}"
+
+        monkeypatch.setattr(adapter, "handle_message", handled.append)
+        monkeypatch.setattr(adapter, "_download_attachment", download)
+
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                self._payload(
+                    attachments=[
+                        {
+                            "guid": "failed-photo",
+                            "mimeType": "image/png",
+                            "error": 1,
+                        }
+                    ]
+                )
+            )
+        )
+        await asyncio.sleep(0)
+
+        assert handled == []
+        assert downloads == []
 
 
 class TestBlueBubblesAttachmentDownload:
@@ -326,6 +4796,7 @@ class TestBlueBubblesWebhookUrl:
     """_webhook_url property normalises local hosts to 'localhost'."""
 
     def test_default_host(self, monkeypatch):
+        monkeypatch.delenv("BLUEBUBBLES_WEBHOOK_HOST", raising=False)
         adapter = _make_adapter(monkeypatch)
         # Default webhook_host is 0.0.0.0 → normalized to localhost
         assert "localhost" in adapter._webhook_url
@@ -479,8 +4950,6 @@ class TestBlueBubblesWebhookRegistration:
         )
         assert ok is True
         assert len(deleted_ids) == 2
-
-
 # ---------------------------------------------------------------------------
 # Regression for #78183: httpx timeout exceptions stringify to "" which
 # defeats _is_timeout_error, causing the plain-text fallback to re-send an
@@ -565,5 +5034,4 @@ class TestBlueBubblesTimeoutErrorNormalization:
 
         assert not result.success
         assert "500 Internal Server Error" in (result.error or "")
-
 

--- a/tests/gateway/test_bluebubbles_inbound_tapbacks.py
+++ b/tests/gateway/test_bluebubbles_inbound_tapbacks.py
@@ -1,0 +1,199 @@
+"""Inbound BlueBubbles Tapbacks stay local, idempotent, and non-conversational."""
+
+import asyncio
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.bluebubbles import BlueBubblesAdapter
+from gateway.reactions import TapbackAction, TapbackStatus
+
+
+def _adapter(monkeypatch) -> BlueBubblesAdapter:
+    monkeypatch.setenv("BLUEBUBBLES_SERVER_URL", "http://localhost:1234")
+    monkeypatch.setenv("BLUEBUBBLES_PASSWORD", "secret")
+    adapter = BlueBubblesAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "server_url": "http://localhost:1234",
+                "password": "secret",
+                "message_revision_wait_seconds": 0,
+            },
+        )
+    )
+    adapter.set_authorization_check(lambda _user_id, _chat_type, _chat_id: True)
+    return adapter
+
+
+def _payload(associated_type) -> dict:
+    return {
+        "type": "new-message",
+        "data": {
+            "guid": "reaction-event-guid",
+            "text": "must not become a conversational message",
+            "associatedMessageType": associated_type,
+            "associatedMessageGuid": "p:0/target-message-guid",
+            "handle": {"address": "sender@example.com"},
+            "isFromMe": False,
+            "isGroup": True,
+            "chatGuid": "iMessage;+;exact-chat-guid",
+            "chatIdentifier": "family",
+        },
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("associated_type", [2006, "3999", {"malformed": True}])
+async def test_unsupported_or_malformed_reaction_never_becomes_a_message(
+    monkeypatch, associated_type
+):
+    adapter = _adapter(monkeypatch)
+    normal_messages = []
+    platform_events = []
+    outbound_reactions = []
+
+    async def exact_membership(_message_guid, candidate_chat_guid):
+        return candidate_chat_guid
+
+    async def capture_message(event):
+        normal_messages.append(event)
+
+    async def capture_platform_event(event, source):
+        platform_events.append((event, source))
+
+    async def capture_outbound(*args, **kwargs):
+        outbound_reactions.append((args, kwargs))
+        raise AssertionError("inbound Tapbacks must never emit outbound Tapbacks")
+
+    monkeypatch.setattr(adapter, "_verify_inbound_message_membership", exact_membership)
+    monkeypatch.setattr(adapter, "handle_message", capture_message)
+    monkeypatch.setattr(adapter, "send_reaction", capture_outbound)
+    adapter.set_platform_event_handler(capture_platform_event)
+
+    response = await adapter._handle_webhook(object(), _trusted_payload=_payload(associated_type))
+    await asyncio.sleep(0)
+
+    assert response.status == 200
+    assert normal_messages == []
+    assert platform_events == []
+    assert outbound_reactions == []
+    assert adapter._tapback_event_states == {}
+
+
+@pytest.mark.asyncio
+async def test_removal_from_one_sender_preserves_other_sender_and_never_sends_outbound(
+    monkeypatch,
+):
+    adapter = _adapter(monkeypatch)
+    platform_events = []
+    outbound_reactions = []
+
+    async def capture_platform_event(event, source):
+        platform_events.append((event, source))
+
+    async def capture_outbound(*args, **kwargs):
+        outbound_reactions.append((args, kwargs))
+        raise AssertionError("inbound Tapbacks must never emit outbound Tapbacks")
+
+    adapter.set_platform_event_handler(capture_platform_event)
+    monkeypatch.setattr(adapter, "send_reaction", capture_outbound)
+
+    common = {
+        "payload": {"type": "updated-message"},
+        "target_guid": "target-message-guid",
+        "part_index": 0,
+        "session_chat_id": "iMessage;+;exact-chat-guid",
+        "chat_identifier": "family",
+        "is_group": True,
+    }
+    await adapter._dispatch_inbound_tapback(
+        **common,
+        tapback=("added", "like"),
+        sender="first@example.com",
+        message_guid="first-add-guid",
+    )
+    await adapter._dispatch_inbound_tapback(
+        **common,
+        tapback=("added", "love"),
+        sender="second@example.com",
+        message_guid="second-add-guid",
+    )
+    await adapter._dispatch_inbound_tapback(
+        **common,
+        tapback=("removed", "like"),
+        sender="first@example.com",
+        message_guid="first-remove-guid",
+    )
+
+    assert outbound_reactions == []
+    assert [event["payload"]["action"] for event, _source in platform_events] == [
+        "added",
+        "added",
+        "removed",
+    ]
+    assert len(adapter._tapback_event_states) == 2
+    states = {
+        operation.sender_id: operation
+        for operation, _serial in adapter._tapback_event_states.values()
+    }
+    assert states["first@example.com"].action is TapbackAction.REMOVE
+    assert states["first@example.com"].status is TapbackStatus.APPLIED
+    assert states["second@example.com"].action is TapbackAction.ADD
+    assert states["second@example.com"].status is TapbackStatus.APPLIED
+
+
+@pytest.mark.asyncio
+async def test_out_of_order_replay_and_overlapping_participants_stay_chat_local(monkeypatch):
+    adapter = _adapter(monkeypatch)
+    platform_events = []
+    outbound_reactions = []
+
+    async def capture_platform_event(event, source):
+        platform_events.append((event, source))
+
+    async def capture_outbound(*args, **kwargs):
+        outbound_reactions.append((args, kwargs))
+        raise AssertionError("inbound Tapbacks must never emit outbound Tapbacks")
+
+    adapter.set_platform_event_handler(capture_platform_event)
+    monkeypatch.setattr(adapter, "send_reaction", capture_outbound)
+    common = {
+        "payload": {"type": "updated-message"},
+        "target_guid": "reused-target-guid",
+        "part_index": 0,
+        "chat_identifier": "same-visible-name",
+        "sender": "shared-participant@example.com",
+        "is_group": True,
+    }
+
+    # A stale add replay after a newer removal is accepted as a state transition,
+    # but its duplicate transport replay is suppressed in that exact chat only.
+    for chat_id, action, source_id in (
+        ("iMessage;+;chat-a", "added", "source-add"),
+        ("iMessage;+;chat-a", "removed", "source-remove"),
+        ("iMessage;+;chat-a", "added", "source-add"),
+        ("iMessage;+;chat-a", "added", "source-add"),
+        ("iMessage;+;chat-b", "added", "source-add"),
+    ):
+        await adapter._dispatch_inbound_tapback(
+            **common,
+            tapback=(action, "like"),
+            session_chat_id=chat_id,
+            message_guid=source_id,
+        )
+
+    assert outbound_reactions == []
+    assert [event["payload"]["chat_id"] for event, _source in platform_events] == [
+        "iMessage;+;chat-a",
+        "iMessage;+;chat-a",
+        "iMessage;+;chat-a",
+        "iMessage;+;chat-b",
+    ]
+    assert [event["payload"]["action"] for event, _source in platform_events] == [
+        "added",
+        "removed",
+        "added",
+        "added",
+    ]
+    assert len(adapter._tapback_event_states) == 2

--- a/tests/gateway/test_bluebubbles_lifecycle.py
+++ b/tests/gateway/test_bluebubbles_lifecycle.py
@@ -1,0 +1,247 @@
+"""Focused cancellation and retry contracts for BlueBubbles revisions."""
+
+import asyncio
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.platforms.bluebubbles import BlueBubblesAdapter
+
+
+def _adapter(monkeypatch, **extra):
+    monkeypatch.setenv("BLUEBUBBLES_SERVER_URL", "http://localhost:1234")
+    monkeypatch.setenv("BLUEBUBBLES_PASSWORD", "secret")
+    return BlueBubblesAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "server_url": "http://localhost:1234",
+                "password": "secret",
+                "message_revision_wait_seconds": 0,
+                "message_retry_max_attempts": 3,
+                "message_retry_base_delay_seconds": 0,
+                **extra,
+            },
+        )
+    )
+
+
+def _event(adapter, text="revision"):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=adapter.build_source(
+            chat_id="iMessage;-;user@example.com",
+            chat_name="user@example.com",
+            chat_type="dm",
+            user_id="user@example.com",
+        ),
+        message_id="stable-guid",
+    )
+
+
+@pytest.mark.asyncio
+async def test_superseding_revision_cancels_active_attempt_before_commit(monkeypatch):
+    adapter = _adapter(monkeypatch)
+    key = ("iMessage;-;user@example.com", "user@example.com", "stable-guid")
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+    release = asyncio.Event()
+    handled = []
+
+    async def handle(event):
+        handled.append(event.text)
+        if event.text == "old":
+            started.set()
+            try:
+                await release.wait()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+    monkeypatch.setattr(adapter, "handle_message", handle)
+    adapter._message_revision_serials[key] = 1
+    old = asyncio.create_task(
+        adapter._handle_reserved_message(_event(adapter, "old"), "old-id", (), key, 1)
+    )
+    await started.wait()
+    adapter._message_revision_serials[key] = 2
+    await asyncio.wait_for(
+        adapter._handle_reserved_message(
+            _event(adapter, "latest"), "latest-id", (), key, 2
+        ),
+        timeout=0.2,
+    )
+    await asyncio.wait_for(old, timeout=0.2)
+
+    assert cancelled.is_set()
+    assert handled == ["old", "latest"]
+    assert "old-id" not in adapter._seen_message_guids
+    assert "latest-id" in adapter._seen_message_guids
+
+
+@pytest.mark.asyncio
+async def test_latest_revision_is_not_cancelled_by_stale_cleanup(monkeypatch):
+    adapter = _adapter(monkeypatch)
+    key = ("iMessage;-;user@example.com", "user@example.com", "stable-guid")
+    latest_started = asyncio.Event()
+    latest_release = asyncio.Event()
+    latest_cancelled = False
+
+    async def handle(event):
+        nonlocal latest_cancelled
+        if event.text == "latest":
+            latest_started.set()
+            try:
+                await latest_release.wait()
+            except asyncio.CancelledError:
+                latest_cancelled = True
+                raise
+        else:
+            await asyncio.Event().wait()
+
+    monkeypatch.setattr(adapter, "handle_message", handle)
+    adapter._message_revision_serials[key] = 1
+    stale = asyncio.create_task(
+        adapter._handle_reserved_message(_event(adapter, "stale"), "stale-id", (), key, 1)
+    )
+    await asyncio.sleep(0)
+    adapter._message_revision_serials[key] = 2
+    latest = asyncio.create_task(
+        adapter._handle_reserved_message(_event(adapter, "latest"), "latest-id", (), key, 2)
+    )
+    await asyncio.wait_for(latest_started.wait(), timeout=0.2)
+    await asyncio.wait_for(stale, timeout=0.2)
+    latest_release.set()
+    await latest
+
+    assert latest_cancelled is False
+    assert "latest-id" in adapter._seen_message_guids
+
+
+@pytest.mark.asyncio
+async def test_transient_failure_recovers_with_same_identity(monkeypatch):
+    adapter = _adapter(monkeypatch)
+    key = ("iMessage;-;user@example.com", "user@example.com", "stable-guid")
+    adapter._message_revision_serials[key] = 1
+    attempts = []
+
+    async def handle(event):
+        attempts.append(event.message_id)
+        if len(attempts) < 3:
+            raise ConnectionError("connection reset")
+
+    monkeypatch.setattr(adapter, "handle_message", handle)
+    await adapter._handle_reserved_message(_event(adapter), "stable-id", (), key, 1)
+
+    assert attempts == ["stable-guid", "stable-guid", "stable-guid"], (
+        "BB-RM-FL-001: transient retries must preserve the inbound identity"
+    )
+    assert "stable-id" in adapter._seen_message_guids
+
+
+@pytest.mark.asyncio
+async def test_retry_exhaustion_is_terminal_and_duplicate_delivery_is_idempotent(monkeypatch):
+    adapter = _adapter(monkeypatch)
+    key = ("iMessage;-;user@example.com", "user@example.com", "stable-guid")
+    adapter._message_revision_serials[key] = 1
+    attempts = 0
+
+    async def handle(_event):
+        nonlocal attempts
+        attempts += 1
+        raise ConnectionError("connection reset")
+
+    monkeypatch.setattr(adapter, "handle_message", handle)
+    await adapter._handle_reserved_message(_event(adapter), "stable-id", (), key, 1)
+    await adapter._handle_reserved_message(_event(adapter), "stable-id", (), key, 1)
+
+    assert attempts == 3, "BB-RM-FL-002: exhausted retries must remain bounded"
+    assert "stable-id" in adapter._terminal_message_identities
+    assert "stable-id" not in adapter._seen_message_guids
+
+
+@pytest.mark.asyncio
+async def test_permanent_failure_is_not_retried(monkeypatch):
+    adapter = _adapter(monkeypatch)
+    key = ("iMessage;-;user@example.com", "user@example.com", "stable-guid")
+    adapter._message_revision_serials[key] = 1
+    attempts = 0
+
+    async def handle(_event):
+        nonlocal attempts
+        attempts += 1
+        raise ValueError("invalid payload")
+
+    monkeypatch.setattr(adapter, "handle_message", handle)
+    await adapter._handle_reserved_message(_event(adapter), "stable-id", (), key, 1)
+
+    assert attempts == 1, "BB-RM-FL-002: permanent failures must not retry"
+    assert "stable-id" in adapter._terminal_message_identities
+    assert "stable-id" not in adapter._seen_message_guids
+
+
+@pytest.mark.asyncio
+async def test_duplicate_retry_delivery_joins_active_attempt(monkeypatch):
+    adapter = _adapter(monkeypatch)
+    key = ("iMessage;-;user@example.com", "user@example.com", "stable-guid")
+    adapter._message_revision_serials[key] = 1
+    started = asyncio.Event()
+    release = asyncio.Event()
+    attempts = 0
+
+    async def handle(_event):
+        nonlocal attempts
+        attempts += 1
+        started.set()
+        await release.wait()
+
+    monkeypatch.setattr(adapter, "handle_message", handle)
+    first = asyncio.create_task(
+        adapter._handle_reserved_message(_event(adapter), "stable-id", (), key, 1)
+    )
+    await started.wait()
+    duplicate = asyncio.create_task(
+        adapter._handle_reserved_message(_event(adapter), "stable-id", (), key, 1)
+    )
+    await asyncio.sleep(0)
+    release.set()
+    await asyncio.wait_for(asyncio.gather(first, duplicate), timeout=0.2)
+
+    assert attempts == 1
+    assert "stable-id" in adapter._seen_message_guids
+
+
+@pytest.mark.asyncio
+async def test_superseding_revision_cancels_obsolete_retry_backoff(monkeypatch):
+    adapter = _adapter(monkeypatch, message_retry_base_delay_seconds=1)
+    key = ("iMessage;-;user@example.com", "user@example.com", "stable-guid")
+    adapter._message_revision_serials[key] = 1
+    failed_once = asyncio.Event()
+    attempts = []
+
+    async def handle(event):
+        attempts.append(event.text)
+        if event.text == "old":
+            failed_once.set()
+            raise ConnectionError("connection reset")
+
+    monkeypatch.setattr(adapter, "handle_message", handle)
+    old = asyncio.create_task(
+        adapter._handle_reserved_message(_event(adapter, "old"), "old-id", (), key, 1)
+    )
+    await failed_once.wait()
+    await asyncio.sleep(0)
+    adapter._message_revision_serials[key] = 2
+    await asyncio.wait_for(
+        adapter._handle_reserved_message(
+            _event(adapter, "latest"), "latest-id", (), key, 2
+        ),
+        timeout=0.2,
+    )
+    await asyncio.wait_for(old, timeout=0.2)
+
+    assert attempts == ["old", "latest"]
+    assert "old-id" not in adapter._seen_message_guids
+    assert "latest-id" in adapter._seen_message_guids

--- a/tests/gateway/test_bluebubbles_reaction_model.py
+++ b/tests/gateway/test_bluebubbles_reaction_model.py
@@ -1,5 +1,7 @@
 """BlueBubbles integration contracts for the shared Tapback model."""
 
+import asyncio
+
 import pytest
 
 from gateway.config import PlatformConfig
@@ -141,6 +143,74 @@ async def test_inbound_add_remove_add_are_distinct_current_state_transitions(mon
         "added",
         "removed",
         "added",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_inbound_tapback_pruning_preserves_in_flight_state(monkeypatch):
+    adapter = _adapter(monkeypatch)
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    events = []
+
+    async def capture(event, _source):
+        events.append(event)
+        if (
+            event["payload"]["message_id"] == "first-target"
+            and sum(
+                item["payload"]["message_id"] == "first-target"
+                for item in events
+            )
+            == 1
+        ):
+            first_started.set()
+            await release_first.wait()
+
+    adapter.set_platform_event_handler(capture)
+    monkeypatch.setattr("gateway.platforms.bluebubbles._MESSAGE_DEDUP_SIZE", 1)
+    common = {
+        "payload": {},
+        "tapback": ("added", "like"),
+        "part_index": 0,
+        "session_chat_id": "iMessage;+;exact-chat",
+        "chat_identifier": "family",
+        "sender": "sender@example.com",
+        "is_group": True,
+    }
+
+    first = asyncio.create_task(
+        adapter._dispatch_inbound_tapback(
+            **common,
+            target_guid="first-target",
+            message_guid="first-event",
+        )
+    )
+    await asyncio.sleep(0)
+    if first.done():
+        await first
+    await asyncio.wait_for(first_started.wait(), timeout=2)
+    await asyncio.wait_for(
+        adapter._dispatch_inbound_tapback(
+            **common,
+            target_guid="second-target",
+            message_guid="second-event",
+        ),
+        timeout=2,
+    )
+    await asyncio.wait_for(
+        adapter._dispatch_inbound_tapback(
+            **common,
+            target_guid="first-target",
+            message_guid="first-event",
+        ),
+        timeout=2,
+    )
+    release_first.set()
+    await asyncio.wait_for(first, timeout=2)
+
+    assert [event["payload"]["message_id"] for event in events] == [
+        "first-target",
+        "second-target",
     ]
 
 

--- a/tests/gateway/test_bluebubbles_reaction_model.py
+++ b/tests/gateway/test_bluebubbles_reaction_model.py
@@ -1,0 +1,169 @@
+"""BlueBubbles integration contracts for the shared Tapback model."""
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.bluebubbles import BlueBubblesAdapter
+
+
+def _adapter(monkeypatch):
+    monkeypatch.setenv("BLUEBUBBLES_SERVER_URL", "http://localhost:1234")
+    monkeypatch.setenv("BLUEBUBBLES_PASSWORD", "secret")
+    return BlueBubblesAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "server_url": "http://localhost:1234",
+                "password": "secret",
+                "message_revision_wait_seconds": 0,
+            },
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_outbound_reaction_uses_exact_resolved_chat_and_target(monkeypatch):
+    adapter = _adapter(monkeypatch)
+    adapter.client = object()
+    adapter._private_api_enabled = True
+    adapter._helper_connected = True
+    posts = []
+
+    async def resolve(_chat_id):
+        return "iMessage;+;exact-family-guid"
+
+    async def exact(chat_id, message_id, **_kwargs):
+        assert (chat_id, message_id) == (
+            "iMessage;+;exact-family-guid",
+            "target-message-guid",
+        )
+        return {"guid": message_id, "chats": [{"guid": chat_id}]}
+
+    async def post(path, payload):
+        posts.append((path, payload))
+        return {"data": {"guid": "reaction-guid"}}
+
+    monkeypatch.setattr(adapter, "_resolve_chat_guid", resolve)
+    monkeypatch.setattr(adapter, "_query_exact_message", exact)
+    monkeypatch.setattr(adapter, "_api_post", post)
+
+    result = await adapter.send_reaction(
+        "family-alias",
+        "target-message-guid",
+        "-like",
+        part_index=2,
+        source_event_id="approved-request-id",
+    )
+
+    assert result.success is True
+    assert posts == [
+        (
+            "/api/v1/message/react",
+            {
+                "chatGuid": "iMessage;+;exact-family-guid",
+                "selectedMessageGuid": "target-message-guid",
+                "reaction": "-like",
+                "partIndex": 2,
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_inbound_shared_model_is_idempotent_and_chat_local(monkeypatch):
+    adapter = _adapter(monkeypatch)
+    events = []
+
+    async def capture(event, _source):
+        events.append(event)
+
+    adapter.set_platform_event_handler(capture)
+    common = {
+        "payload": {"type": "updated-message"},
+        "tapback": ("added", "like"),
+        "target_guid": "reused-target-guid",
+        "part_index": 0,
+        "chat_identifier": "family",
+        "sender": "sender@example.com",
+        "is_group": True,
+        "message_guid": "tapback-source-guid",
+    }
+
+    await adapter._dispatch_inbound_tapback(
+        **common,
+        session_chat_id="iMessage;+;first-chat",
+    )
+    await adapter._dispatch_inbound_tapback(
+        **common,
+        session_chat_id="iMessage;+;first-chat",
+    )
+    await adapter._dispatch_inbound_tapback(
+        **common,
+        session_chat_id="iMessage;+;second-chat",
+    )
+
+    assert [event["payload"]["chat_id"] for event in events] == [
+        "iMessage;+;first-chat",
+        "iMessage;+;second-chat",
+    ]
+    assert events[0]["payload"]["deduplication_key"] != events[1]["payload"]["deduplication_key"]
+    assert all(event["payload"]["direction"] == "inbound" for event in events)
+    assert all(event["payload"]["status"] == "processing" for event in events)
+
+
+@pytest.mark.asyncio
+async def test_inbound_add_remove_add_are_distinct_current_state_transitions(monkeypatch):
+    adapter = _adapter(monkeypatch)
+    events = []
+
+    async def capture(event, _source):
+        events.append(event)
+
+    adapter.set_platform_event_handler(capture)
+    common = {
+        "payload": {},
+        "target_guid": "target-guid",
+        "part_index": 0,
+        "session_chat_id": "iMessage;+;exact-chat",
+        "chat_identifier": "family",
+        "sender": "sender@example.com",
+        "is_group": True,
+        "message_guid": "provider-reused-guid",
+    }
+
+    for action in ("added", "removed", "added"):
+        await adapter._dispatch_inbound_tapback(
+            **common,
+            tapback=(action, "love"),
+        )
+
+    assert [event["payload"]["action"] for event in events] == [
+        "added",
+        "removed",
+        "added",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_inbound_tapback_without_source_event_fails_closed(monkeypatch):
+    adapter = _adapter(monkeypatch)
+    events = []
+
+    async def capture(event, _source):
+        events.append(event)
+
+    adapter.set_platform_event_handler(capture)
+    await adapter._dispatch_inbound_tapback(
+        payload={},
+        tapback=("added", "like"),
+        target_guid="target-guid",
+        part_index=0,
+        session_chat_id="iMessage;+;exact-chat",
+        chat_identifier="family",
+        sender="sender@example.com",
+        is_group=True,
+        message_guid=None,
+    )
+
+    assert events == []
+    assert adapter._tapback_event_states == {}

--- a/tests/gateway/test_bluebubbles_read_receipts.py
+++ b/tests/gateway/test_bluebubbles_read_receipts.py
@@ -1,0 +1,307 @@
+"""Focused lifecycle tests for BlueBubbles read receipts."""
+
+import asyncio
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.bluebubbles import BlueBubblesAdapter
+
+
+def _adapter(**extra):
+    return BlueBubblesAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "server_url": "http://localhost:1234",
+                "password": "secret",
+                **extra,
+            },
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_queued_receipt_survives_helper_cold_boot(monkeypatch):
+    adapter = _adapter()
+    delivered = asyncio.Event()
+    posts = []
+    refreshes = 0
+
+    class FakeClient:
+        async def post(self, url, timeout):
+            posts.append((url, timeout))
+            delivered.set()
+
+    async def refresh_helper():
+        nonlocal refreshes
+        refreshes += 1
+        return refreshes > 1
+
+    async def resolve_chat(chat_id):
+        return chat_id
+
+    adapter.client = FakeClient()
+    monkeypatch.setattr(adapter, "_refresh_helper_state", refresh_helper)
+    monkeypatch.setattr(adapter, "_resolve_chat_guid", resolve_chat)
+    monkeypatch.setattr(
+        "gateway.platforms.bluebubbles._READ_RECEIPT_RETRY_SECONDS", 0
+    )
+
+    assert await adapter._queue_read_receipt(
+        "iMessage;-;user@example.com",
+        "message-1",
+        is_group=False,
+        admitted=True,
+    )
+    await asyncio.wait_for(delivered.wait(), timeout=0.2)
+
+    assert refreshes >= 2
+    assert len(posts) == 1
+    await adapter.cancel_background_tasks()
+
+
+@pytest.mark.asyncio
+async def test_group_receipt_requires_policy_admission(monkeypatch):
+    adapter = _adapter(require_mention=True)
+    posts = []
+
+    class FakeClient:
+        async def post(self, url, timeout):
+            posts.append((url, timeout))
+
+    async def helper_ready():
+        return True
+
+    async def resolve_chat(chat_id):
+        return chat_id
+
+    adapter.client = FakeClient()
+    monkeypatch.setattr(adapter, "_refresh_helper_state", helper_ready)
+    monkeypatch.setattr(adapter, "_resolve_chat_guid", resolve_chat)
+
+    assert not await adapter._queue_read_receipt(
+        "iMessage;+;family-group",
+        "message-1",
+        is_group=True,
+        admitted=False,
+    )
+    assert not await adapter.mark_read("iMessage;+;family-group")
+    await asyncio.sleep(0)
+
+    assert posts == []
+    assert adapter._pending_read_receipts == {}
+    assert adapter._read_receipt_tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_admitted_group_receipt_is_delivered(monkeypatch):
+    adapter = _adapter(require_mention=True)
+    delivered = asyncio.Event()
+    posts = []
+
+    class FakeClient:
+        async def post(self, url, timeout):
+            posts.append((url, timeout))
+            delivered.set()
+
+    async def helper_ready():
+        return True
+
+    async def resolve_chat(chat_id):
+        return chat_id
+
+    adapter.client = FakeClient()
+    monkeypatch.setattr(adapter, "_refresh_helper_state", helper_ready)
+    monkeypatch.setattr(adapter, "_resolve_chat_guid", resolve_chat)
+
+    assert await adapter._queue_read_receipt(
+        "iMessage;+;family-group",
+        "message-1",
+        is_group=True,
+        admitted=True,
+    )
+    await asyncio.wait_for(delivered.wait(), timeout=0.2)
+
+    assert len(posts) == 1
+    await adapter.cancel_background_tasks()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_receipt_lifecycle_events_send_once(monkeypatch):
+    adapter = _adapter()
+    delivered = asyncio.Event()
+    posts = []
+
+    class FakeClient:
+        async def post(self, url, timeout):
+            posts.append((url, timeout))
+            delivered.set()
+
+    async def helper_ready():
+        return True
+
+    async def resolve_chat(chat_id):
+        return chat_id
+
+    adapter.client = FakeClient()
+    monkeypatch.setattr(adapter, "_refresh_helper_state", helper_ready)
+    monkeypatch.setattr(adapter, "_resolve_chat_guid", resolve_chat)
+
+    first, duplicate = await asyncio.gather(
+        adapter._queue_read_receipt(
+            "iMessage;-;user@example.com",
+            "message-1",
+            is_group=False,
+            admitted=True,
+        ),
+        adapter._queue_read_receipt(
+            "iMessage;-;user@example.com",
+            "message-1",
+            is_group=False,
+            admitted=True,
+        ),
+    )
+    await asyncio.wait_for(delivered.wait(), timeout=0.2)
+    assert first is True
+    assert duplicate is False
+
+    assert not await adapter._queue_read_receipt(
+        "iMessage;-;user@example.com",
+        "message-1",
+        is_group=False,
+        admitted=True,
+    )
+    await asyncio.sleep(0)
+
+    assert len(posts) == 1
+    await adapter.cancel_background_tasks()
+
+
+@pytest.mark.asyncio
+async def test_receipt_cancellation_prevents_later_send(monkeypatch):
+    adapter = _adapter()
+    refresh_started = asyncio.Event()
+    release_refresh = asyncio.Event()
+    posts = []
+
+    class FakeClient:
+        async def post(self, url, timeout):
+            posts.append((url, timeout))
+
+    async def blocked_refresh():
+        refresh_started.set()
+        await release_refresh.wait()
+        return True
+
+    async def resolve_chat(chat_id):
+        return chat_id
+
+    adapter.client = FakeClient()
+    monkeypatch.setattr(adapter, "_refresh_helper_state", blocked_refresh)
+    monkeypatch.setattr(adapter, "_resolve_chat_guid", resolve_chat)
+
+    assert await adapter._queue_read_receipt(
+        "iMessage;-;user@example.com",
+        "message-1",
+        is_group=False,
+        admitted=True,
+    )
+    await refresh_started.wait()
+    await adapter.cancel_background_tasks()
+    release_refresh.set()
+    await asyncio.sleep(0)
+
+    assert posts == []
+    assert adapter._pending_read_receipts == {}
+    assert adapter._read_receipt_tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_receipt_cancellation_during_delivery_blocks_completion_callback(
+    monkeypatch,
+):
+    adapter = _adapter()
+    delivery_started = asyncio.Event()
+    delivery_cancelled = asyncio.Event()
+    completed = []
+
+    class FakeClient:
+        async def post(self, url, timeout):
+            delivery_started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                delivery_cancelled.set()
+            completed.append((url, timeout))
+
+    async def helper_ready():
+        return True
+
+    async def resolve_chat(chat_id):
+        return chat_id
+
+    adapter.client = FakeClient()
+    monkeypatch.setattr(adapter, "_refresh_helper_state", helper_ready)
+    monkeypatch.setattr(adapter, "_resolve_chat_guid", resolve_chat)
+
+    assert await adapter._queue_read_receipt(
+        "iMessage;-;user@example.com",
+        "message-1",
+        is_group=False,
+        admitted=True,
+    )
+    await delivery_started.wait()
+
+    await adapter.cancel_background_tasks()
+
+    assert delivery_cancelled.is_set()
+    assert completed == []
+    assert adapter._pending_read_receipts == {}
+    assert adapter._read_receipt_tasks == {}
+    assert adapter._sent_read_receipts == {}
+    assert not await adapter._queue_read_receipt(
+        "iMessage;-;user@example.com",
+        "message-2",
+        is_group=False,
+        admitted=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_repeated_cleanup_cancels_pending_receipt_retry(monkeypatch):
+    adapter = _adapter()
+    helper_checked = asyncio.Event()
+    posts = []
+
+    class FakeClient:
+        async def post(self, url, timeout):
+            posts.append((url, timeout))
+
+    async def helper_unavailable():
+        helper_checked.set()
+        return False
+
+    adapter.client = FakeClient()
+    monkeypatch.setattr(adapter, "_refresh_helper_state", helper_unavailable)
+    monkeypatch.setattr(
+        "gateway.platforms.bluebubbles._READ_RECEIPT_RETRY_SECONDS", 60
+    )
+
+    assert await adapter._queue_read_receipt(
+        "iMessage;-;user@example.com",
+        "message-1",
+        is_group=False,
+        admitted=True,
+    )
+    await helper_checked.wait()
+    worker = adapter._read_receipt_tasks["iMessage;-;user@example.com"]
+
+    await adapter.cancel_background_tasks()
+    await adapter.cancel_background_tasks()
+
+    assert worker.done()
+    assert posts == []
+    assert adapter._pending_read_receipts == {}
+    assert adapter._read_receipt_tasks == {}
+    assert adapter._sent_read_receipts == {}

--- a/tests/gateway/test_bluebubbles_read_receipts.py
+++ b/tests/gateway/test_bluebubbles_read_receipts.py
@@ -8,6 +8,11 @@ from gateway.config import PlatformConfig
 from gateway.platforms.bluebubbles import BlueBubblesAdapter
 
 
+class _SuccessfulResponse:
+    def raise_for_status(self):
+        return None
+
+
 def _adapter(**extra):
     return BlueBubblesAdapter(
         PlatformConfig(
@@ -32,6 +37,7 @@ async def test_queued_receipt_survives_helper_cold_boot(monkeypatch):
         async def post(self, url, timeout):
             posts.append((url, timeout))
             delivered.set()
+            return _SuccessfulResponse()
 
     async def refresh_helper():
         nonlocal refreshes
@@ -58,6 +64,59 @@ async def test_queued_receipt_survives_helper_cold_boot(monkeypatch):
 
     assert refreshes >= 2
     assert len(posts) == 1
+    await adapter.cancel_background_tasks()
+
+
+@pytest.mark.asyncio
+async def test_http_error_receipt_is_retried_before_acknowledgement(monkeypatch):
+    adapter = _adapter()
+    delivered = asyncio.Event()
+    posts = 0
+
+    class FakeResponse:
+        def __init__(self, successful):
+            self.successful = successful
+
+        def raise_for_status(self):
+            if not self.successful:
+                raise RuntimeError("server error")
+
+    class FakeClient:
+        async def post(self, _url, timeout):
+            nonlocal posts
+            assert timeout == 5
+            posts += 1
+            response = FakeResponse(successful=posts > 1)
+            if response.successful:
+                delivered.set()
+            return response
+
+    async def helper_ready():
+        return True
+
+    async def resolve_chat(chat_id):
+        return chat_id
+
+    adapter.client = FakeClient()
+    monkeypatch.setattr(adapter, "_refresh_helper_state", helper_ready)
+    monkeypatch.setattr(adapter, "_resolve_chat_guid", resolve_chat)
+    monkeypatch.setattr(
+        "gateway.platforms.bluebubbles._READ_RECEIPT_RETRY_SECONDS", 0
+    )
+
+    assert await adapter._queue_read_receipt(
+        "iMessage;-;user@example.com",
+        "message-1",
+        is_group=False,
+        admitted=True,
+    )
+    await asyncio.wait_for(delivered.wait(), timeout=0.2)
+    await asyncio.sleep(0)
+
+    assert posts == 2
+    assert ("iMessage;-;user@example.com", "message-1") in (
+        adapter._sent_read_receipts
+    )
     await adapter.cancel_background_tasks()
 
 
@@ -104,6 +163,7 @@ async def test_admitted_group_receipt_is_delivered(monkeypatch):
         async def post(self, url, timeout):
             posts.append((url, timeout))
             delivered.set()
+            return _SuccessfulResponse()
 
     async def helper_ready():
         return True
@@ -137,6 +197,7 @@ async def test_duplicate_receipt_lifecycle_events_send_once(monkeypatch):
         async def post(self, url, timeout):
             posts.append((url, timeout))
             delivered.set()
+            return _SuccessfulResponse()
 
     async def helper_ready():
         return True

--- a/tests/gateway/test_internal_notice_metadata.py
+++ b/tests/gateway/test_internal_notice_metadata.py
@@ -1,0 +1,74 @@
+"""Regression tests for structured internal gateway notice metadata."""
+
+import pytest
+
+from gateway.config import Platform
+from gateway.run import (
+    _internal_notice_metadata,
+    _non_conversational_metadata,
+    _send_or_update_status_coro,
+)
+
+
+def test_non_conversational_metadata_leaves_bluebubbles_actionable():
+    metadata = _non_conversational_metadata(
+        {"thread_id": "thread-1"},
+        platform=Platform.BLUEBUBBLES,
+    )
+
+    assert metadata == {"thread_id": "thread-1"}
+
+
+def test_internal_notice_metadata_marks_bluebubbles_suppressible():
+    metadata = _internal_notice_metadata(
+        {"thread_id": "thread-1"},
+        platform=Platform.BLUEBUBBLES,
+    )
+
+    assert metadata == {
+        "thread_id": "thread-1",
+        "_interim_send": True,
+        "internal_notice": True,
+    }
+
+
+def test_non_conversational_metadata_preserves_discord_marker():
+    metadata = _non_conversational_metadata({}, platform=Platform.DISCORD)
+
+    assert metadata == {"non_conversational": True}
+
+
+def test_internal_notice_metadata_marks_discord_both_ways():
+    metadata = _internal_notice_metadata({}, platform=Platform.DISCORD)
+
+    assert metadata == {
+        "_interim_send": True,
+        "internal_notice": True,
+        "non_conversational": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_status_delivery_marks_notice_internal():
+    class Adapter:
+        def __init__(self):
+            self.metadata = None
+
+        async def send(self, chat_id, content, metadata=None):
+            self.metadata = metadata
+            return "ok"
+
+    adapter = Adapter()
+    result = await _send_or_update_status_coro(
+        adapter,
+        "chat-1",
+        "compaction",
+        "Compacting context",
+        {"thread_id": "thread-1"},
+    )
+
+    assert result == "ok"
+    assert adapter.metadata == {
+        "thread_id": "thread-1",
+        "internal_notice": True,
+    }

--- a/tests/gateway/test_reactions.py
+++ b/tests/gateway/test_reactions.py
@@ -1,0 +1,151 @@
+"""Behavior contracts for exact-target Tapback operations."""
+
+import pytest
+
+from gateway.reactions import (
+    TapbackAction,
+    TapbackDirection,
+    TapbackOperation,
+    TapbackStatus,
+    TapbackType,
+    TapbackValidationError,
+)
+
+
+def _operation(**overrides):
+    fields = {
+        "platform": "bluebubbles",
+        "chat_id": "iMessage;+;family-guid",
+        "target_message_id": "target-message-guid",
+        "sender_id": "+15555550100",
+        "reaction": TapbackType.LIKE,
+        "action": TapbackAction.ADD,
+        "direction": TapbackDirection.INBOUND,
+        "source_event_id": "tapback-event-guid",
+        "part_index": 0,
+    }
+    fields.update(overrides)
+    return TapbackOperation(**fields)
+
+
+def test_operation_represents_exact_inbound_and_outbound_identity():
+    inbound = _operation()
+    outbound = _operation(
+        sender_id="self",
+        direction=TapbackDirection.OUTBOUND,
+        source_event_id="approved-request-id",
+    )
+
+    assert inbound.chat_id == "iMessage;+;family-guid"
+    assert inbound.target_message_id == "target-message-guid"
+    assert inbound.sender_id == "+15555550100"
+    assert inbound.status is TapbackStatus.RECEIVED
+    assert outbound.direction is TapbackDirection.OUTBOUND
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("platform", ""),
+        ("chat_id", ""),
+        ("chat_id", "   "),
+        ("chat_id", ["chat-a", "chat-b"]),
+        ("target_message_id", ""),
+        ("target_message_id", ["message-a", "message-b"]),
+        ("sender_id", ""),
+        ("source_event_id", ""),
+        ("part_index", -1),
+        ("part_index", True),
+    ],
+)
+def test_ambiguous_or_malformed_identity_fails_closed(field, value):
+    with pytest.raises(TapbackValidationError):
+        _operation(**{field: value})
+
+
+@pytest.mark.parametrize("reaction", list(TapbackType))
+def test_all_six_native_tapbacks_are_allowed(reaction):
+    assert _operation(reaction=reaction).reaction is reaction
+
+
+def test_unsupported_reaction_and_untyped_semantics_are_rejected():
+    with pytest.raises(TapbackValidationError):
+        _operation(reaction="party")
+    with pytest.raises(TapbackValidationError):
+        _operation(action="add")
+    with pytest.raises(TapbackValidationError):
+        _operation(direction="inbound")
+
+
+def test_deduplication_key_is_deterministic_for_identical_events():
+    assert _operation().deduplication_key == _operation().deduplication_key
+
+
+def test_deduplication_key_distinguishes_add_remove_chat_sender_and_direction():
+    base = _operation()
+    variants = [
+        _operation(action=TapbackAction.REMOVE),
+        _operation(chat_id="iMessage;+;other-family-guid"),
+        _operation(sender_id="other@example.com"),
+        _operation(direction=TapbackDirection.OUTBOUND),
+        _operation(source_event_id="different-source-event"),
+        _operation(part_index=1),
+    ]
+
+    assert all(item.deduplication_key != base.deduplication_key for item in variants)
+
+
+def test_state_key_is_local_to_chat_message_sender_and_direction():
+    add = _operation(action=TapbackAction.ADD, source_event_id="event-add")
+    remove = _operation(action=TapbackAction.REMOVE, source_event_id="event-remove")
+
+    assert add.state_key == remove.state_key
+    assert add.state_key != _operation(chat_id="other-chat").state_key
+    assert add.state_key != _operation(sender_id="other-sender").state_key
+
+
+def test_status_transitions_document_happy_path_and_terminal_states():
+    operation = _operation()
+    operation = operation.transition_to(TapbackStatus.VALIDATED)
+    operation = operation.transition_to(TapbackStatus.PENDING)
+    operation = operation.transition_to(TapbackStatus.PROCESSING)
+    operation = operation.transition_to(TapbackStatus.APPLIED)
+
+    assert operation.status is TapbackStatus.APPLIED
+    with pytest.raises(ValueError, match="cannot transition"):
+        operation.transition_to(TapbackStatus.PROCESSING)
+
+
+def test_failure_can_retry_but_rejection_is_terminal():
+    failed = (
+        _operation()
+        .transition_to(TapbackStatus.VALIDATED)
+        .transition_to(TapbackStatus.PENDING)
+        .transition_to(TapbackStatus.PROCESSING)
+        .transition_to(TapbackStatus.FAILED)
+    )
+    assert failed.transition_to(TapbackStatus.PENDING).status is TapbackStatus.PENDING
+
+    rejected = _operation().transition_to(TapbackStatus.REJECTED)
+    with pytest.raises(ValueError, match="cannot transition"):
+        rejected.transition_to(TapbackStatus.PENDING)
+
+
+def test_platform_payload_contains_only_exact_routing_fields():
+    payload = _operation().to_platform_payload()
+
+    assert payload == {
+        "action": "added",
+        "reaction": "like",
+        "message_id": "target-message-guid",
+        "reaction_message_id": "tapback-event-guid",
+        "part_index": 0,
+        "chat_id": "iMessage;+;family-guid",
+        "user_id": "+15555550100",
+        "direction": "inbound",
+        "status": "received",
+        "deduplication_key": _operation().deduplication_key,
+    }
+    assert "text" not in payload
+    assert "participants" not in payload
+    assert "fallback_chat" not in payload

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -198,11 +198,13 @@ async def test_send_home_channel_startup_notification_preserves_thread_metadata(
     adapter.send.assert_called_once_with(
         "parent-42",
         "♻️ Gateway online — Hermes is back and ready.",
-        metadata={
-            "thread_id": "777",
-            "telegram_dm_topic_reply_fallback": True,
-            "direct_messages_topic_id": "777",
-        },
+            metadata={
+                "thread_id": "777",
+                "telegram_dm_topic_reply_fallback": True,
+                "direct_messages_topic_id": "777",
+                "_interim_send": True,
+                "internal_notice": True,
+            },
     )
 
 
@@ -410,5 +412,4 @@ async def test_shutdown_notifications_are_fully_muted_when_flag_disabled():
     await runner._notify_active_sessions_of_shutdown()
 
     adapter.send.assert_not_awaited()
-
 

--- a/tests/plugins/platforms/photon/test_reactions.py
+++ b/tests/plugins/platforms/photon/test_reactions.py
@@ -128,6 +128,21 @@ async def test_remove_reaction_posts_unreact(monkeypatch: pytest.MonkeyPatch) ->
 
 
 @pytest.mark.asyncio
+async def test_agent_remove_reaction_requires_exact_message_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    calls = _capture_sidecar(adapter)
+    adapter._last_inbound_by_chat[adapter._normalize_chat_key("+15551234567")] = "recent-message"
+
+    result = await adapter.remove_reaction("+15551234567", emoji="👍")
+
+    assert result["success"] is False
+    assert "message_id" in result["error"]
+    assert calls == []
+
+
+@pytest.mark.asyncio
 async def test_reaction_failure_is_soft(monkeypatch: pytest.MonkeyPatch) -> None:
     adapter = _make_adapter(monkeypatch)
 
@@ -191,5 +206,4 @@ async def test_inbound_reaction_on_bot_message_routed(
     assert event.reply_to_message_id == "bot-msg-1"
     assert event.reply_to_text == "the bot's earlier reply"
     assert event.reply_to_is_own_message is True
-
 

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -11,6 +11,7 @@ import pytest
 
 import tools.approval as approval_module
 from tools import approval_context
+from tools import approval_prompt as approval_prompt_module
 from tools import approval_smart
 from hermes_constants import get_hermes_home
 from tools.approval import approve_session, detect_dangerous_command, detect_hardline_command, is_approved, load_permanent, prompt_dangerous_approval
@@ -580,6 +581,57 @@ class TestFullCommandAlwaysShown:
             with mock_patch("builtins.input", return_value=keystroke):
                 result = prompt_dangerous_approval(long_cmd, "recursive delete")
             assert result == expected, keystroke
+
+
+def test_one_time_consent_hides_session_and_permanent_choices():
+    with (
+        mock_patch.object(
+            approval_prompt_module._ctx, "_is_gateway_approval_context", return_value=False
+        ),
+        mock_patch.object(
+            approval_prompt_module, "prompt_dangerous_approval", return_value="once"
+        ) as prompt,
+    ):
+        result = approval_prompt_module.request_one_time_consent(
+            "react to message", "one exact outbound reaction"
+        )
+
+    assert result == "accept"
+    prompt.assert_called_once_with(
+        "react to message",
+        "one exact outbound reaction",
+        timeout_seconds=None,
+        allow_permanent=False,
+        allow_session=False,
+    )
+
+
+def test_one_time_consent_gateway_payload_hides_session_and_permanent_choices(monkeypatch):
+    session_key = "test-one-time-consent"
+    notified = []
+
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+    monkeypatch.setenv("HERMES_SESSION_KEY", session_key)
+
+    def notify(approval_data):
+        notified.append(approval_data)
+        approval_module.resolve_gateway_approval(
+            session_key, "once", request_id=approval_data["request_id"]
+        )
+
+    approval_module.register_gateway_notify(session_key, notify)
+    try:
+        result = approval_prompt_module.request_one_time_consent(
+            "react to message", "one exact outbound reaction"
+        )
+    finally:
+        approval_module.unregister_gateway_notify(session_key)
+
+    assert result == "accept"
+    assert notified[0]["allow_permanent"] is False
+    assert notified[0]["allow_session"] is False
+    assert notified[0]["choices"] == ["once", "deny"]
 
 
 class TestSmartDeniedPrompt:

--- a/tests/tools/test_bluebubbles_standalone.py
+++ b/tests/tools/test_bluebubbles_standalone.py
@@ -1,0 +1,51 @@
+import pytest
+
+from gateway.platforms.base import SendResult
+from gateway.platforms.bluebubbles import BlueBubblesAdapter
+from tools.send_message_tool import _send_bluebubbles
+
+
+@pytest.mark.asyncio
+async def test_standalone_bluebubbles_send_uses_outbound_only_lifecycle(monkeypatch):
+    calls = []
+
+    async def fail_full_connect(self, *, is_reconnect=False):
+        raise AssertionError("standalone delivery must not bind or register a webhook")
+
+    async def fail_full_disconnect(self):
+        raise AssertionError("standalone delivery must not unregister the live webhook")
+
+    async def connect_outbound(self):
+        calls.append("connect_outbound")
+        return True
+
+    async def disconnect_outbound(self):
+        calls.append("disconnect_outbound")
+
+    async def send(self, chat_id, message, **kwargs):
+        calls.append(("send", chat_id, message))
+        return SendResult(success=True, message_id="message-guid")
+
+    monkeypatch.setattr(BlueBubblesAdapter, "connect", fail_full_connect)
+    monkeypatch.setattr(BlueBubblesAdapter, "disconnect", fail_full_disconnect)
+    monkeypatch.setattr(BlueBubblesAdapter, "connect_outbound", connect_outbound, raising=False)
+    monkeypatch.setattr(BlueBubblesAdapter, "disconnect_outbound", disconnect_outbound, raising=False)
+    monkeypatch.setattr(BlueBubblesAdapter, "send", send)
+
+    result = await _send_bluebubbles(
+        {"server_url": "http://bluebubbles.test", "password": "secret"},
+        "iMessage;-;user@example.com",
+        "Reminder text",
+    )
+
+    assert result == {
+        "success": True,
+        "platform": "bluebubbles",
+        "chat_id": "iMessage;-;user@example.com",
+        "message_id": "message-guid",
+    }
+    assert calls == [
+        "connect_outbound",
+        ("send", "iMessage;-;user@example.com", "Reminder text"),
+        "disconnect_outbound",
+    ]

--- a/tests/tools/test_send_message_react.py
+++ b/tests/tools/test_send_message_react.py
@@ -113,6 +113,98 @@ def test_repeated_approved_operation_is_idempotent():
     consent.assert_called_once()
 
 
+def test_applied_reaction_can_be_reapplied_after_opposite_state_transition():
+    adapter = _FakePhotonAdapter()
+    common = {
+        "target": "photon:+155****4567",
+        "emoji": "😂",
+        "message_id": "message-guid",
+    }
+    with (
+        patch("gateway.run._gateway_runner_ref", lambda: _runner_with(adapter)),
+        patch(
+            "tools.approval_prompt.request_one_time_consent", return_value="accept"
+        ) as consent,
+    ):
+        added = _call({**common, "action": "react"})
+        removed = _call({**common, "action": "unreact"})
+        readded = _call({**common, "action": "react"})
+
+    assert added["status"] == removed["status"] == readded["status"] == "applied"
+    assert adapter.calls == [
+        ("add", "+155****4567", "😂", "message-guid"),
+        ("remove", "+155****4567", "😂", "message-guid"),
+        ("add", "+155****4567", "😂", "message-guid"),
+    ]
+    assert consent.call_count == 3
+
+
+def test_rejected_reaction_can_be_approved_on_a_later_attempt():
+    adapter = _FakePhotonAdapter()
+    args = {
+        "action": "react",
+        "target": "photon:+155****4567",
+        "emoji": "👍",
+        "message_id": "message-guid",
+    }
+    with (
+        patch("gateway.run._gateway_runner_ref", lambda: _runner_with(adapter)),
+        patch(
+            "tools.approval_prompt.request_one_time_consent",
+            side_effect=["decline", "accept"],
+        ) as consent,
+    ):
+        rejected = _call(args)
+        retried = _call(args)
+
+    assert rejected["status"] == "rejected"
+    assert retried["status"] == "applied"
+    assert adapter.calls == [("add", "+155****4567", "👍", "message-guid")]
+    assert consent.call_count == 2
+
+
+def test_in_flight_reaction_is_not_evicted_by_capacity_pruning():
+    adapter = _FakePhotonAdapter()
+    first_args = {
+        "action": "react",
+        "target": "photon:first-chat",
+        "emoji": "👍",
+        "message_id": "first-message",
+    }
+    second_args = {
+        "action": "react",
+        "target": "photon:second-chat",
+        "emoji": "❤️",
+        "message_id": "second-message",
+    }
+    nested = None
+    prompting_first = True
+
+    def approve_with_nested_operation(_prompt, _description, **_kwargs):
+        nonlocal nested, prompting_first
+        if prompting_first:
+            prompting_first = False
+            nested = _call(second_args)
+        return "accept"
+
+    with (
+        patch("gateway.run._gateway_runner_ref", lambda: _runner_with(adapter)),
+        patch("tools.send_message_tool._REACTION_OPERATION_LIMIT", 1),
+        patch(
+            "tools.approval_prompt.request_one_time_consent",
+            side_effect=approve_with_nested_operation,
+        ),
+    ):
+        first = _call(first_args)
+
+    assert nested is not None and nested["status"] == "applied"
+    assert first["status"] == "applied"
+    assert adapter.calls == [
+        ("add", "second-chat", "❤️", "second-message"),
+        ("add", "first-chat", "👍", "first-message"),
+    ]
+
+
 def test_rapid_repeat_while_approval_is_pending_sends_nothing_early():
     adapter = _FakePhotonAdapter()
     args = {

--- a/tests/tools/test_send_message_react.py
+++ b/tests/tools/test_send_message_react.py
@@ -21,8 +21,8 @@ class _FakePhotonAdapter:
         self.calls.append(("add", chat_id, emoji, message_id))
         return {"success": True, "emoji": emoji}
 
-    async def remove_reaction(self, chat_id, message_id=None):
-        self.calls.append(("remove", chat_id, message_id))
+    async def remove_reaction(self, chat_id, emoji=None, message_id=None):
+        self.calls.append(("remove", chat_id, emoji, message_id))
         return {"success": True}
 
 
@@ -40,20 +40,206 @@ def _call(args):
     return json.loads(smt.send_message_tool(args))
 
 
+def setup_function():
+    smt._reaction_operations.clear()
+
+
 def test_react_dispatches_to_add_reaction():
     adapter = _FakePhotonAdapter()
-    with patch("gateway.run._gateway_runner_ref", lambda: _runner_with(adapter)):
+    with (
+        patch("gateway.run._gateway_runner_ref", lambda: _runner_with(adapter)),
+        patch("tools.approval_prompt.request_one_time_consent", return_value="accept") as consent,
+    ):
         result = _call(
-            {"action": "react", "target": "photon:+15551234567", "emoji": "❤️"}
+            {
+                "action": "react",
+                "target": "photon:+155****4567",
+                "emoji": "❤️",
+                "message_id": "message-guid",
+            }
         )
     assert result["success"] is True
-    assert adapter.calls == [("add", "+15551234567", "❤️", None)]
+    assert result["status"] == "applied"
+    assert adapter.calls == [("add", "+155****4567", "❤️", "message-guid")]
+    shown, description = consent.call_args.args
+    assert "❤️" in shown
+    assert "photon:+155****4567" in shown
+    assert "message-guid" in shown
+    assert "approval" in description.lower()
+
+
+def test_reaction_requires_an_exact_message_and_rejection_sends_nothing():
+    adapter = _FakePhotonAdapter()
+    with (
+        patch("gateway.run._gateway_runner_ref", lambda: _runner_with(adapter)),
+        patch("tools.approval_prompt.request_one_time_consent", return_value="decline"),
+    ):
+        missing = _call({"action": "react", "target": "photon:+155****4567", "emoji": "👍"})
+        rejected = _call(
+            {
+                "action": "react",
+                "target": "photon:+155****4567",
+                "emoji": "👍",
+                "message_id": "message-guid",
+            }
+        )
+
+    assert missing["success"] is False
+    assert "message_id" in json.dumps(missing)
+    assert rejected["success"] is False
+    assert rejected["status"] == "rejected"
+    assert adapter.calls == []
+
+
+def test_repeated_approved_operation_is_idempotent():
+    adapter = _FakePhotonAdapter()
+    args = {
+        "action": "react",
+        "target": "photon:+155****4567",
+        "emoji": "😂",
+        "message_id": "message-guid",
+    }
+    with (
+        patch("gateway.run._gateway_runner_ref", lambda: _runner_with(adapter)),
+        patch("tools.approval_prompt.request_one_time_consent", return_value="accept") as consent,
+    ):
+        first = _call(args)
+        replay = _call(args)
+
+    assert first["success"] is True
+    assert replay["success"] is True
+    assert replay["duplicate"] is True
+    assert adapter.calls == [("add", "+155****4567", "😂", "message-guid")]
+    consent.assert_called_once()
+
+
+def test_rapid_repeat_while_approval_is_pending_sends_nothing_early():
+    adapter = _FakePhotonAdapter()
+    args = {
+        "action": "react",
+        "target": "photon:+155****4567",
+        "emoji": "👍",
+        "message_id": "message-guid",
+    }
+    replay = None
+
+    def approve_after_replay(_prompt, _description, **_kwargs):
+        nonlocal replay
+        assert adapter.calls == []
+        replay = _call(args)
+        assert adapter.calls == []
+        return "accept"
+
+    with (
+        patch("gateway.run._gateway_runner_ref", lambda: _runner_with(adapter)),
+        patch("tools.approval_prompt.request_one_time_consent", side_effect=approve_after_replay),
+    ):
+        first = _call(args)
+
+    assert first["status"] == "applied"
+    assert replay is not None
+    assert replay["status"] == "pending"
+    assert replay["duplicate"] is True
+    assert adapter.calls == [("add", "+155****4567", "👍", "message-guid")]
+
+
+def test_exact_chat_is_part_of_outbound_idempotency_identity():
+    adapter = _FakePhotonAdapter()
+    common = {"action": "react", "emoji": "❤️", "message_id": "reused-guid"}
+    with (
+        patch("gateway.run._gateway_runner_ref", lambda: _runner_with(adapter)),
+        patch("tools.approval_prompt.request_one_time_consent", return_value="accept") as consent,
+    ):
+        first = _call({**common, "target": "photon:first-chat"})
+        second = _call({**common, "target": "photon:second-chat"})
+
+    assert first["status"] == second["status"] == "applied"
+    assert adapter.calls == [
+        ("add", "first-chat", "❤️", "reused-guid"),
+        ("add", "second-chat", "❤️", "reused-guid"),
+    ]
+    assert consent.call_count == 2
+
+
+def test_unreact_keeps_reaction_identity_and_exact_target():
+    adapter = _FakePhotonAdapter()
+    with (
+        patch("gateway.run._gateway_runner_ref", lambda: _runner_with(adapter)),
+        patch("tools.approval_prompt.request_one_time_consent", return_value="accept"),
+    ):
+        result = _call(
+            {
+                "action": "unreact",
+                "target": "photon:+155****4567",
+                "emoji": "‼️",
+                "message_id": "message-guid",
+            }
+        )
+
+    assert result["status"] == "applied"
+    assert adapter.calls == [("remove", "+155****4567", "‼️", "message-guid")]
 
 
 def test_react_without_live_gateway():
     with patch("gateway.run._gateway_runner_ref", lambda: None):
         result = _call(
-            {"action": "react", "target": "photon:+15551234567", "emoji": "👍"}
+            {
+                "action": "react",
+                "target": "photon:+155****4567",
+                "emoji": "👍",
+                "message_id": "message-guid",
+            }
         )
     assert result.get("success") is not True
     assert "live" in json.dumps(result)
+
+
+def test_unsupported_adapter_fails_before_requesting_approval():
+    adapter = _NoReactionAdapter()
+    with (
+        patch("gateway.run._gateway_runner_ref", lambda: _runner_with(adapter)),
+        patch("tools.approval_prompt.request_one_time_consent") as consent,
+    ):
+        result = _call(
+            {
+                "action": "react",
+                "target": "photon:+155****4567",
+                "emoji": "👍",
+                "message_id": "message-guid",
+            }
+        )
+
+    assert result.get("success") is not True
+    assert "does not support" in result["error"]
+    consent.assert_not_called()
+
+
+def test_failed_provider_operation_can_be_reapproved_and_retried():
+    class FlakyAdapter(_FakePhotonAdapter):
+        async def add_reaction(self, chat_id, emoji, message_id=None):
+            self.calls.append(("add", chat_id, emoji, message_id))
+            return {"success": len(self.calls) > 1, "error": "temporary failure"}
+
+    adapter = FlakyAdapter()
+    args = {
+        "action": "react",
+        "target": "photon:+155****4567",
+        "emoji": "👍",
+        "message_id": "message-guid",
+    }
+    with (
+        patch("gateway.run._gateway_runner_ref", lambda: _runner_with(adapter)),
+        patch("tools.approval_prompt.request_one_time_consent", return_value="accept") as consent,
+    ):
+        failed = _call(args)
+        retried = _call(args)
+
+    assert failed["success"] is False
+    assert failed["status"] == "failed"
+    assert retried["success"] is True
+    assert retried["status"] == "applied"
+    assert adapter.calls == [
+        ("add", "+155****4567", "👍", "message-guid"),
+        ("add", "+155****4567", "👍", "message-guid"),
+    ]
+    assert consent.call_count == 2

--- a/tools/approval_prompt.py
+++ b/tools/approval_prompt.py
@@ -326,6 +326,7 @@ def request_one_time_consent(
             "pattern_key": surface,
             "pattern_keys": [surface],
             "allow_permanent": False,
+            "allow_session": False,
             "choices": ["once", "deny"],
         }
         try:

--- a/tools/approval_prompt.py
+++ b/tools/approval_prompt.py
@@ -294,3 +294,64 @@ def request_elicitation_consent(message: str, description: str, *,
         logger.error("Elicitation CLI prompt failed: %s", exc, exc_info=True)
         return "decline"
     return _consent(choice, "cancel")  # timeout mirrors the gateway's unresolved outcome
+
+
+def request_one_time_consent(
+    message: str,
+    description: str,
+    *,
+    timeout_seconds: int | None = None,
+    surface: str = "one-time-action",
+) -> str:
+    """Request non-persistent consent for one exact external side effect."""
+    from tools import approval as _a
+
+    try:
+        session_key = _ctx.get_current_session_key()
+    except Exception as exc:  # pragma: no cover -- defensive
+        logger.warning("One-time consent: session lookup failed: %s", exc)
+        return "decline"
+
+    if _ctx._is_gateway_approval_context():
+        notify_cb = _a._gateway_notify_cb(session_key)
+        if notify_cb is None:
+            logger.warning(
+                "One-time consent requested in gateway session %s without a notify callback — failing closed",
+                session_key,
+            )
+            return "decline"
+        approval_data = {
+            "command": message,
+            "description": description,
+            "pattern_key": surface,
+            "pattern_keys": [surface],
+            "allow_permanent": False,
+            "choices": ["once", "deny"],
+        }
+        try:
+            decision = _gw._await_gateway_decision(
+                session_key, notify_cb, approval_data, surface=surface
+            )
+        except Exception as exc:
+            logger.error("One-time consent dispatch failed: %s", exc, exc_info=True)
+            return "decline"
+        if decision.get("notify_failed"):
+            return "decline"
+        if not decision.get("resolved"):
+            return "cancel"
+        return "accept" if decision.get("choice") == "once" else "decline"
+
+    try:
+        choice = prompt_dangerous_approval(
+            message,
+            description,
+            timeout_seconds=timeout_seconds,
+            allow_permanent=False,
+            allow_session=False,
+        )
+    except Exception as exc:
+        logger.error("One-time consent prompt failed: %s", exc, exc_info=True)
+        return "decline"
+    if choice == "once":
+        return "accept"
+    return "cancel" if choice == "timeout" else "decline"

--- a/tools/send_message_senders.py
+++ b/tools/send_message_senders.py
@@ -571,12 +571,12 @@ async def _send_bluebubbles(extra, chat_id, message):
     try:
         from gateway.config import PlatformConfig
         adapter = bb.BlueBubblesAdapter(PlatformConfig(extra=extra))
-        if not await adapter.connect():
+        if not await adapter.connect_outbound():
             return _error("BlueBubbles: failed to connect to server")
         try:
             result = await adapter.send(chat_id, message)
         finally:
-            await adapter.disconnect()
+            await adapter.disconnect_outbound()
         if not result.success:
             return _error(f"BlueBubbles send failed: {result.error}")
         return _success("bluebubbles", chat_id, message_id=result.message_id)

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -19,6 +19,18 @@ _reaction_operations: dict[tuple[str, str, str, str, bool], dict] = {}
 _reaction_operations_lock = threading.Lock()
 _REACTION_OPERATION_LIMIT = 2048
 
+
+def _prune_reaction_operations_locked() -> None:
+    """Bound terminal history without dropping work that can still commit."""
+    if len(_reaction_operations) <= _REACTION_OPERATION_LIMIT:
+        return
+    for key, operation in list(_reaction_operations.items()):
+        if operation.get("status") in {"pending", "processing"}:
+            continue
+        _reaction_operations.pop(key, None)
+        if len(_reaction_operations) <= _REACTION_OPERATION_LIMIT:
+            return
+
 from tools.send_message_targets import _HOME_CHANNEL_ENV_OVERRIDES, _SLACK_USER_ID_RE, resolve_send_target
 from tools.send_message_senders import (
     _AUDIO_EXTS, _DEFAULT_CAPTION_LIMIT, _IMAGE_EXTS, _NO_DELIVERABLE, _VIDEO_EXTS, _VOICE_EXTS,
@@ -105,7 +117,7 @@ def _handle_react(args, remove=False):
     operation_key = (platform_name, str(chat_id), message_id, emoji, bool(remove))
     with _reaction_operations_lock:
         prior = _reaction_operations.get(operation_key)
-        if prior and prior.get("status") in {"pending", "processing", "applied", "rejected"}:
+        if prior and prior.get("status") in {"pending", "processing", "applied"}:
             return json.dumps({**prior, "duplicate": True})
         _reaction_operations[operation_key] = {
             "success": False,
@@ -116,8 +128,7 @@ def _handle_react(args, remove=False):
             "emoji": emoji,
             "action": "remove" if remove else "add",
         }
-        while len(_reaction_operations) > _REACTION_OPERATION_LIMIT:
-            _reaction_operations.pop(next(iter(_reaction_operations)))
+        _prune_reaction_operations_locked()
 
     verb = "Remove" if remove else "Add"
     prompt = (
@@ -134,17 +145,18 @@ def _handle_react(args, remove=False):
     )
     if consent != "accept":
         status = "rejected" if consent == "decline" else "failed"
-        result = {
-            **_reaction_operations[operation_key],
-            "status": status,
-            "error": (
-                "Tapback rejected; nothing was sent."
-                if status == "rejected"
-                else "Tapback approval expired; nothing was sent."
-            ),
-        }
         with _reaction_operations_lock:
+            result = {
+                **_reaction_operations[operation_key],
+                "status": status,
+                "error": (
+                    "Tapback rejected; nothing was sent."
+                    if status == "rejected"
+                    else "Tapback approval expired; nothing was sent."
+                ),
+            }
             _reaction_operations[operation_key] = result
+            _prune_reaction_operations_locked()
         return json.dumps(result)
 
     with _reaction_operations_lock:
@@ -159,13 +171,19 @@ def _handle_react(args, remove=False):
         result = {"success": False, "error": f"Reaction failed: {e}"}
     provider_result = result if isinstance(result, dict) else {"success": bool(result)}
     applied = bool(provider_result.get("success"))
-    final = {
-        **_reaction_operations[operation_key],
-        **provider_result,
-        "status": "applied" if applied else "failed",
-    }
     with _reaction_operations_lock:
+        final = {
+            **_reaction_operations[operation_key],
+            **provider_result,
+            "status": "applied" if applied else "failed",
+        }
         _reaction_operations[operation_key] = final
+        if applied:
+            inverse_key = (*operation_key[:-1], not operation_key[-1])
+            inverse = _reaction_operations.get(inverse_key)
+            if inverse and inverse.get("status") not in {"pending", "processing"}:
+                _reaction_operations.pop(inverse_key, None)
+        _prune_reaction_operations_locked()
     return json.dumps(final)
 
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -5,11 +5,19 @@ import asyncio
 import json
 import logging
 import os
+import threading
 from functools import partial
 
 from agent.secret_scope import get_secret
 
 logger = logging.getLogger(__name__)
+
+# Exact live-adapter operations double as pending-click and transport-retry
+# idempotency keys. They are process-local because reactions have no standalone
+# sender path.
+_reaction_operations: dict[tuple[str, str, str, str, bool], dict] = {}
+_reaction_operations_lock = threading.Lock()
+_REACTION_OPERATION_LIMIT = 2048
 
 from tools.send_message_targets import _HOME_CHANNEL_ENV_OVERRIDES, _SLACK_USER_ID_RE, resolve_send_target
 from tools.send_message_senders import (
@@ -65,9 +73,12 @@ def _handle_react(args, remove=False):
     standalone fallback because reacting needs the adapter's live message-id state."""
     target, emoji = args.get("target", ""), (args.get("emoji") or "").strip()
     message_id = (args.get("message_id") or "").strip() or None
-    if not target or (not remove and not emoji):
-        return tool_error("'target' is required when action='unreact'" if remove
-                          else "Both 'target' and 'emoji' are required when action='react'")
+    if not target or not emoji or not message_id:
+        return json.dumps({
+            "success": False,
+            "status": "failed",
+            "error": "'target', 'emoji', and exact 'message_id' are required for reactions",
+        })
 
     # Platform-native ids (e.g. photon GUIDs) match no parser/directory entry; the adapter validates.
     platform_name, chat_id, _thread_id, resolution_error = _resolve_tool_target(target, pass_unresolved_references=True)
@@ -90,12 +101,72 @@ def _handle_react(args, remove=False):
     react_fn = getattr(adapter, "remove_reaction" if remove else "add_reaction", None)
     if not callable(react_fn):
         return tool_error(f"Platform '{platform_name}' does not support message reactions.")
+
+    operation_key = (platform_name, str(chat_id), message_id, emoji, bool(remove))
+    with _reaction_operations_lock:
+        prior = _reaction_operations.get(operation_key)
+        if prior and prior.get("status") in {"pending", "processing", "applied", "rejected"}:
+            return json.dumps({**prior, "duplicate": True})
+        _reaction_operations[operation_key] = {
+            "success": False,
+            "status": "pending",
+            "platform": platform_name,
+            "chat_id": str(chat_id),
+            "message_id": message_id,
+            "emoji": emoji,
+            "action": "remove" if remove else "add",
+        }
+        while len(_reaction_operations) > _REACTION_OPERATION_LIMIT:
+            _reaction_operations.pop(next(iter(_reaction_operations)))
+
+    verb = "Remove" if remove else "Add"
+    prompt = (
+        f"{verb} Tapback {emoji}\n"
+        f"Destination: {platform_name}:{chat_id}\n"
+        f"Message: {message_id}"
+    )
+    from tools.approval_prompt import request_one_time_consent
+
+    consent = request_one_time_consent(
+        prompt,
+        "Explicit approval is required before sending this outbound reaction.",
+        surface="outbound-tapback",
+    )
+    if consent != "accept":
+        status = "rejected" if consent == "decline" else "failed"
+        result = {
+            **_reaction_operations[operation_key],
+            "status": status,
+            "error": (
+                "Tapback rejected; nothing was sent."
+                if status == "rejected"
+                else "Tapback approval expired; nothing was sent."
+            ),
+        }
+        with _reaction_operations_lock:
+            _reaction_operations[operation_key] = result
+        return json.dumps(result)
+
+    with _reaction_operations_lock:
+        _reaction_operations[operation_key] = {
+            **_reaction_operations[operation_key],
+            "status": "processing",
+        }
     try:
         from model_tools import _run_async
-        result = _run_async(react_fn(chat_id=chat_id, message_id=message_id, **({} if remove else {"emoji": emoji})))
+        result = _run_async(react_fn(chat_id=chat_id, emoji=emoji, message_id=message_id))
     except Exception as e:
-        return json.dumps(_error(f"Reaction failed: {e}"))
-    return json.dumps(result if isinstance(result, dict) else {"success": bool(result)})
+        result = {"success": False, "error": f"Reaction failed: {e}"}
+    provider_result = result if isinstance(result, dict) else {"success": bool(result)}
+    applied = bool(provider_result.get("success"))
+    final = {
+        **_reaction_operations[operation_key],
+        **provider_result,
+        "status": "applied" if applied else "failed",
+    }
+    with _reaction_operations_lock:
+        _reaction_operations[operation_key] = final
+    return json.dumps(final)
 
 
 def _handle_send(args):
@@ -562,11 +633,11 @@ SEND_MESSAGE_SCHEMA = {
             },
             "emoji": {
                 "type": "string",
-                "description": "For action='react': the emoji to react with (e.g. '❤️'). On iMessage, ❤️👍👎😂‼️❓ render as native tapbacks; other emoji use custom-emoji reactions."
+                "description": "For action='react'/'unreact': the exact emoji identity (e.g. '❤️'). On iMessage, ❤️👍👎😂‼️❓ render as native tapbacks; other emoji use custom-emoji reactions."
             },
             "message_id": {
                 "type": "string",
-                "description": "For action='react'/'unreact': id of the message to react to. Omit to target the most recent message received in that chat (usually the one being replied to)."
+                "description": "For action='react'/'unreact': exact id of the message to react to. Required; reactions never fall back to a recent message or another chat."
             }
         },
         "required": []


### PR DESCRIPTION
## Summary

Harden BlueBubbles message delivery and reaction handling around exact identity, retries, and concurrent lifecycle transitions.

This series:

- models Tapback operations as explicit state transitions and preserves legitimate add/remove/add cycles;
- keeps in-flight reaction work from being evicted while allowing completed entries to age out;
- materializes attachment sets atomically before dispatch;
- requires authoritative message-to-chat identity before attachments, reads, Tapbacks, reply context, or model dispatch;
- preserves explicit reply placement and revision ownership across retries;
- makes outbound delivery retries idempotent and validates read-receipt HTTP responses;
- requires exact platform/message/emoji targeting for reaction tools, including Photon removal;
- prevents one-time reaction consent from escalating to session-wide permission.

The commits remain split by invariant so each behavior can be reviewed independently.

## Compatibility and migration

- Existing BlueBubbles configuration remains supported.
- No schema migration or credential change is required.
- Reaction operations now fail closed when an exact target cannot be established instead of falling back to a recent message.
- One-time reaction approval remains one-time; it no longer offers or records session-wide escalation through this path.
- Delivery-health persistence/restart recovery work is intentionally excluded from this PR pending a separately verified persistence contract.

## Testing

Validated on upstream base `13e72fb205b735df679e0fd5f5996a34ac4accc6`:

- 363 focused BlueBubbles/reaction/approval/Photon/send-message tests passed during implementation;
- 189 adjacent gateway/config/notification tests passed during implementation;
- independent review reproduced 256 focused tests and a 375-test broader suite;
- one unrelated approval-classifier failure was reproduced unchanged on the exact upstream base;
- Ruff passed for all 21 changed Python files;
- compileall, compatibility-pointer checks, `git diff --check`, conflict-marker scan, and privacy/scope scan passed;
- range-diff and stable patch-ID review confirmed no accepted source hunks were dropped; adaptations are limited to current upstream's split config, notification, approval, and sender modules.

## Scope

This PR does not include delivery-health persistence, unrelated gateway refactors, dependency upgrades, local configuration, generated artifacts, or household-specific behavior.