### PR TITLE
fix(kanban): default verifier goal_max_turns to 40 on spawn

### DIFF
--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -1568,11 +1568,28 @@ def _dispatch_lane_task(
     if claimed.workspace_kind == "worktree":
         _kbw.set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
     _kbw._maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
+    # Spawn-time default budget for verifier/goal-loop cards (see
+    # ``_apply_default_verifier_goal_max_turns``). Returns the
+    # effective value so the spawn log line below shows the resolved
+    # budget; the helper is idempotent so a second tick on the same
+    # claim is a no-op.
+    effective_goal_max = _apply_default_verifier_goal_max_turns(conn, claimed)
+    if effective_goal_max is not None and claimed.goal_max_turns is None:
+        # The helper persisted a default; refresh the in-memory view
+        # so the env-var wiring in ``_default_spawn`` reflects it.
+        claimed = _kb.get_task(conn, claimed.id) or claimed
     if lane == "review":
         # Force-load sdlc-review; the kanban lifecycle is already in every
         # worker's system prompt via KANBAN_GUIDANCE.
         claimed.skills = list(dict.fromkeys([*(claimed.skills or []), "sdlc-review"]))
     try:
+        if claimed.goal_mode:
+            _kb._log.info(
+                "kanban dispatcher: spawning goal_mode task %s assignee=%r goal_budget=%s",
+                claimed.id,
+                claimed.assignee,
+                claimed.goal_max_turns if claimed.goal_max_turns is not None else "default",
+            )
         pid = _call_spawn_fn(spawn_fn if spawn_fn is not None else _default_spawn, claimed, str(workspace), board)
         if pid:
             _set_worker_pid(conn, claimed.id, int(pid))
@@ -2158,6 +2175,84 @@ def _restart_safe_worker_argv(task: Task, command: list[str]) -> list[str]:
         command,
         unit_suffix=f"kanban-{task.id}-run-{task.current_run_id}",
     )
+
+
+# Spawn-time default budget for verifier/goal-loop cards.
+# A goal_mode card with ``goal_max_turns`` unset inherits 150 iterations
+# from the goals engine — far more than a stuck verify run needs, and the
+# growing context burns context-window budget every iteration. For
+# review-style cards the empirically-right cap is ~40; we apply that
+# default at spawn time (idempotent against explicit overrides) so future
+# review/verify cards land with the right budget without manual capping.
+#
+# Trigger rule (matches the dispatcher-side spec, see t_bb181168):
+#   - card is goal_mode AND ``goal_max_turns`` is currently NULL, AND
+#   - assignee == "reviewer" OR title starts with one of
+#     {"Verify", "Re-verify", "Review"}.
+_DEFAULT_VERIFIER_GOAL_MAX_TURNS = 40
+_VERIFIER_TITLE_PREFIXES: tuple[str, ...] = (
+    "Verify",
+    "Re-verify",
+    "Review",
+)
+
+
+def _is_verifier_card(task) -> bool:
+    """Return True if ``task`` matches the spawn-time verifier/goal rule.
+
+    Matching is case-sensitive against the spec text; case-insensitive
+    matching would over-match ("verify" in prose mid-title) and is not
+    what the spec asks for.
+    """
+    if not task.goal_mode:
+        return False
+    if task.goal_max_turns is not None:
+        return False
+    if (task.assignee or "").strip() == "reviewer":
+        return True
+    title = (task.title or "").lstrip()
+    for prefix in _VERIFIER_TITLE_PREFIXES:
+        if title.startswith(prefix):
+            return True
+    return False
+
+
+def _apply_default_verifier_goal_max_turns(conn: sqlite3.Connection, task) -> Optional[int]:
+    """Persist the verifier-default budget for matching cards.
+
+    Returns the effective ``goal_max_turns`` value the spawn should use
+    (either the resolved default or the explicit override) so callers
+    can log it without re-reading the DB. Returns ``None`` for non-goal
+    cards or cards whose rule doesn't match (caller leaves the value
+    untouched and the worker falls back to the goals-engine default).
+
+    The UPDATE is gated on ``goal_max_turns IS NULL`` so an explicit
+    override set after create is never stomped; the helper is also
+    idempotent across dispatcher ticks because the second tick sees
+    the column non-NULL.
+    """
+    if not task.goal_mode:
+        return None
+    if task.goal_max_turns is not None:
+        return int(task.goal_max_turns)
+    if not _is_verifier_card(task):
+        return None
+    with _kb.write_txn(conn):
+        # Row-level guard: only stamp when the column is still NULL. A
+        # concurrent dispatcher tick or a post-create override that
+        # arrived between get_task() and here wins.
+        conn.execute(
+            "UPDATE tasks SET goal_max_turns = ? WHERE id = ? AND goal_max_turns IS NULL",
+            (_DEFAULT_VERIFIER_GOAL_MAX_TURNS, task.id),
+        )
+    _kb._log.info(
+        "kanban dispatcher: applied verifier default goal_max_turns=%d for task %s (assignee=%r title=%r)",
+        _DEFAULT_VERIFIER_GOAL_MAX_TURNS,
+        task.id,
+        task.assignee,
+        (task.title or "")[:80],
+    )
+    return _DEFAULT_VERIFIER_GOAL_MAX_TURNS
 
 
 def _default_spawn(task: Task, workspace: str, *, board: Optional[str] = None) -> Optional[int]:

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -22,6 +22,7 @@ from hermes_cli import kanban_db_connect as kbc
 from hermes_cli import goals
 
 
+
 @pytest.fixture
 def kanban_home(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
@@ -35,7 +36,6 @@ def kanban_home(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 # DB layer
 # ---------------------------------------------------------------------------
-
 
 
 
@@ -95,7 +95,6 @@ def test_legacy_db_migrates_goal_columns(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-
 # ---------------------------------------------------------------------------
 # Goal loop logic (callback-injected, no live model)
 # ---------------------------------------------------------------------------
@@ -127,7 +126,6 @@ def test_loop_stops_when_worker_already_completed(monkeypatch):
     )
     assert res["outcome"] == "completed_by_worker"
     assert turns == []  # no extra turns
-
 
 
 
@@ -224,3 +222,192 @@ class TestCLIJudgeGate:
         assert complete_calls == [], "an unachievable goal must never reach complete_task"
         assert "unachievable" in err.lower()
         assert "kanban block" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Verifier / goal-loop budget default (t_bb181168)
+# ---------------------------------------------------------------------------
+
+
+class TestVerifierGoalBudgetDefault:
+    """Spawn-time default ``goal_max_turns=40`` for verifier-style cards.
+
+    Verifier-style = goal_mode AND ``goal_max_turns`` NULL AND
+    (assignee==\"reviewer\" OR title starts with Verify / Re-verify / Review).
+    Default applies via a one-shot UPDATE gated on ``goal_max_turns IS
+    NULL`` so explicit overrides and idempotency across ticks are
+    preserved.
+    """
+
+    def _create_task(self, conn, *, title, assignee, goal_mode=True, goal_max_turns=None):
+        return kb.create_task(
+            conn,
+            title=title,
+            body="x",
+            assignee=assignee,
+            goal_mode=goal_mode,
+            goal_max_turns=goal_max_turns,
+        )
+
+    def test_reviewer_assignee_gets_default(self, kanban_home):
+        from hermes_cli.kanban_db_dispatch import (
+            _apply_default_verifier_goal_max_turns,
+            _DEFAULT_VERIFIER_GOAL_MAX_TURNS,
+        )
+
+        with kbc.connect() as conn:
+            tid = self._create_task(conn, title="Ship the patch", assignee="reviewer")
+            task = kb.get_task(conn, tid)
+            assert task.goal_max_turns is None
+            effective = _apply_default_verifier_goal_max_turns(conn, task)
+            assert effective == _DEFAULT_VERIFIER_GOAL_MAX_TURNS == 40
+            assert kb.get_task(conn, tid).goal_max_turns == 40
+
+    def test_verify_title_prefix_gets_default(self, kanban_home):
+        from hermes_cli.kanban_db_dispatch import _apply_default_verifier_goal_max_turns
+
+        with kbc.connect() as conn:
+            tid = self._create_task(conn, title="Verify auth flow", assignee="engineer")
+            task = kb.get_task(conn, tid)
+            assert _apply_default_verifier_goal_max_turns(conn, task) == 40
+            assert kb.get_task(conn, tid).goal_max_turns == 40
+
+    def test_re_verify_title_prefix_gets_default(self, kanban_home):
+        from hermes_cli.kanban_db_dispatch import _apply_default_verifier_goal_max_turns
+
+        with kbc.connect() as conn:
+            tid = self._create_task(
+                conn, title="Re-verify regression suite", assignee="engineer"
+            )
+            task = kb.get_task(conn, tid)
+            assert _apply_default_verifier_goal_max_turns(conn, task) == 40
+            assert kb.get_task(conn, tid).goal_max_turns == 40
+
+    def test_review_title_prefix_gets_default(self, kanban_home):
+        from hermes_cli.kanban_db_dispatch import _apply_default_verifier_goal_max_turns
+
+        with kbc.connect() as conn:
+            tid = self._create_task(
+                conn, title="Review the PR diff", assignee="engineer"
+            )
+            task = kb.get_task(conn, tid)
+            assert _apply_default_verifier_goal_max_turns(conn, task) == 40
+            assert kb.get_task(conn, tid).goal_max_turns == 40
+
+    def test_explicit_override_is_not_stomped(self, kanban_home):
+        from hermes_cli.kanban_db_dispatch import _apply_default_verifier_goal_max_turns
+
+        with kbc.connect() as conn:
+            tid = self._create_task(
+                conn,
+                title="Verify auth flow",
+                assignee="reviewer",
+                goal_max_turns=12,
+            )
+            task = kb.get_task(conn, tid)
+            assert _apply_default_verifier_goal_max_turns(conn, task) == 12
+            assert kb.get_task(conn, tid).goal_max_turns == 12
+
+    def test_non_goal_mode_skipped(self, kanban_home):
+        from hermes_cli.kanban_db_dispatch import _apply_default_verifier_goal_max_turns
+
+        with kbc.connect() as conn:
+            tid = self._create_task(
+                conn,
+                title="Verify something",
+                assignee="reviewer",
+                goal_mode=False,
+            )
+            task = kb.get_task(conn, tid)
+            assert _apply_default_verifier_goal_max_turns(conn, task) is None
+            assert kb.get_task(conn, tid).goal_max_turns is None
+
+    def test_non_matching_goal_mode_left_null(self, kanban_home):
+        from hermes_cli.kanban_db_dispatch import _apply_default_verifier_goal_max_turns
+
+        with kbc.connect() as conn:
+            tid = self._create_task(
+                conn,
+                title="Investigate flaky test",
+                assignee="engineer",
+            )
+            task = kb.get_task(conn, tid)
+            assert _apply_default_verifier_goal_max_turns(conn, task) is None
+            assert kb.get_task(conn, tid).goal_max_turns is None
+
+    def test_idempotent_on_second_call(self, kanban_home):
+        from hermes_cli.kanban_db_dispatch import _apply_default_verifier_goal_max_turns
+
+        with kbc.connect() as conn:
+            tid = self._create_task(conn, title="Verify login", assignee="reviewer")
+            task = kb.get_task(conn, tid)
+            assert _apply_default_verifier_goal_max_turns(conn, task) == 40
+            task2 = kb.get_task(conn, tid)
+            assert _apply_default_verifier_goal_max_turns(conn, task2) == 40
+            assert kb.get_task(conn, tid).goal_max_turns == 40
+
+    def test_spawned_task_carries_default_through_dispatch_once(
+        self, kanban_home, all_assignees_spawnable, monkeypatch, caplog
+    ):
+        """Claim + spawn path stamps 40 and logs ``goal_budget=40``."""
+        import logging
+
+        from hermes_cli import kanban_db_dispatch as kbd
+
+        monkeypatch.setattr(
+            kbd, "_system_memory_sample",
+            lambda: {"mem_available_kib": 8 * 1024 * 1024, "mem_total_kib": 16 * 1024 * 1024},
+        )
+
+        seen: list[tuple[str, object]] = []
+
+        def _stub_spawn(task, workspace, board=None):
+            seen.append((task.id, task.goal_max_turns))
+            return 4242
+
+        caplog.set_level(logging.INFO)
+        with kbc.connect() as conn:
+            tid = kb.create_task(
+                conn,
+                title="Verify smoke pack",
+                assignee="reviewer",
+                goal_mode=True,
+            )
+            res = kbd.dispatch_once(conn, spawn_fn=_stub_spawn)
+        assert tid in [row[0] for row in res.spawned]
+        assert seen == [(tid, 40)]
+        with kbc.connect() as conn:
+            assert kb.get_task(conn, tid).goal_max_turns == 40
+        assert any(
+            "goal_budget=40" in rec.getMessage() and tid in rec.getMessage()
+            for rec in caplog.records
+        )
+
+    def test_explicit_override_survives_dispatch_once(
+        self, kanban_home, all_assignees_spawnable, monkeypatch
+    ):
+        from hermes_cli import kanban_db_dispatch as kbd
+
+        monkeypatch.setattr(
+            kbd, "_system_memory_sample",
+            lambda: {"mem_available_kib": 8 * 1024 * 1024, "mem_total_kib": 16 * 1024 * 1024},
+        )
+        seen: list[tuple[str, object]] = []
+
+        def _stub_spawn(task, workspace, board=None):
+            seen.append((task.id, task.goal_max_turns))
+            return 4242
+
+        with kbc.connect() as conn:
+            tid = kb.create_task(
+                conn,
+                title="Verify smoke pack",
+                assignee="reviewer",
+                goal_mode=True,
+                goal_max_turns=80,
+            )
+            res = kbd.dispatch_once(conn, spawn_fn=_stub_spawn)
+        assert tid in [row[0] for row in res.spawned]
+        assert seen == [(tid, 80)]
+        with kbc.connect() as conn:
+            assert kb.get_task(conn, tid).goal_max_turns == 80


### PR DESCRIPTION
## Summary

Review/verify `goal_mode` cards with `goal_max_turns` NULL inherit the goals-engine default of 150 iterations. A stuck verify run burns 150 turns of growing context. This stamps `goal_max_turns=40` at spawn time when:

- the card is `goal_mode`, AND
- `goal_max_turns` is currently NULL, AND
- assignee is `reviewer` OR the title starts with `Verify` / `Re-verify` / `Review`.

An explicit `goal_max_turns` is never overwritten. The dispatcher spawn log now prints the resolved `goal_budget`.

No changes to auto_decompose, flow config, dispatcher caps, or role routing.

## Test plan

- [x] `TMPDIR=~/tmp .venv/bin/python -m pytest tests/hermes_cli/test_kanban_goal_mode.py -q` — 15 passed
- [ ] Review/verify card spawn log shows `goal_budget=40` when no explicit override exists
- [ ] Other goal_mode spawns with an explicit `goal_max_turns` keep that value
