### PR TITLE
fix(config): register delegation.worktree_isolation as a known key (#103149)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1246,6 +1246,10 @@ DEFAULT_CONFIG = {
         # notifications to the PARENT; false suppresses them (the child's result is the
         # deliverable). Async-delegation results are NEVER suppressed.
         "surface_child_process_notifications": False,
+        # Each child gets its own git worktree off the parent's HEAD so parallel children
+        # never contend for one working copy (local backend + git repos only; otherwise
+        # silently ignored). See tools/subagent_worktree.py.
+        "worktree_isolation": False,
     },
     # Ephemeral prefill messages file — JSON list of {role, content} dicts injected at the start of
     # every API call for few-shot priming. Never saved to sessions/logs/trajectories.

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -119,6 +119,15 @@ class TestConfigYamlRouting:
         assert "not a recognized config key" not in capsys.readouterr().out
         assert "nudge_interval: 0" in _read_config(_isolated_hermes_home)
 
+    def test_delegation_worktree_isolation_is_recognized(
+        self, _isolated_hermes_home, capsys
+    ):
+        """The documented subagent worktree isolation flag is runtime config."""
+        set_config_value("delegation.worktree_isolation", "true")
+
+        assert "not a recognized config key" not in capsys.readouterr().out
+        assert "worktree_isolation: true" in _read_config(_isolated_hermes_home)
+
     def test_terminal_docker_cwd_mount_flag_goes_to_config_and_env(self, _isolated_hermes_home):
         set_config_value("terminal.docker_mount_cwd_to_workspace", "true")
         config = _read_config(_isolated_hermes_home)


### PR DESCRIPTION
## Bug Description

Fixes #103149.

Setting the documented `delegation.worktree_isolation` key warned "not a recognized config key" even though the runtime reads and honors it — `tools/delegate_tool_config.py` `_get_worktree_isolation()` gates subagent worktree setup on this key, and both `website/docs/user-guide/configuration.md` and `website/docs/user-guide/features/delegation.md` document it in the `delegation` block.

## Root Cause

`_validate_config_key()` in `hermes_cli/config.py` walks `DEFAULT_CONFIG` to decide whether a dotted key is known. `DEFAULT_CONFIG["delegation"]` enumerated every other delegation knob (`max_concurrent_children`, `max_spawn_depth`, `orchestrator_enabled`, `subagent_auto_approve`, `surface_child_process_notifications`, …) — but not `worktree_isolation`. So the sub-key check failed and `set_config_value()` printed the post-write unknown-key notice (#34067 machinery) right after a write the runtime fully honors.

## Fix

Register the key where the runtime already reads it: add `"worktree_isolation": False` to the `delegation` section of `DEFAULT_CONFIG` (`hermes_cli/config_defaults.py`). Schema validation now matches the documented runtime behavior, and `hermes config get delegation.worktree_isolation` reports the documented default instead of "not set".

Before:

```
$ hermes config set delegation.worktree_isolation true
✓ Set delegation.worktree_isolation = True in ~/.hermes/config.yaml
⚠ 'delegation.worktree_isolation' is not a recognized config key — it was saved anyway, but Hermes may not read it.
```

After:

```
✓ Set delegation.worktree_isolation = True in <config>/config.yaml
(no notice — key is part of the schema)
```

## Testing

- New regression test `test_delegation_worktree_isolation_is_recognized` (verified RED on main before the fix, GREEN after) alongside the existing `cron.script_timeout_seconds` / `memory.nudge_interval` precedents.
- Full `tests/hermes_cli/test_set_config_value.py` (94 passed), `tests/hermes_cli/test_config.py` (120 passed, 4 skipped), `tests/tools/test_subagent_worktree.py` + `tests/tools/test_delegate_timeout_cleanup.py` (23 passed) — no golden-config or migration drift.
- `ruff check` clean on both files; `ruff format --diff` touches none of the changed lines.