### PR TITLE
fix(desktop): wire /reload-mcp to the reload.mcp RPC; fix dead live-session mirror

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
@@ -496,6 +496,29 @@ describe('renderRpcResult', () => {
     })
   })
 
+  describe('reload.mcp', () => {
+    it('renders the confirmation prompt when the gate is on', () => {
+      expect(
+        renderRpcResult(
+          { status: 'confirm_required', message: '⚠️  /reload-mcp invalidates the prompt cache' },
+          'reload-mcp'
+        )
+      ).toBe('⚠️  /reload-mcp invalidates the prompt cache')
+    })
+
+    it('falls back to a generic prompt when confirm_required carries no message', () => {
+      expect(renderRpcResult({ status: 'confirm_required' }, 'reload-mcp')).toBe(
+        '/reload-mcp requires confirmation'
+      )
+    })
+
+    it('reports a successful reload', () => {
+      expect(renderRpcResult({ status: 'reloaded', loaded_rev: 'abc123' }, 'reload-mcp')).toBe(
+        'MCP servers reloaded'
+      )
+    })
+  })
+
   describe('process.stop', () => {
     it('reports the numeric number of stopped processes', () => {
       expect(renderRpcResult({ killed: 2 }, 'stop')).toBe('Stopped 2 background processes.')

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -553,6 +553,15 @@ export function renderRpcResult(response: unknown, name: string): string {
     return 'Steer rejected — agent declined input'
   }
 
+  // reload.mcp — { status: 'confirm_required' | 'reloaded', message?, loaded_rev? }
+  if (r.status === 'confirm_required' || r.status === 'reloaded') {
+    if (r.status === 'confirm_required') {
+      return typeof r.message === 'string' && r.message ? r.message : '/reload-mcp requires confirmation'
+    }
+
+    return 'MCP servers reloaded'
+  }
+
   // process.stop — { killed: number }
   if ('killed' in r && typeof r.killed === 'number') {
     return r.killed > 0

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -211,6 +211,37 @@ describe('desktop slash command curation', () => {
     expect(isDesktopSlashSuggestion('/compact')).toBe(false)
   })
 
+  it('routes /reload-mcp through the reload.mcp RPC with confirm parsing', () => {
+    // /reload-mcp used to be desktop-blocked ("advanced"); the backend
+    // reload.mcp RPC is first-class, so the desktop drives it directly —
+    // same arg contract as the TUI handler (ui-tui ops.ts).
+    const surface = resolveDesktopCommand('/reload-mcp')?.surface
+    expect(surface?.kind).toBe('rpc')
+
+    if (surface?.kind !== 'rpc') {
+      throw new Error('expected rpc surface')
+    }
+
+    expect(surface.rpc).toBe('reload.mcp')
+    // Bare command → no confirm: the backend answers confirm_required and the
+    // user re-invokes with an explicit argument.
+    expect(surface.buildParams({ arg: '', command: '/reload-mcp', name: 'reload-mcp', sessionId: 's-1' }))
+      .toEqual({ session_id: 's-1' })
+    expect(surface.buildParams({ arg: 'now', command: '/reload-mcp', name: 'reload-mcp', sessionId: 's-1' }))
+      .toEqual({ session_id: 's-1', confirm: true })
+    expect(surface.buildParams({ arg: 'always', command: '/reload-mcp', name: 'reload-mcp', sessionId: 's-1' }))
+      .toEqual({ session_id: 's-1', confirm: true, always: true })
+    // Long timeout: a full reload reconnects every server (cold stdio fleet).
+    expect(surface.timeoutMs).toBeGreaterThan(30_000)
+    expect(isDesktopSlashCommand('/reload-mcp')).toBe(true)
+    expect(isDesktopSlashSuggestion('/reload-mcp')).toBe(true)
+    expect(desktopSlashUnavailableMessage('/reload-mcp')).toBeNull()
+    // /reload_mcp is an alias — executes but stays out of the popover.
+    expect(resolveDesktopCommand('/reload_mcp')?.surface).toEqual(surface)
+    expect(isDesktopSlashCommand('/reload_mcp')).toBe(true)
+    expect(isDesktopSlashSuggestion('/reload_mcp')).toBe(false)
+  })
+
   it('routes only stateless session commands through dedicated gateway RPCs', () => {
     const expected = {
       '/save': 'session.save',

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -269,6 +269,33 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     surface: action('hatch')
   },
   {
+    name: '/reload-mcp',
+    description: 'Reload MCP servers in the live session [now|always]',
+    aliases: ['/reload_mcp'],
+    surface: rpc(
+      'reload.mcp',
+      ctx => {
+        // Mirror the TUI handler (ui-tui ops.ts): `now`/`always` skip the
+        // confirmation gate; `always` also persists the opt-out.
+        const a = ctx.arg.trim().toLowerCase()
+        const params: Record<string, unknown> = { session_id: ctx.sessionId || null }
+
+        if (a === 'now' || a === 'approve' || a === 'once' || a === 'yes') {
+          params.confirm = true
+        } else if (a === 'always') {
+          params.confirm = true
+          params.always = true
+        }
+
+        return params
+      },
+      // A full reload reconnects every MCP server; the default 30s gateway
+      // timeout is too tight for a cold stdio fleet.
+      120_000
+    ),
+    argumentMode: 'options'
+  },
+  {
     name: '/save',
     description: 'Save the current transcript to JSON',
     surface: rpc('session.save', ctx => ({ session_id: ctx.sessionId }))
@@ -324,8 +351,6 @@ const NO_DESKTOP_SURFACE: Record<DesktopUnavailableReason, readonly string[]> = 
     '/insights',
     '/kanban',
     '/reasoning',
-    '/reload-mcp',
-    '/reload_mcp',
     '/reload-skills',
     '/reload_skills'
   ],

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -255,7 +255,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("reload", "Reload .env variables into the running session", "Tools & Skills",
                cli_only=True, desktop="terminal"),
     CommandDef("reload-mcp", "Reload MCP servers from config", "Tools & Skills",
-               aliases=("reload_mcp",), desktop="advanced"),
+               aliases=("reload_mcp",), args_hint="[now|always]"),
     CommandDef("reload-skills", "Re-scan ~/.hermes/skills/ for newly installed or removed skills",
                "Tools & Skills", aliases=("reload_skills",), desktop="advanced"),
     CommandDef("browser", "Connect browser tools to your live Chromium-family browser via CDP, or switch to Browser Use mode", "Tools & Skills",

--- a/tests/tui_gateway/test_reload_mcp_mirror.py
+++ b/tests/tui_gateway/test_reload_mcp_mirror.py
@@ -1,0 +1,102 @@
+"""``/reload-mcp`` live-session mirror (``_mirror_reload_mcp``).
+
+The slash worker runs in its own subprocess, so a worker-run ``/reload-mcp``
+reloads the WORKER's throwaway MCP pool — the live session's pool only changes
+through the ``_SLASH_MIRRORS`` hook in ``tui_gateway/methods_slash.py``. That
+mirror used to call ``agent.reload_mcp_tools()``, a method no agent ever
+implemented, making the whole path a silent no-op. These tests pin the real
+behavior: shutdown → reprobe → discover → refresh the live agent's snapshot,
+plus the running-turn guard.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tui_gateway import server
+
+
+@pytest.fixture()
+def reload_env(monkeypatch):
+    """Fake the reload pipeline; count calls."""
+    calls = {"shutdown": 0, "reprobe": 0, "discover": 0, "refresh": 0}
+
+    monkeypatch.setattr(
+        "tools.mcp_tool_lifecycle.shutdown_mcp_servers",
+        lambda: calls.__setitem__("shutdown", calls["shutdown"] + 1))
+    monkeypatch.setattr(
+        "tools.mcp_tool_agent.reprobe_tool_availability",
+        lambda: calls.__setitem__("reprobe", calls["reprobe"] + 1))
+    monkeypatch.setattr(
+        "tools.mcp_tool_discovery.discover_mcp_tools",
+        lambda: calls.__setitem__("discover", calls["discover"] + 1))
+
+    def fake_refresh(agent, *, enabled_override=None, quiet_mode=False, **_kw):
+        calls["refresh"] += 1
+        calls["refresh_agent"] = agent
+        calls["refresh_override"] = enabled_override
+
+    monkeypatch.setattr("tools.mcp_tool_agent.refresh_agent_mcp_tools", fake_refresh)
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda platform=None: ["mcp"])
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_session_info", lambda agent, session: {"fake": True})
+    return calls
+
+
+def _make_session(running: bool = False):
+    agent = MagicMock()
+    agent.enabled_toolsets = ["mcp"]
+    return {"agent": agent, "running": running, "session_key": "k", "history": []}
+
+
+def test_mirror_reloads_pools_and_refreshes_live_agent(reload_env):
+    sid = "sid-reload-mirror"
+    session = _make_session()
+    server._sessions[sid] = session
+    try:
+        output = server._mirror_slash_side_effects(sid, session, "/reload-mcp")
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert output == "", output
+    assert reload_env["shutdown"] == 1
+    assert reload_env["reprobe"] == 1
+    assert reload_env["discover"] == 1
+    assert reload_env["refresh"] == 1
+    assert reload_env["refresh_agent"] is session["agent"]
+    # enabled_override re-resolves toolsets so a server enabled in config this
+    # session is picked up (parity with the CLI worker and the reload.mcp RPC).
+    assert reload_env["refresh_override"] == ["mcp"]
+
+
+def test_mirror_rejects_while_turn_is_running(reload_env):
+    sid = "sid-reload-busy"
+    session = _make_session(running=True)
+    server._sessions[sid] = session
+    try:
+        output = server._mirror_slash_side_effects(sid, session, "/reload-mcp")
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert "session busy" in output
+    assert reload_env["shutdown"] == 0
+    assert reload_env["refresh"] == 0
+
+
+def test_mirror_without_agent_still_reloads_the_shared_pool(reload_env):
+    # The MCP pool is gateway-global, not per-agent: a session with no agent
+    # yet still needs the pool rebuilt (its future turns read from it). The
+    # RPC's session refresh tolerates agent=None.
+    sid = "sid-reload-noagent"
+    session = {"agent": None, "running": False, "session_key": "k", "history": []}
+    server._sessions[sid] = session
+    try:
+        output = server._mirror_slash_side_effects(sid, session, "/reload-mcp")
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert output == ""
+    assert reload_env["shutdown"] == 1
+    assert reload_env["discover"] == 1

--- a/tui_gateway/methods_slash.py
+++ b/tui_gateway/methods_slash.py
@@ -300,9 +300,21 @@ def _mirror_fast(sid, session, agent, arg) -> None:
         _emit("session.info", sid, _session_info(agent, session))
 
 
-def _mirror_reload_mcp(sid, session, agent, arg) -> None:
-    if agent and hasattr(agent, "reload_mcp_tools"):
-        agent.reload_mcp_tools()
+def _mirror_reload_mcp(sid, session, agent, arg) -> str:
+    """Live-session side effect for a worker-run ``/reload-mcp``: the worker subprocess
+    reloads its OWN throwaway MCP pool, so without this mirror the live session's pool
+    (and tool snapshot) never changes. Re-enter the shared ``reload.mcp`` RPC with
+    ``confirm=True`` (the worker already ran the interactive gate) so every reload
+    path — local pool rebuild, compute-host forwarding, revision-generation bump,
+    session tool refresh — stays in lockstep. Previously this called
+    ``agent.reload_mcp_tools()``, which no agent ever implemented — a silent no-op
+    since the mirror was introduced."""
+    if session is not None and session.get("running"):
+        return "session busy — /interrupt the current turn before reloading MCP servers"
+    response = _methods["reload.mcp"]("reload-mcp-mirror", {"session_id": sid, "confirm": True})
+    if error := response.get("error"):
+        return f"reload failed: {error.get('message')}"
+    return ""
 
 
 def _mirror_stop(sid, session, agent, arg) -> None:


### PR DESCRIPTION
## What does this PR do?

Desktop users had no way to reload MCP servers into a running thread: `/reload-mcp` was desktop-blocked (`NO_DESKTOP_SURFACE: 'advanced'`) with no RPC wired, so the only options were restarting the app or flushing the conversation with `/new`. Meanwhile the backend machinery was already complete — the `reload.mcp` gateway RPC (confirm gate, `always` persistence, revision coalescing, session tool refresh) and the TUI client driving it — the desktop just never called it.

While wiring it, this PR also fixes a deeper bug: the `slash.exec` live-session mirror for `/reload-mcp` called `agent.reload_mcp_tools()`, **a method no agent ever implemented**. The mirror has been a silent no-op since it was introduced — a worker-run `/reload-mcp` reloaded only the worker subprocess's throwaway MCP pool while the live session kept its stale pool and tool snapshot. That is the root cause behind 'MCP fixed but this thread still can't see it' reports.

The mirror now re-enters the shared `reload.mcp` RPC with `confirm=True` (the worker already ran the interactive gate), so every reload path — local pool rebuild, compute-host forwarding, revision-generation bump, session tool refresh — stays in lockstep instead of each surface hand-rolling its own sequence.

## Related Issue

None filed — surfaced while debugging a real-world session where OAuth MCP servers re-authed successfully but the desktop thread never picked up the reconnected servers.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/desktop-slash-commands.ts` — new `/reload-mcp` rpc surface (`reload.mcp`): bare command → backend `confirm_required` flow, `now`/`always` skip the gate, `always` persists the opt-out (same arg contract as the TUI handler in `ui-tui/src/app/slash/commands/ops.ts`); 120s timeout for cold stdio fleets; `/reload_mcp` alias; removed from `NO_DESKTOP_SURFACE`.
- `tui_gateway/methods_slash.py` — `_mirror_reload_mcp` re-enters the `reload.mcp` RPC instead of calling the nonexistent `agent.reload_mcp_tools()`; adds a running-turn guard (reload mid-turn would tear the pool out from under a live request).
- `apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts` — `renderRpcResult` shapes `reload.mcp` responses (`confirm_required` message / `reloaded`) instead of the raw-JSON fallback.
- `hermes_cli/commands.py` — drop `desktop="advanced"` from `reload-mcp`, add `args_hint="[now|always]"` so completions surface the arguments.
- `tests/tui_gateway/test_reload_mcp_mirror.py` — mirror behavior: reload+refresh of the live agent, running-turn guard, shared-pool reload for agent-less sessions.
- Desktop vitest: spec routing + confirm-arg parsing; renderer shaping for both response statuses.

## How to Test

1. In the desktop app, type `/reload-mcp` — it now appears in the palette (previously: 'not shown in the desktop slash palette'). The backend answers `confirm_required` and the message renders inline.
2. `/reload-mcp now` — runs the reload; transcript shows 'MCP servers reloaded'. A server enabled in config mid-session appears in the tool catalog on the next turn (append-only, prompt-cache-preserving).
3. `/reload-mcp always` — reloads and persists `approvals.mcp_reload_confirm: false`.
4. From a session with a running turn, `/reload-mcp now` → 'session busy — /interrupt the current turn before reloading MCP servers'.
5. `pytest tests/tui_gateway/test_reload_mcp_mirror.py tests/tui_gateway/test_mcp_reload_rev.py -q` and `cd apps/desktop && npx vitest run src/lib/desktop-slash-commands.test.ts src/app/session/hooks/use-prompt-actions/utils.test.ts`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (tui_gateway suite: 985 passed, 0 failed; desktop vitest: 90 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A