### PR TITLE
fix(cron): prefer Git Bash over the WSL launcher for .sh cron scripts on Windows

### DIFF
--- a/cron/scheduler_script.py
+++ b/cron/scheduler_script.py
@@ -293,20 +293,79 @@ def _resolve_script_path(script_path: str) -> tuple[Optional[Path], Optional[str
     return path, None
 
 
+def _is_wsl_bash(bash_path: "str | os.PathLike[str] | None") -> bool:
+    """True when *bash_path* is Windows' WSL launcher (System32 / WindowsApps).
+
+    That binary starts a Linux bash which cannot open Win32 paths: the
+    backslashes are eaten as escapes and the script fails with exit 127.
+    """
+    if not bash_path:
+        return False
+    parts = {p.lower() for p in Path(str(bash_path)).parts}
+    if "windowsapps" in parts:
+        return True
+    return "windows" in parts and ("system32" in parts or "sysnative" in parts)
+
+
+def _cron_bash_script_arg(path: Path, is_windows: "bool | None" = None) -> str:
+    """Script argument for bash. On Windows return a slash-only form.
+
+    Git Bash treats backslashes as escapes, so ``C:\\x\\y.sh`` turns into
+    ``C:xy.sh``. Prefer the shared MSYS form (``/c/x/y.sh``); fall back to
+    ``Path.as_posix()``. POSIX paths are returned unchanged.
+    """
+    if is_windows is None:
+        is_windows = sys.platform == "win32"
+    if not is_windows:
+        return str(path)
+    try:
+        from tools.environments.local import _bash_safe_path
+
+        return _bash_safe_path(str(path))
+    except Exception:
+        return path.as_posix()
+
+
+def _resolve_cron_bash() -> Optional[str]:
+    """Pick a bash that can run ``HERMES_HOME/scripts/*.sh``.
+
+    Delegates to ``tools.environments.local._find_bash`` (portable Git, Git for
+    Windows install dirs, then PATH). Returns ``None`` instead of the WSL
+    launcher so the caller can fail with a clear message.
+    """
+    found: Optional[str] = None
+    try:
+        from tools.environments.local import _find_bash
+
+        found = _find_bash()
+    except RuntimeError:
+        found = None
+    except Exception:
+        found = shutil.which("bash") or ("/bin/bash" if os.path.isfile("/bin/bash") else None)
+    if not found or _is_wsl_bash(found):
+        return None
+    return found
+
+
 def _script_argv(path: Path) -> tuple[Optional[list[str]], dict[str, str], Optional[str]]:
     """``(argv, env_overlay, error)`` for a validated script. Interpreter by extension — the
     shebang is deliberately NOT honoured (small, auditable surface): ``.sh``/``.bash`` → bash,
     else ``sys.executable`` (Windows uv-venv overlay gets the .pth bootstrap)."""
     if path.suffix.lower() in {".sh", ".bash"}:
-        # which() finds Git Bash on Windows; None there → clear error instead of a "[WinError 2]".
-        _bash = shutil.which("bash") or ("/bin/bash" if os.path.isfile("/bin/bash") else None)
+        # Use the shared Windows-aware resolver and refuse the WSL shim. When
+        # ``System32\bash.exe`` sits first on PATH (typical for a gateway started
+        # from the Windows autostart folder) ``shutil.which("bash")`` returns it,
+        # bash then receives a Win32 path, collapses the backslashes and exits
+        # 127 (#46332). Git Bash gets the script in POSIX form for the same reason.
+        _bash = _resolve_cron_bash()
         if _bash is None:
             return None, {}, (
-                f"Cannot run .sh/.bash script {path.name!r}: bash not found on PATH. "
+                f"Cannot run .sh/.bash script {path.name!r}: no usable bash found "
+                "(the WSL launcher in System32 cannot open Windows paths). "
                 "On Windows, install Git for Windows (which ships Git Bash) "
                 "or rewrite the script as Python (.py)."
             )
-        return [_bash, str(path)], {}, None
+        return [_bash, _cron_bash_script_arg(path)], {}, None
     python_exe, env_overlay = _windows_cron_python_invocation(sys.executable)
     if env_overlay:
         return _windows_cron_bootstrap_argv(python_exe, env_overlay, str(path)), env_overlay, None

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -807,3 +807,78 @@ class TestScriptTimeoutTreeKill:
                     psutil.Process(gpid).kill()
                 except psutil.NoSuchProcess:
                     pass
+
+
+# --- Windows bash resolution for .sh cron scripts (#46332) ---------------------------------
+
+
+def test_cron_bash_script_arg_windows_has_no_backslash():
+    from cron.scheduler_script import _cron_bash_script_arg
+
+    arg = _cron_bash_script_arg(Path("D:/Hermes/scripts/watchdog.sh"), is_windows=True)
+    assert "\\" not in arg
+    assert arg.lower().endswith("/hermes/scripts/watchdog.sh")
+
+
+def test_cron_bash_script_arg_posix_keeps_native():
+    from cron.scheduler_script import _cron_bash_script_arg
+
+    path = Path("/home/user/.hermes/scripts/watch.sh")
+    assert _cron_bash_script_arg(path, is_windows=False) == str(path)
+
+
+def test_is_wsl_bash_detects_system32_and_windowsapps():
+    from cron.scheduler_script import _is_wsl_bash
+
+    assert _is_wsl_bash(r"C:\Windows\System32\bash.exe") is True
+    assert _is_wsl_bash(r"C:\Windows\Sysnative\bash.exe") is True
+    assert _is_wsl_bash(r"C:\Users\x\AppData\Local\Microsoft\WindowsApps\bash.exe") is True
+    assert _is_wsl_bash(r"C:\Program Files\Git\usr\bin\bash.exe") is False
+    assert _is_wsl_bash("/usr/bin/bash") is False
+    assert _is_wsl_bash(None) is False
+
+
+def test_resolve_cron_bash_refuses_wsl_shim(monkeypatch):
+    from cron import scheduler_script as mod
+
+    monkeypatch.setattr("tools.environments.local._find_bash", lambda: r"C:\Windows\System32\bash.exe")
+    assert mod._resolve_cron_bash() is None
+
+
+def test_resolve_cron_bash_runtime_error_is_none(monkeypatch):
+    from cron import scheduler_script as mod
+
+    def _boom():
+        raise RuntimeError("Git Bash not found")
+
+    monkeypatch.setattr("tools.environments.local._find_bash", _boom)
+    assert mod._resolve_cron_bash() is None
+
+
+def test_script_argv_uses_git_bash_and_posix_path(cron_env, monkeypatch):
+    from cron import scheduler_script as mod
+
+    script = cron_env / "scripts" / "probe.sh"
+    script.write_text("echo ok\n", encoding="utf-8")
+    git_bash = r"C:\Program Files\Git\usr\bin\bash.EXE"
+    monkeypatch.setattr("tools.environments.local._find_bash", lambda: git_bash)
+    monkeypatch.setattr(mod.sys, "platform", "win32")
+
+    argv, env_overlay, err = mod._script_argv(script)
+    assert err is None
+    assert argv[0] == git_bash
+    assert mod._is_wsl_bash(argv[0]) is False
+    assert "\\" not in argv[1]
+    assert env_overlay == {}
+
+
+def test_script_argv_fails_closed_when_only_wsl_bash(cron_env, monkeypatch):
+    from cron import scheduler_script as mod
+
+    script = cron_env / "scripts" / "probe.sh"
+    script.write_text("echo ok\n", encoding="utf-8")
+    monkeypatch.setattr("tools.environments.local._find_bash", lambda: r"C:\Windows\System32\bash.exe")
+
+    argv, _, err = mod._script_argv(script)
+    assert argv is None
+    assert "no usable bash" in err


### PR DESCRIPTION
## What does this PR do?

On Windows, `.sh`/`.bash` cron scripts are started with `shutil.which("bash")`. When `C:\Windows\System32\bash.exe` (the WSL launcher) comes before Git for Windows on PATH, which is the normal PATH order for a gateway started from the autostart folder, WSL bash receives a Win32 path, eats the backslashes and exits 127:

    /bin/bash: C:UsersEren...scriptshello.sh: No such file or directory

The script never runs and the job reports a script error. With Git first on PATH everything works, which is why this only bites in autostarted gateways.

This change resolves bash through the existing Windows-aware resolver (`tools.environments.local._find_bash`), refuses the WSL launcher (System32 / WindowsApps) so the job fails with a clear message instead of spawning WSL, and hands Git Bash the script path in POSIX form (`/c/...`) so backslashes are never treated as escapes.

It is the approach of #99470 (and #77532) rebased onto current main: since the scheduler split, `_script_argv` lives in `cron/scheduler_script.py`, so those diffs no longer apply. Credit for the approach goes to the author of #99470.

## Related Issue

Fixes #46332
Also covers #62514

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler_script.py`: new helpers `_is_wsl_bash`, `_cron_bash_script_arg`, `_resolve_cron_bash`; `_script_argv` uses them for `.sh`/`.bash`.
- `tests/cron/test_cron_script.py`: 7 tests (WSL detection, POSIX script arg, fail-closed when only WSL bash exists, argv shape).

## How to Test

1. Windows 11 with Git for Windows and WSL installed. Put `C:\Windows\System32` before `C:\Program Files\Git\bin` on PATH.
2. Create `HERMES_HOME/scripts/hello.sh` containing `echo "hello from $0"` and resolve it with `cron.scheduler_script._script_argv` (or run it as a no-agent cron job).
3. Before: argv is `['C:\WINDOWS\System32\bash.EXE', 'C:\...\hello.sh']`, exit 127, path collapsed. After: argv is `['C:\Program Files\Git\bin\bash.exe', '/c/.../hello.sh']`, exit 0.
4. `pytest tests/cron/test_cron_script.py tests/cron/test_cron_no_agent.py tests/cron/test_scheduler.py -q` → 159 passed, 2 skipped (both skips are pre-existing platform skips).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (rebase of #99470, which no longer applies)
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the affected cron tests and they pass (see How to Test)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 Pro 10.0.26200, Python 3.11, Git for Windows, WSL installed

### Documentation & Housekeeping

- [x] Documentation: N/A (behavior fix; error message updated in code)
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered: POSIX path unchanged (`str(path)`), only Windows behavior changes
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

Before (current main, System32 first on PATH):

    which(bash) -> C:\WINDOWS\System32\bash.EXE
    _script_argv -> ['C:\\WINDOWS\\System32\\bash.EXE', 'C:\\Users\\...\\scripts\\hello.sh']
    Exit-Code: 127
    stderr: /bin/bash: C:Users...scriptshello.sh: No such file or directory

After (this branch, same PATH):

    which(bash) -> C:\WINDOWS\System32\bash.EXE
    _script_argv -> ['C:\\Program Files\\Git\\bin\\bash.exe', '/c/Users/.../scripts/hello.sh']
    Exit-Code: 0
    stdout: hello from /c/Users/.../scripts/hello.sh
