### PR TITLE
fix(mem0): move _read_mem0_json import to fix ImportError during plugin load

### DIFF
--- a/plugins/memory/mem0/_setup.py
+++ b/plugins/memory/mem0/_setup.py
@@ -18,7 +18,6 @@ from typing import Any
 
 from hermes_constants import get_hermes_home  # noqa: F401 — patched by tests
 
-from . import _read_mem0_json
 from ._oss_providers import EMBEDDER_PROVIDERS, KNOWN_DIMS, LLM_PROVIDERS, SECTION_REGISTRIES, VECTOR_PROVIDERS, validate_oss_config
 
 _OLLAMA_URL = "http://localhost:11434"
@@ -170,6 +169,7 @@ def _persist_provider_config(hermes_home: str, config: dict, provider_config: di
 
 def _setup_platform(hermes_home: str, config: dict, flags: dict[str, str]) -> None:
     """Platform mode setup — prompts for API key (secret -> .env), user/agent ids and rerank (-> mem0.json)."""
+    from . import _read_mem0_json
     provider_config = _read_mem0_json(Path(hermes_home) / "mem0.json")
     print("\n  Configuring mem0:\n")
     env_writes = _api_key_writes(flags, "Mem0 Platform API key", url="https://app.mem0.ai")
@@ -205,6 +205,7 @@ def _check_selfhosted_server(host: str) -> None:
 
 def _setup_selfhosted(hermes_home: str, config: dict, flags: dict[str, str]) -> None:
     """Self-hosted mode — point at an existing Mem0 server: URL -> mem0.json, key -> .env (MEM0_API_KEY)."""
+    from . import _read_mem0_json
     provider_config = _read_mem0_json(Path(hermes_home) / "mem0.json")
     print("\n  Configuring mem0 (self-hosted server):\n")
     host = flags.get("host") or _prompt("Mem0 server URL (e.g. http://localhost:8888)", default=provider_config.get("host") or None)
@@ -237,6 +238,7 @@ def _print_oss_summary(oss_config: dict, env_writes: dict, dry_run: bool = False
 
 def _finish_oss(hermes_home: str, config: dict, oss_config: dict, env_writes: dict[str, str], user_id: str, agent_id: str, pgvector_config: dict | None = None) -> None:
     """Shared OSS tail: write secrets + mem0.json, install deps, activate, check, summarize."""
+    from . import _read_mem0_json
     if env_writes:
         _write_env(Path(hermes_home) / ".env", env_writes)
     config_path = Path(hermes_home) / "mem0.json"  # merge-write, plain text (platform path uses save_config's 0600 atomic write)


### PR DESCRIPTION
## What's wrong

Running `hermes memory setup mem0` (or `hermes memory setup` and picking mem0) crashes immediately:

```
Traceback (most recent call last):
  File ".../hermes-agent/hermes_cli/main.py", line ..., in main
    ...
  File ".../hermes-agent/plugins/memory/mem0/__init__.py", line 126, in post_setup
    from ._setup import post_setup
ImportError: cannot import name 'post_setup' from 'plugins.memory.mem0._setup'
```

The function exists at line 497 of `_setup.py`. The real failure is silent: the plugin loader runs sibling submodules before the parent package, so when `_setup.py:21` does `from . import _read_mem0_json`, Python finds an empty placeholder shell (the `__init__.py` hasn't run yet), the import fails, the loader swallows it at debug level, and `_setup.py` never finishes loading. `post_setup` is never defined, and the user only sees the misleading "cannot import name" error.

## Repro

```bash
curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
hermes memory setup mem0
```

Expected: interactive wizard starts.
Actual: `ImportError: cannot import name 'post_setup'`.

## What this does

Moves `from . import _read_mem0_json` from module-level into the three functions that use it. By the time any setup function runs, the parent package is fully loaded and the import works. Matches the late-import pattern `__init__.py` already uses for `post_setup`. 4 lines changed.