### PR TITLE
fix(delegate): fail child error summaries (#82599)

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -831,6 +831,68 @@ class TestDelegateFailedChildStatus(unittest.TestCase):
         self.assertEqual(entry["exit_reason"], "error")
         self.assertFalse(entry["truncated"])
 
+    def test_client_error_summary_without_error_field_marks_failed(self):
+        """Regression (#82599): older child result shapes can surface a
+        non-retryable provider/auth failure only as final_response while leaving
+        completed=False and omitting structured failed/error fields. A non-empty
+        HTTP error summary must not be mistaken for successful truncated work."""
+        entry = self._delegate_single(
+            {
+                "final_response": "HTTP 401: invalid x-api-key",
+                "completed": False,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [],
+            }
+        )
+        self.assertEqual(entry["status"], "failed")
+        self.assertEqual(entry["exit_reason"], "error")
+        self.assertFalse(entry["truncated"])
+        self.assertIn("HTTP 401", entry["error"])
+
+    def test_batch_client_error_summary_without_error_field_marks_failed(self):
+        """The public batch JSON must carry the same failure contract; callers
+        and UI icons read the serialized status/exit_reason, not private child
+        fields."""
+        parent = _make_mock_parent(depth=0)
+        with patch("run_agent.AIAgent") as MockAgent:
+            failed_child = MagicMock()
+            failed_child.model = "claude-sonnet-4-6"
+            failed_child.session_prompt_tokens = 0
+            failed_child.session_completion_tokens = 0
+            failed_child.run_conversation.return_value = {
+                "final_response": "HTTP 401: token expired or incorrect",
+                "completed": False,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [],
+            }
+            ok_child = MagicMock()
+            ok_child.model = "claude-sonnet-4-6"
+            ok_child.session_prompt_tokens = 0
+            ok_child.session_completion_tokens = 0
+            ok_child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [],
+            }
+            MockAgent.side_effect = [failed_child, ok_child]
+            result = json.loads(
+                delegate_task(
+                    tasks=[{"goal": "will fail auth"}, {"goal": "will finish"}],
+                    parent_agent=parent,
+                )
+            )
+
+        by_index = {entry["task_index"]: entry for entry in result["results"]}
+        self.assertEqual(by_index[0]["status"], "failed")
+        self.assertEqual(by_index[0]["exit_reason"], "error")
+        self.assertFalse(by_index[0]["truncated"])
+        self.assertIn("HTTP 401", by_index[0]["error"])
+        self.assertEqual(by_index[1]["status"], "completed")
+
     def test_empty_error_with_summary_is_completed(self):
         """REGRESSION PIN: an empty-string ``error`` field must NOT be treated as
         a failure. ``result.get('error')`` returns ``''`` which is falsy, so the

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -240,8 +240,9 @@ def _run_single_child(
 
     Contract, derived from the child's structured completion fields:
       status      ∈ {completed, interrupted, failed} — a structured failure
-                    (failed=True / non-empty error) or an invalid terminal state
-                    is "failed" even when a summary exists.
+                    (failed=True / non-empty error), a provider-error summary,
+                    or an invalid terminal state is "failed" even when a
+                    summary exists.
       exit_reason ∈ {completed, max_iterations, interrupted, error} —
                     "max_iterations" only for genuine budget exhaustion
                     (completed=False with no failure fields), never for errors.

--- a/tools/delegate_tool_child_run.py
+++ b/tools/delegate_tool_child_run.py
@@ -30,6 +30,38 @@ def _num(value: Any, default: int = 0) -> int:
 def _str_or_none(value: Any) -> Optional[str]:
     return value if isinstance(value, str) else None
 
+def _looks_like_child_error_summary(summary: str) -> bool:
+    """Detect legacy child result shapes that put the provider/client error in
+    ``final_response`` but omitted the newer ``failed``/``error`` fields.
+
+    Keep this intentionally narrower than a generic substring search so genuine
+    max-iteration summaries remain completed+truncated.
+    """
+    if _looks_like_error_output(summary):
+        return True
+    lines = (summary or "").strip().splitlines()
+    first = lines[0].strip().lower() if lines else ""
+    if first.startswith("http "):
+        parts = first.split(maxsplit=2)
+        status_token = parts[1].rstrip(":,") if len(parts) > 1 else ""
+        if status_token.isdigit() and 400 <= int(status_token) <= 599:
+            return True
+    return any(
+        marker in first
+        for marker in (
+            "authenticationerror",
+            "authorizationerror",
+            "badrequesterror",
+            "permissiondeniederror",
+            "rate limit",
+            "token expired",
+            "unauthorized",
+            "forbidden",
+            "invalid api key",
+            "invalid x-api-key",
+        )
+    )
+
 def _fabricated_entry(idx: int, status: str, error: str, child: Any, duration: float = 0) -> Dict[str, Any]:
     """Result entry for a child that raised, never finished, or was abandoned."""
     return {
@@ -471,7 +503,9 @@ def _build_result_entry(
     usable_summary = bool(summary) and summary.strip() != "(empty)"
     if result.get("interrupted", False):
         status, exit_reason = "interrupted", "interrupted"
-    elif result.get("failed") or result.get("error"):
+    elif result.get("failed") or result.get("error") or (
+        not result.get("completed", False) and _looks_like_child_error_summary(summary)
+    ):
         # The loop returns the error text as final_response, which would otherwise read as "completed". Never report a
         # provider rejection as "max_iterations" — that is only truthful for real budget exhaustion.
         status, exit_reason = "failed", "error"
@@ -518,7 +552,7 @@ def _build_result_entry(
                 "Final answer does not satisfy the declared output_schema" + (" (after 1 retry)." if schema.retries else ".")
             )
         else:
-            entry["error"] = result.get("error", "Subagent did not produce a response.")
+            entry["error"] = result.get("error") or summary or "Subagent did not produce a response."
         # Classified reason from the child loop (e.g. "rate_limit", "billing")
         # lets the parent tell a quota wall from a task error without parsing prose.
         _failure_reason = result.get("failure_reason")


### PR DESCRIPTION
## Summary

Closes #82599.

`delegate_task` now treats legacy child results with `completed=false` and an error-looking `final_response` as failed, instead of reporting them as successful truncated work.

This covers provider/auth failures such as `HTTP 401: token expired or incorrect` when older or partial child result shapes omit structured `failed`/`error` fields.

## What changed

- Added a narrow detector for child summaries whose first line is a clear provider/client failure (`HTTP 4xx/5xx`, auth/authorization errors, token expiry, rate limit markers).
- `_build_result_entry()` now returns `status="failed"`, `exit_reason="error"`, and `truncated=false` for those failure-shaped summaries.
- The error text is surfaced in the serialized delegate result when no structured `error` field exists.
- Genuine budget exhaustion still reports `status="completed"`, `exit_reason="max_iterations"`, and `truncated=true` when the child returned partial work without failure signals.

This PR intentionally does not change the related `delegation.base_url` credential-precedence behavior discussed in the issue. It fixes the false-success reporting path so that those and other auth/provider failures are visible to the parent agent and operator.

## Verification

- RED proof on upstream/main: the two new production-path regression tests failed before the fix with `AssertionError: 'completed' != 'failed'`.
- GREEN after the fix:
  - `scripts/run_tests.sh tests/tools/test_delegate.py::TestDelegateFailedChildStatus::test_client_error_summary_without_error_field_marks_failed tests/tools/test_delegate.py::TestDelegateFailedChildStatus::test_batch_client_error_summary_without_error_field_marks_failed tests/tools/test_delegate.py::TestDelegateFailedChildStatus::test_genuine_truncation_stays_completed_max_iterations tests/tools/test_delegate.py::TestDelegateFailedChildStatus::test_failed_flag_marks_status_failed -q`
  - Result: 4 passed, 0 failed.
- Nearby suite from the build phase:
  - `scripts/run_tests.sh tests/tools/test_delegate.py -q`
  - Result: 82 passed, 1 unrelated pre-existing macOS `/tmp` vs `/private/tmp` path-canonicalization failure in `TestDelegateTask.test_child_dedicated_db_follows_parents_db_path`.
- `git diff --check upstream/main...HEAD`: passed.
- `git rev-list --left-right --count upstream/main...HEAD`: `0 1`.

## Competitor check

- No open Tranquil-Flow PR references #82599 or uses a `fix/82599*` branch.
- Closed related PRs #91940 and #94503 were found.
- Open topic-overlap PR #97665 has green CI, but it covers the older structured `failed`/`error`-field provider-failure path and does not cover the legacy `final_response`-only result shape reproduced by #82599 on current upstream/main; it also predates the delegate module split. I scored it 6/10 for this issue, below the publication-blocking threshold.
- Guardrail-halt PRs #102705 and #102862 target #102694 and are not direct competitors.

Auto-published by Moonsong via Path B automated pipeline.
