### PR TITLE
fix(kanban): block the worker on a terminal provider wall instead of exiting 0

### DIFF
--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -76,4 +76,81 @@ def build_kanban_stop_nudge(
     )
 
 
-__all__ = ["build_kanban_stop_nudge", "kanban_stop_nudge_enabled", "session_called_kanban_terminal"]
+# ---- Terminal provider-wall guard -----------------------------------------------
+
+# ``FailureReason`` values that mean the provider/credential itself is unusable, so
+# retrying the run now would end the same way. Auth is included: a dead key blocks
+# every model call, and the dispatcher requeues instead of looping a requeue.
+_PROVIDER_WALL_REASONS = frozenset({"billing", "rate_limit", "auth", "auth_permanent"})
+
+# Text markers for provider walls whose result carries no ``failure_reason``
+# (e.g. a non-retryable abort built by ``_failed_turn_result`` directly).
+# Keep these specific — ``failed=True`` is already required, but a task-level
+# error whose body happens to mention "quota" must not trip this.
+_PROVIDER_WALL_TEXT = (
+    "out of credits", "insufficient balance", "spending limit",
+    "usage limit", "exceeded your current quota", "invalid api key",
+    "incorrect api key", "personal-team-blocked",
+    "http 402", "http 403", "http 429", "error code: 402", "error code: 403",
+    "error code: 429",
+)
+
+
+def _looks_like_provider_wall(reason: Any, error_text: str) -> bool:
+    if isinstance(reason, str) and reason in _PROVIDER_WALL_REASONS:
+        return True
+    lowered = (error_text or "").lower()
+    return any(marker in lowered for marker in _PROVIDER_WALL_TEXT)
+
+
+def maybe_block_kanban_on_provider_failure(result: Any, *, received_provider_response: bool | None = None) -> bool:
+    """Terminal provider-wall guard for kanban workers.
+
+    When every model call failed with a payment / credit / auth / rate-limit
+    error, ``run_conversation`` returns early from the retry loop and never
+    reaches ``finalize_turn`` — so the budget-exhausted kanban bookkeeping
+    there is skipped, and a plain-text exit reads as ``rc=0`` → dispatcher
+    ``protocol_violation`` → requeue loop. This closes the run as a
+    real ``kanban_block`` (``kind="transient"``) carrying the last provider
+    error instead.
+
+    Fires only when: this process is a kanban worker, the turn result says
+    the turn failed, the failure looks like a provider wall, no model
+    response survived validation this turn, and the conversation never
+    invoked a terminal kanban tool itself. Every step is best-effort: the
+    exit path must never crash here. Returns True when a block was recorded.
+    """
+    try:
+        task_id = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+        if not task_id or not isinstance(result, dict):
+            return False
+        if not result.get("failed"):
+            return False
+        error_text = str(result.get("error") or result.get("final_response") or "")
+        if not _looks_like_provider_wall(result.get("failure_reason"), error_text):
+            return False
+        if received_provider_response is None:
+            received_provider_response = result.get("received_provider_response") is True
+        if received_provider_response:
+            return False
+        if result.get("messages") and session_called_kanban_terminal(result.get("messages")):
+            return False
+        reason = str(result.get("failure_reason") or "unknown")
+        block_reason = (
+            f"All model calls failed with a provider error ({reason}) — blocking with "
+            f"the last provider error instead of exiting cleanly: {error_text[:500]}"
+        )
+        from hermes_cli import kanban_db as _kb
+        from hermes_cli import kanban_db_connect as _kbc
+        with _kbc.connect_closing() as conn:
+            return bool(_kb.block_task(conn, task_id, reason=block_reason, kind="transient"))
+    except Exception:
+        return False
+
+
+__all__ = [
+    "build_kanban_stop_nudge",
+    "kanban_stop_nudge_enabled",
+    "maybe_block_kanban_on_provider_failure",
+    "session_called_kanban_terminal",
+]

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -726,7 +726,10 @@ def nonretryable_client_error_result(
             classified=classified, summary=_nonretryable_summary, messages=messages,
             api_call_count=api_call_count, provider=provider, base_url=base_url, model=model,
         )
-    return _failed_turn_result(_nonretryable_summary, messages, api_call_count, _nonretryable_summary)
+    result = _failed_turn_result(_nonretryable_summary, messages, api_call_count, _nonretryable_summary)
+    result["failure_reason"] = classified.reason.value
+    result["failure_retryable"] = bool(classified.retryable)
+    return result
 
 
 _STREAM_DROP_MARKERS = (

--- a/cli.py
+++ b/cli.py
@@ -4103,6 +4103,19 @@ def _run_quiet_single_query(cli, effective_query):
     # without this sync it would point at the ended parent after compression.
     _sync_cli_session_id_from_agent(cli)
     response = result.get("final_response", "") if isinstance(result, dict) else str(result)
+    # Terminal provider-wall guard (billing / credit / auth / rate-limit exhaustion):
+    # the early return above skips finalize_turn's kanban bookkeeping, so a dispatcher
+    # worker whose every model call failed would exit as plain text — rc=0 →
+    # protocol_violation → requeue loop. Block the card with the last provider error
+    # instead. The agent's own validated-response flag rides along on the result.
+    if os.environ.get("HERMES_KANBAN_TASK") and isinstance(result, dict):
+        from agent.kanban_stop import maybe_block_kanban_on_provider_failure
+        if maybe_block_kanban_on_provider_failure(
+            result,
+            received_provider_response=getattr(cli.agent, "_turn_received_provider_response", False) is True,
+        ):
+            print(f"Error: {result.get('error') or 'provider wall'}", file=sys.stderr)
+            sys.exit(1)
     # Surface backend errors that produced no visible output (e.g. invalid model slug
     # -> provider 4xx) on stderr so piped stdout stays clean.
     if (

--- a/hermes_cli/cli_chat_turn_mixin.py
+++ b/hermes_cli/cli_chat_turn_mixin.py
@@ -309,6 +309,12 @@ class CLIChatTurnMixin:
                 stream_callback=turn.stream_callback, task_id=self.session_id,
                 persist_user_message=_persist_clean_user_message, moa_config=_moa_cfg,
             )
+            if os.environ.get("HERMES_KANBAN_TASK") and isinstance(turn.result, dict):
+                from agent.kanban_stop import maybe_block_kanban_on_provider_failure
+                maybe_block_kanban_on_provider_failure(
+                    turn.result,
+                    received_provider_response=getattr(self.agent, "_turn_received_provider_response", False) is True,
+                )
             if getattr(self, "_pending_moa_disable_after_turn", False):
                 _restore = getattr(self, "_pending_moa_restore_model", None) or {}
                 for _key, _value in _restore.items():
@@ -324,6 +330,9 @@ class CLIChatTurnMixin:
                 "final_response": f"Error: {_summary}", "messages": [], "api_calls": 0,
                 "completed": False, "failed": True, "error": _summary,
             }
+            if os.environ.get("HERMES_KANBAN_TASK"):
+                from agent.kanban_stop import maybe_block_kanban_on_provider_failure
+                maybe_block_kanban_on_provider_failure(turn.result)
         finally:
             if _one_turn_model_restore:
                 self._restore_model_runtime_snapshot(_one_turn_model_restore)

--- a/tests/agent/test_kanban_provider_failure_block.py
+++ b/tests/agent/test_kanban_provider_failure_block.py
@@ -1,0 +1,180 @@
+"""Kanban worker must block on a terminal provider failure, not exit 0.
+
+When every model/credential is exhausted, ``run_conversation`` returns
+``failed=True`` from ``_failed_turn_result`` — an early return that never
+reaches ``finalize_turn``. Dispatcher-spawned workers use ``chat -q``
+and currently ignore that result, so the process exits 0 and the
+dispatcher records a protocol violation instead of the last provider
+error.
+
+``maybe_block_kanban_on_provider_failure`` is the single hook both the
+quiet and human-facing one-shot paths call so the card is blocked with
+the last error text.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agent.error_classifier import FailoverReason
+from agent.turn_recovery import _failed_turn_result, max_retries_exhausted_result
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _claimed(conn, *, assignee="engineer"):
+    task_id = kb.create_task(conn, title="work", assignee=assignee)
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (task_id,))
+    task = kb.claim_task(conn, task_id, claimer=assignee)
+    assert task is not None and task.current_run_id is not None
+    return task_id, task.current_run_id
+
+
+def test_failed_turn_result_blocks_kanban_task_with_last_error(kanban_home, monkeypatch):
+    """Provider-wall result must close the run as blocked with the last error."""
+    from agent.kanban_stop import maybe_block_kanban_on_provider_failure
+
+    with kbc.connect_closing() as conn:
+        task_id, run_id = _claimed(conn)
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+
+    last_error = (
+        "Error code: 429 - Token Plan usage limit reached: "
+        "Upgrade your Token Plan or purchase Credits for more usage."
+    )
+    result = _failed_turn_result(
+        last_error, messages=[], api_call_count=3, error=last_error,
+    )
+    result["failure_reason"] = "rate_limit"
+
+    maybe_block_kanban_on_provider_failure(result)
+
+    with kbc.connect_closing() as conn:
+        task = kb.get_task(conn, task_id)
+        run = kb.get_run(conn, run_id)
+        events = kb.list_events(conn, task_id)
+        assert task.status == "blocked"
+        assert task.block_kind == "transient"
+        assert run.outcome == "blocked"
+        assert run.ended_at is not None
+        combined = " ".join(
+            filter(None, [run.summary, run.error, *(str(e.payload) for e in events)])
+        )
+        assert last_error in combined
+
+
+def test_failed_turn_result_is_noop_outside_kanban_worker(kanban_home, monkeypatch):
+    from agent.kanban_stop import maybe_block_kanban_on_provider_failure
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    result = _failed_turn_result("boom", messages=[], api_call_count=1, error="boom")
+    maybe_block_kanban_on_provider_failure(result)  # must not raise
+
+
+def test_successful_turn_does_not_block(kanban_home, monkeypatch):
+    from agent.kanban_stop import maybe_block_kanban_on_provider_failure
+
+    with kbc.connect_closing() as conn:
+        task_id, run_id = _claimed(conn)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+
+    maybe_block_kanban_on_provider_failure(
+        {"final_response": "ok", "completed": True, "failed": False}
+    )
+
+    with kbc.connect_closing() as conn:
+        assert kb.get_task(conn, task_id).status == "running"
+        assert kb.get_run(conn, run_id).ended_at is None
+
+
+def test_max_retries_exhausted_result_blocks_with_classified_error(
+    kanban_home, monkeypatch,
+):
+    from agent.kanban_stop import maybe_block_kanban_on_provider_failure
+
+    with kbc.connect_closing() as conn:
+        task_id, run_id = _claimed(conn)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+
+    last_error = "personal-team-blocked: all model calls failed"
+    classified = SimpleNamespace(
+        reason=FailoverReason.rate_limit,
+        retryable=True,
+        billing_unverified=False,
+    )
+    agent = SimpleNamespace(
+        log_prefix="",
+        _flush_status_buffer=lambda: None,
+        _summarize_api_error=lambda _e: last_error,
+        _emit_status=lambda *_a, **_k: None,
+        _dump_api_request_debug=lambda *_a, **_k: None,
+        _persist_session=lambda *_a, **_k: None,
+        _safe_print=lambda *_a, **_k: None,
+    )
+    with patch("agent.turn_recovery._vlines"):
+        result = max_retries_exhausted_result(
+            agent,
+            Exception(last_error),
+            classified,
+            max_retries=8,
+            is_rate_limited=True,
+            error_msg=last_error,
+            api_kwargs=None,
+            api_messages=[],
+            messages=[],
+            conversation_history=[],
+            api_call_count=8,
+            approx_tokens=0,
+            provider="xai",
+            base_url="https://api.x.ai",
+            model="grok-4",
+        )
+
+    maybe_block_kanban_on_provider_failure(result)
+
+    with kbc.connect_closing() as conn:
+        task = kb.get_task(conn, task_id)
+        run = kb.get_run(conn, run_id)
+        events = kb.list_events(conn, task_id)
+        assert task.status == "blocked"
+        assert run.outcome == "blocked"
+        combined = " ".join(
+            filter(None, [run.summary, run.error, *(str(e.payload) for e in events)])
+        )
+        assert last_error in combined
+
+
+def test_received_provider_response_skips_block(kanban_home, monkeypatch):
+    from agent.kanban_stop import maybe_block_kanban_on_provider_failure
+
+    with kbc.connect_closing() as conn:
+        task_id, run_id = _claimed(conn)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+
+    last_error = "Error code: 429 - usage limit reached"
+    result = _failed_turn_result(last_error, messages=[], api_call_count=1, error=last_error)
+    result["failure_reason"] = "rate_limit"
+    maybe_block_kanban_on_provider_failure(result, received_provider_response=True)
+
+    with kbc.connect_closing() as conn:
+        assert kb.get_task(conn, task_id).status == "running"
+        assert kb.get_run(conn, run_id).ended_at is None


### PR DESCRIPTION
## Summary

When every model call fails with a billing / credit / auth / rate-limit error, `run_conversation` returns early from the retry loop and never reaches `finalize_turn`. A dispatcher-spawned worker (`chat -q`) then prints the error and exits 0 while the card is still `running`. The dispatcher classifies that as a protocol violation (`worker exited cleanly (rc=0) without calling kanban_complete or kanban_block`) and the requeue watchdog loops forever.

This records a real `kanban_block(kind=transient)` carrying the last provider error instead.

- `agent/kanban_stop.py`: `maybe_block_kanban_on_provider_failure` — fires only for a kanban worker, a failed turn, a provider-wall reason/text, no validated provider response this turn, and no terminal kanban tool already invoked.
- Wired on the quiet (`-Q`) one-shot path and the `chat()` one-shot path the dispatcher actually uses.
- `nonretryable_client_error_result` now stamps `failure_reason` so an auth abort is classified, not just a billing one.

Does not change auto_decompose, flow config, dispatcher caps, or role routing.

## Test plan

- [x] `TMPDIR=~/tmp pytest tests/agent/test_kanban_provider_failure_block.py tests/agent/test_kanban_stop.py tests/agent/test_nous_oauth_401_guidance.py -q` — 10 passed