### PR TITLE
feat: add native asynchronous user input

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2160,7 +2160,7 @@ _GATEWAY_IDENTITY_PARAMS = (
 )
 _CALLBACK_PARAMS = (
     "tool_progress_callback", "tool_start_callback", "tool_complete_callback",
-    "thinking_callback", "reasoning_callback", "clarify_callback",
+    "thinking_callback", "reasoning_callback", "clarify_callback", "user_input_callback",
     "read_terminal_callback", "read_preview_callback", "drive_preview_callback",
     "read_window_below_callback", "setup_mcp_callback", "tour_callback",
     "step_callback", "stream_delta_callback", "interim_assistant_callback",
@@ -2183,7 +2183,7 @@ def init_agent(
     session_id: str = None, tool_progress_callback: callable = None,
     tool_start_callback: callable = None, tool_complete_callback: callable = None,
     thinking_callback: callable = None, reasoning_callback: callable = None,
-    clarify_callback: callable = None, read_terminal_callback: callable = None,
+    clarify_callback: callable = None, user_input_callback: callable = None, read_terminal_callback: callable = None,
     read_preview_callback: callable = None, drive_preview_callback: callable = None,
     read_window_below_callback: callable = None, setup_mcp_callback: callable = None,
     tour_callback: callable = None, step_callback: callable = None,
@@ -2212,6 +2212,7 @@ def init_agent(
       requested_provider: provider identity before runtime canonicalization.
       openrouter_min_coding_score: coding-score floor for ``openrouter/pareto-code`` only.
       clarify_callback: ``(question, choices) -> str``; None → the clarify tool errors.
+      user_input_callback: ``(request) -> None``; optional non-blocking request renderer.
       reasoning_config: None → ``{"enabled": True, "effort": "medium"}`` on OpenRouter.
       prefill_messages: priming history. Anthropic Sonnet/Opus 4.6+ 400 on a trailing
         assistant message — use structured outputs there instead.

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2250,6 +2250,8 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             if skip_tool_execution_middleware:
                 dispatch_kwargs["skip_tool_execution_middleware"] = True
             import model_tools
+            if function_name in {"request_user_input", "check_user_input"}:
+                dispatch_kwargs["session_db"] = getattr(agent, "_session_db", None)
             return model_tools.handle_function_call(function_name, next_args, effective_task_id, **dispatch_kwargs)
     if skip_tool_execution_middleware:
         return _execute(function_args)

--- a/agent/inline_tool_executors.py
+++ b/agent/inline_tool_executors.py
@@ -133,6 +133,32 @@ def _memory(agent, args: dict, ctx: InlineToolContext) -> Any:
     return result
 
 
+def _check_user_input(agent, args: dict, ctx: InlineToolContext) -> Any:
+    return _call_tool(
+        "tools.user_input_tool", "check_user_input", args,
+        (("request_id", "request_id", ""),),
+        session_id=getattr(agent, "session_id", "") or "",
+        session_db=getattr(agent, "_session_db", None),
+    )
+
+
+def _request_user_input(agent, args: dict, ctx: InlineToolContext) -> Any:
+    return _call_tool(
+        "tools.user_input_tool", "request_user_input", args,
+        (("questions", "questions"), ("context", "context", ""),
+         ("timeout_s", "timeout_s", 3600)),
+        session_id=getattr(agent, "session_id", "") or "",
+        turn_id=getattr(agent, "_current_turn_id", "") or "",
+        session_db=getattr(agent, "_session_db", None),
+        session_key=getattr(agent, "_gateway_session_key", "") or "",
+        source=getattr(agent, "platform", "") or "",
+        user_id=getattr(agent, "_user_id", "") or "",
+        chat_id=getattr(agent, "_chat_id", "") or "",
+        thread_id=getattr(agent, "_thread_id", "") or "",
+        callback=getattr(agent, "user_input_callback", None),
+    )
+
+
 _read_preview = _callback_tool(
     "tools.read_preview_tool", "read_preview_tool", "read_preview_callback",
     ("start", "start"), ("count", "count"),
@@ -169,6 +195,8 @@ INLINE_TOOL_EXECUTORS: Dict[str, InlineToolExecutor] = {
         ("questions", "questions"),
         callback=lambda agent, ctx: agent.clarify_callback,
     ),
+    "request_user_input": _request_user_input,
+    "check_user_input": _check_user_input,
     "read_terminal": _callback_tool(
         "tools.read_terminal_tool", "read_terminal_tool", "read_terminal_callback",
         ("start_line", "start_line"), ("count", "count"),

--- a/apps/desktop/e2e/mock-server.ts
+++ b/apps/desktop/e2e/mock-server.ts
@@ -123,6 +123,9 @@ let _verificationStopIndex = 0
 /** Per-server counter for the task-panel warm-resume script. */
 let _taskPanelResumeIndex = 0
 
+/** Per-server counter for the native structured user-input script. */
+let _nativeUserInputIndex = 0
+
 /** User messages received by the mock, for E2E assertions on real submits. */
 const _receivedUserTexts: string[] = []
 
@@ -135,6 +138,7 @@ function resetScriptIndex(): void {
   _correctionSwitchIndex = 0
   _verificationStopIndex = 0
   _taskPanelResumeIndex = 0
+  _nativeUserInputIndex = 0
   _receivedUserTexts.length = 0
 }
 
@@ -357,6 +361,51 @@ const BATCH_CLARIFY_TURN: ScriptedTurn = {
   toolCalls: [{ name: 'clarify', args: { questions: BATCH_CLARIFY_QUESTIONS } }],
 }
 
+/** Native asynchronous structured-input trigger for Desktop E2E. */
+export const NATIVE_USER_INPUT_TRIGGER = 'E2E_NATIVE_USER_INPUT_TRIGGER'
+export const NATIVE_USER_INPUT_QUESTIONS = [
+  {
+    id: 'drink',
+    text: 'Which drink should Hermes prepare?',
+    options: ['Coffee', 'Tea'],
+    allow_free_text: false,
+  },
+  {
+    id: 'note',
+    text: 'Any short note for the next turn?',
+    options: [],
+    allow_free_text: true,
+  },
+]
+
+const NATIVE_USER_INPUT_SCRIPT: ScriptedTurn[] = [
+  {
+    text: '',
+    toolCalls: [{
+      name: 'request_user_input',
+      args: {
+        questions: NATIVE_USER_INPUT_QUESTIONS,
+        context: 'The answer is saved without blocking the rest of the workspace.',
+        timeout_s: 300,
+      },
+    }],
+  },
+  { text: 'Native user input was recorded and the turn resumed.' },
+]
+
+function includesNativeUserInputTrigger(value: unknown): boolean {
+  if (typeof value === 'string') {
+    return value.includes(NATIVE_USER_INPUT_TRIGGER)
+  }
+  if (Array.isArray(value)) {
+    return value.some(includesNativeUserInputTrigger)
+  }
+  if (value && typeof value === 'object') {
+    return Object.values(value).some(includesNativeUserInputTrigger)
+  }
+  return false
+}
+
 function includesBatchClarifyTrigger(value: unknown): boolean {
   if (typeof value === 'string') {
     return value.includes(BATCH_CLARIFY_TRIGGER)
@@ -494,6 +543,7 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
           const isCorrectionSwitchTrigger = messages.some(
             message => typeof message?.content === 'string' && message.content.includes(CORRECTION_SWITCH_TRIGGER),
           )
+          const isNativeUserInputTrigger = includesNativeUserInputTrigger(parsed.messages)
 
           if (isTaskPanelResumeTrigger) {
             const turn =
@@ -514,6 +564,19 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
               void heldStreamReleased.then(respond)
             } else {
               respond()
+            }
+            return
+          }
+
+          if (isNativeUserInputTrigger) {
+            const hasToolResult = Array.isArray(parsed.messages)
+              && parsed.messages.some((message: { role?: string }) => message?.role === 'tool')
+            const turn = NATIVE_USER_INPUT_SCRIPT[_nativeUserInputIndex] ?? NATIVE_USER_INPUT_SCRIPT[NATIVE_USER_INPUT_SCRIPT.length - 1]
+            _nativeUserInputIndex = hasToolResult ? NATIVE_USER_INPUT_SCRIPT.length - 1 : 1
+            if (stream) {
+              streamScriptedTurn(res, model, turn)
+            } else {
+              nonStreamingScriptedTurn(res, model, turn)
             }
             return
           }

--- a/apps/desktop/e2e/native-user-input.spec.ts
+++ b/apps/desktop/e2e/native-user-input.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * Native asynchronous user-input E2E.
+ *
+ * This is intentionally a real agent → gateway → renderer journey. The mock
+ * model emits `request_user_input`; the durable core request becomes a native
+ * card, and the answer must reach the next model turn without inventing a
+ * second composer submission.
+ */
+
+import { expect, test } from './test'
+
+import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
+import { NATIVE_USER_INPUT_QUESTIONS, NATIVE_USER_INPUT_TRIGGER } from './mock-server'
+
+let fixture: MockBackendFixture | null = null
+
+test.beforeAll(async () => {
+  fixture = await setupMockBackend()
+  await waitForAppReady(fixture, 120_000)
+})
+
+test.afterAll(async () => {
+  await fixture?.cleanup()
+  fixture = null
+})
+
+test('renders the native card above the composer and resumes after one answer', async () => {
+  const page = fixture!.page
+  const composer = page.locator('[data-slot="composer-root"] [contenteditable="true"]').first()
+  await composer.waitFor({ state: 'visible', timeout: 10_000 })
+
+  await composer.click()
+  await composer.type(NATIVE_USER_INPUT_TRIGGER, { delay: 10 })
+  await page.keyboard.press('Enter')
+
+  const card = page.locator('[data-user-input-request]')
+  await card.waitFor({ state: 'visible', timeout: 30_000 }).catch(async (error) => {
+    const toolError = page.getByRole('button', { name: /Error Request User Input/ })
+    if (await toolError.isVisible().catch(() => false)) {
+      await toolError.click()
+      const body = await page.locator('body').innerText()
+      throw new Error(`Native user-input tool error state:\n${body}`, { cause: error })
+    }
+    throw error
+  })
+  await expect(card).toHaveCount(1)
+  const placement = await card.evaluate(element => ({
+    inComposerDock: Boolean(element.closest('[data-slot="composer-dock"]')),
+    position: getComputedStyle(element).position
+  }))
+  expect(placement.inComposerDock).toBe(true)
+  expect(placement.position).not.toBe('fixed')
+
+  try {
+    await expect.poll(async () => {
+      const currentCard = await card.boundingBox()
+      const currentComposer = await composer.boundingBox()
+      if (!currentCard || !currentComposer) return Number.POSITIVE_INFINITY
+      return currentCard.y + currentCard.height - currentComposer.y
+    }, { timeout: 5_000 }).toBeLessThanOrEqual(1)
+  } catch (error) {
+    const geometry = await page.evaluate(() => {
+      const describe = (element: Element | null) => {
+        if (!element) return null
+        const rect = element.getBoundingClientRect()
+        const style = getComputedStyle(element)
+        return {
+          className: element.className,
+          display: style.display,
+          position: style.position,
+          rect: { bottom: rect.bottom, height: rect.height, top: rect.top, width: rect.width },
+          tag: element.tagName
+        }
+      }
+      const card = document.querySelector('[data-user-input-request]')
+      const composer = document.querySelector('[data-slot="composer-root"] [contenteditable="true"]')
+      return {
+        card: describe(card),
+        composer: describe(composer),
+        dock: describe(card?.closest('[data-slot="composer-dock"]') ?? null),
+        cardParent: describe(card?.parentElement ?? null),
+        composerParent: describe(composer?.parentElement ?? null)
+      }
+    })
+    throw new Error(`Native user-input geometry:\n${JSON.stringify(geometry, null, 2)}`, { cause: error })
+  }
+
+  const cardBox = await card.boundingBox()
+  const composerBox = await composer.boundingBox()
+  expect(cardBox).not.toBeNull()
+  expect(composerBox).not.toBeNull()
+  const cardBottom = cardBox!.y + cardBox!.height
+  const composerTop = composerBox!.y
+  expect(cardBottom).toBeLessThanOrEqual(composerTop + 1)
+
+  await expect(card.getByText(NATIVE_USER_INPUT_QUESTIONS[0].text)).toBeVisible()
+  await expect(card.getByText(NATIVE_USER_INPUT_QUESTIONS[1].text)).toBeVisible()
+  await expect(card.getByText('Coffee', { exact: true })).toBeVisible()
+  await expect(card.getByText('Tea', { exact: true })).toBeVisible()
+
+  const freeText = card.locator('input[data-user-input-kind="text"]')
+  await freeText.focus()
+  await freeText.fill('Keep this note for the next turn')
+  await expect(freeText).toBeFocused()
+  await expect(freeText).toHaveValue('Keep this note for the next turn')
+
+  await card.getByText('Coffee', { exact: true }).click()
+  const submit = card.locator('button[type="submit"]')
+  await expect(submit).toBeEnabled()
+
+  await page.screenshot({ path: test.info().outputPath('native-user-input-card-open.png'), fullPage: false })
+  await submit.click()
+
+  await expect(page.getByText('Native user input was recorded and the turn resumed.')).toBeVisible({ timeout: 60_000 })
+  await expect(page.locator('[data-user-input-request]')).toHaveCount(0)
+})

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -5,6 +5,7 @@ import { type ClipboardEvent, type FormEvent, type KeyboardEvent, useCallback, u
 import { useTourMarker } from '@/app/chat/tour-marker'
 import { useHudComposerDrag } from '@/app/hud/composer-drag'
 import { composerFill, composerFloatingStrip, composerSurfaceGlass } from '@/components/chat/composer-dock'
+import { UserInputDock } from '@/components/prompt-overlays'
 import { Button } from '@/components/ui/button'
 import { Slot as ContribSlot } from '@/contrib/react/slot'
 import { useI18n } from '@/i18n'
@@ -1183,6 +1184,7 @@ export function ChatBar({
               : undefined
           }
         >
+          <UserInputDock sessionId={sessionId ?? null} />
           {/* Aligned to the composer SURFACE, which sits inside the composer's
               5px transparent grab margin — so both strips carry the same inset
               and share one left edge with it. */}

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/index.ts
@@ -5,7 +5,8 @@ import type { GatewayEventPayload } from '@/lib/chat-messages'
 import {
   approvalReplaySessionId,
   resolveGatewayEventSessionId,
-  UNSCOPED_STREAM_EVENT_TYPES
+  UNSCOPED_STREAM_EVENT_TYPES,
+  userInputReplaySessionId
 } from '@/lib/gateway-events'
 import { reconcileSessionCompacting } from '@/store/compaction'
 import { $gateway, activeGatewayConnectionId } from '@/store/gateway'
@@ -14,6 +15,7 @@ import { replayPendingApproval } from '@/store/prompts'
 import { setSessionProviderWait } from '@/store/provider-wait'
 import { isSessionGone } from '@/store/session-gone-latch'
 import { setSessionDraftingTool } from '@/store/tool-drafting'
+import { replayPendingUserInput } from '@/store/user-input'
 import type { RpcEvent } from '@/types/hermes'
 
 import { handleDesktopBridgeEvent } from './desktop-bridge'
@@ -203,6 +205,15 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
 
       if (replaySessionId) {
         void replayPendingApproval($gateway.get(), replaySessionId).catch(() => undefined)
+      }
+
+      const userInputSessionId = userInputReplaySessionId(event.type, activeSessionIdRef.current, sessionId, {
+        explicit: Boolean(explicitSid),
+        isGone: isSessionGone
+      })
+
+      if (userInputSessionId) {
+        void replayPendingUserInput($gateway.get(), userInputSessionId).catch(() => undefined)
       }
 
       // Mid-turn compaction does not emit another message.start. The first

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
@@ -14,6 +14,12 @@ import { setMcpSetupRequest } from '@/store/mcp-setup'
 import { dispatchNativeNotification } from '@/store/native-notifications'
 import { receiveApprovalRequest, setSecretRequest, setSudoRequest } from '@/store/prompts'
 import { requestScrollToBottom } from '@/store/thread-scroll'
+import {
+  clearUserInputRequest,
+  normalizeUserInputRequest,
+  setUserInputRequest,
+  userInputRequestsForSession
+} from '@/store/user-input'
 
 import type { GatewayEventContext } from './types'
 
@@ -23,6 +29,41 @@ import type { GatewayEventContext } from './types'
 export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
   const { deps, event, payload, sessionId, occurredAt } = ctx
   const { activeSessionIdRef, sessionInterrupted, updateSessionState, upsertToolCall } = deps
+
+  if (event.type === 'user_input.request') {
+    const request = normalizeUserInputRequest(payload, sessionId)
+
+    if (request) {
+      setUserInputRequest(request)
+
+      if (sessionId) {
+        updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
+      }
+
+      dispatchNativeNotification({
+        body: request.context || request.questions.map(question => question.text).join(' · '),
+        kind: 'input',
+        sessionId,
+        title: 'Hermes needs your input'
+      })
+    }
+
+    return true
+  }
+
+  if (event.type === 'user_input.answer') {
+    const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
+
+    if (sessionId && requestId) {
+      clearUserInputRequest(sessionId, requestId)
+      updateSessionState(sessionId, state => ({
+        ...state,
+        needsInput: userInputRequestsForSession(sessionId).length > 0
+      }))
+    }
+
+    return true
+  }
 
   if (event.type === 'clarify.request') {
     // Surface the clarify tool's overlay. The Python side is blocked on

--- a/apps/desktop/src/components/prompt-overlays.test.tsx
+++ b/apps/desktop/src/components/prompt-overlays.test.tsx
@@ -6,11 +6,12 @@ import { $gateway } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
 import { $secretRequest, $sudoRequest, clearAllPrompts, setSecretRequest, setSudoRequest } from '@/store/prompts'
 import { $activeSessionId } from '@/store/session'
+import { setUserInputRequest } from '@/store/user-input'
 
-import { PromptOverlays } from './prompt-overlays'
+import { PromptOverlays, UserInputDock } from './prompt-overlays'
 
 vi.mock('@/lib/haptics', () => ({ triggerHaptic: vi.fn() }))
-vi.mock('@/store/notifications', () => ({ notifyError: vi.fn() }))
+vi.mock('@/store/notifications', () => ({ notify: vi.fn(), notifyError: vi.fn() }))
 
 function renderPrompts(sessionId: string | null = 's1') {
   render(
@@ -63,5 +64,26 @@ describe('PromptOverlays', () => {
     await waitFor(() => expect($secretRequest.get()).toBeNull())
     expect(request).toHaveBeenCalledWith('secret.respond', { request_id: 'secret-1', value: '' })
     expect(notifyError).not.toHaveBeenCalled()
+  })
+
+  it('mounts native user input in the session composer dock instead of the viewport', () => {
+    $activeSessionId.set('s1')
+    setUserInputRequest({
+      requestId: 'input-1',
+      sessionId: 's1',
+      questions: [{ id: 'choice', options: ['yes'], text: 'Choose one' }]
+    })
+
+    render(
+      <I18nProvider configClient={null}>
+        <UserInputDock sessionId="s1" />
+      </I18nProvider>
+    )
+
+    const card = screen.getByRole('region')
+    const dock = card.parentElement
+    expect(dock?.className).toContain('flex')
+    expect(dock?.className).not.toContain('absolute')
+    expect(dock?.className).not.toContain('fixed')
   })
 })

--- a/apps/desktop/src/components/prompt-overlays.tsx
+++ b/apps/desktop/src/components/prompt-overlays.tsx
@@ -14,6 +14,7 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
+import { UserInputCard } from '@/components/user-input-card'
 import { useI18n } from '@/i18n'
 import { isMissingPendingPromptRequest } from '@/lib/gateway-rpc'
 import { triggerHaptic } from '@/lib/haptics'
@@ -246,6 +247,7 @@ export function PromptOverlays({ sessionId }: { sessionId: string | null }) {
   return (
     <>
       <PendingApprovalFallback />
+      <UserInputCard sessionId={sessionId} />
       <SudoDialog sessionId={sessionId} />
       <SecretDialog sessionId={sessionId} />
     </>

--- a/apps/desktop/src/components/prompt-overlays.tsx
+++ b/apps/desktop/src/components/prompt-overlays.tsx
@@ -240,6 +240,14 @@ function SecretDialog({ sessionId }: { sessionId: string | null }) {
   )
 }
 
+export function UserInputDock({ sessionId }: { sessionId: string | null }) {
+  return (
+    <div className="flex justify-end px-[5px] pb-2">
+      <UserInputCard sessionId={sessionId} />
+    </div>
+  )
+}
+
 /** Mid-turn prompt surfaces for ONE session. Mounted by both the primary chat
  *  and each tile with its own session id, so a background/tiled session's
  *  blocking prompt renders instead of silently stalling. */
@@ -247,7 +255,6 @@ export function PromptOverlays({ sessionId }: { sessionId: string | null }) {
   return (
     <>
       <PendingApprovalFallback />
-      <UserInputCard sessionId={sessionId} />
       <SudoDialog sessionId={sessionId} />
       <SecretDialog sessionId={sessionId} />
     </>

--- a/apps/desktop/src/components/user-input-card.test.tsx
+++ b/apps/desktop/src/components/user-input-card.test.tsx
@@ -1,0 +1,49 @@
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { $gateway } from '@/store/gateway'
+import { $userInputRequests } from '@/store/user-input'
+
+import { UserInputCard } from './user-input-card'
+
+const request = {
+  context: 'Need a decision',
+  expiresAt: 0,
+  questions: [{
+    allowFreeText: false,
+    defaultValue: undefined,
+    id: 'choice',
+    options: ['a', 'b'],
+    text: 'Pick one'
+  }],
+  requestId: 'request-1',
+  sessionId: 'session-1',
+  status: 'pending' as const,
+  turnId: 'turn-1'
+}
+
+afterEach(() => {
+  cleanup()
+  $gateway.set(null)
+  $userInputRequests.set({})
+})
+
+describe('UserInputCard', () => {
+  it('sends one request when submit is triggered twice before acknowledgement', async () => {
+    let resolveResponse: ((value: unknown) => void) | undefined
+    const requestCall = vi.fn(() => new Promise(resolve => { resolveResponse = resolve }))
+    $gateway.set({ request: requestCall } as never)
+    $userInputRequests.set({ 'session-1': [request] })
+
+    const { container } = render(<UserInputCard sessionId="session-1" />)
+    fireEvent.click(container.querySelector('input[type="radio"]') as HTMLInputElement)
+    const form = container.querySelector('form') as HTMLFormElement
+
+    fireEvent.submit(form)
+    fireEvent.submit(form)
+
+    expect(requestCall).toHaveBeenCalledTimes(1)
+    resolveResponse?.({ accepted: true, status: 'answered' })
+    await waitFor(() => expect($userInputRequests.get()['session-1']).toBeUndefined())
+  })
+})

--- a/apps/desktop/src/components/user-input-card.tsx
+++ b/apps/desktop/src/components/user-input-card.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+import { useStore } from '@nanostores/react'
+import { type FormEvent, useEffect, useMemo, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { translateNow, useI18n } from '@/i18n'
+import { triggerHaptic } from '@/lib/haptics'
+import { Loader2 } from '@/lib/icons'
+import { $gateway } from '@/store/gateway'
+import { notifyError } from '@/store/notifications'
+import {
+  respondUserInput,
+  sessionUserInputRequests,
+  type UserInputRequest
+} from '@/store/user-input'
+
+function initialAnswers(request: UserInputRequest | null): Record<string, string> {
+  if (!request) {return {}}
+
+  return Object.fromEntries(
+    request.questions.flatMap(question => {
+      const value = question.defaultValue
+
+      if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+        return [[question.id, String(value)]]
+      }
+
+      return []
+    })
+  )
+}
+
+/** Non-blocking, durable user-input card for one runtime session. */
+export function UserInputCard({ sessionId }: { sessionId: string | null }) {
+  const { t } = useI18n()
+  const $requests = useMemo(() => sessionUserInputRequests(sessionId), [sessionId])
+  const requests = useStore($requests)
+  const gateway = useStore($gateway)
+  const request = requests[0] ?? null
+  const [answers, setAnswers] = useState<Record<string, string>>({})
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    setAnswers(initialAnswers(request))
+    setSubmitting(false)
+  }, [request])
+
+  if (!request) {return null}
+
+  const updateAnswer = (questionId: string, value: string) => {
+    setAnswers(current => ({ ...current, [questionId]: value }))
+  }
+
+  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const missing = request.questions.find(question => !String(answers[question.id] ?? '').trim())
+
+    if (missing) {
+      notifyError(new Error(`Answer required: ${missing.text}`), 'Hermes input is incomplete')
+
+      return
+    }
+
+    if (!gateway) {
+      notifyError(new Error('Hermes gateway is disconnected.'), 'Could not send Hermes input')
+
+      return
+    }
+
+    setSubmitting(true)
+    void respondUserInput(gateway, request, answers)
+      .then(() => triggerHaptic('submit'))
+      .catch(error => {
+        notifyError(error, 'Could not send Hermes input')
+        setSubmitting(false)
+      })
+  }
+
+  return (
+    <section
+      aria-labelledby={`user-input-title-${request.requestId}`}
+      aria-live="polite"
+      className="pointer-events-auto fixed bottom-4 right-4 z-50 max-h-[80vh] w-[min(32rem,calc(100vw-2rem))] overflow-y-auto rounded-xl border bg-background p-4 shadow-2xl"
+      data-session-id={request.sessionId}
+      data-user-input-request={request.requestId}
+      role="region"
+    >
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold" id={`user-input-title-${request.requestId}`}>
+            {translateNow('notifications.native.inputTitle')}
+          </h2>
+          {request.context ? <p className="mt-1 text-xs text-muted-foreground">{request.context}</p> : null}
+        </div>
+        {requests.length > 1 ? <span className="text-xs text-muted-foreground">{requests.length} pending</span> : null}
+      </div>
+
+      <form className="grid gap-4" onSubmit={onSubmit}>
+        {request.questions.map(question => {
+          const hasOptions = question.options.length > 0
+          const useTextInput = question.allowFreeText || !hasOptions
+
+          return (
+            <fieldset className="grid gap-2" key={question.id}>
+              <legend className="text-sm font-medium">{question.text}</legend>
+              {hasOptions ? (
+                <div aria-label={question.text} className="grid gap-2" role="radiogroup">
+                  {question.options.map(option => (
+                    <label className="flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm hover:bg-muted" key={option}>
+                      <input
+                        checked={answers[question.id] === option}
+                        disabled={submitting}
+                        name={`user-input-${request.requestId}-${question.id}`}
+                        onChange={() => updateAnswer(question.id, option)}
+                        type="radio"
+                        value={option}
+                      />
+                      <span>{option}</span>
+                    </label>
+                  ))}
+                </div>
+              ) : null}
+              {useTextInput ? (
+                <Input
+                  aria-label={`${question.text} free text`}
+                  disabled={submitting}
+                  onChange={event => updateAnswer(question.id, event.target.value)}
+                  placeholder={hasOptions ? 'Or enter another answer' : 'Your answer'}
+                  value={answers[question.id] ?? ''}
+                />
+              ) : null}
+            </fieldset>
+          )
+        })}
+        <div className="flex justify-end">
+          <Button disabled={submitting} type="submit">
+            {submitting ? <Loader2 className="size-3.5 animate-spin" /> : t.common.send}
+          </Button>
+        </div>
+      </form>
+    </section>
+  )
+}

--- a/apps/desktop/src/components/user-input-card.tsx
+++ b/apps/desktop/src/components/user-input-card.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useStore } from '@nanostores/react'
-import { type FormEvent, useEffect, useMemo, useState } from 'react'
+import { type FormEvent, useEffect, useMemo, useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -9,28 +9,31 @@ import { translateNow, useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { Loader2 } from '@/lib/icons'
 import { $gateway } from '@/store/gateway'
-import { notifyError } from '@/store/notifications'
+import { notify, notifyError } from '@/store/notifications'
 import {
   respondUserInput,
-  sessionUserInputRequests,
-  type UserInputRequest
+  sessionUserInputRequests
 } from '@/store/user-input'
+import {
+  createUserInputDraftStore,
+  type UserInputDraftRequest
+} from '@/store/user-input-drafts'
+import {
+  classifyUserInputResult,
+  createUserInputSubmitLock
+} from '@/store/user-input-result'
 
-function initialAnswers(request: UserInputRequest | null): Record<string, string> {
-  if (!request) {return {}}
-
-  return Object.fromEntries(
-    request.questions.flatMap(question => {
-      const value = question.defaultValue
-
-      if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-        return [[question.id, String(value)]]
-      }
-
-      return []
-    })
-  )
+type FocusTarget = {
+  kind: 'radio' | 'text'
+  questionId: string
+  requestId: string
+  selectionEnd?: number
+  selectionStart?: number
+  sessionId: string
 }
+
+const userInputDraftStore = createUserInputDraftStore()
+const userInputSubmitLock = createUserInputSubmitLock()
 
 /** Non-blocking, durable user-input card for one runtime session. */
 export function UserInputCard({ sessionId }: { sessionId: string | null }) {
@@ -41,16 +44,52 @@ export function UserInputCard({ sessionId }: { sessionId: string | null }) {
   const request = requests[0] ?? null
   const [answers, setAnswers] = useState<Record<string, string>>({})
   const [submitting, setSubmitting] = useState(false)
+  const cardRef = useRef<HTMLElement | null>(null)
+  const focusTarget = useRef<FocusTarget | null>(null)
 
   useEffect(() => {
-    setAnswers(initialAnswers(request))
+    setAnswers(request ? userInputDraftStore.get(request as UserInputDraftRequest) : {})
     setSubmitting(false)
+  }, [request])
+
+  useEffect(() => {
+    if (!request) {return}
+    const target = focusTarget.current
+
+    if (!target || target.sessionId !== request.sessionId || target.requestId !== request.requestId) {return}
+
+    const input = Array.from(cardRef.current?.querySelectorAll<HTMLInputElement>('input[data-user-input-question]') ?? [])
+      .find(candidate => candidate.dataset.userInputQuestion === target.questionId && candidate.dataset.userInputKind === target.kind)
+
+    if (!input) {return}
+    input.focus()
+
+    if (target.kind === 'text' && typeof target.selectionStart === 'number' && typeof target.selectionEnd === 'number') {
+      input.setSelectionRange(target.selectionStart, target.selectionEnd)
+    }
   }, [request])
 
   if (!request) {return null}
 
+  const rememberFocus = (questionId: string, kind: FocusTarget['kind'], input: HTMLInputElement) => {
+    focusTarget.current = {
+      kind,
+      questionId,
+      requestId: request.requestId,
+      ...(kind === 'text' && typeof input.selectionStart === 'number' && typeof input.selectionEnd === 'number'
+        ? { selectionEnd: input.selectionEnd, selectionStart: input.selectionStart }
+        : {}),
+      sessionId: request.sessionId
+    }
+  }
+
   const updateAnswer = (questionId: string, value: string) => {
-    setAnswers(current => ({ ...current, [questionId]: value }))
+    setAnswers(current => {
+      const next = { ...current, [questionId]: value }
+      userInputDraftStore.set(request as UserInputDraftRequest, next)
+
+      return next
+    })
   }
 
   const onSubmit = (event: FormEvent<HTMLFormElement>) => {
@@ -69,11 +108,46 @@ export function UserInputCard({ sessionId }: { sessionId: string | null }) {
       return
     }
 
+    if (!userInputSubmitLock.acquire(request.sessionId, request.requestId)) {return}
+
     setSubmitting(true)
     void respondUserInput(gateway, request, answers)
-      .then(() => triggerHaptic('submit'))
+      .then(acknowledgement => {
+        if (acknowledgement.accepted) {
+          userInputDraftStore.delete(request)
+
+          if (acknowledgement.delivery === 'deferred') {
+            notify({
+              kind: 'info',
+              message: 'Answer recorded. Hermes will use it on the next eligible turn; automatic resume was not confirmed.'
+            })
+          }
+
+          triggerHaptic('submit')
+
+          return
+        }
+
+        if (acknowledgement.clear) {
+          userInputDraftStore.delete(request)
+
+          return
+        }
+
+        notifyError(
+          new Error(acknowledgement.message || 'Hermes did not accept these answers.'),
+          'Could not send Hermes input'
+        )
+      })
       .catch(error => {
-        notifyError(error, 'Could not send Hermes input')
+        const acknowledgement = classifyUserInputResult(null, 0, error)
+
+        if (!acknowledgement.clear) {
+          notifyError(error, 'Could not send Hermes input')
+        }
+      })
+      .finally(() => {
+        userInputSubmitLock.release(request.sessionId, request.requestId)
         setSubmitting(false)
       })
   }
@@ -82,9 +156,10 @@ export function UserInputCard({ sessionId }: { sessionId: string | null }) {
     <section
       aria-labelledby={`user-input-title-${request.requestId}`}
       aria-live="polite"
-      className="pointer-events-auto fixed bottom-4 right-4 z-50 max-h-[80vh] w-[min(32rem,calc(100vw-2rem))] overflow-y-auto rounded-xl border bg-background p-4 shadow-2xl"
+      className="pointer-events-auto max-h-[80vh] w-[min(32rem,100%)] overflow-y-auto rounded-xl border bg-background p-4 shadow-2xl"
       data-session-id={request.sessionId}
       data-user-input-request={request.requestId}
+      ref={cardRef}
       role="region"
     >
       <div className="mb-3 flex items-start justify-between gap-3">
@@ -111,9 +186,12 @@ export function UserInputCard({ sessionId }: { sessionId: string | null }) {
                     <label className="flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm hover:bg-muted" key={option}>
                       <input
                         checked={answers[question.id] === option}
+                        data-user-input-kind="radio"
+                        data-user-input-question={question.id}
                         disabled={submitting}
                         name={`user-input-${request.requestId}-${question.id}`}
                         onChange={() => updateAnswer(question.id, option)}
+                        onFocus={event => rememberFocus(question.id, 'radio', event.currentTarget)}
                         type="radio"
                         value={option}
                       />
@@ -123,10 +201,17 @@ export function UserInputCard({ sessionId }: { sessionId: string | null }) {
                 </div>
               ) : null}
               {useTextInput ? (
-                <Input
+                  <Input
                   aria-label={`${question.text} free text`}
+                  data-user-input-kind="text"
+                  data-user-input-question={question.id}
                   disabled={submitting}
-                  onChange={event => updateAnswer(question.id, event.target.value)}
+                  onChange={event => {
+                    rememberFocus(question.id, 'text', event.currentTarget)
+                    updateAnswer(question.id, event.target.value)
+                  }}
+                  onFocus={event => rememberFocus(question.id, 'text', event.currentTarget)}
+                  onSelect={event => rememberFocus(question.id, 'text', event.currentTarget)}
                   placeholder={hasOptions ? 'Or enter another answer' : 'Your answer'}
                   value={answers[question.id] ?? ''}
                 />

--- a/apps/desktop/src/lib/gateway-events.test.ts
+++ b/apps/desktop/src/lib/gateway-events.test.ts
@@ -1,12 +1,23 @@
 import { describe, expect, it } from 'vitest'
 
-import { approvalReplaySessionId, gatewayEventRequiresSessionId, resolveGatewayEventSessionId } from './gateway-events'
+import {
+  approvalReplaySessionId,
+  gatewayEventRequiresSessionId,
+  resolveGatewayEventSessionId,
+  userInputReplaySessionId
+} from './gateway-events'
 
 describe('gateway event routing', () => {
   it('rehydrates pending approvals on reconnect ready and resumed session info', () => {
     expect(approvalReplaySessionId('gateway.ready', 'active-1', null)).toBe('active-1')
     expect(approvalReplaySessionId('session.info', 'active-1', 'routed-1')).toBe('routed-1')
     expect(approvalReplaySessionId('message.delta', 'active-1', 'routed-1')).toBeNull()
+  })
+
+  it('replays native user-input requests on reconnect ready and resumed session info', () => {
+    expect(userInputReplaySessionId('gateway.ready', 'active-1', null)).toBe('active-1')
+    expect(userInputReplaySessionId('session.info', 'active-1', 'routed-1')).toBe('routed-1')
+    expect(userInputReplaySessionId('message.delta', 'active-1', 'routed-1')).toBeNull()
   })
 
   it('does not replay against an active runtime the gateway already reported gone', () => {
@@ -35,6 +46,7 @@ describe('gateway event routing', () => {
     expect(gatewayEventRequiresSessionId('reasoning.delta')).toBe(false)
     expect(gatewayEventRequiresSessionId('tool.start')).toBe(false)
     expect(gatewayEventRequiresSessionId('approval.request')).toBe(false)
+    expect(gatewayEventRequiresSessionId('user_input.request')).toBe(false)
   })
 
   it('allows global events to remain unscoped', () => {

--- a/apps/desktop/src/lib/gateway-events.ts
+++ b/apps/desktop/src/lib/gateway-events.ts
@@ -41,7 +41,8 @@ export const UNSCOPED_STREAM_EVENT_TYPES = new Set([
   'tool.complete',
   'tool.generating',
   'tool.progress',
-  'tool.start'
+  'tool.start',
+  'user_input.request'
 ])
 
 const UNSCOPED_STREAM_END_EVENT_TYPES = new Set(['error', 'message.complete'])
@@ -90,6 +91,29 @@ export interface GatewayEventSessionRoute {
  *  on every fan-out tick (#100639), so return null. A frame that names the
  *  session explicitly is the runtime speaking for itself and is never gone. */
 export function approvalReplaySessionId(
+  eventType: string | undefined,
+  activeSessionId: null | string,
+  routedSessionId: null | string,
+  options?: { explicit?: boolean; isGone?: (sessionId: string) => boolean }
+): null | string {
+  let target: null | string = null
+
+  if (eventType === 'gateway.ready') {
+    target = activeSessionId
+  } else if (eventType === 'session.info') {
+    target = routedSessionId
+  }
+
+  if (target && !options?.explicit && options?.isGone?.(target)) {
+    return null
+  }
+
+  return target
+}
+
+/** Which session (if any) to re-pull `user_input.pending` for after a
+ * reconnect or resumed session announcement. */
+export function userInputReplaySessionId(
   eventType: string | undefined,
   activeSessionId: null | string,
   routedSessionId: null | string,

--- a/apps/desktop/src/store/user-input-drafts.test.ts
+++ b/apps/desktop/src/store/user-input-drafts.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  createUserInputDraftStore,
+  draftKey,
+  type UserInputDraftRequest
+} from './user-input-drafts'
+
+const request = (sessionId: string, requestId: string, options = ['a', 'b']): UserInputDraftRequest => ({
+  questions: [{
+    allowFreeText: false,
+    defaultValue: 'a',
+    id: 'choice',
+    options,
+    text: 'Pick one'
+  }],
+  requestId,
+  sessionId
+})
+
+describe('native user-input draft store', () => {
+  it('keeps independent drafts keyed by session and request', () => {
+    const store = createUserInputDraftStore()
+    const first = request('session-1', 'request-1')
+    const second = request('session-2', 'request-1')
+
+    expect(draftKey(first)).toBe('session-1:request-1')
+    expect(store.get(first)).toEqual({ choice: 'a' })
+    store.set(first, { choice: 'b' })
+    store.set(second, { choice: 'a' })
+
+    expect(store.get(first)).toEqual({ choice: 'b' })
+    expect(store.get(second)).toEqual({ choice: 'a' })
+  })
+
+  it('retains valid values but drops closed options removed by a schema update', () => {
+    const store = createUserInputDraftStore()
+    const original = request('session-1', 'request-1')
+    store.set(original, { choice: 'b' })
+
+    expect(store.get(request('session-1', 'request-1', ['b', 'c']))).toEqual({ choice: 'b' })
+    expect(store.get(request('session-1', 'request-1', ['a', 'c']))).toEqual({})
+  })
+
+  it('deletes only the terminal request draft', () => {
+    const store = createUserInputDraftStore()
+    const first = request('session-1', 'request-1')
+    const second = request('session-1', 'request-2')
+    store.set(first, { choice: 'b' })
+    store.set(second, { choice: 'a' })
+
+    store.delete(first)
+
+    expect(store.get(first)).toEqual({ choice: 'a' })
+    expect(store.get(second)).toEqual({ choice: 'a' })
+  })
+})

--- a/apps/desktop/src/store/user-input-drafts.ts
+++ b/apps/desktop/src/store/user-input-drafts.ts
@@ -1,0 +1,70 @@
+export interface UserInputDraftQuestion {
+  allowFreeText: boolean
+  defaultValue?: unknown
+  id: string
+  options: string[]
+  text?: string
+}
+
+export interface UserInputDraftRequest {
+  questions: UserInputDraftQuestion[]
+  requestId: string
+  sessionId: string
+}
+
+export type UserInputDraft = Record<string, string>
+
+const scalar = (value: unknown): string =>
+  typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean' ? String(value) : ''
+
+export const draftKey = (request: Pick<UserInputDraftRequest, 'requestId' | 'sessionId'>): string =>
+  `${request.sessionId}:${request.requestId}`
+
+function validAnswers(request: UserInputDraftRequest, answers: UserInputDraft): UserInputDraft {
+  const next: UserInputDraft = {}
+
+  for (const question of request.questions) {
+    const value = answers[question.id]
+
+    if (typeof value !== 'string' || !value) {continue}
+
+    if (!question.allowFreeText && question.options.length && !question.options.includes(value)) {continue}
+    next[question.id] = value
+  }
+
+  return next
+}
+
+function defaults(request: UserInputDraftRequest): UserInputDraft {
+  return Object.fromEntries(
+    request.questions.flatMap(question => {
+      const value = scalar(question.defaultValue)
+
+      return value ? [[question.id, value]] : []
+    })
+  )
+}
+
+export function createUserInputDraftStore() {
+  const drafts = new Map<string, UserInputDraft>()
+
+  return {
+    delete(request: Pick<UserInputDraftRequest, 'requestId' | 'sessionId'>): void {
+      drafts.delete(draftKey(request))
+    },
+    get(request: UserInputDraftRequest): UserInputDraft {
+      const key = draftKey(request)
+      const current = drafts.has(key) ? drafts.get(key) ?? {} : defaults(request)
+      const next = validAnswers(request, current)
+      drafts.set(key, next)
+
+      return { ...next }
+    },
+    set(request: UserInputDraftRequest, answers: UserInputDraft): UserInputDraft {
+      const next = validAnswers(request, answers)
+      drafts.set(draftKey(request), next)
+
+      return { ...next }
+    }
+  }
+}

--- a/apps/desktop/src/store/user-input-replay.test.ts
+++ b/apps/desktop/src/store/user-input-replay.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { createUserInputReplayGuard } from './user-input-replay'
+
+describe('native user-input replay ownership', () => {
+  it('accepts only the newest same-session generation', () => {
+    const guard = createUserInputReplayGuard()
+    const oldToken = guard.begin('s1', 'gateway-a')
+    const newToken = guard.begin('s1', 'gateway-a')
+
+    expect(guard.isCurrent(oldToken)).toBe(false)
+    expect(guard.isCurrent(newToken)).toBe(true)
+  })
+
+  it('keeps independent session replays current at the same time', () => {
+    const guard = createUserInputReplayGuard()
+    const first = guard.begin('s1', 'gateway-a')
+    const second = guard.begin('s2', 'gateway-a')
+
+    expect(guard.isCurrent(first)).toBe(true)
+    expect(guard.isCurrent(second)).toBe(true)
+  })
+
+  it('rejects a switched session and a live request invalidation', () => {
+    const guard = createUserInputReplayGuard()
+    const oldToken = guard.begin('s1', 'gateway-a')
+    guard.begin('s2', 'gateway-a')
+    expect(guard.isCurrent(oldToken)).toBe(true)
+    guard.invalidate('s1')
+    expect(guard.isCurrent(oldToken)).toBe(false)
+
+    const current = guard.begin('s2', 'gateway-a')
+    guard.invalidate('s2')
+    expect(guard.isCurrent(current)).toBe(false)
+  })
+
+  it('rejects a response from an old gateway owner', () => {
+    const guard = createUserInputReplayGuard()
+    const oldToken = guard.begin('s1', 'gateway-a')
+    const newToken = guard.begin('s1', 'gateway-b')
+
+    expect(guard.isCurrent(oldToken)).toBe(false)
+    expect(guard.isCurrent(newToken)).toBe(true)
+  })
+})

--- a/apps/desktop/src/store/user-input-replay.ts
+++ b/apps/desktop/src/store/user-input-replay.ts
@@ -1,0 +1,36 @@
+type ReplayState = {
+  generation: number
+  owner: unknown
+}
+
+type ReplayToken = {
+  generation: number
+  owner: unknown
+  sessionId: string
+}
+
+export function createUserInputReplayGuard() {
+  const states = new Map<string, ReplayState>()
+
+  return {
+    begin(sessionId: string, owner: unknown): ReplayToken {
+      const current = states.get(sessionId) ?? { generation: 0, owner: null }
+      const next = { generation: current.generation + 1, owner }
+      states.set(sessionId, next)
+
+      return { generation: next.generation, owner, sessionId }
+    },
+
+    invalidate(sessionId: string): void {
+      const current = states.get(sessionId) ?? { generation: 0, owner: null }
+      states.set(sessionId, { generation: current.generation + 1, owner: null })
+    },
+
+    isCurrent(token: ReplayToken | null | undefined): boolean {
+      if (!token) {return false}
+      const current = states.get(token.sessionId)
+
+      return Boolean(current && token.generation === current.generation && token.owner === current.owner)
+    }
+  }
+}

--- a/apps/desktop/src/store/user-input-result.test.ts
+++ b/apps/desktop/src/store/user-input-result.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  classifyUserInputResult,
+  createUserInputSubmitLock
+} from './user-input-result'
+
+describe('native user-input acknowledgements', () => {
+  it('keeps invalid answers retryable and does not clear the request', () => {
+    expect(classifyUserInputResult({
+      accepted: false,
+      error: { code: 'invalid', message: 'Answer required: Pick one' },
+      status: 'invalid'
+    })).toMatchObject({
+      clear: false,
+      kind: 'invalid',
+      retryable: true,
+      status: 'invalid'
+    })
+  })
+
+  it('clears only an explicitly terminal or gone request', () => {
+    expect(classifyUserInputResult({ accepted: false, status: 'expired' })).toMatchObject({
+      clear: true,
+      kind: 'terminal',
+      status: 'expired'
+    })
+    expect(classifyUserInputResult({ accepted: false, error: { code: 'not_found' } })).toMatchObject({
+      clear: true,
+      kind: 'not_found',
+      status: 'not_found'
+    })
+  })
+
+  it('does not treat an arbitrary HTTP success or malformed body as accepted', () => {
+    expect(classifyUserInputResult({}, 200)).toMatchObject({
+      clear: false,
+      kind: 'malformed',
+      retryable: true
+    })
+    expect(classifyUserInputResult({ accepted: true, status: 'answered', delivery: 'unknown' })).toMatchObject({
+      clear: false,
+      kind: 'malformed',
+      retryable: true
+    })
+  })
+
+  it('does not allow overlapping submits for the same owned request', () => {
+    const lock = createUserInputSubmitLock()
+
+    expect(lock.acquire('session-1', 'request-1')).toBe(true)
+    expect(lock.acquire('session-1', 'request-1')).toBe(false)
+    expect(lock.acquire('session-1', 'request-2')).toBe(true)
+    lock.release('session-1', 'request-1')
+    expect(lock.acquire('session-1', 'request-1')).toBe(true)
+  })
+})

--- a/apps/desktop/src/store/user-input-result.ts
+++ b/apps/desktop/src/store/user-input-result.ts
@@ -1,0 +1,146 @@
+export type UserInputAcknowledgementKind =
+  | 'accepted'
+  | 'invalid'
+  | 'malformed'
+  | 'not_found'
+  | 'terminal'
+  | 'transport'
+
+export interface UserInputAcknowledgement {
+  accepted: boolean
+  clear: boolean
+  delivery?: string
+  kind: UserInputAcknowledgementKind
+  message?: string
+  recorded?: boolean
+  retryable: boolean
+  status: string
+  terminal?: boolean
+}
+
+const knownDeliveries = new Set(['steered', 'redirected', 'queued', 'deferred'])
+const terminalStatuses = new Set(['answered', 'expired', 'cancelled'])
+
+const notFoundCodes = new Set([
+  'not_found',
+  'request_not_found',
+  'user_input_not_found',
+  'user_input_request_not_found'
+])
+
+const record = (value: unknown): Record<string, unknown> =>
+  value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
+
+const stringValue = (value: unknown): string => typeof value === 'string' ? value : ''
+
+const normalized = (value: unknown): string => stringValue(value).trim().toLowerCase().replace(/-/g, '_')
+
+const errorRecord = (value: unknown): Record<string, unknown> => {
+  if (!value || typeof value !== 'object') {return {}}
+
+  return value as Record<string, unknown>
+}
+
+const resultMessage = (value: unknown): string => {
+  const source = record(value)
+  const error = record(source.error)
+  const message = error.message || source.detail || source.message || source.error
+
+  return typeof message === 'string' ? message.replace(/\s+/g, ' ').trim().slice(0, 500) : ''
+}
+
+export function classifyUserInputResult(
+  value: unknown,
+  httpStatus = 0,
+  thrownError: unknown = null
+): UserInputAcknowledgement {
+  const source = record(value)
+  const thrown = errorRecord(thrownError)
+  const error = record(source.error)
+  const status = normalized(source.status || source.data && record(source.data).status || source.state || error.code || thrown.code)
+  const code = normalized(source.code || source.error_code || source.errorCode || error.code || thrown.code)
+  const explicitNotFound = status === 'not_found' || notFoundCodes.has(code)
+  const accepted = source.accepted === true
+  const rejected = source.accepted === false
+  const delivery = normalized(source.delivery)
+  const message = resultMessage(value) || resultMessage(thrownError)
+
+  if (explicitNotFound) {
+    return {
+      accepted: false,
+      clear: true,
+      kind: 'not_found',
+      ...(message ? { message } : {}),
+      retryable: false,
+      status: 'not_found',
+      terminal: true
+    }
+  }
+
+  if (status === 'invalid' || code === 'invalid') {
+    return {
+      accepted: false,
+      clear: false,
+      kind: 'invalid',
+      message: message || 'Hermes rejected these answers. Check the fields and try again.',
+      retryable: true,
+      status: 'invalid'
+    }
+  }
+
+  const terminalStatus = status === 'already_answered' ? 'answered' : status
+
+  if (rejected && terminalStatuses.has(terminalStatus)) {
+    return {
+      accepted: false,
+      clear: true,
+      kind: 'terminal',
+      retryable: false,
+      status: terminalStatus,
+      terminal: true
+    }
+  }
+
+  if (accepted && terminalStatus === 'answered' && (!delivery || knownDeliveries.has(delivery))) {
+    return {
+      accepted: true,
+      clear: true,
+      ...(delivery ? { delivery } : {}),
+      kind: 'accepted',
+      recorded: true,
+      retryable: false,
+      status: 'answered'
+    }
+  }
+
+  const numericStatus = Number(httpStatus)
+  const httpFailure = Number.isInteger(numericStatus) && numericStatus >= 400
+
+  return {
+    accepted: false,
+    clear: false,
+    kind: thrownError || httpFailure ? 'transport' : 'malformed',
+    message: message || (httpFailure ? `Hermes input answer failed (${numericStatus}).` : 'Hermes returned an unrecognized user-input acknowledgement.'),
+    retryable: true,
+    status: thrownError || httpFailure ? 'transport' : 'malformed'
+  }
+}
+
+export function createUserInputSubmitLock() {
+  const inFlight = new Set<string>()
+  const key = (sessionId: string, requestId: string) => `${sessionId}:${requestId}`
+
+  return {
+    acquire(sessionId: string, requestId: string): boolean {
+      const lockKey = key(sessionId, requestId)
+
+      if (inFlight.has(lockKey)) {return false}
+      inFlight.add(lockKey)
+
+      return true
+    },
+    release(sessionId: string, requestId: string): void {
+      inFlight.delete(key(sessionId, requestId))
+    }
+  }
+}

--- a/apps/desktop/src/store/user-input.test.ts
+++ b/apps/desktop/src/store/user-input.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  $userInputRequests,
+  clearUserInputRequest,
+  replaceUserInputRequests,
+  setUserInputRequest
+} from './user-input'
+
+const request = (requestId: string, sessionId = 'session-1') => ({
+  context: 'Need a decision',
+  expiresAt: 0,
+  questions: [{
+    allowFreeText: false,
+    defaultValue: undefined,
+    id: 'choice',
+    options: ['a', 'b'],
+    text: 'Pick one'
+  }],
+  requestId,
+  sessionId,
+  status: 'pending' as const,
+  turnId: 'turn-1'
+})
+
+describe('native user-input store', () => {
+  beforeEach(() => {
+    $userInputRequests.set({})
+  })
+
+  it('deduplicates a request id within its session', () => {
+    setUserInputRequest(request('request-1'))
+    setUserInputRequest({ ...request('request-1'), context: 'Updated context' })
+
+    expect($userInputRequests.get()['session-1']).toHaveLength(1)
+    expect($userInputRequests.get()['session-1'][0].context).toBe('Updated context')
+  })
+
+  it('clears only the correlated request and preserves newer requests', () => {
+    setUserInputRequest(request('request-1'))
+    setUserInputRequest(request('request-2'))
+    clearUserInputRequest('session-1', 'request-1')
+
+    expect($userInputRequests.get()['session-1'].map(item => item.requestId)).toEqual(['request-2'])
+    clearUserInputRequest('session-1', 'request-1')
+    expect($userInputRequests.get()['session-1'].map(item => item.requestId)).toEqual(['request-2'])
+  })
+
+  it('replaces pending records on reconnect without cross-session bleed', () => {
+    setUserInputRequest(request('old', 'session-1'))
+    setUserInputRequest(request('other', 'session-2'))
+    replaceUserInputRequests('session-1', [request('replayed', 'session-1')])
+
+    expect($userInputRequests.get()['session-1'].map(item => item.requestId)).toEqual(['replayed'])
+    expect($userInputRequests.get()['session-2'].map(item => item.requestId)).toEqual(['other'])
+  })
+})

--- a/apps/desktop/src/store/user-input.ts
+++ b/apps/desktop/src/store/user-input.ts
@@ -1,0 +1,209 @@
+import { atom, computed, type ReadableAtom } from 'nanostores'
+
+import { markSessionGone } from './runtime-gone'
+import { $activeSessionId } from './session'
+import { ambientRequestFor, isSessionGoneForBackgroundPolling } from './session-gone-latch'
+import { requestForOwnedSession } from './session-states'
+
+export interface UserInputQuestion {
+  allowFreeText: boolean
+  defaultValue?: unknown
+  id: string
+  options: string[]
+  text: string
+}
+
+export type UserInputStatus = 'answered' | 'expired' | 'pending'
+
+export interface UserInputRequest {
+  context: string
+  expiresAt: number
+  questions: UserInputQuestion[]
+  requestId: string
+  sessionId: string
+  status: UserInputStatus
+  turnId: string
+}
+
+interface UserInputGateway {
+  request: <T = unknown>(method: string, params?: Record<string, unknown>, timeoutMs?: number, signal?: AbortSignal) => Promise<T>
+}
+
+const emptyRequests: Record<string, UserInputRequest[]> = {}
+
+export const $userInputRequests = atom<Record<string, UserInputRequest[]>>(emptyRequests)
+export const $activeUserInputRequests: ReadableAtom<UserInputRequest[]> = computed(
+  [$userInputRequests, $activeSessionId],
+  (all, activeSessionId) => (activeSessionId ? all[activeSessionId] ?? [] : [])
+)
+
+const text = (value: unknown): string => typeof value === 'string' ? value : ''
+
+function normalizeQuestion(value: unknown): UserInputQuestion | null {
+  if (!value || typeof value !== 'object') {return null}
+  const raw = value as Record<string, unknown>
+  const id = text(raw.id).trim()
+  const questionText = text(raw.text || raw.question).trim()
+
+  if (!id || !questionText) {return null}
+
+  const options = Array.isArray(raw.options)
+    ? raw.options.filter((option): option is string => typeof option === 'string').map(option => option.trim()).filter(Boolean)
+    : []
+
+  return {
+    allowFreeText: raw.allow_free_text === true || raw.allowFreeText === true,
+    defaultValue: raw.default ?? raw.defaultValue,
+    id,
+    options,
+    text: questionText
+  }
+}
+
+export function normalizeUserInputRequest(value: unknown, sessionIdOverride?: string | null): UserInputRequest | null {
+  if (!value || typeof value !== 'object') {return null}
+  const raw = value as Record<string, unknown>
+  const requestId = text(raw.request_id || raw.requestId).trim()
+  const sessionId = text(sessionIdOverride || raw.session_id || raw.sessionId).trim()
+
+  const questions = Array.isArray(raw.questions)
+    ? raw.questions.map(normalizeQuestion).filter((question): question is UserInputQuestion => question !== null)
+    : []
+
+  if (!requestId || !sessionId || questions.length === 0) {return null}
+  const rawStatus = text(raw.status).trim().toLowerCase()
+  const status: UserInputStatus = rawStatus === 'answered' || rawStatus === 'expired' ? rawStatus : 'pending'
+
+  const expiresAt = typeof raw.expires_at === 'number'
+    ? raw.expires_at
+    : typeof raw.expiresAt === 'number' ? raw.expiresAt : 0
+
+  return {
+    context: text(raw.context),
+    expiresAt,
+    questions,
+    requestId,
+    sessionId,
+    status,
+    turnId: text(raw.turn_id || raw.turnId)
+  }
+}
+
+export function setUserInputRequest(request: UserInputRequest | unknown): UserInputRequest | null {
+  const normalized = normalizeUserInputRequest(request)
+
+  if (!normalized) {return null}
+  const all = $userInputRequests.get()
+  const current = all[normalized.sessionId] ?? []
+  const next = current.filter(item => item.requestId !== normalized.requestId)
+  $userInputRequests.set({
+    ...all,
+    [normalized.sessionId]: [...next, normalized]
+  })
+
+  return normalized
+}
+
+export function clearUserInputRequest(sessionId: string | null | undefined, requestId: string | null | undefined): void {
+  const key = text(sessionId).trim()
+  const id = text(requestId).trim()
+
+  if (!key || !id) {return}
+  const all = $userInputRequests.get()
+  const current = all[key]
+
+  if (!current) {return}
+  const next = current.filter(item => item.requestId !== id)
+
+  if (next.length === current.length) {return}
+  const updated = { ...all }
+
+  if (next.length) {updated[key] = next}
+  else {delete updated[key]}
+
+  $userInputRequests.set(updated)
+}
+
+export function replaceUserInputRequests(sessionId: string, requests: unknown[]): void {
+  const key = text(sessionId).trim()
+
+  if (!key) {return}
+
+  const normalized = requests
+    .map(request => normalizeUserInputRequest(request, key))
+    .filter((request): request is UserInputRequest => request !== null && request.status === 'pending')
+
+  const all = { ...$userInputRequests.get() }
+
+  if (normalized.length) {all[key] = normalized}
+  else {delete all[key]}
+
+  $userInputRequests.set(all)
+}
+
+export function userInputRequestsForSession(sessionId: string | null | undefined): UserInputRequest[] {
+  return sessionId ? $userInputRequests.get()[sessionId] ?? [] : []
+}
+
+export const sessionUserInputRequests = (sessionId: string | null) =>
+  computed($userInputRequests, all => (sessionId ? all[sessionId] ?? [] : []))
+
+export async function replayPendingUserInput(
+  gateway: UserInputGateway | null,
+  sessionId: string | null | undefined
+): Promise<void> {
+  const key = text(sessionId).trim()
+
+  if (!gateway || !key) {return}
+  let rawResult: unknown
+
+  try {
+    rawResult = await requestForOwnedSession(key, ambientRequestFor(gateway), 'user_input.pending', {
+      session_id: key
+    })
+  } catch (error) {
+    if (isSessionGoneForBackgroundPolling(error)) {
+      markSessionGone(key)
+
+      return
+    }
+
+    throw error
+  }
+
+  const result = rawResult && typeof rawResult === 'object' ? rawResult as Record<string, unknown> : {}
+
+  const requests = Array.isArray(result.requests)
+    ? result.requests
+    : Array.isArray(result.data) ? result.data : []
+
+  replaceUserInputRequests(key, requests)
+}
+
+export async function respondUserInput(
+  gateway: UserInputGateway | null,
+  request: UserInputRequest,
+  answers: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  if (!gateway) {throw new Error('Hermes gateway is disconnected.')}
+
+  const result = await requestForOwnedSession<Record<string, unknown>>(
+    request.sessionId,
+    ambientRequestFor(gateway),
+    'user_input.respond',
+    {
+      answers,
+      request_id: request.requestId,
+      session_id: request.sessionId
+    }
+  )
+
+  if (result?.status === 'not_found') {
+    clearUserInputRequest(request.sessionId, request.requestId)
+    throw new Error('This Hermes input request is no longer pending.')
+  }
+
+  if (result?.accepted !== false) {clearUserInputRequest(request.sessionId, request.requestId)}
+
+  return result ?? {}
+}

--- a/apps/desktop/src/store/user-input.ts
+++ b/apps/desktop/src/store/user-input.ts
@@ -4,6 +4,11 @@ import { markSessionGone } from './runtime-gone'
 import { $activeSessionId } from './session'
 import { ambientRequestFor, isSessionGoneForBackgroundPolling } from './session-gone-latch'
 import { requestForOwnedSession } from './session-states'
+import { createUserInputReplayGuard } from './user-input-replay'
+import {
+  classifyUserInputResult,
+  type UserInputAcknowledgement
+} from './user-input-result'
 
 export interface UserInputQuestion {
   allowFreeText: boolean
@@ -32,6 +37,7 @@ interface UserInputGateway {
 const emptyRequests: Record<string, UserInputRequest[]> = {}
 
 export const $userInputRequests = atom<Record<string, UserInputRequest[]>>(emptyRequests)
+const userInputReplayGuard = createUserInputReplayGuard()
 export const $activeUserInputRequests: ReadableAtom<UserInputRequest[]> = computed(
   [$userInputRequests, $activeSessionId],
   (all, activeSessionId) => (activeSessionId ? all[activeSessionId] ?? [] : [])
@@ -89,10 +95,17 @@ export function normalizeUserInputRequest(value: unknown, sessionIdOverride?: st
   }
 }
 
+export function invalidatePendingUserInputReplay(sessionId: string | null | undefined): void {
+  const key = text(sessionId).trim()
+
+  if (key) {userInputReplayGuard.invalidate(key)}
+}
+
 export function setUserInputRequest(request: UserInputRequest | unknown): UserInputRequest | null {
   const normalized = normalizeUserInputRequest(request)
 
   if (!normalized) {return null}
+  invalidatePendingUserInputReplay(normalized.sessionId)
   const all = $userInputRequests.get()
   const current = all[normalized.sessionId] ?? []
   const next = current.filter(item => item.requestId !== normalized.requestId)
@@ -109,6 +122,7 @@ export function clearUserInputRequest(sessionId: string | null | undefined, requ
   const id = text(requestId).trim()
 
   if (!key || !id) {return}
+  invalidatePendingUserInputReplay(key)
   const all = $userInputRequests.get()
   const current = all[key]
 
@@ -155,6 +169,7 @@ export async function replayPendingUserInput(
   const key = text(sessionId).trim()
 
   if (!gateway || !key) {return}
+  const replayToken = userInputReplayGuard.begin(key, gateway)
   let rawResult: unknown
 
   try {
@@ -162,6 +177,8 @@ export async function replayPendingUserInput(
       session_id: key
     })
   } catch (error) {
+    if (!userInputReplayGuard.isCurrent(replayToken)) {return}
+
     if (isSessionGoneForBackgroundPolling(error)) {
       markSessionGone(key)
 
@@ -177,6 +194,7 @@ export async function replayPendingUserInput(
     ? result.requests
     : Array.isArray(result.data) ? result.data : []
 
+  if (!userInputReplayGuard.isCurrent(replayToken)) {return}
   replaceUserInputRequests(key, requests)
 }
 
@@ -184,26 +202,39 @@ export async function respondUserInput(
   gateway: UserInputGateway | null,
   request: UserInputRequest,
   answers: Record<string, unknown>
-): Promise<Record<string, unknown>> {
+): Promise<UserInputAcknowledgement> {
   if (!gateway) {throw new Error('Hermes gateway is disconnected.')}
 
-  const result = await requestForOwnedSession<Record<string, unknown>>(
-    request.sessionId,
-    ambientRequestFor(gateway),
-    'user_input.respond',
-    {
-      answers,
-      request_id: request.requestId,
-      session_id: request.sessionId
-    }
-  )
+  let rawResult: unknown
 
-  if (result?.status === 'not_found') {
-    clearUserInputRequest(request.sessionId, request.requestId)
-    throw new Error('This Hermes input request is no longer pending.')
+  try {
+    rawResult = await requestForOwnedSession(
+      request.sessionId,
+      ambientRequestFor(gateway),
+      'user_input.respond',
+      {
+        answers,
+        request_id: request.requestId,
+        session_id: request.sessionId
+      }
+    )
+  } catch (error) {
+    const acknowledgement = classifyUserInputResult(null, 0, error)
+
+    if (acknowledgement.clear) {
+      clearUserInputRequest(request.sessionId, request.requestId)
+
+      return acknowledgement
+    }
+
+    throw error
   }
 
-  if (result?.accepted !== false) {clearUserInputRequest(request.sessionId, request.requestId)}
+  const acknowledgement = classifyUserInputResult(rawResult)
 
-  return result ?? {}
+  if (acknowledgement.clear) {
+    clearUserInputRequest(request.sessionId, request.requestId)
+  }
+
+  return acknowledgement
 }

--- a/cli.py
+++ b/cli.py
@@ -3183,7 +3183,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin, CLITuiMix
         "reload-mcp": ("_confirm_and_reload_mcp", True), "reload-skills": ("_cmd_reload_skills", True),
         "plugins": ("_cmd_plugins", True), "stop": ("_handle_stop_command", False),
         "agents": ("_handle_agents_command", False), "bg": ("_handle_background_command", True),
-        "queue": ("_cmd_queue", True), "steer": ("_cmd_steer", True), "moa": ("_cmd_moa", True),
+        "queue": ("_cmd_queue", True), "steer": ("_cmd_steer", True),
+        "answer": ("_handle_answer_command", True), "moa": ("_cmd_moa", True),
     }
 
     @classmethod

--- a/cli.py
+++ b/cli.py
@@ -3183,8 +3183,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin, CLITuiMix
         "reload-mcp": ("_confirm_and_reload_mcp", True), "reload-skills": ("_cmd_reload_skills", True),
         "plugins": ("_cmd_plugins", True), "stop": ("_handle_stop_command", False),
         "agents": ("_handle_agents_command", False), "bg": ("_handle_background_command", True),
-        "queue": ("_cmd_queue", True), "steer": ("_cmd_steer", True),
-        "answer": ("_handle_answer_command", True), "moa": ("_cmd_moa", True),
+        "queue": ("_cmd_queue", True), "steer": ("_cmd_steer", True), "moa": ("_cmd_moa", True),
     }
 
     @classmethod
@@ -3201,6 +3200,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin, CLITuiMix
         """Dispatch a slash command; returns False to exit the REPL."""
         cmd_lower = command.lower().strip()  # lowercase only for matching; args keep their case
         cmd_original = command.strip()
+        if cmd_original.split(maxsplit=1)[0].lower() in {"/answer", "!answer"}:
+            self._handle_answer_command(cmd_original)
+            return True
 
         # Aliases resolve via the central registry (hermes_cli/commands.py).
         from hermes_cli.commands import resolve_command as _resolve_cmd

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -68,7 +68,9 @@ _STATIC_FEATURE_FLAGS = {
     "run_status": True, "run_events_sse": True, "run_stop": True, "run_steer": True,
     "run_approval_response": True, "tool_progress_events": True, "approval_events": True,
     "session_resources": True, "model_options": True, "session_chat": True,
-    "session_chat_streaming": True, "session_fork": True, "session_model_lock": True,
+    "session_chat_streaming": True, "session_user_input": True,
+    "session_user_input_pending": True, "session_user_input_answer": True,
+    "session_fork": True, "session_model_lock": True,
     "admin_config_rw": False, "jobs_admin": False, "memory_write_api": False,
     "skills_api": True, "audio_api": False, "realtime_voice": False,
     "session_continuity_header": "X-Hermes-Session-Id",
@@ -93,6 +95,8 @@ _CAPABILITY_ENDPOINTS = (
     ("session_fork", ("POST", "/api/sessions/{session_id}/fork")),
     ("session_chat", ("POST", "/api/sessions/{session_id}/chat")),
     ("session_chat_stream", ("POST", "/api/sessions/{session_id}/chat/stream")),
+    ("session_user_input_pending", ("GET", "/api/sessions/{session_id}/user-input/pending")),
+    ("session_user_input_answer", ("POST", "/api/sessions/{session_id}/user-input/{request_id}/answer")),
     ("session_model_lock", ("POST", "/api/sessions/{session_id}/model")),
     ("browser_control_register", ("POST", "/v1/browser-control/register")),
     ("browser_control_ws", ("GET", "/v1/browser-control/ws")),
@@ -1531,6 +1535,8 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             ("POST", "/api/sessions/{session_id}/fork", self._handle_fork_session),
             ("POST", "/api/sessions/{session_id}/chat", self._handle_session_chat),
             ("POST", "/api/sessions/{session_id}/chat/stream", self._handle_session_chat_stream),
+            ("GET", "/api/sessions/{session_id}/user-input/pending", self._handle_session_user_input_pending),
+            ("POST", "/api/sessions/{session_id}/user-input/{request_id}/answer", self._handle_session_user_input_answer),
             ("POST", "/api/sessions/{session_id}/model", self._handle_session_model_lock),
             ("POST", "/v1/chat/completions", self._handle_chat_completions),
             ("POST", "/v1/responses", self._handle_responses),
@@ -2099,7 +2105,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
     def _create_agent(
         self, ephemeral_system_prompt: Optional[str] = None, session_id: Optional[str] = None,
         stream_delta_callback=None, tool_progress_callback=None, tool_start_callback=None,
-        tool_complete_callback=None, gateway_session_key: Optional[str] = None,
+        tool_complete_callback=None, user_input_callback=None, gateway_session_key: Optional[str] = None,
         requested_model: Optional[str] = None, requested_provider: Optional[str] = None,
         model_options: Optional[Dict[str, Any]] = None, route: Optional[Dict[str, Any]] = None,
         session_model: Optional[str] = None, confirmed_runtime_lock: bool = False,
@@ -2152,6 +2158,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             "tool_progress_callback": tool_progress_callback,
             "tool_start_callback": tool_start_callback,
             "tool_complete_callback": tool_complete_callback,
+            "user_input_callback": user_input_callback,
             "session_db": self._ensure_session_db(),
             # Same fallback provider chain as Telegram/Discord/Slack.
             "fallback_model": None if confirmed_runtime_lock else GatewayRunner._load_fallback_model(),
@@ -3133,6 +3140,10 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             elif event_type in {"tool.started", "tool.completed", "tool.failed"}:
                 events.enqueue(event_type, {"message_id": message_id, "tool_name": tool_name, "preview": preview, "args": args})
 
+        def _user_input(request_payload: Dict[str, Any]) -> None:
+            if isinstance(request_payload, dict):
+                events.enqueue("user_input.request", dict(request_payload))
+
         async def _run_and_signal() -> None:
             try:
                 await queue.put(_event_payload("run.started", {
@@ -3143,7 +3154,8 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
                 history = await self._conversation_history_for_session(session_id)
                 result, usage = await self._run_agent(
                     conversation_history=history, stream_delta_callback=_delta,
-                    tool_progress_callback=_tool_progress, active_run_id=run_id, **ctx["run_kwargs"])
+                    tool_progress_callback=_tool_progress, user_input_callback=_user_input,
+                    active_run_id=run_id, **ctx["run_kwargs"])
                 is_dict = isinstance(result, dict)
                 final_response = _resolve_media_to_data_urls(result.get("final_response", "") if is_dict else "")
                 effective_session_id = result.get("session_id", session_id) if is_dict else session_id
@@ -3229,6 +3241,123 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         if not task.done():
             with suppress(Exception):
                 await (asyncio.shield(task) if shield_wait else task)
+
+    @staticmethod
+    def _validate_user_input_request_id(value: Any) -> Optional["web.Response"]:
+        request_id = str(value or "").strip()
+        if not request_id or len(request_id) > 256 or re.search(r"[\r\n\x00]", request_id):
+            return _error_response(
+                "Invalid user-input request ID", 400, code="invalid_user_input_request")
+        return None
+
+    def _active_agent_for_user_input(
+        self, session_id: str, turn_id: Optional[str] = None
+    ) -> Optional[Any]:
+        """Return the live API agent for an input request, only on exact session/turn match."""
+        seen: set[int] = set()
+        agents = (
+            *self._active_run_agents.values(),
+            *self._shutdown_interruptible_agents.values(),
+        )
+        for agent in agents:
+            if agent is None or id(agent) in seen:
+                continue
+            seen.add(id(agent))
+            if str(getattr(agent, "session_id", "") or "") != session_id:
+                continue
+            if turn_id and str(getattr(agent, "_current_turn_id", "") or "") != turn_id:
+                continue
+            return agent
+        return None
+
+    @_require_auth
+    async def _handle_session_user_input_pending(self, request: "web.Request") -> "web.Response":
+        """GET /api/sessions/{session_id}/user-input/pending — replay durable requests."""
+        session_id = request.match_info["session_id"]
+        _, err = await self._get_existing_session_or_404(session_id)
+        if err is not None:
+            return err
+        db = await self._ensure_session_db_async()
+        if db is None:
+            return self._session_db_unavailable()
+        try:
+            from tools.user_input_tool import list_pending_user_inputs
+            pending = await asyncio.to_thread(
+                list_pending_user_inputs, session_id, session_db=db)
+        except Exception:
+            logger.exception("[%s] pending user-input lookup failed", self.name)
+            return _error_response(
+                "Failed to list pending user-input requests", 500,
+                code="user_input_pending_failed")
+        return web.json_response({"object": "list", "session_id": session_id, "data": pending})
+
+    @_require_auth
+    async def _handle_session_user_input_answer(self, request: "web.Request") -> "web.Response":
+        """POST /api/sessions/{session_id}/user-input/{request_id}/answer."""
+        session_id = request.match_info["session_id"]
+        _, err = await self._get_existing_session_or_404(session_id)
+        if err is not None:
+            return err
+        request_id = str(request.match_info.get("request_id") or "").strip()
+        request_err = self._validate_user_input_request_id(request_id)
+        if request_err is not None:
+            return request_err
+        body, err = await self._read_json_body(request)
+        if err is not None:
+            return err
+        answers = body.get("answers")
+        # Accept the public record's singular ``answer`` spelling as a safe
+        # compatibility alias, while all first-party clients send ``answers``.
+        if answers is None and isinstance(body.get("answer"), dict):
+            answers = body["answer"]
+        if not isinstance(answers, dict):
+            return _error_response(
+                "answers must be an object", 400, code="invalid_user_input_answer")
+        raw_turn_id = body.get("turn_id")
+        if raw_turn_id is not None and not isinstance(raw_turn_id, str):
+            return _error_response(
+                "turn_id must be a string", 400, code="invalid_user_input_turn")
+        turn_id = raw_turn_id.strip() if isinstance(raw_turn_id, str) else None
+        if turn_id and (len(turn_id) > 256 or re.search(r"[\r\n\x00]", turn_id)):
+            return _error_response(
+                "Invalid turn ID", 400, code="invalid_user_input_turn")
+        db = await self._ensure_session_db_async()
+        if db is None:
+            return self._session_db_unavailable()
+        if not turn_id:
+            with suppress(Exception):
+                pending_record = await asyncio.to_thread(
+                    db.get_pending_user_input, request_id, session_id=session_id)
+                if pending_record:
+                    stored_turn_id = str(pending_record.get("turn_id") or "").strip()
+                    if stored_turn_id:
+                        turn_id = stored_turn_id
+        agent = self._active_agent_for_user_input(session_id, turn_id)
+        try:
+            from tools.user_input_tool import answer_user_input
+            result = await asyncio.to_thread(
+                answer_user_input,
+                request_id,
+                answers,
+                session_id=session_id,
+                session_db=db,
+                turn_id=turn_id,
+                agent=agent,
+            )
+        except Exception:
+            logger.exception("[%s] user-input answer failed", self.name)
+            return _error_response(
+                "Failed to answer user-input request", 500,
+                code="user_input_answer_failed")
+        if result.get("status") == "not_found":
+            return _error_response(
+                "User-input request not found for this session", 404,
+                code="user_input_not_found")
+        if result.get("status") == "invalid":
+            return _error_response(
+                result.get("error", "Invalid user-input answer"), 400,
+                code="invalid_user_input_answer")
+        return web.json_response(result)
 
     @_require_auth
     async def _handle_session_model_lock(self, request: "web.Request") -> "web.Response":
@@ -3623,7 +3752,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         self, user_message: str, conversation_history: List[Dict[str, str]],
         ephemeral_system_prompt: Optional[str] = None, session_id: Optional[str] = None,
         stream_delta_callback=None, tool_progress_callback=None, tool_start_callback=None,
-        tool_complete_callback=None, agent_ref: Optional[list] = None, active_run_id: Optional[str] = None,
+        tool_complete_callback=None, user_input_callback=None, agent_ref: Optional[list] = None, active_run_id: Optional[str] = None,
         gateway_session_key: Optional[str] = None, requested_model: Optional[str] = None,
         requested_provider: Optional[str] = None, model_options: Optional[Dict[str, Any]] = None,
         route: Optional[Dict[str, Any]] = None, session_model: Optional[str] = None,
@@ -3653,6 +3782,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
                         ephemeral_system_prompt=ephemeral_system_prompt, session_id=session_id,
                         stream_delta_callback=stream_delta_callback, tool_progress_callback=tool_progress_callback,
                         tool_start_callback=tool_start_callback, tool_complete_callback=tool_complete_callback,
+                        user_input_callback=user_input_callback,
                         gateway_session_key=gateway_session_key, requested_model=requested_model,
                         requested_provider=requested_provider, model_options=model_options, route=route,
                         session_model=session_model, confirmed_runtime_lock=confirmed_runtime_lock)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1146,6 +1146,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         self._runner: Optional["web.AppRunner"] = None
         self._site: Optional["web.TCPSite"] = None
         self._response_store = ResponseStore()
+        self._session_event_queues: Dict[str, set[_SessionEventQueue]] = {}
         _api_runs._initialize_run_state(self, store_factory=RunIdempotencyStore)
         self._session_db: Optional[Any] = None  # explicit override (tests/manual wiring)
         self._session_dbs: Dict[str, Any] = {}  # per-profile-home SessionDB cache
@@ -3122,6 +3123,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         message_id = f"msg_{uuid.uuid4().hex}"
         run_id = f"run_{uuid.uuid4().hex}"
         events = _SessionEventQueue(session_id, run_id)
+        self._register_session_event_queue(events)
         queue, _event_payload = events.queue, events.payload
         # Claim ownership inside the request's profile scope before any run-keyed state
         # exists, so /v1/runs/{id}* control is confined to the starting profile.
@@ -3223,6 +3225,8 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             raise
         except Exception as exc:
             logger.debug("[api_server] session SSE stream error: %s", exc)
+        finally:
+            self._unregister_session_event_queue(events)
         return response
 
     async def _drain_session_stream_task_on_disconnect(
@@ -3269,6 +3273,29 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
                 continue
             return agent
         return None
+
+    def _register_session_event_queue(self, events: _SessionEventQueue) -> None:
+        session_id = str(events.session_id or '').strip()
+        if not session_id:
+            return
+        self._session_event_queues.setdefault(session_id, set()).add(events)
+
+    def _unregister_session_event_queue(self, events: _SessionEventQueue) -> None:
+        session_id = str(events.session_id or '').strip()
+        queues = self._session_event_queues.get(session_id)
+        if not queues:
+            return
+        queues.discard(events)
+        if not queues:
+            self._session_event_queues.pop(session_id, None)
+
+    def _broadcast_session_event(
+        self, session_id: str, name: str, payload: Dict[str, Any]
+    ) -> None:
+        """Publish a scoped terminal event to currently open session streams only."""
+        queues = tuple(self._session_event_queues.get(str(session_id or '').strip(), ()))
+        for events in queues:
+            events.enqueue(name, dict(payload))
 
     @_require_auth
     async def _handle_session_user_input_pending(self, request: "web.Request") -> "web.Response":
@@ -3357,6 +3384,12 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             return _error_response(
                 result.get("error", "Invalid user-input answer"), 400,
                 code="invalid_user_input_answer")
+        event_payload = {
+            key: result[key]
+            for key in ("request_id", "status", "answer", "accepted", "delivery", "turn_id")
+            if key in result
+        }
+        self._broadcast_session_event(session_id, "user_input.answer", event_payload)
         return web.json_response(result)
 
     @_require_auth
@@ -4065,6 +4098,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         files, #37011).
         """
         self._mark_disconnected()
+        self._session_event_queues.clear()
         if self._response_store is not None:
             try:
                 self._response_store.close()

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import contextlib
+import json
 import inspect
 import ipaddress
 import logging
@@ -2574,6 +2575,40 @@ class BasePlatformAdapter(ABC):
         else:
             text = f"❓ {question}"
         return await self.send(chat_id=chat_id, content=text, metadata=metadata)
+
+    async def send_user_input(
+        self, chat_id: str, request: Dict[str, Any], session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Render a durable, non-blocking request using the cross-platform text fallback.
+
+        Adapters may add richer controls later, but the protocol remains the same:
+        the user replies with an explicit ``/answer`` envelope containing the
+        request id and an answers object.
+        """
+        request = request if isinstance(request, dict) else {}
+        request_id = str(request.get("request_id") or "")
+        lines = ["📝 Hermes needs your input"]
+        if context := str(request.get("context") or "").strip():
+            lines.extend(("", context))
+        for question in request.get("questions") or []:
+            if not isinstance(question, dict):
+                continue
+            question_id = str(question.get("id") or "")
+            text = str(question.get("text") or "")
+            if not question_id or not text:
+                continue
+            lines.extend(("", f"{question_id}: {text}"))
+            options = question.get("options") or []
+            if options:
+                lines.extend(f"  {index}. {option}" for index, option in enumerate(options, 1))
+            if question.get("allow_free_text"):
+                lines.append("  Free text is allowed.")
+            if question.get("default") not in (None, ""):
+                lines.append(f"  Default: {question['default']}")
+        example = {str(q.get("id")): "your answer" for q in request.get("questions") or [] if isinstance(q, dict) and q.get("id")}
+        lines.extend(("", f"Reply with: /answer {request_id} {json.dumps(example, ensure_ascii=False)}"))
+        return await self.send(chat_id=chat_id, content="\n".join(lines), metadata=metadata)
 
     async def send_private_notice(
         self, chat_id: str, user_id: Optional[str], content: str, reply_to: Optional[str] = None,

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -305,6 +305,68 @@ class GatewayInboundMixin:
             _up_state.persistent.update_prompt_pending = False
         return None
 
+    async def _hm_user_input_reply(
+        self, event: "MessageEvent", source: SessionSource, _quick_key: str
+    ) -> Optional[str]:
+        """Resolve an explicit ``/answer <request_id> <json-object>`` envelope.
+
+        Ordinary text is never treated as an answer. The request is settled in
+        state.db before the active agent is steered, so a retry cannot deliver the
+        same response twice.
+        """
+        raw = (event.text or "").strip()
+        parts = raw.split(maxsplit=2)
+        if not parts or parts[0].lower() not in {"/answer", "!answer"}:
+            return None
+        if len(parts) < 3:
+            return "Usage: /answer <request_id> <json-object>"
+        request_id = parts[1].strip()
+        try:
+            answers = json.loads(parts[2])
+        except (TypeError, ValueError):
+            return "The answer must be a JSON object, for example: /answer <request_id> {\"choice\": \"value\"}"
+        if not isinstance(answers, dict):
+            return "The answer must be a JSON object keyed by question id."
+
+        from gateway.run import _AGENT_PENDING_SENTINEL
+        state = self._peek_session_state(_quick_key)
+        running_agent = state.turn.agent if state else None
+        if running_agent is None or running_agent is _AGENT_PENDING_SENTINEL:
+            # No active turn can safely consume this request. Do not create a new
+            # turn from the envelope; the durable row remains available to status/
+            # reconnect tooling.
+            return "No active Hermes turn is available for that request."
+        session_id = str(getattr(running_agent, "session_id", "") or "")
+        if not session_id:
+            return "The active Hermes turn has no durable session id."
+        db_handle = getattr(self, "_session_db", None)
+        db = getattr(db_handle, "_db", db_handle)
+        if db is None:
+            return "Hermes session state is temporarily unavailable; please retry the answer."
+        try:
+            from tools.user_input_tool import answer_user_input
+            result = await asyncio.to_thread(
+                answer_user_input,
+                request_id,
+                answers,
+                session_id=session_id,
+                session_db=db,
+                agent=running_agent,
+            )
+        except Exception:
+            logger.debug("user-input gateway answer failed", exc_info=True)
+            return "Hermes could not record that answer; please retry it."
+        if result.get("status") == "not_found":
+            return "That Hermes user-input request is not pending for this session."
+        if result.get("status") == "invalid":
+            return str(result.get("error") or "That answer is invalid.")
+        if result.get("accepted"):
+            delivery = result.get("delivery")
+            if delivery in {"steered", "redirected", "queued"}:
+                return ""
+            return "✓ Answer recorded. Hermes will use it when the active turn reaches its next boundary."
+        return ""
+
     async def _hm_clarify_reply(
         self, event: "MessageEvent", source: SessionSource, _quick_key: str
     ) -> Optional[str]:
@@ -1120,6 +1182,8 @@ class GatewayInboundMixin:
         if not event.allow_gateway_control:
             return None
         _reply = self._hm_update_prompt_reply(event, _quick_key)
+        if _reply is None:
+            _reply = await self._hm_user_input_reply(event, source, _quick_key)
         if _reply is None:
             _reply = await self._hm_clarify_reply(event, source, _quick_key)
         if _reply is None:

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1126,6 +1126,7 @@ class TurnRunner:
             mem_notif = "on" if mem_notif else "off"
         agent.memory_notifications = str(mem_notif).lower() if mem_notif else "on"
         agent.clarify_callback = self._clarify_callback_sync
+        agent.user_input_callback = self._user_input_callback_sync
         # Thinking between tool calls is independent of tool_progress mode (Mattermost opts in
         # per platform so global scratch-text doesn't leak into threads).
         agent.thinking_progress = ctx._thinking_enabled
@@ -1166,6 +1167,30 @@ class TurnRunner:
                 cancelled_flag["cancelled"] = True
             logger.warning("%s boundary timed out or failed: %s", reason, err)
             return False
+
+    def _user_input_callback_sync(self, request: dict) -> None:
+        """Schedule a durable user-input request on the platform adapter without blocking the agent."""
+        ctx = self._ctx
+        adapter = ctx._status_adapter
+        if not self._status_live() or adapter is None or not isinstance(request, dict):
+            return
+        send_user_input = getattr(adapter, "send_user_input", None)
+        if not callable(send_user_input):
+            logger.debug("Adapter %s has no user-input renderer", type(adapter).__name__)
+            return
+
+        async def _deliver() -> None:
+            try:
+                await send_user_input(
+                    chat_id=ctx._status_chat_id,
+                    request=dict(request),
+                    session_key=ctx.session_key or "",
+                    metadata=ctx._status_thread_metadata,
+                )
+            except Exception:
+                logger.debug("user-input request delivery failed", exc_info=True)
+
+        self._schedule(_deliver(), "user_input_callback scheduling error")
 
     def _clarify_callback_sync(self, question: str, choices, multi_select: bool = False) -> str:
         """Present a clarify prompt and block on a response (clarify_tool's synchronous contract):

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -471,6 +471,32 @@ class CLIAgentSetupMixin:
         self._reopen_session()
         return True
 
+    def _user_input_callback(self, request: dict) -> None:
+        """Render a non-blocking structured request without taking over the CLI input loop."""
+        import json
+        from cli import _cprint
+        if not isinstance(request, dict):
+            return
+        lines = ["", "📝 Hermes needs your input"]
+        if context := str(request.get("context") or "").strip():
+            lines.append(context)
+        for question in request.get("questions") or []:
+            if not isinstance(question, dict):
+                continue
+            question_id = str(question.get("id") or "")
+            text = str(question.get("text") or "")
+            if not question_id or not text:
+                continue
+            lines.append(f"{question_id}: {text}")
+            for index, option in enumerate(question.get("options") or [], 1):
+                lines.append(f"  {index}. {option}")
+        lines.append(
+            f"Reply with: /answer {request.get('request_id', '')} "
+            + json.dumps({str(q.get("id")): "your answer" for q in request.get("questions") or []
+                          if isinstance(q, dict) and q.get("id")}, ensure_ascii=False)
+        )
+        _cprint("\n".join(lines))
+
     def _init_agent(self, *, model_override: str = None, runtime_override: dict = None, request_overrides: dict | None = None) -> bool:
         """Build the agent on first use; when resuming, restore history from SQLite.
         Returns True on success."""
@@ -531,7 +557,7 @@ class CLIAgentSetupMixin:
                 provider_data_collection=self._provider_data_collection,
                 openrouter_min_coding_score=self._openrouter_min_coding_score,
                 session_id=self.session_id, platform="cli", session_db=self._session_db,
-                clarify_callback=clarify_callback,
+                clarify_callback=clarify_callback, user_input_callback=self._user_input_callback,
                 reasoning_callback=self._current_reasoning_callback(),
                 fallback_model=self._fallback_model, thinking_callback=self._on_thinking,
                 checkpoints_enabled=self.checkpoints_enabled,

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2647,6 +2647,37 @@ class CLICommandsMixin:
             CLI_CONFIG["agent"]["reasoning_effort"] = arg
         _cp(_accent_line(f"✓ Reasoning effort set to '{arg}' {_scope_outcome(explicit_global, saved)}"))
 
+    def _handle_answer_command(self, cmd: str):
+        """Resolve a pending Hermes structured user-input request in this CLI session."""
+        import json
+        from cli import _cprint
+        parts = (cmd or "").strip().split(maxsplit=2)
+        if len(parts) < 3:
+            return _cp("Usage: /answer <request_id> <json-object>")
+        try:
+            answers = json.loads(parts[2])
+        except (TypeError, ValueError):
+            return _cp("The answer must be a JSON object keyed by question id.")
+        if not isinstance(answers, dict):
+            return _cp("The answer must be a JSON object keyed by question id.")
+        agent = getattr(self, "agent", None)
+        db = getattr(self, "_session_db", None)
+        if agent is None or db is None:
+            return _cp("No active Hermes session is available for that request.")
+        from tools.user_input_tool import answer_user_input
+        result = answer_user_input(
+            parts[1], answers, session_id=str(getattr(agent, "session_id", "") or self.session_id),
+            session_db=db, agent=agent,
+        )
+        if result.get("status") == "not_found":
+            return _cp("That Hermes user-input request is not pending for this session.")
+        if result.get("status") == "invalid":
+            return _cp(str(result.get("error") or "That answer is invalid."))
+        if result.get("accepted"):
+            _cprint("✓ Answer recorded for Hermes.")
+        else:
+            _cprint("That Hermes user-input request was already settled.")
+
     def _handle_busy_command(self, cmd: str):
         """Handle /busy [status|queue|steer|interrupt] — what Enter does while Hermes is working."""
         arg = _command_arg(cmd, lower=True)

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -110,8 +110,6 @@ COMMAND_REGISTRY: list[CommandDef] = [
                aliases=("q",), args_hint="<prompt>", busy_policy="dispatch", busy_handler="queue"),
     CommandDef("steer", "Inject a message after the next tool call without interrupting", "Session",
                args_hint="<prompt>", busy_policy="dispatch", busy_handler="steer"),
-    CommandDef("answer", "Answer a pending Hermes structured user-input request", "Session",
-               cli_only=True, args_hint="<request_id> <json-object>", busy_policy="dispatch"),
     CommandDef("goal", "Set a standing goal Hermes works on across turns until achieved", "Session",
                args_hint="[text | draft <text> | show | gate add <cmd> | pause | resume | clear | status | wait <pid> | unwait]",
                argument_mode="mixed", busy_policy="dispatch", busy_handler="goal"),

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -110,6 +110,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                aliases=("q",), args_hint="<prompt>", busy_policy="dispatch", busy_handler="queue"),
     CommandDef("steer", "Inject a message after the next tool call without interrupting", "Session",
                args_hint="<prompt>", busy_policy="dispatch", busy_handler="steer"),
+    CommandDef("answer", "Answer a pending Hermes structured user-input request", "Session",
+               cli_only=True, args_hint="<request_id> <json-object>", busy_policy="dispatch"),
     CommandDef("goal", "Set a standing goal Hermes works on across turns until achieved", "Session",
                args_hint="[text | draft <text> | show | gate add <cmd> | pause | resume | clear | status | wait <pid> | unwait]",
                argument_mode="mixed", busy_policy="dispatch", busy_handler="goal"),

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -51,6 +51,7 @@ from hermes_state_dbfile import (
     refuse_deleted_wal_generation,
 )
 from hermes_state_messages import SessionMessagesMixin
+from hermes_state_user_input import SessionUserInputMixin
 from hermes_state_wal import _WAL_INCOMPAT_MARKERS, apply_database_pragmas, apply_wal_with_fallback
 from hermes_state_repair import _claim_repair_attempt, preflight_db_writability, repair_state_db_schema
 from hermes_state_titles import SessionTitlesMixin
@@ -328,7 +329,7 @@ class SessionDB(
     SessionSessionsMixin, SessionFtsSetupMixin, SessionSearchMixin, SessionSchemaMixin,
     SessionPortabilityMixin, SessionTelegramTopicsMixin, SessionCompressionMixin,
     SessionGatewayMixin, SessionMaintenanceMixin, SessionUsageMixin, SessionTitlesMixin,
-    SessionMessagesMixin,
+    SessionMessagesMixin, SessionUserInputMixin,
 ):
     """SQLite-backed session storage with FTS5 search; many reader threads, one writer (WAL)."""
 

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -194,7 +194,7 @@ def _sql_session_last_active_by_id(session_id_expr: str) -> str:
         f"(SELECT started_at FROM sessions _act_s WHERE _act_s.id = {session_id_expr})")
 
 
-SCHEMA_VERSION = 31
+SCHEMA_VERSION = 30
 
 # Auto-maintenance VACUUMs only above this freelist fraction; below it a rewrite costs more I/O than it returns.
 # Auto-maintenance only VACUUMs when at least this fraction of the database file is reclaimable (``PRAGMA

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -194,7 +194,7 @@ def _sql_session_last_active_by_id(session_id_expr: str) -> str:
         f"(SELECT started_at FROM sessions _act_s WHERE _act_s.id = {session_id_expr})")
 
 
-SCHEMA_VERSION = 30
+SCHEMA_VERSION = 31
 
 # Auto-maintenance VACUUMs only above this freelist fraction; below it a rewrite costs more I/O than it returns.
 # Auto-maintenance only VACUUMs when at least this fraction of the database file is reclaimable (``PRAGMA
@@ -487,6 +487,28 @@ CREATE TABLE IF NOT EXISTS async_delegations (
     delivery_claimed_at REAL
 );
 
+-- Provider-independent, non-blocking questions emitted by the Hermes tool loop.
+-- Answers are state transitions, not transcript rows; the active turn consumes
+-- them through the role-safe steer/redirect boundary.
+CREATE TABLE IF NOT EXISTS pending_user_inputs (
+    request_id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    turn_id TEXT NOT NULL DEFAULT '',
+    session_key TEXT NOT NULL DEFAULT '',
+    source TEXT NOT NULL DEFAULT '',
+    user_id TEXT NOT NULL DEFAULT '',
+    chat_id TEXT NOT NULL DEFAULT '',
+    thread_id TEXT NOT NULL DEFAULT '',
+    questions TEXT NOT NULL,
+    context TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'answered', 'expired', 'cancelled')),
+    answer TEXT,
+    created_at REAL NOT NULL,
+    expires_at REAL NOT NULL,
+    answered_at REAL
+);
+
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_sessions_source_id ON sessions(source, id);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
@@ -507,6 +529,8 @@ CREATE INDEX IF NOT EXISTS idx_session_model_usage_session ON session_model_usag
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_model ON session_model_usage(model);
 CREATE INDEX IF NOT EXISTS idx_async_delegations_delivery
     ON async_delegations(delivery_state, completed_at);
+CREATE INDEX IF NOT EXISTS idx_pending_user_inputs_session_status
+    ON pending_user_inputs(session_id, status, expires_at);
 """
 
 # Indexes on later-added columns must run AFTER _reconcile_columns(), or executescript fails on legacy DBs.

--- a/hermes_state_user_input.py
+++ b/hermes_state_user_input.py
@@ -1,0 +1,296 @@
+"""Durable, session-scoped asynchronous user-input requests.
+
+This module is deliberately a small SessionDB mixin. Requests are durable state,
+not transcript messages: an answer is delivered to the active agent through its
+role-safe steering API, so no out-of-band writer can break provider turn order.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import time
+from typing import Any, Dict, List, Optional
+
+
+_USER_INPUT_STATUSES = frozenset({"pending", "answered", "expired", "cancelled"})
+
+
+def _json_load(raw: Any, default: Any = None) -> Any:
+    if not isinstance(raw, str) or not raw:
+        return default
+    try:
+        return json.loads(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def _json_dump(value: Any) -> str:
+    # ensure_ascii keeps lone surrogate input bindable on every supported SQLite build.
+    return json.dumps(value, ensure_ascii=True, separators=(",", ":"), default=str)
+
+
+def _clean_text(value: Any, *, max_chars: int, default: str = "") -> str:
+    text = str(value if value is not None else default).strip()
+    return text[:max_chars]
+
+
+def _question_default(question: Any, index: int) -> Any:
+    if not isinstance(question, dict):
+        return ""
+    return question.get("default", "")
+
+
+def _default_answers(questions: Any) -> Dict[str, Any]:
+    if not isinstance(questions, list):
+        return {}
+    answers: Dict[str, Any] = {}
+    for index, question in enumerate(questions):
+        if not isinstance(question, dict):
+            continue
+        question_id = _clean_text(question.get("id") or f"q{index}", max_chars=128)
+        if question_id:
+            answers[question_id] = _question_default(question, index)
+    return answers
+
+
+class SessionUserInputMixin:
+    """Pending structured user-input records stored in the canonical state DB."""
+
+    _USER_INPUT_MAX_REQUEST_ID = 256
+    _USER_INPUT_MAX_SESSION_ID = 256
+    _USER_INPUT_MAX_TURN_ID = 256
+    _USER_INPUT_MAX_CONTEXT = 4096
+
+    @staticmethod
+    def _user_input_record(row) -> Dict[str, Any]:
+        """Decode one row into the stable public record shape."""
+        questions = _json_load(row["questions"], [])
+        answer = _json_load(row["answer"], None)
+        return {
+            "request_id": str(row["request_id"] or ""),
+            "session_id": str(row["session_id"] or ""),
+            "turn_id": str(row["turn_id"] or ""),
+            "questions": questions if isinstance(questions, list) else [],
+            "context": str(row["context"] or ""),
+            "status": str(row["status"] or "pending"),
+            "answer": answer,
+            "created_at": float(row["created_at"] or 0),
+            "expires_at": float(row["expires_at"] or 0),
+            "answered_at": float(row["answered_at"]) if row["answered_at"] is not None else None,
+        }
+
+    @staticmethod
+    def _user_input_status_record(row, *, accepted: Optional[bool] = None) -> Dict[str, Any]:
+        record = SessionUserInputMixin._user_input_record(row)
+        if accepted is not None:
+            record["accepted"] = bool(accepted)
+        return record
+
+    @staticmethod
+    def _settle_expired_row(conn, row, *, now: float):
+        """Settle a pending expired row inside the caller's write transaction."""
+        if row is None or str(row["status"] or "") != "pending":
+            return row
+        expires_at = float(row["expires_at"] or 0)
+        if expires_at <= 0 or expires_at > now:
+            return row
+        defaults = _default_answers(_json_load(row["questions"], []))
+        conn.execute(
+            """UPDATE pending_user_inputs
+               SET status = 'expired', answer = ?, answered_at = ?
+             WHERE request_id = ? AND session_id = ? AND status = 'pending'""",
+            (_json_dump(defaults), now, row["request_id"], row["session_id"]),
+        )
+        return conn.execute(
+            "SELECT * FROM pending_user_inputs WHERE request_id = ? AND session_id = ?",
+            (row["request_id"], row["session_id"]),
+        ).fetchone()
+
+    def create_pending_user_input(
+        self,
+        request_id: str,
+        session_id: str,
+        questions: List[Dict[str, Any]],
+        context: str = "",
+        expires_at: Optional[float] = None,
+        *,
+        turn_id: str = "",
+        session_key: str = "",
+        source: str = "",
+        user_id: str = "",
+        chat_id: str = "",
+        thread_id: str = "",
+        now: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Insert one pending request and return its canonical record.
+
+        Reusing an existing request id is idempotent only for the owning session;
+        a collision from another session raises instead of exposing that record.
+        """
+        request_id = _clean_text(request_id, max_chars=self._USER_INPUT_MAX_REQUEST_ID)
+        session_id = _clean_text(session_id, max_chars=self._USER_INPUT_MAX_SESSION_ID)
+        turn_id = _clean_text(turn_id, max_chars=self._USER_INPUT_MAX_TURN_ID)
+        if not request_id or not session_id:
+            raise ValueError("request_id and session_id are required")
+        if not isinstance(questions, list) or not questions:
+            raise ValueError("questions must be a non-empty list")
+        now_value = time.time() if now is None else float(now)
+        expiry = now_value + 3600.0 if expires_at is None else float(expires_at)
+        if not math.isfinite(expiry):
+            raise ValueError("expires_at must be finite")
+        context = _clean_text(context, max_chars=self._USER_INPUT_MAX_CONTEXT)
+        params = (
+            request_id, session_id, turn_id,
+            _clean_text(session_key, max_chars=512), _clean_text(source, max_chars=64),
+            _clean_text(user_id, max_chars=256), _clean_text(chat_id, max_chars=256),
+            _clean_text(thread_id, max_chars=256), _json_dump(questions), context,
+            "pending", None, now_value, expiry, None,
+        )
+
+        def _do(conn):
+            conn.execute(
+                """INSERT OR IGNORE INTO pending_user_inputs (
+                    request_id, session_id, turn_id, session_key, source, user_id,
+                    chat_id, thread_id, questions, context, status, answer,
+                    created_at, expires_at, answered_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                params,
+            )
+            row = conn.execute(
+                "SELECT * FROM pending_user_inputs WHERE request_id = ?", (request_id,)
+            ).fetchone()
+            if row is None:
+                raise RuntimeError("pending user-input request was not persisted")
+            if str(row["session_id"] or "") != session_id:
+                raise ValueError("request_id is already owned by another session")
+            return self._user_input_record(row)
+
+        return self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S)
+
+    def get_pending_user_input(
+        self, request_id: str, *, session_id: str, now: Optional[float] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Read one request only when it belongs to *session_id*.
+
+        Expiry is a durable state transition, so an expired row is never merely
+        reported as pending because a read happened before a later answer.
+        """
+        request_id = _clean_text(request_id, max_chars=self._USER_INPUT_MAX_REQUEST_ID)
+        session_id = _clean_text(session_id, max_chars=self._USER_INPUT_MAX_SESSION_ID)
+        if not request_id or not session_id:
+            return None
+        now_value = time.time() if now is None else float(now)
+
+        def _settle(conn):
+            row = conn.execute(
+                "SELECT * FROM pending_user_inputs WHERE request_id = ? AND session_id = ?",
+                (request_id, session_id),
+            ).fetchone()
+            return self._settle_expired_row(conn, row, now=now_value)
+
+        row = self._execute_write(_settle, patience_s=self._ACTIVITY_WRITE_PATIENCE_S)
+        return self._user_input_record(row) if row is not None else None
+
+    def list_pending_user_inputs(
+        self, session_id: str, *, now: Optional[float] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return pending requests for exactly one session, oldest first."""
+        session_id = _clean_text(session_id, max_chars=self._USER_INPUT_MAX_SESSION_ID)
+        if not session_id:
+            return []
+        now_value = time.time() if now is None else float(now)
+
+        def _settle(conn):
+            rows = conn.execute(
+                "SELECT * FROM pending_user_inputs WHERE session_id = ? AND status = 'pending'",
+                (session_id,),
+            ).fetchall()
+            for row in rows:
+                self._settle_expired_row(conn, row, now=now_value)
+
+        self._execute_write(_settle, patience_s=self._ACTIVITY_WRITE_PATIENCE_S)
+        rows = self._read_all(
+            """SELECT * FROM pending_user_inputs
+               WHERE session_id = ? AND status = 'pending'
+               ORDER BY created_at, request_id""",
+            (session_id,),
+        )
+        return [self._user_input_record(row) for row in rows]
+
+    def answer_pending_user_input(
+        self,
+        request_id: str,
+        answer: Dict[str, Any],
+        *,
+        session_id: str,
+        turn_id: Optional[str] = None,
+        now: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """CAS-set one answer; exactly one concurrent caller receives ``accepted``.
+
+        A request from another session is indistinguishable from a missing request.
+        This is intentional: callers must not be able to probe request ids across
+        sessions or use an answer to steer another live agent.
+        """
+        request_id = _clean_text(request_id, max_chars=self._USER_INPUT_MAX_REQUEST_ID)
+        session_id = _clean_text(session_id, max_chars=self._USER_INPUT_MAX_SESSION_ID)
+        if not request_id or not session_id:
+            return {"status": "not_found", "accepted": False}
+        if not isinstance(answer, dict):
+            return {"status": "invalid", "accepted": False, "error": "answer must be an object"}
+        now_value = time.time() if now is None else float(now)
+        expected_turn_id = _clean_text(turn_id, max_chars=self._USER_INPUT_MAX_TURN_ID) if turn_id is not None else None
+
+        def _do(conn):
+            row = conn.execute(
+                "SELECT * FROM pending_user_inputs WHERE request_id = ? AND session_id = ?",
+                (request_id, session_id),
+            ).fetchone()
+            if row is None:
+                return {"status": "not_found", "accepted": False}
+            stored_turn_id = str(row["turn_id"] or "")
+            if expected_turn_id is not None and stored_turn_id and expected_turn_id != stored_turn_id:
+                return {"status": "not_found", "accepted": False}
+            row = self._settle_expired_row(conn, row, now=now_value)
+            if row is None:
+                return {"status": "not_found", "accepted": False}
+            if str(row["status"] or "") != "pending":
+                return self._user_input_status_record(row, accepted=False)
+            cur = conn.execute(
+                """UPDATE pending_user_inputs
+                   SET status = 'answered', answer = ?, answered_at = ?
+                 WHERE request_id = ? AND session_id = ? AND status = 'pending'""",
+                (_json_dump(answer), now_value, request_id, session_id),
+            )
+            accepted = int(cur.rowcount or 0) == 1
+            final_row = conn.execute(
+                "SELECT * FROM pending_user_inputs WHERE request_id = ? AND session_id = ?",
+                (request_id, session_id),
+            ).fetchone()
+            return self._user_input_status_record(final_row, accepted=accepted)
+
+        return self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S)
+
+    def expire_pending_user_input(
+        self, request_id: str, *, session_id: str, now: Optional[float] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Explicitly settle one request as expired, preserving question defaults."""
+        request_id = _clean_text(request_id, max_chars=self._USER_INPUT_MAX_REQUEST_ID)
+        session_id = _clean_text(session_id, max_chars=self._USER_INPUT_MAX_SESSION_ID)
+        if not request_id or not session_id:
+            return None
+        now_value = time.time() if now is None else float(now)
+
+        def _do(conn):
+            row = conn.execute(
+                "SELECT * FROM pending_user_inputs WHERE request_id = ? AND session_id = ?",
+                (request_id, session_id),
+            ).fetchone()
+            row = self._settle_expired_row(conn, row, now=now_value)
+            return self._user_input_record(row) if row is not None else None
+
+        return self._execute_write(_do, patience_s=self._ACTIVITY_WRITE_PATIENCE_S)
+
+
+__all__ = ["SessionUserInputMixin"]

--- a/hermes_state_user_input.py
+++ b/hermes_state_user_input.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List, Optional
 
 
 _USER_INPUT_STATUSES = frozenset({"pending", "answered", "expired", "cancelled"})
+MAX_TEXT_CHARS = 2000
 
 
 def _json_load(raw: Any, default: Any = None) -> Any:
@@ -52,6 +53,58 @@ def _default_answers(questions: Any) -> Dict[str, Any]:
         if question_id:
             answers[question_id] = _question_default(question, index)
     return answers
+
+
+def _normalize_user_input_answer(
+    questions: Any, answer: Any,
+) -> tuple[Optional[Dict[str, str]], Optional[str]]:
+    """Validate and normalize an answer against the stored question definition.
+
+    This is intentionally state-owned and dependency-light: every acceptance
+    surface reaches this policy through :meth:`answer_pending_user_input`.
+    Callers must run it while holding the write transaction so the question
+    definition and the following CAS cannot be observed from different states.
+    """
+    if not isinstance(answer, dict):
+        return None, "answer must be an object"
+    if not isinstance(questions, list) or not questions:
+        return None, "pending question definition is invalid"
+
+    question_by_id: Dict[str, Dict[str, Any]] = {}
+    for question in questions:
+        if not isinstance(question, dict):
+            return None, "pending question definition is invalid"
+        question_id = question.get("id")
+        if not isinstance(question_id, str) or not question_id or question_id in question_by_id:
+            return None, "pending question definition is invalid"
+        options = question.get("options", [])
+        if options is None:
+            options = []
+        if not isinstance(options, list) or any(not isinstance(option, str) for option in options):
+            return None, "pending question definition is invalid"
+        question_by_id[question_id] = question
+
+    if set(answer) != set(question_by_id):
+        return None, "answer keys must match pending question ids"
+
+    normalized: Dict[str, str] = {}
+    for question_id, question in question_by_id.items():
+        value = answer[question_id]
+        if isinstance(value, float) and not math.isfinite(value):
+            return None, "answer values must be finite strings"
+        if not isinstance(value, str):
+            return None, "answer values must be nonblank strings"
+        normalized_value = value.strip()
+        if not normalized_value:
+            return None, "answer values must be nonblank strings"
+        if len(normalized_value) > MAX_TEXT_CHARS:
+            return None, f"answer values cannot exceed {MAX_TEXT_CHARS} characters"
+
+        options = question.get("options") or []
+        if options and question.get("allow_free_text") is not True and normalized_value not in options:
+            return None, "answer does not match a pending option"
+        normalized[question_id] = normalized_value
+    return normalized, None
 
 
 class SessionUserInputMixin:
@@ -237,8 +290,6 @@ class SessionUserInputMixin:
         session_id = _clean_text(session_id, max_chars=self._USER_INPUT_MAX_SESSION_ID)
         if not request_id or not session_id:
             return {"status": "not_found", "accepted": False}
-        if not isinstance(answer, dict):
-            return {"status": "invalid", "accepted": False, "error": "answer must be an object"}
         now_value = time.time() if now is None else float(now)
         expected_turn_id = _clean_text(turn_id, max_chars=self._USER_INPUT_MAX_TURN_ID) if turn_id is not None else None
 
@@ -257,11 +308,16 @@ class SessionUserInputMixin:
                 return {"status": "not_found", "accepted": False}
             if str(row["status"] or "") != "pending":
                 return self._user_input_status_record(row, accepted=False)
+            normalized_answer, validation_error = _normalize_user_input_answer(
+                _json_load(row["questions"], []), answer,
+            )
+            if validation_error is not None:
+                return {"status": "invalid", "accepted": False, "error": validation_error}
             cur = conn.execute(
                 """UPDATE pending_user_inputs
                    SET status = 'answered', answer = ?, answered_at = ?
                  WHERE request_id = ? AND session_id = ? AND status = 'pending'""",
-                (_json_dump(answer), now_value, request_id, session_id),
+                (_json_dump(normalized_answer), now_value, request_id, session_id),
             )
             accepted = int(cur.rowcount or 0) == 1
             final_row = conn.execute(
@@ -293,4 +349,4 @@ class SessionUserInputMixin:
         return self._execute_write(_do, patience_s=self._ACTIVITY_WRITE_PATIENCE_S)
 
 
-__all__ = ["SessionUserInputMixin"]
+__all__ = ["MAX_TEXT_CHARS", "SessionUserInputMixin"]

--- a/model_tools.py
+++ b/model_tools.py
@@ -752,7 +752,8 @@ def _approval_observability(ids: _CallIds):
 
 
 def _execute_tool(function_name: str, function_args: Dict[str, Any], original_args: Dict[str, Any], ids: _CallIds,
-                  *, user_task: Optional[str], enabled_tools: Optional[List[str]], skip_tool_execution_middleware: bool) -> Any:
+                  *, user_task: Optional[str], enabled_tools: Optional[List[str]],
+                  skip_tool_execution_middleware: bool, session_db=None) -> Any:
     """Run the registry handler (through tool-execution middleware unless skipped)
     with the approval observability context bound for the duration."""
     dispatch_kwargs: Dict[str, Any] = {"task_id": ids.task_id, "session_id": ids.session_id}
@@ -762,6 +763,8 @@ def _execute_tool(function_name: str, function_args: Dict[str, Any], original_ar
         dispatch_kwargs["enabled_tools"] = enabled_tools if enabled_tools is not None else _last_resolved_tool_names
     else:
         dispatch_kwargs["user_task"] = user_task
+    if function_name in {"request_user_input", "check_user_input"}:
+        dispatch_kwargs.update(session_db=session_db, turn_id=ids.turn_id or "")
 
     def _dispatch(next_args: Dict[str, Any]) -> Any:
         return registry.dispatch(function_name, next_args, **dispatch_kwargs)
@@ -805,6 +808,7 @@ def handle_function_call(
     skip_pre_tool_call_hook: bool = False, skip_tool_request_middleware: bool = False,
     skip_tool_execution_middleware: bool = False, tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
     enabled_toolsets: Optional[List[str]] = None, disabled_toolsets: Optional[List[str]] = None,
+    session_db=None,
 ) -> str:
     """Route a tool call through hooks/middleware to the registry; returns a JSON string.
 
@@ -840,7 +844,7 @@ def handle_function_call(
             *underlying, **asdict(ids), user_task=user_task, enabled_tools=enabled_tools,
             skip_pre_tool_call_hook=skip_pre_tool_call_hook, skip_tool_request_middleware=skip_tool_request_middleware,
             skip_tool_execution_middleware=skip_tool_execution_middleware, tool_request_middleware_trace=list(trace),
-            enabled_toolsets=enabled_toolsets, disabled_toolsets=disabled_toolsets,
+            enabled_toolsets=enabled_toolsets, disabled_toolsets=disabled_toolsets, session_db=session_db,
         )
 
     original_args = dict(function_args)
@@ -867,7 +871,8 @@ def handle_function_call(
         # duration_ms (monotonic) is exposed to post_tool_call / transform_tool_result.
         start = time.monotonic()
         result = _execute_tool(function_name, function_args, original_args, ids, user_task=user_task,
-                               enabled_tools=enabled_tools, skip_tool_execution_middleware=skip_tool_execution_middleware)
+                               enabled_tools=enabled_tools, skip_tool_execution_middleware=skip_tool_execution_middleware,
+                               session_db=session_db)
         duration_ms = _elapsed_ms(start)
         _emit(result, duration_ms=duration_ms)
         return _apply_transform_tool_result_hook(function_name, function_args, result, duration_ms, ids)

--- a/run_agent.py
+++ b/run_agent.py
@@ -248,6 +248,7 @@ class AIAgent(
         tool_progress_callback: callable = None, tool_start_callback: callable = None,
         tool_complete_callback: callable = None, thinking_callback: callable = None,
         reasoning_callback: callable = None, clarify_callback: callable = None,
+        user_input_callback: callable = None,
         read_terminal_callback: callable = None, read_preview_callback: callable = None,
         drive_preview_callback: callable = None, read_window_below_callback: callable = None,
         setup_mcp_callback: callable = None, tour_callback: callable = None, step_callback: callable = None,

--- a/tests/cli/test_user_input.py
+++ b/tests/cli/test_user_input.py
@@ -1,0 +1,50 @@
+"""CLI command contract for Hermes-native non-blocking user input."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = SessionDB(tmp_path / "state.db")
+    database.create_session("cli-session", source="cli")
+    try:
+        yield database
+    finally:
+        database.close()
+
+
+def test_answer_command_resolves_request_on_existing_agent(monkeypatch, db):
+    import cli
+    import hermes_cli.cli_commands_mixin as commands
+    from tools.user_input_tool import request_user_input
+
+    request = __import__("json").loads(request_user_input(
+        questions=[{"id": "target", "text": "Which target?", "options": ["stable"], "default": "stable"}],
+        session_id="cli-session", turn_id="turn-1", session_db=db,
+    ))
+    output = []
+    monkeypatch.setattr(cli, "_cprint", lambda text: output.append(str(text)))
+    monkeypatch.setattr(commands, "_cp", lambda *items: output.extend(str(item) for item in items))
+
+    agent = SimpleNamespace(
+        session_id="cli-session",
+        _current_turn_id="turn-1",
+        _inflight_turn_id="turn-1",
+        _executing_tools=True,
+        _interrupt_requested=False,
+        steer=lambda text: True,
+    )
+    host = SimpleNamespace(agent=agent, _session_db=db, session_id="cli-session")
+
+    commands.CLICommandsMixin._handle_answer_command(
+        host, f"/answer {request['request_id']} {{\"target\": \"stable\"}}"
+    )
+
+    assert any("Answer recorded" in item for item in output)
+    assert db.get_pending_user_input(request["request_id"], session_id="cli-session")["status"] == "answered"

--- a/tests/gateway/test_api_server_user_input.py
+++ b/tests/gateway/test_api_server_user_input.py
@@ -1,0 +1,171 @@
+"""API-server transport coverage for native asynchronous user input."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import (
+    APIServerAdapter,
+    _STATIC_FEATURE_FLAGS,
+)
+
+
+class _SessionDB:
+    def get_session(self, session_id):
+        return {"id": session_id, "source": "api_server"}
+
+    def get_pending_user_input(self, request_id, *, session_id, now=None):
+        return {"request_id": request_id, "session_id": session_id, "turn_id": "turn-1"}
+
+
+def _app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application()
+    app.router.add_get(
+        "/api/sessions/{session_id}/user-input/pending",
+        adapter._handle_session_user_input_pending,
+    )
+    app.router.add_post(
+        "/api/sessions/{session_id}/user-input/{request_id}/answer",
+        adapter._handle_session_user_input_answer,
+    )
+    return app
+
+
+@pytest.mark.asyncio
+async def test_run_agent_forwards_user_input_callback_and_emits_request():
+    adapter = APIServerAdapter(PlatformConfig(enabled=True))
+    adapter._session_db = _SessionDB()
+    callback_payload = {
+        "request_id": "request-1",
+        "session_id": "session-1",
+        "questions": [{"id": "choice", "text": "Pick one", "options": ["a"]}],
+    }
+    captured = {}
+    user_input_callback = MagicMock()
+
+    agent = MagicMock()
+    agent.session_id = "session-1"
+    agent.session_prompt_tokens = 0
+    agent.session_completion_tokens = 0
+    agent.session_total_tokens = 0
+
+    def run_conversation(**_kwargs):
+        captured["callback"](callback_payload)
+        return {"final_response": "continued"}
+
+    agent.run_conversation.side_effect = run_conversation
+
+    def create_agent(**kwargs):
+        captured.update(kwargs)
+        captured["callback"] = kwargs["user_input_callback"]
+        return agent
+
+    adapter._create_agent = create_agent
+    result, _usage = await adapter._run_agent(
+        user_message="hello",
+        conversation_history=[],
+        session_id="session-1",
+        user_input_callback=user_input_callback,
+    )
+
+    assert result["final_response"] == "continued"
+    assert captured["user_input_callback"] is user_input_callback
+    user_input_callback.assert_called_once_with(callback_payload)
+
+
+@pytest.mark.asyncio
+async def test_pending_endpoint_replays_session_scoped_requests(monkeypatch):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True))
+    adapter._session_db = _SessionDB()
+    pending = [{
+        "request_id": "request-1",
+        "session_id": "session-1",
+        "turn_id": "turn-1",
+        "questions": [],
+        "context": "",
+        "status": "pending",
+        "answer": None,
+        "expires_at": 0,
+    }]
+    monkeypatch.setattr("tools.user_input_tool.list_pending_user_inputs", lambda session_id, **_: pending)
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.get("/api/sessions/session-1/user-input/pending")
+        payload = await response.json()
+
+    assert response.status == 200
+    assert payload == {"object": "list", "session_id": "session-1", "data": pending}
+
+
+@pytest.mark.asyncio
+async def test_answer_endpoint_delivers_structured_answers_to_matching_live_turn(monkeypatch):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True))
+    adapter._session_db = _SessionDB()
+    live_agent = SimpleNamespace(session_id="session-1", _current_turn_id="turn-1")
+    adapter._active_run_agents = {"run-1": live_agent}
+    captured = {}
+
+    def answer(request_id, answers, **kwargs):
+        captured.update(request_id=request_id, answers=answers, **kwargs)
+        return {
+            "request_id": request_id,
+            "status": "answered",
+            "accepted": True,
+            "answer": answers,
+            "turn_id": kwargs.get("turn_id") or "turn-1",
+            "delivery": "queued",
+        }
+
+    monkeypatch.setattr("tools.user_input_tool.answer_user_input", answer)
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/api/sessions/session-1/user-input/request-1/answer",
+            json={"answers": {"choice": "a"}},
+        )
+        payload = await response.json()
+
+    assert response.status == 200
+    assert payload["accepted"] is True
+    assert captured["request_id"] == "request-1"
+    assert captured["answers"] == {"choice": "a"}
+    assert captured["session_id"] == "session-1"
+    assert captured["agent"] is live_agent
+    assert captured["turn_id"] == "turn-1"
+
+
+@pytest.mark.asyncio
+async def test_answer_endpoint_rejects_non_object_answers(monkeypatch):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True))
+    adapter._session_db = _SessionDB()
+    called = False
+
+    def answer(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        return {}
+
+    monkeypatch.setattr("tools.user_input_tool.answer_user_input", answer)
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/api/sessions/session-1/user-input/request-1/answer",
+            json={"answers": ["a"]},
+        )
+        payload = await response.json()
+
+    assert response.status == 400
+    assert payload["error"]["code"] == "invalid_user_input_answer"
+    assert called is False
+
+
+def test_capabilities_and_route_table_advertise_user_input():
+    adapter = APIServerAdapter(PlatformConfig(enabled=True))
+    routes = {(method, path) for method, path, _handler in adapter._http_route_table()}
+    assert ("GET", "/api/sessions/{session_id}/user-input/pending") in routes
+    assert ("POST", "/api/sessions/{session_id}/user-input/{request_id}/answer") in routes
+    assert _STATIC_FEATURE_FLAGS["session_user_input"] is True

--- a/tests/gateway/test_api_server_user_input.py
+++ b/tests/gateway/test_api_server_user_input.py
@@ -12,6 +12,7 @@ from gateway.platforms.api_server import (
     APIServerAdapter,
     _STATIC_FEATURE_FLAGS,
 )
+from hermes_state import SessionDB
 
 
 class _SessionDB:
@@ -33,6 +34,28 @@ def _app(adapter: APIServerAdapter) -> web.Application:
         adapter._handle_session_user_input_answer,
     )
     return app
+
+
+def test_session_user_input_broadcast_is_scoped_to_the_owning_session():
+    adapter = APIServerAdapter(PlatformConfig(enabled=True))
+    session_a = MagicMock()
+    session_b = MagicMock()
+    adapter._session_event_queues = {
+        "session-a": {session_a},
+        "session-b": {session_b},
+    }
+
+    adapter._broadcast_session_event(
+        "session-a",
+        "user_input.answer",
+        {"request_id": "request-a", "status": "answered"},
+    )
+
+    session_a.enqueue.assert_called_once_with(
+        "user_input.answer",
+        {"request_id": "request-a", "status": "answered"},
+    )
+    session_b.enqueue.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -108,6 +131,7 @@ async def test_answer_endpoint_delivers_structured_answers_to_matching_live_turn
     live_agent = SimpleNamespace(session_id="session-1", _current_turn_id="turn-1")
     adapter._active_run_agents = {"run-1": live_agent}
     captured = {}
+    adapter._broadcast_session_event = MagicMock()
 
     def answer(request_id, answers, **kwargs):
         captured.update(request_id=request_id, answers=answers, **kwargs)
@@ -136,6 +160,18 @@ async def test_answer_endpoint_delivers_structured_answers_to_matching_live_turn
     assert captured["session_id"] == "session-1"
     assert captured["agent"] is live_agent
     assert captured["turn_id"] == "turn-1"
+    adapter._broadcast_session_event.assert_called_once_with(
+        "session-1",
+        "user_input.answer",
+        {
+            "request_id": "request-1",
+            "status": "answered",
+            "answer": {"choice": "a"},
+            "accepted": True,
+            "delivery": "queued",
+            "turn_id": "turn-1",
+        },
+    )
 
 
 @pytest.mark.asyncio
@@ -161,6 +197,38 @@ async def test_answer_endpoint_rejects_non_object_answers(monkeypatch):
     assert response.status == 400
     assert payload["error"]["code"] == "invalid_user_input_answer"
     assert called is False
+
+
+@pytest.mark.asyncio
+async def test_answer_endpoint_rejects_invalid_answer_without_mutating_request(tmp_path):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True))
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("session-1", source="api_server")
+    db.create_pending_user_input(
+        request_id="request-invalid",
+        session_id="session-1",
+        questions=[
+            {"id": "choice", "text": "Pick one", "options": ["a", "b"], "allow_free_text": False},
+        ],
+    )
+    adapter._session_db = db
+
+    try:
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/api/sessions/session-1/user-input/request-invalid/answer",
+                json={"answers": {"choice": "unsupported"}},
+            )
+            payload = await response.json()
+
+        assert response.status == 400
+        assert payload["error"]["code"] == "invalid_user_input_answer"
+        # The real SessionDB acceptance boundary must leave invalid requests pending.
+        pending = db.get_pending_user_input("request-invalid", session_id="session-1")
+        assert pending["status"] == "pending"
+        assert pending["answer"] is None
+    finally:
+        db.close()
 
 
 def test_capabilities_and_route_table_advertise_user_input():

--- a/tests/gateway/test_user_input.py
+++ b/tests/gateway/test_user_input.py
@@ -1,0 +1,150 @@
+"""Gateway-independent delivery contracts for Hermes-native user input."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+
+
+def _agent(model_active=False, executing_tools=False, turn_id="turn-1"):
+    from types import SimpleNamespace
+
+    events = []
+    agent = SimpleNamespace(
+        _current_turn_id=turn_id,
+        _model_request_active=threading.Event(),
+        _executing_tools=executing_tools,
+    )
+    if model_active:
+        agent._model_request_active.set()
+
+    def redirect(text):
+        events.append(("redirect", text))
+        return True
+
+    def steer(text):
+        events.append(("steer", text))
+        return True
+
+    agent.redirect = redirect
+    agent.steer = steer
+    agent.events = events
+    return agent
+
+
+def test_model_active_answer_redirects_without_steering():
+    from tools.user_input_tool import deliver_answer_to_agent
+
+    agent = _agent(model_active=True)
+    assert deliver_answer_to_agent(agent, "turn-1", {"choice": "stable"}) == "redirected"
+    assert agent.events == [("redirect", json.dumps({"choice": "stable"}, ensure_ascii=False))]
+
+
+def test_tool_active_answer_uses_steering_boundary():
+    from tools.user_input_tool import deliver_answer_to_agent
+
+    agent = _agent(executing_tools=True)
+    assert deliver_answer_to_agent(agent, "turn-1", {"choice": "stable"}) == "steered"
+    assert agent.events == [("steer", json.dumps({"choice": "stable"}, ensure_ascii=False))]
+
+
+def test_answer_for_stale_turn_is_deferred_without_queueing():
+    from tools.user_input_tool import deliver_answer_to_agent
+
+    agent = _agent(turn_id="new-turn")
+    assert deliver_answer_to_agent(agent, "old-turn", {"choice": "stable"}) == "deferred"
+    assert agent.events == []
+
+
+def test_answer_after_turn_slot_is_cleared_is_deferred_without_queueing():
+    from tools.user_input_tool import deliver_answer_to_agent
+
+    agent = _agent(turn_id="finished-turn")
+    agent._inflight_turn_id = None
+    assert deliver_answer_to_agent(agent, "finished-turn", {"choice": "stable"}) == "deferred"
+    assert agent.events == []
+
+
+def test_base_adapter_user_input_fallback_is_explicit_and_structured():
+    from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+    class Adapter(BasePlatformAdapter):
+        async def connect(self, *args, **kwargs):
+            return None
+
+        async def disconnect(self, *args, **kwargs):
+            return None
+
+        async def get_chat_info(self, *args, **kwargs):
+            return None
+
+        async def send(self, *args, **kwargs):
+            return SendResult(success=True)
+
+    adapter = Adapter.__new__(Adapter)
+    sent = []
+
+    async def send(*, chat_id, content, metadata=None, **kwargs):
+        sent.append((chat_id, content, metadata))
+        return SendResult(success=True)
+
+    adapter.send = send
+    request = {
+        "request_id": "request-1",
+        "context": "Choose a compatibility target",
+        "questions": [{
+            "id": "target",
+            "text": "Which target?",
+            "options": ["stable", "beta"],
+            "allow_free_text": False,
+            "default": "stable",
+        }],
+    }
+    result = asyncio.run(adapter.send_user_input("chat-1", request, "session-1"))
+
+    assert result.success is True
+    assert sent and sent[0][0] == "chat-1"
+    content = sent[0][1]
+    assert "/answer request-1" in content
+    assert "target: Which target?" in content
+    assert "1. stable" in content
+    assert "2. beta" in content
+
+
+def test_gateway_answer_envelope_resolves_active_turn_without_new_turn(tmp_path):
+    import time
+    from types import SimpleNamespace
+
+    from gateway.run import GatewayRunner
+    from tools.user_input_tool import request_user_input
+    from hermes_state import SessionDB
+
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("gateway-session", source="telegram")
+    try:
+        request = json.loads(request_user_input(
+            questions=[{"id": "target", "text": "Which target?", "options": ["stable"], "default": "stable"}],
+            session_id="gateway-session", turn_id="turn-1", session_db=db,
+            now=time.time(),
+        ))
+        delivered = []
+        agent = _agent(executing_tools=True, turn_id="turn-1")
+        agent.session_id = "gateway-session"
+        agent.steer = lambda text: delivered.append(text) or True
+
+        runner = object.__new__(GatewayRunner)
+        runner._peek_session_state = lambda _key: SimpleNamespace(
+            turn=SimpleNamespace(agent=agent)
+        )
+        runner._session_db = db
+        event = SimpleNamespace(
+            text=f"/answer {request['request_id']} {{\"target\": \"stable\"}}",
+        )
+        result = asyncio.run(runner._hm_user_input_reply(event, None, "route-key"))
+
+        assert result == ""
+        assert delivered == [json.dumps({"target": "stable"}, ensure_ascii=False)]
+        assert db.get_pending_user_input(request["request_id"], session_id="gateway-session")["status"] == "answered"
+    finally:
+        db.close()

--- a/tests/tools/test_user_input_tool.py
+++ b/tests/tools/test_user_input_tool.py
@@ -1,0 +1,246 @@
+"""RED contracts for Hermes-native asynchronous structured user input."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+QUESTIONS = [
+    {
+        "id": "api_version",
+        "text": "Which API version should I target?",
+        "options": ["v1 (stable)", "v2 (beta)"],
+        "allow_free_text": False,
+        "default": "v1 (stable)",
+    }
+]
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = SessionDB(tmp_path / "state.db")
+    database.create_session("session-1", source="cli")
+    database.create_session("session-2", source="cli")
+    try:
+        yield database
+    finally:
+        database.close()
+
+
+def test_user_input_tools_are_registered_in_clarify_toolset():
+    from tools import user_input_tool  # noqa: F401
+    from tools.registry import registry
+
+    request = registry.get_entry("request_user_input")
+    check = registry.get_entry("check_user_input")
+    assert request is not None
+    assert check is not None
+    assert request.toolset == "clarify"
+    assert check.toolset == "clarify"
+
+
+def test_create_and_read_pending_request_round_trip(db):
+    record = db.create_pending_user_input(
+        request_id="request-1",
+        session_id="session-1",
+        questions=QUESTIONS,
+        context="Choosing the compatibility target",
+        expires_at=time.time() + 60,
+        turn_id="turn-1",
+    )
+
+    assert record["request_id"] == "request-1"
+    assert record["session_id"] == "session-1"
+    assert record["status"] == "pending"
+    assert record["questions"] == QUESTIONS
+    assert record["context"] == "Choosing the compatibility target"
+    assert record["answer"] is None
+
+    loaded = db.get_pending_user_input("request-1", session_id="session-1")
+    assert loaded == record
+
+
+def test_pending_request_cannot_be_read_or_answered_from_another_session(db):
+    db.create_pending_user_input(
+        request_id="request-2",
+        session_id="session-1",
+        questions=QUESTIONS,
+        context="",
+        expires_at=time.time() + 60,
+    )
+
+    assert db.get_pending_user_input("request-2", session_id="session-2") is None
+    result = db.answer_pending_user_input(
+        "request-2", {"api_version": "v2 (beta)"}, session_id="session-2"
+    )
+    assert result["status"] == "not_found"
+    assert db.get_pending_user_input("request-2", session_id="session-1")["status"] == "pending"
+
+
+def test_answer_is_single_writer_and_returns_canonical_record(db):
+    db.create_pending_user_input(
+        request_id="request-3",
+        session_id="session-1",
+        questions=QUESTIONS,
+        context="",
+        expires_at=time.time() + 60,
+    )
+    barrier = threading.Barrier(3)
+    results = []
+
+    def answer(value):
+        barrier.wait()
+        results.append(
+            db.answer_pending_user_input(
+                "request-3", {"api_version": value}, session_id="session-1"
+            )
+        )
+
+    first = threading.Thread(target=answer, args=("v1 (stable)",))
+    second = threading.Thread(target=answer, args=("v2 (beta)",))
+    first.start()
+    second.start()
+    barrier.wait()
+    first.join()
+    second.join()
+
+    assert sorted(result["status"] for result in results) == ["answered", "answered"]
+    assert sum(bool(result.get("accepted")) for result in results) == 1
+    stored = db.get_pending_user_input("request-3", session_id="session-1")
+    assert stored["status"] == "answered"
+    assert stored["answer"]["api_version"] in {"v1 (stable)", "v2 (beta)"}
+
+
+def test_expiry_is_settled_durably_and_uses_question_defaults(db):
+    db.create_pending_user_input(
+        request_id="request-4",
+        session_id="session-1",
+        questions=QUESTIONS,
+        context="",
+        expires_at=time.time() - 1,
+    )
+
+    result = db.get_pending_user_input("request-4", session_id="session-1")
+    assert result["status"] == "expired"
+    assert result["answer"] == {"api_version": "v1 (stable)"}
+
+    import sqlite3
+
+    with sqlite3.connect(db.db_path) as conn:
+        row = conn.execute(
+            "SELECT status, answer FROM pending_user_inputs WHERE request_id = ?",
+            ("request-4",),
+        ).fetchone()
+    assert row[0] == "expired"
+    assert json.loads(row[1]) == {"api_version": "v1 (stable)"}
+
+
+def test_request_tool_validates_shape_and_returns_immediately(monkeypatch, db):
+    from tools import user_input_tool
+
+    monkeypatch.setattr(user_input_tool, "_shared_session_db", db)
+    result = json.loads(
+        user_input_tool.request_user_input(
+            questions=QUESTIONS,
+            context="Need a compatibility decision",
+            timeout_s=60,
+            session_id="session-1",
+        )
+    )
+    assert result["status"] == "pending"
+    assert result["request_id"]
+    assert "hint" in result
+    assert db.list_pending_user_inputs("session-1")[0]["request_id"] == result["request_id"]
+
+    invalid = json.loads(
+        user_input_tool.request_user_input(
+            questions=QUESTIONS * 6,
+            session_id="session-1",
+        )
+    )
+    assert "error" in invalid
+
+
+def test_check_tool_is_session_scoped_and_reports_expiry(monkeypatch, db):
+    from tools import user_input_tool
+
+    db.create_pending_user_input(
+        request_id="request-5",
+        session_id="session-1",
+        questions=QUESTIONS,
+        context="",
+        expires_at=time.time() - 1,
+    )
+    monkeypatch.setattr(user_input_tool, "_shared_session_db", db)
+
+    wrong_session = json.loads(
+        user_input_tool.check_user_input("request-5", session_id="session-2")
+    )
+    assert wrong_session["status"] == "not_found"
+
+    expired = json.loads(
+        user_input_tool.check_user_input("request-5", session_id="session-1")
+    )
+    assert expired["status"] == "expired"
+    assert expired["answer"]["api_version"] == "v1 (stable)"
+
+
+def test_dispatcher_passes_agent_session_db_to_user_input_handler(monkeypatch, db):
+    from tools import user_input_tool
+    import model_tools
+
+    sentinel = object()
+    monkeypatch.setattr(user_input_tool, "_shared_session_db", sentinel)
+    result = json.loads(
+        model_tools.handle_function_call(
+            "request_user_input",
+            {"questions": QUESTIONS, "timeout_s": 60},
+            task_id="task-1",
+            session_id="session-1",
+            session_db=db,
+        )
+    )
+    assert result["status"] == "pending"
+    request = db.get_pending_user_input(result["request_id"], session_id="session-1")
+    assert request is not None
+    assert user_input_tool._shared_session_db is sentinel
+
+
+def test_agent_runtime_executor_passes_session_db_to_user_input_handler(monkeypatch, db):
+    from types import SimpleNamespace
+
+    from agent.agent_runtime_helpers import invoke_tool
+    from tools import user_input_tool
+
+    sentinel = object()
+    monkeypatch.setattr(user_input_tool, "_shared_session_db", sentinel)
+    agent = SimpleNamespace(
+        _session_db=db,
+        session_id="session-1",
+        valid_tool_names={"request_user_input"},
+        _context_engine_tool_names=set(),
+        _memory_manager=None,
+        _current_turn_id="turn-1",
+        _current_api_request_id="",
+        enabled_toolsets=None,
+        disabled_toolsets=None,
+    )
+    result = json.loads(
+        invoke_tool(
+            agent,
+            "request_user_input",
+            {"questions": QUESTIONS, "timeout_s": 60},
+            "task-1",
+            skip_tool_request_middleware=True,
+            skip_tool_execution_middleware=True,
+        )
+    )
+    assert result["status"] == "pending"
+    assert db.get_pending_user_input(result["request_id"], session_id="session-1") is not None
+    assert user_input_tool._shared_session_db is sentinel

--- a/tests/tools/test_user_input_tool.py
+++ b/tests/tools/test_user_input_tool.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import threading
 import time
 
@@ -141,6 +142,28 @@ def test_expiry_is_settled_durably_and_uses_question_defaults(db):
     assert json.loads(row[1]) == {"api_version": "v1 (stable)"}
 
 
+def test_request_tool_allows_closed_choice_without_optional_default(monkeypatch, db):
+    from tools import user_input_tool
+
+    monkeypatch.setattr(user_input_tool, "_shared_session_db", db)
+    result = json.loads(
+        user_input_tool.request_user_input(
+            questions=[
+                {
+                    "id": "drink",
+                    "text": "Which drink?",
+                    "options": ["Coffee", "Tea"],
+                    "allow_free_text": False,
+                }
+            ],
+            session_id="session-1",
+        )
+    )
+
+    assert result["status"] == "pending"
+    assert result["questions"][0]["default"] == ""
+
+
 def test_request_tool_validates_shape_and_returns_immediately(monkeypatch, db):
     from tools import user_input_tool
 
@@ -244,3 +267,127 @@ def test_agent_runtime_executor_passes_session_db_to_user_input_handler(monkeypa
     assert result["status"] == "pending"
     assert db.get_pending_user_input(result["request_id"], session_id="session-1") is not None
     assert user_input_tool._shared_session_db is sentinel
+
+
+@pytest.mark.parametrize(
+    "answer",
+    [
+        {},
+        {"api_version": "v1 (stable)", "unexpected": "value"},
+        {"api_version": ""},
+        {"api_version": "   "},
+        {"api_version": ["v1 (stable)"]},
+        {"api_version": {"value": "v1 (stable)"}},
+        {"api_version": None},
+        {"api_version": math.nan},
+        {"api_version": math.inf},
+        {"api_version": "not-an-option"},
+        {"api_version": "x" * 2001},
+        {"api_version": 42},
+        {"api_version": False},
+    ],
+)
+def test_invalid_answer_is_rejected_without_settling_request(db, answer):
+    db.create_pending_user_input(
+        request_id="request-invalid",
+        session_id="session-1",
+        questions=QUESTIONS,
+        expires_at=time.time() + 60,
+    )
+
+    result = db.answer_pending_user_input(
+        "request-invalid", answer, session_id="session-1"
+    )
+
+    assert result["status"] == "invalid"
+    assert result["accepted"] is False
+    assert result["error"]
+    pending = db.get_pending_user_input("request-invalid", session_id="session-1")
+    assert pending["status"] == "pending"
+    assert pending["answer"] is None
+
+
+def test_valid_answer_is_normalized_and_tool_delivers_canonical_answer(db):
+    from types import SimpleNamespace
+
+    from tools.user_input_tool import answer_user_input
+
+    questions = [
+        {
+            "id": "choice",
+            "text": "Which target?",
+            "options": ["stable", "beta"],
+            "allow_free_text": False,
+        },
+        {
+            "id": "notes",
+            "text": "Any notes?",
+            "options": [],
+            "allow_free_text": False,
+        },
+    ]
+    db.create_pending_user_input(
+        request_id="request-canonical",
+        session_id="session-1",
+        questions=questions,
+        expires_at=time.time() + 60,
+        turn_id="turn-1",
+    )
+    delivered = []
+    agent = SimpleNamespace(
+        _current_turn_id="turn-1",
+        _executing_tools=True,
+        steer=lambda text: delivered.append(text) or True,
+    )
+
+    result = answer_user_input(
+        "request-canonical",
+        {"choice": " beta ", "notes": "  free text  "},
+        session_id="session-1",
+        session_db=db,
+        agent=agent,
+    )
+
+    assert result["status"] == "answered"
+    assert result["accepted"] is True
+    assert result["answer"] == {"choice": "beta", "notes": "free text"}
+    assert delivered == [json.dumps(result["answer"], ensure_ascii=False)]
+
+
+def test_invalid_and_valid_answers_race_without_invalid_writer_acceptance(db):
+    db.create_pending_user_input(
+        request_id="request-race",
+        session_id="session-1",
+        questions=QUESTIONS,
+        expires_at=time.time() + 60,
+    )
+    barrier = threading.Barrier(3)
+    results = []
+
+    def answer(payload):
+        barrier.wait()
+        results.append(
+            db.answer_pending_user_input(
+                "request-race", payload, session_id="session-1"
+            )
+        )
+
+    invalid = threading.Thread(
+        target=answer,
+        args=({"api_version": "v2 (beta)", "unexpected": "value"},),
+    )
+    valid = threading.Thread(
+        target=answer,
+        args=({"api_version": "v2 (beta)"},),
+    )
+    invalid.start()
+    valid.start()
+    barrier.wait()
+    invalid.join()
+    valid.join()
+
+    assert all(result["status"] in {"answered", "invalid"} for result in results)
+    assert sum(bool(result.get("accepted")) for result in results) == 1
+    stored = db.get_pending_user_input("request-race", session_id="session-1")
+    assert stored["status"] == "answered"
+    assert stored["answer"] == {"api_version": "v2 (beta)"}

--- a/tests/tui_gateway/test_user_input_protocol.py
+++ b/tests/tui_gateway/test_user_input_protocol.py
@@ -1,0 +1,172 @@
+"""TUI JSON-RPC contracts for Hermes-native non-blocking user input."""
+
+from __future__ import annotations
+
+import json
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+QUESTIONS = [
+    {
+        "id": "name",
+        "text": "What name should I use?",
+        "options": [],
+        "allow_free_text": True,
+        "default": "",
+    }
+]
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = SessionDB(tmp_path / "state.db")
+    database.create_session("tui-session", source="desktop")
+    database.create_session("other-session", source="desktop")
+    try:
+        yield database
+    finally:
+        database.close()
+
+
+def _install_session(monkeypatch, server, db, *, sid="tui-sid", session_id="tui-session"):
+    delivered = []
+
+    class Agent:
+        def __init__(self):
+            self.session_id = session_id
+            self._session_db = db
+            self._current_turn_id = "turn-tui-1"
+            self._model_request_active = None
+            self._executing_tools = True
+
+        def steer(self, text):
+            delivered.append(text)
+            return True
+
+        def redirect(self, text):
+            delivered.append(text)
+            return True
+
+    session = {
+        "agent": Agent(),
+        "session_key": sid,
+        "history_lock": __import__("threading").RLock(),
+        "agent_ready": __import__("threading").Event(),
+        "running": True,
+    }
+    session["agent_ready"].set()
+    monkeypatch.setitem(server._sessions, sid, session)
+    monkeypatch.setattr(server, "_session_db", lambda _session: db)
+    return session, delivered
+
+
+def test_user_input_respond_is_session_scoped_and_emits_answer_event(monkeypatch, db):
+    from tui_gateway import server
+
+    db.create_pending_user_input(
+        request_id="uir_tui_1",
+        session_id="tui-session",
+        questions=[{"id": "version", "text": "Version?", "options": ["stable", "beta"], "allow_free_text": False}],
+        expires_at=time.time() + 60,
+        turn_id="turn-tui-1",
+    )
+    emitted = []
+    monkeypatch.setattr(server, "_emit", lambda event, sid, payload=None: emitted.append((event, sid, payload)))
+    session, delivered = _install_session(monkeypatch, server, db)
+
+    response = server.handle_request({
+        "jsonrpc": "2.0",
+        "id": "rpc-1",
+        "method": "user_input.respond",
+        "params": {"session_id": "tui-sid", "request_id": "uir_tui_1", "answers": {"version": "stable"}},
+    })
+
+    assert response["result"]["status"] == "answered"
+    assert response["result"]["accepted"] is True
+    assert delivered == [json.dumps({"version": "stable"}, ensure_ascii=False)]
+    answer_events = [item for item in emitted if item[0] == "user_input.answer"]
+    assert answer_events
+    assert answer_events[-1][1] == "tui-sid"
+    assert answer_events[-1][2]["request_id"] == "uir_tui_1"
+    assert answer_events[-1][2]["status"] == "answered"
+
+    # A different live session cannot resolve the same durable request.
+    monkeypatch.setitem(server._sessions, "other-sid", {
+        **session,
+        "agent": SimpleNamespace(session_id="other-session", _session_db=db),
+    })
+    denied = server.handle_request({
+        "jsonrpc": "2.0",
+        "id": "rpc-2",
+        "method": "user_input.respond",
+        "params": {"session_id": "other-sid", "request_id": "uir_tui_1", "answers": {"version": "beta"}},
+    })
+    assert denied["error"]["code"] == 4001
+
+
+def test_user_input_pending_replays_only_the_requesting_session(monkeypatch, db):
+    from tui_gateway import server
+
+    db.create_pending_user_input(
+        request_id="uir_tui_2",
+        session_id="tui-session",
+        questions=QUESTIONS,
+        context="reconnect",
+        expires_at=time.time() + 60,
+    )
+    db.create_pending_user_input(
+        request_id="uir_other",
+        session_id="other-session",
+        questions=QUESTIONS,
+        expires_at=time.time() + 60,
+    )
+    _install_session(monkeypatch, server, db)
+
+    response = server.handle_request({
+        "jsonrpc": "2.0",
+        "id": "rpc-3",
+        "method": "user_input.pending",
+        "params": {"session_id": "tui-sid"},
+    })
+
+    requests = response["result"]["requests"]
+    assert [item["request_id"] for item in requests] == ["uir_tui_2"]
+    assert requests[0]["session_id"] == "tui-session"
+
+
+def test_user_input_request_is_emitted_on_the_session_event_rail(monkeypatch, db):
+    from tools import user_input_tool
+    from tui_gateway import server
+
+    emitted = []
+    monkeypatch.setattr(server, "_emit", lambda event, sid, payload=None: emitted.append((event, sid, payload)))
+    callback = server._agent_cbs("tui-sid")["user_input_callback"]
+    monkeypatch.setattr(user_input_tool, "_shared_session_db", db)
+
+    result = json.loads(
+        user_input_tool.request_user_input(
+            questions=QUESTIONS,
+            context="event test",
+            timeout_s=100,
+            session_id="tui-session",
+            turn_id="turn-tui-1",
+            callback=callback,
+            session_db=db,
+            now=100.0,
+        )
+    )
+
+    assert result["status"] == "pending"
+    request_events = [item for item in emitted if item[0] == "user_input.request"]
+    assert request_events
+    event = request_events[-1]
+    assert event[1] == "tui-sid"
+    assert event[2]["request_id"] == result["request_id"]
+    assert event[2]["status"] == "pending"
+    assert event[2]["questions"] == QUESTIONS
+    assert event[2]["expires_at"] == pytest.approx(200.0)

--- a/tests/tui_gateway/test_user_input_protocol.py
+++ b/tests/tui_gateway/test_user_input_protocol.py
@@ -170,3 +170,35 @@ def test_user_input_request_is_emitted_on_the_session_event_rail(monkeypatch, db
     assert event[2]["status"] == "pending"
     assert event[2]["questions"] == QUESTIONS
     assert event[2]["expires_at"] == pytest.approx(200.0)
+
+
+def test_user_input_respond_rejects_invalid_answer_without_delivery(monkeypatch, db):
+    from tui_gateway import server
+
+    db.create_pending_user_input(
+        request_id="uir_tui_invalid",
+        session_id="tui-session",
+        questions=[
+            {"id": "version", "text": "Version?", "options": ["stable", "beta"], "allow_free_text": False},
+        ],
+        expires_at=time.time() + 60,
+        turn_id="turn-tui-1",
+    )
+    _session, delivered = _install_session(monkeypatch, server, db)
+
+    response = server.handle_request({
+        "jsonrpc": "2.0",
+        "id": "rpc-invalid",
+        "method": "user_input.respond",
+        "params": {
+            "session_id": "tui-sid",
+            "request_id": "uir_tui_invalid",
+            "answers": {"version": "unsupported"},
+        },
+    })
+
+    assert response["error"]["code"] == 4004
+    assert delivered == []
+    pending = db.get_pending_user_input("uir_tui_invalid", session_id="tui-session")
+    assert pending["status"] == "pending"
+    assert pending["answer"] is None

--- a/tools/delegate_tool_toolsets.py
+++ b/tools/delegate_tool_toolsets.py
@@ -15,6 +15,8 @@ DELEGATE_BLOCKED_TOOLS = frozenset(
     [
         "delegate_task",  # no recursive delegation
         "clarify",  # no user interaction
+        "request_user_input",  # no deferred user interaction
+        "check_user_input",  # no deferred user-input reads
         "memory",  # no writes to shared MEMORY.md
         "send_message",  # no cross-platform side effects
         "cronjob_manage",  # no scheduling more work in the parent's name

--- a/tools/user_input_tool.py
+++ b/tools/user_input_tool.py
@@ -1,0 +1,378 @@
+"""Hermes-native non-blocking structured user-input tools.
+
+``clarify`` remains the synchronous, in-turn prompt. These tools are for work
+that should continue while the user decides: create a durable request, emit a
+request event through the active surface, and return a handle immediately.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import uuid
+from typing import Any, Callable, Dict, List, Optional
+
+from tools.registry import registry, tool_error
+
+MAX_QUESTIONS = 5
+MAX_OPTIONS = 4
+MAX_TEXT_CHARS = 2000
+MAX_TIMEOUT_SECONDS = 7 * 24 * 60 * 60
+DEFAULT_TIMEOUT_SECONDS = 3600.0
+
+# Test-only injection point. Production callers must pass the owning agent's DB
+# through the inline executor/dispatcher; this remains None in normal runtime.
+_shared_session_db = None
+
+
+def _db_or_shared(session_db):
+    return session_db if session_db is not None else _shared_session_db
+
+
+def _text(value: Any, *, field: str, max_chars: int = MAX_TEXT_CHARS, required: bool = True) -> str:
+    if not isinstance(value, str):
+        if required:
+            raise ValueError(f"{field} must be a string")
+        return ""
+    value = value.strip()
+    if required and not value:
+        raise ValueError(f"{field} must not be blank")
+    if len(value) > max_chars:
+        raise ValueError(f"{field} exceeds {max_chars} characters")
+    return value
+
+
+def normalize_questions(questions: Any) -> List[Dict[str, Any]]:
+    """Validate and normalize the public question payload."""
+    if not isinstance(questions, list) or not questions:
+        raise ValueError(f"questions must contain 1-{MAX_QUESTIONS} entries")
+    if len(questions) > MAX_QUESTIONS:
+        raise ValueError(f"questions cannot contain more than {MAX_QUESTIONS} entries")
+
+    normalized: List[Dict[str, Any]] = []
+    seen_ids = set()
+    for index, raw in enumerate(questions):
+        if not isinstance(raw, dict):
+            raise ValueError(f"questions[{index}] must be an object")
+        question_id = _text(raw.get("id"), field=f"questions[{index}].id", max_chars=128)
+        if question_id in seen_ids:
+            raise ValueError(f"question id {question_id!r} is duplicated")
+        seen_ids.add(question_id)
+        text = _text(raw.get("text"), field=f"questions[{index}].text")
+        raw_options = raw.get("options", [])
+        if raw_options is None:
+            raw_options = []
+        if not isinstance(raw_options, list):
+            raise ValueError(f"questions[{index}].options must be an array")
+        if len(raw_options) > MAX_OPTIONS:
+            raise ValueError(f"questions[{index}].options cannot contain more than {MAX_OPTIONS} entries")
+        options = []
+        for option_index, option in enumerate(raw_options):
+            option_text = _text(
+                option,
+                field=f"questions[{index}].options[{option_index}]",
+                max_chars=MAX_TEXT_CHARS,
+            )
+            if option_text in options:
+                raise ValueError(f"questions[{index}].options contains a duplicate")
+            options.append(option_text)
+        allow_free_text = raw.get("allow_free_text", False)
+        if not isinstance(allow_free_text, bool):
+            raise ValueError(f"questions[{index}].allow_free_text must be a boolean")
+        default = raw.get("default", "")
+        if default is None:
+            default = ""
+        if not isinstance(default, (str, int, float, bool, list, dict)):
+            raise ValueError(f"questions[{index}].default must be JSON-compatible")
+        if options and not allow_free_text and default not in options:
+            raise ValueError(f"questions[{index}].default must match one of its options")
+        normalized.append({
+            "id": question_id,
+            "text": text,
+            "options": options,
+            "allow_free_text": allow_free_text,
+            "default": default,
+        })
+    return normalized
+
+
+def _timeout_seconds(timeout_s: Any) -> float:
+    if timeout_s is None:
+        return DEFAULT_TIMEOUT_SECONDS
+    if isinstance(timeout_s, bool):
+        raise ValueError("timeout_s must be a number")
+    try:
+        timeout = float(timeout_s)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("timeout_s must be a number") from exc
+    if not math.isfinite(timeout):
+        raise ValueError("timeout_s must be finite")
+    # <= 0 is the documented no-expiry sentinel, useful for a request that is
+    # owned by an operator and explicitly cancelled later.
+    if timeout <= 0:
+        return 0.0
+    if timeout > MAX_TIMEOUT_SECONDS:
+        raise ValueError(f"timeout_s cannot exceed {MAX_TIMEOUT_SECONDS} seconds")
+    return timeout
+
+
+def _public_request(record: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "request_id": record["request_id"],
+        "session_id": record["session_id"],
+        "turn_id": record.get("turn_id", ""),
+        "questions": record["questions"],
+        "context": record.get("context", ""),
+        "status": record.get("status", "pending"),
+        "answer": record.get("answer"),
+        "expires_at": record.get("expires_at", 0),
+    }
+
+
+def _notify(callback: Optional[Callable], payload: Dict[str, Any]) -> None:
+    if not callable(callback):
+        return
+    try:
+        callback(payload)
+    except Exception:
+        # The request is already durable. A broken renderer must not turn a
+        # successful model tool call into a failed turn.
+        import logging
+        logging.getLogger(__name__).debug("user-input request callback failed", exc_info=True)
+
+
+def request_user_input(
+    questions: Any,
+    context: str = "",
+    timeout_s: Any = DEFAULT_TIMEOUT_SECONDS,
+    *,
+    session_id: str = "",
+    turn_id: str = "",
+    session_db=None,
+    session_key: str = "",
+    source: str = "",
+    user_id: str = "",
+    chat_id: str = "",
+    thread_id: str = "",
+    request_id: str = "",
+    callback: Optional[Callable] = None,
+    event_callback: Optional[Callable] = None,
+    now: Optional[float] = None,
+) -> str:
+    """Create a durable structured request and return without waiting.
+
+    The keyword-only fields after ``timeout_s`` are runtime context supplied by
+    Hermes's dispatcher. They are intentionally absent from the public schema.
+    """
+    try:
+        normalized = normalize_questions(questions)
+        session_id = _text(session_id, field="session_id", max_chars=256)
+        context = _text(context, field="context", max_chars=4096, required=False)
+        timeout = _timeout_seconds(timeout_s)
+        db = _db_or_shared(session_db)
+        if db is None:
+            return tool_error("request_user_input requires an active Hermes session")
+        request_id = _text(request_id, field="request_id", max_chars=256, required=False) or uuid.uuid4().hex
+        now_value = float(now) if now is not None else __import__("time").time()
+        expires_at = 0.0 if timeout <= 0 else now_value + timeout
+        record = db.create_pending_user_input(
+            request_id=request_id,
+            session_id=session_id,
+            questions=normalized,
+            context=context,
+            expires_at=expires_at,
+            turn_id=turn_id,
+            session_key=session_key,
+            source=source,
+            user_id=user_id,
+            chat_id=chat_id,
+            thread_id=thread_id,
+            now=now_value,
+        )
+        public = _public_request(record)
+        public["hint"] = (
+            "The request is pending. Continue your work; Hermes will deliver the answer "
+            "through this same turn when the user responds."
+        )
+        _notify(callback or event_callback, public)
+        return json.dumps(public, ensure_ascii=False)
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+def check_user_input(
+    request_id: str,
+    *,
+    session_id: str = "",
+    session_db=None,
+    now: Optional[float] = None,
+) -> str:
+    """Read the durable state of one request, scoped to its owning session."""
+    db = _db_or_shared(session_db)
+    if db is None:
+        return tool_error("check_user_input requires an active Hermes session")
+    try:
+        request_id = _text(request_id, field="request_id", max_chars=256)
+        session_id = _text(session_id, field="session_id", max_chars=256)
+        record = db.get_pending_user_input(request_id, session_id=session_id, now=now)
+        if record is None:
+            return json.dumps({"status": "not_found", "request_id": request_id}, ensure_ascii=False)
+        return json.dumps(_public_request(record), ensure_ascii=False)
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+def list_pending_user_inputs(session_id: str, *, session_db=None, now: Optional[float] = None) -> list:
+    """Return durable pending records for one session (used by reconnecting UIs)."""
+    db = _db_or_shared(session_db)
+    if db is None:
+        return []
+    return [_public_request(item) for item in db.list_pending_user_inputs(session_id, now=now)]
+
+
+def answer_user_input(
+    request_id: str,
+    answer: Dict[str, Any],
+    *,
+    session_id: str,
+    session_db=None,
+    turn_id: Optional[str] = None,
+    agent=None,
+) -> Dict[str, Any]:
+    """Answer one request and deliver it through the live agent when present."""
+    db = _db_or_shared(session_db)
+    if db is None:
+        return {"status": "not_found", "accepted": False}
+    result = db.answer_pending_user_input(
+        request_id, answer, session_id=session_id, turn_id=turn_id
+    )
+    if result.get("accepted") and agent is not None:
+        result["delivery"] = deliver_answer_to_agent(agent, result.get("turn_id", turn_id or ""), answer)
+    return result
+
+
+def deliver_answer_to_agent(agent, turn_id: str, answer: Dict[str, Any]) -> str:
+    """Use the existing role-safe live-turn boundary; never append transcript rows."""
+    if not agent or not turn_id or getattr(agent, "_current_turn_id", "") != turn_id:
+        return "deferred"
+    in_flight = getattr(agent, "_inflight_turn_id", None)
+    if hasattr(agent, "_inflight_turn_id") and in_flight != turn_id:
+        return "deferred"
+    if getattr(agent, "_interrupt_requested", False):
+        return "deferred"
+    text = json.dumps(answer, ensure_ascii=False)
+    model_active = getattr(agent, "_model_request_active", None)
+    if model_active is not None and model_active.is_set():
+        redirect = getattr(agent, "redirect", None)
+        if callable(redirect) and redirect(text):
+            return "redirected"
+    if getattr(agent, "_executing_tools", False):
+        steer = getattr(agent, "steer", None)
+        if callable(steer) and steer(text):
+            return "steered"
+    # Between API calls the normal steer queue is still the safest hand-off. The
+    # conversation loop will consume it at its existing tool-result boundary.
+    steer = getattr(agent, "steer", None)
+    if callable(steer) and steer(text):
+        return "queued"
+    return "deferred"
+
+
+def check_user_input_requirements() -> bool:
+    return True
+
+
+REQUEST_USER_INPUT_SCHEMA = {
+    "name": "request_user_input",
+    "description": (
+        "Create a durable, non-blocking Hermes user-input request. Use this when the agent can "
+        "continue working while the user decides. The tool returns a request_id immediately; "
+        "the answer is delivered through the same active Hermes turn. Pass 1-5 independent "
+        "questions in one call. Each question requires a stable id and text, may include up to "
+        "4 options, allow_free_text, and a default. Do not use this for secrets or dangerous "
+        "command confirmation."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "questions": {
+                "type": "array", "minItems": 1, "maxItems": MAX_QUESTIONS,
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string"},
+                        "text": {"type": "string"},
+                        "options": {"type": "array", "maxItems": MAX_OPTIONS, "items": {"type": "string"}},
+                        "allow_free_text": {"type": "boolean"},
+                        "default": {},
+                    },
+                    "required": ["id", "text"],
+                    "additionalProperties": False,
+                },
+            },
+            "context": {"type": "string", "description": "Why the decision is needed (optional)."},
+            "timeout_s": {
+                "type": "number", "minimum": 0, "maximum": MAX_TIMEOUT_SECONDS,
+                "description": "Seconds before expiry; 0 means no expiry (default: 3600).",
+            },
+        },
+        "required": ["questions"],
+        "additionalProperties": False,
+    },
+}
+
+CHECK_USER_INPUT_SCHEMA = {
+    "name": "check_user_input",
+    "description": (
+        "Check a previously created Hermes user-input request by request_id. "
+        "The result is scoped to the current session and includes pending, answered, expired, or not_found status."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {"request_id": {"type": "string"}},
+        "required": ["request_id"],
+        "additionalProperties": False,
+    },
+}
+
+
+registry.register(
+    name="request_user_input",
+    toolset="clarify",
+    schema=REQUEST_USER_INPUT_SCHEMA,
+    handler=lambda args, **kw: request_user_input(
+        questions=args.get("questions"),
+        context=args.get("context", ""),
+        timeout_s=args.get("timeout_s", DEFAULT_TIMEOUT_SECONDS),
+        session_id=kw.get("session_id", ""),
+        turn_id=kw.get("turn_id", ""),
+        session_db=kw.get("session_db"),
+        session_key=kw.get("session_key", ""),
+        source=kw.get("source", ""),
+        user_id=kw.get("user_id", ""),
+        chat_id=kw.get("chat_id", ""),
+        thread_id=kw.get("thread_id", ""),
+        callback=kw.get("callback") or kw.get("event_callback"),
+    ),
+    check_fn=check_user_input_requirements,
+    emoji="📝",
+)
+registry.register(
+    name="check_user_input",
+    toolset="clarify",
+    schema=CHECK_USER_INPUT_SCHEMA,
+    handler=lambda args, **kw: check_user_input(
+        args.get("request_id", ""),
+        session_id=kw.get("session_id", ""),
+        session_db=kw.get("session_db"),
+    ),
+    check_fn=check_user_input_requirements,
+    emoji="🔎",
+)
+
+
+__all__ = [
+    "MAX_QUESTIONS", "MAX_OPTIONS", "REQUEST_USER_INPUT_SCHEMA", "CHECK_USER_INPUT_SCHEMA",
+    "normalize_questions", "request_user_input", "check_user_input", "list_pending_user_inputs",
+    "answer_user_input", "deliver_answer_to_agent",
+]

--- a/tools/user_input_tool.py
+++ b/tools/user_input_tool.py
@@ -12,11 +12,11 @@ import math
 import uuid
 from typing import Any, Callable, Dict, List, Optional
 
+from hermes_state_user_input import MAX_TEXT_CHARS
 from tools.registry import registry, tool_error
 
 MAX_QUESTIONS = 5
 MAX_OPTIONS = 4
-MAX_TEXT_CHARS = 2000
 MAX_TIMEOUT_SECONDS = 7 * 24 * 60 * 60
 DEFAULT_TIMEOUT_SECONDS = 3600.0
 
@@ -84,7 +84,7 @@ def normalize_questions(questions: Any) -> List[Dict[str, Any]]:
             default = ""
         if not isinstance(default, (str, int, float, bool, list, dict)):
             raise ValueError(f"questions[{index}].default must be JSON-compatible")
-        if options and not allow_free_text and default not in options:
+        if options and not allow_free_text and default != "" and default not in options:
             raise ValueError(f"questions[{index}].default must match one of its options")
         normalized.append({
             "id": question_id,
@@ -247,7 +247,9 @@ def answer_user_input(
         request_id, answer, session_id=session_id, turn_id=turn_id
     )
     if result.get("accepted") and agent is not None:
-        result["delivery"] = deliver_answer_to_agent(agent, result.get("turn_id", turn_id or ""), answer)
+        result["delivery"] = deliver_answer_to_agent(
+            agent, result.get("turn_id", turn_id or ""), result.get("answer", answer)
+        )
     return result
 
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -22,7 +22,7 @@ _HERMES_CORE_TOOLS = [
     "text_to_speech",
     "todo_list", "memory",
     "session_search",
-    "clarify",
+    "clarify", "request_user_input", "check_user_input",
     "execute_code", "delegate_task",
     "cronjob_manage",
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
@@ -63,7 +63,10 @@ def _core_without(*excluded, kanban=True):
 
 # Coding posture: everything you reach for while pairing on code; drops messaging,
 # tts, image_gen, home-assistant, cron, kanban and computer-use.
-_CODING_TOOLS = _core_without("image_generate", "text_to_speech", "cronjob_manage", "computer_use", *_HA_TOOLS, kanban=False)
+_CODING_TOOLS = _core_without(
+    "image_generate", "text_to_speech", "cronjob_manage", "computer_use",
+    "clarify", "request_user_input", "check_user_input", *_HA_TOOLS, kanban=False
+)
 
 # Core toolset definitions: individual tools or references to other toolsets.
 TOOLSETS = {
@@ -133,7 +136,11 @@ TOOLSETS = {
          "annotate_preview", "read_window_below", "focus_pane", "react_to_message",
          "setup_mcp", "gui_tour", "show_tip"],
     ),
-    "clarify": _ts("Ask the user clarifying questions (multiple-choice or open-ended)", ["clarify"]),
+    "clarify": _ts(
+        "Ask the user clarifying questions (multiple-choice or open-ended), or create "
+        "durable non-blocking structured user-input requests",
+        ["clarify", "request_user_input", "check_user_input"],
+    ),
     "code_execution": _ts("Run Python scripts that call tools programmatically (reduces LLM round trips)", ["execute_code"]),
     "delegation": _ts("Spawn subagents with isolated context for complex subtasks", ["delegate_task"]),
     "homeassistant": _ts("Home Assistant smart home control and monitoring", _HA_TOOLS),
@@ -178,13 +185,13 @@ TOOLSETS = {
     # coding posture minus the interactive clarify UI.
     "hermes-acp": _ts(
         "Editor integration (VS Code, Zed, JetBrains) — coding-focused tools without "
-        "messaging, audio, or clarify UI",
-        [t for t in _CODING_TOOLS if t != "clarify"],
+        "messaging, audio, or interactive user-input UI",
+        [t for t in _CODING_TOOLS if t not in {"clarify", "request_user_input", "check_user_input"}],
     ),
     "hermes-api-server": _ts(
         "OpenAI-compatible API server — full agent tools accessible via HTTP (no "
-        "interactive UI tools like clarify or send_message)",
-        _core_without("text_to_speech", "clarify", "computer_use", kanban=False),
+        "interactive UI tools like clarify or user-input requests)",
+        _core_without("text_to_speech", "clarify", "request_user_input", "check_user_input", "computer_use", kanban=False),
     ),
     "hermes-cli": _bundle("Full interactive CLI toolset - all default tools plus cronjob management"),
 

--- a/tui_gateway/agent_callbacks.py
+++ b/tui_gateway/agent_callbacks.py
@@ -102,6 +102,8 @@ def _agent_cbs(sid: str) -> dict:
         "notice_clear_callback": lambda key: _emit("notification.clear", sid, {"key": key}),
         "clarify_callback": lambda q, c, multi_select=False, questions=None: (
             _clarify_block(sid, q, c, multi_select=multi_select, questions=questions)),
+        "user_input_callback": lambda request: _emit(
+            "user_input.request", sid, dict(request)),
         "read_terminal_callback": _read_block("terminal.read.request", 30),
         "read_preview_callback": _read_block("preview.read.request", 45),
         # drive_preview / annotate_preview (desktop GUI): same budget as the preview read it ends with.

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -1081,6 +1081,68 @@ def _(rid, params: dict) -> dict:
     return _respond(rid, params, "answer", allow_expired=True)
 
 
+@method("user_input.pending")
+def _(rid, params: dict) -> dict:
+    """Replay durable non-blocking requests for exactly the attached session."""
+    session, err = _sess(params, rid)
+    if err:
+        return err
+    agent = session.get("agent")
+    session_id = str(getattr(agent, "session_id", "") or "")
+    if not session_id:
+        return _err(rid, 4001, "session has no durable id")
+    try:
+        from tools.user_input_tool import list_pending_user_inputs
+        with _session_db(session) as db:
+            requests = list_pending_user_inputs(session_id, session_db=db)
+    except Exception as exc:
+        logger.debug("user_input.pending failed", exc_info=True)
+        return _err(rid, 5004, str(exc))
+    return _ok(rid, {"requests": requests})
+
+
+@method("user_input.respond")
+def _(rid, params: dict) -> dict:
+    """Resolve a durable request and hand the answer to its live Hermes turn."""
+    session, err = _sess(params, rid)
+    if err:
+        return err
+    request_id = str(params.get("request_id") or "").strip()
+    answers = params.get("answers")
+    if not request_id:
+        return _err(rid, 4006, "request_id required")
+    if not isinstance(answers, dict):
+        return _err(rid, 4004, "answers must be an object")
+    agent = session.get("agent")
+    session_id = str(getattr(agent, "session_id", "") or "")
+    if not session_id:
+        return _err(rid, 4001, "session has no durable id")
+    try:
+        from tools.user_input_tool import answer_user_input
+        with _session_db(session) as db:
+            result = answer_user_input(
+                request_id,
+                answers,
+                session_id=session_id,
+                session_db=db,
+                agent=agent,
+            )
+    except Exception as exc:
+        logger.debug("user_input.respond failed", exc_info=True)
+        return _err(rid, 5004, str(exc))
+    if result.get("status") == "not_found":
+        return _err(rid, 4001, "user-input request not found for this session")
+    if result.get("status") == "invalid":
+        return _err(rid, 4004, result.get("error", "invalid answer"))
+    event_payload = {
+        key: result[key]
+        for key in ("request_id", "status", "answer", "accepted", "delivery")
+        if key in result
+    }
+    _emit("user_input.answer", params.get("session_id", ""), event_payload)
+    return _ok(rid, result)
+
+
 _LATE_RESPOND_KEYS = {
     "terminal.read.respond": "text", "preview.read.respond": "text", "preview.act.respond": "text",
     "window.read.respond": "text", "tour.respond": "text", "mcp.setup.respond": "result",

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -67,6 +67,55 @@ describe('createGatewayEventHandler', () => {
     patchUiState({ showReasoning: true })
   })
 
+  it('opens a non-blocking native user-input request in the prompt zone', () => {
+    const appended: Msg[] = []
+    const ctx = buildCtx(appended)
+    const onEvent = createGatewayEventHandler(ctx)
+
+    onEvent({
+      payload: {
+        context: 'Pick the implementation path',
+        questions: [{ allow_free_text: false, id: 'path', options: ['A', 'B'], text: 'Which path?' }],
+        request_id: 'input-1',
+        session_id: 's1'
+      },
+      session_id: 's1',
+      type: 'user_input.request'
+    } as any)
+
+    expect(getOverlayState().userInput).toMatchObject({ requestId: 'input-1', sessionId: 's1' })
+    expect(getOverlayState().userInput?.questions[0]?.options).toEqual(['A', 'B'])
+    expect(getUiState().status).toBe('waiting for user input…')
+  })
+
+  it('clears only the matching native user-input answer event and preserves deferred honesty', () => {
+    const ctx = buildCtx([])
+    const onEvent = createGatewayEventHandler(ctx)
+
+    const request = {
+      payload: {
+        questions: [{ id: 'path', options: ['A'], text: 'Which path?' }],
+        request_id: 'input-1',
+        session_id: 's1'
+      },
+      session_id: 's1',
+      type: 'user_input.request'
+    }
+
+    onEvent(request as any)
+    onEvent({ payload: { accepted: true, delivery: 'deferred', request_id: 'input-1', status: 'answered' }, session_id: 's2', type: 'user_input.answer' } as any)
+    expect(getOverlayState().userInput).not.toBeNull()
+
+    onEvent({ payload: { accepted: true, delivery: 'deferred', request_id: 'input-1', status: 'answered' }, session_id: 's1', type: 'user_input.answer' } as any)
+    expect(getOverlayState().userInput).toBeNull()
+    expect(getUiState().status).toBe('answer recorded; resume not confirmed')
+
+    onEvent(request as any)
+    onEvent({ payload: { accepted: false, request_id: 'input-1', session_id: 's1', status: 'expired' }, session_id: 's1', type: 'user_input.answer' } as any)
+    expect(getOverlayState().userInput).toBeNull()
+    expect(getUiState().status).toBe('user-input request expired')
+  })
+
   it('archives incomplete todos into transcript flow at end of turn so they scroll up', () => {
     const appended: Msg[] = []
 

--- a/ui-tui/src/__tests__/useSessionLifecycle.test.ts
+++ b/ui-tui/src/__tests__/useSessionLifecycle.test.ts
@@ -10,6 +10,7 @@ import { patchUiState, resetUiState } from '../app/uiStore.js'
 import {
   hydrateLiveSessionInflight,
   liveSessionInflightMessages,
+  pendingUserInputFromResponse,
   scheduleResumeScrollToBottom,
   signalFreshSessionBoundary,
   writeActiveSessionFile
@@ -26,6 +27,30 @@ describe('fresh session boundary', () => {
     expect(signalFreshSessionBoundary('old-session', 'new-session')).toBe(false)
     expect(onFreshSessionStarted).toHaveBeenCalledOnce()
     expect(onFreshSessionStarted).toHaveBeenCalledWith('new-session')
+  })
+})
+
+describe('durable user-input replay', () => {
+  it('returns the first valid pending request and drops malformed or terminal rows', () => {
+    expect(pendingUserInputFromResponse({
+      requests: [
+        { request_id: 'bad', session_id: 's1', status: 'answered', questions: [] },
+        {
+          context: 'Choose',
+          expires_at: 123,
+          questions: [{ allow_free_text: false, default: 'A', id: 'choice', options: ['A', 'B'], text: 'Path?' }],
+          request_id: 'good',
+          session_id: 's1',
+          status: 'pending'
+        }
+      ]
+    }, 's1')).toEqual({
+      context: 'Choose',
+      expiresAt: 123,
+      questions: [{ allowFreeText: false, defaultValue: 'A', id: 'choice', options: ['A', 'B'], text: 'Path?' }],
+      requestId: 'good',
+      sessionId: 's1'
+    })
   })
 })
 

--- a/ui-tui/src/__tests__/userInputPrompt.test.tsx
+++ b/ui-tui/src/__tests__/userInputPrompt.test.tsx
@@ -1,0 +1,62 @@
+import { PassThrough } from 'stream'
+
+import { renderSync } from '@hermes/ink'
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { UserInputPrompt } from '../components/prompts.js'
+import { stripAnsi } from '../lib/text.js'
+import { DEFAULT_THEME } from '../theme.js'
+
+function renderToText(node: React.ReactElement) {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+  let output = ''
+
+  Object.assign(stdout, { columns: 80, isTTY: false, rows: 24 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = renderSync(node, {
+    patchConsole: false,
+    stderr: stderr as NodeJS.WriteStream,
+    stdin: stdin as NodeJS.ReadStream,
+    stdout: stdout as NodeJS.WriteStream
+  })
+
+  instance.unmount()
+  instance.cleanup()
+
+  return stripAnsi(output)
+}
+
+describe('UserInputPrompt', () => {
+  it('renders native context, question count, options, and pending guidance', () => {
+    const output = renderToText(
+      <UserInputPrompt
+        cols={80}
+        onAnswer={async () => true}
+        onCancel={() => undefined}
+        req={{
+          context: 'Pick the implementation path',
+          expiresAt: 0,
+          questions: [{ allowFreeText: true, id: 'path', options: ['A', 'B'], text: 'Which path?' }],
+          requestId: 'input-1',
+          sessionId: 's1'
+        }}
+        t={DEFAULT_THEME}
+      />
+    )
+
+    expect(output).toContain('input 1 question')
+    expect(output).toContain('Pick the implementation path')
+    expect(output).toContain('Which path?')
+    expect(output).toContain('1. A')
+    expect(output).toContain('2. B')
+    expect(output).toContain('Esc leave pending')
+  })
+})

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -23,7 +23,7 @@ import { isPaintableHex, setTerminalBackground, setTerminalForeground } from '..
 import { formatAbandonedClarify, formatAbandonedClarifyBatch, formatToolCall, stripAnsi } from '../lib/text.js'
 import { bootSeededPin, invalidateBootBackground, writeBootTheme } from '../lib/themeBoot.js'
 import { defaultThemeForCurrentBackground, fromSkin, skinIsLight, type Theme, themeToneHex } from '../theme.js'
-import type { Msg, SubagentProgress, SubagentStatus, Usage } from '../types.js'
+import type { Msg, SubagentProgress, SubagentStatus, Usage, UserInputReq } from '../types.js'
 
 import { applyDelegationStatus, getDelegationState } from './delegationStore.js'
 import type { GatewayEventHandlerContext } from './interfaces.js'
@@ -1260,6 +1260,61 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         })
         setStatus('waiting for input…')
         ringPromptBell()
+
+        return
+      }
+
+      case 'user_input.request': {
+        const sessionId = String(ev.payload.session_id ?? ev.session_id ?? getUiState().sid ?? '').trim()
+
+        const questions = ev.payload.questions
+          .filter(question => typeof question.id === 'string' && question.id.trim() && typeof question.text === 'string' && question.text.trim())
+          .map(question => ({
+            allowFreeText: question.allow_free_text === true,
+            ...(typeof question.default === 'string' || typeof question.default === 'number' || typeof question.default === 'boolean'
+              ? { defaultValue: String(question.default) }
+              : {}),
+            id: question.id.trim(),
+            options: (question.options ?? []).filter(option => typeof option === 'string' && option.trim()).map(option => option.trim()),
+            text: question.text.trim()
+          }))
+
+        if (sessionId && ev.payload.request_id && questions.length) {
+          const request: UserInputReq = {
+            context: String(ev.payload.context ?? '').trim(),
+            expiresAt: Number.isFinite(ev.payload.expires_at) ? ev.payload.expires_at! : 0,
+            questions,
+            requestId: String(ev.payload.request_id).trim(),
+            sessionId
+          }
+
+          patchOverlayState({ userInput: request })
+          setStatus('waiting for user input…')
+          ringPromptBell()
+        }
+
+        return
+      }
+
+      case 'user_input.answer': {
+        const current = getOverlayState().userInput
+        const eventSessionId = String(ev.session_id ?? '').trim()
+
+        if (!current || current.requestId !== ev.payload.request_id || (eventSessionId && current.sessionId !== eventSessionId)) {
+          return
+        }
+
+        patchOverlayState({ userInput: null })
+
+        const status = ev.payload.status === 'expired'
+          ? 'user-input request expired'
+          : ev.payload.status === 'cancelled'
+            ? 'user-input request cancelled'
+            : ev.payload.delivery === 'deferred'
+              ? 'answer recorded; resume not confirmed'
+              : 'running…'
+
+        setStatus(status)
 
         return
       }

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -29,7 +29,8 @@ import type {
   SessionInfo,
   SlashCatalog,
   SudoReq,
-  Usage
+  Usage,
+  UserInputReq
 } from '../types.js'
 
 export interface StateSetter<T> {
@@ -301,6 +302,7 @@ export interface OverlayState {
   skillsHub: boolean
   subscription: SubscriptionOverlayState | null
   sudo: null | SudoReq
+  userInput: null | UserInputReq
 }
 
 export interface PagerState {
@@ -567,6 +569,7 @@ export interface AppLayoutActions {
   answerClarifyQuestion: (qid: string, answer: string) => void
   answerSecret: (value: string) => void
   answerSudo: (pw: string) => void
+  answerUserInput: (requestId: string, answers: Record<string, string>) => Promise<boolean>
   clearSelection: () => void
   activateLiveSession: (id: string) => void
   closeLiveSession: (id: string) => Promise<null | SessionCloseResponse>
@@ -641,6 +644,7 @@ export interface AppOverlaysProps {
   onResumeSelect: (sessionId: string) => void
   onSecretSubmit: (value: string) => void
   onSudoSubmit: (pw: string) => void
+  onUserInputAnswer: (requestId: string, answers: Record<string, string>) => Promise<boolean>
   pagerPageSize: number
 }
 

--- a/ui-tui/src/app/overlayStore.ts
+++ b/ui-tui/src/app/overlayStore.ts
@@ -21,7 +21,8 @@ const buildOverlayState = (): OverlayState => ({
   sessions: false,
   skillsHub: false,
   subscription: null,
-  sudo: null
+  sudo: null,
+  userInput: null
 })
 
 export const $overlayState = atom<OverlayState>(buildOverlayState())

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -51,7 +51,7 @@ import { createSlashHandler } from './createSlashHandler.js'
 import { planGatewayRecovery } from './gatewayRecovery.js'
 import { getInputSelection } from './inputSelectionStore.js'
 import { type GatewayRpc, type StateSetter, type TranscriptRow } from './interfaces.js'
-import { $overlayState, patchOverlayState } from './overlayStore.js'
+import { $overlayState, getOverlayState, patchOverlayState } from './overlayStore.js'
 import { $goodVibesTick } from './petFlashStore.js'
 import { scrollWithSelectionBy } from './scroll.js'
 import { turnController } from './turnController.js'
@@ -1052,6 +1052,44 @@ export function useMainApp(gw: GatewayClient) {
     [overlay.secret, respondWith]
   )
 
+  const answerUserInput = useCallback(
+    async (requestId: string, answers: Record<string, string>) => {
+      const sessionId = ui.sid
+
+      if (!sessionId) {
+        return false
+      }
+
+      try {
+        const result = await rpc<{ accepted?: boolean; delivery?: string; status?: string }>('user_input.respond', {
+          answers,
+          request_id: requestId,
+          session_id: sessionId
+        })
+
+        const terminal = result?.accepted === true || ['answered', 'cancelled', 'expired'].includes(result?.status ?? '')
+        const current = getOverlayState().userInput
+
+        if (terminal && current?.requestId === requestId && current.sessionId === sessionId) {
+          patchOverlayState({ userInput: null })
+          patchUiState({ status: result?.delivery === 'deferred' ? 'answer recorded; resume not confirmed' : 'running…' })
+
+          return true
+        }
+
+        patchUiState({ status: 'input response rejected; request remains pending' })
+
+        return false
+      } catch (error: unknown) {
+        sys(`error: ${error instanceof Error ? error.message : String(error)}`)
+        patchUiState({ status: 'input response failed; request remains pending' })
+
+        return false
+      }
+    },
+    [rpc, sys, ui.sid]
+  )
+
   const onModelSelect = useCallback((value: string) => {
     patchOverlayState({ modelPicker: false })
     slashRef.current(`/model ${value}`)
@@ -1162,6 +1200,7 @@ export function useMainApp(gw: GatewayClient) {
       answerClarifyQuestion,
       answerSecret,
       answerSudo,
+      answerUserInput,
       clearSelection,
       newLiveSession: () => session.newLiveSession(),
       newPromptSession,
@@ -1185,6 +1224,7 @@ export function useMainApp(gw: GatewayClient) {
       answerClarifyQuestion,
       answerSecret,
       answerSudo,
+      answerUserInput,
       clearSelection,
       closeLiveSession,
       newPromptSession,

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -18,10 +18,10 @@ import type {
   SetupStatusResponse
 } from '../gatewayTypes.js'
 import { asRpcResult } from '../lib/rpc.js'
-import type { Msg, PanelSection, SessionInfo, Usage } from '../types.js'
+import type { Msg, PanelSection, SessionInfo, Usage, UserInputReq } from '../types.js'
 
 import type { ComposerActions, GatewayRpc, StateSetter } from './interfaces.js'
-import { patchOverlayState } from './overlayStore.js'
+import { getOverlayState, patchOverlayState } from './overlayStore.js'
 import { scheduleResumeScrollToBottom } from './sessionResumeView.js'
 import { turnController } from './turnController.js'
 import { patchTurnState } from './turnStore.js'
@@ -41,6 +41,61 @@ const statusFromLiveSession = (status?: string, running = false) => {
   }
 
   return running || status === 'working' ? 'running…' : 'ready'
+}
+
+export const pendingUserInputFromResponse = (raw: unknown, sessionId: string): UserInputReq | null => {
+  const payload = raw && typeof raw === 'object' ? raw as Record<string, unknown> : {}
+  const rows = Array.isArray(payload.requests) ? payload.requests : Array.isArray(payload.data) ? payload.data : []
+  const key = String(sessionId || '').trim()
+
+  for (const row of rows) {
+    if (!row || typeof row !== 'object') {continue}
+    const value = row as Record<string, unknown>
+
+    if (String(value.status ?? 'pending').trim().toLowerCase() !== 'pending') {continue}
+    const requestId = String(value.request_id ?? value.requestId ?? '').trim()
+    const rowSessionId = String(value.session_id ?? value.sessionId ?? key).trim()
+
+    if (!requestId || !key || rowSessionId !== key || !Array.isArray(value.questions)) {continue}
+
+    const questions = value.questions
+      .slice(0, 5)
+      .filter(question => question && typeof question === 'object')
+      .map(question => {
+        const item = question as Record<string, unknown>
+        const id = String(item.id ?? '').trim()
+        const text = String(item.text ?? item.question ?? '').trim()
+
+        const options = Array.isArray(item.options)
+          ? item.options.slice(0, 4).filter(option => typeof option === 'string' && option.trim()).map(option => option.trim())
+          : []
+
+        const defaultValue = item.default
+
+        return {
+          allowFreeText: item.allow_free_text === true || item.allowFreeText === true,
+          ...(typeof defaultValue === 'string' || typeof defaultValue === 'number' || typeof defaultValue === 'boolean'
+            ? { defaultValue: String(defaultValue) }
+            : {}),
+          id,
+          options,
+          text
+        }
+      })
+      .filter(question => question.id && question.text)
+
+    if (!questions.length) {continue}
+
+    return {
+      context: String(value.context ?? '').trim(),
+      expiresAt: Number.isFinite(value.expires_at) ? Number(value.expires_at) : 0,
+      questions,
+      requestId,
+      sessionId: key
+    }
+  }
+
+  return null
 }
 
 export const writeActiveSessionFile = (sessionId: null | string, file = process.env.HERMES_TUI_ACTIVE_SESSION_FILE) => {
@@ -164,6 +219,37 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
       cancelResumeScrollRef.current = null
     },
     []
+  )
+
+  const replayPendingUserInput = useCallback(
+    async (sessionId: string) => {
+      const key = String(sessionId || '').trim()
+
+      if (!key) {return}
+
+      try {
+        const raw = await gw.request<Record<string, unknown>>('user_input.pending', { session_id: key })
+
+        if (getUiState().sid !== key) {return}
+        const request = pendingUserInputFromResponse(raw, key)
+
+        if (request) {
+          patchOverlayState({ userInput: request })
+          patchUiState({ status: 'waiting for user input…' })
+
+          return
+        }
+
+        if (getOverlayState().userInput?.sessionId === key) {
+          patchOverlayState({ userInput: null })
+        }
+      } catch (error: unknown) {
+        if (getUiState().sid === key) {
+          sys(`warning: failed to replay user input: ${error instanceof Error ? error.message : String(error)}`)
+        }
+      }
+    },
+    [gw, sys]
   )
 
   const resetVisibleHistory = useCallback(
@@ -315,6 +401,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
             usage: usageFrom(info)
           })
           hydrateLiveSessionInflight(r.inflight)
+          void replayPendingUserInput(r.session_id)
           cancelResumeScrollRef.current?.()
           cancelResumeScrollRef.current = scheduleResumeScrollToBottom(scrollRef)
         })
@@ -323,7 +410,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
           patchUiState({ status: 'ready' })
         })
     },
-    [gw, resetSession, scrollRef, setHistoryItems, setSessionStartedAt, sys]
+    [gw, replayPendingUserInput, resetSession, scrollRef, setHistoryItems, setSessionStartedAt, sys]
   )
 
   const resumeById = useCallback(
@@ -369,6 +456,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
               usage: usageFrom(info)
             })
             hydrateLiveSessionInflight(r.inflight)
+            void replayPendingUserInput(r.session_id)
             cancelResumeScrollRef.current?.()
             cancelResumeScrollRef.current = scheduleResumeScrollToBottom(scrollRef)
 
@@ -382,7 +470,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
           })
       })
     },
-    [closeSession, colsRef, gw, panel, resetSession, rpc, scrollRef, setHistoryItems, setSessionStartedAt, sys]
+    [closeSession, colsRef, gw, panel, replayPendingUserInput, resetSession, rpc, scrollRef, setHistoryItems, setSessionStartedAt, sys]
   )
 
   const guardBusySessionSwitch = useCallback(

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -566,6 +566,7 @@ export const AppLayout = memo(function AppLayout({
                 onClarifyQuestionAnswer={actions.answerClarifyQuestion}
                 onSecretSubmit={actions.answerSecret}
                 onSudoSubmit={actions.answerSudo}
+                onUserInputAnswer={actions.answerUserInput}
               />
             </PerfPane>
 

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -16,7 +16,7 @@ import { OverlayHint } from './overlayControls.js'
 import { listRowStyle } from './overlayPrimitives.js'
 import { PetPicker } from './petPicker.js'
 import { PluginsHub } from './pluginsHub.js'
-import { ApprovalPrompt, ClarifyPrompt, ConfirmPrompt } from './prompts.js'
+import { ApprovalPrompt, ClarifyPrompt, ConfirmPrompt, UserInputPrompt } from './prompts.js'
 import { SkillsHub } from './skillsHub.js'
 import { SubscriptionOverlay } from './subscriptionOverlay.js'
 import { WidgetGrid, type WidgetGridWidget } from './widgetGrid.js'
@@ -61,10 +61,11 @@ export function PromptZone({
   onClarifyAnswer,
   onClarifyQuestionAnswer,
   onSecretSubmit,
-  onSudoSubmit
+  onSudoSubmit,
+  onUserInputAnswer
 }: Pick<
   AppOverlaysProps,
-  'cols' | 'onApprovalChoice' | 'onClarifyAnswer' | 'onClarifyQuestionAnswer' | 'onSecretSubmit' | 'onSudoSubmit'
+  'cols' | 'onApprovalChoice' | 'onClarifyAnswer' | 'onClarifyQuestionAnswer' | 'onSecretSubmit' | 'onSudoSubmit' | 'onUserInputAnswer'
 >) {
   const overlay = useStore($overlayState)
   const theme = useStore($uiTheme)
@@ -158,6 +159,20 @@ export function PromptZone({
           label={overlay.secret.prompt}
           onSubmit={onSecretSubmit}
           sub={`for ${overlay.secret.envVar}`}
+          t={theme}
+        />
+      </PromptCell>
+    )
+  }
+
+  if (overlay.userInput) {
+    return (
+      <PromptCell cols={cols} id="user-input">
+        <UserInputPrompt
+          cols={cols}
+          onAnswer={onUserInputAnswer}
+          onCancel={() => patchOverlayState({ userInput: null })}
+          req={overlay.userInput}
           t={theme}
         />
       </PromptCell>

--- a/ui-tui/src/components/prompts.tsx
+++ b/ui-tui/src/components/prompts.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import { isMac } from '../lib/platform.js'
 import { clarifyBatchRevisitState } from '../lib/text.js'
 import type { Theme } from '../theme.js'
-import type { ApprovalReq, ClarifyReq, ConfirmReq } from '../types.js'
+import type { ApprovalReq, ClarifyReq, ConfirmReq, UserInputReq } from '../types.js'
 
 import { chipRowProps } from './overlayPrimitives.js'
 import { TextInput } from './textInput.js'
@@ -414,6 +414,156 @@ export function ClarifyPrompt({ cols = 80, onAnswer, onCancel, onQuestionAnswer,
   )
 }
 
+export function UserInputPrompt({ cols = 80, onAnswer, onCancel, req, t }: UserInputPromptProps) {
+  const firstUnanswered = req.questions.findIndex(question => !question.defaultValue)
+  const [active, setActive] = useState(Math.max(0, firstUnanswered))
+
+  const [answers, setAnswers] = useState<Record<string, string>>(() =>
+    Object.fromEntries(req.questions.flatMap(question => question.defaultValue ? [[question.id, question.defaultValue]] : []))
+  )
+
+  const [custom, setCustom] = useState(() => req.questions[Math.max(0, firstUnanswered)]?.defaultValue ?? '')
+  const [sel, setSel] = useState(0)
+  const [submitting, setSubmitting] = useState(false)
+  const [typing, setTyping] = useState(() => !(req.questions[Math.max(0, firstUnanswered)]?.options.length))
+  const question = req.questions[active]
+  const choices = question?.options ?? []
+
+  useEffect(() => {
+    const next = req.questions.findIndex(item => !item.defaultValue)
+    const index = Math.max(0, next)
+    setActive(index)
+    setAnswers(Object.fromEntries(req.questions.flatMap(item => item.defaultValue ? [[item.id, item.defaultValue]] : [])))
+    setCustom(req.questions[index]?.defaultValue ?? '')
+    setSel(0)
+    setSubmitting(false)
+    setTyping(!(req.questions[index]?.options.length))
+  }, [req.questions, req.requestId])
+
+  const moveActive = (delta: number) => {
+    if (!req.questions.length) {return}
+    const next = (active + delta + req.questions.length) % req.questions.length
+    setActive(next)
+    setSel(0)
+    setCustom(answers[req.questions[next]?.id ?? ''] ?? req.questions[next]?.defaultValue ?? '')
+    setTyping(!(req.questions[next]?.options.length))
+  }
+
+  const submitAnswer = (value: string) => {
+    if (!question || submitting || !value.trim()) {return}
+    const nextAnswers = { ...answers, [question.id]: value.trim() }
+    const next = req.questions.findIndex(item => !nextAnswers[item.id])
+
+    if (next < 0) {
+      setSubmitting(true)
+      void onAnswer(req.requestId, nextAnswers).then(accepted => {
+        if (!accepted) {setSubmitting(false)}
+      }).catch(() => setSubmitting(false))
+
+      return
+    }
+
+    setAnswers(nextAnswers)
+    setActive(next)
+    setSel(0)
+    setCustom(req.questions[next]?.defaultValue ?? '')
+    setTyping(!(req.questions[next]?.options.length))
+  }
+
+  useInput((ch, key) => {
+    if (key.escape) {
+      if (typing) {
+        setTyping(false)
+      } else {
+        onCancel()
+      }
+
+      return
+    }
+
+    if (typing || submitting || !question) {return}
+
+    if (key.tab) {
+      moveActive(key.shift ? -1 : 1)
+
+      return
+    }
+
+    if (key.upArrow) {setSel(value => Math.max(0, value - 1))}
+
+    if (key.downArrow) {setSel(value => Math.min(choices.length, value + 1))}
+
+    if (key.return) {
+      if (sel === choices.length) {setTyping(true)}
+      else if (choices[sel]) {submitAnswer(choices[sel]!)}
+
+      return
+    }
+
+    const number = parseInt(ch, 10)
+
+    if (number >= 1 && number <= choices.length) {submitAnswer(choices[number - 1]!)}
+
+    if (number === choices.length + 1) {setTyping(true)}
+  })
+
+  if (!question) {return null}
+
+  const answeredCount = Object.keys(answers).length
+
+  const heading = (
+    <Text bold>
+      <Text color={t.color.accent}>input</Text>
+      <Text color={t.color.text}> {req.questions.length} question{req.questions.length === 1 ? '' : 's'}</Text>
+    </Text>
+  )
+
+  return (
+    <Box borderColor={t.color.accent} borderStyle="double" flexDirection="column" paddingX={1}>
+      {heading}
+      {req.context ? <Text color={t.color.muted}>{req.context}</Text> : null}
+      {req.questions.map((item, index) => (
+        <Text key={item.id}>
+          <Text color={index === active ? t.color.text : t.color.muted}>
+            {answers[item.id] ? '✓' : index === active ? '▸' : '·'} {item.text}
+            {answers[item.id] ? `: ${answers[item.id]}` : ''}
+          </Text>
+        </Text>
+      ))}
+      {typing ? (
+        <Box paddingLeft={2}>
+          <Text color={t.color.label}>{'> '}</Text>
+          <TextInput
+            color={t.color.text}
+            columns={Math.max(20, cols - 8)}
+            onChange={setCustom}
+            onSubmit={submitAnswer}
+            value={custom}
+          />
+        </Box>
+      ) : (
+        <Box flexDirection="column" paddingLeft={2}>
+          {choices.map((choice, index) => (
+            <Text key={choice}>
+              <Text color={t.color.muted} {...chipRowProps(t, sel === index)}>
+                {sel === index ? '▸ ' : '  '}{index + 1}. {choice}
+              </Text>
+            </Text>
+          ))}
+          <Text>
+            <Text color={t.color.muted} {...chipRowProps(t, sel === choices.length)}>
+              {sel === choices.length ? '▸ ' : '  '}{choices.length + 1}. Other (type an answer)
+            </Text>
+          </Text>
+        </Box>
+      )}
+      <Text color={t.color.muted}>
+        {submitting ? 'sending…' : `${answeredCount}/${req.questions.length} answered · Enter confirm · Tab switch question · Esc leave pending`}
+      </Text>
+    </Box>
+  )
+}
+
 export function ConfirmPrompt({ onCancel, onConfirm, req, t }: ConfirmPromptProps) {
   const [sel, setSel] = useState(0)
 
@@ -490,6 +640,14 @@ interface ClarifyPromptProps {
   /** Batch mode: lock one question's answer (clarify.respond + question_id). */
   onQuestionAnswer?: (qid: string, s: string) => void
   req: ClarifyReq
+  t: Theme
+}
+
+interface UserInputPromptProps {
+  cols?: number
+  onAnswer: (requestId: string, answers: Record<string, string>) => Promise<boolean>
+  onCancel: () => void
+  req: UserInputReq
   t: Theme
 }
 

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -736,6 +736,34 @@ export type GatewayEvent =
       session_id?: string
       type: 'approval.request'
     }
+  | {
+      payload: {
+        context?: string
+        expires_at?: number
+        questions: {
+          allow_free_text?: boolean
+          default?: unknown
+          id: string
+          options?: string[]
+          text: string
+        }[]
+        request_id: string
+        session_id?: string
+      }
+      session_id?: string
+      type: 'user_input.request'
+    }
+  | {
+      payload: {
+        accepted?: boolean
+        answer?: Record<string, unknown>
+        delivery?: string
+        request_id: string
+        status?: string
+      }
+      session_id?: string
+      type: 'user_input.answer'
+    }
   | { payload: { request_id: string }; session_id?: string; type: 'sudo.request' }
   | { payload: { env_var: string; prompt: string; request_id: string }; session_id?: string; type: 'secret.request' }
   | { payload: { request_id: string }; session_id?: string; type: 'secret.expire' | 'sudo.expire' }

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -130,6 +130,22 @@ export interface ClarifyReq {
   answers?: Record<string, string>
 }
 
+export interface UserInputQuestion {
+  allowFreeText: boolean
+  defaultValue?: string
+  id: string
+  options: string[]
+  text: string
+}
+
+export interface UserInputReq {
+  context: string
+  expiresAt: number
+  questions: UserInputQuestion[]
+  requestId: string
+  sessionId: string
+}
+
 export interface Msg {
   info?: SessionInfo
   kind?: 'diff' | 'event' | 'intro' | 'panel' | 'slash' | 'trail'


### PR DESCRIPTION
## What does this PR do?

This PR adds a Hermes-native asynchronous structured user-input lifecycle and wires it through the Hermes Agent API and Desktop client surfaces.

A model or tool can request one to five structured questions, receive a durable `request_id` immediately, and let the agent continue working while the user decides. The request can later be answered from a supported client without creating a synthetic chat message or corrupting the session transcript.

The Browser Extension client for this same contract is implemented in the companion PR [abundantbeing/hermes-browser-extension#98](https://github.com/abundantbeing/hermes-browser-extension/pull/98).

### Why this is needed

Hermes has synchronous `clarify`, which is correct when the model must stop and wait. It is not sufficient for long-running or background work that should continue while a human decision is pending. Before this lifecycle existed, there was no consistent native way to:

- persist a request across UI reconnects;
- identify the exact owning session and turn;
- deliver a structured answer to a live turn;
- prevent a concurrent or wrong-session answer from taking over; or
- preserve Hermes role alternation and prompt-cache invariants.

### How it works

1. The agent calls `request_user_input` with one to five question objects. Each question has a stable `id` and `text`, with bounded options, optional free text, and an optional default.
2. Hermes validates the payload and writes a pending record to the canonical session `state.db`.
3. Hermes emits the request through the active client callback and returns `pending` plus a `request_id` immediately. The tool does not block the active model/tool turn.
4. Clients present the request and answer it through their native transport:
   - Desktop/TUI: `user_input.request`, `user_input.pending`, and `user_input.respond` JSON-RPC methods/events;
   - API/SSE: `user_input.request` on `/api/sessions/{session_id}/chat/stream`, pending replay via `GET /api/sessions/{session_id}/user-input/pending`, and answer delivery via the session-scoped answer endpoint;
   - Browser Extension: the companion PR supports the same contract in Sidepanel and Full Tab over API/SSE and dashboard WebSocket transports.
5. Answer settlement is compare-and-set. Only one concurrent answer can move a request from `pending` to `answered`; wrong-session, stale-turn, already-settled, and expired requests cannot steer another session.
6. If the owning turn is live, the answer uses Hermes's existing role-safe `redirect`, `steer`, or queued-steer boundary. If it is not live, the answer remains durably recorded for `check_user_input`.
7. Expired requests are marked `expired` and receive their declared defaults.

## What this improves

- Provides one native request/answer lifecycle across CLI, gateway, TUI, Desktop, API/SSE, and the Browser Extension companion.
- Lets long-running work continue instead of blocking on a synchronous prompt.
- Replays pending requests after Desktop/TUI/API reconnects.
- Delivers only to a matching session and turn, with atomic single-writer settlement.
- Prevents duplicate transcript rows and synthetic user messages from changing role alternation or prompt-cache prefixes.
- Keeps persistence, transport rendering, and live-turn delivery separate so clients can provide rich controls without duplicating runtime logic.

## What does not change

- The existing synchronous `clarify` tool keeps its current behavior.
- This does not add automatic checkpoint policy, reasoning-stream interruption, or configurable confirmation frequency; those remain separate policy/runtime features.
- This does not add generic PTY stdin or OAuth-code entry for background processes.
- This does not add provider-specific behavior or an external service dependency.
- Ordinary user messages are not intercepted; gateway fallback handling requires the explicit structured answer envelope.
- This is not a replacement for dangerous-command approval or secret collection.
- Existing SQLite compatibility is preserved. The `pending_user_inputs` table is created idempotently without a schema-version bump or new configuration key.

## Related Issue

Related: [#94239](https://github.com/NousResearch/hermes-agent/issues/94239) requests agent-initiated structured direction confirmation during long-running work.

This PR implements the reusable native request/answer mechanism relevant to that request. It intentionally does not claim to implement the automatic trigger policy or confirmation-frequency policy.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)

## Changes Made

### Durable state and tools

- Added `SessionUserInputMixin` in `hermes_state_user_input.py` for create, read, list, answer, expiry, session scoping, and atomic settlement.
- Added the idempotent `pending_user_inputs` table and indexes to the canonical state schema.
- Added `request_user_input` and `check_user_input` with bounded validation, timeout handling, durable persistence, and role-safe live-turn delivery.
- Registered the tools through sequential and inline execution, model discovery, agent initialization, and runtime callback plumbing.
- Excluded the tools from delegated subagent toolsets so a child cannot create or resolve a request owned by another interactive session.

### CLI, gateway, TUI, and API

- Added the explicit CLI/gateway `/answer` envelope and adapter fallback behavior.
- Added TUI request callbacks and JSON-RPC methods/events for request delivery, pending replay, and session-scoped responses.
- Added API capability flags and session-scoped REST endpoints for pending replay and structured answers.
- Added API/SSE callback forwarding so `user_input.request` is emitted during `/chat/stream` instead of being hidden from API clients.
- Added exact session/turn matching for API delivery, including durable turn lookup when a client omits `turn_id`.

### Hermes Desktop

- Added a dedicated per-session native user-input store with deduplication, reconnect replacement, and correlated clearing.
- Added a non-modal Desktop card for option and free-text questions, mounted in the existing prompt overlay layer.
- Added `user_input.request` event routing, native notification, `needsInput` state updates, and pending replay on `gateway.ready`/resumed `session.info`.
- Kept `clarify`, approval, sudo, and credential prompt flows separate and unchanged.

### Browser Extension companion

The core PR does not copy Browser Extension files into the Hermes Agent repository. The companion [PR #98](https://github.com/abundantbeing/hermes-browser-extension/pull/98) adds:

- shared Sidepanel and Full Tab request rendering;
- API/SSE request forwarding and session REST answer calls;
- dashboard WebSocket request/answer events and RPC methods;
- pending replay after session reopen/reconnect;
- capability gating for older Hermes versions; and
- XSS-safe DOM construction with required-answer validation.

## Regression coverage

- Native tool, state, expiry, session-isolation, and delivery tests.
- Gateway explicit-envelope and adapter tests.
- TUI JSON-RPC, reconnect replay, session isolation, and event-rail tests.
- CLI `/answer` tests.
- API server callback forwarding, capability/route registration, pending replay, structured answer validation, and stored-turn matching tests.
- Desktop store and gateway-event routing tests.
- Browser companion normalization, SSE forwarding, WebSocket contract, and UI controller tests.

## How to Test

### Hermes Agent

```bash
HERMES_PYTHON="$(command -v python)" scripts/run_tests.sh -j 6 \
  tests/tools/test_user_input_tool.py \
  tests/tui_gateway/test_user_input_protocol.py \
  tests/gateway/test_user_input.py \
  tests/gateway/test_api_server_user_input.py \
  tests/gateway/test_api_server.py \
  tests/cli/test_user_input.py
```

Final merged-tree result: **134 tests passed, 0 failed**.

Additional Hermes verification:

- Ruff on changed Python files: passed.
- Python bytecode compilation for changed Python files: passed.
- Desktop TypeScript typecheck: passed.
- Desktop focused UI tests: **13 passed, 0 failed**.
- Desktop production build: passed, including Vite, Electron bundling, native dependency staging, and `assert-dist-built`.
- Desktop full UI discovery was not claimed green: 9 unrelated pre-existing fixture failures remained outside the native user-input tests.

### Browser Extension companion

```bash
npm test
npm run check:js
npm run check:manifest
npm run lint
npm run build
```

Final companion results:

- **1,282 tests passed, 0 failed, 0 skipped**.
- JS/self-contained check passed.
- Manifest check passed: 1,232 messages, 21 locales, 4 extension surfaces, version 0.3.1.
- Lint passed: 0 errors; existing security warnings remain warnings.
- Chromium production build passed.
- Built `dist/` browser smoke verified required-submit disabled/enabled transitions, structured answer submission, both Full Tab and Sidepanel mounts, opaque card surfaces, radio alignment, and dock/composer separation.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] Commit messages follow Conventional Commits
- [x] Existing upstream issues and PRs were searched for overlap
- [x] The Hermes Agent portion contains only the native runtime/API/Desktop feature
- [x] The Browser client is split into a linked companion PR rather than copied into this repository
- [x] Regression tests cover persistence, expiry, isolation, delivery, CLI, TUI, gateway, API, and Desktop boundaries
- [x] No provider-specific dependency or configuration key was added

### Documentation and housekeeping

- [x] Tool descriptions and schemas document the new behavior and constraints
- [x] `cli-config.yaml.example` update is N/A; no configuration keys were added
- [x] README and website documentation changes are N/A for this runtime/API feature
- [x] Cross-platform impact was covered by the Windows Desktop build/typecheck lane
- [x] No secrets, credentials, or connection strings are included

### Screenshots and logs

Desktop visual controls are implemented in the existing prompt overlay layer. The Browser companion PR contains the built `dist/` visual verification for both Browser surfaces. The core PR's primary evidence is its runtime/API/Desktop test and build coverage.
