### PR TITLE
fix(cli): one-shot runs must still write agent.log and errors.log (#103056)

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -174,10 +174,6 @@ def run_oneshot(
     JSON usage report even when the run fails. Returns the exit code; the caller owns process
     termination.
     """
-    # Silence every stdlib logger: AIAgent, tools and provider adapters log to stderr through the
-    # root logger. File handlers from setup_logging() keep working (level-independent).
-    logging.disable(logging.CRITICAL)
-
     # --provider without --model is ambiguous (the provider may not host the configured model, and
     # picking its catalog default hides the mismatch). Validate BEFORE the stderr redirect.
     env_model_early = os.getenv("HERMES_INFERENCE_MODEL", "").strip()
@@ -208,24 +204,37 @@ def run_oneshot(
     real_stdout = sys.stdout
     real_stderr = sys.stderr
 
+    # Silence the console without starving file logging. ``logging.disable()`` (the old
+    # approach) sets ``Logger.manager.disable``, which blocks record creation at the root
+    # logger BEFORE handlers run — so the file handlers behind setup_logging() received
+    # nothing either and one-shot runs wrote neither agent.log nor errors.log (#103056).
+    # Mute only stdout/stderr-bound handlers for the (redirected) run instead, and restore
+    # them afterwards; placed after validation so early returns leave logging untouched.
+    from hermes_logging import mute_console_logging
+
+    _restore_console_logging = mute_console_logging()
+
     response: Optional[str] = None
     result: dict = {}
     failure: BaseException | None = None
-    with open(os.devnull, "w", encoding="utf-8") as devnull, redirect_stdout(devnull), redirect_stderr(devnull):
-        try:
-            response, result = _run_agent(
-                prompt,
-                model=model,
-                provider=provider,
-                toolsets=explicit_toolsets,
-                use_config_toolsets=use_config_toolsets,
-                skills=skills,
-            )
-        except BaseException as exc:  # noqa: BLE001
-            # Capture anything escaping the agent (OSError from prompt_toolkit on a non-TTY pipe,
-            # KeyboardInterrupt, SystemExit, ...) so it reaches the real stderr instead of dying
-            # silently past the redirect — the worst failure mode in cron / SSH / subprocess use.
-            failure = exc
+    try:
+        with open(os.devnull, "w", encoding="utf-8") as devnull, redirect_stdout(devnull), redirect_stderr(devnull):
+            try:
+                response, result = _run_agent(
+                    prompt,
+                    model=model,
+                    provider=provider,
+                    toolsets=explicit_toolsets,
+                    use_config_toolsets=use_config_toolsets,
+                    skills=skills,
+                )
+            except BaseException as exc:  # noqa: BLE001
+                # Capture anything escaping the agent (OSError from prompt_toolkit on a non-TTY pipe,
+                # KeyboardInterrupt, SystemExit, ...) so it reaches the real stderr instead of dying
+                # silently past the redirect — the worst failure mode in cron / SSH / subprocess use.
+                failure = exc
+    finally:
+        _restore_console_logging()
 
     if failure is not None:
         # Control-flow exceptions (Ctrl-C / sys.exit inside the agent) re-raise to the parent.

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -16,7 +16,7 @@ import sys
 import threading
 from logging.handlers import QueueHandler, QueueListener
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Callable, Optional, Sequence
 
 # Windows-ONLY swap (#44873): stdlib ``RotatingFileHandler.doRollover()`` calls
 # ``os.rename()``, which fails with ``PermissionError [WinError 32]`` whenever
@@ -236,6 +236,68 @@ def setup_verbose_logging() -> None:
     _quiet_noisy_loggers()
     # rex-deploy at INFO for sandbox status.
     logging.getLogger("rex-deploy").setLevel(logging.INFO)
+
+
+# CRITICAL + 1 rejects CRITICAL records too: the mute target for console handlers.
+_MUTED_CONSOLE_LEVEL = logging.CRITICAL + 1
+
+
+def _is_console_stream(stream) -> bool:
+    """True when *stream* writes to the process console (stdout/stderr).
+
+    Covers the raw streams, any stream that resolved to them at construction time
+    (a ``StreamHandler`` created without an explicit stream keeps the ``sys.stderr``
+    it bound then — even after the CLI redirects ``sys.stderr`` to ``devnull``), and
+    the UTF-8 wrapper ``_safe_stderr()`` builds over a non-UTF-8 console (its
+    ``buffer`` is the console's own).
+    """
+    if stream is sys.stdout or stream is sys.stderr:
+        return True
+    if getattr(stream, "name", None) in ("<stdout>", "<stderr>"):
+        return True
+    try:
+        buffer = getattr(stream, "buffer", None)
+        if buffer is not None and (buffer is sys.stdout.buffer or buffer is sys.stderr.buffer):
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def mute_console_logging() -> Callable[[], None]:
+    """Raise every console-bound handler's level past CRITICAL; return the restore callable.
+
+    One-shot/quiet CLI paths want a silent terminal, but must not use
+    ``logging.disable()`` for it: that sets ``Logger.manager.disable``, which blocks
+    record creation at the root logger *before* any handler runs, so the queued file
+    handlers (agent.log / errors.log) starve too (#103056). This walks the whole
+    logger tree and mutes only stdout/stderr-bound ``StreamHandler``s — file handlers
+    live behind the async ``QueueListener``, off the loggers, and keep receiving
+    records. Call the returned function to restore the previous levels. Safe when no
+    console handler exists (no-op).
+    """
+    loggers = [logging.getLogger()]
+    for candidate in logging.Logger.manager.loggerDict.values():
+        if isinstance(candidate, logging.Logger):
+            loggers.append(candidate)
+
+    previously: list[tuple[logging.Handler, int]] = []
+    for logger in loggers:
+        for handler in list(logger.handlers):
+            if not isinstance(handler, logging.StreamHandler):
+                continue
+            stream = getattr(handler, "stream", None)
+            if stream is None or not _is_console_stream(stream):
+                continue
+            if handler.level < _MUTED_CONSOLE_LEVEL:
+                previously.append((handler, handler.level))
+                handler.setLevel(_MUTED_CONSOLE_LEVEL)
+
+    def _restore() -> None:
+        for handler, level in previously:
+            handler.setLevel(level)
+
+    return _restore
 
 
 def _quietly(fn) -> None:

--- a/tests/cli/test_oneshot_logging.py
+++ b/tests/cli/test_oneshot_logging.py
@@ -1,0 +1,114 @@
+"""Regression tests for #103056 — one-shot (-z) runs must still write log files.
+
+``hermes -z`` (``hermes_cli/oneshot.run_oneshot``) used to call
+``logging.disable(logging.CRITICAL)`` to silence the console. That sets
+``Logger.manager.disable``, which blocks record creation at the root logger BEFORE
+any handler runs — so the queued file handlers behind ``setup_logging()`` received
+nothing either, and one-shot runs wrote neither agent.log nor errors.log.
+
+The fix mutes only stdout/stderr-bound handlers (``mute_console_logging()``) for the
+duration of the redirected run, so file logging keeps flowing while the console stays
+silent.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+import hermes_logging
+from hermes_cli import oneshot as oneshot_mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_logging_state():
+    """Isolate the queued file-logging state for each test in this module."""
+    hermes_logging._logging_initialized = False
+    hermes_logging._reset_queued_handlers()
+    yield
+    hermes_logging._reset_queued_handlers()
+    hermes_logging._logging_initialized = False
+    hermes_logging.clear_session_context()
+
+
+def _fake_run_agent_logging(prompt, **kwargs):
+    """Stand-in for _run_agent: emit records like an agent turn would, then succeed."""
+    logging.getLogger("agent").info("oneshot-turn-info-marker")
+    logging.getLogger("agent").warning("oneshot-turn-warning-marker")
+    return ("done", {"model": "test-model", "provider": "test", "completed": True})
+
+
+class TestOneShotKeepsFileLogging:
+    def test_one_shot_writes_files_and_silences_console(self, monkeypatch, capsys):
+        """`hermes -z` equivalent: files receive records, the console receives none."""
+        home = Path(os.environ["HERMES_HOME"])
+        hermes_logging.setup_logging(hermes_home=home)
+
+        # A real console handler bound to stderr (as setup_verbose_logging creates).
+        console = logging.StreamHandler()
+        console.setLevel(logging.DEBUG)
+        logging.getLogger().addHandler(console)
+
+        monkeypatch.setattr(oneshot_mod, "_run_agent", _fake_run_agent_logging)
+        captured_stdout = io.StringIO()
+        monkeypatch.setattr(sys, "stdout", captured_stdout)
+        try:
+            rc = oneshot_mod.run_oneshot("hello", usage_file=None)
+        finally:
+            logging.getLogger().removeHandler(console)
+            if console.stream not in (sys.stdout, sys.stderr):
+                console.close()
+
+        assert rc == 0
+        # Only the final content block reached stdout.
+        assert captured_stdout.getvalue() == "done\n"
+        # The console handler stayed silent for the whole run.
+        assert capsys.readouterr().err == ""
+
+        hermes_logging.flush_log_queue()
+        agent_log = (home / "logs" / "agent.log").read_text()
+        errors_log = (home / "logs" / "errors.log").read_text()
+        assert "oneshot-turn-info-marker" in agent_log
+        assert "oneshot-turn-warning-marker" in errors_log
+        # Logging state is restored once the run is over: a later record reaches files.
+        logging.getLogger("agent").info("post-run marker")
+        hermes_logging.flush_log_queue()
+        assert "post-run marker" in (home / "logs" / "agent.log").read_text()
+
+    def test_failed_one_shot_still_writes_files(self, monkeypatch):
+        """The failure path (agent raised) must log too — that is what errors.log is for."""
+        home = Path(os.environ["HERMES_HOME"])
+        hermes_logging.setup_logging(hermes_home=home)
+
+        def _failing_run_agent(prompt, **kwargs):
+            logging.getLogger("agent").error("oneshot-failure-marker")
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(oneshot_mod, "_run_agent", _failing_run_agent)
+        rc = oneshot_mod.run_oneshot("hello", usage_file=None)
+        assert rc == 1
+
+        hermes_logging.flush_log_queue()
+        assert "oneshot-failure-marker" in (home / "logs" / "errors.log").read_text()
+        assert "oneshot-failure-marker" in (home / "logs" / "agent.log").read_text()
+
+    def test_no_console_handler_is_still_silent(self, monkeypatch, capsys):
+        """Default -z setup (no console handler) prints nothing while files log."""
+        home = Path(os.environ["HERMES_HOME"])
+        hermes_logging.setup_logging(hermes_home=home)
+
+        monkeypatch.setattr(oneshot_mod, "_run_agent", _fake_run_agent_logging)
+        captured_stdout = io.StringIO()
+        monkeypatch.setattr(sys, "stdout", captured_stdout)
+        rc = oneshot_mod.run_oneshot("hello", usage_file=None)
+
+        assert rc == 0
+        assert captured_stdout.getvalue() == "done\n"
+        assert capsys.readouterr().err == ""
+        hermes_logging.flush_log_queue()
+        assert "oneshot-turn-info-marker" in (home / "logs" / "agent.log").read_text()

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -686,3 +686,108 @@ class TestAsyncQueueLogging:
             for h in hermes_logging._queued_file_handlers
         )
 
+
+class TestMuteConsoleLogging:
+    """#103056: console handlers are muted without starving the file handlers.
+
+    ``logging.disable()`` (previously used by the one-shot CLI path) blocks record
+    creation at the root logger via ``Logger.manager.disable``, so the queued file
+    handlers never see a record either. ``mute_console_logging()`` must silence only
+    stdout/stderr-bound ``StreamHandler``s and leave file logging untouched.
+    """
+
+    def test_console_handler_muted_and_file_logging_kept(self, hermes_home, capsys):
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+        # Bound to sys.stderr like a real console handler (setup_verbose_logging uses
+        # _safe_stderr(); a plain StreamHandler() binds whatever sys.stderr was when
+        # created — which survives the CLI's runtime devnull redirect).
+        console = logging.StreamHandler()
+        console.setLevel(logging.DEBUG)
+        root = logging.getLogger()
+        root.addHandler(console)
+        try:
+            restore = hermes_logging.mute_console_logging()
+            # The console handler is pushed past CRITICAL...
+            assert console.level == logging.CRITICAL + 1
+            # ...while records still reach the queued file handlers.
+            logging.getLogger("test_mute_console.kept").info("console muted but file alive")
+            logging.getLogger("test_mute_console.kept").warning("console muted but errors alive")
+            hermes_logging.flush_log_queue()
+            assert (
+                "console muted but file alive"
+                in (hermes_home / "logs" / "agent.log").read_text()
+            )
+            assert (
+                "console muted but errors alive"
+                in (hermes_home / "logs" / "errors.log").read_text()
+            )
+            # Nothing reached the (muted) console handler.
+            assert capsys.readouterr().err == ""
+            # Restore brings the previous level back.
+            restore()
+            assert console.level == logging.DEBUG
+        finally:
+            root.removeHandler(console)
+            # Never close a handler bound to the real console streams — StreamHandler.close()
+            # would close sys.stderr/stdout for the rest of the process.
+            if console.stream not in (sys.stdout, sys.stderr):
+                console.close()
+
+    def test_queue_and_file_handlers_untouched(self, hermes_home):
+        """Only stdout/stderr handlers are muted — not the queue or file handlers."""
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+        file_stream = hermes_home / "file-handler-stream.log"
+        file_handler = logging.FileHandler(file_stream, encoding="utf-8")
+        file_handler.setLevel(logging.DEBUG)
+        root = logging.getLogger()
+        root.addHandler(file_handler)
+        try:
+            queue_handlers = [
+                h for h in root.handlers if getattr(h, "_hermes_queue", False)
+            ]
+            assert len(queue_handlers) == 1
+            restore = hermes_logging.mute_console_logging()
+            try:
+                # Console-bound only: the queue handler and a file-stream handler keep
+                # their levels after mute_console_logging().
+                assert queue_handlers[0].level == logging.NOTSET
+                assert file_handler.level == logging.DEBUG
+            finally:
+                restore()
+            logging.getLogger("test_mute_console.file_stream").info(
+                "direct file handler still records"
+            )
+            file_handler.flush()
+            hermes_logging.flush_log_queue()
+            assert "direct file handler still records" in file_stream.read_text()
+        finally:
+            root.removeHandler(file_handler)
+            file_handler.close()
+
+    def test_mute_is_a_noop_without_console_handlers(self, hermes_home):
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+        restore = hermes_logging.mute_console_logging()
+        restore()  # must not raise
+        logging.getLogger("test_mute_console.noop").warning("no console handler present")
+        hermes_logging.flush_log_queue()
+        assert "no console handler present" in (
+            hermes_home / "logs" / "errors.log"
+        ).read_text()
+
+    def test_console_stream_detection(self, monkeypatch):
+        """_is_console_stream() recognizes raw, bound, and wrapped console streams."""
+        assert hermes_logging._is_console_stream(sys.stdout)
+        assert hermes_logging._is_console_stream(sys.stderr)
+        # A stream that resolved to sys.stderr at construction time.
+        bound = logging.StreamHandler().stream
+        assert hermes_logging._is_console_stream(bound)
+        # The UTF-8 wrapper _safe_stderr() builds over a non-UTF-8 console.
+        if not sys.platform.startswith("win"):
+            monkeypatch.setattr(sys, "stderr", io.TextIOWrapper(io.BytesIO(), encoding="ascii"))
+            wrapped = hermes_logging._safe_stderr()
+            assert hermes_logging._is_console_stream(wrapped)
+        # A plain file stream is not the console.
+        fake_file = io.StringIO("")
+        fake_file.name = "agent.log"  # type: ignore[attr-defined]
+        assert not hermes_logging._is_console_stream(fake_file)
+


### PR DESCRIPTION
Closes #103056

## Problem

`hermes -z` (one-shot mode) never writes anything to `agent.log` or `errors.log`: a run produces a response (and a `--usage-file` report) but both log files stay empty.

`hermes_cli/oneshot.py::run_oneshot` silenced the console with `logging.disable(logging.CRITICAL)`. That sets `Logger.manager.disable`, which is consulted **before any handler runs** — no `LogRecord` is ever created, so the queued file handlers behind `setup_logging()` (agent.log at INFO, errors.log at WARNING) are starved too. The original comment claimed file handlers "keep working (level-independent)", which is not how `logging.disable()` behaves.

## Fix

Replace the process-wide `logging.disable()` with console-only silencing:

- **`hermes_logging.py`**: new `mute_console_logging()` — walks the whole logger tree and raises the level of stdout/stderr-bound `StreamHandler`s past `CRITICAL` (`_MUTED_CONSOLE_LEVEL`), returning a restore callable. File handlers are untouched: they live behind the async `QueueListener`, off the loggers, so records keep flowing to disk. Console detection (`_is_console_stream`) covers the raw streams, handlers that bound `sys.stderr`/`sys.stdout` at construction time (which survive the CLI's runtime `devnull` redirect), and the `_safe_stderr()` UTF-8 wrapper.
- **`hermes_cli/oneshot.py`**: `run_oneshot` now mutes console handlers for the duration of the redirected run (`try/finally` restores them afterwards) instead of calling `logging.disable()`. The mute is placed after argument validation, so the early `return 2` paths leave logging state untouched.

Behavior is preserved: stdout/stderr are still redirected to `devnull` for the whole agent call tree, the agent runs with `quiet_mode=True` and no display callbacks, and console-bound handlers are muted — but records now reach `agent.log`/`errors.log` exactly as in `hermes chat -Q --oneshot`.

## Tests

Added:

- `tests/test_hermes_logging.py::TestMuteConsoleLogging` — console handler level raised past CRITICAL + restored; queued file handlers and plain file-stream handlers keep their levels; records reach agent.log/errors.log while the console captures nothing; no-op when no console handler exists; `_is_console_stream` detection.
- `tests/cli/test_oneshot_logging.py` — end-to-end `run_oneshot` with `_run_agent` stubbed: agent.log/errors.log receive the turn's records, stdout receives only the final response, the console handler stays silent, a post-run record still logs (restore works), and the failure path (`_run_agent` raises) also writes errors.log/agent.log.

Command:

```
PYTHONPATH=$PWD /usr/local/lib/hermes-agent/venv/bin/python3 -m pytest -q tests/test_hermes_logging.py tests/cli/test_oneshot_logging.py tests/test_cli_quiet_stdout_leak.py -x
```

Result: `41 passed, 2 skipped in 1.59s` (the 2 skips are pre-existing platform-conditional tests in `test_hermes_logging.py`).

Also verified directly: with the old `logging.disable(logging.CRITICAL)`, agent.log and errors.log stayed at 0 bytes; with `mute_console_logging()`, INFO records land in agent.log, ERROR records land in errors.log, and 0 bytes leak to a stderr-bound console handler.
