### PR TITLE
fix(constants): don't misdetect a Docker host as a container via mountinfo

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1046,8 +1046,23 @@ def _detect_container() -> bool:
         or _proc_file_has_marker("/proc/1/cgroup", ("docker", "podman", "/lxc/", "kubepods", "containerd", "crio"))
     ):
         return True
-    # cgroup v2: /proc/1/cgroup is just "0::/"; the runtime still shows in mountinfo.
-    return _proc_file_has_marker("/proc/self/mountinfo", ("kubepods", "containerd", "crio"))
+    # cgroup v2: /proc/1/cgroup is just "0::/"; the runtime still shows in mountinfo — but ONLY on the
+    # root ("/") mount entry. A Docker/containerd HOST also lists every container's overlay under
+    # /var/lib/docker|containerd in its own mountinfo, so scanning the whole file misdetects the host.
+    return _root_mount_has_marker("/proc/self/mountinfo", ("kubepods", "containerd", "crio", "docker"))
+
+
+def _root_mount_has_marker(path: str, markers: tuple[str, ...]) -> bool:
+    """True when the mountinfo entry whose mount point is "/" mentions a container runtime."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                fields = line.split()
+                if len(fields) > 4 and fields[4] == "/":
+                    return any(marker in line for marker in markers)
+    except OSError:
+        return False
+    return False
 
 
 def get_config_path() -> Path:

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -1152,3 +1152,33 @@ class TestHealAttemptFlagSemantics:
         # The flag is set, so the once-per-process budget is spent.
         assert heal_hermes_managed_node() is False
         assert calls["n"] == 1
+
+
+# --- container detection: a Docker/containerd HOST is not a container -----------------------------
+
+_HOST_ROOT_LINE = "30 1 0:28 /@ / rw,relatime shared:1 - btrfs /dev/mapper/root rw,compress=zstd:3\n"
+_HOST_OVERLAY_LINE = (
+    "754 30 0:81 / /var/lib/docker/rootfs/overlayfs/8128c6f rw,relatime shared:713 - overlay overlay "
+    "rw,lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/53/fs\n"
+)
+_CONTAINER_ROOT_LINE = (
+    "1264 1263 0:81 / / rw,relatime master:713 - overlay overlay "
+    "rw,lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/53/fs\n"
+)
+
+
+def test_root_mount_marker_ignores_other_mounts_on_a_container_host(tmp_path):
+    """A host running Docker lists every container's overlay in its own mountinfo; only the "/" entry counts."""
+    mi = tmp_path / "mountinfo"
+    mi.write_text(_HOST_ROOT_LINE + _HOST_OVERLAY_LINE, encoding="utf-8")
+    assert hermes_constants._root_mount_has_marker(str(mi), ("containerd", "docker")) is False
+
+
+def test_root_mount_marker_detects_container_rootfs(tmp_path):
+    mi = tmp_path / "mountinfo"
+    mi.write_text(_CONTAINER_ROOT_LINE, encoding="utf-8")
+    assert hermes_constants._root_mount_has_marker(str(mi), ("containerd", "docker")) is True
+
+
+def test_root_mount_marker_missing_file_is_not_a_container(tmp_path):
+    assert hermes_constants._root_mount_has_marker(str(tmp_path / "nope"), ("containerd",)) is False


### PR DESCRIPTION
## Bug

`_detect_container()` in `hermes_constants.py` falls through to scanning the **whole** of `/proc/self/mountinfo` for `containerd`/`crio`/`kubepods` when `/proc/1/cgroup` is the cgroup-v2 `0::/...`.

A **host** that runs Docker lists every container's overlay in its own mountinfo:

```
754 30 0:81 / /var/lib/docker/rootfs/overlayfs/8128c6f… rw - overlay overlay rw,lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/53/fs,…
```

so any desktop/server with a running container (here: the Honcho docker-compose stack) is reported as running *inside* a container. Downstream: `hermes doctor` prints "Running inside a container — using local terminal backend" and skips the Docker backend check, `voice_mode` reports no audio devices, gateway service install prints container-only guidance, `web_server_files`/profile-home repair take the container branch.

Reproduced on Arch (kernel 6.18, cgroup v2, `/proc/1/cgroup` = `0::/init.scope`, `systemd-detect-virt` = none) with 4 containers up.

## Fix

Only the mountinfo entry whose **mount point is `/`** says what our own rootfs is. Restrict the probe to that line (`_root_mount_has_marker`). Verified a real container's mountinfo root line (`… / / … overlay … lowerdir=/var/lib/containerd/…`) still matches, and the host no longer does.

## Tests

3 invariant tests in `tests/test_hermes_constants.py`: host-with-overlays → False, container root overlay → True, missing file → False. `scripts/run_tests.sh tests/test_hermes_constants.py tests/hermes_cli/test_container_aware_cli.py tests/hermes_cli/test_gateway_service.py` green.