### PR TITLE
fix(tests): make the three tautological assertions falsifiable

### DIFF
--- a/tests/hermes_cli/test_noninteractive_git.py
+++ b/tests/hermes_cli/test_noninteractive_git.py
@@ -44,11 +44,12 @@ class TestNoninteractiveGitEnv:
 
     def test_defaults_to_process_environ_copy(self, monkeypatch):
         monkeypatch.setenv("HERMES_TEST_SENTINEL", "xyz")
+        live_prompt_before = os.environ.get("GIT_TERMINAL_PROMPT")
         env = noninteractive_git_env()
         assert env["HERMES_TEST_SENTINEL"] == "xyz"
         assert env["GIT_TERMINAL_PROMPT"] == "0"
         # Never mutates the live process environment.
-        assert os.environ.get("GIT_TERMINAL_PROMPT") != "0" or True
+        assert os.environ.get("GIT_TERMINAL_PROMPT") == live_prompt_before
         assert "GCM_INTERACTIVE" not in os.environ or os.environ["GCM_INTERACTIVE"] == env["GCM_INTERACTIVE"]
 
 

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -98,7 +98,6 @@ class TestWriteFileHandler:
         result = json.loads(_handle_write_file({"path": "/tmp/oops.md"}))
         assert "error" in result
         assert "content" in result["error"]
-        assert "path" not in result.get("error", "").lower() or "missing" not in result.get("error", "").lower() or True  # just check error present
 
     def test_missing_path_key_returns_error(self):
         """#19096 — handler must reject tool calls where 'path' key is absent."""

--- a/tests/tools/test_yolo_mode.py
+++ b/tests/tools/test_yolo_mode.py
@@ -1,6 +1,10 @@
 """Tests for --yolo (HERMES_YOLO_MODE) approval bypass."""
 
 import os
+import subprocess
+import sys
+from pathlib import Path
+
 import pytest
 
 import tools.approval as approval_module
@@ -101,10 +105,18 @@ class TestYoloMode:
         assert called["value"] is False
 
     def test_yolo_mode_not_set_by_default(self):
-        """HERMES_YOLO_MODE should not be set by default."""
-        # Clean env check — if it happens to be set in test env, that's fine,
-        # we just verify the mechanism exists
-        assert os.getenv("HERMES_YOLO_MODE") is None or True  # no-op, documents intent
+        """A clean environment must not enable YOLO; the flag is frozen at import time."""
+        code = "import tools.approval as a; raise SystemExit(0 if not a._YOLO_MODE_FROZEN else 1)"
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            cwd=str(Path(__file__).resolve().parents[2]),
+            env={k: v for k, v in os.environ.items() if k != "HERMES_YOLO_MODE"},
+        )
+        assert result.returncode == 0, (
+            f"YOLO bypass enabled without HERMES_YOLO_MODE:\n{result.stderr}"
+        )
 
 
     @pytest.mark.parametrize("value", ["false", "False", "0", "off", "no"])


### PR DESCRIPTION
## Summary

Closes #103047.

Three assertions in the suite were unconditionally true (`or True`), so breaking the code under test could never turn them red:

- **`tests/hermes_cli/test_noninteractive_git.py`** — the comment above the assertion states a property ("never mutates the live process environment") that the `or True` assertion could not check. Now the live `GIT_TERMINAL_PROMPT` is snapshotted before the call and asserted unchanged after, which is exactly that property and no longer depends on the ambient environment.
- **`tests/tools/test_yolo_mode.py`** — the docstring claimed "HERMES_YOLO_MODE should not be set by default" while the test passed regardless. The bypass flag is frozen at import time (`_YOLO_MODE_FROZEN`), so the check now runs in a clean subprocess with `HERMES_YOLO_MODE` stripped from the environment and asserts the flag stays disabled — the docstring's claim becomes a checkable fact. A side benefit: the check no longer silently tolerates an ambient `HERMES_YOLO_MODE=1` leaking into the test process.
- **`tests/tools/test_file_tools.py`** — the dead `or True` line is removed; the two assertions above it already assert exactly what its comment described ("error present"), so no coverage is lost.

Each rewritten assertion is verified falsifiable: with `os.environ["GIT_TERMINAL_PROMPT"] = "0"` injected into `noninteractive_git_env` the first test fails; with `_YOLO_MODE_FROZEN = True` hardcoded the second fails.

## Testing

- `ruff check` clean on all three files; `ruff format --diff` touches only pre-existing lines, not the new code.
- Full run of the three files (with ambient `HERMES_YOLO_MODE` stripped, matching CI's clean env): `2 failed, 70 passed, 2 skipped` — the 2 failures (`test_writes_content`, `test_replace_mode_calls_patch_replace`) are pre-existing on unmodified `main` under macOS where `/tmp` resolves to `/private/tmp` in mock call assertions, unrelated to this diff.
