### PR TITLE
fix(desktop): a skin from ~/.hermes/skins survives relaunch

### DIFF
--- a/apps/desktop/src/themes/backend-sync.test.ts
+++ b/apps/desktop/src/themes/backend-sync.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $backendThemes, $pendingSkinApply, __resetBackendSkinSync, ingestBackendSkin } from './backend-sync'
 
@@ -8,7 +8,10 @@ const skin = (name: string) => ({
 })
 
 describe('ingestBackendSkin', () => {
-  beforeEach(() => __resetBackendSkinSync())
+  beforeEach(() => {
+    window.localStorage.clear()
+    __resetBackendSkinSync()
+  })
 
   it('registers a converted skin without applying when apply=false', () => {
     ingestBackendSkin(skin('neon'), { apply: false })
@@ -105,5 +108,26 @@ describe('ingestBackendSkin', () => {
     ingestBackendSkin({ name: '' }, { apply: true })
 
     expect($pendingSkinApply.get()).toBeNull()
+  })
+
+  it('hydrates the registry from storage on load, so a persisted pick resolves before the gateway connects', async () => {
+    ingestBackendSkin(skin('neon'), { apply: false })
+    expect(JSON.parse(window.localStorage.getItem('hermes-desktop-backend-themes-v1') ?? '{}').neon?.name).toBe('neon')
+
+    // Relaunch: a fresh module instance with the same storage.
+    vi.resetModules()
+    const fresh = await import('./backend-sync')
+
+    expect(fresh.$backendThemes.get().neon?.name).toBe('neon')
+  })
+
+  it('drops junk and built-in names from the cached registry', async () => {
+    const mono = { name: 'mono', label: 'x', colors: { background: '#000', foreground: '#fff', primary: '#f0f' } }
+    window.localStorage.setItem('hermes-desktop-backend-themes-v1', JSON.stringify({ mono, bad: { name: 'bad' } }))
+
+    vi.resetModules()
+    const fresh = await import('./backend-sync')
+
+    expect(fresh.$backendThemes.get()).toEqual({})
   })
 })

--- a/apps/desktop/src/themes/backend-sync.ts
+++ b/apps/desktop/src/themes/backend-sync.ts
@@ -19,12 +19,29 @@
 import type { HermesSkin } from '@hermes/shared/skin'
 import { atom } from 'nanostores'
 
+import { readJson, writeJson } from '@/lib/storage'
+
 import { BUILTIN_THEMES } from './presets'
 import { skinToDesktopTheme } from './skin'
-import type { DesktopTheme } from './types'
+import { type DesktopTheme, isValidTheme } from './types'
+
+// Cached so the boot-time paint (which runs before the gateway connects) can
+// resolve a persisted skin pick synchronously, like a built-in or a user
+// install. Without it the stored name failed `resolveTheme` on every launch
+// and the app silently painted the default until the next `skin.changed`.
+const BACKEND_THEMES_KEY = 'hermes-desktop-backend-themes-v1'
+
+const readCached = (): Record<string, DesktopTheme> =>
+  Object.fromEntries(
+    Object.entries(readJson<Record<string, unknown>>(BACKEND_THEMES_KEY) ?? {}).filter(
+      (entry): entry is [string, DesktopTheme] => !BUILTIN_THEMES[entry[0]] && isValidTheme(entry[1])
+    )
+  )
 
 /** Skins pushed by the backend, keyed by name. Merged by `listAllThemes`. */
-export const $backendThemes = atom<Record<string, DesktopTheme>>({})
+export const $backendThemes = atom<Record<string, DesktopTheme>>(typeof window === 'undefined' ? {} : readCached())
+
+$backendThemes.listen(themes => writeJson(BACKEND_THEMES_KEY, themes))
 
 /** One-shot skin name the ThemeProvider should switch to (it clears this). */
 export const $pendingSkinApply = atom<string | null>(null)

--- a/apps/desktop/src/themes/context.test.tsx
+++ b/apps/desktop/src/themes/context.test.tsx
@@ -68,6 +68,29 @@ describe('ThemeProvider ← backend skin sync', () => {
     )
     expect(cssVar('--theme-foreground')).toBe('#ff9f0a')
   })
+
+  // The relaunch bug: the persisted pick was a backend skin, and the boot paint
+  // ran before the gateway seeded it. `normalizeSkin` could not resolve the
+  // name, flattened it to the default, and the connect-time seed (apply: false,
+  // by design) never repainted — so the theme "didn't stick" until `/skin`.
+  it('paints a persisted backend skin once the connect-time seed makes it resolvable', () => {
+    window.localStorage.setItem('hermes-desktop-theme-v2', 'bloomberg')
+
+    render(
+      <ThemeProvider>
+        <div />
+      </ThemeProvider>
+    )
+
+    // Boot: nothing resolves 'bloomberg' yet → default paint...
+    expect(cssVar('--theme-background-seed')).not.toBe('#000000')
+
+    // ...but the pick survives, so the seed alone repaints it.
+    act(() => ingestBackendSkin(bloomberg('#ff9f0a'), { apply: false }))
+
+    expect(cssVar('--theme-background-seed')).toBe('#000000')
+    expect(skinPref.resolve('default')).toBe('bloomberg')
+  })
 })
 
 describe('ThemeProvider highlight preview', () => {

--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -68,19 +68,30 @@ const normalizeMode = (value: string | null): ThemeMode =>
 // it *is* the legacy global slot, so it reads/writes the global directly. Named
 // profiles get their own entry and fall back to that global until assigned, so
 // unassigned profiles and pre-per-profile installs stay on the global value.
-const profilePref = <T extends string>(record: string, legacy: string, normalize: (v: string | null) => T) => ({
-  resolve: (profile: string): T => normalize(storedStringRecord(record)[profile] ?? storedString(legacy)),
-  assign: (profile: string, value: T): void => {
-    if (profile === 'default') {
-      persistString(legacy, value)
-    } else {
-      persistStringRecord(record, { ...storedStringRecord(record), [profile]: value })
+const profilePref = <T extends string>(record: string, legacy: string, normalize: (v: string | null) => T) => {
+  const stored = (profile: string): string | null => storedStringRecord(record)[profile] ?? storedString(legacy)
+
+  return {
+    /** The pick as written, un-normalized. */
+    stored,
+    resolve: (profile: string): T => normalize(stored(profile)),
+    assign: (profile: string, value: T): void => {
+      if (profile === 'default') {
+        persistString(legacy, value)
+      } else {
+        persistStringRecord(record, { ...storedStringRecord(record), [profile]: value })
+      }
     }
   }
-})
+}
 
 export const skinPref = profilePref(PROFILE_SKINS_KEY, SKIN_KEY, normalizeSkin)
 export const modePref = profilePref(PROFILE_MODES_KEY, MODE_KEY, normalizeMode)
+
+// Provider state keeps the raw pick so a name nothing resolves YET (a backend
+// skin the gateway hasn't seeded on this launch) isn't flattened to the default
+// for the rest of the session — it paints as soon as the registry can resolve it.
+const storedSkin = (profile: string): string => skinPref.stored(profile) ?? DEFAULT_SKIN_NAME
 
 /** Everything a peer window could change that this one has to repaint for. */
 const APPEARANCE_KEYS = new Set([SKIN_KEY, PROFILE_SKINS_KEY, MODE_KEY, PROFILE_MODES_KEY])
@@ -387,7 +398,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   )
 
   const [themeName, setThemeNameState] = useState(() =>
-    typeof window === 'undefined' ? DEFAULT_SKIN_NAME : skinPref.resolve(readBootProfileKey())
+    typeof window === 'undefined' ? DEFAULT_SKIN_NAME : storedSkin(readBootProfileKey())
   )
 
   const [mode, setModeState] = useState<ThemeMode>(() =>
@@ -398,7 +409,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   // remember it for the next boot's first paint.
   useEffect(() => {
     rememberActiveProfileKey(profileKey)
-    setThemeNameState(skinPref.resolve(profileKey))
+    setThemeNameState(storedSkin(profileKey))
     setModeState(modePref.resolve(profileKey))
   }, [profileKey])
 
@@ -414,7 +425,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
       const live = normalizeProfileKey($activeGatewayProfile.get())
 
-      setThemeNameState(skinPref.resolve(live))
+      setThemeNameState(storedSkin(live))
       setModeState(modePref.resolve(live))
     }
 
@@ -431,7 +442,16 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   // committed appearance.
   const [preview, setPreview] = useState<{ name: string; mode: 'light' | 'dark' } | null>(null)
 
-  const paintedName = preview ? preview.name : themeName
+  // The committed skin, resolved against the CURRENT registry — so a stored
+  // backend skin that failed to resolve at boot paints once the gateway seeds it.
+  const committedName = useMemo(
+    () => normalizeSkin(themeName),
+    // normalizeSkin resolves through the merged registry; the stores are its reactivity.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [themeName, userThemes, backendThemes, registryVersion]
+  )
+
+  const paintedName = preview ? preview.name : committedName
   const paintedMode = preview ? preview.mode : resolvedMode
 
   const activeTheme = useMemo(
@@ -503,7 +523,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const value = useMemo<ThemeContextValue>(
     () => ({
       theme: paintedTheme,
-      themeName,
+      themeName: committedName,
       mode,
       resolvedMode,
       renderedMode,
@@ -515,7 +535,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     }),
     [
       paintedTheme,
-      themeName,
+      committedName,
       mode,
       resolvedMode,
       renderedMode,

--- a/apps/desktop/src/themes/types.ts
+++ b/apps/desktop/src/themes/types.ts
@@ -99,3 +99,25 @@ export interface DesktopTheme {
   /** Dark-variant terminal ANSI palette. Falls back to `terminal`. */
   darkTerminal?: DesktopTerminalPalette
 }
+
+// The minimal set of color keys a stored theme must carry to be usable. We keep
+// this loose — `applyTheme` tolerates missing optionals via fallbacks — but a
+// theme with no background/foreground/primary is junk and gets dropped.
+const REQUIRED_COLOR_KEYS: ReadonlyArray<keyof DesktopThemeColors> = ['background', 'foreground', 'primary']
+
+/** Shape check for a theme read back from storage or a contribution. */
+export function isValidTheme(value: unknown): value is DesktopTheme {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const theme = value as Partial<DesktopTheme>
+
+  if (typeof theme.name !== 'string' || typeof theme.label !== 'string' || !theme.colors) {
+    return false
+  }
+
+  const colors = theme.colors as unknown as Record<string, unknown>
+
+  return REQUIRED_COLOR_KEYS.every(key => typeof colors[key] === 'string')
+}

--- a/apps/desktop/src/themes/user-themes.ts
+++ b/apps/desktop/src/themes/user-themes.ts
@@ -16,7 +16,7 @@ import { registry } from '@/contrib/registry'
 
 import { $backendThemes } from './backend-sync'
 import { BUILTIN_THEMES } from './presets'
-import type { DesktopTheme, DesktopThemeColors } from './types'
+import { type DesktopTheme, isValidTheme } from './types'
 
 const USER_THEMES_KEY = 'hermes-desktop-user-themes-v1'
 
@@ -24,27 +24,6 @@ const USER_THEMES_KEY = 'hermes-desktop-user-themes-v1'
 // (see `convertVscodeColorTheme`). This is the one place that convention is read
 // back out, so every install surface can tell what's already installed.
 const MARKETPLACE_DESC_PREFIX = 'VS Code · '
-
-// The minimal set of color keys a stored theme must carry to be usable. We keep
-// this loose — `applyTheme` tolerates missing optionals via fallbacks — but a
-// theme with no background/foreground/primary is junk and gets dropped.
-const REQUIRED_COLOR_KEYS: ReadonlyArray<keyof DesktopThemeColors> = ['background', 'foreground', 'primary']
-
-function isValidTheme(value: unknown): value is DesktopTheme {
-  if (!value || typeof value !== 'object') {
-    return false
-  }
-
-  const theme = value as Partial<DesktopTheme>
-
-  if (typeof theme.name !== 'string' || typeof theme.label !== 'string' || !theme.colors) {
-    return false
-  }
-
-  const colors = theme.colors as unknown as Record<string, unknown>
-
-  return REQUIRED_COLOR_KEYS.every(key => typeof colors[key] === 'string')
-}
 
 function readStored(): Record<string, DesktopTheme> {
   try {


### PR DESCRIPTION
## Summary

A skin from `~/.hermes/skins/*.yaml` didn't survive a relaunch of the desktop app. `display.skin` said `brooklyn`, localStorage said `brooklyn`, and the window came up on the default palette anyway until something fired `skin.changed` (`/skin`, `hermes config set display.skin`).

Two things stacked:

- `$backendThemes` only lived in memory. The boot paint ran with an empty registry, so `resolveTheme('brooklyn')` failed and `normalizeSkin` flattened the stored name to the default for the rest of the session.
- The `gateway.ready` seed is `apply: false` on purpose (never stomp a persisted desktop pick on connect), so once the registry did know the skin, nothing re-resolved the already-flattened name.

Fix, in the same shape user-installed themes already use:

- `$backendThemes` hydrates from `hermes-desktop-backend-themes-v1` and writes back on change, so a saved backend skin resolves synchronously on the first frame, with no default-then-pink flash.
- Provider state keeps the raw stored name and normalizes it against the live registry in a memo, so even with a stale or missing cache the saved pick repaints as soon as the seed lands. `themeName` on the context is still the normalized name, so `/skin` completions and Appearance are unchanged.
- `isValidTheme` moved to `types.ts` so both registries share one shape check instead of a copy.

## Test plan

- [x] `src/themes` vitest: 108/108. New: boot hydration from cache, junk/built-in rejection from the cache, and the seed-repaints-a-saved-skin case. That last one fails on `main`'s `context.tsx` and passes here.
- [x] Neighboring suites (`src/app/settings`, `src/app/chat/composer`, `src/store/profile-share`): 738/738.
- [ ] Relaunch the desktop with `display.skin` pointing at a `~/.hermes/skins` file: first frame is that skin, not nous.
