### PR TITLE
feat(openai): add native GPT-6 Astra mid-turn steering

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3161,14 +3161,22 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
     marker = format_steer_marker(steer_text)
     existing_content = target.get("content", "")
     if isinstance(existing_content, str):
-        target["content"] = existing_content + marker
+        delivered_content = existing_content + marker
     else:
         # Anthropic multimodal content blocks: preserve them and append a text block.
         try:
-            target["content"] = [*(existing_content or []), {"type": "text", "text": marker.lstrip()}]
+            delivered_content = [*(existing_content or []), {"type": "text", "text": marker.lstrip()}]
         except Exception:
             # Fall back to string replacement if content shape is unexpected.
-            target["content"] = f"{existing_content}{marker}"
+            delivered_content = f"{existing_content}{marker}"
+    target["content"] = delivered_content
+    from agent.transports.astra_websocket_session import durably_deliver_fallback_steer
+    if durably_deliver_fallback_steer(
+        agent, target, existing_content, delivered_content, steer_text
+    ) is False:
+        target["content"] = existing_content
+        _requeue_pending_steer(agent, steer_text)
+        return
     _ra().logger.info(
         "Delivered /steer to agent after tool batch (%d chars): %s", len(steer_text),
         steer_text[:120] + ("..." if len(steer_text) > 120 else ""),

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3161,22 +3161,14 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
     marker = format_steer_marker(steer_text)
     existing_content = target.get("content", "")
     if isinstance(existing_content, str):
-        delivered_content = existing_content + marker
+        target["content"] = existing_content + marker
     else:
         # Anthropic multimodal content blocks: preserve them and append a text block.
         try:
-            delivered_content = [*(existing_content or []), {"type": "text", "text": marker.lstrip()}]
+            target["content"] = [*(existing_content or []), {"type": "text", "text": marker.lstrip()}]
         except Exception:
             # Fall back to string replacement if content shape is unexpected.
-            delivered_content = f"{existing_content}{marker}"
-    target["content"] = delivered_content
-    from agent.transports.astra_websocket_session import durably_deliver_fallback_steer
-    if durably_deliver_fallback_steer(
-        agent, target, existing_content, delivered_content, steer_text
-    ) is False:
-        target["content"] = existing_content
-        _requeue_pending_steer(agent, steer_text)
-        return
+            target["content"] = f"{existing_content}{marker}"
     _ra().logger.info(
         "Delivered /steer to agent after tool batch (%d chars): %s", len(steer_text),
         steer_text[:120] + ("..." if len(steer_text) > 120 else ""),

--- a/agent/astra_async_tools.py
+++ b/agent/astra_async_tools.py
@@ -2,8 +2,8 @@
 
 The provider can finish an ``async`` function-call item before the Responses stream reaches its
 terminal frame.  This module admits those items into the existing tool middleware while keeping
-their assistant fragments durable and delaying tool-result rows until the complete stream has
-settled.  It is intentionally an internal coordinator: ordinary providers never instantiate it.
+their assistant fragments durable. Tool-result rows settle in order at stream completion or when
+steering requires a durable prefix. Ordinary providers never instantiate this internal coordinator.
 """
 
 from __future__ import annotations

--- a/agent/astra_async_tools.py
+++ b/agent/astra_async_tools.py
@@ -67,6 +67,7 @@ class AstraAsyncExecutor:
         self.api_call_count = api_call_count
         self._lock = threading.RLock()
         self._changed = threading.Condition(self._lock)
+        self._settlement_lock = threading.Lock()
         self._jobs: list[_AstraJob] = []
         self._reservations: list[str] = []
         self._pending_calls: dict[str, Any] = {}
@@ -296,6 +297,107 @@ class AstraAsyncExecutor:
     def _all_done_locked(self) -> bool:
         return all(job.done for job in self._jobs)
 
+    @staticmethod
+    def _canonical_call_id(value: Any) -> str:
+        return str(value or "").split("|", 1)[0].strip()
+
+    def _job_call_ids(self, job: _AstraJob) -> set[str]:
+        ref = job.parsed.ref(self.effective_task_id)
+        return {
+            call_id for call_id in (
+                self._canonical_call_id(ref.call_id),
+                self._canonical_call_id(getattr(job.call, "call_id", None)),
+                self._canonical_call_id(getattr(job.call, "id", None)),
+            ) if call_id
+        }
+
+    def _required_jobs_locked(self, call_ids: Any) -> Optional[list[_AstraJob]]:
+        required = {self._canonical_call_id(call_id) for call_id in call_ids or ()}
+        required.discard("")
+        if not required:
+            return []
+        positions = {
+            call_id: index
+            for index, job in enumerate(self._jobs)
+            for call_id in self._job_call_ids(job)
+        }
+        if not required.issubset(positions):
+            return None
+        # Publishing in assistant-call order requires every earlier job.  The scheduler's
+        # segmented barriers also require those predecessors to have completed first.
+        return list(self._jobs[:max(positions[call_id] for call_id in required) + 1])
+
+    def _wait_for_jobs(self, jobs: list[_AstraJob]) -> bool:
+        while True:
+            abort = False
+            with self._lock:
+                if all(job.committed for job in jobs):
+                    return True
+                if self._closed or self._failed:
+                    return False
+                if getattr(self.agent, "_interrupt_requested", False):
+                    abort = True
+                elif all(job.done for job in jobs):
+                    return True
+                else:
+                    self._pump_locked()
+                    self._changed.wait(timeout=0.1)
+            if abort:
+                self.abort_stream()
+                return False
+
+    def _publish_jobs(self, jobs: list[_AstraJob], *, finalize: bool = False) -> bool:
+        """Persist one ordered job prefix, skipping rows already committed by settlement."""
+        if not jobs:
+            return True
+        from agent.tool_executor import (
+            _append_invalid_arguments_result, _budget_for_agent, _finalize_tool_batch, _publish_sequential_result,
+        )
+
+        selected = {id(job) for job in jobs}
+        ordered = [job for job in self._jobs if id(job) in selected]
+        budget = _budget_for_agent(self.agent)
+        for index, job in enumerate(ordered):
+            if job.committed:
+                continue
+            ref = job.parsed.ref(self.effective_task_id)
+            message_count = len(self.messages)
+            if job.parsed.parse_error is not None:
+                published = _append_invalid_arguments_result(self.agent, self.messages, ref, job.parsed.parse_error)
+            else:
+                published = _publish_sequential_result(
+                    self.agent, self.messages, ref, job.managed, tool_duration=job.duration,
+                    index=job.index + 1, budget=budget,
+                )
+            if not published:
+                self._failed = True
+                del self.messages[message_count:]
+                recovered = self._recover_uncommitted_results(ordered[index:])
+                self.agent._session_messages = self.messages
+                return recovered
+            job.committed = True
+        if finalize and not self._failed and self._jobs:
+            _finalize_tool_batch(self.agent, self.messages, self.effective_task_id, len(self._jobs), budget)
+        self.agent._session_messages = self.messages
+        return True
+
+    def settle_required(self, call_ids: Any) -> bool:
+        """Wait for required calls and ordered predecessors, then durably publish them once.
+
+        This is the PR3 pending-steer boundary.  It never exposes an in-memory managed result;
+        callers may construct required input only after this returns ``True`` and read the
+        canonical persisted tool rows from ``agent._session_messages``.
+        """
+        with self._settlement_lock:
+            with self._lock:
+                jobs = self._required_jobs_locked(call_ids)
+            if jobs is None or not self._wait_for_jobs(jobs):
+                return False
+            published = self._publish_jobs(jobs)
+            # A recovery notice is durable, but it is not the requested tool result.  Keep
+            # pending continuation fail-closed after a canonical publication failure.
+            return published and not self.failed
+
     def _recover_uncommitted_results(self, jobs: list[_AstraJob]) -> bool:
         from agent.replay_cleanup import _DANGLING_NOTICES, _orphan_recovery
         from agent.tool_dispatch_helpers import make_tool_result_message
@@ -325,85 +427,53 @@ class AstraAsyncExecutor:
 
     def finish_stream(self, assistant_content: str = "", settled_calls: Any = None) -> bool:
         """Wait for all admitted jobs and publish results in original call order."""
-        with self._lock:
-            if self._closed:
-                return self._finalized
-            if getattr(self.agent, "_interrupt_requested", False):
-                self.abort_stream()
-                return False
-            # The assembler settles announced items that lack an output_item.done frame only when
-            # it builds the terminal response.  Admit those calls before retiring reservations.
-            for call in settled_calls or ():
-                if provider_async_marker(call):
-                    self.admit(call)
-            self._stream_closed = True
-            self._drain_admissions_locked()
-            self._pending_calls.clear()
-            self._reservations.clear()
-            self._pump_locked()
-            while not self._all_done_locked():
+        with self._settlement_lock:
+            with self._lock:
+                if self._closed:
+                    return self._finalized
                 if getattr(self.agent, "_interrupt_requested", False):
                     self.abort_stream()
                     return False
-                self._changed.wait(timeout=0.1)
+                # The assembler settles announced items that lack an output_item.done frame only when
+                # it builds the terminal response.  Admit those calls before retiring reservations.
+                for call in settled_calls or ():
+                    if provider_async_marker(call):
+                        self.admit(call)
+                self._stream_closed = True
+                self._drain_admissions_locked()
+                self._pending_calls.clear()
+                self._reservations.clear()
+                self._pump_locked()
+                while not self._all_done_locked():
+                    if getattr(self.agent, "_interrupt_requested", False):
+                        self.abort_stream()
+                        return False
+                    self._changed.wait(timeout=0.1)
 
-        from agent.tool_executor import (
-            _append_invalid_arguments_result, _budget_for_agent, _finalize_tool_batch, _publish_sequential_result,
-        )
-        if assistant_content:
-            from agent.chat_completion_helpers import build_assistant_message
+            if assistant_content:
+                from agent.chat_completion_helpers import build_assistant_message
 
-            text_message = build_assistant_message(
-                self.agent, SimpleNamespace(content=assistant_content, tool_calls=[]), "tool_calls",
-            )
-            text_message.pop("tool_calls", None)
-            self.messages.append(text_message)
-            try:
-                if self.agent._flush_messages_to_session_db(self.messages) is not True:
+                text_message = build_assistant_message(
+                    self.agent, SimpleNamespace(content=assistant_content, tool_calls=[]), "tool_calls",
+                )
+                text_message.pop("tool_calls", None)
+                self.messages.append(text_message)
+                try:
+                    if self.agent._flush_messages_to_session_db(self.messages) is not True:
+                        self._failed = True
+                except Exception:
                     self._failed = True
-            except Exception:
-                self._failed = True
-        if self._failed:
-            recovered = self._recover_uncommitted_results(self._jobs)
-            self._closed = True
-            self._finalized = recovered
-            self._executor.shutdown(wait=True)
-            return recovered
-        budget = _budget_for_agent(self.agent)
-        for index, job in enumerate(self._jobs):
-            ref = job.parsed.ref(self.effective_task_id)
-            if job.parsed.parse_error is not None:
-                message_count = len(self.messages)
-                if not _append_invalid_arguments_result(self.agent, self.messages, ref, job.parsed.parse_error):
-                    self._failed = True
-                    del self.messages[message_count:]
-                    recovered = self._recover_uncommitted_results(self._jobs[index:])
-                    self._closed = True
-                    self._finalized = recovered
-                    self._executor.shutdown(wait=True)
-                    return recovered
-                job.committed = True
-                continue
-            message_count = len(self.messages)
-            if not _publish_sequential_result(
-                self.agent, self.messages, ref, job.managed, tool_duration=job.duration,
-                index=job.index + 1, budget=budget,
-            ):
-                self._failed = True
-                del self.messages[message_count:]
-                recovered = self._recover_uncommitted_results(self._jobs[index:])
+            if self._failed:
+                recovered = self._recover_uncommitted_results(self._jobs)
                 self._closed = True
                 self._finalized = recovered
                 self._executor.shutdown(wait=True)
                 return recovered
-            job.committed = True
-        self._closed = True
-        if not self._failed and self._jobs:
-            _finalize_tool_batch(self.agent, self.messages, self.effective_task_id, len(self._jobs), budget)
-        self.agent._session_messages = self.messages
-        self._finalized = not self._failed
-        self._executor.shutdown(wait=True)
-        return self._finalized
+            finalized = self._publish_jobs(self._jobs, finalize=True)
+            self._closed = True
+            self._finalized = finalized
+            self._executor.shutdown(wait=True)
+            return self._finalized
 
     def abort_stream(self) -> None:
         """Retire scheduling after interruption/stream failure without retrying handlers."""

--- a/agent/astra_async_tools.py
+++ b/agent/astra_async_tools.py
@@ -323,7 +323,7 @@ class AstraAsyncExecutor:
         self.agent._session_messages = self.messages
         return persisted
 
-    def finish_stream(self, assistant_content: str = "") -> bool:
+    def finish_stream(self, assistant_content: str = "", settled_calls: Any = None) -> bool:
         """Wait for all admitted jobs and publish results in original call order."""
         with self._lock:
             if self._closed:
@@ -331,6 +331,11 @@ class AstraAsyncExecutor:
             if getattr(self.agent, "_interrupt_requested", False):
                 self.abort_stream()
                 return False
+            # The assembler settles announced items that lack an output_item.done frame only when
+            # it builds the terminal response.  Admit those calls before retiring reservations.
+            for call in settled_calls or ():
+                if provider_async_marker(call):
+                    self.admit(call)
             self._stream_closed = True
             self._drain_admissions_locked()
             self._pending_calls.clear()

--- a/agent/astra_async_tools.py
+++ b/agent/astra_async_tools.py
@@ -1,0 +1,345 @@
+"""Midstream application-tool execution for direct GPT-6 Astra Responses turns.
+
+The provider can finish an ``async`` function-call item before the Responses stream reaches its
+terminal frame.  This module admits those items into the existing tool middleware while keeping
+their assistant fragments durable and delaying tool-result rows until the complete stream has
+settled.  It is intentionally an internal coordinator: ordinary providers never instantiate it.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Optional
+
+from agent.tool_dispatch_helpers import _plan_tool_batch_segments
+from tools.daemon_pool import DaemonThreadPoolExecutor
+from tools.thread_context import propagate_context_to_thread
+
+
+def is_direct_astra(agent: Any) -> bool:
+    """True only for the exact official OpenAI Responses Astra route."""
+    if getattr(agent, "api_mode", None) != "codex_responses":
+        return False
+    model = str(getattr(agent, "model", "") or "").strip().lower().rsplit("/", 1)[-1]
+    if model != "gpt-6-astra":
+        return False
+    from utils import base_url_host_matches
+
+    return base_url_host_matches(str(getattr(agent, "base_url", "") or ""), "api.openai.com")
+
+
+def provider_async_marker(tool_call: Any) -> bool:
+    """Read the provider marker, not the registry's Python coroutine metadata."""
+    if isinstance(tool_call, dict):
+        return tool_call.get("async") is True or tool_call.get("async_") is True
+    provider_data = getattr(tool_call, "provider_data", None) or {}
+    return (
+        getattr(tool_call, "async", False) is True
+        or getattr(tool_call, "async_", False) is True
+        or provider_data.get("async") is True
+    )
+
+
+@dataclass
+class _AstraJob:
+    call: Any
+    parsed: Any
+    index: int
+    future: Any = None
+    managed: Any = None
+    duration: float = 0.0
+    done: bool = False
+    committed: bool = False
+
+
+class AstraAsyncExecutor:
+    """Admit, schedule, and commit provider-marked Astra application tools."""
+
+    def __init__(self, agent: Any, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
+        self.agent = agent
+        self.messages = messages
+        self.effective_task_id = effective_task_id
+        self.api_call_count = api_call_count
+        self._lock = threading.RLock()
+        self._changed = threading.Condition(self._lock)
+        self._jobs: list[_AstraJob] = []
+        self._admitted_ids: set[str] = set()
+        self._stream_closed = False
+        self._closed = False
+        self._finalized = False
+        self._failed = False
+        self._consumed = False
+        self._aborted_results = False
+        self._executor = DaemonThreadPoolExecutor(max_workers=8)
+
+        from tools.terminal_tool_lifecycle import get_active_env
+
+        active_env = get_active_env(effective_task_id)
+        self._execution_cwd = Path(active_env.cwd) if active_env is not None and active_env.cwd else None
+
+    @property
+    def has_admitted(self) -> bool:
+        with self._lock:
+            return bool(self._jobs)
+
+    @property
+    def failed(self) -> bool:
+        with self._lock:
+            return self._failed
+
+    @property
+    def finalized(self) -> bool:
+        with self._lock:
+            return self._finalized
+
+    @property
+    def closed(self) -> bool:
+        with self._lock:
+            return self._closed
+
+    def retire_empty(self) -> bool:
+        """Close an executor that admitted no calls so its turn-owned state cannot be reused."""
+        with self._lock:
+            if self._jobs or self._closed:
+                return False
+            self._stream_closed = self._closed = True
+        self._executor.shutdown(wait=True)
+        return True
+
+    def _call_id(self, call: Any, index: int) -> str:
+        from agent.chat_completion_helpers import _assistant_tool_call_dict
+
+        # The normal builder is the source of truth for Responses aliases and deterministic IDs.
+        try:
+            return str(_assistant_tool_call_dict(self.agent, call, index).get("id") or "").strip()
+        except Exception:
+            raw = getattr(call, "call_id", None) or getattr(call, "id", None)
+            return str(raw or f"astra_async_{index}").strip()
+
+    def _assistant_fragment(self, call: Any, index: int) -> dict:
+        from agent.chat_completion_helpers import _assistant_tool_call_dict
+
+        tc = _assistant_tool_call_dict(self.agent, call, index)
+        return {"role": "assistant", "content": None, "tool_calls": [tc], "finish_reason": "tool_calls"}
+
+    def admit(self, call: Any) -> bool:
+        """Persist one completed async call, then make it eligible for dispatch.
+
+        A duplicate call ID is an idempotent no-op.  Persistence is intentionally before the first
+        scheduler submission; a failed flush never reaches a tool handler.
+        """
+        if not provider_async_marker(call):
+            return False
+        with self._lock:
+            if self._closed or self._stream_closed:
+                return False
+            index = len(self._jobs)
+            if not getattr(call, "function", None):
+                setattr(call, "function", SimpleNamespace(
+                    name=getattr(call, "name", ""), arguments=getattr(call, "arguments", "{}") or "{}",
+                ))
+            call_id = self._call_id(call, index)
+            if call_id in self._admitted_ids:
+                return True
+            try:
+                fragment = self._assistant_fragment(call, index)
+            except Exception:
+                self._failed = True
+                return False
+            self.messages.append(fragment)
+            try:
+                persisted = self.agent._flush_messages_to_session_db(self.messages) is True
+            except Exception:
+                persisted = False
+            if not persisted:
+                self.messages.pop()
+                self._failed = True
+                return False
+
+            # Bind the canonical ID back to this transient streamed object so the existing parser,
+            # middleware, and result pairing all see the same identity.
+            if not getattr(call, "id", None):
+                setattr(call, "id", call_id)
+            if not getattr(call, "call_id", None):
+                setattr(call, "call_id", call_id)
+            from agent.tool_executor import _parse_tool_call
+
+            try:
+                parsed = _parse_tool_call(self.agent, call)
+            except Exception:
+                self._failed = True
+                return False
+            job = _AstraJob(call=call, parsed=parsed, index=index)
+            self._jobs.append(job)
+            self._admitted_ids.add(call_id)
+            self.agent._session_messages = self.messages
+            self._pump_locked()
+            return True
+
+    def _segments_locked(self) -> list[tuple[str, list[Any]]]:
+        calls = [job.call for job in self._jobs]
+        return _plan_tool_batch_segments(calls, execution_cwd=self._execution_cwd)
+
+    def _submit_locked(self, job: _AstraJob) -> None:
+        if job.future is not None or self._closed:
+            return
+        job.future = self._executor.submit(propagate_context_to_thread(self._run_job), job)
+        job.future.add_done_callback(lambda future, current=job: self._job_done(current, future))
+
+    def _pump_locked(self) -> None:
+        """Start the earliest runnable segment; later segments remain barriers."""
+        if self._closed:
+            return
+        segments = self._segments_locked()
+        offset = 0
+        for kind, calls in segments:
+            indexes = range(offset, offset + len(calls))
+            group = [self._jobs[index] for index in indexes]
+            if any(not job.done for job in self._jobs[:offset]):
+                return
+            if kind == "parallel":
+                for job in group:
+                    self._submit_locked(job)
+                if any(not job.done for job in group):
+                    return
+                offset += len(group)
+                continue
+            unstarted = next((job for job in group if job.future is None), None)
+            if unstarted is not None:
+                self._submit_locked(unstarted)
+                return
+            if any(not job.done for job in group):
+                return
+            offset += len(group)
+
+    def _run_job(self, job: _AstraJob):
+        from agent.tool_executor import _resolve_sequential_dispatch, _run_sequential_call
+
+        start = time.time()
+        ref = job.parsed.ref(self.effective_task_id)
+        dispatch = _resolve_sequential_dispatch(self.agent, ref, self.messages)
+        managed, duration = _run_sequential_call(
+            self.agent, dispatch, ref, scope_block=job.parsed.scope_block, messages=self.messages,
+            remaining_calls=[], display_index=job.index + 1, tool_start_time=start,
+        )
+        return managed, duration
+
+    def _job_done(self, job: _AstraJob, future: Any) -> None:
+        try:
+            managed, duration = future.result()
+        except Exception as exc:
+            from agent.tool_executor import _ManagedToolResult
+
+            managed, duration = _ManagedToolResult(
+                result=f"Error executing tool '{job.parsed.name}': {exc}", args=job.parsed.args,
+                middleware_trace=job.parsed.middleware_trace, blocked=False, dispatched=False,
+            ), 0.0
+        with self._lock:
+            job.managed, job.duration, job.done = managed, duration, True
+            self._pump_locked()
+            self._changed.notify_all()
+
+    def _all_done_locked(self) -> bool:
+        return all(job.done for job in self._jobs)
+
+    def finish_stream(self, assistant_content: str = "") -> bool:
+        """Wait for all admitted jobs and publish results in original call order."""
+        with self._lock:
+            if self._closed:
+                return self._finalized
+            if getattr(self.agent, "_interrupt_requested", False):
+                self.abort_stream()
+                return False
+            self._stream_closed = True
+            self._pump_locked()
+            while not self._all_done_locked():
+                if getattr(self.agent, "_interrupt_requested", False):
+                    self.abort_stream()
+                    return False
+                self._changed.wait(timeout=0.1)
+            self._closed = True
+
+        from agent.tool_executor import (
+            _append_invalid_arguments_result, _budget_for_agent, _finalize_tool_batch, _publish_sequential_result,
+        )
+        if assistant_content:
+            from agent.chat_completion_helpers import build_assistant_message
+
+            text_message = build_assistant_message(
+                self.agent, SimpleNamespace(content=assistant_content, tool_calls=[]), "tool_calls",
+            )
+            text_message.pop("tool_calls", None)
+            self.messages.append(text_message)
+            try:
+                if self.agent._flush_messages_to_session_db(self.messages) is not True:
+                    self._failed = True
+            except Exception:
+                self._failed = True
+        budget = _budget_for_agent(self.agent)
+        for job in self._jobs:
+            ref = job.parsed.ref(self.effective_task_id)
+            if job.parsed.parse_error is not None:
+                if not _append_invalid_arguments_result(self.agent, self.messages, ref, job.parsed.parse_error):
+                    self._failed = True
+                    break
+                job.committed = True
+                continue
+            if not _publish_sequential_result(
+                self.agent, self.messages, ref, job.managed, tool_duration=job.duration,
+                index=job.index + 1, budget=budget,
+            ):
+                self._failed = True
+                break
+            job.committed = True
+        if not self._failed and self._jobs:
+            _finalize_tool_batch(self.agent, self.messages, self.effective_task_id, len(self._jobs), budget)
+        self.agent._session_messages = self.messages
+        self._finalized = not self._failed
+        self._executor.shutdown(wait=True)
+        return self._finalized
+
+    def abort_stream(self) -> None:
+        """Retire scheduling after interruption/stream failure without retrying handlers."""
+        with self._lock:
+            if self._closed:
+                return
+            self._stream_closed = True
+            self._closed = True
+            for job in self._jobs:
+                if job.future is not None and not job.future.done():
+                    job.future.cancel()
+            if not self._aborted_results and self._jobs:
+                from agent.replay_cleanup import _DANGLING_NOTICES, _orphan_recovery
+                from agent.tool_dispatch_helpers import make_tool_result_message
+
+                for job in self._jobs:
+                    ref = job.parsed.ref(self.effective_task_id)
+                    disposition, content = _orphan_recovery(job.parsed.name, _DANGLING_NOTICES)
+                    self.messages.append(make_tool_result_message(
+                        job.parsed.name, content, ref.call_id, effect_disposition=disposition,
+                    ))
+                    try:
+                        if self.agent._flush_messages_to_session_db(self.messages) is not True:
+                            self._failed = True
+                    except Exception:
+                        self._failed = True
+                self.agent._session_messages = self.messages
+                self._aborted_results = True
+            self._changed.notify_all()
+        self._executor.shutdown(wait=False, cancel_futures=True)
+
+    def consume_response(self, assistant_message: Any) -> bool:
+        """Tell the ordinary turn loop that this response's handlers already ran."""
+        with self._lock:
+            if not self._finalized or self._consumed or not self._jobs:
+                return False
+            self._consumed = True
+            return True
+
+
+__all__ = ["AstraAsyncExecutor", "is_direct_astra", "provider_async_marker"]

--- a/agent/astra_async_tools.py
+++ b/agent/astra_async_tools.py
@@ -28,9 +28,9 @@ def is_direct_astra(agent: Any) -> bool:
     model = str(getattr(agent, "model", "") or "").strip().lower().rsplit("/", 1)[-1]
     if model != "gpt-6-astra":
         return False
-    from utils import base_url_host_matches
+    from utils import base_url_hostname
 
-    return base_url_host_matches(str(getattr(agent, "base_url", "") or ""), "api.openai.com")
+    return base_url_hostname(str(getattr(agent, "base_url", "") or "")) == "api.openai.com"
 
 
 def provider_async_marker(tool_call: Any) -> bool:
@@ -68,6 +68,8 @@ class AstraAsyncExecutor:
         self._lock = threading.RLock()
         self._changed = threading.Condition(self._lock)
         self._jobs: list[_AstraJob] = []
+        self._reservations: list[str] = []
+        self._pending_calls: dict[str, Any] = {}
         self._admitted_ids: set[str] = set()
         self._stream_closed = False
         self._closed = False
@@ -88,6 +90,11 @@ class AstraAsyncExecutor:
             return bool(self._jobs)
 
     @property
+    def has_pending(self) -> bool:
+        with self._lock:
+            return bool(self._reservations or self._pending_calls)
+
+    @property
     def failed(self) -> bool:
         with self._lock:
             return self._failed
@@ -105,7 +112,7 @@ class AstraAsyncExecutor:
     def retire_empty(self) -> bool:
         """Close an executor that admitted no calls so its turn-owned state cannot be reused."""
         with self._lock:
-            if self._jobs or self._closed:
+            if self._jobs or self._reservations or self._pending_calls or self._closed:
                 return False
             self._stream_closed = self._closed = True
         self._executor.shutdown(wait=True)
@@ -127,66 +134,106 @@ class AstraAsyncExecutor:
         tc = _assistant_tool_call_dict(self.agent, call, index)
         return {"role": "assistant", "content": None, "tool_calls": [tc], "finish_reason": "tool_calls"}
 
-    def admit(self, call: Any) -> bool:
-        """Persist one completed async call, then make it eligible for dispatch.
+    def _reservation_key(self, call: Any) -> str:
+        if isinstance(call, dict):
+            raw = call.get("call_id") or call.get("id") or call.get("response_item_id")
+        else:
+            raw = getattr(call, "call_id", None) or getattr(call, "id", None) or getattr(call, "response_item_id", None)
+        return str(raw or "").strip()
 
-        A duplicate call ID is an idempotent no-op.  Persistence is intentionally before the first
-        scheduler submission; a failed flush never reaches a tool handler.
-        """
+    def reserve(self, call: Any) -> bool:
+        """Record provider output order before arguments are complete or executable."""
         if not provider_async_marker(call):
             return False
         with self._lock:
             if self._closed or self._stream_closed:
                 return False
-            index = len(self._jobs)
-            if not getattr(call, "function", None):
-                setattr(call, "function", SimpleNamespace(
-                    name=getattr(call, "name", ""), arguments=getattr(call, "arguments", "{}") or "{}",
-                ))
-            call_id = self._call_id(call, index)
-            if call_id in self._admitted_ids:
+            key = self._reservation_key(call)
+            if not key or key in self._admitted_ids:
                 return True
-            try:
-                fragment = self._assistant_fragment(call, index)
-            except Exception:
-                self._failed = True
-                return False
-            self.messages.append(fragment)
-            try:
-                persisted = self.agent._flush_messages_to_session_db(self.messages) is True
-            except Exception:
-                persisted = False
-            if not persisted:
-                self.messages.pop()
-                self._failed = True
-                return False
-
-            # Bind the canonical ID back to this transient streamed object so the existing parser,
-            # middleware, and result pairing all see the same identity.
-            if not getattr(call, "id", None):
-                setattr(call, "id", call_id)
-            if not getattr(call, "call_id", None):
-                setattr(call, "call_id", call_id)
-            from agent.tool_executor import _parse_tool_call
-
-            try:
-                parsed = _parse_tool_call(self.agent, call)
-            except Exception:
-                self._failed = True
-                return False
-            job = _AstraJob(call=call, parsed=parsed, index=index)
-            self._jobs.append(job)
-            self._admitted_ids.add(call_id)
-            self.agent._session_messages = self.messages
-            self._pump_locked()
+            if key not in self._reservations:
+                self._reservations.append(key)
             return True
+
+    def _drain_admissions_locked(self) -> None:
+        while self._reservations:
+            key = self._reservations[0]
+            call = self._pending_calls.get(key)
+            if call is None:
+                return
+            self._pending_calls.pop(key, None)
+            self._reservations.pop(0)
+            if not self._admit_one_locked(call):
+                return
+
+    def admit(self, call: Any) -> bool:
+        """Queue one completed call and admit only the completed announced prefix."""
+        if not provider_async_marker(call):
+            return False
+        with self._lock:
+            if self._closed or self._stream_closed:
+                return False
+            key = self._reservation_key(call)
+            if not key:
+                key = f"anonymous:{len(self._reservations) + len(self._pending_calls)}"
+            if key in self._admitted_ids:
+                return True
+            if key not in self._reservations:
+                self._reservations.append(key)
+            self._pending_calls[key] = call
+            self._drain_admissions_locked()
+            return key in self._admitted_ids or key in self._pending_calls
+
+    def _admit_one_locked(self, call: Any) -> bool:
+        index = len(self._jobs)
+        if not getattr(call, "function", None):
+            setattr(call, "function", SimpleNamespace(
+                name=getattr(call, "name", ""), arguments=getattr(call, "arguments", "{}") or "{}",
+            ))
+        call_id = self._call_id(call, index)
+        if call_id in self._admitted_ids:
+            return True
+        try:
+            fragment = self._assistant_fragment(call, index)
+        except Exception:
+            self._failed = True
+            return False
+        self.messages.append(fragment)
+        try:
+            persisted = self.agent._flush_messages_to_session_db(self.messages) is True
+        except Exception:
+            persisted = False
+        if not persisted:
+            self.messages.pop()
+            self._failed = True
+            return False
+
+        # Bind the canonical ID back to this transient streamed object so the existing parser,
+        # middleware, and result pairing all see the same identity.
+        if not getattr(call, "id", None):
+            setattr(call, "id", call_id)
+        if not getattr(call, "call_id", None):
+            setattr(call, "call_id", call_id)
+        from agent.tool_executor import _parse_tool_call
+
+        try:
+            parsed = _parse_tool_call(self.agent, call)
+        except Exception:
+            self._failed = True
+            return False
+        job = _AstraJob(call=call, parsed=parsed, index=index, done=parsed.parse_error is not None)
+        self._jobs.append(job)
+        self._admitted_ids.add(call_id)
+        self.agent._session_messages = self.messages
+        self._pump_locked()
+        return True
 
     def _segments_locked(self) -> list[tuple[str, list[Any]]]:
         calls = [job.call for job in self._jobs]
         return _plan_tool_batch_segments(calls, execution_cwd=self._execution_cwd)
 
     def _submit_locked(self, job: _AstraJob) -> None:
-        if job.future is not None or self._closed:
+        if job.future is not None or self._closed or job.parsed.parse_error is not None:
             return
         job.future = self._executor.submit(propagate_context_to_thread(self._run_job), job)
         job.future.add_done_callback(lambda future, current=job: self._job_done(current, future))
@@ -209,7 +256,9 @@ class AstraAsyncExecutor:
                     return
                 offset += len(group)
                 continue
-            unstarted = next((job for job in group if job.future is None), None)
+            unstarted = next(
+                (job for job in group if job.future is None and job.parsed.parse_error is None), None,
+            )
             if unstarted is not None:
                 self._submit_locked(unstarted)
                 return
@@ -247,6 +296,33 @@ class AstraAsyncExecutor:
     def _all_done_locked(self) -> bool:
         return all(job.done for job in self._jobs)
 
+    def _recover_uncommitted_results(self, jobs: list[_AstraJob]) -> bool:
+        from agent.replay_cleanup import _DANGLING_NOTICES, _orphan_recovery
+        from agent.tool_dispatch_helpers import make_tool_result_message
+
+        uncommitted = [job for job in jobs if not job.committed]
+        for job in uncommitted:
+            ref = job.parsed.ref(self.effective_task_id)
+            if job.parsed.parse_error is not None:
+                content = job.parsed.parse_error
+                disposition = None
+            else:
+                disposition, content = _orphan_recovery(job.parsed.name, _DANGLING_NOTICES)
+            self.messages.append(make_tool_result_message(
+                job.parsed.name, content, ref.call_id, effect_disposition=disposition,
+            ))
+        if not uncommitted:
+            return True
+        try:
+            persisted = self.agent._flush_messages_to_session_db(self.messages) is True
+        except Exception:
+            persisted = False
+        if persisted:
+            for job in uncommitted:
+                job.committed = True
+        self.agent._session_messages = self.messages
+        return persisted
+
     def finish_stream(self, assistant_content: str = "") -> bool:
         """Wait for all admitted jobs and publish results in original call order."""
         with self._lock:
@@ -256,13 +332,15 @@ class AstraAsyncExecutor:
                 self.abort_stream()
                 return False
             self._stream_closed = True
+            self._drain_admissions_locked()
+            self._pending_calls.clear()
+            self._reservations.clear()
             self._pump_locked()
             while not self._all_done_locked():
                 if getattr(self.agent, "_interrupt_requested", False):
                     self.abort_stream()
                     return False
                 self._changed.wait(timeout=0.1)
-            self._closed = True
 
         from agent.tool_executor import (
             _append_invalid_arguments_result, _budget_for_agent, _finalize_tool_batch, _publish_sequential_result,
@@ -280,22 +358,41 @@ class AstraAsyncExecutor:
                     self._failed = True
             except Exception:
                 self._failed = True
+        if self._failed:
+            recovered = self._recover_uncommitted_results(self._jobs)
+            self._closed = True
+            self._finalized = recovered
+            self._executor.shutdown(wait=True)
+            return recovered
         budget = _budget_for_agent(self.agent)
-        for job in self._jobs:
+        for index, job in enumerate(self._jobs):
             ref = job.parsed.ref(self.effective_task_id)
             if job.parsed.parse_error is not None:
+                message_count = len(self.messages)
                 if not _append_invalid_arguments_result(self.agent, self.messages, ref, job.parsed.parse_error):
                     self._failed = True
-                    break
+                    del self.messages[message_count:]
+                    recovered = self._recover_uncommitted_results(self._jobs[index:])
+                    self._closed = True
+                    self._finalized = recovered
+                    self._executor.shutdown(wait=True)
+                    return recovered
                 job.committed = True
                 continue
+            message_count = len(self.messages)
             if not _publish_sequential_result(
                 self.agent, self.messages, ref, job.managed, tool_duration=job.duration,
                 index=job.index + 1, budget=budget,
             ):
                 self._failed = True
-                break
+                del self.messages[message_count:]
+                recovered = self._recover_uncommitted_results(self._jobs[index:])
+                self._closed = True
+                self._finalized = recovered
+                self._executor.shutdown(wait=True)
+                return recovered
             job.committed = True
+        self._closed = True
         if not self._failed and self._jobs:
             _finalize_tool_batch(self.agent, self.messages, self.effective_task_id, len(self._jobs), budget)
         self.agent._session_messages = self.messages
@@ -309,27 +406,16 @@ class AstraAsyncExecutor:
             if self._closed:
                 return
             self._stream_closed = True
-            self._closed = True
             for job in self._jobs:
                 if job.future is not None and not job.future.done():
                     job.future.cancel()
+            self._pending_calls.clear()
+            self._reservations.clear()
             if not self._aborted_results and self._jobs:
-                from agent.replay_cleanup import _DANGLING_NOTICES, _orphan_recovery
-                from agent.tool_dispatch_helpers import make_tool_result_message
-
-                for job in self._jobs:
-                    ref = job.parsed.ref(self.effective_task_id)
-                    disposition, content = _orphan_recovery(job.parsed.name, _DANGLING_NOTICES)
-                    self.messages.append(make_tool_result_message(
-                        job.parsed.name, content, ref.call_id, effect_disposition=disposition,
-                    ))
-                    try:
-                        if self.agent._flush_messages_to_session_db(self.messages) is not True:
-                            self._failed = True
-                    except Exception:
-                        self._failed = True
+                self._recover_uncommitted_results(self._jobs)
                 self.agent._session_messages = self.messages
                 self._aborted_results = True
+            self._closed = True
             self._changed.notify_all()
         self._executor.shutdown(wait=False, cancel_futures=True)
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1392,8 +1392,13 @@ class _CodexCompletionsAdapter:
             if isinstance(reasoning_cfg, dict) and reasoning_cfg.get("enabled") is not False:
                 # Truthy-only: Codex 400s on e.g. {"effort": null}, so falsy → default. Shared
                 # per-model clamp with the main transport ("max" is gpt-5.6-only; "minimal"/"ultra" rejected).
-                from agent.reasoning_effort import clamp_effort, codex_supported_efforts
-                effort = clamp_effort(reasoning_cfg.get("effort") or "medium", codex_supported_efforts(model))
+                from agent.reasoning_effort import clamp_effort
+                from agent.transports.codex import _codex_efforts_for_route
+                is_codex_backend = base_url_host_matches(host, "chatgpt.com") and "/backend-api/codex" in host.lower()
+                effort = clamp_effort(
+                    reasoning_cfg.get("effort") or "medium",
+                    _codex_efforts_for_route(model, host, is_codex_backend=is_codex_backend),
+                )
                 resp_kwargs["reasoning"] = {"effort": effort, "summary": "auto"}
                 resp_kwargs["include"] = ["reasoning.encrypted_content"]
         tools = kwargs.get("tools")

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1446,6 +1446,11 @@ class _CodexCompletionsAdapter:
                     resp_kwargs["prompt_cache_retention"] = cache_retention
         except Exception:
             logger.debug("Codex auxiliary: prompt_cache_key derivation skipped", exc_info=True)
+        # Keep auxiliary Responses calls on the same exact-model contract as main
+        # turns. This runs last so caller overrides cannot reintroduce unsupported
+        # Astra reasoning/sampling fields or replace the official cache TTL.
+        from agent.transports.codex import _sanitize_astra_request_kwargs
+        _sanitize_astra_request_kwargs(resp_kwargs, model, host)
         return resp_kwargs, model, timeout
 
     def create(self, **kwargs) -> Any:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1413,6 +1413,8 @@ def _build_bedrock_kwargs(agent, api_messages, tools_for_api):
 def _build_codex_kwargs(agent, api_messages, tools_for_api, reasoning_config, request_overrides, cache_scope_id):
     from agent.codex_responses_adapter import classify_responses_route
     from agent.native_compaction import native_compaction_context_management
+    from agent.astra_async_tools import is_direct_astra
+    from agent.turn_api_call import _should_stream
     is_codex_backend, is_xai_responses, is_github_responses = classify_responses_route(agent)
     # Native server-side compaction (gpt-5.6 on direct OpenAI / ChatGPT Codex routes
     # only) — None on every other route/model, leaving the request unchanged.
@@ -1439,7 +1441,8 @@ def _build_codex_kwargs(agent, api_messages, tools_for_api, reasoning_config, re
         is_codex_backend=is_codex_backend, is_xai_responses=is_xai_responses,
         github_reasoning_extra=agent._github_models_reasoning_extra_body() if is_github_responses else None,
         replay_encrypted_reasoning=bool(getattr(agent, "_codex_reasoning_replay_enabled", True)),
-        context_management=context_management)
+        context_management=context_management,
+        midstream_executor_active=bool(_should_stream(agent) and is_direct_astra(agent)))
 
 
 def _anthropic_max_output_for_model(agent):
@@ -1631,6 +1634,10 @@ def _assistant_tool_call_dict(agent, tool_call, index: int) -> dict:
     tc_dict = {"id": call_id, "call_id": call_id, "response_item_id": response_item_id,
         "type": tool_call.type,
         "function": {"name": tool_call.function.name, "arguments": tool_call.function.arguments}}
+    provider_data = getattr(tool_call, "provider_data", None) or {}
+    if getattr(tool_call, "async", False) is True or getattr(tool_call, "async_", False) is True \
+            or provider_data.get("async") is True:
+        tc_dict["async"] = True
     # Preserve extra_content (Gemini thought_signature) or Gemini 3 thinking
     # models 400 on the next request.
     # Tool-call arguments are intentionally NOT redacted here. This dict enters the in-memory conversation

--- a/agent/client_lifecycle.py
+++ b/agent/client_lifecycle.py
@@ -196,6 +196,12 @@ class ClientLifecycleMixin:
                 request_interrupt()
         except Exception:
             logger.debug("Abandoned-worker drain: codex interrupt failed", exc_info=True)
+        try:
+            request_interrupt = getattr(getattr(self, "_astra_websocket_session", None), "request_interrupt", None)
+            if callable(request_interrupt):
+                request_interrupt()
+        except Exception:
+            logger.debug("Abandoned-worker drain: Astra WebSocket interrupt failed", exc_info=True)
         # Inline (cron-style) request abort hook, when registered.
         try:
             abort_active = getattr(self, "_active_request_abort", None)

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -739,7 +739,7 @@ _PREFLIGHT_OPTIONAL_FIELDS: tuple[tuple[str, Callable[[Any], bool], Optional[Cal
     # Cache routing/retention and tool-dispatch hints pass through as-is.
     *(
         (key, lambda v: v is not None, None)
-        for key in ("tool_choice", "parallel_tool_calls", "prompt_cache_key", "prompt_cache_retention")
+        for key in ("tool_choice", "parallel_tool_calls", "prompt_cache_key", "prompt_cache_retention", "prompt_cache_options")
     ),
     # Native compaction directive; eligibility is resolved in agent/native_compaction.py.
     ("context_management", lambda v: isinstance(v, list) and bool(v), None),

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -279,13 +279,20 @@ def _derive_responses_function_call_id(call_id: str, response_item_id: Optional[
 
 # --- Schema conversion --------------------------------------------------------
 
-def _responses_tools(tools: Optional[List[Dict[str, Any]]] = None) -> Optional[List[Dict[str, Any]]]:
-    """Convert chat-completions tool schemas to Responses function-tool schemas."""
+def _responses_tools(
+    tools: Optional[List[Dict[str, Any]]] = None, *, async_tools: bool = False,
+) -> Optional[List[Dict[str, Any]]]:
+    """Convert chat-completions schemas to Responses function-tool schemas.
+
+    ``async_tools`` is explicit and only enabled by the direct Astra midstream executor.
+    It is intentionally unrelated to the registry's Python-coroutine metadata.
+    """
     fns = [item.get("function", {}) if isinstance(item, dict) else {} for item in tools or []]
     converted = [
         {
             "type": "function", "name": fn["name"], "description": fn.get("description", ""), "strict": False,
             "parameters": fn.get("parameters", {"type": "object", "properties": {}}),
+            **({"async": True} if async_tools else {}),
         }
         for fn in fns if _nonblank(fn.get("name"))
     ]
@@ -381,10 +388,13 @@ def _replay_tool_call_items(msg: Dict[str, Any], *, start_index: int) -> List[Di
             continue
         index = start_index + len(replayed)
         call_id = _resolve_call_id(tc.get("call_id"), tc.get("id"), fn_name, str(arguments), index, canonicalize_fc=True)
-        replayed.append({
+        replayed_item = {
             "type": "function_call", "call_id": _clamp_responses_call_id(call_id),
             "name": _sanitize_replayed_fn_name(fn_name), "arguments": _coerce_arguments(arguments),
-        })
+        }
+        if tc.get("async") is True or tc.get("async_") is True:
+            replayed_item["async"] = True
+        replayed.append(replayed_item)
     return replayed
 
 
@@ -584,10 +594,13 @@ def _preflight_function_call(item: Dict[str, Any], idx: int, ctx: _PreflightCtx)
         raise ValueError(f"Codex Responses input[{idx}] function_call is missing call_id.")
     if not _nonblank(name):
         raise ValueError(f"Codex Responses input[{idx}] function_call is missing name.")
-    return {
+    normalized = {
         "type": "function_call", "call_id": call_id.strip(), "name": _sanitize_replayed_fn_name(name),
         "arguments": ctx.sanitize_text(_coerce_arguments(item.get("arguments", "{}"))),
     }
+    if item.get("async") is True or item.get("async_") is True:
+        normalized["async"] = True
+    return normalized
 
 
 def _preflight_function_call_output(item: Dict[str, Any], idx: int, ctx: _PreflightCtx) -> Dict[str, Any]:
@@ -721,10 +734,13 @@ def _preflight_tool(tool: Any, idx: int) -> Dict[str, Any]:
     for ok, what in ((_nonblank(name), "a valid name"), (isinstance(parameters, dict), "valid parameters")):
         if not ok:
             raise ValueError(f"Codex Responses tools[{idx}] is missing {what}.")
-    return {
+    normalized = {
         "type": "function", "name": name.strip(), "description": _str_or_empty(tool.get("description", "")),
         "strict": bool(tool.get("strict", False)), "parameters": parameters,
     }
+    if tool.get("async") is True or tool.get("async_") is True:
+        normalized["async"] = True
+    return normalized
 
 
 # Optional scalar request fields, in wire order: (key, accept(value), coerce). Values
@@ -866,10 +882,14 @@ def _response_tool_call(item: Any, item_type: str, index: int) -> SimpleNamespac
     raw_item_id = getattr(item, "id", None)
     call_id = _resolve_call_id(getattr(item, "call_id", None), raw_item_id, fn_name, arguments, index, canonicalize_fc=False)
     fc_id = _derive_responses_function_call_id(call_id, raw_item_id if isinstance(raw_item_id, str) else None)
-    return SimpleNamespace(
+    tool_call = SimpleNamespace(
         id=call_id, call_id=call_id, response_item_id=fc_id, type="function",
         function=SimpleNamespace(name=fn_name, arguments=arguments),
     )
+    if getattr(item, "async", False) is True or getattr(item, "async_", False) is True:
+        setattr(tool_call, "async", True)
+        setattr(tool_call, "async_", True)
+    return tool_call
 
 
 def _capture_encrypted_item(item: Any, item_type: str, issuer_kind: Optional[str]) -> Optional[Dict[str, Any]]:

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -1024,7 +1024,10 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 raise
             executor = _astra_executor()
             if executor is not None and (executor.has_admitted or executor.has_pending or executor.failed):
-                if not executor.finish_stream(assistant_content=getattr(final, "output_text", "") or ""):
+                if not executor.finish_stream(
+                    assistant_content=getattr(final, "output_text", "") or "",
+                    settled_calls=getattr(final, "output", None),
+                ):
                     raise RuntimeError("Astra async tool execution did not reach a durable result boundary")
             elif executor is not None and executor.retire_empty():
                 agent._astra_async_executor = None

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -862,6 +862,18 @@ def _bypass_sdk_request_transform(stream_kwargs: dict) -> dict:
 
 def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta=None):
     """One streaming Responses API request over raw ``responses.create(stream=True)`` events."""
+    from agent.transports.astra_websocket_session import (
+        AstraPreDispatchError, is_astra_websocket_eligible, run_astra_websocket_stream,
+    )
+    if is_astra_websocket_eligible(agent, api_kwargs):
+        try:
+            # The WS API has implicit streaming and receives the already-built Responses body directly.
+            return run_astra_websocket_stream(
+                agent, _sanitize_consumer_codex_request(agent, api_kwargs), on_first_delta=on_first_delta,
+            )
+        except AstraPreDispatchError as exc:
+            # A connect failure before any request bytes were sent is the only safe native-WS fallback.
+            logger.warning("Astra WebSocket connect failed before dispatch; falling back to SSE: %s", exc)
     import httpx as _httpx
     from openai import APIConnectionError as _APIConnectionError
     from agent import relay_llm

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -535,6 +535,11 @@ def _output_text_of(item: Any) -> str:
     ).strip()
 
 
+def _provider_async_marker(item: Any) -> bool:
+    """Read the Responses provider's async marker without conflating it with tool metadata."""
+    return any(_event_field(item, key, False) is True for key in ("async", "async_"))
+
+
 class _CodexResponseAssembler:
     """Assemble a Response-shaped ``SimpleNamespace`` from raw Responses SSE events.
 
@@ -552,9 +557,11 @@ class _CodexResponseAssembler:
     # terminal_status defaults to "completed", so settlement needs an explicitly observed response.completed frame.
     saw_response_completed = False
 
-    def __init__(self, *, model, on_text_delta, on_reasoning_delta, on_commentary_message, on_first_delta):
+    def __init__(self, *, model, on_text_delta, on_reasoning_delta, on_commentary_message, on_first_delta,
+                 on_async_tool_call=None):
         self.model, self.on_text_delta, self.on_reasoning_delta = model, on_text_delta, on_reasoning_delta
         self.on_commentary_message, self.on_first_delta = on_commentary_message, on_first_delta
+        self.on_async_tool_call = on_async_tool_call
         self.output_items: List[Any] = []
         # output_index / first-observed sequence per output item, in lockstep, so settled pending calls merge
         # back in stream order.
@@ -564,6 +571,27 @@ class _CodexResponseAssembler:
         # first-observed (sequence, output_index) per announced item id so a later .done keeps its announced position.
         self.pending_function_calls: Dict[str, Dict[str, Any]] = {}
         self.announced_output_order: Dict[str, tuple] = {}
+
+    def _emit_async_tool_call(self, item: Any, arguments: Any = None) -> None:
+        """Admit one completed provider-marked call exactly once."""
+        if not _provider_async_marker(item) or self.on_async_tool_call is None:
+            return
+        item_id = str(_event_field(item, "id", "") or _event_field(item, "call_id", ""))
+        pending = self.pending_function_calls.get(item_id) if item_id else None
+        if pending is not None and pending.get("async_emitted"):
+            return
+        if pending is not None:
+            pending["async_emitted"] = True
+        call_arguments = (str(arguments) if arguments is not None else str(_event_field(item, "arguments", "") or "")) or "{}"
+        call_name = _event_field(item, "name", None)
+        call = SimpleNamespace(
+            type="function", id=_event_field(item, "id", None), call_id=_event_field(item, "call_id", None),
+            response_item_id=_event_field(item, "id", None), status="completed",
+            function=SimpleNamespace(name=call_name, arguments=call_arguments),
+        )
+        setattr(call, "async", True)
+        setattr(call, "async_", True)
+        self._safe(self.on_async_tool_call, "on_async_tool_call", call)
 
     def _safe(self, cb: Callable | None, label: str, *args: Any) -> None:
         _call_guarded(cb, f"Codex stream {label} raised", args=args)
@@ -623,6 +651,7 @@ class _CodexResponseAssembler:
             # missing field keeps the streamed deltas.
             if (done_args := _event_field(event, "arguments", None)) is not None:
                 pending["arguments"] = str(done_args)
+            self._emit_async_tool_call(pending["item"], pending["arguments"] or "{}")
 
     def _on_reasoning_delta(self, event: Any, event_type: str) -> None:
         reasoning_text = _event_field(event, "delta", "")
@@ -649,6 +678,8 @@ class _CodexResponseAssembler:
         self.output_indexes.append(_event_field(event, "output_index", announced_index))
         self.output_sequences.append(announced_sequence)
         # Confirmed by the authoritative done event; never settle it twice.
+        if "function_call" in str(_event_field(done_item, "type", "")):
+            self._emit_async_tool_call(done_item, _event_field(done_item, "arguments", "{}"))
         self.pending_function_calls.pop(done_id, None)
         if _message_phase(done_item) == "commentary" and self.on_commentary_message is not None:
             commentary_text = "".join(self.commentary_text_deltas).strip() or _output_text_of(done_item)
@@ -696,13 +727,17 @@ class _CodexResponseAssembler:
         indexed = list(zip(self.output_indexes, self.output_sequences, self.output_items))
         for pending in self.pending_function_calls.values():
             item = pending["item"]
-            indexed.append((pending.get("output_index"), pending["sequence"], SimpleNamespace(
+            settled_arguments = (pending["arguments"] or "").strip() or "{}"
+            self._emit_async_tool_call(item, settled_arguments)
+            settled_item = SimpleNamespace(
                 type="function_call", id=_event_field(item, "id", None), call_id=_event_field(item, "call_id", None),
                 name=_event_field(item, "name", None), status="completed",
                 # Empty/whitespace arguments become "{}" so zero-delta calls stay executable; malformed
                 # non-empty JSON passes through untouched.
-                arguments=(pending["arguments"] or "").strip() or "{}",
-            )))
+                arguments=settled_arguments,
+                **({"async": True} if _provider_async_marker(item) else {}),
+            )
+            indexed.append((pending.get("output_index"), pending["sequence"], settled_item))
         # output_index is optional: protocol order only when every entry has one, else wire order.
         if all(entry[0] is not None for entry in indexed):
             with suppress(TypeError):  # non-comparable index values: keep wire order
@@ -732,7 +767,7 @@ class _CodexResponseAssembler:
 
 def _consume_codex_event_stream(
     event_iter: Any, *, model: str, on_text_delta=None, on_reasoning_delta=None, on_commentary_message=None,
-    on_first_delta=None, on_event=None, interrupt_check=None,
+    on_first_delta=None, on_event=None, interrupt_check=None, on_async_tool_call=None,
 ) -> SimpleNamespace:
     """Consume a Codex Responses SSE stream into a Response-shaped ``SimpleNamespace`` (see
     :class:`_CodexResponseAssembler`; ``status`` is ``completed`` when the stream ended with content but no
@@ -745,7 +780,8 @@ def _consume_codex_event_stream(
     True breaks the loop and may raise ``TimeoutError`` / ``InterruptedError`` for request retirement that
     must not become a partial final response."""
     assembler = _CodexResponseAssembler(model=model, on_text_delta=on_text_delta, on_reasoning_delta=on_reasoning_delta,
-                                        on_commentary_message=on_commentary_message, on_first_delta=on_first_delta)
+                                        on_commentary_message=on_commentary_message, on_first_delta=on_first_delta,
+                                        on_async_tool_call=on_async_tool_call)
     for event in event_iter:
         if on_event is not None:
             try:
@@ -910,6 +946,11 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
     on_commentary_message = _fenced(lambda text: agent._fire_streamed_codex_commentary(text)) if wants_commentary else None
     call_role = ("delegated" if getattr(agent, "is_subagent", False)
                  else "fallback" if int(getattr(agent, "_fallback_index", 0) or 0) > 0 else "primary")
+    from agent.astra_async_tools import is_direct_astra
+
+    def _astra_executor():
+        return getattr(agent, "_astra_async_executor", None) if is_direct_astra(agent) else None
+
     for attempt in range(max_stream_retries + 1):
         if agent._interrupt_requested:
             raise InterruptedError("Agent interrupted before Codex stream retry")
@@ -929,13 +970,28 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                               "api_request_id": getattr(agent, "_current_api_request_id", None)},
                     defer_logical_completion=True,
                 )
+                async_executor = _astra_executor()
+                async_callback = getattr(async_executor, "admit", None)
+                async_callback = _fenced(async_callback) if callable(async_callback) else None
                 final = _consume_codex_event_stream(
                     event_stream, model=model, on_text_delta=_fenced(_on_text_delta),
                     on_reasoning_delta=_fenced(lambda text: agent._fire_reasoning_delta(text)),
                     on_commentary_message=on_commentary_message, on_first_delta=on_first_delta,
                     on_event=_fenced(_on_event), interrupt_check=_interrupt_or_superseded,
+                    on_async_tool_call=async_callback,
                 )
+            except (InterruptedError, TimeoutError):
+                executor = _astra_executor()
+                if executor is not None:
+                    executor.abort_stream()
+                raise
             except transport_errors as exc:
+                executor = _astra_executor()
+                if executor is not None and executor.has_admitted:
+                    # A durable assistant fragment already owns every admitted side effect.  Do not
+                    # retry this physical request: the resume cleanup will classify any unpaired call.
+                    executor.abort_stream()
+                    raise
                 if attempt >= max_stream_retries:
                     _log_failure(exc)
                     raise
@@ -947,12 +1003,24 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 continue
             except RuntimeError:
                 # "No terminal response"; Relay may still hold a finalizer-assembled response.
+                executor = _astra_executor()
+                if executor is not None and (executor.has_admitted or executor.failed):
+                    executor.abort_stream()
                 if event_stream is not None and event_stream.final_response is not None:
                     return event_stream.final_response
                 raise
             except _APIConnectionError as exc:
+                executor = _astra_executor()
+                if executor is not None and executor.has_admitted:
+                    executor.abort_stream()
                 _log_failure(exc)
                 raise
+            executor = _astra_executor()
+            if executor is not None and (executor.has_admitted or executor.failed):
+                if not executor.finish_stream(assistant_content=getattr(final, "output_text", "") or ""):
+                    raise RuntimeError("Astra async tool execution did not reach a durable result boundary")
+            elif executor is not None and executor.retire_empty():
+                agent._astra_async_executor = None
             if not agent._interrupt_requested:
                 _drain_for_finalizer(event_stream)
             if final.status in {"incomplete", "failed"}:

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -558,10 +558,11 @@ class _CodexResponseAssembler:
     saw_response_completed = False
 
     def __init__(self, *, model, on_text_delta, on_reasoning_delta, on_commentary_message, on_first_delta,
-                 on_async_tool_call=None):
+                 on_async_tool_call=None, on_async_tool_announcement=None):
         self.model, self.on_text_delta, self.on_reasoning_delta = model, on_text_delta, on_reasoning_delta
         self.on_commentary_message, self.on_first_delta = on_commentary_message, on_first_delta
         self.on_async_tool_call = on_async_tool_call
+        self.on_async_tool_announcement = on_async_tool_announcement
         self.output_items: List[Any] = []
         # output_index / first-observed sequence per output item, in lockstep, so settled pending calls merge
         # back in stream order.
@@ -616,6 +617,8 @@ class _CodexResponseAssembler:
                     "item": item, "arguments": str(_event_field(item, "arguments", "") or ""),
                     "output_index": announced_index, "sequence": announced_sequence,
                 }
+                if _provider_async_marker(item):
+                    self._safe(self.on_async_tool_announcement, "on_async_tool_announcement", item)
 
     def _on_text_delta(self, event: Any, event_type: str) -> None:
         delta_text = _event_field(event, "delta", "")
@@ -768,6 +771,7 @@ class _CodexResponseAssembler:
 def _consume_codex_event_stream(
     event_iter: Any, *, model: str, on_text_delta=None, on_reasoning_delta=None, on_commentary_message=None,
     on_first_delta=None, on_event=None, interrupt_check=None, on_async_tool_call=None,
+    on_async_tool_announcement=None,
 ) -> SimpleNamespace:
     """Consume a Codex Responses SSE stream into a Response-shaped ``SimpleNamespace`` (see
     :class:`_CodexResponseAssembler`; ``status`` is ``completed`` when the stream ended with content but no
@@ -781,7 +785,8 @@ def _consume_codex_event_stream(
     must not become a partial final response."""
     assembler = _CodexResponseAssembler(model=model, on_text_delta=on_text_delta, on_reasoning_delta=on_reasoning_delta,
                                         on_commentary_message=on_commentary_message, on_first_delta=on_first_delta,
-                                        on_async_tool_call=on_async_tool_call)
+                                        on_async_tool_call=on_async_tool_call,
+                                        on_async_tool_announcement=on_async_tool_announcement)
     for event in event_iter:
         if on_event is not None:
             try:
@@ -973,12 +978,14 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 async_executor = _astra_executor()
                 async_callback = getattr(async_executor, "admit", None)
                 async_callback = _fenced(async_callback) if callable(async_callback) else None
+                async_announcement = getattr(async_executor, "reserve", None)
+                async_announcement = _fenced(async_announcement) if callable(async_announcement) else None
                 final = _consume_codex_event_stream(
                     event_stream, model=model, on_text_delta=_fenced(_on_text_delta),
                     on_reasoning_delta=_fenced(lambda text: agent._fire_reasoning_delta(text)),
                     on_commentary_message=on_commentary_message, on_first_delta=on_first_delta,
                     on_event=_fenced(_on_event), interrupt_check=_interrupt_or_superseded,
-                    on_async_tool_call=async_callback,
+                    on_async_tool_call=async_callback, on_async_tool_announcement=async_announcement,
                 )
             except (InterruptedError, TimeoutError):
                 executor = _astra_executor()
@@ -1016,7 +1023,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 _log_failure(exc)
                 raise
             executor = _astra_executor()
-            if executor is not None and (executor.has_admitted or executor.failed):
+            if executor is not None and (executor.has_admitted or executor.has_pending or executor.failed):
                 if not executor.finish_stream(assistant_content=getattr(final, "output_text", "") or ""):
                     raise RuntimeError("Astra async tool execution did not reach a durable result boundary")
             elif executor is not None and executor.retire_empty():

--- a/agent/interrupt_control.py
+++ b/agent/interrupt_control.py
@@ -310,6 +310,9 @@ class InterruptControlMixin:
         with _ic_lock(self, "_pending_redirect_lock"):
             text = _ic_slot(self, "_pending_redirect_lock", "_pending_redirect")
             self._pending_redirect = None
+            if text and getattr(self, "_astra_pending_redirect_receipts", None):
+                self._astra_drained_redirect_receipts = self._astra_pending_redirect_receipts
+                self._astra_pending_redirect_receipts = []
         return text
 
     def _drain_pending_steer(self) -> Optional[str]:

--- a/agent/interrupt_control.py
+++ b/agent/interrupt_control.py
@@ -317,6 +317,4 @@ class InterruptControlMixin:
         with _ic_lock(self, "_pending_steer_lock"):
             text = _ic_slot(self, "_pending_steer_lock", "_pending_steer")
             self._pending_steer = None
-        if text:
-            self._astra_steer_drain_claim = text
         return text

--- a/agent/interrupt_control.py
+++ b/agent/interrupt_control.py
@@ -317,4 +317,6 @@ class InterruptControlMixin:
         with _ic_lock(self, "_pending_steer_lock"):
             text = _ic_slot(self, "_pending_steer_lock", "_pending_steer")
             self._pending_steer = None
+        if text:
+            self._astra_steer_drain_claim = text
         return text

--- a/agent/interrupt_control.py
+++ b/agent/interrupt_control.py
@@ -57,6 +57,14 @@ def _ic_codex_method(agent, name: str):
     return method if callable(method) else None
 
 
+def _ic_astra_method(agent, name: str):
+    """Return a live direct-Astra WebSocket control hook, if this turn owns one."""
+    if getattr(agent, "api_mode", None) != "codex_responses":
+        return None
+    method = getattr(getattr(agent, "_astra_websocket_session", None), name, None)
+    return method if callable(method) else None
+
+
 def _ic_abort_active_request(agent, reason: str, failure_log: str) -> None:
     """Shut the registered in-flight request's sockets (cron turns register their client here)."""
     abort = getattr(agent, "_active_request_abort", None)
@@ -219,6 +227,18 @@ class InterruptControlMixin:
         if not text or not text.strip():
             return False
         cleaned = text.strip()
+        _native_steer = _ic_astra_method(self, "request_steer")
+        if _native_steer is not None:
+            try:
+                return bool(_native_steer(cleaned))
+            except Exception:
+                # A post-dispatch socket outcome is ambiguous: never let the caller enqueue a duplicate.
+                session = getattr(self, "_astra_websocket_session", None)
+                if getattr(session, "delivery_uncertain", False):
+                    logger.warning("Astra WebSocket steer outcome is delivery-uncertain; suppressing resend")
+                    return True
+                logger.debug("Astra WebSocket steer failed before admission", exc_info=True)
+                return False
         with _ic_lock(self, "_pending_steer_lock"):
             existing = _ic_slot(self, "_pending_steer_lock", "_pending_steer")
             self._pending_steer = (existing + "\n" + cleaned) if existing else cleaned
@@ -233,7 +253,7 @@ class InterruptControlMixin:
             return False
         cleaned = text.strip()
 
-        _native_steer = _ic_codex_method(self, "request_steer")
+        _native_steer = _ic_codex_method(self, "request_steer") or _ic_astra_method(self, "request_steer")
         if _native_steer is not None:
             with _ic_lock(self, "_pending_redirect_lock"):
                 if self._interrupt_requested:

--- a/agent/interrupt_control.py
+++ b/agent/interrupt_control.py
@@ -253,7 +253,10 @@ class InterruptControlMixin:
             return False
         cleaned = text.strip()
 
-        _native_steer = _ic_codex_method(self, "request_steer") or _ic_astra_method(self, "request_steer")
+        _native_steer = _ic_codex_method(self, "request_steer")
+        _astra_redirect = _native_steer is None
+        if _astra_redirect:
+            _native_steer = _ic_astra_method(self, "request_steer")
         if _native_steer is not None:
             with _ic_lock(self, "_pending_redirect_lock"):
                 if self._interrupt_requested:
@@ -261,6 +264,12 @@ class InterruptControlMixin:
             try:
                 return bool(_native_steer(cleaned))
             except Exception:
+                # A post-dispatch socket outcome is ambiguous: the gateway must not
+                # turn the same correction into an interrupt/requeue duplicate.
+                session = getattr(self, "_astra_websocket_session", None) if _astra_redirect else None
+                if getattr(session, "delivery_uncertain", False):
+                    logger.warning("Astra WebSocket redirect outcome is delivery-uncertain; suppressing resend")
+                    return True
                 logger.debug("Codex app-server turn/steer failed", exc_info=True)
                 return False
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1437,7 +1437,7 @@ def _query_anthropic_context_length(model: str, base_url: str, api_key: str) -> 
 # Codex OAuth `context_window` values (what Codex enforces — lower than the direct API for the same
 # slugs). Fallback when the live probe fails; longest-key-first. gpt-5.3-codex-spark is listed so "gpt-5.3-codex" doesn't win.
 _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
-    "gpt-6-astra": 1_050_000,
+    "gpt-6-astra": 272_000,
     "gpt-5.1-codex-max": 272_000, "gpt-5.1-codex-mini": 272_000, "gpt-5.3-codex": 272_000,
     "gpt-5.3-codex-spark": 128_000, "gpt-5.2-codex": 272_000, "gpt-5.4-mini": 272_000,
     "gpt-5.6-sol": 272_000, "gpt-5.6-terra": 272_000, "gpt-5.6-luna": 272_000, "gpt-daybreak-blue-latest": 272_000,

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1449,13 +1449,16 @@ _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
 # The bump fires ONLY when the resolved value is exactly the stale 272,000. ``gpt-5.6`` is a FAMILY
 # PREFIX (``-pro`` slugs aren't routable on Codex); ``gpt-5.4`` is EXACT because gpt-5.4-mini enforces 272K.
 _CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_PREFIXES: Dict[str, int] = {"gpt-5.6": 900_000}  # sol / terra / luna
-_CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_EXACT: Dict[str, int] = {"gpt-5.4": 900_000, "gpt-daybreak-blue-latest": 900_000}
+_CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_EXACT: Dict[str, int] = {
+    "gpt-5.4": 900_000, "gpt-daybreak-blue-latest": 900_000,
+    "gpt-6-astra": 900_000,  # advertised 272K; 920,043 input OK, 1,000,043 rejected (live 2026-09-04)
+}
 _CODEX_OAUTH_STALE_ADVERTISED_CTX = 272_000  # the only advertised value the bump may override
 CODEX_CONTEXT_VARIANT_SUFFIX = "-900k"  # picker-only opt-in suffix; never sent on the wire
 # The ONLY bases eligible for ``-900k``: routable, live-verified. No family prefixing (it would synthesize
 # dead ``-pro`` variants); dated snapshots of the 5.6 bases are allowed. gpt-daybreak-blue-latest is a verified Sol alias.
 _CODEX_900K_SNAPSHOT_BASES = ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna")
-_CODEX_900K_ELIGIBLE_BASES = frozenset({*_CODEX_900K_SNAPSHOT_BASES, "gpt-5.4", "gpt-daybreak-blue-latest"})
+_CODEX_900K_ELIGIBLE_BASES = frozenset({*_CODEX_900K_SNAPSHOT_BASES, "gpt-5.4", "gpt-daybreak-blue-latest", "gpt-6-astra"})
 _CODEX_900K_SNAPSHOT_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -331,6 +331,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     # OpenAI — direct-API windows (Codex OAuth caps gpt-5.4+/5.5/5.6 at 272K, resolved by
     # its own branch). 5.4-nano/-mini are 400k, not 1.05M; gpt-5.3-codex-spark is
     # Codex-OAuth-only and listed so "gpt-5" (400k) doesn't win.
+    "gpt-6-astra": 1_050_000,
     "gpt-5.6-luna": 1050000, "gpt-5.6-terra": 1050000, "gpt-5.6-sol": 1050000, "gpt-5.5": 1050000,
     "gpt-5.4-nano": 400000, "gpt-5.4-mini": 400000, "gpt-5.4": 1050000,
     "gpt-5.3-codex-spark": 128000, "gpt-5.1-chat": 128000, "gpt-5": 400000,
@@ -1436,6 +1437,7 @@ def _query_anthropic_context_length(model: str, base_url: str, api_key: str) -> 
 # Codex OAuth `context_window` values (what Codex enforces — lower than the direct API for the same
 # slugs). Fallback when the live probe fails; longest-key-first. gpt-5.3-codex-spark is listed so "gpt-5.3-codex" doesn't win.
 _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
+    "gpt-6-astra": 1_050_000,
     "gpt-5.1-codex-max": 272_000, "gpt-5.1-codex-mini": 272_000, "gpt-5.3-codex": 272_000,
     "gpt-5.3-codex-spark": 128_000, "gpt-5.2-codex": 272_000, "gpt-5.4-mini": 272_000,
     "gpt-5.6-sol": 272_000, "gpt-5.6-terra": 272_000, "gpt-5.6-luna": 272_000, "gpt-daybreak-blue-latest": 272_000,

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -107,7 +107,7 @@ class ModelCapabilities:
 # Hermes provider names → models.dev provider IDs
 PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "openrouter": "openrouter", "novita": "novita-ai", "anthropic": "anthropic",
-    "openai": "openai", "openai-codex": "openai", "zai": "zai",
+    "openai": "openai", "openai-api": "openai", "openai-codex": "openai", "zai": "zai",
     "kimi": "kimi-for-coding", "kimi-coding": "kimi-for-coding",
     "moonshot": "kimi-for-coding", "stepfun": "stepfun",
     "kimi-coding-cn": "kimi-for-coding", "minimax": "minimax",

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -522,6 +522,19 @@ _OVERRIDE_WARNED_KEYS: set = set()
 # shared by get_model_capabilities and get_model_info so the two unknown-model paths agree.
 _UNKNOWN_MODEL_BASE: Dict[str, Any] = {"limit": {"context": 200000, "output": 8192}, "tool_call": True}
 
+# Account-gated models may be usable before models.dev has indexed them.  Keep
+# their capabilities available for an explicitly selected/discovered model
+# without adding them to any picker catalog.
+_BUILTIN_MODEL_METADATA: Dict[Tuple[str, str], Dict[str, Any]] = {
+    ("openai", "gpt-6-astra"): {
+        "limit": {"context": 1_050_000, "output": 128_000},
+        "modalities": {"input": ["text", "image"], "output": ["text"]},
+        "tool_call": True,
+        "reasoning": True,
+        "family": "gpt-6",
+    },
+}
+
 
 def _load_model_overrides() -> Dict[str, Any]:
     """The ``model_overrides`` config section ({} on any failure). Deliberately not memoized:
@@ -646,8 +659,11 @@ def _merge_catalog_entry_with_override(raw: Dict[str, Any], override: Dict[str, 
 def _apply_overrides(provider: str, model: str, entry: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
     """*entry* patched by its override; ``_UNKNOWN_MODEL_BASE`` patched by a fill-gap override on a
     catalog miss (selected AFTER lookup: _default only fills misses); None when neither exists."""
-    override = _override_for(provider, model, catalog_hit=entry is not None)
-    return entry if override is None else _merge_catalog_entry_with_override(entry if entry is not None else _UNKNOWN_MODEL_BASE, override)
+    provider_key = PROVIDER_TO_MODELS_DEV.get((provider or "").strip(), (provider or "").strip())
+    builtin = _BUILTIN_MODEL_METADATA.get((provider_key, (model or "").strip().lower()))
+    base = entry if entry is not None else builtin
+    override = _override_for(provider, model, catalog_hit=base is not None)
+    return base if override is None else _merge_catalog_entry_with_override(base if base is not None else _UNKNOWN_MODEL_BASE, override)
 
 
 def _entry_supports_vision(entry: Dict[str, Any]) -> bool:

--- a/agent/reasoning_effort.py
+++ b/agent/reasoning_effort.py
@@ -83,7 +83,7 @@ META_AI_EFFORTS: tuple[str, ...] = ("minimal", "low", "medium", "high", "xhigh")
 
 def codex_supported_efforts(model: Optional[str]) -> tuple[str, ...]:
     """Supported effort set for an OpenAI/Codex Responses model."""
-    if (model or "").strip().lower().rsplit("/", 1)[-1] == "gpt-6-astra":
+    if (model or "").strip().lower().rsplit("/", 1)[-1] in ("gpt-6-astra", "gpt-6-astra-900k"):
         return CODEX_ASTRA_EFFORTS
     return CODEX_GPT56_EFFORTS if "gpt-5.6" in (model or "").lower() else CODEX_LEGACY_EFFORTS
 

--- a/agent/reasoning_effort.py
+++ b/agent/reasoning_effort.py
@@ -31,6 +31,9 @@ OPENAI_COMPAT_WIRE_EFFORTS: tuple[str, ...] = ("none", "minimal", "low", "medium
 #: both (clamps to low); ``max`` is gpt-5.6-only.
 CODEX_GPT56_EFFORTS: tuple[str, ...] = ("none", "low", "medium", "high", "xhigh", "max")
 CODEX_LEGACY_EFFORTS: tuple[str, ...] = ("none", "low", "medium", "high", "xhigh")
+# GPT-6 Astra is account-gated and its Responses API accepts no disable/minimal
+# wire level; callers normalize those requests to ``low`` at the transport boundary.
+CODEX_ASTRA_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh", "max")
 
 #: xAI Responses — Grok 4.6+ accepts xhigh; older Grok tops out at high.
 XAI_GROK46_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh")
@@ -80,6 +83,8 @@ META_AI_EFFORTS: tuple[str, ...] = ("minimal", "low", "medium", "high", "xhigh")
 
 def codex_supported_efforts(model: Optional[str]) -> tuple[str, ...]:
     """Supported effort set for an OpenAI/Codex Responses model."""
+    if (model or "").strip().lower().rsplit("/", 1)[-1] == "gpt-6-astra":
+        return CODEX_ASTRA_EFFORTS
     return CODEX_GPT56_EFFORTS if "gpt-5.6" in (model or "").lower() else CODEX_LEGACY_EFFORTS
 
 

--- a/agent/transports/astra_websocket_session.py
+++ b/agent/transports/astra_websocket_session.py
@@ -330,7 +330,10 @@ class AstraWebSocketSession:
     def _is_duplicate(self, event: Any, event_type: str, response_id: str | None) -> bool:
         sequence_number = _event_field(event, "sequence_number")
         if sequence_number is not None:
-            sequence_key = str(sequence_number)
+            # Sequence numbers are monotonic only within one response generation; automatic successors may
+            # restart at zero/one on the same WebSocket. Scope the key before deciding whether to drop a frame.
+            sequence_scope = response_id or self._response_id or "session"
+            sequence_key = f"{sequence_scope}:{sequence_number}"
             if sequence_key in self._seen_sequences:
                 return True
             self._seen_sequences.add(sequence_key)
@@ -475,10 +478,16 @@ class AstraWebSocketSession:
                 # Claim terminal ownership before feeding the event.  A concurrent steer that observes
                 # terminal processing has begun must return False rather than dispatching after completion.
                 terminal_event = event_type in {"response.completed", "response.incomplete", "response.failed"}
-                terminal_waits_for_successor = self._await_successor or self._terminal_reason(event) == "steered"
-                if terminal_event and not terminal_waits_for_successor:
+                terminal_waits_for_successor = False
+                if terminal_event:
+                    # The wait decision and terminal claim are one linearization point. A steer can either
+                    # acquire this lock first (and force successor wait) or observe TERMINAL_PROCESSING and
+                    # return False; it cannot be admitted against a stale pre-lock snapshot.
                     with self._state_lock:
-                        if self._state in {"ACTIVE", "SUCCESSOR_CREATED", "ACCEPTED", "STEER_ADMITTED"}:
+                        terminal_waits_for_successor = self._await_successor or self._terminal_reason(event) == "steered"
+                        if terminal_waits_for_successor:
+                            pass
+                        elif self._state in {"ACTIVE", "SUCCESSOR_CREATED", "ACCEPTED", "STEER_ADMITTED"}:
                             self._set_state("TERMINAL_PROCESSING")
                 terminal = assembler.feed(event)
                 if terminal:

--- a/agent/transports/astra_websocket_session.py
+++ b/agent/transports/astra_websocket_session.py
@@ -23,10 +23,11 @@ logger = logging.getLogger(__name__)
 _STEERING_MODEL_CONFIG_KEY = "_astra_steering"
 _STEERING_JOURNAL_VERSION = 1
 _STEERING_JOURNAL_LIMIT = 16
-_STEERING_UNRESOLVED_STATES = frozenset({"prepared", "sent", "failed", "accepted", "ambiguous"})
+_STEERING_UNRESOLVED_STATES = frozenset({"prepared", "sent", "failed", "accepted", "ambiguous", "fallback_queued"})
 _STEERING_STATE_RANK = {
     "prepared": 10, "sent": 20, "failed": 25, "accepted": 30,
     "ambiguous": 40, "successor_created": 50, "fallback_queued": 60,
+    "fallback_delivered": 70,
 }
 
 
@@ -155,6 +156,58 @@ def _parse_model_config(raw: Any) -> dict[str, Any]:
     return {}
 
 
+def _queue_failed_redirects(agent: Any, entries: list[dict[str, Any]]) -> None:
+    """Keep exact admission identities on Hermes' internal redirect queue until persistence."""
+    lock = getattr(agent, "_pending_redirect_lock", None) or threading.RLock()
+    with lock:
+        queued = getattr(agent, "_astra_pending_redirect_receipts", None) or []
+        drained = getattr(agent, "_astra_drained_redirect_receipts", None) or []
+        known = {item["admission_id"] for item in [*queued, *drained]}
+        for entry in entries:
+            if entry.get("state") not in {"failed", "fallback_queued"}:
+                continue
+            admission_id, text = entry.get("admission_id"), entry.get("text")
+            if not admission_id or not isinstance(text, str) or not text or admission_id in known:
+                continue
+            existing = getattr(agent, "_pending_redirect", None)
+            agent._pending_redirect = f"{existing}\n\n[Additional user correction]\n{text}" if existing else text
+            queued.append({"admission_id": admission_id, "input_sha256": entry.get("input_sha256", "")})
+            known.add(admission_id)
+        agent._astra_pending_redirect_receipts = queued
+
+
+def restore_astra_fallback_redirects(agent: Any) -> None:
+    """Restore before iteration preparation, including after a crash with no tool result."""
+    if not is_astra_websocket_eligible(agent):
+        return
+    session_id = str(getattr(agent, "session_id", "") or "")
+    if getattr(agent, "_astra_fallback_restore_session", None) == session_id:
+        return
+    getter = getattr(getattr(agent, "_session_db", None), "get_session_model_config_value", None)
+    if not session_id or not callable(getter):
+        return
+    raw = getter(session_id, _STEERING_MODEL_CONFIG_KEY, {})
+    entries = raw.get("entries", []) if isinstance(raw, dict) else []
+    _queue_failed_redirects(agent, [entry for entry in entries if isinstance(entry, dict)])
+    agent._astra_fallback_restore_session = session_id
+
+
+def confirm_astra_redirect_persisted(agent: Any, receipts: list[dict[str, Any]]) -> None:
+    """Do not send another request until the user row and its acknowledgement are durable."""
+    if not receipts:
+        return
+    getter = getattr(getattr(agent, "_session_db", None), "get_session_model_config_value", None)
+    if not callable(getter):
+        raise AstraSteeringPersistenceError("Astra fallback redirect has no durable session store")
+    raw = getter(agent.session_id, _STEERING_MODEL_CONFIG_KEY, {})
+    entries = raw.get("entries", []) if isinstance(raw, dict) else []
+    saved = {entry.get("admission_id") for entry in entries
+             if isinstance(entry, dict) and entry.get("state") == "fallback_delivered"}
+    if any(receipt["admission_id"] not in saved for receipt in receipts):
+        raise AstraSteeringPersistenceError("Astra fallback redirect was not durably delivered")
+    agent._astra_drained_redirect_receipts = []
+
+
 def _safe_steering_text(text: str) -> str:
     """Keep the journal useful without copying credential-like text into metadata."""
     try:
@@ -247,21 +300,7 @@ class AstraWebSocketSession:
                      if isinstance(entry.get("generation", 0), int)),
                     default=0,
                 )
-            # An explicit provider failure is the sole state eligible for the legacy one-shot fallback.
-            fallback_changed = False
-            for entry in self._steering_receipts:
-                if entry.get("state") == "failed":
-                    text = str(entry.get("text") or "").strip()
-                    if text:
-                        pending = str(getattr(self.agent, "_pending_steer", "") or "")
-                        if text not in pending.splitlines():
-                            _append_pending(self.agent, text)
-                    # Claim the one legacy fallback durably before exposing a
-                    # fresh session to another restart, even when text is empty.
-                    entry["state"] = "fallback_queued"
-                    fallback_changed = True
-            if fallback_changed:
-                self._persist_steering_receipts()
+            _queue_failed_redirects(self.agent, self._steering_receipts)
         except Exception as exc:
             self._steering_persistence_error = exc
             self._steering_load_failed = True
@@ -301,7 +340,7 @@ class AstraWebSocketSession:
             self._steering_persistence_error = exc
             raise AstraSteeringPersistenceError("Astra steering ownership admission could not be persisted") from exc
 
-    def _record_steering_state(self, sequence: int, state: str) -> None:
+    def _record_steering_state(self, sequence: int, state: str) -> bool:
         with self._steering_receipt_lock:
             for entry in reversed(self._steering_receipts):
                 if entry.get("generation") == sequence:
@@ -311,10 +350,12 @@ class AstraWebSocketSession:
                     break
             try:
                 self._persist_steering_receipts()
+                return True
             except Exception:
                 # A pre-dispatch record already exists. Never turn an accepted/ambiguous
                 # wire outcome into a retry merely because its later state stamp failed.
                 logger.warning("Astra steering ownership state update failed", exc_info=True)
+                return False
 
     def _append_steering_receipt(self, sequence: int, text: str, previous_id: str) -> None:
         safe_text = _safe_steering_text(text)
@@ -620,11 +661,15 @@ class AstraWebSocketSession:
                 if pending is not None:
                     pending.failed = True
                     sequence = pending.sequence
+                    _remove_pending(self.agent, pending.text)
                 self._await_successor = any(not item.failed and not item.accepted for item in self._steers.values())
                 self._set_state("ACTIVE")
             if sequence is not None:
-                # The explicit failure transfers ownership to the one-shot legacy queue.
-                self._record_steering_state(sequence, "fallback_queued")
+                # Redirect stays internal to the agent loop even when there is no tool
+                # result. Its user row acknowledges this receipt in one DB transaction.
+                if not self._record_steering_state(sequence, "failed"):
+                    raise AstraSteeringPersistenceError("Astra rejection could not be persisted")
+                _queue_failed_redirects(self.agent, self._steering_receipts)
         elif event_type == "response.steer.pending":
             self._set_state("PENDING_REQUIRED_INPUT")
             self._send_required_continuation(event)

--- a/agent/transports/astra_websocket_session.py
+++ b/agent/transports/astra_websocket_session.py
@@ -23,10 +23,11 @@ logger = logging.getLogger(__name__)
 _STEERING_MODEL_CONFIG_KEY = "_astra_steering"
 _STEERING_JOURNAL_VERSION = 1
 _STEERING_JOURNAL_LIMIT = 16
-_STEERING_UNRESOLVED_STATES = frozenset({"prepared", "sent", "failed", "accepted", "ambiguous"})
+_STEERING_UNRESOLVED_STATES = frozenset({"prepared", "sent", "failed", "accepted", "ambiguous", "fallback_queued"})
 _STEERING_STATE_RANK = {
     "prepared": 10, "sent": 20, "failed": 25, "accepted": 30,
     "ambiguous": 40, "successor_created": 50, "fallback_queued": 60,
+    "fallback_delivered": 70,
 }
 
 
@@ -143,6 +144,51 @@ def _remove_pending(agent: Any, text: str) -> None:
             agent._pending_steer = "\n".join(parts) or None
 
 
+def _fallback_records_for_text(agent: Any, text: str) -> list[dict[str, Any]] | None:
+    db = getattr(agent, "_session_db", None)
+    getter = getattr(db, "get_session_model_config_value", None)
+    if not callable(getter):
+        return None
+    try:
+        raw = getter(str(getattr(agent, "session_id", "") or ""), _STEERING_MODEL_CONFIG_KEY, {})
+        entries = raw.get("entries", []) if isinstance(raw, dict) else []
+        records = [entry for entry in entries if isinstance(entry, dict) and entry.get("state") in {"failed", "fallback_queued"}]
+    except Exception:
+        return []
+    if not records:
+        return None
+    for record in records:
+        if str(record.get("text") or "").strip() == text:
+            return [record]
+    for count in range(2, len(records) + 1):
+        if "\n".join(str(item.get("text") or "") for item in records[:count]) == text:
+            return records[:count]
+    return []
+
+
+def durably_deliver_fallback_steer(
+    agent: Any, target: dict[str, Any], before_content: Any, delivered_content: Any, steer_text: str,
+) -> bool | None:
+    records = _fallback_records_for_text(agent, steer_text)
+    if records is None:
+        return None
+    if not records:
+        return False
+    db = getattr(agent, "_session_db", None)
+    persist = getattr(db, "persist_astra_steering_fallback", None)
+    tool_call_id = str(target.get("tool_call_id") or "").strip()
+    session_id = str(getattr(agent, "session_id", "") or "").strip()
+    if not session_id or not tool_call_id or not callable(persist):
+        return False
+    try:
+        delivered = bool(persist(session_id, target.get("_row_id"), tool_call_id,
+                                 before_content, delivered_content, records))
+    except Exception:
+        logger.warning("Astra fallback steering delivery could not be persisted", exc_info=True)
+        return False
+    return delivered
+
+
 def _parse_model_config(raw: Any) -> dict[str, Any]:
     if isinstance(raw, dict):
         return dict(raw)
@@ -247,19 +293,22 @@ class AstraWebSocketSession:
                      if isinstance(entry.get("generation", 0), int)),
                     default=0,
                 )
-            # An explicit provider failure is the sole state eligible for the legacy one-shot fallback.
             fallback_changed = False
             for entry in self._steering_receipts:
-                if entry.get("state") == "failed":
+                if entry.get("state") in {"failed", "fallback_queued"}:
+                    claimed = str(getattr(self.agent, "_astra_steer_drain_claim", "") or "")
                     text = str(entry.get("text") or "").strip()
+                    if claimed and text and (claimed == text or text in claimed.splitlines()):
+                        if entry.get("state") == "failed": entry["state"] = "fallback_queued"; fallback_changed = True
+                        setattr(self.agent, "_astra_steer_drain_claim", "")
+                        continue
                     if text:
                         pending = str(getattr(self.agent, "_pending_steer", "") or "")
                         if text not in pending.splitlines():
                             _append_pending(self.agent, text)
-                    # Claim the one legacy fallback durably before exposing a
-                    # fresh session to another restart, even when text is empty.
-                    entry["state"] = "fallback_queued"
-                    fallback_changed = True
+                    if entry.get("state") == "failed":
+                        entry["state"] = "fallback_queued"
+                        fallback_changed = True
             if fallback_changed:
                 self._persist_steering_receipts()
         except Exception as exc:

--- a/agent/transports/astra_websocket_session.py
+++ b/agent/transports/astra_websocket_session.py
@@ -7,6 +7,7 @@ the existing Responses assembler; the socket is only a transport for the provide
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import threading
@@ -17,6 +18,19 @@ from urllib.parse import urlsplit
 from typing import Any, Callable
 
 logger = logging.getLogger(__name__)
+
+
+_STEERING_MODEL_CONFIG_KEY = "_astra_steering"
+_STEERING_JOURNAL_VERSION = 1
+_STEERING_JOURNAL_LIMIT = 16
+_STEERING_STATE_RANK = {
+    "prepared": 10, "sent": 20, "failed": 25, "accepted": 30,
+    "ambiguous": 40, "successor_created": 50, "fallback_queued": 60,
+}
+
+
+class AstraSteeringPersistenceError(RuntimeError):
+    """The durable steering admission record could not be written before dispatch."""
 
 
 class AstraPreDispatchError(RuntimeError):
@@ -128,6 +142,28 @@ def _remove_pending(agent: Any, text: str) -> None:
             agent._pending_steer = "\n".join(parts) or None
 
 
+def _parse_model_config(raw: Any) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        return dict(raw)
+    if isinstance(raw, str) and raw.strip():
+        try:
+            value = json.loads(raw)
+        except (TypeError, ValueError):
+            return {}
+        return dict(value) if isinstance(value, dict) else {}
+    return {}
+
+
+def _safe_steering_text(text: str) -> str:
+    """Keep the journal useful without copying credential-like text into metadata."""
+    try:
+        from agent.redact import redact_sensitive_text
+
+        return redact_sensitive_text(text)
+    except Exception:
+        return "[steering input redacted]"
+
+
 @dataclass
 class _Steer:
     sequence: int
@@ -161,6 +197,138 @@ class AstraWebSocketSession:
         self._seen_items: set[tuple[str, str, str]] = set()
         self.delivery_uncertain = False
         self.last_error: Exception | None = None
+        self._steering_receipts: list[dict[str, Any]] = []
+        self._steering_receipt_lock = threading.RLock()
+        self._steering_persistence_error: Exception | None = None
+        self._steering_load_failed = False
+        self._load_steering_receipts()
+
+    def _session_db(self) -> Any:
+        db = getattr(self.agent, "_session_db", None)
+        if db is None:
+            acquire = getattr(self.agent, "_get_session_db_for_recall", None)
+            if callable(acquire):
+                try:
+                    db = acquire()
+                except Exception as exc:
+                    self._steering_persistence_error = exc
+        return db
+
+    def _load_steering_receipts(self) -> None:
+        """Load only the bounded ownership journal; never reconstruct an in-flight send."""
+        db = self._session_db()
+        session_id = str(getattr(self.agent, "session_id", "") or "")
+        if db is None or not session_id:
+            return
+        try:
+            getter = getattr(db, "get_session_model_config_value", None)
+            if callable(getter):
+                raw = getter(session_id, _STEERING_MODEL_CONFIG_KEY, {})
+            else:
+                row = db.get_session(session_id)
+                raw = _parse_model_config((row or {}).get("model_config")).get(_STEERING_MODEL_CONFIG_KEY, {})
+            entries = raw.get("entries", []) if isinstance(raw, dict) else []
+            if isinstance(entries, list):
+                self._steering_receipts = [entry for entry in entries[-_STEERING_JOURNAL_LIMIT:]
+                                           if isinstance(entry, dict)]
+                self._next_sequence = max(
+                    (int(entry.get("generation", 0)) for entry in self._steering_receipts
+                     if isinstance(entry.get("generation", 0), int)),
+                    default=0,
+                )
+            # An explicit provider failure is the sole state eligible for the legacy one-shot fallback.
+            fallback_changed = False
+            for entry in self._steering_receipts:
+                if entry.get("state") == "failed":
+                    text = str(entry.get("text") or "").strip()
+                    if text:
+                        pending = str(getattr(self.agent, "_pending_steer", "") or "")
+                        if text not in pending.splitlines():
+                            _append_pending(self.agent, text)
+                        # Claim the one legacy fallback durably before exposing a
+                        # fresh session to another restart. The current in-memory
+                        # failed path already owns its pending text.
+                        entry["state"] = "fallback_queued"
+                        fallback_changed = True
+            if fallback_changed:
+                self._persist_steering_receipts()
+        except Exception as exc:
+            self._steering_persistence_error = exc
+            self._steering_load_failed = True
+            logger.warning("Astra steering ownership journal read failed; native steering is disabled")
+
+    def _persist_steering_receipts(self) -> None:
+        """Atomically replace the small journal in the existing session model metadata."""
+        db = self._session_db()
+        session_id = str(getattr(self.agent, "session_id", "") or "")
+        if self._steering_load_failed:
+            raise AstraSteeringPersistenceError("Astra steering ownership journal could not be read") from self._steering_persistence_error
+        if db is None or not session_id:
+            # Bare test doubles and legacy non-session callers retain the in-memory ABI.
+            if self._steering_persistence_error is not None:
+                raise AstraSteeringPersistenceError("Astra steering ownership journal is unavailable") from self._steering_persistence_error
+            return
+        ensure = getattr(self.agent, "_ensure_db_session", None)
+        if callable(ensure) and not bool(getattr(self.agent, "_session_db_created", True)):
+            ensure()
+            if not bool(getattr(self.agent, "_session_db_created", False)):
+                raise AstraSteeringPersistenceError("Astra session row is not durable")
+        patch = getattr(db, "patch_session_model_config", None)
+        if not callable(patch):
+            raise AstraSteeringPersistenceError("Astra session store lacks model metadata patching")
+        with self._steering_receipt_lock:
+            payload = {
+                "version": _STEERING_JOURNAL_VERSION,
+                "entries": [dict(entry) for entry in self._steering_receipts[-_STEERING_JOURNAL_LIMIT:]],
+            }
+        try:
+            patch(session_id, {_STEERING_MODEL_CONFIG_KEY: payload})
+            self._steering_persistence_error = None
+        except Exception as exc:
+            self._steering_persistence_error = exc
+            raise AstraSteeringPersistenceError("Astra steering ownership admission could not be persisted") from exc
+
+    def _record_steering_state(self, sequence: int, state: str) -> None:
+        with self._steering_receipt_lock:
+            for entry in reversed(self._steering_receipts):
+                if entry.get("generation") == sequence:
+                    old_state = str(entry.get("state") or "prepared")
+                    if _STEERING_STATE_RANK.get(state, 0) >= _STEERING_STATE_RANK.get(old_state, 0):
+                        entry["state"] = state
+                    break
+            try:
+                self._persist_steering_receipts()
+            except Exception:
+                # A pre-dispatch record already exists. Never turn an accepted/ambiguous
+                # wire outcome into a retry merely because its later state stamp failed.
+                logger.warning("Astra steering ownership state update failed", exc_info=True)
+
+    def _append_steering_receipt(self, sequence: int, text: str, previous_id: str) -> None:
+        safe_text = _safe_steering_text(text)
+        wire_input = [{"role": "user", "content": [{"type": "input_text", "text": safe_text}]}]
+        input_digest = hashlib.sha256(
+            json.dumps(
+                [{"role": "user", "content": [{"type": "input_text", "text": text}]}],
+                ensure_ascii=False, separators=(",", ":"),
+            ).encode("utf-8", errors="surrogatepass")
+        ).hexdigest()
+        session_id = str(getattr(self.agent, "session_id", "") or "")
+        admission_id = hashlib.sha256(
+            f"{session_id}\0{sequence}\0{previous_id}".encode("utf-8", errors="surrogatepass")
+        ).hexdigest()[:24]
+        with self._steering_receipt_lock:
+            self._steering_receipts.append({
+                "version": _STEERING_JOURNAL_VERSION,
+                "admission_id": admission_id,
+                "generation": sequence,
+                "response_id": previous_id,
+                "input": wire_input,
+                "input_sha256": input_digest,
+                "text": safe_text,
+                "state": "prepared",
+            })
+            del self._steering_receipts[:-_STEERING_JOURNAL_LIMIT]
+        self._persist_steering_receipts()
 
     @property
     def state(self) -> str:
@@ -208,17 +376,36 @@ class AstraWebSocketSession:
             if self._socket is None or self._state not in {"ACTIVE", "SUCCESSOR_CREATED", "ACCEPTED"} or not self._response_id:
                 return False
             previous_id = self._response_id
+            previous_state = self._state
+            previous_await_successor = self._await_successor
             sequence = self._append_steer(cleaned)
+            try:
+                # Ownership is durable before any provider bytes leave the socket.
+                self._append_steering_receipt(sequence, cleaned, previous_id)
+            except Exception:
+                with self._steering_receipt_lock:
+                    self._steering_receipts = [
+                        entry for entry in self._steering_receipts
+                        if entry.get("generation") != sequence
+                    ]
+                self._steers.pop(sequence, None)
+                self._await_successor = previous_await_successor
+                self._set_state(previous_state)
+                _remove_pending(self.agent, cleaned)
+                raise
+            wire_input = [{"role": "user", "content": [{"type": "input_text", "text": cleaned}]}]
         try:
             # Responses steering deliberately has a tiny wire shape. In particular, stream_id is never sent.
             self._send({
                 "type": "response.steer", "previous_response_id": previous_id,
-                "input": [{"role": "user", "content": [{"type": "input_text", "text": cleaned}]}],
+                "input": wire_input,
             })
         except AstraDeliveryUncertainError:
             # The provider may have accepted the input; leaving it in Hermes' fallback queue could duplicate it.
             _remove_pending(self.agent, cleaned)
+            self._record_steering_state(sequence, "ambiguous")
             raise
+        self._record_steering_state(sequence, "sent")
         return bool(sequence)
 
     def request_interrupt(self) -> None:
@@ -370,26 +557,43 @@ class AstraWebSocketSession:
                 return
             if not self._await_successor:
                 return
+            predecessor_id = self._response_id
+            successor_sequences = [
+                item.sequence for item in self._steers.values()
+                if item.previous_response_id == predecessor_id and not item.failed
+            ]
             self._response_id = response_id
             self._assemblers[response_id] = self._new_assembler(response_id)
             self._await_successor = False
             self._set_state("SUCCESSOR_CREATED")
+        # A successor is the provider's durable ownership receipt. Once observed,
+        # reconstruction must never put these steer inputs back in the fallback queue.
+        for sequence in successor_sequences:
+            self._record_steering_state(sequence, "successor_created")
 
     def _steer_event(self, event: Any, event_type: str) -> None:
         if event_type == "response.steer.accepted":
+            sequence = None
             with self._state_lock:
                 pending = next((item for item in self._steers.values() if not item.accepted and not item.failed), None)
                 if pending is not None:
                     pending.accepted = True
+                    sequence = pending.sequence
                     _remove_pending(self.agent, pending.text)
                 self._set_state("ACCEPTED")
+            if sequence is not None:
+                self._record_steering_state(sequence, "accepted")
         elif event_type == "response.steer.failed":
+            sequence = None
             with self._state_lock:
                 pending = next((item for item in self._steers.values() if not item.accepted and not item.failed), None)
                 if pending is not None:
                     pending.failed = True
+                    sequence = pending.sequence
                 self._await_successor = any(not item.failed and not item.accepted for item in self._steers.values())
                 self._set_state("ACTIVE")
+            if sequence is not None:
+                self._record_steering_state(sequence, "failed")
         elif event_type == "response.steer.pending":
             self._set_state("PENDING_REQUIRED_INPUT")
             self._send_required_continuation(event)

--- a/agent/transports/astra_websocket_session.py
+++ b/agent/transports/astra_websocket_session.py
@@ -508,6 +508,16 @@ class AstraWebSocketSession:
         if required is None:
             response = _event_field(event, "response")
             required = _event_field(response, "required_input")
+        executor = getattr(self.agent, "_astra_async_executor", None)
+        settle_required = getattr(executor, "settle_required", None)
+        if callable(settle_required):
+            required_items = required if isinstance(required, list) else ()
+            call_ids = [
+                str(item.get("call_id") or item.get("id") or "").strip()
+                for item in required_items if isinstance(item, dict)
+            ]
+            if isinstance(required, list) and not settle_required(call_ids):
+                raise AstraProtocolError("Astra async tool results were not durably settled")
         input_items = self._fill_required_input(required)
         settings = {k: v for k, v in self._request.items() if k not in {"type", "input", "stream", "previous_response_id"}}
         self._send({"type": "response.create", **settings, "previous_response_id": parent, "input": input_items})

--- a/agent/transports/astra_websocket_session.py
+++ b/agent/transports/astra_websocket_session.py
@@ -1,0 +1,482 @@
+"""Internal Responses WebSocket driver for the direct GPT-6 Astra route.
+
+The driver is deliberately small and synchronous.  Hermes owns the receive loop and
+the existing Responses assembler; the socket is only a transport for the provider's
+``response.create``/``response.steer`` events.  No other Responses route is eligible.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from types import SimpleNamespace
+from urllib.parse import urlsplit
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+
+class AstraPreDispatchError(RuntimeError):
+    """The WebSocket lane failed before the initial request could be sent."""
+
+
+class AstraDeliveryUncertainError(RuntimeError):
+    """The provider may own bytes already sent; retrying would be unsafe."""
+
+    delivery_uncertain = True
+
+
+class AstraProtocolError(RuntimeError):
+    """The provider returned an explicit protocol/error condition."""
+
+
+def _base_url_is_official(base_url: Any) -> bool:
+    try:
+        parsed = urlsplit(str(base_url or "").strip())
+    except ValueError:
+        return False
+    return parsed.scheme == "https" and parsed.hostname == "api.openai.com" and parsed.path.rstrip("/") == "/v1"
+
+
+def is_astra_websocket_eligible(agent: Any, request: dict[str, Any] | None = None) -> bool:
+    """Exact API-key Astra gate; all unsupported routes retain the SSE path."""
+    model = str(getattr(agent, "model", "") or "").strip().lower().rsplit("/", 1)[-1]
+    if getattr(agent, "api_mode", None) != "codex_responses" or model != "gpt-6-astra":
+        return False
+    if not _base_url_is_official(getattr(agent, "base_url", "")):
+        return False
+    if not isinstance(getattr(agent, "api_key", None), str) or not agent.api_key.strip():
+        return False
+    auth_mode = str(getattr(agent, "auth_mode", "api_key") or "api_key").strip().lower()
+    if auth_mode not in {"", "api_key", "apikey"}:
+        return False
+    if getattr(agent, "provider", None) in {"openai-codex", "xai-oauth", "azure", "azure-foundry"}:
+        return False
+    if callable(getattr(agent, "_is_codex_backend", None)) and agent._is_codex_backend():
+        return False
+    if getattr(agent, "is_subagent", False) or getattr(agent, "compression_checkpoint_required", False):
+        return False
+    request = request or {}
+    if (request.get("context_management") or request.get("conversation") or request.get("conversation_id")
+            or request.get("previous_response_id")):
+        return False
+    return True
+
+
+def _event_field(event: Any, name: str, default: Any = None) -> Any:
+    value = event.get(name, default) if isinstance(event, dict) else getattr(event, name, default)
+    return default if value is None else value
+
+
+def _event_response_id(event: Any) -> str | None:
+    response = _event_field(event, "response")
+    raw = _event_field(event, "response_id") or _event_field(response, "id")
+    return str(raw).strip() if raw else None
+
+
+def _event_item_id(event: Any) -> str | None:
+    item = _event_field(event, "item")
+    raw = _event_field(event, "item_id") or _event_field(item, "id")
+    return str(raw).strip() if raw else None
+
+
+def _ws_url(base_url: str) -> str:
+    return "wss://api.openai.com/v1/responses"
+
+
+def _default_connect(url: str, api_key: str, timeout: float):
+    from websockets.sync.client import connect
+
+    return connect(
+        url,
+        additional_headers={
+            "Authorization": f"Bearer {api_key}",
+            "OpenAI-Beta": "responses_websockets=2026-02-06",
+        },
+        open_timeout=timeout,
+    )
+
+
+def _append_pending(agent: Any, text: str) -> None:
+    lock = getattr(agent, "_pending_steer_lock", None)
+    context = lock if lock is not None else threading.Lock()
+    with context:
+        existing = getattr(agent, "_pending_steer", None)
+        agent._pending_steer = f"{existing}\n{text}" if existing else text
+
+
+def _remove_pending(agent: Any, text: str) -> None:
+    lock = getattr(agent, "_pending_steer_lock", None)
+    context = lock if lock is not None else threading.Lock()
+    with context:
+        existing = getattr(agent, "_pending_steer", None)
+        if not existing:
+            return
+        if existing == text:
+            agent._pending_steer = None
+        elif existing.startswith(text + "\n"):
+            agent._pending_steer = existing[len(text) + 1:] or None
+        else:
+            parts = existing.splitlines()
+            try:
+                parts.remove(text)
+            except ValueError:
+                return
+            agent._pending_steer = "\n".join(parts) or None
+
+
+@dataclass
+class _Steer:
+    sequence: int
+    text: str
+    previous_response_id: str
+    accepted: bool = False
+    failed: bool = False
+
+
+class AstraWebSocketSession:
+    """One owner-thread receive loop plus lock-protected cross-thread steering."""
+
+    def __init__(self, agent: Any, *, connect: Callable[..., Any] | None = None, timeout: float = 30.0) -> None:
+        self.agent = agent
+        self._connect = connect or _default_connect
+        self.timeout = timeout
+        self._state = "IDLE"
+        self._state_lock = threading.RLock()
+        self._send_lock = threading.Lock()
+        self._interrupt = threading.Event()
+        self._socket: Any = None
+        self._request: dict[str, Any] = {}
+        self._response_id: str | None = None
+        self._assemblers: dict[str, Any] = {}
+        self._steers: dict[int, _Steer] = {}
+        self._next_sequence = 0
+        self._await_successor = False
+        self._continuations: set[str] = set()
+        self._seen_events: set[str] = set()
+        self._seen_items: set[tuple[str, str, str]] = set()
+        self.delivery_uncertain = False
+        self.last_error: Exception | None = None
+
+    @property
+    def state(self) -> str:
+        with self._state_lock:
+            return self._state
+
+    @property
+    def response_id(self) -> str | None:
+        with self._state_lock:
+            return self._response_id
+
+    def _set_state(self, state: str) -> None:
+        with self._state_lock:
+            self._state = state
+
+    def _send(self, payload: dict[str, Any]) -> None:
+        if self._socket is None:
+            raise AstraDeliveryUncertainError("Astra WebSocket is not open")
+        wire = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+        with self._send_lock:
+            try:
+                self._socket.send(wire)
+            except Exception as exc:
+                self.delivery_uncertain = True
+                self.last_error = exc
+                self._set_state("POST_DISPATCH_AMBIGUOUS")
+                raise AstraDeliveryUncertainError("Astra WebSocket send outcome is uncertain") from exc
+
+    def _append_steer(self, text: str) -> int:
+        with self._state_lock:
+            self._next_sequence += 1
+            sequence = self._next_sequence
+            self._steers[sequence] = _Steer(sequence, text, self._response_id or "")
+            self._await_successor = True
+            _append_pending(self.agent, text)
+            self._set_state("STEER_ADMITTED")
+            return sequence
+
+    def request_steer(self, text: str) -> bool:
+        """Admit and send one steer, returning False when no active response exists."""
+        cleaned = str(text or "").strip()
+        if not cleaned:
+            return False
+        with self._state_lock:
+            if self._socket is None or self._state not in {"ACTIVE", "SUCCESSOR_CREATED", "ACCEPTED"} or not self._response_id:
+                return False
+            previous_id = self._response_id
+            sequence = self._append_steer(cleaned)
+        try:
+            # Responses steering deliberately has a tiny wire shape. In particular, stream_id is never sent.
+            self._send({
+                "type": "response.steer", "previous_response_id": previous_id,
+                "input": [{"role": "user", "content": [{"type": "input_text", "text": cleaned}]}],
+            })
+        except AstraDeliveryUncertainError:
+            # The provider may have accepted the input; leaving it in Hermes' fallback queue could duplicate it.
+            _remove_pending(self.agent, cleaned)
+            raise
+        return bool(sequence)
+
+    def request_interrupt(self) -> None:
+        self._interrupt.set()
+        self.close()
+
+    def close(self) -> None:
+        socket, self._socket = self._socket, None
+        if socket is not None:
+            with self._send_lock:
+                try:
+                    socket.close()
+                except Exception:
+                    logger.debug("Astra WebSocket close failed", exc_info=True)
+
+    def _new_assembler(self, response_id: str):
+        from agent.codex_runtime import _CodexResponseAssembler
+
+        return _CodexResponseAssembler(
+            model=self._request.get("model", getattr(self.agent, "model", "")),
+            on_text_delta=self._on_text_delta,
+            on_reasoning_delta=self._on_reasoning_delta,
+            on_commentary_message=self._on_commentary_message,
+            on_first_delta=self._on_first_delta,
+            on_async_tool_call=self._async_tool_call,
+            on_async_tool_announcement=self._async_tool_announcement,
+        )
+
+    def _on_text_delta(self, text: str) -> None:
+        if not text:
+            return
+        self.agent._codex_streamed_text_parts.append(text)
+        callback = getattr(self.agent, "_fire_stream_delta", None)
+        if callable(callback):
+            callback(text)
+
+    def _on_reasoning_delta(self, text: str) -> None:
+        callback = getattr(self.agent, "_fire_reasoning_delta", None)
+        if callable(callback):
+            callback(text)
+
+    def _on_commentary_message(self, text: str) -> None:
+        callback = getattr(self.agent, "_fire_streamed_codex_commentary", None)
+        if callable(callback):
+            callback(text)
+
+    def _on_first_delta(self) -> None:
+        callback = getattr(self, "_first_delta", None)
+        if callable(callback):
+            callback()
+
+    @property
+    def _first_delta(self):
+        return getattr(self, "_on_first_delta_callback", None)
+
+    def _async_tool_call(self, call: Any) -> None:
+        callback = getattr(getattr(self.agent, "_astra_async_executor", None), "admit", None)
+        if callable(callback):
+            callback(call)
+
+    def _async_tool_announcement(self, call: Any) -> None:
+        callback = getattr(getattr(self.agent, "_astra_async_executor", None), "reserve", None)
+        if callable(callback):
+            callback(call)
+
+    def _saved_tool_result(self, call_id: str) -> Any:
+        messages = getattr(self.agent, "_session_messages", None) or []
+        for message in reversed(messages):
+            if not isinstance(message, dict) or message.get("role") != "tool":
+                continue
+            stored_id = str(message.get("tool_call_id") or "").split("|", 1)[0]
+            if stored_id == call_id:
+                return message.get("content", "")
+        return None
+
+    def _fill_required_input(self, required: Any) -> list[Any]:
+        if not isinstance(required, list):
+            raise AstraProtocolError("Astra steer.pending did not provide required_input")
+        filled = []
+        for stub in required:
+            if not isinstance(stub, dict):
+                raise AstraProtocolError("Astra required_input item is not an object")
+            item = dict(stub)
+            call_id = str(item.get("call_id") or item.get("id") or "").strip()
+            result = self._saved_tool_result(call_id) if call_id else None
+            if result is None:
+                raise AstraProtocolError(f"No saved tool result for required call {call_id or '<missing>'}")
+            if "result" in item:
+                item["result"] = result
+            else:
+                item["output"] = result
+            filled.append(item)
+        return filled
+
+    def _send_required_continuation(self, event: Any) -> None:
+        parent = _event_response_id(event) or self._response_id
+        if not parent or parent in self._continuations:
+            return
+        required = _event_field(event, "required_input")
+        if required is None:
+            response = _event_field(event, "response")
+            required = _event_field(response, "required_input")
+        input_items = self._fill_required_input(required)
+        settings = {k: v for k, v in self._request.items() if k not in {"type", "input", "stream", "previous_response_id"}}
+        self._send({"type": "response.create", **settings, "previous_response_id": parent, "input": input_items})
+        self._continuations.add(parent)
+        self._await_successor = True
+
+    def _is_duplicate(self, event: Any, event_type: str, response_id: str | None) -> bool:
+        event_id = _event_field(event, "event_id") or _event_field(event, "id")
+        if event_id:
+            key = str(event_id)
+            if key in self._seen_events:
+                return True
+            self._seen_events.add(key)
+        if event_type.endswith("output_item.done"):
+            item_id = _event_item_id(event)
+            if item_id and response_id:
+                key = (response_id, item_id, event_type)
+                if key in self._seen_items:
+                    return True
+                self._seen_items.add(key)
+        return False
+
+    def _event_belongs_to_active_response(self, event: Any, response_id: str | None, event_type: str) -> bool:
+        if not response_id or not self._response_id or response_id == self._response_id:
+            return True
+        return event_type == "response.created" and self._await_successor
+
+    def _handle_created(self, event: Any, response_id: str | None) -> None:
+        if not response_id:
+            raise AstraProtocolError("Astra response.created omitted response id")
+        with self._state_lock:
+            if self._response_id is None:
+                self._response_id = response_id
+                self._assemblers[response_id] = self._new_assembler(response_id)
+                self._set_state("ACTIVE")
+                return
+            if response_id == self._response_id:
+                return
+            if not self._await_successor:
+                return
+            self._response_id = response_id
+            self._assemblers[response_id] = self._new_assembler(response_id)
+            self._await_successor = False
+            self._set_state("SUCCESSOR_CREATED")
+
+    def _steer_event(self, event: Any, event_type: str) -> None:
+        if event_type == "response.steer.accepted":
+            with self._state_lock:
+                pending = next((item for item in self._steers.values() if not item.accepted and not item.failed), None)
+                if pending is not None:
+                    pending.accepted = True
+                    _remove_pending(self.agent, pending.text)
+                self._set_state("ACCEPTED")
+        elif event_type == "response.steer.failed":
+            with self._state_lock:
+                pending = next((item for item in self._steers.values() if not item.accepted and not item.failed), None)
+                if pending is not None:
+                    pending.failed = True
+                self._await_successor = any(not item.failed and not item.accepted for item in self._steers.values())
+                self._set_state("ACTIVE")
+        elif event_type == "response.steer.pending":
+            self._set_state("PENDING_REQUIRED_INPUT")
+            self._send_required_continuation(event)
+
+    def _terminal_reason(self, event: Any) -> str:
+        response = _event_field(event, "response")
+        details = _event_field(response, "incomplete_details") or _event_field(event, "incomplete_details") or {}
+        return str(_event_field(details, "reason", "") or "").strip().lower()
+
+    def run(self, request: dict[str, Any], *, on_first_delta: Callable[[], None] | None = None) -> Any:
+        from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
+
+        self._request = dict(request)
+        self._request.pop("stream", None)
+        self._on_first_delta_callback = on_first_delta
+        self.agent._codex_streamed_text_parts = []
+        writer_token = claim_stream_writer(self.agent)
+        try:
+            self._set_state("DISPATCHING")
+            try:
+                self._socket = self._connect(_ws_url(str(getattr(self.agent, "base_url", ""))), self.agent.api_key, self.timeout)
+            except Exception as exc:
+                self.last_error = exc
+                self._set_state("PRE_DISPATCH_FAILURE")
+                raise AstraPreDispatchError("Astra WebSocket connection failed before dispatch") from exc
+            initial = {"type": "response.create", **{k: v for k, v in self._request.items() if k != "type"}}
+            try:
+                self._send(initial)
+            except AstraDeliveryUncertainError:
+                raise
+            while True:
+                if self._interrupt.is_set() or getattr(self.agent, "_interrupt_requested", False):
+                    raise InterruptedError("Astra WebSocket turn interrupted")
+                try:
+                    raw = self._socket.recv()
+                except Exception as exc:
+                    if self._interrupt.is_set() or getattr(self.agent, "_interrupt_requested", False):
+                        raise InterruptedError("Astra WebSocket turn interrupted") from exc
+                    self.delivery_uncertain = True
+                    self.last_error = exc
+                    self._set_state("POST_DISPATCH_AMBIGUOUS")
+                    raise AstraDeliveryUncertainError("Astra WebSocket response delivery is uncertain") from exc
+                if isinstance(raw, bytes):
+                    raw = raw.decode("utf-8")
+                try:
+                    event = json.loads(raw) if isinstance(raw, str) else raw
+                except (TypeError, ValueError) as exc:
+                    raise AstraProtocolError("Astra WebSocket returned invalid JSON") from exc
+                if not isinstance(event, dict):
+                    raise AstraProtocolError("Astra WebSocket returned a non-object event")
+                event_type = str(event.get("type") or "")
+                response_id = _event_response_id(event)
+                if self._is_duplicate(event, event_type, response_id):
+                    continue
+                if event_type == "response.created":
+                    self._handle_created(event, response_id)
+                    continue
+                if event_type.startswith("response.steer."):
+                    self._steer_event(event, event_type)
+                    continue
+                if not self._event_belongs_to_active_response(event, response_id, event_type):
+                    continue
+                assembler = self._assemblers.get(self._response_id or "")
+                if assembler is None:
+                    raise AstraProtocolError("Astra event arrived before response.created")
+                self.agent._codex_stream_last_event_ts = time.time()
+                touch = getattr(self.agent, "_touch_activity", None)
+                if callable(touch):
+                    touch("receiving Astra WebSocket response")
+                if not stream_writer_is_current(self.agent, writer_token):
+                    raise TimeoutError("Astra WebSocket stream was superseded")
+                terminal = assembler.feed(event)
+                if terminal:
+                    if self._await_successor or self._terminal_reason(event) == "steered":
+                        continue
+                    with self._state_lock:
+                        self._set_state("COMPLETED" if event_type == "response.completed" else "EXPLICIT_FAILURE")
+                    return assembler.result()
+        finally:
+            self.close()
+
+
+def run_astra_websocket_stream(agent: Any, request: dict[str, Any], *, on_first_delta=None, connect=None):
+    """Attach one turn-owned session so concurrent Hermes control calls can steer it."""
+    session = AstraWebSocketSession(agent, connect=connect)
+    previous = getattr(agent, "_astra_websocket_session", None)
+    if previous is not None:
+        previous.close()
+    agent._astra_websocket_session = session
+    try:
+        return session.run(request, on_first_delta=on_first_delta)
+    finally:
+        if getattr(agent, "_astra_websocket_session", None) is session:
+            agent._astra_websocket_session = None
+
+
+__all__ = [
+    "AstraDeliveryUncertainError", "AstraPreDispatchError", "AstraProtocolError", "AstraWebSocketSession",
+    "is_astra_websocket_eligible", "run_astra_websocket_stream",
+]

--- a/agent/transports/astra_websocket_session.py
+++ b/agent/transports/astra_websocket_session.py
@@ -157,6 +157,7 @@ class AstraWebSocketSession:
         self._await_successor = False
         self._continuations: set[str] = set()
         self._seen_events: set[str] = set()
+        self._seen_sequences: set[str] = set()
         self._seen_items: set[tuple[str, str, str]] = set()
         self.delivery_uncertain = False
         self.last_error: Exception | None = None
@@ -327,6 +328,12 @@ class AstraWebSocketSession:
         self._await_successor = True
 
     def _is_duplicate(self, event: Any, event_type: str, response_id: str | None) -> bool:
+        sequence_number = _event_field(event, "sequence_number")
+        if sequence_number is not None:
+            sequence_key = str(sequence_number)
+            if sequence_key in self._seen_sequences:
+                return True
+            self._seen_sequences.add(sequence_key)
         event_id = _event_field(event, "event_id") or _event_field(event, "id")
         if event_id:
             key = str(event_id)
@@ -388,6 +395,20 @@ class AstraWebSocketSession:
         response = _event_field(event, "response")
         details = _event_field(response, "incomplete_details") or _event_field(event, "incomplete_details") or {}
         return str(_event_field(details, "reason", "") or "").strip().lower()
+
+    def _settle_async_executor(self, final: Any) -> None:
+        """Use the PR2 persist-before-execute settlement boundary for the final WS response."""
+        executor = getattr(self.agent, "_astra_async_executor", None)
+        if executor is None:
+            return
+        if getattr(executor, "has_admitted", False) or getattr(executor, "has_pending", False) or getattr(executor, "failed", False):
+            if not executor.finish_stream(
+                assistant_content=getattr(final, "output_text", "") or "",
+                settled_calls=getattr(final, "output", None),
+            ):
+                raise RuntimeError("Astra async tool execution did not reach a durable result boundary")
+        elif executor.retire_empty():
+            self.agent._astra_async_executor = None
 
     def run(self, request: dict[str, Any], *, on_first_delta: Callable[[], None] | None = None) -> Any:
         from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
@@ -451,13 +472,23 @@ class AstraWebSocketSession:
                     touch("receiving Astra WebSocket response")
                 if not stream_writer_is_current(self.agent, writer_token):
                     raise TimeoutError("Astra WebSocket stream was superseded")
+                # Claim terminal ownership before feeding the event.  A concurrent steer that observes
+                # terminal processing has begun must return False rather than dispatching after completion.
+                terminal_event = event_type in {"response.completed", "response.incomplete", "response.failed"}
+                terminal_waits_for_successor = self._await_successor or self._terminal_reason(event) == "steered"
+                if terminal_event and not terminal_waits_for_successor:
+                    with self._state_lock:
+                        if self._state in {"ACTIVE", "SUCCESSOR_CREATED", "ACCEPTED", "STEER_ADMITTED"}:
+                            self._set_state("TERMINAL_PROCESSING")
                 terminal = assembler.feed(event)
                 if terminal:
-                    if self._await_successor or self._terminal_reason(event) == "steered":
+                    if terminal_waits_for_successor:
                         continue
                     with self._state_lock:
                         self._set_state("COMPLETED" if event_type == "response.completed" else "EXPLICIT_FAILURE")
-                    return assembler.result()
+                    final = assembler.result()
+                    self._settle_async_executor(final)
+                    return final
         finally:
             self.close()
 

--- a/agent/transports/astra_websocket_session.py
+++ b/agent/transports/astra_websocket_session.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 _STEERING_MODEL_CONFIG_KEY = "_astra_steering"
 _STEERING_JOURNAL_VERSION = 1
 _STEERING_JOURNAL_LIMIT = 16
+_STEERING_UNRESOLVED_STATES = frozenset({"prepared", "sent", "failed", "accepted", "ambiguous"})
 _STEERING_STATE_RANK = {
     "prepared": 10, "sent": 20, "failed": 25, "accepted": 30,
     "ambiguous": 40, "successor_created": 50, "fallback_queued": 60,
@@ -214,6 +215,17 @@ class AstraWebSocketSession:
                     self._steering_persistence_error = exc
         return db
 
+    @staticmethod
+    def _steering_config_value(db: Any, session_id: str) -> Any:
+        getter = getattr(db, "get_session_model_config_value", None)
+        if callable(getter):
+            return getter(session_id, _STEERING_MODEL_CONFIG_KEY, {})
+        get_session = getattr(db, "get_session", None)
+        if not callable(get_session):
+            raise AstraSteeringPersistenceError("Astra session store lacks model metadata reads")
+        row = get_session(session_id) or {}
+        return _parse_model_config(row.get("model_config")).get(_STEERING_MODEL_CONFIG_KEY, {})
+
     def _load_steering_receipts(self) -> None:
         """Load only the bounded ownership journal; never reconstruct an in-flight send."""
         db = self._session_db()
@@ -221,16 +233,15 @@ class AstraWebSocketSession:
         if db is None or not session_id:
             return
         try:
-            getter = getattr(db, "get_session_model_config_value", None)
-            if callable(getter):
-                raw = getter(session_id, _STEERING_MODEL_CONFIG_KEY, {})
-            else:
-                row = db.get_session(session_id)
-                raw = _parse_model_config((row or {}).get("model_config")).get(_STEERING_MODEL_CONFIG_KEY, {})
+            raw = self._steering_config_value(db, session_id)
             entries = raw.get("entries", []) if isinstance(raw, dict) else []
             if isinstance(entries, list):
-                self._steering_receipts = [entry for entry in entries[-_STEERING_JOURNAL_LIMIT:]
-                                           if isinstance(entry, dict)]
+                loaded = [dict(entry) for entry in entries if isinstance(entry, dict)]
+                unresolved = any(entry.get("state") in _STEERING_UNRESOLVED_STATES for entry in loaded)
+                self._steering_receipts = (
+                    loaded if len(loaded) <= _STEERING_JOURNAL_LIMIT or unresolved
+                    else loaded[-_STEERING_JOURNAL_LIMIT:]
+                )
                 self._next_sequence = max(
                     (int(entry.get("generation", 0)) for entry in self._steering_receipts
                      if isinstance(entry.get("generation", 0), int)),
@@ -245,11 +256,10 @@ class AstraWebSocketSession:
                         pending = str(getattr(self.agent, "_pending_steer", "") or "")
                         if text not in pending.splitlines():
                             _append_pending(self.agent, text)
-                        # Claim the one legacy fallback durably before exposing a
-                        # fresh session to another restart. The current in-memory
-                        # failed path already owns its pending text.
-                        entry["state"] = "fallback_queued"
-                        fallback_changed = True
+                    # Claim the one legacy fallback durably before exposing a
+                    # fresh session to another restart, even when text is empty.
+                    entry["state"] = "fallback_queued"
+                    fallback_changed = True
             if fallback_changed:
                 self._persist_steering_receipts()
         except Exception as exc:
@@ -264,10 +274,7 @@ class AstraWebSocketSession:
         if self._steering_load_failed:
             raise AstraSteeringPersistenceError("Astra steering ownership journal could not be read") from self._steering_persistence_error
         if db is None or not session_id:
-            # Bare test doubles and legacy non-session callers retain the in-memory ABI.
-            if self._steering_persistence_error is not None:
-                raise AstraSteeringPersistenceError("Astra steering ownership journal is unavailable") from self._steering_persistence_error
-            return
+            raise AstraSteeringPersistenceError("Astra steering ownership journal is unavailable") from self._steering_persistence_error
         ensure = getattr(self.agent, "_ensure_db_session", None)
         if callable(ensure) and not bool(getattr(self.agent, "_session_db_created", True)):
             ensure()
@@ -277,12 +284,18 @@ class AstraWebSocketSession:
         if not callable(patch):
             raise AstraSteeringPersistenceError("Astra session store lacks model metadata patching")
         with self._steering_receipt_lock:
+            if len(self._steering_receipts) > _STEERING_JOURNAL_LIMIT:
+                raise AstraSteeringPersistenceError("Astra steering ownership journal exceeds its bounded limit")
             payload = {
                 "version": _STEERING_JOURNAL_VERSION,
                 "entries": [dict(entry) for entry in self._steering_receipts[-_STEERING_JOURNAL_LIMIT:]],
             }
         try:
             patch(session_id, {_STEERING_MODEL_CONFIG_KEY: payload})
+            stored = self._steering_config_value(db, session_id)
+            if not isinstance(stored, dict) or stored.get("version") != _STEERING_JOURNAL_VERSION \
+                    or stored.get("entries") != payload["entries"]:
+                raise AstraSteeringPersistenceError("Astra session metadata write was not durable")
             self._steering_persistence_error = None
         except Exception as exc:
             self._steering_persistence_error = exc
@@ -305,7 +318,9 @@ class AstraWebSocketSession:
 
     def _append_steering_receipt(self, sequence: int, text: str, previous_id: str) -> None:
         safe_text = _safe_steering_text(text)
-        wire_input = [{"role": "user", "content": [{"type": "input_text", "text": safe_text}]}]
+        if safe_text != text:
+            raise AstraSteeringPersistenceError("Astra steering input would be changed by redaction")
+        wire_input = [{"role": "user", "content": [{"type": "input_text", "text": text}]}]
         input_digest = hashlib.sha256(
             json.dumps(
                 [{"role": "user", "content": [{"type": "input_text", "text": text}]}],
@@ -317,6 +332,11 @@ class AstraWebSocketSession:
             f"{session_id}\0{sequence}\0{previous_id}".encode("utf-8", errors="surrogatepass")
         ).hexdigest()[:24]
         with self._steering_receipt_lock:
+            if (
+                len(self._steering_receipts) >= _STEERING_JOURNAL_LIMIT
+                and any(entry.get("state") in _STEERING_UNRESOLVED_STATES for entry in self._steering_receipts)
+            ):
+                raise AstraSteeringPersistenceError("Astra steering ownership journal is full of unresolved inputs")
             self._steering_receipts.append({
                 "version": _STEERING_JOURNAL_VERSION,
                 "admission_id": admission_id,
@@ -603,7 +623,8 @@ class AstraWebSocketSession:
                 self._await_successor = any(not item.failed and not item.accepted for item in self._steers.values())
                 self._set_state("ACTIVE")
             if sequence is not None:
-                self._record_steering_state(sequence, "failed")
+                # The explicit failure transfers ownership to the one-shot legacy queue.
+                self._record_steering_state(sequence, "fallback_queued")
         elif event_type == "response.steer.pending":
             self._set_state("PENDING_REQUIRED_INPUT")
             self._send_required_continuation(event)

--- a/agent/transports/astra_websocket_session.py
+++ b/agent/transports/astra_websocket_session.py
@@ -23,11 +23,10 @@ logger = logging.getLogger(__name__)
 _STEERING_MODEL_CONFIG_KEY = "_astra_steering"
 _STEERING_JOURNAL_VERSION = 1
 _STEERING_JOURNAL_LIMIT = 16
-_STEERING_UNRESOLVED_STATES = frozenset({"prepared", "sent", "failed", "accepted", "ambiguous", "fallback_queued"})
+_STEERING_UNRESOLVED_STATES = frozenset({"prepared", "sent", "failed", "accepted", "ambiguous"})
 _STEERING_STATE_RANK = {
     "prepared": 10, "sent": 20, "failed": 25, "accepted": 30,
     "ambiguous": 40, "successor_created": 50, "fallback_queued": 60,
-    "fallback_delivered": 70,
 }
 
 
@@ -144,51 +143,6 @@ def _remove_pending(agent: Any, text: str) -> None:
             agent._pending_steer = "\n".join(parts) or None
 
 
-def _fallback_records_for_text(agent: Any, text: str) -> list[dict[str, Any]] | None:
-    db = getattr(agent, "_session_db", None)
-    getter = getattr(db, "get_session_model_config_value", None)
-    if not callable(getter):
-        return None
-    try:
-        raw = getter(str(getattr(agent, "session_id", "") or ""), _STEERING_MODEL_CONFIG_KEY, {})
-        entries = raw.get("entries", []) if isinstance(raw, dict) else []
-        records = [entry for entry in entries if isinstance(entry, dict) and entry.get("state") in {"failed", "fallback_queued"}]
-    except Exception:
-        return []
-    if not records:
-        return None
-    for record in records:
-        if str(record.get("text") or "").strip() == text:
-            return [record]
-    for count in range(2, len(records) + 1):
-        if "\n".join(str(item.get("text") or "") for item in records[:count]) == text:
-            return records[:count]
-    return []
-
-
-def durably_deliver_fallback_steer(
-    agent: Any, target: dict[str, Any], before_content: Any, delivered_content: Any, steer_text: str,
-) -> bool | None:
-    records = _fallback_records_for_text(agent, steer_text)
-    if records is None:
-        return None
-    if not records:
-        return False
-    db = getattr(agent, "_session_db", None)
-    persist = getattr(db, "persist_astra_steering_fallback", None)
-    tool_call_id = str(target.get("tool_call_id") or "").strip()
-    session_id = str(getattr(agent, "session_id", "") or "").strip()
-    if not session_id or not tool_call_id or not callable(persist):
-        return False
-    try:
-        delivered = bool(persist(session_id, target.get("_row_id"), tool_call_id,
-                                 before_content, delivered_content, records))
-    except Exception:
-        logger.warning("Astra fallback steering delivery could not be persisted", exc_info=True)
-        return False
-    return delivered
-
-
 def _parse_model_config(raw: Any) -> dict[str, Any]:
     if isinstance(raw, dict):
         return dict(raw)
@@ -293,22 +247,19 @@ class AstraWebSocketSession:
                      if isinstance(entry.get("generation", 0), int)),
                     default=0,
                 )
+            # An explicit provider failure is the sole state eligible for the legacy one-shot fallback.
             fallback_changed = False
             for entry in self._steering_receipts:
-                if entry.get("state") in {"failed", "fallback_queued"}:
-                    claimed = str(getattr(self.agent, "_astra_steer_drain_claim", "") or "")
+                if entry.get("state") == "failed":
                     text = str(entry.get("text") or "").strip()
-                    if claimed and text and (claimed == text or text in claimed.splitlines()):
-                        if entry.get("state") == "failed": entry["state"] = "fallback_queued"; fallback_changed = True
-                        setattr(self.agent, "_astra_steer_drain_claim", "")
-                        continue
                     if text:
                         pending = str(getattr(self.agent, "_pending_steer", "") or "")
                         if text not in pending.splitlines():
                             _append_pending(self.agent, text)
-                    if entry.get("state") == "failed":
-                        entry["state"] = "fallback_queued"
-                        fallback_changed = True
+                    # Claim the one legacy fallback durably before exposing a
+                    # fresh session to another restart, even when text is empty.
+                    entry["state"] = "fallback_queued"
+                    fallback_changed = True
             if fallback_changed:
                 self._persist_steering_receipts()
         except Exception as exc:

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -273,9 +273,11 @@ def _is_official_openai_responses_route(model: Any, base_url: Any) -> bool:
     """Astra cache semantics apply only to the official OpenAI API host."""
     if not _is_astra_model(model):
         return False
-    from utils import base_url_host_matches
+    from utils import base_url_hostname
 
-    return base_url_host_matches(str(base_url or ""), "api.openai.com")
+    # Astra's account-gated cache contract is for the canonical API origin only.
+    # Do not extend it to subdomains (or lookalike hosts) by suffix matching.
+    return base_url_hostname(str(base_url or "")).lower() == "api.openai.com"
 
 
 def _codex_efforts_for_route(model: Any, base_url: Any, *, is_codex_backend: bool = False) -> tuple[str, ...]:

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -11,7 +11,7 @@ import re
 from typing import Any, Callable, Optional
 
 from agent.reasoning_effort import (
-    ACTUAL_RELAY_EFFORTS, XAI_GROK46_EFFORTS, XAI_LEGACY_EFFORTS, clamp_effort,
+    ACTUAL_RELAY_EFFORTS, CODEX_ASTRA_EFFORTS, XAI_GROK46_EFFORTS, XAI_LEGACY_EFFORTS, clamp_effort,
     # Same declared vocabulary + shared clamp as the main Codex transport (agent.reasoning_effort):
     # per-model — "max" is gpt-5.6-only, "minimal"/"ultra" always rejected (live-verified, #68365).
     codex_supported_efforts,
@@ -211,6 +211,15 @@ def _resolve_reasoning(model: str, params: dict[str, Any]) -> tuple[Any, bool]:
         elif reasoning_config.get("effort"):
             reasoning_effort = reasoning_config["effort"]
 
+    # Astra has no wire-level disable/minimal setting.  Preserve Hermes' user-facing
+    # controls by sending the documented lowest enabled level instead; this also keeps
+    # an explicit ``enabled: false`` request valid on the Responses API.
+    if model.strip().lower().rsplit("/", 1)[-1] == "gpt-6-astra":
+        requested = str(reasoning_effort or "").strip().lower()
+        if not reasoning_enabled or requested in {"", "none", "minimal", "disabled", "off"}:
+            return "low", True
+        return clamp_effort(reasoning_effort, CODEX_ASTRA_EFFORTS), True
+
     # Wire vocabularies are declared in agent.reasoning_effort; the shared clamp policy (nearest weaker
     # supported level, never escalate, never invert the ladder) replaces the per-backend hand maps that
     # repeatedly leaked internal levels like "ultra" to the wire (#89503 class) or clamped one rung below a
@@ -260,6 +269,37 @@ def _default_prompt_cache_retention_for_request(model: str, base_url: Any) -> Op
         return None
     normalized = str(model or "").strip().lower().replace("_", "-")
     return "24h" if _EXTENDED_PROMPT_CACHE_MODEL_RE.search(normalized) else None
+
+
+def _is_astra_model(model: Any) -> bool:
+    return str(model or "").strip().lower().rsplit("/", 1)[-1] == "gpt-6-astra"
+
+
+def _is_official_openai_responses_route(model: Any, base_url: Any) -> bool:
+    """Astra cache semantics apply only to the official OpenAI API host."""
+    if not _is_astra_model(model):
+        return False
+    from utils import base_url_host_matches
+
+    return base_url_host_matches(str(base_url or ""), "api.openai.com")
+
+
+def _sanitize_astra_request_kwargs(kwargs: dict[str, Any], model: Any, base_url: Any) -> None:
+    """Apply Astra's model-specific restrictions after all request overrides are merged."""
+    if not _is_astra_model(model):
+        return
+    for key in ("temperature", "top_p", "top_logprobs", "logprobs"):
+        kwargs.pop(key, None)
+    include = kwargs.get("include")
+    if isinstance(include, list):
+        kwargs["include"] = [item for item in include if "logprob" not in str(item).lower()]
+    if _is_official_openai_responses_route(model, base_url):
+        kwargs["prompt_cache_options"] = {"ttl": "30m"}
+        kwargs.pop("prompt_cache_retention", None)
+    else:
+        # A caller override must not accidentally send official-only cache syntax to a
+        # proxy or another provider that happens to accept the Astra model name.
+        kwargs.pop("prompt_cache_options", None)
 
 
 def _content_cache_key(instructions: str, tools: Optional[list[dict[str, Any]]], scope_id: str = "") -> Optional[str]:
@@ -543,6 +583,8 @@ class ResponsesApiTransport(ProviderTransport):
         ))
         if params.get("request_overrides"):
             kwargs.update(params["request_overrides"])
+
+        _sanitize_astra_request_kwargs(kwargs, model, params.get("base_url"))
 
         _bound_prompt_cache_key_field(kwargs)
 

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -11,7 +11,8 @@ import re
 from typing import Any, Callable, Optional
 
 from agent.reasoning_effort import (
-    ACTUAL_RELAY_EFFORTS, CODEX_ASTRA_EFFORTS, XAI_GROK46_EFFORTS, XAI_LEGACY_EFFORTS, clamp_effort,
+    ACTUAL_RELAY_EFFORTS, CODEX_ASTRA_EFFORTS, CODEX_LEGACY_EFFORTS,
+    XAI_GROK46_EFFORTS, XAI_LEGACY_EFFORTS, clamp_effort,
     # Same declared vocabulary + shared clamp as the main Codex transport (agent.reasoning_effort):
     # per-model — "max" is gpt-5.6-only, "minimal"/"ultra" always rejected (live-verified, #68365).
     codex_supported_efforts,
@@ -226,7 +227,9 @@ def _resolve_reasoning(model: str, params: dict[str, Any]) -> tuple[Any, bool]:
         declared = _profile_declared_efforts(params.get("provider"), model, params.get("base_url"))
         if declared is not None and not declared:
             reasoning_enabled = False
-        supported = declared or codex_supported_efforts(model)
+        supported = declared or _codex_efforts_for_route(
+            model, params.get("base_url"), is_codex_backend=params.get("is_codex_backend") is True
+        )
     return clamp_effort(reasoning_effort, supported), reasoning_enabled
 
 
@@ -273,6 +276,15 @@ def _is_official_openai_responses_route(model: Any, base_url: Any) -> bool:
     from utils import base_url_host_matches
 
     return base_url_host_matches(str(base_url or ""), "api.openai.com")
+
+
+def _codex_efforts_for_route(model: Any, base_url: Any, *, is_codex_backend: bool = False) -> tuple[str, ...]:
+    """Keep Astra's new vocabulary off unrelated Responses-compatible endpoints."""
+    if _is_astra_model(model) and not (
+        is_codex_backend or _is_official_openai_responses_route(model, base_url)
+    ):
+        return CODEX_LEGACY_EFFORTS
+    return codex_supported_efforts(str(model or ""))
 
 
 def _sanitize_astra_request_kwargs(kwargs: dict[str, Any], model: Any, base_url: Any) -> None:

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -266,7 +266,7 @@ def _default_prompt_cache_retention_for_request(model: str, base_url: Any) -> Op
 
 
 def _is_astra_model(model: Any) -> bool:
-    return str(model or "").strip().lower().rsplit("/", 1)[-1] == "gpt-6-astra"
+    return str(model or "").strip().lower().rsplit("/", 1)[-1] in ("gpt-6-astra", "gpt-6-astra-900k")
 
 
 def _is_official_openai_responses_route(model: Any, base_url: Any) -> bool:

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -211,15 +211,6 @@ def _resolve_reasoning(model: str, params: dict[str, Any]) -> tuple[Any, bool]:
         elif reasoning_config.get("effort"):
             reasoning_effort = reasoning_config["effort"]
 
-    # Astra has no wire-level disable/minimal setting.  Preserve Hermes' user-facing
-    # controls by sending the documented lowest enabled level instead; this also keeps
-    # an explicit ``enabled: false`` request valid on the Responses API.
-    if model.strip().lower().rsplit("/", 1)[-1] == "gpt-6-astra":
-        requested = str(reasoning_effort or "").strip().lower()
-        if not reasoning_enabled or requested in {"", "none", "minimal", "disabled", "off"}:
-            return "low", True
-        return clamp_effort(reasoning_effort, CODEX_ASTRA_EFFORTS), True
-
     # Wire vocabularies are declared in agent.reasoning_effort; the shared clamp policy (nearest weaker
     # supported level, never escalate, never invert the ladder) replaces the per-backend hand maps that
     # repeatedly leaked internal levels like "ultra" to the wire (#89503 class) or clamped one rung below a
@@ -288,18 +279,24 @@ def _sanitize_astra_request_kwargs(kwargs: dict[str, Any], model: Any, base_url:
     """Apply Astra's model-specific restrictions after all request overrides are merged."""
     if not _is_astra_model(model):
         return
+    if not _is_official_openai_responses_route(model, base_url):
+        kwargs.pop("prompt_cache_options", None)
+        return
+    reasoning = kwargs.get("reasoning")
+    requested = reasoning.get("effort") if isinstance(reasoning, dict) else None
+    normalized = str(requested or "").strip().lower()
+    effort = "low" if normalized in {"", "none", "minimal", "disabled", "off"} else clamp_effort(
+        requested, CODEX_ASTRA_EFFORTS
+    )
+    kwargs["reasoning"] = {**(reasoning if isinstance(reasoning, dict) else {}), "effort": effort}
+    kwargs["reasoning"].setdefault("summary", "auto")
     for key in ("temperature", "top_p", "top_logprobs", "logprobs"):
         kwargs.pop(key, None)
     include = kwargs.get("include")
     if isinstance(include, list):
         kwargs["include"] = [item for item in include if "logprob" not in str(item).lower()]
-    if _is_official_openai_responses_route(model, base_url):
-        kwargs["prompt_cache_options"] = {"ttl": "30m"}
-        kwargs.pop("prompt_cache_retention", None)
-    else:
-        # A caller override must not accidentally send official-only cache syntax to a
-        # proxy or another provider that happens to accept the Astra model name.
-        kwargs.pop("prompt_cache_options", None)
+    kwargs["prompt_cache_options"] = {"ttl": "30m"}
+    kwargs.pop("prompt_cache_retention", None)
 
 
 def _content_cache_key(instructions: str, tools: Optional[list[dict[str, Any]]], scope_id: str = "") -> Optional[str]:

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -499,10 +499,12 @@ class ResponsesApiTransport(ProviderTransport):
             native_compaction_eligible=_native_compaction_active(kwargs.get("context_management")),
         )
 
-    def convert_tools(self, tools: Optional[list[dict[str, Any]]]) -> Any:
+    def convert_tools(self, tools: Optional[list[dict[str, Any]]], **kwargs) -> Any:
         """Convert OpenAI tool schemas to Responses API function definitions."""
         from agent.codex_responses_adapter import _responses_tools
 
+        if kwargs.get("async_tools") is True:
+            return _responses_tools(tools, async_tools=True)
         return _responses_tools(tools)
 
     def build_kwargs(
@@ -551,7 +553,18 @@ class ResponsesApiTransport(ProviderTransport):
         native_compaction_active = _native_compaction_active(context_management)
 
         reasoning_effort, reasoning_enabled = _resolve_reasoning(model, params)
-        response_tools, self._last_wire_aliases = _alias_wire_tools(self.convert_tools(tools), params, is_xai_responses)
+        # The marker is emitted only for exact direct Astra turns whose midstream executor
+        # was admitted by the caller.  Keep the internal hint out of returned kwargs so the
+        # normal Responses preflight contract remains unchanged.
+        async_tools = (
+            params.get("midstream_executor_active") is True
+            and str(model or "").strip().lower().rsplit("/", 1)[-1] == "gpt-6-astra"
+            and not is_codex_backend and not is_xai_responses and not is_github_responses
+            and _is_official_openai_responses_route(model, params.get("base_url"))
+        )
+        response_tools, self._last_wire_aliases = _alias_wire_tools(
+            self.convert_tools(tools, async_tools=async_tools), params, is_xai_responses
+        )
 
         # Lazy: provider plugins import this transport during model_metadata init.
         from agent.model_metadata import strip_codex_context_variant_suffix as _strip_ctx_variant
@@ -663,6 +676,8 @@ class ResponsesApiTransport(ProviderTransport):
                 provider_data = {
                     key: getattr(tc, key) for key in ("call_id", "response_item_id") if getattr(tc, key, None)
                 }
+                if getattr(tc, "async", False) is True or getattr(tc, "async_", False) is True:
+                    provider_data["async"] = True
                 has_fn = hasattr(tc, "function")
                 name = tc.function.name if has_fn else getattr(tc, "name", "")
                 # Undo only aliases THIS request emitted; the legacy map is for normalize-only call sites.

--- a/agent/turn_api_call.py
+++ b/agent/turn_api_call.py
@@ -62,7 +62,7 @@ def perform_api_call(
     agent: Any, *, api_kwargs: Any, _original_api_kwargs: Any, _llm_middleware_trace: Any,
     _moa_prepared_request: Any, _retry: Any, thinking_spinner: Any, retry_count: Any,
     api_call_count: Any, api_request_id: Any, effective_task_id: Any, turn_id: Any,
-    interrupted: Any,
+    interrupted: Any, messages: Any,
 ) -> ApiCallVerdict:
     """Issue the request (see ``_should_stream`` for the streaming decision)."""
     response = None
@@ -78,6 +78,20 @@ def perform_api_call(
         thinking_spinner = stop_thinking_spinner(agent, thinking_spinner)
 
     _use_streaming = _should_stream(agent)
+    from agent.astra_async_tools import AstraAsyncExecutor, is_direct_astra
+    if _use_streaming and is_direct_astra(agent):
+        existing_executor = getattr(agent, "_astra_async_executor", None)
+        if existing_executor is not None and existing_executor.has_admitted and getattr(existing_executor, "closed", False):
+            raise RuntimeError("Astra async tool stream was retired after durable dispatch")
+        if existing_executor is not None and not existing_executor.has_admitted:
+            existing_executor.retire_empty()
+        if existing_executor is None or not existing_executor.has_admitted or getattr(existing_executor, "finalized", False) \
+                or (getattr(existing_executor, "closed", False) and not existing_executor.has_admitted):
+            agent._astra_async_executor = AstraAsyncExecutor(agent, messages, effective_task_id, api_call_count)
+    elif getattr(agent, "_astra_async_executor", None) is not None and not getattr(
+        agent._astra_async_executor, "has_admitted", False
+    ):
+        agent._astra_async_executor = None
 
     def _perform_api_call(next_api_kwargs):
         if agent.api_mode == "codex_responses":
@@ -171,6 +185,13 @@ def handle_api_interrupt(
     from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 
     thinking_spinner = stop_thinking_spinner(agent, thinking_spinner)
+    try:
+        executor = getattr(agent, "_astra_async_executor", None)
+        if executor is not None:
+            executor.abort_stream()
+            agent._astra_async_executor = None
+    except Exception:
+        logger.debug("Astra async executor retirement failed", exc_info=True)
     # redirect() cancelled only this request: keep the correction queued, clear the
     # cancellation bit, let the outer loop rebuild. Never materialize incomplete
     # signed/encrypted reasoning items.

--- a/agent/turn_iteration_prep.py
+++ b/agent/turn_iteration_prep.py
@@ -252,8 +252,18 @@ def begin_iteration(
             original_user_message = (
                 f"{original_user_message}\n\n" f"User correction during the turn: {_redirect_text}"
             )
-        agent._persist_session(messages, conversation_history)
-        confirm_astra_redirect_persisted(agent, _astra_receipts)
+        try:
+            agent._persist_session(messages, conversation_history)
+            confirm_astra_redirect_persisted(agent, _astra_receipts)
+        except Exception:
+            if _astra_receipts:
+                # The CLI can keep this agent after discarding the failed turn's
+                # messages. Re-read durable truth on retry: the transaction may
+                # have rolled back OR committed before a readback failure. Never
+                # blindly requeue the text and risk delivering it twice.
+                agent._astra_fallback_restore_session = None
+                agent._astra_drained_redirect_receipts = []
+            raise
 
     # Reset per-turn checkpoint dedup so each iteration can take one snapshot.
     agent._checkpoint_mgr.new_turn()

--- a/agent/turn_iteration_prep.py
+++ b/agent/turn_iteration_prep.py
@@ -140,22 +140,13 @@ def _inject_steer_into_newest_tool_result(agent: Any, messages: Any, steer_text:
             marker = format_steer_marker(steer_text)
             existing = _sm.get("content", "")
             if isinstance(existing, str):
-                delivered_content = existing + marker
+                _sm["content"] = existing + marker
             else:
                 # Multimodal content blocks — append a text block.
-                try:
+                with suppress(Exception):
                     blocks = list(existing) if existing else []
                     blocks.append({"type": "text", "text": marker})
-                    delivered_content = blocks
-                except Exception:
-                    delivered_content = existing
-            _sm["content"] = delivered_content
-            from agent.transports.astra_websocket_session import durably_deliver_fallback_steer
-            if durably_deliver_fallback_steer(agent, _sm, existing, delivered_content, steer_text) is False:
-                _sm["content"] = existing
-                from agent.agent_runtime_helpers import _requeue_pending_steer
-                _requeue_pending_steer(agent, steer_text)
-                return
+                    _sm["content"] = blocks
             logger.debug(
                 "Pre-API-call steer drain: injected into tool msg at index %d", _si
             )

--- a/agent/turn_iteration_prep.py
+++ b/agent/turn_iteration_prep.py
@@ -235,14 +235,25 @@ def begin_iteration(
             _turn_exit_reason=_turn_exit_reason,
         )
 
+    from agent.transports.astra_websocket_session import (
+        confirm_astra_redirect_persisted, restore_astra_fallback_redirects,
+    )
+    restore_astra_fallback_redirects(agent)
     _redirect_text = agent._drain_pending_redirect()
     if _redirect_text:
         _apply_active_turn_redirect(agent, messages, _redirect_text)
+        _astra_receipts = getattr(agent, "_astra_drained_redirect_receipts", None) or []
+        if _astra_receipts:
+            messages[-1]["display_metadata"] = {
+                **(messages[-1].get("display_metadata") or {}),
+                "_astra_steering_fallback": list(_astra_receipts),
+            }
         if isinstance(original_user_message, str):
             original_user_message = (
                 f"{original_user_message}\n\n" f"User correction during the turn: {_redirect_text}"
             )
         agent._persist_session(messages, conversation_history)
+        confirm_astra_redirect_persisted(agent, _astra_receipts)
 
     # Reset per-turn checkpoint dedup so each iteration can take one snapshot.
     agent._checkpoint_mgr.new_turn()

--- a/agent/turn_iteration_prep.py
+++ b/agent/turn_iteration_prep.py
@@ -140,13 +140,22 @@ def _inject_steer_into_newest_tool_result(agent: Any, messages: Any, steer_text:
             marker = format_steer_marker(steer_text)
             existing = _sm.get("content", "")
             if isinstance(existing, str):
-                _sm["content"] = existing + marker
+                delivered_content = existing + marker
             else:
                 # Multimodal content blocks — append a text block.
-                with suppress(Exception):
+                try:
                     blocks = list(existing) if existing else []
                     blocks.append({"type": "text", "text": marker})
-                    _sm["content"] = blocks
+                    delivered_content = blocks
+                except Exception:
+                    delivered_content = existing
+            _sm["content"] = delivered_content
+            from agent.transports.astra_websocket_session import durably_deliver_fallback_steer
+            if durably_deliver_fallback_steer(agent, _sm, existing, delivered_content, steer_text) is False:
+                _sm["content"] = existing
+                from agent.agent_runtime_helpers import _requeue_pending_steer
+                _requeue_pending_steer(agent, steer_text)
+                return
             logger.debug(
                 "Pre-API-call steer drain: injected into tool msg at index %d", _si
             )

--- a/agent/turn_tool_round.py
+++ b/agent/turn_tool_round.py
@@ -63,6 +63,14 @@ def run_tool_round(
             truncated_tool_call_retries=truncated_tool_call_retries, result=result,
         )
 
+    # Direct Astra async calls were persisted and executed while the provider stream was
+    # still open.  Their result rows are already committed in original order; never send
+    # the same normalized response through the ordinary dispatcher a second time.
+    astra_executor = getattr(agent, "_astra_async_executor", None)
+    if astra_executor is not None and astra_executor.consume_response(assistant_message):
+        agent._astra_async_executor = None
+        return _verdict("continue")
+
     if not agent.quiet_mode:
         agent._vprint(f"{agent.log_prefix}🔧 Processing {len(assistant_message.tool_calls)} tool call(s)...")
 

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -109,6 +109,7 @@ class PricingEntry:
     input_cost_per_million_above: Optional[Decimal] = None
     output_cost_per_million_above: Optional[Decimal] = None
     cache_read_cost_per_million_above: Optional[Decimal] = None
+    cache_write_cost_per_million_above: Optional[Decimal] = None
 
 
 @dataclass(frozen=True)
@@ -237,6 +238,20 @@ for _provider, _url, _version, _rows in _SNAPSHOTS:
         for _model in ((_models,) if isinstance(_models, str) else _models):
             _OFFICIAL_DOCS_PRICING[(_provider, _model)] = _entry
 del _SNAPSHOTS, _provider, _url, _version, _rows, _models, _rates, _entry, _model
+
+# GPT-6 Astra uses whole-request pricing above the 272K prompt tier.  Keep this
+# account-gated model out of generic static catalogs, but retain published billing
+# metadata for an explicitly selected route.
+_OFFICIAL_DOCS_PRICING[("openai", "gpt-6-astra")] = _snap(
+    "10.00", "50.00", "1.00", "12.50",
+    url="https://developers.openai.com/api/docs/models/gpt-6-astra",
+    version="openai-gpt-6-astra-2026-09",
+    tier_threshold_tokens=272_000,
+    input_cost_per_million_above=Decimal("20.00"),
+    output_cost_per_million_above=Decimal("75.00"),
+    cache_read_cost_per_million_above=Decimal("2.00"),
+    cache_write_cost_per_million_above=Decimal("25.00"),
+)
 
 # Context-tiered Gemini Pro: above 200k prompt tokens the *_above rates apply to
 # the whole request (see PricingEntry).
@@ -555,7 +570,7 @@ def estimate_usage_cost(
         (usage.output_tokens, entry.output_cost_per_million, entry.output_cost_per_million_above, ()),
         (usage.cache_read_tokens, entry.cache_read_cost_per_million, entry.cache_read_cost_per_million_above,
          ("cache-read pricing unavailable for route",)),
-        (usage.cache_write_tokens, entry.cache_write_cost_per_million, None,
+        (usage.cache_write_tokens, entry.cache_write_cost_per_million, entry.cache_write_cost_per_million_above,
          ("cache-write pricing unavailable for route",)),
     ):
         if above and rate_above is not None:

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -96,7 +96,7 @@ def _finalize_codex_models(model_ids: List[str], *, allow_astra: bool = False) -
     """
     finalized = _add_forward_compat_models(model_ids)
     if not allow_astra:
-        finalized = [model for model in finalized if model.lower() != "gpt-6-astra"]
+        finalized = [model for model in finalized if model.lower().rsplit("/", 1)[-1] != "gpt-6-astra"]
     return _add_context_variants(finalized)
 
 

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -94,9 +94,12 @@ def _finalize_codex_models(model_ids: List[str], *, allow_astra: bool = False) -
     Cached/configured model names are useful compatibility hints, but only the
     account-scoped Codex endpoint is authoritative for current Astra access.
     """
+    from agent.model_metadata import strip_codex_context_variant_suffix
+
     finalized = _add_forward_compat_models(model_ids)
     if not allow_astra:
-        finalized = [model for model in finalized if model.lower().rsplit("/", 1)[-1] != "gpt-6-astra"]
+        finalized = [model for model in finalized
+                     if strip_codex_context_variant_suffix(model.lower()).rsplit("/", 1)[-1] != "gpt-6-astra"]
     return _add_context_variants(finalized)
 
 

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -88,9 +88,16 @@ def _add_context_variants(model_ids: List[str]) -> List[str]:
     return out
 
 
-def _finalize_codex_models(model_ids: List[str]) -> List[str]:
-    """Forward-compat synthesis + large-context variant synthesis."""
-    return _add_context_variants(_add_forward_compat_models(model_ids))
+def _finalize_codex_models(model_ids: List[str], *, allow_astra: bool = False) -> List[str]:
+    """Forward-compat/context synthesis with an entitlement gate for Astra.
+
+    Cached/configured model names are useful compatibility hints, but only the
+    account-scoped Codex endpoint is authoritative for current Astra access.
+    """
+    finalized = _add_forward_compat_models(model_ids)
+    if not allow_astra:
+        finalized = [model for model in finalized if model.lower() != "gpt-6-astra"]
+    return _add_context_variants(finalized)
 
 
 def _extract_chatgpt_account_id(access_token: str) -> Optional[str]:
@@ -159,7 +166,7 @@ def _fetch_models_from_api(access_token: str) -> List[str]:
         logger.debug("Failed to fetch Codex models from API: %s", exc)
         return []
 
-    return _finalize_codex_models(_ranked_slugs(entries))
+    return _finalize_codex_models(_ranked_slugs(entries), allow_astra=True)
 
 
 def _read_default_model(codex_home: Path) -> Optional[str]:
@@ -194,7 +201,7 @@ def get_codex_model_ids(access_token: Optional[str] = None) -> List[str]:
     if access_token:
         api_models = _fetch_models_from_api(access_token)
         if api_models:
-            return _finalize_codex_models(api_models)
+            return _finalize_codex_models(api_models, allow_astra=True)
     default_model = _read_default_model(codex_home)
     return _finalize_codex_models(_dedupe([
         *([default_model] if default_model else []), *_read_cache_models(codex_home),

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -407,7 +407,7 @@ def _append_unconfigured_rows(
     """Empty setup skeletons for canonical providers missing from ``rows`` — except the *current* one:
     if config.yaml still points at it but credentials are gone, keep a row carrying the saved model so
     GUI pickers don't silently snap to another provider."""
-    from hermes_cli.models import CANONICAL_PROVIDERS
+    from hermes_cli.models import CANONICAL_PROVIDERS, _model_requires_account_discovery
 
     seen = {r["slug"].lower() for r in rows}
     cur = (ctx.current_provider or "").lower()
@@ -419,6 +419,7 @@ def _append_unconfigured_rows(
         if current_only and entry.slug.lower() != cur:
             continue
         if entry.slug.lower() == cur:
+            saved_model = "" if _model_requires_account_discovery(entry.slug, cur_model) else cur_model
             auth_type, key_env = _provider_auth_hint(entry.slug)
             warning = (
                 f"Configured provider missing usable credentials; paste {key_env} to reactivate. "
@@ -427,8 +428,10 @@ def _append_unconfigured_rows(
                 else "Configured provider is not authenticated; run `hermes model` to reactivate. "
                 "Showing the saved model only."
             )
+            if cur_model and not saved_model:
+                warning = warning.replace("Showing the saved model only.", "Astra requires successful account-scoped model discovery.")
             extras.append(_canonical_row(
-                entry, cur, models=[cur_model] if cur_model else [], total_models=1 if cur_model else 0,
+                entry, cur, models=[saved_model] if saved_model else [], total_models=1 if saved_model else 0,
                 source="configured-current", authenticated=False, auth_type=auth_type, key_env=key_env,
                 warning=warning,
             ))

--- a/hermes_cli/model_switch_providers.py
+++ b/hermes_cli/model_switch_providers.py
@@ -1111,6 +1111,10 @@ def _finalize_picker_rows(results: list, user_providers, current_model: str) -> 
                 continue
             models = row.get("models") or []
             if current_model not in models:
+                from hermes_cli.models import _model_requires_account_discovery
+
+                if _model_requires_account_discovery(row.get("slug"), current_model):
+                    break
                 row["models"] = [current_model, *models]
                 row["total_models"] = row.get("total_models", len(models)) + 1
             break

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1516,6 +1516,13 @@ def _normalized_cache_slug(provider: Optional[str]) -> str:
     return requested if requested == "ollama" else (normalize_provider(provider) or (provider or ""))
 
 
+def _model_requires_account_discovery(provider: Optional[str], model: str) -> bool:
+    """Astra names cannot confer API/OAuth entitlement through picker state."""
+    return _normalized_cache_slug(provider) in {"openai", "openai-codex"} and str(model or "").strip().lower().rsplit("/", 1)[-1] in {
+        "gpt-6-astra", "gpt-6-astra-900k",
+    }
+
+
 def cached_provider_model_ids(
     provider: Optional[str], *, force_refresh: bool = False,
     ttl_seconds: int = _PROVIDER_MODELS_CACHE_TTL) -> list[str]:
@@ -1532,8 +1539,14 @@ def cached_provider_model_ids(
     fp = _credential_fingerprint(normalized)
     entry = cache.get(normalized)
     now = time.time()
+    # Even a credential-matched fresh disk cache predates the current account's
+    # entitlement check. Revalidate gated entries before offering them again.
+    cached_models = entry.get("models") if isinstance(entry, dict) else None
+    gated_cache = isinstance(cached_models, list) and any(
+        _model_requires_account_discovery(normalized, model) for model in cached_models
+    )
 
-    if not force_refresh and _cache_entry_valid(entry, fp, allow_empty=is_ollama):
+    if not force_refresh and not gated_cache and _cache_entry_valid(entry, fp, allow_empty=is_ollama):
         age = now - entry["at"]
         if age < ttl_seconds:
             return list(entry["models"])
@@ -1562,7 +1575,7 @@ def cached_provider_model_ids(
         return []
     # Live returned nothing: a stale same-fingerprint entry beats an empty result.
     if _cache_entry_valid(entry, fp):
-        return list(entry["models"])
+        return [model for model in entry["models"] if not _model_requires_account_discovery(normalized, model)]
     return []
 
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1203,7 +1203,12 @@ def _openai_catalog(normalized: str, force_refresh: bool) -> Optional[list[str]]
     curated = list(_PROVIDER_MODELS.get(normalized, []))
     # Curated order, only models the account has access to; an account serving none of them (rare)
     # falls back to curated so the picker still offers sane defaults.
-    return [m for m in curated if m.lower() in live_lower] or curated or live
+    discovered = [m for m in curated if m.lower() in live_lower]
+    # Astra is intentionally absent from offline/static catalogs: the official API's
+    # account-scoped /models response is the only source that may advertise it.
+    if "gpt-6-astra" in live_lower:
+        discovered.append(next((m for m in live if m.lower() == "gpt-6-astra"), "gpt-6-astra"))
+    return discovered or curated or live
 
 
 def _custom_catalog(normalized: str, force_refresh: bool) -> Optional[list[str]]:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1518,7 +1518,7 @@ def _normalized_cache_slug(provider: Optional[str]) -> str:
 
 def _model_requires_account_discovery(provider: Optional[str], model: str) -> bool:
     """Astra names cannot confer API/OAuth entitlement through picker state."""
-    return _normalized_cache_slug(provider) in {"openai", "openai-codex"} and str(model or "").strip().lower().rsplit("/", 1)[-1] in {
+    return _normalized_cache_slug(provider) in {"openai", "openai-api", "openai-codex"} and str(model or "").strip().lower().rsplit("/", 1)[-1] in {
         "gpt-6-astra", "gpt-6-astra-900k",
     }
 

--- a/hermes_state_compression.py
+++ b/hermes_state_compression.py
@@ -215,7 +215,7 @@ class SessionCompressionMixin:
             parent = conn.execute(
                 """SELECT ended_at, end_reason, cwd, git_branch, git_repo_root,
                           user_id, session_key, chat_id, chat_type,
-                          thread_id, display_name, origin_json, profile_name
+                          thread_id, display_name, origin_json, profile_name, model_config
                    FROM sessions WHERE id = ?""",
                 (parent_session_id,),
             ).fetchone()
@@ -233,9 +233,19 @@ class SessionCompressionMixin:
                     (parent_session_id,))
             if not messages:
                 raise RuntimeError("Compression child handoff must not be empty")
+            # Runtime steering admissions are newer than the agent's initial
+            # model config. Carry their current durable state in this transaction
+            # so rotation cannot lose a rejected correction or replay an accepted
+            # one. Do not copy unrelated dynamic settings into the child.
+            from hermes_state_sessions import _parse_model_config
+            parent_config = _parse_model_config(parent["model_config"])
+            child_model_config = model_config
+            if "_astra_steering" in parent_config:
+                child_model_config = {**(model_config or {}),
+                                      "_astra_steering": parent_config["_astra_steering"]}
             self._publish_child_session_row(
                 conn, parent, parent_session_id=parent_session_id, child_session_id=child_session_id,
-                source=source, model=model, model_config=model_config, system_prompt=system_prompt,
+                source=source, model=model, model_config=child_model_config, system_prompt=system_prompt,
                 cwd=cwd, profile_name=profile_name)
             total_messages, total_tool_calls = self._insert_message_rows(conn, child_session_id, messages)
             if watermark is not None:

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -310,9 +310,33 @@ class SessionMessagesMixin:
             inserted_rows = resolve_and_repair_transcript_batch(conn, session_id, messages,
                 encode_content_fn=self._encode_content, decode_content_fn=self._decode_content)
             inserted, tool_calls_total = self._insert_message_rows(conn, session_id, inserted_rows)
+            self._ack_astra_fallback_redirects(conn, session_id, inserted_rows)
             self._bump_session_counters(conn, session_id, inserted, tool_calls_total, unit=False)
             return inserted
         return self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S)
+
+    def _ack_astra_fallback_redirects(self, conn, session_id: str, messages: List[Dict[str, Any]]) -> None:
+        """Ack exact rejected-steer admissions in the transaction inserting their user row."""
+        deliveries = [(msg, (msg.get("display_metadata") or {}).get("_astra_steering_fallback"))
+                      for msg in messages if msg.get("role") == "user"
+                      and isinstance(msg.get("display_metadata"), dict)]
+        deliveries = [(msg, receipts) for msg, receipts in deliveries if receipts]
+        if not deliveries:
+            return
+        row = conn.execute("SELECT model_config FROM sessions WHERE id = ?", (session_id,)).fetchone()
+        config = json.loads(row[0] or "{}") if row else {}
+        journal = config.get("_astra_steering") or {}
+        entries = {entry.get("admission_id"): entry for entry in journal.get("entries", [])
+                   if isinstance(entry, dict)}
+        for msg, receipts in deliveries:
+            for receipt in receipts:
+                entry = entries.get(receipt.get("admission_id"))
+                if (entry is None or entry.get("state") not in {"failed", "fallback_queued"}
+                        or entry.get("input_sha256", "") != receipt.get("input_sha256", "")):
+                    raise ValueError("Astra fallback redirect lacks an unconsumed rejected admission")
+                entry["state"] = "fallback_delivered"
+                entry["fallback_message_row_id"] = msg["_row_id"]
+        conn.execute("UPDATE sessions SET model_config = ? WHERE id = ?", (json.dumps(config), session_id))
 
     def set_latest_matching_message_display_kind(self, session_id: str, *, role: str, content: str,
                                                  display_kind: str,

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -38,7 +38,6 @@ _ACTIVE_IDS_SQL = "SELECT id FROM messages WHERE session_id = ? AND active = 1 O
 _SET_COUNTERS_SQL = "UPDATE sessions SET message_count = ?, tool_call_count = ?"
 _RESET_COUNTERS_SQL = "UPDATE sessions SET message_count = 0, tool_call_count = 0 WHERE id = ?"
 _SET_DISPLAY_META_SQL = "UPDATE messages SET display_metadata = ? WHERE id = ?"
-_ASTRA_STEERING_FALLBACK_KEY = "_astra_steering_fallback"
 _ARCHIVE_ACTIVE_SQL = "UPDATE messages SET active = 0, compacted = 1 WHERE session_id = ? AND active = 1"
 _INVALID = object()  # _json_or sentinel where the fallback must be distinguishable from JSON null
 
@@ -333,67 +332,6 @@ class SessionMessagesMixin:
                 (_scrub_surrogates(display_kind), self._encode_display_metadata(display_metadata), row[0]))
             return True
         return self._execute_write(_do)
-
-    def persist_astra_steering_fallback(
-        self, session_id: str, message_row_id: Optional[int], tool_call_id: str,
-        expected_content: Any, delivered_content: Any, receipts: List[Dict[str, Any]],
-    ) -> bool:
-        if not session_id or not tool_call_id or not isinstance(receipts, list):
-            return False
-        requested = {
-            str(item.get("admission_id")): str(item.get("input_sha256") or "")
-            for item in receipts if isinstance(item, dict) and item.get("admission_id")
-        }
-        if not requested:
-            return False
-
-        def _do(conn):
-            identity = "id = ? AND " if isinstance(message_row_id, int) else ""
-            params = ((message_row_id, session_id, tool_call_id) if isinstance(message_row_id, int)
-                      else (session_id, tool_call_id))
-            row = conn.execute(
-                "SELECT id, content, display_metadata FROM messages WHERE " + identity +
-                "session_id = ? AND role = 'tool' AND tool_call_id = ? AND active = 1 "
-                "ORDER BY id DESC LIMIT 1", params).fetchone()
-            if row is None:
-                return False
-            current = self._decode_content(row["content"])
-            meta = self._decode_display_metadata(row["display_metadata"]) or {}
-            delivered = [item for item in meta.get(_ASTRA_STEERING_FALLBACK_KEY, [])
-                         if isinstance(item, dict)]
-            delivered_ids = {str(item.get("admission_id")) for item in delivered}
-            config_row = conn.execute("SELECT model_config FROM sessions WHERE id = ?", (session_id,)).fetchone()
-            if config_row is None:
-                return False
-            config = json.loads(config_row[0] or "{}")
-            steering = config.get("_astra_steering")
-            entries = steering.get("entries") if isinstance(steering, dict) else None
-            allowed = {"failed", "fallback_queued", "fallback_delivered"}
-            if not isinstance(entries, list) or any(
-                not any(isinstance(entry, dict) and str(entry.get("admission_id")) == admission_id
-                        and entry.get("state") in allowed for entry in entries)
-                for admission_id in requested
-            ):
-                return False
-            if current != delivered_content and current != expected_content:
-                return False
-
-            for admission_id, digest in requested.items():
-                if admission_id not in delivered_ids:
-                    delivered.append({"admission_id": admission_id, "input_sha256": digest})
-                for entry in entries:
-                    if isinstance(entry, dict) and str(entry.get("admission_id")) == admission_id:
-                        entry["state"] = "fallback_delivered"
-            meta[_ASTRA_STEERING_FALLBACK_KEY] = delivered[-16:]
-            config["_astra_steering"] = steering
-            conn.execute(
-                "UPDATE messages SET content = ?, display_metadata = ? WHERE id = ?",
-                (self._encode_content(delivered_content), self._encode_display_metadata(meta), row["id"]),
-            )
-            conn.execute("UPDATE sessions SET model_config = ? WHERE id = ?", (json.dumps(config), session_id))
-            return True
-
-        return bool(self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S))
 
     def _reaction_list(self, meta: Optional[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Well-formed (dict) reactions stored under ``REACTIONS_METADATA_KEY``."""

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -38,6 +38,7 @@ _ACTIVE_IDS_SQL = "SELECT id FROM messages WHERE session_id = ? AND active = 1 O
 _SET_COUNTERS_SQL = "UPDATE sessions SET message_count = ?, tool_call_count = ?"
 _RESET_COUNTERS_SQL = "UPDATE sessions SET message_count = 0, tool_call_count = 0 WHERE id = ?"
 _SET_DISPLAY_META_SQL = "UPDATE messages SET display_metadata = ? WHERE id = ?"
+_ASTRA_STEERING_FALLBACK_KEY = "_astra_steering_fallback"
 _ARCHIVE_ACTIVE_SQL = "UPDATE messages SET active = 0, compacted = 1 WHERE session_id = ? AND active = 1"
 _INVALID = object()  # _json_or sentinel where the fallback must be distinguishable from JSON null
 
@@ -332,6 +333,67 @@ class SessionMessagesMixin:
                 (_scrub_surrogates(display_kind), self._encode_display_metadata(display_metadata), row[0]))
             return True
         return self._execute_write(_do)
+
+    def persist_astra_steering_fallback(
+        self, session_id: str, message_row_id: Optional[int], tool_call_id: str,
+        expected_content: Any, delivered_content: Any, receipts: List[Dict[str, Any]],
+    ) -> bool:
+        if not session_id or not tool_call_id or not isinstance(receipts, list):
+            return False
+        requested = {
+            str(item.get("admission_id")): str(item.get("input_sha256") or "")
+            for item in receipts if isinstance(item, dict) and item.get("admission_id")
+        }
+        if not requested:
+            return False
+
+        def _do(conn):
+            identity = "id = ? AND " if isinstance(message_row_id, int) else ""
+            params = ((message_row_id, session_id, tool_call_id) if isinstance(message_row_id, int)
+                      else (session_id, tool_call_id))
+            row = conn.execute(
+                "SELECT id, content, display_metadata FROM messages WHERE " + identity +
+                "session_id = ? AND role = 'tool' AND tool_call_id = ? AND active = 1 "
+                "ORDER BY id DESC LIMIT 1", params).fetchone()
+            if row is None:
+                return False
+            current = self._decode_content(row["content"])
+            meta = self._decode_display_metadata(row["display_metadata"]) or {}
+            delivered = [item for item in meta.get(_ASTRA_STEERING_FALLBACK_KEY, [])
+                         if isinstance(item, dict)]
+            delivered_ids = {str(item.get("admission_id")) for item in delivered}
+            config_row = conn.execute("SELECT model_config FROM sessions WHERE id = ?", (session_id,)).fetchone()
+            if config_row is None:
+                return False
+            config = json.loads(config_row[0] or "{}")
+            steering = config.get("_astra_steering")
+            entries = steering.get("entries") if isinstance(steering, dict) else None
+            allowed = {"failed", "fallback_queued", "fallback_delivered"}
+            if not isinstance(entries, list) or any(
+                not any(isinstance(entry, dict) and str(entry.get("admission_id")) == admission_id
+                        and entry.get("state") in allowed for entry in entries)
+                for admission_id in requested
+            ):
+                return False
+            if current != delivered_content and current != expected_content:
+                return False
+
+            for admission_id, digest in requested.items():
+                if admission_id not in delivered_ids:
+                    delivered.append({"admission_id": admission_id, "input_sha256": digest})
+                for entry in entries:
+                    if isinstance(entry, dict) and str(entry.get("admission_id")) == admission_id:
+                        entry["state"] = "fallback_delivered"
+            meta[_ASTRA_STEERING_FALLBACK_KEY] = delivered[-16:]
+            config["_astra_steering"] = steering
+            conn.execute(
+                "UPDATE messages SET content = ?, display_metadata = ? WHERE id = ?",
+                (self._encode_content(delivered_content), self._encode_display_metadata(meta), row["id"]),
+            )
+            conn.execute("UPDATE sessions SET model_config = ? WHERE id = ?", (json.dumps(config), session_id))
+            return True
+
+        return bool(self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S))
 
     def _reaction_list(self, meta: Optional[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Well-formed (dict) reactions stored under ``REACTIONS_METADATA_KEY``."""

--- a/run_agent.py
+++ b/run_agent.py
@@ -899,6 +899,7 @@ class AIAgent(
         # and a cross-thread close can release TLS FDs under a still-unwinding worker.
         _quietly(self._drop_shared_client, lambda c: self._retire_shared_openai_client(c, reason="cache_evict"))
         self._close_request_clients("cache_evict")
+        _quietly(self._close_astra_websocket_session)
 
     def close(self) -> None:
         """Release every resource this agent holds (idempotent); each phase is guarded so one failure never
@@ -911,6 +912,7 @@ class AIAgent(
         self._close_active_children(soft=False)
         _quietly(self._drop_shared_client, lambda c: self._close_openai_client(c, reason="agent_close", shared=True))
         self._close_request_clients("agent_close")
+        _quietly(self._close_astra_websocket_session)
         _quietly(self._close_codex_session)
         # Free conversation history proactively: callers may still hold the closed agent. The DB-flush
         # settled-prefix snapshot and the streamed-text accumulator are shadow copies of the same transcript;
@@ -978,6 +980,13 @@ class AIAgent(
         if codex_session is not None:
             self._codex_session = None
             codex_session.close()
+
+    def _close_astra_websocket_session(self) -> None:
+        """Close a turn-owned Astra lane before releasing the agent's other clients."""
+        session = getattr(self, "_astra_websocket_session", None)
+        if session is not None:
+            self._astra_websocket_session = None
+            session.close()
 
     @staticmethod
     def _trim_process_memory() -> None:

--- a/tests/agent/test_astra_async_tools.py
+++ b/tests/agent/test_astra_async_tools.py
@@ -6,7 +6,7 @@ import time
 
 import pytest
 
-from agent.astra_async_tools import AstraAsyncExecutor, provider_async_marker
+from agent.astra_async_tools import AstraAsyncExecutor, is_direct_astra, provider_async_marker
 from agent.codex_responses_adapter import _response_tool_call, _responses_tools
 from agent.codex_runtime import _consume_codex_event_stream
 
@@ -66,6 +66,16 @@ def test_async_marker_spellings_survive_raw_and_normalized_paths(marker):
     assert provider_async_marker(normalized)
 
 
+@pytest.mark.parametrize(("base_url", "expected"), [
+    ("https://api.openai.com/v1", True),
+    ("https://evil.api.openai.com/v1", False),
+    ("https://api.openai.com.evil.test/v1", False),
+])
+def test_direct_astra_requires_exact_official_hostname(base_url, expected):
+    agent = SimpleNamespace(api_mode="codex_responses", model="gpt-6-astra", base_url=base_url)
+    assert is_direct_astra(agent) is expected
+
+
 class _FakeAgent:
     api_mode = "codex_responses"
     model = "gpt-6-astra"
@@ -113,7 +123,7 @@ def patched_executor(monkeypatch):
             self.name = call.name
             self.args = {}
             self.middleware_trace = []
-            self.parse_error = None
+            self.parse_error = "invalid arguments" if call.name == "malformed" else None
             self.scope_block = None
 
         def ref(self, task_id):
@@ -219,3 +229,67 @@ def test_interrupt_retirement_is_idempotent_and_does_not_re_admit(patched_execut
     assert executor.admit(call) is True
     executor.abort_stream()
     assert executor.admit(call) is False
+
+
+def test_parse_error_is_reported_without_handler_dispatch(patched_executor, monkeypatch):
+    _, starts, _ = patched_executor
+    import agent.tool_executor as tool_executor
+
+    invalid = []
+
+    def append_invalid(agent, messages, ref, parse_error):
+        invalid.append(ref.call_id)
+        messages.append({"role": "tool", "tool_call_id": ref.call_id, "content": parse_error})
+        return True
+
+    monkeypatch.setattr(tool_executor, "_append_invalid_arguments_result", append_invalid)
+    agent = _FakeAgent([])
+    executor = AstraAsyncExecutor(agent, [], "task")
+    assert executor.admit(_tool("malformed", "bad")) is True
+    assert executor.finish_stream() is True
+    assert starts == []
+    assert invalid == ["call_bad"]
+    assert agent._session_messages[-1]["content"] == "invalid arguments"
+
+
+def test_announced_order_blocks_later_completion_until_earlier_call_is_admitted(patched_executor):
+    _, starts, committed = patched_executor
+    agent = _FakeAgent([])
+    executor = AstraAsyncExecutor(agent, [], "task")
+    first, second = _tool("safe_a", "a"), _tool("safe_b", "b")
+    assert executor.reserve(first) is True
+    assert executor.reserve(second) is True
+    assert executor.admit(second) is True
+    assert starts == []
+    assert executor.admit(first) is True
+    assert executor.finish_stream() is True
+    assert committed == ["call_a", "call_b"]
+
+
+def test_publish_failure_recovers_once_without_reexecuting_handler(patched_executor, monkeypatch):
+    _, starts, _ = patched_executor
+    import agent.tool_executor as tool_executor
+
+    publish_calls = []
+
+    def fail_publish(agent, messages, ref, managed, **kwargs):
+        publish_calls.append(ref.call_id)
+        messages.append({"role": "tool", "tool_call_id": ref.call_id, "content": managed.result})
+        return False
+
+    monkeypatch.setattr(tool_executor, "_publish_sequential_result", fail_publish)
+    flushes = []
+    agent = _FakeAgent([])
+
+    def flush(messages):
+        flushes.append([row.copy() for row in messages])
+        return True
+
+    agent._flush_messages_to_session_db = flush
+    executor = AstraAsyncExecutor(agent, [], "task")
+    assert executor.admit(_tool("safe", "fail")) is True
+    assert executor.finish_stream() is True
+    assert starts == ["call_fail"]
+    assert publish_calls == ["call_fail"]
+    assert len(flushes) == 2
+    assert "[Orphan recovery:" in flushes[-1][-1]["content"]

--- a/tests/agent/test_astra_async_tools.py
+++ b/tests/agent/test_astra_async_tools.py
@@ -309,3 +309,65 @@ def test_publish_failure_recovers_once_without_reexecuting_handler(patched_execu
     assert publish_calls == ["call_fail"]
     assert len(flushes) == 2
     assert "[Orphan recovery:" in flushes[-1][-1]["content"]
+
+
+def test_settle_required_persists_ordered_prefix_once_and_finish_stream_is_idempotent(patched_executor, monkeypatch):
+    _, starts, committed = patched_executor
+    import agent.tool_executor as tool_executor
+
+    persisted = []
+    agent = _FakeAgent(persisted)
+
+    def publish(agent, messages, ref, managed, **kwargs):
+        committed.append(ref.call_id)
+        messages.append({"role": "tool", "tool_call_id": ref.call_id, "content": managed.result})
+        assert agent._flush_messages_to_session_db(messages) is True
+        return True
+
+    monkeypatch.setattr(tool_executor, "_publish_sequential_result", publish)
+    executor = AstraAsyncExecutor(agent, [], "task")
+    executor.admit(_tool("safe_a", "a"))
+    executor.admit(_tool("unsafe", "b"))
+    last = _tool("safe_c", "c")
+    executor.admit(last)
+
+    assert executor.settle_required([last.call_id]) is True
+    assert committed == ["call_a", "call_b", "call_c"]
+    assert [row["tool_call_id"] for row in persisted[-1] if row.get("role") == "tool"] == committed
+    assert executor.settle_required([last.call_id]) is True
+    assert committed == ["call_a", "call_b", "call_c"]
+
+    assert executor.finish_stream() is True
+    assert executor.finish_stream() is True
+    assert committed == ["call_a", "call_b", "call_c"]
+    assert [row["tool_call_id"] for row in agent._session_messages if row.get("role") == "tool"] == committed
+    assert starts.count("call_c") == 1
+
+
+def test_settle_required_persistence_failure_never_reexecutes_or_exposes_result(patched_executor, monkeypatch):
+    _, starts, _ = patched_executor
+    import agent.tool_executor as tool_executor
+
+    persisted = []
+    agent = _FakeAgent(persisted)
+
+    def flush(messages):
+        if any(row.get("role") == "tool" for row in messages):
+            return False
+        persisted.append([row.copy() for row in messages])
+        return True
+
+    agent._flush_messages_to_session_db = flush
+
+    def publish(agent, messages, ref, managed, **kwargs):
+        messages.append({"role": "tool", "tool_call_id": ref.call_id, "content": managed.result})
+        return agent._flush_messages_to_session_db(messages)
+
+    monkeypatch.setattr(tool_executor, "_publish_sequential_result", publish)
+    executor = AstraAsyncExecutor(agent, [], "task")
+    call = _tool("safe", "no-durable-result")
+    assert executor.admit(call) is True
+
+    assert executor.settle_required([call.call_id]) is False
+    assert starts == [call.call_id]
+    assert all(not any(row.get("role") == "tool" for row in batch) for batch in persisted)

--- a/tests/agent/test_astra_async_tools.py
+++ b/tests/agent/test_astra_async_tools.py
@@ -266,6 +266,22 @@ def test_announced_order_blocks_later_completion_until_earlier_call_is_admitted(
     assert committed == ["call_a", "call_b"]
 
 
+def test_terminal_settlement_admits_pending_announced_call_before_retirement(patched_executor):
+    _, starts, committed = patched_executor
+    agent = _FakeAgent([])
+    executor = AstraAsyncExecutor(agent, [], "task")
+    first, second = _tool("safe_a", "a"), _tool("safe_b", "b")
+    assert executor.admit(first) is True
+    final = _consume_codex_event_stream([
+        SimpleNamespace(type="response.output_item.added", output_index=1, item=second),
+        SimpleNamespace(type="response.completed", response=SimpleNamespace(id="resp", status="completed")),
+    ], model="gpt-6-astra", on_async_tool_announcement=executor.reserve)
+    assert executor.has_pending
+    assert executor.finish_stream(settled_calls=final.output) is True
+    assert starts == ["call_a", "call_b"]
+    assert committed == ["call_a", "call_b"]
+
+
 def test_publish_failure_recovers_once_without_reexecuting_handler(patched_executor, monkeypatch):
     _, starts, _ = patched_executor
     import agent.tool_executor as tool_executor

--- a/tests/agent/test_astra_async_tools.py
+++ b/tests/agent/test_astra_async_tools.py
@@ -1,0 +1,221 @@
+"""Focused deterministic coverage for direct GPT-6 Astra async application tools."""
+
+from types import SimpleNamespace
+import threading
+import time
+
+import pytest
+
+from agent.astra_async_tools import AstraAsyncExecutor, provider_async_marker
+from agent.codex_responses_adapter import _response_tool_call, _responses_tools
+from agent.codex_runtime import _consume_codex_event_stream
+
+
+def _tool(name, call_id):
+    call = SimpleNamespace(
+        type="function_call", id=f"fc_{call_id}", call_id=f"call_{call_id}", name=name,
+        arguments="{}", async_=True,
+    )
+    return call
+
+
+def test_astra_schema_marker_is_explicit_and_non_astra_shape_is_unchanged():
+    source = [{"type": "function", "function": {"name": "read_file", "parameters": {"type": "object"}}}]
+    plain = _responses_tools(source)
+    async_tools = _responses_tools(source, async_tools=True)
+    assert "async" not in plain[0]
+    assert async_tools[0]["async"] is True
+
+
+def test_stream_preserves_async_marker_and_admits_only_completed_call():
+    admitted = []
+    events = [
+        SimpleNamespace(type="response.output_item.added", output_index=0, item=SimpleNamespace(
+            type="function_call", id="fc_1", call_id="call_1", name="read_file", arguments="", **{"async": True},
+        )),
+        SimpleNamespace(type="response.function_call_arguments.delta", item_id="fc_1", delta="{}"),
+        SimpleNamespace(type="response.function_call_arguments.done", item_id="fc_1", arguments="{}"),
+        SimpleNamespace(type="response.completed", response=SimpleNamespace(id="resp_1", status="completed")),
+    ]
+    final = _consume_codex_event_stream(events, model="gpt-6-astra", on_async_tool_call=admitted.append)
+    assert len(admitted) == 1
+    assert admitted[0].call_id == "call_1"
+    assert getattr(admitted[0], "async", False) is True
+    assert final.output[0].call_id == "call_1"
+
+
+@pytest.mark.parametrize("marker", ["async", "async_"])
+def test_async_marker_spellings_survive_raw_and_normalized_paths(marker):
+    emitted = []
+    item = {"type": "function_call", "id": "fc_alias", "call_id": "call_alias", "name": "read_file",
+            "arguments": "{}", marker: True}
+    events = [
+        {"type": "response.output_item.added", "output_index": 0, "item": item},
+        {"type": "response.function_call_arguments.done", "item_id": "fc_alias", "arguments": "{}"},
+        {"type": "response.completed", "response": {"id": "resp_alias", "status": "completed"}},
+    ]
+    _consume_codex_event_stream(events, model="gpt-6-astra", on_async_tool_call=emitted.append)
+    assert len(emitted) == 1
+    assert provider_async_marker(emitted[0])
+
+    normalized = _response_tool_call(
+        SimpleNamespace(type="function_call", id="fc_alias", call_id="call_alias", name="read_file",
+                        arguments="{}", **{marker: True}),
+        "function_call", 0,
+    )
+    assert provider_async_marker(normalized)
+
+
+class _FakeAgent:
+    api_mode = "codex_responses"
+    model = "gpt-6-astra"
+    base_url = "https://api.openai.com/v1"
+    session_id = "session-test"
+    session_start = None
+    _interrupt_requested = False
+
+    def __init__(self, persisted):
+        self.persisted = persisted
+        self._session_messages = []
+        self.verbose_logging = False
+        self.reasoning_callback = None
+        self.stream_delta_callback = None
+        self._stream_callback = None
+
+    def _extract_reasoning(self, message):
+        return None
+
+    def _strip_think_blocks(self, content):
+        return content
+
+    def _split_responses_tool_id(self, value):
+        return (value, value)
+
+    def _derive_responses_function_call_id(self, call_id, response_item_id=None):
+        return response_item_id or f"fc_{call_id.removeprefix('call_')}"
+
+    def _deterministic_call_id(self, name, arguments, index):
+        return f"call_deterministic_{index}"
+
+    def _flush_messages_to_session_db(self, messages):
+        self.persisted.append([m.copy() for m in messages])
+        return True
+
+
+@pytest.fixture
+def patched_executor(monkeypatch):
+    import agent.astra_async_tools as module
+    import agent.tool_executor as tool_executor
+
+    class Parsed:
+        def __init__(self, call):
+            self.call = call
+            self.name = call.name
+            self.args = {}
+            self.middleware_trace = []
+            self.parse_error = None
+            self.scope_block = None
+
+        def ref(self, task_id):
+            return SimpleNamespace(name=self.name, args={}, task_id=task_id, call_id=self.call.call_id, trace=[])
+
+    monkeypatch.setattr(tool_executor, "_parse_tool_call", lambda agent, call: Parsed(call))
+    monkeypatch.setattr(tool_executor, "_resolve_sequential_dispatch", lambda *args: SimpleNamespace())
+
+    running = set()
+    overlap = threading.Event()
+    starts = []
+
+    def run_call(agent, dispatch, ref, **kwargs):
+        starts.append(ref.call_id)
+        running.add(ref.call_id)
+        if len(running) >= 2:
+            overlap.set()
+        time.sleep(0.03)
+        running.remove(ref.call_id)
+        return SimpleNamespace(result=f"result:{ref.call_id}", args={}, middleware_trace=[], blocked=False, dispatched=True), 0.03
+
+    monkeypatch.setattr(tool_executor, "_run_sequential_call", run_call)
+    committed = []
+
+    def publish(agent, messages, ref, managed, **kwargs):
+        committed.append(ref.call_id)
+        messages.append({"role": "tool", "tool_call_id": ref.call_id, "content": managed.result})
+        return True
+
+    monkeypatch.setattr(tool_executor, "_publish_sequential_result", publish)
+    monkeypatch.setattr(tool_executor, "_budget_for_agent", lambda agent: object())
+    monkeypatch.setattr(tool_executor, "_finalize_tool_batch", lambda *args, **kwargs: None)
+
+    def plan(calls, **kwargs):
+        segments = []
+        current = []
+        for call in calls:
+            if call.name == "unsafe":
+                if current:
+                    segments.append(("parallel", current) if len(current) > 1 else ("sequential", current))
+                    current = []
+                segments.append(("sequential", [call]))
+            else:
+                current.append(call)
+        if current:
+            segments.append(("parallel", current) if len(current) > 1 else ("sequential", current))
+        return segments
+
+    monkeypatch.setattr(module, "_plan_tool_batch_segments", plan)
+    return overlap, starts, committed
+
+
+def test_admit_persists_before_handler_and_barriers_keep_result_order(patched_executor):
+    overlap, starts, committed = patched_executor
+    persisted = []
+    agent = _FakeAgent(persisted)
+    executor = AstraAsyncExecutor(agent, [], "task")
+
+    first = _tool("safe_a", "a")
+    assert executor.admit(first) is True
+    # The first worker may start immediately, but its assistant fragment was flushed first.
+    assert persisted and persisted[0][0]["role"] == "assistant"
+
+    second = _tool("safe_b", "b")
+    assert executor.admit(second) is True
+    assert executor.admit(_tool("unsafe", "c")) is True
+    assert executor.admit(_tool("safe_d", "d")) is True
+    assert executor.finish_stream() is True
+    assert overlap.is_set()
+    assert committed == ["call_a", "call_b", "call_c", "call_d"]
+    assert starts.count("call_c") == 1
+
+
+def test_empty_executor_is_retired_before_later_turn_state_can_be_reused():
+    agent = _FakeAgent([])
+    stale_messages = [{"role": "assistant", "content": "stale"}]
+    stale = AstraAsyncExecutor(agent, stale_messages, "task")
+    assert stale.retire_empty() is True
+    assert stale.closed is True
+
+    fresh_messages = [{"role": "user", "content": "new"}]
+    fresh = AstraAsyncExecutor(agent, fresh_messages, "task")
+    assert fresh.messages is fresh_messages
+    assert fresh.messages is not stale.messages
+    fresh.retire_empty()
+
+
+def test_mixed_assistant_text_is_persisted_before_async_results(patched_executor):
+    persisted = []
+    agent = _FakeAgent(persisted)
+    executor = AstraAsyncExecutor(agent, [], "task")
+    assert executor.admit(_tool("safe", "text")) is True
+    assert executor.finish_stream(assistant_content="Visible assistant text") is True
+    assistant_rows = [row for batch in persisted for row in batch if row.get("role") == "assistant"]
+    assert any(row.get("content") == "Visible assistant text" for row in assistant_rows)
+
+
+def test_interrupt_retirement_is_idempotent_and_does_not_re_admit(patched_executor):
+    persisted = []
+    agent = _FakeAgent(persisted)
+    executor = AstraAsyncExecutor(agent, [], "task")
+    call = _tool("safe", "once")
+    assert executor.admit(call) is True
+    executor.abort_stream()
+    assert executor.admit(call) is False

--- a/tests/agent/test_astra_baseline_runtime.py
+++ b/tests/agent/test_astra_baseline_runtime.py
@@ -2,6 +2,8 @@
 
 from types import SimpleNamespace
 
+import pytest
+
 
 def test_explicit_astra_resolves_and_uses_official_responses(monkeypatch, tmp_path):
     """A fresh profile resolves metadata and routes the official endpoint without live I/O."""
@@ -46,3 +48,33 @@ def test_astra_codex_oauth_fallback_uses_backend_context_limit():
 
     assert DEFAULT_CONTEXT_LENGTHS["gpt-6-astra"] == 1_050_000
     assert _resolve_codex_oauth_context_length_with_source("gpt-6-astra") == (272_000, "fallback")
+
+
+@pytest.mark.parametrize("advertised,expected", [(272_000, 900_000), (200_000, 200_000), (1_050_000, 1_050_000)])
+def test_astra_900k_opt_in_preserves_live_limits_and_wire_contract(monkeypatch, tmp_path, advertised, expected):
+    """Only the known stale advertisement is lifted; the alias never reaches the wire."""
+    from agent import model_metadata as metadata
+    from agent.reasoning_effort import CODEX_ASTRA_EFFORTS, codex_supported_efforts
+    from agent.transports.codex import ResponsesApiTransport
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(metadata, "_codex_oauth_context_cache", {})
+    monkeypatch.setattr(metadata.requests, "get", lambda *args, **kwargs: SimpleNamespace(
+        status_code=200,
+        json=lambda: {"models": [{"slug": "gpt-6-astra", "context_window": advertised}]},
+    ))
+    route = {"base_url": "https://chatgpt.com/backend-api/codex", "provider": "openai-codex"}
+    assert metadata.get_model_context_length("gpt-6-astra-900k", api_key="test-token", **route) == expected
+    assert metadata.get_model_context_length("gpt-6-astra", api_key="test-token", **route) == advertised
+    assert codex_supported_efforts("gpt-6-astra-900k") == CODEX_ASTRA_EFFORTS
+
+    for config, expected_effort in [({"effort": "max"}, "max"), ({"enabled": False}, "low")]:
+        kwargs = ResponsesApiTransport().build_kwargs(
+            model="gpt-6-astra-900k", messages=[{"role": "user", "content": "Hi"}], tools=[],
+            is_codex_backend=True, reasoning_config=config,
+            request_overrides={"temperature": 0.5, "logprobs": True}, **route,
+        )
+        assert kwargs["model"] == "gpt-6-astra"
+        assert kwargs["reasoning"]["effort"] == expected_effort
+        assert "temperature" not in kwargs and "logprobs" not in kwargs
+        assert "prompt_cache_options" not in kwargs

--- a/tests/agent/test_astra_baseline_runtime.py
+++ b/tests/agent/test_astra_baseline_runtime.py
@@ -35,3 +35,14 @@ def test_explicit_astra_resolves_and_uses_official_responses(monkeypatch, tmp_pa
     )
     assert kwargs["reasoning"]["effort"] == "low"
     assert kwargs["prompt_cache_options"] == {"ttl": "30m"}
+
+
+def test_astra_codex_oauth_fallback_uses_backend_context_limit():
+    """OAuth keeps the Codex backend's 272K fallback; direct API metadata remains 1.05M."""
+    from agent.model_metadata import (
+        DEFAULT_CONTEXT_LENGTHS,
+        _resolve_codex_oauth_context_length_with_source,
+    )
+
+    assert DEFAULT_CONTEXT_LENGTHS["gpt-6-astra"] == 1_050_000
+    assert _resolve_codex_oauth_context_length_with_source("gpt-6-astra") == (272_000, "fallback")

--- a/tests/agent/test_astra_baseline_runtime.py
+++ b/tests/agent/test_astra_baseline_runtime.py
@@ -68,13 +68,43 @@ def test_astra_900k_opt_in_preserves_live_limits_and_wire_contract(monkeypatch, 
     assert metadata.get_model_context_length("gpt-6-astra", api_key="test-token", **route) == advertised
     assert codex_supported_efforts("gpt-6-astra-900k") == CODEX_ASTRA_EFFORTS
 
-    for config, expected_effort in [({"effort": "max"}, "max"), ({"enabled": False}, "low")]:
-        kwargs = ResponsesApiTransport().build_kwargs(
-            model="gpt-6-astra-900k", messages=[{"role": "user", "content": "Hi"}], tools=[],
+    for config in ({"effort": "max"}, {"enabled": False}):
+        params = dict(
+            messages=[{"role": "user", "content": "Hi"}], tools=[],
             is_codex_backend=True, reasoning_config=config,
             request_overrides={"temperature": 0.5, "logprobs": True}, **route,
         )
+        kwargs = ResponsesApiTransport().build_kwargs(model="gpt-6-astra-900k", **params)
         assert kwargs["model"] == "gpt-6-astra"
-        assert kwargs["reasoning"]["effort"] == expected_effort
-        assert "temperature" not in kwargs and "logprobs" not in kwargs
+        assert kwargs == ResponsesApiTransport().build_kwargs(model="gpt-6-astra", **params)
         assert "prompt_cache_options" not in kwargs
+
+
+@pytest.mark.parametrize("provider,model", [
+    ("openai-codex", "gpt-6-astra"), ("openai-codex", "gpt-6-astra-900k"), ("openai", "gpt-6-astra"),
+])
+def test_picker_revalidates_cached_astra_and_never_injects_saved_entitlement(monkeypatch, tmp_path, provider, model):
+    from hermes_cli import models
+    from hermes_cli.inventory import ConfigContext, _append_unconfigured_rows
+    from hermes_cli.model_switch_providers import _finalize_picker_rows
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(models, "_credential_fingerprint", lambda _: "synthetic-account")
+    models.update_provider_cache_entry(provider, ["gpt-5.6-sol", model])
+    live = []
+    calls = []
+
+    def discover(slug, **kwargs):
+        calls.append(slug)
+        return list(live)
+
+    monkeypatch.setattr(models, "provider_model_ids", discover)
+    assert models.cached_provider_model_ids(provider) == ["gpt-5.6-sol"]
+    assert calls == [provider]
+    row = {"slug": provider, "is_current": True, "models": ["gpt-5.6-sol"], "total_models": 1}
+    assert model not in _finalize_picker_rows([row], {}, model)[0]["models"]
+    ctx = ConfigContext(provider, model, "", {}, [])
+    assert _append_unconfigured_rows([], ctx, current_only=True)[0]["models"] == []
+
+    live[:] = ["gpt-5.6-sol", model]
+    assert model in models.cached_provider_model_ids(provider)

--- a/tests/agent/test_astra_baseline_runtime.py
+++ b/tests/agent/test_astra_baseline_runtime.py
@@ -81,7 +81,7 @@ def test_astra_900k_opt_in_preserves_live_limits_and_wire_contract(monkeypatch, 
 
 
 @pytest.mark.parametrize("provider,model", [
-    ("openai-codex", "gpt-6-astra"), ("openai-codex", "gpt-6-astra-900k"), ("openai", "gpt-6-astra"),
+    ("openai-codex", "gpt-6-astra"), ("openai-codex", "gpt-6-astra-900k"), ("openai-api", "gpt-6-astra"),
 ])
 def test_picker_revalidates_cached_astra_and_never_injects_saved_entitlement(monkeypatch, tmp_path, provider, model):
     from hermes_cli import models

--- a/tests/agent/test_astra_baseline_runtime.py
+++ b/tests/agent/test_astra_baseline_runtime.py
@@ -1,0 +1,37 @@
+"""Focused real-path coverage for the GPT-6 Astra baseline contract."""
+
+from types import SimpleNamespace
+
+
+def test_explicit_astra_resolves_and_uses_official_responses(monkeypatch, tmp_path):
+    """A fresh profile resolves metadata and routes the official endpoint without live I/O."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda *args, **kwargs: {})
+    monkeypatch.setattr("agent.process_bootstrap.OpenAI", lambda **_kwargs: SimpleNamespace())
+    monkeypatch.setattr("model_tools.get_tool_definitions", lambda *args, **kwargs: [])
+
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        model="gpt-6-astra",
+        provider="openai",
+        api_key="test-key",
+        base_url="https://api.openai.com/v1",
+        platform="cli",
+        max_iterations=2,
+        quiet_mode=True,
+        skip_memory=True,
+    )
+
+    assert agent.api_mode == "codex_responses"
+    assert agent.context_compressor.context_length == 1_050_000
+    kwargs = agent._get_transport().build_kwargs(
+        model=agent.model,
+        messages=[{"role": "user", "content": "Hi"}],
+        tools=[],
+        provider=agent.provider,
+        base_url=agent.base_url,
+        reasoning_config={"enabled": False, "effort": "none"},
+    )
+    assert kwargs["reasoning"]["effort"] == "low"
+    assert kwargs["prompt_cache_options"] == {"ttl": "30m"}

--- a/tests/agent/test_astra_failed_steer_recovery.py
+++ b/tests/agent/test_astra_failed_steer_recovery.py
@@ -1,0 +1,149 @@
+"""Same-agent retry and rotating local compression use durable steering truth."""
+
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def rejected_steer(monkeypatch, tmp_path):
+    from agent import turn_iteration_prep
+    from hermes_state import SessionDB
+    from run_agent import AIAgent
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda *args, **kwargs: {})
+    monkeypatch.setattr("agent.process_bootstrap.OpenAI", lambda **kwargs: SimpleNamespace())
+    monkeypatch.setattr("model_tools.get_tool_definitions", lambda *args, **kwargs: [])
+    db, agents = SessionDB(tmp_path / "state.db"), []
+
+    def make_agent(sid="synthetic-retry-parent"):
+        agent = AIAgent(
+            model="gpt-6-astra", provider="openai", api_key="placeholder-key",
+            base_url="https://api.openai.com/v1", platform="cli", session_id=sid, session_db=db,
+            quiet_mode=True, skip_memory=True, skip_context_files=True, skip_background_review=True,
+        )
+        agent._checkpoint_mgr = SimpleNamespace(new_turn=lambda: None)
+        agent._budget_grace_call = False
+        agent.iteration_budget = SimpleNamespace(consume=lambda: True)
+        agents.append(agent)
+        return agent
+
+    def begin(agent):
+        # The CLI keeps the agent but resets turn messages after an exception.
+        messages = db.get_messages_as_conversation(agent.session_id, include_row_ids=True)
+        return turn_iteration_prep.begin_iteration(
+            agent, messages=messages, conversation_history=messages[:], original_user_message="repeat me",
+            api_call_count=0, interrupted=False, _turn_exit_reason=None,
+        )
+
+    first = make_agent()
+    assert first._flush_messages_to_session_db([
+        {"role": "user", "content": "repeat me"},
+        {"role": "assistant", "content": "completed answer"},
+    ]) is True
+    # The WebSocket/replay suite proves production admission -> explicit failure.
+    # Start this recovery gate at that durable state, without any provider call.
+    db.patch_session_model_config(first.session_id, {"_astra_steering": {"entries": [{
+        "admission_id": "synthetic-rejected-admission", "input_sha256": "synthetic-digest",
+        "text": "repeat me", "state": "failed",
+    }]}})
+    try:
+        yield db, first, make_agent, begin
+    finally:
+        for agent in agents:
+            agent.close()
+        db.close()
+
+
+@pytest.mark.parametrize("failure", ["rollback", "readback", "persist_raises"])
+def test_same_agent_retry_reloads_journal_without_duplicate_delivery(monkeypatch, rejected_steer, failure):
+    from agent.transports.astra_websocket_session import AstraSteeringPersistenceError
+
+    db, agent, _, begin = rejected_steer
+    before = db.get_messages(agent.session_id)
+    with monkeypatch.context() as patch:
+        if failure == "rollback":
+            original_ack = db._ack_astra_fallback_redirects
+
+            def fail_ack(*args):
+                original_ack(*args)
+                raise OSError("synthetic rollback after acknowledgement")
+
+            patch.setattr(db, "_ack_astra_fallback_redirects", fail_ack)
+            expected = AstraSteeringPersistenceError
+        elif failure == "readback":
+            original_get = db.get_session_model_config_value
+
+            def fail_readback(*args, **kwargs):
+                value = original_get(*args, **kwargs)
+                if args[1] == "_astra_steering" and value["entries"][-1]["state"] == "fallback_delivered":
+                    raise OSError("synthetic readback failure after commit")
+                return value
+
+            patch.setattr(db, "get_session_model_config_value", fail_readback)
+            expected = OSError
+        else:
+            def fail_persist(*args):
+                raise OSError("synthetic persistence exception before commit")
+
+            patch.setattr(agent, "_persist_session", fail_persist)
+            expected = OSError
+        with pytest.raises(expected):
+            begin(agent)
+    if failure != "readback":
+        assert db.get_messages(agent.session_id) == before
+    assert agent._astra_fallback_restore_session is None
+    assert not agent._astra_drained_redirect_receipts
+    assert begin(agent).action == "fallthrough"
+    after = db.get_messages(agent.session_id)
+    assert [row["content"] for row in after if row["role"] == "user"] == ["repeat me", "repeat me"]
+    receipt = db.get_session_model_config_value(agent.session_id, "_astra_steering")["entries"][-1]
+    assert receipt["state"] == "fallback_delivered"
+    assert receipt["fallback_message_row_id"] == after[-1]["id"]
+    assert begin(agent).action == "fallthrough"
+    assert db.get_messages(agent.session_id) == after
+
+
+@pytest.mark.parametrize("delivered", [False, True])
+def test_restart_rotation_carries_current_journal_atomically(monkeypatch, rejected_steer, delivered):
+    from agent.conversation_compression import _publish_rotated_compaction
+
+    db, first, make_agent, begin = rejected_steer
+    if delivered:
+        assert begin(first).action == "fallthrough"
+    parent_sid = first.session_id
+    journal = db.get_session_model_config_value(parent_sid, "_astra_steering")
+    restarted = make_agent(parent_sid)
+    assert "_astra_steering" not in (restarted._session_init_model_config or {})
+    history = db.get_messages_as_conversation(parent_sid, include_row_ids=True)
+    handoff = [{"role": "user", "content": "retained task facts"},
+               {"role": "assistant", "content": "local compression handoff"}]
+    original_publish, publications = db._publish_child_session_row, []
+
+    def inspect_publication(conn, parent, **kwargs):
+        assert conn.in_transaction
+        assert kwargs["model_config"]["_astra_steering"] == journal
+        publications.append(kwargs["child_session_id"])
+        return original_publish(conn, parent, **kwargs)
+
+    monkeypatch.setattr(db, "_publish_child_session_row", inspect_publication)
+    _publish_rotated_compaction(
+        restarted, history, handoff, new_system_prompt="same system prompt\n",
+        lease=SimpleNamespace(holder=None, ttl=300, watermark=None), old_session_id=parent_sid,
+        compressed_user_turn_outcome="already_present",
+    )
+    child_sid = restarted.session_id
+    assert publications == [child_sid]
+    assert db.find_live_compression_child(parent_sid)["id"] == child_sid
+    assert db.get_session(parent_sid)["end_reason"] == "compression"
+    assert db.get_session_model_config_value(child_sid, "_astra_steering") == journal
+    after_rotation = make_agent(child_sid)
+    assert begin(after_rotation).action == "fallthrough"
+    after = db.get_messages(child_sid)
+    assert [row["content"] for row in after if row["role"] == "user"] == (
+        ["retained task facts"] if delivered else ["retained task facts", "repeat me"]
+    )
+    assert db.get_session_model_config_value(child_sid, "_astra_steering")["entries"][-1]["state"] == "fallback_delivered"
+    assert begin(make_agent(child_sid)).action == "fallthrough"
+    assert db.get_messages(child_sid) == after

--- a/tests/agent/test_astra_failed_steer_replay.py
+++ b/tests/agent/test_astra_failed_steer_replay.py
@@ -1,0 +1,132 @@
+"""Real SQLite/iteration proof for rejected Astra steering, with and without tools."""
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from tests.agent.test_astra_websocket import FakeWebSocket, _connect_socket, _created, _completed
+
+
+@pytest.mark.parametrize("with_tool", [False, True])
+@pytest.mark.parametrize("crash", [None, "rollback", "after_commit"])
+def test_failed_steer_redirect_is_atomic_and_restart_safe(monkeypatch, tmp_path, with_tool, crash):
+    from agent import turn_iteration_prep
+    from agent.transports.astra_websocket_session import AstraSteeringPersistenceError, AstraWebSocketSession
+    from hermes_state import SessionDB
+    from run_agent import AIAgent
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda *args, **kwargs: {})
+    monkeypatch.setattr("agent.process_bootstrap.OpenAI", lambda **kwargs: SimpleNamespace())
+    monkeypatch.setattr("model_tools.get_tool_definitions", lambda *args, **kwargs: [])
+    db = SessionDB(tmp_path / "state.db")
+    sid, agents = "synthetic-rejected-steer", []
+
+    def make_agent():
+        agent = AIAgent(
+            model="gpt-6-astra", provider="openai", api_key="placeholder-key",
+            base_url="https://api.openai.com/v1", platform="cli", session_id=sid, session_db=db,
+            quiet_mode=True, skip_memory=True, skip_context_files=True, skip_background_review=True,
+        )
+        agent._checkpoint_mgr = SimpleNamespace(new_turn=lambda: None)
+        agent._budget_grace_call = False
+        agent.iteration_budget = SimpleNamespace(consume=lambda: True)
+        agents.append(agent)
+        return agent
+
+    def begin(agent):
+        messages = db.get_messages_as_conversation(sid, include_row_ids=True)
+        return turn_iteration_prep.begin_iteration(
+            agent, messages=messages, conversation_history=messages[:], original_user_message="repeat me",
+            api_call_count=0, interrupted=False, _turn_exit_reason=None,
+        )
+
+    first = make_agent()
+    # Identical earlier user text must not consume the later admission by content equality.
+    messages = [{"role": "user", "content": "repeat me"}]
+    if with_tool:
+        messages += [
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "original-call", "type": "function",
+                "function": {"name": "read_file", "arguments": "{}"}}]},
+            {"role": "tool", "content": "saved tool result", "tool_call_id": "original-call"},
+        ]
+    messages.append({"role": "assistant", "content": "completed answer"})
+    assert first._flush_messages_to_session_db(messages) is True
+    first._session_messages = messages
+    socket, active, errors = FakeWebSocket(), threading.Event(), []
+    session = AstraWebSocketSession(first, connect=_connect_socket(socket))
+
+    def on_send(message, ws):
+        if message["type"] == "response.create":
+            ws.push(_created("r1"))
+        elif message["type"] == "response.steer":
+            ws.push({"type": "response.steer.failed", "id": "failed"})
+            for event in _completed("r1", "r1"):
+                ws.push(event)
+
+    socket._on_send = on_send
+    original_created = session._handle_created
+
+    def created(event, response_id):
+        original_created(event, response_id)
+        active.set()
+
+    session._handle_created = created
+
+    def run():
+        try:
+            session.run({"model": "gpt-6-astra", "input": [{"role": "user", "content": "repeat me"}]})
+        except Exception as exc:
+            errors.append(exc)
+
+    worker = threading.Thread(target=run)
+    worker.start()
+    try:
+        assert active.wait(2)
+        assert session.request_steer("repeat me") is True
+        worker.join(2)
+        assert not worker.is_alive() and not errors
+        assert first._pending_steer is None  # Never the external next-user string handoff.
+        assert first._pending_redirect == "repeat me"
+        before = db.get_messages(sid)
+
+        if crash == "rollback":
+            original_ack = db._ack_astra_fallback_redirects
+
+            def fail_ack(*args):
+                original_ack(*args)
+                raise OSError("synthetic transaction rollback")
+
+            with monkeypatch.context() as patch:
+                patch.setattr(db, "_ack_astra_fallback_redirects", fail_ack)
+                with pytest.raises(AstraSteeringPersistenceError):
+                    begin(make_agent())
+            assert db.get_messages(sid) == before
+            assert db.get_session_model_config_value(sid, "_astra_steering")["entries"][-1]["state"] == "failed"
+        elif crash == "after_commit":
+            def stop_after_commit(*args):
+                raise RuntimeError("synthetic process loss after commit")
+
+            with monkeypatch.context() as patch:
+                patch.setattr("agent.transports.astra_websocket_session.confirm_astra_redirect_persisted", stop_after_commit)
+                with pytest.raises(RuntimeError, match="process loss"):
+                    begin(make_agent())
+
+        assert begin(make_agent()).action == "fallthrough"
+        after = db.get_messages(sid)
+        assert [row["content"] for row in after if row["role"] == "user"] == ["repeat me", "repeat me"]
+        receipt = db.get_session_model_config_value(sid, "_astra_steering")["entries"][-1]
+        assert receipt["state"] == "fallback_delivered"
+        delivered = next(row for row in after if row["id"] == receipt["fallback_message_row_id"])
+        assert delivered["display_metadata"]["_astra_steering_fallback"][0]["admission_id"] == receipt["admission_id"]
+        assert [row["content"] for row in after if row["role"] == "tool"] == (["saved tool result"] if with_tool else [])
+        assert begin(make_agent()).action == "fallthrough"
+        assert db.get_messages(sid) == after
+        assert sum(item["type"] == "response.steer" for item in socket.sent) == 1
+    finally:
+        session.close()
+        worker.join(2)
+        for agent in agents:
+            agent.close()
+        db.close()

--- a/tests/agent/test_astra_pending_tool_steering.py
+++ b/tests/agent/test_astra_pending_tool_steering.py
@@ -1,0 +1,116 @@
+"""Real executor and SQLite proof at the pending-tool steering boundary."""
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from tests.agent.test_astra_websocket import FakeWebSocket, _connect_socket, _created, _completed
+
+
+@pytest.mark.parametrize("persistence_fails", [False, True])
+def test_pending_steer_settles_real_executor_before_one_continuation(monkeypatch, tmp_path, persistence_fails):
+    from agent.astra_async_tools import AstraAsyncExecutor
+    from agent import tool_executor
+    from agent.transports.astra_websocket_session import AstraWebSocketSession, AstraProtocolError
+    from hermes_state import SessionDB
+    from run_agent import AIAgent
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda *args, **kwargs: {})
+    monkeypatch.setattr("agent.process_bootstrap.OpenAI", lambda **kwargs: SimpleNamespace())
+    monkeypatch.setattr("model_tools.get_tool_definitions", lambda *args, **kwargs: [])
+    db = SessionDB(tmp_path / "state.db")
+    agent = AIAgent(
+        model="gpt-6-astra", provider="openai", api_key="placeholder-key",
+        base_url="https://api.openai.com/v1", platform="cli", session_id="synthetic-pending-steer",
+        session_db=db, quiet_mode=True, skip_memory=True, skip_context_files=True, skip_background_review=True,
+    )
+    messages = [{"role": "user", "content": "Use the read tool"}]
+    assert agent._flush_messages_to_session_db(messages) is True
+    started, release = threading.Event(), threading.Event()
+    starts, outcomes, errors = [], [], []
+    original_flush = agent._flush_messages_to_session_db
+
+    def flush(rows, *args, **kwargs):
+        if persistence_fails and any(row.get("role") == "tool" for row in rows):
+            return False
+        return original_flush(rows, *args, **kwargs)
+
+    agent._flush_messages_to_session_db = flush
+
+    def run_call(owner, dispatch, ref, **kwargs):
+        rows = db.get_messages(agent.session_id)
+        assert any(row.get("role") == "assistant" and row.get("tool_calls") for row in rows)
+        starts.append(ref.call_id)
+        started.set()
+        assert release.wait(2)
+        return tool_executor._ManagedToolResult("durable result", {}, [], False, True), 0.01
+
+    monkeypatch.setattr(tool_executor, "_resolve_sequential_dispatch", lambda *args: SimpleNamespace())
+    monkeypatch.setattr(tool_executor, "_run_sequential_call", run_call)
+    executor = agent._astra_async_executor = AstraAsyncExecutor(agent, messages, "synthetic-task")
+    socket = FakeWebSocket()
+    item = {"type": "function_call", "id": "fc_live", "call_id": "call_live", "name": "read_file",
+            "arguments": "{}", "async": True}
+
+    def on_send(message, ws):
+        if message["type"] == "response.create" and "previous_response_id" not in message:
+            ws.push(_created("r1"))
+            ws.push({"type": "response.output_item.added", "response_id": "r1", "output_index": 0, "item": item})
+            ws.push({"type": "response.output_item.done", "response_id": "r1", "output_index": 0, "item": item})
+        elif message["type"] == "response.steer":
+            release.set()
+            ws.push({"type": "response.steer.accepted", "id": "ack"})
+            ws.push({"type": "response.completed", "response": {"id": "r1", "status": "completed", "output": [item]}})
+            for event_id in ("pending", "duplicate-pending"):
+                ws.push({"type": "response.steer.pending", "response_id": "r1", "id": event_id,
+                         "required_input": [{"type": "function_call_output", "call_id": "call_live", "output": ""}]})
+        elif message["type"] == "response.create":
+            assert not persistence_fails
+            saved = [row for row in db.get_messages(agent.session_id) if row.get("role") == "tool"]
+            assert len(saved) == 1 and saved[0]["content"] == "durable result"
+            assert message["input"] == [{"type": "function_call_output", "call_id": "call_live", "output": "durable result"}]
+            assert message["max_output_tokens"] == 4096
+            assert message["reasoning"] == {"effort": "high", "summary": "concise"}
+            ws.push(_created("r2"))
+            for event in _completed("r2", "r2", "continued"):
+                ws.push(event)
+
+    socket._on_send = on_send
+    session = AstraWebSocketSession(agent, connect=_connect_socket(socket))
+
+    def run():
+        try:
+            outcomes.append(session.run({"model": "gpt-6-astra", "input": [{"role": "user", "content": "Use the read tool"}],
+                                         "max_output_tokens": 4096, "reasoning": {"effort": "high", "summary": "concise"}}))
+        except Exception as exc:
+            errors.append(exc)
+
+    worker = threading.Thread(target=run)
+    worker.start()
+    try:
+        assert started.wait(2), errors
+        assert not any(row.get("role") == "tool" for row in db.get_messages(agent.session_id))
+        assert session.request_steer("continue with the result") is True
+        worker.join(3)
+        assert not worker.is_alive()
+        assert len(starts) == 1
+        continuations = [entry for entry in socket.sent if entry.get("previous_response_id") and entry["type"] == "response.create"]
+        if persistence_fails:
+            assert len(errors) == 1 and isinstance(errors[0], AstraProtocolError)
+            assert not continuations
+            assert not any(row.get("role") == "tool" for row in db.get_messages(agent.session_id))
+        else:
+            assert errors == [] and outcomes[0].output_text == "continued"
+            assert len(continuations) == 1
+            assert executor.finish_stream() is True
+            assert len([row for row in db.get_messages(agent.session_id) if row.get("role") == "tool"]) == 1
+    finally:
+        release.set()
+        session.close()
+        worker.join(3)
+        if not executor.closed:
+            executor.abort_stream()
+        agent.close()
+        db.close()

--- a/tests/agent/test_astra_websocket.py
+++ b/tests/agent/test_astra_websocket.py
@@ -14,6 +14,7 @@ import pytest
 from agent.transports.astra_websocket_session import (
     AstraDeliveryUncertainError,
     AstraPreDispatchError,
+    AstraSteeringPersistenceError,
     AstraWebSocketSession,
     is_astra_websocket_eligible,
     run_astra_websocket_stream,
@@ -67,6 +68,23 @@ class FakeWebSocket:
         self.closed = True
         with self._changed:
             self._changed.notify_all()
+
+
+class FakeSessionDB:
+    """Small model_config seam; the real SessionDB supplies the same atomic helpers."""
+
+    def __init__(self, entries=None):
+        self.model_config = {"_astra_steering": {"version": 1, "entries": list(entries or [])}}
+        self.patches = []
+
+    def get_session_model_config_value(self, session_id, key, default=None):
+        del session_id
+        return self.model_config.get(key, default)
+
+    def patch_session_model_config(self, session_id, patch):
+        del session_id
+        self.patches.append(patch)
+        self.model_config.update(patch)
 
 
 def _connect_socket(socket):
@@ -363,6 +381,118 @@ def test_connect_failure_falls_back_but_send_or_recv_is_uncertain():
     socket._on_send = lambda message, ws: (_ for _ in ()).throw(ConnectionError("lost after send")) if message["type"] == "response.create" else None
     with pytest.raises(AstraDeliveryUncertainError):
         AstraWebSocketSession(agent, connect=_connect_socket(socket)).run({})
+
+
+def test_steering_admission_is_persisted_before_socket_dispatch_and_owned_by_successor():
+    socket = FakeWebSocket()
+    db = FakeSessionDB()
+    agent = _agent(_session_db=db, session_id="synthetic-session", _session_db_created=True)
+    observed = {}
+
+    def on_send(message, ws):
+        if message["type"] == "response.create":
+            ws.push(_created("r1"))
+        elif message["type"] == "response.steer":
+            entry = db.model_config["_astra_steering"]["entries"][-1]
+            observed["before_send_state"] = entry["state"]
+            observed["input"] = entry["input"]
+            ws.push({"type": "response.steer.accepted", "id": "ack"})
+            ws.push({"type": "response.incomplete", "response_id": "r1", "response": {
+                "id": "r1", "status": "incomplete", "incomplete_details": {"reason": "steered"},
+            }, "id": "incomplete"})
+            ws.push(_created("r2"))
+            for frame in _completed("r2", "r2", "success"):
+                ws.push(frame)
+
+    socket._on_send = on_send
+    session = AstraWebSocketSession(agent, connect=_connect_socket(socket))
+    worker = threading.Thread(target=lambda: session.run({"model": "gpt-6-astra"}))
+    worker.start()
+    deadline = time.time() + 2
+    while session.state != "ACTIVE" and time.time() < deadline:
+        time.sleep(0.005)
+    assert session.request_steer("synthetic correction") is True
+    worker.join(timeout=2)
+    assert not worker.is_alive()
+    assert observed["before_send_state"] == "prepared"
+    assert observed["input"] == [{"role": "user", "content": [{"type": "input_text", "text": "synthetic correction"}]}]
+    receipt = db.model_config["_astra_steering"]["entries"][-1]
+    assert receipt["response_id"] == "r1"
+    assert receipt["generation"] == 1
+    assert receipt["admission_id"]
+    assert receipt["state"] == "successor_created"
+
+
+def test_restart_does_not_resend_accepted_or_ambiguous_steering():
+    entries = [
+        {"version": 1, "admission_id": "a", "generation": 1, "response_id": "r1",
+         "input": [{"role": "user", "content": [{"type": "input_text", "text": "accepted"}]}],
+         "text": "accepted", "state": "accepted"},
+        {"version": 1, "admission_id": "b", "generation": 2, "response_id": "r1",
+         "input": [{"role": "user", "content": [{"type": "input_text", "text": "ambiguous"}]}],
+         "text": "ambiguous", "state": "ambiguous"},
+    ]
+    db = FakeSessionDB(entries)
+    agent = _agent(_session_db=db, session_id="synthetic-session", _session_db_created=True)
+    session = AstraWebSocketSession(agent)
+    session._socket = FakeWebSocket()
+    session._response_id = "r2"
+    session._set_state("ACTIVE")
+    assert agent._pending_steer is None
+    assert session.request_steer("new correction") is True
+    sent = session._socket.sent
+    assert len(sent) == 1
+    assert sent[0]["input"][0]["content"][0]["text"] == "new correction"
+    assert sum(item["state"] == "ambiguous" for item in db.model_config["_astra_steering"]["entries"]) == 1
+
+
+def test_explicit_failure_requeues_once_after_restart():
+    entry = {"version": 1, "admission_id": "failed", "generation": 1, "response_id": "r1",
+             "input": [{"role": "user", "content": [{"type": "input_text", "text": "retry once"}]}],
+             "text": "retry once", "state": "failed"}
+    db = FakeSessionDB([entry])
+    first = _agent(_session_db=db, session_id="synthetic-session", _session_db_created=True)
+    AstraWebSocketSession(first)
+    assert first._pending_steer == "retry once"
+    assert db.model_config["_astra_steering"]["entries"][0]["state"] == "fallback_queued"
+    second = _agent(_session_db=db, session_id="synthetic-session", _session_db_created=True)
+    AstraWebSocketSession(second)
+    assert second._pending_steer is None
+
+
+def test_persistence_failure_before_steer_send_is_fail_closed():
+    class FailingDB(FakeSessionDB):
+        def patch_session_model_config(self, session_id, patch):
+            raise OSError("synthetic persistence failure")
+
+    socket = FakeWebSocket()
+    db = FailingDB()
+    agent = _agent(_session_db=db, session_id="synthetic-session", _session_db_created=True)
+    session = AstraWebSocketSession(agent, connect=_connect_socket(socket))
+    session._socket = socket
+    session._response_id = "r1"
+    session._set_state("ACTIVE")
+    with pytest.raises(AstraSteeringPersistenceError):
+        session.request_steer("must not dispatch")
+    assert socket.sent == []
+    assert agent._pending_steer is None
+
+
+def test_ambiguous_steer_send_retains_durable_no_resend_receipt():
+    socket = FakeWebSocket()
+    socket._on_send = lambda message, ws: (_ for _ in ()).throw(ConnectionError("lost after steer"))
+    db = FakeSessionDB()
+    agent = _agent(_session_db=db, session_id="synthetic-session", _session_db_created=True)
+    session = AstraWebSocketSession(agent, connect=_connect_socket(socket))
+    session._socket = socket
+    session._response_id = "r1"
+    session._set_state("ACTIVE")
+
+    with pytest.raises(AstraDeliveryUncertainError):
+        session.request_steer("ambiguous correction")
+    receipt = db.model_config["_astra_steering"]["entries"][-1]
+    assert receipt["state"] == "ambiguous"
+    assert agent._pending_steer is None
 
 
 def test_duplicate_frames_do_not_duplicate_output_items():

--- a/tests/agent/test_astra_websocket.py
+++ b/tests/agent/test_astra_websocket.py
@@ -464,7 +464,7 @@ def test_restart_does_not_resend_accepted_or_ambiguous_steering():
     assert all(item["state"] == "accepted" for item in full_db.model_config["_astra_steering"]["entries"])
 
 
-def test_explicit_failure_requeues_until_fallback_delivery():
+def test_explicit_failure_requeues_once_after_restart():
     entry = {"version": 1, "admission_id": "failed", "generation": 1, "response_id": "r1",
              "input": [{"role": "user", "content": [{"type": "input_text", "text": "retry once"}]}],
              "text": "retry once", "state": "failed"}
@@ -475,7 +475,7 @@ def test_explicit_failure_requeues_until_fallback_delivery():
     assert db.model_config["_astra_steering"]["entries"][0]["state"] == "fallback_queued"
     second = _agent(_session_db=db, session_id="synthetic-session", _session_db_created=True)
     AstraWebSocketSession(second)
-    assert second._pending_steer == "retry once"
+    assert second._pending_steer is None
 
 
 def test_persistence_failure_before_steer_send_is_fail_closed():
@@ -529,40 +529,6 @@ def test_redacted_steer_declines_before_dispatch(monkeypatch):
         session.request_steer("credential-like steering input")
     assert socket.sent == []
     assert db.model_config["_astra_steering"]["entries"] == []
-
-
-def test_live_failed_steer_reconstructs_then_delivers_once(tmp_path):
-    from hermes_state import SessionDB
-    from agent.turn_iteration_prep import _inject_steer_into_newest_tool_result
-    db = SessionDB(tmp_path / "state.db")
-    sid = "synthetic-fallback"
-    db.create_session(sid, source="cli", model="gpt-6-astra")
-    db.append_message(sid, "tool", "result", tool_call_id="call-fallback")
-    socket = FakeWebSocket()
-    agent = _agent(_session_db=db, session_id=sid)
-    session = AstraWebSocketSession(agent, connect=_connect_socket(socket))
-
-    def on_send(message, ws):
-        if message["type"] == "response.create":
-            ws.push(_created("r1"))
-        elif message["type"] == "response.steer":
-            ws.push({"type": "response.steer.failed", "id": "failed"})
-            ws.events.extend(_completed("r1", "r1"))
-    socket._on_send = on_send
-    worker = threading.Thread(target=lambda: session.run({"model": "gpt-6-astra"}))
-    worker.start()
-    deadline = time.time() + 2
-    while session.state != "ACTIVE" and time.time() < deadline:
-        time.sleep(0.005)
-    assert session.request_steer("retry once") is True
-    worker.join(2)
-    restarted = _agent(_session_db=db, session_id=sid, _session_messages=db.get_messages_as_conversation(sid, include_row_ids=True))
-    AstraWebSocketSession(restarted)
-    _inject_steer_into_newest_tool_result(restarted, restarted._session_messages, restarted._drain_pending_steer())
-    assert db.get_session_model_config_value(sid, "_astra_steering", {})["entries"][-1]["state"] == "fallback_delivered"
-    assert "retry once" in db.get_messages_as_conversation(sid)[-1]["content"]
-    assert AstraWebSocketSession(_agent(_session_db=db, session_id=sid)).agent._pending_steer is None
-    db.close()
 
 
 def test_ambiguous_steer_send_retains_durable_no_resend_receipt():

--- a/tests/agent/test_astra_websocket.py
+++ b/tests/agent/test_astra_websocket.py
@@ -210,6 +210,47 @@ def test_terminal_processing_fences_late_steer_before_assembler_feed():
     assert outcome and outcome[0].status == "completed"
 
 
+def test_steer_interleaving_before_terminal_lock_waits_for_successor():
+    socket = FakeWebSocket()
+    socket.push(_created("r1"))
+    socket.push({"type": "response.completed", "response_id": "r1",
+                 "response": {"id": "r1", "status": "completed"}, "id": "complete-r1"})
+    agent = _agent()
+    session = AstraWebSocketSession(agent, connect=_connect_socket(socket))
+
+    def on_send(message, ws):
+        if message["type"] == "response.steer":
+            ws.push({"type": "response.steer.accepted", "id": "ack"})
+            ws.push(_created("r2"))
+            for frame in _completed("r2", "r2", "success"):
+                ws.push(frame)
+
+    socket._on_send = on_send
+    outcome = []
+    reason_started = threading.Event()
+    release_reason = threading.Event()
+
+    original_reason = session._terminal_reason
+
+    def blocked_reason(event):
+        reason_started.set()
+        release_reason.wait(timeout=2)
+        return original_reason(event)
+
+    session._terminal_reason = blocked_reason
+    worker = threading.Thread(target=lambda: outcome.append(
+        session.run({"model": "gpt-6-astra"}),
+    ))
+    worker.start()
+    assert reason_started.wait(timeout=2)
+    release_reason.set()
+    assert session.request_steer("arrived at the terminal boundary") is False
+    worker.join(timeout=2)
+    assert not worker.is_alive()
+    assert outcome and outcome[0].output_text == ""
+    assert not any(item["type"] == "response.steer" for item in socket.sent)
+
+
 def test_steer_acceptance_successor_and_predecessor_fencing():
     socket = FakeWebSocket()
     agent = _agent()
@@ -352,12 +393,52 @@ def test_duplicate_sequence_number_is_fenced_before_assembler_effects():
     assert result.output_text == "once"
 
 
+def test_successor_sequence_restart_does_not_drop_successor_frames():
+    socket = FakeWebSocket()
+    agent = _agent()
+    session = AstraWebSocketSession(agent, connect=_connect_socket(socket))
+
+    def on_send(message, ws):
+        # The provider can restart sequence numbering for a later response generation.
+        if message["type"] == "response.create":
+            if message.get("model") == "gpt-6-astra":
+                ws.push({**_created("r1"), "sequence_number": 1})
+        elif message["type"] == "response.steer":
+            ws.push({"type": "response.steer.accepted", "id": "ack", "sequence_number": 6})
+            ws.push({"type": "response.incomplete", "response_id": "r1", "response": {
+                "id": "r1", "status": "incomplete", "incomplete_details": {"reason": "steered"},
+            }, "id": "incomplete-r1", "sequence_number": 7})
+            ws.push({**_created("r2"), "sequence_number": 1})
+            successor = _completed("r2", "r2", "new")
+            for offset, frame in enumerate(successor, 2):
+                frame["sequence_number"] = offset
+                ws.push(frame)
+
+    socket._on_send = on_send
+    # Initial response is supplied by the callback; make the first turn wait for the active state.
+    worker = threading.Thread(target=lambda: session.run({"model": "gpt-6-astra"}))
+    worker.start()
+    deadline = time.time() + 2
+    while session.state != "ACTIVE" and time.time() < deadline:
+        time.sleep(0.005)
+    assert session.request_steer("new generation") is True
+    worker.join(timeout=2)
+    assert not worker.is_alive()
+    assert session.response_id == "r2"
+
+
 def test_interrupt_closes_lane_without_reconnect():
     socket = FakeWebSocket()
     agent = _agent()
     session = AstraWebSocketSession(agent, connect=_connect_socket(socket))
     socket.push(_created("r1"))
-    worker = threading.Thread(target=lambda: session.run({"model": "gpt-6-astra"}))
+    def run_interruptible():
+        try:
+            session.run({"model": "gpt-6-astra"})
+        except InterruptedError:
+            pass
+
+    worker = threading.Thread(target=run_interruptible)
     worker.start()
     deadline = time.time() + 2
     while session.state != "ACTIVE" and time.time() < deadline:

--- a/tests/agent/test_astra_websocket.py
+++ b/tests/agent/test_astra_websocket.py
@@ -1,0 +1,292 @@
+"""Deterministic coverage for the direct GPT-6 Astra Responses WebSocket lane."""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import time
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from agent.transports.astra_websocket_session import (
+    AstraDeliveryUncertainError,
+    AstraPreDispatchError,
+    AstraWebSocketSession,
+    is_astra_websocket_eligible,
+    run_astra_websocket_stream,
+)
+
+
+def _agent(**overrides):
+    values = dict(
+        api_mode="codex_responses", model="gpt-6-astra", provider="openai",
+        base_url="https://api.openai.com/v1", api_key="placeholder-key", auth_mode="api_key",
+        is_subagent=False, compression_checkpoint_required=False, _interrupt_requested=False,
+        _pending_steer=None, _pending_steer_lock=threading.Lock(), _session_messages=[],
+        _codex_streamed_text_parts=[],
+    )
+    values.update(overrides)
+    values["_is_codex_backend"] = lambda: False
+    values["_fire_stream_delta"] = lambda text: None
+    values["_fire_reasoning_delta"] = lambda text: None
+    values["_touch_activity"] = lambda text: None
+    return SimpleNamespace(**values)
+
+
+class FakeWebSocket:
+    def __init__(self, on_send=None):
+        self.events = []
+        self.sent = []
+        self.closed = False
+        self._changed = threading.Condition()
+        self._on_send = on_send
+
+    def send(self, payload):
+        message = json.loads(payload)
+        self.sent.append(message)
+        if self._on_send:
+            self._on_send(message, self)
+
+    def recv(self):
+        with self._changed:
+            if not self.events:
+                self._changed.wait(timeout=1)
+            if not self.events:
+                raise ConnectionError("fake socket exhausted")
+            return json.dumps(self.events.pop(0))
+
+    def push(self, event):
+        with self._changed:
+            self.events.append(event)
+            self._changed.notify_all()
+
+    def close(self):
+        self.closed = True
+        with self._changed:
+            self._changed.notify_all()
+
+
+def _connect_socket(socket):
+    def connect(url, key, timeout):
+        assert url == "wss://api.openai.com/v1/responses"
+        assert key == "placeholder-key"
+        return socket
+    return connect
+
+
+def test_default_connect_uses_static_key_and_responses_feature_header(monkeypatch):
+    calls = {}
+    client_module = types.ModuleType("websockets.sync.client")
+
+    def connect(url, **kwargs):
+        calls["url"] = url
+        calls["kwargs"] = kwargs
+        return object()
+
+    client_module.connect = connect
+    monkeypatch.setitem(sys.modules, "websockets.sync.client", client_module)
+    from agent.transports.astra_websocket_session import _default_connect
+
+    assert _default_connect("wss://api.openai.com/v1/responses", "placeholder-key", 5) is not None
+    assert calls == {
+        "url": "wss://api.openai.com/v1/responses",
+        "kwargs": {
+            "additional_headers": {
+                "Authorization": "Bearer placeholder-key",
+                "OpenAI-Beta": "responses_websockets=2026-02-06",
+            },
+            "open_timeout": 5,
+        },
+    }
+
+
+def _created(response_id):
+    return {"type": "response.created", "response": {"id": response_id, "status": "in_progress"}, "id": f"created-{response_id}"}
+
+
+def _completed(response_id, event_id, text="done"):
+    return [
+        {"type": "response.output_item.added", "response_id": response_id, "output_index": 0,
+         "item": {"id": f"item-{response_id}", "type": "message", "role": "assistant"}, "id": f"added-{event_id}"},
+        {"type": "response.output_text.delta", "response_id": response_id, "delta": text,
+         "id": f"delta-{event_id}"},
+        {"type": "response.output_item.done", "response_id": response_id, "output_index": 0,
+         "item": {"id": f"item-{response_id}", "type": "message", "role": "assistant", "status": "completed",
+                  "content": [{"type": "output_text", "text": text}]}, "id": f"done-{event_id}"},
+        {"type": "response.completed", "response_id": response_id,
+         "response": {"id": response_id, "status": "completed"}, "id": f"complete-{event_id}"},
+    ]
+
+
+def test_eligibility_is_exact_and_excludes_unsupported_routes():
+    agent = _agent()
+    assert is_astra_websocket_eligible(agent, {"model": "gpt-6-astra"})
+    for changes in (
+        {"auth_mode": "chatgpt"}, {"base_url": "https://sub.api.openai.com/v1"},
+        {"base_url": "https://api.openai.com/v1/other"}, {"model": "gpt-5.6"},
+        {"provider": "openai-codex"}, {"context_management": {"type": "compaction"}},
+        {"previous_response_id": "resp_1"},
+        {"is_subagent": True}, {"api_key": ""},
+    ):
+        request = {key: value for key, value in changes.items() if key in {"context_management", "previous_response_id"}}
+        agent_changes = {key: value for key, value in changes.items() if key not in request}
+        assert not is_astra_websocket_eligible(_agent(**agent_changes), request), changes
+
+
+def test_initial_create_uses_existing_body_without_stream():
+    socket = FakeWebSocket()
+    socket.push(_created("r1"))
+    socket.events.extend(_completed("r1", "r1"))
+    agent = _agent()
+    request = {"model": "gpt-6-astra", "input": [{"role": "user", "content": "hi"}], "stream": True,
+               "reasoning": {"effort": "low"}}
+
+    result = AstraWebSocketSession(agent, connect=_connect_socket(socket)).run(request)
+
+    assert result.status == "completed"
+    assert socket.sent == [{"type": "response.create", "model": "gpt-6-astra",
+                            "input": [{"role": "user", "content": "hi"}], "reasoning": {"effort": "low"}}]
+
+
+def test_steer_acceptance_successor_and_predecessor_fencing():
+    socket = FakeWebSocket()
+    agent = _agent()
+    session = AstraWebSocketSession(agent, connect=_connect_socket(socket))
+
+    def on_send(message, ws):
+        if message["type"] == "response.create":
+            ws.push(_created("r1"))
+        elif message["type"] == "response.steer":
+            ws.push({"type": "response.steer.accepted", "id": "ack-1"})
+            ws.push({"type": "response.incomplete", "response_id": "r1", "response": {
+                "id": "r1", "status": "incomplete", "incomplete_details": {"reason": "steered"},
+            }, "id": "incomplete-r1"})
+            ws.push(_created("r2"))
+            ws.push({"type": "response.output_text.delta", "response_id": "r1", "delta": "stale", "id": "stale"})
+            for frame in _completed("r2", "r2", "success"):
+                ws.push(frame)
+
+    socket._on_send = on_send
+
+    def run():
+        session.run({"model": "gpt-6-astra", "input": [{"role": "user", "content": "hi"}]})
+
+    worker = threading.Thread(target=run)
+    worker.start()
+    deadline = time.time() + 2
+    while session.state != "ACTIVE" and time.time() < deadline:
+        time.sleep(0.005)
+    assert session.request_steer("use the second plan") is True
+    worker.join(timeout=2)
+    assert not worker.is_alive()
+    steer = next(item for item in socket.sent if item["type"] == "response.steer")
+    assert set(steer) == {"type", "previous_response_id", "input"}
+    assert steer["previous_response_id"] == "r1"
+    assert agent._pending_steer is None
+
+
+def test_pending_required_input_continues_once_from_saved_result():
+    socket = FakeWebSocket()
+    agent = _agent(_session_messages=[{"role": "tool", "tool_call_id": "call-1", "content": "saved result"}])
+
+    def on_send(message, ws):
+        if message["type"] == "response.create" and "previous_response_id" not in message:
+            ws.push(_created("r1"))
+        elif message["type"] == "response.steer":
+            ws.push({"type": "response.steer.accepted", "id": "ack"})
+            ws.push({"type": "response.steer.pending", "response_id": "r1", "required_input": [
+                {"type": "function_call_output", "call_id": "call-1", "output": ""},
+            ], "id": "pending"})
+        elif message["type"] == "response.create" and message.get("previous_response_id") == "r1":
+            assert message["input"][0]["output"] == "saved result"
+            ws.push(_created("r2"))
+            for frame in _completed("r2", "r2", "continued"):
+                ws.push(frame)
+
+    socket._on_send = on_send
+    session = AstraWebSocketSession(agent, connect=_connect_socket(socket))
+
+    worker = threading.Thread(target=lambda: session.run({"model": "gpt-6-astra", "input": [{"role": "user", "content": "hi"}]}))
+    worker.start()
+    deadline = time.time() + 2
+    while session.state != "ACTIVE" and time.time() < deadline:
+        time.sleep(0.005)
+    assert session.request_steer("continue") is True
+    worker.join(timeout=2)
+    assert not worker.is_alive()
+    creates = [item for item in socket.sent if item["type"] == "response.create"]
+    assert len(creates) == 2
+    assert sum(item["type"] == "response.steer" for item in socket.sent) == 1
+
+
+def test_explicit_steer_failure_keeps_one_legacy_pending_text():
+    socket = FakeWebSocket()
+    agent = _agent()
+    session = AstraWebSocketSession(agent, connect=_connect_socket(socket))
+
+    def on_send(message, ws):
+        if message["type"] == "response.create":
+            ws.push(_created("r1"))
+        elif message["type"] == "response.steer":
+            ws.push({"type": "response.steer.failed", "id": "failed"})
+            for frame in _completed("r1", "r1"):
+                ws.push(frame)
+
+    socket._on_send = on_send
+    def run_interruptible():
+        try:
+            session.run({"model": "gpt-6-astra"})
+        except InterruptedError:
+            pass
+
+    worker = threading.Thread(target=run_interruptible)
+    worker.start()
+    deadline = time.time() + 2
+    while session.state != "ACTIVE" and time.time() < deadline:
+        time.sleep(0.005)
+    assert session.request_steer("legacy once") is True
+    worker.join(timeout=2)
+    assert agent._pending_steer == "legacy once"
+    assert sum(item["type"] == "response.steer" for item in socket.sent) == 1
+
+
+def test_connect_failure_falls_back_but_send_or_recv_is_uncertain():
+    agent = _agent()
+    with pytest.raises(AstraPreDispatchError):
+        AstraWebSocketSession(agent, connect=lambda *_: (_ for _ in ()).throw(ConnectionError("offline"))).run({})
+
+    socket = FakeWebSocket()
+    socket.push(_created("r1"))
+    socket._on_send = lambda message, ws: (_ for _ in ()).throw(ConnectionError("lost after send")) if message["type"] == "response.create" else None
+    with pytest.raises(AstraDeliveryUncertainError):
+        AstraWebSocketSession(agent, connect=_connect_socket(socket)).run({})
+
+
+def test_duplicate_frames_do_not_duplicate_output_items():
+    socket = FakeWebSocket()
+    socket.push(_created("r1"))
+    frames = _completed("r1", "r1", "once")
+    socket.events.extend(frames[:3] + [frames[2], frames[3]])
+    agent = _agent()
+    result = AstraWebSocketSession(agent, connect=_connect_socket(socket)).run({"model": "gpt-6-astra"})
+    assert len(result.output) == 1
+    assert result.output_text == "once"
+
+
+def test_interrupt_closes_lane_without_reconnect():
+    socket = FakeWebSocket()
+    agent = _agent()
+    session = AstraWebSocketSession(agent, connect=_connect_socket(socket))
+    socket.push(_created("r1"))
+    worker = threading.Thread(target=lambda: session.run({"model": "gpt-6-astra"}))
+    worker.start()
+    deadline = time.time() + 2
+    while session.state != "ACTIVE" and time.time() < deadline:
+        time.sleep(0.005)
+    session.request_interrupt()
+    worker.join(timeout=2)
+    assert not worker.is_alive()
+    assert socket.closed

--- a/tests/agent/test_astra_websocket.py
+++ b/tests/agent/test_astra_websocket.py
@@ -151,6 +151,65 @@ def test_initial_create_uses_existing_body_without_stream():
                             "input": [{"role": "user", "content": "hi"}], "reasoning": {"effort": "low"}}]
 
 
+def test_terminal_ws_response_settles_pr2_async_executor_once():
+    socket = FakeWebSocket()
+    socket.push(_created("r1"))
+    socket.events.extend(_completed("r1", "r1"))
+    calls = []
+
+    class Executor:
+        has_admitted = True
+        has_pending = False
+        failed = False
+
+        def finish_stream(self, **kwargs):
+            calls.append(kwargs)
+            return True
+
+    agent = _agent(_astra_async_executor=Executor())
+    result = AstraWebSocketSession(agent, connect=_connect_socket(socket)).run({"model": "gpt-6-astra"})
+
+    assert result.status == "completed"
+    assert len(calls) == 1
+    assert calls[0]["assistant_content"] == "done"
+
+
+def test_terminal_processing_fences_late_steer_before_assembler_feed():
+    socket = FakeWebSocket()
+    socket.push(_created("r1"))
+    socket.push({"type": "response.completed", "response_id": "r1",
+                 "response": {"id": "r1", "status": "completed"}, "id": "complete"})
+    agent = _agent()
+    session = AstraWebSocketSession(agent, connect=_connect_socket(socket))
+    feed_started = threading.Event()
+    release_feed = threading.Event()
+
+    class BlockingAssembler:
+        def feed(self, event):
+            feed_started.set()
+            release_feed.wait(timeout=2)
+            return True
+
+        def result(self):
+            return SimpleNamespace(status="completed", output=[], output_text="", model="gpt-6-astra")
+
+    session._new_assembler = lambda _response_id: BlockingAssembler()
+    outcome = []
+
+    def run():
+        outcome.append(session.run({"model": "gpt-6-astra"}))
+
+    worker = threading.Thread(target=run)
+    worker.start()
+    assert feed_started.wait(timeout=2)
+    assert session.request_steer("too late") is False
+    assert not any(item["type"] == "response.steer" for item in socket.sent)
+    release_feed.set()
+    worker.join(timeout=2)
+    assert not worker.is_alive()
+    assert outcome and outcome[0].status == "completed"
+
+
 def test_steer_acceptance_successor_and_predecessor_fencing():
     socket = FakeWebSocket()
     agent = _agent()
@@ -273,6 +332,23 @@ def test_duplicate_frames_do_not_duplicate_output_items():
     agent = _agent()
     result = AstraWebSocketSession(agent, connect=_connect_socket(socket)).run({"model": "gpt-6-astra"})
     assert len(result.output) == 1
+    assert result.output_text == "once"
+
+
+def test_duplicate_sequence_number_is_fenced_before_assembler_effects():
+    socket = FakeWebSocket()
+    socket.push(_created("r1"))
+    frames = _completed("r1", "r1", "once")
+    frames[1]["sequence_number"] = 17
+    duplicate = dict(frames[1])
+    duplicate["id"] = "different-event-id"
+    duplicate["delta"] = "duplicate"
+    duplicate["sequence_number"] = 17
+    socket.events.extend([frames[0], frames[1], duplicate, frames[2], frames[3]])
+    agent = _agent()
+
+    result = AstraWebSocketSession(agent, connect=_connect_socket(socket)).run({"model": "gpt-6-astra"})
+
     assert result.output_text == "once"
 
 

--- a/tests/agent/test_astra_websocket.py
+++ b/tests/agent/test_astra_websocket.py
@@ -27,7 +27,8 @@ def _agent(**overrides):
         base_url="https://api.openai.com/v1", api_key="placeholder-key", auth_mode="api_key",
         is_subagent=False, compression_checkpoint_required=False, _interrupt_requested=False,
         _pending_steer=None, _pending_steer_lock=threading.Lock(), _session_messages=[],
-        _codex_streamed_text_parts=[],
+        _codex_streamed_text_parts=[], _session_db=FakeSessionDB(), session_id="synthetic-session",
+        _session_db_created=True,
     )
     values.update(overrides)
     values["_is_codex_backend"] = lambda: False
@@ -369,6 +370,7 @@ def test_explicit_steer_failure_keeps_one_legacy_pending_text():
     worker.join(timeout=2)
     assert agent._pending_steer == "legacy once"
     assert sum(item["type"] == "response.steer" for item in socket.sent) == 1
+    assert session._steering_receipts[-1]["state"] == "fallback_queued"
 
 
 def test_connect_failure_falls_back_but_send_or_recv_is_uncertain():
@@ -445,6 +447,22 @@ def test_restart_does_not_resend_accepted_or_ambiguous_steering():
     assert sent[0]["input"][0]["content"][0]["text"] == "new correction"
     assert sum(item["state"] == "ambiguous" for item in db.model_config["_astra_steering"]["entries"]) == 1
 
+    full_db = FakeSessionDB([
+        {"version": 1, "admission_id": str(index), "generation": index, "response_id": "r1",
+         "input": [{"role": "user", "content": [{"type": "input_text", "text": str(index)}]}],
+         "text": str(index), "state": "accepted"}
+        for index in range(1, 17)
+    ])
+    full_agent = _agent(_session_db=full_db)
+    full_session = AstraWebSocketSession(full_agent)
+    full_session._socket = FakeWebSocket()
+    full_session._response_id = "r2"
+    full_session._set_state("ACTIVE")
+    with pytest.raises(AstraSteeringPersistenceError):
+        full_session.request_steer("journal is full")
+    assert len(full_db.model_config["_astra_steering"]["entries"]) == 16
+    assert all(item["state"] == "accepted" for item in full_db.model_config["_astra_steering"]["entries"])
+
 
 def test_explicit_failure_requeues_once_after_restart():
     entry = {"version": 1, "admission_id": "failed", "generation": 1, "response_id": "r1",
@@ -476,6 +494,41 @@ def test_persistence_failure_before_steer_send_is_fail_closed():
         session.request_steer("must not dispatch")
     assert socket.sent == []
     assert agent._pending_steer is None
+
+
+def test_missing_or_noop_session_store_is_fail_closed_before_steer_send():
+    class NoOpDB(FakeSessionDB):
+        def patch_session_model_config(self, session_id, patch):
+            del session_id, patch
+
+    for db in (None, NoOpDB()):
+        socket = FakeWebSocket()
+        agent = _agent(_session_db=db)
+        session = AstraWebSocketSession(agent)
+        session._socket = socket
+        session._response_id = "r1"
+        session._set_state("ACTIVE")
+        with pytest.raises(AstraSteeringPersistenceError):
+            session.request_steer("must not dispatch")
+        assert socket.sent == []
+
+
+def test_redacted_steer_declines_before_dispatch(monkeypatch):
+    monkeypatch.setattr(
+        "agent.transports.astra_websocket_session._safe_steering_text",
+        lambda text: "[steering input redacted]",
+    )
+    socket = FakeWebSocket()
+    db = FakeSessionDB()
+    agent = _agent(_session_db=db)
+    session = AstraWebSocketSession(agent)
+    session._socket = socket
+    session._response_id = "r1"
+    session._set_state("ACTIVE")
+    with pytest.raises(AstraSteeringPersistenceError):
+        session.request_steer("credential-like steering input")
+    assert socket.sent == []
+    assert db.model_config["_astra_steering"]["entries"] == []
 
 
 def test_ambiguous_steer_send_retains_durable_no_resend_receipt():

--- a/tests/agent/test_astra_websocket.py
+++ b/tests/agent/test_astra_websocket.py
@@ -464,7 +464,7 @@ def test_restart_does_not_resend_accepted_or_ambiguous_steering():
     assert all(item["state"] == "accepted" for item in full_db.model_config["_astra_steering"]["entries"])
 
 
-def test_explicit_failure_requeues_once_after_restart():
+def test_explicit_failure_requeues_until_fallback_delivery():
     entry = {"version": 1, "admission_id": "failed", "generation": 1, "response_id": "r1",
              "input": [{"role": "user", "content": [{"type": "input_text", "text": "retry once"}]}],
              "text": "retry once", "state": "failed"}
@@ -475,7 +475,7 @@ def test_explicit_failure_requeues_once_after_restart():
     assert db.model_config["_astra_steering"]["entries"][0]["state"] == "fallback_queued"
     second = _agent(_session_db=db, session_id="synthetic-session", _session_db_created=True)
     AstraWebSocketSession(second)
-    assert second._pending_steer is None
+    assert second._pending_steer == "retry once"
 
 
 def test_persistence_failure_before_steer_send_is_fail_closed():
@@ -529,6 +529,40 @@ def test_redacted_steer_declines_before_dispatch(monkeypatch):
         session.request_steer("credential-like steering input")
     assert socket.sent == []
     assert db.model_config["_astra_steering"]["entries"] == []
+
+
+def test_live_failed_steer_reconstructs_then_delivers_once(tmp_path):
+    from hermes_state import SessionDB
+    from agent.turn_iteration_prep import _inject_steer_into_newest_tool_result
+    db = SessionDB(tmp_path / "state.db")
+    sid = "synthetic-fallback"
+    db.create_session(sid, source="cli", model="gpt-6-astra")
+    db.append_message(sid, "tool", "result", tool_call_id="call-fallback")
+    socket = FakeWebSocket()
+    agent = _agent(_session_db=db, session_id=sid)
+    session = AstraWebSocketSession(agent, connect=_connect_socket(socket))
+
+    def on_send(message, ws):
+        if message["type"] == "response.create":
+            ws.push(_created("r1"))
+        elif message["type"] == "response.steer":
+            ws.push({"type": "response.steer.failed", "id": "failed"})
+            ws.events.extend(_completed("r1", "r1"))
+    socket._on_send = on_send
+    worker = threading.Thread(target=lambda: session.run({"model": "gpt-6-astra"}))
+    worker.start()
+    deadline = time.time() + 2
+    while session.state != "ACTIVE" and time.time() < deadline:
+        time.sleep(0.005)
+    assert session.request_steer("retry once") is True
+    worker.join(2)
+    restarted = _agent(_session_db=db, session_id=sid, _session_messages=db.get_messages_as_conversation(sid, include_row_ids=True))
+    AstraWebSocketSession(restarted)
+    _inject_steer_into_newest_tool_result(restarted, restarted._session_messages, restarted._drain_pending_steer())
+    assert db.get_session_model_config_value(sid, "_astra_steering", {})["entries"][-1]["state"] == "fallback_delivered"
+    assert "retry once" in db.get_messages_as_conversation(sid)[-1]["content"]
+    assert AstraWebSocketSession(_agent(_session_db=db, session_id=sid)).agent._pending_steer is None
+    db.close()
 
 
 def test_ambiguous_steer_send_retains_durable_no_resend_receipt():

--- a/tests/agent/test_astra_websocket.py
+++ b/tests/agent/test_astra_websocket.py
@@ -341,7 +341,7 @@ def test_pending_required_input_continues_once_from_saved_result():
     assert sum(item["type"] == "response.steer" for item in socket.sent) == 1
 
 
-def test_explicit_steer_failure_keeps_one_legacy_pending_text():
+def test_explicit_steer_failure_keeps_one_legacy_redirect():
     socket = FakeWebSocket()
     agent = _agent()
     session = AstraWebSocketSession(agent, connect=_connect_socket(socket))
@@ -368,9 +368,10 @@ def test_explicit_steer_failure_keeps_one_legacy_pending_text():
         time.sleep(0.005)
     assert session.request_steer("legacy once") is True
     worker.join(timeout=2)
-    assert agent._pending_steer == "legacy once"
+    assert agent._pending_steer is None
+    assert agent._pending_redirect == "legacy once"
     assert sum(item["type"] == "response.steer" for item in socket.sent) == 1
-    assert session._steering_receipts[-1]["state"] == "fallback_queued"
+    assert session._steering_receipts[-1]["state"] == "failed"
 
 
 def test_connect_failure_falls_back_but_send_or_recv_is_uncertain():
@@ -464,18 +465,20 @@ def test_restart_does_not_resend_accepted_or_ambiguous_steering():
     assert all(item["state"] == "accepted" for item in full_db.model_config["_astra_steering"]["entries"])
 
 
-def test_explicit_failure_requeues_once_after_restart():
+def test_explicit_failure_restores_redirect_until_durable_delivery():
     entry = {"version": 1, "admission_id": "failed", "generation": 1, "response_id": "r1",
              "input": [{"role": "user", "content": [{"type": "input_text", "text": "retry once"}]}],
              "text": "retry once", "state": "failed"}
     db = FakeSessionDB([entry])
     first = _agent(_session_db=db, session_id="synthetic-session", _session_db_created=True)
     AstraWebSocketSession(first)
-    assert first._pending_steer == "retry once"
-    assert db.model_config["_astra_steering"]["entries"][0]["state"] == "fallback_queued"
+    assert first._pending_redirect == "retry once"
+    assert db.model_config["_astra_steering"]["entries"][0]["state"] == "failed"
+    AstraWebSocketSession(first)
+    assert first._pending_redirect == "retry once"
     second = _agent(_session_db=db, session_id="synthetic-session", _session_db_created=True)
     AstraWebSocketSession(second)
-    assert second._pending_steer is None
+    assert second._pending_redirect == "retry once"
 
 
 def test_persistence_failure_before_steer_send_is_fail_closed():

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3171,6 +3171,19 @@ class TestCodexAdapterPromptCacheKey:
         ])
         assert "prompt_cache_retention" not in captured
 
+    def test_astra_auxiliary_request_uses_official_contract(self):
+        adapter, captured = self._build_adapter(
+            base_url="https://api.openai.com/v1",
+            model="gpt-6-astra",
+        )
+        adapter.create(
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"reasoning": {"enabled": False, "effort": "none"}},
+        )
+        assert captured["reasoning"]["effort"] == "low"
+        assert captured["prompt_cache_options"] == {"ttl": "30m"}
+        assert "prompt_cache_retention" not in captured
+
     def test_codex_backend_forwards_auxiliary_service_tier(self):
         adapter, captured = self._build_adapter(
             base_url="https://chatgpt.com/backend-api/codex",

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3184,6 +3184,18 @@ class TestCodexAdapterPromptCacheKey:
         assert captured["prompt_cache_options"] == {"ttl": "30m"}
         assert "prompt_cache_retention" not in captured
 
+    def test_astra_auxiliary_proxy_keeps_legacy_effort_contract(self):
+        adapter, captured = self._build_adapter(
+            base_url="https://responses.example.com/v1",
+            model="gpt-6-astra",
+        )
+        adapter.create(
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"reasoning": {"effort": "none"}},
+        )
+        assert captured["reasoning"]["effort"] == "none"
+        assert "prompt_cache_options" not in captured
+
     def test_codex_backend_forwards_auxiliary_service_tier(self):
         adapter, captured = self._build_adapter(
             base_url="https://chatgpt.com/backend-api/codex",

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -825,6 +825,18 @@ class TestGetModelCapabilities:
         assert caps is not None
         assert caps.supports_vision is False
 
+    def test_astra_builtin_metadata_fills_catalog_lag_without_listing_it(self):
+        """An explicitly discovered Astra remains fully described before models.dev catches up."""
+        with patch("agent.models_dev.fetch_models_dev", return_value={}):
+            caps = get_model_capabilities("openai", "gpt-6-astra")
+
+        assert caps is not None
+        assert caps.context_window == 1_050_000
+        assert caps.max_output_tokens == 128_000
+        assert caps.supports_tools is True
+        assert caps.supports_vision is True
+        assert caps.supports_reasoning is True
+
 
 # ---------------------------------------------------------------------------
 # Per-model metadata overrides (model_overrides config)

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -837,6 +837,9 @@ class TestGetModelCapabilities:
         assert caps.supports_vision is True
         assert caps.supports_reasoning is True
 
+        api_caps = get_model_capabilities("openai-api", "gpt-6-astra")
+        assert api_caps == caps
+
 
 # ---------------------------------------------------------------------------
 # Per-model metadata overrides (model_overrides config)

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -11,6 +11,23 @@ from agent.usage_pricing import (
 from decimal import Decimal
 
 
+def test_astra_whole_request_price_tier_includes_cache_writes():
+    below = estimate_usage_cost(
+        "gpt-6-astra",
+        CanonicalUsage(input_tokens=100_000, output_tokens=10_000, cache_read_tokens=10_000, cache_write_tokens=10_000),
+        provider="openai",
+    )
+    above = estimate_usage_cost(
+        "gpt-6-astra",
+        CanonicalUsage(input_tokens=100_000, output_tokens=10_000, cache_read_tokens=100_000, cache_write_tokens=100_001),
+        provider="openai",
+    )
+
+    assert below.amount_usd == Decimal("1.635")
+    assert above.amount_usd == Decimal("5.450025")
+    assert above.pricing_version == "openai-gpt-6-astra-2026-09"
+
+
 
 
 

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -51,6 +51,7 @@ class TestCodexBuildKwargs:
                 "top_p": 0.9,
                 "top_logprobs": 5,
                 "logprobs": True,
+                "reasoning": {"effort": "none"},
                 "include": ["reasoning.encrypted_content", "message.output_text.logprobs"],
                 "prompt_cache_retention": "24h",
                 "prompt_cache_options": {"ttl": "1h"},
@@ -63,6 +64,31 @@ class TestCodexBuildKwargs:
         assert kw["include"] == ["reasoning.encrypted_content"]
         for unsupported in ("temperature", "top_p", "top_logprobs", "logprobs"):
             assert unsupported not in kw
+        assert transport.preflight_kwargs(kw)["prompt_cache_options"] == {"ttl": "30m"}
+
+    @pytest.mark.parametrize("effort", ["none", "minimal"])
+    def test_astra_normalizes_unsupported_low_efforts_after_overrides(self, transport, effort):
+        kw = transport.build_kwargs(
+            model="gpt-6-astra",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url="https://api.openai.com/v1",
+            request_overrides={"reasoning": {"effort": effort}},
+        )
+
+        assert kw["reasoning"]["effort"] == "low"
+
+    @pytest.mark.parametrize("effort", ["low", "medium", "high", "xhigh", "max"])
+    def test_astra_accepts_complete_effort_ladder(self, transport, effort):
+        kw = transport.build_kwargs(
+            model="gpt-6-astra",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url="https://api.openai.com/v1",
+            reasoning_config={"enabled": True, "effort": effort},
+        )
+
+        assert kw["reasoning"]["effort"] == effort
 
     def test_astra_proxy_does_not_receive_official_cache_options(self, transport):
         kw = transport.build_kwargs(

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -39,6 +39,42 @@ class TestCodexTransportBasic:
 
 class TestCodexBuildKwargs:
 
+    def test_astra_direct_request_applies_model_contract_after_overrides(self, transport):
+        kw = transport.build_kwargs(
+            model="gpt-6-astra",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url="https://api.openai.com/v1",
+            reasoning_config={"enabled": False, "effort": "none"},
+            request_overrides={
+                "temperature": 0.4,
+                "top_p": 0.9,
+                "top_logprobs": 5,
+                "logprobs": True,
+                "include": ["reasoning.encrypted_content", "message.output_text.logprobs"],
+                "prompt_cache_retention": "24h",
+                "prompt_cache_options": {"ttl": "1h"},
+            },
+        )
+
+        assert kw["reasoning"]["effort"] == "low"
+        assert kw["prompt_cache_options"] == {"ttl": "30m"}
+        assert "prompt_cache_retention" not in kw
+        assert kw["include"] == ["reasoning.encrypted_content"]
+        for unsupported in ("temperature", "top_p", "top_logprobs", "logprobs"):
+            assert unsupported not in kw
+
+    def test_astra_proxy_does_not_receive_official_cache_options(self, transport):
+        kw = transport.build_kwargs(
+            model="gpt-6-astra",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url="https://responses.example.com/v1",
+            request_overrides={"prompt_cache_options": {"ttl": "30m"}},
+        )
+
+        assert "prompt_cache_options" not in kw
+
     def test_900k_context_variant_suffix_stripped_on_wire(self, transport):
         """``-900k`` large-context picker variants are Hermes-side aliases —
         the Codex backend only knows the base slug, so build_kwargs must

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -103,6 +103,18 @@ class TestCodexBuildKwargs:
         assert "prompt_cache_options" not in kw
         assert kw["reasoning"]["effort"] == "none"
 
+    def test_astra_openai_subdomain_is_not_official_route(self, transport):
+        """Only api.openai.com gets Astra's official cache contract."""
+        kw = transport.build_kwargs(
+            model="gpt-6-astra",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url="https://evil.api.openai.com/v1",
+            request_overrides={"prompt_cache_options": {"ttl": "30m"}},
+        )
+
+        assert "prompt_cache_options" not in kw
+
     def test_900k_context_variant_suffix_stripped_on_wire(self, transport):
         """``-900k`` large-context picker variants are Hermes-side aliases —
         the Codex backend only knows the base slug, so build_kwargs must

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -96,10 +96,12 @@ class TestCodexBuildKwargs:
             messages=[{"role": "user", "content": "Hi"}],
             tools=[],
             base_url="https://responses.example.com/v1",
+            reasoning_config={"enabled": True, "effort": "none"},
             request_overrides={"prompt_cache_options": {"ttl": "30m"}},
         )
 
         assert "prompt_cache_options" not in kw
+        assert kw["reasoning"]["effort"] == "none"
 
     def test_900k_context_variant_suffix_stripped_on_wire(self, transport):
         """``-900k`` large-context picker variants are Hermes-side aliases —

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -226,6 +226,28 @@ class TestBusySessionAck:
         assert "Interrupting" not in content
 
     @pytest.mark.asyncio
+    async def test_uncertain_astra_redirect_is_handled_without_interrupt_or_requeue(self):
+        """A native redirect that owns an ambiguous send must stop the busy fallback path."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+        event = _make_event(text="do not send this twice")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent._supports_active_turn_redirect = True
+        agent.redirect.return_value = True
+        runner._running_agents[sk] = agent
+
+        with patch("gateway.platforms.base.merge_pending_message_event") as mock_merge:
+            await runner._handle_active_session_busy_message(event, sk)
+
+        agent.redirect.assert_called_once_with("do not send this twice")
+        agent.interrupt.assert_not_called()
+        mock_merge.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_steer_mode_transcribes_voice_before_injection(self, monkeypatch):
         """A busy voice follow-up is transcribed and steered, never queued."""
         import gateway.run as _gr

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -118,13 +118,17 @@ def test_astra_requires_live_codex_account_discovery(monkeypatch, tmp_path):
 
     (tmp_path / "config.toml").write_text('model = "gpt-6-astra"\n', encoding="utf-8")
     (tmp_path / "models_cache.json").write_text(
-        json.dumps({"models": [{"slug": "gpt-6-astra", "priority": 0}]}),
+        json.dumps({"models": [
+            {"slug": "gpt-6-astra", "priority": 0},
+            {"slug": "openai/gpt-6-astra", "priority": 1},
+        ]}),
         encoding="utf-8",
     )
     monkeypatch.setenv("CODEX_HOME", str(tmp_path))
     monkeypatch.setattr(codex_models, "_fetch_models_from_api", lambda _token: [])
 
     assert "gpt-6-astra" not in get_codex_model_ids(access_token="stale-token")
+    assert "openai/gpt-6-astra" not in get_codex_model_ids(access_token="stale-token")
 
     monkeypatch.setattr(
         codex_models,

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -121,6 +121,8 @@ def test_astra_requires_live_codex_account_discovery(monkeypatch, tmp_path):
         json.dumps({"models": [
             {"slug": "gpt-6-astra", "priority": 0},
             {"slug": "openai/gpt-6-astra", "priority": 1},
+            {"slug": "gpt-6-astra-900k", "priority": 2},
+            {"slug": "openai/gpt-6-astra-900k", "priority": 3},
         ]}),
         encoding="utf-8",
     )
@@ -129,13 +131,16 @@ def test_astra_requires_live_codex_account_discovery(monkeypatch, tmp_path):
 
     assert "gpt-6-astra" not in get_codex_model_ids(access_token="stale-token")
     assert "openai/gpt-6-astra" not in get_codex_model_ids(access_token="stale-token")
+    assert "gpt-6-astra-900k" not in get_codex_model_ids(access_token="stale-token")
+    assert "openai/gpt-6-astra-900k" not in get_codex_model_ids(access_token="stale-token")
 
     monkeypatch.setattr(
         codex_models,
         "_fetch_models_from_api",
         lambda _token: codex_models._finalize_codex_models(["gpt-6-astra"], allow_astra=True),
     )
-    assert "gpt-6-astra" in get_codex_model_ids(access_token="entitled-token")
+    entitled = get_codex_model_ids(access_token="entitled-token")
+    assert entitled[entitled.index("gpt-6-astra") + 1] == "gpt-6-astra-900k"
 
 
 

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -112,6 +112,28 @@ def test_fetch_from_api_keeps_supported_in_api_false_models(monkeypatch):
     assert "gpt-5-internal" not in models
 
 
+def test_astra_requires_live_codex_account_discovery(monkeypatch, tmp_path):
+    """Cached/configured Astra names must not manufacture current OAuth entitlement."""
+    from hermes_cli import codex_models
+
+    (tmp_path / "config.toml").write_text('model = "gpt-6-astra"\n', encoding="utf-8")
+    (tmp_path / "models_cache.json").write_text(
+        json.dumps({"models": [{"slug": "gpt-6-astra", "priority": 0}]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    monkeypatch.setattr(codex_models, "_fetch_models_from_api", lambda _token: [])
+
+    assert "gpt-6-astra" not in get_codex_model_ids(access_token="stale-token")
+
+    monkeypatch.setattr(
+        codex_models,
+        "_fetch_models_from_api",
+        lambda _token: codex_models._finalize_codex_models(["gpt-6-astra"], allow_astra=True),
+    )
+    assert "gpt-6-astra" in get_codex_model_ids(access_token="entitled-token")
+
+
 
 
 
@@ -238,4 +260,3 @@ class TestNormalizeModelForProvider:
         assert changed is True
         # Uses first from available list
         assert cli.model == "gpt-5.3-codex"
-

--- a/tests/hermes_cli/test_openai_picker_curated.py
+++ b/tests/hermes_cli/test_openai_picker_curated.py
@@ -70,3 +70,16 @@ def test_default_openai_endpoint_intersects_account_access(monkeypatch):
     assert result == list(curated[:2])
 
 
+def test_astra_is_offered_only_by_successful_account_discovery(monkeypatch):
+    """A gated preview may enrich the picker only when this API key lists it."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-fake")
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+    with patch.object(M, "fetch_api_models", return_value=["gpt-5.6-sol", "gpt-6-astra"]):
+        discovered = M.provider_model_ids("openai-api", force_refresh=True)
+    with patch.object(M, "fetch_api_models", return_value=["gpt-5.6-sol"]):
+        not_entitled = M.provider_model_ids("openai-api", force_refresh=True)
+
+    assert "gpt-6-astra" in discovered
+    assert "gpt-6-astra" not in not_entitled
+

--- a/tests/hermes_cli/test_openai_picker_curated.py
+++ b/tests/hermes_cli/test_openai_picker_curated.py
@@ -79,7 +79,9 @@ def test_astra_is_offered_only_by_successful_account_discovery(monkeypatch):
         discovered = M.provider_model_ids("openai-api", force_refresh=True)
     with patch.object(M, "fetch_api_models", return_value=["gpt-5.6-sol"]):
         not_entitled = M.provider_model_ids("openai-api", force_refresh=True)
+    with patch.object(M, "fetch_api_models", side_effect=RuntimeError("discovery unavailable")):
+        discovery_failed = M.provider_model_ids("openai-api", force_refresh=True)
 
     assert "gpt-6-astra" in discovered
     assert "gpt-6-astra" not in not_entitled
-
+    assert "gpt-6-astra" not in discovery_failed

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -49,6 +49,18 @@ class TestSteerAcceptance:
         assert agent.steer("go ahead and check the logs") is True
         assert agent._pending_steer == "go ahead and check the logs"
 
+    def test_direct_astra_uses_live_websocket_session(self):
+        agent = _bare_agent()
+        agent.api_mode = "codex_responses"
+        calls = []
+        agent._astra_websocket_session = type(
+            "_AstraSession", (), {"request_steer": lambda self, text: calls.append(text) or True},
+        )()
+
+        assert agent.steer("use the second plan") is True
+        assert calls == ["use the second plan"]
+        assert agent._pending_steer is None
+
 
 
 

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -61,6 +61,20 @@ class TestSteerAcceptance:
         assert calls == ["use the second plan"]
         assert agent._pending_steer is None
 
+    def test_direct_astra_uncertain_redirect_is_handled_without_interrupt_fallback(self):
+        agent = _bare_agent()
+        agent.api_mode = "codex_responses"
+        agent._astra_websocket_session = type(
+            "_AstraSession", (), {
+                "delivery_uncertain": True,
+                "request_steer": lambda self, text: (_ for _ in ()).throw(ConnectionError("ambiguous")),
+            },
+        )()
+
+        assert agent.redirect("do not duplicate") is True
+        assert agent._interrupt_requested is False
+        assert agent._pending_steer is None
+
 
 
 


### PR DESCRIPTION
## TL;DR

**Optional Astra runtime enhancement; baseline compatibility does not depend on it.** Hermes already lets users steer or redirect an agent. This PR connects the existing `steer()` control to Astra's active response over a persistent WebSocket, so guidance can reach the provider while it is generating.

It is **not a new steering UI**. It adds a provider-specific transport and delivery state machine. **Draft / evidence gate:** #103015 asks for measured benefit over Hermes' existing behavior before accepting that complexity; #103020 owns the live comparison.

Fixes #103018 · Depends on #103129 · Tracker: #103015

## Native Hermes versus this addition

| Existing Hermes behavior | Added by this PR |
| --- | --- |
| `steer()` queues guidance for the tool-result boundary | Try native delivery to an eligible active Astra response. |
| `redirect()` can interrupt/rebuild a model request; other backends may have their own native controls | Consume Astra's steering acknowledgement and automatic successor response. |
| Existing Responses assembly, tool execution and durable results | Reuse those paths while tracking socket delivery, response IDs and pending tool input. |

The proposed benefit is earlier guidance delivery without the ordinary queue boundary or a client-driven restart. It is **not yet a measured latency or quality improvement**.

## How it works

```mermaid
flowchart TD
    A["Existing steer control"] --> B{"Eligible active Astra socket?"}
    B -->|No| C["Existing Hermes steering path"]
    B -->|Yes| L["Persist frozen input and admission"]
    L --> D["Send response.steer"]
    D --> E{"Provider outcome"}
    E -->|Accepted| F["Remove accepted text from local queue"]
    F --> G["Consume automatic successor response"]
    E -->|Explicit failure| M["Queue rejected admission as internal redirect"]
    M --> N["Commit user message and delivery receipt together"]
    E -->|Delivery uncertain| H["Report uncertainty - do not resend"]
    G --> I{"Client tool output required?"}
    I -->|Yes| J["Continue with saved results and original call IDs"]
    I -->|No| K["Finish through existing response handling"]
```

An explicit failure may enqueue the guidance once through the legacy path. If initial socket setup fails **before dispatch**, SSE (the existing streaming HTTP path) may be used. Once a request may have reached the provider, ambiguity must not trigger a blind retry or resend. Pending tool continuations reuse saved outputs; they do not rerun tools or repeat accepted steering.

## Eligibility and cross-PR boundary

Eligible route: `gpt-6-astra`, API-key authentication, official `https://api.openai.com/v1` Responses endpoint. OAuth, Azure, custom endpoints/relays, non-Astra models and incompatible conversation/compaction-bound requests retain the existing transport.

**Known stack dependency:** this head checks `is_subagent`, but Hermes' production delegated-agent signals (`platform` / `_delegate_depth`) are additionally excluded in #103183. Do not treat delegated-child exclusion as complete in this PR alone. If this PR is landed separately from PR 4, that guard must be carried forward first.

No new command or setting. This does not replace Hermes' scheduler or make WebSocket-only features available through OAuth.

## Review scope and maintenance cost

The main addition is `agent/transports/astra_websocket_session.py`. Review its routing and delivery states first, followed by `agent/interrupt_control.py` and `agent/codex_runtime.py`. The costly cases are accepted-steer/successor races, late or duplicate events, pending tool outputs and uncertain delivery.

**Stack warning:** the default upstream-`main` diff includes PRs 1–2. [Feature-only tree comparison](https://github.com/100yenadmin/hermes-agent-for-upstream-PR-only/compare/e2a23bbcbf6ef99ad05917d0e36af5abfeb1bd79..c3ca520169b0bf2f827f7bb1f4b95e6892e2fc63): **14 files, +1,999 / −3**, including tests. These are this layer's changes, not a second copy of the baseline and async work.

## Validation and review follow-up

Current head: `c3ca520169b0bf2f827f7bb1f4b95e6892e2fc63`; parent: `e2a23bbcbf6ef99ad05917d0e36af5abfeb1bd79`. Synchronized upstream base: `1e69c12b64dba4090eddffeae27f5a147068d34b`.

[All required CI passed](https://github.com/NousResearch/hermes-agent/actions/runs/33953008908/job/101271726230) on this exact head.

The [three ownership/settlement findings](https://github.com/NousResearch/hermes-agent/pull/103144#pullrequestreview-5117265831) are handled at their existing ownership boundaries:

1. **PR 2 owns settlement:** wait for required jobs and ordering predecessors, persist results through the canonical publisher, then construct one continuation from saved rows and original IDs.
2. **PR 3 owns redirect admission:** delivery uncertainty is consumed without allowing the gateway to interrupt/requeue the same correction.
3. **PR 3 owns steering durability:** journal exact prepared input and admission identity before dispatch; preserve accepted/ambiguous ownership across reconstruction. Explicit rejection uses Hermes' existing internal redirect queue, with exact admission IDs. Its user message and delivery acknowledgment commit together, so crash recovery works with or without a tool result. Same-agent retry rereads the durable journal after a persistence/readback failure, without blindly requeueing a possibly committed correction. Rotating local compression carries the current journal inside the atomic child-publication transaction. No external next-user payload, new setting or database migration is added.

On combined descendant `d3ae318d37de4ad1199ab385cfc8e67f6ce3c4aa`, the real-session crash/restart file passed **6/6** and the new same-agent retry/rotation recovery file passed **5/5**. Existing local rotation also passed **44/44** on that combined head. The cases cover rollback, failed confirmation after commit, identical earlier user text, and pending/already-delivered correction ownership after rotation. Tool results remain unchanged. Earlier unchanged-path checks: WebSocket/journal **21** and legacy steering **36** passed at `72fb4a762`; real executor/current-settings continuation **4** and gateway busy routing **11** passed at `7955ebded`. These are explicitly prior-head local receipts; current-head CI is listed above.

One independent read-only runtime reviewer examined the changed settlement/ownership paths, then bounded correction-only deltas. The final targeted pass **passed** on combined head `d3ae318d37de4ad1199ab385cfc8e67f6ce3c4aa`, clearing explicit-failure restart recovery, same-agent retry and rotating-session journal ownership. No accepted/ambiguous resend or new tool execution path was found. This is source review, not upstream reviewer approval or provider-live acceptance. [Finding-by-finding response and review receipt](https://github.com/NousResearch/hermes-agent/pull/103144#issuecomment-5550359139).

Earlier CI/review receipts on `5ab1f7eb1` and `aae49cb179` are historical evidence, not proof for a changed head. Reconstruction tests do not claim transparent reconnection to an interrupted provider response.

**Live validation still required:** entitled live steering during generation and while tool output is pending, plus a controlled comparison of guidance-delivery latency and resulting behavior against native Hermes steering/redirect. No provider-live acceptance, performance gain, release or paid run is claimed.

