### PR TITLE
cron: queue continuable manual runs for the live gateway tick

### DIFF
--- a/hermes_cli/web_routers/cron.py
+++ b/hermes_cli/web_routers/cron.py
@@ -80,6 +80,17 @@ def _found(job):
     return job
 
 
+def _dashboard_cron_owned_by_gateway(profile: str) -> bool:
+    """True while a live gateway owns ``profile``'s cron store (has the adapters)."""
+    try:
+        from hermes_cli.profiles import _check_gateway_running
+
+        _name, home = _cron_profile_home(profile)
+        return bool(_check_gateway_running(Path(home)))
+    except Exception:
+        return False
+
+
 def _list_cron_jobs_sync(profile: str = "all"):
     requested = (profile or "all").strip()
     if requested.lower() != "all":
@@ -172,6 +183,21 @@ def _resume_cron_job_sync(job_id: str, profile: Optional[str] = None):
 def _trigger_cron_job_sync(job_id: str, profile: Optional[str] = None):
     selected = _job_profile(job_id, profile)
     job = _found(_call_cron_for_profile(selected, "resolve_job_ref", job_id))
+    deliver = job.get("deliver") or "local"
+    targets = deliver if isinstance(deliver, list) else str(deliver).split(",")
+    continuable_delivery = bool(job.get("attach_to_session")) and any(
+        str(target).strip().lower() not in {"", "local"}
+        for target in targets
+    )
+    if continuable_delivery and _dashboard_cron_owned_by_gateway(selected):
+        queued = _mutate_cron_for_profile(selected, "trigger_job", job["id"])
+        if not queued:
+            raise HTTPException(status_code=404, detail="Job not found")
+        return {
+            **queued,
+            "scheduled_for_gateway": True,
+            "execution_mode": "gateway_tick",
+        }
     # Never expose the job as due before claiming it: the built-in ticker and
     # external/manual fire paths share one durable claim, so only one executes
     # this run even racing across processes. Active jobs keep the legacy call

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -1190,3 +1190,29 @@ async def test_create_cron_job_without_profile_defaults_when_unscoped(
 
     assert job["profile"] == "default"
     assert (isolated_profiles["default"] / "cron" / "jobs.json").exists()
+
+
+def test_trigger_queues_continuable_job_for_gateway(monkeypatch):
+    """Dashboard trigger on a continuable job owned by a live gateway queues it
+    for the gateway tick instead of firing in-process without adapters."""
+    job = {
+        "id": "dash-gw-1", "attach_to_session": True, "deliver": "discord",
+        "origin": {"platform": "discord", "chat_id": "7"},
+    }
+    monkeypatch.setattr(_rt_cron, "_job_profile", lambda job_id, profile: "default")
+    monkeypatch.setattr(
+        _web_server_cron, "_call_cron_for_profile", lambda *a, **k: dict(job))
+    monkeypatch.setattr(
+        _rt_cron, "_dashboard_cron_owned_by_gateway", lambda profile: True)
+    monkeypatch.setattr(
+        _rt_cron, "_mutate_cron_for_profile", lambda *a, **k: {"id": "dash-gw-1"})
+    fired = []
+    monkeypatch.setattr(
+        _web_server_cron, "_fire_cron_job_for_profile",
+        lambda *a, **k: fired.append(1) or True)
+
+    out = _rt_cron._trigger_cron_job_sync("dash-gw-1", None)
+
+    assert out["scheduled_for_gateway"] is True
+    assert out["execution_mode"] == "gateway_tick"
+    assert fired == []

--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -325,3 +325,33 @@ class TestManualRunReportsDeliveryFailure:
             res = _execute_job_now(dict(_JOB))
         assert res["success"] is True
         assert res["error"] is None
+
+
+class TestCronjobRunQueuesContinuableForGateway:
+    def test_run_queues_continuable_job_for_live_gateway(self):
+        """action='run' on a continuable job with a foreign live gateway must
+        queue it for the gateway tick instead of executing inline without
+        platform adapters."""
+        job = {
+            "id": "job-gw-1", "name": "gw job", "prompt": "hi",
+            "schedule": {"kind": "cron", "expr": "0 9 * * *"},
+            "attach_to_session": True,
+            "origin": {"platform": "discord", "chat_id": "123"},
+            "deliver": "origin",
+        }
+        queued = {**job, "next_run_at": "2030-01-01T00:00:00"}
+        refreshed = {**queued, "last_status": "ok"}
+        with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(job)), \
+             patch("gateway.status.get_running_pid", return_value=999999), \
+             patch("tools.cronjob_tools.trigger_job",
+                   return_value=dict(queued)) as m_trigger, \
+             patch("tools.cronjob_tools.get_job", return_value=dict(refreshed)), \
+             patch("tools.cronjob_tools._execute_job_now") as m_exec:
+            out = json.loads(cronjob(action="run", job_id="job-gw-1"))
+
+        assert out["success"] is True
+        assert out["job"]["executed"] is False
+        assert out["job"]["scheduled_for_gateway"] is True
+        assert out["job"]["execution_mode"] == "gateway_tick"
+        m_trigger.assert_called_once_with("job-gw-1", extra_prompt=None)
+        m_exec.assert_not_called()

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -40,6 +40,7 @@ from cron.jobs import (
     remove_job,
     resolve_job_ref,
     resume_job,
+    trigger_job,
     update_job)
 from tools.cronjob_prompt_scan import _scan_cron_prompt
 from tools.cronjob_job_args import (
@@ -74,6 +75,37 @@ def _notify_provider_jobs_changed_safe() -> None:
         _notify_provider_jobs_changed()
     except Exception:
         pass
+
+
+def _continuable_run_should_use_gateway_tick(job: Dict[str, Any]) -> bool:
+    """Whether this manual run needs another process's live gateway adapter."""
+    if not job.get("attach_to_session"):
+        return False
+    origin = job.get("origin")
+    if not isinstance(origin, dict):
+        return False
+    origin_platform = str(origin.get("platform") or "").strip().lower()
+    origin_chat = str(origin.get("chat_id") or "").strip()
+    if not origin_platform or not origin_chat:
+        return False
+    deliver = job.get("deliver") or "local"
+    targets = deliver if isinstance(deliver, list) else str(deliver).split(",")
+    normalized = [str(target).strip().lower() for target in targets if str(target).strip()]
+    if not any(
+        target == "origin"
+        or target == origin_platform
+        or target.startswith(f"{origin_platform}:{origin_chat}")
+        for target in normalized
+    ):
+        return False
+    try:
+        import os
+        from gateway.status import get_running_pid
+
+        gateway_pid = get_running_pid(cleanup_stale=False)
+    except Exception:
+        return False
+    return bool(gateway_pid and int(gateway_pid) != os.getpid())
 
 
 # ---------------------------------------------------------------------------
@@ -631,6 +663,26 @@ def _action_run(job: Dict[str, Any], a: Dict[str, Any]) -> str:
         scan_error = _scan_cron_prompt(extra_prompt)
         if scan_error:
             return tool_error(scan_error, success=False)
+    if _continuable_run_should_use_gateway_tick(job):
+        triggered = trigger_job(str(job_id), extra_prompt=extra_prompt)
+        if not triggered:
+            return tool_error(
+                f"Failed to queue continuable job '{job_id}' for the live gateway",
+                success=False,
+            )
+        _notify_provider_jobs_changed_safe()
+        result = _refreshed_job_view(str(job_id))
+        result["executed"] = False
+        result["scheduled_for_gateway"] = True
+        result["execution_mode"] = "gateway_tick"
+        return _dumps({
+            "success": True,
+            "job": result,
+            "note": (
+                "Continuable job queued for the live gateway's next "
+                "scheduler tick so delivery can use its platform adapter."
+            ),
+        })
     # A manual run must actually run even with no ticker active. Preferred: background
     # dispatch (handle now, outcome as a completion event); inline fallback otherwise.
     bg = _try_dispatch_background_run(job, session_id=a["session_id"], extra_prompt=extra_prompt)


### PR DESCRIPTION
## Summary
Manual runs of continuable cron jobs (`attach_to_session` + platform deliver) are queued for the live gateway's next scheduler tick instead of executing in a process without platform adapters. Both entry points return `scheduled_for_gateway: true` with `execution_mode: gateway_tick`:
- `cronjob(action=run)` tool (new `_continuable_run_should_use_gateway_tick` gate before background/relay/inline execution; queues via `trigger_job`);
- dashboard `POST /api/cron/jobs/{id}/trigger` (same decision when a live gateway owns the profile, via the established `_check_gateway_running` idiom).

Without a foreign live gateway, or for non-continuable jobs, behavior is unchanged (purely additive: +134/-0).

## Relation to #91399
Complementary, no overlap: #91399 yields inside `_execute_job_now` (`queued_for_gateway` from the scheduler-owned check); this covers the tool-level routing decision and the dashboard trigger path with stable result markers. Different symbols, different hunks; neither touches the other.

## Test plan
- Two new contract tests RED on base (missing symbols, no mock masking), GREEN with the fix.
- `scripts/run_tests.sh tests/tools/test_cronjob_run_immediate.py tests/hermes_cli/test_web_server_cron_profiles.py`: 48/48 pass.
- `git diff --check` clean.