### PR TITLE
fix(photon): install-sidecar must provision all modules index.mjs imports (#103051)

### DIFF
--- a/plugins/platforms/photon/sidecar_paths.py
+++ b/plugins/platforms/photon/sidecar_paths.py
@@ -21,8 +21,16 @@ logger = logging.getLogger(__name__)
 
 SOURCE_SIDECAR_DIR = Path(__file__).parent / "sidecar"
 # Files that define the sidecar; node_modules is deliberately absent (baked on managed
-# images or installed by npm in the mirror).
-_MIRROR_FILES = ("index.mjs", "package.json", "package-lock.json", "patch-spectrum-mixed-attachments.mjs")
+# images or installed by npm in the mirror). Every local module index.mjs imports must
+# be listed here or the mirrored sidecar dies with ERR_MODULE_NOT_FOUND (#103051).
+_MIRROR_FILES = (
+    "index.mjs",
+    "package.json",
+    "package-lock.json",
+    "patch-spectrum-mixed-attachments.mjs",
+    "send-format.mjs",
+    "stream-staleness.mjs",
+)
 # Tests monkeypatch these module globals directly; the accessors honor a non-None value.
 _SIDECAR_DIR: Optional[Path] = None
 # Written by `hermes photon install-sidecar` on npm failure so check_requirements() can

--- a/tests/plugins/platforms/photon/test_sidecar_paths.py
+++ b/tests/plugins/platforms/photon/test_sidecar_paths.py
@@ -9,6 +9,7 @@ volume when a runtime install is unavoidable.
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 
 import pytest
@@ -60,6 +61,37 @@ def test_readonly_source_with_baked_fresh_deps_runs_in_place(
     os.utime(marker, (2000.0, 2000.0))
     _freeze_writability(monkeypatch, writable=False)
     assert sidecar_paths.resolve_sidecar_dir(source) == source
+
+
+_LOCAL_IMPORT_RE = re.compile(r'from "\./([^"]+\.mjs)"|import "\./([^"]+\.mjs)"')
+
+
+def test_mirror_files_cover_every_local_import_of_index_mjs() -> None:
+    """The mirror list must provision every module index.mjs imports locally.
+
+    Regression for #103051: send-format.mjs and stream-staleness.mjs were added
+    as imports without joining _MIRROR_FILES, so the mirrored sidecar crashed
+    with ERR_MODULE_NOT_FOUND on every start.
+    """
+    index = sidecar_paths.SOURCE_SIDECAR_DIR / "index.mjs"
+    imported = sorted(
+        {
+            match.group(1) or match.group(2)
+            for match in _LOCAL_IMPORT_RE.finditer(index.read_text(encoding="utf-8"))
+        }
+    )
+    assert imported, "no local imports found — index.mjs layout changed?"
+    missing = [name for name in imported if name not in sidecar_paths._MIRROR_FILES]
+    assert not missing, (
+        "index.mjs imports modules that install-sidecar's mirror does not provision: "
+        f"{missing}. Add them to sidecar_paths._MIRROR_FILES."
+    )
+    # And every listed module must actually exist in the source tree.
+    absent = [
+        name for name in sidecar_paths._MIRROR_FILES
+        if not (sidecar_paths.SOURCE_SIDECAR_DIR / name).exists()
+    ]
+    assert not absent, f"_MIRROR_FILES references missing source files: {absent}"
 
 
 def test_mirror_refresh_updates_changed_files_and_keeps_node_modules(


### PR DESCRIPTION
Closes #103051

## Problem

`hermes photon install-sidecar` provisions `$HERMES_HOME/photon/sidecar/` from a hardcoded file list (`_MIRROR_FILES` in `plugins/platforms/photon/sidecar_paths.py`). When `send-format.mjs` and `stream-staleness.mjs` were added as local imports of `index.mjs`, they were never added to that list, so the mirrored sidecar starts with `ERR_MODULE_NOT_FOUND` and the photon platform never connects (retry loop never recovers — missing file, not a transient failure).

## Fix

- Add `send-format.mjs` and `stream-staleness.mjs` to `_MIRROR_FILES` so the mirror (hosted/immutable-image path) provisions every local module `index.mjs` imports. Both files exist in `plugins/platforms/photon/sidecar/` alongside the other `.mjs` files.
- Add a structural regression test asserting `_MIRROR_FILES` covers every local `./*.mjs` import of `index.mjs` and that every listed file exists in the source tree, so a future module can never be missed again.

The Dockerfile's bake-time `COPY` list is intentionally unchanged: it only feeds the layer-cached `npm ci` (package manifests + postinstall patch); the full source tree (including both modules) is restored by the later `COPY . .`.

## Tests

- New: `tests/plugins/platforms/photon/test_sidecar_paths.py::test_mirror_files_cover_every_local_import_of_index_mjs`
- Full photon suite: `PYTHONPATH=$PWD python3 -m pytest -q tests/plugins/platforms/photon/ -x` → 133 passed, 1 skipped (root-perms skip).