### PR TITLE
fix(desktop): one session-timer clock — row started_at for primary and tile focus

### DIFF
--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -176,15 +176,17 @@ export function useStatusbarItems({
 
   const turnStartedAt = primaryFocused ? primaryTurnStartedAt : focusedTurnStartedAt
 
-  // A tile's session-start + cold cwd come from its stored row (the cache only
-  // knows runtime state). Only these scalars are read off `$sessions`, so
-  // select them — a whole-list `useStore` re-ran the hook on every session-list
-  // write (title updates, poll refreshes, archives).
-  const focusedRowStartedAt = useStoreSelector($sessions, sessions =>
-    focusedStoredSessionId
-      ? (sessions.find(s => sessionMatchesStoredId(s, focusedStoredSessionId))?.started_at ?? null)
-      : null
-  )
+  // The focused surface's session-start + a tile's cold cwd come from the
+  // stored row (the cache only knows runtime state). Primary focus resolves its
+  // row by the selection, tile focus by the focused tile's stored id — both
+  // read the same durable `started_at`. Only these scalars are read off
+  // `$sessions`, so select them — a whole-list `useStore` re-ran the hook on
+  // every session-list write (title updates, poll refreshes, archives).
+  const focusedRowStartedAt = useStoreSelector($sessions, sessions => {
+    const id = primaryFocused ? selectedStoredSessionId : focusedStoredSessionId
+
+    return id ? (sessions.find(s => sessionMatchesStoredId(s, id))?.started_at ?? null) : null
+  })
 
   const focusedRowCwd = useStoreSelector($sessions, sessions => {
     if (!focusedStoredSessionId) {
@@ -235,10 +237,17 @@ export function useStatusbarItems({
   const projectTree = useStore($projectTree)
   const projectName = useMemo(() => projectNameForCwd(currentCwd), [currentCwd, projectTree])
 
-  const sessionStartedAt = primaryFocused
-    ? primarySessionStartedAt
-    : focusedRowStartedAt
-      ? focusedRowStartedAt * 1000
+  // The session timer reads ONE clock: the durable `started_at` of the focused
+  // session's row, so switching focus between the primary pane and a tile never
+  // changes what "Session" means (a per-switch `Date.now()` stamp made the
+  // primary read "focused since" while tiles read row age — #103123). The
+  // per-switch stamp survives only as a transient fallback for a brand-new
+  // session whose optimistic row hasn't landed in the list yet (or a draft
+  // runtime with no row at all).
+  const sessionStartedAt = focusedRowStartedAt
+    ? focusedRowStartedAt * 1000
+    : primaryFocused
+      ? primarySessionStartedAt
       : null
 
   // The backend only knows a session's MEASURED occupancy once a turn has run

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-session-timer.test.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-session-timer.test.tsx
@@ -1,0 +1,143 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { group } from '@/components/pane-shell/tree/model'
+import { $activeTreeGroup, $layoutTree } from '@/components/pane-shell/tree/store'
+import {
+  setSelectedStoredSessionId,
+  setSessions,
+  setSessionStartedAt
+} from '@/store/session'
+import type { SessionInfo } from '@/types/hermes'
+
+import { useStatusbarItems } from './use-statusbar-items'
+
+vi.mock('@/app/chat/sidebar/connection-switcher', () => ({ ConnectionSwitcher: () => null }))
+vi.mock('@/app/shell/approval-mode-menu', () => ({
+  useApprovalModeStatusbarItem: () => ({ id: 'approval-mode' })
+}))
+vi.mock('@/app/shell/system-resources-statusbar', () => ({
+  useSystemResourcesStatusbarItem: () => ({ id: 'system-resources' })
+}))
+
+const requestGateway = vi.fn(async () => ({}))
+
+const STARTED_AT = Date.now() / 1000 - 23 * 3600 - 3 * 60
+
+function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    ended_at: null,
+    id: 'sess-a',
+    input_tokens: 0,
+    is_active: true,
+    is_default_profile: true,
+    last_active: STARTED_AT,
+    message_count: 0,
+    model: null,
+    output_tokens: 0,
+    preview: null,
+    profile: 'default',
+    source: 'tui',
+    started_at: STARTED_AT,
+    title: null,
+    tool_call_count: 0,
+    cwd: '/repo',
+    ...overrides
+  }
+}
+
+/** The "Session" item's LiveDuration `since` value under the current focus. */
+function sessionTimerSince(): number | null {
+  const { result } = renderHook(() =>
+    useStatusbarItems({
+      agentsOpen: false,
+      chatOpen: true,
+      commandCenterOpen: false,
+      extraLeftItems: [],
+      extraRightItems: [],
+      freshDraftReady: false,
+      gatewayState: 'open',
+      inferenceStatus: null,
+      openAgents: () => undefined,
+      openCommandCenterSection: () => undefined,
+      requestGateway: requestGateway as unknown as Parameters<typeof useStatusbarItems>[0]['requestGateway'],
+      statusSnapshot: null,
+      toggleCommandCenter: () => undefined
+    })
+  )
+
+  const item = result.current.statusbarItems.find(candidate => candidate.id === 'session-timer')
+  const detail = item && 'detail' in item ? (item.detail as { props: { since: number | null } }) : null
+
+  return detail ? detail.props.since : null
+}
+
+/** Move the "interacted zone" focus onto a session tile, as the layout tree does. */
+function focusTile(storedId: string): void {
+  const tree = group(['tile-pane', `session-tile:${storedId}`], { active: `session-tile:${storedId}` })
+
+  act(() => {
+    $layoutTree.set(tree)
+    $activeTreeGroup.set(tree.id)
+  })
+}
+
+beforeEach(() => {
+  $activeTreeGroup.set(null)
+  $layoutTree.set(null)
+  setSelectedStoredSessionId(null)
+  setSessions([])
+  setSessionStartedAt(null)
+})
+
+afterEach(() => {
+  cleanup()
+  $activeTreeGroup.set(null)
+  $layoutTree.set(null)
+  setSelectedStoredSessionId(null)
+  setSessions([])
+  setSessionStartedAt(null)
+})
+
+describe('statusbar session timer semantics', () => {
+  it('reads the same row age whether the primary pane or a tile has focus', () => {
+    act(() => {
+      setSessions([makeSession()])
+      setSelectedStoredSessionId('sess-a')
+      setSessionStartedAt(Date.now())
+    })
+
+    expect(sessionTimerSince()).toBe(STARTED_AT * 1000)
+
+    focusTile('sess-a')
+
+    expect(sessionTimerSince()).toBe(STARTED_AT * 1000)
+  })
+
+  it('falls back to the create-time stamp only while the row is missing', () => {
+    act(() => {
+      setSelectedStoredSessionId('sess-a')
+      setSessionStartedAt(123_450_000)
+    })
+
+    expect(sessionTimerSince()).toBe(123_450_000)
+
+    act(() => {
+      setSessions([makeSession()])
+    })
+
+    expect(sessionTimerSince()).toBe(STARTED_AT * 1000)
+  })
+
+  it('hides the timer for a focused tile whose row cannot be resolved', () => {
+    act(() => {
+      setSessions([makeSession()])
+      setSelectedStoredSessionId('sess-a')
+      setSessionStartedAt(Date.now())
+    })
+
+    focusTile('sess-b')
+
+    expect(sessionTimerSince()).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
The statusbar "Session" timer meant two different things depending on which surface had focus (#103123):

- **Primary pane focused** — the clock was `Date.now()` restamped on every session create/warm-switch/cold-resume (`setSessionStartedAt`), so it read "time since this session was last focused here".
- **Tile/tab focused** — the clock was the durable `sessions.started_at` row value, so the same session jumped to e.g. `23:03:00`.

The fix makes **row age the single contract**: `useStatusbarItems` now resolves the focused surface's `started_at` from the session list for both paths (primary focus resolves its row by `$selectedStoredSessionId`, tile focus by the tile's stored id), and the per-switch `Date.now()` atom survives only as a transient fallback for a brand-new session whose optimistic row hasn't landed in `$sessions` yet (or a draft runtime with no row at all). No more jumping between `0:05` and `23:03:00` when moving focus between the main chat pane and a session tile of the same conversation.

## Testing
- `npx vitest run src/app/shell/hooks/use-statusbar-session-timer.test.tsx --project ui` — 3 passed (new regression spec: identical `since` for primary vs tile focus on the same row; create-time fallback only while the row is missing; hidden timer for an unresolvable focused tile). On unpatched `main` the first two fail exactly as reported.
- `npx tsc -p . --noEmit` — clean.
- `eslint` on both touched files — 0 new warnings (the one `exhaustive-deps` warning on `use-statusbar-items.tsx` pre-exists on `main`).

Fixes #103123