### PR TITLE
fix(desktop): hash shared workspace build inputs

### DIFF
--- a/hermes_cli/main_desktop.py
+++ b/hermes_cli/main_desktop.py
@@ -35,8 +35,12 @@ def _desktop_dist_exists(desktop_dir: Path) -> bool:
 
 
 def _compute_desktop_content_hash(project_root: Path) -> str:
-    """SHA-256 of ``apps/desktop/`` (minus .gitignore matches) plus root workspace config."""
-    return _hash_source_tree(project_root, project_root / "apps" / "desktop")
+    """SHA-256 of Desktop and its shared workspace sources plus root workspace config."""
+    return _hash_source_tree(
+        project_root,
+        project_root / "apps" / "desktop",
+        project_root / "apps" / "shared",
+    )
 
 
 def _desktop_stamp_path() -> Path:

--- a/hermes_cli/main_web_build.py
+++ b/hermes_cli/main_web_build.py
@@ -90,9 +90,11 @@ def _web_dist_dir(web_dir: Path) -> Path:
     return _web_project_root(web_dir) / "hermes_cli" / "web_dist"
 
 
-def _hash_source_tree(project_root: Path, tree_dir: Path) -> str:
-    """SHA-256 over *tree_dir* plus the root ``package.json`` / ``package-lock.json``.
+def _hash_source_tree(project_root: Path, tree_dir: Path, *additional_tree_dirs: Path) -> str:
+    """SHA-256 over source trees plus the root ``package.json`` / ``package-lock.json``.
 
+    ``additional_tree_dirs`` lets a build hash workspace sources outside its own
+    directory (for example Desktop's direct dependency on ``apps/shared``).
     Ignored paths (``node_modules/``, ``dist/``, ``*.pyc``, ...) are skipped via
     the repo-root ``.gitignore`` (pathspec) so build output never feeds back into
     its own staleness check. Filenames are sorted for a deterministic digest.
@@ -122,12 +124,13 @@ def _hash_source_tree(project_root: Path, tree_dir: Path) -> str:
             _hash_file(p)
 
     # Prune ignored directories in place so we never descend into them.
-    for dirpath, dirnames, filenames in os.walk(tree_dir, topdown=True):
-        dirnames[:] = [d for d in dirnames if not _ignored(Path(dirpath) / d)]
-        for fn in sorted(filenames):
-            fp = Path(dirpath) / fn
-            if not _ignored(fp):
-                _hash_file(fp)
+    for source_tree in (tree_dir, *additional_tree_dirs):
+        for dirpath, dirnames, filenames in os.walk(source_tree, topdown=True):
+            dirnames[:] = [d for d in dirnames if not _ignored(Path(dirpath) / d)]
+            for fn in sorted(filenames):
+                fp = Path(dirpath) / fn
+                if not _ignored(fp):
+                    _hash_file(fp)
 
     return h.hexdigest()
 

--- a/tests/hermes_cli/test_desktop_content_hash.py
+++ b/tests/hermes_cli/test_desktop_content_hash.py
@@ -1,0 +1,40 @@
+"""Desktop content-hash coverage for workspace build inputs."""
+
+from pathlib import Path
+
+from hermes_cli.main_desktop import _compute_desktop_content_hash
+
+
+def _desktop_workspace(root: Path) -> None:
+    (root / "apps" / "desktop" / "src").mkdir(parents=True)
+    (root / "apps" / "shared" / "src").mkdir(parents=True)
+    (root / "apps" / "desktop" / "src" / "app.tsx").write_text(
+        "export const app = 1\n", encoding="utf-8"
+    )
+    (root / "apps" / "shared" / "src" / "shared.ts").write_text(
+        "export const shared = 1\n", encoding="utf-8"
+    )
+    (root / "package.json").write_text("{}\n", encoding="utf-8")
+    (root / ".gitignore").write_text("apps/desktop/dist/\n", encoding="utf-8")
+
+
+def test_desktop_hash_changes_with_shared_workspace_source(tmp_path: Path) -> None:
+    _desktop_workspace(tmp_path)
+    before = _compute_desktop_content_hash(tmp_path)
+
+    (tmp_path / "apps" / "shared" / "src" / "shared.ts").write_text(
+        "export const shared = 2\n", encoding="utf-8"
+    )
+
+    assert _compute_desktop_content_hash(tmp_path) != before
+
+
+def test_desktop_hash_still_ignores_build_output(tmp_path: Path) -> None:
+    _desktop_workspace(tmp_path)
+    before = _compute_desktop_content_hash(tmp_path)
+
+    dist = tmp_path / "apps" / "desktop" / "dist"
+    dist.mkdir()
+    (dist / "bundle.js").write_text("generated\n", encoding="utf-8")
+
+    assert _compute_desktop_content_hash(tmp_path) == before


### PR DESCRIPTION
## Summary

- include `apps/shared` in the Desktop content hash
- preserve the generic source-tree hash helper while allowing additional workspace source roots
- add regression coverage proving shared-source changes invalidate the Desktop stamp while generated `dist/` remains ignored

## Why

The Desktop workspace directly imports `@hermes/shared` (`file:../shared`, with TypeScript/Vite aliases into `apps/shared/src`), but `_compute_desktop_content_hash` only walked `apps/desktop`. A source update confined to shared code could therefore leave the recorded hash unchanged and make `hermes update` print `Desktop app up to date` while launching a bundle built from older shared sources. This closes that reproducible hash-input gap reported in #103055.

This is separate from packaged-provenance validation proposed in #91525: that PR verifies the package corresponds to a recorded hash; this change ensures the hash itself covers the Desktop build input closure.

## Validation

- `uv run --with pytest --with pathspec --with pyyaml --with rich python -m pytest tests/hermes_cli/test_desktop_content_hash.py tests/hermes_cli/test_update_desktop_stale_warning.py -q` — 10 passed
- `uv run python -m py_compile hermes_cli/main_web_build.py hermes_cli/main_desktop.py tests/hermes_cli/test_desktop_content_hash.py` — passed
- `git diff --check origin/main...HEAD` — passed

## Notes

A broader Windows run collected 53 passing / 15 skipped tests and 3 failures in existing GUI fixtures because their synthetic `Hermes.exe` files do not satisfy the current Windows executable-integrity gate; those failures do not exercise this hash change.