### PR TITLE
cron: deliver configured silent_fallback instead of suppressing [SILENT]

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2727,8 +2727,28 @@ def _save_compose_deliver(
         # Cron silence suppression — see _is_cron_silence_response. Replaces the old `SILENT_MARKER in
         # ...upper()` substring check, which both leaked bracketless near-markers ("SILENT" / "NO_REPLY")
         # and wrongly swallowed a real report that merely quoted "[SILENT]" mid-sentence (#51438, #46917).
-        logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
-        d.should_deliver = False
+        # A configured fallback (job-level `silent_fallback` or global `cron.silent_fallback`)
+        # is delivered instead so every scheduled job keeps a visible result.
+        try:
+            silent_cfg = load_config() or {}
+        except Exception:
+            silent_cfg = {}
+        cron_cfg = silent_cfg.get("cron") if isinstance(silent_cfg, dict) else None
+        global_silent_fallback = (
+            cron_cfg.get("silent_fallback") if isinstance(cron_cfg, dict) else None
+        )
+        silent_fallback = str(
+            job.get("silent_fallback") or global_silent_fallback or ""
+        ).strip()
+        if silent_fallback:
+            logger.info(
+                "Job '%s': agent returned %s — delivering configured fallback",
+                job["id"], SILENT_MARKER,
+            )
+            deliver_content = silent_fallback
+        else:
+            logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
+            d.should_deliver = False
 
     if d.should_deliver and fence.lost():
         d.should_deliver = False

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1520,6 +1520,22 @@ class TestSilentDelivery:
         deliver_mock.assert_called_once()
 
 
+    def test_silent_response_uses_global_fallback(self):
+        """A configured cron.silent_fallback is delivered instead of suppressing."""
+        job = self._make_job()
+        with patch("cron.scheduler.get_due_jobs", return_value=[job]), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"silent_fallback": "No new information to report."}}), \
+             patch("cron.scheduler.claim_job_for_fire", return_value=True), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "[SILENT]", None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+
+        deliver_mock.assert_called_once()
+        assert deliver_mock.call_args.args[1] == "No new information to report."
+
     def test_failed_job_always_delivers(self):
         """Failed jobs deliver regardless of [SILENT] in output."""
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \


### PR DESCRIPTION
## Summary
When a cron agent returns a silence response ([SILENT] / SILENT / NO_REPLY), a configured fallback is delivered instead of suppressing the run silently: job-level `silent_fallback`, else global `cron.silent_fallback`. Without any configured fallback the previous behavior is unchanged (delivery suppressed, output still saved).

Motivation: every scheduled job keeps a visible result instead of a silent tick.

## Scope
- `cron/scheduler.py` (`_save_compose_deliver`): fallback lookup, fail-open to suppression on missing/broken config.
- `tests/cron/test_scheduler.py`: one behavior-contract test (`test_silent_response_uses_global_fallback` via `tick`).

## Test plan
- New test RED on base (fails without the fix), GREEN with it.
- `TestSilentDelivery`: 10/10 pass via `scripts/run_tests.sh`.
- `git diff --check` clean.

## Cross-link
Relates to #53230 — implements the `silent_fallback` path that issue asks for. Once this lands, #53230 should be verified to confirm the operational requirement ('always visible cron with explicit all-clear') is fully covered for jobs that opt in via `silent_fallback` (job-level or global `cron.silent_fallback`).
