### PR TITLE
fix(gateway): skip a not-found systemd scope in TimeoutStopSec check

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -215,22 +215,35 @@ def check_systemd_timing_alignment(
 
 
 def _systemd_timeout_stop_us(unit_name: str) -> Optional[int]:
-    """``TimeoutStopUSec`` of ``unit_name`` in microseconds; ``--user`` first (hermes' usual)."""
+    """``TimeoutStopUSec`` of ``unit_name`` in microseconds; ``--user`` first (hermes' usual).
+
+    Skips a scope that reports ``LoadState=not-found``. ``systemctl show`` on a unit a
+    given scope has never heard of still exits 0 and prints ``TimeoutStopUSec=1min 30s``
+    -- systemd's compiled-in *default*, not that unit's real configured value. Trusting it
+    produces a false "Stale systemd unit" mismatch whenever a leftover or never-existed
+    unit name shadows the real, correctly-configured unit living in the other scope
+    (#103062, e.g. gateway runs as a system unit while a stale same-named user unit no
+    longer/never existed).
+    """
     for flag in (["--user"], []):
         try:
             result = subprocess.run(
-                ["systemctl", *flag, "show", unit_name, "--property=TimeoutStopUSec"],
+                ["systemctl", *flag, "show", unit_name,
+                 "--property=TimeoutStopUSec", "--property=LoadState"],
                 capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=2.0,
             )
         except (subprocess.TimeoutExpired, OSError):
             continue
-        # Output: "TimeoutStopUSec=1min 30s" or "TimeoutStopUSec=90000000"
-        for line in result.stdout.splitlines() if result.returncode == 0 else ():
-            if line.startswith("TimeoutStopUSec="):
-                value = line.split("=", 1)[1].strip()
-                timeout_us = int(value) if value.isdigit() else parse_systemd_duration_to_us(value)
-                if timeout_us is not None:
-                    return timeout_us
+        if result.returncode != 0:
+            continue
+        # Output: one "Key=value" line per --property, e.g. "TimeoutStopUSec=1min 30s".
+        props = dict(line.split("=", 1) for line in result.stdout.splitlines() if "=" in line)
+        if props.get("LoadState") == "not-found":
+            continue  # this scope's TimeoutStopUSec is systemd's default, not real -- try the other scope
+        value = props.get("TimeoutStopUSec", "").strip()
+        timeout_us = int(value) if value.isdigit() else parse_systemd_duration_to_us(value)
+        if timeout_us is not None:
+            return timeout_us
     return None
 
 

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -142,3 +142,108 @@ class TestCheckSystemdTimingAlignment:
         # for whatever unit pytest IS in.  Both are valid; we just ensure
         # the function doesn't raise.
         assert result is None or isinstance(result, dict)
+
+
+# ---------------------------------------------------------------------------
+# _systemd_timeout_stop_us
+# ---------------------------------------------------------------------------
+
+class _FakeCompletedProcess:
+    def __init__(self, stdout: str, returncode: int = 0):
+        self.stdout = stdout
+        self.returncode = returncode
+
+
+class TestSystemdTimeoutStopUs:
+    """#103062: a scope reporting LoadState=not-found must be skipped -- its
+    TimeoutStopUSec is systemd's compiled-in default (90s), not a real value."""
+
+    def test_not_found_user_scope_falls_through_to_system_scope(self, monkeypatch):
+        """The exact bug: --user has a stale/never-existed unit name (default
+        90s, LoadState=not-found); the real, correctly-configured unit lives
+        in the system scope (210s) and must be the value returned."""
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if "--user" in cmd:
+                return _FakeCompletedProcess(
+                    "TimeoutStopUSec=1min 30s\nLoadState=not-found\n"
+                )
+            return _FakeCompletedProcess(
+                "TimeoutStopUSec=3min 30s\nLoadState=loaded\n"
+            )
+
+        monkeypatch.setattr(sf.subprocess, "run", fake_run)
+        assert sf._systemd_timeout_stop_us("hermes-gateway.service") == 210_000_000
+        assert len(calls) == 2  # tried --user first, then fell through to system scope
+
+    def test_not_found_in_both_scopes_returns_none(self, monkeypatch):
+        def fake_run(cmd, **kwargs):
+            return _FakeCompletedProcess(
+                "TimeoutStopUSec=1min 30s\nLoadState=not-found\n"
+            )
+
+        monkeypatch.setattr(sf.subprocess, "run", fake_run)
+        assert sf._systemd_timeout_stop_us("nonexistent-xyz.service") is None
+
+    def test_loaded_user_scope_is_trusted_and_short_circuits(self, monkeypatch):
+        """A genuinely loaded --user unit must still win outright (the
+        common case: hermes usually runs as a --user unit) -- the fix must
+        not make every lookup fall through to the system scope."""
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return _FakeCompletedProcess(
+                "TimeoutStopUSec=1min 30s\nLoadState=loaded\n"
+            )
+
+        monkeypatch.setattr(sf.subprocess, "run", fake_run)
+        assert sf._systemd_timeout_stop_us("hermes-gateway.service") == 90_000_000
+        assert len(calls) == 1  # never had to try the system scope
+
+    def test_missing_loadstate_property_preserves_old_behaviour(self, monkeypatch):
+        """Some environment where systemctl doesn't report LoadState at all
+        (unexpected, but must degrade to the pre-fix behaviour rather than
+        treating the value as untrustworthy)."""
+        def fake_run(cmd, **kwargs):
+            return _FakeCompletedProcess("TimeoutStopUSec=90s\n")
+
+        monkeypatch.setattr(sf.subprocess, "run", fake_run)
+        assert sf._systemd_timeout_stop_us("hermes-gateway.service") == 90_000_000
+
+    def test_nonzero_returncode_scope_is_skipped(self, monkeypatch):
+        def fake_run(cmd, **kwargs):
+            if "--user" in cmd:
+                return _FakeCompletedProcess("", returncode=1)
+            return _FakeCompletedProcess(
+                "TimeoutStopUSec=3min 30s\nLoadState=loaded\n"
+            )
+
+        monkeypatch.setattr(sf.subprocess, "run", fake_run)
+        assert sf._systemd_timeout_stop_us("hermes-gateway.service") == 210_000_000
+
+    def test_check_systemd_timing_alignment_no_longer_false_positives(self, monkeypatch, tmp_path):
+        """End-to-end repro of the reported false 'Stale systemd unit' warning:
+        a healthy system-scope unit (210s) shadowed by a not-found user-scope
+        leftover must no longer report a mismatch."""
+        monkeypatch.setenv("INVOCATION_ID", "abc")
+        cgroup_file = tmp_path / "cgroup"
+        cgroup_file.write_text("0::/system.slice/hermes-gateway.service\n")
+        monkeypatch.setattr(sf, "open", lambda *a, **k: open(cgroup_file, *a[1:], **k), raising=False)
+
+        def fake_run(cmd, **kwargs):
+            if "--user" in cmd:
+                return _FakeCompletedProcess(
+                    "TimeoutStopUSec=1min 30s\nLoadState=not-found\n"
+                )
+            return _FakeCompletedProcess(
+                "TimeoutStopUSec=3min 30s\nLoadState=loaded\n"
+            )
+
+        monkeypatch.setattr(sf.subprocess, "run", fake_run)
+        result = sf.check_systemd_timing_alignment(180.0, cron_drain_timeout=30.0)
+        assert result is not None
+        assert result["timeout_stop_sec"] == 210.0
+        assert result["mismatch"] is False


### PR DESCRIPTION
check_systemd_timing_alignment() sanity-checks systemd's TimeoutStopSec against the gateway's drain budget at startup, warning "Stale systemd unit detected" when the unit's configured stop timeout is too low. _systemd_timeout_stop_us() probes the --user scope first, then falls back to the system scope.

`systemctl show <unit> --property=TimeoutStopUSec` exits 0 and prints "TimeoutStopUSec=1min 30s" (systemd's compiled-in default) even for a unit that scope has never heard of -- it does not error. Since the probe only checked TimeoutStopUSec, a leftover or never-existed --user-scope unit name (LoadState=not-found) shadowed the real, correctly-configured unit living in the system scope: the function returned the bogus 90s default instead of falling through, and the gateway logged a false "Stale systemd unit detected: ... has TimeoutStopSec=90s but drain_timeout=180s ... (expected >=210s)" warning even though the active system unit's real TimeoutStopSec was 210s and perfectly fine.

Fix: also request --property=LoadState in the same systemctl call and skip a scope reporting LoadState=not-found, falling through to the next scope instead of trusting its default-valued TimeoutStopUSec. A scope where systemctl exits non-zero, times out, or omits LoadState (preserving the previous behaviour if that property is ever unavailable) is handled the same way it was before.

Added tests/gateway/test_shutdown_forensics.py::TestSystemdTimeoutStopUs: a not-found --user scope correctly falls through to a loaded system scope (the exact repro), both scopes not-found returns None (undeterminable, matching the documented contract), a genuinely loaded --user scope still wins outright without probing the system scope (the common case -- hermes usually runs as a --user unit), a missing LoadState property degrades to the pre-fix behaviour, a non-zero systemctl exit is still skipped, and an end-to-end check_systemd_timing_alignment() repro of the reported false positive now returns mismatch=False.

Fixes #103062

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

