### PR TITLE
feat(providers): add Kyma API provider plugin

### DIFF
--- a/plugins/model-providers/kyma/__init__.py
+++ b/plugins/model-providers/kyma/__init__.py
@@ -1,0 +1,21 @@
+"""Kyma API provider profile."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+kyma = ProviderProfile(
+    name="kyma", aliases=("kyma-api",), display_name="Kyma API",
+    description="Kyma API: open and frontier models behind one endpoint, uptime measured per model",
+    signup_url="https://kymaapi.com/keys", env_vars=("KYMA_API_KEY",),
+    base_url="https://api.kymaapi.com/v1", auth_type="api_key",
+    default_aux_model="deepseek-v4-flash",
+    # Live catalog ids as of 2026-09-04 (GET https://api.kymaapi.com/v1/models).
+    # The full catalog is fetched dynamically; this is only the picker fallback.
+    fallback_models=(
+        "qwen-3.6-plus", "qwen-3-coder", "kimi-k2.6", "glm-5.2",
+        "deepseek-v3", "claude-sonnet-4-6", "gemini-3.5-flash-lite",
+    ),
+)
+
+register_provider(kyma)

--- a/plugins/model-providers/kyma/plugin.yaml
+++ b/plugins/model-providers/kyma/plugin.yaml
@@ -1,0 +1,5 @@
+name: kyma-provider
+kind: model-provider
+version: 1.0.0
+description: Kyma API: open and frontier models behind one endpoint
+author: Kyma


### PR DESCRIPTION
## What this PR does

Adds Kyma API as a model provider plugin: plugins/model-providers/kyma/__init__.py
+ plugin.yaml, mirroring the existing `novita` profile (a plain OpenAI-compatible
aggregator with no custom hooks) since Kyma is the same shape — one endpoint in
front of open and frontier models, no per-provider quirks to translate.

- Base URL: https://api.kymaapi.com/v1 (OpenAI-compatible)
- Env var: KYMA_API_KEY
- Fallback picker models sourced from the live catalog (GET
  https://api.kymaapi.com/v1/models): qwen-3.6-plus, qwen-3-coder, kimi-k2.6,
  glm-5.2, deepseek-v3, claude-sonnet-4-6, gemini-3.5-flash-lite

## Validation

| Check | Result |
|---|---|
| ruff check (pinned 0.15.10) | clean |
| scripts/run_tests.sh tests/providers/ | 10 files, 78 tests passed |
| scripts/check-windows-footguns.py | clean |
| scripts/check_compat_pointers.py | clean |

## Notes for reviewers

No dedicated test file: plain aggregator profiles (e.g. `novita`) don't ship one per
plugins/model-providers/README.md, and the existing plugin-discovery/registry suite
already covers loading. Happy to adjust naming, fields or add a test file to match
your conventions. Maintenance: hello@kymaapi.com.
