### PR TITLE
fix: use system manager scopes for root gateways

### DIFF
--- a/tests/cron/test_restart_safe_worker.py
+++ b/tests/cron/test_restart_safe_worker.py
@@ -16,6 +16,25 @@ from unittest.mock import Mock
 import pytest
 
 
+def _set_cgroup_topology(monkeypatch, manager):
+    """Make the runtime cgroup identify a user or system systemd manager."""
+    import tools.process_registry as process_registry
+
+    real_read_text = process_registry.Path.read_text
+    cgroup = (
+        "0::/user.slice/user-1000.slice/user@1000.service/app.slice/hermes.service\n"
+        if manager == "user"
+        else "0::/system.slice/hermes-gateway.service\n"
+    )
+
+    def read_text(path, *args, **kwargs):
+        if path == Path("/proc/self/cgroup"):
+            return cgroup
+        return real_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(process_registry.Path, "read_text", read_text)
+
+
 @pytest.fixture
 def execution_ledger(tmp_path, monkeypatch):
     import cron.executions as executions
@@ -78,17 +97,84 @@ def test_genuine_external_worker_crash_is_recovered_unknown(
 
 
 @pytest.mark.linux_only
-def test_restart_safe_gateway_child_fails_closed_without_scope(monkeypatch):
+@pytest.mark.parametrize(
+    ("manager", "uses_user_manager"),
+    [("user", True), ("system", False)],
+)
+def test_restart_safe_gateway_child_uses_its_cgroup_manager(
+    monkeypatch, manager, uses_user_manager
+):
+    """Cron workers must leave a user or system gateway through that manager."""
     import tools.process_registry as process_registry
 
     monkeypatch.setattr(process_registry, "_is_supervised_gateway_process", lambda: True)
     monkeypatch.setenv("INVOCATION_ID", "managed-service")
-    monkeypatch.setattr(process_registry, "_systemd_run_user_scope_available", lambda: False)
+    _set_cgroup_topology(monkeypatch, manager)
+    monkeypatch.setattr(
+        process_registry, "_systemd_run_scope_available", lambda _manager: True,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        process_registry, "_systemd_run_user_scope_available", lambda: True
+    )
+    monkeypatch.setattr("shutil.which", lambda _name: "/usr/bin/systemd-run")
 
-    with pytest.raises(RuntimeError, match="systemd-run --user --scope is unavailable"):
+    argv = process_registry.restart_safe_gateway_child_argv(
+        ["python", "worker.py"], unit_suffix="cron-job-1"
+    )
+
+    assert "--scope" in argv
+    assert ("--user" in argv) is uses_user_manager
+
+
+@pytest.mark.linux_only
+def test_restart_safe_gateway_child_fails_closed_when_its_manager_scope_is_unavailable(
+    monkeypatch,
+):
+    import tools.process_registry as process_registry
+
+    monkeypatch.setattr(process_registry, "_is_supervised_gateway_process", lambda: True)
+    monkeypatch.setenv("INVOCATION_ID", "managed-system-service")
+    _set_cgroup_topology(monkeypatch, "system")
+    monkeypatch.setattr(
+        process_registry, "_systemd_run_scope_available", lambda _manager: False,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        process_registry, "_systemd_run_user_scope_available", lambda: True
+    )
+
+    with pytest.raises(RuntimeError, match="systemd-run --scope is unavailable"):
         process_registry.restart_safe_gateway_child_argv(
             ["python", "worker.py"], unit_suffix="cron-job-1"
         )
+
+
+@pytest.mark.linux_only
+@pytest.mark.parametrize(
+    ("manager", "expected_prefix"),
+    [
+        ("user", ["/usr/bin/systemctl", "--user", "stop"]),
+        ("system", ["/usr/bin/systemctl", "stop"]),
+    ],
+)
+def test_systemd_scope_cleanup_uses_the_scope_manager(
+    monkeypatch, manager, expected_prefix
+):
+    """Scope cleanup must address the same manager used for worker creation."""
+    import tools.process_registry as process_registry
+
+    calls = []
+    _set_cgroup_topology(monkeypatch, manager)
+    monkeypatch.setattr("shutil.which", lambda _name: "/usr/bin/systemctl")
+    monkeypatch.setattr(
+        process_registry.subprocess,
+        "run",
+        lambda argv, **_kwargs: calls.append(argv) or subprocess.CompletedProcess(argv, 0),
+    )
+
+    assert process_registry._stop_systemd_unit("hermes-worker-cron.scope") is True
+    assert calls == [expected_prefix + ["hermes-worker-cron.scope"]]
 
 
 def test_restart_safe_gateway_child_is_unchanged_outside_managed_gateway(monkeypatch):

--- a/tests/hermes_cli/test_kanban_gateway_restart_handoff.py
+++ b/tests/hermes_cli/test_kanban_gateway_restart_handoff.py
@@ -14,6 +14,20 @@ from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_db_dispatch as kbd
 
 
+def _set_user_service_cgroup(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Model the user-service topology this handoff contract covers."""
+    import tools.process_registry as process_registry
+
+    real_read_text = process_registry.Path.read_text
+
+    def read_text(path: Path, *args, **kwargs) -> str:
+        if path == Path("/proc/self/cgroup"):
+            return "0::/user.slice/user-1000.slice/user@1000.service/app.slice/hermes.service\n"
+        return real_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(process_registry.Path, "read_text", read_text)
+
+
 @pytest.fixture
 def worker_setup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, kb.Task]:
     root = tmp_path / ".hermes"
@@ -54,9 +68,11 @@ def test_managed_gateway_worker_is_spawned_in_restart_safe_scope(
     worker_setup: tuple[Path, kb.Task], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     workspace, task = worker_setup
+    _set_user_service_cgroup(monkeypatch)
     captured_cmd: list[str] = []
     captured_env: dict[str, str] = {}
     captured_cwd: str | None = None
+    probed_managers: list[str] = []
 
     class FakeProc:
         pid = 4242
@@ -73,11 +89,15 @@ def test_managed_gateway_worker_is_spawned_in_restart_safe_scope(
     monkeypatch.setattr("agent.secret_scope.is_multiplex_active", lambda: True)
     monkeypatch.setattr(subprocess, "Popen", fake_popen)
     monkeypatch.setattr("tools.process_registry._is_supervised_gateway_process", lambda: True)
-    monkeypatch.setattr("tools.process_registry._systemd_run_user_scope_available", lambda: True)
+    monkeypatch.setattr(
+        "tools.process_registry._systemd_run_scope_available",
+        lambda manager: probed_managers.append(manager) or True,
+    )
     monkeypatch.setattr("tools.process_registry._worker_memory_max_bytes", lambda: 536_870_912)
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
 
     assert kbd._default_spawn(task, str(workspace)) == 4242
+    assert probed_managers == ["user"]
     assert captured_cmd[:4] == ["/usr/bin/systemd-run", "--user", "--scope", "--quiet"]
     unit_index = captured_cmd.index("--unit")
     assert captured_cmd[unit_index + 1] == "hermes-worker-kanban-t_candidate_restart-run-23"
@@ -95,11 +115,12 @@ def test_managed_gateway_worker_spawn_fails_closed_without_scope(
     worker_setup: tuple[Path, kb.Task], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     workspace, task = worker_setup
+    _set_user_service_cgroup(monkeypatch)
     popen_calls: list[list[str]] = []
     monkeypatch.setenv("INVOCATION_ID", "managed-gateway-test")
     monkeypatch.setattr(subprocess, "Popen", lambda cmd, **kwargs: popen_calls.append(list(cmd)))
     monkeypatch.setattr("tools.process_registry._is_supervised_gateway_process", lambda: True)
-    monkeypatch.setattr("tools.process_registry._systemd_run_user_scope_available", lambda: False)
+    monkeypatch.setattr("tools.process_registry._systemd_run_scope_available", lambda _manager: False)
 
     with pytest.raises(RuntimeError, match="restart-safe systemd scope"):
         kbd._default_spawn(task, str(workspace))
@@ -111,9 +132,10 @@ def test_managed_gateway_scope_builder_fails_closed_if_binary_disappears(
     worker_setup: tuple[Path, kb.Task], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     workspace, task = worker_setup
+    _set_user_service_cgroup(monkeypatch)
     monkeypatch.setenv("INVOCATION_ID", "managed-gateway-test")
     monkeypatch.setattr("tools.process_registry._is_supervised_gateway_process", lambda: True)
-    monkeypatch.setattr("tools.process_registry._systemd_run_user_scope_available", lambda: True)
+    monkeypatch.setattr("tools.process_registry._systemd_run_scope_available", lambda _manager: True)
     monkeypatch.setattr("shutil.which", lambda _name: None)
     monkeypatch.setattr(subprocess, "Popen", lambda *_args, **_kwargs: pytest.fail("unsafe direct spawn"))
 

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1919,6 +1919,7 @@ class TestSystemdCgroupIsolation:
         fake_popen, captured = self._fake_popen_capture()
 
         monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr("tools.process_registry._systemd_scope_manager", lambda: "user")
         monkeypatch.setattr(
             "tools.process_registry._systemd_run_user_scope_available",
             lambda: True,
@@ -1984,6 +1985,7 @@ class TestSystemdCgroupIsolation:
         fake_popen, captured = self._fake_popen_capture()
 
         monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr("tools.process_registry._systemd_scope_manager", lambda: "user")
         monkeypatch.setattr(
             "tools.process_registry._systemd_run_user_scope_available",
             lambda: False,
@@ -2011,6 +2013,7 @@ class TestSystemdCgroupIsolation:
         fake_popen, captured = self._fake_popen_capture()
 
         monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr("tools.process_registry._systemd_scope_manager", lambda: "user")
         monkeypatch.setattr(
             "tools.process_registry._systemd_run_user_scope_available",
             lambda: True,
@@ -2043,6 +2046,7 @@ class TestSystemdCgroupIsolation:
         monkeypatch.setenv("INVOCATION_ID", "herdr-service-inherited-marker")
         monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
         monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr("tools.process_registry._systemd_scope_manager", lambda: "user")
         monkeypatch.setattr(
             "tools.process_registry._systemd_run_user_scope_available",
             lambda: True,
@@ -2094,6 +2098,7 @@ class TestSystemdCgroupIsolation:
             lambda *, cleanup_stale=False: os.getpid() + 1,
         )
         monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr("tools.process_registry._systemd_scope_manager", lambda: "user")
         monkeypatch.setattr(
             "tools.process_registry._systemd_run_user_scope_available",
             lambda: True,
@@ -2136,6 +2141,7 @@ class TestSystemdCgroupIsolation:
         fake_proc = fake_popen(["placeholder"])
 
         monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr("tools.process_registry._systemd_scope_manager", lambda: "user")
         monkeypatch.setattr(
             "tools.process_registry._systemd_run_user_scope_available",
             lambda: True,
@@ -2170,6 +2176,7 @@ class TestSystemdCgroupIsolation:
         fake_pty.pid = 4321
 
         monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr("tools.process_registry._systemd_scope_manager", lambda: "user")
         monkeypatch.setattr(
             "tools.process_registry._systemd_run_user_scope_available",
             lambda: True,
@@ -2219,6 +2226,7 @@ class TestSystemdCgroupIsolation:
             raise RuntimeError("PTY wrapper failed after scope creation")
 
         monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr("tools.process_registry._systemd_scope_manager", lambda: "user")
         monkeypatch.setattr(
             "tools.process_registry._systemd_run_user_scope_available",
             lambda: True,
@@ -2255,6 +2263,7 @@ class TestSystemdCgroupIsolation:
         from ptyprocess import PtyProcess
 
         monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr("tools.process_registry._systemd_scope_manager", lambda: "user")
         monkeypatch.setattr(
             "tools.process_registry._systemd_run_user_scope_available",
             lambda: True,

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -77,8 +77,10 @@ WATCH_GLOBAL_COOLDOWN_SECONDS = 30
 # exist on the PATH while the user D-Bus session is unavailable — common for system services and
 # containers), and cache the result for the process lifetime. See #70716.
 _SYSTEMD_SCOPE_AVAILABLE: Optional[bool] = None
+_SYSTEMD_SYSTEM_SCOPE_AVAILABLE: Optional[bool] = None
 _SYSTEMD_SCOPE_PROBE_LOCK = threading.Lock()
 _SYSTEMD_SCOPE_PROBED_AT = 0.0
+_SYSTEMD_SYSTEM_SCOPE_PROBED_AT = 0.0
 _SYSTEMD_SCOPE_FAILURE_TTL_SECONDS = 60.0
 _MIN_WORKER_MEMORY_MAX_BYTES = 64 * 1024 * 1024
 _DEFAULT_WORKER_MEMORY_MAX_BYTES = 1024 * 1024 * 1024
@@ -124,11 +126,13 @@ def _worker_memory_max_bytes() -> int:
     return min(override_bound, safe_bound) if override_bound else safe_bound
 
 
-def _systemd_scope_argv(binary: str, unit_name: str, *argv: str) -> List[str]:
-    """``systemd-run --user --scope`` argv shared by the probe and real spawns.
-    ``--collect`` self-cleans the scope after exit; ``--unit`` names it for systemctl."""
+def _systemd_scope_argv(
+    binary: str, unit_name: str, *argv: str, user_manager: bool = True
+) -> List[str]:
+    """Build a transient scope argv for the gateway's owning systemd manager."""
+    manager_args = ["--user"] if user_manager else []
     return [
-        binary, "--user", "--scope", "--quiet", "--unit", unit_name, "--collect",
+        binary, *manager_args, "--scope", "--quiet", "--unit", unit_name, "--collect",
         "--property", "MemoryAccounting=yes",
         "--property", f"MemoryMax={_worker_memory_max_bytes()}",
         "--property", "OOMPolicy=kill",
@@ -136,53 +140,96 @@ def _systemd_scope_argv(binary: str, unit_name: str, *argv: str) -> List[str]:
     ]
 
 
-def _systemd_scope_cached() -> Optional[bool]:
-    """Cached probe verdict, or None when a (re)probe is due. True is permanent; False
-    expires after ``_SYSTEMD_SCOPE_FAILURE_TTL_SECONDS`` so a D-Bus blip isn't sticky."""
-    if _SYSTEMD_SCOPE_AVAILABLE is True:
+def _systemd_scope_manager() -> str:
+    """Return the manager owning this process's cgroup.
+
+    A system service belongs under ``/system.slice``; a user manager belongs
+    under ``/user.slice``.  Preserve the established user-manager route for
+    non-systemd test/container cgroups, while treating the decisive system
+    cgroup evidence as authoritative.
+    """
+    if not _IS_LINUX:
+        return "user"
+    try:
+        for line in Path("/proc/self/cgroup").read_text(encoding="utf-8").splitlines():
+            if not line.startswith("0::"):
+                continue
+            cgroup_path = line.partition("::")[2]
+            if cgroup_path == "/system.slice" or cgroup_path.startswith("/system.slice/"):
+                return "system"
+            if cgroup_path == "/user.slice" or cgroup_path.startswith("/user.slice/"):
+                return "user"
+    except OSError:
+        pass
+    return "user"
+
+
+def _systemd_scope_cached(available: Optional[bool], probed_at: float) -> Optional[bool]:
+    """Cached probe verdict, or None when a (re)probe is due."""
+    if available is True:
         return True
-    stale = time.monotonic() - _SYSTEMD_SCOPE_PROBED_AT >= _SYSTEMD_SCOPE_FAILURE_TTL_SECONDS
-    return None if _SYSTEMD_SCOPE_AVAILABLE is None or stale else False
+    stale = time.monotonic() - probed_at >= _SYSTEMD_SCOPE_FAILURE_TTL_SECONDS
+    return None if available is None or stale else False
 
 
-def _systemd_run_user_scope_available() -> bool:
-    """True if ``systemd-run --user --scope`` can create a cgroup.
-    ``shutil.which`` alone is insufficient: system services and containers may lack
-    the user D-Bus bus even with the binary on PATH (every spawn would fail with
-    ``Failed to connect to user bus``), so a cheap ``/bin/true`` probe is run and cached."""
-    global _SYSTEMD_SCOPE_AVAILABLE, _SYSTEMD_SCOPE_PROBED_AT
-    verdict = _systemd_scope_cached()
+def _systemd_run_scope_available(manager: str) -> bool:
+    """True if the selected systemd manager can create a transient scope."""
+    global _SYSTEMD_SCOPE_AVAILABLE, _SYSTEMD_SYSTEM_SCOPE_AVAILABLE
+    global _SYSTEMD_SCOPE_PROBED_AT, _SYSTEMD_SYSTEM_SCOPE_PROBED_AT
+    if manager not in {"user", "system"} or not _IS_LINUX:
+        return False
+    user_manager = manager == "user"
+    available = _SYSTEMD_SCOPE_AVAILABLE if user_manager else _SYSTEMD_SYSTEM_SCOPE_AVAILABLE
+    probed_at = _SYSTEMD_SCOPE_PROBED_AT if user_manager else _SYSTEMD_SYSTEM_SCOPE_PROBED_AT
+    verdict = _systemd_scope_cached(available, probed_at)
     if verdict is not None:
         return verdict
-    # Double-checked locking: a concurrent first-use spawn must not observe a temporary
-    # False mid-probe, or it would launch back inside the gateway cgroup.
     with _SYSTEMD_SCOPE_PROBE_LOCK:
-        verdict = _systemd_scope_cached()
+        available = _SYSTEMD_SCOPE_AVAILABLE if user_manager else _SYSTEMD_SYSTEM_SCOPE_AVAILABLE
+        probed_at = _SYSTEMD_SCOPE_PROBED_AT if user_manager else _SYSTEMD_SYSTEM_SCOPE_PROBED_AT
+        verdict = _systemd_scope_cached(available, probed_at)
         if verdict is not None:
             return verdict
         available = False
-        if _IS_LINUX:
-            try:
-                import shutil
+        try:
+            import shutil
 
-                binary = shutil.which("systemd-run")
-                if binary:
-                    # Unique unit avoids collisions; the timeout bounds D-Bus.
-                    probe_unit = f"hermes-probe-scope-{os.getpid()}-{uuid.uuid4().hex[:8]}"
-                    result = subprocess.run(
-                        _systemd_scope_argv(binary, probe_unit, "/bin/true"), capture_output=True, timeout=3,
+            binary = shutil.which("systemd-run")
+            if binary:
+                probe_unit = f"hermes-probe-scope-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+                result = subprocess.run(
+                    _systemd_scope_argv(
+                        binary, probe_unit, "/bin/true", user_manager=user_manager
+                    ),
+                    capture_output=True,
+                    timeout=3,
+                )
+                available = result.returncode == 0
+                if not available:
+                    logger.debug(
+                        "systemd-run %s--scope probe failed (rc=%s): %s",
+                        "--user " if user_manager else "",
+                        result.returncode,
+                        (result.stderr or b"").decode("utf-8", "replace").strip(),
                     )
-                    available = result.returncode == 0
-                    if not available:
-                        logger.debug(
-                            "systemd-run --user --scope probe failed (rc=%s): %s",
-                            result.returncode, (result.stderr or b"").decode("utf-8", "replace").strip(),
-                        )
-            except Exception as exc:
-                logger.debug("systemd-run --user --scope probe error: %s", exc)
-        _SYSTEMD_SCOPE_AVAILABLE = available
-        _SYSTEMD_SCOPE_PROBED_AT = time.monotonic()
+        except Exception as exc:
+            logger.debug(
+                "systemd-run %s--scope probe error: %s",
+                "--user " if user_manager else "",
+                exc,
+            )
+        if user_manager:
+            _SYSTEMD_SCOPE_AVAILABLE = available
+            _SYSTEMD_SCOPE_PROBED_AT = time.monotonic()
+        else:
+            _SYSTEMD_SYSTEM_SCOPE_AVAILABLE = available
+            _SYSTEMD_SYSTEM_SCOPE_PROBED_AT = time.monotonic()
         return available
+
+
+def _systemd_run_user_scope_available() -> bool:
+    """Compatibility wrapper for the established user-manager availability probe."""
+    return _systemd_run_scope_available("user")
 
 
 def _is_supervised_gateway_process() -> bool:
@@ -202,20 +249,22 @@ def _is_supervised_gateway_process() -> bool:
         return False
 
 
-def _build_systemd_scope_argv(shell_argv: List[str], unit_suffix: str) -> List[str]:
-    """Wrap *shell_argv* in a ``systemd-run --user --scope`` invocation with its own
-    memory accounting, so an OOM in the worker cannot kill the gateway cgroup.
-
-    ``--collect`` makes the transient scope self-clean after exit; ``--unit`` gives it a recognisable name
-    for ``systemctl --user status`` / journalctl. See #70716.
-    """
+def _build_systemd_scope_argv(
+    shell_argv: List[str], unit_suffix: str, *, user_manager: bool = True
+) -> List[str]:
+    """Wrap *shell_argv* in a transient scope for its owning systemd manager."""
     import shutil
 
     binary = shutil.which("systemd-run")
     if binary is None:
         # Caller should have probed availability; never pass None into Popen anyway.
         return shell_argv
-    return _systemd_scope_argv(binary, f"hermes-worker-{unit_suffix}", *shell_argv)
+    return _systemd_scope_argv(
+        binary,
+        f"hermes-worker-{unit_suffix}",
+        *shell_argv,
+        user_manager=user_manager,
+    )
 
 
 def restart_safe_gateway_child_argv(
@@ -225,20 +274,26 @@ def restart_safe_gateway_child_argv(
 
     Children that must survive an intentional gateway restart cannot rely on
     ``start_new_session`` alone: systemd still kills every process in the
-    service cgroup.  In that topology, require a transient user scope and fail
-    closed if it cannot be established.  Standalone processes, non-systemd
-    supervisors, and non-Linux hosts retain the direct command.
+    service cgroup.  The transient scope must be created through the manager
+    that owns the gateway cgroup; fail closed if that manager cannot create it.
+    Standalone processes, non-systemd supervisors, and non-Linux hosts retain
+    the direct command.
     """
     if not _IS_LINUX:
         return command
     if not _is_supervised_gateway_process() or not os.environ.get("INVOCATION_ID"):
         return command
-    if not _systemd_run_user_scope_available():
+    manager = _systemd_scope_manager()
+    if not _systemd_run_scope_available(manager):
         raise RuntimeError(
             "cannot create restart-safe systemd scope for gateway child: "
-            "systemd-run --user --scope is unavailable"
+            "systemd-run --scope is unavailable"
         )
-    scoped = _build_systemd_scope_argv(command, unit_suffix=unit_suffix)
+    scoped = _build_systemd_scope_argv(
+        command,
+        unit_suffix=unit_suffix,
+        user_manager=manager == "user",
+    )
     if scoped == command:
         raise RuntimeError(
             "cannot create restart-safe systemd scope for gateway child: "
@@ -248,31 +303,34 @@ def restart_safe_gateway_child_argv(
 
 
 def _stop_systemd_unit(unit_name: str) -> bool:
-    """Stop a transient systemd user scope by unit name.
-    Reaps the *entire* cgroup — catching double-forked descendants reparented to init
-    inside the scope that survive a plain PID signal (SIGTERM all, SIGKILL after
-    ``TimeoutStopSec``). True if stopped or already gone; False if ``systemctl`` is
-    unavailable or the stop failed.
+    """Stop a transient scope through the manager owning the gateway cgroup.
 
-    See #70716.
+    Reaps the *entire* cgroup — catching double-forked descendants reparented
+    to init inside the scope that survive a plain PID signal.  True means the
+    scope was stopped or was already absent; False means the appropriate
+    ``systemctl`` route was unavailable or failed.
     """
     import shutil
 
     binary = shutil.which("systemctl")
     if binary is None:
         return False
+    manager = _systemd_scope_manager()
+    argv = [binary]
+    if manager == "user":
+        argv.append("--user")
+    argv.extend(("stop", unit_name))
     try:
-        result = subprocess.run([binary, "--user", "stop", unit_name], capture_output=True, timeout=15,
-                                stdin=subprocess.DEVNULL)
+        result = subprocess.run(argv, capture_output=True, timeout=15, stdin=subprocess.DEVNULL)
         if result.returncode != 0:
             stderr = (result.stderr or b"").decode(errors="replace").strip()
             if any(marker in stderr.lower() for marker in ("not loaded", "not found", "does not exist")):
                 return True
-            logger.debug("systemctl --user stop %s exited %d: %s", unit_name, result.returncode, stderr)
+            logger.debug("systemctl %sstop %s exited %d: %s", "--user " if manager == "user" else "", unit_name, result.returncode, stderr)
             return False
         return True
     except Exception as exc:
-        logger.debug("systemctl --user stop %s failed: %s", unit_name, exc)
+        logger.debug("systemctl %sstop %s failed: %s", "--user " if manager == "user" else "", unit_name, exc)
         return False
 
 
@@ -764,15 +822,27 @@ class ProcessRegistry:
         argv = [_find_shell(), "-lic", f"set +m; {safe_command}"]
         # This applies to both pipe mode and the PTY path above. See #70716.
         in_supervised_gateway = _IS_LINUX and _is_supervised_gateway_process()
-        if in_supervised_gateway and _systemd_run_user_scope_available():
+        if not in_supervised_gateway:
+            return argv
+        manager = _systemd_scope_manager()
+        scope_available = (
+            _systemd_run_user_scope_available()
+            if manager == "user"
+            else _systemd_run_scope_available(manager)
+        )
+        if scope_available:
             session.systemd_unit = f"hermes-worker-{unit_suffix}.scope"
-            return _build_systemd_scope_argv(argv, unit_suffix=unit_suffix)
-        if in_supervised_gateway:
-            # Under a supervisor but no private cgroup: a worker OOM can still take
-            # the whole gateway down.
-            logger.debug(
-                "%s background executor not isolated in a systemd scope "
-                "(systemd-run --user unavailable); worker shares the gateway cgroup.", label)
+            return _build_systemd_scope_argv(
+                argv, unit_suffix=unit_suffix, user_manager=manager == "user"
+            )
+        # Under a supervisor but no private cgroup: a worker OOM can still take
+        # the whole gateway down.
+        logger.debug(
+            "%s background executor not isolated in a systemd scope "
+            "(systemd-run %s--scope unavailable); worker shares the gateway cgroup.",
+            label,
+            "--user " if manager == "user" else "",
+        )
         return argv
 
     @staticmethod


### PR DESCRIPTION
Summary:
- Select the transient-scope manager from the supervised gateway cgroup: /system.slice uses the system manager; /user.slice retains --user.
- Probe, spawn, and stop scopes through that same manager; restart-safe handoff fails closed when it is unavailable.
- Add cgroup-topology regression coverage for cron handoff and matching cleanup.

Tests:
- HERMES_PYTHON=/usr/local/lib/hermes-agent/.venv/bin/python scripts/run_tests.sh tests/cron/test_restart_safe_worker.py -v --tb=short
- HERMES_PYTHON=/usr/local/lib/hermes-agent/.venv/bin/python scripts/run_tests.sh tests/tools/test_process_registry.py -v --tb=short
- /usr/local/lib/hermes-agent/.venv/bin/python -m py_compile tools/process_registry.py tests/cron/test_restart_safe_worker.py tests/tools/test_process_registry.py
- /usr/local/lib/hermes-agent/.venv/bin/python -m ruff check tools/process_registry.py tests/cron/test_restart_safe_worker.py tests/tools/test_process_registry.py
- git diff --check