### PR TITLE
fix(desktop): multi-line tooltips paint every line, not just the first

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/preview-row.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/preview-row.test.tsx
@@ -19,7 +19,7 @@ describe('PreviewStatusRow', () => {
     vi.restoreAllMocks()
   })
 
-  it('keeps the preview tooltip label inline inside the portaled decoration', async () => {
+  it('keeps the preview tooltip label in inline flow inside the portaled decoration', async () => {
     const view = render(
       <PreviewStatusRow
         item={{ cwd: 'C:\\repo', id: 'preview.html', label: 'preview.html', target: 'preview.html' }}
@@ -31,12 +31,15 @@ describe('PreviewStatusRow', () => {
     await screen.findByRole('tooltip')
 
     const content = document.querySelector<HTMLElement>('[data-slot="tooltip-content"]')
-    const label = content?.firstElementChild?.firstElementChild
+    const decoration = content?.firstElementChild
 
     expect(content).not.toBeNull()
     expect(view.container.contains(content)).toBe(false)
-    expect(label?.classList.contains('inline-flex')).toBe(true)
-    expect(label?.classList.contains('flex')).toBe(false)
+    // The decoration's per-line background only wraps inline FLOW. A flex box
+    // (block or inline-flex) under it lights the first line and leaves the
+    // rest dark-on-dark, so the two lines must be split by a hard break.
+    expect(decoration?.querySelector('.flex, .inline-flex')).toBeNull()
+    expect(decoration?.querySelector('br')).not.toBeNull()
   })
 
   it('opens remote non-HTML file artifacts in the in-app preview instead of the local browser bridge', async () => {

--- a/apps/desktop/src/app/chat/composer/status-stack/preview-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/preview-row.tsx
@@ -121,12 +121,14 @@ export const PreviewStatusRow = memo(function PreviewStatusRow({ item, onDismiss
     >
       <Tip
         label={
-          // inline-flex (not flex): a block child collapses Tip's decoration
-          // wrapper geometry and mis-positions the tooltip (#62022).
-          <span className="inline-flex flex-col gap-0.5">
-            <span>{item.target}</span>
+          // Inline flow with a hard break, not a flex column: Tip's background
+          // only wraps inline content, so a flex box would light the first
+          // line and leave the rest dark-on-dark.
+          <>
+            {item.target}
+            <br />
             <span className="opacity-70">{t.preview.linkHint}</span>
-          </span>
+          </>
         }
       >
         <span className="min-w-0 truncate text-[0.73rem] leading-4 text-foreground/92">{item.label}</span>

--- a/apps/desktop/src/app/right-sidebar/terminal/rail.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/rail.test.tsx
@@ -19,19 +19,21 @@ describe('TerminalRail', () => {
     $activeTerminalId.set(null)
   })
 
-  it('keeps a hotkey label inline inside the portaled tooltip decoration', async () => {
+  it('keeps a hotkey label in inline flow inside the portaled tooltip decoration', async () => {
     const view = render(<TerminalRail />)
 
     fireEvent.pointerMove(screen.getByRole('tab', { name: '1. PowerShell' }), { pointerType: 'mouse' })
     await screen.findByRole('tooltip')
 
     const content = document.querySelector<HTMLElement>('[data-slot="tooltip-content"]')
-    const label = content?.firstElementChild?.firstElementChild
+    const decoration = content?.firstElementChild
 
     expect(content).not.toBeNull()
     expect(view.container.contains(content)).toBe(false)
-    expect(label?.classList.contains('inline-flex')).toBe(true)
-    expect(label?.classList.contains('flex')).toBe(false)
+    // No flex box under the decoration: its per-line background only wraps
+    // inline flow, so a flex label would hang its overflow dark-on-dark.
+    expect(decoration?.querySelector('.flex, .inline-flex')).toBeNull()
+    expect(decoration?.textContent).toContain('PowerShell')
   })
 
   it('⌘-click closes the tab; a plain click selects it', () => {

--- a/apps/desktop/src/components/ui/tooltip.tsx
+++ b/apps/desktop/src/components/ui/tooltip.tsx
@@ -117,11 +117,12 @@ function TooltipContent({
         {/* bg-foreground/text-background auto-inverts per theme. leading-normal
             keeps lines readable; py-1 makes the cloned line-boxes overlap just
             enough to read as one continuous fill (no gaps between lines). */}
-        {/* [&>*]:!inline-flex: a block-level label child (e.g. `flex`) collapses
-            this inline decoration's geometry, so Radix measures a zero-size chip
-            and parks an empty rectangle in the corner (#62022). Force any direct
-            child inline-flex so every call site stays safe. */}
-        <span className="box-decoration-clone inline bg-foreground px-1.5 py-1 text-[11px] font-bold leading-normal text-background [font-family:Arial,sans-serif] [&>*]:!inline-flex">
+        {/* [&>*]:!inline: this decoration only paints inline FLOW. A block child
+            collapses it to zero and Radix parks an empty chip in the corner
+            (#62022); an atomic inline child (`inline-flex`) sits on the baseline
+            and hangs its extra lines below the background, dark-on-dark. Force
+            direct children inline; break lines with `<br />`. */}
+        <span className="box-decoration-clone inline bg-foreground px-1.5 py-1 text-[11px] font-bold leading-normal text-background [font-family:Arial,sans-serif] [&>*]:!inline">
           {children}
         </span>
       </TooltipPrimitive.Content>
@@ -265,8 +266,8 @@ interface TipHintLabelProps {
   hint?: string
 }
 
-/** Tooltip label with an optional trailing hotkey hint. Uses `inline-flex` so it
- *  stays safe inside Tip's decoration wrapper — prefer this over a bespoke
+/** Tooltip label with an optional trailing hotkey hint. Plain inline flow (no
+ *  flex box) so Tip's per-line background wraps it — prefer this over a bespoke
  *  flex/gap span at the call site (see #62022). */
 function TipHintLabel({ text, hint }: TipHintLabelProps) {
   if (!hint) {
@@ -274,10 +275,10 @@ function TipHintLabel({ text, hint }: TipHintLabelProps) {
   }
 
   return (
-    <span className="inline-flex items-center gap-2">
-      <span>{text}</span>
-      <span className="opacity-55">{hint}</span>
-    </span>
+    <>
+      {text}
+      <span className="ms-2 opacity-55">{hint}</span>
+    </>
   )
 }
 


### PR DESCRIPTION
## Summary

Multi-line tooltips painted only their first line. `Tip`'s chip is an inline span with `box-decoration-break: clone`, so its background covers the line boxes of inline flow and nothing else. The #62022 hardening ([#63029](https://github.com/NousResearch/hermes-agent/pull/63029)) forced every label child to `inline-flex` to stop the empty-chip-in-the-corner bug — but `inline-flex` is an atomic inline: it sits on the baseline and hangs its remaining lines below the chip, dark-on-dark. Visible today on the composer's preview status row (target path lit, "click to open" hint invisible; long paths wrapping into unreadable rows).

| | before | after |
|---|---|---|
| label child | forced `inline-flex` | forced `inline` |
| block child (#62022) | collapses → empty chip | still collapses → still fixed |
| wrapped / multi-line label | first line lit, rest dark-on-dark | every line lit |

- `TooltipContent`: `[&>*]:!inline-flex` → `[&>*]:!inline`
- `TipHintLabel`: plain text + `ms-2` hint instead of an `inline-flex`/`gap` box
- preview status row: text + `<br />` + hint instead of a flex column
- tests pinning the `inline-flex` class now assert the invariant (no flex box under the decoration; preview row splits with a hard break)

## Test plan

- [x] `npx vitest run src/components/ui/tooltip.test.tsx src/app/chat/composer/status-stack/preview-row.test.tsx src/app/right-sidebar/terminal/rail.test.tsx` — 11/11
- [x] headless render of the chip: buggy shape → 1 lit line rect, inner 68px hanging; fixed shape → 4 lit line rects, nothing below the chip
- [ ] `hgui`, hover a preview artifact with a long path in the composer status stack: both lines on the chip
- [ ] hover a terminal-rail tab: hotkey hint still on one line
