### PR TITLE
feat(browser): choose which browser and profile real-profile browsing uses

### DIFF
--- a/apps/desktop/src/api/toolsets.ts
+++ b/apps/desktop/src/api/toolsets.ts
@@ -1,6 +1,7 @@
 import type {
   ActionResponse,
   ComputerUseStatus,
+  RealProfileCandidates,
   TerminalBackendsResponse,
   ToolsetConfig,
   ToolsetInfo,
@@ -122,6 +123,16 @@ export function selectTerminalBackend(backend: string): Promise<{ ok: boolean; b
     path: '/api/tools/terminal/backend',
     method: 'PUT',
     body: { backend }
+  })
+}
+
+/** Read-only discovery for the real-profile browser/profile picker. Capability-scoped
+ *  like the other Capabilities fetchers, so it reports the browser and profile THAT
+ *  profile's config resolves to — on the gateway that actually launches the browser. */
+export function getBrowserRealProfile(profile?: ProfileScope): Promise<RealProfileCandidates> {
+  return window.hermesDesktop.api<RealProfileCandidates>({
+    ...capabilityScoped(profile),
+    path: '/api/tools/browser/real-profile'
   })
 }
 

--- a/apps/desktop/src/app/chat/right-rail/real-profile-consent-dialog.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/real-profile-consent-dialog.test.tsx
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -12,6 +14,7 @@ import { RealProfileConsentDialog } from './real-profile-consent-dialog'
 
 const mocks = vi.hoisted(() => ({
   cache: vi.fn(),
+  candidates: vi.fn(),
   loadedConfig: {} as Record<string, unknown> | undefined,
   notify: vi.fn(),
   notifyError: vi.fn(),
@@ -19,6 +22,8 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('@/hermes', () => ({
+  getBrowserRealProfile: () => mocks.candidates(),
+  profileScopeKey: (profile?: unknown) => String(profile ?? 'active'),
   saveHermesConfigRecord: (config: Record<string, unknown>, profile?: unknown) => mocks.save(config, profile)
 }))
 
@@ -28,9 +33,14 @@ const promptCopy = {
   bulletSnapshot: 'Cookies and logins are copied into a managed snapshot.',
   bulletLiveProfile: 'Your live browser profile is never opened directly.',
   bulletLocal: 'Nothing leaves this computer.',
+  bulletTarget: (target: string) => `Uses ${target} — change it in Settings any time.`,
   dontShowAgain: "Don't show again",
   notNow: 'Not now',
   enable: 'Use my profile'
+}
+
+const pickerCopy = {
+  browsingAs: (browser: string, profile: string) => `Browsing as ${browser} · ${profile}`
 }
 
 vi.mock('@/i18n', () => ({
@@ -43,6 +53,7 @@ vi.mock('@/i18n', () => ({
             enabledTitle: 'Real-profile browsing on',
             enabledMessage: 'New sessions use the snapshot.',
             failedSave: 'Could not save the real-profile setting',
+            picker: pickerCopy,
             prompt: promptCopy
           }
         }
@@ -62,9 +73,39 @@ vi.mock('../../hooks/use-config-record', () => ({
 }))
 
 describe('RealProfileConsentDialog', () => {
+  /** The dialog now names the identity it is about to copy, so it fetches the
+   *  resolved browser/profile — which needs a query provider in the tree. */
+  function renderDialog(ui: ReactNode) {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+    return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>)
+  }
+
   beforeEach(() => {
     mocks.loadedConfig = { browser: { allow_private_urls: false }, model: { provider: 'nous' } }
     mocks.save.mockResolvedValue({ ok: true })
+    mocks.candidates.mockResolvedValue({
+      supported: true,
+      platform: 'Linux',
+      detected_default: 'brave',
+      detected_unsupported_channel: false,
+      resolved_browser: 'brave',
+      resolved_profile: 'Profile 2',
+      pinned_browser: null,
+      pinned_profile: null,
+      error: null,
+      browsers: [
+        {
+          key: 'brave',
+          label: 'Brave',
+          installed: true,
+          has_profile: true,
+          is_system_default: true,
+          data_dir: '/home/u/.config/BraveSoftware/Brave-Browser',
+          profiles: [{ directory: 'Profile 2', name: 'Personal', last_used: true }]
+        }
+      ]
+    })
     $realProfilePromptDismissed.set(false)
     $realProfilePromptMuted.set(false)
     $realProfilePromptClaim.set(null)
@@ -75,8 +116,25 @@ describe('RealProfileConsentDialog', () => {
     vi.clearAllMocks()
   })
 
+  it('names the browser and profile it will copy, so consent is informed', async () => {
+    renderDialog(<RealProfileConsentDialog tabId="tab-1" />)
+
+    // Resolved server-side from the same keys the picker writes, so the dialog
+    // can never advertise a different identity than the launch will use.
+    expect(await screen.findByText(promptCopy.bulletTarget('Browsing as Brave · Personal'))).toBeTruthy()
+  })
+
+  it('still renders when the identity cannot be resolved', async () => {
+    mocks.candidates.mockRejectedValue(new Error('no browsers'))
+    renderDialog(<RealProfileConsentDialog tabId="tab-1" />)
+
+    // Discovery is decoration on this dialog — a failure must not block consent.
+    expect(screen.getByText(promptCopy.title)).toBeTruthy()
+    expect(screen.getByRole('button', { name: promptCopy.enable })).toBeTruthy()
+  })
+
   it('shows when the feature is off and accepting writes browser.use_real_profile', async () => {
-    render(<RealProfileConsentDialog tabId="tab-1" />)
+    renderDialog(<RealProfileConsentDialog tabId="tab-1" />)
 
     expect(screen.getByText(promptCopy.title)).toBeTruthy()
 
@@ -100,20 +158,20 @@ describe('RealProfileConsentDialog', () => {
 
   it('does not show when real-profile browsing is already on', () => {
     mocks.loadedConfig = { browser: { use_real_profile: true } }
-    render(<RealProfileConsentDialog tabId="tab-1" />)
+    renderDialog(<RealProfileConsentDialog tabId="tab-1" />)
 
     expect(screen.queryByText(promptCopy.title)).toBeNull()
   })
 
   it('does not show before the config record loads', () => {
     mocks.loadedConfig = undefined
-    render(<RealProfileConsentDialog tabId="tab-1" />)
+    renderDialog(<RealProfileConsentDialog tabId="tab-1" />)
 
     expect(screen.queryByText(promptCopy.title)).toBeNull()
   })
 
   it('"Not now" mutes for the app run without persisting the opt-out', () => {
-    render(<RealProfileConsentDialog tabId="tab-1" />)
+    renderDialog(<RealProfileConsentDialog tabId="tab-1" />)
 
     fireEvent.click(screen.getByRole('button', { name: promptCopy.notNow }))
 
@@ -124,7 +182,7 @@ describe('RealProfileConsentDialog', () => {
   })
 
   it('"Don\'t show again" persists the opt-out', () => {
-    render(<RealProfileConsentDialog tabId="tab-1" />)
+    renderDialog(<RealProfileConsentDialog tabId="tab-1" />)
 
     fireEvent.click(screen.getByRole('button', { name: promptCopy.dontShowAgain }))
 
@@ -134,7 +192,7 @@ describe('RealProfileConsentDialog', () => {
   })
 
   it('only the claiming pane renders the dialog when several Browser panes mount', () => {
-    render(
+    renderDialog(
       <>
         <RealProfileConsentDialog tabId="tab-1" />
         <RealProfileConsentDialog tabId="tab-2" />
@@ -147,7 +205,7 @@ describe('RealProfileConsentDialog', () => {
 
   it('rolls the optimistic cache write back when the save fails', async () => {
     mocks.save.mockRejectedValue(new Error('boom'))
-    render(<RealProfileConsentDialog tabId="tab-1" />)
+    renderDialog(<RealProfileConsentDialog tabId="tab-1" />)
 
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: promptCopy.enable }))

--- a/apps/desktop/src/app/chat/right-rail/real-profile-consent-dialog.tsx
+++ b/apps/desktop/src/app/chat/right-rail/real-profile-consent-dialog.tsx
@@ -1,7 +1,12 @@
 import { useStore } from '@nanostores/react'
+import { useQuery } from '@tanstack/react-query'
 import { useCallback, useEffect, useState } from 'react'
 
-import { readUseRealProfile } from '@/app/settings/browser-real-profile-panel'
+import {
+  describeResolved,
+  readUseRealProfile,
+  realProfileCandidatesKey
+} from '@/app/settings/browser-real-profile-panel'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -11,7 +16,7 @@ import {
   DialogHeader,
   DialogTitle
 } from '@/components/ui/dialog'
-import { saveHermesConfigRecord } from '@/hermes'
+import { getBrowserRealProfile, saveHermesConfigRecord } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { Check, Globe } from '@/lib/icons'
 import { notify, notifyError } from '@/store/notifications'
@@ -62,6 +67,18 @@ export function RealProfileConsentDialog({ tabId }: RealProfileConsentDialogProp
 
   const enabled = readUseRealProfile(config)
 
+  // Name the identity the user is about to hand over ("Brave · Personal")
+  // instead of the vague "your default browser profile": consent to copy
+  // cookies should say WHOSE cookies. Fetched only while the dialog can show.
+  const { data: candidates } = useQuery({
+    queryKey: realProfileCandidatesKey(),
+    queryFn: () => getBrowserRealProfile(),
+    enabled: Boolean(config) && !enabled && !dismissed && !muted && claim === tabId,
+    staleTime: 30_000
+  })
+
+  const target = describeResolved(candidates, copy.picker)
+
   const enable = useCallback(async () => {
     if (!config || busy) {
       return
@@ -97,7 +114,12 @@ export function RealProfileConsentDialog({ tabId }: RealProfileConsentDialogProp
     return null
   }
 
-  const bullets = [prompt.bulletSnapshot, prompt.bulletLiveProfile, prompt.bulletLocal]
+  const bullets = [
+    prompt.bulletSnapshot,
+    prompt.bulletLiveProfile,
+    prompt.bulletLocal,
+    ...(target ? [prompt.bulletTarget(target)] : [])
+  ]
 
   return (
     <Dialog

--- a/apps/desktop/src/app/settings/browser-real-profile-panel.test.tsx
+++ b/apps/desktop/src/app/settings/browser-real-profile-panel.test.tsx
@@ -1,11 +1,21 @@
 // @vitest-environment jsdom
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { BrowserRealProfilePanel } from './browser-real-profile-panel'
+import { BrowserRealProfilePanel, describeResolved } from './browser-real-profile-panel'
+
+// Radix Select calls scrollIntoView / pointer-capture APIs jsdom lacks.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+})
 
 const mocks = vi.hoisted(() => ({
   cache: vi.fn(),
+  candidates: vi.fn(),
   loadedConfig: {} as Record<string, unknown>,
   notify: vi.fn(),
   notifyError: vi.fn(),
@@ -13,8 +23,29 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('@/hermes', () => ({
+  getBrowserRealProfile: (profile?: unknown) => mocks.candidates(profile),
+  profileScopeKey: (profile?: unknown) => String(profile ?? 'active'),
   saveHermesConfigRecord: (config: Record<string, unknown>, profile?: unknown) => mocks.save(config, profile)
 }))
+
+const pickerCopy = {
+  browserLabel: 'Browser',
+  browserDescription: 'Which installed browser the agent borrows logins from.',
+  profileLabel: 'Browser profile',
+  profileDescription: 'Which profile inside that browser.',
+  systemDefault: 'System default',
+  systemDefaultNamed: (browser: string) => `System default (${browser})`,
+  lastUsed: 'Last used',
+  lastUsedNamed: (profile: string) => `Last used (${profile})`,
+  notInstalled: 'Not installed',
+  noProfile: 'Never launched',
+  loading: 'Looking for browsers…',
+  failedLoad: 'Could not list browsers on this machine',
+  browsingAs: (browser: string, profile: string) => `Browsing as ${browser} · ${profile}`,
+  unsupportedPlatform: (platform: string) => `Not available on ${platform}.`,
+  savedTitle: 'Browsing identity updated',
+  savedMessage: (target: string) => `New sessions will browse as ${target}.`
+}
 
 vi.mock('@/i18n', () => ({
   useI18n: () => ({
@@ -23,12 +54,13 @@ vi.mock('@/i18n', () => ({
         toolsets: {
           browserRealProfile: {
             label: 'Use My Real Browser Profile',
-            description: 'Copies your default browser profile into a managed snapshot.',
+            description: 'Copies your browser profile into a managed snapshot.',
             enabledTitle: 'Real-profile browsing on',
             enabledMessage: 'New sessions use the snapshot.',
             disabledTitle: 'Real-profile browsing off',
             disabledMessage: 'Snapshot will be deleted.',
-            failedSave: 'Could not save the real-profile setting'
+            failedSave: 'Could not save the real-profile setting',
+            picker: pickerCopy
           }
         }
       }
@@ -46,10 +78,58 @@ vi.mock('../hooks/use-config-record', () => ({
   useHermesConfigRecord: () => ({ data: mocks.loadedConfig })
 }))
 
+/** Two browsers, one uninstalled — the shape the picker has to survive. */
+function candidatesFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    supported: true,
+    platform: 'Linux',
+    detected_default: 'brave',
+    detected_unsupported_channel: false,
+    resolved_browser: 'brave',
+    resolved_profile: 'Profile 1',
+    pinned_browser: null,
+    pinned_profile: null,
+    error: null,
+    browsers: [
+      {
+        key: 'chrome',
+        label: 'Google Chrome',
+        installed: false,
+        has_profile: false,
+        is_system_default: false,
+        data_dir: '',
+        profiles: []
+      },
+      {
+        key: 'brave',
+        label: 'Brave',
+        installed: true,
+        has_profile: true,
+        is_system_default: true,
+        data_dir: '/home/u/.config/BraveSoftware/Brave-Browser',
+        profiles: [
+          { directory: 'Profile 1', name: 'Me', last_used: true },
+          { directory: 'Profile 2', name: 'Personal', last_used: false }
+        ]
+      }
+    ],
+    ...overrides
+  }
+}
+
+function renderPanel(ui: ReactNode) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>)
+}
+
+const toggleOn = { browser: { use_real_profile: true } }
+
 describe('BrowserRealProfilePanel', () => {
   beforeEach(() => {
     mocks.loadedConfig = { browser: { allow_private_urls: false }, model: { provider: 'nous' } }
     mocks.save.mockResolvedValue({ ok: true })
+    mocks.candidates.mockResolvedValue(candidatesFixture())
   })
 
   afterEach(() => {
@@ -58,7 +138,7 @@ describe('BrowserRealProfilePanel', () => {
   })
 
   it('renders off for a config without the key and turns it on', async () => {
-    render(<BrowserRealProfilePanel />)
+    renderPanel(<BrowserRealProfilePanel />)
     const toggle = screen.getByRole('switch', { name: 'Use My Real Browser Profile' })
 
     expect(toggle).toHaveProperty('ariaChecked', 'false')
@@ -81,8 +161,8 @@ describe('BrowserRealProfilePanel', () => {
   })
 
   it('turns an enabled toggle off', async () => {
-    mocks.loadedConfig = { browser: { use_real_profile: true } }
-    render(<BrowserRealProfilePanel />)
+    mocks.loadedConfig = toggleOn
+    renderPanel(<BrowserRealProfilePanel />)
     const toggle = screen.getByRole('switch', { name: 'Use My Real Browser Profile' })
 
     expect(toggle).toHaveProperty('ariaChecked', 'true')
@@ -96,7 +176,7 @@ describe('BrowserRealProfilePanel', () => {
 
   it('rolls the optimistic cache write back when the save fails', async () => {
     mocks.save.mockRejectedValue(new Error('boom'))
-    render(<BrowserRealProfilePanel />)
+    renderPanel(<BrowserRealProfilePanel />)
 
     await act(async () => {
       fireEvent.click(screen.getByRole('switch', { name: 'Use My Real Browser Profile' }))
@@ -105,5 +185,158 @@ describe('BrowserRealProfilePanel', () => {
     // Last cache write restores the original record.
     expect(mocks.cache).toHaveBeenLastCalledWith(mocks.loadedConfig)
     expect(mocks.notifyError).toHaveBeenCalled()
+  })
+
+  it('does not probe for browsers until consent is on', () => {
+    renderPanel(<BrowserRealProfilePanel />)
+
+    // Enumerating browser profiles is a filesystem walk on the gateway host;
+    // it must not run for users who never opted in.
+    expect(mocks.candidates).not.toHaveBeenCalled()
+    expect(screen.queryByText(pickerCopy.browserLabel)).toBeNull()
+  })
+
+  it('shows the browser and profile pickers once enabled', async () => {
+    mocks.loadedConfig = toggleOn
+    renderPanel(<BrowserRealProfilePanel />)
+
+    expect(await screen.findByText(pickerCopy.browserLabel)).toBeTruthy()
+    expect(screen.getByText(pickerCopy.profileLabel)).toBeTruthy()
+    // Names the identity a launch would actually use, not "your default browser".
+    expect(screen.getByText(pickerCopy.browsingAs('Brave', 'Me'))).toBeTruthy()
+  })
+
+  it('writes real_profile_pin when a profile is chosen', async () => {
+    mocks.loadedConfig = toggleOn
+    renderPanel(<BrowserRealProfilePanel />)
+
+    await screen.findByText(pickerCopy.profileLabel)
+
+    fireEvent.click(screen.getAllByRole('combobox')[1])
+    await act(async () => {
+      fireEvent.click(await screen.findByRole('option', { name: /Personal/ }))
+    })
+
+    expect(mocks.save).toHaveBeenCalledWith(
+      { browser: { use_real_profile: true, real_profile_pin: 'Profile 2' } },
+      undefined
+    )
+  })
+
+  it('clears a stale profile pin when the browser changes', async () => {
+    // A pin names a directory inside ONE browser's user-data dir; carrying
+    // "Profile 2" from Brave to Chrome would fail closed on the next launch.
+    mocks.loadedConfig = { browser: { use_real_profile: true, real_profile_pin: 'Profile 2' } }
+    mocks.candidates.mockResolvedValue(
+      candidatesFixture({
+        browsers: [
+          {
+            key: 'chrome',
+            label: 'Google Chrome',
+            installed: true,
+            has_profile: true,
+            is_system_default: false,
+            data_dir: '/home/u/.config/google-chrome',
+            profiles: [{ directory: 'Default', name: 'Work', last_used: true }]
+          }
+        ]
+      })
+    )
+    renderPanel(<BrowserRealProfilePanel />)
+
+    await screen.findByText(pickerCopy.browserLabel)
+
+    fireEvent.click(screen.getAllByRole('combobox')[0])
+    await act(async () => {
+      fireEvent.click(await screen.findByRole('option', { name: /Google Chrome/ }))
+    })
+
+    expect(mocks.save).toHaveBeenCalledWith(
+      { browser: { use_real_profile: true, real_profile_browser: 'chrome', real_profile_pin: '' } },
+      undefined
+    )
+  })
+
+  it('writes an empty string (not the sentinel) when reverting to the system default', async () => {
+    mocks.loadedConfig = { browser: { use_real_profile: true, real_profile_browser: 'brave' } }
+    renderPanel(<BrowserRealProfilePanel />)
+
+    await screen.findByText(pickerCopy.browserLabel)
+
+    fireEvent.click(screen.getAllByRole('combobox')[0])
+    await act(async () => {
+      fireEvent.click(await screen.findByRole('option', { name: /System default/ }))
+    })
+
+    // The config contract is "" = follow the OS default; the UI sentinel must
+    // never reach config.yaml, where the resolver would reject it.
+    expect(mocks.save).toHaveBeenCalledWith(
+      { browser: { use_real_profile: true, real_profile_browser: '', real_profile_pin: '' } },
+      undefined
+    )
+  })
+
+  it('surfaces the backend fail-closed error instead of silently ignoring it', async () => {
+    mocks.loadedConfig = { browser: { use_real_profile: true, real_profile_pin: 'Profile 99' } }
+    mocks.candidates.mockResolvedValue(
+      candidatesFixture({
+        resolved_profile: null,
+        error: "browser.real_profile_pin is set to 'Profile 99' but that profile does not exist."
+      })
+    )
+    renderPanel(<BrowserRealProfilePanel />)
+
+    // Two surfaces on purpose: the trigger keeps showing the pin the config
+    // still holds, and the error explains why it isn't being honored.
+    const shown = await screen.findAllByText(/Profile 99/)
+
+    expect(shown.length).toBeGreaterThan(1)
+    expect(shown.some(node => node.textContent?.includes('does not exist'))).toBe(true)
+  })
+
+  it('reports platforms where real-profile browsing cannot work', async () => {
+    mocks.loadedConfig = toggleOn
+    mocks.candidates.mockResolvedValue(candidatesFixture({ supported: false, platform: 'FreeBSD' }))
+    renderPanel(<BrowserRealProfilePanel />)
+
+    expect(await screen.findByText(pickerCopy.unsupportedPlatform('FreeBSD'))).toBeTruthy()
+    // No pickers on an unsupported platform — nothing to pick.
+    expect(screen.queryByText(pickerCopy.browserLabel)).toBeNull()
+  })
+
+  it('keeps the toggle usable when browser discovery fails', async () => {
+    mocks.loadedConfig = toggleOn
+    mocks.candidates.mockRejectedValue(new Error('probe failed'))
+    renderPanel(<BrowserRealProfilePanel />)
+
+    expect(await screen.findByText(pickerCopy.failedLoad)).toBeTruthy()
+    expect(screen.getByRole('switch', { name: 'Use My Real Browser Profile' })).toBeTruthy()
+  })
+
+  it('scopes the discovery fetch to the panel profile', async () => {
+    // Per-profile identities are the point: the Capabilities scope selector
+    // configuring another profile must read THAT profile's resolution.
+    mocks.loadedConfig = toggleOn
+    renderPanel(<BrowserRealProfilePanel profile="omar" />)
+
+    await waitFor(() => expect(mocks.candidates).toHaveBeenCalledWith('omar'))
+  })
+})
+
+describe('describeResolved', () => {
+  it('prefers display names over directory names', () => {
+    expect(describeResolved(candidatesFixture() as never, pickerCopy)).toBe('Browsing as Brave · Me')
+  })
+
+  it('is null until both halves of the identity are known', () => {
+    expect(describeResolved(undefined, pickerCopy)).toBeNull()
+    expect(describeResolved(candidatesFixture({ resolved_profile: null }) as never, pickerCopy)).toBeNull()
+    expect(describeResolved(candidatesFixture({ resolved_browser: null }) as never, pickerCopy)).toBeNull()
+  })
+
+  it('falls back to raw keys when the browser reports no label', () => {
+    const data = candidatesFixture({ resolved_browser: 'edge', resolved_profile: 'Profile 7' })
+
+    expect(describeResolved(data as never, pickerCopy)).toBe('Browsing as edge · Profile 7')
   })
 })

--- a/apps/desktop/src/app/settings/browser-real-profile-panel.tsx
+++ b/apps/desktop/src/app/settings/browser-real-profile-panel.tsx
@@ -1,12 +1,18 @@
+import { useQuery } from '@tanstack/react-query'
 import { useCallback, useState } from 'react'
 
-import { type ProfileScope, saveHermesConfigRecord } from '@/hermes'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { getBrowserRealProfile, type ProfileScope, profileScopeKey, saveHermesConfigRecord } from '@/hermes'
 import { useI18n } from '@/i18n'
+import { AlertTriangle, Loader2 } from '@/lib/icons'
+import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
+import type { HermesConfigRecord, RealProfileBrowser, RealProfileCandidates } from '@/types/hermes'
 
 import { hermesConfigCacheWriter, useHermesConfigRecord } from '../hooks/use-config-record'
 
-import { ToggleRow } from './primitives'
+import { CONTROL_TEXT } from './constants'
+import { ListRow, ToggleRow } from './primitives'
 
 interface BrowserRealProfilePanelProps {
   /** Capabilities profile-scope override — the toggle reads/writes THIS
@@ -14,63 +20,119 @@ interface BrowserRealProfilePanelProps {
   profile?: ProfileScope
 }
 
+/** Sentinel for the "follow the system / last used" rows. Empty string is what
+ *  the config keys actually store, but Radix Select reserves '' for "no value",
+ *  so the option value is a marker translated at the write boundary. */
+const AUTO = '__auto__'
+
+function browserSection(record: Record<string, unknown> | undefined): Record<string, unknown> {
+  const browser = record?.browser
+
+  return browser && typeof browser === 'object' && !Array.isArray(browser)
+    ? (browser as Record<string, unknown>)
+    : {}
+}
+
+function readStringSetting(record: Record<string, unknown> | undefined, key: string): string {
+  const value = browserSection(record)[key]
+
+  return typeof value === 'string' ? value.trim() : ''
+}
+
 /** Shared with the Browser pane's first-open consent prompt, so both surfaces
  *  agree on what "on" means for `browser.use_real_profile`. */
 export function readUseRealProfile(record: Record<string, unknown> | undefined): boolean {
-  const browser = record?.browser
+  return Boolean(browserSection(record).use_real_profile)
+}
 
-  if (browser && typeof browser === 'object' && !Array.isArray(browser)) {
-    return Boolean((browser as Record<string, unknown>).use_real_profile)
+/** Cache key for the discovery fetch. Scoped like the config record it sits
+ *  next to: two profiles (or two gateways' same-named profiles) resolve to
+ *  different browsers, so they must never share a cache row. */
+export const realProfileCandidatesKey = (profile?: ProfileScope) =>
+  ['browser-real-profile', profileScopeKey(profile)] as const
+
+/** Human name of the identity a launch would use right now, e.g. "Brave · Personal".
+ *  Falls back to the raw directory when the browser reports no display name. */
+export function describeResolved(
+  data: RealProfileCandidates | undefined,
+  copy: { browsingAs: (browser: string, profile: string) => string }
+): null | string {
+  if (!data?.resolved_browser || !data.resolved_profile) {
+    return null
   }
 
-  return false
+  const browser = data.browsers.find(row => row.key === data.resolved_browser)
+  const profile = browser?.profiles.find(row => row.directory === data.resolved_profile)
+
+  return copy.browsingAs(browser?.label ?? data.resolved_browser, profile?.name ?? data.resolved_profile)
 }
 
 /**
- * The `browser.use_real_profile` consent toggle, rendered at the top of the
- * Capabilities → Tools → Browser detail pane (above the backend/provider
- * matrix). This is the GUI home of the real-profile browsing switch: without
- * it the only desktop path was the generic Settings → Config editor, which
- * users reasonably never found ("no toggle in the browser section").
+ * Real-profile browsing controls, rendered at the top of the Capabilities →
+ * Tools → Browser detail pane: the `browser.use_real_profile` consent toggle
+ * plus — once it is on — pickers for WHICH browser and WHICH profile inside it
+ * the agent borrows logins from (`browser.real_profile_browser` /
+ * `browser.real_profile_pin`).
  *
- * Semantics mirror the config comment: turning it ON consents to snapshotting
- * the default browser's profile (cookies/logins) into a Hermes-owned copy;
- * turning it OFF deletes the snapshot store on next use. The toggle writes
- * config.yaml through the same deep-merging PUT /api/config every other
- * settings surface uses — applies to new sessions.
+ * Why the pickers matter: unpinned, the snapshot follows the OS default browser
+ * and its last-used profile, so on a machine with work and personal profiles
+ * "whichever you touched last" silently decides the agent's identity. Pinning is
+ * what lets one Hermes profile browse as Brave/Work while another browses as
+ * Chrome/Personal — the settings live in each profile's own config.yaml, and
+ * this panel is profile-scoped, so both are configurable from one window.
+ *
+ * All three settings write config.yaml through the same deep-merging
+ * PUT /api/config every other settings surface uses (applies to new sessions).
+ * The candidate list is READ from the gateway that would launch the browser, so
+ * a desktop attached to a remote gateway lists that machine's browsers — the
+ * only correct answer, since that is where the snapshot is taken.
  */
 export function BrowserRealProfilePanel({ profile }: BrowserRealProfilePanelProps) {
   const { t } = useI18n()
   const copy = t.settings.toolsets.browserRealProfile
+  const pickerCopy = copy.picker
   const { data: config } = useHermesConfigRecord(profile)
   const setConfig = hermesConfigCacheWriter(profile)
   const [busy, setBusy] = useState(false)
 
   const enabled = readUseRealProfile(config)
 
-  const toggle = useCallback(
-    async (on: boolean) => {
+  const {
+    data: candidates,
+    error: candidatesError,
+    isLoading: candidatesLoading,
+    refetch: refetchCandidates
+  } = useQuery({
+    queryKey: realProfileCandidatesKey(profile),
+    queryFn: () => getBrowserRealProfile(profile ?? undefined),
+    // Only probe the filesystem for browsers once the user has consented —
+    // before that the panel is a single toggle and the answer is unused.
+    enabled,
+    staleTime: 30_000
+  })
+
+  /** Deep-merge `browser.*` keys and persist, rolling the cache back on failure. */
+  const writeBrowserSettings = useCallback(
+    async (patch: Record<string, unknown>, toast?: { title: string; message: string }) => {
       if (!config) {
         return
       }
 
-      const browser =
-        config.browser && typeof config.browser === 'object' && !Array.isArray(config.browser)
-          ? (config.browser as Record<string, unknown>)
-          : {}
-
-      const next = { ...config, browser: { ...browser, use_real_profile: on } }
+      const next: HermesConfigRecord = { ...config, browser: { ...browserSection(config), ...patch } }
 
       setBusy(true)
       setConfig(next)
 
       try {
         await saveHermesConfigRecord(next, profile)
-        notify({
-          kind: 'info',
-          title: on ? copy.enabledTitle : copy.disabledTitle,
-          message: on ? copy.enabledMessage : copy.disabledMessage
-        })
+
+        if (toast) {
+          notify({ kind: 'info', title: toast.title, message: toast.message })
+        }
+
+        // The resolved identity is computed server-side from these very keys,
+        // so re-read it rather than guessing what the backend now resolves to.
+        void refetchCandidates()
       } catch (err) {
         setConfig(config)
         notifyError(err, copy.failedSave)
@@ -78,16 +140,167 @@ export function BrowserRealProfilePanel({ profile }: BrowserRealProfilePanelProp
         setBusy(false)
       }
     },
-    [config, copy, profile, setConfig]
+    [config, copy.failedSave, profile, refetchCandidates, setConfig]
+  )
+
+  const toggle = useCallback(
+    (on: boolean) =>
+      writeBrowserSettings(
+        { use_real_profile: on },
+        {
+          title: on ? copy.enabledTitle : copy.disabledTitle,
+          message: on ? copy.enabledMessage : copy.disabledMessage
+        }
+      ),
+    [copy, writeBrowserSettings]
+  )
+
+  const selectedBrowser = readStringSetting(config, 'real_profile_browser')
+  const selectedPin = readStringSetting(config, 'real_profile_pin')
+
+  // Profiles of the browser the picker currently targets: the explicit pick if
+  // there is one, else whatever the backend resolved (system default).
+  const activeBrowser: RealProfileBrowser | undefined = candidates?.browsers.find(
+    row => row.key === (selectedBrowser || candidates.resolved_browser)
+  )
+
+  const resolvedLabel = describeResolved(candidates, pickerCopy)
+
+  // A pin the backend rejected (renamed/removed profile) must stay visible in
+  // the trigger instead of silently reading as "Last used" — the config still
+  // says it, and the error row explains why it is not being honored.
+  const pinIsMissing = Boolean(
+    selectedPin && activeBrowser && !activeBrowser.profiles.some(row => row.directory === selectedPin)
   )
 
   return (
-    <ToggleRow
-      checked={enabled}
-      description={copy.description}
-      disabled={busy || !config}
-      label={copy.label}
-      onChange={on => void toggle(on)}
-    />
+    <div className="grid gap-1">
+      <ToggleRow
+        checked={enabled}
+        description={copy.description}
+        disabled={busy || !config}
+        label={copy.label}
+        onChange={on => void toggle(on)}
+      />
+
+      {enabled && candidatesLoading && (
+        <div className="flex items-center gap-2 px-1 pb-2 text-xs text-muted-foreground">
+          <Loader2 className="size-3.5 animate-spin" />
+          {pickerCopy.loading}
+        </div>
+      )}
+
+      {enabled && Boolean(candidatesError) && (
+        <p className="px-1 pb-2 text-[0.68rem] text-amber-600 dark:text-amber-300">{pickerCopy.failedLoad}</p>
+      )}
+
+      {enabled && candidates && !candidates.supported && (
+        <p className="px-1 pb-2 text-[0.68rem] text-muted-foreground">
+          {pickerCopy.unsupportedPlatform(candidates.platform)}
+        </p>
+      )}
+
+      {enabled && candidates?.supported && (
+        <>
+          <ListRow
+            action={
+              <Select
+                disabled={busy}
+                onValueChange={value =>
+                  void writeBrowserSettings(
+                    // Switching browsers clears the profile pin: a pin names a
+                    // directory inside ONE browser's user-data dir, so carrying
+                    // it across would fail closed against the new browser.
+                    { real_profile_browser: value === AUTO ? '' : value, real_profile_pin: '' }
+                  )
+                }
+                value={selectedBrowser || AUTO}
+              >
+                <SelectTrigger className={cn('min-w-56', CONTROL_TEXT)}>
+                  <SelectValue />
+                </SelectTrigger>
+
+                <SelectContent>
+                  <SelectItem value={AUTO}>
+                    {candidates.detected_default
+                      ? pickerCopy.systemDefaultNamed(
+                          candidates.browsers.find(row => row.key === candidates.detected_default)?.label ??
+                            candidates.detected_default
+                        )
+                      : pickerCopy.systemDefault}
+                  </SelectItem>
+
+                  {candidates.browsers.map(row => (
+                    // A browser can't be driven unless BOTH halves exist: a
+                    // profile to snapshot and a binary to run the copy on. Show
+                    // the row disabled with the reason — the absence is
+                    // information, not something to hide.
+                    <SelectItem disabled={!row.has_profile || !row.installed} key={row.key} value={row.key}>
+                      {row.label}
+                      {!row.installed && ` — ${pickerCopy.notInstalled}`}
+                      {row.installed && !row.has_profile && ` — ${pickerCopy.noProfile}`}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            }
+            description={pickerCopy.browserDescription}
+            title={pickerCopy.browserLabel}
+          />
+
+          <ListRow
+            action={
+              <Select
+                disabled={busy || !activeBrowser?.profiles.length}
+                onValueChange={value =>
+                  void writeBrowserSettings(
+                    { real_profile_pin: value === AUTO ? '' : value },
+                    resolvedLabel
+                      ? undefined
+                      : { title: pickerCopy.savedTitle, message: pickerCopy.savedMessage(value) }
+                  )
+                }
+                value={selectedPin || AUTO}
+              >
+                <SelectTrigger className={cn('min-w-56', CONTROL_TEXT)}>
+                  <SelectValue />
+                </SelectTrigger>
+
+                <SelectContent>
+                  <SelectItem value={AUTO}>
+                    {(() => {
+                      const lastUsed = activeBrowser?.profiles.find(row => row.last_used)
+
+                      return lastUsed ? pickerCopy.lastUsedNamed(lastUsed.name) : pickerCopy.lastUsed
+                    })()}
+                  </SelectItem>
+
+                  {activeBrowser?.profiles.map(row => (
+                    <SelectItem key={row.directory} value={row.directory}>
+                      {row.name}
+                      {row.name !== row.directory && ` (${row.directory})`}
+                    </SelectItem>
+                  ))}
+
+                  {/* Keep a stale pin selectable so the trigger shows the truth. */}
+                  {pinIsMissing && <SelectItem value={selectedPin}>{selectedPin}</SelectItem>}
+                </SelectContent>
+              </Select>
+            }
+            description={pickerCopy.profileDescription}
+            title={pickerCopy.profileLabel}
+          />
+
+          {resolvedLabel && <p className="px-1 pb-1 text-[0.68rem] text-muted-foreground">{resolvedLabel}</p>}
+
+          {candidates.error && (
+            <p className="flex items-start gap-1 px-1 pb-2 text-[0.68rem] text-amber-600 dark:text-amber-300">
+              <AlertTriangle className="mt-0.5 size-3 shrink-0" />
+              {candidates.error}
+            </p>
+          )}
+        </>
+      )}
+    </div>
   )
 }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1390,12 +1390,32 @@ export const en: Translations = {
         disabledTitle: 'Real-profile browsing off',
         disabledMessage: 'The profile snapshot will be deleted; new sessions use a clean browser.',
         failedSave: 'Could not save the real-profile setting',
+        picker: {
+          browserLabel: 'Browser',
+          browserDescription: 'Which installed browser the agent borrows logins from.',
+          profileLabel: 'Browser profile',
+          profileDescription: 'Which profile inside that browser — its cookies decide who the agent is signed in as.',
+          systemDefault: 'System default',
+          systemDefaultNamed: (browser: string) => `System default (${browser})`,
+          lastUsed: 'Last used',
+          lastUsedNamed: (profile: string) => `Last used (${profile})`,
+          notInstalled: 'Not installed',
+          noProfile: 'Never launched',
+          loading: 'Looking for browsers…',
+          failedLoad: 'Could not list browsers on this machine',
+          browsingAs: (browser: string, profile: string) => `Browsing as ${browser} · ${profile}`,
+          unsupportedPlatform: (platform: string) =>
+            `Real-profile browsing needs a desktop browser and is not available on ${platform}.`,
+          savedTitle: 'Browsing identity updated',
+          savedMessage: (target: string) => `New sessions will browse as ${target}.`
+        },
         prompt: {
           title: 'Stay signed in to your sites',
-          body: 'Let Hermes browse with a snapshot of your default browser profile, so sites open already signed in.',
+          body: 'Let Hermes browse with a snapshot of your browser profile, so sites open already signed in.',
           bulletSnapshot: 'Cookies and logins are copied into a managed snapshot.',
           bulletLiveProfile: 'Your live browser profile is never opened directly.',
           bulletLocal: 'Nothing leaves this computer.',
+          bulletTarget: (target: string) => `Uses ${target} — change it in Settings any time.`,
           dontShowAgain: "Don't show again",
           notNow: 'Not now',
           enable: 'Use my profile'

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1213,12 +1213,31 @@ export interface Translations {
         disabledTitle: string
         disabledMessage: string
         failedSave: string
+        picker: {
+          browserLabel: string
+          browserDescription: string
+          profileLabel: string
+          profileDescription: string
+          systemDefault: string
+          systemDefaultNamed: (browser: string) => string
+          lastUsed: string
+          lastUsedNamed: (profile: string) => string
+          notInstalled: string
+          noProfile: string
+          loading: string
+          failedLoad: string
+          browsingAs: (browser: string, profile: string) => string
+          unsupportedPlatform: (platform: string) => string
+          savedTitle: string
+          savedMessage: (target: string) => string
+        }
         prompt: {
           title: string
           body: string
           bulletSnapshot: string
           bulletLiveProfile: string
           bulletLocal: string
+          bulletTarget: (target: string) => string
           dontShowAgain: string
           notNow: string
           enable: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1566,12 +1566,32 @@ export const zh: Translations = {
         disabledTitle: '真实配置文件浏览：已关闭',
         disabledMessage: '配置文件快照将被删除；新会话使用干净的浏览器。',
         failedSave: '无法保存真实配置文件设置',
+        picker: {
+          browserLabel: '浏览器',
+          browserDescription: '代理从哪个已安装的浏览器借用登录信息。',
+          profileLabel: '浏览器配置文件',
+          profileDescription: '该浏览器中的哪个配置文件——其 Cookie 决定代理以谁的身份登录。',
+          systemDefault: '系统默认',
+          systemDefaultNamed: (browser: string) => `系统默认（${browser}）`,
+          lastUsed: '最近使用',
+          lastUsedNamed: (profile: string) => `最近使用（${profile}）`,
+          notInstalled: '未安装',
+          noProfile: '从未启动',
+          loading: '正在查找浏览器…',
+          failedLoad: '无法列出这台电脑上的浏览器',
+          browsingAs: (browser: string, profile: string) => `以 ${browser} · ${profile} 身份浏览`,
+          unsupportedPlatform: (platform: string) =>
+            `真实配置文件浏览需要桌面浏览器，在 ${platform} 上不可用。`,
+          savedTitle: '浏览身份已更新',
+          savedMessage: (target: string) => `新会话将以 ${target} 身份浏览。`
+        },
         prompt: {
           title: '让网站保持登录状态',
-          body: '让 Hermes 使用默认浏览器配置文件的快照进行浏览，网站打开时即已登录。',
+          body: '让 Hermes 使用你的浏览器配置文件快照进行浏览，网站打开时即已登录。',
           bulletSnapshot: 'Cookie 和登录信息会复制到托管快照中。',
           bulletLiveProfile: '绝不会直接打开你的真实浏览器配置文件。',
           bulletLocal: '所有数据都不会离开这台电脑。',
+          bulletTarget: (target: string) => `使用 ${target}——可随时在设置中更改。`,
           dontShowAgain: '不再显示',
           notNow: '暂不',
           enable: '使用我的配置文件'

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1148,6 +1148,48 @@ export interface TerminalBackendsResponse {
   backends: TerminalBackendInfo[]
 }
 
+/** One profile directory inside a browser's user-data dir. `directory` is what
+ *  `browser.real_profile_pin` takes ("Default", "Profile 2"); `name` is the
+ *  display name the user knows it by. */
+export interface RealProfileEntry {
+  directory: string
+  name: string
+  /** The profile an unpinned snapshot would copy (Local State → last_used). */
+  last_used: boolean
+}
+
+/** One Chromium-family browser real-profile browsing could drive. */
+export interface RealProfileBrowser {
+  /** Canonical key written to `browser.real_profile_browser`. */
+  key: string
+  label: string
+  /** Binary present on this host. */
+  installed: boolean
+  /** User-data dir present — a browser can be installed but never launched. */
+  has_profile: boolean
+  is_system_default: boolean
+  data_dir: string
+  profiles: RealProfileEntry[]
+}
+
+/** Shape of `GET /api/tools/browser/real-profile` — read-only discovery for the
+ *  browser/profile picker. `resolved_*` is what a launch would use RIGHT NOW,
+ *  so the UI can name the identity instead of saying "your default browser". */
+export interface RealProfileCandidates {
+  /** False on a platform where real-profile browsing cannot work at all. */
+  supported: boolean
+  platform: string
+  detected_default: null | string
+  detected_unsupported_channel: boolean
+  resolved_browser: null | string
+  resolved_profile: null | string
+  pinned_browser: null | string
+  pinned_profile: null | string
+  /** Fail-closed guidance (bad pin, non-Chromium default, …); null when fine. */
+  error: null | string
+  browsers: RealProfileBrowser[]
+}
+
 /** One model row from a toolset backend's catalog (image/video gen). */
 export interface ToolsetModel {
   id: string

--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -38,6 +38,7 @@ DEFAULT_BROWSER_CDP_URL = f"http://127.0.0.1:{DEFAULT_BROWSER_CDP_PORT}"
 class _Browser:
     """Per-browser install/profile locations for one Chromium-family product."""
     key: str
+    label: str                            # human name for pickers (`hermes doctor`, desktop)
     mac_app: str
     mac_support: tuple[str, ...]          # under ~/Library/Application Support
     win_bins: tuple[str, ...]             # shutil.which names on Windows
@@ -57,11 +58,11 @@ class _Browser:
 # ``com.brave.Browser.origin`` bundle id) that installs side-by-side with Brave. Its
 # profile is NOT under Brave-Browser and must never be conflated with the ``brave``
 # key — a "brave" lookup resolving to the Origin binary drives the wrong profile.
-# Positional layout per entry: key, mac_app / mac_support, win_bins / win_install /
+# Positional layout per entry: key, label, mac_app / mac_support, win_bins / win_install /
 # win_profile / linux_bins / linux_paths / linux_config [, linux_exec].
 _BROWSERS = (
     _Browser(
-        "chrome", "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        "chrome", "Google Chrome", "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
         ("Google", "Chrome"), ("chrome.exe", "chrome"),
         (("Google", "Chrome", "Application", "chrome.exe"),),
         ("Google", "Chrome", "User Data"),
@@ -69,7 +70,7 @@ _BROWSERS = (
         ("/opt/google/chrome/chrome", "/usr/bin/google-chrome", "/usr/bin/google-chrome-stable"),
         "google-chrome"),
     _Browser(
-        "chromium", "/Applications/Chromium.app/Contents/MacOS/Chromium",
+        "chromium", "Chromium", "/Applications/Chromium.app/Contents/MacOS/Chromium",
         ("Chromium",), ("chromium.exe", "chromium"),
         (("Chromium", "Application", "chrome.exe"), ("Chromium", "Application", "chromium.exe")),
         ("Chromium", "User Data"),
@@ -77,7 +78,7 @@ _BROWSERS = (
         ("/usr/bin/chromium-browser", "/usr/bin/chromium"),
         "chromium"),
     _Browser(
-        "brave", "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+        "brave", "Brave", "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
         ("BraveSoftware", "Brave-Browser"), ("brave.exe", "brave"),
         (("BraveSoftware", "Brave-Browser", "Application", "brave.exe"),),
         ("BraveSoftware", "Brave-Browser", "User Data"),
@@ -87,7 +88,7 @@ _BROWSERS = (
          "/opt/brave-bin/brave"),
         "BraveSoftware/Brave-Browser"),
     _Browser(
-        "brave-origin", "/Applications/Brave Origin.app/Contents/MacOS/Brave Origin",
+        "brave-origin", "Brave Origin", "/Applications/Brave Origin.app/Contents/MacOS/Brave Origin",
         ("BraveSoftware", "Brave-Origin"), ("brave-origin.exe", "brave-origin"),
         (("BraveSoftware", "Brave-Origin", "Application", "brave.exe"),
          ("BraveSoftware", "Brave-Origin", "Application", "brave-origin.exe")),
@@ -97,7 +98,7 @@ _BROWSERS = (
          "/opt/brave.com/brave-origin-nightly/brave-origin"),
         "BraveSoftware/Brave-Origin", linux_exec=("brave-origin",)),
     _Browser(
-        "edge", "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+        "edge", "Microsoft Edge", "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
         ("Microsoft Edge",), ("msedge.exe", "msedge"),
         (("Microsoft", "Edge", "Application", "msedge.exe"),),
         ("Microsoft", "Edge", "User Data"),
@@ -310,6 +311,160 @@ def detect_default_chromium(system: str | None = None) -> str | None:
     return detect.get(system or platform.system(), _detect_default_linux)()
 
 
+# --- Which browser does real-profile browsing drive? ------------------------------------
+# ONE resolver, so the launch path, `hermes browser close-profile` and the desktop picker
+# can never disagree about the principal. Precedence: an explicit ``browser.real_profile_browser``
+# override, else the OS default. Every rung fails closed with a fixable message rather than
+# falling through to another browser's profile (#95549 wrong-principal invariant).
+
+def real_profile_browser_keys() -> tuple[str, ...]:
+    """Canonical keys real-profile browsing supports, in picker order."""
+    return tuple(b.key for b in _BROWSERS)
+
+
+def browser_label(browser: str) -> str:
+    """Human-readable product name for ``browser`` (falls back to the key)."""
+    b = _BROWSER_BY_KEY.get(browser)
+    return b.label if b else browser
+
+
+def _real_profile_browser_override() -> str | None:
+    """``browser.real_profile_browser`` from config; None when unset/blank."""
+    value = _browser_setting("real_profile_browser")
+    return value.strip().lower() if isinstance(value, str) and value.strip() else None
+
+
+def resolve_real_profile_browser(system: str | None = None) -> tuple[str | None, str | None]:
+    """``(browser_key, error)`` for real-profile browsing.
+
+    An explicit ``browser.real_profile_browser`` pin wins over the OS default so a Hermes
+    profile can drive Brave while the machine defaults to Chrome (and two profiles on one
+    machine can drive different browsers). An unknown key, or a pinned browser missing
+    either half of what a launch needs — its profile directory (to snapshot) or its binary
+    (to run the copy) — FAILS CLOSED. Silently falling back to the OS default would browse
+    as a different identity than the one the user picked, which is exactly the
+    wrong-principal bug the pin exists to prevent. Unset: the OS default, whose own
+    non-Chromium / pre-release-channel outcomes the caller reports.
+    """
+    override = _real_profile_browser_override()
+    if override is None:
+        return detect_default_chromium(system), None
+    if override not in _BROWSER_BY_KEY:
+        return None, (
+            f"browser.real_profile_browser is set to '{override}', which is not a supported "
+            f"Chromium browser. Use one of: {', '.join(real_profile_browser_keys())} — or clear "
+            "it to follow your system default browser.")
+    src = real_profile_data_dir(override, system)
+    if not src or not os.path.isdir(src):
+        return None, (
+            f"browser.real_profile_browser is set to '{override}' but no profile directory was "
+            f"found for it ({src!r}). Launch {browser_label(override)} at least once, pick a "
+            "different browser, or clear the setting to follow your system default.")
+    # A leftover profile dir from an uninstalled browser would pass the check above and
+    # then die at launch ("binary could not be found"); catch it where it is fixable.
+    if chromium_executable(override, system) is None:
+        return None, (
+            f"browser.real_profile_browser is set to '{override}' but {browser_label(override)} "
+            "is not installed on this machine. Install it, pick a different browser, or clear "
+            "the setting to follow your system default.")
+    return override, None
+
+
+def list_profiles_in_data_dir(src: str | None) -> list[dict]:
+    """Profile directories inside a Chromium user-data-dir, newest-identity info first.
+
+    Each row is ``{"directory", "name", "last_used"}``: ``directory`` is what
+    ``browser.real_profile_pin`` takes ("Default", "Profile 2"), ``name`` the display name
+    from ``Local State`` → ``profile.info_cache`` (falling back to the directory name), and
+    ``last_used`` marks the one an unpinned snapshot would copy. Read-only: nothing is
+    copied, launched, or written. Missing/unreadable ``Local State`` still yields the dirs
+    that exist on disk, so the picker degrades to bare directory names instead of empty.
+    """
+    if not src or not os.path.isdir(src):
+        return []
+    try:
+        with open(os.path.join(src, "Local State"), encoding="utf-8", errors="replace") as fh:
+            info_cache = ((json.load(fh).get("profile") or {}).get("info_cache")) or {}
+    except (OSError, ValueError, AttributeError):
+        info_cache = {}
+    if not isinstance(info_cache, dict):
+        info_cache = {}
+    last_used = _last_used_profile(src)
+    rows = []
+    for entry in sorted(os.listdir(src)):
+        if entry != "Default" and not entry.startswith("Profile "):
+            continue
+        if not os.path.isdir(os.path.join(src, entry)):
+            continue
+        meta = info_cache.get(entry)
+        name = meta.get("name") if isinstance(meta, dict) else None
+        rows.append({
+            "directory": entry,
+            "name": str(name).strip() if isinstance(name, str) and str(name).strip() else entry,
+            "last_used": entry == last_used})
+    return rows
+
+
+def list_real_profile_candidates(system: str | None = None) -> dict:
+    """Everything a picker needs to choose a browser + profile, without touching credentials.
+
+    Returns ``{"supported", "detected_default", "resolved_browser", "resolved_profile",
+    "error", "browsers": [...]}`` where each browser row carries ``key``/``label``, whether it
+    is ``installed`` (binary present) and ``has_profile`` (user-data-dir present), the
+    ``data_dir``, and its ``profiles`` (see ``list_profiles_in_data_dir``). ``resolved_*``
+    are what a launch RIGHT NOW would use, so the UI can name the identity instead of saying
+    "your default browser". ``supported`` is False on a platform where real-profile browsing
+    cannot work at all, and ``error`` carries the same fail-closed message the launch path
+    would give (unknown pin, missing profile dir, non-Chromium default, pre-release channel).
+    """
+    system = system or platform.system()
+    detected = detect_default_chromium(system)
+    resolved, error = resolve_real_profile_browser(system)
+    if error is None:
+        if resolved is None:
+            error = (
+                "Your default browser is not a supported Chromium browser. Pick one below, or "
+                "set a Chromium browser (Chrome, Edge, Brave, Brave Origin, Chromium) as your "
+                "system default.")
+        elif resolved == UNSUPPORTED_CHANNEL:
+            error = (
+                "Your default browser is a pre-release Chromium channel (Beta / Dev / Canary), "
+                "which real-profile browsing does not support. Pick a stable browser below.")
+    browsers = []
+    for b in _BROWSERS:
+        data_dir = real_profile_data_dir(b.key, system)
+        has_profile = bool(data_dir and os.path.isdir(data_dir))
+        browsers.append({
+            "key": b.key,
+            "label": b.label,
+            "installed": chromium_executable(b.key, system) is not None,
+            "has_profile": has_profile,
+            "is_system_default": b.key == detected,
+            "data_dir": data_dir or "",
+            "profiles": list_profiles_in_data_dir(data_dir) if has_profile else []})
+    resolved_key = resolved if resolved in _BROWSER_BY_KEY else None
+    resolved_profile = None
+    if resolved_key:
+        src = real_profile_data_dir(resolved_key, system)
+        if src and os.path.isdir(src):
+            profile, resolve_err = _resolve_source_profile(src)
+            resolved_profile = profile
+            error = error or resolve_err
+    return {
+        # Real-profile browsing drives a locally-installed Chromium, so it is a desktop-OS
+        # capability: Linux, macOS and Windows all work; anything else has no browser to drive.
+        "supported": system in ("Linux", "Darwin", "Windows"),
+        "platform": system,
+        "detected_default": detected if detected in _BROWSER_BY_KEY else None,
+        "detected_unsupported_channel": detected == UNSUPPORTED_CHANNEL,
+        "resolved_browser": resolved_key,
+        "resolved_profile": resolved_profile,
+        "pinned_browser": _real_profile_browser_override(),
+        "pinned_profile": _real_profile_pin(),
+        "error": error,
+        "browsers": browsers}
+
+
 # --- Real-profile SNAPSHOT launch -------------------------------------------------------
 # Never drive the live default user-data-dir: Chromium ≥136 (Google builds) refuses remote
 # debugging on it, and the user's running browser holds it (SingletonLock). Instead snapshot
@@ -434,6 +589,23 @@ _SNAPSHOT_DONE_MARKER = ".hermes-snapshot-complete"
 # Prefix stamped on the "profile is locked" error so the calling layer can recognize the
 # needs-the-browser-closed condition and surface the close-with-approval flow.
 _PROFILE_LOCKED_PREFIX = "[profile-locked] "
+
+
+def _snapshot_matches(marker: str, source_profile: str) -> bool:
+    """True when a completed snapshot at ``marker`` was built from ``source_profile``.
+
+    The marker records which profile dir was copied. A mismatch means the user re-pinned
+    (or last_used moved) since the tree was built, so the tree belongs to a DIFFERENT
+    identity and must be rebuilt rather than auth-overlaid — an overlay would leave the old
+    profile's Preferences/Local Storage under the new profile's cookies. An empty/unreadable
+    marker (older builds wrote the name; a torn write may not have) is treated as a
+    mismatch: rebuilding is always safe, reusing a foreign tree is not.
+    """
+    try:
+        with open(marker, encoding="utf-8") as fh:
+            return fh.read().strip() == source_profile
+    except OSError:
+        return False
 
 
 def _profile_is_locked(src: str, source_profile: str) -> bool:
@@ -645,9 +817,13 @@ def snapshot_real_profile(browser: str, src: str | None = None) -> tuple[str | N
     if _profile_is_locked(src, source_profile):
         return None, _locked_profile_error(browser)
     marker = os.path.join(dst, _SNAPSHOT_DONE_MARKER)
-    # Only a copy that previously COMPLETED counts as populated; a half-written tree is
-    # rebuilt — otherwise a torn first copy poisons freshness forever.
-    populated = os.path.isfile(marker)
+    # Only a copy that previously COMPLETED **for this same source profile** counts as
+    # populated. The marker stores the profile it was built from, so re-pinning
+    # (browser.real_profile_pin: "Profile 1" -> "Profile 2") rebuilds the tree instead of
+    # overlaying the new profile's auth onto the old profile's Preferences/Local Storage —
+    # a half-swapped identity. A half-written tree (no marker) is rebuilt for the same
+    # reason: a torn first copy must not poison freshness forever.
+    populated = _snapshot_matches(marker, source_profile)
     try:
         os.makedirs(dst, exist_ok=True)
         # Secure the snapshot dir AND its browser-profile parent on EVERY launch so a failed
@@ -680,12 +856,26 @@ def snapshot_real_profile(browser: str, src: str | None = None) -> tuple[str | N
     return dst, None
 
 
-def cleanup_real_profile_snapshots() -> None:
-    """Delete the whole real-profile snapshot store when consent is OFF (idempotent)."""
-    root = str(get_hermes_home() / "browser-profile")
-    if os.path.isdir(root):
+def cleanup_real_profile_snapshots(keep: str | None = None) -> None:
+    """Delete real-profile snapshot stores (idempotent).
+
+    With no ``keep``, removes the whole store — what revoking consent does, so copied
+    cookies/logins never outlive the consent that created them. With ``keep``, removes every
+    OTHER browser's snapshot: switching ``browser.real_profile_browser`` must not leave the
+    previous browser's credential copy sitting on disk indefinitely, unreachable from the UI
+    that could have told you it was there.
+    """
+    root = get_hermes_home() / "browser-profile"
+    if not root.is_dir():
+        return
+    if keep is None:
         shutil.rmtree(root, ignore_errors=True)
         logger.info("real-profile: removed snapshot store %s (consent off)", root)
+        return
+    for child in root.iterdir():
+        if child.is_dir() and child.name != keep:
+            shutil.rmtree(child, ignore_errors=True)
+            logger.info("real-profile: removed stale snapshot %s (now driving %s)", child, keep)
 
 
 def _debug_candidate_paths(system: str):

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -407,6 +407,13 @@ DEFAULT_CONFIG = {
         # and retries once; still locked -> stays blocked, no auto-kill. No effect on macOS/Linux
         # (copy-while-running works).
         "real_profile_autoclose": False,
+        # Which browser real-profile browsing drives. Empty = the OS default browser. Set a
+        # key (chrome / chromium / brave / brave-origin / edge) to pin one regardless of the
+        # system default — e.g. two Hermes profiles on one machine driving different browsers.
+        # A key that isn't supported, or whose profile directory doesn't exist, FAILS CLOSED
+        # rather than silently falling back to the default (wrong-principal). Desktop:
+        # Settings -> Capabilities -> Tools -> Browser.
+        "real_profile_browser": "",
         # Pin WHICH source profile directory is snapshotted for real-profile browsing (e.g. "Profile
         # 2"). Empty = browser's last-used profile, which on multi-profile machines can hand the
         # agent the wrong identity. A pin naming a missing directory FAILS CLOSED.

--- a/hermes_cli/subcommands/browser.py
+++ b/hermes_cli/subcommands/browser.py
@@ -21,20 +21,56 @@ def build_browser_parser(subparsers) -> None:
              "run only with the user's explicit OK; loses unsaved tabs)")
     browser_close.add_argument(
         "--browser",
-        help="Override detected default browser (chrome/edge/brave/brave-origin/chromium)")
+        help="Override the resolved browser (chrome/edge/brave/brave-origin/chromium)")
+    browser_subparsers.add_parser(
+        "profiles", help="List the browsers and profiles real-profile browsing can use")
+
+    def _print_profiles() -> int:
+        from hermes_cli.browser_connect import list_real_profile_candidates
+
+        info = list_real_profile_candidates()
+        for row in info["browsers"]:
+            tags = [t for t, on in (("system default", row["is_system_default"]),
+                                    ("active", row["key"] == info["resolved_browser"]),
+                                    ("not installed", not row["installed"]),
+                                    ("never launched", row["installed"] and not row["has_profile"]))
+                    if on]
+            print(f"{row['key']}  ({row['label']}){' — ' + ', '.join(tags) if tags else ''}")
+            for prof in row["profiles"]:
+                marks = [t for t, on in (
+                    ("last used", prof["last_used"]),
+                    ("in use", row["key"] == info["resolved_browser"]
+                     and prof["directory"] == info["resolved_profile"])) if on]
+                print(f"    {prof['directory']:<12} {prof['name']}"
+                      f"{'  [' + ', '.join(marks) + ']' if marks else ''}")
+        print("\nSet browser.real_profile_browser to a key above and browser.real_profile_pin "
+              "to a profile directory to choose which identity the agent browses as.")
+        if info["error"]:
+            print(f"\n! {info['error']}", file=sys.stderr)
+        return 0
 
     def _dispatch_browser(_args):
         from hermes_cli.browser_connect import (
-            UNSUPPORTED_CHANNEL, close_browser_holding_profile, detect_default_chromium,
-            real_profile_data_dir)
+            UNSUPPORTED_CHANNEL, close_browser_holding_profile, real_profile_data_dir,
+            resolve_real_profile_browser)
 
         action = getattr(_args, "browser_action", None)
+        if action == "profiles":
+            return _print_profiles()
         if action != "close-profile":
             browser_parser.print_help()
             return 2
-        browser = getattr(_args, "browser", None) or detect_default_chromium()
+        # Same resolver the launch path uses, so this closes the browser Hermes would
+        # actually drive — an explicit --browser still wins for recovery.
+        browser = getattr(_args, "browser", None)
+        if not browser:
+            browser, err = resolve_real_profile_browser()
+            if err:
+                print(f"✗ {err}", file=sys.stderr)
+                return 1
         if not browser or browser == UNSUPPORTED_CHANNEL:
-            print("✗ No supported Chromium default browser detected.", file=sys.stderr)
+            print("✗ No supported Chromium browser resolved for real-profile browsing.",
+                  file=sys.stderr)
             return 1
         src = real_profile_data_dir(browser)
         if not src:

--- a/hermes_cli/web_routers/tools.py
+++ b/hermes_cli/web_routers/tools.py
@@ -663,6 +663,22 @@ async def select_terminal_backend(
     return {"ok": True, "backend": backend}
 
 
+@router.get("/api/tools/browser/real-profile")
+async def get_browser_real_profile(profile: Optional[str] = None):
+    """Browsers + profiles real-profile browsing can use on THIS host, for the desktop picker.
+
+    Read-only discovery (see ``list_real_profile_candidates``): no credential is copied, no
+    browser launched. Runs inside ``_profile_scope`` so the resolved browser/profile reflect
+    the scoped profile's own ``config.yaml`` — a Hermes profile driving Brave/Profile 2 and
+    another driving Chrome/Default report different answers from the same gateway. The
+    picker WRITES through ``PUT /api/config`` like every other browser setting; this endpoint
+    only tells it what exists and what a launch would resolve to right now.
+    """
+    from hermes_cli.browser_connect import list_real_profile_candidates
+
+    return await scoped_to_thread(profile, list_real_profile_candidates)
+
+
 @router.get("/api/tools/computer-use/status")
 async def get_computer_use_status(profile: Optional[str] = None):
     """Computer Use readiness for the desktop card (payload shape: see

--- a/tests/hermes_cli/test_web_routers_browser_real_profile.py
+++ b/tests/hermes_cli/test_web_routers_browser_real_profile.py
@@ -1,0 +1,143 @@
+"""E2E for ``GET /api/tools/browser/real-profile`` — the desktop picker's data source.
+
+Exercises the real FastAPI route against a real temp ``HERMES_HOME``, because the
+whole point of the endpoint is config propagation across profile scopes: the desktop
+Capabilities surface can configure ANY profile, and each must report the browsing
+identity ITS own config.yaml resolves to. A mocked resolver would prove nothing here.
+"""
+
+import json
+
+import pytest
+
+
+def _make_user_data_dir(root, profiles=("Default", "Profile 2"), last_used="Default",
+                        names=None):
+    names = names or {}
+    for prof in profiles:
+        (root / prof / "Network").mkdir(parents=True)
+        (root / prof / "Cookies").write_text(f"cookies-{prof}")
+    (root / "Local State").write_text(json.dumps({
+        "profile": {"last_used": last_used,
+                    "info_cache": {p: {"name": names.get(p, p)} for p in profiles}}}))
+    return root
+
+
+class TestBrowserRealProfileEndpoint:
+    @pytest.fixture(autouse=True)
+    def _setup(self, monkeypatch, tmp_path, _isolate_hermes_home):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+
+        import hermes_cli.browser_connect as bc
+        import hermes_state
+        from hermes_constants import get_hermes_home
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
+        self.home = get_hermes_home()
+        self.client = TestClient(app)
+        self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+
+        # Two synthetic browsers on disk so the route has something real to list.
+        self.chrome = _make_user_data_dir(tmp_path / "chrome-data",
+                                          profiles=("Default", "Profile 2"),
+                                          names={"Profile 2": "Personal"})
+        self.brave = _make_user_data_dir(tmp_path / "brave-data", profiles=("Default",))
+        monkeypatch.setattr(bc, "real_profile_data_dir", lambda browser, system=None: {
+            "chrome": str(self.chrome), "brave": str(self.brave)}.get(browser))
+        monkeypatch.setattr(bc, "chromium_executable", lambda browser, system=None:
+                            "/usr/bin/x" if browser in ("chrome", "brave") else None)
+        monkeypatch.setattr(bc, "detect_default_chromium", lambda system=None: "brave")
+
+    def _write_config(self, **browser_keys):
+        import yaml
+        path = self.home / "config.yaml"
+        config = yaml.safe_load(path.read_text()) if path.exists() else {}
+        config.setdefault("browser", {}).update(browser_keys)
+        path.write_text(yaml.safe_dump(config))
+
+    def test_lists_installed_browsers_and_their_profiles(self):
+        body = self.client.get("/api/tools/browser/real-profile").json()
+
+        rows = {row["key"]: row for row in body["browsers"]}
+        assert rows["chrome"]["installed"] and rows["chrome"]["has_profile"]
+        assert [p["directory"] for p in rows["chrome"]["profiles"]] == ["Default", "Profile 2"]
+        assert rows["chrome"]["profiles"][1]["name"] == "Personal"
+        # A browser with no data dir is still listed (disabled in the UI), not hidden.
+        assert rows["edge"]["has_profile"] is False
+
+    def test_no_credentials_are_exposed(self):
+        """Discovery must never leak cookie contents — only names and paths."""
+        raw = self.client.get("/api/tools/browser/real-profile").text
+
+        assert "cookies-Default" not in raw and "cookies-Profile 2" not in raw
+
+    def test_unset_config_follows_the_system_default(self):
+        body = self.client.get("/api/tools/browser/real-profile").json()
+
+        assert body["detected_default"] == "brave"
+        assert body["resolved_browser"] == "brave"
+        assert body["pinned_browser"] is None
+        assert body["error"] is None
+
+    def test_config_pin_changes_the_resolved_identity(self):
+        self._write_config(use_real_profile=True, real_profile_browser="chrome",
+                           real_profile_pin="Profile 2")
+
+        body = self.client.get("/api/tools/browser/real-profile").json()
+
+        assert (body["resolved_browser"], body["resolved_profile"]) == ("chrome", "Profile 2")
+        assert body["error"] is None
+
+    def test_bad_pin_reports_a_fixable_error_instead_of_falling_back(self):
+        self._write_config(use_real_profile=True, real_profile_browser="chrome",
+                           real_profile_pin="Profile 99")
+
+        body = self.client.get("/api/tools/browser/real-profile").json()
+
+        assert body["error"] and "Profile 99" in body["error"]
+        assert body["resolved_profile"] != "Default", "must not silently use another profile"
+
+    def test_unknown_browser_reports_an_error(self):
+        self._write_config(use_real_profile=True, real_profile_browser="firefox")
+
+        body = self.client.get("/api/tools/browser/real-profile").json()
+
+        assert body["resolved_browser"] is None
+        assert body["error"] and "firefox" in body["error"]
+
+    def test_profile_scope_reads_that_profiles_config(self, monkeypatch):
+        """The desktop can point Capabilities at another profile; ?profile= must read
+        THAT profile's config.yaml, not the active one — this is what makes per-agent
+        browsing identities work from a single window."""
+        import yaml
+
+        # Active profile: brave/Default (default resolution, no pins).
+        other = self.home / "profiles" / "omar"
+        other.mkdir(parents=True, exist_ok=True)
+        (other / "config.yaml").write_text(yaml.safe_dump(
+            {"browser": {"use_real_profile": True, "real_profile_browser": "chrome",
+                         "real_profile_pin": "Profile 2"}}))
+
+        active = self.client.get("/api/tools/browser/real-profile").json()
+        scoped = self.client.get("/api/tools/browser/real-profile?profile=omar").json()
+
+        assert active["resolved_browser"] == "brave"
+        assert (scoped["resolved_browser"], scoped["resolved_profile"]) == ("chrome", "Profile 2")
+        assert active["resolved_browser"] != scoped["resolved_browser"], \
+            "two profiles on one gateway must be able to browse as different identities"
+
+    def test_response_shape_is_stable_for_the_picker(self):
+        """The desktop types this response; every key it reads must be present."""
+        body = self.client.get("/api/tools/browser/real-profile").json()
+
+        for key in ("supported", "platform", "detected_default", "detected_unsupported_channel",
+                    "resolved_browser", "resolved_profile", "pinned_browser", "pinned_profile",
+                    "error", "browsers"):
+            assert key in body, f"picker reads {key}"
+        for row in body["browsers"]:
+            assert set(row) >= {"key", "label", "installed", "has_profile", "is_system_default",
+                                "data_dir", "profiles"}

--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -959,6 +959,8 @@ class TestReviewRound3:
         with patch.object(bt_cloud, "_use_real_profile", return_value=True), \
              patch.object(bt_lightpanda_fallback, "_using_lightpanda_engine", return_value=False), \
              patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
+             patch("hermes_cli.browser_connect.chromium_executable",
+                   return_value="/usr/bin/google-chrome"), \
              patch("hermes_cli.browser_connect.real_profile_copy_dir", return_value=str(tmp_path)), \
              patch("hermes_cli.browser_connect.snapshot_real_profile",
                    return_value=(str(tmp_path), None)) as snap, \
@@ -966,6 +968,8 @@ class TestReviewRound3:
                           side_effect=[None, "http://127.0.0.1:9251"]), \
              patch.object(bt_install, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
              patch.object(bt.subprocess, "run", return_value=proc), \
+             patch.object(bt_real_profile, "_launch_real_profile_chrome",
+                          return_value=(9251, None)), \
              patch.object(bt_cloud, "_is_headed_mode", return_value=False):
             cdp, err = bt_real_profile._real_profile_cdp()
         assert err is None

--- a/tests/tools/test_browser_real_profile_picker.py
+++ b/tests/tools/test_browser_real_profile_picker.py
@@ -1,0 +1,327 @@
+"""Real-profile browser + profile SELECTION (browser.real_profile_browser and the
+discovery the desktop picker reads).
+
+The invariant under every case is the wrong-principal rule (#95549): a selection may
+resolve to exactly the identity the user chose, or fail closed with a fixable message.
+It may never silently fall through to a different browser or a different profile.
+"""
+import json
+
+import pytest
+
+
+def _make_user_data_dir(root, profiles=("Default", "Profile 2"), last_used="Default",
+                        names=None):
+    """Synthetic Chromium user-data-dir with profile dirs + a Local State info_cache."""
+    names = names or {}
+    for prof in profiles:
+        (root / prof / "Network").mkdir(parents=True)
+        (root / prof / "Cookies").write_text(f"cookies-{prof}")
+        (root / prof / "Login Data").write_text(f"logins-{prof}")
+        (root / prof / "Preferences").write_text("{}")
+    (root / "Local State").write_text(json.dumps({
+        "os_crypt": {},
+        "profile": {
+            "last_used": last_used,
+            "info_cache": {p: {"name": names.get(p, p)} for p in profiles}}}))
+    return root
+
+
+@pytest.fixture
+def bc():
+    import hermes_cli.browser_connect as module
+    return module
+
+
+class TestResolveRealProfileBrowser:
+    """browser.real_profile_browser: pin wins, bad pin fails closed, unset = OS default."""
+
+    def test_unset_follows_os_default(self, bc, monkeypatch):
+        monkeypatch.setattr(bc, "_real_profile_browser_override", lambda: None)
+        monkeypatch.setattr(bc, "detect_default_chromium", lambda system=None: "brave")
+
+        assert bc.resolve_real_profile_browser() == ("brave", None)
+
+    def test_pin_overrides_os_default(self, bc, tmp_path, monkeypatch):
+        _make_user_data_dir(tmp_path / "chrome-data")
+        monkeypatch.setattr(bc, "_real_profile_browser_override", lambda: "chrome")
+        monkeypatch.setattr(bc, "detect_default_chromium", lambda system=None: "brave")
+        monkeypatch.setattr(bc, "real_profile_data_dir",
+                            lambda browser, system=None: str(tmp_path / "chrome-data"))
+        monkeypatch.setattr(bc, "chromium_executable", lambda browser, system=None: "/usr/bin/x")
+
+        browser, err = bc.resolve_real_profile_browser()
+        assert (browser, err) == ("chrome", None), "an explicit pin must beat the OS default"
+
+    def test_unknown_browser_fails_closed(self, bc, monkeypatch):
+        monkeypatch.setattr(bc, "_real_profile_browser_override", lambda: "firefox")
+        monkeypatch.setattr(bc, "detect_default_chromium", lambda system=None: "chrome")
+
+        browser, err = bc.resolve_real_profile_browser()
+        assert browser is None, "must never fall back to the default browser"
+        assert err and "firefox" in err and "real_profile_browser" in err
+
+    def test_pinned_browser_without_profile_dir_fails_closed(self, bc, tmp_path, monkeypatch):
+        monkeypatch.setattr(bc, "_real_profile_browser_override", lambda: "edge")
+        monkeypatch.setattr(bc, "detect_default_chromium", lambda system=None: "chrome")
+        monkeypatch.setattr(bc, "real_profile_data_dir",
+                            lambda browser, system=None: str(tmp_path / "missing"))
+
+        browser, err = bc.resolve_real_profile_browser()
+        assert browser is None
+        assert err and "edge" in err.lower()
+
+    def test_pinned_browser_without_binary_fails_closed(self, bc, tmp_path, monkeypatch):
+        """A leftover ~/.config dir from an uninstalled browser must fail HERE, with a
+        fixable message, not later at launch with 'binary could not be found'."""
+        _make_user_data_dir(tmp_path / "chrome-data")
+        monkeypatch.setattr(bc, "_real_profile_browser_override", lambda: "chrome")
+        monkeypatch.setattr(bc, "real_profile_data_dir",
+                            lambda browser, system=None: str(tmp_path / "chrome-data"))
+        monkeypatch.setattr(bc, "chromium_executable", lambda browser, system=None: None)
+
+        browser, err = bc.resolve_real_profile_browser()
+        assert browser is None
+        assert err and "not installed" in err
+
+    def test_case_and_whitespace_tolerant(self, bc, tmp_path, monkeypatch):
+        """A hand-edited config.yaml ('  Brave ') resolves like the canonical key."""
+        _make_user_data_dir(tmp_path / "brave-data")
+        monkeypatch.setattr(bc, "_browser_setting",
+                            lambda key: "  Brave " if key == "real_profile_browser" else None)
+        monkeypatch.setattr(bc, "real_profile_data_dir",
+                            lambda browser, system=None: str(tmp_path / "brave-data"))
+        monkeypatch.setattr(bc, "chromium_executable", lambda browser, system=None: "/usr/bin/x")
+
+        assert bc.resolve_real_profile_browser() == ("brave", None)
+
+
+class TestListProfilesInDataDir:
+    def test_lists_directories_with_display_names(self, bc, tmp_path):
+        src = _make_user_data_dir(
+            tmp_path / "data", profiles=("Default", "Profile 1", "Profile 2"),
+            last_used="Profile 1", names={"Profile 1": "Work", "Profile 2": "Personal"})
+
+        rows = bc.list_profiles_in_data_dir(str(src))
+        assert [r["directory"] for r in rows] == ["Default", "Profile 1", "Profile 2"]
+        assert {r["directory"]: r["name"] for r in rows}["Profile 2"] == "Personal"
+        assert [r["directory"] for r in rows if r["last_used"]] == ["Profile 1"]
+
+    def test_pin_target_is_the_directory_key(self, bc, tmp_path, monkeypatch):
+        """Contract with browser.real_profile_pin: every `directory` the picker offers must
+        be a pin _resolve_source_profile accepts — otherwise the UI can write a config the
+        launch path rejects."""
+        src = _make_user_data_dir(tmp_path / "data", profiles=("Default", "Profile 2"),
+                                  names={"Profile 2": "Personal"})
+
+        for row in bc.list_profiles_in_data_dir(str(src)):
+            monkeypatch.setattr(bc, "_real_profile_pin", lambda d=row["directory"]: d)
+            assert bc._resolve_source_profile(str(src)) == (row["directory"], None)
+
+    def test_missing_local_state_degrades_to_directory_names(self, bc, tmp_path):
+        src = _make_user_data_dir(tmp_path / "data")
+        (src / "Local State").unlink()
+
+        rows = bc.list_profiles_in_data_dir(str(src))
+        assert [r["name"] for r in rows] == ["Default", "Profile 2"]
+
+    def test_non_profile_directories_are_ignored(self, bc, tmp_path):
+        src = _make_user_data_dir(tmp_path / "data")
+        (src / "Crashpad").mkdir()
+        (src / "ShaderCache").mkdir()
+
+        assert [r["directory"] for r in bc.list_profiles_in_data_dir(str(src))] == [
+            "Default", "Profile 2"]
+
+    def test_absent_dir_is_empty_not_error(self, bc, tmp_path):
+        assert bc.list_profiles_in_data_dir(str(tmp_path / "nope")) == []
+        assert bc.list_profiles_in_data_dir(None) == []
+
+
+class TestListRealProfileCandidates:
+    def test_resolved_pair_matches_what_a_launch_would_use(self, bc, tmp_path, monkeypatch):
+        """The picker's `resolved_browser`/`resolved_profile` is the SAME answer the
+        launch path gets — one resolver, or the UI lies about the identity."""
+        src = _make_user_data_dir(tmp_path / "brave-data",
+                                  profiles=("Default", "Profile 1", "Profile 2"),
+                                  last_used="Profile 1")
+        monkeypatch.setattr(bc, "real_profile_data_dir",
+                            lambda browser, system=None: str(src) if browser == "brave" else None)
+        monkeypatch.setattr(bc, "chromium_executable",
+                            lambda browser, system=None: "/usr/bin/x" if browser == "brave" else None)
+        monkeypatch.setattr(bc, "_real_profile_browser_override", lambda: "brave")
+        monkeypatch.setattr(bc, "_real_profile_pin", lambda: "Profile 2")
+
+        info = bc.list_real_profile_candidates(system="Linux")
+        assert info["resolved_browser"] == "brave"
+        assert info["resolved_profile"] == "Profile 2"
+        assert info["error"] is None
+        # And it agrees with the resolvers the launch path calls.
+        assert bc.resolve_real_profile_browser("Linux")[0] == info["resolved_browser"]
+        assert bc._resolve_source_profile(str(src))[0] == info["resolved_profile"]
+
+    def test_every_supported_browser_has_a_row_with_a_label(self, bc, monkeypatch):
+        monkeypatch.setattr(bc, "detect_default_chromium", lambda system=None: None)
+        monkeypatch.setattr(bc, "_real_profile_browser_override", lambda: None)
+
+        info = bc.list_real_profile_candidates(system="Linux")
+        keys = [row["key"] for row in info["browsers"]]
+        assert keys == list(bc.real_profile_browser_keys())
+        assert all(row["label"] and row["label"] != row["key"] for row in info["browsers"]), \
+            "each row needs a human label for the picker"
+
+    def test_non_chromium_default_surfaces_a_fixable_error(self, bc, monkeypatch):
+        monkeypatch.setattr(bc, "detect_default_chromium", lambda system=None: None)
+        monkeypatch.setattr(bc, "_real_profile_browser_override", lambda: None)
+
+        info = bc.list_real_profile_candidates(system="Linux")
+        assert info["resolved_browser"] is None
+        assert info["error"] and "Chromium" in info["error"]
+
+    def test_unsupported_channel_default_is_flagged_not_normalized(self, bc, monkeypatch):
+        monkeypatch.setattr(bc, "detect_default_chromium",
+                            lambda system=None: bc.UNSUPPORTED_CHANNEL)
+        monkeypatch.setattr(bc, "_real_profile_browser_override", lambda: None)
+
+        info = bc.list_real_profile_candidates(system="Linux")
+        assert info["detected_unsupported_channel"] is True
+        assert info["resolved_browser"] is None, "a Beta/Dev default must not resolve to stable"
+        assert info["detected_default"] is None
+
+    def test_bad_pin_error_reaches_the_picker(self, bc, tmp_path, monkeypatch):
+        src = _make_user_data_dir(tmp_path / "data")
+        monkeypatch.setattr(bc, "real_profile_data_dir",
+                            lambda browser, system=None: str(src) if browser == "chrome" else None)
+        monkeypatch.setattr(bc, "chromium_executable",
+                            lambda browser, system=None: "/usr/bin/x" if browser == "chrome" else None)
+        monkeypatch.setattr(bc, "_real_profile_browser_override", lambda: "chrome")
+        monkeypatch.setattr(bc, "_real_profile_pin", lambda: "Profile 99")
+
+        info = bc.list_real_profile_candidates(system="Linux")
+        assert info["error"] and "Profile 99" in info["error"]
+
+    @pytest.mark.parametrize("system,supported", [
+        ("Linux", True), ("Darwin", True), ("Windows", True), ("FreeBSD", False)])
+    def test_platform_support_is_reported(self, bc, monkeypatch, system, supported):
+        """The desktop shows/hides the picker from this flag, so it must be honest per OS."""
+        monkeypatch.setattr(bc, "detect_default_chromium", lambda system=None: None)
+        monkeypatch.setattr(bc, "_real_profile_browser_override", lambda: None)
+
+        assert bc.list_real_profile_candidates(system=system)["supported"] is supported
+
+
+class TestSnapshotIdentitySwap:
+    """Re-pinning must REBUILD the snapshot, not overlay auth onto the old identity."""
+
+    def test_changing_the_pin_rebuilds_the_tree(self, bc, tmp_path, monkeypatch):
+        src = _make_user_data_dir(tmp_path / "real", profiles=("Default", "Profile 2"),
+                                  last_used="Default")
+        # A file that only exists in Default: if the tree is reused, it survives the swap.
+        (src / "Default" / "Bookmarks").write_text("default-bookmarks")
+        home = tmp_path / "hermes-home"
+        monkeypatch.setattr(bc, "get_hermes_home", lambda: home)
+
+        monkeypatch.setattr(bc, "_real_profile_pin", lambda: "Default")
+        dst, err = bc.snapshot_real_profile("chrome", src=str(src))
+        assert err is None
+        copy = home / "browser-profile" / "chrome" / "Default"
+        assert (copy / "Bookmarks").exists()
+
+        # User re-pins to Profile 2 (which has no Bookmarks).
+        monkeypatch.setattr(bc, "_real_profile_pin", lambda: "Profile 2")
+        dst2, err2 = bc.snapshot_real_profile("chrome", src=str(src))
+        assert err2 is None and dst2 == dst
+        assert (copy / "Cookies").read_text() == "cookies-Profile 2"
+        assert not (copy / "Bookmarks").exists(), \
+            "re-pinning must rebuild, not overlay onto the previous identity's tree"
+
+    def test_same_pin_reuses_the_tree(self, bc, tmp_path, monkeypatch):
+        """The rebuild must trigger on a CHANGE only — a stable pin keeps the fast path."""
+        src = _make_user_data_dir(tmp_path / "real", last_used="Default")
+        home = tmp_path / "hermes-home"
+        monkeypatch.setattr(bc, "get_hermes_home", lambda: home)
+        monkeypatch.setattr(bc, "_real_profile_pin", lambda: "Default")
+
+        bc.snapshot_real_profile("chrome", src=str(src))
+        copy = home / "browser-profile" / "chrome" / "Default"
+        (copy / "marker-of-reuse").write_text("kept")
+
+        bc.snapshot_real_profile("chrome", src=str(src))
+        assert (copy / "marker-of-reuse").exists(), "an unchanged pin must not rebuild"
+
+
+class TestSnapshotCleanup:
+    def test_keep_removes_only_other_browsers(self, bc, tmp_path, monkeypatch):
+        """Switching browsers must not leave the old browser's cookie copy on disk."""
+        home = tmp_path / "hermes-home"
+        for browser in ("chrome", "brave"):
+            (home / "browser-profile" / browser / "Default").mkdir(parents=True)
+        monkeypatch.setattr(bc, "get_hermes_home", lambda: home)
+
+        bc.cleanup_real_profile_snapshots(keep="brave")
+        assert (home / "browser-profile" / "brave").is_dir()
+        assert not (home / "browser-profile" / "chrome").exists()
+
+    def test_no_keep_removes_everything(self, bc, tmp_path, monkeypatch):
+        home = tmp_path / "hermes-home"
+        (home / "browser-profile" / "chrome" / "Default").mkdir(parents=True)
+        monkeypatch.setattr(bc, "get_hermes_home", lambda: home)
+
+        bc.cleanup_real_profile_snapshots()
+        assert not (home / "browser-profile").exists()
+
+    def test_absent_store_is_a_no_op(self, bc, tmp_path, monkeypatch):
+        monkeypatch.setattr(bc, "get_hermes_home", lambda: tmp_path / "empty-home")
+        bc.cleanup_real_profile_snapshots()
+        bc.cleanup_real_profile_snapshots(keep="chrome")
+
+
+class TestProfileScopedSelection:
+    """Two Hermes profiles on one machine must be able to browse as different identities.
+
+    This is the whole point of the feature: the settings live in each profile's own
+    config.yaml, so the resolver must read the CURRENT HERMES_HOME, never a cached one.
+    """
+
+    def test_two_homes_resolve_to_different_browsers(self, bc, tmp_path, monkeypatch):
+        """E2E through the REAL config loader: write two profiles' config.yaml, point
+        HERMES_HOME at each in turn, and confirm the resolver reads that home's file."""
+        for browser_dir in ("chrome-data", "brave-data"):
+            _make_user_data_dir(tmp_path / browser_dir, profiles=("Default", "Profile 2"))
+        monkeypatch.setattr(bc, "real_profile_data_dir", lambda browser, system=None: {
+            "chrome": str(tmp_path / "chrome-data"),
+            "brave": str(tmp_path / "brave-data")}.get(browser))
+        monkeypatch.setattr(bc, "chromium_executable", lambda browser, system=None: "/usr/bin/x")
+
+        homes = {}
+        for name, browser, pin in (("coder", "chrome", "Profile 2"), ("omar", "brave", "Default")):
+            home = tmp_path / name
+            home.mkdir()
+            (home / "config.yaml").write_text(
+                "browser:\n"
+                "  use_real_profile: true\n"
+                f"  real_profile_browser: {browser}\n"
+                f"  real_profile_pin: '{pin}'\n")
+            homes[name] = home
+
+        seen = {}
+        for name, home in homes.items():
+            monkeypatch.setenv("HERMES_HOME", str(home))
+            browser, err = bc.resolve_real_profile_browser("Linux")
+            assert err is None, err
+            src = bc.real_profile_data_dir(browser)
+            seen[name] = (browser, bc._resolve_source_profile(src)[0])
+
+        assert seen["coder"] == ("chrome", "Profile 2")
+        assert seen["omar"] == ("brave", "Default")
+        assert seen["coder"] != seen["omar"], \
+            "per-profile config must give per-profile browsing identities"
+
+    def test_snapshot_stores_are_per_home(self, bc, tmp_path, monkeypatch):
+        """Two profiles browsing as different identities must not share one snapshot dir,
+        or the second launch would overwrite the first's cookies."""
+        seen = set()
+        for name in ("coder", "omar"):
+            monkeypatch.setenv("HERMES_HOME", str(tmp_path / name))
+            seen.add(bc.real_profile_copy_dir("chrome"))
+        assert len(seen) == 2, "snapshot dir must be scoped to HERMES_HOME"

--- a/tools/browser_tool_real_profile.py
+++ b/tools/browser_tool_real_profile.py
@@ -89,7 +89,7 @@ _REAL_PROFILE_CHROME_FLAGS = (
 
 
 def _real_profile_unsupported_reason(browser) -> Optional[str]:
-    """Fail-closed message when the default browser can't be used, else None.
+    """Fail-closed message when the resolved browser can't be used, else None.
 
     A pre-release channel lives in a profile dir we don't resolve; normalizing to the stable
     family would drive a DIFFERENT profile/account (wrong-principal bug), so refuse rather than guess.
@@ -97,11 +97,13 @@ def _real_profile_unsupported_reason(browser) -> Optional[str]:
     from hermes_cli.browser_connect import UNSUPPORTED_CHANNEL
     if browser is None:
         return (_RP + "your default browser is not a supported Chromium browser (Chrome, Edge, Brave, "
-                "Brave Origin, Chromium). Real-profile browsing requires a Chromium default; set one or turn the toggle off.")
+                "Brave Origin, Chromium). Real-profile browsing requires a Chromium default; set one, "
+                "pick a browser with browser.real_profile_browser, or turn the toggle off.")
     if browser == UNSUPPORTED_CHANNEL:
         return (_RP + "your default browser is a pre-release Chromium channel (Beta / Dev / Canary), which "
                 "real-profile browsing does not support. Set your default to a "
-                "stable Chrome / Edge / Brave / Brave Origin / Chromium, or turn the toggle off.")
+                "stable Chrome / Edge / Brave / Brave Origin / Chromium, pick one with "
+                "browser.real_profile_browser, or turn the toggle off.")
     return None
 
 
@@ -213,8 +215,9 @@ def _real_profile_cdp() -> tuple:
         return None, (_RP + "browser.engine is set to 'lightpanda', which cannot load a real Chromium profile. "
                       "Set browser.engine to 'auto' or 'chrome' to use real-profile browsing, or turn the toggle off.")
 
-    from hermes_cli.browser_connect import (chromium_executable, detect_default_chromium,
-                                            real_profile_copy_dir, snapshot_real_profile)
+    from hermes_cli.browser_connect import (chromium_executable, cleanup_real_profile_snapshots,
+                                            real_profile_copy_dir, resolve_real_profile_browser,
+                                            snapshot_real_profile)
 
     with _bt._real_profile_cdp_lock:
         cached = _bt._real_profile_cdp_cache.get("cdp")
@@ -222,7 +225,12 @@ def _real_profile_cdp() -> tuple:
             return cached, None
         _bt._real_profile_cdp_cache.pop("cdp", None)
 
-        browser = detect_default_chromium()
+        # ONE resolver decides the principal (browser.real_profile_browser pin, else the OS
+        # default) so this launch, `hermes browser close-profile` and the desktop picker can
+        # never disagree about whose logins the agent gets.
+        browser, resolve_err = resolve_real_profile_browser()
+        if resolve_err:
+            return None, f"{_RP}{resolve_err}"
         unsupported = _real_profile_unsupported_reason(browser)
         if unsupported:
             return None, unsupported
@@ -237,6 +245,14 @@ def _real_profile_cdp() -> tuple:
             return existing, None
         if existing:  # stale/wrong-dir session: close it so nothing holds the dir open
             _agent_browser_close_session(_bt._REAL_PROFILE_SESSION)
+
+        # Switching browsers leaves the previous one's cookie/login copy on disk; drop it now
+        # that a different browser owns the session. AFTER the session close above, so we never
+        # rmtree a dir a live copy-browser still holds. Best-effort: never blocks a launch.
+        try:
+            cleanup_real_profile_snapshots(keep=browser)
+        except Exception as e:
+            _bt.logger.debug("real-profile stale-snapshot cleanup failed: %s", e)
 
         copy_dir, err = snapshot_real_profile(browser)
         if err or not copy_dir:

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -199,22 +199,55 @@ same [headed-mode](#headed-mode-visible-browser-window) toggle applies —
 real-profile browsing too. On a display-less host (servers, CI) it always runs
 headless regardless.
 
-If your browser has several profiles (say a work profile and a personal one)
-and you don't want "whichever profile you touched last" deciding the agent's
-identity, pin the snapshot source explicitly:
+### Choosing the browser and profile
+
+By default the agent borrows logins from your **system default browser**, using
+whichever profile you last browsed in. On a machine with several browsers or
+several profiles that is "last-touched roulette" — so both halves of the
+identity can be pinned. In the desktop app: **Settings → Capabilities → Tools →
+Browser**, where the two pickers appear under the toggle and the panel tells you
+exactly who the agent will browse as ("Browsing as Brave · Personal"). In YAML:
 
 ```yaml
 # ~/.hermes/config.yaml
 browser:
   use_real_profile: true
-  real_profile_pin: "Profile 2"   # directory name under the browser's user-data dir
+  real_profile_browser: brave        # chrome | chromium | brave | brave-origin | edge
+  real_profile_pin: "Profile 2"      # directory name under that browser's user-data dir
 ```
 
-A pin naming a profile directory that doesn't exist fails closed with a
-fixable message — it never silently falls back to the last-used profile.
+- `real_profile_browser` — empty follows your OS default. Set it to drive a
+  browser that is *not* your default, e.g. a machine that defaults to Chrome
+  while the agent should use Brave.
+- `real_profile_pin` — empty follows `Local State → profile.last_used`. Set it
+  to the profile **directory** name (`Default`, `Profile 2`), not the display
+  name.
+
+Both fail closed: a browser key that isn't supported or has no profile
+directory, and a pin naming a directory that doesn't exist, produce a fixable
+error rather than silently falling back to a different identity. Run
+`hermes browser profiles` to list what's available on the machine:
+
+```
+$ hermes browser profiles
+brave  (Brave) — system default, active
+    Default      Default
+    Profile 1    Me            [last used]
+    Profile 2    Personal      [in use]
+chromium  (Chromium)
+    Default      Your Chromium
+```
+
+Because these are ordinary `config.yaml` keys, **each Hermes profile gets its
+own browsing identity**: `~/.hermes/profiles/work/config.yaml` can pin
+Chrome/Default while `~/.hermes/profiles/personal/config.yaml` pins
+Brave/Profile 2, and each profile's snapshot lives under its own
+`HERMES_HOME/browser-profile/`. Changing the pin rebuilds the snapshot from the
+newly selected profile, and switching browsers deletes the previous browser's
+snapshot so credential copies don't linger.
 
 When you turn the toggle back off, Hermes deletes the snapshot store
-(`~/.hermes/browser-profile/`) on the next browser use, so the copied
+(`<HERMES_HOME>/browser-profile/`) on the next browser use, so the copied
 credentials don't linger after you revoke consent.
 
 :::note Windows: the browser must be fully closed


### PR DESCRIPTION
## Summary

Real-profile browsing always drove the **OS default browser's last-used profile**. On a machine with several browsers or several profiles that means "whichever profile you touched last" silently decides the agent's identity — and there was no way to give two Hermes profiles different browsing identities.

This adds `browser.real_profile_browser` next to the existing `real_profile_pin`, and routes both halves through **one resolver** so the launch path, the CLI, and the new desktop picker can never disagree about whose logins the agent gets.

## Design

**Core — one resolver, fail-closed** (`hermes_cli/browser_connect.py`)

- `resolve_real_profile_browser()` — the config pin, else the OS default. An unknown key, a missing profile directory, or a missing binary **fails closed** with a fixable message; it never falls back to another browser's profile (the #95549 wrong-principal invariant the existing pin already protects). `tools/browser_tool_real_profile.py` and `hermes browser close-profile` both call it now.
- `list_real_profile_candidates()` — read-only discovery: installed / has-profile / system-default per browser, profile directories with their display names, plus the browser+profile a launch would resolve to *right now*. No credential is read, nothing is copied or launched.

**API** — `GET /api/tools/browser/real-profile`, profile-scoped like the other Capabilities routes (mirrors `GET /api/tools/terminal/backends`). Each Hermes profile reports its own resolution, and the answer comes from the gateway that actually launches the browser, so a desktop attached to a remote gateway lists *that* machine's browsers. Writes still go through the existing deep-merging `PUT /api/config` — no new write route.

**Desktop** — two pickers under the existing consent toggle in Capabilities → Tools → Browser, rendered only once consent is on (the filesystem walk doesn't run for users who never opted in). Uninstalled / never-launched browsers are listed **disabled with the reason** rather than hidden; switching browsers clears the now-meaningless profile pin; the panel names the resolved identity ("Browsing as Brave · Personal"). The first-open consent dialog names it too, instead of the vague "your default browser profile" — consent to copy cookies should say whose.

**CLI** — `hermes browser profiles` prints the same data for headless hosts.

## Two adjacent bugs this exposed

- **Re-pinning half-swapped the identity.** The snapshot completion marker recorded the source profile but never compared it, so changing `real_profile_pin` overlaid the new profile's auth onto the *old* profile's tree (its Preferences/Local Storage). Now a mismatch rebuilds.
- **Switching browsers orphaned credentials.** The previous browser's cookie/login copy stayed on disk. `cleanup_real_profile_snapshots(keep=...)` drops it — sequenced *after* the session close so we never rmtree a dir a live copy-browser holds.

## Platform support

Linux, macOS and Windows all work (the resolver tables already carried all three); the response carries `supported` + `platform` so the desktop states plainly when a host can't do it rather than showing dead controls.

## Test plan

- `164` python tests pass — new `tests/tools/test_browser_real_profile_picker.py` (resolver precedence, every fail-closed path, marker-mismatch rebuild, cross-browser cleanup, and two `HERMES_HOME`s resolving to different browsers through the real config loader) and `tests/hermes_cli/test_web_routers_browser_real_profile.py` (real FastAPI route + real temp `HERMES_HOME`, including `?profile=` isolation and a no-credentials-in-the-payload assertion).
- `483` desktop tests pass; `tsc --noEmit` and eslint clean.
- Also fixes a pre-existing host-dependent failure in `test_relaunch_path_does_snapshot` (it assumed a Chrome binary on the host; fails on `main` today).

**Verified end-to-end in a dev desktop build against real browsers**, not just unit mocks:

- pickers listed the host's actual Brave profiles (4, with display names) and Chromium;
- selecting a profile wrote `real_profile_pin` to `config.yaml` and the panel re-read the backend → "Browsing as Brave · APC";
- selecting a different browser wrote `real_profile_browser` **and cleared the stale pin**;
- switching the Capabilities profile selector showed two profiles resolving to **different browsers in one window** (default → Chromium, second profile → Brave/Profile 1);
- a bad pin surfaced the fail-closed error instead of silently browsing as someone else;
- `hermes browser profiles` agreed with the UI.
