### PR TITLE
fix(hindsight): diagnose empty TimeoutError message from tool handlers

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1095,6 +1095,19 @@ class HindsightMemoryProvider(MemoryProvider):
             return tool_error(f"Missing required parameter: {required}")
         try:
             return json.dumps({"result": handler(self, args)})
+        except (TimeoutError, asyncio.TimeoutError) as e:
+            # Python's builtin TimeoutError stringifies to "" (asyncio raises
+            # TimeoutError() with no message), so without this the agent sees
+            # a blank error like "Failed to store memory: " with no diagnosis.
+            logger.warning("%s timed out after %ss: %s", tool_name, self._timeout, e, exc_info=True)
+            return tool_error(
+                f"{failure}: {e or 'timed out'} "
+                f"({tool_name} timed out after {self._timeout}s; the Hindsight server may "
+                "be slow or unreachable (for retain, the LLM fact-extraction chain is the "
+                "usual culprit; the memory may still have been stored asynchronously — "
+                "verify with hindsight_recall before retrying). If this recurs, check "
+                "server health or raise the hindsight timeout.)"
+            )
         except Exception as e:
             logger.warning("%s failed: %s", tool_name, e, exc_info=True)
             return tool_error(f"{failure}: {e}")


### PR DESCRIPTION
## What does this PR do?

Python's builtin `TimeoutError` stringifies to an empty string (asyncio raises `TimeoutError()` with no message), so when a Hindsight tool call hits the plugin's async timeout, the agent sees a blank error — literally `Failed to store memory: ` — with no diagnosis. This adds an explicit `except (TimeoutError, asyncio.TimeoutError)` branch before the generic handler in `handle_tool_call`, returning an actionable message: the timeout duration, the likely culprit, and the next step (verify with `hindsight_recall` before retrying, since the memory may have been stored asynchronously).

**Reported symptom (production):** three consecutive `hindsight_retain` calls failed with the empty error during a Hindsight LLM fact-extraction slowdown. The server was actually healthy — and had partially stored the data asynchronously — but the blank error cost a full debugging session to root-cause. Error strings are the model's steering input for agentic tools; a blank one gives the agent nothing to act on.

Since all three tools (`hindsight_retain`/`hindsight_recall`/`hindsight_reflect`) route through the single `handle_tool_call` dispatch site, this fixes the whole bug class in one place.

## Related Issue

No existing issue — reporting and fix came from a live deployment. Happy to file one if maintainers prefer.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/hindsight/__init__.py` — `handle_tool_call`: added a dedicated `except (TimeoutError, asyncio.TimeoutError)` branch (before the generic `except Exception`) that returns a diagnostic message including `self._timeout`, the async-storage caveat, and the `hindsight_recall` verification step. Non-timeout exceptions keep their existing message unchanged.

**Message before / after:**

Before:
```
Failed to store memory: 
```

After:
```
Failed to store memory: timed out (hindsight_retain timed out after 120s; the Hindsight
server may be slow or unreachable (for retain, the LLM fact-extraction chain is the
usual culprit; the memory may still have been stored asynchronously — verify with
hindsight_recall before retrying). If this recurs, check server health or raise the
hindsight timeout.)
```

## How to Test

1. Configure the hindsight memory provider (`memory.provider: hindsight`) with a working Hindsight server and a low `timeout` setting (e.g. 1s).
2. Call `hindsight_retain` with content while the Hindsight LLM fact-extraction chain is slow/unreachable.
3. Before this PR: error is `Failed to store memory: ` (blank). After: error names `timed out after 1s` and the diagnostic hint.
4. Alternative: unit-level — raise `TimeoutError()` from a monkeypatched `_run_hindsight_operation` and assert the returned `tool_error` contains the timeout duration.

`tests/plugins/memory/test_hindsight_provider.py`: 37 passed with this patch. One failure (`TestPrefetchServerRetainVisibility::test_prefetch_waits_for_server_completion_before_recall`) is **pre-existing on clean `origin/main`** — verified by stashing this patch and re-running (fails identically). Not caused by this change; happy to help chase it separately.

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md) (and the in-repo AGENTS.md rubric — this follows the fix-the-whole-bug-class guidance, plugin-local only, no core changes, no new env vars)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) — `fix(hindsight): diagnose empty TimeoutError message from tool handlers`
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (single commit, single file, +13 lines)
- [ ] I've run `pytest tests/ -q` and all tests pass — targeted plugin suite: 37/38 pass; the 1 failure is pre-existing on clean main (see Testing)
- [ ] I've added tests for my changes — not yet; can add a unit test for the timeout branch if maintainers want it
- [x] I've tested on my platform: macOS (live deployment — this exact scenario occurred in production and the patch is running there)

### Documentation & Housekeeping
- [ ] I've updated relevant documentation — or N/A (behavior-only change to an error string)
- [x] I've updated `cli-config.yaml.example` — N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A (no architecture/workflow change)