### PR TITLE
test(hf-browse): fix stub-bypass flake from a stale sys.modules reference

### DIFF
--- a/tests/hermes_cli/test_hf_browse.py
+++ b/tests/hermes_cli/test_hf_browse.py
@@ -10,13 +10,28 @@ import pytest
 from fastapi.testclient import TestClient
 
 from hermes_cli.local_runtime.estimator import HardwareBudget
-from hermes_cli.local_runtime.hf_browse import (
-    HFFileGroup,
-    HFModelHit,
-    repo_files,
-    rough_fit,
-    search_models,
-)
+from hermes_cli.local_runtime.hf_browse import HFFileGroup, HFModelHit, rough_fit
+
+
+def _hf():
+    """The ``hf_browse`` module as ``monkeypatch`` sees it, resolved per call.
+
+    ``search_models`` / ``repo_files`` resolve ``_get_json`` through their own
+    module globals, and these tests stub that name by dotted path — which
+    monkeypatch resolves through ``sys.modules`` at patch time. In a
+    shared-process run something evicts the ``hf_browse`` entry, so a later
+    import builds a SECOND module object from the same file. Any name bound at
+    import time (whether the functions themselves or the module) then points at
+    the first, now-unregistered copy: the stub lands on copy #2 while the test
+    calls copy #1, the real ``_get_json`` runs, and the assertion sees live
+    huggingface.co data instead of the canned fixture. Re-reading
+    ``sys.modules`` at call time is what guarantees the call and the patch meet
+    on one object. Invisible under the canonical per-file runner; reproducible
+    in a single bulk ``pytest`` invocation across many files.
+    """
+    import sys
+
+    return sys.modules["hermes_cli.local_runtime.hf_browse"]
 
 GIB = 1 << 30
 
@@ -47,7 +62,7 @@ def test_search_parses_hf_hits(monkeypatch):
     ]
     monkeypatch.setattr("hermes_cli.local_runtime.hf_browse._get_json",
                         lambda url: canned)
-    hits = search_models("qwen")
+    hits = _hf().search_models("qwen")
     assert hits[0].repo == "unsloth/Qwen3.8-27B-GGUF"
     assert hits[0].downloads == 872724
     assert hits[1].gated is True  # HF 'auto'-gated counts as gated
@@ -64,7 +79,7 @@ def test_repo_files_groups_splits_and_excludes_companions(monkeypatch):
     ]
     monkeypatch.setattr("hermes_cli.local_runtime.hf_browse._get_json",
                         lambda url: canned)
-    groups = repo_files("any/repo")
+    groups = _hf().repo_files("any/repo")
     labels = {g.label: g for g in groups}
     assert "Q4_K_M" in labels and labels["Q4_K_M"].total_bytes == 17 * GIB
     # Split parts collapse into one group, ordered, summed.


### PR DESCRIPTION
## Symptom

Two tests in `tests/hermes_cli/test_hf_browse.py` fail in a shared-process run while passing 8/8 in isolation. Both stub `hermes_cli.local_runtime.hf_browse._get_json`, yet the assertion receives **live huggingface.co data**:

```
assert 'unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF' == 'unsloth/Qwen3.8-27B-GGUF'
```

The canned fixture never reached the parser, so a real network request went out. An earlier capture of the same failure shows `urllib` frames and an HTTP 401.

## Root cause

I instrumented the failing run with a diagnostic pytest plugin instead of reasoning from the traceback, and it found **two `hf_browse` namespaces alive simultaneously**, both from the same file:

```
test's search_models.__globals__ is vars(sys.modules[...])  -> False
sys.modules keys mapping to the test's namespace            -> []
```

The test's namespace is *orphaned*. Something evicts the `hf_browse` entry from `sys.modules` during the run; a later import builds a second module object from the same path; and the by-value `from ...hf_browse import search_models` leaves the test file holding a function whose `__globals__` belong to copy #1.

`monkeypatch.setattr` resolves its dotted target through `sys.modules`, so **the stub lands on copy #2 while the test calls copy #1** — and copy #1's globals still hold the real `_get_json`.

Two checks confirmed it rather than assuming: patching the test's *own* namespace made the stub take effect, and deliberately reproducing the eviction (`del sys.modules[key]`, re-import, patch, call the stale reference) reproduces the exact failing repo name.

Hypotheses I tested and discarded first, so nobody retreads them:

- **Module-level `_CACHE` poisoning.** Real leak — the cache is global with a 300s TTL and nothing clears it between tests — but an autouse fixture clearing it did **not** fix the failure. Not the cause.
- **`importlib.reload` orphaning the patch.** Disproven: `reload()` mutates the same module object and reuses its `__dict__`, so a patch survives it.
- **Duplicate `hermes_cli` on `sys.path`.** Disproven: editable install, single path, one `sys.modules` key.

## The change

Resolve both functions through `sys.modules` at call time via a small `_hf()` helper.

Importing the *module* was not sufficient — I tried `from ... import hf_browse` plus `hf_browse.search_models(...)` and it still failed, because a module name bound at import time is stale in exactly the same way. Only re-reading the registry guarantees the call and the patch meet on one object.

Scope is one test file, +24/-9, no production code touched.

## Verification

- **Reproduction, then fix, in the shared-process file set that surfaced it:** hf_browse failures **2 → 0**. Unrelated pre-existing failures went 73 → 71 and are untouched by this change.
- **Canonical runner** (`scripts/run_tests.sh`, per-file isolation, what CI uses): 8 passed, exit 0.
- **`ruff check`**: clean.
- **Positive controls** — the test must still catch real regressions, not just tolerate ordering. Breaking the `gated` parse (`gated=False`) and breaking the `downloads` parse (`downloads=0`) each fail the suite (exit 1); restoring the source passes 8/8. So this is not an order-robust no-op.

## Why CI never caught it

`scripts/run_tests.sh` gives every file its own `python -m pytest` subprocess, so cross-file module identity damage is invisible there. It takes one bulk `pytest` invocation across many files to hit — which is how a differential verification run surfaces it.
