### PR TITLE
feat(harness): add execution-governance layer around the agent

### DIFF
--- a/harness/AGENTS.md
+++ b/harness/AGENTS.md
@@ -1,0 +1,34 @@
+# harness/ — Dynamic Agent Harness (execution governance)
+
+Applies on top of the root `AGENTS.md` (narrow waist, facade + siblings,
+behavior contracts, real-path tests with temp `HERMES_HOME`).
+
+## What lives here
+
+The harness controls execution around the Hermes agent loop; it never
+replaces the loop. One harness iteration maps to one agent turn
+(`AIAgent.chat`), so prompt caching and role alternation are preserved.
+
+- `state.py` — Task / FeatureState / ExecutionState / budgets / lock. Pure data.
+- `store.py` — persistence via `SessionDB` meta KV (`harness:` prefix). No new
+  files, no schema change. Never `Path.home()/.hermes`; the store takes a
+  `SessionDB` (profile-aware, temp-home testable).
+- `loop.py` — `HarnessRunner`: create / step / run / pause / cancel / resume /
+  status plus every LOOP gate. Owns all state mutation.
+- `verify.py` — evidence hierarchy (tests > typecheck > runtime > static >
+  config > claim) + real check runners (`pytest_check`, `command_check`).
+- `recovery.py` — failure classification + strategy table + identical-failure rule.
+- `budget.py` — multi-dimensional hard-limit counters.
+- `knowledge.py` — durability gate for observations → knowledge.
+- `adapter.py` — thin `chat_step(agent)` bridge. No model imports at module level.
+
+## Rules
+
+- No imports from `run_agent`, `model_tools`, or `tools/` at module level in
+  `harness/` (keeps unit tests key-free and avoids import cycles; late-import
+  inside the adapter factory only).
+- No new model tools, hooks, env vars, or dependencies (stdlib only).
+- No `if/elif` ladders on names/kinds — tables (`_FIRST_SEEN`, strength order).
+- Outcomes are runtime-owned: agent hints (`StepStatus`) are advisory; gates decide.
+- Tests live in `tests/harness/`, assert contracts, and use a real `SessionDB`
+  on `tmp_path` — never mocks of the store, never source reading.

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -1,0 +1,98 @@
+"""Dynamic agent harness: execution governance around the Hermes agent.
+
+The agent reasons; the harness controls execution — tasks, features,
+budgets, verification, recovery, persistence, and completion evidence.
+"""
+
+from .adapter import chat_step
+from .budget import BudgetGovernor, BudgetUsage
+from .knowledge import (
+    KnowledgeCandidate,
+    extract,
+    is_durable,
+    knowledge_id,
+    resolve_conflict,
+)
+from .loop import AgentStep, HarnessRunner, StepResult
+from .recovery import FailureClass, Strategy, classify_failure, decide, progress_made
+from .state import (
+    TERMINAL_OUTCOMES,
+    TERMINAL_STATUSES,
+    Checkpoint,
+    ExecutionBudget,
+    ExecutionState,
+    FeatureLock,
+    FeatureState,
+    FeatureStatus,
+    KnowledgeItem,
+    KnowledgeType,
+    Outcome,
+    RiskLevel,
+    ScopeReason,
+    ScopeRejected,
+    StepStatus,
+    Task,
+    TaskStatus,
+    TaskType,
+    ToolObservation,
+    VerificationCheck,
+    VerificationResult,
+)
+from .store import HarnessStore
+from .verify import (
+    CheckStrength,
+    command_check,
+    completion_allowed,
+    file_contains_check,
+    pytest_check,
+    run_all,
+    verify,
+)
+
+__all__ = [
+    "AgentStep",
+    "BudgetGovernor",
+    "BudgetUsage",
+    "CheckStrength",
+    "Checkpoint",
+    "ExecutionBudget",
+    "ExecutionState",
+    "FailureClass",
+    "FeatureLock",
+    "FeatureState",
+    "FeatureStatus",
+    "HarnessRunner",
+    "HarnessStore",
+    "KnowledgeCandidate",
+    "KnowledgeItem",
+    "KnowledgeType",
+    "Outcome",
+    "RiskLevel",
+    "ScopeReason",
+    "ScopeRejected",
+    "StepResult",
+    "StepStatus",
+    "Strategy",
+    "Task",
+    "TaskStatus",
+    "TaskType",
+    "ToolObservation",
+    "VerificationCheck",
+    "VerificationResult",
+    "chat_step",
+    "classify_failure",
+    "command_check",
+    "completion_allowed",
+    "decide",
+    "extract",
+    "file_contains_check",
+    "is_durable",
+    "knowledge_id",
+    "progress_made",
+    "pytest_check",
+    "resolve_conflict",
+    "run_all",
+    "verify",
+    "TERMINAL_OUTCOMES",
+    "TERMINAL_STATUSES",
+]

--- a/harness/adapter.py
+++ b/harness/adapter.py
@@ -1,0 +1,39 @@
+"""Live adapter: one harness iteration as one Hermes agent turn.
+
+The adapter is deliberately thin. It sends the harness-compiled context as
+the next user turn (a real turn — prompt caching and role alternation are
+preserved) and wraps the final response. Functional verification of the
+work itself belongs to explicit :mod:`harness.verify` checkers, never to
+the model's own claims.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .loop import AgentStep, StepResult
+from .state import FeatureState, Outcome, Task
+
+
+def chat_step(agent) -> AgentStep:
+    """Build a step around an object exposing ``chat(message) -> str``."""
+
+    def run(task: Task, feature: FeatureState, context: Dict[str, Any]) -> StepResult:
+        message = (
+            f"Task: {task.goal}\n"
+            f"Success criteria: {'; '.join(task.success_criteria)}\n"
+            f"Active feature: {feature.name} ({feature.status})\n"
+            f"Hypothesis: {feature.hypothesis or 'none yet'}\n"
+            f"Known issues: {'; '.join(feature.known_issues) or 'none'}"
+        )
+        try:
+            reply = agent.chat(message)
+        except Exception as exc:  # noqa: BLE001 — surfaced as a step error
+            return StepResult(error=str(exc)[:500], transient_error=False)
+        return StepResult(
+            summary=reply[:500],
+            status_hint=Outcome.CONTINUE,
+            evidence=[reply[:2000]] if reply else [],
+        )
+
+    return run

--- a/harness/budget.py
+++ b/harness/budget.py
@@ -1,0 +1,96 @@
+"""Multi-dimensional execution budgets with hard stops.
+
+Hermes already caps agent iterations (:class:`IterationBudget`); the harness
+additionally governs tool calls, retries, replans, tokens, and elapsed time.
+A hard limit ends the task — it is never silently exceeded.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from .state import ExecutionBudget
+
+
+@dataclass
+class BudgetUsage:
+    tool_calls: int = 0
+    retries: int = 0
+    replans: int = 0
+    iterations: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    started_at: float = field(default_factory=time.monotonic)
+
+    @property
+    def elapsed_seconds(self) -> float:
+        return time.monotonic() - self.started_at
+
+    def to_dict(self) -> Dict[str, float | int]:
+        return {
+            "tool_calls": self.tool_calls,
+            "retries": self.retries,
+            "replans": self.replans,
+            "iterations": self.iterations,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "elapsed_seconds": round(self.elapsed_seconds, 3),
+        }
+
+
+_LIMIT_CHECKS = (
+    ("max_tool_calls", "tool_calls", "tool calls"),
+    ("max_retries", "retries", "retries"),
+    ("max_replans", "replans", "replans"),
+    ("max_iterations", "iterations", "iterations"),
+)
+
+
+class BudgetGovernor:
+    """Thread-safe usage counters against an :class:`ExecutionBudget`."""
+
+    def __init__(self, budget: ExecutionBudget) -> None:
+        self.budget = budget
+        self.usage = BudgetUsage()
+        self._lock = threading.Lock()
+
+    def consume_tool_call(self) -> bool:
+        return self._consume("tool_calls", self.budget.max_tool_calls)
+
+    def consume_retry(self) -> bool:
+        return self._consume("retries", self.budget.max_retries)
+
+    def consume_replan(self) -> bool:
+        return self._consume("replans", self.budget.max_replans)
+
+    def consume_iteration(self) -> bool:
+        return self._consume("iterations", self.budget.max_iterations)
+
+    def add_tokens(self, input_tokens: int, output_tokens: int) -> None:
+        with self._lock:
+            self.usage.input_tokens += max(0, input_tokens)
+            self.usage.output_tokens += max(0, output_tokens)
+
+    def _consume(self, attr: str, limit: int) -> bool:
+        with self._lock:
+            if limit > 0 and getattr(self.usage, attr) >= limit:
+                return False
+            setattr(self.usage, attr, getattr(self.usage, attr) + 1)
+            return True
+
+    def exhausted(self) -> List[str]:
+        """Names of exhausted dimensions; empty means budget remains."""
+        used = self.usage
+        hit = [
+            label
+            for limit_attr, use_attr, label in _LIMIT_CHECKS
+            if getattr(self.budget, limit_attr) > 0
+            and getattr(used, use_attr) >= getattr(self.budget, limit_attr)
+        ]
+        max_elapsed = self.budget.max_elapsed_seconds
+        if max_elapsed is not None and used.elapsed_seconds >= max_elapsed:
+            hit.append("elapsed time")
+        return hit

--- a/harness/demo.py
+++ b/harness/demo.py
@@ -1,0 +1,94 @@
+"""Manual E2E for the harness contribution (no API keys needed).
+
+Exercises the real path — real SessionDB under a temp HERMES_HOME, real
+workspace file work, real verification checks, real persistence + resume —
+with a scripted agent standing in for model turns::
+
+    python -m harness.demo
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+
+def main() -> int:
+    home = Path(tempfile.mkdtemp(prefix="harness-demo-home"))
+    os.environ["HERMES_HOME"] = str(home)
+    workspace = Path(tempfile.mkdtemp(prefix="harness-demo-work"))
+    target = workspace / "hello.txt"
+
+    from hermes_state import SessionDB
+
+    from harness.loop import HarnessRunner, StepResult
+    from harness.state import Outcome, StepStatus, ToolObservation
+    from harness.store import HarnessStore
+    from harness.verify import file_contains_check
+
+    store = HarnessStore(SessionDB())
+    attempts = {"n": 0}
+
+    def scripted(task, feature, context):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            # First turn claims progress but does nothing verifiable.
+            return StepResult(
+                summary="wrote the file (unverified)",
+                status_hint=StepStatus.DONE,
+                evidence=["trust me"],
+            )
+        target.write_text("hello\n", encoding="utf-8")
+        check = file_contains_check("hello-present", target, "hello")
+        return StepResult(
+            summary="wrote hello.txt",
+            status_hint=StepStatus.DONE if check.passed else StepStatus.CONTINUE,
+            observations=[
+                ToolObservation(
+                    id=f"obs-{attempts['n']}",
+                    tool="write",
+                    success=True,
+                    summary=f"wrote {target.name}",
+                )
+            ],
+            evidence=[check.detail],
+        )
+
+    def make_step(task):
+        return scripted
+
+    runner = HarnessRunner(store, make_step)
+    task = runner.create(
+        "write hello.txt containing hello", ["hello.txt contains hello"]
+    )
+    print(f"task {task.id} created; Hermes home: {home}")
+
+    first = runner.step(task.id)
+    print(f"turn 1 -> {first} (unverified claim must not complete)")
+    assert first == Outcome.CONTINUE, first
+
+    # New process, same home: resume from persisted state.
+    store.close()
+    resumed = HarnessRunner(HarnessStore(SessionDB()), make_step)
+    status = resumed.status(task.id)
+    print(
+        f"resumed: iteration={status['iteration']} observations={status['observations']}"
+    )
+    assert status["iteration"] == 0  # claim-only turn verified nothing
+
+    final = resumed.run(task.id, max_rounds=5)
+    print(f"run -> {final}")
+    assert final == Outcome.COMPLETED, final
+    assert target.read_text(encoding="utf-8") == "hello\n"
+    print(f"verified on disk: {target}")
+    print(
+        "E2E OK: task, harness, tools, observations, verification, "
+        "recovery, persistence, resume, completion"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/harness/knowledge.py
+++ b/harness/knowledge.py
@@ -1,0 +1,91 @@
+"""Durable knowledge gate: observations become knowledge only when they are
+reusable, evidence-backed, non-temporary, deduplicated, and conflict-free.
+Unresolvable conflicts become open questions — never invented truths.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import List, Sequence
+
+from .state import KnowledgeItem
+
+
+def knowledge_id(kind: str, content: str) -> str:
+    digest = hashlib.sha256(f"{kind}\x00{content}".encode("utf-8")).hexdigest()[:16]
+    return f"k-{digest}"
+
+
+@dataclass
+class KnowledgeCandidate:
+    type: str
+    content: str
+    scope: str = ""
+
+
+_NON_DURABLE_MARKERS = ("tmp", "temp", "debug-print", "wip", "todo:")
+
+
+def is_durable(candidate: KnowledgeCandidate) -> bool:
+    text = candidate.content.strip()
+    if len(text) < 8:
+        return False
+    lowered = text.lower()
+    return not any(marker in lowered for marker in _NON_DURABLE_MARKERS)
+
+
+def extract(
+    candidates: Sequence[KnowledgeCandidate],
+    existing: Sequence[KnowledgeItem],
+    *,
+    has_evidence: bool,
+) -> List[KnowledgeItem]:
+    """Validate candidates into storable items. No evidence → nothing stored."""
+    if not has_evidence:
+        return []
+    known = {item.content for item in existing}
+    items = []
+    for candidate in candidates:
+        content = candidate.content.strip()
+        if not content or content in known:
+            continue
+        if not is_durable(candidate):
+            continue
+        known.add(content)
+        items.append(
+            KnowledgeItem(
+                id=knowledge_id(candidate.type, content),
+                type=candidate.type,
+                content=content,
+                scope=candidate.scope,
+            )
+        )
+    return items
+
+
+# Conflict priority, strongest first (system design §31).
+_CONFLICT_PRIORITY = (
+    "architecture_decision",
+    "verified_source",
+    "verified_evidence",
+    "project_version",
+    "durable_knowledge",
+    "model_inference",
+)
+
+
+def resolve_conflict(sources: Sequence[str]) -> str:
+    """Strongest source wins; unknown sources rank below everything known.
+    Empty input means no conflict to resolve."""
+    if not sources:
+        return ""
+    ranked = sorted(
+        sources,
+        key=lambda s: (
+            _CONFLICT_PRIORITY.index(s)
+            if s in _CONFLICT_PRIORITY
+            else len(_CONFLICT_PRIORITY)
+        ),
+    )
+    return ranked[0]

--- a/harness/loop.py
+++ b/harness/loop.py
@@ -1,0 +1,448 @@
+"""Harness run driver: the strict execution loop around the Hermes agent.
+
+One harness iteration maps to one agent turn (``AIAgent.chat``) — the turn
+loop's natural unit. That preserves prompt caching (no mid-conversation
+rebuilds) and role alternation (harness guidance rides as the next user
+turn, never a synthetic injection). The driver decides CONTINUE /
+COMPLETED / BLOCKED / FAILED / STOPPED / BUDGET_EXHAUSTED from state,
+evidence, verification, policy, and budget — never the model.
+"""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Protocol
+
+from . import recovery as _recovery
+from .budget import BudgetGovernor
+from .knowledge import KnowledgeCandidate, extract as extract_knowledge
+from .state import (
+    TERMINAL_OUTCOMES,
+    Checkpoint,
+    ExecutionBudget,
+    ExecutionState,
+    FeatureLock,
+    FeatureState,
+    FeatureStatus,
+    Outcome,
+    ScopeReason,
+    StepStatus,
+    Task,
+    TaskStatus,
+    ToolObservation,
+    VerificationResult,
+)
+from .store import HarnessStore
+from .verify import completion_allowed, verify
+
+
+@dataclass
+class StepResult:
+    """Structured outcome of one agent turn, as seen by the harness."""
+
+    summary: str = ""
+    status_hint: str = StepStatus.CONTINUE
+    observations: List[ToolObservation] = field(default_factory=list)
+    evidence: List[str] = field(default_factory=list)
+    assumptions: List[str] = field(default_factory=list)
+    open_questions: List[str] = field(default_factory=list)
+    proposed_knowledge: List[KnowledgeCandidate] = field(default_factory=list)
+    error: Optional[str] = None
+    transient_error: bool = False
+
+
+class AgentStep(Protocol):
+    def __call__(
+        self, task: Task, feature: FeatureState, context: Dict[str, Any]
+    ) -> StepResult: ...
+
+
+_STAGNATION_LIMIT = 5
+
+
+def _new_id(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+class HarnessRunner:
+    """Owns task runners: gates, budgets, recovery, persistence, completion."""
+
+    def __init__(
+        self, store: HarnessStore, make_step: Callable[[Task], AgentStep]
+    ) -> None:
+        self._store = store
+        self._make_step = make_step
+        self._locks: Dict[str, FeatureLock] = {}
+        self._governors: Dict[str, BudgetGovernor] = {}
+        self._seen: Dict[str, Dict[str, int]] = {}
+        self._stagnant: Dict[str, int] = {}
+        self._stop_flags: Dict[str, threading.Event] = {}
+        self._outcomes: Dict[str, str] = {}
+
+    # -- task lifecycle ---------------------------------------------------
+
+    def create(
+        self, goal: str, success_criteria: List[str], *, task_type: str = "FEATURE"
+    ) -> Task:
+        if not goal:
+            raise ValueError("goal is required")
+        task = Task(
+            id=_new_id("t"),
+            goal=goal,
+            success_criteria=success_criteria or ["done"],
+            type=task_type,
+        )
+        feature = FeatureState(
+            id=f"{task.id}-f1",
+            task_id=task.id,
+            name="main",
+            status=FeatureStatus.IMPLEMENTING,
+        )
+        task.feature_id = feature.id
+        lock = FeatureLock()
+        lock.select(
+            feature, reason=ScopeReason.USER_SCOPE_CHANGE, evidence="task created"
+        )
+        self._locks[task.id] = lock
+        self._governors[task.id] = BudgetGovernor(task.budget)
+        self._store.save_task(task)
+        self._store.save_feature(feature)
+        self._store.save_execution(
+            ExecutionState(task_id=task.id, feature_id=feature.id)
+        )
+        self._store.append_event("TASK", f"TASK_CREATED:{task.id}")
+        return task
+
+    def _load(self, task_id: str) -> Task:
+        task = self._store.load_task(task_id)
+        if task is None:
+            raise KeyError(f"unknown task {task_id!r}")
+        if task_id not in self._locks:
+            lock = FeatureLock()
+            for feature in self._store.features_for_task(task_id):
+                if task.feature_id in (None, feature.id):
+                    lock.select(feature)
+                    task.feature_id = feature.id
+            self._locks[task_id] = lock
+        if task_id not in self._governors:
+            self._governors[task_id] = BudgetGovernor(task.budget)
+        if task_id not in self._outcomes:
+            terminal = self._store.task_terminal_outcome(task_id)
+            if terminal:
+                self._outcomes[task_id] = terminal
+        return task
+
+    def status(self, task_id: str) -> Dict[str, Any]:
+        task = self._load(task_id)
+        state = self._store.load_execution(task_id)
+        observations = self._store.observations_for_task(task_id)
+        return {
+            "id": task_id,
+            "goal": task.goal,
+            "status": task.status,
+            "outcome": self._outcomes.get(task_id, ""),
+            "iteration": state.iteration if state else 0,
+            "observations": len(observations),
+            "feature_id": task.feature_id,
+        }
+
+    # -- one gated iteration ------------------------------------------------
+
+    def compile_context(self, task: Task, feature: FeatureState) -> Dict[str, Any]:
+        """Smallest sufficient context doc for the next turn (bounded)."""
+        knowledge = self._store.list_knowledge()[:5]
+        return {
+            "goal": task.goal,
+            "success_criteria": task.success_criteria,
+            "feature": feature.to_dict(),
+            "hypothesis": feature.hypothesis,
+            "known_issues": feature.known_issues[:5],
+            "knowledge": [k.content for k in knowledge],
+            "budget_remaining": self._governors[task.id].budget.to_dict()
+            if task.id in self._governors
+            else {},
+        }
+
+    def step(self, task_id: str) -> str:
+        task = self._load(task_id)
+        if self._outcomes.get(task_id) in TERMINAL_OUTCOMES:
+            raise RuntimeError(
+                f"task {task_id} is terminal ({self._outcomes[task_id]}); start a new task"
+            )
+        governor = self._governors[task_id]
+        lock = self._locks[task_id]
+        if lock.active is None:
+            return Outcome.BLOCKED
+        feature = lock.active
+
+        state = self._store.load_execution(task_id) or ExecutionState(
+            task_id=task_id, feature_id=feature.id
+        )
+        budget = (
+            task.budget
+            if isinstance(task.budget, ExecutionBudget)
+            else ExecutionBudget()
+        )
+        if governor.exhausted():
+            return self._finish(
+                task, Outcome.BUDGET_EXHAUSTED, state, "budget exhausted"
+            )
+
+        context_id = f"ctx-{task_id}-{state.iteration + 1}"
+        context = self.compile_context(task, feature)
+        self._store.save_context(context_id, context)
+        self._store.append_event("RUN", f"CONTEXT_COMPILED:{context_id}")
+
+        if not governor.consume_iteration():
+            return self._finish(
+                task, Outcome.BUDGET_EXHAUSTED, state, "iteration budget exhausted"
+            )
+
+        step_fn = self._make_step(task)
+        try:
+            result = step_fn(task, feature, context)
+        except Exception as exc:  # noqa: BLE001 — harness must survive agent errors
+            result = StepResult(error=str(exc)[:500], transient_error=False)
+
+        if result.error is not None:
+            return self._recover(
+                task,
+                feature,
+                state,
+                result,
+                context_id,
+                governor,
+                action_fp="",
+                failure=result.error,
+                failure_class=_recovery.classify_failure(
+                    result.error, transient=result.transient_error
+                ),
+            )
+
+        if result.assumptions:
+            newest = result.assumptions[0]
+            if feature.hypothesis and feature.hypothesis != newest:
+                self._store.append_event("RUN", "HYPOTHESIS_CHANGED")
+            feature.hypothesis = newest
+
+        for obs in result.observations:
+            self._store.append_event("RUN", f"OBSERVATION_RECORDED:{obs.id}")
+            self._store.save_observation(task.id, obs.to_dict())
+            governor.consume_tool_call()
+            if not obs.success:
+                return self._recover(
+                    task,
+                    feature,
+                    state,
+                    result,
+                    context_id,
+                    governor,
+                    action_fp=f"{obs.tool}\x00{obs.summary}",
+                    failure=obs.summary,
+                    failure_class=_recovery.classify_failure(obs.summary),
+                )
+
+        progressed = _recovery.progress_made(
+            new_evidence=bool(result.evidence),
+            implementation_progress=any(o.success for o in result.observations),
+        )
+        if not progressed:
+            count = self._stagnant.get(task_id, 0) + 1
+            self._stagnant[task_id] = count
+            if count >= _STAGNATION_LIMIT:
+                return self._finish(task, Outcome.STOPPED, state, "stagnation limit")
+            self._store.append_event("RUN", f"STAGNATION:{count}")
+            return Outcome.CONTINUE
+        self._stagnant[task_id] = 0
+
+        checks = self._checks_from_observations(result)
+        verification = verify(checks, task.success_criteria)
+        if not verification.passed:
+            return self._recover(
+                task,
+                feature,
+                state,
+                result,
+                context_id,
+                governor,
+                action_fp="verification",
+                failure=";".join(verification.failures) or "verification failed",
+                failure_class=_recovery.FailureClass.DETERMINISTIC,
+            )
+        self._store.append_event("RUN", "VERIFICATION_PASSED")
+
+        if result.proposed_knowledge:
+            items = extract_knowledge(
+                result.proposed_knowledge,
+                self._store.list_knowledge(),
+                has_evidence=bool(result.evidence)
+                or any(o.success for o in result.observations),
+            )
+            for item in items:
+                self._store.save_knowledge(item)
+                self._store.append_event("RUN", f"KNOWLEDGE_STORED:{item.id}")
+
+        state.iteration += 1
+        state.last_evidence = list(result.evidence)
+        self._store.save_execution(state)
+        self._store.save_feature(feature)
+        self._store.save_task(task)
+
+        if result.status_hint == StepStatus.DONE and completion_allowed(
+            True, True, verification.passed, not state.open_questions
+        ):
+            return self._finish(task, Outcome.COMPLETED, state, result.summary)
+        if result.status_hint == StepStatus.BLOCKED:
+            return self._finish(task, Outcome.BLOCKED, state, result.summary)
+        if result.status_hint == StepStatus.FAILED:
+            return self._finish(task, Outcome.FAILED, state, result.summary)
+        return Outcome.CONTINUE
+
+    # -- helpers --------------------------------------------------------------
+
+    def _checks_from_observations(self, result: StepResult) -> list:
+        from .verify import CheckStrength, VerificationCheck
+
+        return [
+            VerificationCheck(
+                name=o.tool or "tool",
+                passed=o.success,
+                detail=o.summary,
+                strength=CheckStrength.RUNTIME,
+            )
+            for o in result.observations
+        ]
+
+    def _recover(
+        self,
+        task: Task,
+        feature: FeatureState,
+        state: ExecutionState,
+        result: StepResult,
+        context_id: str,
+        governor: BudgetGovernor,
+        *,
+        action_fp: str,
+        failure: str,
+        failure_class: str,
+    ) -> str:
+        seen = self._seen.setdefault(task.id, {})
+        key = f"{failure}\x00{feature.hypothesis or ''}\x00{action_fp}"
+        seen[key] = seen.get(key, 0) + 1
+        strategy = _recovery.decide(
+            failure, feature.hypothesis or "", action_fp, failure_class, seen
+        )
+        self._store.append_event("RUN", f"RECOVERY:{strategy}:{failure[:200]}")
+        if strategy == _recovery.Strategy.RETRY:
+            if governor.consume_retry():
+                return Outcome.CONTINUE
+            return self._finish(
+                task, Outcome.BUDGET_EXHAUSTED, state, "retry budget exhausted"
+            )
+        if strategy == _recovery.Strategy.REPLAN:
+            if governor.consume_replan():
+                self._checkpoint(task, feature, state, context_id, "before-replan")
+                return Outcome.CONTINUE
+            return self._finish(
+                task, Outcome.BUDGET_EXHAUSTED, state, "replan budget exhausted"
+            )
+        if strategy in (_recovery.Strategy.STOP, _recovery.Strategy.ESCALATE):
+            return self._finish(task, Outcome.STOPPED, state, f"recovery:{strategy}")
+        return Outcome.CONTINUE
+
+    def _checkpoint(
+        self,
+        task: Task,
+        feature: FeatureState,
+        state: ExecutionState,
+        context_id: str,
+        reason: str,
+    ) -> Checkpoint:
+        existing = self._store.checkpoints_for_task(task.id)
+        checkpoint = Checkpoint(
+            id=f"cp-{task.id}-{len(existing) + 1}",
+            task_id=task.id,
+            feature_id=feature.id,
+            state=state,
+            context_ref=context_id,
+            reason=reason,
+        )
+        self._store.save_checkpoint(checkpoint)
+        self._store.append_event("RUN", f"CHECKPOINT:{checkpoint.id}:{reason}")
+        return checkpoint
+
+    def _finish(
+        self, task: Task, outcome: str, state: ExecutionState, detail: str
+    ) -> str:
+        phase = {
+            "COMPLETED": TaskStatus.COMPLETED,
+            "BLOCKED": TaskStatus.BLOCKED,
+            "FAILED": TaskStatus.FAILED,
+            "STOPPED": TaskStatus.STOPPED,
+            "BUDGET_EXHAUSTED": TaskStatus.BUDGET_EXHAUSTED,
+        }.get(outcome, task.status)
+        task.status = phase
+        state.phase = phase
+        self._store.save_task(task)
+        self._store.save_execution(state)
+        if outcome in TERMINAL_OUTCOMES:
+            self._checkpoint(
+                task,
+                self._locks[task.id].active
+                or FeatureState(id="?", task_id=task.id, name="?"),
+                state,
+                "",
+                f"task-{outcome.lower()}",
+            )
+            self._store.append_event("TASK", f"TASK_{outcome}:{task.id}")
+            if detail:
+                self._store.append_event(
+                    "TASK", f"TASK_DETAIL:{task.id}:{detail[:200]}"
+                )
+        self._outcomes[task.id] = outcome
+        return outcome
+
+    # -- multi-iteration runs -----------------------------------------------------
+
+    def run(self, task_id: str, max_rounds: int = 50) -> str:
+        flag = self._stop_flags.setdefault(task_id, threading.Event())
+        flag.clear()
+        outcome = Outcome.CONTINUE
+        for _ in range(max_rounds):
+            if flag.is_set():
+                task = self._load(task_id)
+                state = self._store.load_execution(task_id) or ExecutionState(
+                    task_id=task_id, feature_id=task.feature_id or ""
+                )
+                outcome = self._finish(task, Outcome.STOPPED, state, "cancelled")
+                break
+            outcome = self.step(task_id)
+            if outcome in TERMINAL_OUTCOMES:
+                break
+        return outcome
+
+    def pause(self, task_id: str) -> None:
+        self._stop_flags.setdefault(task_id, threading.Event()).set()
+        task = self._load(task_id)
+        state = self._store.load_execution(task_id) or ExecutionState(
+            task_id=task_id, feature_id=task.feature_id or ""
+        )
+        feature = self._locks[task_id].active or FeatureState(
+            id=task.feature_id or "?", task_id=task_id, name="?"
+        )
+        self._checkpoint(task, feature, state, "", "paused")
+        self._store.append_event("TASK", f"TASK_PAUSED:{task_id}")
+
+    def cancel(self, task_id: str) -> None:
+        self.pause(task_id)
+        self._store.append_event("TASK", f"TASK_CANCELLED:{task_id}")
+
+    def resume(self, task_id: str, max_rounds: int = 50) -> str:
+        """Continue from persisted state + retrieval, never replayed history."""
+        task = self._load(task_id)
+        if self._outcomes.get(task_id) in TERMINAL_OUTCOMES:
+            raise RuntimeError(f"task {task_id} is terminal; start a new task")
+        self._store.append_event("TASK", f"TASK_RESUMED:{task_id}")
+        return self.run(task_id, max_rounds)

--- a/harness/recovery.py
+++ b/harness/recovery.py
@@ -1,0 +1,108 @@
+"""Failure classification and recovery strategy selection.
+
+Never blindly retry: classify first, then pick a strategy from evidence.
+The identical-failure rule forces a strategy change when the same action,
+failure, and hypothesis repeat — deterministic loops are refused.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Mapping
+
+_TRANSIENT_SIGNALS = (
+    "timeout",
+    "timed out",
+    "rate limit",
+    "429",
+    "503",
+    "temporar",
+    "unavailab",
+    "network",
+    "econn",
+    "try again",
+    "connection reset",
+    "overloaded",
+)
+
+
+class FailureClass:
+    TRANSIENT = "TRANSIENT"
+    DETERMINISTIC = "DETERMINISTIC"
+    UNKNOWN = "UNKNOWN"
+
+
+class Strategy:
+    RETRY = "RETRY"
+    REPLAN = "REPLAN"
+    RETRIEVE_MORE_CONTEXT = "RETRIEVE_MORE_CONTEXT"
+    INSPECT_DEPENDENCY = "INSPECT_DEPENDENCY"
+    CHANGE_IMPLEMENTATION = "CHANGE_IMPLEMENTATION"
+    ROLLBACK = "ROLLBACK"
+    ESCALATE = "ESCALATE"
+    STOP = "STOP"
+
+
+def classify_failure(message: str, *, transient: bool = False) -> str:
+    """Classify a failure. Explicit transient flags win; otherwise match
+    transport-level signals, else structural (deterministic). Empty text
+    without a flag is UNKNOWN rather than a guess."""
+    if transient:
+        return FailureClass.TRANSIENT
+    lowered = (message or "").lower()
+    if not lowered.strip():
+        return FailureClass.UNKNOWN
+    if any(signal in lowered for signal in _TRANSIENT_SIGNALS):
+        return FailureClass.TRANSIENT
+    return FailureClass.DETERMINISTIC
+
+
+# First-seen strategy per class (table, not a branch ladder).
+_FIRST_SEEN: Dict[str, str] = {
+    FailureClass.TRANSIENT: Strategy.RETRY,
+    FailureClass.DETERMINISTIC: Strategy.REPLAN,
+    FailureClass.UNKNOWN: Strategy.INSPECT_DEPENDENCY,
+}
+
+# Forced escalation once the identical triple repeats: never repeat the
+# same failing strategy. Counts: 1st repeat retrieves, 2nd changes the
+# implementation, further repeats escalate, then stop.
+_REPEAT_LADDER = (
+    Strategy.RETRIEVE_MORE_CONTEXT,
+    Strategy.CHANGE_IMPLEMENTATION,
+    Strategy.ESCALATE,
+    Strategy.STOP,
+)
+
+
+def decide(
+    failure_fp: str,
+    hypothesis_fp: str,
+    action_fp: str,
+    failure_class: str,
+    seen: Mapping[str, int],
+) -> str:
+    repeats = seen.get(failure_fp + "\x00" + hypothesis_fp + "\x00" + action_fp, 0)
+    if repeats <= 1:
+        return _FIRST_SEEN.get(failure_class, Strategy.ESCALATE)
+    rung = min(repeats - 2, len(_REPEAT_LADDER) - 1)
+    return _REPEAT_LADDER[rung]
+
+
+def progress_made(
+    *,
+    new_evidence: bool = False,
+    implementation_progress: bool = False,
+    reduced_uncertainty: bool = False,
+    verified_knowledge: bool = False,
+    successful_verification: bool = False,
+    completed_milestone: bool = False,
+) -> bool:
+    """Progress invariant: at least one must hold per non-terminal iteration."""
+    return any((
+        new_evidence,
+        implementation_progress,
+        reduced_uncertainty,
+        verified_knowledge,
+        successful_verification,
+        completed_milestone,
+    ))

--- a/harness/state.py
+++ b/harness/state.py
@@ -1,0 +1,349 @@
+"""Harness domain state: tasks, features, execution, and the feature lock.
+
+Pure data + transitions. The agent never writes these directly; the run
+driver in :mod:`harness.loop` owns every mutation. All types serialize to
+plain JSON dicts for :mod:`harness.store`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+class TaskStatus:
+    CREATED = "CREATED"
+    ANALYZING = "ANALYZING"
+    PLANNING = "PLANNING"
+    IMPLEMENTING = "IMPLEMENTING"
+    VERIFYING = "VERIFYING"
+    RECOVERING = "RECOVERING"
+    COMPLETED = "COMPLETED"
+    BLOCKED = "BLOCKED"
+    FAILED = "FAILED"
+    STOPPED = "STOPPED"
+    BUDGET_EXHAUSTED = "BUDGET_EXHAUSTED"
+    CANCELLED = "CANCELLED"
+
+
+TERMINAL_STATUSES = frozenset({
+    TaskStatus.COMPLETED,
+    TaskStatus.FAILED,
+    TaskStatus.STOPPED,
+    TaskStatus.BUDGET_EXHAUSTED,
+    TaskStatus.CANCELLED,
+})
+
+
+class FeatureStatus:
+    PENDING = "pending"
+    INVESTIGATING = "investigating"
+    IMPLEMENTING = "implementing"
+    VERIFYING = "verifying"
+    BLOCKED = "blocked"
+    COMPLETED = "completed"
+
+
+class Outcome:
+    """Runtime iteration decision. The model may hint; only the driver sets these."""
+
+    CONTINUE = "CONTINUE"
+    COMPLETED = "COMPLETED"
+    BLOCKED = "BLOCKED"
+    FAILED = "FAILED"
+    STOPPED = "STOPPED"
+    BUDGET_EXHAUSTED = "BUDGET_EXHAUSTED"
+
+
+class StepStatus:
+    """Agent-side hint for one turn. Advisory only — gates decide."""
+
+    CONTINUE = "CONTINUE"
+    DONE = "DONE"
+    BLOCKED = "BLOCKED"
+    FAILED = "FAILED"
+
+
+TERMINAL_OUTCOMES = frozenset({
+    Outcome.COMPLETED,
+    Outcome.FAILED,
+    Outcome.STOPPED,
+    Outcome.BUDGET_EXHAUSTED,
+})
+
+
+class TaskType:
+    BUG_FIX = "BUG_FIX"
+    FEATURE = "FEATURE"
+    REFACTOR = "REFACTOR"
+    DATABASE_CHANGE = "DATABASE_CHANGE"
+    DEPENDENCY_CHANGE = "DEPENDENCY_CHANGE"
+    DEBUG = "DEBUG"
+    INVESTIGATION = "INVESTIGATION"
+    TEST = "TEST"
+    DOCUMENTATION = "DOCUMENTATION"
+    MIGRATION = "MIGRATION"
+
+
+class RiskLevel:
+    LOW = "LOW"
+    MEDIUM = "MEDIUM"
+    HIGH = "HIGH"
+    CRITICAL = "CRITICAL"
+
+
+@dataclass
+class ExecutionBudget:
+    max_context_tokens: int = 32000
+    max_output_tokens: int = 8000
+    max_tool_calls: int = 50
+    max_retries: int = 5
+    max_replans: int = 3
+    max_iterations: int = 20
+    max_elapsed_seconds: Optional[float] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ExecutionBudget":
+        known = {f for f in cls.__dataclass_fields__}
+        return cls(**{k: v for k, v in data.items() if k in known})
+
+
+@dataclass
+class Task:
+    id: str
+    goal: str
+    success_criteria: List[str] = field(default_factory=list)
+    type: str = TaskType.FEATURE
+    constraints: List[str] = field(default_factory=list)
+    risk: str = RiskLevel.MEDIUM
+    budget: ExecutionBudget = field(default_factory=ExecutionBudget)
+    status: str = TaskStatus.CREATED
+    feature_id: Optional[str] = None
+    created_at: str = field(default_factory=_utcnow)
+    updated_at: str = field(default_factory=_utcnow)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data["budget"] = self.budget.to_dict()
+        return data
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Task":
+        data = dict(data)
+        if isinstance(data.get("budget"), dict):
+            data["budget"] = ExecutionBudget.from_dict(data["budget"])
+        return cls(**data)
+
+
+@dataclass
+class FeatureState:
+    id: str
+    task_id: str
+    name: str
+    status: str = FeatureStatus.PENDING
+    confidence: float = 0.0
+    relevant_files: List[str] = field(default_factory=list)
+    dependencies: List[str] = field(default_factory=list)
+    open_questions: List[str] = field(default_factory=list)
+    known_issues: List[str] = field(default_factory=list)
+    hypothesis: Optional[str] = None
+    verification_results: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "FeatureState":
+        return cls(**data)
+
+
+@dataclass
+class ExecutionState:
+    task_id: str
+    feature_id: str
+    phase: str = TaskStatus.ANALYZING
+    hypothesis: Optional[str] = None
+    relevant_files: List[str] = field(default_factory=list)
+    open_questions: List[str] = field(default_factory=list)
+    known_issues: List[str] = field(default_factory=list)
+    iteration: int = 0
+    last_evidence: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ExecutionState":
+        return cls(**data)
+
+
+@dataclass
+class ToolObservation:
+    id: str
+    tool: str
+    success: bool
+    summary: str
+    evidence: List[str] = field(default_factory=list)
+    artifacts: List[str] = field(default_factory=list)
+    timestamp: str = field(default_factory=_utcnow)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ToolObservation":
+        return cls(**data)
+
+
+@dataclass
+class VerificationCheck:
+    name: str
+    passed: bool
+    detail: str = ""
+    strength: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "VerificationCheck":
+        return cls(**data)
+
+
+@dataclass
+class VerificationResult:
+    passed: bool
+    checks: List[VerificationCheck] = field(default_factory=list)
+    failures: List[str] = field(default_factory=list)
+    confidence: float = 0.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "passed": self.passed,
+            "checks": [c.to_dict() for c in self.checks],
+            "failures": list(self.failures),
+            "confidence": self.confidence,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "VerificationResult":
+        return cls(
+            passed=data.get("passed", False),
+            checks=[VerificationCheck.from_dict(c) for c in data.get("checks", [])],
+            failures=list(data.get("failures", [])),
+            confidence=data.get("confidence", 0.0),
+        )
+
+
+class KnowledgeType:
+    ARCHITECTURE_DECISION = "ARCHITECTURE_DECISION"
+    PROJECT_INVARIANT = "PROJECT_INVARIANT"
+    DEPENDENCY = "DEPENDENCY"
+    KNOWN_BUG = "KNOWN_BUG"
+    SOLUTION = "SOLUTION"
+    FEATURE_FACT = "FEATURE_FACT"
+    PROCEDURE = "PROCEDURE"
+
+
+@dataclass
+class KnowledgeItem:
+    id: str
+    type: str
+    content: str
+    scope: str = ""
+    confidence: float = 0.5
+    source: List[str] = field(default_factory=list)
+    last_verified: str = field(default_factory=_utcnow)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "KnowledgeItem":
+        return cls(**data)
+
+
+@dataclass
+class Checkpoint:
+    id: str
+    task_id: str
+    feature_id: str
+    state: ExecutionState = field(
+        default_factory=lambda: ExecutionState(task_id="", feature_id="")
+    )
+    context_ref: Optional[str] = None
+    reason: str = ""
+    created_at: str = field(default_factory=_utcnow)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data["state"] = self.state.to_dict()
+        return data
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Checkpoint":
+        data = dict(data)
+        if isinstance(data.get("state"), dict):
+            data["state"] = ExecutionState.from_dict(data["state"])
+        return cls(**data)
+
+
+class ScopeReason:
+    FEATURE_COMPLETE = "FEATURE_COMPLETE"
+    DEPENDENCY_BLOCK = "DEPENDENCY_BLOCK"
+    VERIFICATION_REQUIRES_CHANGE = "VERIFICATION_REQUIRES_CHANGE"
+    USER_SCOPE_CHANGE = "USER_SCOPE_CHANGE"
+
+
+_ALLOWED_SCOPE_REASONS = frozenset({
+    ScopeReason.FEATURE_COMPLETE,
+    ScopeReason.DEPENDENCY_BLOCK,
+    ScopeReason.VERIFICATION_REQUIRES_CHANGE,
+    ScopeReason.USER_SCOPE_CHANGE,
+})
+
+
+class ScopeRejected(Exception):
+    """Raised when a feature switch lacks a justified reason."""
+
+
+class FeatureLock:
+    """One active feature per task. Switches require a recorded reason."""
+
+    def __init__(self) -> None:
+        self._active: Optional[FeatureState] = None
+        self.transitions: List[Dict[str, Any]] = []
+
+    @property
+    def active(self) -> Optional[FeatureState]:
+        return self._active
+
+    def select(
+        self,
+        feature: FeatureState,
+        reason: str = ScopeReason.USER_SCOPE_CHANGE,
+        evidence: str = "",
+    ) -> FeatureState:
+        previous = self._active.id if self._active else None
+        if previous is not None and previous != feature.id:
+            if reason not in _ALLOWED_SCOPE_REASONS:
+                raise ScopeRejected(
+                    f"switch {previous} -> {feature.id} needs a scope reason"
+                )
+            self.transitions.append({
+                "from": previous,
+                "to": feature.id,
+                "reason": reason,
+                "evidence": evidence,
+                "at": _utcnow(),
+            })
+        self._active = feature
+        return feature

--- a/harness/store.py
+++ b/harness/store.py
@@ -1,0 +1,169 @@
+"""Harness persistence on top of the session database.
+
+No new files, no schema change: every harness record is a JSON document in
+``state_meta`` under a ``harness:`` key prefix (``SessionDB.get_meta`` /
+``set_meta`` / ``list_meta_prefix``). WAL, repair, profiles, and temp-home
+test isolation all come from the existing session store.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from .state import Checkpoint, ExecutionState, FeatureState, KnowledgeItem, Task
+
+_PREFIX = "harness:"
+_TASKS = _PREFIX + "task:"
+_FEATURES = _PREFIX + "feature:"
+_EXEC = _PREFIX + "exec:"
+_OBS = _PREFIX + "obs:"
+_CHECKPOINTS = _PREFIX + "checkpoint:"
+_KNOWLEDGE = _PREFIX + "knowledge:"
+_EVENTS = _PREFIX + "event:"
+_SEQ = _PREFIX + "event_seq"
+_BUDGETS = _PREFIX + "budget:"
+_CONTEXTS = _PREFIX + "context:"
+
+
+def _doc_key(prefix: str, doc_id: str) -> str:
+    return f"{prefix}{doc_id}"
+
+
+class HarnessStore:
+    """Persist harness records through a SessionDB's meta KV."""
+
+    def __init__(self, session_db) -> None:
+        self._db = session_db
+
+    @classmethod
+    def open(cls, db_path: Optional[Path | str] = None) -> "HarnessStore":
+        from hermes_state import SessionDB
+
+        if db_path is None:
+            return cls(SessionDB())
+        return cls(SessionDB(db_path=Path(db_path)))
+
+    def close(self) -> None:
+        self._db.close()
+
+    # -- generic docs ----------------------------------------------------
+
+    def _put(self, key: str, doc: Dict[str, Any]) -> None:
+        self._db.set_meta(key, json.dumps(doc, sort_keys=True))
+
+    def _get(self, key: str) -> Optional[Dict[str, Any]]:
+        raw = self._db.get_meta(key)
+        return json.loads(raw) if raw is not None else None
+
+    def _scan(self, prefix: str) -> List[Tuple[str, Dict[str, Any]]]:
+        out = []
+        for key, raw in self._db.list_meta_prefix(prefix):
+            try:
+                out.append((key, json.loads(raw)))
+            except ValueError:
+                continue
+        out.sort(key=lambda item: item[0])
+        return out
+
+    # -- tasks / features / execution ------------------------------------
+
+    def save_task(self, task: Task) -> None:
+        self._put(_doc_key(_TASKS, task.id), task.to_dict())
+
+    def load_task(self, task_id: str) -> Optional[Task]:
+        doc = self._get(_doc_key(_TASKS, task_id))
+        return Task.from_dict(doc) if doc else None
+
+    def list_tasks(self) -> List[Task]:
+        return [Task.from_dict(doc) for _, doc in self._scan(_TASKS)]
+
+    def save_feature(self, feature: FeatureState) -> None:
+        self._put(_doc_key(_FEATURES, feature.id), feature.to_dict())
+
+    def features_for_task(self, task_id: str) -> List[FeatureState]:
+        return [
+            FeatureState.from_dict(doc)
+            for _, doc in self._scan(_FEATURES)
+            if doc.get("task_id") == task_id
+        ]
+
+    def save_execution(self, state: ExecutionState) -> None:
+        self._put(_doc_key(_EXEC, state.task_id), state.to_dict())
+
+    def load_execution(self, task_id: str) -> Optional[ExecutionState]:
+        doc = self._get(_doc_key(_EXEC, task_id))
+        return ExecutionState.from_dict(doc) if doc else None
+
+    # -- observations (per-tool records, not just events) --------------------
+
+    def save_observation(self, task_id: str, doc: Dict[str, Any]) -> None:
+        obs_id = doc.get("id") or "obs"
+        self._put(_doc_key(_OBS, f"{task_id}:{obs_id}"), dict(doc, task_id=task_id))
+
+    def observations_for_task(self, task_id: str) -> List[Dict[str, Any]]:
+        return [doc for _, doc in self._scan(_OBS + task_id + ":")]
+
+    # -- events (append-only log) -----------------------------------------
+
+    def append_event(self, kind: str, payload: str) -> int:
+        raw = self._db.get_meta(_SEQ)
+        seq = int(raw) + 1 if raw is not None else 1
+        self._put(
+            _doc_key(_EVENTS, f"{seq:010d}"),
+            {"seq": seq, "kind": kind, "payload": payload},
+        )
+        self._db.set_meta(_SEQ, str(seq))
+        return seq
+
+    def list_events(self, after: int = 0) -> List[Dict[str, Any]]:
+        return [doc for _, doc in self._scan(_EVENTS) if doc.get("seq", 0) > after]
+
+    def task_terminal_outcome(self, task_id: str) -> Optional[str]:
+        """Latest terminal TASK_* marker for the task, replayed from the log."""
+        last: Optional[str] = None
+        for doc in self.list_events():
+            payload = doc.get("payload", "")
+            if doc.get("kind") == "TASK" and payload.endswith(":" + task_id):
+                last = payload
+        if not last:
+            return None
+        marker = last.split(":", 1)[0]
+        if marker in ("TASK_COMPLETED", "TASK_FAILED", "TASK_BUDGET_EXHAUSTED"):
+            return marker[len("TASK_") :]
+        return None
+
+    # -- checkpoints / knowledge / budgets / contexts ---------------------
+
+    def save_checkpoint(self, checkpoint: Checkpoint) -> None:
+        self._put(_doc_key(_CHECKPOINTS, checkpoint.id), checkpoint.to_dict())
+
+    def checkpoints_for_task(self, task_id: str) -> List[Checkpoint]:
+        return [
+            Checkpoint.from_dict(doc)
+            for _, doc in self._scan(_CHECKPOINTS)
+            if doc.get("task_id") == task_id
+        ]
+
+    def latest_checkpoint(self, task_id: str) -> Optional[Checkpoint]:
+        found = self.checkpoints_for_task(task_id)
+        return found[-1] if found else None
+
+    def save_knowledge(self, item: KnowledgeItem) -> None:
+        self._put(_doc_key(_KNOWLEDGE, item.id), item.to_dict())
+
+    def list_knowledge(self) -> List[KnowledgeItem]:
+        return [KnowledgeItem.from_dict(doc) for _, doc in self._scan(_KNOWLEDGE)]
+
+    def save_budget(self, budget_id: str, doc: Dict[str, Any]) -> None:
+        self._put(_doc_key(_BUDGETS, budget_id), doc)
+
+    def load_budget(self, budget_id: str) -> Optional[Dict[str, Any]]:
+        return self._get(_doc_key(_BUDGETS, budget_id))
+
+    def save_context(self, context_id: str, doc: Dict[str, Any]) -> None:
+        self._put(_doc_key(_CONTEXTS, context_id), doc)
+
+    def load_context(self, context_id: str) -> Optional[Dict[str, Any]]:
+        return self._get(_doc_key(_CONTEXTS, context_id))

--- a/harness/verify.py
+++ b/harness/verify.py
@@ -1,0 +1,128 @@
+"""Independent verification: evidence hierarchy, not model claims.
+
+Strength order (strongest first): tests, type checker, runtime behavior,
+static inspection, configuration, agent reasoning. ``"It works"`` from the
+model scores lowest and can never alone pass a gate.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable, List, Sequence
+
+from .state import VerificationCheck, VerificationResult
+
+
+class CheckStrength:
+    CLAIM = 0
+    CONFIG = 1
+    STATIC = 2
+    RUNTIME = 3
+    TYPECHECK = 4
+    TESTS = 5
+
+
+def verify(
+    checks: Sequence[VerificationCheck], success_criteria: Sequence[str]
+) -> VerificationResult:
+    collected = list(checks)
+    failures = [f"{c.name}: {c.detail or 'failed'}" for c in collected if not c.passed]
+    confidence = 0.0
+    if collected and not failures:
+        # Strongest available evidence sets the confidence (system design
+        # §32); a bare claim stays at the floor and never verifies alone.
+        strongest = max(c.strength for c in collected)
+        confidence = round(0.5 + 0.1 * strongest, 2)
+    return VerificationResult(
+        passed=bool(collected) and not failures and bool(success_criteria),
+        checks=collected,
+        failures=failures,
+        confidence=confidence,
+    )
+
+
+def completion_allowed(
+    goal_done: bool, criteria_done: bool, verified: bool, no_blocker: bool
+) -> bool:
+    return bool(goal_done and criteria_done and verified and no_blocker)
+
+
+def pytest_check(
+    targets: Sequence[str], cwd: str | Path, timeout_s: int = 300
+) -> VerificationCheck:
+    """Run pytest as evidence. The subprocess result is the check."""
+    cmd = [sys.executable, "-m", "pytest", "-q", *targets]
+    try:
+        proc = subprocess.run(
+            cmd, cwd=str(cwd), capture_output=True, text=True, timeout=timeout_s
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return VerificationCheck(
+            name="pytest",
+            passed=False,
+            detail=str(exc)[:500],
+            strength=CheckStrength.TESTS,
+        )
+    tail = (proc.stdout + proc.stderr)[-2000:]
+    return VerificationCheck(
+        name="pytest",
+        passed=proc.returncode == 0,
+        detail=tail,
+        strength=CheckStrength.TESTS,
+    )
+
+
+def command_check(
+    name: str, command: Sequence[str], cwd: str | Path, timeout_s: int = 120
+) -> VerificationCheck:
+    """Run an arbitrary verification command (build, typecheck, migrate)."""
+    try:
+        proc = subprocess.run(
+            list(command),
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return VerificationCheck(
+            name=name,
+            passed=False,
+            detail=str(exc)[:500],
+            strength=CheckStrength.RUNTIME,
+        )
+    return VerificationCheck(
+        name=name,
+        passed=proc.returncode == 0,
+        detail=(proc.stdout + proc.stderr)[-2000:],
+        strength=CheckStrength.RUNTIME,
+    )
+
+
+def file_contains_check(name: str, path: str | Path, needle: str) -> VerificationCheck:
+    """Static source inspection: the file must exist and contain the needle."""
+    try:
+        content = Path(path).read_text(encoding="utf-8")
+    except OSError as exc:
+        return VerificationCheck(
+            name=name,
+            passed=False,
+            detail=str(exc)[:300],
+            strength=CheckStrength.STATIC,
+        )
+    ok = needle in content
+    return VerificationCheck(
+        name=name,
+        passed=ok,
+        detail="found" if ok else f"missing {needle!r}",
+        strength=CheckStrength.STATIC,
+    )
+
+
+Checker = Callable[[], VerificationCheck]
+
+
+def run_all(checkers: Sequence[Checker]) -> List[VerificationCheck]:
+    return [check() for check in checkers]

--- a/tests/harness/test_gates.py
+++ b/tests/harness/test_gates.py
@@ -1,0 +1,103 @@
+"""Gate contracts: budgets, verification hierarchy, recovery decisions."""
+
+import time
+
+from harness.budget import BudgetGovernor
+from harness.knowledge import extract, is_durable, resolve_conflict, KnowledgeCandidate
+from harness.recovery import (
+    FailureClass,
+    Strategy,
+    classify_failure,
+    decide,
+    progress_made,
+)
+from harness.state import ExecutionBudget, KnowledgeItem, VerificationCheck
+from harness.verify import (
+    CheckStrength,
+    completion_allowed,
+    file_contains_check,
+    verify,
+)
+
+
+def test_budget_hard_stop():
+    gov = BudgetGovernor(ExecutionBudget(max_tool_calls=2, max_retries=1))
+    assert gov.consume_tool_call() and gov.consume_tool_call()
+    assert not gov.consume_tool_call()
+    assert gov.exhausted() == ["tool calls"]
+    assert gov.consume_retry() and not gov.consume_retry()
+
+
+def test_budget_elapsed_limit(tmp_path):
+    gov = BudgetGovernor(ExecutionBudget(max_elapsed_seconds=1000))
+    assert gov.exhausted() == []
+    gov.usage.started_at -= 2000
+    assert gov.exhausted() == ["elapsed time"]
+
+
+def test_verification_hierarchy_prefers_strongest():
+    weak = VerificationCheck(name="claim", passed=True, strength=CheckStrength.CLAIM)
+    strong = VerificationCheck(name="pytest", passed=True, strength=CheckStrength.TESTS)
+    assert (
+        verify([weak], ["done"]).confidence
+        < verify([weak, strong], ["done"]).confidence
+    )
+
+
+def test_model_claim_alone_never_verifies():
+    assert not verify([], ["done"]).passed
+    failed = verify([VerificationCheck(name="t", passed=False)], ["done"])
+    assert not failed.passed and failed.failures
+
+
+def test_completion_gate_needs_everything():
+    assert completion_allowed(True, True, True, True)
+    assert not completion_allowed(True, True, False, True)
+
+
+def test_file_check_is_real_inspection(tmp_path):
+    target = tmp_path / "a.txt"
+    target.write_text("hello world")
+    assert file_contains_check("has-hello", target, "hello").passed
+    assert not file_contains_check("has-bye", target, "bye").passed
+    assert not file_contains_check("missing", tmp_path / "nope.txt", "x").passed
+
+
+def test_classify_transient_vs_deterministic():
+    assert classify_failure("connection timeout after 30s") == FailureClass.TRANSIENT
+    assert classify_failure("file does not exist") == FailureClass.DETERMINISTIC
+    assert classify_failure("", transient=True) == FailureClass.TRANSIENT
+    assert classify_failure("   ") == FailureClass.UNKNOWN
+
+
+def test_identical_failure_forces_new_strategy():
+    seen = {"a\x00h\x00x": 1}
+    assert decide("a", "h", "x", FailureClass.TRANSIENT, seen) == Strategy.RETRY
+    seen["a\x00h\x00x"] = 2
+    assert (
+        decide("a", "h", "x", FailureClass.TRANSIENT, seen)
+        == Strategy.RETRIEVE_MORE_CONTEXT
+    )
+    seen["a\x00h\x00x"] = 9
+    assert decide("a", "h", "x", FailureClass.DETERMINISTIC, seen) == Strategy.STOP
+
+
+def test_progress_invariant():
+    assert not progress_made()
+    assert progress_made(new_evidence=True)
+
+
+def test_knowledge_gate():
+    good = KnowledgeCandidate(type="SOLUTION", content="restart the worker to clear it")
+    assert extract([good], [], has_evidence=False) == []
+    assert extract([good], [], has_evidence=True)[0].content == good.content
+    assert (
+        extract(
+            [good],
+            [KnowledgeItem(id="k", type="SOLUTION", content=good.content)],
+            has_evidence=True,
+        )
+        == []
+    )
+    assert not is_durable(KnowledgeCandidate(type="SOLUTION", content="tmp debug"))
+    assert resolve_conflict(["model_inference", "verified_source"]) == "verified_source"

--- a/tests/harness/test_loop.py
+++ b/tests/harness/test_loop.py
@@ -1,0 +1,143 @@
+"""Driver contracts: scripted agent steps, real SessionDB, no model calls."""
+
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from harness.knowledge import KnowledgeCandidate
+from harness.loop import HarnessRunner, StepResult
+from harness.state import Outcome, StepStatus, ToolObservation
+from harness.store import HarnessStore
+from hermes_state import SessionDB
+
+
+def _runner(tmp_path: Path, make_step):
+    db = SessionDB(db_path=tmp_path / "loop-test.db")
+    return HarnessRunner(HarnessStore(db), make_step)
+
+
+def _ok_step(**overrides):
+    def run(task, feature, context):
+        base: Dict[str, Any] = dict(
+            summary="did work",
+            status_hint=Outcome.CONTINUE,
+            observations=[
+                ToolObservation(
+                    id="obs-1", tool="read", success=True, summary="read ok"
+                )
+            ],
+            evidence=["file content"],
+        )
+        base.update(overrides)
+        return StepResult(**base)
+
+    return run
+
+
+def test_full_cycle_completes_with_evidence(tmp_path):
+    runner = _runner(tmp_path, lambda task: _ok_step(status_hint=StepStatus.DONE))
+    task = runner.create("ship it", ["tests pass"])
+    assert runner.step(task.id) == Outcome.COMPLETED
+    status = runner.status(task.id)
+    assert status["iteration"] == 1 and status["observations"] == 1
+    with pytest.raises(RuntimeError):
+        runner.step(task.id)
+
+
+def test_done_without_evidence_does_not_complete(tmp_path):
+    runner = _runner(
+        tmp_path,
+        lambda task: _ok_step(
+            status_hint=StepStatus.DONE, observations=[], evidence=[]
+        ),
+    )
+    task = runner.create("ship it", ["tests pass"])
+    assert runner.step(task.id) == Outcome.CONTINUE
+
+
+def test_tool_failure_recovers_without_blind_retry(tmp_path):
+    calls = []
+
+    def flaky(task, feature, context):
+        calls.append(1)
+        if len(calls) == 1:
+            return StepResult(
+                observations=[
+                    ToolObservation(
+                        id="obs-1", tool="write", success=False, summary="disk gone"
+                    )
+                ]
+            )
+        return StepResult(
+            summary="replanned",
+            status_hint=Outcome.CONTINUE,
+            observations=[
+                ToolObservation(
+                    id="obs-2", tool="read", success=True, summary="read ok"
+                )
+            ],
+            evidence=["content"],
+        )
+
+    runner = _runner(tmp_path, lambda task: flaky)
+    task = runner.create("write it", ["file exists"])
+    assert runner.step(task.id) == Outcome.CONTINUE
+    assert runner.step(task.id) == Outcome.CONTINUE
+    assert len(calls) == 2
+
+
+def test_repeated_identical_failure_stops(tmp_path):
+    def broken(task, feature, context):
+        return StepResult(
+            observations=[
+                ToolObservation(
+                    id="obs-x", tool="write", success=False, summary="disk gone"
+                )
+            ]
+        )
+
+    runner = _runner(tmp_path, lambda task: broken)
+    task = runner.create("write it", ["file exists"])
+    outcome = runner.run(task.id, max_rounds=30)
+    assert outcome == Outcome.STOPPED
+
+
+def test_pause_cancel_resume(tmp_path):
+    runner = _runner(tmp_path, lambda task: _ok_step())
+    task = runner.create("long job", ["done"])
+    runner.pause(task.id)
+    runner.cancel(task.id)
+    assert runner.resume(task.id, max_rounds=2) == Outcome.CONTINUE
+    kinds = [
+        e["payload"].split(":")[0]
+        for e in runner._store.list_events()
+        if e["kind"] == "TASK"
+    ]
+    assert (
+        "TASK_PAUSED" in kinds and "TASK_CANCELLED" in kinds and "TASK_RESUMED" in kinds
+    )
+
+
+def test_resume_rebuilds_from_store(tmp_path):
+    db_path = tmp_path / "resume.db"
+    first = HarnessRunner(
+        HarnessStore(SessionDB(db_path=db_path)), lambda task: _ok_step()
+    )
+    task = first.create("persist me", ["done"])
+    assert first.step(task.id) == Outcome.CONTINUE
+    second = HarnessRunner(
+        HarnessStore(SessionDB(db_path=db_path)), lambda task: _ok_step()
+    )
+    assert second.status(task.id)["iteration"] == 1
+    assert second.resume(task.id, max_rounds=1) == Outcome.CONTINUE
+
+
+def test_knowledge_stored_only_with_evidence(tmp_path):
+    candidate = KnowledgeCandidate(
+        type="SOLUTION", content="restart the worker to clear it"
+    )
+    runner = _runner(tmp_path, lambda task: _ok_step(proposed_knowledge=[candidate]))
+    task = runner.create("learn", ["done"])
+    runner.step(task.id)
+    assert [k.content for k in runner._store.list_knowledge()] == [candidate.content]

--- a/tests/harness/test_state.py
+++ b/tests/harness/test_state.py
@@ -1,0 +1,57 @@
+"""State contracts: lock behavior and JSON round-trips."""
+
+import pytest
+
+from harness.state import (
+    TERMINAL_STATUSES,
+    FeatureLock,
+    FeatureState,
+    FeatureStatus,
+    ScopeReason,
+    ScopeRejected,
+    Task,
+    TaskStatus,
+)
+
+
+def _feature(fid="f1", task="t1"):
+    return FeatureState(id=fid, task_id=task, name=fid)
+
+
+def test_first_selection_needs_no_reason():
+    lock = FeatureLock()
+    assert lock.select(_feature()).id == "f1"
+    assert lock.active is not None and lock.active.id == "f1"
+
+
+def test_unjustified_switch_is_rejected():
+    lock = FeatureLock()
+    lock.select(_feature("f1"))
+    with pytest.raises(ScopeRejected):
+        lock.select(_feature("f2"), reason="because-i-said-so")
+
+
+def test_justified_switch_records_transition():
+    lock = FeatureLock()
+    lock.select(_feature("f1"))
+    lock.select(
+        _feature("f2"), reason=ScopeReason.FEATURE_COMPLETE, evidence="tests pass"
+    )
+    assert lock.active is not None and lock.active.id == "f2"
+    assert lock.transitions[-1]["reason"] == ScopeReason.FEATURE_COMPLETE
+
+
+def test_task_round_trip_preserves_budget():
+    task = Task(id="t1", goal="fix it", success_criteria=["tests pass"])
+    clone = Task.from_dict(task.to_dict())
+    assert clone.goal == "fix it"
+    assert clone.budget.max_tool_calls == task.budget.max_tool_calls
+    assert clone.status == TaskStatus.CREATED
+
+
+def test_terminal_statuses_cover_failure_modes():
+    assert {"COMPLETED", "FAILED", "BUDGET_EXHAUSTED", "STOPPED"} <= TERMINAL_STATUSES
+
+
+def test_feature_status_defaults_to_pending():
+    assert _feature().status == FeatureStatus.PENDING

--- a/tests/harness/test_store.py
+++ b/tests/harness/test_store.py
@@ -1,0 +1,82 @@
+"""Store contracts: real SessionDB on a temp path, no mocks."""
+
+from pathlib import Path
+
+from hermes_state import SessionDB
+
+from harness.state import Checkpoint, ExecutionState, FeatureState, KnowledgeItem, Task
+from harness.store import HarnessStore
+
+
+def _store(tmp_path: Path) -> HarnessStore:
+    db = SessionDB(db_path=tmp_path / "harness-test.db")
+    return HarnessStore(db)
+
+
+def test_task_feature_execution_round_trip(tmp_path):
+    store = _store(tmp_path)
+    try:
+        store.save_task(Task(id="t1", goal="ship it"))
+        store.save_feature(FeatureState(id="f1", task_id="t1", name="work"))
+        store.save_execution(ExecutionState(task_id="t1", feature_id="f1", iteration=3))
+        loaded = store.load_task("t1")
+        assert loaded is not None and loaded.goal == "ship it"
+        assert [f.id for f in store.features_for_task("t1")] == ["f1"]
+        executed = store.load_execution("t1")
+        assert executed is not None and executed.iteration == 3
+        assert store.load_task("missing") is None
+    finally:
+        store.close()
+
+
+def test_events_append_in_order_with_cursor(tmp_path):
+    store = _store(tmp_path)
+    try:
+        first = store.append_event("RUN", "one")
+        second = store.append_event("RUN", "two")
+        assert second == first + 1
+        assert [e["payload"] for e in store.list_events()] == ["one", "two"]
+        assert [e["payload"] for e in store.list_events(after=first)] == ["two"]
+    finally:
+        store.close()
+
+
+def test_terminal_outcome_replays_from_log(tmp_path):
+    store = _store(tmp_path)
+    try:
+        assert store.task_terminal_outcome("t1") is None
+        store.append_event("TASK", "TASK_CREATED:t1")
+        store.append_event("TASK", "TASK_STOPPED:t1")
+        assert store.task_terminal_outcome("t1") is None
+        store.append_event("TASK", "TASK_BUDGET_EXHAUSTED:t1")
+        assert store.task_terminal_outcome("t1") == "BUDGET_EXHAUSTED"
+        assert store.task_terminal_outcome("t2") is None
+    finally:
+        store.close()
+
+
+def test_checkpoints_keep_latest_per_task(tmp_path):
+    store = _store(tmp_path)
+    try:
+        for i in ("cp-1", "cp-2"):
+            store.save_checkpoint(
+                Checkpoint(id=i, task_id="t1", feature_id="f1", reason="test")
+            )
+        latest = store.latest_checkpoint("t1")
+        assert latest is not None and latest.id == "cp-2"
+        assert store.latest_checkpoint("t9") is None
+    finally:
+        store.close()
+
+
+def test_knowledge_and_context_docs(tmp_path):
+    store = _store(tmp_path)
+    try:
+        store.save_knowledge(
+            KnowledgeItem(id="k1", type="SOLUTION", content="restart it")
+        )
+        store.save_context("ctx-1", {"items": ["a"]})
+        assert [k.id for k in store.list_knowledge()] == ["k1"]
+        assert store.load_context("ctx-1") == {"items": ["a"]}
+    finally:
+        store.close()


### PR DESCRIPTION
## What does this PR do?

Adds a `harness/` package that manages agent work as tasks with explicit, persisted state.

The problem: today nothing stands between the model and "done" — a task is whatever the conversation says it is, retries can loop forever on the same failure, and an unverified claim looks the same as a verified result. This PR adds a small governance layer that fixes that:

- **Tasks with explicit state** — goal, success criteria, status, budgets, and one active feature at a time. Switching features requires a recorded reason.
- **A run driver with gates** — create / step / run / pause / cancel / resume / status. Each iteration checks budget, compiles a bounded context, invokes one agent turn, records observations, evaluates progress, and only marks completion when verification passes.
- **Verification from real evidence** — a strength-ordered check system (tests > typecheck > runtime > static > config > bare claim) plus runners that actually execute pytest, commands, and file checks. A DONE without evidence stays CONTINUE.
- **Recovery that doesn't loop** — failures are classified first (transient vs structural); the same action + failure + hypothesis twice forces a new strategy, then escalates, then stops.
- **Hard-limit budgets** — tool calls, retries, replans, iterations, tokens, elapsed time. Terminal states (completed/failed/budget-exhausted) refuse re-runs, including after a restart.
- **Knowledge gate** — observations become durable knowledge only with evidence; conflicts resolve by source strength.
- **Persistence without touching existing storage** — everything is JSON docs in the session DB's existing key/value area, so profiles, WAL, and repair keep working. No schema change, no new files, no new dependencies.
- **Key-free testing** — 28 tests run against a real session DB on a temp dir, plus a `python -m harness.demo` end-to-end that finishes COMPLETED.

What it deliberately does **not** do: add model tools, hooks, config keys, or dependencies; modify any existing file (additions only — 15 new files); change the turn loop, prompting, or caching behavior.

## Related Issue

No linked issue. Searched open/merged PR titles for `harness` / `dynamic agent harness` — 61 hits, all unrelated (eval, browser, K8s, and temp-cleanup harnesses, plus one conductor skill).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `harness/__init__.py`, `harness/AGENTS.md`, `harness/state.py`, `harness/store.py`, `harness/loop.py`, `harness/verify.py`, `harness/recovery.py`, `harness/budget.py`, `harness/knowledge.py`, `harness/adapter.py`, `harness/demo.py`
- `tests/harness/test_state.py`, `test_store.py`, `test_gates.py`, `test_loop.py`

## How to Test

1. `scripts/run_tests.sh tests/harness/` — 28 passed, 0 failed.
2. `.venv/Scripts/python.exe -m harness.demo` — ends with `run -> COMPLETED` and `E2E OK: ...`.
3. `.venv/Scripts/python.exe -m ruff check harness/ tests/harness/`, `ruff format --check`, `ty check` — all clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit follows Conventional Commits (`feat(harness): …`)
- [x] Searched existing PRs — no duplicates
- [x] Only related changes, no unrelated commits
- [ ] Full `pytest tests/ -q` not run (39k-file suite; ran `tests/harness/` with the same runner CI uses; no tracked files modified — leaving the full signal to CI)
- [x] Tests added (28, real session DB, no store mocks)
- [x] Tested on Windows 11, Python 3.11

### Documentation & Housekeeping

- [x] `harness/AGENTS.md` + module docstrings
- [x] No config keys, no tool schema changes (N/A)
- [x] Cross-platform: stdlib only, `pathlib`, no OS-specific code (tested on Windows)

## Screenshots / Logs

```text
task t-97724e89 created; Hermes home: ...\harness-demo-home...
turn 1 -> CONTINUE (unverified claim must not complete)
resumed: iteration=0 observations=0
run -> COMPLETED
verified on disk: ...\hello.txt
E2E OK: task, harness, tools, observations, verification, recovery, persistence, resume, completion
```

Test summary: `4 files, 28 tests passed, 0 failed (100% complete)`.
