### PR TITLE
fix(search): make session titles searchable and surface them in results

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -258,7 +258,7 @@ const HEADER_NAV_BTN =
 
 // FTS results cover sessions that aren't in the loaded page; synthesize a
 // minimal SessionInfo so they render in the same row component (resume works
-// by id; the snippet stands in for the preview).
+// by id; the snippet stands in for the preview when the row has no title).
 
 // The backend's FTS layer wraps matched terms in literal '>>>' / '<<<'
 // highlight markers (sqlite snippet() delimiters — see hermes_state_search.py).
@@ -269,7 +269,7 @@ export function stripFtsMarkers(snippet: string): string {
   return snippet.replaceAll('>>>', '').replaceAll('<<<', '')
 }
 
-function searchResultToSession(result: SessionSearchResult): SessionInfo {
+export function searchResultToSession(result: SessionSearchResult): SessionInfo {
   const ts = result.session_started ?? Date.now() / 1000
 
   return {
@@ -287,7 +287,9 @@ function searchResultToSession(result: SessionSearchResult): SessionInfo {
     preview: stripFtsMarkers(result.snippet ?? '').trim() || null,
     source: result.source ?? null,
     started_at: ts,
-    title: null,
+    // Surface the conversation's own title (user/LLM assigned) instead of
+    // forcing null and showing only the content snippet.
+    title: result.title ?? null,
     tool_call_count: 0
   }
 }

--- a/apps/desktop/src/app/chat/sidebar/strip-fts-markers.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/strip-fts-markers.test.ts
@@ -4,7 +4,7 @@
 // rows titled ">>>foo<<<" (Aug 2026 desktop audit).
 import { describe, expect, it } from 'vitest'
 
-import { stripFtsMarkers } from './index'
+import { searchResultToSession, stripFtsMarkers } from './index'
 
 describe('stripFtsMarkers', () => {
   it('strips highlight markers around the matched term', () => {
@@ -23,5 +23,27 @@ describe('stripFtsMarkers', () => {
 
   it('handles empty string', () => {
     expect(stripFtsMarkers('')).toBe('')
+  })
+})
+
+describe('searchResultToSession', () => {
+  const result = {
+    model: 'test-model',
+    role: null,
+    session_id: '20260811_125725_5d4fac',
+    session_started: 1_760_000_000,
+    snippet: 'run buyer discovery',
+    source: 'desktop'
+  }
+
+  it('keeps a server-result title instead of replacing it with a content snippet', () => {
+    const session = searchResultToSession({ ...result, title: "Arby's Faribault, MN" })
+
+    expect(session.title).toBe("Arby's Faribault, MN")
+    expect(session.preview).toBe('run buyer discovery')
+  })
+
+  it('stays compatible with an older backend that omits title', () => {
+    expect(searchResultToSession(result).title).toBeNull()
   })
 })

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1224,6 +1224,8 @@ export interface SessionSearchResult {
   session_started: number | null
   snippet: string
   source: string | null
+  /** User/LLM-assigned title of the matched conversation, when present. */
+  title?: string | null
 }
 
 export interface SessionSearchResponse {

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -373,7 +373,36 @@ async def search_sessions(
                 tok if tok.startswith('"') or tok.endswith("*") else tok + "*"
                 for tok in re.findall(r'"[^"]*"|\S+', q.strip()))
             # Over-fetch so lineage dedup can still surface `limit` distinct
-            # conversations when several hits collapse onto one root.
+            # Title matches next: a user-named session (e.g. "Arby's Faribault,
+            # MN") is found by typing its title. The FTS index only covers
+            # message content, and the id matcher only matches the raw session
+            # id string — neither sees sessions.title. search_sessions_by_title
+            # is SQL-bounded (reuses list_sessions_rich's search_query filter)
+            # and runs after exact-id hits so a conversation that matches both
+            # collapses onto its lineage root exactly once.
+            for row in db.search_sessions_by_title(
+                q,
+                limit=safe_limit,
+                include_archived=True,
+                source=source_filter,
+                sources=source_list or None,
+                exclude_sources=exclude_list or None,
+            ):
+                sid = row.get("id")
+                preview = (row.get("preview") or "").strip()
+                title = (row.get("title") or "").strip()
+                snippet = preview or title or f"Session ID: {sid}"
+                add_lineage_result(
+                    sid,
+                    {
+                        "snippet": snippet,
+                        "role": None,
+                        "source": row.get("source"),
+                        "model": row.get("model"),
+                        "session_started": row.get("started_at"),
+                    },
+                )
+
             matches = db.search_messages(
                 query=prefix_query, source_filter=include_sources,
                 exclude_sources=exclude_list or None, limit=max(safe_limit * 5, 50),

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -1172,6 +1172,46 @@ class SessionSearchMixin:
         ranked = sorted(enumerate(candidates), key=lambda item: (score(item[1]), item[0]))
         return [row for _, row in ranked[:limit]]
 
+    def search_sessions_by_title(
+        self, query: str, limit: int = 20, include_archived: bool = True, source: str = None,
+        sources: List[str] = None, exclude_sources: List[str] = None) -> List[Dict[str, Any]]:
+        """Search surfaced sessions by case-insensitive title substring.
+
+        Desktop search uses this so a user-named session (e.g. "Arby's Faribault,
+        MN") can be found by typing its title — the FTS content index does not
+        cover ``sessions.title``, and the id matcher only matches the raw id
+        string. This fills that gap by reusing ``list_sessions_rich``'s
+        ``search_query`` filter, which already matches title (and id) across
+        each conversation's forward compression chain, so a titled compression
+        root still resolves to its live continuation.
+        """
+        needle = (query or "").strip().lower()
+        if not needle or limit <= 0:
+            return []
+
+        # SQL-bounded like the id matcher: list_sessions_rich pushes the title
+        # LIKE filter into the query (matching the row's title AND every title
+        # in its forward compression chain), so we only materialize matching
+        # rows instead of scanning every session.
+        candidates = self.list_sessions_rich(
+            source=source, sources=sources, exclude_sources=exclude_sources, limit=max(limit * 4, limit),
+            offset=0, include_archived=include_archived, order_by_last_active=True, search_query=needle)
+
+        # Prefer exact-title and prefix-title matches over loose substrings so
+        # "Faribault" ranks a session literally titled "Arby's Faribault, MN"
+        # ahead of one where the word merely appears mid-title.
+        def score(row: Dict[str, Any]) -> int:
+            title = str(row.get("title") or "").lower()
+            if not title:
+                return 3
+            if title == needle:
+                return 0
+            if title.startswith(needle):
+                return 1
+            return 2 if needle in title else 3
+        ranked = sorted(enumerate(candidates), key=lambda item: (score(item[1]), item[0]))
+        return [row for _, row in ranked[:limit]]
+
     # ── FTS maintenance commands ───────────────────────────────────────────
 
     def _fts_table_exists(self, name: str) -> bool:

--- a/tests/hermes_cli/test_web_server_session_search.py
+++ b/tests/hermes_cli/test_web_server_session_search.py
@@ -40,8 +40,10 @@ class _FakeSessionDB:
         sources=None,
         exclude_sources=None,
     ):
-        assert query == "20260603"
+        assert query in ("20260603", "Arby's Faribault, MN")
         assert include_archived is True
+        if query != "20260603":
+            return []
         rows = [
             {
                 "id": "20260603_090200_exact",
@@ -59,6 +61,52 @@ class _FakeSessionDB:
             )
         ][:limit]
 
+    def search_sessions_by_title(
+        self,
+        query,
+        limit=20,
+        include_archived=True,
+        source=None,
+        sources=None,
+        exclude_sources=None,
+    ):
+        # In the id/content test this runs with "20260603" and must contribute
+        # nothing (no titled sessions); in the title test it runs with the title.
+        if query == "20260603":
+            return []
+        assert query == "Arby's Faribault, MN"
+        rows = [
+            {
+                "id": "titled_session",
+                "preview": "run buyer discovery",
+                "title": "Arby's Faribault, MN",
+                "source": "desktop",
+                "model": "gpt",
+                "started_at": 150,
+            }
+        ]
+        return [
+            row
+            for row in rows
+            if self._source_allowed(
+                row, source=source, sources=sources, exclude_sources=exclude_sources
+            )
+        ][:limit]
+
+    def get_session_rich_row(self, session_id):
+        # Lets add_lineage_result hydrate the title back into the payload.
+        if session_id == "titled_session":
+            return {
+                "id": "titled_session",
+                "source": "desktop",
+                "model": "gpt",
+                "title": "Arby's Faribault, MN",
+                "started_at": 150,
+                "last_active": 150,
+                "preview": "run buyer discovery",
+            }
+        return None
+
     def search_messages(
         self,
         query,
@@ -67,7 +115,8 @@ class _FakeSessionDB:
         limit=20,
         fields=None,
     ):
-        assert query == "20260603*"
+        # Accept the title query's prefix tokens too (Arby's* AND Faribault,* MN*).
+        assert query == "20260603*" or query.startswith("Arby")
         type(self).requested_fields = fields
         rows = [
             {
@@ -142,3 +191,24 @@ def test_desktop_session_search_merges_id_matches_before_content_matches(monkeyp
         ]
     }
     assert _FakeSessionDB.opened_read_only is True
+
+
+def test_desktop_session_search_surfaces_titled_session_by_title(monkeypatch):
+    """A user-named session is findable by typing its title. The FTS index
+    only covers message content and the id matcher only covers session ids, so
+    this is the path that makes a title-string search return the session — and
+    the result must carry the stored title through for the desktop row."""
+    _FakeSessionDB.opened_read_only = None
+    _FakeSessionDB.requested_fields = None
+    monkeypatch.setattr("hermes_state.SessionDB", _FakeSessionDB)
+
+    response = asyncio.run(_rt_sessions.search_sessions(q="Arby's Faribault, MN", limit=5))
+
+    assert _FakeSessionDB.opened_read_only is True
+    results = response["results"]
+    assert results[0]["id"] == "titled_session"
+    assert results[0]["title"] == "Arby's Faribault, MN"
+    # Content hits remain available after the title-priority result.
+    assert any(r.get("id") == "content_session" for r in results)
+    # The snippet falls back to the preview when the row carries a title.
+    assert results[0]["snippet"] == "run buyer discovery"

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4520,6 +4520,52 @@ class TestSessionIdSearch:
         assert [s["id"] for s in db.search_sessions_by_id("20260603")] == ["20260603_090200_abcd12"]
         assert [s["id"] for s in db.search_sessions_by_id("ABCD12")] == ["20260603_090200_abcd12"]
 
+    def test_search_sessions_by_title_matches_titled_sessions_case_insensitively(self, db):
+        """A user-named session is findable by its title, not just its id or
+        message content. The FTS index does not cover sessions.title, so this is
+        the path that makes "Arby's Faribault, MN" show up for that string."""
+        db.create_session(session_id="20260811_125725_5d4fac", source="desktop", model="test-model")
+        db.set_session_title("20260811_125725_5d4fac", "Arby's Faribault, MN")
+        db.append_message(session_id="20260811_125725_5d4fac", role="user", content="run buyer discovery")
+
+        db.create_session(session_id="20260811_125726_prefix", source="desktop", model="test-model")
+        db.set_session_title("20260811_125726_prefix", "Arby's Faribault, MN - diligence")
+        db.append_message(session_id="20260811_125726_prefix", role="user", content="title-only prefix match")
+
+        db.create_session(session_id="20260811_125727_substring", source="desktop", model="test-model")
+        db.set_session_title("20260811_125727_substring", "Diligence for Arby's Faribault, MN")
+        db.append_message(session_id="20260811_125727_substring", role="user", content="title-only substring match")
+
+        db.create_session(session_id="20260814_144119_a9d5d1", source="desktop", model="test-model")
+        db.set_session_title("20260814_144119_a9d5d1", "Arby's Antioch")
+        db.append_message(session_id="20260814_144119_a9d5d1", role="user", content="run buyer discovery")
+
+        # Untitled session must NOT match (no title).
+        db.create_session(session_id="20260818_100000_untitled", source="desktop", model="test-model")
+        db.append_message(session_id="20260818_100000_untitled", role="user", content="Faribault appears in content only")
+
+        # Exact title, title-prefix, then loose title-substring is the ranking
+        # contract used by Desktop before falling through to content hits.
+        exact = [s["id"] for s in db.search_sessions_by_title("Arby's Faribault, MN")]
+        assert exact == [
+            "20260811_125725_5d4fac",
+            "20260811_125726_prefix",
+            "20260811_125727_substring",
+        ]
+
+        # Case-insensitive substring matches every title containing the query.
+        all_arbys = [s["id"] for s in db.search_sessions_by_title("arby's")]
+        assert set(all_arbys) == {
+            "20260811_125725_5d4fac",
+            "20260811_125726_prefix",
+            "20260811_125727_substring",
+            "20260814_144119_a9d5d1",
+        }
+
+        # Word present only in message content, not in a title, does not match.
+        content_only = db.search_sessions_by_title("Faribault appears in content")
+        assert content_only == []
+
 
 
 


### PR DESCRIPTION
Fixes #66242 — session titles are now searchable from the desktop search bar.

**The bug:** `GET /api/sessions/search` only matched session IDs and FTS5 message content. A session named "Arby's Faribault, MN" could not be found by typing its title — the FTS index doesn't cover `sessions.title`, and the id matcher only matches raw id strings. The sidebar's client-side title filter couldn't compensate because it only sees the ~200 most-recent sessions (cron-heavy profiles push real conversations out of that window).

**The fix (two defects, one commit):**
1. **Titles were never searched** — adds `SessionDB.search_sessions_by_title()`, SQL-bounded via `list_sessions_rich`'s existing `search_query` filter (case-insensitive, compression-chain aware, ranks exact > prefix > substring), and wires it into `search_sessions()` between the ID and content passes, deduped by lineage root.
2. **Search results discarded the title** — the desktop `searchResultToSession()` mapper hard-coded `title: null` and used the content snippet as the label. The title now carries through `SessionSearchResult` so a titled session shows its name, not a raw file-path/JSON snippet.

**Verified against a live 2,600-session DB:** `q=Faribault` now returns "Arby's Faribault, MN"; `q=trackpad` returns both title matches. Tests: `test_web_server_session_search.py` (2 passed), `test_hermes_state.py` title tests (passed), `strip-fts-markers.test.ts` (6 passed).

Note: `test_search_projection_skips_context_enrichment_queries` fails on pristine `main` (pre-existing, unrelated — confirmed identical failure on an unmodified checkout).
