### PR TITLE
fix(vision): hard wall-time cap for the whole vision_analyze chain

### DIFF
--- a/tests/tools/test_vision_hard_timeout.py
+++ b/tests/tools/test_vision_hard_timeout.py
@@ -1,0 +1,41 @@
+"""Hard wall-time cap for the whole vision_analyze call chain.
+
+Invariant: _handle_vision_analyze always returns within its configured hard
+timeout, even when every sub-step hangs. Sub-step timeouts stack (download 30s +
+encode + LLM 120s + retry paths), so a wedged provider could previously exceed
+any bound with no cancellation point (observed 362s wedge).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+
+import pytest
+
+from tools import vision_tools
+from tools.vision_tools import _handle_vision_analyze
+
+
+@pytest.mark.asyncio
+async def test_wedged_provider_returns_within_hard_timeout(monkeypatch):
+    """A sub-step that never completes must not hang the tool call.
+
+    Simulates the observed failure: provider call (or download) wedges with no
+    sub-step timeout firing — the chain has no outer bound without the fix.
+    """
+    async def _wedged_analysis(image_url, full_prompt, model, task_id=None, region=None):
+        await asyncio.Event().wait()  # never completes
+
+    monkeypatch.setattr(vision_tools, "_should_use_native_vision_fast_path", lambda: False)
+    monkeypatch.setattr(vision_tools, "vision_analyze_tool", _wedged_analysis)
+    monkeypatch.setattr(vision_tools, "_vision_hard_timeout", lambda: 0.2)
+
+    start = time.monotonic()
+    result = await _handle_vision_analyze({"image_url": "https://x/y.png", "question": "?"})
+    elapsed = time.monotonic() - start
+
+    data = json.loads(result)
+    assert data["success"] is False
+    assert "timed out" in data["error"].lower()
+    assert elapsed < 5, f"tool call took {elapsed:.1f}s with a 0.2s cap — no outer bound"

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -873,21 +873,61 @@ def _configured_aux_model(sections: tuple, env_vars: tuple) -> Optional[str]:
     return next((v for v in (os.getenv(e, "").strip() for e in env_vars) if v), None)
 
 
+def _vision_hard_timeout() -> float:
+    """Outer wall-time cap for the whole vision_analyze call chain.
+
+    Sub-steps carry their own timeouts (download 30s, encode bounded by
+    _MAX_BASE64_BYTES, LLM 120s) but they stack: a size-rejection retry
+    re-downloads nothing yet re-encodes and re-calls, and _call_vision_llm
+    retries once on empty content — a slow provider can legally exceed
+    2x120s + encode + a second resize. Observed in production: a wedged
+    provider call hung the tool call for 362s with no outer bound and no
+    cancellation point. Cap the whole chain so the caller always gets an
+    answer within a configurable ceiling (auxiliary.vision.hard_timeout,
+    default 180s).
+    """
+    try:
+        from hermes_cli.config import cfg_get, load_config
+        _ht = cfg_get(load_config(), "auxiliary", "vision", "hard_timeout")
+        if _ht is not None:
+            return float(_ht)
+    except Exception:
+        pass
+    return 180.0
+
+
 async def _handle_vision_analyze(args: Dict[str, Any], **kw: Any) -> str:
     image_url, question, region = args.get("image_url", ""), args.get("question", ""), args.get("region")
     task_id = kw.get("task_id")
-    # No concurrency gate around the whole analysis — the CPU burst is bounded inside the
-    # encode/resize step, so multi-image fan-out keeps full request concurrency.
-    if _should_use_native_vision_fast_path():
-        logger.info("vision_analyze: native fast path")
-        return await _vision_analyze_native(image_url, question, task_id=task_id, region=region)
 
-    # Legacy path: aux LLM describes the image and we return its text.
-    full_prompt = (
-        "Fully describe and explain everything about this image, then answer the "
-        f"following question:\n\n{question}")
-    model = _configured_aux_model(("vision",), ("AUXILIARY_VISION_MODEL",))
-    return await vision_analyze_tool(image_url, full_prompt, model, task_id=task_id, region=region)
+    async def _analyze() -> str:
+        # No concurrency gate around the whole analysis — the CPU burst is bounded inside the
+        # encode/resize step, so multi-image fan-out keeps full request concurrency.
+        if _should_use_native_vision_fast_path():
+            logger.info("vision_analyze: native fast path")
+            return await _vision_analyze_native(image_url, question, task_id=task_id, region=region)
+
+        # Legacy path: aux LLM describes the image and we return its text.
+        full_prompt = (
+            "Fully describe and explain everything about this image, then answer the "
+            f"following question:\n\n{question}")
+        model = _configured_aux_model(("vision",), ("AUXILIARY_VISION_MODEL",))
+        return await vision_analyze_tool(image_url, full_prompt, model, task_id=task_id, region=region)
+
+    try:
+        return await asyncio.wait_for(_analyze(), timeout=_vision_hard_timeout())
+    except asyncio.TimeoutError:
+        logger.error("vision_analyze hit the %.0fs hard timeout — image_url=%s",
+                     _vision_hard_timeout(), image_url[:80])
+        return json.dumps({
+            "success": False,
+            "error": "Vision analysis timed out (hard timeout)",
+            "analysis": (
+                "The vision analysis exceeded its total wall-time cap and was "
+                "cancelled. This happens with slow providers or very large "
+                "images. Retry, or lower auxiliary.vision.hard_timeout."
+            ),
+        }, indent=2, ensure_ascii=False)
 
 
 registry.register(


### PR DESCRIPTION
## Summary
- vision_analyze sub-step timeouts stack (download 30s + encode + LLM 120s + retry paths), so a wedged provider call could hang the tool indefinitely — observed 362s wedge in production with no outer bound and no cancellation point.
- Wraps the handler in `asyncio.wait_for` with a configurable ceiling: `auxiliary.vision.hard_timeout` (default 180s), falling back cleanly on config-parse errors.
- On timeout the tool returns a JSON failure result instead of hanging the conversation loop.

## Test plan
- [x] New invariant test proven **red on base, green on fix**: `tests/tools/test_vision_hard_timeout.py` — a sub-step that never completes must return failure within the cap, not hang (`scripts/run_tests.sh tests/tools/test_vision_hard_timeout.py`).
- [x] Full existing vision suite green with the fix: `test_vision_tools.py`, `test_vision_native_fast_path.py`, `test_vision_region.py`, `test_vision_scale_disclosure.py`, `test_computer_use_vision_routing.py` — 96 tests, 0 failures.

Follows the repo testing rules: invariant contract (returns within cap), not a change-detector; real `scripts/run_tests.sh` runner.