### PR TITLE
Desktop: readable transcript timestamps + a Message Bubble transparency slider

### DIFF
--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -48,6 +48,7 @@ import {
   TRANSLUCENCY_STEP,
   TRANSLUCENCY_SUPPORTED
 } from '@/store/translucency'
+import { $userBubbleTransparency, setUserBubbleTransparency } from '@/store/user-bubble-transparency'
 import { $vibeHeartsEnabled, setVibeHeartsEnabled } from '@/store/vibe-hearts-enabled'
 import { $zoomPercent, setZoomPercent } from '@/store/zoom'
 import { getBaseColors, useTheme } from '@/themes/context'
@@ -402,6 +403,7 @@ export function AppearanceSettings() {
   const composerPopoutGesturesEnabled = useStore($composerPopoutGesturesEnabled)
   const translucency = useStore($translucency)
   const glassMode = translucency.mode === 'glass' && GLASS_SUPPORTED
+  const userBubbleTransparency = useStore($userBubbleTransparency)
   const reactionsEnabled = useStore($reactionsEnabled)
   const tipsEnabled = useStore($tipsEnabled)
   const toursEnabled = useStore($toursEnabled)
@@ -742,6 +744,24 @@ export function AppearanceSettings() {
               title={a.translucencyTitle}
             />
           )}
+
+          <ListRow
+            action={
+              // Same peek as the window lever: the bubble being tuned sits
+              // behind this overlay, so the overlay ghosts while the hand is
+              // on the slider.
+              <div className="flex items-center gap-3" data-translucency-peek-scope="">
+                <TranslucencySlider
+                  label={a.userBubbleTitle}
+                  onChange={setUserBubbleTransparency}
+                  value={userBubbleTransparency}
+                />
+              </div>
+            }
+            description={a.userBubbleDesc}
+            id={appearanceSettingElementId(APPEARANCE_SETTING_IDS.userBubble)}
+            title={a.userBubbleTitle}
+          />
 
           <ListRow
             action={

--- a/apps/desktop/src/app/settings/settings-search.ts
+++ b/apps/desktop/src/app/settings/settings-search.ts
@@ -18,7 +18,8 @@ export const APPEARANCE_SETTING_IDS = {
   theme: 'appearance.theme',
   toolView: 'appearance.tool-view',
   translucency: 'appearance.translucency',
-  uiScale: 'appearance.ui-scale'
+  uiScale: 'appearance.ui-scale',
+  userBubble: 'appearance.user-bubble'
 } as const
 
 export interface SettingsSearchTarget {

--- a/apps/desktop/src/app/settings/use-settings-search.ts
+++ b/apps/desktop/src/app/settings/use-settings-search.ts
@@ -153,6 +153,15 @@ export function useSettingsSearchCatalog(enabled: boolean) {
       : []),
     {
       context: appearanceContext,
+      description: appearance.userBubbleDesc,
+      icon: Palette,
+      id: `setting:${APPEARANCE_SETTING_IDS.userBubble}`,
+      keywords: ['opacity', 'transparent', 'message', 'bubble'],
+      label: appearance.userBubbleTitle,
+      target: { setting: APPEARANCE_SETTING_IDS.userBubble, view: 'config:appearance' }
+    },
+    {
+      context: appearanceContext,
       description: appearance.backdropDesc,
       icon: Palette,
       id: `setting:${APPEARANCE_SETTING_IDS.backdrop}`,

--- a/apps/desktop/src/components/assistant-ui/thread/timeline-timestamp.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline-timestamp.tsx
@@ -57,7 +57,11 @@ export const TimelineTimestamp: FC<{
 
   return (
     <span
-      className={cn('text-[0.625rem] leading-4 tabular-nums text-muted-foreground/55', className)}
+      // The same meta ink as the tool rows' stamps (SCAFFOLD_META_CLASS).
+      // `text-muted-foreground/55` doubled an alpha: muted-foreground is
+      // already a 54% mix of the base ink, so the stamp landed near 30% —
+      // faint over a dark chrome and fainter over a light one.
+      className={cn('text-[0.625rem] leading-4 tabular-nums text-(--conversation-scaffold-meta)', className)}
       data-slot="timeline-timestamp"
       title={title}
     >

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -466,6 +466,8 @@ export const ar = defineLocale({
       },
       backdropTitle: 'خلفية النافذة',
       backdropDesc: 'اختيار مقدار مزج خلفية سطح المكتب مع سطح Hermes.',
+      userBubbleTitle: 'فقاعة الرسالة',
+      userBubbleDesc: 'مدى شفافية رسائلك. معتمة عند 0؛ يبقى الإطار فقط عند 100.',
       introSplashTitle: 'شاشة المقدمة',
       introSplashDesc: 'الشعار النصي والعبارة التمهيدية في محادثة فارغة.',
       reactionsTitle: 'تفاعلات الرسائل',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -586,6 +586,8 @@ export const en: Translations = {
       },
       backdropTitle: 'Chat Backdrop',
       backdropDesc: 'The faint statue image behind the conversation.',
+      userBubbleTitle: 'Message Bubble',
+      userBubbleDesc: 'How see-through your own messages are. Solid at 0; only the outline remains at 100.',
       introSplashTitle: 'Intro Splash',
       introSplashDesc: 'The wordmark and prompt shown on an empty chat.',
       reactionsTitle: 'Message Reactions',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -409,6 +409,8 @@ export const ja = defineLocale({
       },
       backdropTitle: 'チャット背景',
       backdropDesc: '会話の背後に表示される淡い彫像の画像。',
+      userBubbleTitle: 'メッセージの吹き出し',
+      userBubbleDesc: '自分のメッセージの透け具合。0 で不透明、100 で枠線だけが残ります。',
       introSplashTitle: 'イントロ表示',
       introSplashDesc: '空のチャットに表示されるワードマークとプロンプト。',
       reactionsTitle: 'メッセージリアクション',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -579,6 +579,8 @@ export const ru = defineLocale({
       },
       backdropTitle: 'Фон чата',
       backdropDesc: 'Блёклый силуэт позади диалога.',
+      userBubbleTitle: 'Пузырь сообщения',
+      userBubbleDesc: 'Насколько прозрачны ваши сообщения. 0 — сплошная заливка, 100 — остаётся только контур.',
       introSplashTitle: 'Экран приветствия',
       introSplashDesc: 'Логотип и подсказка, показываемые на пустом чате.',
       reactionsTitle: 'Реакции на сообщения',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -478,6 +478,8 @@ export interface Translations {
       }
       backdropTitle: string
       backdropDesc: string
+      userBubbleTitle: string
+      userBubbleDesc: string
       introSplashTitle: string
       introSplashDesc: string
       reactionsTitle: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -398,6 +398,8 @@ export const zhHant = defineLocale({
       },
       backdropTitle: '聊天背景',
       backdropDesc: '對話後方那張淡淡的雕像圖片。',
+      userBubbleTitle: '訊息氣泡',
+      userBubbleDesc: '你自己的訊息有多透明。0 為不透明，100 時只保留邊框。',
       introSplashTitle: '開場標識',
       introSplashDesc: '空白對話中顯示的字標和提示語。',
       reactionsTitle: '訊息回應',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -572,6 +572,8 @@ export const zh: Translations = {
       },
       backdropTitle: '聊天背景',
       backdropDesc: '对话后方那张淡淡的雕像图片。',
+      userBubbleTitle: '消息气泡',
+      userBubbleDesc: '你自己的消息有多透明。0 为不透明，100 时只保留边框。',
       introSplashTitle: '开场标识',
       introSplashDesc: '空白对话中显示的字标和提示语。',
       reactionsTitle: '消息回应',

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -5,6 +5,8 @@ import './store/active-work'
 import './store/power'
 // Side-effect: applies the persisted window translucency on load.
 import './store/translucency'
+// Side-effect: applies the persisted user-bubble transparency on load.
+import './store/user-bubble-transparency'
 // Dev-only render/state churn counters. MUST precede the `react-dom` import
 // below: react-dom captures the devtools hook at module init, so bippy has to
 // install during THIS import's evaluation or every commit goes unseen

--- a/apps/desktop/src/store/user-bubble-transparency.ts
+++ b/apps/desktop/src/store/user-bubble-transparency.ts
@@ -1,0 +1,41 @@
+/**
+ * Message bubble transparency — how much of your own bubble's fill shows.
+ *
+ * One 0–100 lever, same direction as Window Translucency: 0 keeps the bubble
+ * solid (default), 100 leaves only the outline. Presentation-only, so the
+ * renderer owns it (desktop AGENTS.md: state lives with its authority) and
+ * paints it as ONE root variable — `--user-bubble-keep`, the share of the
+ * theme's bubble fill to keep — that `--dt-user-bubble` mixes in (styles.css).
+ * The bubble and the inline edit composer share that token, so both follow.
+ */
+
+import { clampIntensity, TRANSLUCENCY_MAX, TRANSLUCENCY_MIN } from '@hermes/shared/translucency'
+import { atom } from 'nanostores'
+
+import { persistString, storedString } from '@/lib/storage'
+
+const KEY = 'hermes.desktop.user-bubble-transparency.v1'
+
+export const $userBubbleTransparency = atom<number>(
+  typeof window === 'undefined' ? TRANSLUCENCY_MIN : clampIntensity(storedString(KEY))
+)
+
+export function setUserBubbleTransparency(value: number): void {
+  $userBubbleTransparency.set(clampIntensity(value))
+}
+
+if (typeof window !== 'undefined') {
+  $userBubbleTransparency.subscribe(value => {
+    const root = document.documentElement
+
+    // The default paints nothing: styles.css falls back to the full fill, so a
+    // user who never touched the lever gets byte-identical CSS to before.
+    if (value === TRANSLUCENCY_MIN) {
+      root.style.removeProperty('--user-bubble-keep')
+      persistString(KEY, null)
+    } else {
+      root.style.setProperty('--user-bubble-keep', `${TRANSLUCENCY_MAX - value}%`)
+      persistString(KEY, String(value))
+    }
+  })
+}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -432,7 +432,12 @@
     --dt-destructive-foreground: #ffffff;
     --dt-sidebar-bg: var(--ui-bg-sidebar);
     --dt-sidebar-border: var(--ui-stroke-secondary);
-    --dt-user-bubble: var(--ui-chat-bubble-background);
+    /* `--user-bubble-keep` is the Settings → Appearance → Message Bubble lever
+       (store/user-bubble-transparency.ts): the share of the theme's bubble
+       fill to keep. Unset at the default, so the mix is a no-op and the bubble
+       is the theme's fill exactly as before. The border stays put either way —
+       at full transparency the outline is what still marks your turn. */
+    --dt-user-bubble: color-mix(in srgb, var(--ui-chat-bubble-background) var(--user-bubble-keep, 100%), transparent);
     --dt-user-bubble-border: var(--ui-stroke-tertiary);
 
     --dt-font-sans:


### PR DESCRIPTION
## What does this PR do?

Two small Appearance fixes for the desktop transcript.

**Timestamps were nearly invisible in both modes.** `TimelineTimestamp` used `text-muted-foreground/55` on top of a token that is already a 54% mix of the base ink, so the stamp painted at ~30% alpha (2.3:1 on a dark chrome, 1.9:1 on a light one, measured on a live window). It now uses `--conversation-scaffold-meta`, the token the tool-row stamps already wear, so every stamp in the transcript reads from one place.

**New Message Bubble slider** (Settings → Appearance, under Window Translucency). 0–100; 0 keeps your bubble solid (default), 100 leaves only the outline.

| | |
|---|---|
| Store | `store/user-bubble-transparency.ts`: renderer-owned, persisted, paints one root var `--user-bubble-keep` |
| CSS | `--dt-user-bubble` becomes `color-mix(fill var(--user-bubble-keep, 100%), transparent)`; unset at default, so anyone who never touches the lever gets byte-identical CSS |
| Coverage | the read-only bubble and the inline edit composer share the token; the border stays so the outline still marks your turn at 100 |
| UI | reuses `TranslucencySlider` (the overlay peeks while dragging), `ListRow`, a ⌘K search entry, copy in all six locales |

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `apps/desktop/src/components/assistant-ui/thread/timeline-timestamp.tsx`: stamp ink → `--conversation-scaffold-meta`
- `apps/desktop/src/store/user-bubble-transparency.ts`: new store, `--user-bubble-keep` root var
- `apps/desktop/src/styles.css`: `--dt-user-bubble` mixes the fill by `--user-bubble-keep`
- `apps/desktop/src/app/settings/appearance-settings.tsx`, `settings-search.ts`, `use-settings-search.ts`: the row + ⌘K entry
- `apps/desktop/src/i18n/*`: `userBubbleTitle` / `userBubbleDesc`
- `apps/desktop/src/main.tsx`: side-effect import so the persisted value paints on boot

## How to Test

1. Dark and light, `display.timestamps: true`: timestamps on a settled turn and on tool rows are legible and the same shade.
2. Settings → Appearance → Message Bubble: drag 0→100. The bubble fill fades, the border stays; the inline edit composer matches.
3. Reload: the value persists. At 0, `<html>` has no `--user-bubble-keep`.
4. ⌘K "bubble" lands on the row.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (desktop-only change; no Python touched)
- [ ] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.7

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (renderer-local setting)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — CSS + localStorage only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
