### PR TITLE
feat: support GPT-6 Astra async application tools

### DIFF
--- a/agent/astra_async_tools.py
+++ b/agent/astra_async_tools.py
@@ -2,8 +2,8 @@
 
 The provider can finish an ``async`` function-call item before the Responses stream reaches its
 terminal frame.  This module admits those items into the existing tool middleware while keeping
-their assistant fragments durable and delaying tool-result rows until the complete stream has
-settled.  It is intentionally an internal coordinator: ordinary providers never instantiate it.
+their assistant fragments durable. Tool-result rows settle in order at stream completion or when
+steering requires a durable prefix. Ordinary providers never instantiate this internal coordinator.
 """
 
 from __future__ import annotations

--- a/agent/astra_async_tools.py
+++ b/agent/astra_async_tools.py
@@ -67,6 +67,7 @@ class AstraAsyncExecutor:
         self.api_call_count = api_call_count
         self._lock = threading.RLock()
         self._changed = threading.Condition(self._lock)
+        self._settlement_lock = threading.Lock()
         self._jobs: list[_AstraJob] = []
         self._reservations: list[str] = []
         self._pending_calls: dict[str, Any] = {}
@@ -296,6 +297,107 @@ class AstraAsyncExecutor:
     def _all_done_locked(self) -> bool:
         return all(job.done for job in self._jobs)
 
+    @staticmethod
+    def _canonical_call_id(value: Any) -> str:
+        return str(value or "").split("|", 1)[0].strip()
+
+    def _job_call_ids(self, job: _AstraJob) -> set[str]:
+        ref = job.parsed.ref(self.effective_task_id)
+        return {
+            call_id for call_id in (
+                self._canonical_call_id(ref.call_id),
+                self._canonical_call_id(getattr(job.call, "call_id", None)),
+                self._canonical_call_id(getattr(job.call, "id", None)),
+            ) if call_id
+        }
+
+    def _required_jobs_locked(self, call_ids: Any) -> Optional[list[_AstraJob]]:
+        required = {self._canonical_call_id(call_id) for call_id in call_ids or ()}
+        required.discard("")
+        if not required:
+            return []
+        positions = {
+            call_id: index
+            for index, job in enumerate(self._jobs)
+            for call_id in self._job_call_ids(job)
+        }
+        if not required.issubset(positions):
+            return None
+        # Publishing in assistant-call order requires every earlier job.  The scheduler's
+        # segmented barriers also require those predecessors to have completed first.
+        return list(self._jobs[:max(positions[call_id] for call_id in required) + 1])
+
+    def _wait_for_jobs(self, jobs: list[_AstraJob]) -> bool:
+        while True:
+            abort = False
+            with self._lock:
+                if all(job.committed for job in jobs):
+                    return True
+                if self._closed or self._failed:
+                    return False
+                if getattr(self.agent, "_interrupt_requested", False):
+                    abort = True
+                elif all(job.done for job in jobs):
+                    return True
+                else:
+                    self._pump_locked()
+                    self._changed.wait(timeout=0.1)
+            if abort:
+                self.abort_stream()
+                return False
+
+    def _publish_jobs(self, jobs: list[_AstraJob], *, finalize: bool = False) -> bool:
+        """Persist one ordered job prefix, skipping rows already committed by settlement."""
+        if not jobs:
+            return True
+        from agent.tool_executor import (
+            _append_invalid_arguments_result, _budget_for_agent, _finalize_tool_batch, _publish_sequential_result,
+        )
+
+        selected = {id(job) for job in jobs}
+        ordered = [job for job in self._jobs if id(job) in selected]
+        budget = _budget_for_agent(self.agent)
+        for index, job in enumerate(ordered):
+            if job.committed:
+                continue
+            ref = job.parsed.ref(self.effective_task_id)
+            message_count = len(self.messages)
+            if job.parsed.parse_error is not None:
+                published = _append_invalid_arguments_result(self.agent, self.messages, ref, job.parsed.parse_error)
+            else:
+                published = _publish_sequential_result(
+                    self.agent, self.messages, ref, job.managed, tool_duration=job.duration,
+                    index=job.index + 1, budget=budget,
+                )
+            if not published:
+                self._failed = True
+                del self.messages[message_count:]
+                recovered = self._recover_uncommitted_results(ordered[index:])
+                self.agent._session_messages = self.messages
+                return recovered
+            job.committed = True
+        if finalize and not self._failed and self._jobs:
+            _finalize_tool_batch(self.agent, self.messages, self.effective_task_id, len(self._jobs), budget)
+        self.agent._session_messages = self.messages
+        return True
+
+    def settle_required(self, call_ids: Any) -> bool:
+        """Wait for required calls and ordered predecessors, then durably publish them once.
+
+        This is the PR3 pending-steer boundary.  It never exposes an in-memory managed result;
+        callers may construct required input only after this returns ``True`` and read the
+        canonical persisted tool rows from ``agent._session_messages``.
+        """
+        with self._settlement_lock:
+            with self._lock:
+                jobs = self._required_jobs_locked(call_ids)
+            if jobs is None or not self._wait_for_jobs(jobs):
+                return False
+            published = self._publish_jobs(jobs)
+            # A recovery notice is durable, but it is not the requested tool result.  Keep
+            # pending continuation fail-closed after a canonical publication failure.
+            return published and not self.failed
+
     def _recover_uncommitted_results(self, jobs: list[_AstraJob]) -> bool:
         from agent.replay_cleanup import _DANGLING_NOTICES, _orphan_recovery
         from agent.tool_dispatch_helpers import make_tool_result_message
@@ -325,85 +427,53 @@ class AstraAsyncExecutor:
 
     def finish_stream(self, assistant_content: str = "", settled_calls: Any = None) -> bool:
         """Wait for all admitted jobs and publish results in original call order."""
-        with self._lock:
-            if self._closed:
-                return self._finalized
-            if getattr(self.agent, "_interrupt_requested", False):
-                self.abort_stream()
-                return False
-            # The assembler settles announced items that lack an output_item.done frame only when
-            # it builds the terminal response.  Admit those calls before retiring reservations.
-            for call in settled_calls or ():
-                if provider_async_marker(call):
-                    self.admit(call)
-            self._stream_closed = True
-            self._drain_admissions_locked()
-            self._pending_calls.clear()
-            self._reservations.clear()
-            self._pump_locked()
-            while not self._all_done_locked():
+        with self._settlement_lock:
+            with self._lock:
+                if self._closed:
+                    return self._finalized
                 if getattr(self.agent, "_interrupt_requested", False):
                     self.abort_stream()
                     return False
-                self._changed.wait(timeout=0.1)
+                # The assembler settles announced items that lack an output_item.done frame only when
+                # it builds the terminal response.  Admit those calls before retiring reservations.
+                for call in settled_calls or ():
+                    if provider_async_marker(call):
+                        self.admit(call)
+                self._stream_closed = True
+                self._drain_admissions_locked()
+                self._pending_calls.clear()
+                self._reservations.clear()
+                self._pump_locked()
+                while not self._all_done_locked():
+                    if getattr(self.agent, "_interrupt_requested", False):
+                        self.abort_stream()
+                        return False
+                    self._changed.wait(timeout=0.1)
 
-        from agent.tool_executor import (
-            _append_invalid_arguments_result, _budget_for_agent, _finalize_tool_batch, _publish_sequential_result,
-        )
-        if assistant_content:
-            from agent.chat_completion_helpers import build_assistant_message
+            if assistant_content:
+                from agent.chat_completion_helpers import build_assistant_message
 
-            text_message = build_assistant_message(
-                self.agent, SimpleNamespace(content=assistant_content, tool_calls=[]), "tool_calls",
-            )
-            text_message.pop("tool_calls", None)
-            self.messages.append(text_message)
-            try:
-                if self.agent._flush_messages_to_session_db(self.messages) is not True:
+                text_message = build_assistant_message(
+                    self.agent, SimpleNamespace(content=assistant_content, tool_calls=[]), "tool_calls",
+                )
+                text_message.pop("tool_calls", None)
+                self.messages.append(text_message)
+                try:
+                    if self.agent._flush_messages_to_session_db(self.messages) is not True:
+                        self._failed = True
+                except Exception:
                     self._failed = True
-            except Exception:
-                self._failed = True
-        if self._failed:
-            recovered = self._recover_uncommitted_results(self._jobs)
-            self._closed = True
-            self._finalized = recovered
-            self._executor.shutdown(wait=True)
-            return recovered
-        budget = _budget_for_agent(self.agent)
-        for index, job in enumerate(self._jobs):
-            ref = job.parsed.ref(self.effective_task_id)
-            if job.parsed.parse_error is not None:
-                message_count = len(self.messages)
-                if not _append_invalid_arguments_result(self.agent, self.messages, ref, job.parsed.parse_error):
-                    self._failed = True
-                    del self.messages[message_count:]
-                    recovered = self._recover_uncommitted_results(self._jobs[index:])
-                    self._closed = True
-                    self._finalized = recovered
-                    self._executor.shutdown(wait=True)
-                    return recovered
-                job.committed = True
-                continue
-            message_count = len(self.messages)
-            if not _publish_sequential_result(
-                self.agent, self.messages, ref, job.managed, tool_duration=job.duration,
-                index=job.index + 1, budget=budget,
-            ):
-                self._failed = True
-                del self.messages[message_count:]
-                recovered = self._recover_uncommitted_results(self._jobs[index:])
+            if self._failed:
+                recovered = self._recover_uncommitted_results(self._jobs)
                 self._closed = True
                 self._finalized = recovered
                 self._executor.shutdown(wait=True)
                 return recovered
-            job.committed = True
-        self._closed = True
-        if not self._failed and self._jobs:
-            _finalize_tool_batch(self.agent, self.messages, self.effective_task_id, len(self._jobs), budget)
-        self.agent._session_messages = self.messages
-        self._finalized = not self._failed
-        self._executor.shutdown(wait=True)
-        return self._finalized
+            finalized = self._publish_jobs(self._jobs, finalize=True)
+            self._closed = True
+            self._finalized = finalized
+            self._executor.shutdown(wait=True)
+            return self._finalized
 
     def abort_stream(self) -> None:
         """Retire scheduling after interruption/stream failure without retrying handlers."""

--- a/agent/astra_async_tools.py
+++ b/agent/astra_async_tools.py
@@ -323,7 +323,7 @@ class AstraAsyncExecutor:
         self.agent._session_messages = self.messages
         return persisted
 
-    def finish_stream(self, assistant_content: str = "") -> bool:
+    def finish_stream(self, assistant_content: str = "", settled_calls: Any = None) -> bool:
         """Wait for all admitted jobs and publish results in original call order."""
         with self._lock:
             if self._closed:
@@ -331,6 +331,11 @@ class AstraAsyncExecutor:
             if getattr(self.agent, "_interrupt_requested", False):
                 self.abort_stream()
                 return False
+            # The assembler settles announced items that lack an output_item.done frame only when
+            # it builds the terminal response.  Admit those calls before retiring reservations.
+            for call in settled_calls or ():
+                if provider_async_marker(call):
+                    self.admit(call)
             self._stream_closed = True
             self._drain_admissions_locked()
             self._pending_calls.clear()

--- a/agent/astra_async_tools.py
+++ b/agent/astra_async_tools.py
@@ -1,0 +1,345 @@
+"""Midstream application-tool execution for direct GPT-6 Astra Responses turns.
+
+The provider can finish an ``async`` function-call item before the Responses stream reaches its
+terminal frame.  This module admits those items into the existing tool middleware while keeping
+their assistant fragments durable and delaying tool-result rows until the complete stream has
+settled.  It is intentionally an internal coordinator: ordinary providers never instantiate it.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Optional
+
+from agent.tool_dispatch_helpers import _plan_tool_batch_segments
+from tools.daemon_pool import DaemonThreadPoolExecutor
+from tools.thread_context import propagate_context_to_thread
+
+
+def is_direct_astra(agent: Any) -> bool:
+    """True only for the exact official OpenAI Responses Astra route."""
+    if getattr(agent, "api_mode", None) != "codex_responses":
+        return False
+    model = str(getattr(agent, "model", "") or "").strip().lower().rsplit("/", 1)[-1]
+    if model != "gpt-6-astra":
+        return False
+    from utils import base_url_host_matches
+
+    return base_url_host_matches(str(getattr(agent, "base_url", "") or ""), "api.openai.com")
+
+
+def provider_async_marker(tool_call: Any) -> bool:
+    """Read the provider marker, not the registry's Python coroutine metadata."""
+    if isinstance(tool_call, dict):
+        return tool_call.get("async") is True or tool_call.get("async_") is True
+    provider_data = getattr(tool_call, "provider_data", None) or {}
+    return (
+        getattr(tool_call, "async", False) is True
+        or getattr(tool_call, "async_", False) is True
+        or provider_data.get("async") is True
+    )
+
+
+@dataclass
+class _AstraJob:
+    call: Any
+    parsed: Any
+    index: int
+    future: Any = None
+    managed: Any = None
+    duration: float = 0.0
+    done: bool = False
+    committed: bool = False
+
+
+class AstraAsyncExecutor:
+    """Admit, schedule, and commit provider-marked Astra application tools."""
+
+    def __init__(self, agent: Any, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
+        self.agent = agent
+        self.messages = messages
+        self.effective_task_id = effective_task_id
+        self.api_call_count = api_call_count
+        self._lock = threading.RLock()
+        self._changed = threading.Condition(self._lock)
+        self._jobs: list[_AstraJob] = []
+        self._admitted_ids: set[str] = set()
+        self._stream_closed = False
+        self._closed = False
+        self._finalized = False
+        self._failed = False
+        self._consumed = False
+        self._aborted_results = False
+        self._executor = DaemonThreadPoolExecutor(max_workers=8)
+
+        from tools.terminal_tool_lifecycle import get_active_env
+
+        active_env = get_active_env(effective_task_id)
+        self._execution_cwd = Path(active_env.cwd) if active_env is not None and active_env.cwd else None
+
+    @property
+    def has_admitted(self) -> bool:
+        with self._lock:
+            return bool(self._jobs)
+
+    @property
+    def failed(self) -> bool:
+        with self._lock:
+            return self._failed
+
+    @property
+    def finalized(self) -> bool:
+        with self._lock:
+            return self._finalized
+
+    @property
+    def closed(self) -> bool:
+        with self._lock:
+            return self._closed
+
+    def retire_empty(self) -> bool:
+        """Close an executor that admitted no calls so its turn-owned state cannot be reused."""
+        with self._lock:
+            if self._jobs or self._closed:
+                return False
+            self._stream_closed = self._closed = True
+        self._executor.shutdown(wait=True)
+        return True
+
+    def _call_id(self, call: Any, index: int) -> str:
+        from agent.chat_completion_helpers import _assistant_tool_call_dict
+
+        # The normal builder is the source of truth for Responses aliases and deterministic IDs.
+        try:
+            return str(_assistant_tool_call_dict(self.agent, call, index).get("id") or "").strip()
+        except Exception:
+            raw = getattr(call, "call_id", None) or getattr(call, "id", None)
+            return str(raw or f"astra_async_{index}").strip()
+
+    def _assistant_fragment(self, call: Any, index: int) -> dict:
+        from agent.chat_completion_helpers import _assistant_tool_call_dict
+
+        tc = _assistant_tool_call_dict(self.agent, call, index)
+        return {"role": "assistant", "content": None, "tool_calls": [tc], "finish_reason": "tool_calls"}
+
+    def admit(self, call: Any) -> bool:
+        """Persist one completed async call, then make it eligible for dispatch.
+
+        A duplicate call ID is an idempotent no-op.  Persistence is intentionally before the first
+        scheduler submission; a failed flush never reaches a tool handler.
+        """
+        if not provider_async_marker(call):
+            return False
+        with self._lock:
+            if self._closed or self._stream_closed:
+                return False
+            index = len(self._jobs)
+            if not getattr(call, "function", None):
+                setattr(call, "function", SimpleNamespace(
+                    name=getattr(call, "name", ""), arguments=getattr(call, "arguments", "{}") or "{}",
+                ))
+            call_id = self._call_id(call, index)
+            if call_id in self._admitted_ids:
+                return True
+            try:
+                fragment = self._assistant_fragment(call, index)
+            except Exception:
+                self._failed = True
+                return False
+            self.messages.append(fragment)
+            try:
+                persisted = self.agent._flush_messages_to_session_db(self.messages) is True
+            except Exception:
+                persisted = False
+            if not persisted:
+                self.messages.pop()
+                self._failed = True
+                return False
+
+            # Bind the canonical ID back to this transient streamed object so the existing parser,
+            # middleware, and result pairing all see the same identity.
+            if not getattr(call, "id", None):
+                setattr(call, "id", call_id)
+            if not getattr(call, "call_id", None):
+                setattr(call, "call_id", call_id)
+            from agent.tool_executor import _parse_tool_call
+
+            try:
+                parsed = _parse_tool_call(self.agent, call)
+            except Exception:
+                self._failed = True
+                return False
+            job = _AstraJob(call=call, parsed=parsed, index=index)
+            self._jobs.append(job)
+            self._admitted_ids.add(call_id)
+            self.agent._session_messages = self.messages
+            self._pump_locked()
+            return True
+
+    def _segments_locked(self) -> list[tuple[str, list[Any]]]:
+        calls = [job.call for job in self._jobs]
+        return _plan_tool_batch_segments(calls, execution_cwd=self._execution_cwd)
+
+    def _submit_locked(self, job: _AstraJob) -> None:
+        if job.future is not None or self._closed:
+            return
+        job.future = self._executor.submit(propagate_context_to_thread(self._run_job), job)
+        job.future.add_done_callback(lambda future, current=job: self._job_done(current, future))
+
+    def _pump_locked(self) -> None:
+        """Start the earliest runnable segment; later segments remain barriers."""
+        if self._closed:
+            return
+        segments = self._segments_locked()
+        offset = 0
+        for kind, calls in segments:
+            indexes = range(offset, offset + len(calls))
+            group = [self._jobs[index] for index in indexes]
+            if any(not job.done for job in self._jobs[:offset]):
+                return
+            if kind == "parallel":
+                for job in group:
+                    self._submit_locked(job)
+                if any(not job.done for job in group):
+                    return
+                offset += len(group)
+                continue
+            unstarted = next((job for job in group if job.future is None), None)
+            if unstarted is not None:
+                self._submit_locked(unstarted)
+                return
+            if any(not job.done for job in group):
+                return
+            offset += len(group)
+
+    def _run_job(self, job: _AstraJob):
+        from agent.tool_executor import _resolve_sequential_dispatch, _run_sequential_call
+
+        start = time.time()
+        ref = job.parsed.ref(self.effective_task_id)
+        dispatch = _resolve_sequential_dispatch(self.agent, ref, self.messages)
+        managed, duration = _run_sequential_call(
+            self.agent, dispatch, ref, scope_block=job.parsed.scope_block, messages=self.messages,
+            remaining_calls=[], display_index=job.index + 1, tool_start_time=start,
+        )
+        return managed, duration
+
+    def _job_done(self, job: _AstraJob, future: Any) -> None:
+        try:
+            managed, duration = future.result()
+        except Exception as exc:
+            from agent.tool_executor import _ManagedToolResult
+
+            managed, duration = _ManagedToolResult(
+                result=f"Error executing tool '{job.parsed.name}': {exc}", args=job.parsed.args,
+                middleware_trace=job.parsed.middleware_trace, blocked=False, dispatched=False,
+            ), 0.0
+        with self._lock:
+            job.managed, job.duration, job.done = managed, duration, True
+            self._pump_locked()
+            self._changed.notify_all()
+
+    def _all_done_locked(self) -> bool:
+        return all(job.done for job in self._jobs)
+
+    def finish_stream(self, assistant_content: str = "") -> bool:
+        """Wait for all admitted jobs and publish results in original call order."""
+        with self._lock:
+            if self._closed:
+                return self._finalized
+            if getattr(self.agent, "_interrupt_requested", False):
+                self.abort_stream()
+                return False
+            self._stream_closed = True
+            self._pump_locked()
+            while not self._all_done_locked():
+                if getattr(self.agent, "_interrupt_requested", False):
+                    self.abort_stream()
+                    return False
+                self._changed.wait(timeout=0.1)
+            self._closed = True
+
+        from agent.tool_executor import (
+            _append_invalid_arguments_result, _budget_for_agent, _finalize_tool_batch, _publish_sequential_result,
+        )
+        if assistant_content:
+            from agent.chat_completion_helpers import build_assistant_message
+
+            text_message = build_assistant_message(
+                self.agent, SimpleNamespace(content=assistant_content, tool_calls=[]), "tool_calls",
+            )
+            text_message.pop("tool_calls", None)
+            self.messages.append(text_message)
+            try:
+                if self.agent._flush_messages_to_session_db(self.messages) is not True:
+                    self._failed = True
+            except Exception:
+                self._failed = True
+        budget = _budget_for_agent(self.agent)
+        for job in self._jobs:
+            ref = job.parsed.ref(self.effective_task_id)
+            if job.parsed.parse_error is not None:
+                if not _append_invalid_arguments_result(self.agent, self.messages, ref, job.parsed.parse_error):
+                    self._failed = True
+                    break
+                job.committed = True
+                continue
+            if not _publish_sequential_result(
+                self.agent, self.messages, ref, job.managed, tool_duration=job.duration,
+                index=job.index + 1, budget=budget,
+            ):
+                self._failed = True
+                break
+            job.committed = True
+        if not self._failed and self._jobs:
+            _finalize_tool_batch(self.agent, self.messages, self.effective_task_id, len(self._jobs), budget)
+        self.agent._session_messages = self.messages
+        self._finalized = not self._failed
+        self._executor.shutdown(wait=True)
+        return self._finalized
+
+    def abort_stream(self) -> None:
+        """Retire scheduling after interruption/stream failure without retrying handlers."""
+        with self._lock:
+            if self._closed:
+                return
+            self._stream_closed = True
+            self._closed = True
+            for job in self._jobs:
+                if job.future is not None and not job.future.done():
+                    job.future.cancel()
+            if not self._aborted_results and self._jobs:
+                from agent.replay_cleanup import _DANGLING_NOTICES, _orphan_recovery
+                from agent.tool_dispatch_helpers import make_tool_result_message
+
+                for job in self._jobs:
+                    ref = job.parsed.ref(self.effective_task_id)
+                    disposition, content = _orphan_recovery(job.parsed.name, _DANGLING_NOTICES)
+                    self.messages.append(make_tool_result_message(
+                        job.parsed.name, content, ref.call_id, effect_disposition=disposition,
+                    ))
+                    try:
+                        if self.agent._flush_messages_to_session_db(self.messages) is not True:
+                            self._failed = True
+                    except Exception:
+                        self._failed = True
+                self.agent._session_messages = self.messages
+                self._aborted_results = True
+            self._changed.notify_all()
+        self._executor.shutdown(wait=False, cancel_futures=True)
+
+    def consume_response(self, assistant_message: Any) -> bool:
+        """Tell the ordinary turn loop that this response's handlers already ran."""
+        with self._lock:
+            if not self._finalized or self._consumed or not self._jobs:
+                return False
+            self._consumed = True
+            return True
+
+
+__all__ = ["AstraAsyncExecutor", "is_direct_astra", "provider_async_marker"]

--- a/agent/astra_async_tools.py
+++ b/agent/astra_async_tools.py
@@ -28,9 +28,9 @@ def is_direct_astra(agent: Any) -> bool:
     model = str(getattr(agent, "model", "") or "").strip().lower().rsplit("/", 1)[-1]
     if model != "gpt-6-astra":
         return False
-    from utils import base_url_host_matches
+    from utils import base_url_hostname
 
-    return base_url_host_matches(str(getattr(agent, "base_url", "") or ""), "api.openai.com")
+    return base_url_hostname(str(getattr(agent, "base_url", "") or "")) == "api.openai.com"
 
 
 def provider_async_marker(tool_call: Any) -> bool:
@@ -68,6 +68,8 @@ class AstraAsyncExecutor:
         self._lock = threading.RLock()
         self._changed = threading.Condition(self._lock)
         self._jobs: list[_AstraJob] = []
+        self._reservations: list[str] = []
+        self._pending_calls: dict[str, Any] = {}
         self._admitted_ids: set[str] = set()
         self._stream_closed = False
         self._closed = False
@@ -88,6 +90,11 @@ class AstraAsyncExecutor:
             return bool(self._jobs)
 
     @property
+    def has_pending(self) -> bool:
+        with self._lock:
+            return bool(self._reservations or self._pending_calls)
+
+    @property
     def failed(self) -> bool:
         with self._lock:
             return self._failed
@@ -105,7 +112,7 @@ class AstraAsyncExecutor:
     def retire_empty(self) -> bool:
         """Close an executor that admitted no calls so its turn-owned state cannot be reused."""
         with self._lock:
-            if self._jobs or self._closed:
+            if self._jobs or self._reservations or self._pending_calls or self._closed:
                 return False
             self._stream_closed = self._closed = True
         self._executor.shutdown(wait=True)
@@ -127,66 +134,106 @@ class AstraAsyncExecutor:
         tc = _assistant_tool_call_dict(self.agent, call, index)
         return {"role": "assistant", "content": None, "tool_calls": [tc], "finish_reason": "tool_calls"}
 
-    def admit(self, call: Any) -> bool:
-        """Persist one completed async call, then make it eligible for dispatch.
+    def _reservation_key(self, call: Any) -> str:
+        if isinstance(call, dict):
+            raw = call.get("call_id") or call.get("id") or call.get("response_item_id")
+        else:
+            raw = getattr(call, "call_id", None) or getattr(call, "id", None) or getattr(call, "response_item_id", None)
+        return str(raw or "").strip()
 
-        A duplicate call ID is an idempotent no-op.  Persistence is intentionally before the first
-        scheduler submission; a failed flush never reaches a tool handler.
-        """
+    def reserve(self, call: Any) -> bool:
+        """Record provider output order before arguments are complete or executable."""
         if not provider_async_marker(call):
             return False
         with self._lock:
             if self._closed or self._stream_closed:
                 return False
-            index = len(self._jobs)
-            if not getattr(call, "function", None):
-                setattr(call, "function", SimpleNamespace(
-                    name=getattr(call, "name", ""), arguments=getattr(call, "arguments", "{}") or "{}",
-                ))
-            call_id = self._call_id(call, index)
-            if call_id in self._admitted_ids:
+            key = self._reservation_key(call)
+            if not key or key in self._admitted_ids:
                 return True
-            try:
-                fragment = self._assistant_fragment(call, index)
-            except Exception:
-                self._failed = True
-                return False
-            self.messages.append(fragment)
-            try:
-                persisted = self.agent._flush_messages_to_session_db(self.messages) is True
-            except Exception:
-                persisted = False
-            if not persisted:
-                self.messages.pop()
-                self._failed = True
-                return False
-
-            # Bind the canonical ID back to this transient streamed object so the existing parser,
-            # middleware, and result pairing all see the same identity.
-            if not getattr(call, "id", None):
-                setattr(call, "id", call_id)
-            if not getattr(call, "call_id", None):
-                setattr(call, "call_id", call_id)
-            from agent.tool_executor import _parse_tool_call
-
-            try:
-                parsed = _parse_tool_call(self.agent, call)
-            except Exception:
-                self._failed = True
-                return False
-            job = _AstraJob(call=call, parsed=parsed, index=index)
-            self._jobs.append(job)
-            self._admitted_ids.add(call_id)
-            self.agent._session_messages = self.messages
-            self._pump_locked()
+            if key not in self._reservations:
+                self._reservations.append(key)
             return True
+
+    def _drain_admissions_locked(self) -> None:
+        while self._reservations:
+            key = self._reservations[0]
+            call = self._pending_calls.get(key)
+            if call is None:
+                return
+            self._pending_calls.pop(key, None)
+            self._reservations.pop(0)
+            if not self._admit_one_locked(call):
+                return
+
+    def admit(self, call: Any) -> bool:
+        """Queue one completed call and admit only the completed announced prefix."""
+        if not provider_async_marker(call):
+            return False
+        with self._lock:
+            if self._closed or self._stream_closed:
+                return False
+            key = self._reservation_key(call)
+            if not key:
+                key = f"anonymous:{len(self._reservations) + len(self._pending_calls)}"
+            if key in self._admitted_ids:
+                return True
+            if key not in self._reservations:
+                self._reservations.append(key)
+            self._pending_calls[key] = call
+            self._drain_admissions_locked()
+            return key in self._admitted_ids or key in self._pending_calls
+
+    def _admit_one_locked(self, call: Any) -> bool:
+        index = len(self._jobs)
+        if not getattr(call, "function", None):
+            setattr(call, "function", SimpleNamespace(
+                name=getattr(call, "name", ""), arguments=getattr(call, "arguments", "{}") or "{}",
+            ))
+        call_id = self._call_id(call, index)
+        if call_id in self._admitted_ids:
+            return True
+        try:
+            fragment = self._assistant_fragment(call, index)
+        except Exception:
+            self._failed = True
+            return False
+        self.messages.append(fragment)
+        try:
+            persisted = self.agent._flush_messages_to_session_db(self.messages) is True
+        except Exception:
+            persisted = False
+        if not persisted:
+            self.messages.pop()
+            self._failed = True
+            return False
+
+        # Bind the canonical ID back to this transient streamed object so the existing parser,
+        # middleware, and result pairing all see the same identity.
+        if not getattr(call, "id", None):
+            setattr(call, "id", call_id)
+        if not getattr(call, "call_id", None):
+            setattr(call, "call_id", call_id)
+        from agent.tool_executor import _parse_tool_call
+
+        try:
+            parsed = _parse_tool_call(self.agent, call)
+        except Exception:
+            self._failed = True
+            return False
+        job = _AstraJob(call=call, parsed=parsed, index=index, done=parsed.parse_error is not None)
+        self._jobs.append(job)
+        self._admitted_ids.add(call_id)
+        self.agent._session_messages = self.messages
+        self._pump_locked()
+        return True
 
     def _segments_locked(self) -> list[tuple[str, list[Any]]]:
         calls = [job.call for job in self._jobs]
         return _plan_tool_batch_segments(calls, execution_cwd=self._execution_cwd)
 
     def _submit_locked(self, job: _AstraJob) -> None:
-        if job.future is not None or self._closed:
+        if job.future is not None or self._closed or job.parsed.parse_error is not None:
             return
         job.future = self._executor.submit(propagate_context_to_thread(self._run_job), job)
         job.future.add_done_callback(lambda future, current=job: self._job_done(current, future))
@@ -209,7 +256,9 @@ class AstraAsyncExecutor:
                     return
                 offset += len(group)
                 continue
-            unstarted = next((job for job in group if job.future is None), None)
+            unstarted = next(
+                (job for job in group if job.future is None and job.parsed.parse_error is None), None,
+            )
             if unstarted is not None:
                 self._submit_locked(unstarted)
                 return
@@ -247,6 +296,33 @@ class AstraAsyncExecutor:
     def _all_done_locked(self) -> bool:
         return all(job.done for job in self._jobs)
 
+    def _recover_uncommitted_results(self, jobs: list[_AstraJob]) -> bool:
+        from agent.replay_cleanup import _DANGLING_NOTICES, _orphan_recovery
+        from agent.tool_dispatch_helpers import make_tool_result_message
+
+        uncommitted = [job for job in jobs if not job.committed]
+        for job in uncommitted:
+            ref = job.parsed.ref(self.effective_task_id)
+            if job.parsed.parse_error is not None:
+                content = job.parsed.parse_error
+                disposition = None
+            else:
+                disposition, content = _orphan_recovery(job.parsed.name, _DANGLING_NOTICES)
+            self.messages.append(make_tool_result_message(
+                job.parsed.name, content, ref.call_id, effect_disposition=disposition,
+            ))
+        if not uncommitted:
+            return True
+        try:
+            persisted = self.agent._flush_messages_to_session_db(self.messages) is True
+        except Exception:
+            persisted = False
+        if persisted:
+            for job in uncommitted:
+                job.committed = True
+        self.agent._session_messages = self.messages
+        return persisted
+
     def finish_stream(self, assistant_content: str = "") -> bool:
         """Wait for all admitted jobs and publish results in original call order."""
         with self._lock:
@@ -256,13 +332,15 @@ class AstraAsyncExecutor:
                 self.abort_stream()
                 return False
             self._stream_closed = True
+            self._drain_admissions_locked()
+            self._pending_calls.clear()
+            self._reservations.clear()
             self._pump_locked()
             while not self._all_done_locked():
                 if getattr(self.agent, "_interrupt_requested", False):
                     self.abort_stream()
                     return False
                 self._changed.wait(timeout=0.1)
-            self._closed = True
 
         from agent.tool_executor import (
             _append_invalid_arguments_result, _budget_for_agent, _finalize_tool_batch, _publish_sequential_result,
@@ -280,22 +358,41 @@ class AstraAsyncExecutor:
                     self._failed = True
             except Exception:
                 self._failed = True
+        if self._failed:
+            recovered = self._recover_uncommitted_results(self._jobs)
+            self._closed = True
+            self._finalized = recovered
+            self._executor.shutdown(wait=True)
+            return recovered
         budget = _budget_for_agent(self.agent)
-        for job in self._jobs:
+        for index, job in enumerate(self._jobs):
             ref = job.parsed.ref(self.effective_task_id)
             if job.parsed.parse_error is not None:
+                message_count = len(self.messages)
                 if not _append_invalid_arguments_result(self.agent, self.messages, ref, job.parsed.parse_error):
                     self._failed = True
-                    break
+                    del self.messages[message_count:]
+                    recovered = self._recover_uncommitted_results(self._jobs[index:])
+                    self._closed = True
+                    self._finalized = recovered
+                    self._executor.shutdown(wait=True)
+                    return recovered
                 job.committed = True
                 continue
+            message_count = len(self.messages)
             if not _publish_sequential_result(
                 self.agent, self.messages, ref, job.managed, tool_duration=job.duration,
                 index=job.index + 1, budget=budget,
             ):
                 self._failed = True
-                break
+                del self.messages[message_count:]
+                recovered = self._recover_uncommitted_results(self._jobs[index:])
+                self._closed = True
+                self._finalized = recovered
+                self._executor.shutdown(wait=True)
+                return recovered
             job.committed = True
+        self._closed = True
         if not self._failed and self._jobs:
             _finalize_tool_batch(self.agent, self.messages, self.effective_task_id, len(self._jobs), budget)
         self.agent._session_messages = self.messages
@@ -309,27 +406,16 @@ class AstraAsyncExecutor:
             if self._closed:
                 return
             self._stream_closed = True
-            self._closed = True
             for job in self._jobs:
                 if job.future is not None and not job.future.done():
                     job.future.cancel()
+            self._pending_calls.clear()
+            self._reservations.clear()
             if not self._aborted_results and self._jobs:
-                from agent.replay_cleanup import _DANGLING_NOTICES, _orphan_recovery
-                from agent.tool_dispatch_helpers import make_tool_result_message
-
-                for job in self._jobs:
-                    ref = job.parsed.ref(self.effective_task_id)
-                    disposition, content = _orphan_recovery(job.parsed.name, _DANGLING_NOTICES)
-                    self.messages.append(make_tool_result_message(
-                        job.parsed.name, content, ref.call_id, effect_disposition=disposition,
-                    ))
-                    try:
-                        if self.agent._flush_messages_to_session_db(self.messages) is not True:
-                            self._failed = True
-                    except Exception:
-                        self._failed = True
+                self._recover_uncommitted_results(self._jobs)
                 self.agent._session_messages = self.messages
                 self._aborted_results = True
+            self._closed = True
             self._changed.notify_all()
         self._executor.shutdown(wait=False, cancel_futures=True)
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1392,8 +1392,13 @@ class _CodexCompletionsAdapter:
             if isinstance(reasoning_cfg, dict) and reasoning_cfg.get("enabled") is not False:
                 # Truthy-only: Codex 400s on e.g. {"effort": null}, so falsy → default. Shared
                 # per-model clamp with the main transport ("max" is gpt-5.6-only; "minimal"/"ultra" rejected).
-                from agent.reasoning_effort import clamp_effort, codex_supported_efforts
-                effort = clamp_effort(reasoning_cfg.get("effort") or "medium", codex_supported_efforts(model))
+                from agent.reasoning_effort import clamp_effort
+                from agent.transports.codex import _codex_efforts_for_route
+                is_codex_backend = base_url_host_matches(host, "chatgpt.com") and "/backend-api/codex" in host.lower()
+                effort = clamp_effort(
+                    reasoning_cfg.get("effort") or "medium",
+                    _codex_efforts_for_route(model, host, is_codex_backend=is_codex_backend),
+                )
                 resp_kwargs["reasoning"] = {"effort": effort, "summary": "auto"}
                 resp_kwargs["include"] = ["reasoning.encrypted_content"]
         tools = kwargs.get("tools")

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1446,6 +1446,11 @@ class _CodexCompletionsAdapter:
                     resp_kwargs["prompt_cache_retention"] = cache_retention
         except Exception:
             logger.debug("Codex auxiliary: prompt_cache_key derivation skipped", exc_info=True)
+        # Keep auxiliary Responses calls on the same exact-model contract as main
+        # turns. This runs last so caller overrides cannot reintroduce unsupported
+        # Astra reasoning/sampling fields or replace the official cache TTL.
+        from agent.transports.codex import _sanitize_astra_request_kwargs
+        _sanitize_astra_request_kwargs(resp_kwargs, model, host)
         return resp_kwargs, model, timeout
 
     def create(self, **kwargs) -> Any:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1413,6 +1413,8 @@ def _build_bedrock_kwargs(agent, api_messages, tools_for_api):
 def _build_codex_kwargs(agent, api_messages, tools_for_api, reasoning_config, request_overrides, cache_scope_id):
     from agent.codex_responses_adapter import classify_responses_route
     from agent.native_compaction import native_compaction_context_management
+    from agent.astra_async_tools import is_direct_astra
+    from agent.turn_api_call import _should_stream
     is_codex_backend, is_xai_responses, is_github_responses = classify_responses_route(agent)
     # Native server-side compaction (gpt-5.6 on direct OpenAI / ChatGPT Codex routes
     # only) — None on every other route/model, leaving the request unchanged.
@@ -1439,7 +1441,8 @@ def _build_codex_kwargs(agent, api_messages, tools_for_api, reasoning_config, re
         is_codex_backend=is_codex_backend, is_xai_responses=is_xai_responses,
         github_reasoning_extra=agent._github_models_reasoning_extra_body() if is_github_responses else None,
         replay_encrypted_reasoning=bool(getattr(agent, "_codex_reasoning_replay_enabled", True)),
-        context_management=context_management)
+        context_management=context_management,
+        midstream_executor_active=bool(_should_stream(agent) and is_direct_astra(agent)))
 
 
 def _anthropic_max_output_for_model(agent):
@@ -1631,6 +1634,10 @@ def _assistant_tool_call_dict(agent, tool_call, index: int) -> dict:
     tc_dict = {"id": call_id, "call_id": call_id, "response_item_id": response_item_id,
         "type": tool_call.type,
         "function": {"name": tool_call.function.name, "arguments": tool_call.function.arguments}}
+    provider_data = getattr(tool_call, "provider_data", None) or {}
+    if getattr(tool_call, "async", False) is True or getattr(tool_call, "async_", False) is True \
+            or provider_data.get("async") is True:
+        tc_dict["async"] = True
     # Preserve extra_content (Gemini thought_signature) or Gemini 3 thinking
     # models 400 on the next request.
     # Tool-call arguments are intentionally NOT redacted here. This dict enters the in-memory conversation

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -739,7 +739,7 @@ _PREFLIGHT_OPTIONAL_FIELDS: tuple[tuple[str, Callable[[Any], bool], Optional[Cal
     # Cache routing/retention and tool-dispatch hints pass through as-is.
     *(
         (key, lambda v: v is not None, None)
-        for key in ("tool_choice", "parallel_tool_calls", "prompt_cache_key", "prompt_cache_retention")
+        for key in ("tool_choice", "parallel_tool_calls", "prompt_cache_key", "prompt_cache_retention", "prompt_cache_options")
     ),
     # Native compaction directive; eligibility is resolved in agent/native_compaction.py.
     ("context_management", lambda v: isinstance(v, list) and bool(v), None),

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -279,13 +279,20 @@ def _derive_responses_function_call_id(call_id: str, response_item_id: Optional[
 
 # --- Schema conversion --------------------------------------------------------
 
-def _responses_tools(tools: Optional[List[Dict[str, Any]]] = None) -> Optional[List[Dict[str, Any]]]:
-    """Convert chat-completions tool schemas to Responses function-tool schemas."""
+def _responses_tools(
+    tools: Optional[List[Dict[str, Any]]] = None, *, async_tools: bool = False,
+) -> Optional[List[Dict[str, Any]]]:
+    """Convert chat-completions schemas to Responses function-tool schemas.
+
+    ``async_tools`` is explicit and only enabled by the direct Astra midstream executor.
+    It is intentionally unrelated to the registry's Python-coroutine metadata.
+    """
     fns = [item.get("function", {}) if isinstance(item, dict) else {} for item in tools or []]
     converted = [
         {
             "type": "function", "name": fn["name"], "description": fn.get("description", ""), "strict": False,
             "parameters": fn.get("parameters", {"type": "object", "properties": {}}),
+            **({"async": True} if async_tools else {}),
         }
         for fn in fns if _nonblank(fn.get("name"))
     ]
@@ -381,10 +388,13 @@ def _replay_tool_call_items(msg: Dict[str, Any], *, start_index: int) -> List[Di
             continue
         index = start_index + len(replayed)
         call_id = _resolve_call_id(tc.get("call_id"), tc.get("id"), fn_name, str(arguments), index, canonicalize_fc=True)
-        replayed.append({
+        replayed_item = {
             "type": "function_call", "call_id": _clamp_responses_call_id(call_id),
             "name": _sanitize_replayed_fn_name(fn_name), "arguments": _coerce_arguments(arguments),
-        })
+        }
+        if tc.get("async") is True or tc.get("async_") is True:
+            replayed_item["async"] = True
+        replayed.append(replayed_item)
     return replayed
 
 
@@ -584,10 +594,13 @@ def _preflight_function_call(item: Dict[str, Any], idx: int, ctx: _PreflightCtx)
         raise ValueError(f"Codex Responses input[{idx}] function_call is missing call_id.")
     if not _nonblank(name):
         raise ValueError(f"Codex Responses input[{idx}] function_call is missing name.")
-    return {
+    normalized = {
         "type": "function_call", "call_id": call_id.strip(), "name": _sanitize_replayed_fn_name(name),
         "arguments": ctx.sanitize_text(_coerce_arguments(item.get("arguments", "{}"))),
     }
+    if item.get("async") is True or item.get("async_") is True:
+        normalized["async"] = True
+    return normalized
 
 
 def _preflight_function_call_output(item: Dict[str, Any], idx: int, ctx: _PreflightCtx) -> Dict[str, Any]:
@@ -721,10 +734,13 @@ def _preflight_tool(tool: Any, idx: int) -> Dict[str, Any]:
     for ok, what in ((_nonblank(name), "a valid name"), (isinstance(parameters, dict), "valid parameters")):
         if not ok:
             raise ValueError(f"Codex Responses tools[{idx}] is missing {what}.")
-    return {
+    normalized = {
         "type": "function", "name": name.strip(), "description": _str_or_empty(tool.get("description", "")),
         "strict": bool(tool.get("strict", False)), "parameters": parameters,
     }
+    if tool.get("async") is True or tool.get("async_") is True:
+        normalized["async"] = True
+    return normalized
 
 
 # Optional scalar request fields, in wire order: (key, accept(value), coerce). Values
@@ -866,10 +882,14 @@ def _response_tool_call(item: Any, item_type: str, index: int) -> SimpleNamespac
     raw_item_id = getattr(item, "id", None)
     call_id = _resolve_call_id(getattr(item, "call_id", None), raw_item_id, fn_name, arguments, index, canonicalize_fc=False)
     fc_id = _derive_responses_function_call_id(call_id, raw_item_id if isinstance(raw_item_id, str) else None)
-    return SimpleNamespace(
+    tool_call = SimpleNamespace(
         id=call_id, call_id=call_id, response_item_id=fc_id, type="function",
         function=SimpleNamespace(name=fn_name, arguments=arguments),
     )
+    if getattr(item, "async", False) is True or getattr(item, "async_", False) is True:
+        setattr(tool_call, "async", True)
+        setattr(tool_call, "async_", True)
+    return tool_call
 
 
 def _capture_encrypted_item(item: Any, item_type: str, issuer_kind: Optional[str]) -> Optional[Dict[str, Any]]:

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -1024,7 +1024,10 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 raise
             executor = _astra_executor()
             if executor is not None and (executor.has_admitted or executor.has_pending or executor.failed):
-                if not executor.finish_stream(assistant_content=getattr(final, "output_text", "") or ""):
+                if not executor.finish_stream(
+                    assistant_content=getattr(final, "output_text", "") or "",
+                    settled_calls=getattr(final, "output", None),
+                ):
                     raise RuntimeError("Astra async tool execution did not reach a durable result boundary")
             elif executor is not None and executor.retire_empty():
                 agent._astra_async_executor = None

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -535,6 +535,11 @@ def _output_text_of(item: Any) -> str:
     ).strip()
 
 
+def _provider_async_marker(item: Any) -> bool:
+    """Read the Responses provider's async marker without conflating it with tool metadata."""
+    return any(_event_field(item, key, False) is True for key in ("async", "async_"))
+
+
 class _CodexResponseAssembler:
     """Assemble a Response-shaped ``SimpleNamespace`` from raw Responses SSE events.
 
@@ -552,9 +557,11 @@ class _CodexResponseAssembler:
     # terminal_status defaults to "completed", so settlement needs an explicitly observed response.completed frame.
     saw_response_completed = False
 
-    def __init__(self, *, model, on_text_delta, on_reasoning_delta, on_commentary_message, on_first_delta):
+    def __init__(self, *, model, on_text_delta, on_reasoning_delta, on_commentary_message, on_first_delta,
+                 on_async_tool_call=None):
         self.model, self.on_text_delta, self.on_reasoning_delta = model, on_text_delta, on_reasoning_delta
         self.on_commentary_message, self.on_first_delta = on_commentary_message, on_first_delta
+        self.on_async_tool_call = on_async_tool_call
         self.output_items: List[Any] = []
         # output_index / first-observed sequence per output item, in lockstep, so settled pending calls merge
         # back in stream order.
@@ -564,6 +571,27 @@ class _CodexResponseAssembler:
         # first-observed (sequence, output_index) per announced item id so a later .done keeps its announced position.
         self.pending_function_calls: Dict[str, Dict[str, Any]] = {}
         self.announced_output_order: Dict[str, tuple] = {}
+
+    def _emit_async_tool_call(self, item: Any, arguments: Any = None) -> None:
+        """Admit one completed provider-marked call exactly once."""
+        if not _provider_async_marker(item) or self.on_async_tool_call is None:
+            return
+        item_id = str(_event_field(item, "id", "") or _event_field(item, "call_id", ""))
+        pending = self.pending_function_calls.get(item_id) if item_id else None
+        if pending is not None and pending.get("async_emitted"):
+            return
+        if pending is not None:
+            pending["async_emitted"] = True
+        call_arguments = (str(arguments) if arguments is not None else str(_event_field(item, "arguments", "") or "")) or "{}"
+        call_name = _event_field(item, "name", None)
+        call = SimpleNamespace(
+            type="function", id=_event_field(item, "id", None), call_id=_event_field(item, "call_id", None),
+            response_item_id=_event_field(item, "id", None), status="completed",
+            function=SimpleNamespace(name=call_name, arguments=call_arguments),
+        )
+        setattr(call, "async", True)
+        setattr(call, "async_", True)
+        self._safe(self.on_async_tool_call, "on_async_tool_call", call)
 
     def _safe(self, cb: Callable | None, label: str, *args: Any) -> None:
         _call_guarded(cb, f"Codex stream {label} raised", args=args)
@@ -623,6 +651,7 @@ class _CodexResponseAssembler:
             # missing field keeps the streamed deltas.
             if (done_args := _event_field(event, "arguments", None)) is not None:
                 pending["arguments"] = str(done_args)
+            self._emit_async_tool_call(pending["item"], pending["arguments"] or "{}")
 
     def _on_reasoning_delta(self, event: Any, event_type: str) -> None:
         reasoning_text = _event_field(event, "delta", "")
@@ -649,6 +678,8 @@ class _CodexResponseAssembler:
         self.output_indexes.append(_event_field(event, "output_index", announced_index))
         self.output_sequences.append(announced_sequence)
         # Confirmed by the authoritative done event; never settle it twice.
+        if "function_call" in str(_event_field(done_item, "type", "")):
+            self._emit_async_tool_call(done_item, _event_field(done_item, "arguments", "{}"))
         self.pending_function_calls.pop(done_id, None)
         if _message_phase(done_item) == "commentary" and self.on_commentary_message is not None:
             commentary_text = "".join(self.commentary_text_deltas).strip() or _output_text_of(done_item)
@@ -696,13 +727,17 @@ class _CodexResponseAssembler:
         indexed = list(zip(self.output_indexes, self.output_sequences, self.output_items))
         for pending in self.pending_function_calls.values():
             item = pending["item"]
-            indexed.append((pending.get("output_index"), pending["sequence"], SimpleNamespace(
+            settled_arguments = (pending["arguments"] or "").strip() or "{}"
+            self._emit_async_tool_call(item, settled_arguments)
+            settled_item = SimpleNamespace(
                 type="function_call", id=_event_field(item, "id", None), call_id=_event_field(item, "call_id", None),
                 name=_event_field(item, "name", None), status="completed",
                 # Empty/whitespace arguments become "{}" so zero-delta calls stay executable; malformed
                 # non-empty JSON passes through untouched.
-                arguments=(pending["arguments"] or "").strip() or "{}",
-            )))
+                arguments=settled_arguments,
+                **({"async": True} if _provider_async_marker(item) else {}),
+            )
+            indexed.append((pending.get("output_index"), pending["sequence"], settled_item))
         # output_index is optional: protocol order only when every entry has one, else wire order.
         if all(entry[0] is not None for entry in indexed):
             with suppress(TypeError):  # non-comparable index values: keep wire order
@@ -732,7 +767,7 @@ class _CodexResponseAssembler:
 
 def _consume_codex_event_stream(
     event_iter: Any, *, model: str, on_text_delta=None, on_reasoning_delta=None, on_commentary_message=None,
-    on_first_delta=None, on_event=None, interrupt_check=None,
+    on_first_delta=None, on_event=None, interrupt_check=None, on_async_tool_call=None,
 ) -> SimpleNamespace:
     """Consume a Codex Responses SSE stream into a Response-shaped ``SimpleNamespace`` (see
     :class:`_CodexResponseAssembler`; ``status`` is ``completed`` when the stream ended with content but no
@@ -745,7 +780,8 @@ def _consume_codex_event_stream(
     True breaks the loop and may raise ``TimeoutError`` / ``InterruptedError`` for request retirement that
     must not become a partial final response."""
     assembler = _CodexResponseAssembler(model=model, on_text_delta=on_text_delta, on_reasoning_delta=on_reasoning_delta,
-                                        on_commentary_message=on_commentary_message, on_first_delta=on_first_delta)
+                                        on_commentary_message=on_commentary_message, on_first_delta=on_first_delta,
+                                        on_async_tool_call=on_async_tool_call)
     for event in event_iter:
         if on_event is not None:
             try:
@@ -910,6 +946,11 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
     on_commentary_message = _fenced(lambda text: agent._fire_streamed_codex_commentary(text)) if wants_commentary else None
     call_role = ("delegated" if getattr(agent, "is_subagent", False)
                  else "fallback" if int(getattr(agent, "_fallback_index", 0) or 0) > 0 else "primary")
+    from agent.astra_async_tools import is_direct_astra
+
+    def _astra_executor():
+        return getattr(agent, "_astra_async_executor", None) if is_direct_astra(agent) else None
+
     for attempt in range(max_stream_retries + 1):
         if agent._interrupt_requested:
             raise InterruptedError("Agent interrupted before Codex stream retry")
@@ -929,13 +970,28 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                               "api_request_id": getattr(agent, "_current_api_request_id", None)},
                     defer_logical_completion=True,
                 )
+                async_executor = _astra_executor()
+                async_callback = getattr(async_executor, "admit", None)
+                async_callback = _fenced(async_callback) if callable(async_callback) else None
                 final = _consume_codex_event_stream(
                     event_stream, model=model, on_text_delta=_fenced(_on_text_delta),
                     on_reasoning_delta=_fenced(lambda text: agent._fire_reasoning_delta(text)),
                     on_commentary_message=on_commentary_message, on_first_delta=on_first_delta,
                     on_event=_fenced(_on_event), interrupt_check=_interrupt_or_superseded,
+                    on_async_tool_call=async_callback,
                 )
+            except (InterruptedError, TimeoutError):
+                executor = _astra_executor()
+                if executor is not None:
+                    executor.abort_stream()
+                raise
             except transport_errors as exc:
+                executor = _astra_executor()
+                if executor is not None and executor.has_admitted:
+                    # A durable assistant fragment already owns every admitted side effect.  Do not
+                    # retry this physical request: the resume cleanup will classify any unpaired call.
+                    executor.abort_stream()
+                    raise
                 if attempt >= max_stream_retries:
                     _log_failure(exc)
                     raise
@@ -947,12 +1003,24 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 continue
             except RuntimeError:
                 # "No terminal response"; Relay may still hold a finalizer-assembled response.
+                executor = _astra_executor()
+                if executor is not None and (executor.has_admitted or executor.failed):
+                    executor.abort_stream()
                 if event_stream is not None and event_stream.final_response is not None:
                     return event_stream.final_response
                 raise
             except _APIConnectionError as exc:
+                executor = _astra_executor()
+                if executor is not None and executor.has_admitted:
+                    executor.abort_stream()
                 _log_failure(exc)
                 raise
+            executor = _astra_executor()
+            if executor is not None and (executor.has_admitted or executor.failed):
+                if not executor.finish_stream(assistant_content=getattr(final, "output_text", "") or ""):
+                    raise RuntimeError("Astra async tool execution did not reach a durable result boundary")
+            elif executor is not None and executor.retire_empty():
+                agent._astra_async_executor = None
             if not agent._interrupt_requested:
                 _drain_for_finalizer(event_stream)
             if final.status in {"incomplete", "failed"}:

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -558,10 +558,11 @@ class _CodexResponseAssembler:
     saw_response_completed = False
 
     def __init__(self, *, model, on_text_delta, on_reasoning_delta, on_commentary_message, on_first_delta,
-                 on_async_tool_call=None):
+                 on_async_tool_call=None, on_async_tool_announcement=None):
         self.model, self.on_text_delta, self.on_reasoning_delta = model, on_text_delta, on_reasoning_delta
         self.on_commentary_message, self.on_first_delta = on_commentary_message, on_first_delta
         self.on_async_tool_call = on_async_tool_call
+        self.on_async_tool_announcement = on_async_tool_announcement
         self.output_items: List[Any] = []
         # output_index / first-observed sequence per output item, in lockstep, so settled pending calls merge
         # back in stream order.
@@ -616,6 +617,8 @@ class _CodexResponseAssembler:
                     "item": item, "arguments": str(_event_field(item, "arguments", "") or ""),
                     "output_index": announced_index, "sequence": announced_sequence,
                 }
+                if _provider_async_marker(item):
+                    self._safe(self.on_async_tool_announcement, "on_async_tool_announcement", item)
 
     def _on_text_delta(self, event: Any, event_type: str) -> None:
         delta_text = _event_field(event, "delta", "")
@@ -768,6 +771,7 @@ class _CodexResponseAssembler:
 def _consume_codex_event_stream(
     event_iter: Any, *, model: str, on_text_delta=None, on_reasoning_delta=None, on_commentary_message=None,
     on_first_delta=None, on_event=None, interrupt_check=None, on_async_tool_call=None,
+    on_async_tool_announcement=None,
 ) -> SimpleNamespace:
     """Consume a Codex Responses SSE stream into a Response-shaped ``SimpleNamespace`` (see
     :class:`_CodexResponseAssembler`; ``status`` is ``completed`` when the stream ended with content but no
@@ -781,7 +785,8 @@ def _consume_codex_event_stream(
     must not become a partial final response."""
     assembler = _CodexResponseAssembler(model=model, on_text_delta=on_text_delta, on_reasoning_delta=on_reasoning_delta,
                                         on_commentary_message=on_commentary_message, on_first_delta=on_first_delta,
-                                        on_async_tool_call=on_async_tool_call)
+                                        on_async_tool_call=on_async_tool_call,
+                                        on_async_tool_announcement=on_async_tool_announcement)
     for event in event_iter:
         if on_event is not None:
             try:
@@ -973,12 +978,14 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 async_executor = _astra_executor()
                 async_callback = getattr(async_executor, "admit", None)
                 async_callback = _fenced(async_callback) if callable(async_callback) else None
+                async_announcement = getattr(async_executor, "reserve", None)
+                async_announcement = _fenced(async_announcement) if callable(async_announcement) else None
                 final = _consume_codex_event_stream(
                     event_stream, model=model, on_text_delta=_fenced(_on_text_delta),
                     on_reasoning_delta=_fenced(lambda text: agent._fire_reasoning_delta(text)),
                     on_commentary_message=on_commentary_message, on_first_delta=on_first_delta,
                     on_event=_fenced(_on_event), interrupt_check=_interrupt_or_superseded,
-                    on_async_tool_call=async_callback,
+                    on_async_tool_call=async_callback, on_async_tool_announcement=async_announcement,
                 )
             except (InterruptedError, TimeoutError):
                 executor = _astra_executor()
@@ -1016,7 +1023,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 _log_failure(exc)
                 raise
             executor = _astra_executor()
-            if executor is not None and (executor.has_admitted or executor.failed):
+            if executor is not None and (executor.has_admitted or executor.has_pending or executor.failed):
                 if not executor.finish_stream(assistant_content=getattr(final, "output_text", "") or ""):
                     raise RuntimeError("Astra async tool execution did not reach a durable result boundary")
             elif executor is not None and executor.retire_empty():

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1437,7 +1437,7 @@ def _query_anthropic_context_length(model: str, base_url: str, api_key: str) -> 
 # Codex OAuth `context_window` values (what Codex enforces — lower than the direct API for the same
 # slugs). Fallback when the live probe fails; longest-key-first. gpt-5.3-codex-spark is listed so "gpt-5.3-codex" doesn't win.
 _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
-    "gpt-6-astra": 1_050_000,
+    "gpt-6-astra": 272_000,
     "gpt-5.1-codex-max": 272_000, "gpt-5.1-codex-mini": 272_000, "gpt-5.3-codex": 272_000,
     "gpt-5.3-codex-spark": 128_000, "gpt-5.2-codex": 272_000, "gpt-5.4-mini": 272_000,
     "gpt-5.6-sol": 272_000, "gpt-5.6-terra": 272_000, "gpt-5.6-luna": 272_000, "gpt-daybreak-blue-latest": 272_000,

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1449,13 +1449,16 @@ _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
 # The bump fires ONLY when the resolved value is exactly the stale 272,000. ``gpt-5.6`` is a FAMILY
 # PREFIX (``-pro`` slugs aren't routable on Codex); ``gpt-5.4`` is EXACT because gpt-5.4-mini enforces 272K.
 _CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_PREFIXES: Dict[str, int] = {"gpt-5.6": 900_000}  # sol / terra / luna
-_CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_EXACT: Dict[str, int] = {"gpt-5.4": 900_000, "gpt-daybreak-blue-latest": 900_000}
+_CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_EXACT: Dict[str, int] = {
+    "gpt-5.4": 900_000, "gpt-daybreak-blue-latest": 900_000,
+    "gpt-6-astra": 900_000,  # advertised 272K; 920,043 input OK, 1,000,043 rejected (live 2026-09-04)
+}
 _CODEX_OAUTH_STALE_ADVERTISED_CTX = 272_000  # the only advertised value the bump may override
 CODEX_CONTEXT_VARIANT_SUFFIX = "-900k"  # picker-only opt-in suffix; never sent on the wire
 # The ONLY bases eligible for ``-900k``: routable, live-verified. No family prefixing (it would synthesize
 # dead ``-pro`` variants); dated snapshots of the 5.6 bases are allowed. gpt-daybreak-blue-latest is a verified Sol alias.
 _CODEX_900K_SNAPSHOT_BASES = ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna")
-_CODEX_900K_ELIGIBLE_BASES = frozenset({*_CODEX_900K_SNAPSHOT_BASES, "gpt-5.4", "gpt-daybreak-blue-latest"})
+_CODEX_900K_ELIGIBLE_BASES = frozenset({*_CODEX_900K_SNAPSHOT_BASES, "gpt-5.4", "gpt-daybreak-blue-latest", "gpt-6-astra"})
 _CODEX_900K_SNAPSHOT_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -331,6 +331,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     # OpenAI — direct-API windows (Codex OAuth caps gpt-5.4+/5.5/5.6 at 272K, resolved by
     # its own branch). 5.4-nano/-mini are 400k, not 1.05M; gpt-5.3-codex-spark is
     # Codex-OAuth-only and listed so "gpt-5" (400k) doesn't win.
+    "gpt-6-astra": 1_050_000,
     "gpt-5.6-luna": 1050000, "gpt-5.6-terra": 1050000, "gpt-5.6-sol": 1050000, "gpt-5.5": 1050000,
     "gpt-5.4-nano": 400000, "gpt-5.4-mini": 400000, "gpt-5.4": 1050000,
     "gpt-5.3-codex-spark": 128000, "gpt-5.1-chat": 128000, "gpt-5": 400000,
@@ -1436,6 +1437,7 @@ def _query_anthropic_context_length(model: str, base_url: str, api_key: str) -> 
 # Codex OAuth `context_window` values (what Codex enforces — lower than the direct API for the same
 # slugs). Fallback when the live probe fails; longest-key-first. gpt-5.3-codex-spark is listed so "gpt-5.3-codex" doesn't win.
 _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
+    "gpt-6-astra": 1_050_000,
     "gpt-5.1-codex-max": 272_000, "gpt-5.1-codex-mini": 272_000, "gpt-5.3-codex": 272_000,
     "gpt-5.3-codex-spark": 128_000, "gpt-5.2-codex": 272_000, "gpt-5.4-mini": 272_000,
     "gpt-5.6-sol": 272_000, "gpt-5.6-terra": 272_000, "gpt-5.6-luna": 272_000, "gpt-daybreak-blue-latest": 272_000,

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -107,7 +107,7 @@ class ModelCapabilities:
 # Hermes provider names → models.dev provider IDs
 PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "openrouter": "openrouter", "novita": "novita-ai", "anthropic": "anthropic",
-    "openai": "openai", "openai-codex": "openai", "zai": "zai",
+    "openai": "openai", "openai-api": "openai", "openai-codex": "openai", "zai": "zai",
     "kimi": "kimi-for-coding", "kimi-coding": "kimi-for-coding",
     "moonshot": "kimi-for-coding", "stepfun": "stepfun",
     "kimi-coding-cn": "kimi-for-coding", "minimax": "minimax",

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -522,6 +522,19 @@ _OVERRIDE_WARNED_KEYS: set = set()
 # shared by get_model_capabilities and get_model_info so the two unknown-model paths agree.
 _UNKNOWN_MODEL_BASE: Dict[str, Any] = {"limit": {"context": 200000, "output": 8192}, "tool_call": True}
 
+# Account-gated models may be usable before models.dev has indexed them.  Keep
+# their capabilities available for an explicitly selected/discovered model
+# without adding them to any picker catalog.
+_BUILTIN_MODEL_METADATA: Dict[Tuple[str, str], Dict[str, Any]] = {
+    ("openai", "gpt-6-astra"): {
+        "limit": {"context": 1_050_000, "output": 128_000},
+        "modalities": {"input": ["text", "image"], "output": ["text"]},
+        "tool_call": True,
+        "reasoning": True,
+        "family": "gpt-6",
+    },
+}
+
 
 def _load_model_overrides() -> Dict[str, Any]:
     """The ``model_overrides`` config section ({} on any failure). Deliberately not memoized:
@@ -646,8 +659,11 @@ def _merge_catalog_entry_with_override(raw: Dict[str, Any], override: Dict[str, 
 def _apply_overrides(provider: str, model: str, entry: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
     """*entry* patched by its override; ``_UNKNOWN_MODEL_BASE`` patched by a fill-gap override on a
     catalog miss (selected AFTER lookup: _default only fills misses); None when neither exists."""
-    override = _override_for(provider, model, catalog_hit=entry is not None)
-    return entry if override is None else _merge_catalog_entry_with_override(entry if entry is not None else _UNKNOWN_MODEL_BASE, override)
+    provider_key = PROVIDER_TO_MODELS_DEV.get((provider or "").strip(), (provider or "").strip())
+    builtin = _BUILTIN_MODEL_METADATA.get((provider_key, (model or "").strip().lower()))
+    base = entry if entry is not None else builtin
+    override = _override_for(provider, model, catalog_hit=base is not None)
+    return base if override is None else _merge_catalog_entry_with_override(base if base is not None else _UNKNOWN_MODEL_BASE, override)
 
 
 def _entry_supports_vision(entry: Dict[str, Any]) -> bool:

--- a/agent/reasoning_effort.py
+++ b/agent/reasoning_effort.py
@@ -83,7 +83,7 @@ META_AI_EFFORTS: tuple[str, ...] = ("minimal", "low", "medium", "high", "xhigh")
 
 def codex_supported_efforts(model: Optional[str]) -> tuple[str, ...]:
     """Supported effort set for an OpenAI/Codex Responses model."""
-    if (model or "").strip().lower().rsplit("/", 1)[-1] == "gpt-6-astra":
+    if (model or "").strip().lower().rsplit("/", 1)[-1] in ("gpt-6-astra", "gpt-6-astra-900k"):
         return CODEX_ASTRA_EFFORTS
     return CODEX_GPT56_EFFORTS if "gpt-5.6" in (model or "").lower() else CODEX_LEGACY_EFFORTS
 

--- a/agent/reasoning_effort.py
+++ b/agent/reasoning_effort.py
@@ -31,6 +31,9 @@ OPENAI_COMPAT_WIRE_EFFORTS: tuple[str, ...] = ("none", "minimal", "low", "medium
 #: both (clamps to low); ``max`` is gpt-5.6-only.
 CODEX_GPT56_EFFORTS: tuple[str, ...] = ("none", "low", "medium", "high", "xhigh", "max")
 CODEX_LEGACY_EFFORTS: tuple[str, ...] = ("none", "low", "medium", "high", "xhigh")
+# GPT-6 Astra is account-gated and its Responses API accepts no disable/minimal
+# wire level; callers normalize those requests to ``low`` at the transport boundary.
+CODEX_ASTRA_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh", "max")
 
 #: xAI Responses — Grok 4.6+ accepts xhigh; older Grok tops out at high.
 XAI_GROK46_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh")
@@ -80,6 +83,8 @@ META_AI_EFFORTS: tuple[str, ...] = ("minimal", "low", "medium", "high", "xhigh")
 
 def codex_supported_efforts(model: Optional[str]) -> tuple[str, ...]:
     """Supported effort set for an OpenAI/Codex Responses model."""
+    if (model or "").strip().lower().rsplit("/", 1)[-1] == "gpt-6-astra":
+        return CODEX_ASTRA_EFFORTS
     return CODEX_GPT56_EFFORTS if "gpt-5.6" in (model or "").lower() else CODEX_LEGACY_EFFORTS
 
 

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -273,9 +273,11 @@ def _is_official_openai_responses_route(model: Any, base_url: Any) -> bool:
     """Astra cache semantics apply only to the official OpenAI API host."""
     if not _is_astra_model(model):
         return False
-    from utils import base_url_host_matches
+    from utils import base_url_hostname
 
-    return base_url_host_matches(str(base_url or ""), "api.openai.com")
+    # Astra's account-gated cache contract is for the canonical API origin only.
+    # Do not extend it to subdomains (or lookalike hosts) by suffix matching.
+    return base_url_hostname(str(base_url or "")).lower() == "api.openai.com"
 
 
 def _codex_efforts_for_route(model: Any, base_url: Any, *, is_codex_backend: bool = False) -> tuple[str, ...]:

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -11,7 +11,7 @@ import re
 from typing import Any, Callable, Optional
 
 from agent.reasoning_effort import (
-    ACTUAL_RELAY_EFFORTS, XAI_GROK46_EFFORTS, XAI_LEGACY_EFFORTS, clamp_effort,
+    ACTUAL_RELAY_EFFORTS, CODEX_ASTRA_EFFORTS, XAI_GROK46_EFFORTS, XAI_LEGACY_EFFORTS, clamp_effort,
     # Same declared vocabulary + shared clamp as the main Codex transport (agent.reasoning_effort):
     # per-model — "max" is gpt-5.6-only, "minimal"/"ultra" always rejected (live-verified, #68365).
     codex_supported_efforts,
@@ -211,6 +211,15 @@ def _resolve_reasoning(model: str, params: dict[str, Any]) -> tuple[Any, bool]:
         elif reasoning_config.get("effort"):
             reasoning_effort = reasoning_config["effort"]
 
+    # Astra has no wire-level disable/minimal setting.  Preserve Hermes' user-facing
+    # controls by sending the documented lowest enabled level instead; this also keeps
+    # an explicit ``enabled: false`` request valid on the Responses API.
+    if model.strip().lower().rsplit("/", 1)[-1] == "gpt-6-astra":
+        requested = str(reasoning_effort or "").strip().lower()
+        if not reasoning_enabled or requested in {"", "none", "minimal", "disabled", "off"}:
+            return "low", True
+        return clamp_effort(reasoning_effort, CODEX_ASTRA_EFFORTS), True
+
     # Wire vocabularies are declared in agent.reasoning_effort; the shared clamp policy (nearest weaker
     # supported level, never escalate, never invert the ladder) replaces the per-backend hand maps that
     # repeatedly leaked internal levels like "ultra" to the wire (#89503 class) or clamped one rung below a
@@ -260,6 +269,37 @@ def _default_prompt_cache_retention_for_request(model: str, base_url: Any) -> Op
         return None
     normalized = str(model or "").strip().lower().replace("_", "-")
     return "24h" if _EXTENDED_PROMPT_CACHE_MODEL_RE.search(normalized) else None
+
+
+def _is_astra_model(model: Any) -> bool:
+    return str(model or "").strip().lower().rsplit("/", 1)[-1] == "gpt-6-astra"
+
+
+def _is_official_openai_responses_route(model: Any, base_url: Any) -> bool:
+    """Astra cache semantics apply only to the official OpenAI API host."""
+    if not _is_astra_model(model):
+        return False
+    from utils import base_url_host_matches
+
+    return base_url_host_matches(str(base_url or ""), "api.openai.com")
+
+
+def _sanitize_astra_request_kwargs(kwargs: dict[str, Any], model: Any, base_url: Any) -> None:
+    """Apply Astra's model-specific restrictions after all request overrides are merged."""
+    if not _is_astra_model(model):
+        return
+    for key in ("temperature", "top_p", "top_logprobs", "logprobs"):
+        kwargs.pop(key, None)
+    include = kwargs.get("include")
+    if isinstance(include, list):
+        kwargs["include"] = [item for item in include if "logprob" not in str(item).lower()]
+    if _is_official_openai_responses_route(model, base_url):
+        kwargs["prompt_cache_options"] = {"ttl": "30m"}
+        kwargs.pop("prompt_cache_retention", None)
+    else:
+        # A caller override must not accidentally send official-only cache syntax to a
+        # proxy or another provider that happens to accept the Astra model name.
+        kwargs.pop("prompt_cache_options", None)
 
 
 def _content_cache_key(instructions: str, tools: Optional[list[dict[str, Any]]], scope_id: str = "") -> Optional[str]:
@@ -543,6 +583,8 @@ class ResponsesApiTransport(ProviderTransport):
         ))
         if params.get("request_overrides"):
             kwargs.update(params["request_overrides"])
+
+        _sanitize_astra_request_kwargs(kwargs, model, params.get("base_url"))
 
         _bound_prompt_cache_key_field(kwargs)
 

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -11,7 +11,8 @@ import re
 from typing import Any, Callable, Optional
 
 from agent.reasoning_effort import (
-    ACTUAL_RELAY_EFFORTS, CODEX_ASTRA_EFFORTS, XAI_GROK46_EFFORTS, XAI_LEGACY_EFFORTS, clamp_effort,
+    ACTUAL_RELAY_EFFORTS, CODEX_ASTRA_EFFORTS, CODEX_LEGACY_EFFORTS,
+    XAI_GROK46_EFFORTS, XAI_LEGACY_EFFORTS, clamp_effort,
     # Same declared vocabulary + shared clamp as the main Codex transport (agent.reasoning_effort):
     # per-model — "max" is gpt-5.6-only, "minimal"/"ultra" always rejected (live-verified, #68365).
     codex_supported_efforts,
@@ -226,7 +227,9 @@ def _resolve_reasoning(model: str, params: dict[str, Any]) -> tuple[Any, bool]:
         declared = _profile_declared_efforts(params.get("provider"), model, params.get("base_url"))
         if declared is not None and not declared:
             reasoning_enabled = False
-        supported = declared or codex_supported_efforts(model)
+        supported = declared or _codex_efforts_for_route(
+            model, params.get("base_url"), is_codex_backend=params.get("is_codex_backend") is True
+        )
     return clamp_effort(reasoning_effort, supported), reasoning_enabled
 
 
@@ -273,6 +276,15 @@ def _is_official_openai_responses_route(model: Any, base_url: Any) -> bool:
     from utils import base_url_host_matches
 
     return base_url_host_matches(str(base_url or ""), "api.openai.com")
+
+
+def _codex_efforts_for_route(model: Any, base_url: Any, *, is_codex_backend: bool = False) -> tuple[str, ...]:
+    """Keep Astra's new vocabulary off unrelated Responses-compatible endpoints."""
+    if _is_astra_model(model) and not (
+        is_codex_backend or _is_official_openai_responses_route(model, base_url)
+    ):
+        return CODEX_LEGACY_EFFORTS
+    return codex_supported_efforts(str(model or ""))
 
 
 def _sanitize_astra_request_kwargs(kwargs: dict[str, Any], model: Any, base_url: Any) -> None:

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -266,7 +266,7 @@ def _default_prompt_cache_retention_for_request(model: str, base_url: Any) -> Op
 
 
 def _is_astra_model(model: Any) -> bool:
-    return str(model or "").strip().lower().rsplit("/", 1)[-1] == "gpt-6-astra"
+    return str(model or "").strip().lower().rsplit("/", 1)[-1] in ("gpt-6-astra", "gpt-6-astra-900k")
 
 
 def _is_official_openai_responses_route(model: Any, base_url: Any) -> bool:

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -211,15 +211,6 @@ def _resolve_reasoning(model: str, params: dict[str, Any]) -> tuple[Any, bool]:
         elif reasoning_config.get("effort"):
             reasoning_effort = reasoning_config["effort"]
 
-    # Astra has no wire-level disable/minimal setting.  Preserve Hermes' user-facing
-    # controls by sending the documented lowest enabled level instead; this also keeps
-    # an explicit ``enabled: false`` request valid on the Responses API.
-    if model.strip().lower().rsplit("/", 1)[-1] == "gpt-6-astra":
-        requested = str(reasoning_effort or "").strip().lower()
-        if not reasoning_enabled or requested in {"", "none", "minimal", "disabled", "off"}:
-            return "low", True
-        return clamp_effort(reasoning_effort, CODEX_ASTRA_EFFORTS), True
-
     # Wire vocabularies are declared in agent.reasoning_effort; the shared clamp policy (nearest weaker
     # supported level, never escalate, never invert the ladder) replaces the per-backend hand maps that
     # repeatedly leaked internal levels like "ultra" to the wire (#89503 class) or clamped one rung below a
@@ -288,18 +279,24 @@ def _sanitize_astra_request_kwargs(kwargs: dict[str, Any], model: Any, base_url:
     """Apply Astra's model-specific restrictions after all request overrides are merged."""
     if not _is_astra_model(model):
         return
+    if not _is_official_openai_responses_route(model, base_url):
+        kwargs.pop("prompt_cache_options", None)
+        return
+    reasoning = kwargs.get("reasoning")
+    requested = reasoning.get("effort") if isinstance(reasoning, dict) else None
+    normalized = str(requested or "").strip().lower()
+    effort = "low" if normalized in {"", "none", "minimal", "disabled", "off"} else clamp_effort(
+        requested, CODEX_ASTRA_EFFORTS
+    )
+    kwargs["reasoning"] = {**(reasoning if isinstance(reasoning, dict) else {}), "effort": effort}
+    kwargs["reasoning"].setdefault("summary", "auto")
     for key in ("temperature", "top_p", "top_logprobs", "logprobs"):
         kwargs.pop(key, None)
     include = kwargs.get("include")
     if isinstance(include, list):
         kwargs["include"] = [item for item in include if "logprob" not in str(item).lower()]
-    if _is_official_openai_responses_route(model, base_url):
-        kwargs["prompt_cache_options"] = {"ttl": "30m"}
-        kwargs.pop("prompt_cache_retention", None)
-    else:
-        # A caller override must not accidentally send official-only cache syntax to a
-        # proxy or another provider that happens to accept the Astra model name.
-        kwargs.pop("prompt_cache_options", None)
+    kwargs["prompt_cache_options"] = {"ttl": "30m"}
+    kwargs.pop("prompt_cache_retention", None)
 
 
 def _content_cache_key(instructions: str, tools: Optional[list[dict[str, Any]]], scope_id: str = "") -> Optional[str]:

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -499,10 +499,12 @@ class ResponsesApiTransport(ProviderTransport):
             native_compaction_eligible=_native_compaction_active(kwargs.get("context_management")),
         )
 
-    def convert_tools(self, tools: Optional[list[dict[str, Any]]]) -> Any:
+    def convert_tools(self, tools: Optional[list[dict[str, Any]]], **kwargs) -> Any:
         """Convert OpenAI tool schemas to Responses API function definitions."""
         from agent.codex_responses_adapter import _responses_tools
 
+        if kwargs.get("async_tools") is True:
+            return _responses_tools(tools, async_tools=True)
         return _responses_tools(tools)
 
     def build_kwargs(
@@ -551,7 +553,18 @@ class ResponsesApiTransport(ProviderTransport):
         native_compaction_active = _native_compaction_active(context_management)
 
         reasoning_effort, reasoning_enabled = _resolve_reasoning(model, params)
-        response_tools, self._last_wire_aliases = _alias_wire_tools(self.convert_tools(tools), params, is_xai_responses)
+        # The marker is emitted only for exact direct Astra turns whose midstream executor
+        # was admitted by the caller.  Keep the internal hint out of returned kwargs so the
+        # normal Responses preflight contract remains unchanged.
+        async_tools = (
+            params.get("midstream_executor_active") is True
+            and str(model or "").strip().lower().rsplit("/", 1)[-1] == "gpt-6-astra"
+            and not is_codex_backend and not is_xai_responses and not is_github_responses
+            and _is_official_openai_responses_route(model, params.get("base_url"))
+        )
+        response_tools, self._last_wire_aliases = _alias_wire_tools(
+            self.convert_tools(tools, async_tools=async_tools), params, is_xai_responses
+        )
 
         # Lazy: provider plugins import this transport during model_metadata init.
         from agent.model_metadata import strip_codex_context_variant_suffix as _strip_ctx_variant
@@ -663,6 +676,8 @@ class ResponsesApiTransport(ProviderTransport):
                 provider_data = {
                     key: getattr(tc, key) for key in ("call_id", "response_item_id") if getattr(tc, key, None)
                 }
+                if getattr(tc, "async", False) is True or getattr(tc, "async_", False) is True:
+                    provider_data["async"] = True
                 has_fn = hasattr(tc, "function")
                 name = tc.function.name if has_fn else getattr(tc, "name", "")
                 # Undo only aliases THIS request emitted; the legacy map is for normalize-only call sites.

--- a/agent/turn_api_call.py
+++ b/agent/turn_api_call.py
@@ -62,7 +62,7 @@ def perform_api_call(
     agent: Any, *, api_kwargs: Any, _original_api_kwargs: Any, _llm_middleware_trace: Any,
     _moa_prepared_request: Any, _retry: Any, thinking_spinner: Any, retry_count: Any,
     api_call_count: Any, api_request_id: Any, effective_task_id: Any, turn_id: Any,
-    interrupted: Any,
+    interrupted: Any, messages: Any,
 ) -> ApiCallVerdict:
     """Issue the request (see ``_should_stream`` for the streaming decision)."""
     response = None
@@ -78,6 +78,20 @@ def perform_api_call(
         thinking_spinner = stop_thinking_spinner(agent, thinking_spinner)
 
     _use_streaming = _should_stream(agent)
+    from agent.astra_async_tools import AstraAsyncExecutor, is_direct_astra
+    if _use_streaming and is_direct_astra(agent):
+        existing_executor = getattr(agent, "_astra_async_executor", None)
+        if existing_executor is not None and existing_executor.has_admitted and getattr(existing_executor, "closed", False):
+            raise RuntimeError("Astra async tool stream was retired after durable dispatch")
+        if existing_executor is not None and not existing_executor.has_admitted:
+            existing_executor.retire_empty()
+        if existing_executor is None or not existing_executor.has_admitted or getattr(existing_executor, "finalized", False) \
+                or (getattr(existing_executor, "closed", False) and not existing_executor.has_admitted):
+            agent._astra_async_executor = AstraAsyncExecutor(agent, messages, effective_task_id, api_call_count)
+    elif getattr(agent, "_astra_async_executor", None) is not None and not getattr(
+        agent._astra_async_executor, "has_admitted", False
+    ):
+        agent._astra_async_executor = None
 
     def _perform_api_call(next_api_kwargs):
         if agent.api_mode == "codex_responses":
@@ -171,6 +185,13 @@ def handle_api_interrupt(
     from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 
     thinking_spinner = stop_thinking_spinner(agent, thinking_spinner)
+    try:
+        executor = getattr(agent, "_astra_async_executor", None)
+        if executor is not None:
+            executor.abort_stream()
+            agent._astra_async_executor = None
+    except Exception:
+        logger.debug("Astra async executor retirement failed", exc_info=True)
     # redirect() cancelled only this request: keep the correction queued, clear the
     # cancellation bit, let the outer loop rebuild. Never materialize incomplete
     # signed/encrypted reasoning items.

--- a/agent/turn_tool_round.py
+++ b/agent/turn_tool_round.py
@@ -63,6 +63,14 @@ def run_tool_round(
             truncated_tool_call_retries=truncated_tool_call_retries, result=result,
         )
 
+    # Direct Astra async calls were persisted and executed while the provider stream was
+    # still open.  Their result rows are already committed in original order; never send
+    # the same normalized response through the ordinary dispatcher a second time.
+    astra_executor = getattr(agent, "_astra_async_executor", None)
+    if astra_executor is not None and astra_executor.consume_response(assistant_message):
+        agent._astra_async_executor = None
+        return _verdict("continue")
+
     if not agent.quiet_mode:
         agent._vprint(f"{agent.log_prefix}🔧 Processing {len(assistant_message.tool_calls)} tool call(s)...")
 

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -109,6 +109,7 @@ class PricingEntry:
     input_cost_per_million_above: Optional[Decimal] = None
     output_cost_per_million_above: Optional[Decimal] = None
     cache_read_cost_per_million_above: Optional[Decimal] = None
+    cache_write_cost_per_million_above: Optional[Decimal] = None
 
 
 @dataclass(frozen=True)
@@ -237,6 +238,20 @@ for _provider, _url, _version, _rows in _SNAPSHOTS:
         for _model in ((_models,) if isinstance(_models, str) else _models):
             _OFFICIAL_DOCS_PRICING[(_provider, _model)] = _entry
 del _SNAPSHOTS, _provider, _url, _version, _rows, _models, _rates, _entry, _model
+
+# GPT-6 Astra uses whole-request pricing above the 272K prompt tier.  Keep this
+# account-gated model out of generic static catalogs, but retain published billing
+# metadata for an explicitly selected route.
+_OFFICIAL_DOCS_PRICING[("openai", "gpt-6-astra")] = _snap(
+    "10.00", "50.00", "1.00", "12.50",
+    url="https://developers.openai.com/api/docs/models/gpt-6-astra",
+    version="openai-gpt-6-astra-2026-09",
+    tier_threshold_tokens=272_000,
+    input_cost_per_million_above=Decimal("20.00"),
+    output_cost_per_million_above=Decimal("75.00"),
+    cache_read_cost_per_million_above=Decimal("2.00"),
+    cache_write_cost_per_million_above=Decimal("25.00"),
+)
 
 # Context-tiered Gemini Pro: above 200k prompt tokens the *_above rates apply to
 # the whole request (see PricingEntry).
@@ -555,7 +570,7 @@ def estimate_usage_cost(
         (usage.output_tokens, entry.output_cost_per_million, entry.output_cost_per_million_above, ()),
         (usage.cache_read_tokens, entry.cache_read_cost_per_million, entry.cache_read_cost_per_million_above,
          ("cache-read pricing unavailable for route",)),
-        (usage.cache_write_tokens, entry.cache_write_cost_per_million, None,
+        (usage.cache_write_tokens, entry.cache_write_cost_per_million, entry.cache_write_cost_per_million_above,
          ("cache-write pricing unavailable for route",)),
     ):
         if above and rate_above is not None:

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -96,7 +96,7 @@ def _finalize_codex_models(model_ids: List[str], *, allow_astra: bool = False) -
     """
     finalized = _add_forward_compat_models(model_ids)
     if not allow_astra:
-        finalized = [model for model in finalized if model.lower() != "gpt-6-astra"]
+        finalized = [model for model in finalized if model.lower().rsplit("/", 1)[-1] != "gpt-6-astra"]
     return _add_context_variants(finalized)
 
 

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -94,9 +94,12 @@ def _finalize_codex_models(model_ids: List[str], *, allow_astra: bool = False) -
     Cached/configured model names are useful compatibility hints, but only the
     account-scoped Codex endpoint is authoritative for current Astra access.
     """
+    from agent.model_metadata import strip_codex_context_variant_suffix
+
     finalized = _add_forward_compat_models(model_ids)
     if not allow_astra:
-        finalized = [model for model in finalized if model.lower().rsplit("/", 1)[-1] != "gpt-6-astra"]
+        finalized = [model for model in finalized
+                     if strip_codex_context_variant_suffix(model.lower()).rsplit("/", 1)[-1] != "gpt-6-astra"]
     return _add_context_variants(finalized)
 
 

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -88,9 +88,16 @@ def _add_context_variants(model_ids: List[str]) -> List[str]:
     return out
 
 
-def _finalize_codex_models(model_ids: List[str]) -> List[str]:
-    """Forward-compat synthesis + large-context variant synthesis."""
-    return _add_context_variants(_add_forward_compat_models(model_ids))
+def _finalize_codex_models(model_ids: List[str], *, allow_astra: bool = False) -> List[str]:
+    """Forward-compat/context synthesis with an entitlement gate for Astra.
+
+    Cached/configured model names are useful compatibility hints, but only the
+    account-scoped Codex endpoint is authoritative for current Astra access.
+    """
+    finalized = _add_forward_compat_models(model_ids)
+    if not allow_astra:
+        finalized = [model for model in finalized if model.lower() != "gpt-6-astra"]
+    return _add_context_variants(finalized)
 
 
 def _extract_chatgpt_account_id(access_token: str) -> Optional[str]:
@@ -159,7 +166,7 @@ def _fetch_models_from_api(access_token: str) -> List[str]:
         logger.debug("Failed to fetch Codex models from API: %s", exc)
         return []
 
-    return _finalize_codex_models(_ranked_slugs(entries))
+    return _finalize_codex_models(_ranked_slugs(entries), allow_astra=True)
 
 
 def _read_default_model(codex_home: Path) -> Optional[str]:
@@ -194,7 +201,7 @@ def get_codex_model_ids(access_token: Optional[str] = None) -> List[str]:
     if access_token:
         api_models = _fetch_models_from_api(access_token)
         if api_models:
-            return _finalize_codex_models(api_models)
+            return _finalize_codex_models(api_models, allow_astra=True)
     default_model = _read_default_model(codex_home)
     return _finalize_codex_models(_dedupe([
         *([default_model] if default_model else []), *_read_cache_models(codex_home),

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -407,7 +407,7 @@ def _append_unconfigured_rows(
     """Empty setup skeletons for canonical providers missing from ``rows`` — except the *current* one:
     if config.yaml still points at it but credentials are gone, keep a row carrying the saved model so
     GUI pickers don't silently snap to another provider."""
-    from hermes_cli.models import CANONICAL_PROVIDERS
+    from hermes_cli.models import CANONICAL_PROVIDERS, _model_requires_account_discovery
 
     seen = {r["slug"].lower() for r in rows}
     cur = (ctx.current_provider or "").lower()
@@ -419,6 +419,7 @@ def _append_unconfigured_rows(
         if current_only and entry.slug.lower() != cur:
             continue
         if entry.slug.lower() == cur:
+            saved_model = "" if _model_requires_account_discovery(entry.slug, cur_model) else cur_model
             auth_type, key_env = _provider_auth_hint(entry.slug)
             warning = (
                 f"Configured provider missing usable credentials; paste {key_env} to reactivate. "
@@ -427,8 +428,10 @@ def _append_unconfigured_rows(
                 else "Configured provider is not authenticated; run `hermes model` to reactivate. "
                 "Showing the saved model only."
             )
+            if cur_model and not saved_model:
+                warning = warning.replace("Showing the saved model only.", "Astra requires successful account-scoped model discovery.")
             extras.append(_canonical_row(
-                entry, cur, models=[cur_model] if cur_model else [], total_models=1 if cur_model else 0,
+                entry, cur, models=[saved_model] if saved_model else [], total_models=1 if saved_model else 0,
                 source="configured-current", authenticated=False, auth_type=auth_type, key_env=key_env,
                 warning=warning,
             ))

--- a/hermes_cli/model_switch_providers.py
+++ b/hermes_cli/model_switch_providers.py
@@ -1111,6 +1111,10 @@ def _finalize_picker_rows(results: list, user_providers, current_model: str) -> 
                 continue
             models = row.get("models") or []
             if current_model not in models:
+                from hermes_cli.models import _model_requires_account_discovery
+
+                if _model_requires_account_discovery(row.get("slug"), current_model):
+                    break
                 row["models"] = [current_model, *models]
                 row["total_models"] = row.get("total_models", len(models)) + 1
             break

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1516,6 +1516,13 @@ def _normalized_cache_slug(provider: Optional[str]) -> str:
     return requested if requested == "ollama" else (normalize_provider(provider) or (provider or ""))
 
 
+def _model_requires_account_discovery(provider: Optional[str], model: str) -> bool:
+    """Astra names cannot confer API/OAuth entitlement through picker state."""
+    return _normalized_cache_slug(provider) in {"openai", "openai-codex"} and str(model or "").strip().lower().rsplit("/", 1)[-1] in {
+        "gpt-6-astra", "gpt-6-astra-900k",
+    }
+
+
 def cached_provider_model_ids(
     provider: Optional[str], *, force_refresh: bool = False,
     ttl_seconds: int = _PROVIDER_MODELS_CACHE_TTL) -> list[str]:
@@ -1532,8 +1539,14 @@ def cached_provider_model_ids(
     fp = _credential_fingerprint(normalized)
     entry = cache.get(normalized)
     now = time.time()
+    # Even a credential-matched fresh disk cache predates the current account's
+    # entitlement check. Revalidate gated entries before offering them again.
+    cached_models = entry.get("models") if isinstance(entry, dict) else None
+    gated_cache = isinstance(cached_models, list) and any(
+        _model_requires_account_discovery(normalized, model) for model in cached_models
+    )
 
-    if not force_refresh and _cache_entry_valid(entry, fp, allow_empty=is_ollama):
+    if not force_refresh and not gated_cache and _cache_entry_valid(entry, fp, allow_empty=is_ollama):
         age = now - entry["at"]
         if age < ttl_seconds:
             return list(entry["models"])
@@ -1562,7 +1575,7 @@ def cached_provider_model_ids(
         return []
     # Live returned nothing: a stale same-fingerprint entry beats an empty result.
     if _cache_entry_valid(entry, fp):
-        return list(entry["models"])
+        return [model for model in entry["models"] if not _model_requires_account_discovery(normalized, model)]
     return []
 
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1203,7 +1203,12 @@ def _openai_catalog(normalized: str, force_refresh: bool) -> Optional[list[str]]
     curated = list(_PROVIDER_MODELS.get(normalized, []))
     # Curated order, only models the account has access to; an account serving none of them (rare)
     # falls back to curated so the picker still offers sane defaults.
-    return [m for m in curated if m.lower() in live_lower] or curated or live
+    discovered = [m for m in curated if m.lower() in live_lower]
+    # Astra is intentionally absent from offline/static catalogs: the official API's
+    # account-scoped /models response is the only source that may advertise it.
+    if "gpt-6-astra" in live_lower:
+        discovered.append(next((m for m in live if m.lower() == "gpt-6-astra"), "gpt-6-astra"))
+    return discovered or curated or live
 
 
 def _custom_catalog(normalized: str, force_refresh: bool) -> Optional[list[str]]:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1518,7 +1518,7 @@ def _normalized_cache_slug(provider: Optional[str]) -> str:
 
 def _model_requires_account_discovery(provider: Optional[str], model: str) -> bool:
     """Astra names cannot confer API/OAuth entitlement through picker state."""
-    return _normalized_cache_slug(provider) in {"openai", "openai-codex"} and str(model or "").strip().lower().rsplit("/", 1)[-1] in {
+    return _normalized_cache_slug(provider) in {"openai", "openai-api", "openai-codex"} and str(model or "").strip().lower().rsplit("/", 1)[-1] in {
         "gpt-6-astra", "gpt-6-astra-900k",
     }
 

--- a/tests/agent/test_astra_async_tools.py
+++ b/tests/agent/test_astra_async_tools.py
@@ -6,7 +6,7 @@ import time
 
 import pytest
 
-from agent.astra_async_tools import AstraAsyncExecutor, provider_async_marker
+from agent.astra_async_tools import AstraAsyncExecutor, is_direct_astra, provider_async_marker
 from agent.codex_responses_adapter import _response_tool_call, _responses_tools
 from agent.codex_runtime import _consume_codex_event_stream
 
@@ -66,6 +66,16 @@ def test_async_marker_spellings_survive_raw_and_normalized_paths(marker):
     assert provider_async_marker(normalized)
 
 
+@pytest.mark.parametrize(("base_url", "expected"), [
+    ("https://api.openai.com/v1", True),
+    ("https://evil.api.openai.com/v1", False),
+    ("https://api.openai.com.evil.test/v1", False),
+])
+def test_direct_astra_requires_exact_official_hostname(base_url, expected):
+    agent = SimpleNamespace(api_mode="codex_responses", model="gpt-6-astra", base_url=base_url)
+    assert is_direct_astra(agent) is expected
+
+
 class _FakeAgent:
     api_mode = "codex_responses"
     model = "gpt-6-astra"
@@ -113,7 +123,7 @@ def patched_executor(monkeypatch):
             self.name = call.name
             self.args = {}
             self.middleware_trace = []
-            self.parse_error = None
+            self.parse_error = "invalid arguments" if call.name == "malformed" else None
             self.scope_block = None
 
         def ref(self, task_id):
@@ -219,3 +229,67 @@ def test_interrupt_retirement_is_idempotent_and_does_not_re_admit(patched_execut
     assert executor.admit(call) is True
     executor.abort_stream()
     assert executor.admit(call) is False
+
+
+def test_parse_error_is_reported_without_handler_dispatch(patched_executor, monkeypatch):
+    _, starts, _ = patched_executor
+    import agent.tool_executor as tool_executor
+
+    invalid = []
+
+    def append_invalid(agent, messages, ref, parse_error):
+        invalid.append(ref.call_id)
+        messages.append({"role": "tool", "tool_call_id": ref.call_id, "content": parse_error})
+        return True
+
+    monkeypatch.setattr(tool_executor, "_append_invalid_arguments_result", append_invalid)
+    agent = _FakeAgent([])
+    executor = AstraAsyncExecutor(agent, [], "task")
+    assert executor.admit(_tool("malformed", "bad")) is True
+    assert executor.finish_stream() is True
+    assert starts == []
+    assert invalid == ["call_bad"]
+    assert agent._session_messages[-1]["content"] == "invalid arguments"
+
+
+def test_announced_order_blocks_later_completion_until_earlier_call_is_admitted(patched_executor):
+    _, starts, committed = patched_executor
+    agent = _FakeAgent([])
+    executor = AstraAsyncExecutor(agent, [], "task")
+    first, second = _tool("safe_a", "a"), _tool("safe_b", "b")
+    assert executor.reserve(first) is True
+    assert executor.reserve(second) is True
+    assert executor.admit(second) is True
+    assert starts == []
+    assert executor.admit(first) is True
+    assert executor.finish_stream() is True
+    assert committed == ["call_a", "call_b"]
+
+
+def test_publish_failure_recovers_once_without_reexecuting_handler(patched_executor, monkeypatch):
+    _, starts, _ = patched_executor
+    import agent.tool_executor as tool_executor
+
+    publish_calls = []
+
+    def fail_publish(agent, messages, ref, managed, **kwargs):
+        publish_calls.append(ref.call_id)
+        messages.append({"role": "tool", "tool_call_id": ref.call_id, "content": managed.result})
+        return False
+
+    monkeypatch.setattr(tool_executor, "_publish_sequential_result", fail_publish)
+    flushes = []
+    agent = _FakeAgent([])
+
+    def flush(messages):
+        flushes.append([row.copy() for row in messages])
+        return True
+
+    agent._flush_messages_to_session_db = flush
+    executor = AstraAsyncExecutor(agent, [], "task")
+    assert executor.admit(_tool("safe", "fail")) is True
+    assert executor.finish_stream() is True
+    assert starts == ["call_fail"]
+    assert publish_calls == ["call_fail"]
+    assert len(flushes) == 2
+    assert "[Orphan recovery:" in flushes[-1][-1]["content"]

--- a/tests/agent/test_astra_async_tools.py
+++ b/tests/agent/test_astra_async_tools.py
@@ -309,3 +309,65 @@ def test_publish_failure_recovers_once_without_reexecuting_handler(patched_execu
     assert publish_calls == ["call_fail"]
     assert len(flushes) == 2
     assert "[Orphan recovery:" in flushes[-1][-1]["content"]
+
+
+def test_settle_required_persists_ordered_prefix_once_and_finish_stream_is_idempotent(patched_executor, monkeypatch):
+    _, starts, committed = patched_executor
+    import agent.tool_executor as tool_executor
+
+    persisted = []
+    agent = _FakeAgent(persisted)
+
+    def publish(agent, messages, ref, managed, **kwargs):
+        committed.append(ref.call_id)
+        messages.append({"role": "tool", "tool_call_id": ref.call_id, "content": managed.result})
+        assert agent._flush_messages_to_session_db(messages) is True
+        return True
+
+    monkeypatch.setattr(tool_executor, "_publish_sequential_result", publish)
+    executor = AstraAsyncExecutor(agent, [], "task")
+    executor.admit(_tool("safe_a", "a"))
+    executor.admit(_tool("unsafe", "b"))
+    last = _tool("safe_c", "c")
+    executor.admit(last)
+
+    assert executor.settle_required([last.call_id]) is True
+    assert committed == ["call_a", "call_b", "call_c"]
+    assert [row["tool_call_id"] for row in persisted[-1] if row.get("role") == "tool"] == committed
+    assert executor.settle_required([last.call_id]) is True
+    assert committed == ["call_a", "call_b", "call_c"]
+
+    assert executor.finish_stream() is True
+    assert executor.finish_stream() is True
+    assert committed == ["call_a", "call_b", "call_c"]
+    assert [row["tool_call_id"] for row in agent._session_messages if row.get("role") == "tool"] == committed
+    assert starts.count("call_c") == 1
+
+
+def test_settle_required_persistence_failure_never_reexecutes_or_exposes_result(patched_executor, monkeypatch):
+    _, starts, _ = patched_executor
+    import agent.tool_executor as tool_executor
+
+    persisted = []
+    agent = _FakeAgent(persisted)
+
+    def flush(messages):
+        if any(row.get("role") == "tool" for row in messages):
+            return False
+        persisted.append([row.copy() for row in messages])
+        return True
+
+    agent._flush_messages_to_session_db = flush
+
+    def publish(agent, messages, ref, managed, **kwargs):
+        messages.append({"role": "tool", "tool_call_id": ref.call_id, "content": managed.result})
+        return agent._flush_messages_to_session_db(messages)
+
+    monkeypatch.setattr(tool_executor, "_publish_sequential_result", publish)
+    executor = AstraAsyncExecutor(agent, [], "task")
+    call = _tool("safe", "no-durable-result")
+    assert executor.admit(call) is True
+
+    assert executor.settle_required([call.call_id]) is False
+    assert starts == [call.call_id]
+    assert all(not any(row.get("role") == "tool" for row in batch) for batch in persisted)

--- a/tests/agent/test_astra_async_tools.py
+++ b/tests/agent/test_astra_async_tools.py
@@ -266,6 +266,22 @@ def test_announced_order_blocks_later_completion_until_earlier_call_is_admitted(
     assert committed == ["call_a", "call_b"]
 
 
+def test_terminal_settlement_admits_pending_announced_call_before_retirement(patched_executor):
+    _, starts, committed = patched_executor
+    agent = _FakeAgent([])
+    executor = AstraAsyncExecutor(agent, [], "task")
+    first, second = _tool("safe_a", "a"), _tool("safe_b", "b")
+    assert executor.admit(first) is True
+    final = _consume_codex_event_stream([
+        SimpleNamespace(type="response.output_item.added", output_index=1, item=second),
+        SimpleNamespace(type="response.completed", response=SimpleNamespace(id="resp", status="completed")),
+    ], model="gpt-6-astra", on_async_tool_announcement=executor.reserve)
+    assert executor.has_pending
+    assert executor.finish_stream(settled_calls=final.output) is True
+    assert starts == ["call_a", "call_b"]
+    assert committed == ["call_a", "call_b"]
+
+
 def test_publish_failure_recovers_once_without_reexecuting_handler(patched_executor, monkeypatch):
     _, starts, _ = patched_executor
     import agent.tool_executor as tool_executor

--- a/tests/agent/test_astra_async_tools.py
+++ b/tests/agent/test_astra_async_tools.py
@@ -1,0 +1,221 @@
+"""Focused deterministic coverage for direct GPT-6 Astra async application tools."""
+
+from types import SimpleNamespace
+import threading
+import time
+
+import pytest
+
+from agent.astra_async_tools import AstraAsyncExecutor, provider_async_marker
+from agent.codex_responses_adapter import _response_tool_call, _responses_tools
+from agent.codex_runtime import _consume_codex_event_stream
+
+
+def _tool(name, call_id):
+    call = SimpleNamespace(
+        type="function_call", id=f"fc_{call_id}", call_id=f"call_{call_id}", name=name,
+        arguments="{}", async_=True,
+    )
+    return call
+
+
+def test_astra_schema_marker_is_explicit_and_non_astra_shape_is_unchanged():
+    source = [{"type": "function", "function": {"name": "read_file", "parameters": {"type": "object"}}}]
+    plain = _responses_tools(source)
+    async_tools = _responses_tools(source, async_tools=True)
+    assert "async" not in plain[0]
+    assert async_tools[0]["async"] is True
+
+
+def test_stream_preserves_async_marker_and_admits_only_completed_call():
+    admitted = []
+    events = [
+        SimpleNamespace(type="response.output_item.added", output_index=0, item=SimpleNamespace(
+            type="function_call", id="fc_1", call_id="call_1", name="read_file", arguments="", **{"async": True},
+        )),
+        SimpleNamespace(type="response.function_call_arguments.delta", item_id="fc_1", delta="{}"),
+        SimpleNamespace(type="response.function_call_arguments.done", item_id="fc_1", arguments="{}"),
+        SimpleNamespace(type="response.completed", response=SimpleNamespace(id="resp_1", status="completed")),
+    ]
+    final = _consume_codex_event_stream(events, model="gpt-6-astra", on_async_tool_call=admitted.append)
+    assert len(admitted) == 1
+    assert admitted[0].call_id == "call_1"
+    assert getattr(admitted[0], "async", False) is True
+    assert final.output[0].call_id == "call_1"
+
+
+@pytest.mark.parametrize("marker", ["async", "async_"])
+def test_async_marker_spellings_survive_raw_and_normalized_paths(marker):
+    emitted = []
+    item = {"type": "function_call", "id": "fc_alias", "call_id": "call_alias", "name": "read_file",
+            "arguments": "{}", marker: True}
+    events = [
+        {"type": "response.output_item.added", "output_index": 0, "item": item},
+        {"type": "response.function_call_arguments.done", "item_id": "fc_alias", "arguments": "{}"},
+        {"type": "response.completed", "response": {"id": "resp_alias", "status": "completed"}},
+    ]
+    _consume_codex_event_stream(events, model="gpt-6-astra", on_async_tool_call=emitted.append)
+    assert len(emitted) == 1
+    assert provider_async_marker(emitted[0])
+
+    normalized = _response_tool_call(
+        SimpleNamespace(type="function_call", id="fc_alias", call_id="call_alias", name="read_file",
+                        arguments="{}", **{marker: True}),
+        "function_call", 0,
+    )
+    assert provider_async_marker(normalized)
+
+
+class _FakeAgent:
+    api_mode = "codex_responses"
+    model = "gpt-6-astra"
+    base_url = "https://api.openai.com/v1"
+    session_id = "session-test"
+    session_start = None
+    _interrupt_requested = False
+
+    def __init__(self, persisted):
+        self.persisted = persisted
+        self._session_messages = []
+        self.verbose_logging = False
+        self.reasoning_callback = None
+        self.stream_delta_callback = None
+        self._stream_callback = None
+
+    def _extract_reasoning(self, message):
+        return None
+
+    def _strip_think_blocks(self, content):
+        return content
+
+    def _split_responses_tool_id(self, value):
+        return (value, value)
+
+    def _derive_responses_function_call_id(self, call_id, response_item_id=None):
+        return response_item_id or f"fc_{call_id.removeprefix('call_')}"
+
+    def _deterministic_call_id(self, name, arguments, index):
+        return f"call_deterministic_{index}"
+
+    def _flush_messages_to_session_db(self, messages):
+        self.persisted.append([m.copy() for m in messages])
+        return True
+
+
+@pytest.fixture
+def patched_executor(monkeypatch):
+    import agent.astra_async_tools as module
+    import agent.tool_executor as tool_executor
+
+    class Parsed:
+        def __init__(self, call):
+            self.call = call
+            self.name = call.name
+            self.args = {}
+            self.middleware_trace = []
+            self.parse_error = None
+            self.scope_block = None
+
+        def ref(self, task_id):
+            return SimpleNamespace(name=self.name, args={}, task_id=task_id, call_id=self.call.call_id, trace=[])
+
+    monkeypatch.setattr(tool_executor, "_parse_tool_call", lambda agent, call: Parsed(call))
+    monkeypatch.setattr(tool_executor, "_resolve_sequential_dispatch", lambda *args: SimpleNamespace())
+
+    running = set()
+    overlap = threading.Event()
+    starts = []
+
+    def run_call(agent, dispatch, ref, **kwargs):
+        starts.append(ref.call_id)
+        running.add(ref.call_id)
+        if len(running) >= 2:
+            overlap.set()
+        time.sleep(0.03)
+        running.remove(ref.call_id)
+        return SimpleNamespace(result=f"result:{ref.call_id}", args={}, middleware_trace=[], blocked=False, dispatched=True), 0.03
+
+    monkeypatch.setattr(tool_executor, "_run_sequential_call", run_call)
+    committed = []
+
+    def publish(agent, messages, ref, managed, **kwargs):
+        committed.append(ref.call_id)
+        messages.append({"role": "tool", "tool_call_id": ref.call_id, "content": managed.result})
+        return True
+
+    monkeypatch.setattr(tool_executor, "_publish_sequential_result", publish)
+    monkeypatch.setattr(tool_executor, "_budget_for_agent", lambda agent: object())
+    monkeypatch.setattr(tool_executor, "_finalize_tool_batch", lambda *args, **kwargs: None)
+
+    def plan(calls, **kwargs):
+        segments = []
+        current = []
+        for call in calls:
+            if call.name == "unsafe":
+                if current:
+                    segments.append(("parallel", current) if len(current) > 1 else ("sequential", current))
+                    current = []
+                segments.append(("sequential", [call]))
+            else:
+                current.append(call)
+        if current:
+            segments.append(("parallel", current) if len(current) > 1 else ("sequential", current))
+        return segments
+
+    monkeypatch.setattr(module, "_plan_tool_batch_segments", plan)
+    return overlap, starts, committed
+
+
+def test_admit_persists_before_handler_and_barriers_keep_result_order(patched_executor):
+    overlap, starts, committed = patched_executor
+    persisted = []
+    agent = _FakeAgent(persisted)
+    executor = AstraAsyncExecutor(agent, [], "task")
+
+    first = _tool("safe_a", "a")
+    assert executor.admit(first) is True
+    # The first worker may start immediately, but its assistant fragment was flushed first.
+    assert persisted and persisted[0][0]["role"] == "assistant"
+
+    second = _tool("safe_b", "b")
+    assert executor.admit(second) is True
+    assert executor.admit(_tool("unsafe", "c")) is True
+    assert executor.admit(_tool("safe_d", "d")) is True
+    assert executor.finish_stream() is True
+    assert overlap.is_set()
+    assert committed == ["call_a", "call_b", "call_c", "call_d"]
+    assert starts.count("call_c") == 1
+
+
+def test_empty_executor_is_retired_before_later_turn_state_can_be_reused():
+    agent = _FakeAgent([])
+    stale_messages = [{"role": "assistant", "content": "stale"}]
+    stale = AstraAsyncExecutor(agent, stale_messages, "task")
+    assert stale.retire_empty() is True
+    assert stale.closed is True
+
+    fresh_messages = [{"role": "user", "content": "new"}]
+    fresh = AstraAsyncExecutor(agent, fresh_messages, "task")
+    assert fresh.messages is fresh_messages
+    assert fresh.messages is not stale.messages
+    fresh.retire_empty()
+
+
+def test_mixed_assistant_text_is_persisted_before_async_results(patched_executor):
+    persisted = []
+    agent = _FakeAgent(persisted)
+    executor = AstraAsyncExecutor(agent, [], "task")
+    assert executor.admit(_tool("safe", "text")) is True
+    assert executor.finish_stream(assistant_content="Visible assistant text") is True
+    assistant_rows = [row for batch in persisted for row in batch if row.get("role") == "assistant"]
+    assert any(row.get("content") == "Visible assistant text" for row in assistant_rows)
+
+
+def test_interrupt_retirement_is_idempotent_and_does_not_re_admit(patched_executor):
+    persisted = []
+    agent = _FakeAgent(persisted)
+    executor = AstraAsyncExecutor(agent, [], "task")
+    call = _tool("safe", "once")
+    assert executor.admit(call) is True
+    executor.abort_stream()
+    assert executor.admit(call) is False

--- a/tests/agent/test_astra_baseline_runtime.py
+++ b/tests/agent/test_astra_baseline_runtime.py
@@ -2,6 +2,8 @@
 
 from types import SimpleNamespace
 
+import pytest
+
 
 def test_explicit_astra_resolves_and_uses_official_responses(monkeypatch, tmp_path):
     """A fresh profile resolves metadata and routes the official endpoint without live I/O."""
@@ -46,3 +48,33 @@ def test_astra_codex_oauth_fallback_uses_backend_context_limit():
 
     assert DEFAULT_CONTEXT_LENGTHS["gpt-6-astra"] == 1_050_000
     assert _resolve_codex_oauth_context_length_with_source("gpt-6-astra") == (272_000, "fallback")
+
+
+@pytest.mark.parametrize("advertised,expected", [(272_000, 900_000), (200_000, 200_000), (1_050_000, 1_050_000)])
+def test_astra_900k_opt_in_preserves_live_limits_and_wire_contract(monkeypatch, tmp_path, advertised, expected):
+    """Only the known stale advertisement is lifted; the alias never reaches the wire."""
+    from agent import model_metadata as metadata
+    from agent.reasoning_effort import CODEX_ASTRA_EFFORTS, codex_supported_efforts
+    from agent.transports.codex import ResponsesApiTransport
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(metadata, "_codex_oauth_context_cache", {})
+    monkeypatch.setattr(metadata.requests, "get", lambda *args, **kwargs: SimpleNamespace(
+        status_code=200,
+        json=lambda: {"models": [{"slug": "gpt-6-astra", "context_window": advertised}]},
+    ))
+    route = {"base_url": "https://chatgpt.com/backend-api/codex", "provider": "openai-codex"}
+    assert metadata.get_model_context_length("gpt-6-astra-900k", api_key="test-token", **route) == expected
+    assert metadata.get_model_context_length("gpt-6-astra", api_key="test-token", **route) == advertised
+    assert codex_supported_efforts("gpt-6-astra-900k") == CODEX_ASTRA_EFFORTS
+
+    for config, expected_effort in [({"effort": "max"}, "max"), ({"enabled": False}, "low")]:
+        kwargs = ResponsesApiTransport().build_kwargs(
+            model="gpt-6-astra-900k", messages=[{"role": "user", "content": "Hi"}], tools=[],
+            is_codex_backend=True, reasoning_config=config,
+            request_overrides={"temperature": 0.5, "logprobs": True}, **route,
+        )
+        assert kwargs["model"] == "gpt-6-astra"
+        assert kwargs["reasoning"]["effort"] == expected_effort
+        assert "temperature" not in kwargs and "logprobs" not in kwargs
+        assert "prompt_cache_options" not in kwargs

--- a/tests/agent/test_astra_baseline_runtime.py
+++ b/tests/agent/test_astra_baseline_runtime.py
@@ -35,3 +35,14 @@ def test_explicit_astra_resolves_and_uses_official_responses(monkeypatch, tmp_pa
     )
     assert kwargs["reasoning"]["effort"] == "low"
     assert kwargs["prompt_cache_options"] == {"ttl": "30m"}
+
+
+def test_astra_codex_oauth_fallback_uses_backend_context_limit():
+    """OAuth keeps the Codex backend's 272K fallback; direct API metadata remains 1.05M."""
+    from agent.model_metadata import (
+        DEFAULT_CONTEXT_LENGTHS,
+        _resolve_codex_oauth_context_length_with_source,
+    )
+
+    assert DEFAULT_CONTEXT_LENGTHS["gpt-6-astra"] == 1_050_000
+    assert _resolve_codex_oauth_context_length_with_source("gpt-6-astra") == (272_000, "fallback")

--- a/tests/agent/test_astra_baseline_runtime.py
+++ b/tests/agent/test_astra_baseline_runtime.py
@@ -68,13 +68,43 @@ def test_astra_900k_opt_in_preserves_live_limits_and_wire_contract(monkeypatch, 
     assert metadata.get_model_context_length("gpt-6-astra", api_key="test-token", **route) == advertised
     assert codex_supported_efforts("gpt-6-astra-900k") == CODEX_ASTRA_EFFORTS
 
-    for config, expected_effort in [({"effort": "max"}, "max"), ({"enabled": False}, "low")]:
-        kwargs = ResponsesApiTransport().build_kwargs(
-            model="gpt-6-astra-900k", messages=[{"role": "user", "content": "Hi"}], tools=[],
+    for config in ({"effort": "max"}, {"enabled": False}):
+        params = dict(
+            messages=[{"role": "user", "content": "Hi"}], tools=[],
             is_codex_backend=True, reasoning_config=config,
             request_overrides={"temperature": 0.5, "logprobs": True}, **route,
         )
+        kwargs = ResponsesApiTransport().build_kwargs(model="gpt-6-astra-900k", **params)
         assert kwargs["model"] == "gpt-6-astra"
-        assert kwargs["reasoning"]["effort"] == expected_effort
-        assert "temperature" not in kwargs and "logprobs" not in kwargs
+        assert kwargs == ResponsesApiTransport().build_kwargs(model="gpt-6-astra", **params)
         assert "prompt_cache_options" not in kwargs
+
+
+@pytest.mark.parametrize("provider,model", [
+    ("openai-codex", "gpt-6-astra"), ("openai-codex", "gpt-6-astra-900k"), ("openai", "gpt-6-astra"),
+])
+def test_picker_revalidates_cached_astra_and_never_injects_saved_entitlement(monkeypatch, tmp_path, provider, model):
+    from hermes_cli import models
+    from hermes_cli.inventory import ConfigContext, _append_unconfigured_rows
+    from hermes_cli.model_switch_providers import _finalize_picker_rows
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(models, "_credential_fingerprint", lambda _: "synthetic-account")
+    models.update_provider_cache_entry(provider, ["gpt-5.6-sol", model])
+    live = []
+    calls = []
+
+    def discover(slug, **kwargs):
+        calls.append(slug)
+        return list(live)
+
+    monkeypatch.setattr(models, "provider_model_ids", discover)
+    assert models.cached_provider_model_ids(provider) == ["gpt-5.6-sol"]
+    assert calls == [provider]
+    row = {"slug": provider, "is_current": True, "models": ["gpt-5.6-sol"], "total_models": 1}
+    assert model not in _finalize_picker_rows([row], {}, model)[0]["models"]
+    ctx = ConfigContext(provider, model, "", {}, [])
+    assert _append_unconfigured_rows([], ctx, current_only=True)[0]["models"] == []
+
+    live[:] = ["gpt-5.6-sol", model]
+    assert model in models.cached_provider_model_ids(provider)

--- a/tests/agent/test_astra_baseline_runtime.py
+++ b/tests/agent/test_astra_baseline_runtime.py
@@ -81,7 +81,7 @@ def test_astra_900k_opt_in_preserves_live_limits_and_wire_contract(monkeypatch, 
 
 
 @pytest.mark.parametrize("provider,model", [
-    ("openai-codex", "gpt-6-astra"), ("openai-codex", "gpt-6-astra-900k"), ("openai", "gpt-6-astra"),
+    ("openai-codex", "gpt-6-astra"), ("openai-codex", "gpt-6-astra-900k"), ("openai-api", "gpt-6-astra"),
 ])
 def test_picker_revalidates_cached_astra_and_never_injects_saved_entitlement(monkeypatch, tmp_path, provider, model):
     from hermes_cli import models

--- a/tests/agent/test_astra_baseline_runtime.py
+++ b/tests/agent/test_astra_baseline_runtime.py
@@ -1,0 +1,37 @@
+"""Focused real-path coverage for the GPT-6 Astra baseline contract."""
+
+from types import SimpleNamespace
+
+
+def test_explicit_astra_resolves_and_uses_official_responses(monkeypatch, tmp_path):
+    """A fresh profile resolves metadata and routes the official endpoint without live I/O."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda *args, **kwargs: {})
+    monkeypatch.setattr("agent.process_bootstrap.OpenAI", lambda **_kwargs: SimpleNamespace())
+    monkeypatch.setattr("model_tools.get_tool_definitions", lambda *args, **kwargs: [])
+
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        model="gpt-6-astra",
+        provider="openai",
+        api_key="test-key",
+        base_url="https://api.openai.com/v1",
+        platform="cli",
+        max_iterations=2,
+        quiet_mode=True,
+        skip_memory=True,
+    )
+
+    assert agent.api_mode == "codex_responses"
+    assert agent.context_compressor.context_length == 1_050_000
+    kwargs = agent._get_transport().build_kwargs(
+        model=agent.model,
+        messages=[{"role": "user", "content": "Hi"}],
+        tools=[],
+        provider=agent.provider,
+        base_url=agent.base_url,
+        reasoning_config={"enabled": False, "effort": "none"},
+    )
+    assert kwargs["reasoning"]["effort"] == "low"
+    assert kwargs["prompt_cache_options"] == {"ttl": "30m"}

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3171,6 +3171,19 @@ class TestCodexAdapterPromptCacheKey:
         ])
         assert "prompt_cache_retention" not in captured
 
+    def test_astra_auxiliary_request_uses_official_contract(self):
+        adapter, captured = self._build_adapter(
+            base_url="https://api.openai.com/v1",
+            model="gpt-6-astra",
+        )
+        adapter.create(
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"reasoning": {"enabled": False, "effort": "none"}},
+        )
+        assert captured["reasoning"]["effort"] == "low"
+        assert captured["prompt_cache_options"] == {"ttl": "30m"}
+        assert "prompt_cache_retention" not in captured
+
     def test_codex_backend_forwards_auxiliary_service_tier(self):
         adapter, captured = self._build_adapter(
             base_url="https://chatgpt.com/backend-api/codex",

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3184,6 +3184,18 @@ class TestCodexAdapterPromptCacheKey:
         assert captured["prompt_cache_options"] == {"ttl": "30m"}
         assert "prompt_cache_retention" not in captured
 
+    def test_astra_auxiliary_proxy_keeps_legacy_effort_contract(self):
+        adapter, captured = self._build_adapter(
+            base_url="https://responses.example.com/v1",
+            model="gpt-6-astra",
+        )
+        adapter.create(
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"reasoning": {"effort": "none"}},
+        )
+        assert captured["reasoning"]["effort"] == "none"
+        assert "prompt_cache_options" not in captured
+
     def test_codex_backend_forwards_auxiliary_service_tier(self):
         adapter, captured = self._build_adapter(
             base_url="https://chatgpt.com/backend-api/codex",

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -825,6 +825,18 @@ class TestGetModelCapabilities:
         assert caps is not None
         assert caps.supports_vision is False
 
+    def test_astra_builtin_metadata_fills_catalog_lag_without_listing_it(self):
+        """An explicitly discovered Astra remains fully described before models.dev catches up."""
+        with patch("agent.models_dev.fetch_models_dev", return_value={}):
+            caps = get_model_capabilities("openai", "gpt-6-astra")
+
+        assert caps is not None
+        assert caps.context_window == 1_050_000
+        assert caps.max_output_tokens == 128_000
+        assert caps.supports_tools is True
+        assert caps.supports_vision is True
+        assert caps.supports_reasoning is True
+
 
 # ---------------------------------------------------------------------------
 # Per-model metadata overrides (model_overrides config)

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -837,6 +837,9 @@ class TestGetModelCapabilities:
         assert caps.supports_vision is True
         assert caps.supports_reasoning is True
 
+        api_caps = get_model_capabilities("openai-api", "gpt-6-astra")
+        assert api_caps == caps
+
 
 # ---------------------------------------------------------------------------
 # Per-model metadata overrides (model_overrides config)

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -11,6 +11,23 @@ from agent.usage_pricing import (
 from decimal import Decimal
 
 
+def test_astra_whole_request_price_tier_includes_cache_writes():
+    below = estimate_usage_cost(
+        "gpt-6-astra",
+        CanonicalUsage(input_tokens=100_000, output_tokens=10_000, cache_read_tokens=10_000, cache_write_tokens=10_000),
+        provider="openai",
+    )
+    above = estimate_usage_cost(
+        "gpt-6-astra",
+        CanonicalUsage(input_tokens=100_000, output_tokens=10_000, cache_read_tokens=100_000, cache_write_tokens=100_001),
+        provider="openai",
+    )
+
+    assert below.amount_usd == Decimal("1.635")
+    assert above.amount_usd == Decimal("5.450025")
+    assert above.pricing_version == "openai-gpt-6-astra-2026-09"
+
+
 
 
 

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -51,6 +51,7 @@ class TestCodexBuildKwargs:
                 "top_p": 0.9,
                 "top_logprobs": 5,
                 "logprobs": True,
+                "reasoning": {"effort": "none"},
                 "include": ["reasoning.encrypted_content", "message.output_text.logprobs"],
                 "prompt_cache_retention": "24h",
                 "prompt_cache_options": {"ttl": "1h"},
@@ -63,6 +64,31 @@ class TestCodexBuildKwargs:
         assert kw["include"] == ["reasoning.encrypted_content"]
         for unsupported in ("temperature", "top_p", "top_logprobs", "logprobs"):
             assert unsupported not in kw
+        assert transport.preflight_kwargs(kw)["prompt_cache_options"] == {"ttl": "30m"}
+
+    @pytest.mark.parametrize("effort", ["none", "minimal"])
+    def test_astra_normalizes_unsupported_low_efforts_after_overrides(self, transport, effort):
+        kw = transport.build_kwargs(
+            model="gpt-6-astra",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url="https://api.openai.com/v1",
+            request_overrides={"reasoning": {"effort": effort}},
+        )
+
+        assert kw["reasoning"]["effort"] == "low"
+
+    @pytest.mark.parametrize("effort", ["low", "medium", "high", "xhigh", "max"])
+    def test_astra_accepts_complete_effort_ladder(self, transport, effort):
+        kw = transport.build_kwargs(
+            model="gpt-6-astra",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url="https://api.openai.com/v1",
+            reasoning_config={"enabled": True, "effort": effort},
+        )
+
+        assert kw["reasoning"]["effort"] == effort
 
     def test_astra_proxy_does_not_receive_official_cache_options(self, transport):
         kw = transport.build_kwargs(

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -39,6 +39,42 @@ class TestCodexTransportBasic:
 
 class TestCodexBuildKwargs:
 
+    def test_astra_direct_request_applies_model_contract_after_overrides(self, transport):
+        kw = transport.build_kwargs(
+            model="gpt-6-astra",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url="https://api.openai.com/v1",
+            reasoning_config={"enabled": False, "effort": "none"},
+            request_overrides={
+                "temperature": 0.4,
+                "top_p": 0.9,
+                "top_logprobs": 5,
+                "logprobs": True,
+                "include": ["reasoning.encrypted_content", "message.output_text.logprobs"],
+                "prompt_cache_retention": "24h",
+                "prompt_cache_options": {"ttl": "1h"},
+            },
+        )
+
+        assert kw["reasoning"]["effort"] == "low"
+        assert kw["prompt_cache_options"] == {"ttl": "30m"}
+        assert "prompt_cache_retention" not in kw
+        assert kw["include"] == ["reasoning.encrypted_content"]
+        for unsupported in ("temperature", "top_p", "top_logprobs", "logprobs"):
+            assert unsupported not in kw
+
+    def test_astra_proxy_does_not_receive_official_cache_options(self, transport):
+        kw = transport.build_kwargs(
+            model="gpt-6-astra",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url="https://responses.example.com/v1",
+            request_overrides={"prompt_cache_options": {"ttl": "30m"}},
+        )
+
+        assert "prompt_cache_options" not in kw
+
     def test_900k_context_variant_suffix_stripped_on_wire(self, transport):
         """``-900k`` large-context picker variants are Hermes-side aliases —
         the Codex backend only knows the base slug, so build_kwargs must

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -103,6 +103,18 @@ class TestCodexBuildKwargs:
         assert "prompt_cache_options" not in kw
         assert kw["reasoning"]["effort"] == "none"
 
+    def test_astra_openai_subdomain_is_not_official_route(self, transport):
+        """Only api.openai.com gets Astra's official cache contract."""
+        kw = transport.build_kwargs(
+            model="gpt-6-astra",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url="https://evil.api.openai.com/v1",
+            request_overrides={"prompt_cache_options": {"ttl": "30m"}},
+        )
+
+        assert "prompt_cache_options" not in kw
+
     def test_900k_context_variant_suffix_stripped_on_wire(self, transport):
         """``-900k`` large-context picker variants are Hermes-side aliases —
         the Codex backend only knows the base slug, so build_kwargs must

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -96,10 +96,12 @@ class TestCodexBuildKwargs:
             messages=[{"role": "user", "content": "Hi"}],
             tools=[],
             base_url="https://responses.example.com/v1",
+            reasoning_config={"enabled": True, "effort": "none"},
             request_overrides={"prompt_cache_options": {"ttl": "30m"}},
         )
 
         assert "prompt_cache_options" not in kw
+        assert kw["reasoning"]["effort"] == "none"
 
     def test_900k_context_variant_suffix_stripped_on_wire(self, transport):
         """``-900k`` large-context picker variants are Hermes-side aliases —

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -118,13 +118,17 @@ def test_astra_requires_live_codex_account_discovery(monkeypatch, tmp_path):
 
     (tmp_path / "config.toml").write_text('model = "gpt-6-astra"\n', encoding="utf-8")
     (tmp_path / "models_cache.json").write_text(
-        json.dumps({"models": [{"slug": "gpt-6-astra", "priority": 0}]}),
+        json.dumps({"models": [
+            {"slug": "gpt-6-astra", "priority": 0},
+            {"slug": "openai/gpt-6-astra", "priority": 1},
+        ]}),
         encoding="utf-8",
     )
     monkeypatch.setenv("CODEX_HOME", str(tmp_path))
     monkeypatch.setattr(codex_models, "_fetch_models_from_api", lambda _token: [])
 
     assert "gpt-6-astra" not in get_codex_model_ids(access_token="stale-token")
+    assert "openai/gpt-6-astra" not in get_codex_model_ids(access_token="stale-token")
 
     monkeypatch.setattr(
         codex_models,

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -121,6 +121,8 @@ def test_astra_requires_live_codex_account_discovery(monkeypatch, tmp_path):
         json.dumps({"models": [
             {"slug": "gpt-6-astra", "priority": 0},
             {"slug": "openai/gpt-6-astra", "priority": 1},
+            {"slug": "gpt-6-astra-900k", "priority": 2},
+            {"slug": "openai/gpt-6-astra-900k", "priority": 3},
         ]}),
         encoding="utf-8",
     )
@@ -129,13 +131,16 @@ def test_astra_requires_live_codex_account_discovery(monkeypatch, tmp_path):
 
     assert "gpt-6-astra" not in get_codex_model_ids(access_token="stale-token")
     assert "openai/gpt-6-astra" not in get_codex_model_ids(access_token="stale-token")
+    assert "gpt-6-astra-900k" not in get_codex_model_ids(access_token="stale-token")
+    assert "openai/gpt-6-astra-900k" not in get_codex_model_ids(access_token="stale-token")
 
     monkeypatch.setattr(
         codex_models,
         "_fetch_models_from_api",
         lambda _token: codex_models._finalize_codex_models(["gpt-6-astra"], allow_astra=True),
     )
-    assert "gpt-6-astra" in get_codex_model_ids(access_token="entitled-token")
+    entitled = get_codex_model_ids(access_token="entitled-token")
+    assert entitled[entitled.index("gpt-6-astra") + 1] == "gpt-6-astra-900k"
 
 
 

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -112,6 +112,28 @@ def test_fetch_from_api_keeps_supported_in_api_false_models(monkeypatch):
     assert "gpt-5-internal" not in models
 
 
+def test_astra_requires_live_codex_account_discovery(monkeypatch, tmp_path):
+    """Cached/configured Astra names must not manufacture current OAuth entitlement."""
+    from hermes_cli import codex_models
+
+    (tmp_path / "config.toml").write_text('model = "gpt-6-astra"\n', encoding="utf-8")
+    (tmp_path / "models_cache.json").write_text(
+        json.dumps({"models": [{"slug": "gpt-6-astra", "priority": 0}]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    monkeypatch.setattr(codex_models, "_fetch_models_from_api", lambda _token: [])
+
+    assert "gpt-6-astra" not in get_codex_model_ids(access_token="stale-token")
+
+    monkeypatch.setattr(
+        codex_models,
+        "_fetch_models_from_api",
+        lambda _token: codex_models._finalize_codex_models(["gpt-6-astra"], allow_astra=True),
+    )
+    assert "gpt-6-astra" in get_codex_model_ids(access_token="entitled-token")
+
+
 
 
 
@@ -238,4 +260,3 @@ class TestNormalizeModelForProvider:
         assert changed is True
         # Uses first from available list
         assert cli.model == "gpt-5.3-codex"
-

--- a/tests/hermes_cli/test_openai_picker_curated.py
+++ b/tests/hermes_cli/test_openai_picker_curated.py
@@ -70,3 +70,16 @@ def test_default_openai_endpoint_intersects_account_access(monkeypatch):
     assert result == list(curated[:2])
 
 
+def test_astra_is_offered_only_by_successful_account_discovery(monkeypatch):
+    """A gated preview may enrich the picker only when this API key lists it."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-fake")
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+    with patch.object(M, "fetch_api_models", return_value=["gpt-5.6-sol", "gpt-6-astra"]):
+        discovered = M.provider_model_ids("openai-api", force_refresh=True)
+    with patch.object(M, "fetch_api_models", return_value=["gpt-5.6-sol"]):
+        not_entitled = M.provider_model_ids("openai-api", force_refresh=True)
+
+    assert "gpt-6-astra" in discovered
+    assert "gpt-6-astra" not in not_entitled
+

--- a/tests/hermes_cli/test_openai_picker_curated.py
+++ b/tests/hermes_cli/test_openai_picker_curated.py
@@ -79,7 +79,9 @@ def test_astra_is_offered_only_by_successful_account_discovery(monkeypatch):
         discovered = M.provider_model_ids("openai-api", force_refresh=True)
     with patch.object(M, "fetch_api_models", return_value=["gpt-5.6-sol"]):
         not_entitled = M.provider_model_ids("openai-api", force_refresh=True)
+    with patch.object(M, "fetch_api_models", side_effect=RuntimeError("discovery unavailable")):
+        discovery_failed = M.provider_model_ids("openai-api", force_refresh=True)
 
     assert "gpt-6-astra" in discovered
     assert "gpt-6-astra" not in not_entitled
-
+    assert "gpt-6-astra" not in discovery_failed


### PR DESCRIPTION
## TL;DR

**Optional Astra runtime enhancement; baseline compatibility does not depend on it.** Hermes already schedules safe tools concurrently.

This PR changes **when they may start**: an eligible Astra tool call can begin while the model's response is still streaming, instead of waiting for the response to finish. Its proposed benefit is earlier tool start; live benefit remains to be measured.

**Draft / evidence gate:** per #103015, adoption remains on hold until an entitled comparison in #103020 demonstrates useful tool overlap or latency improvement over the existing Hermes path. No measured speedup is claimed.

Fixes #103017 · Depends on #103057 · Tracker: #103015

## Native Hermes versus this addition

| Existing Hermes behavior | Added by this PR |
| --- | --- |
| Plan safe parallel work and unsafe/conflicting barriers | Reuse that segmented scheduling policy during response streaming. |
| Execute completed tool calls through the normal tool round | Admit completed provider-marked async calls before the terminal response event. |
| Keep tool-call/result history and recover interrupted work | Persist each call before early dispatch, settle streaming jobs, and prevent the normal loop or recovery from repeating their side effects. |

For example, a safe lookup could run while Astra continues producing the response. This does **not** make every tool parallel or reinterpret `ToolEntry.is_async`, which describes a Python handler.

## How it works

```mermaid
flowchart TD
    A["Completed provider async call arrives"] --> B["Persist assistant call before dispatch"]
    B --> C["Reuse Hermes scheduling policy"]
    C --> D["Start safe independent work"]
    C --> E["Order unsafe or conflicting work behind barriers"]
    F["Provider stream continues"] --> G["Stream and tool jobs settle"]
    D --> G
    E --> G
    G --> H["Persist results in original call order and IDs"]
    H --> I["Continue without executing the calls again"]
```

Only direct official-API Astra streaming requests with the midstream executor active advertise function schemas with `async: true`. The provider marker survives assembly and replay; it stays an internal wire field, not a new user setting.

When steering requires an in-flight tool result, `settle_required(call_ids)` waits for the ordered required prefix, including barrier predecessors, and persists it through Hermes' canonical result publisher before the continuation reads saved rows. Later stream settlement skips already-published jobs. It never copies an in-memory handler result directly to the wire.

If transport fails after dispatch, or history contains a started call without a paired result, the recovery path uses deterministic interrupted-tool results rather than retrying a possibly completed side effect. That favors duplicate-side-effect safety over transparent retries.

## Review scope and maintenance cost

The new coordination layer must manage work while the response is still arriving, then reconcile it with the existing tool loop. The important invariants are persistence-before-handler, barrier safety, stable result order/IDs, and no duplicate execution.

Start with `agent/astra_async_tools.py`, then the stream integration in `agent/codex_runtime.py` and `agent/turn_api_call.py`; `agent/turn_tool_round.py` handles the already-executed handoff.

**Stack warning:** GitHub's default diff against upstream `main` includes PR 1. [This feature-only tree comparison](https://github.com/100yenadmin/hermes-agent-for-upstream-PR-only/compare/de57e601193a955a69201e1a274d5ccab83a7634..e2a23bbcbf6ef99ad05917d0e36af5abfeb1bd79) compares the recorded parent/head directly: **8 files, +1,045 / −17**, including tests. Do not add cumulative PR diff totals to estimate series size.

## Validation

[Required CI is green](https://github.com/NousResearch/hermes-agent/actions/runs/33949971922/job/101263323395) on `e2a23bbcbf6ef99ad05917d0e36af5abfeb1bd79`.

Fake-stream tests cover calls arriving before stream completion, persistence-before-handler, safe overlap/barriers, original order/IDs, and interruption/recovery without duplicate handlers.

<details>
<summary>Test and independent-review receipts</summary>

```sh
scripts/run_tests.sh -j 1 --file-retries 0 --file-timeout 120 tests/agent/test_astra_async_tools.py -q
# 17 passed, 0 failed
```

`git diff --check` passed. The 17-case focused async file passed after integration of the settlement correction (`6b4f5ca91`); the final head only adds the updated baseline and a settlement docstring. PR 3 contains the real executor/SQLite/pending-steering integration regression requested in [review](https://github.com/NousResearch/hermes-agent/pull/103144#pullrequestreview-5117265831).

Independent semantic review of the original async side-effect path passed on `05e05fa821c368d7c3d78b24b0b7e41fba26c8d5`. A new independent runtime-delta review found no violation in ordered settlement or saved-result continuation at descendant `9d8ca656a`; it identified a separate explicit-failure restart issue owned by PR 3. The same reviewer subsequently cleared explicit-failure restart, same-agent retry and rotating-session journal recovery on combined descendant `d3ae318d37de4ad1199ab385cfc8e67f6ce3c4aa`. [Finding dispositions and current source-review receipt](https://github.com/NousResearch/hermes-agent/pull/103144#issuecomment-5550359139).

Recorded current parent: `de57e601193a955a69201e1a274d5ccab83a7634`. Synchronized upstream base: `1e69c12b64dba4090eddffeae27f5a147068d34b`. Original upstream base: `13e72fb205b735df679e0fd5f5996a34ac4accc6`.

</details>

**Live validation still required:** a same-workload live comparison of tool-start timing, actual overlap and end-to-end latency against the existing path, with comparable conditions and sample counts. Fixtures and CI establish tested source behavior, not real-world benefit or provider acceptance. No new command/config, hosted tools, release, or paid live run is included.

