### PR TITLE
fix(local-models): quickstart's 'make it your default' step resolves _apply_model_assignment_sync on its defining module (salvage #102994)

### DIFF
--- a/hermes_cli/web_routers/local_models.py
+++ b/hermes_cli/web_routers/local_models.py
@@ -268,7 +268,7 @@ def _ensure_server(job: Dict[str, Any], config: dict, model_id: str, *, fail_det
 
 
 def _assign_default(job: Dict[str, Any], model_id: str) -> None:
-    """Make ``model_id`` the main model via the same machinery as /api/model/set (late-bound: tests stub web_deps.late)."""
+    """Make ``model_id`` the main model via the same machinery as /api/model/set."""
     _step(job, "setting-default", "Making it your default")
     web_deps.late("_apply_model_assignment_sync", "hermes_cli.web_server_config")("main", "llamacpp", model_id, "", "", "")
 

--- a/hermes_cli/web_routers/local_models.py
+++ b/hermes_cli/web_routers/local_models.py
@@ -270,7 +270,7 @@ def _ensure_server(job: Dict[str, Any], config: dict, model_id: str, *, fail_det
 def _assign_default(job: Dict[str, Any], model_id: str) -> None:
     """Make ``model_id`` the main model via the same machinery as /api/model/set (late-bound: tests stub web_deps.late)."""
     _step(job, "setting-default", "Making it your default")
-    web_deps.late("_apply_model_assignment_sync")("main", "llamacpp", model_id, "", "", "")
+    web_deps.late("_apply_model_assignment_sync", "hermes_cli.web_server_config")("main", "llamacpp", model_id, "", "", "")
 
 
 # ── downloads: ranged parallel streams ───────────────────────

--- a/tests/hermes_cli/test_local_quickstart.py
+++ b/tests/hermes_cli/test_local_quickstart.py
@@ -80,11 +80,9 @@ def test_quickstart_runs_all_three_legs(client, monkeypatch, tmp_path):
     monkeypatch.setattr(
         "hermes_cli.web_routers.local_models._state_endpoint",
         lambda: {"base_url": "http://127.0.0.1:1/v1", "api_key": "k"})
-    from hermes_cli import web_deps
-
     monkeypatch.setattr(
-        web_deps, "late",
-        lambda name, module="hermes_cli.web_server": (lambda *a, **k: calls.append("assign")))
+        "hermes_cli.web_server_config._apply_model_assignment_sync",
+        lambda *a, **k: calls.append("assign"))
 
     r = client.post("/api/local-models/quickstart", json={})
     assert r.status_code == 200
@@ -133,11 +131,9 @@ def test_quickstart_skips_satisfied_legs(client, monkeypatch):
     monkeypatch.setattr(
         "hermes_cli.web_routers.local_models._state_endpoint",
         lambda: {"base_url": "http://127.0.0.1:1/v1", "api_key": "k"})
-    from hermes_cli import web_deps
-
     monkeypatch.setattr(
-        web_deps, "late",
-        lambda name, module="hermes_cli.web_server": (lambda *a, **k: calls.append("assign")))
+        "hermes_cli.web_server_config._apply_model_assignment_sync",
+        lambda *a, **k: calls.append("assign"))
 
     r = client.post("/api/local-models/quickstart", json={})
     assert r.status_code == 200
@@ -185,3 +181,17 @@ def test_quickstart_is_single_flight(client, quickstart_ready, monkeypatch):
         assert "already running" in r.json()["detail"].lower()
     finally:
         lm._QUICKSTART_LOCK.release()
+
+
+def test_assign_default_reaches_model_assignment(monkeypatch):
+    """late() must resolve _apply_model_assignment_sync on web_server_config, the
+    sibling that defines it. Only the leaf is stubbed; the default web_server lookup
+    raised AttributeError at the quickstart's 'making it your default' step."""
+    import hermes_cli.web_routers.local_models as lm
+
+    seen: list[tuple] = []
+    monkeypatch.setattr(
+        "hermes_cli.web_server_config._apply_model_assignment_sync",
+        lambda *a, **k: seen.append(a))
+    lm._assign_default({}, "some-model")
+    assert seen == [("main", "llamacpp", "some-model", "", "", "")]

--- a/tests/hermes_cli/test_local_quickstart.py
+++ b/tests/hermes_cli/test_local_quickstart.py
@@ -84,7 +84,7 @@ def test_quickstart_runs_all_three_legs(client, monkeypatch, tmp_path):
 
     monkeypatch.setattr(
         web_deps, "late",
-        lambda name: (lambda *a, **k: calls.append("assign")))
+        lambda name, module="hermes_cli.web_server": (lambda *a, **k: calls.append("assign")))
 
     r = client.post("/api/local-models/quickstart", json={})
     assert r.status_code == 200
@@ -137,7 +137,7 @@ def test_quickstart_skips_satisfied_legs(client, monkeypatch):
 
     monkeypatch.setattr(
         web_deps, "late",
-        lambda name: (lambda *a, **k: calls.append("assign")))
+        lambda name, module="hermes_cli.web_server": (lambda *a, **k: calls.append("assign")))
 
     r = client.post("/api/local-models/quickstart", json={})
     assert r.status_code == 200


### PR DESCRIPTION
## Summary
The desktop's local-model quickstart no longer fails at its last step ("Making it your default") with `module 'hermes_cli.web_server' has no attribute '_apply_model_assignment_sync'`.

Root cause: the god-file decomposition (5233cbf50f) moved `_apply_model_assignment_sync` from the `web_server` facade to `hermes_cli/web_server_config.py`; the sibling `models.py` router was repointed but `local_models.py:_assign_default` still resolved it through `web_deps.late(name)`, whose module defaults to `web_server`. This was the only stale `late()`/`LateState()` site in the repo (all 10 others resolve on `web_server.py`).

Salvage of #102994 by @Leanolf — fix commit cherry-picked with authorship preserved. Test follow-up by me; @crazyief reviewed the original.

## Changes
- `hermes_cli/web_routers/local_models.py`: pass the owning module to `web_deps.late(...)` (the two-arg form 5f1feb5344 introduced); drop a docstring parenthetical that described test mechanics.
- `tests/hermes_cli/test_local_quickstart.py`: the two leg tests now stub only the leaf (`web_server_config._apply_model_assignment_sync`) so the real `late()` resolution path — the thing that regressed — is exercised; one new invariant test asserts `_assign_default` reaches it with `("main", "llamacpp", model_id, "", "", "")`. Replaces the original PR's three assertions that pinned the module string (change-detectors per AGENTS.md).

## Validation
| | origin/main | this branch |
|---|---|---|
| `_assign_default({}, "m")` with real imports, only the leaf stubbed | `AttributeError: module 'hermes_cli.web_server' has no attribute '_apply_model_assignment_sync'` | called with `('main','llamacpp','m','','','')` |
| `test_assign_default_reaches_model_assignment` with the fix line reverted | — | fails with the same AttributeError (mutation check) |
| `TestClient(web_server.app)` GET `/api/local-models/status`, `/jobs` | — | 200 |
| ruff / `scripts/check_compat_pointers.py` | — | clean |

Note: `test_quickstart_runs_all_three_legs` / `test_quickstart_skips_satisfied_legs` 409 ("no catalog model fits this machine") on a 16 GB Mac both on main and here — pre-existing host dependence (they don't stub `hardware.probe_budget`), out of scope.

Closes #102994
