### PR TITLE
fix(dashboard): serve the live session token, not an import-time copy

### DIFF
--- a/hermes_cli/web_server_dashboard.py
+++ b/hermes_cli/web_server_dashboard.py
@@ -102,7 +102,13 @@ def mount_spa(application: FastAPI):
     with a missing dist per-request (404 JSON / ``check_dir=False``), so a long-lived
     ``--skip-build`` process recovers the moment a build appears on disk — no restart.
     """
-    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, _SESSION_TOKEN, app
+    from hermes_cli import web_server as _ws
+    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, app
+    # Read the session token from the module at request time, never as an import-time
+    # copy: `hermes serve --ssh-session-token-file` rebinds web_server._SESSION_TOKEN via
+    # _apply_ssh_session_token() AFTER these routes are mounted. A captured copy served a
+    # token the API rejected, so Desktop (which adopts the served token) got 401 on every
+    # /api call while /api/health passed.
 
     # `hermes serve` is the headless backend: it must NEVER serve the browser SPA, even if a
     # dist is lying around, so only the JSON-RPC/WS/API surface is reachable.
@@ -120,7 +126,7 @@ def mount_spa(application: FastAPI):
             if full_path == "" and not gated:
                 return HTMLResponse(
                     "<!doctype html><html><head><script>"
-                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(_SESSION_TOKEN)};"
+                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(_ws._SESSION_TOKEN)};"
                     "window.__HERMES_AUTH_REQUIRED__=false;"
                     f"</script></head><body>{_HEADLESS_MSG}</body></html>",
                     headers=_NO_STORE,
@@ -151,7 +157,7 @@ def mount_spa(application: FastAPI):
             return JSONResponse({"error": "Frontend not built. Run: cd web && npm run build"}, status_code=404)
         chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
         gated = bool(getattr(app.state, "auth_required", False))
-        token_js = "" if gated else f'window.__HERMES_SESSION_TOKEN__="{_SESSION_TOKEN}";'
+        token_js = "" if gated else f'window.__HERMES_SESSION_TOKEN__="{_ws._SESSION_TOKEN}";'
         bootstrap_script = (
             f"<script>{token_js}"
             f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5110,6 +5110,29 @@ class TestHeadlessServeTokenPage:
         assert _json.loads(match.group(1)) == ws._SESSION_TOKEN
         assert "window.__HERMES_AUTH_REQUIRED__=false" in resp.text
 
+    def test_root_serves_token_applied_after_mount(self, monkeypatch):
+        """The page must embed the token the API validates *now*, not a copy
+        captured when the routes were mounted. ``hermes serve
+        --ssh-session-token-file`` rebinds ``web_server._SESSION_TOKEN`` via
+        ``_apply_ssh_session_token()`` after mount; serving the stale copy made
+        Desktop adopt a token every non-public ``/api`` route then 401'd.
+        """
+        import json as _json
+        import re
+
+        client, ws = self._headless_client(monkeypatch, gated=False)
+        applied = "a" * 64
+        assert ws._SESSION_TOKEN != applied
+        monkeypatch.setattr(ws, "_SESSION_TOKEN", applied)
+        resp = client.get("/")
+        assert resp.status_code == 200
+        match = re.search(
+            r'window\.__HERMES_SESSION_TOKEN__\s*=\s*("(?:\\.|[^"\\])*")',
+            resp.text,
+        )
+        assert match, resp.text
+        assert _json.loads(match.group(1)) == applied
+
     def test_root_stays_404_json_when_auth_gated(self, monkeypatch):
         client, ws = self._headless_client(monkeypatch, gated=True)
         resp = client.get("/")


### PR DESCRIPTION
## Problem

`hermes_cli/web_server_dashboard.py` mounts its routes with a captured copy of `web_server._SESSION_TOKEN`:

```python
from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, _SESSION_TOKEN, app
```

`hermes serve --ssh-session-token-file` (the Desktop SSH backend) rebinds that module attribute *after* mount via `_apply_ssh_session_token()`. The API middleware validates the applied token, but the headless root page and the SPA `index.html` keep embedding the random token minted at import.

Desktop reads `window.__HERMES_SESSION_TOKEN__` from `/` and adopts it when it differs from the spawn token (`adoptServedDashboardToken`). Result after connecting over SSH: `/api/health` and `/api/status` pass, every other `/api/*` call fails with `401 {"detail":"Unauthorized"}`, and the profiles rail never loads.

Reproduced by hand: spawning `hermes serve --isolated --host 127.0.0.1 --port 0 --ssh-session-token-file … --ssh-owner-nonce …` and comparing the token in the served `/` page with the token file shows they differ; `/api/profiles` returns 200 with the file token and 401 with the served one.

## Fix

Read `web_server._SESSION_TOKEN` through the module at request time in both injection sites (headless token page and `_serve_index`).

## Tests

- New `test_root_serves_token_applied_after_mount`: mounts the headless app, rebinds the token, and asserts the served page embeds the new value. Fails on `main`, passes with the fix.
- `tests/hermes_cli/test_web_server.py`: 187 passed.


## Related Issue

Fixes #103054
