### PR TITLE
fix(gateway): sessions.changed fires on content, not bare WAL mtime

### DIFF
--- a/tests/tui_gateway/test_change_watcher.py
+++ b/tests/tui_gateway/test_change_watcher.py
@@ -26,6 +26,7 @@ def watcher_home(tmp_path, monkeypatch):
     monkeypatch.setattr(server, "_change_checked_at", {})
     monkeypatch.setattr(server, "_change_broadcast_at", {})
     monkeypatch.setattr(server, "_bot_relay_outbox_seen", 0)
+    monkeypatch.setattr(server, "_sessions_content_probe_cache", {})
 
     events = []
     monkeypatch.setattr(
@@ -278,4 +279,117 @@ def test_broken_probe_never_kills_the_pass(watcher_home, monkeypatch):
     server._broadcast_watched_changes(now=10.0)
 
     # The broken cron probe is skipped; sessions still broadcasts.
+    assert ("sessions.changed", {}) in events
+
+
+def _seed_state_db(home) -> None:
+    """A minimal but real state.db: sessions + messages tables the content
+    probe can fingerprint (the production schema's session-list columns)."""
+    import sqlite3
+
+    con = sqlite3.connect(home / "state.db")
+    con.executescript(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY, source TEXT, user_id TEXT, title TEXT,
+            display_name TEXT, archived INTEGER, hidden INTEGER, pinned INTEGER,
+            message_count INTEGER, tool_call_count INTEGER, started_at REAL,
+            ended_at REAL, end_reason TEXT, last_read_at REAL,
+            last_activity_at REAL, cwd TEXT, session_key TEXT, chat_id TEXT,
+            thread_id TEXT, profile_name TEXT
+        );
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT, role TEXT,
+            content TEXT
+        );
+        """
+    )
+    con.execute(
+        "INSERT INTO sessions (id, source, started_at, message_count)"
+        " VALUES ('s1', 'desktop', 1.0, 1)"
+    )
+    con.execute("INSERT INTO messages (session_id, role, content) VALUES ('s1', 'user', 'hi')")
+    con.commit()
+    con.close()
+
+
+def _reset_sessions_sig_state(monkeypatch) -> None:
+    """Fresh watcher baselines + a cleared probe cache between tests."""
+    monkeypatch.setattr(server, "_change_sigs", {})
+    monkeypatch.setattr(server, "_change_checked_at", {})
+    monkeypatch.setattr(server, "_change_broadcast_at", {})
+    monkeypatch.setattr(server, "_sessions_content_probe_cache", {})
+
+
+def test_heartbeat_write_does_not_broadcast_sessions_changed(
+    watcher_home, monkeypatch
+):
+    """The 60s gateway-heartbeat refresh writes gateway_heartbeats through the
+    same state.db WAL. mtime moves; session-visible content does not. With N
+    gateways feeding one Desktop this used to fire an N-per-minute refresh
+    storm (visible flicker) — the content gate must swallow it."""
+    home, events = watcher_home
+    _seed_state_db(home)
+    _reset_sessions_sig_state(monkeypatch)
+    server._broadcast_watched_changes(now=0.0)  # seed
+
+    import sqlite3
+
+    time.sleep(0.02)
+    con = sqlite3.connect(home / "state.db")
+    con.execute(
+        "CREATE TABLE IF NOT EXISTS gateway_heartbeats ("
+        " backend_id TEXT PRIMARY KEY, pid INTEGER, started_at REAL,"
+        " last_heartbeat REAL, profile TEXT, host TEXT)"
+    )
+    con.execute("INSERT OR REPLACE INTO gateway_heartbeats VALUES ('b1', 1, 1.0, 99.0, 'p', 'h')")
+    con.commit()
+    con.close()
+
+    server._broadcast_watched_changes(now=10.0)
+    assert ("sessions.changed", {}) not in events
+
+
+def test_new_session_broadcasts_sessions_changed(watcher_home, monkeypatch):
+    """A genuine new session row must still broadcast — the gate exists to
+    filter bookkeeping, not to hide real changes (#58671 unchanged)."""
+    home, events = watcher_home
+    _seed_state_db(home)
+    _reset_sessions_sig_state(monkeypatch)
+    server._broadcast_watched_changes(now=0.0)
+
+    import sqlite3
+
+    time.sleep(0.02)
+    con = sqlite3.connect(home / "state.db")
+    con.execute(
+        "INSERT INTO sessions (id, source, started_at, message_count)"
+        " VALUES ('s2', 'discord', 2.0, 1)"
+    )
+    con.execute("INSERT INTO messages (session_id, role, content) VALUES ('s2', 'user', 'yo')")
+    con.commit()
+    con.close()
+
+    server._broadcast_watched_changes(now=10.0)
+    assert ("sessions.changed", {}) in events
+
+
+def test_message_append_broadcasts_sessions_changed(watcher_home, monkeypatch):
+    """Message volume/identity is part of the fingerprint: an appended turn in
+    an existing session moves COUNT/MAX(id) even when the session row's own
+    aggregates lag behind."""
+    home, events = watcher_home
+    _seed_state_db(home)
+    _reset_sessions_sig_state(monkeypatch)
+    server._broadcast_watched_changes(now=0.0)
+
+    import sqlite3
+
+    time.sleep(0.02)
+    con = sqlite3.connect(home / "state.db")
+    con.execute("INSERT INTO messages (session_id, role, content) VALUES ('s1', 'assistant', 'ho')")
+    con.commit()
+    con.close()
+
+    server._broadcast_watched_changes(now=10.0)
     assert ("sessions.changed", {}) in events

--- a/tui_gateway/change_watcher.py
+++ b/tui_gateway/change_watcher.py
@@ -115,18 +115,73 @@ def _pet_changed_payload() -> dict:
     return {"enabled": False}
 
 
-def _sessions_sig():
-    """Newest mtime across state.db + WAL: the one thing messaging-gateway turns and cron runs
-    all move. Served sibling profile homes are probed too, else a routed Bot Chat never refreshes.
+_sessions_content_probe_cache: dict[str, tuple[int, tuple]] = {}
 
-    signal. Messaging-gateway turns and cron runs are written by OTHER processes that never touch this
-    gateway's transports; the shared SQLite file is the one thing they all move (#58671). A backend serving
-    several profiles owns one store per profile, so every served sibling home is
-    """
-    return _newest_mtime_ns(
-        root / name
-        for root in (_watcher_home(), *_served_profile_homes)
-        for name in ("state.db", "state.db-wal"))
+
+def _sessions_content_sig(home: Path) -> tuple | None:
+    """Read-only content fingerprint of session-visible state: a stable hash
+    over the session-list-visible columns of every session row, plus message
+    volume/identity. Pure bookkeeping writes — the 60s gateway-heartbeat
+    refresh (#94895), routing tables, usage stats live in OTHER tables — move
+    the WAL mtime but not this fingerprint, so they no longer masquerade as
+    session changes. Returns None when the store cannot be probed (missing
+    table/column in an older schema, locked db) so the caller can fall back."""
+    import hashlib
+    import sqlite3
+
+    db_path = home / "state.db"
+    if not db_path.exists():
+        return None
+    try:
+        con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=1.0)
+        try:
+            rows = con.execute(
+                "SELECT id, source, user_id, title, display_name, archived,"
+                " hidden, pinned, message_count, tool_call_count, started_at,"
+                " ended_at, end_reason, last_read_at, last_activity_at, cwd,"
+                " session_key, chat_id, thread_id, profile_name"
+                " FROM sessions"
+            ).fetchall()
+            msg = con.execute(
+                "SELECT COUNT(*), COALESCE(MAX(id),0) FROM messages"
+            ).fetchone()
+        finally:
+            con.close()
+    except sqlite3.Error:
+        return None
+    h = hashlib.sha256()
+    for row in rows:
+        h.update(repr(row).encode("utf-8", "backslashreplace"))
+    return h.hexdigest(), len(rows), tuple(msg)
+
+
+def _sessions_sig():
+    """Content signature of session-visible state, gated by the cheap mtime
+    probe. The mtime of state.db/WAL stays the trigger (#58671 — messaging
+    turns and cron runs are written by OTHER processes that never touch this
+    gateway's transports), but a moved mtime must now survive a content
+    check: the 60s gateway-heartbeat refresh (#94895) writes
+    gateway_heartbeats through the same WAL and used to fire a spurious
+    sessions.changed per gateway per minute — with N gateways serving one
+    Desktop, an N-per-minute refresh storm (visible flicker)."""
+    sigs = []
+    for home in (_watcher_home(), *_served_profile_homes):
+        mtime = _newest_mtime_ns([home / "state.db", home / "state.db-wal"])
+        if mtime is None:
+            continue
+        cached = _sessions_content_probe_cache.get(str(home))
+        if cached and cached[0] == mtime:
+            sigs.append(cached[1])
+            continue
+        content = _sessions_content_sig(home)
+        if content is None:
+            # Unreadable store (older schema, locked db): keep the legacy
+            # mtime-only behavior so a probe failure can never go silent.
+            sigs.append(mtime)
+            continue
+        _sessions_content_probe_cache[str(home)] = (mtime, content)
+        sigs.append(content)
+    return tuple(sigs) if sigs else None
 
 
 def _pairing_sig():


### PR DESCRIPTION
## Problem

On a multi-gateway Desktop the conversation window visibly flickers: the session list and open threads refetch every minute, on the minute.

Root cause chain (all steps verified on a live machine):

1. Every gateway process runs a 60s heartbeat refresher (#94895) that UPSERTs the `gateway_heartbeats` table through the profile's state.db WAL.
2. `_sessions_sig()` was the newest mtime across state.db + WAL — it cannot distinguish "a real message landed" from "a gateway wrote its own heartbeat bookkeeping".
3. So each gateway fired one spurious `sessions.changed` per minute — **self-inflicted**: the heartbeat and the watcher live in the same process. With N gateways + N sidecar servers feeding one Desktop, that is an N-per-minute refresh storm (measured: 11-12 events/min bursting at the same second each minute).

## Fix

Two-stage signature in `_sessions_sig()` (`tui_gateway/change_watcher.py`):

- **Stage 1 (cheap trigger, unchanged):** mtime of state.db/WAL. If it didn't move, nothing happened — zero added cost on the 0.5s tick.
- **Stage 2 (content gate):** when mtime moves, open a read-only SQLite connection and fingerprint session-visible state: sha256 over the session-list columns of every session row + message `COUNT(*)`/`MAX(id)`. Heartbeats, routing tables, and usage stats live in **other** tables, so they no longer masquerade as session changes.
- **Failure path:** if the probe cannot read the store (older schema, locked db) the signature falls back to legacy mtime-only behavior — the gate can never go silent.

Per-home probe cache keyed by mtime: an unmoved mtime skips stage 2 entirely; a moved mtime costs ~5ms on a 929-session / 72k-message store.

## Verification

**Unit:** 3 new tests + all 16 existing change-watcher tests pass (19/19). New tests cover: heartbeat write → no broadcast; genuine new session → broadcast; message append → broadcast.

**Live (10-gateway Desktop):** spurious `sessions.changed` dropped from 11-12/min to **zero**; a real session created from another profile still broadcasts within 1 second.

Fixes the visible flicker of open conversations refreshing every minute on multi-gateway Desktops.