### PR TITLE
fix(desktop): pane tab ✕ is a real fade again, not 36px of dead padding

### DIFF
--- a/apps/desktop/src/components/ui/pane-tab.test.tsx
+++ b/apps/desktop/src/components/ui/pane-tab.test.tsx
@@ -5,6 +5,10 @@ import { PaneTab, PaneTabLabel } from './pane-tab'
 
 afterEach(cleanup)
 
+/** The tab shell's own classes (the label's grandparent), split for set diffs. */
+const classesOf = (label: string): string[] =>
+  screen.getByText(label).parentElement!.parentElement!.className.split(/\s+/).filter(Boolean)
+
 describe('PaneTab close gestures', () => {
   it('middle-click closes — pointer events only, no auxclick', () => {
     const onClose = vi.fn()
@@ -124,25 +128,50 @@ describe('PaneTab hover close button', () => {
     expect(screen.queryByRole('button', { name: 'Close' })).toBeNull()
   })
 
-  it('reserves a close-button runway only on closeable horizontal tabs', () => {
+  it('floors a closeable horizontal tab instead of padding a runway onto it', () => {
     const onClose = vi.fn()
 
-    const { rerender } = render(
+    const closeable = render(
       <PaneTab onClose={onClose}>
         <PaneTabLabel>BROWSER</PaneTabLabel>
       </PaneTab>
     )
+    const withClose = classesOf('BROWSER')
+    closeable.unmount()
 
-    const horizontalTab = screen.getByText('BROWSER').parentElement?.parentElement
-    expect(horizontalTab?.className).toContain('pr-9')
+    render(
+      <PaneTab>
+        <PaneTabLabel>BROWSER</PaneTabLabel>
+      </PaneTab>
+    )
+    const withoutClose = classesOf('BROWSER')
 
-    rerender(
+    // The ✕ is paid for with a min-width FLOOR, not right padding: a short
+    // label can't be swallowed by its own chip, and a tab whose label already
+    // clears the floor pays nothing — so no tab carries dead runway at rest.
+    const added = withClose.filter(cls => !withoutClose.includes(cls))
+    expect(added.some(cls => /^min-w-/.test(cls))).toBe(true)
+    expect(withClose.some(cls => /^pr-/.test(cls))).toBe(false)
+  })
+
+  it('a vertical rail tab gets no floor — it has no ✕ to make room for', () => {
+    const onClose = vi.fn()
+
+    const railed = render(
       <PaneTab onClose={onClose} vertical>
         <PaneTabLabel>BROWSER</PaneTabLabel>
       </PaneTab>
     )
-    const verticalTab = screen.getByText('BROWSER').parentElement?.parentElement
-    expect(verticalTab?.className).not.toContain('pr-9')
+    const withClose = classesOf('BROWSER')
+    railed.unmount()
+
+    render(
+      <PaneTab vertical>
+        <PaneTabLabel>BROWSER</PaneTabLabel>
+      </PaneTab>
+    )
+
+    expect(withClose).toEqual(classesOf('BROWSER'))
   })
 
   it('a closeable horizontal tab always shows its ✕ — the chip and the pointer gestures are one affordance', () => {

--- a/apps/desktop/src/components/ui/pane-tab.tsx
+++ b/apps/desktop/src/components/ui/pane-tab.tsx
@@ -23,6 +23,11 @@ const TAB =
 // leave uncovered, so tabs fill the bar and no sliver of gutter shows through.
 const TAB_HORIZONTAL = 'h-full min-w-0 max-w-48 not-first:border-l not-first:border-l-(--ui-stroke-quaternary)'
 
+// A closeable tab's floor: 8px label inset + the ~19px opaque ✕ chip, so the
+// shortest labels (FILES, REVIEW) clear the chip and pass under nothing but the
+// gradient. A floor, not padding — a tab already wider than it pays nothing.
+const TAB_CLOSEABLE = 'min-w-13'
+
 const TAB_VERTICAL =
   'w-full max-h-48 justify-center not-first:border-t not-first:border-t-(--ui-stroke-quaternary) [writing-mode:vertical-rl]'
 
@@ -102,7 +107,7 @@ export const PaneTab = React.forwardRef<HTMLDivElement, PaneTabProps>(function P
       className={cn(
         TAB,
         vertical ? TAB_VERTICAL : TAB_HORIZONTAL,
-        !vertical && onClose && 'pr-9',
+        !vertical && onClose && TAB_CLOSEABLE,
         edge,
         active
           ? cn(TAB_ACTIVE, !vertical && TAB_ACTIVE_UNDERLINE)
@@ -164,9 +169,11 @@ export const PaneTab = React.forwardRef<HTMLDivElement, PaneTabProps>(function P
         </span>
       )}
       {onClose && !vertical && (
-        // Hover ✕ stays absolutely positioned so hover never shifts the tab.
-        // The tab reserves a fixed right runway for this overlay, keeping the
-        // label clear of the gradient/button even for short labels like BROWSER.
+        // Hover ✕, painted OVER the label's right edge as an overlay (no
+        // layout shift, tab width never jumps on hover). The runway is a tiny
+        // transparent→`--tab-face` gradient, so the button melts into the
+        // tab's effective surface instead of hard-clipping the text under it.
+        // Short labels are kept legible by TAB_CLOSEABLE, not by padding.
         // Rendered after the dirty dot: on hover the ✕ takes the dot's spot,
         // VS Code-style.
         <span className="pointer-events-none absolute inset-y-0 right-0 flex items-stretch opacity-0 transition-opacity group-hover/tab:pointer-events-auto group-hover/tab:opacity-100">

--- a/apps/desktop/src/components/ui/pane-tab.tsx
+++ b/apps/desktop/src/components/ui/pane-tab.tsx
@@ -16,8 +16,13 @@ export const PANE_TAB_STRIP_LINE_RIGHT = 'shadow-[inset_-1px_0_0_var(--ui-stroke
 // the label after every wash lands. The hover close-button gradient fades into
 // it, so the fade is seamless on any theme. Idle hover repaints it below with
 // the same color-mix the darkening wash applies.
+//
+// `--tab-bg` is the base every wash mixes onto. Under Glass the surface tokens
+// are transparent and the <body> field is what shows through a tab, so the
+// base prefers `--glass-field` (styles.css sets it only under glass, on
+// `data-glass-field` declarers) and falls back to the tab's own surface token.
 const TAB =
-  'group/tab relative flex shrink-0 items-center border-transparent bg-(--tab-bg) text-[0.6875rem] font-medium [-webkit-app-region:no-drag] [--tab-face:var(--tab-bg)]'
+  'group/tab relative flex shrink-0 items-center border-transparent bg-(--tab-bg) text-[0.6875rem] font-medium [-webkit-app-region:no-drag] [--tab-face:var(--tab-bg)] [--tab-bg:var(--glass-field,var(--tab-surface))]'
 
 // Full height: with the strip's rule removed there is no last-pixel row to
 // leave uncovered, so tabs fill the bar and no sliver of gutter shows through.
@@ -31,7 +36,7 @@ const TAB_CLOSEABLE = 'min-w-13'
 const TAB_VERTICAL =
   'w-full max-h-48 justify-center not-first:border-t not-first:border-t-(--ui-stroke-quaternary) [writing-mode:vertical-rl]'
 
-const TAB_ACTIVE = 'h-full text-foreground [--tab-bg:var(--pane-tab-active-bg,var(--ui-editor-surface-background))]'
+const TAB_ACTIVE = 'h-full text-foreground [--tab-surface:var(--pane-tab-active-bg,var(--ui-editor-surface-background))]'
 
 // Horizontal only: the active tab is the sole seam on the strip — a
 // theme-primary underline drawn as an inset shadow in its own last pixel row,
@@ -44,7 +49,7 @@ const TAB_ACTIVE_UNDERLINE = 'shadow-[inset_0_-2px_0_var(--pane-tab-active-accen
 // a darkening wash to register at all. `--tab-face` tracks the wash — the same
 // mix flattened onto `--tab-bg` — so the close gradient matches what shows.
 const TAB_IDLE =
-  'text-(--ui-text-tertiary) [--tab-bg:var(--pane-tab-strip-bg,var(--ui-sidebar-surface-background))] hover:shadow-[inset_0_0_0_100vmax_color-mix(in_srgb,#000_var(--ui-tab-hover-darken),transparent)] hover:[--tab-face:color-mix(in_srgb,#000_var(--ui-tab-hover-darken),var(--tab-bg))] hover:text-(--ui-text-secondary)'
+  'text-(--ui-text-tertiary) [--tab-surface:var(--pane-tab-strip-bg,var(--ui-sidebar-surface-background))] hover:shadow-[inset_0_0_0_100vmax_color-mix(in_srgb,#000_var(--ui-tab-hover-darken),transparent)] hover:[--tab-face:color-mix(in_srgb,#000_var(--ui-tab-hover-darken),var(--tab-bg))] hover:text-(--ui-text-secondary)'
 
 // A tab riding a multi-tab selection: an accent wash over whatever surface the
 // tab sits on. A background-image gradient (not a shadow) so it stacks cleanly
@@ -117,6 +122,7 @@ export const PaneTab = React.forwardRef<HTMLDivElement, PaneTabProps>(function P
       )}
       data-active={active}
       data-closeable={(onClose && !vertical) || undefined}
+      data-glass-field=""
       data-selected={selected || undefined}
       data-vertical={vertical || undefined}
       onClickCapture={event => {

--- a/apps/desktop/src/components/ui/pane-tab.tsx
+++ b/apps/desktop/src/components/ui/pane-tab.tsx
@@ -116,6 +116,7 @@ export const PaneTab = React.forwardRef<HTMLDivElement, PaneTabProps>(function P
         className
       )}
       data-active={active}
+      data-closeable={(onClose && !vertical) || undefined}
       data-selected={selected || undefined}
       data-vertical={vertical || undefined}
       onClickCapture={event => {
@@ -218,7 +219,9 @@ interface PaneTabLabelProps extends React.ComponentProps<'button'> {
 }
 
 /** Truncating label inside a `PaneTab`. `className` merges into the text span
- *  (e.g. `normal-case tracking-normal` for filenames). */
+ *  (e.g. `normal-case tracking-normal` for filenames). On a closeable tab the
+ *  text clips instead of ellipsizing, so it runs under the hover ✕ fade rather
+ *  than stopping short of it with dots. */
 export const PaneTabLabel = React.forwardRef<HTMLElement, PaneTabLabelProps>(function PaneTabLabel(
   { as = 'span', className, children, ...props },
   ref
@@ -231,7 +234,12 @@ export const PaneTabLabel = React.forwardRef<HTMLElement, PaneTabLabelProps>(fun
       ref={ref}
       {...props}
     >
-      <span className={cn('block min-w-0 truncate text-[9px] font-medium tracking-wide uppercase', className)}>
+      <span
+        className={cn(
+          'block min-w-0 truncate text-[9px] font-medium tracking-wide uppercase group-data-[closeable]/tab:text-clip',
+          className
+        )}
+      >
         {children}
       </span>
     </Comp>

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -617,6 +617,16 @@
     background: color-mix(in srgb, var(--ui-bg-chrome) var(--translucency-glass-keep, 100%), transparent);
   }
 
+  /* A surface that FADES INTO the field (a pane tab's hover ✕ runway) declares
+     `data-glass-field` and reads `--glass-field` for its endpoint. Under glass
+     the surface tokens are transparent, so a fade aimed at one goes
+     transparent→transparent and the runway vanishes; the field is the <body>
+     mix above, so that is what a fade must land on. Inert with glass off:
+     the caller's own fallback (its surface token) applies. */
+  :root[data-hermes-glass] [data-glass-field] {
+    --glass-field: color-mix(in srgb, var(--ui-bg-chrome) var(--translucency-glass-keep, 100%), transparent);
+  }
+
   /* Sidebar scope (the Finder shape): glass rail, opaque content column.
      <body> stays the one painter but splits at the rail's visual edge — the
      store publishes it as --glass-rail-edge (live-tracked through collapse


### PR DESCRIPTION
## What does this PR do?

Pane-tab close buttons were paid for with dead space: [#96880](https://github.com/NousResearch/hermes-agent/pull/96880) added `pr-9` to every closeable tab so the hover ✕ could never overlap a label. That is 36px of empty runway at rest on every tab — FILES went 40→76px — and it never made the ✕ any more visible, because the ✕ is hover-only.

This puts the ✕ back the way it was designed (an overlay painted over the label's right edge, gradient-blended into the tab surface, zero layout shift) and fixes the two reasons that overlay never actually read as a fade:

- **Short labels** get a `min-w-13` floor instead of padding. Sized from the chrome: 8px inset + the ~19px opaque chip, so the shortest labels clear the chip and pass only under the translucent gradient. A floor bills only tabs that need it; TERMINAL / BROWSER / NEW CHAT pay nothing.
- **Long labels** stopped short of the fade with an ellipsis, so the gradient faded over bare surface — invisible by construction. A closeable tab publishes `data-closeable`; the label clips instead, so real letterforms run under the fade.
- **Under Glass** (Window Translucency) the surface tokens are transparent and `<body>` is the sole painter, so the fade resolved to transparent→transparent and the ✕ chip painted nothing — a bare ✕ over un-faded text. A `data-glass-field` contract joins the block's existing `data-glass-opaque` / `data-glass-raised`: a declarer receives the same body mix glass already paints, and the tab's base surface prefers it. Inert with glass off — the fallback resolves to the exact opaque surface it did before.

| | FILES | TERMINAL | 8-tab strip |
|---|---|---|---|
| overlay as designed | 40px | 63px | 459px |
| `pr-9` reserve (#96880) | 76px | 99px | 528px |
| **this PR** | **52px** | **63px** | **478px** |

## Related Issue

Fixes #96780 — the BROWSER ✕ is now on its own opaque chip past the label's last glyph, no longer obscured, in every mode.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/components/ui/pane-tab.tsx` — `TAB_CLOSEABLE` floor replaces `pr-9`; `data-closeable` + `group-data-[closeable]/tab:text-clip` on the label; `--tab-bg` = `var(--glass-field, var(--tab-surface))`, with `TAB_ACTIVE` / `TAB_IDLE` setting `--tab-surface` so they feed the chain.
- `apps/desktop/src/styles.css` — `[data-glass-field]` rule in the glass block.
- `apps/desktop/src/components/ui/pane-tab.test.tsx` — the test that pinned `pr-9` by class string becomes a set-diff contract: adding `onClose` adds a `min-w-*` and never a `pr-*`; vertical rails get no floor.

## How to Test

1. Open a long-titled chat and a short pane (Files) in the same strip. At rest, no tab has empty space right of its label.
2. Hover the long tab: the last letters dissolve under a gradient into the ✕ chip — no `…`, no gap.
3. Settings → Appearance → Window Translucency → Glass, 40–60%. Hover again: same fade, chip filled, ✕ visible. Glass off: identical to step 2.
4. `cd apps/desktop` then `npx vitest run src/components/ui/pane-tab.test.tsx src/components/pane-shell/tree/renderer/tab-close-affordance.test.tsx electron/translucency.test.ts`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, desktop-only; the vitest suites above pass (94)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.7

### Documentation & Housekeeping

- [x] Documentation — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — CSS only; Glass is macOS-only and the rule is inert elsewhere
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Before (`pr-9` reserve, ellipsis, glass-transparent face) → after. Same tab, hovered, Glass on:
