### PR TITLE
feat(openai): add GPT-6 Astra baseline support

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1392,8 +1392,13 @@ class _CodexCompletionsAdapter:
             if isinstance(reasoning_cfg, dict) and reasoning_cfg.get("enabled") is not False:
                 # Truthy-only: Codex 400s on e.g. {"effort": null}, so falsy → default. Shared
                 # per-model clamp with the main transport ("max" is gpt-5.6-only; "minimal"/"ultra" rejected).
-                from agent.reasoning_effort import clamp_effort, codex_supported_efforts
-                effort = clamp_effort(reasoning_cfg.get("effort") or "medium", codex_supported_efforts(model))
+                from agent.reasoning_effort import clamp_effort
+                from agent.transports.codex import _codex_efforts_for_route
+                is_codex_backend = base_url_host_matches(host, "chatgpt.com") and "/backend-api/codex" in host.lower()
+                effort = clamp_effort(
+                    reasoning_cfg.get("effort") or "medium",
+                    _codex_efforts_for_route(model, host, is_codex_backend=is_codex_backend),
+                )
                 resp_kwargs["reasoning"] = {"effort": effort, "summary": "auto"}
                 resp_kwargs["include"] = ["reasoning.encrypted_content"]
         tools = kwargs.get("tools")

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1446,6 +1446,11 @@ class _CodexCompletionsAdapter:
                     resp_kwargs["prompt_cache_retention"] = cache_retention
         except Exception:
             logger.debug("Codex auxiliary: prompt_cache_key derivation skipped", exc_info=True)
+        # Keep auxiliary Responses calls on the same exact-model contract as main
+        # turns. This runs last so caller overrides cannot reintroduce unsupported
+        # Astra reasoning/sampling fields or replace the official cache TTL.
+        from agent.transports.codex import _sanitize_astra_request_kwargs
+        _sanitize_astra_request_kwargs(resp_kwargs, model, host)
         return resp_kwargs, model, timeout
 
     def create(self, **kwargs) -> Any:

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -739,7 +739,7 @@ _PREFLIGHT_OPTIONAL_FIELDS: tuple[tuple[str, Callable[[Any], bool], Optional[Cal
     # Cache routing/retention and tool-dispatch hints pass through as-is.
     *(
         (key, lambda v: v is not None, None)
-        for key in ("tool_choice", "parallel_tool_calls", "prompt_cache_key", "prompt_cache_retention")
+        for key in ("tool_choice", "parallel_tool_calls", "prompt_cache_key", "prompt_cache_retention", "prompt_cache_options")
     ),
     # Native compaction directive; eligibility is resolved in agent/native_compaction.py.
     ("context_management", lambda v: isinstance(v, list) and bool(v), None),

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1437,7 +1437,7 @@ def _query_anthropic_context_length(model: str, base_url: str, api_key: str) -> 
 # Codex OAuth `context_window` values (what Codex enforces — lower than the direct API for the same
 # slugs). Fallback when the live probe fails; longest-key-first. gpt-5.3-codex-spark is listed so "gpt-5.3-codex" doesn't win.
 _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
-    "gpt-6-astra": 1_050_000,
+    "gpt-6-astra": 272_000,
     "gpt-5.1-codex-max": 272_000, "gpt-5.1-codex-mini": 272_000, "gpt-5.3-codex": 272_000,
     "gpt-5.3-codex-spark": 128_000, "gpt-5.2-codex": 272_000, "gpt-5.4-mini": 272_000,
     "gpt-5.6-sol": 272_000, "gpt-5.6-terra": 272_000, "gpt-5.6-luna": 272_000, "gpt-daybreak-blue-latest": 272_000,

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1449,13 +1449,16 @@ _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
 # The bump fires ONLY when the resolved value is exactly the stale 272,000. ``gpt-5.6`` is a FAMILY
 # PREFIX (``-pro`` slugs aren't routable on Codex); ``gpt-5.4`` is EXACT because gpt-5.4-mini enforces 272K.
 _CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_PREFIXES: Dict[str, int] = {"gpt-5.6": 900_000}  # sol / terra / luna
-_CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_EXACT: Dict[str, int] = {"gpt-5.4": 900_000, "gpt-daybreak-blue-latest": 900_000}
+_CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_EXACT: Dict[str, int] = {
+    "gpt-5.4": 900_000, "gpt-daybreak-blue-latest": 900_000,
+    "gpt-6-astra": 900_000,  # advertised 272K; 920,043 input OK, 1,000,043 rejected (live 2026-09-04)
+}
 _CODEX_OAUTH_STALE_ADVERTISED_CTX = 272_000  # the only advertised value the bump may override
 CODEX_CONTEXT_VARIANT_SUFFIX = "-900k"  # picker-only opt-in suffix; never sent on the wire
 # The ONLY bases eligible for ``-900k``: routable, live-verified. No family prefixing (it would synthesize
 # dead ``-pro`` variants); dated snapshots of the 5.6 bases are allowed. gpt-daybreak-blue-latest is a verified Sol alias.
 _CODEX_900K_SNAPSHOT_BASES = ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna")
-_CODEX_900K_ELIGIBLE_BASES = frozenset({*_CODEX_900K_SNAPSHOT_BASES, "gpt-5.4", "gpt-daybreak-blue-latest"})
+_CODEX_900K_ELIGIBLE_BASES = frozenset({*_CODEX_900K_SNAPSHOT_BASES, "gpt-5.4", "gpt-daybreak-blue-latest", "gpt-6-astra"})
 _CODEX_900K_SNAPSHOT_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -331,6 +331,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     # OpenAI — direct-API windows (Codex OAuth caps gpt-5.4+/5.5/5.6 at 272K, resolved by
     # its own branch). 5.4-nano/-mini are 400k, not 1.05M; gpt-5.3-codex-spark is
     # Codex-OAuth-only and listed so "gpt-5" (400k) doesn't win.
+    "gpt-6-astra": 1_050_000,
     "gpt-5.6-luna": 1050000, "gpt-5.6-terra": 1050000, "gpt-5.6-sol": 1050000, "gpt-5.5": 1050000,
     "gpt-5.4-nano": 400000, "gpt-5.4-mini": 400000, "gpt-5.4": 1050000,
     "gpt-5.3-codex-spark": 128000, "gpt-5.1-chat": 128000, "gpt-5": 400000,
@@ -1436,6 +1437,7 @@ def _query_anthropic_context_length(model: str, base_url: str, api_key: str) -> 
 # Codex OAuth `context_window` values (what Codex enforces — lower than the direct API for the same
 # slugs). Fallback when the live probe fails; longest-key-first. gpt-5.3-codex-spark is listed so "gpt-5.3-codex" doesn't win.
 _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
+    "gpt-6-astra": 1_050_000,
     "gpt-5.1-codex-max": 272_000, "gpt-5.1-codex-mini": 272_000, "gpt-5.3-codex": 272_000,
     "gpt-5.3-codex-spark": 128_000, "gpt-5.2-codex": 272_000, "gpt-5.4-mini": 272_000,
     "gpt-5.6-sol": 272_000, "gpt-5.6-terra": 272_000, "gpt-5.6-luna": 272_000, "gpt-daybreak-blue-latest": 272_000,

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -107,7 +107,7 @@ class ModelCapabilities:
 # Hermes provider names → models.dev provider IDs
 PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "openrouter": "openrouter", "novita": "novita-ai", "anthropic": "anthropic",
-    "openai": "openai", "openai-codex": "openai", "zai": "zai",
+    "openai": "openai", "openai-api": "openai", "openai-codex": "openai", "zai": "zai",
     "kimi": "kimi-for-coding", "kimi-coding": "kimi-for-coding",
     "moonshot": "kimi-for-coding", "stepfun": "stepfun",
     "kimi-coding-cn": "kimi-for-coding", "minimax": "minimax",

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -522,6 +522,19 @@ _OVERRIDE_WARNED_KEYS: set = set()
 # shared by get_model_capabilities and get_model_info so the two unknown-model paths agree.
 _UNKNOWN_MODEL_BASE: Dict[str, Any] = {"limit": {"context": 200000, "output": 8192}, "tool_call": True}
 
+# Account-gated models may be usable before models.dev has indexed them.  Keep
+# their capabilities available for an explicitly selected/discovered model
+# without adding them to any picker catalog.
+_BUILTIN_MODEL_METADATA: Dict[Tuple[str, str], Dict[str, Any]] = {
+    ("openai", "gpt-6-astra"): {
+        "limit": {"context": 1_050_000, "output": 128_000},
+        "modalities": {"input": ["text", "image"], "output": ["text"]},
+        "tool_call": True,
+        "reasoning": True,
+        "family": "gpt-6",
+    },
+}
+
 
 def _load_model_overrides() -> Dict[str, Any]:
     """The ``model_overrides`` config section ({} on any failure). Deliberately not memoized:
@@ -646,8 +659,11 @@ def _merge_catalog_entry_with_override(raw: Dict[str, Any], override: Dict[str, 
 def _apply_overrides(provider: str, model: str, entry: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
     """*entry* patched by its override; ``_UNKNOWN_MODEL_BASE`` patched by a fill-gap override on a
     catalog miss (selected AFTER lookup: _default only fills misses); None when neither exists."""
-    override = _override_for(provider, model, catalog_hit=entry is not None)
-    return entry if override is None else _merge_catalog_entry_with_override(entry if entry is not None else _UNKNOWN_MODEL_BASE, override)
+    provider_key = PROVIDER_TO_MODELS_DEV.get((provider or "").strip(), (provider or "").strip())
+    builtin = _BUILTIN_MODEL_METADATA.get((provider_key, (model or "").strip().lower()))
+    base = entry if entry is not None else builtin
+    override = _override_for(provider, model, catalog_hit=base is not None)
+    return base if override is None else _merge_catalog_entry_with_override(base if base is not None else _UNKNOWN_MODEL_BASE, override)
 
 
 def _entry_supports_vision(entry: Dict[str, Any]) -> bool:

--- a/agent/reasoning_effort.py
+++ b/agent/reasoning_effort.py
@@ -83,7 +83,7 @@ META_AI_EFFORTS: tuple[str, ...] = ("minimal", "low", "medium", "high", "xhigh")
 
 def codex_supported_efforts(model: Optional[str]) -> tuple[str, ...]:
     """Supported effort set for an OpenAI/Codex Responses model."""
-    if (model or "").strip().lower().rsplit("/", 1)[-1] == "gpt-6-astra":
+    if (model or "").strip().lower().rsplit("/", 1)[-1] in ("gpt-6-astra", "gpt-6-astra-900k"):
         return CODEX_ASTRA_EFFORTS
     return CODEX_GPT56_EFFORTS if "gpt-5.6" in (model or "").lower() else CODEX_LEGACY_EFFORTS
 

--- a/agent/reasoning_effort.py
+++ b/agent/reasoning_effort.py
@@ -31,6 +31,9 @@ OPENAI_COMPAT_WIRE_EFFORTS: tuple[str, ...] = ("none", "minimal", "low", "medium
 #: both (clamps to low); ``max`` is gpt-5.6-only.
 CODEX_GPT56_EFFORTS: tuple[str, ...] = ("none", "low", "medium", "high", "xhigh", "max")
 CODEX_LEGACY_EFFORTS: tuple[str, ...] = ("none", "low", "medium", "high", "xhigh")
+# GPT-6 Astra is account-gated and its Responses API accepts no disable/minimal
+# wire level; callers normalize those requests to ``low`` at the transport boundary.
+CODEX_ASTRA_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh", "max")
 
 #: xAI Responses — Grok 4.6+ accepts xhigh; older Grok tops out at high.
 XAI_GROK46_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh")
@@ -80,6 +83,8 @@ META_AI_EFFORTS: tuple[str, ...] = ("minimal", "low", "medium", "high", "xhigh")
 
 def codex_supported_efforts(model: Optional[str]) -> tuple[str, ...]:
     """Supported effort set for an OpenAI/Codex Responses model."""
+    if (model or "").strip().lower().rsplit("/", 1)[-1] == "gpt-6-astra":
+        return CODEX_ASTRA_EFFORTS
     return CODEX_GPT56_EFFORTS if "gpt-5.6" in (model or "").lower() else CODEX_LEGACY_EFFORTS
 
 

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -273,9 +273,11 @@ def _is_official_openai_responses_route(model: Any, base_url: Any) -> bool:
     """Astra cache semantics apply only to the official OpenAI API host."""
     if not _is_astra_model(model):
         return False
-    from utils import base_url_host_matches
+    from utils import base_url_hostname
 
-    return base_url_host_matches(str(base_url or ""), "api.openai.com")
+    # Astra's account-gated cache contract is for the canonical API origin only.
+    # Do not extend it to subdomains (or lookalike hosts) by suffix matching.
+    return base_url_hostname(str(base_url or "")).lower() == "api.openai.com"
 
 
 def _codex_efforts_for_route(model: Any, base_url: Any, *, is_codex_backend: bool = False) -> tuple[str, ...]:

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -11,7 +11,7 @@ import re
 from typing import Any, Callable, Optional
 
 from agent.reasoning_effort import (
-    ACTUAL_RELAY_EFFORTS, XAI_GROK46_EFFORTS, XAI_LEGACY_EFFORTS, clamp_effort,
+    ACTUAL_RELAY_EFFORTS, CODEX_ASTRA_EFFORTS, XAI_GROK46_EFFORTS, XAI_LEGACY_EFFORTS, clamp_effort,
     # Same declared vocabulary + shared clamp as the main Codex transport (agent.reasoning_effort):
     # per-model — "max" is gpt-5.6-only, "minimal"/"ultra" always rejected (live-verified, #68365).
     codex_supported_efforts,
@@ -211,6 +211,15 @@ def _resolve_reasoning(model: str, params: dict[str, Any]) -> tuple[Any, bool]:
         elif reasoning_config.get("effort"):
             reasoning_effort = reasoning_config["effort"]
 
+    # Astra has no wire-level disable/minimal setting.  Preserve Hermes' user-facing
+    # controls by sending the documented lowest enabled level instead; this also keeps
+    # an explicit ``enabled: false`` request valid on the Responses API.
+    if model.strip().lower().rsplit("/", 1)[-1] == "gpt-6-astra":
+        requested = str(reasoning_effort or "").strip().lower()
+        if not reasoning_enabled or requested in {"", "none", "minimal", "disabled", "off"}:
+            return "low", True
+        return clamp_effort(reasoning_effort, CODEX_ASTRA_EFFORTS), True
+
     # Wire vocabularies are declared in agent.reasoning_effort; the shared clamp policy (nearest weaker
     # supported level, never escalate, never invert the ladder) replaces the per-backend hand maps that
     # repeatedly leaked internal levels like "ultra" to the wire (#89503 class) or clamped one rung below a
@@ -260,6 +269,37 @@ def _default_prompt_cache_retention_for_request(model: str, base_url: Any) -> Op
         return None
     normalized = str(model or "").strip().lower().replace("_", "-")
     return "24h" if _EXTENDED_PROMPT_CACHE_MODEL_RE.search(normalized) else None
+
+
+def _is_astra_model(model: Any) -> bool:
+    return str(model or "").strip().lower().rsplit("/", 1)[-1] == "gpt-6-astra"
+
+
+def _is_official_openai_responses_route(model: Any, base_url: Any) -> bool:
+    """Astra cache semantics apply only to the official OpenAI API host."""
+    if not _is_astra_model(model):
+        return False
+    from utils import base_url_host_matches
+
+    return base_url_host_matches(str(base_url or ""), "api.openai.com")
+
+
+def _sanitize_astra_request_kwargs(kwargs: dict[str, Any], model: Any, base_url: Any) -> None:
+    """Apply Astra's model-specific restrictions after all request overrides are merged."""
+    if not _is_astra_model(model):
+        return
+    for key in ("temperature", "top_p", "top_logprobs", "logprobs"):
+        kwargs.pop(key, None)
+    include = kwargs.get("include")
+    if isinstance(include, list):
+        kwargs["include"] = [item for item in include if "logprob" not in str(item).lower()]
+    if _is_official_openai_responses_route(model, base_url):
+        kwargs["prompt_cache_options"] = {"ttl": "30m"}
+        kwargs.pop("prompt_cache_retention", None)
+    else:
+        # A caller override must not accidentally send official-only cache syntax to a
+        # proxy or another provider that happens to accept the Astra model name.
+        kwargs.pop("prompt_cache_options", None)
 
 
 def _content_cache_key(instructions: str, tools: Optional[list[dict[str, Any]]], scope_id: str = "") -> Optional[str]:
@@ -543,6 +583,8 @@ class ResponsesApiTransport(ProviderTransport):
         ))
         if params.get("request_overrides"):
             kwargs.update(params["request_overrides"])
+
+        _sanitize_astra_request_kwargs(kwargs, model, params.get("base_url"))
 
         _bound_prompt_cache_key_field(kwargs)
 

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -11,7 +11,8 @@ import re
 from typing import Any, Callable, Optional
 
 from agent.reasoning_effort import (
-    ACTUAL_RELAY_EFFORTS, CODEX_ASTRA_EFFORTS, XAI_GROK46_EFFORTS, XAI_LEGACY_EFFORTS, clamp_effort,
+    ACTUAL_RELAY_EFFORTS, CODEX_ASTRA_EFFORTS, CODEX_LEGACY_EFFORTS,
+    XAI_GROK46_EFFORTS, XAI_LEGACY_EFFORTS, clamp_effort,
     # Same declared vocabulary + shared clamp as the main Codex transport (agent.reasoning_effort):
     # per-model — "max" is gpt-5.6-only, "minimal"/"ultra" always rejected (live-verified, #68365).
     codex_supported_efforts,
@@ -226,7 +227,9 @@ def _resolve_reasoning(model: str, params: dict[str, Any]) -> tuple[Any, bool]:
         declared = _profile_declared_efforts(params.get("provider"), model, params.get("base_url"))
         if declared is not None and not declared:
             reasoning_enabled = False
-        supported = declared or codex_supported_efforts(model)
+        supported = declared or _codex_efforts_for_route(
+            model, params.get("base_url"), is_codex_backend=params.get("is_codex_backend") is True
+        )
     return clamp_effort(reasoning_effort, supported), reasoning_enabled
 
 
@@ -273,6 +276,15 @@ def _is_official_openai_responses_route(model: Any, base_url: Any) -> bool:
     from utils import base_url_host_matches
 
     return base_url_host_matches(str(base_url or ""), "api.openai.com")
+
+
+def _codex_efforts_for_route(model: Any, base_url: Any, *, is_codex_backend: bool = False) -> tuple[str, ...]:
+    """Keep Astra's new vocabulary off unrelated Responses-compatible endpoints."""
+    if _is_astra_model(model) and not (
+        is_codex_backend or _is_official_openai_responses_route(model, base_url)
+    ):
+        return CODEX_LEGACY_EFFORTS
+    return codex_supported_efforts(str(model or ""))
 
 
 def _sanitize_astra_request_kwargs(kwargs: dict[str, Any], model: Any, base_url: Any) -> None:

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -266,7 +266,7 @@ def _default_prompt_cache_retention_for_request(model: str, base_url: Any) -> Op
 
 
 def _is_astra_model(model: Any) -> bool:
-    return str(model or "").strip().lower().rsplit("/", 1)[-1] == "gpt-6-astra"
+    return str(model or "").strip().lower().rsplit("/", 1)[-1] in ("gpt-6-astra", "gpt-6-astra-900k")
 
 
 def _is_official_openai_responses_route(model: Any, base_url: Any) -> bool:

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -211,15 +211,6 @@ def _resolve_reasoning(model: str, params: dict[str, Any]) -> tuple[Any, bool]:
         elif reasoning_config.get("effort"):
             reasoning_effort = reasoning_config["effort"]
 
-    # Astra has no wire-level disable/minimal setting.  Preserve Hermes' user-facing
-    # controls by sending the documented lowest enabled level instead; this also keeps
-    # an explicit ``enabled: false`` request valid on the Responses API.
-    if model.strip().lower().rsplit("/", 1)[-1] == "gpt-6-astra":
-        requested = str(reasoning_effort or "").strip().lower()
-        if not reasoning_enabled or requested in {"", "none", "minimal", "disabled", "off"}:
-            return "low", True
-        return clamp_effort(reasoning_effort, CODEX_ASTRA_EFFORTS), True
-
     # Wire vocabularies are declared in agent.reasoning_effort; the shared clamp policy (nearest weaker
     # supported level, never escalate, never invert the ladder) replaces the per-backend hand maps that
     # repeatedly leaked internal levels like "ultra" to the wire (#89503 class) or clamped one rung below a
@@ -288,18 +279,24 @@ def _sanitize_astra_request_kwargs(kwargs: dict[str, Any], model: Any, base_url:
     """Apply Astra's model-specific restrictions after all request overrides are merged."""
     if not _is_astra_model(model):
         return
+    if not _is_official_openai_responses_route(model, base_url):
+        kwargs.pop("prompt_cache_options", None)
+        return
+    reasoning = kwargs.get("reasoning")
+    requested = reasoning.get("effort") if isinstance(reasoning, dict) else None
+    normalized = str(requested or "").strip().lower()
+    effort = "low" if normalized in {"", "none", "minimal", "disabled", "off"} else clamp_effort(
+        requested, CODEX_ASTRA_EFFORTS
+    )
+    kwargs["reasoning"] = {**(reasoning if isinstance(reasoning, dict) else {}), "effort": effort}
+    kwargs["reasoning"].setdefault("summary", "auto")
     for key in ("temperature", "top_p", "top_logprobs", "logprobs"):
         kwargs.pop(key, None)
     include = kwargs.get("include")
     if isinstance(include, list):
         kwargs["include"] = [item for item in include if "logprob" not in str(item).lower()]
-    if _is_official_openai_responses_route(model, base_url):
-        kwargs["prompt_cache_options"] = {"ttl": "30m"}
-        kwargs.pop("prompt_cache_retention", None)
-    else:
-        # A caller override must not accidentally send official-only cache syntax to a
-        # proxy or another provider that happens to accept the Astra model name.
-        kwargs.pop("prompt_cache_options", None)
+    kwargs["prompt_cache_options"] = {"ttl": "30m"}
+    kwargs.pop("prompt_cache_retention", None)
 
 
 def _content_cache_key(instructions: str, tools: Optional[list[dict[str, Any]]], scope_id: str = "") -> Optional[str]:

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -109,6 +109,7 @@ class PricingEntry:
     input_cost_per_million_above: Optional[Decimal] = None
     output_cost_per_million_above: Optional[Decimal] = None
     cache_read_cost_per_million_above: Optional[Decimal] = None
+    cache_write_cost_per_million_above: Optional[Decimal] = None
 
 
 @dataclass(frozen=True)
@@ -237,6 +238,20 @@ for _provider, _url, _version, _rows in _SNAPSHOTS:
         for _model in ((_models,) if isinstance(_models, str) else _models):
             _OFFICIAL_DOCS_PRICING[(_provider, _model)] = _entry
 del _SNAPSHOTS, _provider, _url, _version, _rows, _models, _rates, _entry, _model
+
+# GPT-6 Astra uses whole-request pricing above the 272K prompt tier.  Keep this
+# account-gated model out of generic static catalogs, but retain published billing
+# metadata for an explicitly selected route.
+_OFFICIAL_DOCS_PRICING[("openai", "gpt-6-astra")] = _snap(
+    "10.00", "50.00", "1.00", "12.50",
+    url="https://developers.openai.com/api/docs/models/gpt-6-astra",
+    version="openai-gpt-6-astra-2026-09",
+    tier_threshold_tokens=272_000,
+    input_cost_per_million_above=Decimal("20.00"),
+    output_cost_per_million_above=Decimal("75.00"),
+    cache_read_cost_per_million_above=Decimal("2.00"),
+    cache_write_cost_per_million_above=Decimal("25.00"),
+)
 
 # Context-tiered Gemini Pro: above 200k prompt tokens the *_above rates apply to
 # the whole request (see PricingEntry).
@@ -555,7 +570,7 @@ def estimate_usage_cost(
         (usage.output_tokens, entry.output_cost_per_million, entry.output_cost_per_million_above, ()),
         (usage.cache_read_tokens, entry.cache_read_cost_per_million, entry.cache_read_cost_per_million_above,
          ("cache-read pricing unavailable for route",)),
-        (usage.cache_write_tokens, entry.cache_write_cost_per_million, None,
+        (usage.cache_write_tokens, entry.cache_write_cost_per_million, entry.cache_write_cost_per_million_above,
          ("cache-write pricing unavailable for route",)),
     ):
         if above and rate_above is not None:

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -96,7 +96,7 @@ def _finalize_codex_models(model_ids: List[str], *, allow_astra: bool = False) -
     """
     finalized = _add_forward_compat_models(model_ids)
     if not allow_astra:
-        finalized = [model for model in finalized if model.lower() != "gpt-6-astra"]
+        finalized = [model for model in finalized if model.lower().rsplit("/", 1)[-1] != "gpt-6-astra"]
     return _add_context_variants(finalized)
 
 

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -94,9 +94,12 @@ def _finalize_codex_models(model_ids: List[str], *, allow_astra: bool = False) -
     Cached/configured model names are useful compatibility hints, but only the
     account-scoped Codex endpoint is authoritative for current Astra access.
     """
+    from agent.model_metadata import strip_codex_context_variant_suffix
+
     finalized = _add_forward_compat_models(model_ids)
     if not allow_astra:
-        finalized = [model for model in finalized if model.lower().rsplit("/", 1)[-1] != "gpt-6-astra"]
+        finalized = [model for model in finalized
+                     if strip_codex_context_variant_suffix(model.lower()).rsplit("/", 1)[-1] != "gpt-6-astra"]
     return _add_context_variants(finalized)
 
 

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -88,9 +88,16 @@ def _add_context_variants(model_ids: List[str]) -> List[str]:
     return out
 
 
-def _finalize_codex_models(model_ids: List[str]) -> List[str]:
-    """Forward-compat synthesis + large-context variant synthesis."""
-    return _add_context_variants(_add_forward_compat_models(model_ids))
+def _finalize_codex_models(model_ids: List[str], *, allow_astra: bool = False) -> List[str]:
+    """Forward-compat/context synthesis with an entitlement gate for Astra.
+
+    Cached/configured model names are useful compatibility hints, but only the
+    account-scoped Codex endpoint is authoritative for current Astra access.
+    """
+    finalized = _add_forward_compat_models(model_ids)
+    if not allow_astra:
+        finalized = [model for model in finalized if model.lower() != "gpt-6-astra"]
+    return _add_context_variants(finalized)
 
 
 def _extract_chatgpt_account_id(access_token: str) -> Optional[str]:
@@ -159,7 +166,7 @@ def _fetch_models_from_api(access_token: str) -> List[str]:
         logger.debug("Failed to fetch Codex models from API: %s", exc)
         return []
 
-    return _finalize_codex_models(_ranked_slugs(entries))
+    return _finalize_codex_models(_ranked_slugs(entries), allow_astra=True)
 
 
 def _read_default_model(codex_home: Path) -> Optional[str]:
@@ -194,7 +201,7 @@ def get_codex_model_ids(access_token: Optional[str] = None) -> List[str]:
     if access_token:
         api_models = _fetch_models_from_api(access_token)
         if api_models:
-            return _finalize_codex_models(api_models)
+            return _finalize_codex_models(api_models, allow_astra=True)
     default_model = _read_default_model(codex_home)
     return _finalize_codex_models(_dedupe([
         *([default_model] if default_model else []), *_read_cache_models(codex_home),

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -407,7 +407,7 @@ def _append_unconfigured_rows(
     """Empty setup skeletons for canonical providers missing from ``rows`` — except the *current* one:
     if config.yaml still points at it but credentials are gone, keep a row carrying the saved model so
     GUI pickers don't silently snap to another provider."""
-    from hermes_cli.models import CANONICAL_PROVIDERS
+    from hermes_cli.models import CANONICAL_PROVIDERS, _model_requires_account_discovery
 
     seen = {r["slug"].lower() for r in rows}
     cur = (ctx.current_provider or "").lower()
@@ -419,6 +419,7 @@ def _append_unconfigured_rows(
         if current_only and entry.slug.lower() != cur:
             continue
         if entry.slug.lower() == cur:
+            saved_model = "" if _model_requires_account_discovery(entry.slug, cur_model) else cur_model
             auth_type, key_env = _provider_auth_hint(entry.slug)
             warning = (
                 f"Configured provider missing usable credentials; paste {key_env} to reactivate. "
@@ -427,8 +428,10 @@ def _append_unconfigured_rows(
                 else "Configured provider is not authenticated; run `hermes model` to reactivate. "
                 "Showing the saved model only."
             )
+            if cur_model and not saved_model:
+                warning = warning.replace("Showing the saved model only.", "Astra requires successful account-scoped model discovery.")
             extras.append(_canonical_row(
-                entry, cur, models=[cur_model] if cur_model else [], total_models=1 if cur_model else 0,
+                entry, cur, models=[saved_model] if saved_model else [], total_models=1 if saved_model else 0,
                 source="configured-current", authenticated=False, auth_type=auth_type, key_env=key_env,
                 warning=warning,
             ))

--- a/hermes_cli/model_switch_providers.py
+++ b/hermes_cli/model_switch_providers.py
@@ -1111,6 +1111,10 @@ def _finalize_picker_rows(results: list, user_providers, current_model: str) -> 
                 continue
             models = row.get("models") or []
             if current_model not in models:
+                from hermes_cli.models import _model_requires_account_discovery
+
+                if _model_requires_account_discovery(row.get("slug"), current_model):
+                    break
                 row["models"] = [current_model, *models]
                 row["total_models"] = row.get("total_models", len(models)) + 1
             break

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1516,6 +1516,13 @@ def _normalized_cache_slug(provider: Optional[str]) -> str:
     return requested if requested == "ollama" else (normalize_provider(provider) or (provider or ""))
 
 
+def _model_requires_account_discovery(provider: Optional[str], model: str) -> bool:
+    """Astra names cannot confer API/OAuth entitlement through picker state."""
+    return _normalized_cache_slug(provider) in {"openai", "openai-codex"} and str(model or "").strip().lower().rsplit("/", 1)[-1] in {
+        "gpt-6-astra", "gpt-6-astra-900k",
+    }
+
+
 def cached_provider_model_ids(
     provider: Optional[str], *, force_refresh: bool = False,
     ttl_seconds: int = _PROVIDER_MODELS_CACHE_TTL) -> list[str]:
@@ -1532,8 +1539,14 @@ def cached_provider_model_ids(
     fp = _credential_fingerprint(normalized)
     entry = cache.get(normalized)
     now = time.time()
+    # Even a credential-matched fresh disk cache predates the current account's
+    # entitlement check. Revalidate gated entries before offering them again.
+    cached_models = entry.get("models") if isinstance(entry, dict) else None
+    gated_cache = isinstance(cached_models, list) and any(
+        _model_requires_account_discovery(normalized, model) for model in cached_models
+    )
 
-    if not force_refresh and _cache_entry_valid(entry, fp, allow_empty=is_ollama):
+    if not force_refresh and not gated_cache and _cache_entry_valid(entry, fp, allow_empty=is_ollama):
         age = now - entry["at"]
         if age < ttl_seconds:
             return list(entry["models"])
@@ -1562,7 +1575,7 @@ def cached_provider_model_ids(
         return []
     # Live returned nothing: a stale same-fingerprint entry beats an empty result.
     if _cache_entry_valid(entry, fp):
-        return list(entry["models"])
+        return [model for model in entry["models"] if not _model_requires_account_discovery(normalized, model)]
     return []
 
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1203,7 +1203,12 @@ def _openai_catalog(normalized: str, force_refresh: bool) -> Optional[list[str]]
     curated = list(_PROVIDER_MODELS.get(normalized, []))
     # Curated order, only models the account has access to; an account serving none of them (rare)
     # falls back to curated so the picker still offers sane defaults.
-    return [m for m in curated if m.lower() in live_lower] or curated or live
+    discovered = [m for m in curated if m.lower() in live_lower]
+    # Astra is intentionally absent from offline/static catalogs: the official API's
+    # account-scoped /models response is the only source that may advertise it.
+    if "gpt-6-astra" in live_lower:
+        discovered.append(next((m for m in live if m.lower() == "gpt-6-astra"), "gpt-6-astra"))
+    return discovered or curated or live
 
 
 def _custom_catalog(normalized: str, force_refresh: bool) -> Optional[list[str]]:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1518,7 +1518,7 @@ def _normalized_cache_slug(provider: Optional[str]) -> str:
 
 def _model_requires_account_discovery(provider: Optional[str], model: str) -> bool:
     """Astra names cannot confer API/OAuth entitlement through picker state."""
-    return _normalized_cache_slug(provider) in {"openai", "openai-codex"} and str(model or "").strip().lower().rsplit("/", 1)[-1] in {
+    return _normalized_cache_slug(provider) in {"openai", "openai-api", "openai-codex"} and str(model or "").strip().lower().rsplit("/", 1)[-1] in {
         "gpt-6-astra", "gpt-6-astra-900k",
     }
 

--- a/tests/agent/test_astra_baseline_runtime.py
+++ b/tests/agent/test_astra_baseline_runtime.py
@@ -2,6 +2,8 @@
 
 from types import SimpleNamespace
 
+import pytest
+
 
 def test_explicit_astra_resolves_and_uses_official_responses(monkeypatch, tmp_path):
     """A fresh profile resolves metadata and routes the official endpoint without live I/O."""
@@ -46,3 +48,33 @@ def test_astra_codex_oauth_fallback_uses_backend_context_limit():
 
     assert DEFAULT_CONTEXT_LENGTHS["gpt-6-astra"] == 1_050_000
     assert _resolve_codex_oauth_context_length_with_source("gpt-6-astra") == (272_000, "fallback")
+
+
+@pytest.mark.parametrize("advertised,expected", [(272_000, 900_000), (200_000, 200_000), (1_050_000, 1_050_000)])
+def test_astra_900k_opt_in_preserves_live_limits_and_wire_contract(monkeypatch, tmp_path, advertised, expected):
+    """Only the known stale advertisement is lifted; the alias never reaches the wire."""
+    from agent import model_metadata as metadata
+    from agent.reasoning_effort import CODEX_ASTRA_EFFORTS, codex_supported_efforts
+    from agent.transports.codex import ResponsesApiTransport
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(metadata, "_codex_oauth_context_cache", {})
+    monkeypatch.setattr(metadata.requests, "get", lambda *args, **kwargs: SimpleNamespace(
+        status_code=200,
+        json=lambda: {"models": [{"slug": "gpt-6-astra", "context_window": advertised}]},
+    ))
+    route = {"base_url": "https://chatgpt.com/backend-api/codex", "provider": "openai-codex"}
+    assert metadata.get_model_context_length("gpt-6-astra-900k", api_key="test-token", **route) == expected
+    assert metadata.get_model_context_length("gpt-6-astra", api_key="test-token", **route) == advertised
+    assert codex_supported_efforts("gpt-6-astra-900k") == CODEX_ASTRA_EFFORTS
+
+    for config, expected_effort in [({"effort": "max"}, "max"), ({"enabled": False}, "low")]:
+        kwargs = ResponsesApiTransport().build_kwargs(
+            model="gpt-6-astra-900k", messages=[{"role": "user", "content": "Hi"}], tools=[],
+            is_codex_backend=True, reasoning_config=config,
+            request_overrides={"temperature": 0.5, "logprobs": True}, **route,
+        )
+        assert kwargs["model"] == "gpt-6-astra"
+        assert kwargs["reasoning"]["effort"] == expected_effort
+        assert "temperature" not in kwargs and "logprobs" not in kwargs
+        assert "prompt_cache_options" not in kwargs

--- a/tests/agent/test_astra_baseline_runtime.py
+++ b/tests/agent/test_astra_baseline_runtime.py
@@ -35,3 +35,14 @@ def test_explicit_astra_resolves_and_uses_official_responses(monkeypatch, tmp_pa
     )
     assert kwargs["reasoning"]["effort"] == "low"
     assert kwargs["prompt_cache_options"] == {"ttl": "30m"}
+
+
+def test_astra_codex_oauth_fallback_uses_backend_context_limit():
+    """OAuth keeps the Codex backend's 272K fallback; direct API metadata remains 1.05M."""
+    from agent.model_metadata import (
+        DEFAULT_CONTEXT_LENGTHS,
+        _resolve_codex_oauth_context_length_with_source,
+    )
+
+    assert DEFAULT_CONTEXT_LENGTHS["gpt-6-astra"] == 1_050_000
+    assert _resolve_codex_oauth_context_length_with_source("gpt-6-astra") == (272_000, "fallback")

--- a/tests/agent/test_astra_baseline_runtime.py
+++ b/tests/agent/test_astra_baseline_runtime.py
@@ -68,13 +68,43 @@ def test_astra_900k_opt_in_preserves_live_limits_and_wire_contract(monkeypatch, 
     assert metadata.get_model_context_length("gpt-6-astra", api_key="test-token", **route) == advertised
     assert codex_supported_efforts("gpt-6-astra-900k") == CODEX_ASTRA_EFFORTS
 
-    for config, expected_effort in [({"effort": "max"}, "max"), ({"enabled": False}, "low")]:
-        kwargs = ResponsesApiTransport().build_kwargs(
-            model="gpt-6-astra-900k", messages=[{"role": "user", "content": "Hi"}], tools=[],
+    for config in ({"effort": "max"}, {"enabled": False}):
+        params = dict(
+            messages=[{"role": "user", "content": "Hi"}], tools=[],
             is_codex_backend=True, reasoning_config=config,
             request_overrides={"temperature": 0.5, "logprobs": True}, **route,
         )
+        kwargs = ResponsesApiTransport().build_kwargs(model="gpt-6-astra-900k", **params)
         assert kwargs["model"] == "gpt-6-astra"
-        assert kwargs["reasoning"]["effort"] == expected_effort
-        assert "temperature" not in kwargs and "logprobs" not in kwargs
+        assert kwargs == ResponsesApiTransport().build_kwargs(model="gpt-6-astra", **params)
         assert "prompt_cache_options" not in kwargs
+
+
+@pytest.mark.parametrize("provider,model", [
+    ("openai-codex", "gpt-6-astra"), ("openai-codex", "gpt-6-astra-900k"), ("openai", "gpt-6-astra"),
+])
+def test_picker_revalidates_cached_astra_and_never_injects_saved_entitlement(monkeypatch, tmp_path, provider, model):
+    from hermes_cli import models
+    from hermes_cli.inventory import ConfigContext, _append_unconfigured_rows
+    from hermes_cli.model_switch_providers import _finalize_picker_rows
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(models, "_credential_fingerprint", lambda _: "synthetic-account")
+    models.update_provider_cache_entry(provider, ["gpt-5.6-sol", model])
+    live = []
+    calls = []
+
+    def discover(slug, **kwargs):
+        calls.append(slug)
+        return list(live)
+
+    monkeypatch.setattr(models, "provider_model_ids", discover)
+    assert models.cached_provider_model_ids(provider) == ["gpt-5.6-sol"]
+    assert calls == [provider]
+    row = {"slug": provider, "is_current": True, "models": ["gpt-5.6-sol"], "total_models": 1}
+    assert model not in _finalize_picker_rows([row], {}, model)[0]["models"]
+    ctx = ConfigContext(provider, model, "", {}, [])
+    assert _append_unconfigured_rows([], ctx, current_only=True)[0]["models"] == []
+
+    live[:] = ["gpt-5.6-sol", model]
+    assert model in models.cached_provider_model_ids(provider)

--- a/tests/agent/test_astra_baseline_runtime.py
+++ b/tests/agent/test_astra_baseline_runtime.py
@@ -81,7 +81,7 @@ def test_astra_900k_opt_in_preserves_live_limits_and_wire_contract(monkeypatch, 
 
 
 @pytest.mark.parametrize("provider,model", [
-    ("openai-codex", "gpt-6-astra"), ("openai-codex", "gpt-6-astra-900k"), ("openai", "gpt-6-astra"),
+    ("openai-codex", "gpt-6-astra"), ("openai-codex", "gpt-6-astra-900k"), ("openai-api", "gpt-6-astra"),
 ])
 def test_picker_revalidates_cached_astra_and_never_injects_saved_entitlement(monkeypatch, tmp_path, provider, model):
     from hermes_cli import models

--- a/tests/agent/test_astra_baseline_runtime.py
+++ b/tests/agent/test_astra_baseline_runtime.py
@@ -1,0 +1,37 @@
+"""Focused real-path coverage for the GPT-6 Astra baseline contract."""
+
+from types import SimpleNamespace
+
+
+def test_explicit_astra_resolves_and_uses_official_responses(monkeypatch, tmp_path):
+    """A fresh profile resolves metadata and routes the official endpoint without live I/O."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda *args, **kwargs: {})
+    monkeypatch.setattr("agent.process_bootstrap.OpenAI", lambda **_kwargs: SimpleNamespace())
+    monkeypatch.setattr("model_tools.get_tool_definitions", lambda *args, **kwargs: [])
+
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        model="gpt-6-astra",
+        provider="openai",
+        api_key="test-key",
+        base_url="https://api.openai.com/v1",
+        platform="cli",
+        max_iterations=2,
+        quiet_mode=True,
+        skip_memory=True,
+    )
+
+    assert agent.api_mode == "codex_responses"
+    assert agent.context_compressor.context_length == 1_050_000
+    kwargs = agent._get_transport().build_kwargs(
+        model=agent.model,
+        messages=[{"role": "user", "content": "Hi"}],
+        tools=[],
+        provider=agent.provider,
+        base_url=agent.base_url,
+        reasoning_config={"enabled": False, "effort": "none"},
+    )
+    assert kwargs["reasoning"]["effort"] == "low"
+    assert kwargs["prompt_cache_options"] == {"ttl": "30m"}

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3171,6 +3171,19 @@ class TestCodexAdapterPromptCacheKey:
         ])
         assert "prompt_cache_retention" not in captured
 
+    def test_astra_auxiliary_request_uses_official_contract(self):
+        adapter, captured = self._build_adapter(
+            base_url="https://api.openai.com/v1",
+            model="gpt-6-astra",
+        )
+        adapter.create(
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"reasoning": {"enabled": False, "effort": "none"}},
+        )
+        assert captured["reasoning"]["effort"] == "low"
+        assert captured["prompt_cache_options"] == {"ttl": "30m"}
+        assert "prompt_cache_retention" not in captured
+
     def test_codex_backend_forwards_auxiliary_service_tier(self):
         adapter, captured = self._build_adapter(
             base_url="https://chatgpt.com/backend-api/codex",

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3184,6 +3184,18 @@ class TestCodexAdapterPromptCacheKey:
         assert captured["prompt_cache_options"] == {"ttl": "30m"}
         assert "prompt_cache_retention" not in captured
 
+    def test_astra_auxiliary_proxy_keeps_legacy_effort_contract(self):
+        adapter, captured = self._build_adapter(
+            base_url="https://responses.example.com/v1",
+            model="gpt-6-astra",
+        )
+        adapter.create(
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"reasoning": {"effort": "none"}},
+        )
+        assert captured["reasoning"]["effort"] == "none"
+        assert "prompt_cache_options" not in captured
+
     def test_codex_backend_forwards_auxiliary_service_tier(self):
         adapter, captured = self._build_adapter(
             base_url="https://chatgpt.com/backend-api/codex",

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -825,6 +825,18 @@ class TestGetModelCapabilities:
         assert caps is not None
         assert caps.supports_vision is False
 
+    def test_astra_builtin_metadata_fills_catalog_lag_without_listing_it(self):
+        """An explicitly discovered Astra remains fully described before models.dev catches up."""
+        with patch("agent.models_dev.fetch_models_dev", return_value={}):
+            caps = get_model_capabilities("openai", "gpt-6-astra")
+
+        assert caps is not None
+        assert caps.context_window == 1_050_000
+        assert caps.max_output_tokens == 128_000
+        assert caps.supports_tools is True
+        assert caps.supports_vision is True
+        assert caps.supports_reasoning is True
+
 
 # ---------------------------------------------------------------------------
 # Per-model metadata overrides (model_overrides config)

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -837,6 +837,9 @@ class TestGetModelCapabilities:
         assert caps.supports_vision is True
         assert caps.supports_reasoning is True
 
+        api_caps = get_model_capabilities("openai-api", "gpt-6-astra")
+        assert api_caps == caps
+
 
 # ---------------------------------------------------------------------------
 # Per-model metadata overrides (model_overrides config)

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -11,6 +11,23 @@ from agent.usage_pricing import (
 from decimal import Decimal
 
 
+def test_astra_whole_request_price_tier_includes_cache_writes():
+    below = estimate_usage_cost(
+        "gpt-6-astra",
+        CanonicalUsage(input_tokens=100_000, output_tokens=10_000, cache_read_tokens=10_000, cache_write_tokens=10_000),
+        provider="openai",
+    )
+    above = estimate_usage_cost(
+        "gpt-6-astra",
+        CanonicalUsage(input_tokens=100_000, output_tokens=10_000, cache_read_tokens=100_000, cache_write_tokens=100_001),
+        provider="openai",
+    )
+
+    assert below.amount_usd == Decimal("1.635")
+    assert above.amount_usd == Decimal("5.450025")
+    assert above.pricing_version == "openai-gpt-6-astra-2026-09"
+
+
 
 
 

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -51,6 +51,7 @@ class TestCodexBuildKwargs:
                 "top_p": 0.9,
                 "top_logprobs": 5,
                 "logprobs": True,
+                "reasoning": {"effort": "none"},
                 "include": ["reasoning.encrypted_content", "message.output_text.logprobs"],
                 "prompt_cache_retention": "24h",
                 "prompt_cache_options": {"ttl": "1h"},
@@ -63,6 +64,31 @@ class TestCodexBuildKwargs:
         assert kw["include"] == ["reasoning.encrypted_content"]
         for unsupported in ("temperature", "top_p", "top_logprobs", "logprobs"):
             assert unsupported not in kw
+        assert transport.preflight_kwargs(kw)["prompt_cache_options"] == {"ttl": "30m"}
+
+    @pytest.mark.parametrize("effort", ["none", "minimal"])
+    def test_astra_normalizes_unsupported_low_efforts_after_overrides(self, transport, effort):
+        kw = transport.build_kwargs(
+            model="gpt-6-astra",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url="https://api.openai.com/v1",
+            request_overrides={"reasoning": {"effort": effort}},
+        )
+
+        assert kw["reasoning"]["effort"] == "low"
+
+    @pytest.mark.parametrize("effort", ["low", "medium", "high", "xhigh", "max"])
+    def test_astra_accepts_complete_effort_ladder(self, transport, effort):
+        kw = transport.build_kwargs(
+            model="gpt-6-astra",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url="https://api.openai.com/v1",
+            reasoning_config={"enabled": True, "effort": effort},
+        )
+
+        assert kw["reasoning"]["effort"] == effort
 
     def test_astra_proxy_does_not_receive_official_cache_options(self, transport):
         kw = transport.build_kwargs(

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -39,6 +39,42 @@ class TestCodexTransportBasic:
 
 class TestCodexBuildKwargs:
 
+    def test_astra_direct_request_applies_model_contract_after_overrides(self, transport):
+        kw = transport.build_kwargs(
+            model="gpt-6-astra",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url="https://api.openai.com/v1",
+            reasoning_config={"enabled": False, "effort": "none"},
+            request_overrides={
+                "temperature": 0.4,
+                "top_p": 0.9,
+                "top_logprobs": 5,
+                "logprobs": True,
+                "include": ["reasoning.encrypted_content", "message.output_text.logprobs"],
+                "prompt_cache_retention": "24h",
+                "prompt_cache_options": {"ttl": "1h"},
+            },
+        )
+
+        assert kw["reasoning"]["effort"] == "low"
+        assert kw["prompt_cache_options"] == {"ttl": "30m"}
+        assert "prompt_cache_retention" not in kw
+        assert kw["include"] == ["reasoning.encrypted_content"]
+        for unsupported in ("temperature", "top_p", "top_logprobs", "logprobs"):
+            assert unsupported not in kw
+
+    def test_astra_proxy_does_not_receive_official_cache_options(self, transport):
+        kw = transport.build_kwargs(
+            model="gpt-6-astra",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url="https://responses.example.com/v1",
+            request_overrides={"prompt_cache_options": {"ttl": "30m"}},
+        )
+
+        assert "prompt_cache_options" not in kw
+
     def test_900k_context_variant_suffix_stripped_on_wire(self, transport):
         """``-900k`` large-context picker variants are Hermes-side aliases —
         the Codex backend only knows the base slug, so build_kwargs must

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -103,6 +103,18 @@ class TestCodexBuildKwargs:
         assert "prompt_cache_options" not in kw
         assert kw["reasoning"]["effort"] == "none"
 
+    def test_astra_openai_subdomain_is_not_official_route(self, transport):
+        """Only api.openai.com gets Astra's official cache contract."""
+        kw = transport.build_kwargs(
+            model="gpt-6-astra",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url="https://evil.api.openai.com/v1",
+            request_overrides={"prompt_cache_options": {"ttl": "30m"}},
+        )
+
+        assert "prompt_cache_options" not in kw
+
     def test_900k_context_variant_suffix_stripped_on_wire(self, transport):
         """``-900k`` large-context picker variants are Hermes-side aliases —
         the Codex backend only knows the base slug, so build_kwargs must

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -96,10 +96,12 @@ class TestCodexBuildKwargs:
             messages=[{"role": "user", "content": "Hi"}],
             tools=[],
             base_url="https://responses.example.com/v1",
+            reasoning_config={"enabled": True, "effort": "none"},
             request_overrides={"prompt_cache_options": {"ttl": "30m"}},
         )
 
         assert "prompt_cache_options" not in kw
+        assert kw["reasoning"]["effort"] == "none"
 
     def test_900k_context_variant_suffix_stripped_on_wire(self, transport):
         """``-900k`` large-context picker variants are Hermes-side aliases —

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -118,13 +118,17 @@ def test_astra_requires_live_codex_account_discovery(monkeypatch, tmp_path):
 
     (tmp_path / "config.toml").write_text('model = "gpt-6-astra"\n', encoding="utf-8")
     (tmp_path / "models_cache.json").write_text(
-        json.dumps({"models": [{"slug": "gpt-6-astra", "priority": 0}]}),
+        json.dumps({"models": [
+            {"slug": "gpt-6-astra", "priority": 0},
+            {"slug": "openai/gpt-6-astra", "priority": 1},
+        ]}),
         encoding="utf-8",
     )
     monkeypatch.setenv("CODEX_HOME", str(tmp_path))
     monkeypatch.setattr(codex_models, "_fetch_models_from_api", lambda _token: [])
 
     assert "gpt-6-astra" not in get_codex_model_ids(access_token="stale-token")
+    assert "openai/gpt-6-astra" not in get_codex_model_ids(access_token="stale-token")
 
     monkeypatch.setattr(
         codex_models,

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -121,6 +121,8 @@ def test_astra_requires_live_codex_account_discovery(monkeypatch, tmp_path):
         json.dumps({"models": [
             {"slug": "gpt-6-astra", "priority": 0},
             {"slug": "openai/gpt-6-astra", "priority": 1},
+            {"slug": "gpt-6-astra-900k", "priority": 2},
+            {"slug": "openai/gpt-6-astra-900k", "priority": 3},
         ]}),
         encoding="utf-8",
     )
@@ -129,13 +131,16 @@ def test_astra_requires_live_codex_account_discovery(monkeypatch, tmp_path):
 
     assert "gpt-6-astra" not in get_codex_model_ids(access_token="stale-token")
     assert "openai/gpt-6-astra" not in get_codex_model_ids(access_token="stale-token")
+    assert "gpt-6-astra-900k" not in get_codex_model_ids(access_token="stale-token")
+    assert "openai/gpt-6-astra-900k" not in get_codex_model_ids(access_token="stale-token")
 
     monkeypatch.setattr(
         codex_models,
         "_fetch_models_from_api",
         lambda _token: codex_models._finalize_codex_models(["gpt-6-astra"], allow_astra=True),
     )
-    assert "gpt-6-astra" in get_codex_model_ids(access_token="entitled-token")
+    entitled = get_codex_model_ids(access_token="entitled-token")
+    assert entitled[entitled.index("gpt-6-astra") + 1] == "gpt-6-astra-900k"
 
 
 

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -112,6 +112,28 @@ def test_fetch_from_api_keeps_supported_in_api_false_models(monkeypatch):
     assert "gpt-5-internal" not in models
 
 
+def test_astra_requires_live_codex_account_discovery(monkeypatch, tmp_path):
+    """Cached/configured Astra names must not manufacture current OAuth entitlement."""
+    from hermes_cli import codex_models
+
+    (tmp_path / "config.toml").write_text('model = "gpt-6-astra"\n', encoding="utf-8")
+    (tmp_path / "models_cache.json").write_text(
+        json.dumps({"models": [{"slug": "gpt-6-astra", "priority": 0}]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    monkeypatch.setattr(codex_models, "_fetch_models_from_api", lambda _token: [])
+
+    assert "gpt-6-astra" not in get_codex_model_ids(access_token="stale-token")
+
+    monkeypatch.setattr(
+        codex_models,
+        "_fetch_models_from_api",
+        lambda _token: codex_models._finalize_codex_models(["gpt-6-astra"], allow_astra=True),
+    )
+    assert "gpt-6-astra" in get_codex_model_ids(access_token="entitled-token")
+
+
 
 
 
@@ -238,4 +260,3 @@ class TestNormalizeModelForProvider:
         assert changed is True
         # Uses first from available list
         assert cli.model == "gpt-5.3-codex"
-

--- a/tests/hermes_cli/test_openai_picker_curated.py
+++ b/tests/hermes_cli/test_openai_picker_curated.py
@@ -70,3 +70,16 @@ def test_default_openai_endpoint_intersects_account_access(monkeypatch):
     assert result == list(curated[:2])
 
 
+def test_astra_is_offered_only_by_successful_account_discovery(monkeypatch):
+    """A gated preview may enrich the picker only when this API key lists it."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-fake")
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+    with patch.object(M, "fetch_api_models", return_value=["gpt-5.6-sol", "gpt-6-astra"]):
+        discovered = M.provider_model_ids("openai-api", force_refresh=True)
+    with patch.object(M, "fetch_api_models", return_value=["gpt-5.6-sol"]):
+        not_entitled = M.provider_model_ids("openai-api", force_refresh=True)
+
+    assert "gpt-6-astra" in discovered
+    assert "gpt-6-astra" not in not_entitled
+

--- a/tests/hermes_cli/test_openai_picker_curated.py
+++ b/tests/hermes_cli/test_openai_picker_curated.py
@@ -79,7 +79,9 @@ def test_astra_is_offered_only_by_successful_account_discovery(monkeypatch):
         discovered = M.provider_model_ids("openai-api", force_refresh=True)
     with patch.object(M, "fetch_api_models", return_value=["gpt-5.6-sol"]):
         not_entitled = M.provider_model_ids("openai-api", force_refresh=True)
+    with patch.object(M, "fetch_api_models", side_effect=RuntimeError("discovery unavailable")):
+        discovery_failed = M.provider_model_ids("openai-api", force_refresh=True)
 
     assert "gpt-6-astra" in discovered
     assert "gpt-6-astra" not in not_entitled
-
+    assert "gpt-6-astra" not in discovery_failed


### PR DESCRIPTION
## TL;DR

This is the **baseline compatibility PR**: it teaches Hermes which Astra settings and limits to use, when an account may select it, and how to account for its usage. It uses Hermes' existing agent loop and Responses integration; **none of the advanced runtime PRs is required to land this baseline**.

Fixes #103016 · Series tracker: #103015 · Live validation: #103020

## What Hermes already does, and what changes

| Existing Hermes capability | This PR's addition |
| --- | --- |
| Model discovery and model selection | Show Astra only when that API or OAuth account's own discovery returns it; fallback metadata does not grant or advertise access. |
| Responses requests and ordinary application tools | Apply Astra's supported parameters and reasoning values to the existing request path. |
| Context management and usage/cost reporting | Supply route-specific limits and Astra pricing, including cache writes and the large-input tier. |

```mermaid
flowchart TD
    A["Account-scoped model discovery"] --> B{"Astra returned?"}
    B -->|Yes| C["Offer Astra in the picker"]
    B -->|No or failure| D["Do not advertise Astra"]
    C --> E["Existing Hermes agent and Responses path"]
    F["Explicit Astra model name"] --> E
    E --> G["Normalize Astra request for the eligible route"]
    G --> H["Existing response and tool loop"]
    H --> I["Record usage with Astra pricing"]
```

An explicit name can resolve local metadata; it does not prove provider entitlement.

## Contract and route boundaries

- Direct-API fallback: **1,050,000 context / 128,000 maximum output**, text/image input, tools and reasoning. The **Codex/OAuth fallback remains 272,000 context**, not the direct-API limit.
- Codex/OAuth also retains the explicit **`gpt-6-astra-900k` opt-in** from #103132. It is offered only when that account discovers the base model, resolves through Hermes' existing large-context eligibility rules, and sends `gpt-6-astra` on the wire. Changed live catalog limits continue to take precedence; the ordinary fallback is still 272K.
- Supported effort: `low | medium | high | xhigh | max`. On eligible official routes, `none`, `minimal` and disabled reasoning normalize to `low`, including after request overrides.
- Strip unsupported sampling/logprob fields on the eligible Astra route. Exact direct-API Astra requests to `api.openai.com` receive `prompt_cache_options.ttl = "30m"`; unrelated Responses-compatible endpoints keep their prior behavior. Auxiliary Responses calls use the same route-aware contract.
- Apply published base pricing and the **whole-request >272K tier**, including cache-write accounting.

No new command or config schema. No new tool scheduler, WebSocket steering, or history-based effort updates.

## How this fits the series

| PR | Purpose | Needed for this baseline? |
| --- | --- | --- |
| **This PR** | Account-safe model selection and request/accounting compatibility | Yes |
| #103129 — async tools | Start eligible tool work before response streaming finishes | No — advanced, draft |
| #103144 — native steering | Send existing steering controls to an active provider response | No — advanced, draft |
| #103183 — effort/cache updates | Record effort changes without rewriting the earlier request prefix | No — advanced, draft |

The advanced PRs remain subject to the maintainer's comparative-evidence gate in #103015. They are proposed enhancements, not evidence that Astra needs a different agent architecture.

## Validation and review

[Required CI is green](https://github.com/NousResearch/hermes-agent/actions/runs/33949863759/job/101263088918) on head `de57e601193a955a69201e1a274d5ccab83a7634`.

Focused coverage includes discovery include/exclude/failure, temporary-`HERMES_HOME` resolution, final request JSON after overrides, effort values, exact-host/proxy boundaries, TTL, and pricing below/above 272K.

<details>
<summary>Test receipts, reproduction, and source identity</summary>

- Historical baseline candidate: 443 tests passed across the seven affected files.
- Exact-host correction: 118 transport tests passed.
- Current-head fallback/900K/discovery regression: `tests/agent/test_astra_baseline_runtime.py` passed 8/8 on `de57e601193a955a69201e1a274d5ccab83a7634`.
- Codex model-picker file: 10/10 passed on `c7cd27d7f`; subsequent baseline changes cover the shared cached/current/skeleton picker paths in the 8-case file above.
- Independent entitlement delta review passed on exact head `de57e601193a955a69201e1a274d5ccab83a7634`, covering `openai`, canonical `openai-api`, and OAuth. This is independent source review, not a new maintainer approval.
- Independent baseline semantic review passed on `f92fb9d9964e6e8ea118035c548aae812054f504`; exact-host delta review passed on `6e73cc5cc66e4003276c4472e6ce2d77e602f130`. These are prior-head review receipts, not a claim of live acceptance.

```sh
scripts/run_tests.sh -j 4 tests/agent/test_astra_baseline_runtime.py tests/agent/test_auxiliary_client.py tests/agent/test_models_dev.py tests/agent/transports/test_codex_transport.py tests/hermes_cli/test_codex_models.py tests/hermes_cli/test_openai_picker_curated.py tests/agent/test_usage_pricing.py -q
```

Original upstream base: `13e72fb205b735df679e0fd5f5996a34ac4accc6`. Current synchronized upstream base: `1e69c12b64dba4090eddffeae27f5a147068d34b`.

</details>

**Not yet proven:** entitled live Astra operation in ordinary CLI/gateway sessions. That acceptance belongs to #103020; OAuth is an expected negative when account discovery does not expose Astra. No paid live request was made.

## Review follow-up

- The maintainer-requested 272K OAuth fallback remains fixed; direct API remains 1.05M.
- The 900K eligibility entries preserve @mssteuer's authorship from #103132, supported by @unsupportedpastels' additional account-specific receipt. They do not advertise universal entitlement or an absolute maximum.
- Cached discovery rows, saved-current-model rows, and unauthenticated inventory skeletons cannot reintroduce undiscovered Astra. The opt-in alias retains Astra's supported reasoning ladder.
- The requested **85% automatic compression default is not adopted**: capacity acceptance does not establish the best quality/cost/latency policy. The existing explicit `compression.model_thresholds.gpt-6-astra-900k: 0.85` override remains available; no threshold default or config schema changes.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (focused source tests only)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user config or command was added
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python/provider contract, no platform-specific paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; tool schemas are unchanged in PR 1

