### PR TITLE
fix(desktop): Hide tabs works again in a zone holding more than one tab

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.test.ts
@@ -37,7 +37,7 @@ describe('the stored choice', () => {
 // force-visible rule, so hiding a zone that held only a closeable tile left a
 // surface with no tab, no ✕ and no menu — the "how do I get it back" reports.
 describe('no dead zone', () => {
-  it('keeps the strip for a closeable tile even when the zone says never', () => {
+  it('keeps the strip for a lone closeable tile even when the zone says never', () => {
     expect(resolveTabStripVisible({ mode: 'never', shown: [tile()] })).toBe(true)
   })
 
@@ -57,6 +57,26 @@ describe('no dead zone', () => {
     // the invariant protects handles, it does not veto hiding as such.
     expect(resolveTabStripVisible({ mode: 'never', shown: [workspace()] })).toBe(false)
     expect(resolveTabStripVisible({ mode: 'never', shown: [toolPanel(), toolPanel()] })).toBe(false)
+  })
+})
+
+// The regression the rung above caused on its way to holding that invariant.
+// The stranding check ran over the whole stack, so ONE closeable tile anywhere
+// in a zone pinned the strip on at any tab count — and main is where tabs
+// accumulate. Hide tabs (menu row AND ⌘⌥T) silently did nothing there, which
+// reads as "hide tabs is broken", not as a stranding bug.
+describe('hiding a stack that has other handles', () => {
+  it('honors never once a closeable tile has a neighbor to cycle to', () => {
+    expect(resolveTabStripVisible({ mode: 'never', shown: [workspace(), tile()] })).toBe(false)
+    expect(resolveTabStripVisible({ mode: 'never', shown: [tile(), tile()] })).toBe(false)
+    expect(resolveTabStripVisible({ mode: 'never', shown: [workspace(), tile(), tile()] })).toBe(false)
+  })
+
+  it('leaves those same stacks alone on auto', () => {
+    // The stranding rung is resolved before `mode`, so a stack it no longer
+    // claims must still reach the auto rule and keep its strip.
+    expect(resolveTabStripVisible({ shown: [workspace(), tile()] })).toBe(true)
+    expect(resolveTabStripVisible({ shown: [tile(), tile()] })).toBe(true)
   })
 })
 

--- a/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.ts
@@ -41,26 +41,37 @@ export interface StripZone {
 
 /**
  * A pane is STRANDED without a strip when the strip is the only thing carrying
- * its handle: a closeable tile needs its ✕, a lone tool panel needs a chip to
- * grab, hide-only chrome (sessions / Bots) needs the chip that show/hide lives
- * on. The uncloseable workspace is not strandable — it cannot be closed or
- * lost, so a lone chat is free to be chromeless.
+ * its handle: a lone closeable tile needs its ✕, a lone tool panel needs a chip
+ * to grab, hide-only chrome (sessions / Bots) needs the chip that show/hide
+ * lives on. The uncloseable workspace is not strandable — it cannot be closed
+ * or lost, so a lone chat is free to be chromeless.
  *
  * This outranks an explicit `never` on purpose. "Hide the strip" is a request
  * about chrome, never a request to make a surface unreachable, and a zone that
  * answers no gesture at all is not a state any setting should be able to
  * produce. Hiding still works everywhere it cannot trap you.
+ *
+ * IT IS THE LAST HANDLE THAT IS PROTECTED, NOT THE PRESENCE OF TABS. A stack
+ * of two or more answers tab cycling and ⌘1…⌘9, so hiding its strip costs
+ * chrome and no handle. Scoping the tile and tool-panel rungs to a LONE pane is
+ * what keeps "Hide tabs" a working command in the zone that actually
+ * accumulates tabs: unscoped, one session tab in main pinned the strip on and
+ * both the menu row and ⌘⌥T became silent no-ops.
  */
 function stranded(shown: readonly StripPane[]): boolean {
-  if (shown.some(pane => !pane.uncloseable && pane.placement === 'main')) {
-    return true
-  }
-
+  // Hide-only chrome is stranded at ANY count: it has no close verb at all, and
+  // both the chips and the Show/Hide rows that replace one live on the strip.
   if (shown.some(pane => pane.hideOnly)) {
     return true
   }
 
-  return shown.length === 1 && shown[0].collapsePane
+  if (shown.length !== 1) {
+    return false
+  }
+
+  const [only] = shown
+
+  return only.collapsePane || (!only.uncloseable && only.placement === 'main')
 }
 
 export function resolveTabStripVisible(zone: StripZone): boolean {


### PR DESCRIPTION
## What does this PR do?

"Hide tabs" stopped working in the main zone. The zone menu row and its ⌘⌥T
keybind both wrote the right thing — `tabStrip: 'never'` landed on the zone —
and the resolver overrode it on the next line, so the strip never went away.

The cause is the reachability rung in `strip-visibility.ts` that deliberately
outranks an explicit `never`. It exists so hiding chrome can never make a
surface unreachable: a lone closeable tile has to keep its ✕. But the check ran
over the whole stack rather than a lone pane, so **any** closeable
`placement: 'main'` pane forced the strip visible at any tab count. Session
tabs and bot chats are exactly that pane, which means one session tab in main
was enough to make the command a silent no-op — in the one zone where tabs
actually accumulate.

Stranding is about the last handle, not about tabs existing. A stack of two or
more already answers tab cycling and ⌘1…⌘9, so hiding its strip costs chrome
and no handle. The tile and tool-panel rungs now apply to a lone pane;
hide-only chrome (sessions / Bots) keeps firing at every count, because it has
no close verb at all and the Show/Hide rows that replace one live on the strip
itself.

Regressed in 315307f139 (the `headerHidden` → `tabStrip` refactor), which
lifted the rule above `mode` and dropped the `shown.length <= 1` gate it had
had inline in `TreeGroup`. The `hideOnly` rung added later by #91223 is correct
and is preserved as-is.

## Related Issue

<!-- No filed issue; reported directly. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.ts` —
  scope the tile and tool-panel stranding rungs to a lone pane; keep `hideOnly`
  firing at every count.
- `apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.test.ts` —
  cover the tab count the suite never asserted.

## How to Test

1. Open the main zone with two or more session tabs.
2. Right-click the tab strip → **Hide tabs**. The strip goes away (before this
   change: nothing happened).
3. Press ⌘⌥T to bring it back, and again to hide it.
4. Confirm the guarantees that outrank `never` are intact: a zone holding a
   single closeable tile keeps its strip, and the sessions/Bots sidebar still
   refuses to hide the strip its Show/Hide rows live on (#91223).

Automated:

```
cd apps/desktop && npx vitest run src/components/pane-shell/
# 31 files, 171 tests passed
```

The new case is a verified tripwire — reverting the resolver alone fails
`honors never once a closeable tile has a neighbor to cycle to`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- renderer-only change; ran the desktop vitest suites above -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.3

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A <!-- N/A: the resolver's own doc comment carries the precedence rule and is updated -->
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A <!-- pure layout logic, no platform branch -->
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
