### PR TITLE
fix(mcp): serialize OAuth authorization across duplicate providers (single login transaction)

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -645,10 +645,10 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
     _info(f"Starting OAuth flow for '{name}'...")
 
     # The probe triggers the OAuth flow (browser redirect + callback capture). Honor the configured
-    # connect_timeout, floored at 315s (the 300s OAuth callback window + headroom) — matching the GUI
-    # re-auth path in web_server.py. force_interactive_oauth: `hermes mcp login` is explicitly
-    # user-initiated even when stdin isn't a TTY (desktop / agent-spawned terminals), where
-    # _is_interactive() alone would refuse to open a browser.
+    # connect_timeout, floored at the server's own `oauth.timeout` + 15s headroom (the callback waiter
+    # lives that long), matching the GUI re-auth path in web_server.py. force_interactive_oauth:
+    # `hermes mcp login` is explicitly user-initiated even when stdin isn't a TTY (desktop /
+    # agent-spawned terminals), where _is_interactive() alone would refuse to open a browser.
     try:
         from tools.mcp_oauth import force_interactive_oauth
 
@@ -656,9 +656,13 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
             _login_connect_timeout = float(server_config.get("connect_timeout"))
         except (TypeError, ValueError):
             _login_connect_timeout = 0.0
+        try:
+            _login_oauth_timeout = float((server_config.get("oauth") or {}).get("timeout", 300))
+        except (TypeError, ValueError):
+            _login_oauth_timeout = 300.0
         with force_interactive_oauth():
             tools = _probe_single_server(
-                name, server_config, connect_timeout=max(_login_connect_timeout, 315.0)
+                name, server_config, connect_timeout=max(_login_connect_timeout, _login_oauth_timeout + 15)
             )
         # A clean probe is NOT proof of authentication: some servers (e.g. Google Drive) serve
         # initialize + tools/list without auth, so the flow may have failed (e.g. DCR 400 for

--- a/tests/tools/test_mcp_oauth_bidirectional.py
+++ b/tests/tools/test_mcp_oauth_bidirectional.py
@@ -307,9 +307,392 @@ async def test_long_lived_resource_request_does_not_block_concurrent_post(
         await get_flow.asend(httpx.Response(200, request=get_retry))
 
 
+@pytest.mark.asyncio
+async def test_tokenless_long_lived_request_does_not_block_concurrent_post(
+    tmp_path, monkeypatch
+):
+    """A token-less session-long GET must not hold the provider state lock.
+
+    Regression for the login double-attempt "fix" attempt: gating the lock release on
+    ``sent_access_token is not None`` held ``context.lock`` across a token-less request's
+    entire network round-trip. On an OAuth server that serves its SSE GET without demanding
+    auth (e.g. Google Drive — acknowledged in hermes_cli/mcp_config.py), the GET never 401s,
+    the lock is never returned, and every concurrent tool-call POST hangs for the session.
+
+    The lock MUST be released for every resource request, authenticated or not. OAuth
+    transitions (discovery/registration/authorization) are still serialized: the bridge
+    re-acquires the lock before feeding the response back to the SDK, and the stale-401
+    retry guard (mcp_oauth_manager.py) makes a second token-less flow reuse the first flow's
+    freshly minted token instead of re-entering authorization.
+    """
+    from tools.mcp_tool import sdk_httpx
+    httpx = sdk_httpx()
+    from mcp.shared.auth import OAuthClientMetadata
+    from pydantic import AnyUrl
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+
+    assert _HERMES_PROVIDER_CLS is not None
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+
+    storage = HermesTokenStorage("srv")
+    # No token, no client_info: both flows start token-less.
+
+    provider = _HERMES_PROVIDER_CLS(
+        server_name="srv",
+        server_url="https://example.com/mcp",
+        client_metadata=OAuthClientMetadata(
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            client_name="Hermes Agent",
+        ),
+        storage=storage,
+        redirect_handler=_noop_redirect,
+        callback_handler=_noop_callback,
+    )
+
+    get_request = httpx.Request("GET", "https://example.com/mcp")
+    get_flow = provider.async_auth_flow(get_request)
+    get_outbound = await get_flow.__anext__()
+    assert get_outbound is get_request
+    assert "authorization" not in get_outbound.headers  # token-less: no Bearer yet
+
+    # Keep the token-less GET pending, as streamable HTTP does for the session lifetime.
+    # The concurrent POST must still reach its first yield (acquire the lock) without
+    # waiting for the GET to 401/authorize/complete.
+    post_request = httpx.Request("POST", "https://example.com/mcp")
+    post_flow = provider.async_auth_flow(post_request)
+    post_outbound = await asyncio.wait_for(post_flow.__anext__(), timeout=2.0)
+
+    assert post_outbound is post_request
+    assert "authorization" not in post_outbound.headers
+
+    # Complete both flows cleanly (a 200 short-circuits the SDK's 401/403 branches).
+    with pytest.raises(StopAsyncIteration):
+        await post_flow.asend(httpx.Response(200, request=post_outbound))
+    with pytest.raises(StopAsyncIteration):
+        await get_flow.asend(httpx.Response(200, request=get_outbound))
+
+
 async def _noop_redirect(_url: str) -> None:
     """Redirect handler that does nothing (won't be invoked in these tests)."""
     return None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_authorization_across_providers_triggers_single_authorization(
+    tmp_path, monkeypatch
+):
+    """Two concurrent token-less flows across separate providers must authorize ONCE.
+
+    The login double-attempt bug: `hermes mcp login asana` printed TWO
+    "MCP OAuth: authorization required" blocks (distinct ``state`` / ``code_challenge`` each) and
+    the second flow died with ``OSError: [Errno 98] Address already in use``.
+
+    Two flows on ONE provider already serialize to a single authorization via the SDK's
+    ``context.lock`` + the stale-401 retry guard (covered by the neighbouring test). The live
+    double-trigger requires SEPARATE contexts/locks — a duplicate or rebuilt provider for the same
+    endpoint — so each flow carries its own ``context.lock`` and the SDK cannot serialize them. Both
+    then reach the authorization step, print two URLs, and collide on the resolved callback port.
+
+    The fix is a per-server authorization mutex (``MCPOAuthManager.authorization_lock``) held across
+    the redirect + callback + token exchange: the loser blocks, then adopts the winner's token from
+    shared storage and retries instead of re-authorizing.
+    """
+    from urllib.parse import parse_qs, urlparse
+
+    from mcp.shared.auth import AuthorizationCodeResult, OAuthClientMetadata
+    from pydantic import AnyUrl
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+    from tools.mcp_tool import sdk_httpx
+
+    httpx = sdk_httpx()
+
+    assert _HERMES_PROVIDER_CLS is not None
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+
+    # Both providers point at the SAME server and the SAME shared token storage, exactly as a
+    # duplicate/rebuilt provider for one endpoint would: separate contexts/locks, one token file.
+    storage = HermesTokenStorage("srv")
+    redirect_calls: list[str] = []
+    states: dict = {}
+
+    def make_handlers(tag: str):
+        async def redirect_handler(authorization_url: str) -> None:
+            redirect_calls.append(authorization_url)
+            states[tag] = parse_qs(urlparse(authorization_url).query).get("state", [None])[0]
+
+        async def callback_handler():
+            await asyncio.sleep(0.05)
+            return AuthorizationCodeResult(
+                code="FAKE_AUTH_CODE", state=states.get(tag), iss=None
+            )
+
+        return redirect_handler, callback_handler
+
+    def make_provider(tag: str):
+        redirect_handler, callback_handler = make_handlers(tag)
+        return _HERMES_PROVIDER_CLS(
+            server_name="srv",
+            server_url="https://example.com/mcp",
+            client_metadata=OAuthClientMetadata(
+                redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+                client_name="Hermes Agent",
+            ),
+            storage=storage,
+            redirect_handler=redirect_handler,
+            callback_handler=callback_handler,
+        )
+
+    provider_a = make_provider("a")
+    provider_b = make_provider("b")
+
+    WWW = 'Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource"'
+    PRM = {"resource": "https://example.com/mcp", "authorization_servers": ["https://idp.example.com"]}
+    ASM = {
+        "issuer": "https://idp.example.com",
+        "authorization_endpoint": "https://idp.example.com/authorize",
+        "token_endpoint": "https://idp.example.com/token",
+        "registration_endpoint": "https://idp.example.com/register",
+        "response_types_supported": ["code"],
+    }
+    DCR = {
+        "client_id": "client-1",
+        "redirect_uris": ["http://127.0.0.1:12345/callback"],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none",
+    }
+    TOKEN = {"access_token": "tok", "token_type": "Bearer", "expires_in": 3600, "refresh_token": "ref"}
+
+    async def drive_one_flow(provider) -> None:
+        req = httpx.Request("POST", "https://example.com/mcp")
+        flow = provider.async_auth_flow(req)
+        outbound = await flow.__anext__()
+
+        # A flow that already carries a token completes cleanly and never re-authorizes.
+        if "authorization" in outbound.headers:
+            with pytest.raises(StopAsyncIteration):
+                await flow.asend(httpx.Response(200, request=outbound))
+            return
+
+        # Token-less: 401 -> discovery -> registration -> (authorization OR adopted-token retry).
+        nxt = await flow.asend(httpx.Response(401, request=outbound, headers={"www-authenticate": WWW}))
+        nxt = await flow.asend(httpx.Response(200, request=nxt, json=PRM))
+        nxt = await flow.asend(httpx.Response(200, request=nxt, json=ASM))
+        nxt = await flow.asend(httpx.Response(200, request=nxt, json=DCR))
+
+        # The winner yields the token request; the loser, blocked on the authorization mutex, is
+        # diverted to the adopted-token retry (a request that already carries an Authorization
+        # header) instead of a second token exchange.
+        if "authorization" in nxt.headers:
+            with pytest.raises(StopAsyncIteration):
+                await flow.asend(httpx.Response(200, request=nxt))
+            return
+
+        # Winner: token exchange, then the SDK retries the resource request with the new token.
+        nxt = await flow.asend(httpx.Response(200, request=nxt, json=TOKEN))
+        assert "authorization" in nxt.headers
+        with pytest.raises(StopAsyncIteration):
+            await flow.asend(httpx.Response(200, request=nxt))
+
+    await asyncio.gather(drive_one_flow(provider_a), drive_one_flow(provider_b))
+
+    assert len(redirect_calls) == 1, (
+        f"expected exactly one authorization flow (one browser URL), got {len(redirect_calls)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_401_rejected_token_still_triggers_authorization(tmp_path, monkeypatch):
+    """A 401 with an unexpired-but-rejected token must re-authorize, not re-adopt the same token.
+
+    Regression for the adoption guard in ``_hermes_adopt_external_authorization``: it must adopt
+    only a token that DIFFERS from the one this flow already holds. If it adopted the rejected
+    token itself, a 401 (or 403 step-up) would retry the SAME bad ``Bearer`` forever and never
+    reach the authorization step (zero redirects) — the login would silently spin instead of
+    re-prompting the browser.
+    """
+    from urllib.parse import parse_qs, urlparse
+
+    from mcp.shared.auth import (
+        AuthorizationCodeResult,
+        OAuthClientInformationFull,
+        OAuthClientMetadata,
+        OAuthToken,
+    )
+    from pydantic import AnyUrl
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+    from tools.mcp_tool import sdk_httpx
+
+    httpx = sdk_httpx()
+    assert _HERMES_PROVIDER_CLS is not None
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+
+    storage = HermesTokenStorage("srv")
+    await storage.set_tokens(
+        OAuthToken(access_token="STALE", token_type="Bearer", expires_in=3600, refresh_token="ref")
+    )
+    await storage.set_client_info(
+        OAuthClientInformationFull(
+            client_id="test-client",
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+        )
+    )
+
+    redirect_calls: list[str] = []
+    captured_state: dict = {}
+
+    async def redirect_handler(authorization_url: str) -> None:
+        redirect_calls.append(authorization_url)
+        captured_state["state"] = parse_qs(urlparse(authorization_url).query).get("state", [None])[0]
+
+    async def callback_handler():
+        await asyncio.sleep(0.05)
+        return AuthorizationCodeResult(code="FAKE_AUTH_CODE", state=captured_state.get("state"), iss=None)
+
+    provider = _HERMES_PROVIDER_CLS(
+        server_name="srv",
+        server_url="https://example.com/mcp",
+        client_metadata=OAuthClientMetadata(
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            client_name="Hermes Agent",
+        ),
+        storage=storage,
+        redirect_handler=redirect_handler,
+        callback_handler=callback_handler,
+    )
+
+    WWW = 'Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource"'
+    PRM = {"resource": "https://example.com/mcp", "authorization_servers": ["https://idp.example.com"]}
+    ASM = {
+        "issuer": "https://idp.example.com",
+        "authorization_endpoint": "https://idp.example.com/authorize",
+        "token_endpoint": "https://idp.example.com/token",
+        "response_types_supported": ["code"],
+    }
+    TOKEN = {"access_token": "tok", "token_type": "Bearer", "expires_in": 3600, "refresh_token": "ref"}
+
+    req = httpx.Request("POST", "https://example.com/mcp")
+    flow = provider.async_auth_flow(req)
+
+    outbound = await flow.__anext__()
+    assert "authorization" in outbound.headers  # sends the (rejected) STALE token
+
+    # 401 -> PRM discovery -> ASM discovery -> (client already registered) -> authorization.
+    nxt = await flow.asend(httpx.Response(401, request=outbound, headers={"www-authenticate": WWW}))
+    nxt = await flow.asend(httpx.Response(200, request=nxt, json=PRM))
+    nxt = await flow.asend(httpx.Response(200, request=nxt, json=ASM))
+
+    assert len(redirect_calls) == 1, (
+        f"expected the rejected token to trigger exactly one re-authorization, got {len(redirect_calls)}"
+    )
+
+    nxt = await flow.asend(httpx.Response(200, request=nxt, json=TOKEN))
+    assert "authorization" in nxt.headers
+    with pytest.raises(StopAsyncIteration):
+        await flow.asend(httpx.Response(200, request=nxt))
+
+
+@pytest.mark.asyncio
+async def test_403_insufficient_scope_step_up_still_triggers_authorization(tmp_path, monkeypatch):
+    """A 403 ``insufficient_scope`` step-up must re-authorize, not re-adopt the same token.
+
+    Same adoption guard as the 401 case, exercised through the SDK's 403 step-up branch (the
+    second ``_perform_authorization`` call site). A step-up must produce a fresh authorization
+    (one redirect), never a silent retry of the token that just lacked scope.
+    """
+    from urllib.parse import parse_qs, urlparse
+
+    from mcp.shared.auth import (
+        AuthorizationCodeResult,
+        OAuthClientInformationFull,
+        OAuthClientMetadata,
+        OAuthToken,
+    )
+    from pydantic import AnyUrl
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+    from tools.mcp_tool import sdk_httpx
+
+    httpx = sdk_httpx()
+    assert _HERMES_PROVIDER_CLS is not None
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+
+    storage = HermesTokenStorage("srv")
+    await storage.set_tokens(
+        OAuthToken(access_token="STALE", token_type="Bearer", expires_in=3600, refresh_token="ref")
+    )
+    await storage.set_client_info(
+        OAuthClientInformationFull(
+            client_id="test-client",
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+        )
+    )
+
+    redirect_calls: list[str] = []
+    captured_state: dict = {}
+
+    async def redirect_handler(authorization_url: str) -> None:
+        redirect_calls.append(authorization_url)
+        captured_state["state"] = parse_qs(urlparse(authorization_url).query).get("state", [None])[0]
+
+    async def callback_handler():
+        await asyncio.sleep(0.05)
+        return AuthorizationCodeResult(code="FAKE_AUTH_CODE", state=captured_state.get("state"), iss=None)
+
+    provider = _HERMES_PROVIDER_CLS(
+        server_name="srv",
+        server_url="https://example.com/mcp",
+        client_metadata=OAuthClientMetadata(
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            client_name="Hermes Agent",
+        ),
+        storage=storage,
+        redirect_handler=redirect_handler,
+        callback_handler=callback_handler,
+    )
+
+    TOKEN = {"access_token": "tok", "token_type": "Bearer", "expires_in": 3600, "refresh_token": "ref"}
+
+    req = httpx.Request("POST", "https://example.com/mcp")
+    flow = provider.async_auth_flow(req)
+
+    outbound = await flow.__anext__()
+    assert "authorization" in outbound.headers  # sends the (scope-lacking) STALE token
+
+    # 403 insufficient_scope -> scope union -> authorization (no discovery/registration).
+    nxt = await flow.asend(
+        httpx.Response(403, request=outbound, headers={"www-authenticate": 'Bearer error="insufficient_scope"'})
+    )
+
+    assert len(redirect_calls) == 1, (
+        f"expected the scope step-up to trigger exactly one re-authorization, got {len(redirect_calls)}"
+    )
+
+    nxt = await flow.asend(httpx.Response(200, request=nxt, json=TOKEN))
+    assert "authorization" in nxt.headers
+    with pytest.raises(StopAsyncIteration):
+        await flow.asend(httpx.Response(200, request=nxt))
 
 
 async def _noop_callback() -> tuple[str, str | None]:

--- a/tests/tools/test_mcp_oauth_refresh_rotation_race.py
+++ b/tests/tools/test_mcp_oauth_refresh_rotation_race.py
@@ -1,0 +1,650 @@
+"""Regression tests for the MCP OAuth refresh-token rotation race.
+
+Asana (and other single-use-refresh-token providers) rotates the refresh
+token on every use. When two Hermes *processes* — the long-running gateway,
+a one-shot ``hermes chat`` backfill, and ``hermes mcp test/login`` runs —
+share one token file (``~/.hermes/mcp-tokens/<server>.json``) and both
+decide to refresh the same expired token, they can both POST the same
+refresh token. The provider accepts one and invalidates the other; the
+losing client falls through to a full browser re-authorization even though a
+fresh, valid token was just written by the winner.
+
+The fix mirrors the cross-process single-refresher discipline already used
+for Codex/xAI/Anthropic in ``agent/credential_pool.py``: a cross-process
+advisory flock around the whole read-fresh -> POST -> write-back sequence,
+plus a re-read of the token file once the lock is held so a waiter adopts
+the winner's rotated token instead of re-POSTing the now-spent one.
+
+These tests reproduce the race deterministically with a fake single-use
+token endpoint, run two providers against one token file, and assert exactly
+one rotation with no invalidation loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _set_interactive_stdin(monkeypatch, *, is_tty: bool = True) -> None:
+    mock_stdin = MagicMock()
+    mock_stdin.isatty.return_value = is_tty
+    monkeypatch.setattr("tools.mcp_oauth.sys.stdin", mock_stdin)
+
+
+def _fake_response(status: int, body: bytes):
+    """A minimal stand-in for the httpx2.Response the SDK feeds our handlers."""
+    resp = MagicMock()
+    resp.status_code = status
+
+    async def _aread():
+        return body
+
+    resp.aread = _aread
+    return resp
+
+
+class _SingleUseTokenEndpoint:
+    """Fake token endpoint enforcing the real single-use-refresh contract.
+
+    The first caller to present a given refresh_token gets a fresh pair; every
+    subsequent caller presenting that same (now-spent) token gets
+    ``invalid_grant`` — mirroring Asana's rotation behavior.
+    """
+
+    def __init__(self, latency: float = 0.02):
+        self._spent: set[str] = set()
+        self._rotation = 0
+        self.calls: list[str] = []
+        self._latency = latency
+
+    async def post(self, refresh_token: str):
+        self.calls.append(refresh_token)
+        # Widen the race window so a second client is deterministically forced
+        # to wait on the cross-process lock while the winner is mid-refresh.
+        await asyncio.sleep(self._latency)
+        if refresh_token in self._spent:
+            return 400, b'{"error":"invalid_grant"}'
+        self._spent.add(refresh_token)
+        self._rotation += 1
+        rotation = self._rotation
+        body = json.dumps(
+            {
+                "access_token": f"at-{rotation}",
+                "refresh_token": f"rt-{rotation}",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+            }
+        ).encode()
+        return 200, body
+
+
+async def _refresh_once(provider, endpoint):
+    """Drive one refresh cycle the way the async_auth_flow bridge does.
+
+    Mirrors the SDK's ``_refresh_token() -> POST -> _handle_refresh_response()``
+    sequence, including the skip branch where a sibling already rotated the
+    token and the POST must be omitted.
+    """
+    from urllib.parse import parse_qs
+
+    refresh_request = await provider._refresh_token()
+    if getattr(provider, "_hermes_refresh_skipped", False):
+        # The bridge feeds None instead of POSTing the spent token.
+        return await provider._handle_refresh_response(None)
+    refresh_token = parse_qs(refresh_request.content.decode())["refresh_token"][0]
+    status, body = await endpoint.post(refresh_token)
+    return await provider._handle_refresh_response(_fake_response(status, body))
+
+
+# ---------------------------------------------------------------------------
+# Provider construction helper
+# ---------------------------------------------------------------------------
+
+
+def _make_provider(tmp_path, monkeypatch, *, in_memory_token):
+    """Build a provider whose storage points at the shared tmp_path token file."""
+    from mcp.shared.auth import OAuthToken, OAuthClientInformationFull
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    provider = MCPOAuthManager().get_or_build_provider(
+        "srv", "https://mcp.example.com", None
+    )
+    assert provider is not None
+    provider.context.current_tokens = OAuthToken(
+        access_token=in_memory_token["access_token"],
+        refresh_token=in_memory_token["refresh_token"],
+        expires_in=3600,
+    )
+    provider.context.client_info = OAuthClientInformationFull.model_validate(
+        {"client_id": "client-id"}
+    )
+    provider.context.oauth_metadata = SimpleNamespace(
+        token_endpoint="https://idp.example.com/oauth/token"
+    )
+    return provider
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_adopts_rotated_disk_token(tmp_path, monkeypatch):
+    """_refresh_token re-reads disk and adopts a sibling's rotated token.
+
+    The in-memory token (rt-0) is stale; the file already holds rt-1 because
+    another process rotated it. _refresh_token must adopt rt-1 and mark the
+    POST to skip rather than re-POSTing the spent rt-0.
+    """
+    from mcp.shared.auth import OAuthToken
+    from tools.mcp_oauth import HermesTokenStorage
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+
+    storage = HermesTokenStorage("srv")
+    await storage.set_tokens(
+        OAuthToken(access_token="at-1", refresh_token="rt-1", expires_in=3600)
+    )
+
+    provider = _make_provider(
+        tmp_path,
+        monkeypatch,
+        in_memory_token={"access_token": "at-0", "refresh_token": "rt-0"},
+    )
+
+    await provider._refresh_token()
+
+    assert provider.context.current_tokens.refresh_token == "rt-1"
+    assert provider.context.current_tokens.access_token == "at-1"
+    assert getattr(provider, "_hermes_refresh_skipped", False) is True
+
+    # The skip branch must return True (no clear) and release the lock.
+    assert await provider._handle_refresh_response(None) is True
+    assert getattr(provider, "_hermes_refresh_lock", None) is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_failure_releases_cross_process_lock(tmp_path, monkeypatch):
+    """A failed refresh POST must still release the cross-process lock.
+
+    Without release-on-failure, one dead refresh wedges every other process
+    on the flock and turns a transient token failure into a fleet-wide hang.
+    """
+    from mcp.shared.auth import OAuthToken
+    from tools.mcp_oauth import HermesTokenStorage
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+
+    storage = HermesTokenStorage("srv")
+    await storage.set_tokens(
+        OAuthToken(access_token="at-0", refresh_token="rt-0", expires_in=3600)
+    )
+
+    provider = _make_provider(
+        tmp_path,
+        monkeypatch,
+        in_memory_token={"access_token": "at-0", "refresh_token": "rt-0"},
+    )
+
+    await provider._refresh_token()
+    assert getattr(provider, "_hermes_refresh_lock", None) is not None
+    assert getattr(provider, "_hermes_refresh_skipped", False) is False
+
+    result = await provider._handle_refresh_response(
+        _fake_response(400, b'{"error":"invalid_grant"}')
+    )
+
+    assert result is False
+    assert provider.context.current_tokens is None  # cleared on failure
+    assert getattr(provider, "_hermes_refresh_lock", None) is None  # released
+    # The attribute being None is not proof: _hermes_release_refresh_lock nulls
+    # it before lock.release(). Prove the flock is genuinely free by acquiring
+    # it again (with a short timeout) — a wedged flock would hang/raise here.
+    relock = storage.refresh_lock(timeout_seconds=2)
+    await relock.acquire()
+    relock.release()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_refresh_rotates_once_without_invalidation_loop(
+    tmp_path, monkeypatch
+):
+    """Two clients sharing one token file rotate exactly once, no invalidation loop.
+
+    This is the core acceptance: the cross-process lock plus read-fresh means
+    exactly one process POSTs the refresh token and the other adopts the
+    winner's rotated pair — so the second client never burns the single-use
+    token and never falls through to a browser re-authorization.
+    """
+    from mcp.shared.auth import OAuthToken
+    from tools.mcp_oauth import HermesTokenStorage
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+
+    storage = HermesTokenStorage("srv")
+    await storage.set_tokens(
+        OAuthToken(access_token="at-0", refresh_token="rt-0", expires_in=3600)
+    )
+
+    provider_a = _make_provider(
+        tmp_path,
+        monkeypatch,
+        in_memory_token={"access_token": "at-0", "refresh_token": "rt-0"},
+    )
+    provider_b = _make_provider(
+        tmp_path,
+        monkeypatch,
+        in_memory_token={"access_token": "at-0", "refresh_token": "rt-0"},
+    )
+    # Two independent "processes": separate providers, separate storages, one file.
+    assert provider_a is not provider_b
+    assert provider_a.context.storage is not provider_b.context.storage
+    assert (
+        provider_a.context.storage._tokens_path()
+        == provider_b.context.storage._tokens_path()
+    )
+
+    endpoint = _SingleUseTokenEndpoint()
+
+    await asyncio.gather(
+        _refresh_once(provider_a, endpoint),
+        _refresh_once(provider_b, endpoint),
+    )
+
+    # Exactly one process ever posted, and only the original token was used.
+    assert endpoint.calls == ["rt-0"], f"unexpected refresh POSTs: {endpoint.calls!r}"
+    # Both clients converged on the same fresh pair — no invalidation loop.
+    assert provider_a.context.current_tokens.refresh_token == "rt-1"
+    assert provider_b.context.current_tokens.refresh_token == "rt-1"
+    # The rotation is durable on disk.
+    disk = await storage.get_tokens()
+    assert disk is not None
+    assert disk.refresh_token == "rt-1"
+
+
+def test_bridge_skips_posting_when_token_adopted(tmp_path, monkeypatch):
+    """The async_auth_flow bridge omits the POST when _refresh_token skipped.
+
+    The read-fresh/adopt logic alone is not enough: the bridge must not yield
+    the (now-pointless) refresh request to httpx. This drives the real bridge
+    against a patched SDK base flow and asserts the only outgoing is the
+    resource request, never the refresh POST.
+    """
+    from mcp.shared.auth import OAuthToken, OAuthClientInformationFull
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+
+    from tools.mcp_oauth import HermesTokenStorage
+
+    storage = HermesTokenStorage("srv")
+    asyncio.run(
+        storage.set_tokens(
+            OAuthToken(access_token="at-1", refresh_token="rt-1", expires_in=3600)
+        )
+    )
+
+    provider = _make_provider(
+        tmp_path,
+        monkeypatch,
+        in_memory_token={"access_token": "at-0", "refresh_token": "rt-0"},
+    )
+    provider.context.update_token_expiry(provider.context.current_tokens)
+    # The refresh is skipped here, so no real metadata is needed; leaving the
+    # SimpleNamespace in place would trip _persist_oauth_metadata_if_changed,
+    # which expects a real OAuthMetadata.model_dump().
+    provider.context.oauth_metadata = None
+
+    async def fake_base_flow(self, request):
+        """Mimic the SDK's refresh-then-request sequence in a controlled way."""
+        async with self.context.lock:
+            if self.context.can_refresh_token():
+                refresh_request = await self._refresh_token()
+                refresh_response = yield refresh_request
+                if not await self._handle_refresh_response(refresh_response):
+                    self._initialized = False
+            if self.context.is_token_valid():
+                self._add_auth_header(request)
+            yield request
+
+    from mcp.client.auth.oauth2 import OAuthClientProvider
+
+    monkeypatch.setattr(OAuthClientProvider, "async_auth_flow", fake_base_flow)
+
+    sentinel = SimpleNamespace(headers={})
+    yielded = []
+
+    async def drive():
+        gen = provider.async_auth_flow(sentinel)
+        while True:
+            try:
+                out = await gen.__anext__()
+            except StopAsyncIteration:
+                return
+            yielded.append(out)
+            try:
+                await gen.asend(None)
+            except StopAsyncIteration:
+                return
+
+    asyncio.run(drive())
+
+    assert yielded == [sentinel], (
+        f"bridge yielded {len(yielded)} outgoing request(s); the refresh POST "
+        f"should have been skipped because the token was already rotated"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stale_skip_flag_does_not_swallow_resource_request(tmp_path, monkeypatch):
+    """A skip flag leaked by an aborted refresh must not swallow requests (F1).
+
+    The bridge's skip branch is positional: before the fix, a
+    ``_hermes_refresh_skipped`` left True by a cancelled refresh would suppress
+    the *next* flow's first ``yield`` even when that yield was the resource
+    request itself, silently dropping the MCP call for the provider's lifetime.
+    This drives the real bridge (real SDK generator) with a stuck flag and a
+    valid token and asserts the resource request is still delivered and the
+    flag is cleared.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+
+    provider = _make_provider(
+        tmp_path,
+        monkeypatch,
+        in_memory_token={"access_token": "at-0", "refresh_token": "rt-0"},
+    )
+    # Valid token -> the SDK yields the resource request as its first outgoing.
+    provider.context.update_token_expiry(provider.context.current_tokens)
+    provider._initialized = True
+    provider.context.oauth_metadata = None
+    # Simulate the flag leaked by an aborted refresh (the F1 wedge).
+    provider._hermes_refresh_skipped = True
+
+    sentinel = SimpleNamespace(headers={})
+    gen = provider.async_auth_flow(sentinel)
+
+    # The resource request must be delivered, not swallowed.
+    out = await gen.__anext__()
+    assert out is sentinel
+
+    # Completing the flow must clear the leaked flag (bridge finally).
+    try:
+        await gen.asend(_fake_response(200, b"{}"))
+    except StopAsyncIteration:
+        pass
+    assert provider._hermes_refresh_skipped is False
+
+
+@pytest.mark.asyncio
+async def test_adopt_expired_rotated_token_still_posts_refresh(tmp_path, monkeypatch):
+    """Adopting an already-expired rotated pair must NOT skip the POST (F2).
+
+    ``get_tokens()`` rewrites ``expires_in`` to remaining seconds (0 when
+    expired), so a sibling may have rotated the refresh token into a pair that
+    has since lapsed. Adopting that pair and *skipping* the refresh would drop
+    straight into browser re-auth; the correct action is to adopt the unspent
+    refresh token and still POST it.
+    """
+    from urllib.parse import parse_qs
+
+    from mcp.shared.auth import OAuthToken
+    from tools.mcp_oauth import HermesTokenStorage
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+
+    storage = HermesTokenStorage("srv")
+    # Disk holds a rotated pair whose access token has already expired.
+    await storage.set_tokens(
+        OAuthToken(access_token="at-1", refresh_token="rt-1", expires_in=0)
+    )
+
+    provider = _make_provider(
+        tmp_path,
+        monkeypatch,
+        in_memory_token={"access_token": "at-0", "refresh_token": "rt-0"},
+    )
+
+    refresh_request = await provider._refresh_token()
+
+    # Adopted the rotated pair (rt-1) but, because it is expired, the POST must
+    # NOT be skipped — the request is still built from the adopted token.
+    assert provider.context.current_tokens.refresh_token == "rt-1"
+    assert getattr(provider, "_hermes_refresh_skipped", False) is False
+
+    refresh_token = parse_qs(refresh_request.content.decode())["refresh_token"][0]
+    assert refresh_token == "rt-1"  # POSTs the adopted, unspent refresh token
+
+    # Lock stays held until _handle_refresh_response, then released on success.
+    assert getattr(provider, "_hermes_refresh_lock", None) is not None
+    result = await provider._handle_refresh_response(
+        _fake_response(
+            200,
+            json.dumps(
+                {
+                    "access_token": "at-2",
+                    "refresh_token": "rt-2",
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                }
+            ).encode(),
+        )
+    )
+    assert result is True
+    assert provider.context.current_tokens.refresh_token == "rt-2"
+    assert getattr(provider, "_hermes_refresh_lock", None) is None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_real_bridge_rotates_once(tmp_path, monkeypatch):
+    """Two real bridges sharing one token file rotate exactly once (F3).
+
+    Drives the actual ``async_auth_flow`` bridge (real SDK generator) for two
+    providers against one token file, asserting exactly one refresh POST and
+    that both clients converge on the winner's rotated pair. This exercises the
+    production skip branch under concurrency — not the re-implemented helper —
+    so the bridge's None-sentinel contract is validated against the real SDK.
+    """
+    import time
+    from urllib.parse import parse_qs
+
+    from mcp.shared.auth import OAuthToken
+    from tools.mcp_oauth import HermesTokenStorage
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+
+    storage = HermesTokenStorage("srv")
+    await storage.set_tokens(
+        OAuthToken(access_token="at-0", refresh_token="rt-0", expires_in=3600)
+    )
+
+    def _stale_provider():
+        p = _make_provider(
+            tmp_path,
+            monkeypatch,
+            in_memory_token={"access_token": "at-0", "refresh_token": "rt-0"},
+        )
+        # Stale in-memory token -> the SDK takes the refresh branch.
+        p.context.token_expiry_time = time.time() - 3600
+        p._initialized = True
+        p.context.oauth_metadata = None
+        return p
+
+    provider_a = _stale_provider()
+    provider_b = _stale_provider()
+    assert provider_a.context.storage is not provider_b.context.storage
+    assert (
+        provider_a.context.storage._tokens_path()
+        == provider_b.context.storage._tokens_path()
+    )
+
+    endpoint = _SingleUseTokenEndpoint()
+    outcomes: list[str] = []
+
+    async def drive(provider, sentinel):
+        gen = provider.async_auth_flow(sentinel)
+        out = await gen.__anext__()
+        if out is sentinel:
+            # Loser: adopted the winner's rotated pair, delivered the resource
+            # request without POSTing the now-spent token.
+            outcomes.append("skip")
+        else:
+            # Winner: the first outgoing is the refresh POST.
+            outcomes.append("post")
+            refresh_token = parse_qs(out.content.decode())["refresh_token"][0]
+            status, body = await endpoint.post(refresh_token)
+            out2 = await gen.asend(_fake_response(status, body))
+            assert out2 is sentinel
+        try:
+            await gen.asend(_fake_response(200, b"{}"))
+        except StopAsyncIteration:
+            pass
+
+    await asyncio.gather(
+        drive(provider_a, SimpleNamespace(headers={})),
+        drive(provider_b, SimpleNamespace(headers={})),
+    )
+
+    # Exactly one process ever posted, and only the original token was used.
+    assert sorted(outcomes) == ["post", "skip"], f"outcomes: {outcomes!r}"
+    assert endpoint.calls == ["rt-0"], f"unexpected refresh POSTs: {endpoint.calls!r}"
+    # Both clients converged on the same fresh pair — no invalidation loop.
+    assert provider_a.context.current_tokens.refresh_token == "rt-1"
+    assert provider_b.context.current_tokens.refresh_token == "rt-1"
+    disk = await storage.get_tokens()
+    assert disk is not None
+    assert disk.refresh_token == "rt-1"
+
+
+@pytest.mark.asyncio
+async def test_bridge_cancellation_releases_flock(tmp_path, monkeypatch):
+    """Closing the bridge mid-refresh must release the cross-process flock.
+
+    The bridge ``async_auth_flow`` ``finally`` releases the flock when the
+    generator is cancelled after ``_refresh_token`` acquired it but before
+    ``_handle_refresh_response`` released it. Without this, one cancelled
+    refresh leaks the flock and wedges every other process on this token file
+    for the lock timeout.
+    """
+    from mcp.shared.auth import OAuthToken
+    from tools.mcp_oauth import HermesTokenStorage
+
+    import time
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+
+    storage = HermesTokenStorage("srv")
+    await storage.set_tokens(
+        OAuthToken(access_token="at-0", refresh_token="rt-0", expires_in=3600)
+    )
+
+    provider = _make_provider(
+        tmp_path,
+        monkeypatch,
+        in_memory_token={"access_token": "at-0", "refresh_token": "rt-0"},
+    )
+    provider._initialized = True
+    # Expire the in-memory token so the SDK takes the refresh branch; disk and
+    # memory agree (no adopt), so _refresh_token acquires the flock and yields
+    # a real refresh POST while still holding it.
+    provider.context.token_expiry_time = time.time() - 5.0
+    provider.context.oauth_metadata = None
+
+    sentinel = SimpleNamespace(headers={})
+    gen = provider.async_auth_flow(sentinel)
+    outgoing = await gen.__anext__()
+    # The first outgoing is the refresh POST (not the resource request), and
+    # the cross-process flock is held across it.
+    assert outgoing is not sentinel
+    assert getattr(provider, "_hermes_refresh_lock", None) is not None
+
+    # Cancel the flow before feeding a response -> the bridge finally runs.
+    await gen.aclose()
+
+    assert getattr(provider, "_hermes_refresh_lock", None) is None
+    # A fresh lock must acquire immediately, proving the flock was released
+    # rather than merely nulling the provider's attribute.
+    relock = storage.refresh_lock(timeout_seconds=2)
+    await relock.acquire()
+
+
+@pytest.mark.asyncio
+async def test_bridge_resource_cancellation_preserves_concurrent_refresh(
+    tmp_path, monkeypatch
+):
+    """Closing the bridge at the resource yield must not stomp a sibling's refresh.
+
+    The bridge releases ``context.lock`` around the resource request, so a
+    second flow on the same cached provider can enter ``_refresh_token`` (set
+    ``_hermes_refresh_skipped`` and hold ``_hermes_refresh_lock``) while this
+    flow is suspended at the resource yield. If this flow is then cancelled,
+    its ``finally`` used to clear the flag and release the flock
+    UNCONDITIONALLY, re-POSTing the sibling's spent refresh token and
+    reproducing the browser-re-auth loop. The ownership gate must leave a
+    concurrent refresh's flag+flock untouched when this flow no longer owns
+    them (``resource_lock_released`` is True at the resource yield).
+    """
+    from mcp.shared.auth import OAuthToken
+    from tools.mcp_oauth import HermesTokenStorage
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+
+    storage = HermesTokenStorage("srv")
+    await storage.set_tokens(
+        OAuthToken(access_token="at-0", refresh_token="rt-0", expires_in=3600)
+    )
+
+    provider = _make_provider(
+        tmp_path,
+        monkeypatch,
+        in_memory_token={"access_token": "at-0", "refresh_token": "rt-0"},
+    )
+    # Valid token -> the SDK yields the resource request as its first outgoing,
+    # so the bridge releases context.lock (resource_lock_released=True).
+    provider.context.update_token_expiry(provider.context.current_tokens)
+    provider._initialized = True
+    provider.context.oauth_metadata = None
+
+    # A "concurrent" flow has acquired the cross-process flock and set the skip
+    # flag; this flow must not touch either when it is cancelled at the
+    # resource yield.
+    held_lock = storage.refresh_lock(timeout_seconds=2)
+    await held_lock.acquire()
+    provider._hermes_refresh_lock = held_lock
+    provider._hermes_refresh_skipped = True
+
+    sentinel = SimpleNamespace(headers={})
+    gen = provider.async_auth_flow(sentinel)
+    outgoing = await gen.__anext__()
+    assert outgoing is sentinel  # first outgoing is the resource request
+
+    await gen.aclose()
+
+    # The concurrent refresh's state survives: the skip flag is untouched and
+    # the held flock was not released (release() would null the fd handle).
+    assert provider._hermes_refresh_skipped is True
+    assert provider._hermes_refresh_lock is held_lock
+    assert held_lock._fh is not None
+
+    # Prove the flock is genuinely still held: a fresh lock on the same path
+    # must not acquire within a short window.
+    with pytest.raises(TimeoutError):
+        await storage.refresh_lock(timeout_seconds=1).acquire()

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -29,6 +29,16 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import parse_qs, urlparse
 
+try:
+    import fcntl as _fcntl
+except ImportError:  # pragma: no cover — Windows
+    _fcntl = None
+
+try:
+    import msvcrt as _msvcrt
+except ImportError:  # pragma: no cover — POSIX
+    _msvcrt = None
+
 from hermes_constants import secure_parent_dir
 from tools.mcp_dashboard_oauth import contextvar_set as _contextvar_set, get_dashboard_oauth_flow
 
@@ -92,6 +102,13 @@ _oauth_interactive_forced = contextvars.ContextVar("_oauth_interactive_forced", 
 # OAuthNonInteractiveError("user_skipped") so MCP setup continues without this server.
 _SKIP_TOKENS = frozenset({"skip", "cancel", "s", "n", "no", "q", "quit"})
 _USER_SKIPPED_SENTINEL = "__hermes_user_skipped__"
+
+# Cross-process refresh lock timeout. Bounds how long a second process waits
+# for the current holder of a single-use refresh token to finish rotating it
+# before giving up. Mirrors the spirit of AUTH_LOCK_TIMEOUT_SECONDS plus a
+# refresh-POST margin in hermes_cli/auth.py; the MCP token POST is bounded by
+# the SDK client timeout, so this is a generous ceiling, not a hot path.
+_REFRESH_LOCK_TIMEOUT_SECONDS = 30.0
 
 
 def _get_token_dir(hermes_home: str | Path | None = None) -> Path:
@@ -270,6 +287,80 @@ def _model_json(model: Any) -> dict:
     return model.model_dump(mode="json", exclude_none=True)
 
 
+class _AsyncCrossProcessLock:
+    """Cross-process advisory lock with event-loop-friendly acquisition.
+
+    Serializes a single-use refresh-token rotation across Hermes *processes*
+    (the gateway, a one-shot CLI, a cron job) that share one token file.
+    Mirrors the synchronous ``_file_lock`` helper in ``hermes_cli/auth.py``
+    but acquires asynchronously — non-blocking ``flock`` plus
+    ``await asyncio.sleep`` retries — so the MCP event loop stays responsive
+    while waiting for the current holder.
+
+    ``flock`` locks the open *file description*, so two independent
+    ``open()`` calls in the same process still contend. That is what lets the
+    concurrency test exercise the cross-process path with two providers in a
+    single interpreter.
+    """
+
+    def __init__(self, lock_path: Path, timeout_seconds: float) -> None:
+        self._lock_path = Path(lock_path)
+        self._timeout_seconds = max(1.0, float(timeout_seconds))
+        self._fh = None
+
+    async def acquire(self) -> None:
+        self._lock_path.parent.mkdir(parents=True, exist_ok=True)
+        self._fh = self._lock_path.open("a+", encoding="utf-8")
+        deadline = time.monotonic() + self._timeout_seconds
+        while True:
+            try:
+                if _fcntl is not None:
+                    _fcntl.flock(
+                        self._fh.fileno(), _fcntl.LOCK_EX | _fcntl.LOCK_NB
+                    )
+                elif _msvcrt is not None:
+                    # msvcrt byte-range locking needs >=1 byte at the cursor.
+                    if self._lock_path.stat().st_size == 0:
+                        try:
+                            self._fh.write(" ")
+                            self._fh.flush()
+                        except OSError:
+                            pass
+                    self._fh.seek(0)
+                    _msvcrt.locking(self._fh.fileno(), _msvcrt.LK_NBLCK, 1)
+                else:
+                    # No cross-process primitive available (neither fcntl nor
+                    # msvcrt): best-effort — proceed without serialization.
+                    return
+                return
+            except (BlockingIOError, OSError):
+                if time.monotonic() >= deadline:
+                    self.release()
+                    raise TimeoutError(
+                        f"Timed out waiting for MCP OAuth refresh lock: "
+                        f"{self._lock_path}"
+                    )
+                await asyncio.sleep(0.05)
+
+    def release(self) -> None:
+        """Release the lock and close the fd (idempotent; synchronous)."""
+        if self._fh is None:
+            return
+        fh = self._fh
+        self._fh = None
+        try:
+            if _fcntl is not None:
+                _fcntl.flock(fh.fileno(), _fcntl.LOCK_UN)
+            elif _msvcrt is not None:
+                try:
+                    fh.seek(0)
+                    _msvcrt.locking(fh.fileno(), _msvcrt.LK_UNLCK, 1)
+                except OSError:
+                    pass
+        finally:
+            fh.close()
+
+
 class HermesTokenStorage:
     """Persist OAuth state as ``HERMES_HOME/mcp-tokens/<server_name>`` + ``.json`` (tokens),
     ``.client.json`` (client info), ``.meta.json`` (server metadata), ``.cimd-off`` (CIMD refused)."""
@@ -285,6 +376,24 @@ class HermesTokenStorage:
     _client_info_path = partialmethod(_path, ".client.json")
     _meta_path = partialmethod(_path, ".meta.json")
     _cimd_rejected_path = partialmethod(_path, ".cimd-off")
+
+    def _refresh_lock_path(self) -> Path:
+        return self._tokens_path().with_suffix(".lock")
+
+    def refresh_lock(
+        self, timeout_seconds: float | None = None
+    ) -> "_AsyncCrossProcessLock":
+        """Return the cross-process lock guarding this server's token refresh.
+
+        Serializes the read-fresh -> POST -> write-back sequence across
+        Hermes processes sharing this server's token file, so a single-use
+        refresh token is rotated by exactly one process and every other
+        process adopts the winner's fresh token instead of re-POSTing the
+        spent one.
+        """
+        if timeout_seconds is None:
+            timeout_seconds = _REFRESH_LOCK_TIMEOUT_SECONDS
+        return _AsyncCrossProcessLock(self._refresh_lock_path(), timeout_seconds)
 
     def _state_paths(self) -> tuple[Path, Path, Path]:
         return self._tokens_path(), self._client_info_path(), self._meta_path()

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
 
-from tools.mcp_oauth_provider import HermesProviderMixin
+from tools.mcp_oauth_provider import HermesProviderMixin, _AlreadyAuthorized
 
 logger = logging.getLogger(__name__)
 
@@ -244,6 +244,8 @@ class HermesMCPOAuthProvider(HermesProviderMixin, *_SDK_BASES):
                 if outgoing is request:
                     tokens = self.context.current_tokens
                     sent_access_token = tokens.access_token if tokens is not None else None
+                    # The SDK holds context.lock for its whole generator, even while HTTPX waits on
+                    # the MCP request. Release it for that request only; OAuth transitions stay serialized.
                     self.context.lock.release()
                     resource_lock_released = True
                 if getattr(self, "_hermes_refresh_skipped", False) and (
@@ -279,9 +281,20 @@ class HermesMCPOAuthProvider(HermesProviderMixin, *_SDK_BASES):
                 # path) rather than a real httpx2.Response; the SDK's
                 # _handle_refresh_response short-circuits before reading it.
                 outgoing = await inner.asend(incoming)  # type: ignore[arg-type]
+        except _AlreadyAuthorized:
+            # A concurrent flow already completed authorization for this server while this flow
+            # waited on the per-server authorization mutex. The re-check loaded that token into
+            # self.context; adopt it and retry the request instead of a second authorization.
+            self._add_auth_header(request)
+            await inner.aclose()
+            retry_after_concurrent_auth = True
         except StopAsyncIteration:
             self._persist_oauth_metadata_if_changed()  # metadata discovered lazily in the 401 branch
         finally:
+            # Release the per-server authorization mutex if this flow still holds it — a
+            # cancellation that lands between the acquire in _perform_authorization_code_grant and
+            # the release in _handle_token_response has no other release point. Idempotent.
+            self._hermes_release_auth_lock()
             # If the refresh generator was cancelled between _refresh_token
             # (which acquires the cross-process lock) and
             # _handle_refresh_response (which releases it), the lock would
@@ -329,6 +342,12 @@ class MCPOAuthManager:
         self._entries_lock = threading.Lock()
         # Strong refs to in-flight 401 tasks so the loop's weak bookkeeping cannot GC them mid-run.
         self._inflight_tasks: set[asyncio.Task] = set()
+        # Per-server authorization mutexes, keyed by server_url so a duplicate/rebuilt provider
+        # for the same endpoint serializes behind the in-flight authorization. Each entry is
+        # (owning_event_loop, lock): ``asyncio.Lock`` pins to the loop it is first contended on,
+        # and the MCP loop is torn down and recreated per idle probe, so a lock left bound to a
+        # dead loop would raise "bound to a different event loop" on a later racing authorization.
+        self._authorization_locks: dict[str, tuple[asyncio.AbstractEventLoop, asyncio.Lock]] = {}
 
     def get_or_build_provider(self, server_name: str, server_url: str, oauth_config: Optional[dict]) -> Optional[Any]:
         """Cached OAuth provider for ``server_name``, built on first use (rebuilt when ``server_url`` changes);
@@ -346,6 +365,26 @@ class MCPOAuthManager:
                 if entry.provider is not None:
                     entry.provider._hermes_home = key[0]
             return entry.provider
+
+    def authorization_lock(self, server_url: str) -> asyncio.Lock:
+        """A per-server authorization mutex shared across providers for the same endpoint.
+
+        A duplicate/rebuilt provider carries its own ``context.lock``, so the SDK's serialization
+        does not span them; this shared mutex makes "one login == one authorization transaction"
+        by serializing the authorization step itself (redirect + callback + token exchange).
+
+        Keyed by server_url but loop-bound: ``asyncio.Lock`` pins to the loop it is first
+        contended on, and the MCP loop is torn down and recreated per idle probe. Recreate the
+        mutex when the running loop changed so a stale loop-bound lock can never raise "bound to
+        a different event loop" on a later (racing) authorization.
+        """
+        loop = asyncio.get_running_loop()
+        with self._entries_lock:
+            holder = self._authorization_locks.get(server_url)
+            if holder is None or holder[0] is not loop:
+                holder = (loop, asyncio.Lock())
+                self._authorization_locks[server_url] = holder
+            return holder[1]
 
     @staticmethod
     def _key(server_name: str, hermes_home: str | Path | None = None) -> tuple[str, str]:

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -19,6 +19,22 @@ from tools.mcp_oauth_provider import HermesProviderMixin
 
 logger = logging.getLogger(__name__)
 
+
+class _SkippedRefreshResponse:
+    """Stand-in 2xx refresh response for the single-refresher skip path.
+
+    Duck-typed (``status_code`` + ``aread()``) so that if the pinned SDK ever
+    inspects the yielded response before calling ``_handle_refresh_response``,
+    it still sees a coherent 2xx instead of ``None``. ``_handle_refresh_response``
+    short-circuits on the skip flag before reading it either way.
+    """
+
+    status_code = 200
+
+    async def aread(self) -> bytes:
+        return b""
+
+
 try:
     from mcp.client.auth.oauth2 import OAuthClientProvider as _SDKOAuthClientProvider
     _SDK_BASES: tuple = (_SDKOAuthClientProvider,)
@@ -230,7 +246,20 @@ class HermesMCPOAuthProvider(HermesProviderMixin, *_SDK_BASES):
                     sent_access_token = tokens.access_token if tokens is not None else None
                     self.context.lock.release()
                     resource_lock_released = True
-                incoming = yield outgoing
+                if getattr(self, "_hermes_refresh_skipped", False) and (
+                    outgoing is not request
+                ):
+                    # _refresh_token adopted a token rotated by a sibling
+                    # process; do not POST the now-spent refresh token.
+                    # Feed a duck-typed 2xx stub so _handle_refresh_response
+                    # short-circuits cleanly (it returns True on the skip
+                    # flag before reading the response).
+                    # The `outgoing is not request` guard ensures a stale
+                    # skip flag can only suppress a refresh POST, never the
+                    # resource request itself (F1).
+                    incoming = _SkippedRefreshResponse()
+                else:
+                    incoming = yield outgoing
                 if resource_lock_released:
                     await self.context.lock.acquire()
                     resource_lock_released = False
@@ -246,10 +275,36 @@ class HermesMCPOAuthProvider(HermesProviderMixin, *_SDK_BASES):
                 # Sniff the response for a dead-client-registration signal before handing it back to the SDK
                 # (best-effort, GH#36767).
                 await self._maybe_flag_poisoned_client(incoming)
-                outgoing = await inner.asend(incoming)
+                # `incoming` may be the _SkippedRefreshResponse stub (skip
+                # path) rather than a real httpx2.Response; the SDK's
+                # _handle_refresh_response short-circuits before reading it.
+                outgoing = await inner.asend(incoming)  # type: ignore[arg-type]
         except StopAsyncIteration:
             self._persist_oauth_metadata_if_changed()  # metadata discovered lazily in the 401 branch
         finally:
+            # If the refresh generator was cancelled between _refresh_token
+            # (which acquires the cross-process lock) and
+            # _handle_refresh_response (which releases it), the lock would
+            # otherwise leak and wedge every other process on the flock.
+            # Clear the skip flag for the same reason: a cancelled refresh
+            # must not leave a sticky skip that swallows the next resource
+            # request (F1).
+            #
+            # Ownership gate: the flock and skip flag are held ONLY for the
+            # refresh POST, which is yielded before the resource request.
+            # _handle_refresh_response releases the flock and clears the
+            # flag before the resource request is ever yielded, so by the
+            # time resource_lock_released is True this flow no longer owns
+            # them. A concurrent flow on the same cached provider instance
+            # may have acquired the flock and set the flag while this flow
+            # was suspended at the resource yield; releasing/clearing them
+            # unconditionally would stomp that concurrent flow's live
+            # refresh (re-POSTing a spent refresh token -> browser re-auth).
+            # Only touch them when this flow still owns them.
+            if not resource_lock_released:
+                self._hermes_refresh_skipped = False
+                if getattr(self, "_hermes_refresh_lock", None) is not None:
+                    self._hermes_release_refresh_lock()
             if resource_lock_released:
                 # Balance the SDK's surrounding ``async with`` even when HTTPX cancels/closes the
                 # flow mid-request; shield only this local bookkeeping.

--- a/tools/mcp_oauth_provider.py
+++ b/tools/mcp_oauth_provider.py
@@ -8,12 +8,21 @@ modules keep their own subclass (logger name, disk-watch hooks) on top of it.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from tools.mcp_oauth import HermesTokenStorage
 logger = logging.getLogger(__name__)
+
+
+class _AlreadyAuthorized(Exception):
+    """Internal control signal: a concurrent flow already completed authorization for this
+    server while this flow waited on the per-server authorization mutex. The
+    ``async_auth_flow`` bridge converts it into a token-holding retry instead of running a
+    second (duplicate) authorization that would print a second URL and re-bind the callback
+    port (EADDRINUSE)."""
 
 
 class HermesProviderMixin:
@@ -41,6 +50,13 @@ class HermesProviderMixin:
         # flags that a sibling already rotated it and the POST is omitted.
         self._hermes_refresh_lock = None
         self._hermes_refresh_skipped = False
+        # Per-server authorization mutex held across the authorization step
+        # (redirect + callback + token exchange). Acquired in
+        # _perform_authorization_code_grant, released in _handle_token_response
+        # (or the bridge's finally on cancellation). Stores (owning_task, lock) so
+        # release is task-scoped: a cancelled flow must not release a sibling flow's
+        # mutex on the same cached provider. None when not held.
+        self._hermes_auth_lock = None
 
     def _prepare_token_request(self, request):
         """Stamp the configured User-Agent onto a token/refresh request."""
@@ -92,15 +108,93 @@ class HermesProviderMixin:
     async def _handle_token_response(self, response):
         """Accept any 2xx token response; never echo the body into errors."""
         from mcp.client.auth.oauth2 import OAuthTokenError
-        if not (200 <= response.status_code < 300):
-            raise OAuthTokenError(f"Token exchange failed ({response.status_code})")
-        from httpx import HTTPError
-        from mcp.client.auth.utils import handle_token_response_scopes
         try:
-            token_response = await handle_token_response_scopes(response)
-        except (HTTPError, OAuthTokenError):
-            raise OAuthTokenError("Invalid token response") from None
-        await self._store_tokens(token_response)
+            if not (200 <= response.status_code < 300):
+                raise OAuthTokenError(f"Token exchange failed ({response.status_code})")
+            from httpx import HTTPError
+            from mcp.client.auth.utils import handle_token_response_scopes
+            try:
+                token_response = await handle_token_response_scopes(response)
+            except (HTTPError, OAuthTokenError):
+                raise OAuthTokenError("Invalid token response") from None
+            await self._store_tokens(token_response)
+        finally:
+            # The token exchange is the last leg of the authorization step; release the
+            # per-server authorization mutex even on a failed exchange so the next flow can
+            # retry (or skip) rather than wedge behind a leaked lock.
+            self._hermes_release_auth_lock()
+
+    def _hermes_release_auth_lock(self) -> None:
+        """Release the per-server authorization mutex if THIS flow holds it (idempotent).
+
+        Task-scoped: the mutex is acquired inside one flow's ``async_auth_flow`` generator and
+        released later in ``_handle_token_response`` or the bridge's ``finally`` — always the
+        same task. A concurrent flow on the same cached provider may hold the mutex while this
+        flow is cancelled/suspended; releasing unconditionally would stomp that sibling's
+        still-open authorization. Only the acquiring task releases.
+        """
+        holder = getattr(self, "_hermes_auth_lock", None)  # tests may build via __new__
+        if holder is None:
+            return
+        task, lock = holder
+        if task is not asyncio.current_task():
+            return  # not this flow's mutex — a sibling holds it
+        self._hermes_auth_lock = None
+        lock.release()
+
+    async def _hermes_adopt_external_authorization(self) -> bool:
+        """Adopt a token a concurrent flow already minted for this server, if any.
+
+        A sibling provider for the same endpoint keeps its own in-memory context, so the
+        freshly-minted token is only visible through shared storage. Returns True when a valid
+        token was adopted (the caller should skip re-authorization instead of printing a second
+        URL and re-binding the callback port).
+        """
+        from tools.mcp_oauth import HermesTokenStorage
+
+        storage = self.context.storage
+        if not isinstance(storage, HermesTokenStorage):
+            return False
+        try:
+            fresh = await storage.get_tokens()
+        except Exception:
+            return False
+        if fresh is None or not fresh.access_token:
+            return False
+        # Adopt only a token that DIFFERS from the one this flow already holds. The rejected
+        # or stale token whose 401/403 drove us to the authorization step must not be re-adopted,
+        # or a 403 step-up / 401-with-unexpired-revoked-token would retry the SAME bad token
+        # forever instead of re-authorizing. Mirrors _hermes_adopt_rotated_token.
+        current = self.context.current_tokens
+        if current is not None and current.access_token == fresh.access_token:
+            return False
+        self.context.current_tokens = fresh
+        self.context.update_token_expiry(fresh)
+        return self.context.is_token_valid()
+
+    async def _perform_authorization_code_grant(self):
+        """Serialize the authorization step across providers for the same server.
+
+        The SDK's ``context.lock`` serializes a single provider's flows, but the bridge releases
+        it during the resource round-trip, and a duplicate/rebuilt provider for the same endpoint
+        carries its own lock. Without a shared mutex two token-less requests both reach the
+        authorization step, print two URLs with distinct PKCE states, and collide on the resolved
+        callback port (EADDRINUSE). The mutex is held through the token exchange
+        (``_handle_token_response`` releases it), so a loser that wins the mutex later adopts the
+        winner's token and skips re-authorization instead.
+        """
+        from tools.mcp_oauth_manager import get_manager
+
+        lock = get_manager().authorization_lock(self.context.server_url)
+        await lock.acquire()
+        self._hermes_auth_lock = (asyncio.current_task(), lock)
+        try:
+            if await self._hermes_adopt_external_authorization():
+                raise _AlreadyAuthorized()
+            return await super()._perform_authorization_code_grant()
+        except BaseException:
+            self._hermes_release_auth_lock()
+            raise
 
     async def _handle_refresh_response(self, response) -> bool:
         """Accept any 2xx refresh response; never log the body."""

--- a/tools/mcp_oauth_provider.py
+++ b/tools/mcp_oauth_provider.py
@@ -34,6 +34,13 @@ class HermesProviderMixin:
         # oauth.user_agent — stamped onto token-endpoint requests only; some authorization servers/WAFs
         # reject httpx's default (#75576).
         self._hermes_token_user_agent = token_user_agent
+        # Cross-process single-refresher state (see _refresh_token /
+        # _handle_refresh_response). _hermes_refresh_lock is held across the
+        # whole read-fresh -> POST -> write-back sequence so exactly one
+        # process rotates a single-use refresh token; _hermes_refresh_skipped
+        # flags that a sibling already rotated it and the POST is omitted.
+        self._hermes_refresh_lock = None
+        self._hermes_refresh_skipped = False
 
     def _prepare_token_request(self, request):
         """Stamp the configured User-Agent onto a token/refresh request."""
@@ -60,7 +67,22 @@ class HermesProviderMixin:
 
     async def _refresh_token(self):
         self._coerce_client_secret_post()
-        return self._prepare_token_request(await super()._refresh_token())
+        # Single-refresher discipline: serialize the rotation across
+        # processes, then re-read the token file so a sibling process's
+        # fresh token is adopted instead of re-POSTing the spent one.
+        self._hermes_refresh_skipped = False
+        await self._hermes_acquire_refresh_lock()
+        try:
+            self._hermes_refresh_skipped = await self._hermes_adopt_rotated_token()
+            request = await super()._refresh_token()
+            return self._prepare_token_request(request)
+        except BaseException:
+            # Release the lock AND clear the skip flag so a failed
+            # _refresh_token never leaves a sticky skip that would swallow
+            # the next resource request on this cached provider (F1).
+            self._hermes_refresh_skipped = False
+            self._hermes_release_refresh_lock()
+            raise
 
     async def _store_tokens(self, token_response) -> None:
         self.context.current_tokens = token_response
@@ -82,21 +104,112 @@ class HermesProviderMixin:
 
     async def _handle_refresh_response(self, response) -> bool:
         """Accept any 2xx refresh response; never log the body."""
-        if not (200 <= response.status_code < 300):
-            self._hermes_logger.warning("Token refresh failed: %s", response.status_code)
-            self.context.clear_tokens()
-            return False
-        from httpx import HTTPError
-        from mcp.shared.auth import OAuthToken
-        from pydantic import ValidationError
         try:
-            token_response = OAuthToken.model_validate_json(await response.aread())
-        except (HTTPError, ValidationError):
-            self._hermes_logger.warning("Invalid refresh response: %s", response.status_code)
-            self.context.clear_tokens()
+            if self._hermes_refresh_skipped:
+                # A sibling already rotated the token and we adopted it in
+                # _refresh_token; the bridge fed us no real response.
+                return True
+            if not (200 <= response.status_code < 300):
+                self._hermes_logger.warning("Token refresh failed: %s", response.status_code)
+                self.context.clear_tokens()
+                return False
+            from httpx import HTTPError
+            from mcp.shared.auth import OAuthToken
+            from pydantic import ValidationError
+            try:
+                token_response = OAuthToken.model_validate_json(await response.aread())
+            except (HTTPError, ValidationError):
+                self._hermes_logger.warning("Invalid refresh response: %s", response.status_code)
+                self.context.clear_tokens()
+                return False
+            await self._store_tokens(token_response)
+            return True
+        finally:
+            self._hermes_refresh_skipped = False
+            self._hermes_release_refresh_lock()
+
+    async def _hermes_acquire_refresh_lock(self) -> None:
+        """Acquire the cross-process refresh lock for this server's token file.
+
+        No-op when storage is not a :class:`HermesTokenStorage`
+        (tests/mocks), in which case there is no shared on-disk token to
+        serialize.
+        """
+        from tools.mcp_oauth import HermesTokenStorage
+
+        storage = self.context.storage
+        if not isinstance(storage, HermesTokenStorage):
+            return
+        # Defensive: never orphan a still-held lock from a prior flow on
+        # this cached provider instance (release is idempotent). Orphaning
+        # would GC the old fd and silently release the flock out from under
+        # the first flow's still-open critical section.
+        self._hermes_release_refresh_lock()
+        self._hermes_refresh_lock = storage.refresh_lock()
+        await self._hermes_refresh_lock.acquire()
+
+    def _hermes_release_refresh_lock(self) -> None:
+        """Release the cross-process refresh lock (idempotent)."""
+        lock = self._hermes_refresh_lock
+        self._hermes_refresh_lock = None
+        if lock is not None:
+            lock.release()
+
+    async def _hermes_adopt_rotated_token(self) -> bool:
+        """Re-read the token file and adopt a sibling's rotated token.
+
+        Returns True when the on-disk token differs from our in-memory one
+        AND the adopted pair is still usable — the caller must then skip
+        the refresh POST (a sibling already rotated it). Returns False when
+        we still hold the latest token and should proceed with the refresh.
+
+        If the adopted pair is already *expired*, we still adopt it (its
+        refresh token is the unspent one) but return False so the caller
+        POSTs the refresh with the adopted refresh token rather than
+        skipping straight into a browser re-authorization (F2).
+
+        Best-effort: any read/parse failure returns False so a transient
+        disk error degrades to the ordinary refresh path rather than
+        blocking rotation.
+        """
+        from tools.mcp_oauth import HermesTokenStorage
+
+        storage = self.context.storage
+        if not isinstance(storage, HermesTokenStorage):
             return False
-        await self._store_tokens(token_response)
-        return True
+        current = self.context.current_tokens
+        if current is None:
+            return False
+        try:
+            fresh = await storage.get_tokens()
+        except Exception:
+            return False
+        if fresh is None:
+            return False
+        if (
+            fresh.access_token != current.access_token
+            or fresh.refresh_token != current.refresh_token
+        ):
+            self.context.current_tokens = fresh
+            self.context.update_token_expiry(fresh)
+            # Skip the POST only when the adopted pair is still usable. An
+            # adopted-but-expired access token means the refresh token was
+            # rotated (unspent) but the pair has since lapsed: POST it
+            # rather than dropping into full browser re-auth.
+            if self.context.is_token_valid():
+                self._hermes_logger.info(
+                    "MCP OAuth '%s': adopted a token rotated by another "
+                    "process instead of re-POSTing the spent refresh token",
+                    getattr(self, "_hermes_server_name", ""),
+                )
+                return True
+            self._hermes_logger.info(
+                "MCP OAuth '%s': adopted a rotated token that has already "
+                "expired; refreshing with the adopted refresh token",
+                getattr(self, "_hermes_server_name", ""),
+            )
+            return False
+        return False
 
 
 def prepare_oauth_config(server_name: str, server_url: str, oauth_config: dict | None) -> tuple[dict, "HermesTokenStorage"]:


### PR DESCRIPTION
## Summary

Fixes the MCP login "double-attempt" bug where `hermes mcp login` triggered the OAuth browser authorization **twice**, crashing the second attempt on a callback-port collision (`EADDRINUSE`) before the user could paste the code.

Root cause: OAuth authorization wasn't serialized across duplicate provider instances. A token-less resource request would release the authorization lock for *every* flow, so two concurrent flows each opened a browser authorization and both tried to bind the same callback port.

## Fix

Serializes OAuth authorization across duplicate providers and scopes mutex release to the owning flow:

- Adopt an existing authorization mutex across duplicate provider instances instead of starting a second one.
- Bind the authorization loop to a single server instance.
- Release the mutex only from the owning flow, so a second flow can't re-trigger authorization and collide on the callback port.

## Depends on

**#103029** (serialize OAuth refresh-token rotation across processes). This PR is stacked on top of it and touches two of the same files (`tools/mcp_oauth_manager.py`, `tools/mcp_oauth_provider.py`), so it should land after #103029.

## Test Plan

- New `tests/tools/test_mcp_oauth_bidirectional.py` (383 lines) — bidirectional/provider-duplication coverage.
- 153 tests across 9 OAuth suites pass; ruff / py_compile / `git diff --check` clean.

## Review

Independently reviewed via the unmodified Claude Code CLI (opus, plan mode) — verdict **APPROVE**. Frozen identity `0a6fc45f37` / tree `78d442eac1`. Fixture-only; no live tokens touched.
