### PR TITLE
fix(compression): make hard-ceiling fallback race-independent

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -398,6 +398,7 @@ class CompressionCommitFence:
         self._last_progress = time.monotonic()
         self._progress_observed = False
         self._deadline: float | None = None
+        self._route_deadline_aborted = False
         self._retain_cancelled_lock_until_worker_done = False
         # Set once the active-row watermark is captured: later rows survive as tail, so hosts may keep admission.
         self._commit_watermark_fenced = False
@@ -409,6 +410,7 @@ class CompressionCommitFence:
         seconds = float(seconds)
         if seconds <= 0:
             raise ValueError("total compression ceiling must be positive")
+        self._route_deadline_aborted = False
         self._deadline = time.monotonic() + seconds
 
     def touch_progress(self) -> None:
@@ -437,6 +439,15 @@ class CompressionCommitFence:
         waiting (see ``auxiliary_client.aux_stream_deadline``).
         """
         return self._deadline
+
+    def mark_route_deadline_abort(self) -> None:
+        """Publish that the worker unwound because this deadline expired."""
+        self._route_deadline_aborted = True
+
+    @property
+    def route_deadline_aborted(self) -> bool:
+        """Whether the worker observed this route's deadline cancellation."""
+        return self._route_deadline_aborted
 
     def seconds_since_progress(self) -> float:
         """Seconds since the worker last reported forward progress."""
@@ -494,6 +505,16 @@ class CompressionCommitFence:
     def is_cancelled(self) -> bool:
         """True after cancellation won before the commit boundary."""
         return self._cancelled or self._admission_revoked or self.deadline_exceeded
+
+    @property
+    def cancellation_requested(self) -> bool:
+        """True only after the host actively cancelled this attempt."""
+        return self._cancelled or self._admission_revoked
+
+    @property
+    def commit_started(self) -> bool:
+        """Whether this attempt ever entered the commit boundary."""
+        return self._commit_started
 
     def retain_compression_lock_until_worker_done(self) -> None:
         """Prevent a timed-out live worker from overlapping a retry."""
@@ -903,7 +924,10 @@ def _await_worker_within_budget(
         since_progress = fence.seconds_since_progress()
         wait_slice = min(max(idle - since_progress, 0.005), remaining_ceiling)
         try:
-            return True, future.result(timeout=wait_slice)
+            result = future.result(timeout=wait_slice)
+            if fence.deadline_exceeded and not fence.commit_started:
+                return False, result
+            return True, result
         except concurrent.futures.TimeoutError:
             waited = time.monotonic() - wait_started
             since_progress = fence.seconds_since_progress()
@@ -1068,6 +1092,7 @@ def run_compress_context_with_progress_timeout(
         if settled:
             handled_exit = True
             return result
+        deadline_abort_result = result if fence.route_deadline_aborted else None
 
         # F6: a not-yet-started future must not linger as a stale queued job.
         # cancel() is a no-op for a running worker (fence handles that path).
@@ -1124,6 +1149,8 @@ def run_compress_context_with_progress_timeout(
             )
         # Leave the future on the shared pool: fence cancel won, so a late
         # commit cannot land (same detachment model as gateway hygiene).
+        if deadline_abort_result is not None:
+            return deadline_abort_result
         return messages, _resolve_fallback_prompt()
     finally:
         if not handled_exit:
@@ -2668,13 +2695,13 @@ def _run_summary_dispatch(
         # in the finally below so it cannot leak into later attempts (e.g. a manual /compress force-clear).
         # See #76354.
         _install_compression_cancelled_check(
-            agent.context_compressor, lambda: commit_fence.is_cancelled, attempt_generation
+            agent.context_compressor, lambda: commit_fence.cancellation_requested, attempt_generation
         )
 
     def _compression_cancel_requested() -> bool:
         return bool(
             (hard_cancel_event is not None and hard_cancel_event.is_set())
-            or (commit_fence is not None and commit_fence.is_cancelled)
+            or (commit_fence is not None and commit_fence.cancellation_requested)
         )
 
     try:
@@ -2692,8 +2719,8 @@ def _run_summary_dispatch(
                 aux_interrupt_protection(cancel_check=_compression_cancel_requested),
             ):
                 compressed = compress_fn(messages, **compress_kwargs)
-                # Freeze a hard stop that arrived after the last provider attempt but before session state rotates.
-                if hard_cancel_event is not None and hard_cancel_event.is_set():
+                # Freeze an active stop that arrived after the last provider attempt but before session state rotates.
+                if _compression_cancel_requested():
                     raise AuxiliaryExplicitCancellation()
     finally:
         if commit_fence is not None:
@@ -3413,6 +3440,9 @@ def _run_summary_phase(
             attempt_generation=attempt.generation, hard_cancel_event=hard_cancel_event,
         )
     except AuxiliaryExplicitCancellation:
+        hard_cancelled = bool(hard_cancel_event is not None and hard_cancel_event.is_set())
+        if not hard_cancelled and commit_fence is not None and commit_fence.deadline_exceeded:
+            commit_fence.mark_route_deadline_abort()
         try:
             attempt.restore_compressor(agent.context_compressor)
         except BaseException as _rollback_exc:
@@ -3433,7 +3463,13 @@ def _run_summary_phase(
         _stop_heartbeat("context compression cancelled")
         lease.release()
         _emit_aborted_attempt_telemetry(
-            agent, attempt.started_at, (STALL_INTERRUPTED_FAILURE_CLASS if _stall_backoff else "explicit_interrupt")
+            agent,
+            attempt.started_at,
+            (
+                "route_deadline"
+                if commit_fence is not None and commit_fence.route_deadline_aborted
+                else (STALL_INTERRUPTED_FAILURE_CLASS if _stall_backoff else "explicit_interrupt")
+            ),
         )
         return _SummaryPhase(messages=messages, abort_prompt=_existing_system_prompt(agent, system_message))
     except BaseException as _compress_exc:

--- a/tests/agent/test_compression_attempt_lifecycle.py
+++ b/tests/agent/test_compression_attempt_lifecycle.py
@@ -28,6 +28,7 @@ from unittest.mock import patch
 
 import pytest
 
+from agent import auxiliary_client as aux
 from agent.auxiliary_client import AuxiliaryExplicitCancellation
 from agent.conversation_compression import (
     CompressionCommitFence,
@@ -68,6 +69,178 @@ def _messages():
 
 
 class TestWorkerTeardownOnCeiling:
+    def test_passive_deadline_waits_for_host_cancellation(
+        self, tmp_path: Path
+    ) -> None:
+        """Deadline observation alone must not impersonate a host cancellation."""
+        _db, agent = _build_agent(tmp_path, "PASSIVE_DEADLINE")
+        original = _messages()
+        fence = CompressionCommitFence(total_ceiling_seconds=0.05)
+        provider_started = threading.Event()
+        release_provider = threading.Event()
+        provider_done = threading.Event()
+        owner_done = threading.Event()
+
+        def _provider(_kwargs):
+            provider_started.set()
+            try:
+                assert release_provider.wait(2)
+                return [{"role": "assistant", "content": "late"}]
+            finally:
+                provider_done.set()
+
+        agent.context_compressor.compress = lambda *_a, **_kw: (
+            aux._run_protected_sync_provider_call(_provider, {})
+        )
+
+        def _owner():
+            try:
+                agent._compress_context(
+                    original,
+                    "sys",
+                    approx_tokens=500_000,
+                    commit_fence=fence,
+                )
+            finally:
+                owner_done.set()
+
+        owner = threading.Thread(target=_owner, daemon=True)
+        owner.start()
+        try:
+            assert provider_started.wait(1)
+            assert not owner_done.wait(0.15), (
+                "passive deadline cancelled the auxiliary owner before the host "
+                "won fence cancellation"
+            )
+            assert fence.cancel_before_commit() is True
+            assert owner_done.wait(0.5)
+            assert not provider_done.is_set()
+            assert fence.route_deadline_aborted
+        finally:
+            release_provider.set()
+            assert provider_done.wait(2)
+            owner.join(2)
+
+    def test_completed_future_after_deadline_is_classified_as_total_timeout(
+        self, monkeypatch
+    ) -> None:
+        """A no-commit result at the deadline must still run timeout bookkeeping."""
+        original = _messages()
+        causes = []
+        timeouts = []
+
+        class _DoneFuture:
+            def __init__(self, result):
+                self._result = result
+
+            def add_done_callback(self, callback):
+                callback(self)
+
+            def cancel(self):
+                return False
+
+            def result(self, timeout=None):
+                return self._result
+
+        class _InlineExecutor:
+            def submit(self, fn, worker_fence):
+                return _DoneFuture(fn(worker_fence))
+
+        monkeypatch.setattr(
+            "agent.conversation_compression._get_compress_timeout_executor",
+            lambda: _InlineExecutor(),
+        )
+        monkeypatch.setattr(
+            "agent.conversation_compression._try_admit_compression_job",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "agent.conversation_compression._release_compression_admission",
+            lambda *_args: None,
+        )
+
+        def _worker(worker_fence: CompressionCommitFence):
+            worker_fence._deadline = time.monotonic() - 1
+            return [{"role": "assistant", "content": "too late"}], "late"
+
+        returned, prompt = run_compress_context_with_progress_timeout(
+            worker=_worker,
+            messages=original,
+            system_prompt_fallback="fallback",
+            idle_timeout_seconds=1,
+            total_ceiling_seconds=1,
+            on_timeout_cause=lambda total, progress: causes.append(
+                (total, progress)
+            ),
+            on_timeout=lambda idle, waited, since_progress: timeouts.append(
+                (idle, waited, since_progress)
+            ),
+            stall_fallback=False,
+        )
+
+        assert returned is original
+        assert prompt == "fallback"
+        assert causes == [(True, False)]
+        assert len(timeouts) == 1
+
+    def test_worker_deadline_preserves_adopted_transcript_if_fallback_unavailable(
+        self, monkeypatch
+    ) -> None:
+        """A worker-side deadline no-op must not discard its newer durable snapshot."""
+        original = _messages()
+        adopted = [*original, {"role": "user", "content": "concurrent tail"}]
+
+        class _DoneFuture:
+            def __init__(self, result):
+                self._result = result
+
+            def add_done_callback(self, callback):
+                callback(self)
+
+            def cancel(self):
+                return False
+
+            def result(self, timeout=None):
+                return self._result
+
+        class _InlineExecutor:
+            def submit(self, fn, worker_fence):
+                return _DoneFuture(fn(worker_fence))
+
+        monkeypatch.setattr(
+            "agent.conversation_compression._get_compress_timeout_executor",
+            lambda: _InlineExecutor(),
+        )
+        monkeypatch.setattr(
+            "agent.conversation_compression._try_admit_compression_job",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "agent.conversation_compression._release_compression_admission",
+            lambda *_args: None,
+        )
+        monkeypatch.setattr(
+            "agent.conversation_compression.resolve_compression_fallback_route",
+            lambda: None,
+        )
+
+        def _worker(worker_fence: CompressionCommitFence):
+            worker_fence.mark_route_deadline_abort()
+            worker_fence._deadline = time.monotonic() - 1
+            return adopted, "adopted prompt"
+
+        returned, prompt = run_compress_context_with_progress_timeout(
+            worker=_worker,
+            messages=original,
+            system_prompt_fallback="fallback",
+            idle_timeout_seconds=1,
+            total_ceiling_seconds=1,
+            stall_fallback=True,
+        )
+
+        assert returned is adopted
+        assert prompt == "adopted prompt"
+
     def test_cooperative_worker_joined_within_grace(self):
         """A worker that exits promptly after cancel is joined on the
         total-ceiling path; the lease is released normally (no retention) —


### PR DESCRIPTION
## What does this PR do?

Makes the compression hard-ceiling outcome independent of the worker/host scheduling race.

- Treats an elapsed deadline as a passive observation until the host actively cancels the attempt.
- Sends a completed future that crossed the deadline without starting a commit through the existing total-timeout bookkeeping and fallback path.
- Preserves the worker's newer durable transcript if rotation adopted concurrent tail and no fallback succeeds.
- Preserves an already-admitted atomic commit and keeps explicit cancellation distinct.

## Bug cause

`CompressionCommitFence.is_cancelled` combined two different states: an elapsed deadline and active host cancellation. Near the hard ceiling, the worker could therefore unwind before the host cancellation path ran. If its future completed in that boundary window, `_await_worker_within_budget()` accepted the result and bypassed the timeout/fallback branch.

A second boundary detail matters in rotation mode: the worker may have adopted a newer durable transcript before the deadline. Falling back to the wrapper's older `messages` reference would discard that concurrent tail.

## Fix

- Add explicit fence state for active cancellation, route-deadline abort, and whether commit admission ever succeeded.
- Use active cancellation—not passive deadline observation—for auxiliary-owner cancellation checks.
- After `Future.result()` settles, reject a post-deadline result unless its commit had already started.
- Route deadline-abort results through normal timeout/fallback handling while retaining their authoritative transcript for fail-safe return.
- Report the worker-side deadline cause as `route_deadline`, not `explicit_interrupt`.

This is a minimal current-`main` forward-port of the race fix discussed in #102367 and #102370, without duplicating the total-ceiling infrastructure already present from #97512. It also incorporates the authoritative-transcript concern raised during review of #102367.

Fixes #102339.

## Tests

The regression tests failed before their corresponding production changes and passed afterward.

```text
3 passed (focused deadline-race regressions)
63 passed (lifecycle/timeout/worker-isolation set)
248 passed (compression-family set)
ruff check: passed
git diff --check: passed
```

## Scope

Exactly two files change:

- `agent/conversation_compression.py`
- `tests/agent/test_compression_attempt_lifecycle.py`
