### PR TITLE
fix(gateway): stop printing sys.maxsize as the iteration cap in status lines

### DIFF
--- a/agent/session_activity.py
+++ b/agent/session_activity.py
@@ -4,6 +4,7 @@ only (notification, timeout, kill and retry policy live elsewhere). Provenance i
 
 from __future__ import annotations
 
+import sys
 import time
 from contextlib import suppress
 from enum import Enum
@@ -43,6 +44,25 @@ def normalize_activity_provenance(provenance: Optional[ActivityProvenance | str]
         return ActivityProvenance((provenance or "").strip())
     except ValueError:
         return ActivityProvenance.UNKNOWN
+
+
+def format_iteration_progress(api_call_count: Any, max_iterations: Any) -> str:
+    """Render ``iteration N/M`` for user-facing status, or ``iteration N`` when the cap is unlimited.
+
+    ``AIAgent.max_iterations`` defaults to ``sys.maxsize`` ("unlimited"), so a naive ``N/M`` prints
+    ``iteration 7/9223372036854775807`` in busy acks, heartbeats and timeout diagnostics.
+    """
+    try:
+        count = int(api_call_count or 0)
+    except (TypeError, ValueError):
+        count = 0
+    try:
+        cap = int(max_iterations or 0)
+    except (TypeError, ValueError):
+        cap = 0
+    if cap <= 0 or cap >= sys.maxsize:
+        return f"iteration {count}"
+    return f"iteration {count}/{cap}"
 
 
 def reset_session_activity_persist_window(agent: Any) -> None:

--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -15,6 +15,7 @@ import json
 import os
 import time
 from agent.i18n import t
+from agent.session_activity import format_iteration_progress
 from gateway.config import Platform
 from gateway.platforms.base import EphemeralReply, MessageEvent, MessageType
 from gateway.session import SessionSource
@@ -556,7 +557,7 @@ class GatewayBusySessionMixin:
                     status_parts.append(f"{elapsed_min} min elapsed")
                 if summary.get("max_iterations", 0):
                     status_parts.append(
-                        f"iteration {summary.get('api_call_count', 0)}/{summary.get('max_iterations', 0)}"
+                        format_iteration_progress(summary.get("api_call_count", 0), summary.get("max_iterations", 0))
                     )
                 if summary.get("current_tool"):
                     status_parts.append(f"running: {summary.get('current_tool')}")

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -16,6 +16,7 @@ import queue
 import threading
 import time
 from agent.i18n import t
+from agent.session_activity import format_iteration_progress
 from contextlib import nullcontext, suppress
 from contextvars import copy_context
 from gateway.config import Platform
@@ -3165,6 +3166,7 @@ class GatewayTurnMixin:
         _cur_tool = _activity.get("current_tool")
         _iter_n = _activity.get("api_call_count", 0)
         _iter_max = _activity.get("max_iterations", 0)
+        _iter_label = format_iteration_progress(_iter_n, _iter_max)
         logger.error(
             "Agent idle for %.0fs (timeout %.0fs) in session %s "
             "| last_activity=%s | iteration=%s/%s | tool=%s",
@@ -3180,12 +3182,12 @@ class GatewayTurnMixin:
         if _cur_tool:
             _diag_lines.append(
                 f"The agent appears stuck on tool `{_cur_tool}` ({_secs_ago:.0f}s since last "
-                f"activity, iteration {_iter_n}/{_iter_max})."
+                f"activity, {_iter_label})."
             )
         else:
             _diag_lines.append(
                 f"Last activity: {_last_desc} ({_secs_ago:.0f}s ago, "
-                f"iteration {_iter_n}/{_iter_max}). "
+                f"{_iter_label}). "
                 "The agent may have been waiting on an API response."
             )
         _diag_lines.append(
@@ -3740,7 +3742,7 @@ class GatewayTurnMixin:
                 if _a:
                     _parts = []
                     if _want_iteration_detail:
-                        _parts.append(f"iteration {_a['api_call_count']}/{_a['max_iterations']}")
+                        _parts.append(format_iteration_progress(_a.get("api_call_count", 0), _a.get("max_iterations", 0)))
                     _action = _a.get("current_tool") or _a.get("last_activity_desc")
                     if _action:
                         _parts.append(str(_action))

--- a/tests/agent/test_session_activity.py
+++ b/tests/agent/test_session_activity.py
@@ -7,6 +7,7 @@ from agent.session_activity import (
     ActivityProvenance,
     bound_activity_description,
     build_activity_snapshot,
+    format_iteration_progress,
     normalize_activity_provenance,
     reset_session_activity_persist_window,
 )
@@ -94,3 +95,18 @@ def test_build_activity_snapshot_preserves_compression_transition_provenances():
         assert snap["provenance"] == provenance.value
         assert snap["last_activity_description"] == desc
         assert snap["seconds_since_activity"] == 5.0
+
+
+def test_format_iteration_progress_hides_unlimited_cap():
+    import sys
+
+    # AIAgent.max_iterations defaults to sys.maxsize; the status must not print it.
+    assert format_iteration_progress(7, sys.maxsize) == "iteration 7"
+    assert format_iteration_progress(7, 0) == "iteration 7"
+    assert format_iteration_progress(7, None) == "iteration 7"
+
+
+def test_format_iteration_progress_keeps_finite_cap():
+    assert format_iteration_progress(3, 10) == "iteration 3/10"
+    assert format_iteration_progress("3", "10") == "iteration 3/10"
+    assert format_iteration_progress(None, "garbage") == "iteration 0"


### PR DESCRIPTION
## What

`AIAgent.max_iterations` defaults to `sys.maxsize` ("unlimited"), so gateway status text rendered the raw value:

```
⏳ Working — 57 min — iteration 7/9223372036854775807, receiving stream response
```

This adds `agent.session_activity.format_iteration_progress(api_call_count, max_iterations)`, which prints `iteration N` when the cap is unlimited or unset and `iteration N/M` otherwise, and uses it at the four places that formatted the string by hand:

- `gateway/run_turn.py` long-running heartbeat
- `gateway/run_turn.py` inactivity-timeout diagnostics (both branches)
- `gateway/run_busy.py` busy ack

Finite caps render exactly as before (`iteration 3/10`).

## Tests

- New unit tests in `tests/agent/test_session_activity.py` (unlimited / zero / None cap; finite cap; string and garbage inputs).
- `tests/gateway` + `tests/agent/test_session_activity.py`: 7643 passed; the remaining failures (adapter/systemd/scale-to-zero tests) fail identically on unmodified `main` in this environment.

Observed on a Mattermost gateway running a local llama.cpp model with the default (unlimited) iteration cap.
