### PR TITLE
fix(desktop): restore native macOS Window menu

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -412,6 +412,7 @@ import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-market
 import { createWakeIndicatorWindowController } from './wake-indicator-window'
 import { enumerateWindowsFrontToBack, enumerationFailed, readWindowBelow } from './window-below'
 import { registrySshScopeForWindowRoute, WindowConnectionRouteRegistry } from './window-connection-route'
+import { windowMenuTemplate } from './window-menu'
 import { installWindowRendererLifecycle } from './window-renderer-lifecycle'
 import { createWindowRevealController } from './window-reveal'
 import {
@@ -6930,12 +6931,7 @@ function buildApplicationMenu() {
       { role: 'togglefullscreen' }
     ]
   })
-  template.push({
-    label: 'Window',
-    submenu: IS_MAC
-      ? [{ role: 'minimize' }, { role: 'zoom' }, { role: 'front' }]
-      : [{ role: 'minimize' }, { role: 'close' }]
-  })
+  template.push(windowMenuTemplate(IS_MAC))
   template.push({
     label: 'Help',
     role: 'help',

--- a/apps/desktop/electron/window-menu.test.ts
+++ b/apps/desktop/electron/window-menu.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { windowMenuTemplate } from './window-menu'
+
+test('macOS registers the native Window menu so AppKit window commands remain available', () => {
+  const menu = windowMenuTemplate(true)
+
+  assert.equal(menu.role, 'windowMenu')
+  assert.deepEqual(
+    menu.submenu.map(item => item.role),
+    ['minimize', 'zoom', 'front']
+  )
+})
+
+test('non-macOS keeps the explicit cross-platform Window menu', () => {
+  assert.deepEqual(windowMenuTemplate(false), {
+    label: 'Window',
+    submenu: [{ role: 'minimize' }, { role: 'close' }]
+  })
+})

--- a/apps/desktop/electron/window-menu.ts
+++ b/apps/desktop/electron/window-menu.ts
@@ -1,0 +1,20 @@
+interface WindowMenuItem {
+  label?: string
+  role?: string
+  submenu: Array<{ role: string }>
+}
+
+function windowMenuTemplate(isMac: boolean): WindowMenuItem {
+  return {
+    label: 'Window',
+    // Mark the macOS menu as AppKit's standard Window menu. Without this role,
+    // macOS still exposes tiling from the green button but does not attach its
+    // Move & Resize commands (and their keyboard shortcuts) to the app menu.
+    ...(isMac ? { role: 'windowMenu' } : {}),
+    submenu: isMac
+      ? [{ role: 'minimize' }, { role: 'zoom' }, { role: 'front' }]
+      : [{ role: 'minimize' }, { role: 'close' }]
+  }
+}
+
+export { windowMenuTemplate }


### PR DESCRIPTION
## What does this PR do?

Marks Hermes Desktop's custom macOS **Window** menu with Electron's documented `windowMenu` role. This lets Electron register the submenu as `NSApp.windowsMenu`, allowing AppKit's native **Move & Resize** commands and user-assigned shortcuts to attach to Hermes.

The existing macOS submenu entries (`minimize`, `zoom`, and `front`) and the non-macOS menu remain unchanged.

## Related Issue

Fixes #103105

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Extract the Window menu template into `apps/desktop/electron/window-menu.ts` so it can be tested without initializing Electron's main process.
- Assign `role: 'windowMenu'` only on macOS while preserving the current custom submenu.
- Add regression tests for both macOS and non-macOS templates.

## How to Test

1. Run `cd apps/desktop && npx vitest run --project electron electron/window-menu.test.ts`.
2. Run `cd apps/desktop && npm run typecheck`.
3. On macOS, assign a shortcut to **Window → Move & Resize → Left/Right**, focus Hermes Desktop, and confirm the window tiles using the shortcut.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — not applicable to this scoped Electron change; the targeted Electron tests and TypeScript checks pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform — implementation was verified on Linux with structural Electron tests; manual macOS validation remains required

### Documentation & Housekeeping

- [x] Documentation update — N/A
- [x] `cli-config.yaml.example` update — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A
- [x] Cross-platform impact considered; the native role is macOS-only and non-macOS behavior has a regression test
- [x] Tool descriptions/schemas update — N/A

## Verification

- `npx vitest run --project electron electron/window-menu.test.ts` — 2 tests passed
- `npm run typecheck` — passed
- Prettier check for all three changed files — passed
- Independent review found no security concerns or logic errors
