### PR TITLE
fix(dashboard): inject live _SESSION_TOKEN into served HTML

### DIFF
--- a/hermes_cli/web_server_dashboard.py
+++ b/hermes_cli/web_server_dashboard.py
@@ -118,9 +118,16 @@ def mount_spa(application: FastAPI):
             # See #94227, #95575.
             gated = bool(getattr(application.state, "auth_required", False))
             if full_path == "" and not gated:
+                # Live read: _SESSION_TOKEN is rebound by _apply_ssh_session_token()
+                # AFTER this module is first imported (Desktop SSH token-file path).
+                # A module-level from-import captures the pre-apply random token and
+                # the injected value never matches the token /api/ws actually checks.
+                from hermes_cli import web_server as _web_server_root
+
                 return HTMLResponse(
                     "<!doctype html><html><head><script>"
-                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(_SESSION_TOKEN)};"
+                    "window.__HERMES_SESSION_TOKEN__="
+                    f"{json.dumps(_web_server_root._SESSION_TOKEN)};"
                     "window.__HERMES_AUTH_REQUIRED__=false;"
                     f"</script></head><body>{_HEADLESS_MSG}</body></html>",
                     headers=_NO_STORE,
@@ -151,7 +158,15 @@ def mount_spa(application: FastAPI):
             return JSONResponse({"error": "Frontend not built. Run: cd web && npm run build"}, status_code=404)
         chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
         gated = bool(getattr(app.state, "auth_required", False))
-        token_js = "" if gated else f'window.__HERMES_SESSION_TOKEN__="{_SESSION_TOKEN}";'
+        # Live read — see the no_frontend() note: _SESSION_TOKEN is rebound after
+        # this module's first import on the Desktop SSH token-file path.
+        from hermes_cli import web_server as _web_server_root
+
+        token_js = (
+            ""
+            if gated
+            else f'window.__HERMES_SESSION_TOKEN__="{_web_server_root._SESSION_TOKEN}";'
+        )
         bootstrap_script = (
             f"<script>{token_js}"
             f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5125,6 +5125,69 @@ class TestHeadlessServeTokenPage:
             assert "web UI disabled" in resp.json()["error"]
             assert ws._SESSION_TOKEN not in resp.text
 
+    def test_root_injects_live_token_after_rebind(self, monkeypatch):
+        """The injected token must be resolved at request time.
+
+        Desktop SSH serves rebind ``_SESSION_TOKEN`` via
+        ``_apply_ssh_session_token()`` AFTER this module is first imported
+        (the token-file path). A module-level from-import captures the
+        pre-apply random token, and the injected value then never matches
+        what ``/api/ws`` validates — every Desktop SSH connect fails with
+        an opaque "Could not connect to Hermes gateway" despite green
+        HTTP probes.
+        """
+        import json as _json
+        import re
+
+        client, ws = self._headless_client(monkeypatch, gated=False)
+        rebinding = "b" * 64
+        monkeypatch.setattr(ws, "_SESSION_TOKEN", rebinding)
+        resp = client.get("/")
+        assert resp.status_code == 200
+        match = re.search(
+            r'window\.__HERMES_SESSION_TOKEN__\s*=\s*("(?:\\.|[^"\\])*")',
+            resp.text,
+        )
+        assert match, resp.text
+        assert _json.loads(match.group(1)) == rebinding
+
+
+class TestServeIndexLiveToken:
+    """The SPA index must inject the live ``_SESSION_TOKEN`` for the same
+    reason as TestHeadlessServeTokenPage: the token is rebound after this
+    module's first import on the Desktop SSH token-file path, and the SPA
+    reads the injected value for /api/ws auth."""
+
+    def test_index_injects_live_token_after_rebind(self, tmp_path, monkeypatch):
+        import json as _json
+        import re
+
+        from fastapi import FastAPI
+        from starlette.testclient import TestClient
+        import hermes_cli.web_server as ws
+
+        dist = tmp_path / "web_dist"
+        (dist / "assets").mkdir(parents=True)
+        (dist / "index.html").write_text(
+            "<html><head></head><body>SPA</body></html>", encoding="utf-8"
+        )
+        monkeypatch.setattr(ws, "WEB_DIST", dist)
+        monkeypatch.delenv("HERMES_SERVE_HEADLESS", raising=False)
+        spa_app = FastAPI()
+        _web_server_dashboard.mount_spa(spa_app)
+        client = TestClient(spa_app)
+
+        rebinding = "c" * 64
+        monkeypatch.setattr(ws, "_SESSION_TOKEN", rebinding)
+        resp = client.get("/")
+        assert resp.status_code == 200
+        match = re.search(
+            r'window\.__HERMES_SESSION_TOKEN__\s*=\s*("(?:\\.|[^"\\])*")',
+            resp.text,
+        )
+        assert match, resp.text
+        assert _json.loads(match.group(1)) == rebinding
+
 
 class TestHashedAssetCacheHeaders:
     """Hashed /assets/* responses must be immutable-cacheable; index.html


### PR DESCRIPTION
## What does this PR do?

Fixes a regression introduced by 2497ec5126 (the `web_server` decomposition):
Desktop SSH connections fail **every** connect attempt with an opaque
"Could not connect to Hermes gateway" on the boot overlay, even though all
HTTP probes are green.

**Root cause.** `web_server_dashboard.py` injects the session token into the
served HTML via a module-level `from hermes_cli.web_server import _SESSION_TOKEN`.
A from-import copies the **value at import time**. On the Desktop SSH path,
`start_server()` calls `_apply_ssh_session_token()` — rebinding the token to
the one from the Desktop-provisioned token file — **after** that module is
first imported. Result:

1. the headless token page and the SPA index inject the **pre-apply random token, forever**;
2. the Electron renderer adopts that served token (`adoptServedDashboardToken`) as its `/api/ws` credential;
3. the WS gate (`_ws_auth_reason`) reads the **live** `web_server._SESSION_TOKEN`;
4. mismatch → pre-accept close (4401) → "Could not connect", on every dial, every reconnect, every fresh spawn.

The WS gate kept reading the live value because it lives in a module that resolves
the attribute at request time — only the *injection* side was frozen by the
from-import.

**Fix.** Both injection sites read `web_server._SESSION_TOKEN` at request time
(module attribute access, not a from-import), so the served credential always
matches what `/api/ws` validates — including any future rebind.

## Related Issue

No existing issue found (searched open+closed PRs/issues; nearest neighbors
#43720 and #96490 cover different mechanics). References context: #94227, #95575
(the token handshake page this code serves).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server_dashboard.py`
  - `no_frontend()` (headless token page): inject `web_server._SESSION_TOKEN`
    read at request time instead of the module-level captured value.
  - `_serve_index()` (SPA index): same live-read for the injected
    `window.__HERMES_SESSION_TOKEN__`.
- `tests/hermes_cli/test_web_server.py`
  - `TestHeadlessServeTokenPage.test_root_injects_live_token_after_rebind` —
    rebinding the token after mount must be reflected in the served HTML.
  - `TestServeIndexLiveToken.test_index_injects_live_token_after_rebind` —
    same regression test for the SPA index path.

## How to Test

1. Spawn an isolated SSH serve with a known token file and curl the page —
   before this fix the injected token never matches the token file:
   ```bash
   hermes serve --isolated --host 127.0.0.1 --port 0 --ssh-session-token-file <token-file>
   curl -s http://127.0.0.1:<port>/ | grep HERMES_SESSION_TOKEN
   ```
2. Regression tests: `pytest tests/hermes_cli/test_web_server.py -q -k "live_token_after_rebind"` (both pass).
3. End-to-end (verified on macOS arm64, Hermes v0.21.0): with the fix, a raw
   WebSocket handshake to `/api/ws?token=<injected value>` returns
   `101 Switching Protocols` (previously `403 Forbidden` — the pre-accept
   auth close), and the desktop connects to SSH gateways normally.

Failure signature this fixes (from `~/.hermes/logs/desktop.log`, within ~1s of
a fresh spawn, no timeouts — pure credential rejection):

```
[renderer console:main] [gateway] dial failed for scope="conn:bravobook::aluxe" profile="aluxe": Error: Could not connect to Hermes gateway
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — ran `pytest tests/hermes_cli/test_web_server.py -q`: 186 passed, my 2 new tests included. Two **pre-existing** failures in that file (`TestThemeBootstrapCSS::test_serve_index_injects_bootstrap_for_user_theme`, `test_mount_spa_dynamic_web_dist_recheck`) also fail on a pristine `origin/main` checkout in this environment (they appear sensitive to a locally-built web dist) and are untouched by this PR.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (N/A — behavior now matches the documented handshake contract)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (change is platform-neutral: a module attribute read instead of a from-import)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

WS handshake against an isolated serve, before vs after (raw stdlib probe):

```
BEFORE  GET /api/ws?token=<value injected by page>  ->  HTTP/1.1 403 Forbidden
AFTER   GET /api/ws?token=<value injected by page>  ->  HTTP/1.1 101 Switching Protocols
```

Desktop log showing the failure mode this eliminates:

```
[2026-09-04T17:01:12.209Z] [hermes] [ssh] forwarding 127.0.0.1:50736 -> 127.0.0.1:56008
[2026-09-04T17:01:12.697Z] [hermes] [ssh] connection spawned dashboard: Hermes Agent v0.21.0 ... 
[2026-09-04T17:01:13.060Z] [hermes] [renderer console:main] [gateway] dial failed for scope="conn:bravobook::aluxe" profile="aluxe": Error: Could not connect to Hermes gateway
```
