### PR TITLE
fix(desktop): HUD float/pin on Hyprland now tolerates j/clients lag and repeat-toggle maps

### DIFF
--- a/apps/desktop/electron/hud-hyprland.ts
+++ b/apps/desktop/electron/hud-hyprland.ts
@@ -28,8 +28,8 @@ type HyprlandDispatchSyntax = 'legacy' | 'lua'
 
 export type HyprlandRequestFn = (socketPath: string, command: string) => Promise<null | string>
 
-const DEFAULT_ATTEMPTS = 8
-const DEFAULT_DELAY_MS = 50
+const DEFAULT_ATTEMPTS = 24
+const DEFAULT_DELAY_MS = 100
 
 let cachedSyntax: null | HyprlandDispatchSyntax = null
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -13298,6 +13298,14 @@ function focusWindow(win) {
 
   if (!win.isVisible()) {
     win.show()
+
+    // When the HUD is re-shown (after being hidden), Hyprland retiles it on
+    // the next map event. Re-run the float+pin promotion to correct that.
+    // The first map is handled by wireWindowReveal onRevealed; subsequent
+    // toggle-driven maps need explicit promotion.
+    if (win === hudWindow) {
+      void promoteHudOverlay({ title: HUD_WINDOW_TITLE })
+    }
   }
 
   win.focus()


### PR DESCRIPTION
Fixes #103091

Root cause:
1. The socket-based promoteHudOnHyprland() originally retried for only 8 × 50ms = 400ms total. On some systems j/clients lags >400ms, leaving the HUD tiled instead of floating.
2. After the first HUD show, repeated hide()+show() (toggle) never re-promoted: the wireWindowReveal onRevealed callback fires exactly once.

Fixes:
- Tripled the retry budget: 24 attempts × 100ms each = 2.4s max.
- Re-promote float+pin explicitly when focusWindow re-shows the HUD after it was hidden — repeat maps (Wayland re-tiles) now trigger repeat promotion.

Result:
HUD floats reliably on Hyprland 0.55+ (Lua config) even when j/clients lag, and repeat toggle calls keep it floating.