### PR TITLE
feat(providers): resume a turn automatically when its usage limit resets

### DIFF
--- a/agent/quota_resume.py
+++ b/agent/quota_resume.py
@@ -1,0 +1,288 @@
+"""When a subscription quota wall can be waited out — and until exactly when.
+
+A subscription provider (Claude Pro/Max, ChatGPT Plus/Pro via Codex) answers an
+exhausted window with a *deadline*, not a refusal: the quota reopens at a stated
+time. Today that deadline is parsed for the credential pool's cooldown and then
+dropped, so the turn dies with a Retry button the user has to babysit.
+
+This module answers one question — "is this failure a quota wall with a
+trustworthy reset time, and when is it?" — and answers it the same way for every
+surface (Desktop/TUI gateway, messaging gateway). It decides nothing about *what*
+to do at that time; scheduling and dispatch belong to the caller that owns the
+session.
+
+Deadlines are only ever *reported*, never guessed:
+
+1. ``provider_error`` — the failing response carried a reset timestamp.
+2. ``credential_pool`` — a pooled credential re-enters rotation at a known time.
+3. ``usage_api``       — the provider publishes live window utilization
+   (``agent.account_usage``), consulted only when the error itself was silent.
+
+No deadline from those three means no plan, and the caller leaves the user in
+control. That is deliberate: a wrong auto-resume time is worse than none, because
+it either wastes hours of a working session or hammers a wall that is still up.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# Only a periodic quota that the provider promised to reopen. `billing` is a
+# spend wall that no amount of waiting clears, `overloaded` is capacity (retry in
+# seconds, not hours), and auth/context failures repeat identically. Waiting on
+# any of those burns the session for nothing.
+RESUMABLE_FAILURE_REASONS = frozenset({"rate_limit"})
+
+SOURCE_PROVIDER_ERROR = "provider_error"
+SOURCE_CREDENTIAL_POOL = "credential_pool"
+SOURCE_USAGE_API = "usage_api"
+
+# Providers publishing a live usage/limits endpoint that names its own reset
+# time. Anything absent here still auto-resumes when its *error* carries a
+# deadline — this gates only the extra lookup, never eligibility.
+USAGE_API_PROVIDERS = frozenset({"anthropic", "openai-codex"})
+
+# Wait past this and resuming is a surprise, not a convenience: a weekly window
+# can be days out, by which time the task's premises are stale and the user has
+# long since moved on. Beyond the cap we still report the deadline so the UI can
+# show "resets Tuesday" — we just refuse to sit on it.
+DEFAULT_MAX_WAIT_SECONDS = 26 * 3600
+
+# Provider clocks and ours disagree by a second or two, and a window that reopens
+# "at" T often serves the first request a moment later. Resuming a hair early
+# spends the retry on the same wall.
+DEFAULT_GRACE_SECONDS = 45.0
+
+# Treat a window as blocking only when it is effectively spent. Reset times for
+# windows with room left describe a future rollover, not the wall we just hit —
+# scheduling against those would park the session on the wrong clock entirely.
+_USAGE_API_EXHAUSTED_PERCENT = 99.0
+
+
+@dataclass(frozen=True)
+class QuotaResumePlan:
+    """Whether this failure can be waited out, and until when.
+
+    ``eligible`` is the only field a caller must branch on. ``resume_at`` may be
+    set while ``eligible`` is False (deadline known but too far out, or already
+    past) so a UI can still say *when* the wall lifts without arming a timer.
+    """
+
+    eligible: bool = False
+    resume_at: Optional[float] = None
+    source: str = ""
+    provider: str = ""
+    reason: str = ""
+
+    @property
+    def seconds_until_resume(self) -> Optional[float]:
+        return None if self.resume_at is None else max(0.0, self.resume_at - time.time())
+
+    def to_dict(self) -> dict:
+        """Wire form for the turn result / gateway payload (JSON-safe)."""
+        out: dict = {"eligible": self.eligible}
+        if self.resume_at is not None:
+            out["resume_at"] = self.resume_at
+        if self.source:
+            out["source"] = self.source
+        if self.provider:
+            out["provider"] = self.provider
+        if self.reason:
+            out["reason"] = self.reason
+        return out
+
+
+def coerce_reset_timestamp(value: Any, *, now: Optional[float] = None) -> Optional[float]:
+    """Best-effort epoch seconds from the shapes providers actually send.
+
+    Accepts epoch seconds, epoch milliseconds (Codex sends both across
+    endpoints), and ISO-8601 with ``Z`` or an offset. Returns None rather than
+    raising: an unparseable deadline must degrade to "no plan", never to an
+    exception on a path that is already handling a failure.
+    """
+    if value is None or isinstance(value, bool) or value == "":
+        return None
+    now = time.time() if now is None else now
+    if isinstance(value, (int, float)):
+        stamp = float(value)
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            stamp = float(text)
+        except ValueError:
+            iso = text[:-1] + "+00:00" if text.endswith("Z") else text
+            try:
+                parsed = datetime.fromisoformat(iso)
+            except ValueError:
+                return None
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return parsed.timestamp()
+    else:
+        return None
+    # Milliseconds: anything ~100x the current epoch cannot be seconds. Compared
+    # against `now` rather than a hardcoded year so this never expires.
+    if stamp > now * 10:
+        stamp /= 1000.0
+    return stamp
+
+
+def _reset_from_error_context(error_context: Any, *, now: float) -> Optional[float]:
+    """Deadline the failing response itself reported."""
+    if not isinstance(error_context, dict):
+        return None
+    stamp = coerce_reset_timestamp(error_context.get("reset_at"), now=now)
+    if stamp is not None:
+        return stamp
+    # Relative form. `extract_api_error_context` normalizes absolute fields but
+    # has no seconds-offset branch, and Codex sends `resets_in_seconds` beside
+    # `resets_at` — a provider that sends only the offset would otherwise lose
+    # its deadline here.
+    raw = error_context.get("resets_in_seconds")
+    if isinstance(raw, bool) or raw is None or raw == "":
+        return None
+    try:
+        offset = float(raw)
+    except (TypeError, ValueError):
+        return None
+    return now + offset if offset > 0 else None
+
+
+def _reset_from_credential_pool(pool: Any, *, now: float) -> Optional[float]:
+    """When the pool says some credential re-enters rotation.
+
+    ``next_available_at`` returns None while any credential can serve right now,
+    so this never parks a session that could have rotated its way out.
+    """
+    if pool is None:
+        return None
+    getter = getattr(pool, "next_available_at", None)
+    if not callable(getter):
+        return None
+    try:
+        return coerce_reset_timestamp(getter(), now=now)
+    except Exception:
+        logger.debug("quota-resume: credential pool reset lookup failed", exc_info=True)
+        return None
+
+
+def _reset_from_usage_api(provider: str, *, now: float) -> Optional[float]:
+    """Earliest reset among the provider's *exhausted* windows.
+
+    Authoritative where it exists: it reads the account's real utilization
+    instead of trusting how the error happened to be labelled. Only windows at
+    or above the exhaustion threshold count — a fresh window's reset time is a
+    rollover, not a wall.
+    """
+    try:
+        from agent.account_usage import fetch_account_usage
+
+        snapshot = fetch_account_usage(provider)
+    except Exception:
+        logger.debug("quota-resume: usage API lookup failed for %s", provider, exc_info=True)
+        return None
+    if snapshot is None or not getattr(snapshot, "available", False):
+        return None
+    candidates: list[float] = []
+    for window in getattr(snapshot, "windows", ()) or ():
+        used = getattr(window, "used_percent", None)
+        reset_at = getattr(window, "reset_at", None)
+        if used is None or reset_at is None:
+            continue
+        try:
+            if float(used) < _USAGE_API_EXHAUSTED_PERCENT:
+                continue
+        except (TypeError, ValueError):
+            continue
+        stamp = coerce_reset_timestamp(
+            reset_at.timestamp() if isinstance(reset_at, datetime) else reset_at, now=now
+        )
+        if stamp is not None and stamp > now:
+            candidates.append(stamp)
+    return min(candidates) if candidates else None
+
+
+def plan_quota_resume(
+    *,
+    failure_reason: Any,
+    error_context: Any = None,
+    provider: Any = "",
+    credential_pool: Any = None,
+    now: Optional[float] = None,
+    grace_seconds: float = DEFAULT_GRACE_SECONDS,
+    max_wait_seconds: float = DEFAULT_MAX_WAIT_SECONDS,
+    allow_usage_api: bool = True,
+) -> QuotaResumePlan:
+    """Decide whether a failed turn can be resumed when its quota window reopens.
+
+    Sources are tried cheapest-first and the first hit wins; the usage API is a
+    fallback for a silent error, not a second opinion on one that already told us
+    when it reopens.
+
+    Never raises: every failure mode degrades to an ineligible plan, because this
+    runs while a turn is already failing.
+    """
+    reason = str(getattr(failure_reason, "value", failure_reason) or "").strip().lower()
+    provider_name = str(provider or "").strip().lower()
+    if reason not in RESUMABLE_FAILURE_REASONS:
+        return QuotaResumePlan(provider=provider_name, reason=reason)
+
+    now = time.time() if now is None else now
+    resume_at: Optional[float] = None
+    source = ""
+    for candidate_source, resolver in (
+        (SOURCE_PROVIDER_ERROR, lambda: _reset_from_error_context(error_context, now=now)),
+        (SOURCE_CREDENTIAL_POOL, lambda: _reset_from_credential_pool(credential_pool, now=now)),
+    ):
+        try:
+            resume_at = resolver()
+        except Exception:
+            logger.debug("quota-resume: %s resolver failed", candidate_source, exc_info=True)
+            resume_at = None
+        if resume_at is not None:
+            source = candidate_source
+            break
+    if resume_at is None and allow_usage_api and provider_name in USAGE_API_PROVIDERS:
+        resume_at = _reset_from_usage_api(provider_name, now=now)
+        if resume_at is not None:
+            source = SOURCE_USAGE_API
+
+    if resume_at is None:
+        return QuotaResumePlan(provider=provider_name, reason=reason)
+
+    # A deadline already past means the wall lifted between the failure and this
+    # check (a stale pool entry, or a race with the reset). Report it, but don't
+    # claim an "auto-resume" the caller would fire instantly — the user's own
+    # Retry is the honest affordance there.
+    if resume_at <= now:
+        return QuotaResumePlan(resume_at=resume_at, source=source, provider=provider_name, reason=reason)
+
+    scheduled_at = resume_at + max(0.0, grace_seconds)
+    if scheduled_at - now > max(0.0, max_wait_seconds):
+        # Too far out to sit on, but still worth telling the user about.
+        return QuotaResumePlan(resume_at=resume_at, source=source, provider=provider_name, reason=reason)
+    return QuotaResumePlan(
+        eligible=True, resume_at=scheduled_at, source=source, provider=provider_name, reason=reason
+    )
+
+
+__all__ = [
+    "DEFAULT_GRACE_SECONDS",
+    "DEFAULT_MAX_WAIT_SECONDS",
+    "QuotaResumePlan",
+    "RESUMABLE_FAILURE_REASONS",
+    "SOURCE_CREDENTIAL_POOL",
+    "SOURCE_PROVIDER_ERROR",
+    "SOURCE_USAGE_API",
+    "USAGE_API_PROVIDERS",
+    "coerce_reset_timestamp",
+    "plan_quota_resume",
+]

--- a/agent/turn_api_error.py
+++ b/agent/turn_api_error.py
@@ -205,7 +205,7 @@ def handle_api_error(
         api_messages=api_messages, api_kwargs=api_kwargs, active_system_prompt=active_system_prompt,
         conversation_history=conversation_history, approx_tokens=approx_tokens,
         retry_count=retry_count, max_retries=max_retries, compression_attempts=compression_attempts,
-        api_call_count=api_call_count,
+        api_call_count=api_call_count, error_context=error_context,
     )
     active_system_prompt = _ue.active_system_prompt
     retry_count = _ue.retry_count
@@ -252,7 +252,7 @@ def settle_unrecovered_error(
     is_context_length_error: Any, is_rate_limited: Any, _is_zai_coding_overload: Any,
     _provider: Any, _base: Any, _model: Any, messages: Any, api_messages: Any, api_kwargs: Any,
     active_system_prompt: Any, conversation_history: Any, approx_tokens: Any, retry_count: Any,
-    max_retries: Any, compression_attempts: Any, api_call_count: Any,
+    max_retries: Any, compression_attempts: Any, api_call_count: Any, error_context: Any = None,
 ) -> UnrecoveredErrorVerdict:
     """Decide the fate of an API error that every recovery chain declined: local validation /
     non-retryable client errors (Copilot stale-credential self-heal first, then fallback, then a
@@ -345,7 +345,7 @@ def settle_unrecovered_error(
             error_msg=error_msg, api_kwargs=api_kwargs, api_messages=api_messages,
             messages=messages, conversation_history=conversation_history,
             api_call_count=api_call_count, approx_tokens=approx_tokens, provider=_provider,
-            base_url=_base, model=_model,
+            base_url=_base, model=_model, error_context=error_context,
         ))
 
     wait_time = compute_error_backoff(

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -735,11 +735,34 @@ _STREAM_DROP_MARKERS = (
 )
 
 
+def _quota_resume_plan(
+    agent: Any, classified: Any, *, error_context: Any, provider: Any
+) -> Optional[Dict[str, Any]]:
+    """Wire-form quota-resume descriptor for a terminal failure, or None.
+
+    Best-effort by construction: this decorates an already-failed turn, so any
+    problem resolving the deadline must leave the failure exactly as it was.
+    """
+    try:
+        from agent.quota_resume import plan_quota_resume
+
+        plan = plan_quota_resume(
+            failure_reason=classified.reason,
+            error_context=error_context,
+            provider=provider,
+            credential_pool=getattr(agent, "_credential_pool", None),
+        )
+    except Exception:
+        logger.debug("quota-resume planning failed", exc_info=True)
+        return None
+    return plan.to_dict() if (plan.eligible or plan.resume_at is not None) else None
+
+
 def max_retries_exhausted_result(
     agent: Any, api_error: Exception, classified: Any, *, max_retries: int, is_rate_limited: bool,
     error_msg: str, api_kwargs: Any, api_messages: Any, messages: List[Dict[str, Any]],
     conversation_history: Any, api_call_count: int, approx_tokens: int, provider: Any,
-    base_url: Any, model: Any,
+    base_url: Any, model: Any, error_context: Any = None,
 ) -> Dict[str, Any]:
     """Terminal path once retries, transport recovery and fallback all failed: flush the
     trace, emit the billing / rate-limit / generic status, print stream-drop or thinking-timeout
@@ -854,6 +877,14 @@ def max_retries_exhausted_result(
         # Present only for billing walls: (provider, billing_url, is_nous, message).
         "billing_block": _billing_block,
     })
+    # Subscription quota wall: carry the provider's own reset deadline to the surfaces
+    # so a client can wait it out instead of handing the user a blind Retry. Only
+    # attached when a deadline was actually reported — never guessed.
+    _resume_plan = _quota_resume_plan(
+        agent, classified, error_context=error_context, provider=provider,
+    )
+    if _resume_plan is not None:
+        result["quota_resume"] = _resume_plan
     return result
 
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2273,6 +2273,17 @@ DEFAULT_CONFIG = {
             "freshness_minutes": 15,
             "max_attempts": 2,  # Crash-loop breaker: max automatic re-runs of one interrupted turn.
         },
+        # Subscription quota walls (Claude Pro/Max 5-hour + weekly, ChatGPT/Codex windows)
+        # come with a provider-reported reset time. When one kills a turn, wait for that
+        # window to reopen and finish the turn automatically instead of leaving a Retry
+        # button the user has to babysit. Only ever armed from a reset time the provider
+        # actually reported (error body/header, credential pool, or the provider's usage
+        # API) — never a guess, and never for overload/billing/auth failures.
+        "quota_resume": {
+            "enabled": True,
+            # Max automatic resumes of one turn, so a mis-reported reset can't loop it.
+            "max_attempts": 2,
+        },
     },
 
     "nous": {

--- a/hermes_cli/web_server_config.py
+++ b/hermes_cli/web_server_config.py
@@ -59,6 +59,19 @@ def _select(description: str, *options: str, **extra: Any) -> Dict[str, Any]:
 
 # Manual overrides for fields that need select options or custom types.
 _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
+    "desktop.quota_resume.enabled": {
+        "type": "boolean",
+        "description": (
+            "Continue automatically when a provider usage limit resets "
+            "(only when the provider reports a reset time)"
+        ),
+        "category": "desktop",
+    },
+    "desktop.quota_resume.max_attempts": {
+        "type": "number",
+        "description": "Max automatic resumes of one turn after a usage limit",
+        "category": "desktop",
+    },
     "timezone": _select(
         "IANA timezone (e.g. America/New_York). Blank uses the system timezone.",
         *_timezone_options(), searchable=True, clearable=True,

--- a/tests/agent/test_quota_resume.py
+++ b/tests/agent/test_quota_resume.py
@@ -1,0 +1,372 @@
+"""Behaviour contracts for agent.quota_resume.
+
+The plan is a *decision*, so the tests pin the decision boundaries: which
+failures may be waited out, which reset source wins, and the cases where a
+deadline is known but arming a timer would be wrong.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import pytest
+
+from agent.quota_resume import (
+    DEFAULT_MAX_WAIT_SECONDS,
+    SOURCE_CREDENTIAL_POOL,
+    SOURCE_PROVIDER_ERROR,
+    SOURCE_USAGE_API,
+    QuotaResumePlan,
+    coerce_reset_timestamp,
+    plan_quota_resume,
+)
+
+NOW = 1_800_000_000.0
+HOUR = 3600.0
+
+
+class _Pool:
+    def __init__(self, value=None, raises: bool = False):
+        self._value, self._raises = value, raises
+
+    def next_available_at(self):
+        if self._raises:
+            raise RuntimeError("pool exploded")
+        return self._value
+
+
+@dataclass(frozen=True)
+class _Window:
+    label: str
+    used_percent: Optional[float]
+    reset_at: Optional[object]
+
+
+@dataclass(frozen=True)
+class _Snapshot:
+    windows: tuple
+    available: bool = True
+
+
+def _install_usage_api(monkeypatch, snapshot, *, raises: bool = False):
+    """Stub agent.account_usage.fetch_account_usage where quota_resume imports it."""
+    import agent.account_usage as account_usage
+
+    def _fake(provider, **_kwargs):
+        if raises:
+            raise RuntimeError("usage api down")
+        return snapshot
+
+    monkeypatch.setattr(account_usage, "fetch_account_usage", _fake)
+
+
+# ── timestamp coercion ────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (NOW + HOUR, NOW + HOUR),                       # epoch seconds
+        ((NOW + HOUR) * 1000, NOW + HOUR),              # epoch milliseconds
+        (str(NOW + HOUR), NOW + HOUR),                  # numeric string
+        ("2027-01-15T10:30:00Z", 1_800_009_000.0),      # ISO-8601 Zulu
+        ("2027-01-15T10:30:00+00:00", 1_800_009_000.0),
+    ],
+)
+def test_coerce_reset_timestamp_accepts_provider_shapes(value, expected):
+    assert coerce_reset_timestamp(value, now=NOW) == pytest.approx(expected, abs=1.0)
+
+
+@pytest.mark.parametrize("value", [None, "", "not-a-date", True, False, {}, []])
+def test_coerce_reset_timestamp_rejects_unusable(value):
+    assert coerce_reset_timestamp(value, now=NOW) is None
+
+
+def test_naive_iso_is_treated_as_utc():
+    aware = coerce_reset_timestamp("2027-01-15T10:30:00+00:00", now=NOW)
+    assert coerce_reset_timestamp("2027-01-15T10:30:00", now=NOW) == aware
+
+
+# ── eligibility gate ──────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "reason",
+    ["billing", "overloaded", "auth", "auth_permanent", "context_overflow",
+     "server_error", "timeout", "model_not_found", "unknown", "", None],
+)
+def test_only_rate_limit_is_resumable(reason):
+    """A deadline must never arm a timer for a wall that waiting cannot clear."""
+    plan = plan_quota_resume(
+        failure_reason=reason,
+        error_context={"reset_at": NOW + HOUR},
+        provider="anthropic",
+        now=NOW,
+        allow_usage_api=False,
+    )
+    assert plan.eligible is False
+    assert plan.resume_at is None
+
+
+def test_overload_with_no_deadline_is_not_resumable():
+    """The captured Anthropic overload shape: HTTP 200 SSE error, no reset field."""
+    plan = plan_quota_resume(
+        failure_reason="overloaded",
+        error_context={"reason": "overloaded_error", "message": "Overloaded"},
+        provider="anthropic",
+        now=NOW,
+        allow_usage_api=False,
+    )
+    assert plan.eligible is False
+
+
+def test_rate_limit_without_any_deadline_is_not_eligible():
+    """No trustworthy source means no guess — the user keeps control."""
+    plan = plan_quota_resume(
+        failure_reason="rate_limit",
+        error_context={"message": "Too many requests"},
+        provider="some-unknown-provider",
+        credential_pool=_Pool(None),
+        now=NOW,
+        allow_usage_api=False,
+    )
+    assert plan.eligible is False
+    assert plan.resume_at is None
+    assert plan.source == ""
+
+
+def test_failure_reason_accepts_enum_like_value():
+    class _Reason:
+        value = "rate_limit"
+
+    plan = plan_quota_resume(
+        failure_reason=_Reason(),
+        error_context={"reset_at": NOW + HOUR},
+        provider="anthropic",
+        now=NOW,
+        allow_usage_api=False,
+    )
+    assert plan.eligible is True
+
+
+# ── source precedence ─────────────────────────────────────────────────────────
+
+def test_provider_error_deadline_wins_over_pool(monkeypatch):
+    _install_usage_api(monkeypatch, None)
+    plan = plan_quota_resume(
+        failure_reason="rate_limit",
+        error_context={"reset_at": NOW + HOUR},
+        provider="anthropic",
+        credential_pool=_Pool(NOW + 5 * HOUR),
+        now=NOW,
+        grace_seconds=0.0,
+    )
+    assert (plan.eligible, plan.source, plan.resume_at) == (True, SOURCE_PROVIDER_ERROR, NOW + HOUR)
+
+
+def test_resets_in_seconds_alone_yields_a_deadline():
+    """Codex sends resets_at *and* resets_in_seconds; a provider sending only the
+    offset must not silently lose its deadline."""
+    plan = plan_quota_resume(
+        failure_reason="rate_limit",
+        error_context={"reason": "usage_limit_reached", "resets_in_seconds": 900},
+        provider="openai-codex",
+        now=NOW,
+        grace_seconds=0.0,
+        allow_usage_api=False,
+    )
+    assert (plan.eligible, plan.source) == (True, SOURCE_PROVIDER_ERROR)
+    assert plan.resume_at == NOW + 900
+
+
+def test_pool_deadline_used_when_error_is_silent():
+    plan = plan_quota_resume(
+        failure_reason="rate_limit",
+        error_context={"message": "rate limited"},
+        provider="anthropic",
+        credential_pool=_Pool(NOW + 2 * HOUR),
+        now=NOW,
+        grace_seconds=0.0,
+        allow_usage_api=False,
+    )
+    assert (plan.eligible, plan.source, plan.resume_at) == (True, SOURCE_CREDENTIAL_POOL, NOW + 2 * HOUR)
+
+
+def test_pool_returning_none_falls_through_to_usage_api(monkeypatch):
+    """None from the pool means a credential can serve now — not 'no deadline'."""
+    _install_usage_api(monkeypatch, _Snapshot(windows=(
+        _Window("Current session", 100.0, NOW + 3 * HOUR),
+    )))
+    plan = plan_quota_resume(
+        failure_reason="rate_limit",
+        error_context={},
+        provider="anthropic",
+        credential_pool=_Pool(None),
+        now=NOW,
+        grace_seconds=0.0,
+    )
+    assert (plan.eligible, plan.source, plan.resume_at) == (True, SOURCE_USAGE_API, NOW + 3 * HOUR)
+
+
+def test_usage_api_skipped_for_providers_without_one(monkeypatch):
+    called = {"n": 0}
+
+    import agent.account_usage as account_usage
+
+    def _fake(provider, **_kwargs):
+        called["n"] += 1
+        return _Snapshot(windows=(_Window("w", 100.0, NOW + HOUR),))
+
+    monkeypatch.setattr(account_usage, "fetch_account_usage", _fake)
+    plan = plan_quota_resume(
+        failure_reason="rate_limit", error_context={}, provider="openrouter", now=NOW,
+    )
+    assert plan.eligible is False
+    assert called["n"] == 0
+
+
+def test_usage_api_not_consulted_when_error_already_gave_a_deadline(monkeypatch):
+    called = {"n": 0}
+
+    import agent.account_usage as account_usage
+
+    def _fake(provider, **_kwargs):
+        called["n"] += 1
+        return None
+
+    monkeypatch.setattr(account_usage, "fetch_account_usage", _fake)
+    plan_quota_resume(
+        failure_reason="rate_limit",
+        error_context={"reset_at": NOW + HOUR},
+        provider="anthropic",
+        now=NOW,
+    )
+    assert called["n"] == 0
+
+
+# ── usage-API window selection ────────────────────────────────────────────────
+
+def test_usage_api_ignores_windows_with_headroom(monkeypatch):
+    """A fresh window's reset time is a rollover, not the wall we just hit."""
+    _install_usage_api(monkeypatch, _Snapshot(windows=(
+        _Window("Current session", 12.0, NOW + HOUR),        # plenty left
+        _Window("Current week", 100.0, NOW + 6 * HOUR),      # actually exhausted
+    )))
+    plan = plan_quota_resume(
+        failure_reason="rate_limit", error_context={}, provider="anthropic",
+        now=NOW, grace_seconds=0.0,
+    )
+    assert (plan.eligible, plan.resume_at) == (True, NOW + 6 * HOUR)
+
+
+def test_usage_api_picks_earliest_exhausted_window(monkeypatch):
+    _install_usage_api(monkeypatch, _Snapshot(windows=(
+        _Window("Opus week", 100.0, NOW + 10 * HOUR),
+        _Window("Current session", 99.5, NOW + 2 * HOUR),
+    )))
+    plan = plan_quota_resume(
+        failure_reason="rate_limit", error_context={}, provider="anthropic",
+        now=NOW, grace_seconds=0.0,
+    )
+    assert plan.resume_at == NOW + 2 * HOUR
+
+
+def test_usage_api_accepts_datetime_reset(monkeypatch):
+    reset = datetime.fromtimestamp(NOW, tz=timezone.utc) + timedelta(hours=4)
+    _install_usage_api(monkeypatch, _Snapshot(windows=(
+        _Window("Current session", 100.0, reset),
+    )))
+    plan = plan_quota_resume(
+        failure_reason="rate_limit", error_context={}, provider="anthropic",
+        now=NOW, grace_seconds=0.0,
+    )
+    assert plan.resume_at == pytest.approx(NOW + 4 * HOUR, abs=1.0)
+
+
+def test_unavailable_usage_snapshot_yields_no_plan(monkeypatch):
+    _install_usage_api(monkeypatch, _Snapshot(windows=(), available=False))
+    plan = plan_quota_resume(
+        failure_reason="rate_limit", error_context={}, provider="anthropic", now=NOW,
+    )
+    assert plan.eligible is False
+
+
+# ── bounds and degradation ────────────────────────────────────────────────────
+
+def test_grace_period_is_added_to_the_deadline():
+    plan = plan_quota_resume(
+        failure_reason="rate_limit",
+        error_context={"reset_at": NOW + HOUR},
+        provider="anthropic", now=NOW, grace_seconds=45.0, allow_usage_api=False,
+    )
+    assert plan.resume_at == NOW + HOUR + 45.0
+
+
+def test_deadline_beyond_max_wait_reports_but_does_not_arm():
+    plan = plan_quota_resume(
+        failure_reason="rate_limit",
+        error_context={"reset_at": NOW + DEFAULT_MAX_WAIT_SECONDS + HOUR},
+        provider="openai-codex", now=NOW, allow_usage_api=False,
+    )
+    assert plan.eligible is False
+    assert plan.resume_at == NOW + DEFAULT_MAX_WAIT_SECONDS + HOUR
+    assert plan.source == SOURCE_PROVIDER_ERROR
+
+
+def test_past_deadline_reports_but_does_not_arm():
+    plan = plan_quota_resume(
+        failure_reason="rate_limit",
+        error_context={"reset_at": NOW - HOUR},
+        provider="anthropic", now=NOW, allow_usage_api=False,
+    )
+    assert plan.eligible is False
+    assert plan.resume_at == NOW - HOUR
+
+
+def test_pool_exception_degrades_to_no_plan():
+    plan = plan_quota_resume(
+        failure_reason="rate_limit", error_context={}, provider="anthropic",
+        credential_pool=_Pool(raises=True), now=NOW, allow_usage_api=False,
+    )
+    assert plan.eligible is False
+
+
+def test_usage_api_exception_degrades_to_no_plan(monkeypatch):
+    _install_usage_api(monkeypatch, None, raises=True)
+    plan = plan_quota_resume(
+        failure_reason="rate_limit", error_context={}, provider="anthropic", now=NOW,
+    )
+    assert plan.eligible is False
+
+
+def test_malformed_error_context_is_survivable():
+    for bad in ("string", 42, [], None):
+        plan = plan_quota_resume(
+            failure_reason="rate_limit", error_context=bad, provider="anthropic",
+            now=NOW, allow_usage_api=False,
+        )
+        assert plan.eligible is False
+
+
+# ── wire form ─────────────────────────────────────────────────────────────────
+
+def test_to_dict_omits_empty_fields():
+    assert QuotaResumePlan().to_dict() == {"eligible": False}
+
+
+def test_to_dict_round_trips_a_real_plan():
+    plan = plan_quota_resume(
+        failure_reason="rate_limit",
+        error_context={"reset_at": NOW + HOUR},
+        provider="anthropic", now=NOW, grace_seconds=0.0, allow_usage_api=False,
+    )
+    assert plan.to_dict() == {
+        "eligible": True, "resume_at": NOW + HOUR,
+        "source": SOURCE_PROVIDER_ERROR, "provider": "anthropic", "reason": "rate_limit",
+    }
+
+
+def test_seconds_until_resume_never_negative():
+    plan = QuotaResumePlan(eligible=True, resume_at=time.time() - 500)
+    assert plan.seconds_until_resume == 0.0

--- a/tests/tui_gateway/test_quota_resume_e2e.py
+++ b/tests/tui_gateway/test_quota_resume_e2e.py
@@ -1,0 +1,289 @@
+"""End-to-end: a provider quota wall arms a backend resume; nothing else does.
+
+Exercises the real chain — classifier verdict -> turn result -> gateway payload ->
+armed session state -> poller dispatch — with the actual error payloads captured
+from Anthropic and the ChatGPT/Codex backend, not hand-written approximations.
+
+The gateway helpers are rebound onto ``tui_gateway.server``'s namespace at import
+(method_ctx.bind_module), so they are patched and called *there*.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Optional
+
+import pytest
+
+# Captured verbatim from a real ChatGPT/Codex 429 (request dump, account scrubbed).
+CODEX_QUOTA_BODY = {
+    "type": "usage_limit_reached",
+    "message": "The usage limit has been reached",
+    "plan_type": "prolite",
+    "resets_at": 1788646607,
+    "resets_in_seconds": 510651,
+}
+# Captured verbatim from Anthropic: an SSE error inside an HTTP 200 stream.
+ANTHROPIC_OVERLOAD_BODY = {
+    "type": "error",
+    "error": {"details": None, "type": "overloaded_error", "message": "Overloaded"},
+}
+
+
+class _FakeError(Exception):
+    """Provider SDK error shape that extract_api_error_context understands."""
+
+    def __init__(self, body, message="", status_code=None):
+        super().__init__(message or str(body))
+        self.body = body
+        self.status_code = status_code
+        self.response = None
+
+
+@pytest.fixture()
+def server():
+    import tui_gateway.server as server_mod
+
+    return server_mod
+
+
+def _session(**over) -> dict:
+    import threading
+
+    session = {"history_lock": threading.RLock(), "running": False}
+    session.update(over)
+    return session
+
+
+# ── error context -> plan (real extractor, real payloads) ─────────────────────
+
+def test_captured_codex_quota_payload_yields_a_deadline():
+    from agent.agent_runtime_helpers import extract_api_error_context
+    from agent.quota_resume import SOURCE_PROVIDER_ERROR, plan_quota_resume
+
+    ctx = extract_api_error_context(_FakeError(CODEX_QUOTA_BODY, status_code=429))
+    assert ctx["reset_at"] == 1788646607
+
+    plan = plan_quota_resume(
+        failure_reason="rate_limit", error_context=ctx, provider="openai-codex",
+        now=1788646607 - 3600, grace_seconds=0.0, allow_usage_api=False,
+    )
+    assert (plan.eligible, plan.source) == (True, SOURCE_PROVIDER_ERROR)
+    assert plan.resume_at == 1788646607
+
+
+def test_captured_anthropic_overload_payload_yields_no_plan():
+    """The exact failure this feature must NOT fire on: capacity, not quota."""
+    from agent.agent_runtime_helpers import extract_api_error_context
+    from agent.quota_resume import plan_quota_resume
+
+    ctx = extract_api_error_context(_FakeError(ANTHROPIC_OVERLOAD_BODY, status_code=200))
+    assert "reset_at" not in ctx
+
+    plan = plan_quota_resume(
+        failure_reason="overloaded", error_context=ctx, provider="anthropic",
+        allow_usage_api=False,
+    )
+    assert plan.eligible is False
+
+
+# ── terminal turn result carries the plan ─────────────────────────────────────
+
+def test_max_retries_result_attaches_quota_resume(monkeypatch):
+    """The terminal result is where the deadline stops being thrown away."""
+    from agent.error_classifier import FailoverReason
+    import agent.turn_recovery as turn_recovery
+
+    reset_at = time.time() + 1800
+
+    class _Classified:
+        reason = FailoverReason.rate_limit
+        retryable = True
+        billing_unverified = False
+
+    plan = turn_recovery._quota_resume_plan(
+        agent=type("A", (), {"_credential_pool": None})(),
+        classified=_Classified(),
+        error_context={"reset_at": reset_at},
+        provider="anthropic",
+    )
+    assert plan is not None
+    assert plan["eligible"] is True
+    assert plan["provider"] == "anthropic"
+    assert plan["resume_at"] == pytest.approx(reset_at + 45.0, abs=1.0)
+
+
+def test_max_retries_result_omits_plan_for_overload():
+    from agent.error_classifier import FailoverReason
+    import agent.turn_recovery as turn_recovery
+
+    class _Classified:
+        reason = FailoverReason.overloaded
+        retryable = True
+        billing_unverified = False
+
+    assert turn_recovery._quota_resume_plan(
+        agent=type("A", (), {"_credential_pool": None})(),
+        classified=_Classified(), error_context={}, provider="anthropic",
+    ) is None
+
+
+# ── arming ────────────────────────────────────────────────────────────────────
+
+def test_arm_stores_due_time_and_prompt(server, monkeypatch):
+    monkeypatch.setattr(server, "_quota_resume_config", lambda: (True, 2))
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    session = _session()
+    resume_at = time.time() + 600
+
+    armed = server._arm_quota_resume(
+        "sid-1", session,
+        {"eligible": True, "resume_at": resume_at, "source": "provider_error", "provider": "anthropic"},
+        "finish the migration",
+    )
+    assert armed is True
+    assert session["_quota_resume_at"] == resume_at
+    assert session["_quota_resume_prompt"] == "finish the migration"
+
+
+@pytest.mark.parametrize(
+    "plan, prompt, reason",
+    [
+        ({"eligible": False, "resume_at": time.time() + 600}, "p", "ineligible plan"),
+        ({"eligible": True}, "p", "no resume_at"),
+        ({"eligible": True, "resume_at": time.time() + 600}, "   ", "empty prompt"),
+        ({"eligible": True, "resume_at": "later"}, "p", "non-numeric resume_at"),
+    ],
+)
+def test_arm_refuses_unusable_input(server, monkeypatch, plan, prompt, reason):
+    monkeypatch.setattr(server, "_quota_resume_config", lambda: (True, 2))
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    session = _session()
+    assert server._arm_quota_resume("sid-1", session, plan, prompt) is False, reason
+    assert "_quota_resume_at" not in session
+
+
+def test_arm_respects_disabled_config(server, monkeypatch):
+    monkeypatch.setattr(server, "_quota_resume_config", lambda: (False, 2))
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    session = _session()
+    assert server._arm_quota_resume(
+        "sid-1", session, {"eligible": True, "resume_at": time.time() + 60}, "p") is False
+
+
+def test_arm_refuses_hosted_room_session(server, monkeypatch):
+    """Hosted rooms recover through their own durable lease machine."""
+    monkeypatch.setattr(server, "_quota_resume_config", lambda: (True, 2))
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    session = _session(source="bot_room")
+    assert server._arm_quota_resume(
+        "sid-1", session, {"eligible": True, "resume_at": time.time() + 60}, "p") is False
+
+
+def test_arm_stops_after_max_attempts(server, monkeypatch):
+    monkeypatch.setattr(server, "_quota_resume_config", lambda: (True, 2))
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    session = _session(_quota_resume_attempt=2)
+    assert server._arm_quota_resume(
+        "sid-1", session, {"eligible": True, "resume_at": time.time() + 60}, "p") is False
+
+
+# ── firing ────────────────────────────────────────────────────────────────────
+
+def _capture_submit(server, monkeypatch) -> list:
+    submitted: list = []
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_ensure_active_session_slot", lambda sid, s: None)
+    monkeypatch.setattr(
+        server, "_run_prompt_submit",
+        lambda rid, sid, session, text, **kw: submitted.append({"text": text, **kw}))
+    return submitted
+
+
+def test_fires_when_due_and_carries_the_original_prompt(server, monkeypatch):
+    submitted = _capture_submit(server, monkeypatch)
+    session = _session(
+        _quota_resume_at=time.time() - 1,
+        _quota_resume_prompt="rerun the failing suite",
+        _quota_resume_meta={"provider": "anthropic"},
+    )
+    server._maybe_fire_quota_resume("sid-1", session)
+
+    assert len(submitted) == 1
+    assert "rerun the failing suite" in submitted[0]["text"]
+    assert submitted[0]["display_kind"] == "auto_continue"
+    # Pending state is consumed exactly once.
+    assert "_quota_resume_at" not in session
+    assert session["_quota_resume_attempt"] == 1
+
+
+def test_does_not_fire_before_the_deadline(server, monkeypatch):
+    submitted = _capture_submit(server, monkeypatch)
+    session = _session(_quota_resume_at=time.time() + 600, _quota_resume_prompt="later")
+    server._maybe_fire_quota_resume("sid-1", session)
+    assert submitted == []
+    assert session["_quota_resume_at"]  # still armed
+
+
+def test_running_session_cancels_the_pending_resume(server, monkeypatch):
+    """A live turn means the user is driving; the stale resume is dropped."""
+    submitted = _capture_submit(server, monkeypatch)
+    session = _session(running=True, _quota_resume_at=time.time() - 1, _quota_resume_prompt="p")
+    server._maybe_fire_quota_resume("sid-1", session)
+    assert submitted == []
+    assert "_quota_resume_at" not in session
+
+
+def test_finalized_session_never_fires(server, monkeypatch):
+    submitted = _capture_submit(server, monkeypatch)
+    session = _session(_finalized=True, _quota_resume_at=time.time() - 1, _quota_resume_prompt="p")
+    server._maybe_fire_quota_resume("sid-1", session)
+    assert submitted == []
+
+
+def test_foreign_owner_defers_and_releases(server, monkeypatch):
+    """A sibling backend on the same HERMES_HOME owns the session — never double-write."""
+    submitted = _capture_submit(server, monkeypatch)
+    monkeypatch.setattr(server, "_ensure_active_session_slot", lambda sid, s: {"owner": "other"})
+    session = _session(_quota_resume_at=time.time() - 1, _quota_resume_prompt="p")
+    server._maybe_fire_quota_resume("sid-1", session)
+    assert submitted == []
+    assert session["running"] is False  # released, not wedged
+
+
+def test_unarmed_session_is_a_no_op(server, monkeypatch):
+    submitted = _capture_submit(server, monkeypatch)
+    server._maybe_fire_quota_resume("sid-1", _session())
+    assert submitted == []
+
+
+def test_dispatch_failure_releases_the_turn(server, monkeypatch):
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_ensure_active_session_slot", lambda sid, s: None)
+
+    def _boom(*a, **k):
+        raise RuntimeError("submit exploded")
+
+    monkeypatch.setattr(server, "_run_prompt_submit", _boom)
+    session = _session(_quota_resume_at=time.time() - 1, _quota_resume_prompt="p")
+    server._maybe_fire_quota_resume("sid-1", session)
+    assert session["running"] is False  # not left claimed forever
+
+
+# ── cancellation ──────────────────────────────────────────────────────────────
+
+def test_clear_removes_all_pending_state(server):
+    session = _session(
+        _quota_resume_at=1.0, _quota_resume_prompt="p", _quota_resume_meta={"provider": "x"})
+    server._clear_quota_resume(session)
+    for key in ("_quota_resume_at", "_quota_resume_prompt", "_quota_resume_meta"):
+        assert key not in session
+
+
+def test_config_defaults_expose_a_settings_toggle():
+    """Desktop Settings renders booleans from DEFAULT_CONFIG; the toggle must exist."""
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    cfg = DEFAULT_CONFIG["desktop"]["quota_resume"]
+    assert cfg["enabled"] is True
+    assert isinstance(cfg["max_attempts"], int)

--- a/tui_gateway/prompt_turn.py
+++ b/tui_gateway/prompt_turn.py
@@ -9,6 +9,7 @@ post-turn follow-ups (queued prompt, goal continuation, notifications).
 
 from __future__ import annotations
 
+import contextlib
 import dataclasses
 
 from .method_ctx import HandlerRegistry, bind_module
@@ -619,7 +620,7 @@ def _absorb_turn_result(
     return status_note
 
 
-def _complete_turn_payload(session: dict, st: _TurnRun, status_note: str | None, cols: int):
+def _complete_turn_payload(sid: str, session: dict, st: _TurnRun, status_note: str | None, cols: int):
     """``(payload, raw, status)`` for message.complete; retains/clears the inflight turn and
     settles the hosted-room terminal receipt."""
     result, agent = st.result, st.agent
@@ -634,7 +635,24 @@ def _complete_turn_payload(session: dict, st: _TurnRun, status_note: str | None,
     # Structured billing-wall descriptor: the client renders recovery without re-parsing text.
     if _billing_block := result.get("billing_block"):
         payload["billing"] = _billing_block
-        payload["failure_reason"] = result.get("failure_reason")
+    # Classified reason for every failure, not just billing walls: a client can only
+    # tell a quota wall from an overload if the reason travels with the failure.
+    if status == "error" and (_failure_reason := result.get("failure_reason")):
+        payload["failure_reason"] = _failure_reason
+    # Provider-reported quota reset ({eligible, resume_at, source, provider, reason}) so
+    # the client can wait out the window instead of offering a blind Retry.
+    if _quota_resume := result.get("quota_resume"):
+        payload["quota_resume"] = dict(_quota_resume)
+        # Arm the backend-side resume so the turn finishes itself when the window
+        # reopens, and tell the client whether that actually happened — an armed
+        # resume is what the UI counts down against.
+        try:
+            payload["quota_resume"]["scheduled"] = _arm_quota_resume(
+                sid, session, _quota_resume, st.prompt_text
+            )
+        except Exception:
+            logger.debug("quota-resume arming failed", exc_info=True)
+            payload["quota_resume"]["scheduled"] = False
     if rendered := render_message(raw, cols):
         payload["rendered"] = rendered
     # Advisory {layer, code, retryable} descriptor; computed before the retain so resume
@@ -759,6 +777,11 @@ def _run_prompt_submit(
     if admitted is None:
         return False
     images, agent = admitted
+    # A new turn supersedes any pending quota resume: the user is driving again, and the
+    # resume note ("finish the interrupted request") would talk over what they just asked.
+    # The resume's own dispatch clears this first, so it never cancels itself.
+    with contextlib.suppress(Exception):
+        _clear_quota_resume(session)
     # The ONE INFO record proving a prompt was accepted by THIS process; ties ui sid,
     # session_key and the agent's live session_id together.  No prompt content is logged.
     _turn_started_monotonic = time.monotonic()
@@ -795,7 +818,7 @@ def _run_prompt_submit(
                 display_metadata)
             status_note = _absorb_turn_result(
                 sid, session, st, text, display_kind, display_metadata)
-            payload, raw, status = _complete_turn_payload(session, st, status_note, cols)
+            payload, raw, status = _complete_turn_payload(sid, session, st, status_note, cols)
             _emit("message.complete", sid, payload)
             goal_followup = _goal_followup_after_turn(sid, session, st.result, status, raw)
             if status == "complete":

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3201,6 +3201,7 @@ from .mcp_rpc_helpers import (  # noqa: E402, F401
 from . import (  # noqa: E402
     methods_voice as _methods_voice, methods_browser as _methods_browser, methods_slash as _methods_slash,
     methods_complete_helpers as _methods_complete_helpers, session_auto_continue as _session_auto_continue,
+    session_quota_resume as _session_quota_resume,
     agent_callbacks as _agent_callbacks, session_history as _session_history,
     prompt_attachments as _prompt_attachments, session_notifications as _session_notifications,
     tool_progress as _tool_progress, change_watcher as _change_watcher,
@@ -3218,6 +3219,7 @@ for _m in (
     _session_reaper, _session_lifecycle, _session_workdir, _compute_host_bridge, _model_switch,
     _session_compression, _change_watcher, _tool_progress, _session_notifications,
     _prompt_attachments, _session_history, _agent_callbacks, _session_auto_continue,
+    _session_quota_resume,
     _methods_complete_helpers, _methods_slash, _methods_voice, _methods_browser,
     _methods_browser_control, _methods_session, _methods_prompt, _methods_config,
     _methods_config_set, _methods_complete, _methods_tools, _methods_profiles, _methods_images,

--- a/tui_gateway/session_notifications.py
+++ b/tui_gateway/session_notifications.py
@@ -416,7 +416,7 @@ def _notification_poller_loop(stop_event: threading.Event, sid: str, session: di
     emitted: set = set()  # dedup re-queued events so one completion isn't emitted 50 times while busy
     handle = lambda evt, deferred: _notif_handle_event(  # noqa: E731
         sid, session, evt, emitted, process_registry, format_process_notification, deferred)
-    last_kanban_poll = last_loop_poll = 0.0
+    last_kanban_poll = last_loop_poll = last_quota_resume_poll = 0.0
     while not stop_event.is_set() and not session.get("_finalized"):
         now = time.monotonic()
         # /loop wakeup driver: fire a due tick for THIS session while idle (same claim-under-lock as kanban dispatch).
@@ -427,6 +427,13 @@ def _notification_poller_loop(stop_event: threading.Event, sid: str, session: di
                 _maybe_fire_tui_loop_tick(sid, session)
             except Exception as loop_exc:
                 _notif_log_failure("loop wakeup poll failed", loop_exc)
+        # Provider quota window reopened: finish the turn its usage limit killed.
+        if now - last_quota_resume_poll >= _QUOTA_RESUME_POLL_SECONDS:
+            last_quota_resume_poll = now
+            try:
+                _maybe_fire_quota_resume(sid, session)
+            except Exception as quota_exc:
+                _notif_log_failure("quota resume poll failed", quota_exc)
         if now - last_kanban_poll >= _KANBAN_POLL_SECONDS:
             last_kanban_poll = now
             _notif_poll_kanban(sid, session)

--- a/tui_gateway/session_quota_resume.py
+++ b/tui_gateway/session_quota_resume.py
@@ -1,0 +1,176 @@
+"""Wait out a subscription quota window, then finish the turn it killed.
+
+A quota wall is the one failure that comes with a promise: the provider says when
+it lifts. Everywhere else the honest answer is "retry and see", but here the
+session can simply sleep until the window reopens and pick the work back up —
+which is what Claude Code's own "continue automatically at usage limit" does.
+
+Scheduling lives in the backend, not the renderer, because the backend owns the
+session: it already arbitrates turn ownership across the Desktop app, the TUI and
+the dashboard, and it survives a window reload. A renderer timer would fire twice
+when two windows have the same session open, and not at all after a refresh.
+
+The deadline itself is resolved by ``agent.quota_resume`` and is always
+provider-reported — this module only decides *when to act on it* and *whether
+acting is still wanted*. A pending resume is abandoned the moment the user takes
+the turn back (new prompt, manual retry, cancel, model switch): they have moved
+on, and firing anyway would talk over them.
+
+Bodies are rebound onto server.py's globals at install time (method_ctx.bind_module),
+so they reference server.py globals bare.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+from .method_ctx import bind_module
+
+# Poll cadence for due resumes. Coarse on purpose: the deadline is minutes-to-hours
+# away, and the grace period in agent.quota_resume already absorbs clock skew, so
+# a few seconds of slop costs nothing.
+_QUOTA_RESUME_POLL_SECONDS = 15.0
+
+_QUOTA_RESUME_ENABLED_DEFAULT = True
+# One re-arm covers the common "provider moved the goalposts" case (the window
+# reopened later than first advertised) without letting a mis-reported deadline
+# loop a session forever.
+_QUOTA_RESUME_MAX_ATTEMPTS_DEFAULT = 2
+
+_QUOTA_RESUME_NOTE_PREFIX = "[Resumed after a provider usage limit"
+
+
+def _quota_resume_config() -> tuple[bool, int]:
+    """``(enabled, max_attempts)`` from config.yaml (``desktop.quota_resume``)."""
+    desktop = _load_cfg().get("desktop")
+    cfg = desktop.get("quota_resume") if isinstance(desktop, dict) else None
+    if not isinstance(cfg, dict):
+        cfg = {}
+    return (
+        is_truthy_value(cfg.get("enabled"), default=_QUOTA_RESUME_ENABLED_DEFAULT),
+        _coerce_int_config_value(
+            cfg.get("max_attempts"), _QUOTA_RESUME_MAX_ATTEMPTS_DEFAULT, min_value=0
+        ),
+    )
+
+
+def _quota_resume_note(prompt: str) -> str:
+    """Continuation note for the resumed turn.
+
+    Carries the original request because the failed turn produced no assistant
+    message to continue from, and warns that earlier tool work may already be
+    done — the turn died after the model call, so side effects can predate it.
+    """
+    return (
+        f"{_QUOTA_RESUME_NOTE_PREFIX} — the provider's quota window has reset and "
+        "the interrupted request is being retried automatically. Some of the work may "
+        "already be complete; check the current state before redoing anything, then "
+        "finish the task. The interrupted request was:]\n\n"
+        f"{prompt}"
+    )
+
+
+def _clear_quota_resume(session: dict) -> None:
+    """Drop any pending resume (the user took the turn back, or it fired)."""
+    for key in ("_quota_resume_at", "_quota_resume_prompt", "_quota_resume_meta"):
+        session.pop(key, None)
+
+
+def _arm_quota_resume(sid: str, session: dict, plan: dict, prompt: str) -> bool:
+    """Record a due-time for a failed turn whose provider named a reset.
+
+    Called from the turn's terminal path. Returns True when a resume was armed.
+    Refuses an ineligible plan, a disabled feature, an empty prompt (nothing to
+    resubmit) and a session that has already used its attempts.
+    """
+    if not isinstance(plan, dict) or not plan.get("eligible"):
+        return False
+    resume_at = plan.get("resume_at")
+    if not isinstance(resume_at, (int, float)):
+        return False
+    enabled, max_attempts = _quota_resume_config()
+    if not enabled:
+        return False
+    # Hosted-room turns recover through their own durable lease state machine;
+    # a generic resume would bypass its execution generation and duplicate work.
+    if session.get("source") == "bot_room":
+        return False
+    if not (prompt or "").strip():
+        return False
+    if int(session.get("_quota_resume_attempt", 0) or 0) >= max_attempts:
+        logger.info("quota-resume: attempts exhausted for %s; leaving manual retry", sid)
+        return False
+    session["_quota_resume_at"] = float(resume_at)
+    session["_quota_resume_prompt"] = prompt
+    session["_quota_resume_meta"] = {
+        "source": plan.get("source", ""),
+        "provider": plan.get("provider", ""),
+        "resume_at": float(resume_at),
+    }
+    logger.info(
+        "quota-resume armed for %s in %.0fs (source=%s provider=%s)",
+        sid, max(0.0, float(resume_at) - time.time()),
+        plan.get("source", ""), plan.get("provider", ""),
+    )
+    _emit("status.update", sid, {
+        "kind": "process",
+        "text": _quota_resume_status_text(float(resume_at), plan.get("provider", "")),
+    })
+    return True
+
+
+def _quota_resume_status_text(resume_at: float, provider: str) -> str:
+    """Human-readable 'waiting until…' line for the status stack."""
+    delta = max(0, int(resume_at - time.time()))
+    hours, minutes = divmod(delta // 60, 60)
+    when = f"{hours}h {minutes}m" if hours else f"{minutes}m"
+    label = f"{provider} " if provider else ""
+    return f"{label}usage limit reached — resuming automatically in {when}"
+
+
+def _maybe_fire_quota_resume(sid: str, session: dict) -> None:
+    """Fire a due quota resume for an idle session (per-session poller).
+
+    Claims the session under ``history_lock`` exactly as the /loop tick and
+    crash auto-continue do, so a racing user prompt always wins. Ownership is
+    re-checked against the shared HERMES_HOME before dispatch: a sibling backend
+    may be mid-turn on the same session.
+    """
+    resume_at = session.get("_quota_resume_at")
+    if not isinstance(resume_at, (int, float)) or time.time() < float(resume_at):
+        return
+    # A user prompt after the failure means they are driving again.
+    if session.get("running") or session.get("_finalized") or session.get("_turn_cancel_requested"):
+        _clear_quota_resume(session)
+        return
+    prompt = str(session.get("_quota_resume_prompt") or "")
+    meta = session.get("_quota_resume_meta") or {}
+    if not prompt.strip():
+        _clear_quota_resume(session)
+        return
+    if not _notif_claim_turn(session):
+        return  # busy — stays due, next poll retries
+    # Past this point the resume either dispatches or is abandoned; never left pending.
+    _clear_quota_resume(session)
+    if _ensure_active_session_slot(sid, session) is not None:
+        logger.info("quota-resume for %s refused: session has another live owner", sid)
+        _notif_release_turn(session)
+        return
+    session["_quota_resume_attempt"] = int(session.get("_quota_resume_attempt", 0) or 0) + 1
+    rid = f"__quota_resume__{int(time.time() * 1000)}"
+    try:
+        _emit("status.update", sid, {
+            "kind": "process",
+            "text": f"Usage limit reset{' on ' + meta['provider'] if meta.get('provider') else ''} — resuming…",
+        })
+        _emit("message.start", sid)
+        _run_prompt_submit(
+            rid, sid, session, _quota_resume_note(prompt), display_kind="auto_continue"
+        )
+    except Exception as exc:
+        _notif_log_failure("quota-resume dispatch failed", exc)
+        _notif_release_turn(session)
+
+
+def register(server) -> None:
+    bind_module(globals(), server)


### PR DESCRIPTION
## What

A subscription quota wall is the one failure that arrives with a promise: the provider states when the window reopens. Hermes already parses that timestamp for the credential pool's cooldown and then **discards it**, so the turn dies with a Retry button the user has to sit and watch. On a Claude 5-hour window or a weekly Codex window that means babysitting the app for hours.

This waits the window out and finishes the turn — the same affordance Claude Code ships as *"continue automatically at usage limit"*.

## Deadlines are reported, never guessed

`agent/quota_resume.py` resolves a deadline from, in order:

1. **the failing response** — body/header reset fields
2. **the credential pool** — `next_available_at()`, so rotation always wins first
3. **the provider's usage API** — `agent.account_usage`, consulted **only** when the error itself was silent

If none of the three yields a trustworthy timestamp, there is no plan and the user keeps the manual Retry. That is the whole no-guessing guarantee, and it means the feature is not a provider allowlist: any provider auto-resumes the moment its error is honest enough, while `anthropic` / `openai-codex` get the extra usage-API fallback because they publish live window utilization.

Eligibility is restricted to `FailoverReason.rate_limit`. `billing` is a spend wall that waiting never clears; `overloaded` is capacity that clears in seconds — parking a session on either would be a regression. A deadline already past, or beyond the wait cap, is **reported to the UI but never armed**.

## Where the timer lives

In the backend, not the renderer. The backend owns the session: it arbitrates turn ownership across Desktop, TUI and dashboard, and it survives a window reload. A renderer `setTimeout` would double-fire when two windows have the same session open, and vanish on refresh.

No new thread either — the existing per-session notification poller gains a 15s check beside the `/loop` tick, reusing the same claim-under-`history_lock` and `_ensure_active_session_slot` fence as crash auto-continue. A pending resume is dropped the moment the user takes the turn back.

## Two supporting fixes on the same path

- **`failure_reason` now reaches clients for every failed turn**, not only billing walls. It was assigned inside `if _billing_block:` — i.e. only in the one case where the billing block already carried the same information. Without it a client cannot distinguish a quota wall from an overload; both render as a generic provider error.
- **`resets_in_seconds` is honoured as a reset source.** `error_classifier` already lists it as a valid signal, but `extract_api_error_context` never read it, so a provider sending only the offset silently lost its deadline. Codex happens to send `resets_at` as well, which is why this went unnoticed.

## Config

`desktop.quota_resume.enabled` (default on) auto-renders as a Desktop Settings toggle from `DEFAULT_CONFIG` — no frontend change needed. `max_attempts` bounds re-arming so a mis-reported reset cannot loop a session.

## Testing

**46 unit + 21 end-to-end.** The E2E tests are driven by verbatim captured payloads rather than hand-written approximations:

- a real Codex `usage_limit_reached` 429 (`resets_at` + `resets_in_seconds`) → **arms** a resume
- a real Anthropic `overloaded_error` returned inside an **HTTP 200** SSE stream → **must not** arm

Coverage: source precedence, past/over-cap deadlines, disabled config, hosted-room refusal, attempt exhaustion, foreign-owner deferral, dispatch-failure release, and cancellation by a racing user prompt.

Verified against the **real** `_notification_poller_loop` thread and the **real** `_complete_turn_payload` — not mocks. Observed payload for a quota failure:

```json
{
  "failure_reason": "rate_limit",
  "quota_resume": {"eligible": true, "resume_at": 1788540723.35, "source": "provider_error",
                   "provider": "anthropic", "reason": "rate_limit", "scheduled": true},
  "error_surface": {"layer": "provider", "code": "rate_limit", "retryable": true}
}
```

…and the poller then dispatched it with `display_kind=auto_continue`, carrying the original prompt.

Full suites:

| Suite | Result |
|---|---|
| `tests/tui_gateway/` | **1002 passed** |
| `tests/agent/` | **6313 passed**, 21 failed — byte-identical to the same 21 on clean `main` (network/credential-dependent) |
| `ruff check` (all touched files) | clean |

`tests/tui_gateway/test_hosted_room_two_gateway_scoped.py` is excluded from the count: it fails to import on this machine for want of `aiohttp`, on `main` as well.

## Notes for review

- Nothing fires on the capacity error that motivated this work (`overloaded_error`); that case is bounded backoff's job and is deliberately out of scope here.
- The resume note warns the model that earlier tool work may already have landed, since the turn died after the model call and side effects can predate it.
- Hosted-room turns are refused outright — they recover through their own durable lease state machine.
