### PR TITLE
fix(desktop): make pane resizing fluid and lockable

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/renderer/collapse-restore-affordance.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/collapse-restore-affordance.test.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { cleanup, fireEvent, render } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { registry } from '@/contrib/registry'
@@ -202,7 +202,7 @@ describe('docked tool tile — collapsing keeps the restore chip', () => {
   })
 })
 
-describe('a stacked tool zone collapsed in a row keeps the horizontal strip', () => {
+describe('a stacked tool zone collapsed in a row keeps a usable vertical rail', () => {
   beforeEach(() => {
     registerPane('workspace', { placement: 'main', uncloseable: true }, 'Chat')
     registerPane('terminal', { placement: 'bottom' }, 'Terminal')
@@ -219,12 +219,21 @@ describe('a stacked tool zone collapsed in a row keeps the horizontal strip', ()
     )
   })
 
-  it('keeps both tab labels after minimize so either pane can be restored', () => {
+  it('gives a collapsed right-edge tool an explicit restore control', () => {
+    setTreeGroupMinimized('g-tools', true)
+    render(<LiveTreeGroup index={1} parentAxis="row" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restore Terminal' }))
+
+    expect(zoneAt(1).minimized).toBe(false)
+  })
+
+  it('keeps both tool tabs in the vertical rail so either can be restored', () => {
     setTreeGroupMinimized('g-tools', true)
     render(<LiveTreeGroup index={1} parentAxis="row" />)
 
     expect(tabEl('terminal')).toBeTruthy()
     expect(tabEl('logs')).toBeTruthy()
-    expect(globalThis.document.querySelector('[data-zone-tabstrip="g-tools"]')).toBeTruthy()
+    expect(screen.getByRole('tablist')).toBeTruthy()
   })
 })

--- a/apps/desktop/src/components/pane-shell/tree/renderer/track-model.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/track-model.ts
@@ -153,7 +153,7 @@ export function resolveCssPx(container: HTMLElement, css: number | string, horiz
 export interface TrackContext {
   paneFor: (id: string) => Contribution | undefined
   paneGone: (id: string) => boolean
-  overrides: Record<string, { widthOverride?: number; heightOverride?: number }>
+  overrides: Record<string, { heightLocked?: boolean; heightOverride?: number; widthLocked?: boolean; widthOverride?: number }>
 }
 
 /** A group's panes that are actually on screen (not hidden / narrow-collapsed
@@ -229,18 +229,19 @@ export function fixedTrackSize(node: LayoutNode, axis: 'row' | 'column', ctx: Tr
     }
 
     const overrideKey = axis === 'row' ? 'widthOverride' : 'heightOverride'
+    const lockKey = axis === 'row' ? 'widthLocked' : 'heightLocked'
 
     const declared = (id: string) => {
       const sizing = (ctx.paneFor(id)?.data ?? {}) as PaneSizing
       const css = (axis === 'row' ? sizing.width : sizing.height) ?? null
-      const override = ctx.overrides[id]?.[overrideKey]
+      const state = ctx.overrides[id]
+      const override = state?.[overrideKey]
+      const locked = Boolean(state?.[lockKey])
 
-      // An override only refines a pane that DECLARES a size along this axis
-      // (sash drags write overrides to fixed zones only). One without a
-      // declaration is stale data from another surface — honoring it would
-      // turn a flex-at-heart zone (main!) into a fixed track and hand the
-      // whole leftover to the run's absorber.
-      if (css !== null && override !== undefined) {
+      // A locked user size promotes even a flex-at-heart zone to a fixed track.
+      // An ordinary stale override still cannot do that: those are written only
+      // for declared fixed panes and must never pin the main workspace.
+      if (override !== undefined && (css !== null || locked)) {
         return `${override}px`
       }
 

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group-size-lock.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group-size-lock.test.tsx
@@ -1,0 +1,143 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { registry } from '@/contrib/registry'
+import { $paneStates } from '@/store/panes'
+import { stubMenuDomApis, stubResizeObserver } from '@/test/jsdom'
+
+import { group, split } from '../model'
+import { $hiddenTreePanes, $layoutTree } from '../store'
+
+import { TreeGroup } from './tree-group'
+
+const disposers: (() => void)[] = []
+
+beforeAll(() => {
+  stubResizeObserver()
+  stubMenuDomApis()
+  vi.stubGlobal('CSS', { ...globalThis.CSS, escape: (value: string) => value })
+})
+
+beforeEach(() => {
+  window.localStorage.clear()
+  $hiddenTreePanes.set(new Set())
+  $paneStates.set({})
+  disposers.push(
+    registry.register({ area: 'panes', data: { placement: 'main' }, id: 'chat', render: () => null, title: 'Chat' }),
+    registry.register({ area: 'panes', data: { placement: 'main' }, id: 'browser', render: () => null, title: 'Browser' })
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  $layoutTree.set(null)
+  $paneStates.set({})
+  disposers.splice(0).forEach(dispose => dispose())
+})
+
+function openContextMenu(target: HTMLElement) {
+  fireEvent.pointerDown(target, { button: 2, pointerType: 'mouse' })
+  fireEvent.contextMenu(target, { button: 2 })
+}
+
+describe('zone size locks', () => {
+  it('offers Lock width for a panel that has a horizontal neighbor and persists the lock', async () => {
+    const tree = split('row', [group(['chat'], { id: 'chat-zone' }), group(['browser'], { id: 'browser-zone' })])
+    $layoutTree.set(tree)
+    $paneStates.set({ browser: { open: true, widthOverride: 420 } })
+
+    render(<TreeGroup node={tree.children[1] as ReturnType<typeof group>} parentAxis="row" />)
+
+    Object.defineProperty(document.querySelector('[data-tree-group="browser-zone"]'), 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ height: 600, width: 420 })
+    })
+
+    openContextMenu(document.querySelector<HTMLElement>('[data-tree-tab="browser"]')!)
+    const lock = await screen.findByRole('menuitem', { name: /^lock width$/i })
+    expect(screen.queryByRole('menuitem', { name: /^lock height$/i })).toBeNull()
+    fireEvent.click(lock)
+
+    expect($paneStates.get().browser).toMatchObject({ open: true, widthLocked: true, widthOverride: 420 })
+    expect(JSON.parse(window.localStorage.getItem('hermes.desktop.paneStates.v1') ?? '{}')).toMatchObject({
+      browser: { open: true, widthLocked: true, widthOverride: 420 }
+    })
+
+    openContextMenu(document.querySelector<HTMLElement>('[data-tree-tab="browser"]')!)
+    fireEvent.click(await screen.findByRole('menuitem', { name: /^unlock width$/i }))
+    expect($paneStates.get().browser).toMatchObject({ open: true, widthOverride: 420 })
+    expect($paneStates.get().browser?.widthLocked).toBeUndefined()
+
+    openContextMenu(document.querySelector<HTMLElement>('[data-tree-tab="browser"]')!)
+    fireEvent.click(await screen.findByRole('menuitem', { name: /^lock width$/i }))
+    expect($paneStates.get().browser).toMatchObject({ open: true, widthLocked: true, widthOverride: 420 })
+  })
+
+  it('offers Lock height for a panel that has a vertical neighbor and omits width', async () => {
+    const tree = split('column', [group(['chat'], { id: 'chat-zone' }), group(['browser'], { id: 'browser-zone' })])
+    $layoutTree.set(tree)
+
+    render(<TreeGroup node={tree.children[1] as ReturnType<typeof group>} parentAxis="column" />)
+
+    Object.defineProperty(document.querySelector('[data-tree-group="browser-zone"]'), 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ height: 260, width: 900 })
+    })
+
+    openContextMenu(document.querySelector<HTMLElement>('[data-tree-tab="browser"]')!)
+    const lock = await screen.findByRole('menuitem', { name: /^lock height$/i })
+    expect(screen.queryByRole('menuitem', { name: /^lock width$/i })).toBeNull()
+    fireEvent.click(lock)
+
+    expect($paneStates.get().browser).toMatchObject({ heightLocked: true, heightOverride: 260, open: false })
+  })
+
+  it('offers Lock height from a hidden-tab-strip zone body', async () => {
+    const tree = split(
+      'column',
+      [group(['chat'], { id: 'chat-zone' }), group(['files'], { id: 'files-zone', tabStrip: 'never' })],
+      [1, 1]
+    )
+
+    $layoutTree.set(tree)
+    disposers.push(registry.register({ area: 'panes', data: { placement: 'right' }, id: 'files', render: () => null, title: 'Files' }))
+
+    render(<TreeGroup node={tree.children[1] as ReturnType<typeof group>} parentAxis="column" />)
+
+    Object.defineProperty(document.querySelector('[data-tree-group="files-zone"]'), 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ height: 260, width: 420 })
+    })
+
+    openContextMenu(document.querySelector<HTMLElement>('[data-tree-group="files-zone"]')!)
+    expect(await screen.findByRole('menuitem', { name: /^lock height$/i })).toBeTruthy()
+  })
+
+  it('offers Lock column width and locks every zone in a vertically stacked column', async () => {
+    const stack = split(
+      'column',
+      [group(['chat'], { id: 'files-zone' }), group(['browser'], { id: 'browser-zone' })],
+      [1, 1],
+      'right-column'
+    )
+
+    const tree = split('row', [group(['left'], { id: 'left-zone' }), stack], [1, 1], 'root-row')
+    $layoutTree.set(tree)
+    disposers.push(registry.register({ area: 'panes', data: { placement: 'main' }, id: 'left', render: () => null, title: 'Left' }))
+
+    render(<TreeGroup node={stack.children[1] as ReturnType<typeof group>} parentAxis="column" />)
+
+    Object.defineProperty(document.querySelector('[data-tree-group="browser-zone"]'), 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ height: 260, width: 420 })
+    })
+
+    openContextMenu(document.querySelector<HTMLElement>('[data-tree-tab="browser"]')!)
+    expect(await screen.findByRole('menuitem', { name: /^lock height$/i })).toBeTruthy()
+    const lockColumn = await screen.findByRole('menuitem', { name: /^lock column width$/i })
+    fireEvent.click(lockColumn)
+
+    expect($paneStates.get().chat).toMatchObject({ widthLocked: true, widthOverride: 420 })
+    expect($paneStates.get().browser).toMatchObject({ widthLocked: true, widthOverride: 420 })
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -30,6 +30,7 @@ import { useContributions } from '@/contrib/react/use-contributions'
 import { useI18n } from '@/i18n'
 import { useKeybindHint } from '@/lib/keybinds/use-keybind-hint'
 import { cn } from '@/lib/utils'
+import { $paneStates, setPaneHeightLocked, setPaneHeightOverride, setPaneWidthLocked, setPaneWidthOverride } from '@/store/panes'
 import { closeAllOpenSessionTiles } from '@/store/session-states'
 
 import { $layoutEditMode } from '../../edit-mode'
@@ -43,10 +44,12 @@ import {
   resolveRememberedActivePane,
   workspaceScopeKey
 } from '../../workspace-scope'
+import { allPaneIds, findParentSplit } from '../model'
 import type { DropPosition, GroupNode } from '../model'
 import {
   $dropHint,
   $hiddenTreePanes,
+  $layoutTree,
   $narrowViewport,
   $newSessionTabAction,
   $panesWithCloser,
@@ -91,12 +94,22 @@ import { paneChrome } from './track-model'
  *  tab's menu, so every tab in a strip answers a right-click the same way —
  *  a pane with no domain menu of its own (the file tree, a terminal, the main
  *  tab on a fresh draft) falls through to this one. */
+interface SizeLock {
+  axis: 'height' | 'width'
+  key: string
+  label: string
+  locked: boolean
+  toggle: () => void
+}
+
 function ZoneMenu({
   children,
   closable,
+  disabled,
   minimizable = true,
   minimized,
   nodeId,
+  sizeLocks,
   stripVisible,
   tabMenuPrefix,
   targetPane
@@ -105,11 +118,13 @@ function ZoneMenu({
   /** The pane the menu closes (the right-clicked chip / the active pane);
    *  undefined = not closable (the main zone). */
   closable?: () => string | undefined
+  disabled?: boolean
   /** False for the zone hosting the uncloseable workspace — collapsing the
    *  MAIN pane strands the app behind a strip. */
   minimizable?: boolean
   minimized?: boolean
   nodeId: string
+  sizeLocks?: SizeLock[]
   /** Whether the strip is on screen — the Hide/Show row toggles against what
    *  the user can see, not against the stored mode (a zone on auto has none). */
   stripVisible?: boolean
@@ -183,6 +198,19 @@ function ZoneMenu({
             </>
           )
         })()}
+        {sizeLocks && sizeLocks.length > 0 && (
+          <>
+            <kit.Separator />
+            {sizeLocks.map(sizeLock =>
+              renderActionItem(kit, {
+                icon: sizeLock.locked ? 'unlock' : 'lock',
+                key: `zone-lock-${sizeLock.key}`,
+                label: `${sizeLock.locked ? 'Unlock' : 'Lock'} ${sizeLock.label}`,
+                onSelect: sizeLock.toggle
+              })
+            )}
+          </>
+        )}
         <kit.Separator />
         {renderActionItem(kit, {
           icon: stripVisible ? 'eye-closed' : 'eye',
@@ -210,7 +238,7 @@ function ZoneMenu({
   }
 
   return (
-    <ActionsContextMenu contentClassName="w-40" items={items}>
+    <ActionsContextMenu contentClassName="w-40" disabled={disabled} items={items}>
       {children}
     </ActionsContextMenu>
   )
@@ -277,6 +305,10 @@ export function TreeGroup({
     ? node.active
     : (resolveRememberedActivePane(memoryKey, shown) ?? shown[0] ?? '')
 
+  // Locks can be owned by any shown tenant in a zone or its containing column,
+  // so subscribe to the consolidated snapshot rather than only the active tab.
+  const paneStates = useStore($paneStates)
+
   const active = paneFor(activeId)
   const isEmpty = shown.length === 0
 
@@ -337,16 +369,10 @@ export function TreeGroup({
   })
 
   // A group collapses ALONG its parent split's axis. In a row that means the
-  // WIDTH collapses — a full-width horizontal header would strand a tall
-  // empty column, so the minimized form is a narrow vertical rail instead
-  // (tabs reading top-to-bottom). In a column (stacked zones) the horizontal
-  // header IS the collapsed form, exactly as before.
-  //
-  // EXCEPTION: when the zone has ≥2 shown panes, keep the horizontal tab bar
-  // even when minimized — the user can still switch (and restore) without
-  // expanding first. The vertical rail is only for a lone pane, where it
-  // still renders that pane's tab as the restore handle.
-  const verticalCollapse = Boolean(node.minimized) && parentAxis === 'row' && !isEmpty && shown.length <= 1
+  // WIDTH collapses — use a narrow vertical rail with every shown tab, rather
+  // than clipping a horizontal header into an unusable edge sliver. In a
+  // column (stacked zones) the horizontal header remains the collapsed form.
+  const verticalCollapse = Boolean(node.minimized) && parentAxis === 'row' && !isEmpty
   // A minimized group IS its header, so it shows one regardless.
   const headerVisible = !isEmpty && !verticalCollapse && (Boolean(node.minimized) || stripVisible)
 
@@ -404,19 +430,80 @@ export function TreeGroup({
   // the zone and take the tab with it.
   const toggleCollapse = () => (node.minimized ? restoreTreePane(activeId) : collapseTreePane(activeId))
 
-  // Same menu on the header strip and the edit veil — one prop bag.
+  // A direct split answers the local dimension. A vertically stacked column
+  // nested in a row also exposes one column-wide width lock: its members share
+  // the same outer track, so a width lock must be written to every visible pane
+  // in that column—not merely the tab the user happened to right-click.
+  const tree = $layoutTree.get()
+  const parent = tree ? findParentSplit(tree, node.id) : null
+  const columnParent = tree && parent?.orientation === 'column' ? findParentSplit(tree, parent.id) : null
+
+  const lockAxis: 'height' | 'width' | null =
+    parent?.orientation === 'row' ? 'width' : parent?.orientation === 'column' ? 'height' : null
+
+  const columnPaneIds = parent?.orientation === 'column' && columnParent?.orientation === 'row' ? allPaneIds(parent).filter(paneShown) : []
+
+  const makeSizeLock = (axis: 'height' | 'width', paneIds: string[], key: string, label: string): SizeLock => {
+    const locked = paneIds.some(id => Boolean(paneStates[id]?.[axis === 'width' ? 'widthLocked' : 'heightLocked']))
+
+    return {
+      axis,
+      key,
+      label,
+      locked,
+      toggle: () => {
+        const bounds = ref.current?.getBoundingClientRect()
+
+        if (!bounds) {
+          return
+        }
+
+        const size = Math.round(axis === 'width' ? bounds.width : bounds.height)
+
+        for (const paneId of paneIds) {
+          if (axis === 'width') {
+            if (!locked) {
+              setPaneWidthOverride(paneId, size)
+            }
+
+            setPaneWidthLocked(paneId, !locked)
+          } else {
+            if (!locked) {
+              setPaneHeightOverride(paneId, size)
+            }
+
+            setPaneHeightLocked(paneId, !locked)
+          }
+        }
+      }
+    }
+  }
+
+  const sizeLocks: SizeLock[] = []
+
+  if (lockAxis && parent && parent.children.length > 1 && shown.length > 0) {
+    sizeLocks.push(makeSizeLock(lockAxis, shown, lockAxis, lockAxis))
+  }
+
+  if (columnPaneIds.length > 0 && columnParent && columnParent.children.length > 1) {
+    sizeLocks.push(makeSizeLock('width', columnPaneIds, 'column-width', 'column width'))
+  }
+
+  // Same menu on the header strip, hidden-strip fallback, and edit veil.
   const zoneMenu = {
     closable,
     minimizable,
     minimized: node.minimized,
     nodeId: node.id,
+    sizeLocks,
     stripVisible,
     tabMenuPrefix: (kit: MenuKit) => paneChrome(paneFor(targetPane())).tabMenuPrefix?.(kit),
     targetPane
   }
 
   return (
-    <div
+    <ZoneMenu {...zoneMenu} disabled={stripVisible || verticalCollapse || editMode}>
+      <div
       className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-(--ui-editor-surface-background)"
       data-tree-group={node.id}
       // Advertises the visible tab strip so panes can drop their own
@@ -455,8 +542,20 @@ export function TreeGroup({
             onClick={() => restoreTreePane(activeId)}
             title={t.zones.restore}
           >
+            <button
+              aria-label={`${t.zones.restore} ${tabLabel(activeId)}`}
+              className="grid size-7 shrink-0 place-items-center text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background) hover:text-foreground focus-visible:outline-2 focus-visible:outline-(--ui-focus-ring)"
+              onClick={event => {
+                event.stopPropagation()
+                restoreTreePane(activeId)
+              }}
+              title={`${t.zones.restore} ${tabLabel(activeId)}`}
+              type="button"
+            >
+              <Codicon name={railSide === 'right' ? 'chevron-left' : 'chevron-right'} size="0.875rem" />
+            </button>
             <div
-              className="flex min-h-0 flex-col overflow-y-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+              className="flex min-h-0 flex-1 flex-col overflow-y-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
               role="tablist"
             >
               {shown.map(paneId => {
@@ -752,7 +851,8 @@ export function TreeGroup({
       {/* FancyZones drop overlay — its own component so the per-frame drop
           hint re-renders only this (tiny) node, not the whole zone. */}
       <ZoneDropOverlay node={node} />
-    </div>
+      </div>
+    </ZoneMenu>
   )
 }
 

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-split-cascade-resize.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-split-cascade-resize.test.tsx
@@ -285,6 +285,65 @@ describe('TreeSplit cascading expansion', () => {
     expect(terminalColumn.style.minWidth).toBe('80px')
   })
 
+  it('commits a regular cascade when an unrelated tool rail is already minimized', () => {
+    markCollapsePane('terminal')
+    disposers.push(
+      registry.register({
+        area: 'panes',
+        data: { maxWidth: '600px', minWidth: '160px', placement: 'right', width: '200px' },
+        id: 'browser',
+        render: () => null,
+        title: 'Browser'
+      }),
+      registry.register({
+        area: 'panes',
+        data: { placement: 'bottom' },
+        id: 'terminal',
+        render: () => null,
+        title: 'Terminal'
+      })
+    )
+
+    const tree = split(
+      'row',
+      [
+        group(['chat'], { id: 'chat-zone' }),
+        group(['cron'], { id: 'cron-zone' }),
+        group(['browser'], { id: 'browser-zone' }),
+        group(['terminal'], { id: 'terminal-zone' })
+      ],
+      [5, 1, 2, 0.28],
+      'root-row'
+    )
+
+    $layoutTree.set(tree)
+    $paneStates.set({ browser: { open: true, widthOverride: 200 } })
+    setTreeGroupMinimized('terminal-zone', true)
+
+    render(<TreeSplit node={row()} root rootRow />)
+
+    const container = document.querySelector<HTMLElement>('[data-tree-split="root-row"]')!
+    const [chat, cron, browser, terminal] = [...container.children] as HTMLElement[]
+    setWidth(container, 828)
+    setWidth(chat, 500)
+    setWidth(cron, 100)
+    setWidth(browser, 200)
+    setWidth(terminal, 28)
+    setWidth(document.querySelector<HTMLElement>('[data-tree-group="cron-zone"]')!, 100)
+    setWidth(document.querySelector<HTMLElement>('[data-tree-group="browser-zone"]')!, 200)
+    setWidth(document.querySelector<HTMLElement>('[data-tree-group="terminal-zone"]')!, 28)
+
+    const browserSash = document.querySelectorAll('[role="separator"]')[1]!
+    fireEvent.pointerDown(browserSash, { button: 0, clientX: 600, pointerId: 1, pointerType: 'mouse' })
+    fireEvent.pointerMove(window, { clientX: 300, pointerId: 1, pointerType: 'mouse' })
+    fireEvent.pointerUp(window, { clientX: 300, pointerId: 1, pointerType: 'mouse' })
+
+    expect($paneStates.get().cron?.widthOverride).toBe(80)
+    expect($paneStates.get().browser?.widthOverride).toBe(500)
+    expect(row().weights[0]).toBeCloseTo(2.2)
+    expect(row().children[3]).toMatchObject({ id: 'terminal-zone', minimized: true })
+  })
+
   it('does not let an unrelated collapsible rail disable a regular seam cascade', () => {
     markCollapsePane('bot')
     disposers.push(registry.register({ area: 'panes', data: { placement: 'main' }, id: 'bot', render: () => null, title: 'Bot' }))

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-split-cascade-resize.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-split-cascade-resize.test.tsx
@@ -1,0 +1,327 @@
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { registry } from '@/contrib/registry'
+import { $paneStates } from '@/store/panes'
+
+import { group, split, type SplitNode } from '../model'
+import { $hiddenTreePanes, $layoutTree, markCollapsePane, setTreeGroupMinimized } from '../store'
+
+import { TreeSplit } from './tree-split'
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+const disposers: (() => void)[] = []
+
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', TestResizeObserver)
+  vi.stubGlobal('CSS', { ...globalThis.CSS, escape: (value: string) => value })
+  vi.stubGlobal('requestAnimationFrame', () => 1)
+  vi.stubGlobal('cancelAnimationFrame', () => undefined)
+  Element.prototype.hasPointerCapture ??= () => false
+  Element.prototype.setPointerCapture ??= () => undefined
+  Element.prototype.releasePointerCapture ??= () => undefined
+})
+
+beforeEach(() => {
+  window.localStorage.clear()
+  $hiddenTreePanes.set(new Set())
+  $paneStates.set({})
+
+  disposers.push(
+    registry.register({ area: 'panes', data: { placement: 'main' }, id: 'chat', render: () => null, title: 'Chat' }),
+    registry.register({ area: 'panes', data: { placement: 'main', width: '100px' }, id: 'cron', render: () => null, title: 'Cron' }),
+    registry.register({ area: 'panes', data: { placement: 'main' }, id: 'browser', render: () => null, title: 'Browser' })
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  $layoutTree.set(null)
+  $paneStates.set({})
+  disposers.splice(0).forEach(dispose => dispose())
+})
+
+function rect(width: number): DOMRect {
+  return {
+    bottom: 600,
+    height: 600,
+    left: 0,
+    right: width,
+    toJSON: () => ({}),
+    top: 0,
+    width,
+    x: 0,
+    y: 0
+  } as DOMRect
+}
+
+function setWidth(element: HTMLElement, width: number) {
+  Object.defineProperty(element, 'getBoundingClientRect', { configurable: true, value: () => rect(width) })
+}
+
+function row(): SplitNode {
+  const tree = $layoutTree.get()
+
+  if (!tree || tree.type !== 'split') {
+    throw new Error('expected root row split')
+  }
+
+  return tree
+}
+
+describe('TreeSplit cascading expansion', () => {
+  it('grows Browser through Cron into Chat after Cron reaches its minimum', () => {
+    const tree = split(
+      'row',
+      [
+        group(['chat'], { id: 'chat-zone' }),
+        group(['cron'], { id: 'cron-zone' }),
+        group(['browser'], { id: 'browser-zone' })
+      ],
+      [5, 1, 2],
+      'root-row'
+    )
+
+    $layoutTree.set(tree)
+
+    render(<TreeSplit node={tree} root rootRow />)
+
+    const container = document.querySelector<HTMLElement>('[data-tree-split="root-row"]')!
+    const [chat, cron, browser] = [...container.children] as HTMLElement[]
+    setWidth(container, 800)
+    setWidth(chat, 500)
+    setWidth(cron, 100)
+    setWidth(browser, 200)
+    setWidth(document.querySelector<HTMLElement>('[data-tree-group="cron-zone"]')!, 100)
+
+    const browserSash = document.querySelectorAll('[role="separator"]')[1]!
+    fireEvent.pointerDown(browserSash, { button: 0, clientX: 600, pointerId: 1, pointerType: 'mouse' })
+    fireEvent.pointerMove(window, { clientX: 300, pointerId: 1, pointerType: 'mouse' })
+    fireEvent.pointerUp(window, { clientX: 300, pointerId: 1, pointerType: 'mouse' })
+
+    // Browser's 300px requested growth first takes Cron from 100px to its
+    // 80px floor, then takes the remaining 280px from Chat. The browser gets
+    // every released pixel instead of stopping at Cron's local floor.
+    expect($paneStates.get().cron?.widthOverride).toBe(80)
+    expect(row().weights).toEqual([2.2, 1, 5])
+  })
+
+  it('skips a locked middle zone and continues cascading to the outer donor', () => {
+    const tree = split(
+      'row',
+      [
+        group(['chat'], { id: 'chat-zone' }),
+        group(['cron'], { id: 'cron-zone' }),
+        group(['browser'], { id: 'browser-zone' })
+      ],
+      [5, 1, 2],
+      'root-row'
+    )
+
+    $layoutTree.set(tree)
+    $paneStates.set({ cron: { open: true, widthLocked: true, widthOverride: 100 } })
+
+    render(<TreeSplit node={tree} root rootRow />)
+
+    const container = document.querySelector<HTMLElement>('[data-tree-split="root-row"]')!
+    const [chat, cron, browser] = [...container.children] as HTMLElement[]
+    setWidth(container, 800)
+    setWidth(chat, 500)
+    setWidth(cron, 100)
+    setWidth(browser, 200)
+    setWidth(document.querySelector<HTMLElement>('[data-tree-group="cron-zone"]')!, 100)
+
+    const browserSash = document.querySelectorAll('[role="separator"]')[1]!
+    fireEvent.pointerDown(browserSash, { button: 0, clientX: 600, pointerId: 1, pointerType: 'mouse' })
+    fireEvent.pointerMove(window, { clientX: 300, pointerId: 1, pointerType: 'mouse' })
+    fireEvent.pointerUp(window, { clientX: 300, pointerId: 1, pointerType: 'mouse' })
+
+    expect($paneStates.get().cron).toMatchObject({ widthLocked: true, widthOverride: 100 })
+    expect(row().weights).toEqual([2, 1, 5])
+  })
+
+  it('keeps the return direction local after a cascading drag reverses', () => {
+    disposers.push(
+      registry.register({ area: 'panes', data: { placement: 'main' }, id: 'notes', render: () => null, title: 'Notes' }),
+      registry.register({ area: 'panes', data: { placement: 'main' }, id: 'preview', render: () => null, title: 'Preview' })
+    )
+
+    const tree = split(
+      'row',
+      [
+        group(['chat'], { id: 'chat-zone' }),
+        group(['browser'], { id: 'browser-zone' }),
+        group(['notes'], { id: 'notes-zone' }),
+        group(['preview'], { id: 'preview-zone' })
+      ],
+      [3, 2, 2, 1],
+      'root-row'
+    )
+
+    $layoutTree.set(tree)
+
+    render(<TreeSplit node={tree} root rootRow />)
+
+    const container = document.querySelector<HTMLElement>('[data-tree-split="root-row"]')!
+    const [chat, browser, notes, preview] = [...container.children] as HTMLElement[]
+    setWidth(container, 800)
+    setWidth(chat, 300)
+    setWidth(browser, 200)
+    setWidth(notes, 200)
+    setWidth(preview, 100)
+
+    const middleSash = document.querySelectorAll('[role="separator"]')[1]!
+    fireEvent.pointerDown(middleSash, { button: 0, clientX: 500, pointerId: 1, pointerType: 'mouse' })
+    fireEvent.pointerMove(window, { clientX: 250, pointerId: 1, pointerType: 'mouse' })
+    fireEvent.pointerMove(window, { clientX: 800, pointerId: 1, pointerType: 'mouse' })
+    fireEvent.pointerUp(window, { clientX: 800, pointerId: 1, pointerType: 'mouse' })
+
+    // The first (leftward) motion cascades through Browser into Chat. Returning
+    // right expands Browser from Notes only; Preview was never involved.
+    expect(row().weights).toEqual([3, 3.2, 0.8, 1])
+  })
+
+  it('does not let a tiny opposite false-start disable a later forward cascade', () => {
+    const tree = split(
+      'row',
+      [
+        group(['chat'], { id: 'chat-zone' }),
+        group(['cron'], { id: 'cron-zone' }),
+        group(['browser'], { id: 'browser-zone' })
+      ],
+      [5, 1, 2],
+      'root-row'
+    )
+
+    $layoutTree.set(tree)
+
+    render(<TreeSplit node={tree} root rootRow />)
+
+    const container = document.querySelector<HTMLElement>('[data-tree-split="root-row"]')!
+    const [chat, cron, browser] = [...container.children] as HTMLElement[]
+    setWidth(container, 800)
+    setWidth(chat, 500)
+    setWidth(cron, 100)
+    setWidth(browser, 200)
+    setWidth(document.querySelector<HTMLElement>('[data-tree-group="cron-zone"]')!, 100)
+
+    const browserSash = document.querySelectorAll('[role="separator"]')[1]!
+    fireEvent.pointerDown(browserSash, { button: 0, clientX: 600, pointerId: 1, pointerType: 'mouse' })
+    // A tiny initial wobble grows Cron locally. The real movement then grows
+    // Browser leftward and must still cascade through Cron into Chat.
+    fireEvent.pointerMove(window, { clientX: 605, pointerId: 1, pointerType: 'mouse' })
+    fireEvent.pointerMove(window, { clientX: 300, pointerId: 1, pointerType: 'mouse' })
+    fireEvent.pointerUp(window, { clientX: 300, pointerId: 1, pointerType: 'mouse' })
+
+    expect($paneStates.get().cron?.widthOverride).toBe(80)
+    expect(row().weights).toEqual([2.2, 1, 5])
+  })
+
+  it('does not leak past a locked immediate donor in the local tool-panel path', () => {
+    markCollapsePane('tool')
+    disposers.push(
+      registry.register({ area: 'panes', data: { placement: 'main' }, id: 'tool', render: () => null, title: 'Tool' }),
+      registry.register({ area: 'panes', data: { placement: 'main' }, id: 'notes', render: () => null, title: 'Notes' })
+    )
+
+    const tree = split(
+      'row',
+      [group(['tool'], { id: 'tool-zone' }), group(['browser'], { id: 'browser-zone' }), group(['notes'], { id: 'notes-zone' })],
+      [1, 1, 6],
+      'root-row'
+    )
+
+    $layoutTree.set(tree)
+    $paneStates.set({ browser: { open: true, widthLocked: true, widthOverride: 100 } })
+
+    render(<TreeSplit node={tree} root rootRow />)
+
+    const container = document.querySelector<HTMLElement>('[data-tree-split="root-row"]')!
+    const [tool, browser, notes] = [...container.children] as HTMLElement[]
+    setWidth(container, 800)
+    setWidth(tool, 100)
+    setWidth(browser, 100)
+    setWidth(notes, 600)
+    setWidth(document.querySelector<HTMLElement>('[data-tree-group="browser-zone"]')!, 100)
+
+    const notesSash = document.querySelectorAll('[role="separator"]')[1]!
+    fireEvent.pointerDown(notesSash, { button: 0, clientX: 200, pointerId: 1, pointerType: 'mouse' })
+    fireEvent.pointerMove(window, { clientX: 0, pointerId: 1, pointerType: 'mouse' })
+    fireEvent.pointerUp(window, { clientX: 0, pointerId: 1, pointerType: 'mouse' })
+
+    expect(row().weights).toEqual([1, 1, 6])
+    expect($paneStates.get().browser).toMatchObject({ widthLocked: true, widthOverride: 100 })
+  })
+
+  it('restores a collapsed tool column with an 80px usable width floor', () => {
+    markCollapsePane('terminal')
+    disposers.push(
+      registry.register({ area: 'panes', data: { placement: 'bottom' }, id: 'terminal', render: () => null, title: 'Terminal' })
+    )
+
+    const tree = split(
+      'row',
+      [group(['chat'], { id: 'chat-zone' }), group(['terminal'], { id: 'terminal-zone' })],
+      [5, 0.01],
+      'root-row'
+    )
+
+    $layoutTree.set(tree)
+
+    const view = render(<TreeSplit node={tree} root rootRow />)
+    setTreeGroupMinimized('terminal-zone', true)
+    view.rerender(<TreeSplit node={$layoutTree.get() as SplitNode} root rootRow />)
+    setTreeGroupMinimized('terminal-zone', false)
+    view.rerender(<TreeSplit node={$layoutTree.get() as SplitNode} root rootRow />)
+
+    const container = document.querySelector<HTMLElement>('[data-tree-split="root-row"]')!
+    const terminalColumn = container.children[1] as HTMLElement
+
+    expect(terminalColumn.style.minWidth).toBe('80px')
+  })
+
+  it('does not let an unrelated collapsible rail disable a regular seam cascade', () => {
+    markCollapsePane('bot')
+    disposers.push(registry.register({ area: 'panes', data: { placement: 'main' }, id: 'bot', render: () => null, title: 'Bot' }))
+
+    const tree = split(
+      'row',
+      [
+        group(['bot'], { id: 'bot-zone' }),
+        group(['chat'], { id: 'chat-zone' }),
+        group(['cron'], { id: 'cron-zone' }),
+        group(['browser'], { id: 'browser-zone' })
+      ],
+      [1, 5, 1, 2],
+      'root-row'
+    )
+
+    $layoutTree.set(tree)
+
+    render(<TreeSplit node={tree} root rootRow />)
+
+    const container = document.querySelector<HTMLElement>('[data-tree-split="root-row"]')!
+    const [bot, chat, cron, browser] = [...container.children] as HTMLElement[]
+    setWidth(container, 900)
+    setWidth(bot, 100)
+    setWidth(chat, 500)
+    setWidth(cron, 100)
+    setWidth(browser, 200)
+    setWidth(document.querySelector<HTMLElement>('[data-tree-group="cron-zone"]')!, 100)
+
+    const browserSash = document.querySelectorAll('[role="separator"]')[2]!
+    fireEvent.pointerDown(browserSash, { button: 0, clientX: 700, pointerId: 1, pointerType: 'mouse' })
+    fireEvent.pointerMove(window, { clientX: 400, pointerId: 1, pointerType: 'mouse' })
+    fireEvent.pointerUp(window, { clientX: 400, pointerId: 1, pointerType: 'mouse' })
+
+    // Browser takes Cron to its floor, then continues through Chat. The Bot
+    // rail is unrelated to this seam and must not suppress that cascade.
+    expect($paneStates.get().cron?.widthOverride).toBe(80)
+    expect(row().weights).toEqual([1, 2.2, 1, 5])
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
@@ -440,7 +440,8 @@ export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boo
 
         if (lastPlan && lastPlan.moved !== 0) {
           const collapsedSide = sashTracks.find(
-            (track, index) => track.collapseId && lastPlan!.sizes[index] <= track.floor
+            (track, index) =>
+              track.collapseId && track.initial > track.floor && lastPlan!.sizes[index] <= track.floor
           )?.collapseId
 
           if (collapsedSide) {

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
@@ -73,7 +73,13 @@ function useSubtreeOverrides(paneIds: readonly string[]): TrackContext['override
 
   const snapshot = useCallback(() => {
     const all = $paneStates.get()
-    const sig = paneIds.map(id => `${id}:${all[id]?.widthOverride ?? ''}:${all[id]?.heightOverride ?? ''}`).join('|')
+
+    const sig = paneIds
+      .map(
+        id =>
+          `${id}:${all[id]?.widthOverride ?? ''}:${all[id]?.widthLocked ? 'locked' : ''}:${all[id]?.heightOverride ?? ''}:${all[id]?.heightLocked ? 'locked' : ''}`
+      )
+      .join('|')
 
     if (cache.current.sig !== sig) {
       cache.current = { sig, value: Object.fromEntries(paneIds.flatMap(id => (all[id] ? [[id, all[id]]] : []))) }
@@ -222,14 +228,17 @@ export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boo
         // release minimizes the zone instead of leaving a useless sliver.
         const toolZone = allPaneIds(child).length > 0 && allPaneIds(child).every(isCollapsePane)
         const floor = toolZone ? COLLAPSED_ZONE_PX : MIN_PANE_PX
+        const paneIds = zone ? shownPaneIds(zone, trackCtx) : allPaneIds(child).filter(id => !paneGone(id))
+        const lockKey = horizontal ? 'widthLocked' : 'heightLocked'
 
         return {
           // EVERY shown pane of the zone: the zone's track is the max() of its
           // panes' sizes, so the sash writes the same px to all of them —
           // writing only the active pane would leave the zone pinned at a
           // larger sibling's width.
-          paneIds: zone ? shownPaneIds(zone, trackCtx) : [],
+          paneIds,
           fixed: Boolean(zone),
+          locked: paneIds.some(id => Boolean(overrides[id]?.[lockKey])),
           size: sizeOf(zoneEl ?? wrapper),
           min: toolZone ? floor : Math.max(floor, computedPx(horizontal ? cs.minWidth : cs.minHeight, 0)),
           max: computedPx(horizontal ? cs.maxWidth : cs.maxHeight, Number.POSITIVE_INFINITY),
@@ -245,14 +254,145 @@ export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boo
         return
       }
 
-      const a = sideFor(node.children[aIndex], kidA, 'end')
-      const b = sideFor(node.children[bIndex], kidB, 'start')
-      const a0px = a.fixed ? a.size : sizeOf(kidA)
-      const b0px = b.fixed ? b.size : sizeOf(kidB)
-      const lo = Math.max(a.min - a0px, b0px - b.max)
-      const hi = Math.min(a.max - a0px, b0px - b.min)
+      const tracks = node.children.map((child, index) => {
+        const element = container.children[index] as HTMLElement | undefined
 
+        if (!element) {
+          return null
+        }
+
+        const side = sideFor(child, element, index <= aIndex ? 'end' : 'start')
+
+        return {
+          ...side,
+          element,
+          index,
+          initial: side.fixed ? side.size : sizeOf(element),
+          visible: !isCollapsed(child)
+        }
+      })
+
+      if (tracks.some(track => !track)) {
+        return
+      }
+
+      const sashTracks = tracks as Array<NonNullable<(typeof tracks)[number]>>
       const setOverride = horizontal ? setPaneWidthOverride : setPaneHeightOverride
+
+      const planFor = (requestedShift: number, allowCascade: boolean) => {
+        const targetIndex = requestedShift >= 0 ? aIndex : bIndex
+        const donorStep = requestedShift >= 0 ? 1 : -1
+        const target = sashTracks[targetIndex]
+        const requested = Math.abs(requestedShift)
+        const next = sashTracks.map(track => track.initial)
+        const targetCapacity = target.locked ? 0 : Math.max(0, target.max - target.initial)
+        let remaining = Math.min(requested, targetCapacity)
+        let transferred = 0
+        let cascaded = false
+        const immediateDonorIndex = targetIndex + donorStep
+        // A tool rail is locally resizable at its own seam, but must not make
+        // every unrelated seam in the row local-only. It also remains the
+        // terminal donor when reached only after another regular track.
+        const cascade = allowCascade && !target.collapseId
+
+        for (let donorIndex = immediateDonorIndex; donorIndex >= 0 && donorIndex < sashTracks.length; donorIndex += donorStep) {
+          const donor = sashTracks[donorIndex]
+
+          if (donor.collapseId && donorIndex !== immediateDonorIndex) {
+            break
+          }
+
+          if (!donor.visible || donor.locked) {
+            if (!cascade) {
+              break
+            }
+
+            continue
+          }
+
+          const take = Math.min(remaining, Math.max(0, donor.initial - donor.min))
+          next[donorIndex] -= take
+          transferred += take
+          remaining -= take
+
+          if (take > 0 && donorIndex !== targetIndex + donorStep) {
+            cascaded = true
+          }
+
+          if (remaining === 0 || !cascade) {
+            break
+          }
+        }
+
+        next[targetIndex] += transferred
+
+        return { cascaded, moved: Math.sign(requestedShift) * transferred, sizes: next }
+      }
+
+      const commitPlan = (plan: ReturnType<typeof planFor>) => {
+        const weights = [...node.weights]
+        let weightsChanged = false
+        sashTracks.forEach((track, index) => {
+          const px = Math.round(plan.sizes[index])
+
+          if (track.fixed) {
+            if (!track.locked && px !== Math.round(track.initial)) {
+              track.paneIds.forEach(id => setOverride(id, px))
+            }
+          } else if (track.visible) {
+            // Flex weights are relative. Pixel values preserve the on-screen
+            // ratio after fixed tracks have claimed their current widths.
+            weights[index] = Math.max(0.01, plan.sizes[index] / pxPerWeight)
+            weightsChanged = true
+          }
+        })
+
+        if (weightsChanged) {
+          setTreeSplitWeights(node.id, weights)
+        }
+      }
+
+      const styleSnapshots = sashTracks.map(track => track.element.getAttribute('style'))
+
+      const restoreStyles = () => {
+        sashTracks.forEach((track, index) => {
+          const style = styleSnapshots[index]
+
+          if (style === null) {
+            track.element.removeAttribute('style')
+          } else {
+            track.element.setAttribute('style', style)
+          }
+        })
+      }
+
+      const previewPlan = (plan: ReturnType<typeof planFor>) => {
+        sashTracks.forEach((track, index) => {
+          if (!track.visible) {
+            return
+          }
+
+          const px = plan.sizes[index]
+
+          // Outside a gesture a restored tool has the normal usable 80px CSS
+          // floor. While its sash is actively dragging, temporarily release
+          // that floor so it can reach the 28px collapse threshold; the next
+          // render clears this preview-only inline value.
+          if (track.collapseId) {
+            if (horizontal) {
+              track.element.style.minWidth = '0px'
+            } else {
+              track.element.style.minHeight = '0px'
+            }
+          }
+
+          if (track.fixed) {
+            track.element.style.flexBasis = `${px}px`
+          } else {
+            track.element.style.flex = `0 1 ${px}px`
+          }
+        })
+      }
 
       try {
         handle.setPointerCapture?.(pointerId)
@@ -262,80 +402,29 @@ export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boo
 
       document.body.style.cursor = horizontal ? 'col-resize' : 'row-resize'
       document.body.style.userSelect = 'none'
-      // Webview/iframe guests must not swallow the gesture — without this the
-      // drag froze the moment the pointer entered the in-app browser, so the
-      // seam could only shrink it a few px per press.
       const releaseGuests = guardGuestPointers()
-      // Suppress :root geometry-var writes for the gesture (see geometry.ts —
-      // each one restyles the whole document; they republish on release).
       beginSashDrag()
 
-      // pointermove outpaces 60fps and each write relayouts the whole pane tree,
-      // so coalesce to one apply per frame (rafCoalesce commits on cleanup).
-      //
-      // During the gesture the store is NOT written. setTreeSplitWeights /
-      // setPaneWidthOverride each mint a new tree/pane-state object, and the
-      // resulting commit walks every mounted pane — measured live on a real
-      // 2-session layout: 31 commits across a 58-frame drag, 20.7fps, with
-      // TreeNode at 490ms and Block/Ct re-parsing markdown for 620ms. The
-      // store is written ONCE on release; during the drag the seam is
-      // previewed with inline styles on the same wrappers React sizes.
-      //
-      // Preview rules (learned the hard way — a wrong shape here left a
-      // phantom gap where a hidden sidebar lived):
-      //  - a FIXED side gets ONLY a flex-basis override. Its wrapper renders
-      //    as `flex: 0 1 <track>`, so basis is the whole difference; grow and
-      //    shrink stay React's. Crucially the flex partner is left untouched,
-      //    so it keeps absorbing the remainder and no leftover gap can open.
-      //  - a flex-vs-flex seam pins both sides to `0 1 <px>`. Their combined
-      //    px is constant, so sibling flex tracks see the same leftover.
-      //  - cleanup: a real drag commits the store once, and React's re-render
-      //    rewrites the `flex` shorthand, which clears the overrides (writing
-      //    the shorthand resets the longhands). A no-movement click restores
-      //    the captured style attribute instead, since nothing re-renders.
-      const applyShift = (shiftPx: number) => {
-        if (a.fixed) {
-          a.paneIds.forEach(id => setOverride(id, Math.round(a0px + shiftPx)))
-        }
-
-        if (b.fixed) {
-          b.paneIds.forEach(id => setOverride(id, Math.round(b0px - shiftPx)))
-        }
-
-        if (!a.fixed && !b.fixed) {
-          const weights = [...node.weights]
-          // Clamped px → weights so persisted weights match what's on screen.
-          weights[aIndex] = (a0px + shiftPx) / pxPerWeight
-          weights[bIndex] = (b0px - shiftPx) / pxPerWeight
-          setTreeSplitWeights(node.id, weights)
-        }
-      }
-
-      const styleA = kidA.getAttribute('style')
-      const styleB = kidB.getAttribute('style')
-
-      const previewSide = (el: HTMLElement, fixed: boolean, px: number) => {
-        if (fixed) {
-          el.style.flexBasis = `${px}px`
-        } else if (!a.fixed && !b.fixed) {
-          el.style.flex = `0 1 ${px}px`
-        }
-        // Mixed seam, flex side: untouched — it absorbs what the fixed side
-        // gives up, exactly as the track model would render it.
-      }
-
-      const previewShift = (shiftPx: number) => {
-        previewSide(kidA, a.fixed, a0px + shiftPx)
-        previewSide(kidB, b.fixed, b0px - shiftPx)
-      }
-
-      const resize = rafCoalesce(previewShift)
-      let lastShift: null | number = null
+      const resize = rafCoalesce(previewPlan)
+      // A return drag stays local only after this gesture has actually crossed
+      // a second donor. A one-pixel opposite wobble must not poison the real
+      // forward movement that follows.
+      let cascadeDirection: -1 | 1 | null = null
+      let lastPlan: null | ReturnType<typeof planFor> = null
       let done = false
 
       const onMove = (ev: PointerEvent) => {
-        lastShift = Math.max(lo, Math.min(hi, (horizontal ? ev.clientX : ev.clientY) - start))
-        resize.push(lastShift)
+        const shift = (horizontal ? ev.clientX : ev.clientY) - start
+        const direction = Math.sign(shift) as -1 | 0 | 1
+
+        const allowCascade = cascadeDirection === null || direction === cascadeDirection
+        lastPlan = planFor(shift, allowCascade)
+
+        if (cascadeDirection === null && direction !== 0 && lastPlan.cascaded) {
+          cascadeDirection = direction
+        }
+
+        resize.push(lastPlan)
       }
 
       // Ends through several racing paths (pointerup, pointercancel, window
@@ -349,36 +438,21 @@ export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boo
         done = true
         resize.finish()
 
-        if (lastShift !== null) {
-          // Dragged a tool panel down to its collapsed header? Fold the zone
-          // to its rail instead of persisting a sliver — and DON'T write the
-          // sliver size, so restoring brings back the size it had before.
-          const collapsedSide =
-            (a.collapseId && a0px + lastShift <= a.floor && a.collapseId) ||
-            (b.collapseId && b0px - lastShift <= b.floor && b.collapseId) ||
-            null
+        if (lastPlan && lastPlan.moved !== 0) {
+          const collapsedSide = sashTracks.find(
+            (track, index) => track.collapseId && lastPlan!.sizes[index] <= track.floor
+          )?.collapseId
 
           if (collapsedSide) {
             setTreeGroupMinimized(collapsedSide, true)
           } else {
-            // One store commit; the re-render rewrites `flex` and clears the
-            // preview overrides.
-            applyShift(lastShift)
+            // One store commit; React rewrites the flex styles after release.
+            commitPlan(lastPlan)
           }
         } else {
-          // Click without movement: nothing will re-render, so put the
-          // wrappers' inline styles back exactly as React last wrote them.
-          if (styleA === null) {
-            kidA.removeAttribute('style')
-          } else {
-            kidA.setAttribute('style', styleA)
-          }
-
-          if (styleB === null) {
-            kidB.removeAttribute('style')
-          } else {
-            kidB.setAttribute('style', styleB)
-          }
+          // No usable movement means React will not rerender. Restore every
+          // track, not merely the two immediate seam partners.
+          restoreStyles()
         }
 
         // Geometry vars re-enable AFTER the final store commit above, so the
@@ -520,13 +594,14 @@ export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boo
   const tracks = node.children.map((child, i) => {
     const minimized = isMinimized(child)
     const collapsed = isCollapsed(child) || sideGone(i)
+    const toolZone = allPaneIds(child).length > 0 && allPaneIds(child).every(isCollapsePane)
     const track = minimized || collapsed ? null : fixedTrackSize(child, axis, trackCtx)
     const sizing = minimized || collapsed ? null : sizingFor(child, track)
     // Narrow-collapse UNMOUNTS (the edge overlay owns the live instance) — but
     // only for panes the breakpoint collapsed, not ones a chrome toggle hid.
     const narrowCollapsed = narrow && collapsed && allPaneIds(child).some(id => !hiddenPanes.has(id))
 
-    return { child, collapsed, minimized, narrowCollapsed, sizing, track }
+    return { child, collapsed, minimized, narrowCollapsed, sizing, toolZone, track }
   })
 
   const growable = tracks.map((_, i) => i).filter(i => !tracks[i].collapsed && !tracks[i].minimized)
@@ -578,7 +653,7 @@ export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boo
       data-tree-split={node.id}
       ref={containerRef}
     >
-      {tracks.map(({ child, collapsed, minimized, narrowCollapsed, sizing, track }, i) => {
+      {tracks.map(({ child, collapsed, minimized, narrowCollapsed, sizing, toolZone, track }, i) => {
         const partner = collapsed ? -1 : seamPartner(i)
         const absorbs = i === absorberIndex
 
@@ -603,9 +678,13 @@ export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boo
                       // (a rail's width clamp shouldn't constrain its height).
                       // The absorber is uncapped by selection, so dropping its
                       // max is a no-op; capped tracks always keep theirs.
-                      minWidth: (horizontal && sizing?.minWidth) || 0,
+                      // A restored tool can remain a flex track, so its CSS
+                      // floor must match the 80px floor used by the sash.
+                      // Otherwise a tiny remembered weight redraws Terminal as
+                      // a 0px edge sliver before the user can grab its divider.
+                      minWidth: horizontal ? (sizing?.minWidth ?? (toolZone ? `${MIN_PANE_PX}px` : 0)) : 0,
                       maxWidth: horizontal && !absorbs ? sizing?.maxWidth : undefined,
-                      minHeight: (!horizontal && sizing?.minHeight) || 0,
+                      minHeight: !horizontal ? (sizing?.minHeight ?? (toolZone ? `${MIN_PANE_PX}px` : 0)) : 0,
                       maxHeight: horizontal || absorbs ? undefined : sizing?.maxHeight
                     }
             }

--- a/apps/desktop/src/store/panes.ts
+++ b/apps/desktop/src/store/panes.ts
@@ -3,8 +3,12 @@ import { atom, computed, type ReadableAtom } from 'nanostores'
 export interface PaneStateSnapshot {
   open: boolean
   widthOverride?: number
+  /** True when the current width is a user-owned fixed size during sash drags. */
+  widthLocked?: boolean
   /** Vertical size override (px) for panes that resize on the Y axis (e.g. the bottom-row terminal). */
   heightOverride?: number
+  /** True when the current height is a user-owned fixed size during sash drags. */
+  heightLocked?: boolean
 }
 
 export interface PaneRegisterDefaults {
@@ -28,10 +32,14 @@ function isSnapshot(value: unknown): value is PaneStateSnapshot {
   const widthOk =
     r.widthOverride === undefined || (typeof r.widthOverride === 'number' && Number.isFinite(r.widthOverride))
 
+  const widthLockOk = r.widthLocked === undefined || typeof r.widthLocked === 'boolean'
+
   const heightOk =
     r.heightOverride === undefined || (typeof r.heightOverride === 'number' && Number.isFinite(r.heightOverride))
 
-  return widthOk && heightOk
+  const heightLockOk = r.heightLocked === undefined || typeof r.heightLocked === 'boolean'
+
+  return widthOk && widthLockOk && heightOk && heightLockOk
 }
 
 function load(): Record<string, PaneStateSnapshot> {
@@ -50,7 +58,13 @@ function load(): Record<string, PaneStateSnapshot> {
 
         for (const [id, value] of Object.entries(parsed as Record<string, unknown>)) {
           if (isSnapshot(value)) {
-            out[id] = { open: value.open, widthOverride: value.widthOverride, heightOverride: value.heightOverride }
+            out[id] = {
+              open: value.open,
+              heightLocked: value.heightLocked,
+              heightOverride: value.heightOverride,
+              widthLocked: value.widthLocked,
+              widthOverride: value.widthOverride
+            }
           }
         }
 
@@ -145,6 +159,20 @@ export function setPaneWidthOverride(id: string, width: number | undefined) {
   $paneStates.set({ ...current, [id]: { ...existing, widthOverride: width } })
 }
 
+/** Lock/unlock a pane's current width. A lock is intentionally separate from
+ * the override: unlock leaves the remembered value available to the next lock
+ * but stops treating a flex pane as a fixed track. */
+export function setPaneWidthLocked(id: string, locked: boolean) {
+  const current = $paneStates.get()
+  const existing = current[id] ?? { open: false }
+
+  if (Boolean(existing.widthLocked) === locked) {
+    return
+  }
+
+  $paneStates.set({ ...current, [id]: { ...existing, widthLocked: locked || undefined } })
+}
+
 export function setPaneHeightOverride(id: string, height: number | undefined) {
   const current = $paneStates.get()
   const existing = current[id] ?? { open: false }
@@ -154,6 +182,18 @@ export function setPaneHeightOverride(id: string, height: number | undefined) {
   }
 
   $paneStates.set({ ...current, [id]: { ...existing, heightOverride: height } })
+}
+
+/** See setPaneWidthLocked — the vertical counterpart used by stacked panels. */
+export function setPaneHeightLocked(id: string, locked: boolean) {
+  const current = $paneStates.get()
+  const existing = current[id] ?? { open: false }
+
+  if (Boolean(existing.heightLocked) === locked) {
+    return
+  }
+
+  $paneStates.set({ ...current, [id]: { ...existing, heightLocked: locked || undefined } })
 }
 
 export const clearPaneWidthOverride = (id: string) => setPaneWidthOverride(id, undefined)
@@ -167,7 +207,12 @@ export function clearAllPaneSizeOverrides() {
   const next: Record<string, PaneStateSnapshot> = {}
 
   for (const [id, state] of Object.entries(current)) {
-    if (state.widthOverride !== undefined || state.heightOverride !== undefined) {
+    if (
+      state.widthOverride !== undefined ||
+      state.heightOverride !== undefined ||
+      state.widthLocked ||
+      state.heightLocked
+    ) {
       changed = true
       next[id] = { open: state.open }
     } else {


### PR DESCRIPTION
## What does this PR do?

I changed Desktop pane resizing so a row or column behaves like one workspace instead of a set of unrelated boxes. When a pane grows, its neighbor gives up space first. If that neighbor reaches its minimum, the drag can continue through eligible direct siblings. Dragging back across the same seam stays local.

This also adds persistent width and height locks. A locked dimension remains fixed while the rest of the layout changes.

The follow-up commit fixes a release edge case beside an already-minimized tool rail. A collapsible track now counts as newly collapsed only when it started above its floor and ended at or below it. An unrelated minimized Terminal can no longer cancel persistence of the Files/Chat resize being released.

## Related Issue

I found no matching open issue or PR. I checked the current layout and sash work, including #87206, which fixes a separate nested-rail preview snap.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Cascade row and column resizes through eligible direct siblings while respecting pane floors.
- Keep reverse drags local after a forward cascade.
- Add persistent width and height locks, including one shared width lock for a stacked column inside a row split.
- Keep lock state consistent across visible tabs in the same zone and expose it when the tab strip is hidden.
- Restore collapsed tool zones at a usable width.
- Commit an ordinary resize even when another collapsible track, such as Terminal, was already resting at its floor.
- Add regression coverage for cascade direction, release behavior, dimension locks, hidden strips, shared columns, and restore sizing.

## How to Test

1. Arrange several panes in a row. Expand one until its immediate neighbor reaches its minimum; the drag should continue through eligible direct siblings.
2. Drag back across the same sash. Only the two panes at that seam should change.
3. Stack panes in a column and repeat the resize vertically.
4. Lock a pane's width or height from its menu. The locked axis should stay fixed until it is unlocked.
5. Minimize Terminal, resize the Files/Chat sash, and release it. The new Files width should remain saved while Terminal stays minimized.
6. Restore the tool zone. It should return at a usable width and remain resizable.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only pane-layout changes and their tests
- [ ] I've run `pytest tests/ -q` and all tests pass (N/A: this changes only Desktop TypeScript)
- [x] I've added tests for the changed behavior
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Relevant behavior is documented beside the layout code; no user-facing documentation changed
- [x] No configuration keys changed
- [x] No contributor workflow changed
- [x] I considered Windows and macOS behavior. The implementation stays inside the existing DOM/flex renderer and has no platform branch.
- [x] No tool schema changed

## Validation

On the exact PR branch, I ran the focused cascade, collapse/restore, and dimension-lock suites: 22/22 passed. Desktop TypeScript and changed-file ESLint passed. Prettier and `git diff --check` passed too.

I replayed the minimized-Terminal failure in a packaged Desktop build cloned from the affected layout. Files resized from 318 px to 218 px, Chat grew from 314 px to 414 px, and the saved Files width was 218 px. Terminal remained minimized at 28 px.

The same pane patch was also exercised in the combined local pane/performance package. Its full Desktop UI run passed 7,250/7,250 tests. That package contains separate performance work, so I am treating it as integration evidence rather than claiming it was the exact PR branch.
