### PR TITLE
fix(curator): default prune_builtins to false, opt-in only

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -121,8 +121,9 @@ def get_archive_after_days() -> int:
 
 
 def get_prune_builtins() -> bool:
-    """Bundled built-ins are curation candidates (ON by default); a suppression list keeps them archived across `hermes update` re-seeds. Hub skills are never pruned."""
-    return bool(_load_config().get("prune_builtins", True))
+    """Bundled built-ins are curation candidates only when explicitly opted in (OFF by default);
+    a suppression list keeps them archived across `hermes update` re-seeds. Hub skills are never pruned."""
+    return bool(_load_config().get("prune_builtins", False))
 
 
 def get_consolidate() -> bool:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1351,8 +1351,9 @@ DEFAULT_CONFIG = {
         "consolidate": False,
         # Also prune bundled built-ins (a suppression list stops `hermes update` restoring them);
         # hub-installed skills are NEVER pruned. A built-in's clock starts when the curator first
-        # sees it, so never a mass-prune on the first run. false = keep all.
-        "prune_builtins": True,
+        # sees it, so never a mass-prune on the first run. false = keep all (default: opt-in only,
+        # since bundled skills ship with Hermes and users may not have triggered every one yet).
+        "prune_builtins": False,
         # TTL purge of skills/.archive/: 0 = never; > 0 lets the explicit `hermes curator purge`
         # delete older archived skills (never automatic; logged in the ledger).
         "archive_ttl_days": 0,

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -320,6 +320,28 @@ def _disable_prune_builtins(curator_env, monkeypatch):
     monkeypatch.setattr(u, "_prune_builtins_enabled", lambda: False)
 
 
+def test_get_prune_builtins_defaults_off_with_no_config_key(monkeypatch):
+    """#103098: an absent ``curator.prune_builtins`` key must resolve to
+    False (opt-in), not True — bundled skills ship with Hermes and users
+    may not have triggered every one yet, so pruning them must be a
+    deliberate choice."""
+    import agent.curator as curator
+
+    monkeypatch.setattr(curator, "_load_config", lambda: {})
+    assert curator.get_prune_builtins() is False
+
+
+def test_skill_usage_prune_builtins_enabled_defaults_off_with_no_config_key(monkeypatch):
+    """Same #103098 default, on tools.skill_usage's independent config-reading
+    path (``_prune_builtins_enabled``), exercised without the module's own
+    test stub so the real fallback logic runs."""
+    import tools.skill_usage as usage
+    from hermes_cli import config as hermes_config
+
+    monkeypatch.setattr(hermes_config, "load_config", lambda: {"curator": {}})
+    assert usage._prune_builtins_enabled() is False
+
+
 
 
 

--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -514,11 +514,11 @@ def test_adopt_refuses_skills_the_user_does_not_own(skills_home, monkeypatch, ki
     """Adoption writes a provenance claim, so it must refuse anything with an
     external owner rather than stamping a lie onto the record.
 
-    ``prune_builtins`` is forced ON here — the shipped default — because that
-    is the configuration in which a bundled skill is otherwise curation-
-    eligible. With it off, ``mark_agent_created``'s own eligibility gate would
-    block the write and this test would pass without exercising adopt's guard
-    at all.
+    ``prune_builtins`` is forced ON here (opt-in; the shipped default is OFF)
+    because that is the configuration in which a bundled skill is otherwise
+    curation-eligible. With it off, ``mark_agent_created``'s own eligibility
+    gate would block the write and this test would pass without exercising
+    adopt's guard at all.
     """
     from tools import skill_usage
     from tools.skill_usage import adopt_skill, load_usage

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -165,14 +165,14 @@ def _read_hub_installed_names() -> Set[str]:
 
 
 def _prune_builtins_enabled() -> bool:
-    """``curator.prune_builtins`` (default True); lazy config import keeps this module importable during update/sync."""
+    """``curator.prune_builtins`` (default False); lazy config import keeps this module importable during update/sync."""
     try:
         from hermes_cli.config import load_config
         cur = load_config().get("curator")
-        return bool(cur.get("prune_builtins", True)) if isinstance(cur, dict) else True
+        return bool(cur.get("prune_builtins", False)) if isinstance(cur, dict) else False
     except Exception as e:  # pragma: no cover — best-effort config read
         logger.debug("Failed to read curator.prune_builtins: %s", e)
-        return True
+        return False
 
 
 def read_suppressed_names() -> Set[str]:


### PR DESCRIPTION
## What does this PR do?

Changes the shipped default of `curator.prune_builtins` from `true` to `false`, so bundled/upstream-owned Hermes skills are no longer curation candidates unless the user explicitly opts in.

## Related Issue

Fixes #103098

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config_defaults.py`: shipped `DEFAULT_CONFIG["curator"]["prune_builtins"]` changed from `True` to `False`; the neighboring comment already said "false = keep all" but the shipped value contradicted it.
- `agent/curator.py`: `get_prune_builtins()`'s fallback default changed from `True` to `False`; docstring updated from "(ON by default)" to reflect the opt-in behavior.
- `tools/skill_usage.py`: `_prune_builtins_enabled()`'s fallback default changed from `True` to `False` in all three branches (present-and-dict, present-and-not-dict, and the best-effort exception handler), so its independent config-reading path stays consistent with `agent/curator.py`.
- `tests/agent/test_curator.py`: added two regression tests that exercise the real default-resolution logic (no config file / no `prune_builtins` key) on both `agent.curator.get_prune_builtins()` and `tools.skill_usage._prune_builtins_enabled()`, without the existing test stubs that otherwise mask the default.
- `tests/tools/test_skill_usage.py`: fixed a comment on `test_adopt_refuses_skills_the_user_does_not_own` that asserted "prune_builtins is forced ON here — the shipped default" — that's no longer accurate, so it now says it's forced on for the test (opt-in), not because it ships that way.

## Why this default was wrong

Bundled skills ship with Hermes; a user may simply not have triggered a given one yet within the Curator inactivity window. With `prune_builtins: true` shipped, Curator could archive a bundled skill for inactivity without the user ever opting into pruning built-in functionality — and once archived, `.curator_suppressed` prevents `hermes update` from re-seeding it. Curator otherwise treats bundled/hub skills as upstream-owned and protects them from autonomous LLM writes, which made `prune_builtins: true` an inconsistent default alongside that protection.

## How to Test

1. Fresh/default config, no `curator.prune_builtins` key set.
2. Before this PR: `agent.curator.get_prune_builtins()` and `tools.skill_usage._prune_builtins_enabled()` both return `True`.
3. After this PR: both return `False`, matching `DEFAULT_CONFIG["curator"]["prune_builtins"]`.
4. `pytest tests/agent/test_curator.py tests/tools/test_skill_usage.py tests/hermes_cli/test_curator_pin_visibility.py -q` — 60 passed.
5. `pytest tests/agent/ tests/tools/test_skill_usage.py tests/hermes_cli/test_config.py tests/hermes_cli/test_cmd_update.py -q` — 227 passed, 4 skipped, no regressions.
6. `ruff check` on all changed files — clean.

Users who want the old behavior (auto-prune unused bundled skills) can still opt in with:
```yaml
curator:
  prune_builtins: true
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (ran the scoped suites above; full suite not re-run given repo size, but touched-module suites are green)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — inline docstrings/comments updated to match new default
- [x] N/A — no new config keys added, just a default value change
- [x] N/A — no architecture/workflow change
- [x] N/A — cross-platform: config default, no platform-specific code path
- [x] N/A — no tool schema/behavior change