### PR TITLE
fix(desktop): recover settings after profile switch

### DIFF
--- a/apps/desktop/src/app/settings/config-settings-profile-switch.test.tsx
+++ b/apps/desktop/src/app/settings/config-settings-profile-switch.test.tsx
@@ -187,6 +187,9 @@ describe('ConfigSettings profile switching', () => {
     await new Promise(resolve => setTimeout(resolve, 5))
     resolveRefetch?.({ timezone: 'Remote update' })
     await refetch
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
 
     expect(screen.getByTestId('config-value').textContent).toBe('Local edit')
   })

--- a/apps/desktop/src/app/settings/config-settings-profile-switch.test.tsx
+++ b/apps/desktop/src/app/settings/config-settings-profile-switch.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { act, cleanup, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -80,10 +80,18 @@ vi.mock('../overlays/panel', () => ({
 }))
 
 vi.mock('./config-field', () => ({
-  ConfigField: ({ value }: { value: unknown }) => <div data-testid="config-value">{String(value)}</div>
+  ConfigField: ({ value, onChange }: { value: unknown; onChange: (value: unknown) => void }) => (
+    <>
+      <div data-testid="config-value">{String(value)}</div>
+      <button onClick={() => onChange('Local edit')} type="button">
+        Edit timezone
+      </button>
+    </>
+  )
 }))
 
 vi.mock('./helpers', () => ({
+  clearsEnabledToolsets: () => false,
   enumOptionsFor: vi.fn(),
   getNested: (config: Record<string, unknown>, key: string) => config[key],
   isExternalMemoryProvider: () => false,
@@ -149,5 +157,37 @@ describe('ConfigSettings profile switching', () => {
     await refetch
 
     expect((await screen.findByTestId('config-value')).textContent).toBe('UTC')
+  })
+
+  it('keeps an in-progress edit when a background refetch succeeds', async () => {
+    let resolveRefetch: ((value: { timezone: string }) => void) | undefined
+
+    const refetchResult = new Promise<{ timezone: string }>(resolve => {
+      resolveRefetch = resolve
+    })
+
+    getHermesConfigRecord.mockResolvedValueOnce({ timezone: 'UTC' }).mockReturnValueOnce(refetchResult)
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const { ConfigSettings } = await import('./config-settings')
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ConfigSettings activeSectionId="chat" importInputRef={{ current: null }} />
+      </QueryClientProvider>
+    )
+
+    expect((await screen.findByTestId('config-value')).textContent).toBe('UTC')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit timezone' }))
+    expect(screen.getByTestId('config-value').textContent).toBe('Local edit')
+
+    const refetch = queryClient.invalidateQueries({ queryKey: ['hermes-config-record'] })
+
+    await new Promise(resolve => setTimeout(resolve, 5))
+    resolveRefetch?.({ timezone: 'Remote update' })
+    await refetch
+
+    expect(screen.getByTestId('config-value').textContent).toBe('Local edit')
   })
 })

--- a/apps/desktop/src/app/settings/config-settings-profile-switch.test.tsx
+++ b/apps/desktop/src/app/settings/config-settings-profile-switch.test.tsx
@@ -1,0 +1,153 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getHermesConfigRecord = vi.fn()
+const getHermesConfigSchema = vi.fn()
+
+vi.mock('@/hermes', () => ({
+  getElevenLabsVoices: vi.fn().mockResolvedValue({ available: false, voices: [] }),
+  getHermesConfigRecord: () => getHermesConfigRecord(),
+  getHermesConfigSchema: () => getHermesConfigSchema(),
+  saveHermesConfig: vi.fn()
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      common: { saving: 'Saving' },
+      settings: {
+        config: {
+          autosaveFailed: 'Could not save settings',
+          emptyDesc: 'No settings',
+          emptyTitle: 'No settings',
+          failedLoad: 'Could not load settings',
+          invalidJson: 'Invalid JSON',
+          loading: 'Loading settings'
+        }
+      },
+      skills: { refresh: 'Refresh' }
+    }
+  })
+}))
+
+vi.mock('@/store/data-url-read-max', async () => {
+  const { atom } = await import('nanostores')
+
+  return {
+    $dataUrlReadMaxMb: atom(50),
+    clampDataUrlReadMaxMb: (value: number) => value,
+    DATA_URL_READ_DEFAULT_MAX_MB: 50,
+    DATA_URL_READ_MAX_MAX_MB: 200,
+    DATA_URL_READ_MIN_MAX_MB: 1,
+    refreshDataUrlReadMaxMb: vi.fn(),
+    setDataUrlReadMaxMb: vi.fn()
+  }
+})
+
+vi.mock('@/store/keep-awake', async () => {
+  const { atom } = await import('nanostores')
+
+  return { $keepAwake: atom(false), setKeepAwake: vi.fn() }
+})
+
+vi.mock('@/store/notifications', () => ({ notify: vi.fn(), notifyError: vi.fn() }))
+
+vi.mock('@/store/profile', async () => {
+  const { atom } = await import('nanostores')
+
+  return {
+    $activeGatewayProfile: atom('default'),
+    $profiles: atom([]),
+    normalizeProfileKey: (name: string | null | undefined) => (name ?? '').trim() || 'default',
+    refreshProfiles: vi.fn().mockResolvedValue([])
+  }
+})
+
+vi.mock('@/store/projects', () => ({
+  repoDiscoveryPolicyFromConfig: () => ({}),
+  repoDiscoveryPolicySignature: () => '',
+  scanAndRecordRepos: vi.fn()
+}))
+
+vi.mock('react-router', () => ({
+  useSearchParams: () => [new URLSearchParams(), vi.fn()]
+}))
+
+vi.mock('../overlays/panel', () => ({
+  PanelEmpty: ({ title }: { title: string }) => <div>{title}</div>
+}))
+
+vi.mock('./config-field', () => ({
+  ConfigField: ({ value }: { value: unknown }) => <div data-testid="config-value">{String(value)}</div>
+}))
+
+vi.mock('./helpers', () => ({
+  enumOptionsFor: vi.fn(),
+  getNested: (config: Record<string, unknown>, key: string) => config[key],
+  isExternalMemoryProvider: () => false,
+  sectionFieldEntries: (_schema: unknown, config: Record<string, unknown>) =>
+    new Map([['chat', config.timezone === undefined ? [] : [['timezone', { type: 'string' }]]]]),
+  setNested: (config: Record<string, unknown>, key: string, value: unknown) => ({ ...config, [key]: value })
+}))
+
+vi.mock('./memory/connect', () => ({ MemoryConnect: () => null }))
+vi.mock('./memory/provider-config-panel', () => ({ ProviderConfigPanel: () => null }))
+vi.mock('./model-settings', () => ({ ModelSettings: () => null, ModelSettingsSkeleton: () => null }))
+vi.mock('./primitives', () => ({
+  EmptyState: () => null,
+  ListRow: () => null,
+  SettingsContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SettingsSkeleton: () => <div data-testid="settings-skeleton" />,
+  ToggleRow: () => null
+}))
+vi.mock('./quick-entry-settings', () => ({ QuickEntrySettings: () => null }))
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  const { $activeGatewayProfile } = await import('@/store/profile')
+  $activeGatewayProfile.set('default')
+  getHermesConfigSchema.mockResolvedValue({ fields: { timezone: { type: 'string' } } })
+})
+
+afterEach(() => cleanup())
+
+describe('ConfigSettings profile switching', () => {
+  it('reseeds after an identical config refetch instead of loading forever', async () => {
+    let resolveRefetch: ((value: { timezone: string }) => void) | undefined
+
+    const refetchResult = new Promise<{ timezone: string }>(resolve => {
+      resolveRefetch = resolve
+    })
+
+    getHermesConfigRecord.mockResolvedValueOnce({ timezone: 'UTC' }).mockReturnValueOnce(refetchResult)
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const { ConfigSettings } = await import('./config-settings')
+    const { $activeGatewayProfile } = await import('@/store/profile')
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ConfigSettings activeSectionId="chat" importInputRef={{ current: null }} />
+      </QueryClientProvider>
+    )
+
+    expect((await screen.findByTestId('config-value')).textContent).toBe('UTC')
+
+    let refetch: Promise<void> | undefined
+
+    act(() => {
+      $activeGatewayProfile.set('work')
+      refetch = queryClient.invalidateQueries({ queryKey: ['hermes-config-record'] })
+    })
+
+    expect(await screen.findByTestId('settings-skeleton')).toBeTruthy()
+
+    await new Promise(resolve => setTimeout(resolve, 5))
+    resolveRefetch?.({ timezone: 'UTC' })
+    await refetch
+
+    expect((await screen.findByTestId('config-value')).textContent).toBe('UTC')
+  })
+})

--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -96,7 +96,14 @@ function ConfigSettingsInner({
   // from — and saved back through — the shared config cache, so edits are visible
   // in the MCP/model surfaces and reopening the page doesn't reload-flash.
   const [config, setConfig] = useState<HermesConfigRecord | null>(null)
-  const { data: loadedConfig, isError: configLoadFailed, refetch: refetchConfig } = useHermesConfigRecord(scopeProfile)
+
+  const {
+    data: loadedConfig,
+    dataUpdatedAt: configUpdatedAt,
+    isError: configLoadFailed,
+    refetch: refetchConfig
+  } = useHermesConfigRecord(scopeProfile)
+
   // Writes land on the same cache key the query above reads (base key when
   // following the active profile, suffixed when a scope override is set).
   const writeConfigCache = useMemo(() => hermesConfigCacheWriter(scopeProfile), [scopeProfile])
@@ -123,6 +130,8 @@ function ConfigSettingsInner({
 
   // Seed the local draft once, the first time the shared record lands.
   // Background refetches thereafter must not clobber in-progress edits.
+  // dataUpdatedAt must remain a dependency because structurally equal profile
+  // configs can reuse the same data reference after a successful refetch.
   const configSeeded = useRef(false)
   // Snapshot of the record as it was when the draft was seeded. Autosave
   // diffs the draft against this (not against disk) so a field the user
@@ -142,7 +151,7 @@ function ConfigSettingsInner({
       savedDiscoverySignatureRef.current = repoDiscoveryPolicySignature(repoDiscoveryPolicyFromConfig(loadedConfig))
       setConfig(loadedConfig)
     }
-  }, [loadedConfig])
+  }, [configUpdatedAt, loadedConfig])
 
   // A profile switch invalidates (but doesn't clear) the shared config query, so
   // the local draft would otherwise keep profile A's data and autosave it into


### PR DESCRIPTION
## What does this PR do?

Restores config-backed settings pages after an active profile switch when the refetched profile config is structurally identical.

The profile-switch handler clears the local settings draft, but React Query may reuse the previous data reference for an equal response. The seed effect then does not run again, leaving the page on its loading skeleton even though the query succeeded.

This uses the query's successful update timestamp as the re-seed signal. The existing seed guard still prevents ordinary background refetches from overwriting in-progress edits.

## Related PRs

This fix was discovered while testing the OpenViking Desktop configuration flow and was extracted from #56309 so the generic settings bug can be reviewed and merged independently.

It also overlaps the profile-switch portion of #96253, while keeping this PR limited to the renderer fix and its regression test.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Re-seed the settings draft after a successful profile config refetch, including structurally equal responses.
- Add a focused regression test covering an identical config response after switching profiles.

## How to Test

1. Open a config-backed settings page.
2. Switch to another profile with the same config values.
3. Confirm the settings page renders instead of remaining on the loading skeleton.

Automated checks:

- `npm run test:ui --workspace apps/desktop -- src/app/settings/config-settings-profile-switch.test.tsx src/app/settings/config-settings.test.tsx`
- `npm run typecheck --workspace apps/desktop`
- `npm exec --workspace apps/desktop eslint -- src/app/settings/config-settings.tsx src/app/settings/config-settings-profile-switch.test.tsx`

## Checklist

### Code

- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs
- [x] This PR contains only changes related to this fix
- [x] I added a regression test
- [x] I tested on macOS

### Documentation & Housekeeping

- [x] Documentation changes are not needed
- [x] No config keys or architecture contracts changed
- [x] Cross-platform impact is limited to renderer state management
