### PR TITLE
fix(webhook): accept Standard Webhooks (webhook-*) signature headers

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -1,5 +1,5 @@
 """Generic webhook platform adapter: aiohttp server that validates HMAC-signed POSTs (GitHub, GitLab,
-Svix, Linear, generic), renders payloads into agent prompts, and routes responses back (github_comment
+Svix / Standard Webhooks, Linear, generic), renders payloads into agent prompts, and routes responses back (github_comment
 or any gateway platform). Routes live under platforms.webhook.extra.routes: events (header filter),
 secret (REQUIRED; "INSECURE_NO_AUTH" skips validation, loopback only), prompt template, skills,
 deliver/deliver_extra, deliver_only (rendered prompt IS the message). Per-route rate limiting,
@@ -548,8 +548,8 @@ class WebhookAdapter(BasePlatformAdapter):
             prompt = self._render_prompt(route_config.get("prompt", ""), payload, event_type, route_name)
             if skills := route_config.get("skills", []):
                 prompt = self._apply_skills(prompt, skills)
-        delivery_id = headers.get("X-GitHub-Delivery", headers.get(
-            "svix-id", headers.get("X-Request-ID", str(int(time.time() * 1000)))))
+        delivery_id = next((headers[name] for name in ("X-GitHub-Delivery", "svix-id", "webhook-id", "X-Request-ID")
+                            if headers.get(name)), str(int(time.time() * 1000)))
         now = time.time()  # idempotency: skip duplicate deliveries (webhook retries)
         if not self._record_delivery_id(delivery_id, now):
             logger.info("[webhook] Skipping duplicate delivery %s", delivery_id)
@@ -617,14 +617,17 @@ class WebhookAdapter(BasePlatformAdapter):
     # --- Signature validation ---
 
     def _validate_signature(self, request: "web.Request", body: bytes, secret: str) -> bool:
-        """Validate webhook signature (GitHub, GitLab, Svix, Linear, generic HMAC-SHA256)."""
+        """Validate webhook signature (GitHub, GitLab, Svix / Standard Webhooks, Linear, generic HMAC-SHA256)."""
         headers = request.headers
 
         def _header(name: str) -> str:
             return headers.get(name, "") or headers.get(name.lower(), "") or headers.get(name.upper(), "")
 
-        # Svix / AgentMail: signed content is "{id}.{timestamp}.{raw_body}".
-        svix = [_header(name) for name in ("svix-id", "svix-timestamp", "svix-signature")]
+        # Svix / AgentMail, and the Standard Webhooks spec Svix co-authored (webhook-id / webhook-timestamp /
+        # webhook-signature): identical scheme, signed content "{id}.{timestamp}.{raw_body}", "v1,<base64>"
+        # signatures and whsec_ secrets, so both header families share one validator (#47451, #101837).
+        svix = [_header(svix_name) or _header(standard_name) for svix_name, standard_name in (
+            ("svix-id", "webhook-id"), ("svix-timestamp", "webhook-timestamp"), ("svix-signature", "webhook-signature"))]
         if any(svix):
             return _validate_svix_signature(body, secret, *svix)
         # Linear (any header case): hex HMAC of the body. GitHub: sha256=<hex>. GitLab: plain token.

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -300,6 +300,68 @@ class TestValidateSignature:
         )
         assert adapter._validate_signature(req, body, secret) is True
 
+    # -- Standard Webhooks: webhook-id / webhook-timestamp / webhook-signature (#47451, #101837) --
+    # Same scheme as Svix (which co-authored the spec), only the header names differ.
+
+    @staticmethod
+    def _standard_webhooks_headers(body: bytes, secret: str, msg_id: str = "msg_std", timestamp: str | None = None):
+        timestamp = timestamp or str(int(time.time()))
+        return {
+            "webhook-id": msg_id,
+            "webhook-timestamp": timestamp,
+            "webhook-signature": _svix_signature(body, secret, msg_id, timestamp),
+        }
+
+    def test_standard_webhooks_whsec_secret_valid(self):
+        """A spec-conformant sender using the standard's own header names validates with a whsec_ secret."""
+        adapter = _make_adapter()
+        body = b'{"type":"feed.news_item.emitted"}'
+        secret = "whsec_" + base64.b64encode(b"0123456789abcdef0123456789abcdef").decode()
+        req = _mock_request(headers=self._standard_webhooks_headers(body, secret))
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_standard_webhooks_raw_secret_valid(self):
+        """Raw shared secrets work for webhook-* senders exactly as they do for svix-* senders."""
+        adapter = _make_adapter()
+        body = b'{"type":"invoice.created"}'
+        secret = "raw-shared-secret"
+        req = _mock_request(headers=self._standard_webhooks_headers(body, secret))
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_standard_webhooks_tampered_body_rejects(self):
+        """The signature binds the raw body: a modified body must fail."""
+        adapter = _make_adapter()
+        secret = "whsec_" + base64.b64encode(b"0123456789abcdef0123456789abcdef").decode()
+        req = _mock_request(headers=self._standard_webhooks_headers(b'{"amount":10}', secret))
+        assert adapter._validate_signature(req, b'{"amount":1000}', secret) is False
+
+    def test_standard_webhooks_wrong_secret_rejects(self):
+        adapter = _make_adapter()
+        body = b'{"type":"invoice.created"}'
+        req = _mock_request(headers=self._standard_webhooks_headers(body, "attacker-key"))
+        assert adapter._validate_signature(req, body, "real-secret") is False
+
+    def test_standard_webhooks_stale_timestamp_rejects(self):
+        """webhook-timestamp is bound by the same +/-300s replay window as svix-timestamp."""
+        adapter = _make_adapter()
+        body = b'{"type":"invoice.created"}'
+        secret = "raw-shared-secret"
+        stale = str(int(time.time()) - 3600)
+        req = _mock_request(headers=self._standard_webhooks_headers(body, secret, timestamp=stale))
+        assert adapter._validate_signature(req, body, secret) is False
+
+    def test_standard_webhooks_partial_headers_fail_closed(self):
+        """Presence of any webhook-* header commits to the scheme: a missing timestamp must not fall through
+        to the body-only generic validator."""
+        adapter = _make_adapter()
+        body = b'{"type":"invoice.created"}'
+        secret = "raw-shared-secret"
+        headers = self._standard_webhooks_headers(body, secret)
+        del headers["webhook-timestamp"]
+        headers["X-Webhook-Signature"] = _generic_signature(body, secret)  # would validate on its own
+        req = _mock_request(headers=headers)
+        assert adapter._validate_signature(req, body, secret) is False
+
 
 # ===================================================================
 # Prompt rendering
@@ -537,6 +599,24 @@ class TestIdempotency:
             assert resp2.status == 200
             data = await resp2.json()
             assert data["status"] == "duplicate"
+
+    @pytest.mark.asyncio
+    async def test_standard_webhooks_id_is_the_delivery_id(self):
+        """Standard Webhooks senders retry with the same webhook-id, so it must feed the idempotency cache."""
+        routes = {"idem": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            headers = {"webhook-id": "msg_2abc"}
+            resp1 = await cli.post("/webhooks/idem", json={"a": 1}, headers=headers)
+            assert resp1.status == 202
+            assert (await resp1.json())["delivery_id"] == "msg_2abc"
+
+            resp2 = await cli.post("/webhooks/idem", json={"a": 1}, headers=headers)
+            assert resp2.status == 200
+            assert (await resp2.json())["status"] == "duplicate"
 
 
 # ===================================================================

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -380,7 +380,7 @@ hermes webhook subscribe antenna-matches \
 | Status | Meaning |
 |--------|---------|
 | `200 OK` | Delivered successfully. Body: `{"status": "delivered", "route": "...", "target": "...", "delivery_id": "..."}` |
-| `200 OK` (status=duplicate) | Duplicate `X-GitHub-Delivery` ID within the idempotency TTL (1 hour). Not re-delivered. |
+| `200 OK` (status=duplicate) | Duplicate delivery ID (`X-GitHub-Delivery`, `svix-id`, `webhook-id`, or `X-Request-ID`) within the idempotency TTL (1 hour). Not re-delivered. |
 | `401 Unauthorized` | HMAC signature invalid or missing. |
 | `400 Bad Request` | Malformed JSON body. |
 | `404 Not Found` | Unknown route name. |
@@ -393,7 +393,7 @@ hermes webhook subscribe antenna-matches \
 - `deliver_only: true` requires `deliver` to be a real target. `deliver: log` (or omitting `deliver`) is rejected at startup — the adapter refuses to start if it finds a misconfigured route.
 - The `skills` field is ignored in direct delivery mode (no agent runs, so there's nothing to inject skills into).
 - Template rendering uses the same `{dot.notation}` syntax as agent mode, including the `{__raw__}` token.
-- Idempotency uses the same `X-GitHub-Delivery` / `X-Request-ID` header — retries with the same ID return `status=duplicate` and do NOT re-deliver.
+- Idempotency uses the same delivery ID headers (`X-GitHub-Delivery`, `svix-id`, `webhook-id`, `X-Request-ID`) — retries with the same ID return `status=duplicate` and do NOT re-deliver.
 
 ---
 
@@ -498,6 +498,7 @@ The adapter validates incoming webhook signatures using the appropriate method f
 
 - **GitHub**: `X-Hub-Signature-256` header — HMAC-SHA256 hex digest prefixed with `sha256=`
 - **GitLab**: `X-Gitlab-Token` header — plain secret string match
+- **Svix / Standard Webhooks**: `svix-id` + `svix-timestamp` + `svix-signature`, or the [Standard Webhooks](https://www.standardwebhooks.com/) names `webhook-id` + `webhook-timestamp` + `webhook-signature` — base64 HMAC-SHA256 of `<id>.<timestamp>.<body>` as `v1,<signature>`. Secrets are usually `whsec_<base64>`; a raw shared secret is accepted too. The timestamp must be within ±300 seconds of the server clock.
 - **Generic (V2, recommended)**: `X-Webhook-Signature-V2` + `X-Webhook-Timestamp` headers — HMAC-SHA256 hex digest of `<timestamp>.<body>`. The timestamp (Unix seconds) must be within ±300 seconds of the server clock, which prevents captured requests from being replayed later.
 - **Generic (V1, legacy)**: `X-Webhook-Signature` header — raw HMAC-SHA256 hex digest of the body only. Still accepted for backward compatibility, but it has no replay protection (a captured request replays indefinitely); the gateway logs a deprecation warning once per route. Switch senders to V2.
 
@@ -529,7 +530,7 @@ Requests exceeding the limit receive a `429 Too Many Requests` response.
 
 ### Idempotency
 
-Delivery IDs (from `X-GitHub-Delivery`, `X-Request-ID`, or a timestamp fallback) are cached for **1 hour**. Duplicate deliveries (e.g. webhook retries) are silently skipped with a `200` response, preventing duplicate agent runs.
+Delivery IDs (from `X-GitHub-Delivery`, `svix-id`, `webhook-id`, `X-Request-ID`, or a timestamp fallback) are cached for **1 hour**. Duplicate deliveries (e.g. webhook retries) are silently skipped with a `200` response, preventing duplicate agent runs.
 
 ### Body size limits
 
@@ -588,7 +589,7 @@ This is the same trust model that applies to everything the agent reads: web pag
 
 ### Duplicate responses
 
-- The idempotency cache should prevent this — check that the webhook source is sending a delivery ID header (`X-GitHub-Delivery` or `X-Request-ID`)
+- The idempotency cache should prevent this — check that the webhook source is sending a delivery ID header (`X-GitHub-Delivery`, `svix-id`, `webhook-id`, or `X-Request-ID`)
 - Delivery IDs are cached for 1 hour
 
 ### `gh` CLI errors (GitHub comment delivery)


### PR DESCRIPTION
## What does this PR do?

The webhook adapter validates the Svix signature scheme, but only under the `svix-id` / `svix-timestamp` / `svix-signature` header names. Senders that follow the [Standard Webhooks](https://www.standardwebhooks.com/) spec, which Svix co-authored and which has the identical wire format (HMAC-SHA256 over `{id}.{timestamp}.{body}`, `v1,<base64>` signatures, `whsec_` secrets), use `webhook-id` / `webhook-timestamp` / `webhook-signature` and are rejected with 401 regardless of the configured secret, because no header is ever matched.

This treats the `webhook-*` names as aliases of the `svix-*` names inside the existing `_validate_svix_signature` path (no new crypto), uses `webhook-id` as a delivery ID so Standard Webhooks retries dedupe, and documents both header families.

This is a rebase of #92024 (@teknium1, itself salvaging #47849 by @HwangJohn) onto current `main`: both of those, and #102080, no longer apply after the `_validate_signature` dispatcher refactor. Same behaviour, same test coverage as #92024, plus a fail-closed test for partial `webhook-*` headers. Happy to close this in favour of any of them if a maintainer rebases instead.

## Related Issue

Fixes #47451
Fixes #101837

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/platforms/webhook.py`: `_validate_signature` accepts `webhook-id` / `webhook-timestamp` / `webhook-signature` as aliases for the `svix-*` headers and routes them through the existing Svix validator. `webhook-id` joins `X-GitHub-Delivery`, `svix-id`, and `X-Request-ID` as a delivery ID source for the idempotency cache. Module and method docstrings updated.
- `tests/gateway/test_webhook_adapter.py`: Standard Webhooks accept with `whsec_` and raw secrets; tampered body, wrong secret, and stale timestamp reject; partial `webhook-*` headers fail closed rather than falling through to body-only generic V1; `webhook-id` dedupes a retry.
- `website/docs/user-guide/messaging/webhooks.md`: Svix / Standard Webhooks listed under signature validation; delivery ID headers listed under idempotency and troubleshooting.

## How to Test

1. `pytest tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_signature_rate_limit.py -q` → 45 passed (7 new).
2. `pytest tests/gateway -k webhook -q` → 136 passed, 7 skipped.
3. Manually: configure a route with a `whsec_` secret, POST a body signed per Standard Webhooks with `webhook-id` / `webhook-timestamp` / `webhook-signature` headers → 202; resend the same `webhook-id` → 200 `status=duplicate`; flip one body byte → 401.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (it is a rebase of #92024; see above)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the webhook test suites and all tests pass (full `pytest tests/ -q` not run locally)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (tests), Ubuntu 22.04 (live gateway with a Standard Webhooks sender)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (header matching only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7E27RAcU8Lt9UgNw7RiKT
