### PR TITLE
fix(agent): classify Z.AI "will reset at" usage-limit 429s as transient rate limits

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -132,7 +132,7 @@ _OVERLOADED_PATTERNS = (
 # the signals that mark such a limit as transient (periodic quota, not billing).
 _USAGE_LIMIT_PATTERNS = ("usage limit", "quota", "limit exceeded", "key limit exceeded")
 _USAGE_LIMIT_TRANSIENT_SIGNALS = (
-    "try again", "retry", "resets at", "reset in", "resets in", "reset after", "available in",
+    "try again", "retry", "resets at", "reset at", "reset in", "resets in", "reset after", "available in",
     "wait", "requests remaining", "periodic", "window", "per minute", "per second",
 )
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -357,6 +357,18 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.rate_limit
         assert result.retryable is True
 
+    def test_zai_429_usage_limit_with_will_reset_at_stays_rate_limit(self):
+        e = MockAPIError(
+            "Error code: 429 - Usage limit reached for 5 hour. "
+            "Your limit will reset at 2026-09-04 19:01:25",
+            status_code=429,
+        )
+
+        result = classify_api_error(e, provider="zai", model="glm-5.2")
+
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+
     def test_429_generic_quota_wall_is_billing(self):
         # Broadened from the narrow "usage limit" core to the full
         # _USAGE_LIMIT_PATTERNS: a bare "quota" / "limit exceeded" 429 with no


### PR DESCRIPTION
## Problem

Z.AI (GLM coding plan) returns 429 with:

```
Usage limit reached for 5 hour. Your limit will reset at 2026-09-04 19:01:25
```

`_USAGE_LIMIT_TRANSIENT_SIGNALS` included `"resets at"` / `"reset in"` / `"resets in"` / `"reset after"` but not the bare **`"reset at"`** in Z.AI's phrasing ("Your limit **will reset at** …"). The usage-limit pattern (`"usage limit"`) therefore matched with no transient signal, so the periodic 5-hour quota was classified as **billing (non-retryable)** and the session aborted instead of retrying after the natural reset — hours of dead time for a limit that clears on its own.

Z.AI documents this exact wording for error codes 1308/1310/1316–1321 ([docs.z.ai/api-reference/api-code](https://docs.z.ai/api-reference/api-code)) — the `{next_flush_time}` phrasing is a stable contract, not a one-off.

Verified against real production logs: 7/7 sampled 429s of this shape were misclassified as billing.

## Fix

One entry added to `_USAGE_LIMIT_TRANSIENT_SIGNALS`:

```diff
 _USAGE_LIMIT_TRANSIENT_SIGNALS = (
-    "try again", "retry", "resets at", "reset in", "resets in", "reset after", "available in",
+    "try again", "retry", "resets at", "reset at", "reset in", "resets in", "reset after", "available in",
```

Same shape as #95026 (bare `"resets"` / `"session limit"` for ACP session limits). Related: #46891, #46930 (absolute reset timestamps in `credential_pool`).

## Testing

- [x] New regression test `test_zai_429_usage_limit_with_will_reset_at_stays_rate_limit` uses the verbatim production error string and asserts `rate_limit` + `retryable is True`
- [x] Test fails on unpatched `main` (verified via `git checkout` of the original classifier), passes with the fix
- [x] Full suite `tests/agent/test_error_classifier.py`: 124 passed