### PR TITLE
fix(email): give cron reports dated subjects

### DIFF
--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -1308,14 +1308,15 @@ def _seed_live_delivery_sessions(t: _TargetDelivery, delivered_message_id) -> No
 
 
 def _deliver_via_live_adapter(
-    t: _TargetDelivery, cleaned_text: str, media_files: list, *, target_errors: list,
-    delivery_errors: list, unverified_targets: list,
+    t: _TargetDelivery, cleaned_text: str, media_files: list, *, delivery_metadata: dict,
+    target_errors: list, delivery_errors: list, unverified_targets: list,
 ) -> bool:
     """Deliver one target via the live gateway adapter; True once delivered. ``target_errors`` =
     this lane's soft failures (surfaced only if standalone also fails); ``delivery_errors`` =
     partial failures (media, thread fallback) that surface even on success."""
     job = t.job
     route_thread_id, route_metadata, media_metadata = _live_route_metadata(t)
+    route_metadata = {**(route_metadata or {}), **delivery_metadata}
     delivered = False
     try:
         # Send cleaned text (MEDIA tags stripped) through the gateway's DeliveryRouter so it gets
@@ -1373,7 +1374,8 @@ def _deliver_via_live_adapter(
 
 
 def _standalone_send(
-    t: _TargetDelivery, content: str, media_files: list) -> tuple[Any, Optional[str]]:
+    t: _TargetDelivery, content: str, media_files: list, delivery_metadata: dict,
+) -> tuple[Any, Optional[str]]:
     """Run the standalone sender for one target: ``(result, None)`` or ``(None, error)`` (already
     logged — WARNING for a shutdown race, ERROR with traceback otherwise)."""
     from tools.send_message_tool import _send_to_platform
@@ -1383,7 +1385,7 @@ def _standalone_send(
     def _send():
         return _send_to_platform(
             t.platform, t.pconfig, t.chat_id, content, thread_id=t.thread_id,
-            media_files=media_files)
+            media_files=media_files, metadata=delivery_metadata)
 
     def _warned(msg: str) -> tuple[None, str]:
         logger.warning("Job '%s': %s", job["id"], msg)
@@ -1429,7 +1431,8 @@ def _standalone_send(
 
 
 def _deliver_standalone(
-    t: _TargetDelivery, content: str, media_files: list, target_errors: list, delivery_errors: list,
+    t: _TargetDelivery, content: str, media_files: list, delivery_metadata: dict,
+    target_errors: list, delivery_errors: list,
 ) -> None:
     """Standalone fallback for a target the live lane did not deliver."""
     job = t.job
@@ -1439,7 +1442,7 @@ def _deliver_standalone(
             target_errors.append(f"relay delivery to {t.where} failed")
         delivery_errors.extend(target_errors)
         return
-    result, err = _standalone_send(t, content, media_files)
+    result, err = _standalone_send(t, content, media_files, delivery_metadata)
     if err is None and result and result.get("error"):
         # Not inside an except block — the error comes from the result dict, no traceback.
         err = f"delivery error: {result['error']} (target {t.where})"
@@ -1627,8 +1630,9 @@ def _deliver_result(
     # Targets acked with NO evidence (bare SendResult(success=True) — Slack/Matrix/Mattermost);
     # persisted as ``last_delivery_unverified`` so `hermes cron list` shows it.
     unverified_targets: list = []
+    task_name = job.get("name", job["id"])
+    delivery_metadata = {"hermes_cron_delivery": {"subject": task_name}}
     if wrap_response:
-        task_name = job.get("name", job["id"])
         delivery_content = (
             f"Cronjob Response: {task_name}\n"
             f"(job_id: {job.get('id', '')})\n"
@@ -1692,13 +1696,13 @@ def _deliver_result(
             continue
         target_errors: list = []
         delivered = t.live_adapter_ready and _deliver_via_live_adapter(
-            t, cleaned_delivery_content, media_files,
+            t, cleaned_delivery_content, media_files, delivery_metadata=delivery_metadata,
             target_errors=target_errors, delivery_errors=delivery_errors,
             unverified_targets=unverified_targets,
         )
         if not delivered:
             _deliver_standalone(
-                t, cleaned_delivery_content, media_files, target_errors, delivery_errors)
+                t, cleaned_delivery_content, media_files, delivery_metadata, target_errors, delivery_errors)
 
     # Filter-time drops apply to every target; report them once.
     delivery_errors.extend(policy_drop_errors)

--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -1478,7 +1478,11 @@ def _prepare_target_delivery(
 
     origin = _resolve_origin(job) or {}
     origin_thread = origin.get("thread_id")
-    if origin_thread and not thread_id:
+    same_origin_conversation = (
+        origin.get("platform") == platform_name
+        and str(origin.get("chat_id") or "") == str(chat_id)
+    )
+    if origin_thread and not thread_id and same_origin_conversation:
         logger.warning(
             "Job '%s': origin has thread_id=%s but delivery target lost it (deliver=%s, target=%s)",
             job["id"], origin_thread, job.get("deliver", "local"), target)

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -3,6 +3,7 @@ receives, SMTP sends. Configured via EMAIL_* env vars or ``platforms.email`` in 
 
 import asyncio
 import email as email_lib
+from datetime import date
 from contextlib import contextmanager, suppress
 import imaplib
 import logging
@@ -52,6 +53,15 @@ _HTML_SUBS = ((re.compile(r"<br\s*/?>", re.IGNORECASE), "\n"), (re.compile(r"<p[
 # "method=result" tokens (``dmarc=pass``) and property values (``header.from=x``) in Authentication-Results.
 _AUTH_METHOD_RE = re.compile(r"\b(dmarc|dkim|spf)\s*=\s*([a-z]+)", re.IGNORECASE)
 _AUTH_PROP_RE = re.compile(r"\b(header\.from|header\.d|smtp\.mailfrom|smtp\.from|envelope-from)\s*=\s*([^\s;]+)", re.IGNORECASE)
+_CRON_DELIVERY_SUBJECT_RE = re.compile(r"^Cronjob Response:\s*(.+?)\s*$", re.MULTILINE)
+
+
+def _standalone_subject(message: str, delivery_date: str | None = None) -> str:
+    """Choose a fresh, dated subject for an independently delivered cron run."""
+    match = _CRON_DELIVERY_SUBJECT_RE.search(message)
+    if not match:
+        return "Hermes Agent"
+    return f"{match.group(1)} — {delivery_date or date.today().isoformat()}"
 
 
 def _esecret_int(name: str, default: int) -> int:
@@ -652,10 +662,14 @@ class EmailAdapter(BasePlatformAdapter):
                    attach_empty_body: bool = False) -> Tuple[MIMEMultipart, str, str]:
         """Build a threaded reply skeleton. Returns ``(msg, msg_id, subject)``."""
         msg, ctx = MIMEMultipart(), self._thread_context.get(to_addr, {})
-        subject = ctx.get("subject", "Hermes Agent")
-        if not subject.startswith("Re:"):
-            subject = f"Re: {subject}"
-        original_msg_id = reply_to_msg_id or ctx.get("message_id")
+        is_cron_delivery = _CRON_DELIVERY_SUBJECT_RE.search(body) is not None
+        if is_cron_delivery:
+            subject, original_msg_id = _standalone_subject(body), None
+        else:
+            subject = ctx.get("subject", "Hermes Agent")
+            if not subject.startswith("Re:"):
+                subject = f"Re: {subject}"
+            original_msg_id = reply_to_msg_id or ctx.get("message_id")
         threading = (("In-Reply-To", original_msg_id), ("References", original_msg_id)) if original_msg_id else ()
         msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._message_id_domain()}>"
         for key, value in (("From", self._address), ("To", to_addr), ("Subject", subject), *threading,
@@ -758,7 +772,7 @@ async def _standalone_send(pconfig, chat_id, message, *, thread_id=None, media_f
         return {"error": "Email not configured (EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_SMTP_HOST required)"}
     try:
         msg = MIMEText(message, "plain", "utf-8")
-        for key, value in (("From", address), ("To", chat_id), ("Subject", "Hermes Agent"), ("Date", formatdate(localtime=True))):
+        for key, value in (("From", address), ("To", chat_id), ("Subject", _standalone_subject(message)), ("Date", formatdate(localtime=True))):
             msg[key] = value
         server = _open_smtp(smtp_host, smtp_port, smtp_security, _tls_context(smtp_tls_verify, smtp_host), smtplib.SMTP, smtplib.SMTP_SSL)
         server.login(address, password)

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -53,15 +53,16 @@ _HTML_SUBS = ((re.compile(r"<br\s*/?>", re.IGNORECASE), "\n"), (re.compile(r"<p[
 # "method=result" tokens (``dmarc=pass``) and property values (``header.from=x``) in Authentication-Results.
 _AUTH_METHOD_RE = re.compile(r"\b(dmarc|dkim|spf)\s*=\s*([a-z]+)", re.IGNORECASE)
 _AUTH_PROP_RE = re.compile(r"\b(header\.from|header\.d|smtp\.mailfrom|smtp\.from|envelope-from)\s*=\s*([^\s;]+)", re.IGNORECASE)
-_CRON_DELIVERY_SUBJECT_RE = re.compile(r"^Cronjob Response:\s*(.+?)\s*$", re.MULTILINE)
-
-
-def _standalone_subject(message: str, delivery_date: str | None = None) -> str:
-    """Choose a fresh, dated subject for an independently delivered cron run."""
-    match = _CRON_DELIVERY_SUBJECT_RE.search(message)
-    if not match:
-        return "Hermes Agent"
-    return f"{match.group(1)} — {delivery_date or date.today().isoformat()}"
+def _cron_delivery_subject(metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+    """Return a standalone subject only for an explicitly marked cron delivery."""
+    delivery = (metadata or {}).get("hermes_cron_delivery")
+    if not isinstance(delivery, dict):
+        return None
+    subject = str(delivery.get("subject") or "").strip()
+    if not subject:
+        return None
+    delivery_date = str(delivery.get("date") or date.today().isoformat()).strip()
+    return f"{subject} — {delivery_date}"
 
 
 def _esecret_int(name: str, default: int) -> int:
@@ -652,19 +653,19 @@ class EmailAdapter(BasePlatformAdapter):
 
     async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
         """Send an email reply to the given address."""
-        return await self._run_send(self._send_email, (chat_id, content, reply_to), "[Email] Send failed to %s: %s", chat_id)
+        return await self._run_send(self._send_email, (chat_id, content, reply_to, metadata), "[Email] Send failed to %s: %s", chat_id)
 
     def _message_id_domain(self) -> str:
         """Domain for generated Message-IDs; ``localhost`` when EMAIL_ADDRESS lacks ``@``."""
         return (self._address.rsplit("@", 1)[-1] if "@" in self._address else "") or "localhost"
 
     def _new_reply(self, to_addr: str, body: str, reply_to_msg_id: Optional[str] = None, *,
-                   attach_empty_body: bool = False) -> Tuple[MIMEMultipart, str, str]:
+                   metadata: Optional[Dict[str, Any]] = None, attach_empty_body: bool = False) -> Tuple[MIMEMultipart, str, str]:
         """Build a threaded reply skeleton. Returns ``(msg, msg_id, subject)``."""
         msg, ctx = MIMEMultipart(), self._thread_context.get(to_addr, {})
-        is_cron_delivery = _CRON_DELIVERY_SUBJECT_RE.search(body) is not None
-        if is_cron_delivery:
-            subject, original_msg_id = _standalone_subject(body), None
+        cron_subject = _cron_delivery_subject(metadata)
+        if cron_subject:
+            subject, original_msg_id = cron_subject, None
         else:
             subject = ctx.get("subject", "Hermes Agent")
             if not subject.startswith("Re:"):
@@ -691,9 +692,10 @@ class EmailAdapter(BasePlatformAdapter):
             except Exception:
                 smtp.close()
 
-    def _send_email(self, to_addr: str, body: str, reply_to_msg_id: Optional[str] = None) -> str:
+    def _send_email(self, to_addr: str, body: str, reply_to_msg_id: Optional[str] = None,
+                    metadata: Optional[Dict[str, Any]] = None) -> str:
         """Send an email via SMTP. Runs in executor thread."""
-        msg, msg_id, subject = self._new_reply(to_addr, body, reply_to_msg_id, attach_empty_body=True)
+        msg, msg_id, subject = self._new_reply(to_addr, body, reply_to_msg_id, metadata=metadata, attach_empty_body=True)
         self._smtp_send(msg)
         logger.info("[Email] Sent reply to %s (subject: %s)", to_addr, subject)
         return msg_id
@@ -761,7 +763,8 @@ class EmailAdapter(BasePlatformAdapter):
 
 
 # Plugin glue: register() exposes the platform via the registry; EMAIL_* env → PlatformConfig seeding stays in core.
-async def _standalone_send(pconfig, chat_id, message, *, thread_id=None, media_files=None, force_document=False):
+async def _standalone_send(pconfig, chat_id, message, *, thread_id=None, media_files=None, force_document=False,
+                           metadata=None):
     """Out-of-process Email delivery via SMTP (one-shot); standalone_sender_fn contract."""
     extra = getattr(pconfig, "extra", {}) or {}
     address, password = extra.get("address") or _get_secret("EMAIL_ADDRESS", ""), _get_secret("EMAIL_PASSWORD", "")
@@ -772,7 +775,8 @@ async def _standalone_send(pconfig, chat_id, message, *, thread_id=None, media_f
         return {"error": "Email not configured (EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_SMTP_HOST required)"}
     try:
         msg = MIMEText(message, "plain", "utf-8")
-        for key, value in (("From", address), ("To", chat_id), ("Subject", _standalone_subject(message)), ("Date", formatdate(localtime=True))):
+        subject = _cron_delivery_subject(metadata) or "Hermes Agent"
+        for key, value in (("From", address), ("To", chat_id), ("Subject", subject), ("Date", formatdate(localtime=True))):
             msg[key] = value
         server = _open_smtp(smtp_host, smtp_port, smtp_security, _tls_context(smtp_tls_verify, smtp_host), smtplib.SMTP, smtplib.SMTP_SSL)
         server.login(address, password)

--- a/tests/cron/test_cron_delivery_thread_warning.py
+++ b/tests/cron/test_cron_delivery_thread_warning.py
@@ -1,0 +1,57 @@
+"""Cron thread-loss warnings only apply to the origin conversation."""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+
+def _prepare(job, target):
+    from cron import scheduler_delivery as delivery
+
+    original = delivery._resolve_target_transport
+    delivery._resolve_target_transport = lambda *_args, **_kwargs: (
+        ("standalone", SimpleNamespace(extra={}), None, {}), None
+    )
+    try:
+        return delivery._prepare_target_delivery(
+            job,
+            target,
+            adapters=None,
+            loop=None,
+            config=SimpleNamespace(),
+            notify_delivery=True,
+            mirror_enabled=False,
+            mirror_text="report",
+            delivery_errors=[],
+        )
+    finally:
+        delivery._resolve_target_transport = original
+
+
+def test_cross_platform_target_without_thread_is_not_a_lost_origin_thread(caplog):
+    job = {
+        "id": "daily-report",
+        "deliver": "email",
+        "origin": {"platform": "discord", "chat_id": "discord-thread-parent", "thread_id": "42"},
+    }
+
+    with caplog.at_level(logging.WARNING, logger="cron.scheduler_delivery"):
+        target = _prepare(job, {"platform": "email", "chat_id": "grant@example.com", "thread_id": None})
+
+    assert target is not None
+    assert "delivery target lost it" not in caplog.text
+
+
+def test_same_conversation_target_without_thread_still_warns(caplog):
+    job = {
+        "id": "daily-report",
+        "deliver": "discord",
+        "origin": {"platform": "discord", "chat_id": "discord-thread-parent", "thread_id": "42"},
+    }
+
+    with caplog.at_level(logging.WARNING, logger="cron.scheduler_delivery"):
+        target = _prepare(job, {"platform": "discord", "chat_id": "discord-thread-parent", "thread_id": None})
+
+    assert target is not None
+    assert "delivery target lost it" in caplog.text

--- a/tests/cron/test_scheduler_shutdown_guard.py
+++ b/tests/cron/test_scheduler_shutdown_guard.py
@@ -103,6 +103,9 @@ class TestStandaloneDeliverySkipsDuringShutdown:
             result = _deliver_result(job, "daily report body")
 
         send_mock.assert_called_once()
+        assert send_mock.call_args.kwargs["metadata"] == {
+            "hermes_cron_delivery": {"subject": "model-governor"}
+        }
         assert result is None
 
 

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -382,6 +382,21 @@ class TestThreadContext(unittest.TestCase):
             self.assertEqual(send_call["References"], "<original@test.com>")
             self.assertIn("Date", send_call)
 
+    def test_cron_text_without_scheduler_metadata_remains_threaded(self):
+        """An ordinary reply must not be reclassified from its body text."""
+        adapter = self._make_adapter()
+        adapter._thread_context["user@test.com"] = {
+            "subject": "Project question",
+            "message_id": "<original@test.com>",
+        }
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+            adapter._send_email("user@test.com", "Cronjob Response: quoted text", None)
+        sent = mock_server.send_message.call_args[0][0]
+        self.assertEqual(sent["Subject"], "Re: Project question")
+        self.assertEqual(sent["In-Reply-To"], "<original@test.com>")
+
 
 class TestSendMethods(unittest.TestCase):
     """Test email send methods."""
@@ -839,18 +854,12 @@ class TestSendEmailStandalone(unittest.TestCase):
         "EMAIL_SMTP_HOST": "smtp.test.com",
         "EMAIL_SMTP_PORT": "587",
     })
-    def test_cron_delivery_uses_a_dated_non_reply_subject(self):
-        """Standalone scheduled reports must not collapse into one email thread."""
+    def test_cron_metadata_uses_a_dated_non_reply_subject(self):
+        """Only explicit scheduler metadata may make a standalone email a new report."""
         import asyncio
         from types import SimpleNamespace
         from plugins.platforms.email.adapter import _standalone_send as email_send
-        from plugins.platforms.email.adapter import _standalone_subject
 
-        content = "Cronjob Response: Daily Hermes log health check\nbody"
-        self.assertEqual(
-            _standalone_subject(content, "2026-09-04"),
-            "Daily Hermes log health check — 2026-09-04",
-        )
         with patch("plugins.platforms.email.adapter._open_smtp") as open_smtp:
             server = MagicMock()
             open_smtp.return_value = server
@@ -858,13 +867,15 @@ class TestSendEmailStandalone(unittest.TestCase):
                 email_send(
                     SimpleNamespace(extra={"address": "hermes@test.com", "smtp_host": "smtp.test.com"}),
                     "user@test.com",
-                    content,
+                    "unwrapped report body",
+                    metadata={"hermes_cron_delivery": {"subject": "Daily Hermes log health check", "date": "2026-09-04"}},
                 )
             )
         self.assertTrue(result["success"])
         sent = server.send_message.call_args.args[0]
-        self.assertRegex(sent["Subject"], r"^Daily Hermes log health check — \d{4}-\d{2}-\d{2}$")
+        self.assertEqual(sent["Subject"], "Daily Hermes log health check — 2026-09-04")
         self.assertNotIn("In-Reply-To", sent)
+        self.assertNotIn("References", sent)
 
 
 class TestSmtpConnectionCleanup(unittest.TestCase):

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -833,6 +833,39 @@ class TestSendEmailStandalone(unittest.TestCase):
             self.assertEqual(send_call["To"], "user@test.com")
             self.assertEqual(send_call["From"], "hermes@test.com")
 
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_SMTP_HOST": "smtp.test.com",
+        "EMAIL_SMTP_PORT": "587",
+    })
+    def test_cron_delivery_uses_a_dated_non_reply_subject(self):
+        """Standalone scheduled reports must not collapse into one email thread."""
+        import asyncio
+        from types import SimpleNamespace
+        from plugins.platforms.email.adapter import _standalone_send as email_send
+        from plugins.platforms.email.adapter import _standalone_subject
+
+        content = "Cronjob Response: Daily Hermes log health check\nbody"
+        self.assertEqual(
+            _standalone_subject(content, "2026-09-04"),
+            "Daily Hermes log health check — 2026-09-04",
+        )
+        with patch("plugins.platforms.email.adapter._open_smtp") as open_smtp:
+            server = MagicMock()
+            open_smtp.return_value = server
+            result = asyncio.run(
+                email_send(
+                    SimpleNamespace(extra={"address": "hermes@test.com", "smtp_host": "smtp.test.com"}),
+                    "user@test.com",
+                    content,
+                )
+            )
+        self.assertTrue(result["success"])
+        sent = server.send_message.call_args.args[0]
+        self.assertRegex(sent["Subject"], r"^Daily Hermes log health check — \d{4}-\d{2}-\d{2}$")
+        self.assertNotIn("In-Reply-To", sent)
+
 
 class TestSmtpConnectionCleanup(unittest.TestCase):
     """Verify SMTP connections are closed even when send_message raises."""

--- a/tools/send_message_senders.py
+++ b/tools/send_message_senders.py
@@ -321,10 +321,11 @@ def _plugin_standalone_sender(platform_name, *, label=None, discover=True):
     return entry.standalone_sender_fn, None
 
 
-async def _registry_standalone_send(platform_name, pconfig, chat_id, message, thread_id=None):
+async def _registry_standalone_send(platform_name, pconfig, chat_id, message, thread_id=None, metadata=None):
     """One-shot text send through a plugin's ``standalone_sender_fn``."""
     sender, err = _plugin_standalone_sender(platform_name)
-    return err or await sender(pconfig, chat_id, message, thread_id=thread_id)
+    kwargs = {"metadata": metadata} if platform_name == "email" and metadata else {}
+    return err or await sender(pconfig, chat_id, message, thread_id=thread_id, **kwargs)
 
 
 async def _resolve_slack_user_target(token, chat_id):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -469,7 +469,8 @@ _TEXT_SENDERS = {
 _MEDIA_PLATFORMS_NOTE = "telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp and slack"
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, args=None):
+async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None,
+                            force_document=False, args=None, metadata=None):
     """Route to the platform sender, chunking long text with the adapters' splitter. Order matters:
     Weixin first (its native helper must not be blocked by unrelated optional imports such as
     lark-oapi), Telegram (chunks itself), plugin standalone media, native chunked, generic text."""
@@ -505,7 +506,11 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                    f"native send_message media delivery is currently only supported for {_MEDIA_PLATFORMS_NOTE}")
     text_sender = _TEXT_SENDERS.get(platform_name)
     if text_sender is not None:
-        send_one = lambda chunk, is_last: text_sender(pconfig, chat_id, chunk, thread_id)  # noqa: E731
+        if platform_name == "email":
+            send_one = lambda chunk, is_last: text_sender(  # noqa: E731
+                pconfig, chat_id, chunk, thread_id, metadata=metadata)
+        else:
+            send_one = lambda chunk, is_last: text_sender(pconfig, chat_id, chunk, thread_id)  # noqa: E731
     else:
         from gateway.platform_registry import platform_registry
         entry = platform_registry.get(platform_name)


### PR DESCRIPTION
## Summary
- Mark every scheduler delivery explicitly with `hermes_cron_delivery` metadata, including when `cron.wrap_response: false`.
- The Email adapter uses that metadata to create a dated, standalone report email with no reply headers.
- Normal email messages retain their existing thread behavior regardless of body text.

## Validation
- `python -m unittest tests.gateway.test_email` — 41 passed
- `uvx --from pytest --with PyYAML pytest tests/cron/test_scheduler_shutdown_guard.py -q` — 7 passed