### PR TITLE
fix(skills): clear curator suppression when restoring a bundled skill

### DIFF
--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -702,6 +702,65 @@ class TestResetBundledSkill:
         # User copy is still on disk (we changed nothing).
         assert (dest / "SKILL.md").exists()
 
+    def test_reset_restore_clears_curator_suppression(self, tmp_path):
+        """#103115: a curator-pruned bundled skill is listed in .curator_suppressed, which makes
+        sync_skills() skip the re-seed — so `reset --restore` reported success while the runtime
+        copy never came back. Restore must clear the entry before syncing."""
+        from tools.skill_usage import read_suppressed_names
+
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+        skills_dir.mkdir(parents=True)
+        manifest_file.write_text("google-workspace:STALEHASH000000000000000000000000\n")
+
+        # Curator-pruned state: suppression entry present, no local copy left on disk.
+        hermes_home = tmp_path / "home"
+        suppressed = hermes_home / "skills" / ".curator_suppressed"
+        suppressed.parent.mkdir(parents=True)
+        suppressed.write_text("google-workspace\n")
+
+        with self._patches(bundled, skills_dir, manifest_file), patch(
+            "tools.skill_usage.get_hermes_home", return_value=hermes_home
+        ):
+            result = reset_bundled_skill("google-workspace", restore=True)
+
+            assert result["ok"] is True
+            assert result["action"] == "restored"
+            # The skill was actually re-seeded, not silently skipped as suppressed.
+            assert "google-workspace" in result["synced"]["copied"]
+            assert result["synced"]["suppressed"] == []
+            assert "GW v2" in (skills_dir / "productivity" / "google-workspace" / "SKILL.md").read_text()
+            # The suppression entry is gone: future `hermes update` runs keep seeding it.
+            assert "google-workspace" not in read_suppressed_names()
+            assert "suppression entry" in result["message"]
+
+    def test_plain_reset_keeps_curator_suppression(self, tmp_path):
+        """Plain reset (no --restore) only re-baselines manifest tracking; it must not silently
+        reverse the curator's prune decision."""
+        from tools.skill_usage import read_suppressed_names
+
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+        skills_dir.mkdir(parents=True)
+        manifest_file.write_text("google-workspace:STALEHASH000000000000000000000000\n")
+
+        hermes_home = tmp_path / "home"
+        suppressed = hermes_home / "skills" / ".curator_suppressed"
+        suppressed.parent.mkdir(parents=True)
+        suppressed.write_text("google-workspace\n")
+
+        with self._patches(bundled, skills_dir, manifest_file), patch(
+            "tools.skill_usage.get_hermes_home", return_value=hermes_home
+        ):
+            result = reset_bundled_skill("google-workspace", restore=False)
+
+            assert result["ok"] is True
+            assert result["action"] == "manifest_cleared"
+            # Curator's prune decision survives a plain reset.
+            assert "google-workspace" in read_suppressed_names()
+
 
 class TestNoBundledSkillsOptOut:
     """The .no-bundled-skills marker makes sync_skills() a no-op.

--- a/tools/skills_sync_bundled_ops.py
+++ b/tools/skills_sync_bundled_ops.py
@@ -4,7 +4,7 @@ Profile-scoped paths and patchable helpers resolve through ``_ss()`` at call tim
 from pathlib import Path
 from typing import List, Optional, Tuple
 
-from tools.skill_usage import read_suppressed_names, remove_suppressed_name
+from tools.skill_usage import _toggle_suppressed_name, read_suppressed_names
 from tools.skills_sync_optional import _skill_file_list, _ss
 
 
@@ -59,7 +59,7 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
     # re-seed entirely — restore means "bring it back", so the entry must go before syncing (#103115).
     cleared_suppression = restore and name in read_suppressed_names()
     if cleared_suppression:
-        remove_suppressed_name(name)
+        _toggle_suppressed_name(name, add=False)
     synced = ss.sync_skills(quiet=True)
     if not restore:
         action, message = "manifest_cleared", (f"Cleared manifest entry for '{name}'. Future `hermes update` runs "

--- a/tools/skills_sync_bundled_ops.py
+++ b/tools/skills_sync_bundled_ops.py
@@ -4,6 +4,7 @@ Profile-scoped paths and patchable helpers resolve through ``_ss()`` at call tim
 from pathlib import Path
 from typing import List, Optional, Tuple
 
+from tools.skill_usage import read_suppressed_names, remove_suppressed_name
 from tools.skills_sync_optional import _skill_file_list, _ss
 
 
@@ -24,7 +25,8 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
     """Reset a bundled skill's manifest tracking so future syncs work normally. An edited bundled
     skill stays ``user_modified`` forever because the manifest holds the OLD origin hash; clearing
     the entry breaks that loop. ``restore`` also deletes the user's copy so the next sync re-copies
-    bundled. Returns ``{ok, action, message, synced}``; action is manifest_cleared / restored /
+    bundled, and clears a curator suppression entry so that re-copy is not skipped. Returns
+    ``{ok, action, message, synced}``; action is manifest_cleared / restored /
     not_in_manifest / bundled_missing / not_reset."""
     ss, manifest, bundled_dir, bundled_by_name = _bundled_state()
     in_manifest = name in manifest
@@ -53,6 +55,11 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
     if in_manifest:
         del manifest[name]
         ss._write_manifest(manifest)
+    # A curator-pruned bundled skill stays in .curator_suppressed, which makes sync_skills skip the
+    # re-seed entirely — restore means "bring it back", so the entry must go before syncing (#103115).
+    cleared_suppression = restore and name in read_suppressed_names()
+    if cleared_suppression:
+        remove_suppressed_name(name)
     synced = ss.sync_skills(quiet=True)
     if not restore:
         action, message = "manifest_cleared", (f"Cleared manifest entry for '{name}'. Future `hermes update` runs "
@@ -61,6 +68,8 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
         action = "restored"
         message = (f"Restored '{name}' from bundled source." if deleted_user_copy
                    else f"Restored '{name}' (no prior user copy, re-copied from bundled).")
+        if cleared_suppression:
+            message += " Also cleared its curator suppression entry so future updates keep seeding it."
     return {"ok": True, "action": action, "message": message, "synced": synced}
 
 


### PR DESCRIPTION
## What does this PR do?

`hermes skills reset <name> --restore` is the advertised recovery path for bundled skills, but for a curator-pruned skill it silently did nothing to the runtime: the command cleared the manifest entry (and deleted the user copy), yet the skill name stays listed in `.curator_suppressed` — and `sync_skills()` skips suppressed names at the top of its loop, before install classification. The result was an `ok: true, action: "restored"` message while the bundled copy never came back, leaving the skill with no live upstream-backed copy in the runtime.

This PR clears the suppression entry in the `--restore` path before `sync_skills()` runs, so the re-seed actually happens. It reuses the existing idempotent `remove_suppressed_name()` helper (the same one the `hermes curator restore` path uses), and the success message now mentions the cleared entry so the recovery is honest. Plain reset (no `--restore`) is unchanged: it only re-baselines manifest tracking and does not silently reverse the curator's prune decision.

## Related Issue

Fixes #103115

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skills_sync_bundled_ops.py` — in `reset_bundled_skill()`, when `restore=True` and the name is present in `.curator_suppressed`, call `remove_suppressed_name(name)` after the manifest entry is cleared and before `sync_skills()`; append a note to the restored message; docstring updated.
- `tests/tools/test_skills_sync.py` — two regression tests in `TestResetBundledSkill`: restore re-seeds a suppressed bundled skill and removes the suppression entry; plain reset keeps the curator's prune decision.

## How to Test

1. `python -m pytest tests/tools/test_skills_sync.py -q` — Observed result: **36 passed** (34 pre-existing + 2 new).
2. `python -m pytest tests/tools/test_skill_usage.py tests/tools/test_skills_list_modified_diff.py tests/hermes_cli/test_skills_hub.py tests/tools/test_skills_sync_client.py -q` — Observed result: **99 passed** (suppression helpers, reset/diff ops, and CLI consumers).
3. `ruff check tools/skills_sync_bundled_ops.py tests/tools/test_skills_sync.py` — Observed result: All checks passed.
4. Manual repro of the issue scenario (covered by `test_reset_restore_clears_curator_suppression`): bundled skill exists, name in `.curator_suppressed`, no local copy → `reset_bundled_skill(name, restore=True)` → before this PR the skill ended up in `synced["suppressed"]` with no destination on disk; with this PR it lands in `synced["copied"]`, the destination is re-seeded from bundled source, and the suppression entry is gone.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (darwin 25.4, arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

New regression test output (suppressed bundled skill, restore path):

```
$ python -m pytest tests/tools/test_skills_sync.py::TestResetBundledSkill -q
6 passed in 0.61s
```
