### PR TITLE
Add tool-belt to community plugin index

### DIFF
--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -63,6 +63,18 @@
       "capabilities": ["tools"],
       "api_version": 1,
       "added_at": "2026-08-12"
+    },
+    {
+      "name": "tool-belt",
+      "description": "Adaptive tool loadouts for uncached agents. Carry only what you need, drop the rest. Sharpens with use. Reduces tool token overhead.",
+      "author": "dalemugford",
+      "tags": ["tools", "tokens", "prompt-caching", "cost"],
+      "repo": "dalemugford/hermes-tool-belt",
+      "ref": "0ca32967cd8b3de886b0616536b4679d98988689",
+      "homepage": "https://github.com/dalemugford/hermes-tool-belt",
+      "capabilities": ["tools"],
+      "api_version": 1,
+      "added_at": "2026-09-04"
     }
   ]
 }

--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -70,7 +70,7 @@
       "author": "dalemugford",
       "tags": ["tools", "tokens", "prompt-caching", "cost"],
       "repo": "dalemugford/hermes-tool-belt",
-      "ref": "0ca32967cd8b3de886b0616536b4679d98988689",
+      "ref": "ad220afa814cb8c2e4c5977c30b594a65257dcb2",
       "homepage": "https://github.com/dalemugford/hermes-tool-belt",
       "capabilities": ["tools"],
       "api_version": 1,

--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -70,7 +70,7 @@
       "author": "dalemugford",
       "tags": ["tools", "tokens", "prompt-caching", "cost"],
       "repo": "dalemugford/hermes-tool-belt",
-      "ref": "ad220afa814cb8c2e4c5977c30b594a65257dcb2",
+      "ref": "171f29a4b4a2d04810c128b7eaa4e359a0cd2219",
       "homepage": "https://github.com/dalemugford/hermes-tool-belt",
       "capabilities": ["tools"],
       "api_version": 1,


### PR DESCRIPTION
## Add `tool-belt` to the community plugin index

Adds one entry to `hermes_cli/data/plugin_index.json` for **tool-belt** — adaptive, usage-aware tool loadouts that narrow each request's tool block on non-caching providers (and carry-all on caching ones), reducing tool-schema token overhead and sharpening with use.

- **Repo:** https://github.com/dalemugford/hermes-tool-belt (public, MIT)
- **Pinned ref:** `171f29a` — the `2026.9.5` release commit
- **Capabilities:** `tools` (registers the `expand_tools` meta-tool + 5 lifecycle hooks)

### Entry
```json
{
  "name": "tool-belt",
  "description": "Adaptive tool loadouts for uncached agents. Carry only what you need, drop the rest. Sharpens with use. Reduces tool token overhead.",
  "author": "dalemugford",
  "tags": ["tools", "tokens", "prompt-caching", "cost"],
  "repo": "dalemugford/hermes-tool-belt",
  "ref": "171f29a4b4a2d04810c128b7eaa4e359a0cd2219",
  "homepage": "https://github.com/dalemugford/hermes-tool-belt",
  "capabilities": ["tools"],
  "api_version": 1,
  "added_at": "2026-09-04"
}
```

### Verification
- `hermes plugins doctor --ci .` → `registrations: 1 tool(s), 5 hook(s)`
- Full gate green on the pinned commit (502 tests, smoke 9/9 cache-off + 16/16 cache-on); the 2026.9.5 tag is published as a GitHub Release with CI green on Python 3.11 / 3.12.

Only the `plugins` array is touched — one appended object, existing entries unchanged.
