### PR TITLE
fix(webhook): cross-platform delivery must honor route profile binding

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -451,6 +451,7 @@ class WebhookAdapter(BasePlatformAdapter):
         """deliver_only: the rendered prompt IS the message — skip the agent, reuse the same
         auth/rate-limit/idempotency/template pipeline."""
         delivery = {"deliver": route_config.get("deliver", "log"), "payload": payload,
+                    "profile": route_config.get("profile") if isinstance(route_config.get("profile"), str) else None,
                     "deliver_extra": self._render_delivery_extra(route_config.get("deliver_extra", {}), payload)}
         logger.info("[webhook] direct-deliver event=%s route=%s target=%s msg_len=%d delivery=%s", event_type,
                     route_name, delivery["deliver"], len(prompt), delivery_id)
@@ -566,7 +567,10 @@ class WebhookAdapter(BasePlatformAdapter):
         session_chat_id = f"webhook:{route_name}:{delivery_id}"
         self._delivery_info[session_chat_id] = {
             "deliver": route_config.get("deliver", "log"),
-            "deliver_extra": self._render_delivery_extra(route_config.get("deliver_extra", {}), payload)}
+            "deliver_extra": self._render_delivery_extra(route_config.get("deliver_extra", {}), payload),
+            # Route-resolved profile (None = un-profiled). Read back by _deliver_cross_platform so the
+            # final response egresses through THIS profile's adapter, not the first-connected one.
+            "profile": profile}
         self._delivery_info_created[session_chat_id] = now
         self._delivery_info_order.append((now, session_chat_id))
         self._prune_delivery_info(now)
@@ -750,6 +754,27 @@ class WebhookAdapter(BasePlatformAdapter):
                 return amap[target_platform]
         return None
 
+    def _profile_delivery_adapter(self, target_platform: Platform, delivery: dict):
+        """Profile-aware adapter for cross-platform delivery.
+
+        The route's resolved profile (stored in ``_delivery_info``) wins: a webhook bound to
+        ``profile: X`` must egress through profile X's adapter — its own bot credential — even
+        when the primary profile also connects the same platform. ``_find_adapter`` alone returns
+        the primary adapter first, which is how a trainer-bound route could post as the accountant
+        bot. Resolution reuses the runner's ``_authorization_adapter`` (same profile-scoped map +
+        fail-closed contract as reply routing). Only a route with NO profile binding falls back to
+        ``_find_adapter``; a named profile whose platform never connected stays failed-closed
+        (not-connected error), never a silent cross-profile send.
+        """
+        profile = delivery.get("profile")
+        if isinstance(profile, str) and profile.strip():
+            runner = self.gateway_runner
+            resolver = getattr(runner, "_authorization_adapter", None)
+            if resolver is None:
+                return None
+            return resolver(target_platform, profile)
+        return self._find_adapter(target_platform)
+
     async def _deliver_cross_platform(self, platform_name: str, content: str, delivery: dict) -> SendResult:
         """Route response to another platform (telegram, discord, etc.)."""
         if not self.gateway_runner:
@@ -758,7 +783,7 @@ class WebhookAdapter(BasePlatformAdapter):
             target_platform = Platform(platform_name)
         except ValueError:
             return SendResult(success=False, error=f"Unknown platform: {platform_name}")
-        if not (adapter := self._find_adapter(target_platform)):
+        if not (adapter := self._profile_delivery_adapter(target_platform, delivery)):
             return SendResult(success=False, error=f"Platform {platform_name} not connected")
         extra = delivery.get("deliver_extra", {})
         chat_id = extra.get("chat_id", "")

--- a/tests/gateway/test_webhook_profile_delivery.py
+++ b/tests/gateway/test_webhook_profile_delivery.py
@@ -1,0 +1,288 @@
+"""Invariant: webhook cross-platform delivery must honor the route's profile binding.
+
+A webhook route bound to ``profile: X`` (config key or /p/X/ URL prefix) with
+``deliver: <platform>`` must deliver its response through profile X's adapter —
+the bot credential X actually connected with — never the first-connected adapter
+for that platform. Under multiplex, ``_find_adapter`` falls back to insertion order
+over ``_profile_adapters``; for two Discord profiles that is alphabetical, so the
+final response posts from the wrong bot (live 2026-09-04: the ai-coach-events route
+bound to ``trainer`` posted as the accountant bot 1542626633670991913 instead of
+the trainer bot 1542632896924221460).
+
+Covered here:
+- agent-mode route: the route profile reaches the delivery resolver via
+  ``_delivery_info`` (through ``_dispatch_agent_run``) and selects profile X's adapter;
+- deliver_only routes share the same egress and must honor the binding too;
+- the /p/<profile>/ URL prefix flows end-to-end (HTTP boundary);
+- un-profiled routes keep using the primary adapter (no regression);
+- fail-closed: a bound profile whose platform adapter never connected returns a
+  not-connected error — it must NOT fall back to the primary/first-connected adapter,
+  which would leak the response through another profile's bot.
+"""
+import asyncio
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import SendResult
+from gateway.platforms.webhook import WebhookAdapter, _INSECURE_NO_AUTH
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_config(routes=None):
+    return PlatformConfig(enabled=True, extra={
+        "host": "0.0.0.0", "port": 0, "routes": routes or {},
+        "rate_limit": 30, "max_body_bytes": 1_048_576,
+    })
+
+
+def _make_adapter(routes=None):
+    return WebhookAdapter(_make_config(routes=routes))
+
+
+def _discord(bot_id):
+    """Mock Discord adapter identified by the bot id it would post as."""
+    bot = AsyncMock()
+    bot.platform = Platform.DISCORD
+    bot.bot_user_id = bot_id
+    bot.send = AsyncMock(return_value=SendResult(success=True))
+    return bot
+
+
+def _profile_runner(primary_discord, profile_discords=None):
+    """Bare GatewayRunner exposing the REAL ``_authorization_adapter`` mixin.
+
+    Mirrors the construction in tests/gateway/test_multiplex_interactive_auth.py:
+    ``object.__new__`` plus exactly the attributes the mixin reads (``config``,
+    ``adapters``, ``_profile_adapters``, ``_primary_profile_name``).
+    """
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner._primary_profile_name = "default"
+    runner.adapters = {} if primary_discord is None else {Platform.DISCORD: primary_discord}
+    runner._profile_adapters = profile_discords or {}
+    return runner
+
+
+def _adapter_with_delivery(adapter, delivery, chat_id="webhook:ai-coach-events:d-1"):
+    """Register a delivery entry the way ``_dispatch_agent_run`` would."""
+    adapter._delivery_info[chat_id] = dict(delivery)
+    adapter._delivery_info_created[chat_id] = time.time()
+    return chat_id
+
+
+def _create_app(adapter: WebhookAdapter) -> web.Application:
+    app = web.Application(client_max_size=adapter._max_body_bytes)
+    app.router.add_get("/health", adapter._handle_health)
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+    app.router.add_post("/p/{profile}/webhooks/{route_name}", adapter._handle_webhook)
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Agent-mode delivery: send() must resolve the bound profile's adapter
+# ---------------------------------------------------------------------------
+
+class TestProfileBoundAgentDelivery:
+
+    def _adapter(self, delivery, runner):
+        adapter = _make_adapter()
+        adapter.gateway_runner = runner
+        chat_id = _adapter_with_delivery(adapter, delivery)
+        return adapter, chat_id
+
+    @pytest.mark.asyncio
+    async def test_profile_bound_route_delivers_via_profile_adapter(self):
+        """Route bound to trainer + deliver:discord posts via TRAINER's bot, even though
+        the primary (first-connected) Discord adapter belongs to accountant."""
+        accountant, trainer = _discord("accountant"), _discord("trainer")
+        runner = _profile_runner(
+            primary_discord=accountant,
+            profile_discords={"trainer": {Platform.DISCORD: trainer}},
+        )
+        adapter, chat_id = self._adapter(
+            {"deliver": "discord", "deliver_extra": {"chat_id": "-100123"}, "profile": "trainer"},
+            runner,
+        )
+
+        result = await adapter.send(chat_id, "workout summary")
+
+        assert result.success is True
+        trainer.send.assert_awaited_once()
+        accountant.send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unprofiled_route_still_uses_primary_adapter(self):
+        """No profile in the delivery entry → primary adapter (existing behaviour)."""
+        accountant, trainer = _discord("accountant"), _discord("trainer")
+        runner = _profile_runner(
+            primary_discord=accountant,
+            profile_discords={"trainer": {Platform.DISCORD: trainer}},
+        )
+        adapter, chat_id = self._adapter(
+            {"deliver": "discord", "deliver_extra": {"chat_id": "-100123"}},
+            runner,
+        )
+
+        result = await adapter.send(chat_id, "ci summary")
+
+        assert result.success is True
+        accountant.send.assert_awaited_once()
+        trainer.send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_bound_profile_without_adapter_fails_closed(self):
+        """Trainer bound but its Discord never connected → not-connected error, never a
+        silent fallback through the primary (accountant) bot."""
+        accountant = _discord("accountant")
+        runner = _profile_runner(primary_discord=accountant, profile_discords={"trainer": {}})
+        adapter, chat_id = self._adapter(
+            {"deliver": "discord", "deliver_extra": {"chat_id": "-100123"}, "profile": "trainer"},
+            runner,
+        )
+
+        result = await adapter.send(chat_id, "workout summary")
+
+        assert result.success is False
+        assert "not connected" in (result.error or "")
+        accountant.send.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# The route profile must reach _delivery_info via _dispatch_agent_run
+# ---------------------------------------------------------------------------
+
+class TestDispatchRecordsRouteProfile:
+
+    @pytest.mark.asyncio
+    async def test_dispatch_agent_run_stores_route_profile(self):
+        adapter = _make_adapter(routes={"ai-coach-events": {"deliver": "discord"}})
+        adapter.handle_message = AsyncMock()
+
+        class _Req:
+            method = "POST"
+
+        adapter._dispatch_agent_run(
+            _Req(), {"deliver": "discord"}, "ai-coach-events", "trainer",
+            {"n": 1}, "tick", "push", "d-1", time.time(),
+        )
+
+        info = adapter._delivery_info["webhook:ai-coach-events:d-1"]
+        assert info["deliver"] == "discord"
+        assert info["profile"] == "trainer"
+
+
+# ---------------------------------------------------------------------------
+# deliver_only routes share the same egress helper
+# ---------------------------------------------------------------------------
+
+class TestDeliverOnlyProfileDelivery:
+
+    @pytest.mark.asyncio
+    async def test_deliver_only_honors_route_profile(self):
+        accountant, trainer = _discord("accountant"), _discord("trainer")
+        runner = _profile_runner(
+            primary_discord=accountant,
+            profile_discords={"trainer": {Platform.DISCORD: trainer}},
+        )
+        adapter = _make_adapter()
+        adapter.gateway_runner = runner
+
+        await adapter._handle_deliver_only(
+            "outbound msg", {},
+            {"deliver": "discord", "profile": "trainer", "deliver_extra": {"chat_id": "-100123"}},
+            "notify", "event", "d-9",
+        )
+
+        trainer.send.assert_awaited_once()
+        accountant.send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_deliver_only_without_profile_uses_primary(self):
+        accountant, trainer = _discord("accountant"), _discord("trainer")
+        runner = _profile_runner(
+            primary_discord=accountant,
+            profile_discords={"trainer": {Platform.DISCORD: trainer}},
+        )
+        adapter = _make_adapter()
+        adapter.gateway_runner = runner
+
+        await adapter._handle_deliver_only(
+            "outbound msg", {},
+            {"deliver": "discord", "deliver_extra": {"chat_id": "-100123"}},
+            "notify", "event", "d-9",
+        )
+
+        accountant.send.assert_awaited_once()
+        trainer.send.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# HTTP boundary: /p/<profile>/ prefix flows end-to-end
+# ---------------------------------------------------------------------------
+
+class TestProfilePrefixHttpDelivery:
+
+    @pytest.mark.asyncio
+    async def test_url_profile_prefix_delivers_via_profile_adapter(self, monkeypatch, tmp_path):
+        """POST /p/trainer/webhooks/ai-coach-events → final response posts from the
+        trainer bot, not the primary (accountant) bot."""
+        accountant, trainer = _discord("accountant"), _discord("trainer")
+        runner = _profile_runner(
+            primary_discord=accountant,
+            profile_discords={"trainer": {Platform.DISCORD: trainer}},
+        )
+        routes = {"ai-coach-events": {
+            "secret": _INSECURE_NO_AUTH, "prompt": "tick", "deliver": "discord",
+            "deliver_extra": {"chat_id": "-100123"}, "profile": "trainer",
+        }}
+        adapter = _make_adapter(routes=routes)
+        adapter.gateway_runner = runner
+
+        # Simulate the runner side of the real flow: the agent turn's final response is
+        # delivered through WebhookAdapter.send() keyed on the session chat_id.
+        async def _fake_agent_turn(event):
+            await adapter.send(event.source.chat_id, "workout summary")
+
+        adapter.handle_message = _fake_agent_turn
+
+        # _resolve_request_profile / _profile_scope import these lazily from the module.
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profiles_to_serve",
+            lambda multiplex, profile_allowlist=None: [("default", "/x"), ("trainer", "/x")],
+        )
+        trainer_home = tmp_path / "profiles" / "trainer"
+        trainer_home.mkdir(parents=True)
+        (trainer_home / ".env").write_text("", encoding="utf-8")
+        monkeypatch.setattr("hermes_cli.profiles.get_profile_dir", lambda name: tmp_path / "profiles" / name)
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/p/trainer/webhooks/ai-coach-events",
+                json={"n": 1},
+                headers={"X-GitHub-Delivery": "d-http-1"},
+            )
+            assert resp.status == 202
+
+        # handle_message is spawned as a fire-and-forget task — let it finish.
+        for _ in range(100):
+            if trainer.send.await_count or accountant.send.await_count:
+                break
+            await asyncio.sleep(0.01)
+
+        # The route profile reached the delivery record…
+        info = adapter._delivery_info["webhook:ai-coach-events:d-http-1"]
+        assert info["profile"] == "trainer"
+        # …and egress used the profile's adapter, not the primary bot.
+        trainer.send.assert_awaited_once()
+        accountant.send.assert_not_awaited()


### PR DESCRIPTION
## Summary

A webhook route bound to `profile: X` with `deliver: <platform>` runs its agent session profile-scoped to X, but the final-response egress ignored the binding and posted from whichever adapter `_find_adapter` happened to return first. Under a multiplex gateway with two Discord profiles, that is the alphabetically-first profile's bot — live-verified on 2026-09-04: the `ai-coach-events` route bound to `profile: trainer` posted its response as the **accountant** bot (id `1542626633670991913`) instead of the trainer bot (id `1542632896924221460`).

## Where the bug manifests

`gateway/platforms/webhook.py`:

- `_dispatch_agent_run` stores the per-delivery delivery record (`deliver` + `deliver_extra`) in `_delivery_info[session_chat_id]`. The route-resolved profile is available right there — it is set on `source.profile` a few lines later — but it never reaches `_delivery_info`.
- `send()` reads that record and hands it to `_deliver_cross_platform(deliver_type, content, delivery)`.
- `_deliver_cross_platform` resolves the target adapter via `_find_adapter(target_platform)`, which prefers `gateway_runner.adapters` (the **primary** profile) and then iterates `_profile_adapters` values in insertion order — no profile awareness. Inbound routing already resolves adapters profile-scoped through `GatewayAuthorizationMixin._authorization_adapter(platform, profile)` (fail-closed); egress simply never used it.

`deliver_only` routes share the same egress (`_direct_deliver` → `_deliver_cross_platform`), so the same wrong-bot bug applies to them.

## The fix

- `_dispatch_agent_run` now stores the route-resolved profile in `_delivery_info` alongside `deliver`/`deliver_extra`.
- `_handle_deliver_only` passes the route's `profile` config key through the same delivery dict.
- New `_profile_delivery_adapter(target_platform, delivery)`: when a profile is bound, resolve the adapter via the runner's existing `_authorization_adapter(platform, profile)` — the same profile-scoped resolver reply routing uses (secondary-profile map, primary-profile match, fail-closed). When **no** profile is bound, fall back to `_find_adapter` so un-routed webhooks behave exactly as before.
- Fail-closed semantics preserved: a route bound to a named profile whose platform adapter never connected returns the not-connected error — it does **not** fall back to the primary/first-connected adapter, which would silently leak the response through another profile's bot.

## Invariant test

`tests/gateway/test_webhook_profile_delivery.py` (red on base — 5 failures before the fix, 7/7 green after):

- A route bound to `profile: trainer` + `deliver: discord` delivers via the trainer profile's adapter, not the first-connected (primary) Discord adapter — agent mode and `deliver_only` mode.
- The route profile reaches `_delivery_info` via `_dispatch_agent_run`.
- The `/p/trainer/` URL prefix flows end-to-end through the HTTP handler to profile-scoped egress.
- An un-profiled route still uses the primary adapter (no regression).
- A bound profile without a connected adapter fails closed with `Platform discord not connected` and never sends through the wrong bot.

## Testing

- `scripts/run_tests.sh tests/gateway/test_webhook_profile_delivery.py` — 7/7 pass (red before fix).
- Touched-area: `test_webhook_adapter`, `test_webhook_deliver_only`, `test_webhook_offloop_delivery`, `test_webhook_dynamic_routes`, `test_webhook_integration`, `test_webhook_session_close`, `test_webhook_route_toolsets`, `test_webhook_signature_rate_limit`, `test_cron_fire_webhook`, `test_msgraph_webhook`, `test_multiplex_http_routing`, `test_multiplex_interactive_auth` — 97/97 pass.
- Profile/multiplex scope: `test_multiplex_adapter_registry`, `test_multiplex_credential_isolation`, `test_multiplex_lifecycle`, `test_handoff_secondary_profile_adapter`, `test_api_server_profile_prefix_misdelivery`, `test_64674_multiplex_primary_token_scope` — 73/73 pass.
- `ruff check` clean on both changed files.
