### PR TITLE
fix(gateway): skip systemd scopes where the unit is not loaded (#103062)

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -219,13 +219,25 @@ def _systemd_timeout_stop_us(unit_name: str) -> Optional[int]:
     for flag in (["--user"], []):
         try:
             result = subprocess.run(
-                ["systemctl", *flag, "show", unit_name, "--property=TimeoutStopUSec"],
+                [
+                    "systemctl",
+                    *flag,
+                    "show",
+                    unit_name,
+                    "--property=TimeoutStopUSec,LoadState",
+                ],
                 capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=2.0,
             )
         except (subprocess.TimeoutExpired, OSError):
             continue
-        # Output: "TimeoutStopUSec=1min 30s" or "TimeoutStopUSec=90000000"
-        for line in result.stdout.splitlines() if result.returncode == 0 else ():
+        # Output: "TimeoutStopUSec=1min 30s" or "TimeoutStopUSec=90000000" (plus "LoadState=...")
+        lines = result.stdout.splitlines() if result.returncode == 0 else ()
+        # systemctl answers with systemd's default timeout (exit 0) for a unit that does not
+        # exist in this scope (LoadState=not-found): probe the other scope instead of
+        # mistaking the 90s default for the unit's configured value.
+        if "LoadState=not-found" in lines:
+            continue
+        for line in lines:
             if line.startswith("TimeoutStopUSec="):
                 value = line.split("=", 1)[1].strip()
                 timeout_us = int(value) if value.isdigit() else parse_systemd_duration_to_us(value)

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import signal
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -142,3 +143,49 @@ class TestCheckSystemdTimingAlignment:
         # for whatever unit pytest IS in.  Both are valid; we just ensure
         # the function doesn't raise.
         assert result is None or isinstance(result, dict)
+
+
+# ---------------------------------------------------------------------------
+# _systemd_timeout_stop_us
+# ---------------------------------------------------------------------------
+
+
+class TestSystemdTimeoutStopUs:
+    @staticmethod
+    def _fake_systemctl(responses):
+        """systemctl stub keyed by scope flag ('--user' present or not)."""
+
+        def _run(args, **kwargs):
+            scope = "user" if "--user" in args else "system"
+            stdout, returncode = responses.get(scope, ("", 1))
+            return subprocess.CompletedProcess(
+                args, returncode, stdout=stdout, stderr=""
+            )
+
+        return _run
+
+    def test_skips_user_scope_default_when_unit_not_found(self, monkeypatch):
+        # systemctl --user show answers exit 0 with systemd's DEFAULT timeout for a
+        # unit missing from the user scope; the real loaded system unit has 3min 30s.
+        responses = {
+            "user": ("LoadState=not-found\nTimeoutStopUSec=1min 30s\n", 0),
+            "system": ("LoadState=loaded\nTimeoutStopUSec=3min 30s\n", 0),
+        }
+        monkeypatch.setattr(sf.subprocess, "run", self._fake_systemctl(responses))
+        assert sf._systemd_timeout_stop_us("hermes-gateway.service") == 210 * 1_000_000
+
+    def test_returns_none_when_unit_missing_from_both_scopes(self, monkeypatch):
+        responses = {
+            "user": ("LoadState=not-found\nTimeoutStopUSec=1min 30s\n", 0),
+            "system": ("LoadState=not-found\nTimeoutStopUSec=1min 30s\n", 0),
+        }
+        monkeypatch.setattr(sf.subprocess, "run", self._fake_systemctl(responses))
+        assert sf._systemd_timeout_stop_us("hermes-gateway.service") is None
+
+    def test_user_scope_still_wins_when_unit_is_loaded_there(self, monkeypatch):
+        responses = {
+            "user": ("LoadState=loaded\nTimeoutStopUSec=4min\n", 0),
+            "system": ("LoadState=loaded\nTimeoutStopUSec=2min\n", 0),
+        }
+        monkeypatch.setattr(sf.subprocess, "run", self._fake_systemctl(responses))
+        assert sf._systemd_timeout_stop_us("hermes-gateway.service") == 240 * 1_000_000


### PR DESCRIPTION
## Problem (`#103062`)

`_systemd_timeout_stop_us()` probes the `--user` scope first and trusts the first scope that yields a parsable `TimeoutStopUSec`. But `systemctl --user show <unit>` exits **0** and prints systemd's *default* `1min 30s` (90s) for a unit that does not exist in that scope (`LoadState=not-found`) — it does not fail. When the gateway runs as a healthy **system** unit while the unit name simply doesn't exist in the user scope, the 90s default is mistaken for the unit's configured value, the system scope is never consulted, and startup logs a false:

```
WARNING gateway.run: Stale systemd unit detected: hermes-gateway.service has TimeoutStopSec=90s but drain_timeout=180s cron_drain_timeout=30s (expected >=210s).
```

## Fix

Ask `systemctl show` for `--property=TimeoutStopUSec,LoadState` and skip any scope that reports `LoadState=not-found`, so the probe falls through to the scope where the unit is genuinely loaded (and returns `None` when neither scope has it).

## Tests

Three regression tests with a faked `systemctl`:
- user scope `not-found` + system scope `loaded` → the system value (210s) wins, not the 90s default;
- `not-found` in both scopes → `None`;
- unit loaded in the user scope → user value still wins (probe order unchanged).

Mutation-checked: removing the `LoadState` guard makes both new guards' tests fail with `90000000 == 210000000` / `90000000 is None`.

Fixes #103062