### PR TITLE
fix(web_server_dashboard): read _SESSION_TOKEN live instead of binding it at mount time

### DIFF
--- a/hermes_cli/web_server_dashboard.py
+++ b/hermes_cli/web_server_dashboard.py
@@ -102,7 +102,12 @@ def mount_spa(application: FastAPI):
     with a missing dist per-request (404 JSON / ``check_dir=False``), so a long-lived
     ``--skip-build`` process recovers the moment a build appears on disk — no restart.
     """
-    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, _SESSION_TOKEN, app
+    # ``_SESSION_TOKEN`` is deliberately NOT imported by value: mount_spa() runs at import time
+    # (web_server.py:975), so a local binding freezes the random import-time token while
+    # start_server() -> _apply_ssh_session_token() rebinds only the module global. The handlers
+    # below must read it live off the module or they serve a stale token and every /api/* 401s.
+    from hermes_cli import web_server as _ws
+    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, app
 
     # `hermes serve` is the headless backend: it must NEVER serve the browser SPA, even if a
     # dist is lying around, so only the JSON-RPC/WS/API surface is reachable.
@@ -120,7 +125,7 @@ def mount_spa(application: FastAPI):
             if full_path == "" and not gated:
                 return HTMLResponse(
                     "<!doctype html><html><head><script>"
-                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(_SESSION_TOKEN)};"
+                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(_ws._SESSION_TOKEN)};"
                     "window.__HERMES_AUTH_REQUIRED__=false;"
                     f"</script></head><body>{_HEADLESS_MSG}</body></html>",
                     headers=_NO_STORE,
@@ -151,7 +156,7 @@ def mount_spa(application: FastAPI):
             return JSONResponse({"error": "Frontend not built. Run: cd web && npm run build"}, status_code=404)
         chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
         gated = bool(getattr(app.state, "auth_required", False))
-        token_js = "" if gated else f'window.__HERMES_SESSION_TOKEN__="{_SESSION_TOKEN}";'
+        token_js = "" if gated else f'window.__HERMES_SESSION_TOKEN__="{_ws._SESSION_TOKEN}";'
         bootstrap_script = (
             f"<script>{token_js}"
             f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"


### PR DESCRIPTION
## Problem

Every `/api/*` request to an SSH/desktop-launched dashboard returns `401 {"detail":"Unauthorized"}`.

`mount_spa()` runs at **import time** (`web_server.py:975`), and it does:

```python
from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, _SESSION_TOKEN, app
```

That binds the random import-time `_SESSION_TOKEN` into a function local. `start_server()` later calls `_apply_ssh_session_token()`, which rebinds only the **module global**.

The result is a split view of the token:

| Reader | Sees |
|---|---|
| `_require_token` / `_has_valid_session_token` (auth checks) | fresh module global |
| headless `/` stub (line 123) and `_serve_index` (line 154) | frozen import-time value |

Any client that prefers the *served* token over its own spawn token then authenticates with a value the server no longer accepts. The Electron shell does exactly that in `resolveServedDashboardToken` (`apps/desktop/electron/dashboard-token.ts`), so the desktop app 401s on every call and the renderer loops on `refreshProfiles failed … 401`.

This surfaces whenever a fresh backend is spawned — e.g. a gateway restart that ends a long-lived pre-refactor process the desktop had been reusing.

## Fix

Import the module and read `_ws._SESSION_TOKEN` inside the handlers, so both call sites observe the post-rebind value. Three lines, no behaviour change beyond the token being current.

This is also how the existing tests already reach it — `tests/hermes_cli/test_web_server.py:212-247` assert on `ws._SESSION_TOKEN` through the module rather than a local binding.

## Verification

- Reproduced against a live SSH-mode backend: the spawn token returned **200** while the served token returned **401**, requests otherwise identical.
- Patched build has been running on a remote gateway since, with the desktop connecting over SSH and the served token accepted.
- `python -m py_compile` clean.

⚠️ I could **not** run the pytest suite — no `pytest`/`uv` available in the environment I patched from, and installing test deps would have disturbed the running install. The change is small and the existing token tests exercise the same access pattern, but a CI run is worth having before merge.

## Note

`_serve_index`'s docstring still says the legacy `_SESSION_TOKEN` is not injected under the OAuth gate — that remains accurate and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfFyDEQB8dbzfGg6C4VvBQ
