### PR TITLE
fix(desktop): add absolute deadline to Windows update hand-off to prevent zombie (#102283)

### DIFF
--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -751,6 +751,22 @@ if ($env:HERMES_UPDATE_STEP_IDLE_SECONDS) {
     }
 }
 
+# Absolute wall-clock ceiling for any step. The idle watchdog above only
+# fires after StepIdleTimeoutSeconds of *silence*; a descendant that trickles
+# a byte every few minutes (or a gateway IPC hang that never writes at all
+# but keeps the parent python.exe alive) defeats it and strands the hand-off
+# forever — the exact #102283 failure where the log ends at `running: python
+# ... update` with no exit code, no result file, and a 16-day zombie holding
+# the venv shim. An absolute deadline guarantees the hand-off always reaches
+# its finally block (result file + relaunch + marker cleanup).
+$script:StepTotalTimeoutSeconds = 3600
+if ($env:HERMES_UPDATE_STEP_TOTAL_SECONDS) {
+    $parsedTotal = 0
+    if ([int]::TryParse($env:HERMES_UPDATE_STEP_TOTAL_SECONDS, [ref]$parsedTotal) -and $parsedTotal -gt 0) {
+        $script:StepTotalTimeoutSeconds = $parsedTotal
+    }
+}
+
 # Silence on the pipes is NOT silence in the update. `hermes update` captures
 # the (very loud) Electron/vite build into logs/update.log instead of its own
 # stdout (hermes_cli/update_cmd.py, the update-log tee), so a real update is
@@ -1058,6 +1074,8 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
     $lastProgressAt = Get-Date
     $progressLogStamp = Get-StepProgressLogStamp
     $stalled = $false
+    $stepStartedAt = Get-Date
+    $stepDeadline = $stepStartedAt.AddSeconds($script:StepTotalTimeoutSeconds)
     while ($true) {
         $moved = $false
         $outDone = Step-PipeDrain $stdoutReader ([ref]$outTask) $outBuffer $outSink ([ref]$moved)
@@ -1072,6 +1090,22 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
             } elseif ((Get-Date) -ge $abandonAt) {
                 $abandoned = $true
                 break
+            }
+        } elseif (-not $stalled -and (Get-Date) -ge $stepDeadline) {
+            # Absolute ceiling: even a step that trickles forever (one byte per
+            # idle window) would defeat the silence watchdog and strand the
+            # hand-off with no result file and a zombie python.exe holding the
+            # venv lock (#102283). Kill the whole job tree and fail the step so
+            # the finally block can write the result, run marker self-heal, and
+            # relaunch the Desktop.
+            $elapsedTotal = [Math]::Round(((Get-Date) - $stepStartedAt).TotalSeconds)
+            Write-HandoffLog ("{0}!| step exceeded absolute deadline ({1}s elapsed, budget {2}s); cancelling its process tree." -f $Tag, $elapsedTotal, $script:StepTotalTimeoutSeconds)
+            $stalled = [HermesUpdateJob]::TerminateAndWait($job, 124, 10000)
+            if (-not $stalled) {
+                Write-HandoffLog ("{0}!| process-tree cancellation could not prove quiescence; refusing the timeout retry." -f $Tag)
+                $script:TreeSafeToFinalize = $false
+                [HermesUpdateJob]::Close($job)
+                throw "Unable to quiesce stalled update process tree (total timeout)"
             }
         } elseif (-not $stalled -and $job -ne [IntPtr]::Zero -and ((Get-Date) - $lastProgressAt).TotalSeconds -ge $script:StepIdleTimeoutSeconds) {
             # Quiet pipes are how a healthy `hermes update` looks for 40+

--- a/tests/test_desktop_update_windows_pipe_drain.py
+++ b/tests/test_desktop_update_windows_pipe_drain.py
@@ -107,7 +107,9 @@ class TestIdleWatchdogCountsUpdateLogGrowth:
         # The growth check must gate the termination: compare-and-reset
         # appears before the 124 tree-termination inside the drain loop.
         consult = src.index("if ($currentLogStamp -ne $progressLogStamp)")
-        terminate = src.index("TerminateAndWait($job, 124")
+        # There is now also an absolute-deadline termination before the idle
+        # branch (#102283); find the idle-specific termination after the consult.
+        terminate = src.index("TerminateAndWait($job, 124", consult)
         assert consult < terminate, msg
         # And the clock actually resets on growth.
         growth_block = src[consult:terminate]


### PR DESCRIPTION
Fixes #102283.

After `hermes update` completed, `windows.ps1` stalled at `running: python ... update` with no further log lines, no `.hermes-update-result.json`, and no auto-relaunch. The child `python -m hermes_cli.main update --yes --gateway --force` survived as a zombie holding the venv shim locked for 16 days, blocking all later updates with `venv-blocked`.

**Cause:** `Invoke-HermesStep` only had an idle watchdog (600s of silence on both pipes AND no `logs/update.log` growth). A step that trickles a byte per window or hangs after completing its visible work but never exits (e.g. gateway IPC hang) defeats the idle check and strands the hand-off forever; the `finally` block that writes the result, clears the marker and relaunches the Desktop is never reached.

**Fix:** Add an absolute wall-clock ceiling `StepTotalTimeoutSeconds` (default 3600s, overridable via `HERMES_UPDATE_STEP_TOTAL_SECONDS`) and enforce it in the drain loop. On expiry the whole private Windows job is terminated with the same `124` sentinel, letting the hand-off reach its `finally` obligations and self-heal. Updated the source-contract test to account for the new termination path.

Tested: `pytest tests/test_desktop_update_windows_pipe_drain.py tests/test_desktop_update_windows_timestamp.py` (6 passed, 1 skipped).
