### PR TITLE
fix(compression): forward-port native Responses ownership

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -541,6 +541,25 @@ def classify_responses_route(agent: Any) -> ResponsesRouteFlags:
     )
 
 
+def native_responses_owns_automatic_compaction(agent: Any) -> bool:
+    """Whether this request's provider owns automatic threshold compaction."""
+    if getattr(agent, "api_mode", None) != "codex_responses":
+        return False
+
+    route = classify_responses_route(agent)
+
+    from agent.native_compaction import native_compaction_context_management
+
+    return bool(
+        native_compaction_context_management(
+            agent,
+            is_codex_backend=route.is_codex_backend,
+            is_xai_responses=route.is_xai_responses,
+            is_github_responses=route.is_github_responses,
+        )
+    )
+
+
 def estimate_native_responses_preflight_tokens(
     agent: Any, messages: List[Dict[str, Any]], *, system_prompt: str = "", tools: Optional[List[Dict[str, Any]]] = None,
 ) -> Optional[int]:

--- a/agent/turn_context_compaction.py
+++ b/agent/turn_context_compaction.py
@@ -14,6 +14,7 @@ import time
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from agent.codex_responses_adapter import native_responses_owns_automatic_compaction
 from agent.context_engine import automatic_compaction_status_message
 from agent.conversation_compression import (
     IDLE_COMPACTION_STATUS_TEMPLATE, PREFLIGHT_COMPRESSION_STATUS_TEMPLATE,
@@ -150,7 +151,12 @@ def _idle_compaction(
 
     messages = out.messages
     _idle_after = getattr(agent, "compression_idle_compact_after_seconds", 0)
-    if not (agent.compression_enabled and _idle_after > 0 and messages):
+    if not (
+        agent.compression_enabled
+        and not native_responses_owns_automatic_compaction(agent)
+        and _idle_after > 0
+        and messages
+    ):
         return
     _idle_gap = time.time() - getattr(agent, "_last_activity_ts", time.time())
     if _idle_gap < _idle_after:
@@ -257,6 +263,7 @@ def _preflight_compression(
         _compressor, "should_defer_preflight_to_real_usage", lambda _tokens: False
     )(_preflight_tokens)
     _codex_native_auto = _codex_native_auto_compaction(agent)
+    _responses_native_auto = native_responses_owns_automatic_compaction(agent)
 
     if not _preflight_deferred:
         # Display-only seed: a real provider reading wins and the -1 sentinel stays
@@ -271,7 +278,9 @@ def _preflight_compression(
 
     _should_compress_now = False
     _compress_block_reason = None
-    if _preflight_deferred:
+    if _codex_native_auto or _responses_native_auto:
+        logger.info("Skipping Hermes preflight compression: provider-native compaction owns this route")
+    elif _preflight_deferred:
         logger.info(
             "Skipping preflight compression: rough estimate ~%s >= %s, "
             "but last real provider prompt was %s after compression",
@@ -289,12 +298,6 @@ def _preflight_compression(
             # Over threshold but blocked by the summary-LLM cooldown — surface a warning.
             _cooldown_secs = _compression_cooldown.get("remaining_seconds", 0.0)
             _compress_block_reason = f"cooldown:{_cooldown_secs:.0f}"
-    elif _codex_native_auto:
-        logger.info(
-            "Skipping Hermes preflight compression for codex app-server "
-            "(mode=%s); Hermes will not start thread compaction here.",
-            getattr(agent, "codex_app_server_auto_compaction", "native"),
-        )
     else:
         _should_compress_now = _compressor.should_compress(_preflight_tokens)
         if not _should_compress_now:
@@ -326,7 +329,12 @@ def _preflight_compression(
         _clear_overflow_warn(agent)
         # Engine maintenance only when NO skip-branch fired: cooldown, deferred
         # estimate, or codex-native route keep the engine hook unconsulted.
-        if not (_compression_cooldown or _preflight_deferred or _codex_native_auto):
+        if not (
+            _compression_cooldown
+            or _preflight_deferred
+            or _codex_native_auto
+            or _responses_native_auto
+        ):
             _engine_preflight_maintenance(
                 agent, out, _compressor, _preflight_tokens, system_message, effective_task_id
             )

--- a/agent/turn_preflight.py
+++ b/agent/turn_preflight.py
@@ -13,6 +13,7 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from agent.codex_responses_adapter import native_responses_owns_automatic_compaction
 from agent.context_engine import automatic_compaction_status_message
 from agent.conversation_compression import (
     PRE_API_COMPRESSION_STATUS_TEMPLATE, compression_blocked_transiently,
@@ -90,8 +91,13 @@ def run_preflight_compression(
         and len(v.messages) > 1
         and v.compression_attempts < max_compression_attempts
     )
+    _native_auto = (
+        native_responses_owns_automatic_compaction(agent)
+        and not provider_overflow_preflight
+    )
     if (
         _eligible
+        and not _native_auto
         and not _review_fork_first_request_pending(agent)
         and (not v._preflight_compression_blocked or provider_overflow_preflight)
         and (not defer_preflight(request_pressure_tokens) or provider_overflow_preflight)
@@ -197,7 +203,12 @@ def run_preflight_compression(
         # All recovery passes consumed and still over threshold: fail closed —
         # llama.cpp may silently truncate an oversized retry.
         return _done("return", _exhausted_result())
-    elif _eligible and not defer_preflight(request_pressure_tokens) and _compression_cooldown:
+    elif (
+        _eligible
+        and not _native_auto
+        and not defer_preflight(request_pressure_tokens)
+        and _compression_cooldown
+    ):
         # Summary-LLM cooldown blocks compression: deduped warning only when over
         # threshold (should_compress_info reason is None below it).
         _block_reason = _blocked_compress_reason(compressor, request_pressure_tokens)
@@ -263,6 +274,7 @@ def compress_after_tool_results(
         )
 
     _compressor = agent.context_compressor
+    _native_auto = native_responses_owns_automatic_compaction(agent)
     # Use real token counts from the API response to decide compression.  prompt_tokens + completion_tokens
     # is the actual context size the provider reported plus the assistant turn — a tight lower bound for the
     # next prompt. Tool results appended above aren't counted yet, but the threshold (default 50%) leaves
@@ -296,6 +308,7 @@ def compress_after_tool_results(
 
     if (
         agent.compression_enabled
+        and not _native_auto
         and compression_attempts < max_compression_attempts
         and _compressor.should_compress(_real_tokens)
     ):
@@ -352,7 +365,7 @@ def compress_after_tool_results(
                     final_response = _HANDOFF_SKIP_FINAL_RESPONSE
                 turn_exit_reason = "compaction_handoff_not_actionable"
                 return _verdict(True)
-    elif agent.compression_enabled:
+    elif agent.compression_enabled and not _native_auto:
         # Over threshold but compression blocked (cooldown/anti-thrash): deduped
         # warning so context can't silently overflow. ``attempts_spent`` names the
         # attempts_exhausted lockout when the engine says RUN but the per-turn

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1725,6 +1725,259 @@ def test_run_conversation_compresses_mid_turn_before_output_budget_exhaustion(mo
     assert len(requests) == 2
 
 
+# Native Responses compaction is deliberately armed below the local threshold.
+# These tests pin the missing ownership contract: automatic local compression
+# must let the eligible provider request go first, while ineligible routes keep
+# the existing local fallback.
+def _enable_native_compaction_for_test(agent):
+    agent.model = "gpt-5.6-sol"
+    agent.codex_responses_native_compaction = True
+    agent.compression_checkpoint_required = False
+    agent.runtime_capabilities = {"native_compaction": True}
+    agent.capabilities = {}
+
+
+def _large_preflight_history():
+    return [
+        {
+            "role": "user" if i % 2 == 0 else "assistant",
+            "content": "x" * 15_000,
+        }
+        for i in range(8)
+    ]
+
+
+def _record_compaction(calls):
+    def _fake(messages, system_message, **kwargs):
+        calls.append(kwargs.get("approx_tokens"))
+        return list(messages[-2:]), "You are Hermes."
+
+    return _fake
+
+
+@pytest.mark.parametrize(
+    "user_message",
+    [
+        "continue",
+        "[ASYNC DELEGATION BATCH COMPLETE — deleg_test]\nContinue after the delegated audit.",
+    ],
+)
+def test_native_compaction_owns_turn_prologue_threshold_before_local_preflight(
+    monkeypatch, user_message
+):
+    agent = _build_agent(monkeypatch)
+    _enable_native_compaction_for_test(agent)
+    agent.context_compressor.context_length = 40_000
+    agent.context_compressor.threshold_tokens = 20_000
+    monkeypatch.setattr(
+        agent.context_compressor,
+        "get_active_compression_failure_cooldown",
+        lambda: {"remaining_seconds": 60.0},
+    )
+    warnings = []
+    monkeypatch.setattr(
+        agent,
+        "_warn_context_overflow_blocked",
+        lambda *args: warnings.append(args),
+    )
+
+    requests = []
+    monkeypatch.setattr(
+        agent,
+        "_interruptible_api_call",
+        lambda kwargs: requests.append(kwargs) or _codex_message_response("done"),
+    )
+    compress_calls = []
+    monkeypatch.setattr(agent, "_compress_context", _record_compaction(compress_calls))
+
+    result = agent.run_conversation(
+        user_message, conversation_history=_large_preflight_history()
+    )
+
+    assert result["completed"] is True
+    assert compress_calls == []
+    assert warnings == []
+    assert requests[0]["context_management"] == [
+        {"type": "compaction", "compact_threshold": 11_808}
+    ]
+
+
+def test_native_compaction_owns_idle_threshold_before_local_compaction(monkeypatch):
+    import time
+
+    agent = _build_agent(monkeypatch)
+    _enable_native_compaction_for_test(agent)
+    agent.context_compressor.context_length = 200_000
+    agent.context_compressor.threshold_tokens = 100_000
+    agent.context_compressor.summary_target_ratio = 0.2
+    agent.compression_idle_compact_after_seconds = 1
+    agent._last_activity_ts = time.time() - 10
+
+    requests = []
+    monkeypatch.setattr(
+        agent,
+        "_interruptible_api_call",
+        lambda kwargs: requests.append(kwargs) or _codex_message_response("done"),
+    )
+    compress_calls = []
+    monkeypatch.setattr(agent, "_compress_context", _record_compaction(compress_calls))
+
+    result = agent.run_conversation(
+        "continue", conversation_history=_large_preflight_history()
+    )
+
+    assert result["completed"] is True
+    assert compress_calls == []
+    assert "context_management" in requests[0]
+
+
+def test_native_compaction_owns_midturn_pre_api_threshold(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    _enable_native_compaction_for_test(agent)
+    agent.context_compressor.context_length = 40_000
+    agent.context_compressor.threshold_tokens = 20_000
+
+    responses = [
+        _codex_tool_call_response(),
+        _codex_message_response("done"),
+    ]
+    responses[0].usage = SimpleNamespace(
+        input_tokens=18_000, output_tokens=4, total_tokens=18_004
+    )
+    requests = []
+    monkeypatch.setattr(
+        agent,
+        "_interruptible_api_call",
+        lambda kwargs: requests.append(kwargs) or responses.pop(0),
+    )
+
+    def _large_tool_result(assistant_message, messages, *_args, **_kwargs):
+        for call in assistant_message.tool_calls:
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": call.id,
+                    "content": "x" * 80_000,
+                }
+            )
+
+    compress_calls = []
+    monkeypatch.setattr(agent, "_execute_tool_calls", _large_tool_result)
+    monkeypatch.setattr(agent, "_compress_context", _record_compaction(compress_calls))
+
+    result = agent.run_conversation("do tool work")
+
+    assert result["completed"] is True
+    assert compress_calls == []
+    assert len(requests) == 2
+    assert all("context_management" in request for request in requests)
+
+
+def test_native_compaction_owns_post_response_threshold(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    _enable_native_compaction_for_test(agent)
+    agent.context_compressor.context_length = 40_000
+    agent.context_compressor.threshold_tokens = 20_000
+
+    responses = [
+        _codex_tool_call_response(),
+        _codex_message_response("done"),
+    ]
+    responses[0].usage = SimpleNamespace(
+        input_tokens=25_000, output_tokens=4, total_tokens=25_004
+    )
+    requests = []
+    monkeypatch.setattr(
+        agent,
+        "_interruptible_api_call",
+        lambda kwargs: requests.append(kwargs) or responses.pop(0),
+    )
+
+    def _small_tool_result(assistant_message, messages, *_args, **_kwargs):
+        for call in assistant_message.tool_calls:
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": call.id,
+                    "content": "ok",
+                }
+            )
+
+    compress_calls = []
+    monkeypatch.setattr(agent, "_execute_tool_calls", _small_tool_result)
+    monkeypatch.setattr(agent, "_compress_context", _record_compaction(compress_calls))
+
+    result = agent.run_conversation("do tool work")
+
+    assert result["completed"] is True
+    assert compress_calls == []
+    assert len(requests) == 2
+    assert all("context_management" in request for request in requests)
+
+
+@pytest.mark.parametrize("case", ["disabled", "wrong-model", "checkpoint-required"])
+def test_ineligible_native_route_keeps_local_turn_prologue_preflight(monkeypatch, case):
+    agent = _build_agent(monkeypatch)
+    _enable_native_compaction_for_test(agent)
+    agent.context_compressor.context_length = 40_000
+    agent.context_compressor.threshold_tokens = 20_000
+    if case == "disabled":
+        agent.codex_responses_native_compaction = False
+    elif case == "wrong-model":
+        agent.model = "gpt-5.2"
+    else:
+        agent.compression_checkpoint_required = True
+
+    requests = []
+    monkeypatch.setattr(
+        agent,
+        "_interruptible_api_call",
+        lambda kwargs: requests.append(kwargs) or _codex_message_response("done"),
+    )
+    compress_calls = []
+    monkeypatch.setattr(agent, "_compress_context", _record_compaction(compress_calls))
+
+    result = agent.run_conversation(
+        "continue", conversation_history=_large_preflight_history()
+    )
+
+    assert result["completed"] is True
+    assert len(compress_calls) == 1
+    assert "context_management" not in requests[0]
+
+
+def test_native_compaction_keeps_local_provider_overflow_recovery(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    _enable_native_compaction_for_test(agent)
+    agent.context_compressor.context_length = 40_000
+    agent.context_compressor.threshold_tokens = 20_000
+
+    overflow = Exception("Request entity too large")
+    overflow.status_code = 413
+    responses = [overflow, _codex_message_response("recovered")]
+    requests = []
+
+    def _api_call(kwargs):
+        requests.append(kwargs)
+        response = responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _api_call)
+    compress_calls = []
+    monkeypatch.setattr(agent, "_compress_context", _record_compaction(compress_calls))
+
+    result = agent.run_conversation(
+        "continue", conversation_history=_large_preflight_history()
+    )
+
+    assert result["completed"] is True
+    assert result["final_response"] == "recovered"
+    assert len(compress_calls) == 1
+    assert len(requests) == 2
+
+
 def test_mid_turn_compaction_does_not_double_persist_in_place_rows(monkeypatch, tmp_path):
     """Mid-turn pre-API compaction must re-baseline the flush cursor.
 


### PR DESCRIPTION
## Summary
- let eligible native Codex Responses routes own automatic threshold compaction end to end
- reuse the exact route/capability gate that adds `context_management` to the provider request
- bypass local turn-start, idle, pre-API, and post-tool compaction only while that native owner exists
- preserve local recovery after provider-proven overflow and preserve existing behavior for ineligible routes and Codex app-server

## Context
This is a minimal forward-port of the behavior in #99447 onto the current split compaction architecture (`turn_context_compaction.py` and `turn_preflight.py`). #99447 is currently conflict-blocked against `main`.

## Verification
- `tests/run_agent/test_run_agent_codex_responses.py`: 72 passed
- `tests/run_agent/test_413_compression.py`: 29 passed
- `tests/agent/test_turn_context_compaction.py` + Codex app-server/gateway compaction suites: 27 passed
- `tests/run_agent/test_native_compaction.py` + `tests/agent/test_turn_context.py`: 94 passed
- `tests/run_agent/test_run_agent.py`: 282 passed; one unrelated pre-existing `_BarrierDB.flush_token_counts` test-double warning
- `ruff`, `py_compile`, and `git diff --check`: passed
- independent frozen-candidate review: PASS, no findings
