### PR TITLE
feat(web): add a Last 5 Models strip to the Models page

### DIFF
--- a/web/src/i18n/af.ts
+++ b/web/src/i18n/af.ts
@@ -202,6 +202,7 @@ export const af: Translations = {
   },
 
   models: {
+    lastUsedModels: "Last 5 Models",
     modelsUsed: "Modelle Gebruik",
     estimatedCost: "Geskatte Koste",
     tokens: "tokens",

--- a/web/src/i18n/de.ts
+++ b/web/src/i18n/de.ts
@@ -202,6 +202,7 @@ export const de: Translations = {
   },
 
   models: {
+    lastUsedModels: "Last 5 Models",
     modelsUsed: "Verwendete Modelle",
     estimatedCost: "Gesch. Kosten",
     tokens: "Tokens",

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -227,6 +227,7 @@ export const en: Translations = {
   },
 
   models: {
+    lastUsedModels: "Last 5 Models",
     modelsUsed: "Models Used",
     estimatedCost: "Est. Cost",
     tokens: "tokens",

--- a/web/src/i18n/es.ts
+++ b/web/src/i18n/es.ts
@@ -202,6 +202,7 @@ export const es: Translations = {
   },
 
   models: {
+    lastUsedModels: "Last 5 Models",
     modelsUsed: "Modelos utilizados",
     estimatedCost: "Coste est.",
     tokens: "tokens",

--- a/web/src/i18n/fr.ts
+++ b/web/src/i18n/fr.ts
@@ -202,6 +202,7 @@ export const fr: Translations = {
   },
 
   models: {
+    lastUsedModels: "Last 5 Models",
     modelsUsed: "Modèles utilisés",
     estimatedCost: "Coût est.",
     tokens: "tokens",

--- a/web/src/i18n/ga.ts
+++ b/web/src/i18n/ga.ts
@@ -202,6 +202,7 @@ export const ga: Translations = {
   },
 
   models: {
+    lastUsedModels: "Last 5 Models",
     modelsUsed: "Samhlacha úsáidte",
     estimatedCost: "Costas measta",
     tokens: "tokens",

--- a/web/src/i18n/hu.ts
+++ b/web/src/i18n/hu.ts
@@ -202,6 +202,7 @@ export const hu: Translations = {
   },
 
   models: {
+    lastUsedModels: "Last 5 Models",
     modelsUsed: "Használt modellek",
     estimatedCost: "Becsült költség",
     tokens: "tokenek",

--- a/web/src/i18n/it.ts
+++ b/web/src/i18n/it.ts
@@ -202,6 +202,7 @@ export const it: Translations = {
   },
 
   models: {
+    lastUsedModels: "Last 5 Models",
     modelsUsed: "Modelli utilizzati",
     estimatedCost: "Costo stim.",
     tokens: "token",

--- a/web/src/i18n/ja.ts
+++ b/web/src/i18n/ja.ts
@@ -202,6 +202,7 @@ export const ja: Translations = {
   },
 
   models: {
+    lastUsedModels: "最近使用した5つのモデル",
     modelsUsed: "使用モデル",
     estimatedCost: "推定コスト",
     tokens: "トークン",

--- a/web/src/i18n/ko.ts
+++ b/web/src/i18n/ko.ts
@@ -202,6 +202,7 @@ export const ko: Translations = {
   },
 
   models: {
+    lastUsedModels: "Last 5 Models",
     modelsUsed: "사용된 모델",
     estimatedCost: "예상 비용",
     tokens: "토큰",

--- a/web/src/i18n/pt.ts
+++ b/web/src/i18n/pt.ts
@@ -202,6 +202,7 @@ export const pt: Translations = {
   },
 
   models: {
+    lastUsedModels: "Last 5 Models",
     modelsUsed: "Modelos utilizados",
     estimatedCost: "Custo est.",
     tokens: "tokens",

--- a/web/src/i18n/ru.ts
+++ b/web/src/i18n/ru.ts
@@ -202,6 +202,7 @@ export const ru: Translations = {
   },
 
   models: {
+    lastUsedModels: "Последние 5 моделей",
     modelsUsed: "Использовано моделей",
     estimatedCost: "Оценка стоимости",
     tokens: "токены",

--- a/web/src/i18n/tr.ts
+++ b/web/src/i18n/tr.ts
@@ -202,6 +202,7 @@ export const tr: Translations = {
   },
 
   models: {
+    lastUsedModels: "Last 5 Models",
     modelsUsed: "Kullanılan Modeller",
     estimatedCost: "Tahmini Maliyet",
     tokens: "token",

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -242,6 +242,7 @@ export interface Translations {
 
   // ── Models page ──
   models: {
+    lastUsedModels: string;
     modelsUsed: string;
     estimatedCost: string;
     tokens: string;

--- a/web/src/i18n/uk.ts
+++ b/web/src/i18n/uk.ts
@@ -202,6 +202,7 @@ export const uk: Translations = {
   },
 
   models: {
+    lastUsedModels: "Last 5 Models",
     modelsUsed: "Використано моделей",
     estimatedCost: "Орієнт. вартість",
     tokens: "токени",

--- a/web/src/i18n/zh-hant.ts
+++ b/web/src/i18n/zh-hant.ts
@@ -202,6 +202,7 @@ export const zhHant: Translations = {
   },
 
   models: {
+    lastUsedModels: "最近使用的 5 個模型",
     modelsUsed: "使用模型數",
     estimatedCost: "預估費用",
     tokens: "Token",

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -200,6 +200,7 @@ export const zh: Translations = {
   },
 
   models: {
+    lastUsedModels: "最近使用的 5 个模型",
     modelsUsed: "使用模型数",
     estimatedCost: "预估费用",
     tokens: "Token",

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import {
   Brain,
@@ -6,6 +6,7 @@ import {
   Cpu,
   DollarSign,
   Eye,
+  History,
   RefreshCw,
   Settings2,
   Star,
@@ -365,6 +366,61 @@ function UseAsMenu({
 /* ──────────────────────────────────────────────────────────────────── */
 /*  ModelCard                                                           */
 /* ──────────────────────────────────────────────────────────────────── */
+
+/* ──────────────────────────────────────────────────────────────────── */
+/*  "Last 5 Models" strip: most recently used models, mixed providers  */
+/* ──────────────────────────────────────────────────────────────────── */
+
+function LastUsedModels({ models }: { models: ModelsAnalyticsModelEntry[] }) {
+  const { t } = useI18n();
+
+  const recent = useMemo(
+    () =>
+      [...models]
+        .sort((a, b) => (b.last_used_at || 0) - (a.last_used_at || 0))
+        .slice(0, 5),
+    [models],
+  );
+
+  if (recent.length === 0) return null;
+
+  return (
+    <Card className="min-w-0 max-w-full">
+      <CardContent className="min-w-0 py-4">
+        <div className="flex items-center gap-2 mb-3">
+          <History className="h-4 w-4 text-text-secondary" />
+          <h2 className="text-sm font-medium">{t.models.lastUsedModels}</h2>
+        </div>
+        <div className="grid min-w-0 gap-2 md:grid-cols-2 xl:grid-cols-3">
+          {recent.map((entry) => {
+            const provider = entry.provider || modelVendor(entry.model);
+            return (
+              <div
+                key={`${entry.model}:${entry.provider}`}
+                className="flex min-w-0 items-center gap-2 rounded-md border border-border/60 px-3 py-2"
+              >
+                <span
+                  className="text-sm font-mono-ui truncate"
+                  title={entry.model}
+                >
+                  {shortModelName(entry.model)}
+                </span>
+                {provider && (
+                  <Badge tone="secondary" className="text-xs shrink-0">
+                    {provider}
+                  </Badge>
+                )}
+                <span className="ml-auto shrink-0 text-xs text-text-tertiary">
+                  {entry.last_used_at > 0 ? timeAgo(entry.last_used_at) : ""}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
 
 function ModelCard({
   entry,
@@ -1242,6 +1298,8 @@ export default function ModelsPage() {
   return (
     <div className="flex min-w-0 max-w-full flex-col gap-6">
       <PluginSlot name="models:top" />
+
+      {data && data.models.length > 0 && <LastUsedModels models={data.models} />}
 
       <div className="grid min-w-0 gap-6 lg:grid-cols-2">
         <ModelSettingsPanel


### PR DESCRIPTION
## Summary

Adds the requested "Last 5 Models" section to the top of the web Models page (`web/src/pages/ModelsPage.tsx`).

- The data was already there: `/api/analytics/models` returns per-model rows with `last_used_at` (MAX(started_at)) and `provider`. The page now sorts those rows by `last_used_at` desc and renders the top 5 as one strip directly under the `models:top` plugin slot.
- Providers mix naturally in a single list, since analytics groups by `(model, billing_provider)` — each chip shows the model name, a provider badge, and a relative `timeAgo` stamp.
- New i18n key `models.lastUsedModels`: `types.ts` + `en.ts` + all 16 full web locales (ru/zh/zh-hant/ja translated, English text elsewhere until native speakers refine it; `ar` is a partial locale and falls back automatically).

## Testing

- `tsc -p . --noEmit` (web) — clean.
- `eslint src/pages/ModelsPage.tsx src/i18n/*.ts` — 0 errors, 1 pre-existing warning (`react-hooks/set-state-in-effect`, identical on unpatched main).
- Full web vitest suite: **39 files / 291 tests passed** (`vitest run`).

Fixes #103011