### PR TITLE
discord: request public_thread in handoff direct thread creation

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5430,7 +5430,12 @@ class DiscordAdapter(BasePlatformAdapter):
         try:
             create = getattr(parent, "create_thread", None)
             if create is not None:
-                thread = await create(name=thread_name, auto_archive_duration=1440, reason=reason)
+                thread = await create(
+                    name=thread_name,
+                    type=discord.ChannelType.public_thread,
+                    auto_archive_duration=1440,
+                    reason=reason,
+                )
                 return str(thread.id)
         except Exception as direct_error:
             logger.debug(

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -418,3 +418,27 @@ async def test_send_file_attachment_forum_uses_files_kwarg(tmp_path, monkeypatch
     assert isinstance(thread_kwargs.get("files"), list) and len(thread_kwargs["files"]) == 1
 
 
+@pytest.mark.asyncio
+async def test_handoff_direct_create_requests_public_thread(tmp_path, monkeypatch):
+    """Direct handoff-thread creation must request a public thread (#95670).
+
+    discord.py normalizes an omitted ``type`` to ``private_thread``; the
+    handoff continuation must stay parent-channel-visible instead.
+    """
+    import discord
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    create_thread = AsyncMock(return_value=SimpleNamespace(id=9001))
+    parent = SimpleNamespace(create_thread=create_thread)
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: parent,
+        fetch_channel=AsyncMock(),
+    )
+
+    thread_id = await adapter.create_handoff_thread("555", "Hermes — report")
+
+    assert thread_id == "9001"
+    assert create_thread.await_args.kwargs["type"] is discord.ChannelType.public_thread
+
+


### PR DESCRIPTION
## Summary
`DiscordAdapter.create_handoff_thread()` now passes an explicit `type=discord.ChannelType.public_thread` on the direct `parent.create_thread(...)` path. discord.py normalizes an omitted type to `private_thread`, so handoff continuations were created private and potentially invisible to the destination user.

Fixes #95670. Unrelated to closed #63459 (seed-anchoring + participation tracking; its final branch did not include the explicit type).

## Scope
- `plugins/platforms/discord/adapter.py`: one added kwarg on the direct path; seed-message fallback untouched.
- `tests/gateway/test_discord_send.py`: one behavior-contract test asserting the created thread id and the exact `type` kwarg.

## Test plan
- New test RED on base (`KeyError: 'type'`), GREEN with the fix.
- `scripts/run_tests.sh tests/gateway/test_discord_send.py`: 12/12 pass.
- `git diff --check` clean.
