### PR TITLE
[Superseded] Fix zero-turn provider auth failures in TUI Goals

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1355,6 +1355,17 @@ def _run_phase(fn, agent, state: _LoopState, **extra):
     return verdict
 
 
+def _runtime_trace(agent, event_name: str, **fields: Any) -> None:
+    """Best-effort, opt-in trace hook; diagnostics never alter turn semantics."""
+    callback = getattr(agent, "runtime_trace_callback", None)
+    if not callable(callback):
+        return
+    try:
+        callback(event_name, **fields)
+    except Exception:
+        logger.debug("runtime trace callback failed", exc_info=True)
+
+
 def _run_api_retry_loop(agent, s: _LoopState) -> Optional[Dict[str, Any]]:
     """One API call with its retry/recovery loop (guard → build → call → check, error handlers).
 
@@ -1367,8 +1378,26 @@ def _run_api_retry_loop(agent, s: _LoopState) -> Optional[Dict[str, Any]]:
         if _ng.action == "break":
             return None
         try:
-            _run_phase(build_api_request, agent, s)
-            if _run_phase(perform_api_call, agent, s).action == "break":
+            _runtime_trace(agent, "MODEL_REQUEST_BUILD_ENTER")
+            try:
+                _run_phase(build_api_request, agent, s)
+            except Exception as exc:
+                _runtime_trace(agent, "MODEL_REQUEST_BUILD_EXIT", success=False,
+                               error_class=type(exc).__name__)
+                raise
+            _runtime_trace(agent, "MODEL_REQUEST_BUILD_EXIT", success=True)
+            _runtime_trace(agent, "MODEL_PROVIDER_CALL_ENTER")
+            try:
+                _provider_verdict = _run_phase(perform_api_call, agent, s)
+            except Exception as exc:
+                _runtime_trace(agent, "MODEL_PROVIDER_CALL_EXIT", success=False,
+                               error_class=type(exc).__name__)
+                raise
+            _runtime_trace(agent, "MODEL_PROVIDER_CALL_EXIT", success=True)
+            if not getattr(agent, "_runtime_trace_first_activity_emitted", False):
+                agent._runtime_trace_first_activity_emitted = True
+                _runtime_trace(agent, "MODEL_FIRST_ACTIVITY", success=True)
+            if _provider_verdict.action == "break":
                 return None
             _rc = _run_phase(check_api_response, agent, s)
             if _rc.action == "return":

--- a/agent/turn_facade.py
+++ b/agent/turn_facade.py
@@ -28,13 +28,26 @@ class TurnFacadeMixin:
         persist_user_platform_id: Optional[str]=None, moa_config: Optional[dict[str, Any]]=None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
+        def _runtime_trace(event_name: str, **fields: Any) -> None:
+            callback = getattr(self, "runtime_trace_callback", None)
+            if not callable(callback):
+                return
+            try:
+                callback(event_name, **fields)
+            except Exception:
+                logger.debug("runtime trace callback failed", exc_info=True)
+
+        self._runtime_trace_first_activity_emitted = False
+        _runtime_trace("RUN_CONVERSATION_ENTER")
         # A review shares this session_id for cache parity: fence review startup or interrupt
         # an admitted request and await its exit before opening live-turn instrumentation.
         # Foreground priority is retained if the review does not acknowledge within the bounded deadline
         # (#84423).
         from agent.background_review import cancel_background_review_for_live_turn
 
+        _runtime_trace("BACKGROUND_REVIEW_CANCEL_ENTER")
         cancel_background_review_for_live_turn(self)
+        _runtime_trace("BACKGROUND_REVIEW_CANCEL_EXIT", success=True)
 
         from agent import relay_runtime
         from agent.aux_accounting import reset_accounting_context, set_accounting_context
@@ -74,18 +87,23 @@ class TurnFacadeMixin:
         try:
             # First statement of the try so the finally's note_turn_finished balances every exit.
             _review_queue.note_turn_started()
+            _runtime_trace("DURABLE_TURN_LEASE_ENTER")
             admission = admit_durable_turn_lease(
                 self, session_id=session_id, relay_turn_id=relay_turn_id, task_context=task_context,
                 conversation_history=conversation_history,
             )
             if admission.early_result is not None:
+                _runtime_trace("DURABLE_TURN_LEASE_EXIT", success=False,
+                               error_class="SessionTurnLeaseUnavailable")
                 relay_outcome = (
                     "cancelled" if admission.early_result.get("interrupted") else "timed_out"
                 )
                 return admission.early_result
             lease = admission.lease
+            _runtime_trace("DURABLE_TURN_LEASE_EXIT", success=True)
             conversation_history = admission.conversation_history
 
+            _runtime_trace("RELAY_CONVERSATION_ENTER")
             relay_lease = relay_runtime.SESSION_COORDINATOR.acquire_conversation(
                 profile_key=relay_runtime.current_profile_key(),
                 session_id=task_context["session_id"], platform=task_context["platform"],
@@ -119,6 +137,7 @@ class TurnFacadeMixin:
                 try:
                     if lease is not None:
                         lease.start()
+                    _runtime_trace("CONVERSATION_LOOP_ENTER")
                     result = run_conversation(
                         self, user_message, system_message, conversation_history, effective_task_id,
                         stream_callback, persist_user_message,
@@ -127,6 +146,7 @@ class TurnFacadeMixin:
                         persist_user_display_metadata=persist_user_display_metadata,
                         persist_user_platform_id=persist_user_platform_id, moa_config=moa_config,
                     )
+                    _runtime_trace("CONVERSATION_LOOP_EXIT", success=True)
                 finally:
                     # Post-loop relay/task finalization must not receive a late refresh interrupt;
                     # the interrupt clear itself waits for the thread join in the outer finally.
@@ -142,8 +162,10 @@ class TurnFacadeMixin:
             if task_started:
                 task_finished = True
                 finish_task_run(**task_context, result=result)
+            _runtime_trace("RUN_CONVERSATION_EXIT", success=True)
             return result
         except BaseException as exc:
+            _runtime_trace("RUN_CONVERSATION_EXIT", success=False, error_class=type(exc).__name__)
             if isinstance(exc, (KeyboardInterrupt, InterruptedError)) or (
                 type(exc).__name__ == "CancelledError"
             ):
@@ -159,6 +181,7 @@ class TurnFacadeMixin:
                 finish_task_run(**task_context, error=exc)
             raise
         finally:
+            _runtime_trace("RELAY_CONVERSATION_EXIT", success=True)
             try:
                 if relay_turn is not None:
                     relay_runtime.SESSION_COORDINATOR.end_turn(relay_turn, outcome=relay_outcome)

--- a/tests/tui_gateway/test_goal_command.py
+++ b/tests/tui_gateway/test_goal_command.py
@@ -170,6 +170,177 @@ def _compression_failure():
     }
 
 
+def _first_turn_auth_failure():
+    return {
+        "final_response": "provider authentication rejected",
+        "error": "provider authentication rejected",
+        "failed": True,
+        "completed": False,
+        "failure_reason": "auth",
+        "failure_retryable": False,
+    }
+
+
+def test_runtime_trace_is_opt_in_and_content_free(server, monkeypatch):
+    emitted = []
+    monkeypatch.setattr(
+        server, "_emit", lambda event, sid, payload=None: emitted.append((event, sid, payload)))
+    private_sid = "session-with-private-value"
+    private_correlation = "trace-with-private-value"
+
+    server._runtime_trace(
+        {"runtime_trace_enabled": True, "runtime_trace_id": private_correlation},
+        private_sid, "MODEL_PROVIDER_CALL_ENTER", operation="provider_request")
+
+    assert len(emitted) == 1
+    event, sid, payload = emitted[0]
+    assert event == "runtime.trace"
+    assert sid == private_sid
+    assert payload["event_name"] == "MODEL_PROVIDER_CALL_ENTER"
+    assert set(payload) == {
+        "event_name", "monotonic_ns", "correlation_id", "process_id", "thread_id", "operation"}
+    assert private_sid not in str(payload)
+    assert private_correlation not in str(payload)
+
+    server._runtime_trace({}, private_sid, "MODEL_PROVIDER_CALL_ENTER")
+    assert len(emitted) == 1
+
+
+def test_first_provider_auth_failure_pauses_unstarted_goal_fail_closed(server, hermes_home, turn_env):
+    from hermes_cli.goals import GoalManager
+
+    session_key = "first-turn-auth-failure"
+    GoalManager(session_key).set("harmless goal", max_turns=1)
+    calls = []
+    agent = types.SimpleNamespace(
+        session_id=session_key, provider="openai-codex", model="gpt-test",
+        clear_interrupt=lambda: None,
+        run_conversation=lambda *args, **kwargs: calls.append((args, kwargs)) or _first_turn_auth_failure(),
+    )
+    turn_session = _turn_session(agent, session_key)
+
+    server._run_prompt_submit("rid", "sid", turn_session, "harmless prompt")
+
+    state = GoalManager(session_key).state
+    assert state is not None
+    assert state.status == "paused"
+    assert state.turns_used == 0
+    assert state.paused_reason == "HERMES_RUNTIME_MODEL_AUTH_FAILED"
+    assert len(calls) == 1
+    updates = [p for event, _sid, p in turn_env if event == "status.update"]
+    assert updates == [{
+        "kind": "runtime", "code": "HERMES_RUNTIME_MODEL_AUTH_FAILED",
+        "retryable": False, "text": "HERMES_RUNTIME_MODEL_AUTH_FAILED",
+    }]
+
+
+def test_runtime_failure_does_not_pause_goal_after_a_native_turn(server, hermes_home):
+    from hermes_cli.goals import GoalManager, save_goal
+
+    session_key = "post-turn-runtime-failure"
+    manager = GoalManager(session_key)
+    state = manager.set("harmless goal", max_turns=2)
+    state.turns_used = 1
+    save_goal(session_key, state)
+
+    paused = server._pause_unstarted_goal_for_runtime_failure(
+        {"session_key": session_key}, "sid",
+        {"layer": "auth", "code": "auth", "retryable": False})
+
+    assert paused is False
+    after = GoalManager(session_key).state
+    assert after is not None
+    assert after.status == "active"
+    assert after.turns_used == 1
+
+
+@pytest.mark.parametrize("canary_id", ("one", "two"))
+def test_source_only_first_turn_canary_completes_once(
+    server, hermes_home, monkeypatch, tmp_path, canary_id
+):
+    """Two independent max-turns=1 canaries exercise the native TUI Goal path.
+
+    The model transport is a deterministic test client, but both canaries pass
+    through the actual request-build and provider-call adapter before native
+    Goal persistence.  No network, credential, tool, or business action is
+    involved.
+    """
+    from hermes_cli.goals import GoalManager
+    from run_agent import AIAgent
+
+    emitted = []
+    monkeypatch.setattr(
+        server, "_emit", lambda event, sid, payload=None: emitted.append((event, sid, payload))
+    )
+    monkeypatch.setattr(server, "_wire_callbacks", lambda sid: None)
+    monkeypatch.setattr(server, "_sync_agent_model_with_config", lambda sid, session: None)
+    monkeypatch.setattr(server, "_session_cwd", lambda session: str(tmp_path))
+    monkeypatch.setattr(server, "_register_session_cwd", lambda session: None)
+    monkeypatch.setattr(server, "_tts_stream_begin", lambda: None)
+    monkeypatch.setattr(server, "_sync_session_key_after_compress", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_get_usage", lambda agent: {})
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    monkeypatch.setattr(
+        server,
+        "_start_usage_ticker",
+        lambda *args, **kwargs: (threading.Event(), types.SimpleNamespace(join=lambda: None)),
+    )
+    session_key = f"source-only-first-turn-{canary_id}"
+    GoalManager(session_key).set("harmless source canary", max_turns=1)
+    with (
+        patch("model_tools.get_tool_definitions", return_value=[]),
+        patch("model_tools.check_toolset_requirements", return_value={}),
+        patch("agent.process_bootstrap.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            session_id=session_key,
+        )
+    agent.client = MagicMock()
+    agent.client.chat.completions.create.return_value = types.SimpleNamespace(
+        choices=[types.SimpleNamespace(
+            message=types.SimpleNamespace(content="harmless source-only completion", tool_calls=None),
+            finish_reason="stop",
+        )],
+        model="test/model",
+        usage=None,
+    )
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent._persist_session = lambda *args, **kwargs: None
+    agent._save_trajectory = lambda *args, **kwargs: None
+    agent._cleanup_task_resources = lambda *args, **kwargs: None
+    turn_session = _turn_session(agent, session_key)
+    turn_session.update({"runtime_trace_enabled": True, "runtime_trace_id": f"canary-{canary_id}"})
+    agent.runtime_trace_callback = lambda event_name, **fields: server._runtime_trace(
+        turn_session, f"sid-{canary_id}", event_name, **fields
+    )
+
+    with patch("hermes_cli.goals.judge_goal", return_value=("done", "complete", False, None, False)):
+        server._run_prompt_submit("rid", f"sid-{canary_id}", turn_session, "harmless source canary")
+        run_thread = turn_session.get("_run_thread")
+        assert run_thread is not None
+        run_thread.join(timeout=20)
+        assert not run_thread.is_alive()
+
+    state = GoalManager(session_key).state
+    assert state is not None
+    assert state.status == "done"
+    assert state.turns_used == 1
+    assert agent.client.chat.completions.create.call_count == 1
+    traces = [payload for event, _sid, payload in emitted if event == "runtime.trace"]
+    names = [trace["event_name"] for trace in traces]
+    assert "MODEL_PROVIDER_CALL_ENTER" in names
+    assert "MODEL_FIRST_ACTIVITY" in names
+    assert "FIRST_NATIVE_TURN_PERSISTED" in names
+
+
 # ── command.dispatch /goal ────────────────────────────────────────────
 
 

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -535,6 +535,9 @@ def _lock_in_submit_turn(
 def _(rid, params: dict) -> dict:
     from hermes_cli.input_sanitize import sanitize_user_prompt_text
     sid = params.get("session_id", "")
+    trace_session = _sessions.get(sid)
+    _runtime_trace(trace_session, sid, "GOAL_DISPATCH_ENTER")
+    _runtime_trace(trace_session, sid, "SESSION_RESOLUTION_ENTER")
     raw_text = params.get("text", "")
     text = sanitize_user_prompt_text(raw_text) if isinstance(raw_text, str) else raw_text
     # Off-screen sends (widget intents) type the row so no client renders a bubble;
@@ -548,7 +551,12 @@ def _(rid, params: dict) -> dict:
         mark_speech_interrupted()
     session, err = _sess_nowait(params, rid)
     if err:
+        _runtime_trace(trace_session, sid, "SESSION_RESOLUTION_EXIT", success=False,
+                       error_class="SessionResolutionError")
+        _runtime_trace(trace_session, sid, "GOAL_DISPATCH_EXIT", success=False,
+                       error_class="SessionResolutionError")
         return err
+    _runtime_trace(session, sid, "SESSION_RESOLUTION_EXIT", success=True)
     hosted_task = params.get("_hosted_task")
     hosted_terminal_callback = params.get("_hosted_terminal_callback")
     internal_hosted_submit = hosted_task is not None or hosted_terminal_callback is not None
@@ -630,6 +638,7 @@ def _(rid, params: dict) -> dict:
     # Handle lets session.interrupt tell a live turn from a stuck `running` flag.
     session["_run_thread"] = run_thread
     run_thread.start()
+    _runtime_trace(session, sid, "GOAL_DISPATCH_EXIT", success=True)
     return _ok(rid, {"status": "streaming", **survivor_fields})
 
 

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -296,6 +296,8 @@ def _create_overrides(params: dict) -> tuple:
 @method("session.create")
 def _(rid, params: dict) -> dict:
     (sid, source), key = _new_runtime_ids(params), _new_session_key()
+    runtime_trace_enabled = is_truthy_value(params.get("runtime_trace", False))
+    runtime_trace_id = str(params.get("runtime_trace_id") or "").strip()
     history = _coerce_seed_history(params.get("messages"))
     # Branch: links back so list_sessions_rich keeps it visible and the sidebar nests it.
     parent_session_id = _str_param(params, "parent_session_id") or None
@@ -325,10 +327,13 @@ def _(rid, params: dict) -> dict:
             "pending_hidden": _flag(params, "hidden"), "room_plumbing": _flag(params, "room_plumbing"),
             "follow_profile_config": _flag(params, "follow_profile_config"),
             "profile_home": str(profile_home) if profile_home is not None else None,
-            "running": False, "session_key": key, "show_reasoning": _load_show_reasoning(), "source": source,
+            "running": False, "runtime_id": sid, "session_key": key,
+            "show_reasoning": _load_show_reasoning(), "source": source,
+            "runtime_trace_enabled": runtime_trace_enabled, "runtime_trace_id": runtime_trace_id,
             "slash_worker": None, "tool_progress_mode": _load_tool_progress_mode(), "tool_started_at": {},
             "transport": current_transport() or _stdio_transport}
         _register_session_cwd(_sessions[sid])
+    _runtime_trace(_sessions[sid], sid, "SESSION_RESOLUTION_EXIT", success=True)
     # No DB row here (drafts left "Untitled" litter): created on the first prompt — except seeded branch children.
     # NOTE: we intentionally do NOT persist a DB row here. Every TUI/desktop launch (and every "New agent" /
     # draft) opens a session here just to paint the composer, so eagerly creating a row left an "Untitled"

--- a/tui_gateway/prompt_turn.py
+++ b/tui_gateway/prompt_turn.py
@@ -299,6 +299,7 @@ def _goal_followup_after_turn(
                 _bg_procs = None
             decision = goal_mgr.evaluate_after_turn(
                 raw, user_initiated=True, background_processes=_bg_procs)
+            _runtime_trace(session, sid, "FIRST_NATIVE_TURN_PERSISTED", success=True)
             if verdict_msg := decision.get("message") or "":
                 _emit("status.update", sid, {"kind": "goal", "text": verdict_msg})
             if decision.get("should_continue") and (
@@ -511,6 +512,9 @@ def _invoke_agent(
     agent = st.agent
 
     def _stream(delta):
+        if not getattr(agent, "_runtime_trace_first_activity_emitted", False):
+            agent._runtime_trace_first_activity_emitted = True
+            _runtime_trace(session, sid, "MODEL_FIRST_ACTIVITY", success=True)
         with session["history_lock"]:
             _append_inflight_delta(session, delta)
         payload = {"text": delta}
@@ -619,7 +623,7 @@ def _absorb_turn_result(
     return status_note
 
 
-def _complete_turn_payload(session: dict, st: _TurnRun, status_note: str | None, cols: int):
+def _complete_turn_payload(sid: str, session: dict, st: _TurnRun, status_note: str | None, cols: int):
     """``(payload, raw, status)`` for message.complete; retains/clears the inflight turn and
     settles the hosted-room terminal receipt."""
     result, agent = st.result, st.agent
@@ -648,6 +652,7 @@ def _complete_turn_payload(session: dict, st: _TurnRun, status_note: str | None,
                 model=str(getattr(agent, "model", "") or ""))
         except Exception:
             _error_surface = None
+        _pause_unstarted_goal_for_runtime_failure(session, sid, _error_surface)
     error_value = result.get("error")
     with session["history_lock"]:
         if status == "error":
@@ -795,7 +800,7 @@ def _run_prompt_submit(
                 display_metadata)
             status_note = _absorb_turn_result(
                 sid, session, st, text, display_kind, display_metadata)
-            payload, raw, status = _complete_turn_payload(session, st, status_note, cols)
+            payload, raw, status = _complete_turn_payload(sid, session, st, status_note, cols)
             _emit("message.complete", sid, payload)
             goal_followup = _goal_followup_after_turn(sid, session, st.result, status, raw)
             if status == "complete":

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -577,6 +577,80 @@ def _emit(event: str, sid: str, payload: dict | None = None):
     write_json(_event_frame(event, sid, payload))
 
 
+def _runtime_trace(
+    session: dict | None,
+    sid: str,
+    event_name: str,
+    *,
+    success: bool | None = None,
+    error_class: str | None = None,
+    duration_ms: float | None = None,
+    operation: str | None = None,
+) -> None:
+    """Emit opt-in, content-free runtime boundary telemetry for one session."""
+    if not isinstance(session, dict) or not session.get("runtime_trace_enabled"):
+        return
+    raw_correlation = str(session.get("runtime_trace_id") or sid or "")
+    correlation_id = hashlib.sha256(raw_correlation.encode("utf-8")).hexdigest()[:12]
+    payload: dict[str, Any] = {
+        "event_name": str(event_name),
+        "monotonic_ns": time.monotonic_ns(),
+        "correlation_id": correlation_id,
+        "process_id": os.getpid(),
+        "thread_id": threading.get_ident(),
+    }
+    if success is not None:
+        payload["success"] = bool(success)
+    if error_class:
+        payload["error_class"] = str(error_class)
+    if duration_ms is not None:
+        payload["duration_ms"] = round(float(duration_ms), 3)
+    if operation:
+        payload["operation"] = str(operation)
+    _emit("runtime.trace", sid, payload)
+
+
+def _pause_unstarted_goal_for_runtime_failure(
+    session: dict,
+    sid: str,
+    error_surface: dict | None,
+) -> bool:
+    """Pause only an unstarted active Goal after a non-retryable auth failure.
+
+    The failure is not Goal progress.  Leaving this exact state active at zero
+    turns caused rejected credentials to look like a silent runtime stall;
+    pausing preserves the Goal and requires an explicit later resume.
+    """
+    if not isinstance(session, dict) or not isinstance(error_surface, dict):
+        return False
+    if str(error_surface.get("layer") or "") != "auth" or bool(error_surface.get("retryable")):
+        return False
+    session_key = str(session.get("session_key") or "").strip()
+    if not session_key:
+        return False
+    try:
+        from hermes_cli.goals import GoalManager
+
+        goal_mgr = GoalManager(session_key)
+        state = goal_mgr.state
+        if not goal_mgr.is_active() or state is None or int(state.turns_used or 0) != 0:
+            return False
+        code = "HERMES_RUNTIME_MODEL_AUTH_FAILED"
+        goal_mgr.pause(reason=code)
+    except Exception as exc:
+        _runtime_trace(
+            session, sid, "FIRST_NATIVE_TURN_FAILURE_PERSIST_FAILED",
+            success=False, error_class=type(exc).__name__,
+        )
+        return False
+    _runtime_trace(session, sid, "FIRST_NATIVE_TURN_FAILED", success=False, error_class=code)
+    _emit("status.update", sid, {
+        "kind": "runtime", "code": code,
+        "retryable": bool(error_surface.get("retryable")), "text": code,
+    })
+    return True
+
+
 # Live WS peer transports (maintained by tui_gateway.ws): the only route for session-less background
 # events, which write_json would otherwise drop on stdio (see _broadcast_global_event).
 _live_transports: set[Transport] = set()
@@ -939,6 +1013,10 @@ def _attach_built_agent(current: dict, agent) -> None:
     if _title_hint := str(current.get("pending_title") or "").strip():
         agent._session_title_hint = _title_hint
     current["agent"] = agent
+    if current.get("runtime_trace_enabled"):
+        sid = str(current.get("runtime_id") or "")
+        agent.runtime_trace_callback = lambda event_name, **fields: _runtime_trace(
+            current, sid, event_name, **fields)
     _session_todo_state(current)
     # Baseline for the per-turn config sync (profile home override still active).
     current["config_model_seen"] = _config_model_target()
@@ -997,9 +1075,14 @@ def _start_agent_build(sid: str, session: dict) -> None:
     key = session["session_key"]
 
     def _build() -> None:
+        build_started = time.monotonic()
+        _runtime_trace(session, sid, "AGENT_BUILD_ENTER")
         with _sessions_lock:
             current = _sessions.get(sid)
         if current is None:
+            _runtime_trace(session, sid, "AGENT_BUILD_EXIT", success=False,
+                           error_class="SessionNotFound",
+                           duration_ms=(time.monotonic() - build_started) * 1000)
             ready.set()
             return
         notify_registered, scopes, session_db = False, None, None
@@ -1015,12 +1098,22 @@ def _start_agent_build(sid: str, session: dict) -> None:
                 scopes = _bind_build_profile_scopes(profile_home)
                 session_db = _open_profile_session_db(profile_home)
             try:
+                _runtime_trace(current, sid, "TOOLS_INIT_ENTER", operation="mcp_discovery_start")
                 from tui_gateway.entry import ensure_mcp_discovery_started
                 ensure_mcp_discovery_started()
             except Exception:
                 logger.warning("MCP discovery startup failed", exc_info=True)
+                _runtime_trace(current, sid, "TOOLS_INIT_EXIT", success=False,
+                               error_class="McpDiscoveryStartError", operation="mcp_discovery_start")
+            else:
+                _runtime_trace(current, sid, "TOOLS_INIT_EXIT", success=True,
+                               operation="mcp_discovery_start")
             try:
-                agent = _make_agent(sid, key, **_deferred_build_agent_kwargs(current, session_db))
+                agent = _make_agent(
+                    sid, key,
+                    runtime_trace=lambda event_name, **fields: _runtime_trace(
+                        current, sid, event_name, **fields),
+                    **_deferred_build_agent_kwargs(current, session_db))
             finally:
                 _clear_session_context(tokens)
             _attach_built_agent(current, agent)
@@ -1030,10 +1123,16 @@ def _start_agent_build(sid: str, session: dict) -> None:
             _announce_built_agent(sid, key, current, agent)
         except Exception as e:
             current["agent_error"] = str(e)
+            _runtime_trace(current, sid, "AGENT_BUILD_EXIT", success=False,
+                           error_class=type(e).__name__,
+                           duration_ms=(time.monotonic() - build_started) * 1000)
             _emit("error", sid, {"message": f"agent init failed: {e}"})
         finally:
             _finish_agent_build(
                 sid, key, current, notify_registered=notify_registered, scopes=scopes, session_db=session_db)
+            if current.get("agent") is not None and not current.get("agent_error"):
+                _runtime_trace(current, sid, "AGENT_BUILD_EXIT", success=True,
+                               duration_ms=(time.monotonic() - build_started) * 1000)
             ready.set()
 
     build_thread = threading.Thread(target=_build, daemon=True)
@@ -2260,7 +2359,8 @@ def _make_agent(
     sid: str, key: str, session_id: str | None = None, session_db=None,
     model_override: dict | str | None = None, provider_override: str | None = None,
     reasoning_config_override: dict | None = None, service_tier_override: str | None = None,
-    platform_override: str | None = None, context_cwd_is_launch_artifact: bool | None = None):
+    platform_override: str | None = None, context_cwd_is_launch_artifact: bool | None = None,
+    runtime_trace: Callable[..., None] | None = None):
     # AC-4 test seam: dead unless armed by the isolated certify harness.
     from tui_gateway.synthetic_turn import maybe_build_synthetic_agent
     synthetic = maybe_build_synthetic_agent(session_id or key, model_override)
@@ -2270,37 +2370,65 @@ def _make_agent(
     # MCP discovery runs in a daemon thread (a dead server can't freeze the shell); the agent snapshots its tool
     # list once, so briefly wait for in-flight discovery. Dashboard /api/ws uses mcp_startup; TUI stdio uses entry.
     for _mod in ("hermes_cli.mcp_startup", "tui_gateway.entry"):
-        with contextlib.suppress(Exception):
+        if runtime_trace is not None:
+            runtime_trace("TOOLS_INIT_ENTER", operation=f"{_mod}.wait_for_mcp_discovery")
+        try:
             importlib.import_module(_mod).wait_for_mcp_discovery()
+        except Exception as exc:
+            if runtime_trace is not None:
+                runtime_trace("TOOLS_INIT_EXIT", success=False, error_class=type(exc).__name__,
+                              operation=f"{_mod}.wait_for_mcp_discovery")
+        else:
+            if runtime_trace is not None:
+                runtime_trace("TOOLS_INIT_EXIT", success=True,
+                              operation=f"{_mod}.wait_for_mcp_discovery")
     cfg = _load_cfg()
     system_prompt = _startup_system_prompt(cfg, session_id or key)
-    model, runtime = _resolve_agent_model_runtime(model_override, provider_override)
+    if runtime_trace is not None:
+        runtime_trace("PROVIDER_RESOLUTION_ENTER")
+    try:
+        model, runtime = _resolve_agent_model_runtime(model_override, provider_override)
+    except Exception as exc:
+        if runtime_trace is not None:
+            runtime_trace("PROVIDER_RESOLUTION_EXIT", success=False, error_class=type(exc).__name__)
+        raise
+    if runtime_trace is not None:
+        runtime_trace("PROVIDER_RESOLUTION_EXIT", success=True)
     _pr = _load_provider_routing()
     platform = _resolve_agent_platform(platform_override)
     ignore_rules = is_truthy_value(os.environ.get("HERMES_IGNORE_RULES"))
-    agent = AIAgent(
-        model=model, max_iterations=_cfg_max_turns(cfg, 500), provider=runtime.get("provider"),
-        base_url=runtime.get("base_url"), api_key=runtime.get("api_key"), api_mode=runtime.get("api_mode"),
-        acp_command=runtime.get("command"), acp_args=runtime.get("args"),
-        credential_pool=runtime.get("credential_pool"), quiet_mode=True,
-        verbose_logging=False,  # DEBUG agent logging; independent of tool_progress_mode
-        reasoning_config=(
-            reasoning_config_override if reasoning_config_override is not None else _load_reasoning_config(str(model or ""))),
-        service_tier=service_tier_override if service_tier_override is not None else _load_service_tier(),
-        enabled_toolsets=_load_enabled_toolsets(platform),
-        # OpenRouter provider_routing prefs (gateway + CLI parity).
-        providers_allowed=_pr.get("only"), providers_ignored=_pr.get("ignore"), providers_order=_pr.get("order"),
-        provider_sort=_pr.get("sort"), provider_require_parameters=_pr.get("require_parameters", False),
-        provider_data_collection=_pr.get("data_collection"), platform=platform, session_id=session_id or key,
-        session_db=session_db if session_db is not None else _get_db(), ephemeral_system_prompt=system_prompt or None,
-        checkpoints_enabled=is_truthy_value(os.environ.get("HERMES_TUI_CHECKPOINTS")),
-        pass_session_id=is_truthy_value(os.environ.get("HERMES_TUI_PASS_SESSION_ID")),
-        skip_context_files=ignore_rules, skip_memory=ignore_rules, fallback_model=_load_fallback_model(),
-        **_agent_cbs(sid))
+    if runtime_trace is not None:
+        runtime_trace("AGENT_CONSTRUCTION_ENTER")
+    try:
+        agent = AIAgent(
+            model=model, max_iterations=_cfg_max_turns(cfg, 500), provider=runtime.get("provider"),
+            base_url=runtime.get("base_url"), api_key=runtime.get("api_key"), api_mode=runtime.get("api_mode"),
+            acp_command=runtime.get("command"), acp_args=runtime.get("args"),
+            credential_pool=runtime.get("credential_pool"), quiet_mode=True,
+            verbose_logging=False,  # DEBUG agent logging; independent of tool_progress_mode
+            reasoning_config=(
+                reasoning_config_override if reasoning_config_override is not None else _load_reasoning_config(str(model or ""))),
+            service_tier=service_tier_override if service_tier_override is not None else _load_service_tier(),
+            enabled_toolsets=_load_enabled_toolsets(platform),
+            # OpenRouter provider_routing prefs (gateway + CLI parity).
+            providers_allowed=_pr.get("only"), providers_ignored=_pr.get("ignore"), providers_order=_pr.get("order"),
+            provider_sort=_pr.get("sort"), provider_require_parameters=_pr.get("require_parameters", False),
+            provider_data_collection=_pr.get("data_collection"), platform=platform, session_id=session_id or key,
+            session_db=session_db if session_db is not None else _get_db(), ephemeral_system_prompt=system_prompt or None,
+            checkpoints_enabled=is_truthy_value(os.environ.get("HERMES_TUI_CHECKPOINTS")),
+            pass_session_id=is_truthy_value(os.environ.get("HERMES_TUI_PASS_SESSION_ID")),
+            skip_context_files=ignore_rules, skip_memory=ignore_rules, fallback_model=_load_fallback_model(),
+            **_agent_cbs(sid))
+    except Exception as exc:
+        if runtime_trace is not None:
+            runtime_trace("AGENT_CONSTRUCTION_EXIT", success=False, error_class=type(exc).__name__)
+        raise
     if context_cwd_is_launch_artifact is None:
         with _sessions_lock:
             context_cwd_is_launch_artifact = _context_cwd_is_launch_artifact(_sessions.get(sid))
     agent._context_cwd_is_launch_artifact = bool(context_cwd_is_launch_artifact)
+    if runtime_trace is not None:
+        runtime_trace("AGENT_CONSTRUCTION_EXIT", success=True)
     return agent
 
 


### PR DESCRIPTION
## Summary
- pause an unstarted native Goal after a classified non-retryable provider authentication failure, preserving zero consumed turns and requiring explicit resume
- add opt-in, content-free execution-boundary telemetry from deferred agent build through model request/provider activity and first native-turn persistence
- add hermetic native max-turns=1 canaries that exercise the request-build/provider adapter path and prove one persisted terminal Goal turn

## Validation
- `scripts/run_tests.sh tests/agent/test_error_classifier.py tests/run_agent/test_turn_liveness_watchdog.py tests/run_agent/test_run_agent.py tests/run_agent/test_cross_process_turn_lease.py tests/tui_gateway/test_auto_continue.py tests/tui_gateway/test_failed_turn_retention.py -q` (458 passed)
- `scripts/run_tests.sh tests/tui_gateway/test_goal_command.py tests/hermes_cli/test_goals.py tests/hermes_cli/test_tui_resume_flow.py -q` (61 passed)
- Ruff, Python syntax compilation, and `git diff --check`

No runtime activation, restart, deployment, or business execution is included.