### PR TITLE
feat(kanban): diagnose worktree tasks with no repo to check out in

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -521,7 +521,10 @@ def _cmd_show(args: argparse.Namespace) -> int:
 
     # Diagnostics up top so CLI users see distress signals before scrolling.
     from hermes_cli import kanban_diagnostics as kd
-    diags = kd.compute_task_diagnostics(task, events, runs, graph=graph)
+    diags = kd.compute_task_diagnostics(
+        task, events, runs, graph=graph,
+        config={"board_default_workdir": kd.read_board_default_workdir(kb)},
+    )
     if diags:
         print(f"\n  Diagnostics ({len(diags)}):")
         _print_diagnostics(diags, "    ", with_kind=False)
@@ -629,6 +632,7 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
     from hermes_cli.config import load_config
 
     diag_config = kd.config_from_runtime_config(load_config())
+    diag_config["board_default_workdir"] = kd.read_board_default_workdir(kb)
 
     with kbc.connect_closing() as conn:
         # Either one-task mode or fleet mode.

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -678,6 +678,128 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
     )]
 
 
+# Sentinel: tells "the caller did not supply board_default_workdir" apart
+# from "the caller supplied it and the board genuinely has none". Only the
+# former falls back to reading board metadata.
+_BOARD_WORKDIR_UNSET = object()
+
+# A worktree task in one of these is never dispatched again, so a missing
+# checkout root is history rather than a live fault. Note there is no
+# "cancelled" in VALID_STATUSES.
+_WORKTREE_TERMINAL_STATUSES = ("done", "archived")
+
+
+def read_board_default_workdir(kanban_db_mod, board=None) -> str:
+    """The board's ``default_workdir``, or ``""`` when unset.
+
+    Split out so a multi-board process can thread the *requested* board's
+    value into ``config`` (the dashboard serves several boards from one
+    process), and so tests can pass a stub instead of writing board metadata.
+    """
+    meta = kanban_db_mod.read_board_metadata(board) or {}
+    return str(meta.get("default_workdir") or "")
+
+
+def _rule_worktree_without_checkout_root(task, events, runs, now, cfg) -> list[Diagnostic]:
+    """Worktree task with no repo to check out in.
+
+    ``_resolve_worktree_workspace`` anchors a worktree on the task's own
+    ``workspace_path`` and falls back to the board's ``default_workdir``,
+    raising when it has neither because it "fail[s] loudly rather than
+    guess". That raise lands at dispatch: the task burns its retries and the
+    circuit breaker parks it as ``blocked`` behind a message that reads like
+    an infrastructure fault rather than "this task was created with nowhere
+    to run". This rule reports the same condition while it is still queued.
+
+    ``project_id`` is deliberately not part of the test. A project is what
+    usually supplies the path -- ``create_task`` turns a project link into
+    ``<repo>/.worktrees/<id>`` -- but it does so at CREATE time, and
+    resolution never consults it again. A task that has a project and no
+    path (a project with no primary repo, or a row updated directly) is
+    equally undispatchable, so the rule follows the resolver and uses
+    ``project_id`` only to pick the remedy.
+
+    The rule does not guess the repo. Inheriting the parent task's project
+    looks obvious and is wrong often enough to matter: on a 24-task sample of
+    exactly this failure it would have misdirected 4 (17%), every one of them
+    from a *direct* parent, because cross-repo hand-offs (a spec task in one
+    repo spawning the follow-up that edits another) are normal rather than
+    exceptional. A silent checkout into the wrong repo is worse than a loud
+    stall, which is the reasoning the resolver already applies. Choosing the
+    repo stays with the operator.
+
+    Config: ``board_default_workdir`` -- the default workdir of the board
+    this task lives on. Callers that do not supply it get the current
+    board, which is right for the CLI and wrong for a multi-board process.
+    """
+    if _task_field(task, "workspace_kind") != "worktree":
+        return []
+    if str(_task_field(task, "workspace_path") or "").strip():
+        return []
+    status = str(_task_field(task, "status") or "")
+    if status in _WORKTREE_TERMINAL_STATUSES:
+        return []
+
+    default_workdir = cfg.get("board_default_workdir", _BOARD_WORKDIR_UNSET)
+    if default_workdir is _BOARD_WORKDIR_UNSET:
+        try:
+            from hermes_cli import kanban_db as _kb
+            default_workdir = read_board_default_workdir(_kb)
+        except Exception:
+            default_workdir = ""
+    if str(default_workdir or "").strip():
+        return []
+
+    project_id = str(_task_field(task, "project_id") or "").strip()
+    failures = _positive_int(_task_field(task, "consecutive_failures"), 0)
+    # 0 = mis-created but not yet dispatched; anything else = already
+    # burning attempts against a fault that retrying cannot clear.
+    severity = "critical" if failures else "error"
+
+    if project_id:
+        detail = (
+            f"This worktree task is linked to project {project_id!r} but has no "
+            "workspace_path, and its board has no default_workdir, so there is no "
+            "repo to check it out in. A project only supplies a path when the task "
+            "is created, and only if the project has a primary repo; it is not "
+            "consulted again at dispatch. Give the project a primary repo, or set "
+            "an explicit worktree path on the task."
+        )
+        actions = [
+            _cli_hint("Check the project's primary repo", "hermes project list",
+                      suggested=True),
+        ]
+    else:
+        detail = (
+            "This worktree task has no workspace_path and no project, and its board "
+            "has no default_workdir, so there is no repo to check it out in. It "
+            "cannot be dispatched and will fail at spawn. Create worktree tasks "
+            "with an explicit project, naming the repo the work actually touches -- "
+            "do not copy the parent task's project without reading the task, "
+            "because cross-repo hand-offs are common and the parent is a misleading "
+            "default."
+        )
+        actions = [
+            _cli_hint("Create worktree tasks with an explicit project",
+                      'hermes kanban create "<title>" --workspace worktree '
+                      '--project <slug>', suggested=True),
+            _cli_hint("List the projects to pick from", "hermes project list"),
+        ]
+
+    # int, never None: compute_task_diagnostics sorts on last_seen_at.
+    created_at = _positive_int(_task_field(task, "created_at"), 0)
+    return [Diagnostic(
+        kind="worktree_without_checkout_root", severity=severity,
+        title="Worktree task has no repo to check out in",
+        detail=detail, actions=actions,
+        first_seen_at=created_at, last_seen_at=created_at,
+        data={"status": status, "consecutive_failures": failures,
+              "project_id": project_id or None,
+              "assignee": _task_field(task, "assignee"),
+              "created_by": _task_field(task, "created_by")},
+    )]
+
+
 # Order matters: earlier rules render first on severity ties.
 _RULES: list[RuleFn] = [
     _rule_hallucinated_cards,
@@ -689,6 +811,7 @@ _RULES: list[RuleFn] = [
     _rule_stuck_in_blocked,
     _rule_block_unblock_cycling,
     _rule_stranded_in_ready,
+    _rule_worktree_without_checkout_root,
 ]
 
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -193,7 +193,8 @@ def _placeholders(ids: list) -> str:
     return ",".join(["?"] * len(ids))
 
 
-def _compute_task_diagnostics(conn: sqlite3.Connection, task_ids: Optional[list[str]] = None) -> dict[str, list[dict]]:
+def _compute_task_diagnostics(conn: sqlite3.Connection, task_ids: Optional[list[str]] = None,
+                              board: Optional[str] = None) -> dict[str, list[dict]]:
     """``{task_id: [diagnostic_dict, ...]}`` (tasks with none omitted) via three aggregate
     queries (tasks, events, runs) — slurps the board; paginate if profiling shows a hotspot."""
     from hermes_cli.config import load_config
@@ -201,6 +202,9 @@ def _compute_task_diagnostics(conn: sqlite3.Connection, task_ids: Optional[list[
     if task_ids is not None and not task_ids:
         return {}
     diag_config = kd.config_from_runtime_config(load_config())
+    # One process serves every board, so judge each task against ITS board
+    # rather than whichever board happens to be current.
+    diag_config["board_default_workdir"] = kd.read_board_default_workdir(kanban_db, board)
     if task_ids is not None:
         rows = conn.execute(f"SELECT * FROM tasks WHERE id IN ({_placeholders(task_ids)})", tuple(task_ids)).fetchall()
     else:
@@ -289,7 +293,7 @@ def get_board(
             p = progress.setdefault(row["pid"], {"done": 0, "total": 0})
             p["total"] += 1
             p["done"] += row["cstatus"] == "done"
-        diagnostics_per_task = _compute_task_diagnostics(conn, task_ids=None)
+        diagnostics_per_task = _compute_task_diagnostics(conn, task_ids=None, board=board)
         latest_event_id = conn.execute("SELECT COALESCE(MAX(id), 0) AS m FROM task_events").fetchone()["m"]
         columns: dict[str, list[dict]] = {c: [] for c in BOARD_COLUMNS}
         if include_archived:
@@ -334,7 +338,7 @@ def get_task(
         links = _links_for(conn, task_id)
         child_summaries = kanban_db.latest_summaries(conn, links["children"])
         children = filter(None, (kanban_db.get_task(conn, cid) for cid in links["children"]))
-        _attach_diagnostics(task_d, _compute_task_diagnostics(conn, task_ids=[task_id]).get(task_id) or [])
+        _attach_diagnostics(task_d, _compute_task_diagnostics(conn, task_ids=[task_id], board=board).get(task_id) or [])
         return {
             "task": task_d,
             "comments": [asdict(c) for c in kanban_db.list_comments(conn, task_id)],
@@ -812,7 +816,7 @@ def list_diagnostics(
     """Tasks with an active diagnostic, highest severity first then most recent; also
     consumed by ``hermes kanban diagnostics`` when the dashboard runs."""
     with _board_conn(board) as (board, conn):
-        diags_by_task = _compute_task_diagnostics(conn, task_ids=None)
+        diags_by_task = _compute_task_diagnostics(conn, task_ids=None, board=board)
         if severity and diags_by_task:
             diags_by_task = {
                 tid: keep

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -16,6 +16,7 @@ import pytest
 
 from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban_db_workspace as kbw
 from hermes_cli import kanban_diagnostics as kd
 
 
@@ -225,3 +226,117 @@ def test_severity_at_or_above_uses_threshold_semantics():
     assert kd.severity_at_or_above("error", "critical") is False
     assert kd.severity_at_or_above("mystery", "warning") is False
     assert kd.severity_at_or_above("warning", None) is True
+
+
+# ---------------------------------------------------------------------------
+# worktree_without_checkout_root
+#
+# Mirrors the raise in kanban_db_workspace._resolve_worktree_workspace: a
+# worktree task resolves against its own workspace_path or the board's
+# default_workdir, and with neither the dispatcher refuses to guess.
+# ---------------------------------------------------------------------------
+
+
+# Explicit "this board has no fallback root", so the rule never reads real
+# board metadata off disk during the unit tests.
+_NO_BOARD_WORKDIR = {"board_default_workdir": ""}
+
+
+def _worktree_task(**overrides):
+    base = dict(workspace_kind="worktree", workspace_path=None, project_id=None,
+                created_at=1_000, created_by="orchestrator")
+    base.update(overrides)
+    return _task(**base)
+
+
+def _wt_diags(task, config=None):
+    diags = kd.compute_task_diagnostics(
+        task, [], [], now=2_000,
+        config=_NO_BOARD_WORKDIR if config is None else config)
+    return [d for d in diags if d.kind == "worktree_without_checkout_root"]
+
+
+def test_worktree_without_checkout_root_fires_on_a_board_with_no_default():
+    diags = _wt_diags(_worktree_task())
+    assert len(diags) == 1
+    assert diags[0].severity == "error"
+    assert diags[0].data["project_id"] is None
+    assert "--project" in diags[0].actions[0].payload["command"]
+
+
+def test_worktree_without_checkout_root_escalates_once_it_is_failing():
+    """0 failures = mis-created; >0 = actively burning dispatch attempts."""
+    diags = _wt_diags(_worktree_task(consecutive_failures=3))
+    assert len(diags) == 1
+    assert diags[0].severity == "critical"
+    assert diags[0].data["consecutive_failures"] == 3
+
+
+def test_worktree_without_checkout_root_silent_when_board_has_a_default():
+    """A single-repo board sets default_workdir, so the task resolves."""
+    assert _wt_diags(_worktree_task(),
+                     config={"board_default_workdir": "/srv/repo"}) == []
+
+
+def test_worktree_without_checkout_root_silent_when_task_has_its_own_path():
+    assert _wt_diags(_worktree_task(workspace_path="/srv/repo")) == []
+
+
+@pytest.mark.parametrize("kind", ["scratch", "dir"])
+def test_worktree_without_checkout_root_ignores_other_workspace_kinds(kind):
+    """scratch resolves under the board root; dir has its own guard."""
+    assert _wt_diags(_worktree_task(workspace_kind=kind)) == []
+
+
+@pytest.mark.parametrize("status", ["done", "archived"])
+def test_worktree_without_checkout_root_ignores_terminal_tasks(status):
+    """Never dispatched again, so a missing root is history, not a fault."""
+    assert _wt_diags(_worktree_task(status=status)) == []
+
+
+def test_worktree_without_checkout_root_fires_when_a_project_gave_no_path():
+    """project_id is not what the resolver reads.
+
+    create_task derives <repo>/.worktrees/<id> from a project, but only at
+    creation and only when the project has a primary repo. A row that got a
+    project without a path is still undispatchable, so the rule follows the
+    resolver rather than trusting the link.
+    """
+    diags = _wt_diags(_worktree_task(project_id="p_abc123"))
+    assert len(diags) == 1
+    assert diags[0].data["project_id"] == "p_abc123"
+    # Different cause, different remedy: the project exists, its repo doesn't.
+    assert diags[0].actions[0].payload["command"] == "hermes project list"
+
+
+def test_read_board_default_workdir_normalizes_unset():
+    class _Stub:
+        def __init__(self, meta):
+            self.meta = meta
+
+        def read_board_metadata(self, board=None):
+            return self.meta
+
+    assert kd.read_board_default_workdir(_Stub({"default_workdir": None})) == ""
+    assert kd.read_board_default_workdir(_Stub({})) == ""
+    assert kd.read_board_default_workdir(_Stub({"default_workdir": "/srv/r"})) == "/srv/r"
+
+
+def test_worktree_without_checkout_root_matches_the_resolver(kanban_home):
+    """Pin the rule to the code it predicts.
+
+    The rule is only useful if it fires exactly when resolve_workspace
+    refuses to dispatch, so assert both against one real task instead of
+    trusting a hand-built fixture.
+    """
+    conn = kbc.connect()
+    try:
+        task_id = kb.create_task(
+            conn, title="fix something", assignee="demo", workspace_kind="worktree")
+        task = kb.get_task(conn, task_id)
+        with pytest.raises(ValueError, match="default_workdir"):
+            kbw.resolve_workspace(task)
+        row = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
+        assert _wt_diags(row)
+    finally:
+        conn.close()


### PR DESCRIPTION
## What does this PR do?

A `workspace_kind=worktree` task resolves against its own `workspace_path` or the board's `default_workdir`. With neither, `_resolve_worktree_workspace` raises rather than guess a repo:

```
task {id} has workspace_kind=worktree but no workspace_path, and board {slug!r}
has no default_workdir set.
```

That is the right call â€” the docstring says it fails loudly "rather than guess" â€” but it raises at **dispatch**. The task burns its retries and the circuit breaker parks it as `blocked` behind a message that reads like an infrastructure fault instead of "this task was created with nowhere to run".

Multi-repo boards leave `default_workdir` unset on purpose, because a single fallback root would silently check work out into the *wrong* repo. On those boards this raise is the only way the mistake surfaces, and it surfaces after the retries are gone.

This adds `worktree_without_checkout_root`, reporting the same condition while the task is still queued â€” `error` when it is merely mis-created, `critical` once it is already failing.

**Why the rule keys on the resolver, not on `project_id`.** A project is what usually supplies the path: `create_task` turns a project link into `<repo>/.worktrees/<id>`. But it does that only at creation, and only when the project has a primary repo â€” resolution never consults `project_id` again. A row that has a link and no path (project without a primary repo, or a direct `UPDATE`) is equally undispatchable, so the rule follows `_resolve_worktree_workspace` and uses `project_id` only to choose the remedy text.

**Why it does not guess the repo.** Inheriting the parent task's project looks obvious. On a 24-task sample of exactly this failure it would have misdirected 4 (17%), every one from a *direct* parent, because cross-repo hand-offs (a spec task in one repo spawning the follow-up that edits another) are normal rather than exceptional. A silent checkout into the wrong repo is worse than a loud stall â€” the same reasoning the resolver already applies. Choosing the repo stays with the operator.

## Related Issue

No existing issue â€” I searched open and closed issues and PRs for `worktree`, `missing workdir`, `worktree_without_project` and found none. Happy to open one if you'd prefer it tracked.

## Type of Change

- [x] âœ¨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/kanban_diagnostics.py` â€” `_rule_worktree_without_checkout_root` + registration in `_RULES`; new public helper `read_board_default_workdir()`.
- `hermes_cli/kanban.py` â€” pass `board_default_workdir` at the two `compute_task_diagnostics` call sites (`show`, `diag`).
- `plugins/kanban/dashboard/plugin_api.py` â€” thread the requested `board` into `_compute_task_diagnostics` so a multi-board process judges each task against **its** board rather than whichever board is current.
- `tests/hermes_cli/test_kanban_diagnostics.py` â€” 11 tests.

`DIAGNOSTIC_KINDS` is intentionally **not** touched: per `COMPAT_MANIFEST.md` it is a `restored-def` inside the revert-scheduled `PLUGIN-COMPAT` block, and nothing in-tree may depend on those pointers. `python scripts/check_compat_pointers.py` passes.

## How to Test

1. On a board with no `default_workdir`, create a worktree task with no project:
   ```bash
   hermes kanban create "demo" --workspace worktree
   hermes kanban diag
   ```
   It reports `worktree_without_checkout_root` at `error` *before* the task is ever dispatched. Let it fail once and it escalates to `critical`.
2. Set a `default_workdir` on the board (or give the task an explicit `--workspace worktree:<repo>`) and the diagnostic clears.
3. Tests:
   ```bash
   pytest tests/hermes_cli/test_kanban_diagnostics.py -q   # 16 passed
   python scripts/check_compat_pointers.py
   ```

`test_worktree_without_checkout_root_matches_the_resolver` builds a real task, asserts `resolve_workspace` raises, and asserts the rule fires on the same row â€” so the rule stays pinned to the code it predicts rather than to a hand-built fixture.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run the tests â€” see note below
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (aarch64), Python 3.11.15

Note on the suite: `pytest tests/hermes_cli/ -k "kanban or dashboard or diagnostic or worktree or workspace"` gives **57 failed / 759 passed** on this branch and **57 failed / 748 passed** on pristine `main` â€” same failures, +11 passes (exactly the new tests). Those pre-existing failures are in `test_web_server*` / `test_web_ui_build` and look like in-process pollution that `scripts/run_tests.sh` isolates around; none are related to this change.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on the new rule and helper) â€” the rule's rationale lives in its docstring alongside the other rules
- [x] N/A â€” no config keys added to `cli-config.yaml.example` (`board_default_workdir` is read from existing board metadata, not user config)
- [x] N/A â€” no architecture or workflow change
- [x] Cross-platform: pure stdlib string/dict work, no paths constructed or filesystem access in the rule
- [x] N/A â€” no tool descriptions/schemas changed