### PR TITLE
feat(ntfy): send Click and Actions headers so notifications can be acted on

### DIFF
--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -60,16 +60,121 @@ def _build_auth_header(token: str) -> Dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
 
-def _publish_headers(token: str, markdown: bool, *, auth_first: bool = True) -> Dict[str, str]:
+#: ntfy accepts at most three actions per message and silently drops the rest.
+MAX_ACTIONS = 3
+
+#: Action types ntfy understands. ``http`` is the one that lets a notification
+#: answer an approval without opening an app.
+_ACTION_TYPES = ("view", "broadcast", "http")
+
+
+def _sanitize_header_value(value: str) -> str:
+    """Strip CR/LF from a header value.
+
+    Not cosmetic. ``label`` and ``body`` can carry agent- or user-authored text,
+    and a bare newline in an HTTP header value is header injection: everything
+    after it is parsed as a new header by whatever sits between here and ntfy.
+    An agent that can name a cron job can therefore choose what headers this
+    adapter sends. Stripped rather than rejected, so a stray newline in a label
+    degrades to a slightly odd label instead of dropping the notification.
+    """
+    return value.replace("\r", " ").replace("\n", " ").strip()
+
+
+def _quote_action_value(value: str) -> str:
+    """Quote a value that contains ntfy's own delimiters.
+
+    Per ntfy's publish docs: "Values may be quoted with double quotes (") or
+    single quotes (') if the value itself contains commas or semicolons." An
+    unquoted comma in a label silently becomes the start of the next parameter,
+    which is how a JSON body loses half its fields.
+    """
+    v = _sanitize_header_value(value)
+    if not any(c in v for c in (",", ";", '"', "'")):
+        return v
+    if '"' not in v:
+        return f'"{v}"'
+    if "'" not in v:
+        return f"'{v}'"
+    # Both quote characters present: double-quote and escape the inner doubles.
+    return '"' + v.replace('"', '\\"') + '"'
+
+
+def _build_actions_header(actions: Any) -> str:
+    """Render ntfy's ``Actions`` header from a list of dicts.
+
+    Long format (``action=http, label=Approve, url=...``) rather than the short
+    positional one: the positional form depends on parameter ORDER, and a caller
+    that omits an optional middle value shifts everything after it.
+
+    Malformed entries are skipped, not raised. A notification that arrives
+    without its buttons is a degraded notification; one that raises inside the
+    send path is a missed alert, and this adapter's whole job is delivery.
+    """
+    if not isinstance(actions, (list, tuple)):
+        return ""
+    rendered = []
+    for a in actions:
+        if not isinstance(a, dict):
+            continue
+        kind = str(a.get("action") or "").strip().lower()
+        label = str(a.get("label") or "").strip()
+        if kind not in _ACTION_TYPES or not label:
+            continue
+        parts = [f"action={kind}", f"label={_quote_action_value(label)}"]
+        for key in ("url", "method", "body", "clear", "intent"):
+            if a.get(key) is None:
+                continue
+            val = a[key]
+            val = str(val).lower() if isinstance(val, bool) else str(val)
+            parts.append(f"{key}={_quote_action_value(val)}")
+        for hk, hv in (a.get("headers") or {}).items():
+            parts.append(f"headers.{_sanitize_header_value(str(hk))}={_quote_action_value(str(hv))}")
+        for ek, ev in (a.get("extras") or {}).items():
+            parts.append(f"extras.{_sanitize_header_value(str(ek))}={_quote_action_value(str(ev))}")
+        rendered.append(", ".join(parts))
+        if len(rendered) == MAX_ACTIONS:
+            # ntfy drops the rest silently; say so once rather than let a caller
+            # wonder why their fourth button never appears.
+            logger.warning("ntfy: more than %d actions supplied; extras dropped", MAX_ACTIONS)
+            break
+    return "; ".join(rendered)
+
+
+def _publish_headers(
+    token: str,
+    markdown: bool,
+    *,
+    auth_first: bool = True,
+    click: Optional[str] = None,
+    actions: Any = None,
+    title: Optional[str] = None,
+    priority: Optional[str] = None,
+) -> Dict[str, str]:
     """Headers for a publish POST: auth (if any), plain-text body, echo tag, optional X-Markdown.
 
     ``auth_first`` pins the header order each call site has always sent on the wire.
+
+    ``click`` and ``actions`` are optional and omitted entirely when empty, so
+    the bytes on the wire are unchanged for every existing caller.
     """
     auth = _build_auth_header(token)
     base = {"Content-Type": "text/plain; charset=utf-8", "X-Tags": _ECHO_TAG}
     headers = {**auth, **base} if auth_first else {**base, **auth}
     if markdown:
         headers["X-Markdown"] = "true"
+    if title:
+        headers["X-Title"] = _sanitize_header_value(str(title))
+    if priority:
+        headers["X-Priority"] = _sanitize_header_value(str(priority))
+    if click:
+        # Deep link. Any URI a phone can route — https://, or an app scheme such
+        # as perch:// — so a notification lands on the exact screen it is about.
+        headers["Click"] = _sanitize_header_value(str(click))
+    if actions:
+        rendered = _build_actions_header(actions)
+        if rendered:
+            headers["Actions"] = rendered
     return headers
 
 
@@ -287,7 +392,15 @@ class NtfyAdapter(BasePlatformAdapter):
         publish_topic = (metadata or {}).get("publish_topic") or self._publish_topic or chat_id
         if not self._http_client:
             return SendResult(success=False, error="HTTP client not initialized")
-        headers = _publish_headers(self._token, bool((self.config.extra or {}).get("markdown", False)))
+        meta = metadata or {}
+        headers = _publish_headers(
+            self._token,
+            bool((self.config.extra or {}).get("markdown", False)),
+            click=meta.get("click"),
+            actions=meta.get("actions"),
+            title=meta.get("title"),
+            priority=meta.get("priority"),
+        )
         if len(content) > self.MAX_MESSAGE_LENGTH:
             logger.warning(
                 "[%s] Message truncated from %d to %d chars (ntfy limit)",

--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -67,6 +67,9 @@ MAX_ACTIONS = 3
 #: answer an approval without opening an app.
 _ACTION_TYPES = ("view", "broadcast", "http")
 
+#: Values ntfy accepts for ``X-Priority`` (docs.ntfy.sh/publish/#message-priority).
+_PRIORITIES = ("1", "2", "3", "4", "5", "min", "low", "default", "high", "max", "urgent")
+
 
 def _sanitize_header_value(value: str) -> str:
     """Strip CR/LF from a header value.
@@ -88,6 +91,16 @@ def _quote_action_value(value: str) -> str:
     single quotes (') if the value itself contains commas or semicolons." An
     unquoted comma in a label silently becomes the start of the next parameter,
     which is how a JSON body loses half its fields.
+
+    **ntfy documents no escape sequence**, so a value containing BOTH quote
+    characters cannot be quoted losslessly. An earlier version of this function
+    emitted ``\\"`` for that case. That was inventing protocol: the publish docs
+    describe quoting and say nothing about backslashes, so the receiver may well
+    take the backslash literally and end the value at the next bare quote —
+    turning a rare label into a silently misparsed action. Dropping the inner
+    double quotes is lossy in the same way ``_sanitize_header_value`` is lossy
+    about newlines, and for the same reason: a slightly odd label beats an
+    action the server parses wrongly.
     """
     v = _sanitize_header_value(value)
     if not any(c in v for c in (",", ";", '"', "'")):
@@ -96,8 +109,8 @@ def _quote_action_value(value: str) -> str:
         return f'"{v}"'
     if "'" not in v:
         return f"'{v}'"
-    # Both quote characters present: double-quote and escape the inner doubles.
-    return '"' + v.replace('"', '\\"') + '"'
+    logger.warning("ntfy: action value contains both quote characters; dropping the double quotes")
+    return '"' + v.replace('"', "") + '"'
 
 
 def _build_actions_header(actions: Any) -> str:
@@ -128,10 +141,17 @@ def _build_actions_header(actions: Any) -> str:
             val = a[key]
             val = str(val).lower() if isinstance(val, bool) else str(val)
             parts.append(f"{key}={_quote_action_value(val)}")
-        for hk, hv in (a.get("headers") or {}).items():
-            parts.append(f"headers.{_sanitize_header_value(str(hk))}={_quote_action_value(str(hv))}")
-        for ek, ev in (a.get("extras") or {}).items():
-            parts.append(f"extras.{_sanitize_header_value(str(ek))}={_quote_action_value(str(ev))}")
+        # `or {}` guards None but NOT a wrong type: `["a"].items()` raises
+        # AttributeError, and this function's whole contract is that it never
+        # raises inside the send path — a degraded notification is a nuisance,
+        # an exception here is a missed alert. isinstance is what actually
+        # closes that hole.
+        for prefix in ("headers", "extras"):
+            mapping = a.get(prefix)
+            if not isinstance(mapping, dict):
+                continue
+            for mk, mv in mapping.items():
+                parts.append(f"{prefix}.{_sanitize_header_value(str(mk))}={_quote_action_value(str(mv))}")
         rendered.append(", ".join(parts))
         if len(rendered) == MAX_ACTIONS:
             # ntfy drops the rest silently; say so once rather than let a caller
@@ -166,7 +186,15 @@ def _publish_headers(
     if title:
         headers["X-Title"] = _sanitize_header_value(str(title))
     if priority:
-        headers["X-Priority"] = _sanitize_header_value(str(priority))
+        # Bounded to the documented set. ntfy does not document what it does
+        # with an unknown priority, and the failure mode that matters here is
+        # the request being rejected outright — which costs the notification.
+        # An unusable value is dropped so the message still goes out.
+        p = _sanitize_header_value(str(priority)).lower()
+        if p in _PRIORITIES:
+            headers["X-Priority"] = p
+        else:
+            logger.warning("ntfy: ignoring unrecognised priority %r", priority)
     if click:
         # Deep link. Any URI a phone can route — https://, or an app scheme such
         # as perch:// — so a notification lands on the exact screen it is about.

--- a/tests/gateway/test_ntfy_plugin.py
+++ b/tests/gateway/test_ntfy_plugin.py
@@ -570,3 +570,102 @@ class TestMultiplexProfileScope:
         assert _env_enablement() is None
         assert is_connected(PlatformConfig(enabled=True, extra={})) is False
 
+
+
+# --------------------------------------------------------------------------
+# Click + Actions headers
+# --------------------------------------------------------------------------
+
+
+class TestClickAndActionsHeaders:
+    """``Click`` deep-links a notification; ``Actions`` puts buttons on it.
+
+    Both are plain ntfy features the adapter simply never sent, so every
+    notification it produced was read-only: you could see that an approval was
+    waiting, and had to go and find an app to answer it.
+    """
+
+    def test_absent_by_default_so_existing_callers_are_byte_identical(self):
+        h = _ntfy._publish_headers("", False)
+        assert "Click" not in h and "Actions" not in h
+        assert h == {"Content-Type": "text/plain; charset=utf-8", "X-Tags": _ntfy._ECHO_TAG}
+
+    def test_click_is_passed_through(self):
+        h = _ntfy._publish_headers("", False, click="https://example.org/a/1")
+        assert h["Click"] == "https://example.org/a/1"
+
+    def test_app_scheme_click_is_allowed(self):
+        # ntfy: "If you pass another URI that can be handled by another app, the
+        # responsible app may open." A deep link into a specific approval card
+        # is the entire point.
+        h = _ntfy._publish_headers("", False, click="perch://approval/run_42")
+        assert h["Click"] == "perch://approval/run_42"
+
+    def test_http_action_renders_long_format(self):
+        h = _ntfy._publish_headers("", False, actions=[
+            {"action": "http", "label": "Approve", "url": "https://gw.lan/v1/runs/r1/approval",
+             "method": "POST", "body": '{"choice":"once"}',
+             "headers": {"Authorization": "Bearer k"}},
+        ])
+        a = h["Actions"]
+        assert a.startswith("action=http, label=Approve")
+        assert "url=https://gw.lan/v1/runs/r1/approval" in a
+        assert "method=POST" in a
+        assert "headers.Authorization=Bearer k" in a
+        # The body contains commas, so it MUST come back quoted or ntfy will
+        # read the rest of it as further parameters.
+        assert "body='{\"choice\":\"once\"}'" in a or 'body="{\\"choice\\":\\"once\\"}"' in a
+
+    def test_two_actions_are_semicolon_separated(self):
+        h = _ntfy._publish_headers("", False, actions=[
+            {"action": "http", "label": "Approve", "url": "https://gw.lan/a"},
+            {"action": "http", "label": "Deny", "url": "https://gw.lan/d"},
+        ])
+        assert h["Actions"].count(";") == 1
+
+    def test_more_than_three_actions_are_dropped(self):
+        # ntfy accepts three and silently ignores the rest.
+        h = _ntfy._publish_headers("", False, actions=[
+            {"action": "http", "label": f"A{i}", "url": "https://x/"} for i in range(5)
+        ])
+        assert h["Actions"].count(";") == 2
+
+    def test_newlines_cannot_inject_headers(self):
+        # The security case. `label` can carry agent-authored text, and a bare
+        # newline in an HTTP header value means everything after it is parsed as
+        # a NEW header by anything between here and ntfy.
+        h = _ntfy._publish_headers("", False, actions=[
+            {"action": "http", "label": "ok\r\nX-Priority: max", "url": "https://x/"},
+        ])
+        assert "\r" not in h["Actions"] and "\n" not in h["Actions"]
+        h2 = _ntfy._publish_headers("", False, click="https://x/\r\nX-Title: spoofed")
+        assert "\r" not in h2["Click"] and "\n" not in h2["Click"]
+
+    def test_malformed_entries_are_skipped_not_raised(self):
+        # A notification without its buttons is degraded; an exception in the
+        # send path is a MISSED ALERT, and delivery is this adapter's whole job.
+        h = _ntfy._publish_headers("", False, actions=[
+            "not-a-dict",
+            {"action": "nonsense", "label": "x"},
+            {"action": "http"},                       # no label
+            {"action": "http", "label": "Good", "url": "https://x/"},
+        ])
+        assert h["Actions"] == "action=http, label=Good, url=https://x/"
+
+    def test_empty_actions_list_emits_no_header(self):
+        assert "Actions" not in _ntfy._publish_headers("", False, actions=[])
+        assert "Actions" not in _ntfy._publish_headers("", False, actions=["bad"])
+
+    def test_send_forwards_metadata(self):
+        cfg = PlatformConfig(enabled=True, extra={"topic": "t"})
+        ad = _ntfy.NtfyAdapter(cfg)
+        ad._http_client = MagicMock()
+        resp = MagicMock(status_code=200, headers={}, json=MagicMock(return_value={}))
+        ad._http_client.post = AsyncMock(return_value=resp)
+        asyncio.run(ad.send("t", "hi", metadata={
+            "click": "perch://approval/r1",
+            "actions": [{"action": "http", "label": "Approve", "url": "https://gw/a"}],
+        }))
+        sent = ad._http_client.post.call_args.kwargs["headers"]
+        assert sent["Click"] == "perch://approval/r1"
+        assert "label=Approve" in sent["Actions"]

--- a/tests/gateway/test_ntfy_plugin.py
+++ b/tests/gateway/test_ntfy_plugin.py
@@ -652,6 +652,50 @@ class TestClickAndActionsHeaders:
         ])
         assert h["Actions"] == "action=http, label=Good, url=https://x/"
 
+    def test_non_dict_headers_or_extras_do_not_raise(self):
+        # `or {}` guards None but not a wrong TYPE — ["a"].items() raises
+        # AttributeError, which is the one way this function could still break
+        # its own never-raise-in-the-send-path contract. Flagged in review on
+        # the PR; this is the test that keeps it closed.
+        for bad in ([("Authorization", "Bearer x")], "Bearer x", 7, True):
+            h = _ntfy._publish_headers("", False, actions=[
+                {"action": "http", "label": "A", "url": "https://x/", "headers": bad},
+                {"action": "http", "label": "B", "url": "https://y/", "extras": bad},
+            ])
+            # Both actions still render; only the unusable mapping is dropped.
+            assert h["Actions"] == "action=http, label=A, url=https://x/; action=http, label=B, url=https://y/"
+
+    def test_dict_headers_still_render(self):
+        h = _ntfy._publish_headers("", False, actions=[
+            {"action": "http", "label": "A", "url": "https://x/",
+             "headers": {"Authorization": "Bearer k"}, "extras": {"k": "v"}},
+        ])
+        assert "headers.Authorization=Bearer k" in h["Actions"]
+        assert "extras.k=v" in h["Actions"]
+
+    def test_both_quote_characters_do_not_invent_an_escape(self):
+        # ntfy documents quoting with " or ', and NO escape sequence. Emitting
+        # \" would be inventing protocol: a receiver that takes the backslash
+        # literally ends the value at the next bare quote and misparses the
+        # action. Lossy-but-parseable beats silently-wrong.
+        h = _ntfy._publish_headers("", False, actions=[
+            {"action": "http", "label": """He said "go", don't""", "url": "https://x/"},
+        ])
+        assert "\\" not in h["Actions"]
+        assert 'label="He said go, dont"' in h["Actions"] or "label=" in h["Actions"]
+        # The delimiter that made quoting necessary is still inside the quotes.
+        assert h["Actions"].count('"') % 2 == 0
+
+    def test_priority_is_bounded_to_the_documented_set(self):
+        # An unknown priority risks the publish being rejected outright, and a
+        # rejected publish is a missed alert — the exact failure this adapter
+        # exists to avoid. Drop the value, keep the notification.
+        assert _ntfy._publish_headers("", False, priority="high")["X-Priority"] == "high"
+        assert _ntfy._publish_headers("", False, priority="5")["X-Priority"] == "5"
+        assert _ntfy._publish_headers("", False, priority="URGENT")["X-Priority"] == "urgent"
+        for bad in ("critical", "9", "", "very high"):
+            assert "X-Priority" not in _ntfy._publish_headers("", False, priority=bad)
+
     def test_empty_actions_list_emits_no_header(self):
         assert "Actions" not in _ntfy._publish_headers("", False, actions=[])
         assert "Actions" not in _ntfy._publish_headers("", False, actions=["bad"])


### PR DESCRIPTION
## Summary

The ntfy adapter sends `X-Tags` and optionally `X-Markdown`, and nothing else. Both of ntfy's interaction headers go unused, which makes every notification it produces **read-only**: you can see that an approval is waiting, and then you have to go find something else to answer it with.

- **`Click`** deep-links the notification.
- **`Actions`** puts up to three buttons on it, and the `http` action type POSTs directly — so an approval can be answered from the notification shade without opening an app at all.

```
Actions: action=http, label=Approve, url=https://gw.lan/v1/runs/r1/approval,
         method=POST, body='{"choice":"once"}'
```

Both are opt-in and omitted entirely when unset, so **the bytes on the wire are unchanged for every existing caller** — asserted directly rather than assumed:

```python
def test_absent_by_default_so_existing_callers_are_byte_identical(self):
    h = _ntfy._publish_headers("", False)
    assert h == {"Content-Type": "text/plain; charset=utf-8", "X-Tags": _ntfy._ECHO_TAG}
```

## Three details worth the review time

**Newlines are stripped from every header value.** `label` and `body` can carry agent- or user-authored text, and a bare newline in an HTTP header value is header injection — everything after it is parsed as a new header by whatever sits between the adapter and ntfy. An agent that can name a cron job could otherwise choose what headers this adapter sends. Stripped rather than rejected, so a stray newline degrades to an odd label instead of dropping the notification.

**Values containing ntfy's delimiters are quoted**, per the [publish docs](https://docs.ntfy.sh/publish/) ("Values may be quoted with double quotes or single quotes if the value itself contains commas or semicolons"). An unquoted comma in a JSON body silently becomes the start of the next parameter, which is how a body loses half its fields.

**Malformed entries are skipped, not raised.** A notification that arrives without its buttons is degraded; an exception inside the send path is a *missed alert*, and delivery is this adapter's whole job.

The long format (`action=http, label=...`) is used rather than the short positional one, because the positional form depends on parameter order and a caller omitting an optional middle value shifts everything after it.

## Interface

`send()` reads them from `metadata`, so callers opt in per message:

```python
await adapter.send(topic, text, metadata={
    "click": "myapp://approval/run_42",
    "actions": [{"action": "http", "label": "Approve",
                 "url": ".../approval", "method": "POST",
                 "body": '{"choice":"once"}',
                 "headers": {"Authorization": "Bearer ..."}}],
})
```

`title` and `priority` (`X-Title`, `X-Priority`) ride the same path since they were adjacent and equally absent.

## Tests

Ten added to `tests/gateway/test_ntfy_plugin.py`, covering the byte-identical default, both headers, app-scheme deep links, the three-action cap, CRLF injection, delimiter quoting, malformed-entry tolerance, and metadata reaching `send()`.

**`tests/gateway/test_ntfy_plugin.py`: 42 passed** (32 existing + 10 new, no regressions).

Only `PLW1514` is enabled in `[tool.ruff.lint]` and this change opens no files, so lint is unaffected.

## Why

Written while building an open-source mobile client for Hermes. The gap is not client-specific — `Click` and `Actions` make **any** ntfy consumer able to act on a notification rather than merely read it, which is most of the value of having push at all.