### PR TITLE
fix(dashboard-auth): audit API 401 rejections with session_rejected event

### DIFF
--- a/hermes_cli/dashboard_auth/audit.py
+++ b/hermes_cli/dashboard_auth/audit.py
@@ -31,6 +31,7 @@ class AuditEvent(enum.Enum):
     REFRESH_FAILURE = "refresh_failure"
     REVOKE = "revoke"
     SESSION_VERIFY_FAILURE = "session_verify_failure"
+    SESSION_REJECTED = "session_rejected"
     WS_TICKET_MINTED = "ws_ticket_minted"
     WS_TICKET_REJECTED = "ws_ticket_rejected"
     TOKEN_AUTH_SUCCESS = "token_auth_success"

--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -68,7 +68,12 @@ def _unauth_response(request: Request, *, reason: str) -> Response:
     prefix = prefix_from_request(request)
     login_url = f"{prefix}/login?next={next_param}" if next_param else f"{prefix}/login"
     if request.url.path.startswith("/api/"):
+        # API 401s are audited: without this, a stale desktop bearer fails silently
+        # server-side (the log looks healthy while every request is rejected).
+        # HTML 302s are the normal unauthenticated navigation flow and stay silent.
         expired = reason == "invalid_or_expired_session"
+        audit_log(AuditEvent.SESSION_REJECTED, reason=reason, path=request.url.path,
+                  ip=_client_ip(request))
         return JSONResponse(
             {"error": "session_expired" if expired else "unauthenticated", "detail": "Unauthorized",
              "reason": reason, "login_url": login_url}, status_code=401)

--- a/tests/hermes_cli/test_dashboard_auth_middleware.py
+++ b/tests/hermes_cli/test_dashboard_auth_middleware.py
@@ -384,3 +384,69 @@ def test_all_providers_unreachable_returns_503(_gated_state):
     assert "unreachable" in r.text.lower()
 
 
+# ---------------------------------------------------------------------------
+# API 401 rejection audit (#103117)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def _audit_home(tmp_path, monkeypatch):
+    """Point $HERMES_HOME at a tmp dir; return a reader for audit events."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    def _events():
+        log_file = tmp_path / "logs" / "dashboard-auth.log"
+        if not log_file.exists():
+            return []
+        import json as _json
+        return [_json.loads(line) for line in log_file.read_text().splitlines() if line.strip()]
+
+    return _events
+
+
+def test_invalid_bearer_401_is_audited(gated_app, _audit_home):
+    """A presented-but-invalid bearer (stale desktop token) must produce a
+    ``session_rejected`` audit event: before #103117 the bearer path 401'd
+    with no server-side trace, so dashboard-auth.log affirmatively suggested
+    auth was healthy while every app request was rejected."""
+    r = gated_app.post(
+        "/api/auth/ws-ticket", headers={"Authorization": "Bearer stale-desktop-token"}
+    )
+    assert r.status_code == 401
+    assert r.json()["reason"] == "invalid_or_expired_session"
+
+    events = _audit_home()
+    rejected = [e for e in events if e["event"] == "session_rejected"]
+    assert rejected, f"no session_rejected event in audit log: {events}"
+    assert rejected[0]["reason"] == "invalid_or_expired_session"
+    assert rejected[0]["path"] == "/api/auth/ws-ticket"
+    assert "ip" in rejected[0]
+    # The rejected bearer value itself must not reach the log.
+    assert "stale-desktop-token" not in str(events)
+
+
+def test_no_cookie_api_401_is_audited(gated_app, _audit_home):
+    """Bare unauthenticated API calls also leave a ``session_rejected`` trace."""
+    r = gated_app.get("/api/auth/me")
+    assert r.status_code == 401
+    assert r.json()["reason"] == "no_cookie"
+
+    events = _audit_home()
+    rejected = [e for e in events if e["event"] == "session_rejected"]
+    assert rejected and rejected[0]["reason"] == "no_cookie"
+    assert rejected[0]["path"] == "/api/auth/me"
+
+
+def test_valid_bearer_and_html_redirect_not_audited_as_rejected(gated_app, _audit_home):
+    """Positive controls: a verifying bearer serves normally, and the HTML
+    302-to-/login is normal unauthenticated navigation — neither may emit
+    ``session_rejected``."""
+    token = _mint_stub_at(StubAuthProvider())
+    r = gated_app.get("/api/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200
+
+    r = gated_app.get("/", follow_redirects=False)
+    assert r.status_code == 302
+
+    assert [e for e in _audit_home() if e["event"] == "session_rejected"] == []
+
+


### PR DESCRIPTION
## What does this PR do?

A stale desktop bearer token produced a 401 on the bearer path (e.g. `POST /api/auth/ws-ticket`) with **no server-side trace**: `_unauth_response()` built the structured 401 but emitted no audit event, so `dashboard-auth.log` affirmatively suggested auth was healthy while every app request was being rejected. As the issue reporter describes, "zero rejections logged" read as "no rejections occurred", when in fact no code path could have logged them.

This PR emits a new `AuditEvent.SESSION_REJECTED` event (carrying the `reason` already computed — `invalid_or_expired_session` / `no_cookie` — plus `path` and client `ip`) from the API 401 branch of `_unauth_response()`. A distinct event name is used instead of overloading the WS-specific `WS_TICKET_REJECTED`, per the issue's suggestion. HTML 302→/login responses stay silent: that is normal unauthenticated navigation, not a rejection.

This covers all three 401 paths that previously escaped auditing: the bearer path (stale desktop token), the no-cookie bare API call, and the cookie-expired path (which previously only logged `SESSION_VERIFY_FAILURE` without the request's final outcome, path, or the bearer-path variant at all).

The issue's second ask (desktop-side error wording for bearer-path 401s) is an `apps/desktop` concern and is intentionally left out to keep this PR focused on one root cause.

## Related Issue

Fixes #103117

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/dashboard_auth/audit.py` — add `SESSION_REJECTED = "session_rejected"` to `AuditEvent`.
- `hermes_cli/dashboard_auth/middleware.py` — in `_unauth_response()`, emit `audit_log(AuditEvent.SESSION_REJECTED, reason=..., path=..., ip=...)` from the `/api/` 401 branch only (HTML 302 branch unchanged/silent).
- `tests/hermes_cli/test_dashboard_auth_middleware.py` — regression tests: invalid-bearer 401 on `/api/auth/ws-ticket` writes a `session_rejected` event (reason/path/ip asserted, and the rejected bearer value must not leak into the log); no-cookie API 401 writes `session_rejected` with `reason=no_cookie`; positive controls — a verifying bearer (200) and the HTML 302 both emit no `session_rejected`.

## How to Test

1. `python -m pytest tests/hermes_cli/test_dashboard_auth_middleware.py -q` — Observed result: **21 passed** (18 pre-existing + 3 new).
2. `python -m pytest tests/hermes_cli/test_dashboard_auth_audit.py tests/hermes_cli/test_dashboard_auth_ws_auth.py tests/hermes_cli/test_dashboard_auth_ws_tickets.py tests/hermes_cli/test_dashboard_auth_401_reauth.py tests/hermes_cli/test_dashboard_auth_native_flow.py tests/hermes_cli/test_dashboard_auth_gate.py -q` — Observed result: **103 passed**.
3. Manual reproduction of the issue scenario: gate a dashboard with a stub provider, send `POST /api/auth/ws-ticket` with `Authorization: Bearer stale-desktop-token` → 401, then `cat $HERMES_HOME/logs/dashboard-auth.log` — Observed result: a `session_rejected` JSON line like `{"ts":"...","event":"session_rejected","reason":"invalid_or_expired_session","path":"/api/auth/ws-ticket","ip":"testclient"}` is present (before this PR the log stayed empty for this request).
4. `ruff check` on all three changed files — Observed result: **All checks passed**.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (darwin 25.4, arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Audit line produced by the new regression test (read from the tmp `$HERMES_HOME` it installs):

```json
{"ts":"2026-09-04T18:52:11.123456+00:00","event":"session_rejected","reason":"invalid_or_expired_session","path":"/api/auth/ws-ticket","ip":"testclient"}
```