### PR TITLE
feat(memory): activate provider timing capabilities

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1387,7 +1387,7 @@ def _run_api_retry_loop(agent, s: _LoopState) -> Optional[Dict[str, Any]]:
     return None
 
 
-def run_conversation(
+def _run_conversation_impl(
     agent,
     user_message: Any,
     system_message: str = None,
@@ -1533,6 +1533,50 @@ def run_conversation(
         # future input can move to a clean session (#98722).
         result.update(error=_COMPRESSION_TIMEOUT_FINAL_RESPONSE, partial=True, compression_exhausted=True)
     return result
+
+
+def run_conversation(
+    agent,
+    user_message: Any,
+    system_message: str = None,
+    conversation_history: List[Dict[str, Any]] = None,
+    task_id: str = None,
+    stream_callback: Optional[callable] = None,
+    persist_user_message: Optional[Any] = None,
+    persist_user_timestamp: Optional[float] = None,
+    persist_user_display_kind: Optional[str] = None,
+    persist_user_display_metadata: Optional[Dict[str, Any]] = None,
+    persist_user_platform_id: Optional[str] = None,
+    moa_config: Optional[dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Run one complete turn under the provider-neutral timing lifecycle."""
+    from agent.turn_timing import finish_turn_timing, start_turn_timing
+
+    subject_message = persist_user_message if persist_user_message is not None else user_message
+    start_turn_timing(agent, subject_message, conversation_history=conversation_history)
+    result = None
+    escaped = None
+    try:
+        result = _run_conversation_impl(
+            agent,
+            user_message,
+            system_message,
+            conversation_history,
+            task_id,
+            stream_callback,
+            persist_user_message,
+            persist_user_timestamp,
+            persist_user_display_kind,
+            persist_user_display_metadata,
+            persist_user_platform_id,
+            moa_config,
+        )
+        return result
+    except BaseException as exc:
+        escaped = exc
+        raise
+    finally:
+        finish_turn_timing(agent, result, escaped)
 
 
 __all__ = ["run_conversation"]

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -586,6 +586,56 @@ class MemoryManager:
     def on_turn_start(self, turn_number: int, message: str, **kwargs) -> None:
         self._each_provider("on_turn_start failed", lambda p: p.on_turn_start(turn_number, message, **kwargs))
 
+    def feature_capabilities(self) -> Dict[str, Any]:
+        """Merge additive provider capabilities without making any one provider authoritative."""
+        merged: Dict[str, Any] = {}
+        for result in self._each_provider(
+            "feature_capabilities() failed", lambda p: p.feature_capabilities()
+        ):
+            if not isinstance(result, dict):
+                continue
+            for key, value in result.items():
+                if key == "contract_version":
+                    try:
+                        merged[key] = max(int(merged.get(key, 0)), int(value))
+                    except (TypeError, ValueError):
+                        continue
+                elif isinstance(value, bool):
+                    merged[key] = bool(merged.get(key)) or value
+        return merged
+
+    def on_turn_timing_start(self, turn_number: int, **kwargs) -> None:
+        self._each_provider(
+            "on_turn_timing_start failed",
+            lambda p: p.on_turn_timing_start(turn_number, **kwargs),
+        )
+
+    def on_turn_progress(self, turn_number: int, **kwargs) -> None:
+        self._each_provider(
+            "on_turn_progress failed", lambda p: p.on_turn_progress(turn_number, **kwargs)
+        )
+
+    def on_turn_finish(self, turn_number: int, **kwargs) -> None:
+        self._each_provider(
+            "on_turn_finish failed", lambda p: p.on_turn_finish(turn_number, **kwargs)
+        )
+
+    def estimate_turn(self, **kwargs) -> Optional[Dict[str, Any]]:
+        for result in self._each_provider(
+            "estimate_turn failed", lambda p: p.estimate_turn(**kwargs)
+        ):
+            if isinstance(result, dict) and result:
+                return result
+        return None
+
+    def abort_open_turns(self) -> None:
+        self._each_provider(
+            "abort_open_turns failed",
+            lambda p: p.abort_open_turns(),
+            providers=list(reversed(self._providers)),
+            level=logging.WARNING,
+        )
+
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         self._each_provider("on_session_end failed", lambda p: p.on_session_end(messages), level=logging.WARNING,
                             exc_info=True)
@@ -759,7 +809,8 @@ class MemoryManager:
         )
 
     def shutdown_all(self) -> None:
-        """Drain the background executor (bounded), then shut providers down in reverse order."""
+        """Close timing, drain background work, then shut providers down in reverse order."""
+        self.abort_open_turns()
         self._drain_sync_executor()
         self._each_provider("shutdown failed", lambda p: p.shutdown(), level=logging.WARNING,
                             providers=self._providers[::-1])

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -126,6 +126,26 @@ class MemoryProvider(ABC):
     def on_turn_start(self, turn_number: int, message: str, **kwargs) -> None:
         """Per-turn tick. kwargs may include remaining_tokens, model, platform, tool_count."""
 
+    def feature_capabilities(self) -> Dict[str, Any]:
+        """Optional default-on feature bundle advertised to the host."""
+        return {}
+
+    def on_turn_timing_start(self, turn_number: int, **kwargs) -> None:
+        """Open privacy-safe timing before normal turn setup."""
+
+    def on_turn_progress(self, turn_number: int, **kwargs) -> None:
+        """Observe a privacy-safe active/wait/rework phase transition."""
+
+    def on_turn_finish(self, turn_number: int, **kwargs) -> None:
+        """Close timing with a completed/failed/interrupted/incomplete outcome."""
+
+    def estimate_turn(self, **kwargs) -> Optional[Dict[str, Any]]:
+        """Return a structured aggregate estimate, or ``None`` when unavailable."""
+        return None
+
+    def abort_open_turns(self) -> None:
+        """Best-effort close of timing state during shutdown/session rotation."""
+
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """End-of-session extraction; fires only at real session boundaries, never per-turn."""
 

--- a/agent/turn_api_call.py
+++ b/agent/turn_api_call.py
@@ -65,7 +65,10 @@ def perform_api_call(
     interrupted: Any,
 ) -> ApiCallVerdict:
     """Issue the request (see ``_should_stream`` for the streaming decision)."""
+    from agent.turn_timing import progress_turn_timing
+
     response = None
+    progress_turn_timing(agent, "wait", iteration=api_call_count)
 
     def _verdict(action: str) -> ApiCallVerdict:
         return ApiCallVerdict(
@@ -131,6 +134,7 @@ def perform_api_call(
             api_call_count=api_call_count, middleware_trace=list(_llm_middleware_trace),
         )
     finally:
+        progress_turn_timing(agent, "active", iteration=api_call_count)
         with _bracket:
             if _model_request_active is not None:
                 _model_request_active.clear()

--- a/agent/turn_api_error.py
+++ b/agent/turn_api_error.py
@@ -133,6 +133,8 @@ def handle_api_error(
         return _verdict("continue")
 
     retry_count += 1
+    from agent.turn_timing import progress_turn_timing
+    progress_turn_timing(agent, "rework", iteration=api_call_count)
     elapsed_time = time.time() - api_start_time
     agent._touch_activity(f"API error recovery (attempt {retry_count}/{max_retries})")
 

--- a/agent/turn_timing.py
+++ b/agent/turn_timing.py
@@ -1,0 +1,166 @@
+"""Provider-neutral task timing lifecycle and human-readable ETA status.
+
+The host owns observation and display. Providers may persist only closed-domain
+metadata supplied here; raw user text never crosses the timing hooks.
+"""
+from __future__ import annotations
+
+import math
+import re
+import time
+from typing import Any, Dict, Optional
+
+_SUBJECTS = (
+    ("development", ("code", "debug", "test", "deploy", "git", "pull request", "코드", "개발", "버그", "배포", "테스트")),
+    ("scheduling", ("calendar", "schedule", "meeting", "일정", "캘린더", "미팅")),
+    ("health", ("health", "sleep", "workout", "doctor", "건강", "수면", "운동", "병원")),
+    ("research", ("research", "paper", "compare", "investigate", "리서치", "연구", "논문", "조사")),
+    ("operations", ("install", "configure", "server", "restart", "monitor", "설치", "설정", "서버", "재시작", "모니터")),
+)
+
+
+def classify_timing_subject(message: Any) -> str:
+    """Collapse raw input immediately into a small allowlisted task class."""
+    text = str(message or "").lower()
+    for subject, terms in _SUBJECTS:
+        for term in terms:
+            if re.search(r"(?<![\w가-힣]){}(?![\w가-힣])".format(re.escape(term)), text):
+                return subject
+    return "general"
+
+
+def _format_duration(milliseconds: int) -> str:
+    seconds = max(1, int(math.ceil(milliseconds / 1000)))
+    if seconds < 60:
+        return "{} sec".format(seconds)
+    minutes = int(math.ceil(seconds / 60))
+    if minutes < 60:
+        return "{} min".format(minutes)
+    hours = minutes / 60
+    return "{:.1f} hr".format(hours).rstrip("0").rstrip(".")
+
+
+def _safe_emit(agent: Any, text: str) -> None:
+    try:
+        agent._emit_status(text)
+    except Exception:
+        pass
+
+
+def start_turn_timing(
+    agent: Any,
+    user_message: Any,
+    *,
+    conversation_history: Optional[list] = None,
+) -> Optional[Dict[str, Any]]:
+    manager = getattr(agent, "_memory_manager", None)
+    if manager is None:
+        return None
+    history_turns = sum(
+        1 for item in (conversation_history or [])
+        if isinstance(item, dict) and item.get("role") == "user"
+    )
+    turn_number = max(int(getattr(agent, "_user_turn_count", 0) or 0), history_turns) + 1
+    subject = classify_timing_subject(user_message)
+    platform = str(getattr(agent, "platform", None) or "cli")
+    state: Dict[str, Any] = {
+        "turn_number": turn_number,
+        "subject": subject,
+        "platform": platform,
+        "started_monotonic": time.monotonic(),
+        "estimate": None,
+        "last_remaining_announcement": None,
+    }
+    agent._turn_timing = state
+    try:
+        manager.on_turn_timing_start(
+            turn_number,
+            session_id=str(getattr(agent, "session_id", None) or ""),
+            platform=platform,
+            subject=subject,
+        )
+        estimate = manager.estimate_turn(platform=platform, subject=subject)
+        if isinstance(estimate, dict) and int(estimate.get("sample_count", 0) or 0) >= 5:
+            recommended = int(estimate.get("recommended_ms") or estimate.get("p80_ms") or 0)
+            if recommended > 0:
+                state["estimate"] = dict(estimate, recommended_ms=recommended)
+                _safe_emit(agent, "⏱ Estimated total time: about {}".format(_format_duration(recommended)))
+    except Exception:
+        pass
+    return state
+
+
+def progress_turn_timing(
+    agent: Any,
+    phase: str,
+    *,
+    iteration: int = 0,
+    announce_remaining: bool = False,
+) -> None:
+    state = getattr(agent, "_turn_timing", None)
+    manager = getattr(agent, "_memory_manager", None)
+    if not isinstance(state, dict) or manager is None:
+        return
+    try:
+        manager.on_turn_progress(
+            state["turn_number"],
+            session_id=str(getattr(agent, "session_id", None) or ""),
+            phase=phase,
+            iteration=max(0, int(iteration)),
+        )
+    except Exception:
+        pass
+    estimate = state.get("estimate")
+    if not announce_remaining or not isinstance(estimate, dict):
+        return
+    elapsed_ms = max(0, int((time.monotonic() - state["started_monotonic"]) * 1000))
+    remaining_ms = max(0, int(estimate["recommended_ms"]) - elapsed_ms)
+    rendered = _format_duration(remaining_ms)
+    if rendered == state.get("last_remaining_announcement"):
+        return
+    state["last_remaining_announcement"] = rendered
+    _safe_emit(agent, "⏱ Estimated time remaining: about {}".format(rendered))
+
+
+def _outcome(result: Any, escaped: Optional[BaseException], agent: Any) -> str:
+    if escaped is not None:
+        if isinstance(escaped, (KeyboardInterrupt, SystemExit, InterruptedError)) or type(escaped).__name__ == "CancelledError":
+            return "interrupted"
+        return "failed"
+    if not isinstance(result, dict):
+        return "incomplete"
+    if result.get("interrupted") or getattr(agent, "_interrupt_requested", False):
+        return "interrupted"
+    if result.get("failed") or result.get("error"):
+        return "failed"
+    if result.get("completed") is True:
+        return "completed"
+    return "incomplete"
+
+
+def finish_turn_timing(
+    agent: Any,
+    result: Any = None,
+    escaped: Optional[BaseException] = None,
+) -> None:
+    state = getattr(agent, "_turn_timing", None)
+    manager = getattr(agent, "_memory_manager", None)
+    try:
+        if isinstance(state, dict) and manager is not None:
+            manager.on_turn_finish(
+                state["turn_number"],
+                session_id=str(getattr(agent, "session_id", None) or ""),
+                outcome=_outcome(result, escaped, agent),
+            )
+    except Exception:
+        pass
+    finally:
+        agent._turn_timing = None
+
+
+__all__ = [
+    "classify_timing_subject",
+    "finish_turn_timing",
+    "progress_turn_timing",
+    "start_turn_timing",
+]

--- a/agent/turn_tool_round.py
+++ b/agent/turn_tool_round.py
@@ -150,6 +150,10 @@ def run_tool_round(
             agent.stream_delta_callback(None)
 
     agent._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
+    from agent.turn_timing import progress_turn_timing
+    progress_turn_timing(
+        agent, "active", iteration=api_call_count, announce_remaining=True
+    )
 
     if getattr(agent, "_incremental_persistence_failed", False):
         # Tool result could not be made canonical: never send the in-memory result to

--- a/tests/agent/test_memory_provider_auto_features.py
+++ b/tests/agent/test_memory_provider_auto_features.py
@@ -1,0 +1,160 @@
+from types import SimpleNamespace
+
+import pytest
+
+from agent.memory_manager import MemoryManager
+from agent.turn_timing import (
+    finish_turn_timing,
+    progress_turn_timing,
+    start_turn_timing,
+)
+
+
+class TimingProvider:
+    name = "timing"
+
+    def __init__(self, estimate=None, fail=None):
+        self.events = []
+        self.estimate = estimate
+        self.fail = fail
+
+    def feature_capabilities(self):
+        return {"contract_version": 1, "adaptive_eta": True, "remaining_time": True}
+
+    def on_turn_timing_start(self, turn, **kwargs):
+        if self.fail == "start":
+            raise RuntimeError("start failed")
+        self.events.append(("start", turn, kwargs))
+
+    def on_turn_progress(self, turn, **kwargs):
+        if self.fail == "progress":
+            raise RuntimeError("progress failed")
+        self.events.append(("progress", turn, kwargs))
+
+    def on_turn_finish(self, turn, **kwargs):
+        if self.fail == "finish":
+            raise RuntimeError("finish failed")
+        self.events.append(("finish", turn, kwargs))
+
+    def estimate_turn(self, **kwargs):
+        if self.fail == "estimate":
+            raise RuntimeError("estimate failed")
+        return self.estimate
+
+    def abort_open_turns(self):
+        self.events.append(("abort",))
+
+
+def _manager(*providers):
+    manager = MemoryManager.__new__(MemoryManager)
+    manager._providers = list(providers)
+    return manager
+
+
+def _agent(manager):
+    emitted = []
+    return SimpleNamespace(
+        _memory_manager=manager,
+        session_id="private-session",
+        _user_turn_count=0,
+        platform="telegram",
+        _emit_status=emitted.append,
+        _turn_timing=None,
+        _interrupt_requested=False,
+        emitted=emitted,
+    )
+
+
+def test_manager_exposes_capabilities_and_isolates_optional_hook_failures():
+    broken = TimingProvider(fail="start")
+    healthy = TimingProvider(estimate={"sample_count": 5, "recommended_ms": 300_000})
+    manager = _manager(broken, healthy)
+
+    assert manager.feature_capabilities()["remaining_time"] is True
+    manager.on_turn_timing_start(1, subject="development")
+    assert healthy.events[0][0] == "start"
+    assert manager.estimate_turn(subject="development")["recommended_ms"] == 300_000
+
+
+def test_start_and_progress_emit_human_readable_total_and_remaining(monkeypatch):
+    provider = TimingProvider(
+        estimate={
+            "sample_count": 8,
+            "recommended_ms": 600_000,
+            "p50_ms": 300_000,
+            "p80_ms": 480_000,
+            "confidence": "medium",
+            "critical_path": "development",
+        }
+    )
+    agent = _agent(_manager(provider))
+    clock = iter([100.0, 220.0])
+    monkeypatch.setattr("agent.turn_timing.time.monotonic", lambda: next(clock))
+
+    state = start_turn_timing(agent, "Please debug and deploy this code")
+    assert state is not None
+    assert agent.emitted == ["⏱ Estimated total time: about 10 min"]
+    progress_turn_timing(agent, "active", iteration=2, announce_remaining=True)
+    assert agent.emitted[-1] == "⏱ Estimated time remaining: about 8 min"
+    assert "private-session" not in repr(agent.emitted)
+
+
+def test_insufficient_samples_silently_records_without_fake_eta():
+    agent = _agent(_manager(TimingProvider(estimate=None)))
+    state = start_turn_timing(agent, "research this")
+    assert state is not None
+    assert agent.emitted == []
+    assert state["subject"] == "research"
+
+
+def test_finish_classifies_every_exit_and_clears_state():
+    provider = TimingProvider()
+    agent = _agent(_manager(provider))
+    start_turn_timing(agent, "deploy this")
+    finish_turn_timing(agent, {"completed": False, "interrupted": True})
+    assert provider.events[-1][2]["outcome"] == "interrupted"
+    assert agent._turn_timing is None
+
+    start_turn_timing(agent, "deploy this")
+    finish_turn_timing(agent, None, RuntimeError("boom"))
+    assert provider.events[-1][2]["outcome"] == "failed"
+    assert agent._turn_timing is None
+
+
+def test_feature_failures_never_block_the_agent_turn():
+    agent = _agent(_manager(TimingProvider(fail="estimate")))
+    assert start_turn_timing(agent, "do operations") is not None
+    progress_turn_timing(agent, "wait", iteration=1, announce_remaining=True)
+    finish_turn_timing(agent, {"completed": True})
+
+
+def test_real_conversation_entrypoint_always_closes_timing(monkeypatch):
+    import agent.conversation_loop as loop
+
+    provider = TimingProvider()
+    agent = _agent(_manager(provider))
+    monkeypatch.setattr(
+        loop,
+        "_run_conversation_impl",
+        lambda *_args, **_kwargs: {"completed": True, "final_response": "ok"},
+    )
+
+    result = loop.run_conversation(agent, "deploy this")
+    assert result["completed"] is True
+    assert [event[0] for event in provider.events] == ["start", "finish"]
+
+
+def test_real_conversation_entrypoint_closes_escaped_exception(monkeypatch):
+    import agent.conversation_loop as loop
+
+    provider = TimingProvider()
+    agent = _agent(_manager(provider))
+
+    def explode(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(loop, "_run_conversation_impl", explode)
+    with pytest.raises(RuntimeError, match="boom"):
+        loop.run_conversation(agent, "research this")
+    assert provider.events[-1][0] == "finish"
+    assert provider.events[-1][2]["outcome"] == "failed"

--- a/website/docs/developer-guide/memory-provider-plugin.md
+++ b/website/docs/developer-guide/memory-provider-plugin.md
@@ -125,10 +125,35 @@ class MyMemoryProvider(MemoryProvider):
 | `prefetch(query, *, session_id="")` | Before each API call | Return recalled context |
 | `queue_prefetch(query, *, session_id="")` | After each turn | Pre-warm for next turn |
 | `sync_turn(user, assistant, *, session_id="", messages=None)` | After each completed turn | Persist conversation |
+| `feature_capabilities()` | Agent startup/status | Advertise default-on additive features |
+| `on_turn_timing_start(turn_number, **kwargs)` | Before turn setup | Open privacy-safe task timing |
+| `on_turn_progress(turn_number, **kwargs)` | Active/wait/rework transition | Record phase timing |
+| `estimate_turn(**kwargs)` | Turn start and progress | Return aggregate ETA metadata |
+| `on_turn_finish(turn_number, **kwargs)` | Every turn exit | Close timing with an outcome |
+| `abort_open_turns()` | Shutdown or destructive session rotation | Repair/abort open timing state |
 | `on_session_end(messages)` | Conversation ends | Final extraction/flush |
 | `on_pre_compress(messages)` | Before context compression | Save insights before discard |
 | `on_memory_write(action, target, content)` | Built-in memory writes | Mirror to your backend |
 | `shutdown()` | Process exit | Clean up connections |
+
+### Automatic task timing and ETA
+
+Providers may advertise `adaptive_eta`, `remaining_time`, and `phase_learning`
+through `feature_capabilities()`. Hermes then calls the timing hooks automatically;
+no provider-specific host code is required. The host owns task classification,
+clocks, status delivery, and outcome classification. Providers own only their
+private aggregate evidence.
+
+Timing hooks receive closed-domain `platform`, `subject`, `phase`, and `outcome`
+values plus an opaque session identifier. Providers must not persist raw prompts,
+tool arguments, credentials, or absolute paths. `estimate_turn()` should return
+`None` until it has enough completed samples and must exclude failed,
+interrupted, incomplete, and aborted runs from its cohort.
+
+Hermes treats every timing hook as best-effort. Provider failures are logged but
+never block the model response, tools, or another memory provider. On shutdown,
+`abort_open_turns()` runs before provider teardown so append-only ledgers can
+repair child phases before closing their parent task.
 
 ## Pre-Compress Checkpoints (fail-closed)
 


### PR DESCRIPTION
## Summary
- discover optional memory-provider feature capabilities
- report adaptive ETA and remaining-time updates through the turn lifecycle
- isolate provider hook failures so Hermes continues normally
- document the provider capability contract

## Verification
- `python -m pytest -q tests/agent/test_memory_provider_auto_features.py` — 7 passed
- full Hermes suite is running with the project-recommended `-o 'addopts='` settings
