### PR TITLE
fix(tui): keep native clipboard on xterm.js hosts (VS Code, Cursor)

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/termio/osc-clipboard-utf8.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/termio/osc-clipboard-utf8.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldUseNativeClipboard } from './osc.js'
+
+// Terminals whose OSC 52 handler mangles multi-byte UTF-8. xterm.js decoded
+// the base64 payload one byte per code unit, so every UTF-8 continuation byte
+// landed on the clipboard as its own Latin-1 character: an em dash (E2 80 94)
+// arrives as "â€”" (C3 A2 C2 80 C2 94). Fixed upstream in xterm.js #6002, but
+// VS Code / Cursor ship a pinned addon, so the host is broken for the lifetime
+// of that build. Suppressing native there makes the corruption unrecoverable —
+// the mangled OSC 52 write is the ONLY thing that reaches the clipboard.
+const XTERMJS_HOSTS = ['vscode', 'cursor']
+
+describe('shouldUseNativeClipboard on xterm.js hosts', () => {
+  it('keeps the native tool so a mangled OSC 52 write cannot be the only path', () => {
+    for (const terminal of XTERMJS_HOSTS) {
+      expect(shouldUseNativeClipboard({} as NodeJS.ProcessEnv, terminal)).toBe(true)
+    }
+  })
+
+  it('still suppresses native over SSH (native would target the remote clipboard)', () => {
+    for (const terminal of XTERMJS_HOSTS) {
+      expect(shouldUseNativeClipboard({ SSH_CONNECTION: '1' } as NodeJS.ProcessEnv, terminal)).toBe(false)
+    }
+  })
+
+  it('leaves the genuinely OSC-52-clean terminals suppressed', () => {
+    for (const terminal of ['ghostty', 'kitty', 'WezTerm', 'windows-terminal']) {
+      expect(shouldUseNativeClipboard({} as NodeJS.ProcessEnv, terminal)).toBe(false)
+    }
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/termio/osc.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/termio/osc.test.ts
@@ -58,22 +58,28 @@ describe('supportsOsc52Clipboard', () => {
   // the terminal's own clipboard write. Values must match what
   // detectTerminal() in utils/env.ts returns — TERM=xterm-ghostty normalises
   // to 'ghostty', TERM_PROGRAM=WezTerm stays 'WezTerm', etc.
-  it.each(['ghostty', 'kitty', 'WezTerm', 'windows-terminal', 'vscode'])(
-    'returns true for allowlisted terminal %s',
-    terminal => {
-      expect(supportsOsc52Clipboard(terminal)).toBe(true)
-    }
-  )
+  it.each(['ghostty', 'kitty', 'WezTerm', 'windows-terminal'])('returns true for allowlisted terminal %s', terminal => {
+    expect(supportsOsc52Clipboard(terminal)).toBe(true)
+  })
 
   // Intentionally conservative — iTerm2 disables OSC 52 by default; Alacritty
   // and GNOME Terminal detection is unreliable; xterm/Terminal.app lack
-  // reliable OSC 52. These keep the existing native-safety-net behaviour.
-  it.each(['iTerm.app', 'alacritty', 'Apple_Terminal', 'xterm', 'tmux', 'screen', 'cursor', 'WarpTerminal', ''])(
-    'returns false for non-allowlisted terminal %s',
-    terminal => {
-      expect(supportsOsc52Clipboard(terminal)).toBe(false)
-    }
-  )
+  // reliable OSC 52; xterm.js hosts (vscode/cursor) corrupt multi-byte UTF-8.
+  // These keep the existing native-safety-net behaviour.
+  it.each([
+    'iTerm.app',
+    'alacritty',
+    'Apple_Terminal',
+    'xterm',
+    'tmux',
+    'screen',
+    'vscode',
+    'cursor',
+    'WarpTerminal',
+    ''
+  ])('returns false for non-allowlisted terminal %s', terminal => {
+    expect(supportsOsc52Clipboard(terminal)).toBe(false)
+  })
 
   it('returns false when terminal is null (detection failed)', () => {
     expect(supportsOsc52Clipboard(null)).toBe(false)
@@ -116,14 +122,13 @@ describe('shouldUseNativeClipboard', () => {
   })
 
   it('returns false on allowlisted local terminals (the race-fix case)', () => {
-    // Ghostty / kitty / WezTerm / Windows Terminal / VS Code — OSC 52
-    // alone is reliable, native fallback racing it can corrupt the
-    // clipboard (the wl-copy on Wayland symptom this PR fixes).
+    // Ghostty / kitty / WezTerm / Windows Terminal — OSC 52 alone is
+    // reliable, native fallback racing it can corrupt the clipboard (the
+    // wl-copy on Wayland symptom this PR fixes).
     expect(shouldUseNativeClipboard({} as NodeJS.ProcessEnv, 'ghostty')).toBe(false)
     expect(shouldUseNativeClipboard({} as NodeJS.ProcessEnv, 'kitty')).toBe(false)
     expect(shouldUseNativeClipboard({} as NodeJS.ProcessEnv, 'WezTerm')).toBe(false)
     expect(shouldUseNativeClipboard({} as NodeJS.ProcessEnv, 'windows-terminal')).toBe(false)
-    expect(shouldUseNativeClipboard({} as NodeJS.ProcessEnv, 'vscode')).toBe(false)
   })
 
   it('returns true inside tmux even on allowlisted outer terminal', () => {

--- a/ui-tui/packages/hermes-ink/src/utils/env.ts
+++ b/ui-tui/packages/hermes-ink/src/utils/env.ts
@@ -52,10 +52,18 @@ export const env = {
 // is unreliable) are not on this list. Users on those terminals keep the
 // existing behaviour (native safety net fires alongside OSC 52).
 //
+// xterm.js hosts (VS Code, Cursor) are deliberately excluded: their OSC 52
+// handler decoded the base64 payload one byte per code unit, so every UTF-8
+// continuation byte reached the clipboard as its own Latin-1 character — an
+// em dash (E2 80 94) pastes as "â€”". Fixed upstream in xterm.js #6002, but
+// these hosts pin the addon, so a given build stays broken for its lifetime.
+// Suppressing the native tool there would make the corruption unrecoverable,
+// since the mangled OSC 52 write would be the only path to the clipboard.
+//
 // Lives here in utils/env.ts (rather than ink/terminal.ts) so that
 // ink/termio/osc.ts can import it without creating a circular dependency:
 // ink/terminal.ts already imports `link` from ink/termio/osc.ts.
-const OSC52_CAPABLE_TERMINALS = ['ghostty', 'kitty', 'WezTerm', 'windows-terminal', 'vscode']
+const OSC52_CAPABLE_TERMINALS = ['ghostty', 'kitty', 'WezTerm', 'windows-terminal']
 
 /** True if this terminal is known to correctly handle OSC 52 clipboard
  *  writes, so setClipboard() can skip the native-tool safety net.


### PR DESCRIPTION
## Symptom

Copying selected TUI text in VS Code or Cursor mangles every multi-byte character. The terminal renders correctly; only the clipboard is corrupted:

| rendered | pasted |
|---|---|
| `—` (em dash) | `â€"` |
| `🧪` | `ð\u009f§ª` |
| `→` | `â` |

## Root cause

xterm.js's OSC 52 handler decoded the base64 payload one byte per code unit, so every UTF-8 continuation byte reached the clipboard as its own Latin-1 character. Verified against the actual corrupted bytes:

```
em dash U+2014, correct UTF-8 : e2 80 94
bytes found on the clipboard  : c3 a2 c2 80 c2 94   ← each byte re-encoded as Latin-1
```

That is fixed upstream in xtermjs/xterm.js#6002, but VS Code and Cursor pin the addon, so a shipped build stays broken for its lifetime.

The Hermes-side bug is that `'vscode'` was on `OSC52_CAPABLE_TERMINALS`. That list makes `setClipboard()` skip the native `pbcopy`/`wl-copy`/`xclip` safety net, so on these hosts the corrupting OSC 52 write became the **only** path to the clipboard and the mangling was unrecoverable.

## Fix

Drop `vscode` from the allowlist so the native write — which carries the UTF-8 bytes intact — fires again. `cursor` was never on the list but is now covered by a test so it cannot regress.

The allowlist keeps its original purpose: `ghostty` / `kitty` / `WezTerm` / `windows-terminal` still skip native to avoid the wl-copy-on-Wayland race that motivated it, and the `SSH_CONNECTION` guard still takes precedence so native never writes to the wrong machine's clipboard.

## Verification

End-to-end on macOS + Cursor, simulating the broken handler against the real `pbcopy` path:

```
original      : AutoFill experimentation — ticket index 🧪 (doc-type 47%→79%)
broken OSC 52 : AutoFill experimentation â ticket index ð§ª (doc-type 47%â79%)
native pbcopy : AutoFill experimentation — ticket index 🧪 (doc-type 47%→79%)

OSC52 matches original?  false
native matches original? true
```

- New `osc-clipboard-utf8.test.ts` fails on `main`, passes here.
- `npx vitest run packages/hermes-ink/src` → 234 passed. Two failures in `ink-backpressure.test.ts` are **pre-existing** — reproduced on clean `origin/main` with this branch stashed.
- `npm run typecheck --workspace ui-tui` → clean.
- `npm run lint --workspace ui-tui` → 0 errors (2 pre-existing warnings in untouched files).