### PR TITLE
test: make or-True assertions actually assert (#103047)

### DIFF
--- a/tests/hermes_cli/test_noninteractive_git.py
+++ b/tests/hermes_cli/test_noninteractive_git.py
@@ -44,12 +44,16 @@ class TestNoninteractiveGitEnv:
 
     def test_defaults_to_process_environ_copy(self, monkeypatch):
         monkeypatch.setenv("HERMES_TEST_SENTINEL", "xyz")
+        # Snapshot the live values before the call so we can prove the helper
+        # copies them instead of mutating the process environment in place.
+        live_git_prompt = os.environ.get("GIT_TERMINAL_PROMPT")
+        live_gcm_interactive = os.environ.get("GCM_INTERACTIVE")
         env = noninteractive_git_env()
         assert env["HERMES_TEST_SENTINEL"] == "xyz"
         assert env["GIT_TERMINAL_PROMPT"] == "0"
         # Never mutates the live process environment.
-        assert os.environ.get("GIT_TERMINAL_PROMPT") != "0" or True
-        assert "GCM_INTERACTIVE" not in os.environ or os.environ["GCM_INTERACTIVE"] == env["GCM_INTERACTIVE"]
+        assert os.environ.get("GIT_TERMINAL_PROMPT") == live_git_prompt
+        assert os.environ.get("GCM_INTERACTIVE") == live_gcm_interactive
 
 
     def test_overrides_explicit_prompt_enable(self):

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -98,7 +98,6 @@ class TestWriteFileHandler:
         result = json.loads(_handle_write_file({"path": "/tmp/oops.md"}))
         assert "error" in result
         assert "content" in result["error"]
-        assert "path" not in result.get("error", "").lower() or "missing" not in result.get("error", "").lower() or True  # just check error present
 
     def test_missing_path_key_returns_error(self):
         """#19096 — handler must reject tool calls where 'path' key is absent."""

--- a/tests/tools/test_yolo_mode.py
+++ b/tests/tools/test_yolo_mode.py
@@ -100,11 +100,26 @@ class TestYoloMode:
         assert result["message"] is None
         assert called["value"] is False
 
-    def test_yolo_mode_not_set_by_default(self):
+    def test_yolo_mode_not_set_by_default(self, monkeypatch):
         """HERMES_YOLO_MODE should not be set by default."""
-        # Clean env check — if it happens to be set in test env, that's fine,
-        # we just verify the mechanism exists
-        assert os.getenv("HERMES_YOLO_MODE") is None or True  # no-op, documents intent
+        # Drop any ambient value and mirror the import-time freeze of a process
+        # started without the env var, so the check is deterministic even when
+        # the test runner itself exports HERMES_YOLO_MODE.
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.setenv("HERMES_SESSION_KEY", "test-session")
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
+
+        assert os.getenv("HERMES_YOLO_MODE") is None
+
+        # With yolo off by default the dangerous command is not auto-approved:
+        # it still goes through the approval gate and the deny callback wins.
+        result = check_dangerous_command(
+            "rm -rf /tmp/stuff", "local", approval_callback=lambda *a: "deny"
+        )
+        assert result["approved"] is False
 
 
     @pytest.mark.parametrize("value", ["false", "False", "0", "off", "no"])


### PR DESCRIPTION
Closes #103047

Three test assertions were written with an `or True` tail, making them tautologies that can never fail. Each is now a real check of the property its comment/docstring declares.

1. `tests/hermes_cli/test_noninteractive_git.py` — `test_defaults_to_process_environ_copy`: `assert os.environ.get("GIT_TERMINAL_PROMPT") != "0" or True` never failed. The test now snapshots the live `GIT_TERMINAL_PROMPT` and `GCM_INTERACTIVE` values before calling `noninteractive_git_env()` and asserts the live process environment is unchanged afterwards, actually proving the "never mutates the live process environment" property (the helper only mutates its own copy).

2. `tests/tools/test_yolo_mode.py` — `test_yolo_mode_not_set_by_default`: `assert os.getenv("HERMES_YOLO_MODE") is None or True  # no-op, documents intent` never failed. The test now deletes any ambient `HERMES_YOLO_MODE`, mirrors the import-time `_YOLO_MODE_FROZEN` freeze for a clean process (`monkeypatch.setattr(..., False)` so it is deterministic even when the test runner exports the var), asserts the env var is unset, and verifies the behavioral contract: with yolo off by default a dangerous command is not auto-approved (deny callback wins).

3. `tests/tools/test_file_tools.py` — `test_missing_content_key_returns_error`: the `or True` line was dead weight — the two asserts above it (`"error" in result`, `"content" in result["error"]`) already check exactly what the "just check error present" comment wanted. Deleting it loses no coverage; if the handler ever accepts a call without `content`, the remaining asserts fail.

Only test files changed; no production code touched.

## Tests

```
cd /root/wt/fix/issue103047-test-or-true && PYTHONPATH=$PWD /usr/local/lib/hermes-agent/venv/bin/python3 -m pytest -q tests/hermes_cli/test_noninteractive_git.py tests/tools/test_yolo_mode.py tests/tools/test_file_tools.py -x
```

Result: `72 passed, 2 skipped in 8.54s`