### PR TITLE
Concurrent turns silently drop plugin callbacks

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1149,9 +1149,12 @@ class PluginManager(PluginLoaderMixin, PluginDispatchMixin, PluginLedgerMixin):
         self._event_queue: queue.Queue[Any] = queue.Queue(maxsize=_EVENT_PENDING_CAP)
         self._event_worker: Optional[threading.Thread] = None
         self._emit_depth = threading.local()
-        # In-flight / recently-timed-out hook callbacks keyed by (hook_name, id(cb)) so a stuck
-        # policy hook cannot spawn a new abandoned thread on every fire.
-        self._hook_running_callbacks: Dict[tuple, object] = {}
+        # In-flight / recently-timed-out hook callbacks. Multiple turns may
+        # legitimately invoke the same callback concurrently, so running
+        # tokens are tracked independently. Only a token that actually timed
+        # out suppresses later fires; an ordinary in-flight callback does not.
+        self._hook_running_callbacks: Dict[tuple, Set[object]] = {}
+        self._hook_timed_out_callbacks: Dict[tuple, Set[object]] = {}
         self._hook_timeout_suppressed_until: Dict[tuple, float] = {}
         self._hook_timeout_lock = threading.Lock()
         self._hook_timeout_suppression_seconds = _HOOK_TIMEOUT_SUPPRESSION_SECONDS
@@ -1670,8 +1673,8 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
 
     Hot-path / observer hooks in ``_HOOK_TIMEOUT_BOUNDED_HOOKS`` and the policy hook ``pre_tool_call`` are
     bounded by ``plugins.hook_callback_timeout`` (default 30s). On timeout the worker is abandoned (not
-    joined) so we do not reintroduce the #6622 hang. Timed-out or still-running ``pre_tool_call`` callbacks
-    fail closed with a block directive; other bounded hooks fail open (skip).
+    joined) so we do not reintroduce the #6622 hang. Timed-out ``pre_tool_call`` callbacks and their
+    still-running abandoned workers fail closed with a block directive; other bounded hooks fail open.
     Ensures plugins are discovered on first invocation so callers in processes that never explicitly call
     ``discover_plugins()`` (gateway platform events, TUI slash workers, query mode, cron) still fire
     callbacks registered by user plugins (tracking #64178).

--- a/hermes_cli/plugins_dispatch.py
+++ b/hermes_cli/plugins_dispatch.py
@@ -148,6 +148,13 @@ def _hook_uses_callback_timeout(hook_name: str, timeout: float) -> bool:
 
 
 class PluginDispatchMixin:
+    _hooks: Dict[str, List[Callable]]
+    _hook_running_callbacks: Dict[tuple, Set[object]]
+    _hook_timed_out_callbacks: Dict[tuple, Set[object]]
+    _hook_timeout_suppressed_until: Dict[tuple, float]
+    _hook_timeout_lock: Any
+    _hook_timeout_suppression_seconds: float
+
     @staticmethod
     def _invoke_hook_callback(callback: Callable, payload: Dict[str, Any]) -> Any:
         """Invoke a hook while withholding additive fields from narrow legacy callbacks."""
@@ -202,22 +209,22 @@ class PluginDispatchMixin:
         self, hook_name: str, cb: Callable, kwargs: Dict[str, Any], timeout: float
     ) -> Any:
         """Run one callback on a daemon worker with a wall-clock cap; ``_HOOK_SKIPPED`` when
-        suppressed, still running, or timed out (worker abandoned, never joined). Exceptions
-        propagate."""
+        previously timed out or timed out now (worker abandoned, never joined). Exceptions
+        propagate. Healthy concurrent calls run independently."""
         callback_name = getattr(cb, "__name__", repr(cb))
         callback_key = (hook_name, id(cb))
         token = object()
         with self._hook_timeout_lock:
             suppressed_until = self._hook_timeout_suppressed_until.get(callback_key)
-            running = callback_key in self._hook_running_callbacks
-            if (suppressed_until is not None and suppressed_until > time.monotonic()) or running:
+            timed_out = bool(self._hook_timed_out_callbacks.get(callback_key))
+            if (suppressed_until is not None and suppressed_until > time.monotonic()) or timed_out:
                 logger.warning(
-                    "Hook '%s' callback %s skipped after previous "
-                    "timeout or while still running", hook_name, callback_name)
+                    "Hook '%s' callback %s skipped after a real timeout",
+                    hook_name, callback_name)
                 return _HOOK_SKIPPED
             if suppressed_until is not None:
                 self._hook_timeout_suppressed_until.pop(callback_key, None)
-            self._hook_running_callbacks[callback_key] = token
+            self._hook_running_callbacks.setdefault(callback_key, set()).add(token)
 
         context = contextvars.copy_context()
         done = threading.Event()
@@ -231,8 +238,16 @@ class PluginDispatchMixin:
                 failure["exc"] = exc
             finally:
                 with self._hook_timeout_lock:
-                    if self._hook_running_callbacks.get(callback_key) is token:
-                        self._hook_running_callbacks.pop(callback_key, None)
+                    running_tokens = self._hook_running_callbacks.get(callback_key)
+                    if running_tokens is not None:
+                        running_tokens.discard(token)
+                        if not running_tokens:
+                            self._hook_running_callbacks.pop(callback_key, None)
+                    timed_out_tokens = self._hook_timed_out_callbacks.get(callback_key)
+                    if timed_out_tokens is not None:
+                        timed_out_tokens.discard(token)
+                        if not timed_out_tokens:
+                            self._hook_timed_out_callbacks.pop(callback_key, None)
                 done.set()
 
         thread = threading.Thread(target=_runner, name=f"hermes-hook-{callback_name}"[:40], daemon=True)
@@ -242,6 +257,10 @@ class PluginDispatchMixin:
                 # See #6622.
                 self._hook_timeout_suppressed_until[callback_key] = (
                     time.monotonic() + self._hook_timeout_suppression_seconds)
+                # The worker can finish between done.wait() and this lock
+                # acquisition. Mark it timed out only while genuinely live.
+                if token in self._hook_running_callbacks.get(callback_key, set()):
+                    self._hook_timed_out_callbacks.setdefault(callback_key, set()).add(token)
             logger.warning(
                 "Hook '%s' callback %s timed out after %gs — skipping", hook_name, callback_name, timeout)
             return _HOOK_SKIPPED

--- a/hermes_cli/plugins_ledger.py
+++ b/hermes_cli/plugins_ledger.py
@@ -53,6 +53,11 @@ class PluginRegistration:
 
 
 class PluginLedgerMixin:
+    _hook_running_callbacks: Dict[tuple, Set[object]]
+    _hook_timed_out_callbacks: Dict[tuple, Set[object]]
+    _hook_timeout_suppressed_until: Dict[tuple, float]
+    _hook_timeout_lock: Any
+
     def _track_registration(
         self, manifest: PluginManifest, kind: str, key: str, release: Callable[[], None], *,
         persistent: bool = False,
@@ -265,5 +270,6 @@ class PluginLedgerMixin:
         self._context_engine = None
         with self._hook_timeout_lock:
             self._hook_running_callbacks.clear()
+            self._hook_timed_out_callbacks.clear()
             self._hook_timeout_suppressed_until.clear()
         self._discovered = False

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1070,6 +1070,39 @@ class TestForceReloadSymmetry:
             {"context": "hi"}
         ]
 
+    def test_concurrent_hook_calls_do_not_drop_callback(self, monkeypatch):
+        """Ordinary overlap is not evidence that the first callback hung."""
+        monkeypatch.setattr(
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 1.0
+        )
+
+        both_started = threading.Barrier(2)
+        calls = []
+
+        def callback(**kwargs):
+            calls.append(kwargs["call_id"])
+            both_started.wait(timeout=0.5)
+            return kwargs["call_id"]
+
+        mgr = PluginManager()
+        mgr._hooks["post_tool_call"] = [callback]
+        results = {}
+
+        def invoke(call_id):
+            results[call_id] = mgr.invoke_hook("post_tool_call", call_id=call_id)
+
+        first = threading.Thread(target=invoke, args=("first",))
+        second = threading.Thread(target=invoke, args=("second",))
+        first.start()
+        second.start()
+        first.join(timeout=2.0)
+        second.join(timeout=2.0)
+
+        assert not first.is_alive()
+        assert not second.is_alive()
+        assert sorted(calls) == ["first", "second"]
+        assert results == {"first": ["first"], "second": ["second"]}
+
     def test_hook_exception_still_isolated_under_timeout_path(self, monkeypatch):
         monkeypatch.setattr(
             "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 1.0


### PR DESCRIPTION
## Symptom

Concurrent agent turns invoking the same bounded hook callback are treated as though the first callback timed out. The second invocation is skipped, so observer hooks such as `post_tool_call` silently lose evidence even though the callback is healthy.

## Cause

`PluginManager` used callback identity as a single in-flight exclusion key. Ordinary overlap and an abandoned timed-out worker were indistinguishable.

## Fix

Track independent in-flight tokens per callback and suppress only tokens that actually crossed the timeout. Preserve the existing fail-closed behavior for timed-out `pre_tool_call` policy callbacks.

## Evidence

- Added a concurrent `post_tool_call` regression that requires both overlapping invocations to execute.
- Existing hung-worker suppression and policy fail-closed tests still pass.
- `74 passed` in `tests/hermes_cli/test_plugins.py`.
- `git diff --check` clean.

## Risk

This allows healthy observer callbacks to overlap across concurrent turns, matching the concurrency already present in the caller. Timed-out callbacks remain suppressed until their abandoned worker exits.