### PR TITLE
fix(photon): setup must enable the platform under gateway.platforms (#103050)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2034,11 +2034,29 @@ def _ensure_dict(parent: Dict[str, Any], key: str) -> Dict[str, Any]:
 
 def write_platform_config_field(
     platform_key: str, field_key: str, value: Any, *, raw: bool = False) -> None:
-    """Persist one scalar field under ``platforms.<platform_key>``.
+    """Persist one scalar field under ``gateway.platforms.<platform_key>``.
     ``raw=True`` (CLI setup flows) edits only the user's raw file; dashboard routes use the
-    default loaded-config path to keep their profile-scoped ``load_config`` behavior."""
+    default loaded-config path to keep their profile-scoped ``load_config`` behavior.
+    Hermes reads platform blocks only nested under ``gateway.platforms`` — a root-level
+    ``platforms`` key (what older setup flows wrote) is silently ignored, so the write
+    creates ``gateway`` when absent and preserves every other key in the config."""
     config = read_raw_config() if raw else load_config()
-    platforms = _ensure_dict(config, "platforms")
+    # Older buggy setup flows wrote the platform's block at the ROOT (``platforms.<key>``),
+    # where Hermes never reads it; fold that stray block under ``gateway.platforms`` before
+    # writing so the canonical block is the only one left and re-running setup converges.
+    stray = config.get("platforms")
+    if isinstance(stray, dict) and platform_key in stray:
+        gateway = _ensure_dict(config, "gateway")
+        platforms = _ensure_dict(gateway, "platforms")
+        block = stray[platform_key]
+        if isinstance(block, dict):
+            existing = platforms.get(platform_key)
+            platforms[platform_key] = {**(existing if isinstance(existing, dict) else {}), **block}
+        del stray[platform_key]
+        if not stray:
+            config.pop("platforms", None)
+    gateway = _ensure_dict(config, "gateway")
+    platforms = _ensure_dict(gateway, "platforms")
     _ensure_dict(platforms, platform_key)[field_key] = value
     save_config(config)
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1594,6 +1594,94 @@ feishu:
         assert raw["feishu"]["require_mention"] is True
 
 
+class TestWritePlatformConfigField:
+    """Regression for #103050: platform setup writes must land under ``gateway.platforms``,
+    never at the config root (``platforms.<key>``), or the gateway silently ignores them."""
+
+    def test_writes_under_existing_gateway_platforms(self, tmp_path):
+        body = """_config_version: 30
+gateway:
+  platforms:
+    line:
+      enabled: true
+    a2a:
+      enabled: true
+web:
+  backend: tavily
+"""
+        (tmp_path / "config.yaml").write_text(body, encoding="utf-8")
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            write_platform_config_field("photon", "enabled", True, raw=True)
+            raw = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+
+        # Canonical location has the new platform…
+        assert raw["gateway"]["platforms"]["photon"]["enabled"] is True
+        # …existing platforms and sibling sections are preserved…
+        assert raw["gateway"]["platforms"]["line"]["enabled"] is True
+        assert raw["gateway"]["platforms"]["a2a"]["enabled"] is True
+        assert raw["web"]["backend"] == "tavily"
+        # …and nothing was written at the root.
+        assert "platforms" not in raw
+
+    def test_creates_gateway_section_when_missing(self, tmp_path):
+        body = "_config_version: 30\nmodel:\n  provider: deepseek\n"
+        (tmp_path / "config.yaml").write_text(body, encoding="utf-8")
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            write_platform_config_field("photon", "enabled", True, raw=True)
+            raw = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+
+        assert raw["gateway"]["platforms"]["photon"]["enabled"] is True
+        assert "platforms" not in raw
+        assert raw["model"]["provider"] == "deepseek"
+
+    def test_idempotent_across_runs(self, tmp_path):
+        body = "_config_version: 30\ngateway:\n  platforms:\n    line:\n      enabled: true\n"
+        (tmp_path / "config.yaml").write_text(body, encoding="utf-8")
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            write_platform_config_field("photon", "enabled", True, raw=True)
+            first = (tmp_path / "config.yaml").read_text(encoding="utf-8")
+            write_platform_config_field("photon", "enabled", True, raw=True)
+            second = (tmp_path / "config.yaml").read_text(encoding="utf-8")
+            raw = yaml.safe_load(second)
+
+        assert raw["gateway"]["platforms"]["photon"]["enabled"] is True
+        # Re-running setup must not duplicate the platform block or rewrite the file.
+        assert second == first
+        assert len(raw["gateway"]["platforms"]) == 2
+
+    def test_migrates_stray_root_platforms_block(self, tmp_path):
+        # Older setup runs wrote ``platforms.photon`` at the root (never read); re-running
+        # setup must fold that block under gateway.platforms and drop the stray key.
+        body = """_config_version: 30
+gateway:
+  platforms:
+    line:
+      enabled: true
+platforms:
+  photon:
+    enabled: true
+"""
+        (tmp_path / "config.yaml").write_text(body, encoding="utf-8")
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            write_platform_config_field("photon", "enabled", True, raw=True)
+            raw = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+
+        assert raw["gateway"]["platforms"]["photon"]["enabled"] is True
+        assert raw["gateway"]["platforms"]["line"]["enabled"] is True
+        assert "platforms" not in raw
+
+    def test_dashboard_path_writes_under_gateway_platforms(self, tmp_path):
+        # Non-raw callers (dashboard platform toggles) resolve through load_config().
+        body = "_config_version: 30\nmodel:\n  provider: deepseek\n"
+        (tmp_path / "config.yaml").write_text(body, encoding="utf-8")
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            write_platform_config_field("whatsapp", "enabled", True)
+            raw = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+
+        assert raw["gateway"]["platforms"]["whatsapp"]["enabled"] is True
+        assert "platforms" not in raw
+
+
 class TestVerifyOnStopMigration:
     """v30 → v31: switch verify_on_stop OFF once, preserving explicit choices."""
 


### PR DESCRIPTION
Closes #103050

`hermes photon setup` printed a success message but wrote the `platforms:` block at the **config root** instead of under `gateway:`. The canonical read path is `gateway.platforms` (the root-level block is only a legacy fallback in `merge_platform_sections`), so the photon platform silently never loaded.

Root cause: the shared helper `write_platform_config_field()` in `hermes_cli/config.py` used by `photon setup` (raw write), the dashboard platform toggles, and `unauthorized_dm_behavior`.

Fix:
- `write_platform_config_field()` now writes to `gateway.platforms.<platform>.<field>`, creating the `gateway` / `platforms` sections when absent and preserving every other existing config key (including other keys already inside `gateway`).
- Idempotent: running setup twice does not duplicate or clobber.
- Migration of the bug's residue: a stale root-level `platforms.<platform>` block for the same platform key is folded under `gateway.platforms` and removed only once empty. Legacy root `platforms` blocks belonging to **other** platforms are left untouched (existing preservation tests still pass).

Validation:
- `pytest -q tests/hermes_cli/test_config.py -x` — 125 passed, 4 skipped (5 new tests cover the nested write, idempotency, and migration paths)
