### PR TITLE
feat(discord): support silent progress notifications

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1722,6 +1722,15 @@ display:
   # edit-in-place "⏳ Working — N min" heartbeat). Override under
   # display.platforms.telegram.
 
+  # Per-platform display and delivery behavior.
+  platforms:
+    discord:
+      # Native Discord push notifications:
+      #   all:       Legacy behavior; every message can notify (default)
+      #   important: Keep intermediate activity visible but silent; only the
+      #              last Discord message of notification-worthy output notifies
+      notifications: all
+
   # Auto-cleanup of temporary progress bubbles after the final response lands.
   # On platforms that support message deletion (currently Telegram), this
   # removes the tool-progress bubble, "⏳ Still working..." notices, and

--- a/contributors/emails/BenceBertalan@users.noreply.github.com
+++ b/contributors/emails/BenceBertalan@users.noreply.github.com
@@ -1,0 +1,2 @@
+BenceBertalan
+# PR #38028 salvage

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1960,6 +1960,29 @@ class BasePlatformAdapter(ABC):
         deleting the preview) instead of final-editing it (Telegram: keeps rich rendering)."""
         return False
 
+    @property
+    def notify_only_last_final_delivery(self) -> bool:
+        """Whether ``notify`` belongs only on the last logical delivery of a final response.
+
+        Most adapters keep their historical behavior. Platforms with native silent-message
+        support can opt in so text plus attachments still produces at most one push.
+        """
+        return False
+
+    def _metadata_for_final_delivery(
+        self, metadata: Optional[Dict[str, Any]], *, is_last: bool,
+    ) -> Optional[Dict[str, Any]]:
+        """Return metadata for one logical part of a completed response.
+
+        Opted-in adapters receive ``notify`` only on the last part. All other metadata,
+        including thread routing, is preserved and the caller's dictionary is never mutated.
+        """
+        if is_last or not self.notify_only_last_final_delivery:
+            return metadata
+        quiet_metadata = dict(metadata) if metadata else {}
+        quiet_metadata.pop("notify", None)
+        return quiet_metadata
+
     def streaming_overflow_limit(self) -> Optional[int]:
         """Max single-message length (``message_len_fn`` units) the stream consumer may
         accumulate before splitting, for rich send/draft paths exceeding the legacy cap
@@ -2790,7 +2813,11 @@ class BasePlatformAdapter(ABC):
         else:
             text = _media_failure_text("file", os.path.basename(media_path))
         try:
-            notice = await self.send(chat_id=chat_id, content=text, metadata=metadata)
+            notice = await self.send(
+                chat_id=chat_id,
+                content=text,
+                metadata=_mark_notify_metadata(metadata),
+            )
             problem = None if notice.success else notice.error
         except Exception as notify_err:
             problem = notify_err
@@ -3677,36 +3704,52 @@ class BasePlatformAdapter(ABC):
             return Path(path).suffix.lower() in _IMAGE_EXTS and not force_document_attachments
         _image_paths = [p for p, is_voice in media_files if not is_voice and _as_image(p)]
         _image_paths += [p for p in local_files if _as_image(p)]
+        queue = [(p, v, True) for p, v in media_files if v or not _as_image(p)]
+        queue += [(p, False, False) for p in local_files if not _as_image(p)]
         if _image_paths:
             await self._send_image_batch(
-                event, [(f"file://{_quote(p)}", "") for p in _image_paths], metadata, human_delay)
+                event,
+                [(f"file://{_quote(p)}", "") for p in _image_paths],
+                self._metadata_for_final_delivery(metadata, is_last=not queue) or {},
+                human_delay,
+            )
         chat_id = event.source.chat_id
 
-        async def _send_one(path: str, *, is_voice: bool, media_tag: bool) -> None:
+        async def _send_one(
+            path: str, *, is_voice: bool, media_tag: bool, send_metadata: Dict[str, Any],
+        ) -> None:
             """MEDIA-tag files (``media_tag``) may route to send_voice; bare local files never
             do."""
             ext = Path(path).suffix.lower()
             if media_tag and should_send_media_as_audio(self.platform, ext, is_voice=is_voice):
-                result = await self.send_voice(chat_id=chat_id, audio_path=path, metadata=metadata, is_voice=is_voice)
+                result = await self.send_voice(
+                    chat_id=chat_id, audio_path=path, metadata=send_metadata, is_voice=is_voice)
             elif ext in _VIDEO_EXTS:
                 if media_tag:
                     logger.info("[%s] Sending video attachment (%s) to %s", self.name, ext, chat_id)
-                result = await self.send_video(chat_id=chat_id, video_path=path, metadata=metadata)
+                result = await self.send_video(
+                    chat_id=chat_id, video_path=path, metadata=send_metadata)
             else:
-                result = await self.send_document(chat_id=chat_id, file_path=path, metadata=metadata)
+                result = await self.send_document(
+                    chat_id=chat_id, file_path=path, metadata=send_metadata)
             if not result.success:
                 logger.warning("[%s] Failed to send %s (%s): %s", self.name,
                                "media" if media_tag else "local file", ext, result.error)
-                await self._notify_media_delivery_failure(chat_id, path, is_voice=is_voice, metadata=metadata)
-        queue = [(p, v, True) for p, v in media_files if v or not _as_image(p)]
+                await self._notify_media_delivery_failure(
+                    chat_id, path, is_voice=is_voice, metadata=send_metadata)
         if queue:
             logger.info("[%s] Delivering %d non-image MEDIA attachment(s)", self.name, len(queue))
-        queue += [(p, False, False) for p in local_files if not _as_image(p)]
-        for path, is_voice, media_tag in queue:
+        for index, (path, is_voice, media_tag) in enumerate(queue):
             if human_delay > 0:
                 await asyncio.sleep(human_delay)
+            send_metadata = self._metadata_for_final_delivery(
+                metadata, is_last=index == len(queue) - 1,
+            ) or {}
             try:
-                await _send_one(path, is_voice=is_voice, media_tag=media_tag)
+                await _send_one(
+                    path, is_voice=is_voice, media_tag=media_tag,
+                    send_metadata=send_metadata,
+                )
             except Exception as err:
                 if media_tag:
                     logger.warning("[%s] Error sending media: %s", self.name, err)
@@ -3748,7 +3791,7 @@ class BasePlatformAdapter(ABC):
         _thread_metadata = None
         try:
             error_detail = str(e)[:300] if str(e) else "no details available"
-            _thread_metadata = _thread_metadata_for_event(event)
+            _thread_metadata = _mark_notify_metadata(_thread_metadata_for_event(event))
             await self.send(
                 chat_id=event.source.chat_id,
                 content=(f"Sorry, I encountered an error ({type(e).__name__}).\n{error_detail}\n"
@@ -3766,7 +3809,10 @@ class BasePlatformAdapter(ABC):
         images, media_files, local_files = extracted.images, extracted.media_files, extracted.local_files
         if images:
             logger.info("[%s] Extracted %d image(s) to send as attachments", self.name, len(images))
-            await self._send_image_batch(event, images, metadata, human_delay)
+            image_metadata = self._metadata_for_final_delivery(
+                metadata, is_last=not (media_files or local_files),
+            ) or {}
+            await self._send_image_batch(event, images, image_metadata, human_delay)
         await self._deliver_media_attachments(
             event, media_files, local_files,
             force_document_attachments=extracted.force_document_attachments,
@@ -3905,6 +3951,14 @@ class BasePlatformAdapter(ABC):
                 text_content, media_files = extracted.text_content, extracted.media_files
                 # Final content gets notify=True; typing metadata stays unmarked (thread-strict).
                 _final_thread_metadata = _mark_notify_metadata(_thread_metadata)
+                _notify_last_only = (
+                    self.notify_only_last_final_delivery
+                    and bool(_final_thread_metadata.get("notify"))
+                )
+                _nonfinal_metadata = (
+                    self._metadata_for_final_delivery(_final_thread_metadata, is_last=False)
+                    or {}
+                )
                 _tts_paths, _tts_requested_path = [], None
                 if self._wants_auto_tts(
                         event, session_key, interrupt_event, text_content, media_files):
@@ -3914,7 +3968,8 @@ class BasePlatformAdapter(ABC):
                 for _tts_index, _tts_path in enumerate(_tts_paths):
                     try:
                         _tts_caption_delivered |= await self._play_tts_file(
-                            event, text_content, _tts_path, _tts_index == 0, _final_thread_metadata,
+                            event, text_content, _tts_path, _tts_index == 0,
+                            _nonfinal_metadata if _notify_last_only else _final_thread_metadata,
                             _record_delivery)
                     finally:
                         with contextlib.suppress(OSError):
@@ -3922,13 +3977,27 @@ class BasePlatformAdapter(ABC):
                 if not _tts_paths and _tts_requested_path is not None:
                     with contextlib.suppress(OSError):
                         os.remove(_tts_requested_path)
-                if text_content and not _tts_caption_delivered:
+                if _notify_last_only and text_content and not _tts_caption_delivered:
+                    # Discord ``important`` mode needs the completed text to be the last physical
+                    # message even when the response also has attachments. Deliver attachments
+                    # first without ``notify``; the final text is the sole notification candidate.
+                    await self._deliver_attachments(
+                        event, extracted, _nonfinal_metadata,
+                        anything_sent=(
+                            delivery_attempted or _tts_caption_delivered or bool(text_content)
+                        ),
+                    )
                     await self._send_final_text(
                         event, session_key, text_content, _final_thread_metadata,
                         is_ephemeral_response, _ephemeral_ttl, _record_delivery)
-                await self._deliver_attachments(
-                    event, extracted, _final_thread_metadata,
-                    anything_sent=delivery_attempted or _tts_caption_delivered)
+                else:
+                    if text_content and not _tts_caption_delivered:
+                        await self._send_final_text(
+                            event, session_key, text_content, _final_thread_metadata,
+                            is_ephemeral_response, _ephemeral_ttl, _record_delivery)
+                    await self._deliver_attachments(
+                        event, extracted, _final_thread_metadata,
+                        anything_sent=delivery_attempted or _tts_caption_delivered)
             processing_ok = delivery_succeeded if delivery_attempted else not bool(response)
             # Clean up the per-turn streaming-TTS flag.
             self._streaming_tts_completed_turns.discard(self._streaming_tts_turn_key(

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1278,7 +1278,11 @@ class TurnRunner:
         msg = _format_exec_approval_fallback(cmd, desc, getattr(adapter, "typed_command_prefix", "/"), **flags)
         try:
             # Mark as approval prompt so WeCom routes through the control lane.
-            metadata = {**(ctx._status_thread_metadata or {}), "is_approval_prompt": True}
+            metadata = {
+                **(ctx._status_thread_metadata or {}),
+                "is_approval_prompt": True,
+                "notify": True,
+            }
             fut = self._schedule(
                 adapter.send(ctx._status_chat_id, msg, metadata=_interim_metadata(metadata)), "Approval text-send scheduling error",
             )

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -723,8 +723,15 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
             chunks = self._split_text_chunks(self._accumulated, self._safe_limit, self._len_fn)
         reply_to = self._initial_reply_to_id
         heads_delivered = len(chunks) > 1
+        notify_last_only = (
+            getattr(self.adapter, "notify_only_last_final_delivery", False) is True
+        )
         for chunk in chunks[:-1]:
-            new_id = await self._send_new_chunk(chunk, reply_to, final=tick.got_done)
+            new_id = await self._send_new_chunk(
+                chunk,
+                reply_to,
+                final=tick.got_done and not notify_last_only,
+            )
             if new_id is None or new_id == reply_to:
                 heads_delivered = False  # keep the full text intact for the gateway fallback
                 break
@@ -732,9 +739,11 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
 
         if heads_delivered:
             self._accumulated = chunks[-1]
-            # Flag BEFORE the tail send: fresh-final replaces every tracked preview
-            # with one message, which is only valid while the active message holds
-            # the whole answer — deleting sealed heads drops delivered text.
+            # These ids are sealed heads, not previews of the active tail. Keep
+            # them in the turn-wide ledger but exclude them from segment cleanup.
+            self._segment_preview_message_ids = set()
+            # Flag BEFORE the tail send so fresh-final cleanup is segment-scoped
+            # and cannot delete those sealed heads.
             self._turn_split_delivery = True
         # Heads are sealed (or a later head failed): never edit a sealed message with
         # the unsplit payload — the tail is sent fresh, or the fallback path retries.
@@ -782,6 +791,8 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
             if self._fallback_final_send or not ok:
                 break  # keep the full text intact for the fallback final send
             self._accumulated = self._accumulated[split_at:].lstrip("\n")
+            # The finalized head must survive any fresh replacement of the tail.
+            self._segment_preview_message_ids = set()
             self._message_id = None
             self._last_sent_text = ""
             self._turn_split_delivery = True

--- a/gateway/stream_consumer_fallback.py
+++ b/gateway/stream_consumer_fallback.py
@@ -97,9 +97,12 @@ class StreamFallbackMixin:
         last_message_id: Optional[str] = None
         last_successful_chunk = ""
         sent_any_chunk = False
-        for chunk in chunks:
+        for index, chunk in enumerate(chunks):
             result = await self._send_with_flood_retry(
-                content=chunk, retry_log="Flood control on fallback send, retrying in %.1fs")
+                content=chunk,
+                final=index == len(chunks) - 1,
+                retry_log="Flood control on fallback send, retrying in %.1fs",
+            )
             if not result or not result.success:
                 # Partial continuation landed: do NOT set _final_response_sent (the
                 # gateway must still deliver the full answer); _already_sent only
@@ -191,11 +194,13 @@ class StreamFallbackMixin:
                 logger.debug("per-chat limit resolution failed: %s", e)
         return _len_fn, raw_limit
 
-    async def _send_with_flood_retry(self, *, content: str, retry_log: str, reply_to=None):
-        """adapter.send(final metadata) with ONE bounded flood retry; returns the last
+    async def _send_with_flood_retry(
+        self, *, content: str, retry_log: str, reply_to=None, final: bool = True
+    ):
+        """adapter.send(metadata) with ONE bounded flood retry; returns the last
         SendResult.  Exceptions propagate (callers decide whether a raise is "ambiguous")."""
         kwargs = dict(chat_id=self.chat_id, content=content,
-                      metadata=self._metadata_for_send(final=True))
+                      metadata=self._metadata_for_send(final=final))
         if reply_to is not None:
             kwargs["reply_to"] = reply_to
         result = None

--- a/gateway/stream_consumer_transport.py
+++ b/gateway/stream_consumer_transport.py
@@ -22,17 +22,30 @@ class StreamTransportMixin:
 
     _MIN_NEW_MSG_CHARS = 4
 
-    async def _edit_message(self, *, message_id: str, content: str, finalize: bool = False):
+    async def _edit_message(
+        self, *, message_id: str, content: str, finalize: bool = False,
+        notify: bool = False,
+    ):
         """Edit via the adapter, passing routing metadata when supported."""
         # Contract: adapters must accept finalize= even when False (test-guarded).
-        kwargs = dict(chat_id=self.chat_id, message_id=message_id, content=content,
-                      finalize=finalize)
-        if self.metadata:
+        kwargs: dict[str, Any] = dict(
+            chat_id=getattr(self, "chat_id"),
+            message_id=message_id,
+            content=content,
+            finalize=finalize,
+        )
+        metadata_for_send = getattr(self, "_metadata_for_send", None)
+        send_metadata = (
+            metadata_for_send(final=True)
+            if notify and callable(metadata_for_send)
+            else getattr(self, "metadata", None)
+        )
+        if send_metadata:
             try:
                 params = inspect.signature(self.adapter.edit_message).parameters
                 if "metadata" in params or any(
                     param.kind is inspect.Parameter.VAR_KEYWORD for param in params.values()):
-                    kwargs["metadata"] = self.metadata
+                    kwargs["metadata"] = send_metadata
             except (TypeError, ValueError):
                 pass
         return await self.adapter.edit_message(**kwargs)
@@ -247,7 +260,13 @@ class StreamTransportMixin:
         # ``is True`` keeps MagicMock auto-children from enabling fresh-final.
         return result is True
 
-    async def _try_fresh_final(self, text: str, *, is_turn_final: bool = True) -> bool:
+    async def _try_fresh_final(
+        self,
+        text: str,
+        *,
+        is_turn_final: bool = True,
+        replace_split_tail: bool = False,
+    ) -> bool:
         """Send ``text`` fresh and best-effort delete the preview(s); False on any failure so
         the caller falls back to edit.  ``is_turn_final=False`` leaves the delivery flag unset.
 
@@ -256,14 +275,22 @@ class StreamTransportMixin:
         the real answer from the next API call (#29346).
         Ported from openclaw/openclaw#72038.
         """
-        # Replacing every preview is only sound while ``text`` holds the whole answer;
-        # after a split, deleting sealed heads would erase delivered text.
-        if self._turn_split_delivery:
+        # Generic fresh-final replacement is unsafe after an overflow split: sealed
+        # heads contain earlier portions of the answer while ``text`` is only the
+        # active tail. An adapter that explicitly requires a fresh turn-final send
+        # (Discord important notifications) may replace only that active tail.
+        if self._turn_split_delivery and not replace_split_tail:
             return False
-        stale_ids = self._stale_preview_ids()
+        if self._turn_split_delivery:
+            stale_ids = {str(self._message_id)} if self._has_real_preview() else set()
+        else:
+            stale_ids = self._stale_preview_ids()
         try:
             result = await self.adapter.send(
-                chat_id=self.chat_id, content=text, metadata=self._metadata_for_send(final=True))
+                chat_id=getattr(self, "chat_id"),
+                content=text,
+                metadata=getattr(self, "_metadata_for_send")(final=is_turn_final),
+            )
         except Exception as e:
             logger.debug("Fresh-final send failed, falling back to edit: %s", e)
             return False
@@ -273,6 +300,7 @@ class StreamTransportMixin:
         # Best-effort preview cleanup; never delete the message just sent.
         await self._delete_previews(stale_ids, skip=new_message_id, label="Fresh-final")
         self._preview_message_ids = set()
+        self._segment_preview_message_ids = set()
         self._adopt_message_id(new_message_id)
         self._already_sent = True
         self._last_sent_text = text
@@ -331,7 +359,9 @@ class StreamTransportMixin:
         self._last_edit_overflowed = False
         try:
             if self._message_id is None:
-                return await self._first_send(text, finalize=finalize)
+                return await self._first_send(
+                    text, finalize=finalize, is_turn_final=is_turn_final
+                )
             if not self._edit_supported:
                 return False  # edits unsupported; fallback path sends the final
             return await self._edit_existing(text, finalize=finalize, is_turn_final=is_turn_final)
@@ -415,16 +445,32 @@ class StreamTransportMixin:
         # send must still fire so the user gets a real message.
         return True if await self._send_draft_frame(frame_text) else None
 
-    async def _first_send(self, text: str, *, finalize: bool) -> bool:
+    async def _first_send(
+        self, text: str, *, finalize: bool, is_turn_final: bool
+    ) -> bool:
         """First send, threaded to the user's message (correct topic/thread)."""
+        turn_final = finalize and is_turn_final
         result = await self.adapter.send(
             chat_id=self.chat_id, content=text, reply_to=self._initial_reply_to_id,
-            metadata=self._metadata_for_send(final=finalize, expect_edits=not finalize))
+            metadata=self._metadata_for_send(
+                final=turn_final, expect_edits=not finalize
+            ))
         if not result.success:
             self._edit_supported = False
             return False
         self._already_sent = True
         self._last_sent_text = text
+        if (
+            turn_final
+            and getattr(
+                getattr(self, "adapter"), "notify_only_last_final_delivery", False
+            )
+            is True
+        ):
+            # This was already a fresh notification-capable final send. Do not
+            # run a second fresh-final pass merely because the adapter requires
+            # finalization when the active transport is an edit.
+            self._final_response_sent = True
         if result.message_id:
             self._adopt_message_id(result.message_id)
             self._track_preview_ids_from_result(result)
@@ -450,12 +496,30 @@ class StreamTransportMixin:
             hasattr(type(self.adapter), "prefers_fresh_final_streaming")
             or "prefers_fresh_final_streaming" in getattr(self.adapter, "__dict__", {}))
         prefers_fresh = self._adapter_prefers_fresh_final(text)  # probed every edit (hook contract)
-        if finalize and (
+        fresh_final_requested = finalize and (
             prefers_fresh or (not has_prefers_hook and self._should_send_fresh_final())
-        ) and await self._try_fresh_final(text, is_turn_final=is_turn_final):
-            return True
-        result = await self._edit_message(message_id=self._message_id, content=text,
-                                          finalize=finalize)
+        )
+        if fresh_final_requested:
+            if await self._try_fresh_final(
+                text,
+                is_turn_final=is_turn_final,
+                replace_split_tail=(
+                    self._turn_split_delivery and prefers_fresh and is_turn_final
+                ),
+            ):
+                return True
+            if prefers_fresh and is_turn_final:
+                # The adapter requires a fresh message because an edit cannot
+                # create the intended final notification. Do not silently
+                # downgrade to an edit and mark the turn complete.
+                self._enter_fallback_mode(self._visible_prefix())
+                return False
+        result = await self._edit_message(
+            message_id=self._message_id,
+            content=text,
+            finalize=finalize,
+            notify=finalize and is_turn_final,
+        )
         if not result.success:
             return await self._on_edit_failure(result, text, finalize=finalize,
                                                is_turn_final=is_turn_final)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -31,6 +31,14 @@ from urllib.parse import quote, urljoin
 
 from agent.async_utils import (consume_detached_task_result as _consume_background_task_result)
 from agent.display import ToolPreview
+from plugins.platforms.discord.notifications import (
+    NOTIFICATIONS_ALL,
+    NOTIFICATIONS_IMPORTANT,
+    normalize_notification_mode,
+    notification_kwargs as discord_notification_kwargs,
+    resolve_notification_mode,
+    with_suppress_notifications_flag,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1077,6 +1085,9 @@ class DiscordAdapter(BasePlatformAdapter):
         self._dedup = MessageDeduplicator()
         # Reply threading mode: "off", "first" (default; first chunk only), "all" (every chunk).
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
+        self._set_notifications_mode(
+            self.config.extra.get("notifications", NOTIFICATIONS_ALL)
+        )
         self._slash_commands: bool = self.config.extra.get("slash_commands", True)
         # Bot's last message ID per channel: lets history backfill skip the full channel.history() scan.
         self._last_self_message_id: Dict[str, str] = {}
@@ -2806,6 +2817,42 @@ class DiscordAdapter(BasePlatformAdapter):
         kept.append(notice)
         return kept
 
+    def _notification_kwargs(
+        self,
+        metadata: Optional[Dict[str, Any]] = None,
+        *,
+        final_chunk: bool = True,
+    ) -> Dict[str, Any]:
+        """Return discord.py kwargs for one physical outbound message."""
+        return discord_notification_kwargs(
+            mode=getattr(self, "_notifications_mode", NOTIFICATIONS_ALL),
+            metadata=metadata,
+            final_chunk=final_chunk,
+        )
+
+    def _set_notifications_mode(self, value: Any) -> None:
+        """Apply notification mode and its edit-stream finalization contract together."""
+        self._notifications_mode = normalize_notification_mode(value)
+        # A silent preview cannot gain a Discord push through an edit. Important
+        # mode therefore requires a finalization pass that replaces it with a
+        # fresh notification-capable message.
+        self.REQUIRES_EDIT_FINALIZE = (
+            self._notifications_mode == NOTIFICATIONS_IMPORTANT
+        )
+
+    @property
+    def notify_only_last_final_delivery(self) -> bool:
+        """Put final-turn ``notify`` metadata only on the last logical delivery."""
+        return getattr(self, "_notifications_mode", NOTIFICATIONS_ALL) == NOTIFICATIONS_IMPORTANT
+
+    def prefers_fresh_final_streaming(
+        self,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Replace a silent streaming preview so the completed response can notify."""
+        return self.notify_only_last_final_delivery
+
     async def send(
         self,
         chat_id: str,
@@ -2843,7 +2890,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     return SendResult(success=False, error=f"Channel {chat_id} not found")
             # Forum channels reject channel.send() — create a thread post instead.
             if self._is_forum_parent(channel):
-                result = await self._send_to_forum(channel, content)
+                result = await self._send_to_forum(channel, content, metadata=metadata)
                 return await self._record_response_async(reply_to, result, content, final_delivery)
             formatted = self.format_message(content)
             chunks = self._cap_split_chunks(
@@ -2856,8 +2903,16 @@ class DiscordAdapter(BasePlatformAdapter):
                     chunk_reference = reference
                 else:  # "first" (default) or "off"
                     chunk_reference = reference if i == 0 else None
+                notification_kwargs = self._notification_kwargs(
+                    metadata,
+                    final_chunk=i == len(chunks) - 1,
+                )
                 try:
-                    msg = await channel.send(content=chunk, reference=chunk_reference)
+                    msg = await channel.send(
+                        content=chunk,
+                        reference=chunk_reference,
+                        **notification_kwargs,
+                    )
                 except Exception as e:
                     if chunk_reference is not None and self._is_reply_reference_rejected(e):
                         logger.warning(
@@ -2865,7 +2920,11 @@ class DiscordAdapter(BasePlatformAdapter):
                             self.name, reply_to,
                         )
                         reference = None
-                        msg = await channel.send(content=chunk, reference=None)
+                        msg = await channel.send(
+                            content=chunk,
+                            reference=None,
+                            **notification_kwargs,
+                        )
                     else:
                         raise
                 message_ids.append(str(msg.id))
@@ -2904,7 +2963,12 @@ class DiscordAdapter(BasePlatformAdapter):
         message_id = str(getattr(starter_msg, "id", thread_id)) if starter_msg else thread_id
         return thread_channel, thread_id, starter_msg, message_id
 
-    async def _send_to_forum(self, forum_channel: Any, content: str) -> SendResult:
+    async def _send_to_forum(
+        self,
+        forum_channel: Any,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
         """Create a forum thread post with the message as starter (forum channels reject direct
         sends; name from the first line). Chunk failures land in ``raw_response['warnings']``."""
         formatted = self.format_message(content)
@@ -2912,16 +2976,26 @@ class DiscordAdapter(BasePlatformAdapter):
         thread_name = _derive_forum_thread_name(content)
         starter_content = chunks[0] if chunks else thread_name
         try:
-            thread = await forum_channel.create_thread(name=thread_name, content=starter_content)
+            thread = await forum_channel.create_thread(
+                name=thread_name,
+                content=starter_content,
+                **self._notification_kwargs(metadata, final_chunk=len(chunks) <= 1),
+            )
         except Exception as e:
             logger.error("[%s] Failed to create forum thread in %s: %s", self.name, forum_channel.id, e)
             return SendResult(success=False, error=f"Forum thread creation failed: {e}")
         thread_channel, thread_id, starter_msg, message_id = self._forum_thread_parts(thread)
         message_ids = [message_id]
         warnings: list[str] = []
-        for chunk in chunks[1:]:
+        for index, chunk in enumerate(chunks[1:], start=1):
             try:
-                msg = await thread_channel.send(content=chunk)
+                msg = await thread_channel.send(
+                    content=chunk,
+                    **self._notification_kwargs(
+                        metadata,
+                        final_chunk=index == len(chunks) - 1,
+                    ),
+                )
                 message_ids.append(str(msg.id))
             except Exception as e:
                 warning = f"Failed to send follow-up chunk to forum thread {thread_id}: {e}"
@@ -2935,6 +3009,7 @@ class DiscordAdapter(BasePlatformAdapter):
     async def _forum_post_file(
         self, forum_channel: Any, *, thread_name: Optional[str] = None, content: str = "",
         file: Any = None, files: Optional[list] = None,
+        metadata: Optional[Dict[str, Any]] = None, final_chunk: bool = True,
     ) -> SendResult:
         """Create a forum thread whose starter message carries file attachments."""
         if not thread_name:
@@ -2952,6 +3027,7 @@ class DiscordAdapter(BasePlatformAdapter):
             kwargs["file"] = file
         if files:
             kwargs["files"] = files
+        kwargs.update(self._notification_kwargs(metadata, final_chunk=final_chunk))
         try:
             thread = await forum_channel.create_thread(**kwargs)
         except Exception as e:
@@ -3012,7 +3088,9 @@ class DiscordAdapter(BasePlatformAdapter):
             # Pre-flight oversize: final edits split-and-deliver; streaming edits truncate in place.
             if len(formatted) > self.MAX_MESSAGE_LENGTH:
                 if finalize:
-                    return await self._edit_overflow_split(channel, msg, message_id, content)
+                    return await self._edit_overflow_split(
+                        channel, msg, message_id, content, metadata=metadata,
+                    )
                 formatted = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)[0]
                 _saturated_preview = True
                 # Saturated-preview dedup: past the cap every edit is the same text; skip until finalize.
@@ -3031,7 +3109,9 @@ class DiscordAdapter(BasePlatformAdapter):
                 # Reactive split: format_message inflation can exceed 2,000 (50035) even after pre-flight.
                 if self._is_length_overflow_error(edit_err):
                     if finalize:
-                        return await self._edit_overflow_split(channel, msg, message_id, content)
+                        return await self._edit_overflow_split(
+                            channel, msg, message_id, content, metadata=metadata,
+                        )
                     truncated = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)[0]
                     if self._last_overflow_preview.get(_preview_key) == truncated:
                         # Saturated-preview dedup (see pre-flight path above).
@@ -3067,6 +3147,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def _edit_overflow_split(
         self, channel: Any, msg: Any, message_id: str, content: str,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Deliver an oversized final edit: edit ``message_id`` with chunk 1, send chunks 2..N as
         replies to the previous. Returns ``message_id=<last-id>`` + ``continuation_message_ids``.
@@ -3088,7 +3169,7 @@ class DiscordAdapter(BasePlatformAdapter):
         continuation_ids: list[str] = []
         delivered = 1
         prev_msg = msg
-        for chunk in chunks[1:]:
+        for index, chunk in enumerate(chunks[1:], start=1):
             reference = None
             if hasattr(prev_msg, "to_reference"):
                 try:
@@ -3098,8 +3179,13 @@ class DiscordAdapter(BasePlatformAdapter):
             elif getattr(prev_msg, "id", None):
                 # Prior message without to_reference (duck-typed): build the reference from ids.
                 reference = self._message_reference_from_ids(prev_msg.id, channel)
+            notification_kwargs = self._notification_kwargs(
+                metadata, final_chunk=index == len(chunks) - 1,
+            )
             try:
-                sent = await channel.send(content=chunk, reference=reference)
+                sent = await channel.send(
+                    content=chunk, reference=reference, **notification_kwargs,
+                )
             except Exception as send_err:
                 # Drop the reply anchor and retry once: deleted anchor (10008) / system message (50035).
                 logger.warning(
@@ -3107,7 +3193,9 @@ class DiscordAdapter(BasePlatformAdapter):
                     self.name, send_err,
                 )
                 try:
-                    sent = await channel.send(content=chunk, reference=None)
+                    sent = await channel.send(
+                        content=chunk, reference=None, **notification_kwargs,
+                    )
                 except Exception as retry_err:
                     logger.warning(
                         "[%s] Overflow split: stopped at %d/%d chunks delivered: %s",
@@ -3142,6 +3230,7 @@ class DiscordAdapter(BasePlatformAdapter):
     async def _send_file_attachment(
         self, chat_id: str, file_path: str, caption: Optional[str] = None,
         file_name: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a local file as a Discord attachment (forum channels get a new thread). Path-based
         ``discord.File`` only: the open-handle form can race the multipart encoder after an image
@@ -3165,10 +3254,14 @@ class DiscordAdapter(BasePlatformAdapter):
         discord_file = discord.File(file_path, filename=filename)
         if self._is_forum_parent(channel):
             result = await self._forum_post_file(
-                channel, content=(caption or "").strip(), files=[discord_file],
+                channel, content=(caption or "").strip(), files=[discord_file], metadata=metadata,
             )
             return result
-        msg = await channel.send(content=caption if caption else None, files=[discord_file])
+        msg = await channel.send(
+            content=caption if caption else None,
+            files=[discord_file],
+            **self._notification_kwargs(metadata),
+        )
         attachments = getattr(msg, "attachments", None) or []
         if not attachments:
             # Discord accepted the message but attached nothing: fail loud instead of a silent drop.
@@ -3185,22 +3278,40 @@ class DiscordAdapter(BasePlatformAdapter):
             )
         return SendResult(success=True, message_id=str(msg.id))
 
+    async def _send_multiple_images_individually(
+        self, chat_id: str, images: List[Tuple[str, str]],
+        metadata: Optional[Dict[str, Any]], human_delay: float, *, final_chunk: bool,
+    ) -> None:
+        """Fallback to one image per message while keeping only the last actual send notify-worthy."""
+        for index, image in enumerate(images):
+            image_metadata = self._metadata_for_final_delivery(
+                metadata,
+                is_last=final_chunk and index == len(images) - 1,
+            )
+            await super().send_multiple_images(
+                chat_id, [image], image_metadata, human_delay=human_delay,
+            )
+
     async def send_multiple_images(
         self, chat_id: str, images: List[Tuple[str, str]],
         metadata: Optional[Dict[str, Any]] = None, human_delay: float = 0.0,
     ) -> None:
-        """Send images as one Discord message (<=10 attachments): URLs are downloaded and uploaded
-        inline (bare links don't render); on chunk failure the remainder uses the per-image loop."""
-        if not self._client:
-            return
-        if not images:
+        """Send images in actual <=10-file Discord batches.
+
+        Missing, unsafe, or failed downloads are removed before batching, so the final
+        *delivered* batch receives the only notification. A failed batch falls back to
+        per-image sends with the same last-message invariant.
+        """
+        if not self._client or not images:
             return
         try:
             import discord as _discord_mod
             import io as _io
             from urllib.parse import unquote as _unquote
         except Exception:  # pragma: no cover
-            await super().send_multiple_images(chat_id, images, metadata, human_delay)
+            await self._send_multiple_images_individually(
+                chat_id, images, metadata, human_delay, final_chunk=True,
+            )
             return
         try:
             channel = await self._resolve_channel(chat_id)
@@ -3209,79 +3320,104 @@ class DiscordAdapter(BasePlatformAdapter):
                 return
         except Exception as e:
             logger.warning("[%s] Failed to resolve channel for multi-image send: %s", self.name, e)
-            await super().send_multiple_images(chat_id, images, metadata, human_delay)
+            await self._send_multiple_images_individually(
+                chat_id, images, metadata, human_delay, final_chunk=True,
+            )
             return
-        CHUNK = 10
-        chunks = [images[i:i + CHUNK] for i in range(0, len(images), CHUNK)]
+
+        prepared: List[Tuple[Any, str, Tuple[str, str]]] = []
+        aiohttp_session = None
+        try:
+            for image_url, alt_text in images:
+                discord_file = None
+                if image_url.startswith("file://"):
+                    local_path = _unquote(image_url[7:])
+                    if not os.path.exists(local_path):
+                        logger.warning("[%s] Skipping missing image: %s", self.name, local_path)
+                        continue
+                    discord_file = _discord_mod.File(
+                        local_path, filename=os.path.basename(local_path),
+                    )
+                else:
+                    if not is_safe_url(image_url):
+                        logger.warning("[%s] Blocked unsafe image URL in batch", self.name)
+                        continue
+                    try:
+                        import aiohttp as _aiohttp
+                        from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
+                        _proxy = resolve_proxy_url(platform_env_var="DISCORD_PROXY")
+                        _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
+                        if aiohttp_session is None:
+                            aiohttp_session = _aiohttp.ClientSession(**_sess_kw)
+                        status, data, headers = await _read_url_image_with_redirect_guard(
+                            aiohttp_session, image_url,
+                            timeout=_aiohttp.ClientTimeout(total=30), request_kwargs=_req_kw,
+                        )
+                        if status != 200:
+                            logger.warning(
+                                "[%s] Failed to download image (HTTP %d) in batch: %s",
+                                self.name, status, image_url[:80],
+                            )
+                            continue
+                        ext = _image_ext_from_content_type(
+                            headers.get("content-type", "image/png"),
+                        )
+                        discord_file = _discord_mod.File(
+                            _io.BytesIO(data), filename=f"image_{len(prepared)}.{ext}",
+                        )
+                    except Exception as dl_err:
+                        logger.warning(
+                            "[%s] Download failed for %s: %s",
+                            self.name, image_url[:80], dl_err,
+                        )
+                        continue
+                prepared.append((discord_file, alt_text, (image_url, alt_text)))
+        finally:
+            if aiohttp_session is not None:
+                try:
+                    await aiohttp_session.close()
+                except Exception:
+                    pass
+
+        if not prepared:
+            return
+        chunk_size = 10
+        chunks = [prepared[i:i + chunk_size] for i in range(0, len(prepared), chunk_size)]
         for chunk_idx, chunk in enumerate(chunks):
             if human_delay > 0 and chunk_idx > 0:
                 await asyncio.sleep(human_delay)
-            files: List[Any] = []
-            captions: List[str] = []
-            aiohttp_session = None
+            files = [entry[0] for entry in chunk]
+            captions = [entry[1] for entry in chunk if entry[1]]
+            originals = [entry[2] for entry in chunk]
+            content = captions[0] if captions else None
+            final_chunk = chunk_idx == len(chunks) - 1
+            logger.info(
+                "[%s] Sending %d image(s) as single Discord message (chunk %d/%d)",
+                self.name, len(files), chunk_idx + 1, len(chunks),
+            )
             try:
-                for image_url, alt_text in chunk:
-                    if alt_text:
-                        captions.append(alt_text)
-                    if image_url.startswith("file://"):
-                        local_path = _unquote(image_url[7:])
-                        if not os.path.exists(local_path):
-                            logger.warning("[%s] Skipping missing image: %s", self.name, local_path)
-                            continue
-                        files.append(_discord_mod.File(local_path, filename=os.path.basename(local_path)))
-                    else:
-                        if not is_safe_url(image_url):
-                            logger.warning("[%s] Blocked unsafe image URL in batch", self.name)
-                            continue
-                        # Download to BytesIO so it renders inline
-                        try:
-                            import aiohttp as _aiohttp
-                            from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
-                            _proxy = resolve_proxy_url(platform_env_var="DISCORD_PROXY")
-                            _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
-                            if aiohttp_session is None:
-                                aiohttp_session = _aiohttp.ClientSession(**_sess_kw)
-                            status, data, headers = await _read_url_image_with_redirect_guard(
-                                aiohttp_session, image_url,
-                                timeout=_aiohttp.ClientTimeout(total=30), request_kwargs=_req_kw,
-                            )
-                            if status != 200:
-                                logger.warning(
-                                    "[%s] Failed to download image (HTTP %d) in batch: %s",
-                                    self.name, status, image_url[:80],
-                                )
-                                continue
-                            ext = _image_ext_from_content_type(headers.get("content-type", "image/png"))
-                            files.append(_discord_mod.File(_io.BytesIO(data), filename=f"image_{len(files)}.{ext}"))
-                        except Exception as dl_err:
-                            logger.warning("[%s] Download failed for %s: %s", self.name, image_url[:80], dl_err)
-                            continue
-                if not files:
-                    continue
-                # Use the first caption if any (Discord only has one message body for the group)
-                content = captions[0] if captions else None
-                logger.info(
-                    "[%s] Sending %d image(s) as single Discord message (chunk %d/%d)",
-                    self.name, len(files), chunk_idx + 1, len(chunks),
-                )
                 if self._is_forum_parent(channel):
                     await self._forum_post_file(
-                        channel, content=(content or "").strip(), files=files,
+                        channel,
+                        content=(content or "").strip(),
+                        files=files,
+                        metadata=metadata,
+                        final_chunk=final_chunk,
                     )
                 else:
-                    await channel.send(content=content, files=files)
+                    await channel.send(
+                        content=content,
+                        files=files,
+                        **self._notification_kwargs(metadata, final_chunk=final_chunk),
+                    )
             except Exception as e:
                 logger.warning(
                     "[%s] Multi-image Discord send failed (chunk %d/%d), falling back to per-image: %s",
                     self.name, chunk_idx + 1, len(chunks), e, exc_info=True,
                 )
-                await super().send_multiple_images(chat_id, chunk, metadata, human_delay=human_delay)
-            finally:
-                if aiohttp_session is not None:
-                    try:
-                        await aiohttp_session.close()
-                    except Exception:
-                        pass
+                await self._send_multiple_images_individually(
+                    chat_id, originals, metadata, human_delay, final_chunk=final_chunk,
+                )
 
     async def play_tts(self, chat_id: str, audio_path: str, **kwargs) -> SendResult:
         """Play auto-TTS audio: in the guild's VC if joined, else as a file attachment."""
@@ -3312,8 +3448,12 @@ class DiscordAdapter(BasePlatformAdapter):
             if self._is_forum_parent(channel):
                 forum_file = discord.File(io.BytesIO(file_data), filename=filename)
                 return await self._forum_post_file(
-                    channel, content=(caption or "").strip(), file=forum_file,
+                    channel,
+                    content=(caption or "").strip(),
+                    file=forum_file,
+                    metadata=metadata,
                 )
+            notification_kwargs = self._notification_kwargs(metadata)
             # Try sending as a native voice message via raw API (flags=8192).
             try:
                 import base64
@@ -3323,7 +3463,9 @@ class DiscordAdapter(BasePlatformAdapter):
                 except Exception:
                     duration_secs = max(1.0, len(file_data) / 2000.0)
                 payload_data = {
-                    "flags": 8192,
+                    "flags": with_suppress_notifications_flag(
+                        8192, silent=bool(notification_kwargs.get("silent")),
+                    ),
                     "attachments": [{
                         "id": "0", "filename": "voice-message.ogg", "duration_secs": round(duration_secs, 2),
                         "waveform": base64.b64encode(bytes([128] * 256)).decode(),
@@ -3347,10 +3489,14 @@ class DiscordAdapter(BasePlatformAdapter):
                 logger.debug("Voice message flag failed, falling back to file: %s", voice_err)
                 file = discord.File(io.BytesIO(file_data), filename=filename)
                 try:
-                    msg = await channel.send(file=file, reference=reference)
+                    msg = await channel.send(
+                        file=file, reference=reference, **notification_kwargs,
+                    )
                 except Exception as send_err:
                     if reference is not None and self._is_reply_reference_rejected(send_err):
-                        msg = await channel.send(file=file, reference=None)
+                        msg = await channel.send(
+                            file=file, reference=None, **notification_kwargs,
+                        )
                     else:
                         raise
                 return SendResult(success=True, message_id=str(msg.id))
@@ -3763,7 +3909,10 @@ class DiscordAdapter(BasePlatformAdapter):
             ch = self._client.get_channel(text_ch_id)
             if ch:
                 try:
-                    await ch.send("Left voice channel (inactivity timeout).")
+                    await ch.send(
+                        "Left voice channel (inactivity timeout).",
+                        **self._notification_kwargs(),
+                    )
                 except Exception:
                     pass
 
@@ -4155,10 +4304,15 @@ class DiscordAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.debug("[Discord] Admin notify via %s failed: %s", target, e)
 
-    async def _send_local_file(self, chat_id, path, caption, *, file_name=None, not_found: str, kind: str, fallback):
+    async def _send_local_file(
+        self, chat_id, path, caption, *, file_name=None, not_found: str,
+        kind: str, fallback, metadata: Optional[Dict[str, Any]] = None,
+    ):
         """Native attachment upload for a local file; missing file -> error, other failure -> base adapter."""
         try:
-            return await self._send_file_attachment(chat_id, path, caption, file_name=file_name)
+            return await self._send_file_attachment(
+                chat_id, path, caption, file_name=file_name, metadata=metadata,
+            )
         except FileNotFoundError:
             return SendResult(success=False, error=f"{not_found}: {path}")
         except Exception as e:  # pragma: no cover - defensive logging
@@ -4173,6 +4327,7 @@ class DiscordAdapter(BasePlatformAdapter):
         return await self._send_local_file(
             chat_id, image_path, caption, not_found="Image file not found", kind="local image",
             fallback=lambda: super(DiscordAdapter, self).send_image_file(chat_id, image_path, caption, reply_to, metadata=metadata),
+            metadata=metadata,
         )
 
     async def _send_url_media(
@@ -4202,8 +4357,17 @@ class DiscordAdapter(BasePlatformAdapter):
                 import io
                 file = discord.File(io.BytesIO(data), filename=filename_for(headers))
                 if self._is_forum_parent(channel):
-                    return await self._forum_post_file(channel, content=(caption or "").strip(), file=file)
-                msg = await channel.send(content=caption if caption else None, file=file)
+                    return await self._forum_post_file(
+                        channel,
+                        content=(caption or "").strip(),
+                        file=file,
+                        metadata=metadata,
+                    )
+                msg = await channel.send(
+                    content=caption if caption else None,
+                    file=file,
+                    **self._notification_kwargs(metadata),
+                )
                 return SendResult(success=True, message_id=str(msg.id))
         except ImportError:
             logger.warning("[%s] aiohttp not installed, falling back to URL. Run: pip install aiohttp", self.name, exc_info=True)
@@ -4221,7 +4385,7 @@ class DiscordAdapter(BasePlatformAdapter):
             chat_id, image_url, caption, kind="image",
             filename_for=lambda h: f"image.{_image_ext_from_content_type(h.get('content-type', 'image/png'))}",
             fallback=lambda md: super(DiscordAdapter, self).send_image(chat_id, image_url, caption, reply_to, metadata=md),
-            metadata=metadata, error_metadata=None,
+            metadata=metadata, error_metadata=metadata,
         )
 
     async def send_animation(
@@ -4243,6 +4407,7 @@ class DiscordAdapter(BasePlatformAdapter):
         return await self._send_local_file(
             chat_id, video_path, caption, not_found="Video file not found", kind="local video",
             fallback=lambda: super(DiscordAdapter, self).send_video(chat_id, video_path, caption, reply_to, metadata=metadata),
+            metadata=metadata,
         )
 
     async def send_document(
@@ -4254,6 +4419,7 @@ class DiscordAdapter(BasePlatformAdapter):
         return await self._send_local_file(
             chat_id, file_path, caption, file_name=file_name, not_found="File not found", kind="document",
             fallback=lambda: super(DiscordAdapter, self).send_document(chat_id, file_path, caption, file_name, reply_to, metadata=metadata),
+            metadata=metadata,
         )
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
@@ -5263,12 +5429,14 @@ class DiscordAdapter(BasePlatformAdapter):
                 name=name, auto_archive_duration=auto_archive_duration, reason=reason,
             )
             if starter_message:
-                await thread.send(starter_message)
+                await thread.send(starter_message, **self._notification_kwargs())
             return self._thread_created(thread, name)
         except Exception as direct_error:
             try:
                 seed_content = starter_message or f"\U0001f9f5 Thread created by Hermes: **{name}**"
-                seed_msg = await parent_channel.send(seed_content)
+                seed_msg = await parent_channel.send(
+                    seed_content, **self._notification_kwargs()
+                )
                 thread = await seed_msg.create_thread(
                     name=name, auto_archive_duration=auto_archive_duration, reason=reason,
                 )
@@ -5337,7 +5505,8 @@ class DiscordAdapter(BasePlatformAdapter):
                 last_direct_error = direct_error
                 try:
                     seed_msg = await message.channel.send(
-                        f"\U0001f9f5 Thread created by Hermes: **{thread_name}**"
+                        f"\U0001f9f5 Thread created by Hermes: **{thread_name}**",
+                        **self._notification_kwargs(),
                     )
                     thread = await seed_msg.create_thread(name=thread_name, auto_archive_duration=1440, reason=reason)
                     return self._stamp_auto_thread_name(thread, thread_name)
@@ -5441,7 +5610,10 @@ class DiscordAdapter(BasePlatformAdapter):
             send = getattr(parent, "send", None)
             if send is None:
                 return None
-            seed_msg = await send(f"\U0001f9f5 Hermes handoff: **{thread_name}**")
+            seed_msg = await send(
+                f"\U0001f9f5 Hermes handoff: **{thread_name}**",
+                **self._notification_kwargs(),
+            )
             thread = await seed_msg.create_thread(
                 name=thread_name, auto_archive_duration=1440, reason=reason,
             )
@@ -7321,7 +7493,9 @@ def _is_connected(config) -> bool:
 
 def _build_adapter(config):
     """Factory wrapper that constructs DiscordAdapter from a PlatformConfig."""
-    return DiscordAdapter(config)
+    adapter = DiscordAdapter(config)
+    adapter._set_notifications_mode(resolve_notification_mode(config))
+    return adapter
 
 
 def register(ctx) -> None:

--- a/plugins/platforms/discord/notifications.py
+++ b/plugins/platforms/discord/notifications.py
@@ -1,0 +1,82 @@
+"""Notification policy and plugin-local config resolution for Discord."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+NOTIFICATIONS_ALL = "all"
+NOTIFICATIONS_IMPORTANT = "important"
+VALID_NOTIFICATION_MODES = frozenset({NOTIFICATIONS_ALL, NOTIFICATIONS_IMPORTANT})
+SUPPRESS_NOTIFICATIONS_FLAG = 1 << 12
+
+
+def normalize_notification_mode(value: Any, *, default: str = NOTIFICATIONS_ALL) -> str:
+    """Return a supported mode, falling back to the backward-compatible default."""
+    normalized = str(value or default).strip().lower()
+    return normalized if normalized in VALID_NOTIFICATION_MODES else default
+
+
+def resolve_notification_mode(config: Any) -> str:
+    """Resolve Discord notifications from profile display config or adapter config.
+
+    The display setting is plugin-owned and does not belong in the gateway's
+    generic YAML bridge. ``PlatformConfig.extra`` remains a construction-time
+    fallback for direct adapter users and tests.
+    """
+    extra = getattr(config, "extra", None)
+    raw = None
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        loaded = load_config_readonly() or {}
+        display = loaded.get("display") if isinstance(loaded, Mapping) else None
+        platforms = display.get("platforms") if isinstance(display, Mapping) else None
+        discord = platforms.get("discord") if isinstance(platforms, Mapping) else None
+        configured = discord.get("notifications") if isinstance(discord, Mapping) else None
+        if configured not in {None, ""}:
+            raw = configured
+    except Exception:
+        logger.debug("Could not load Discord notification mode", exc_info=True)
+    if raw is None and isinstance(extra, Mapping):
+        raw = extra.get("notifications")
+
+    normalized = normalize_notification_mode(raw)
+    candidate = str(raw or NOTIFICATIONS_ALL).strip().lower()
+    if candidate not in VALID_NOTIFICATION_MODES:
+        logger.warning(
+            "Unknown Discord notifications mode %r; defaulting to 'all' (valid: all, important)",
+            raw,
+        )
+    return normalized
+
+
+def notification_kwargs(
+    *,
+    mode: str,
+    metadata: Mapping[str, Any] | None,
+    final_chunk: bool,
+) -> dict[str, bool]:
+    """Return discord.py kwargs for one physical message.
+
+    ``notify`` is the authoritative notification-worthy marker, matching the
+    existing Telegram contract and preserving actionable sends. Ordinary
+    ``_interim_send`` deliveries do not carry it. For a split notification-worthy
+    delivery, only its last physical Discord message omits ``silent`` and can
+    generate a push.
+    """
+    if mode != NOTIFICATIONS_IMPORTANT:
+        return {}
+    metadata = metadata or {}
+    notification_worthy = bool(metadata.get("notify"))
+    if notification_worthy and final_chunk:
+        return {}
+    return {"silent": True}
+
+
+def with_suppress_notifications_flag(flags: int, *, silent: bool) -> int:
+    """Set Discord's SUPPRESS_NOTIFICATIONS bit for raw REST payloads."""
+    return flags | SUPPRESS_NOTIFICATIONS_FLAG if silent else flags

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -912,6 +912,28 @@ class TestLoadGatewayConfig:
         assert os.environ.get("DISCORD_THREAD_REQUIRE_MENTION") == "true"
 
 
+    def test_discord_plugin_resolves_display_notifications(self, tmp_path, monkeypatch):
+        """The Discord factory owns its display-only notification setting."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "display:\n"
+            "  platforms:\n"
+            "    discord:\n"
+            "      notifications: important\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        from plugins.platforms.discord.adapter import _build_adapter
+
+        adapter = _build_adapter(PlatformConfig(enabled=True, token="test"))
+
+        assert adapter._notifications_mode == "important"
+        assert adapter.REQUIRES_EDIT_FINALIZE is True
+
+
     def test_bridges_nested_gateway_platforms_dingtalk_allowed_users_to_env(self, tmp_path, monkeypatch):
         """gateway.platforms.dingtalk.extra.allowed_users must reach
         DINGTALK_ALLOWED_USERS — it's the documented config.yaml alternative

--- a/tests/gateway/test_discord_notification_contract.py
+++ b/tests/gateway/test_discord_notification_contract.py
@@ -1,0 +1,836 @@
+# pyright: reportMissingImports=false
+"""Discord ``notifications: important`` delivery contract.
+
+The policy is metadata-driven: Hermes internals decide whether a logical send is
+interim or notification-worthy; Discord decides suppression per physical
+message so a split response produces at most one push notification.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, SendResult
+from gateway.run_turn_runner import TurnRunner
+from gateway.session import build_session_key
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+from plugins.platforms.discord import adapter as discord_adapter_module
+from plugins.platforms.discord import notifications as discord_notifications
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+_SUPPRESS_NOTIFICATIONS = 1 << 12
+
+
+def _adapter(mode: str) -> DiscordAdapter:
+    adapter = DiscordAdapter(
+        PlatformConfig(enabled=True, token="test", extra={"notifications": mode})
+    )
+    setattr(adapter, "format_message", lambda content: content)
+    return adapter
+
+
+def _silent_values(calls: list[dict]) -> list[bool | None]:
+    return [call.get("silent") for call in calls]
+
+
+@pytest.mark.asyncio
+async def test_notification_contract_for_channels_threads_retries_and_edits(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    # The Discord plugin owns config resolution. Direct adapter construction
+    # uses PlatformConfig.extra; the profile-specific display setting overrides it.
+    from hermes_cli import config as hermes_config
+
+    with monkeypatch.context() as config_patch:
+        config_patch.setattr(
+            hermes_config,
+            "load_config_readonly",
+            lambda: {},
+        )
+        assert discord_notifications.resolve_notification_mode(
+            PlatformConfig(enabled=True, token="test", extra={"notifications": "important"})
+        ) == "important"
+        config_patch.setattr(
+            hermes_config,
+            "load_config_readonly",
+            lambda: {
+                "display": {
+                    "platforms": {"discord": {"notifications": "all"}},
+                }
+            },
+        )
+        assert discord_notifications.resolve_notification_mode(
+            PlatformConfig(enabled=True, token="test", extra={"notifications": "important"})
+        ) == "all"
+
+    adapter = _adapter("important")
+    calls: list[dict] = []
+    fail_reference_once = False
+
+    async def send(**kwargs):
+        nonlocal fail_reference_once
+        calls.append(dict(kwargs))
+        if fail_reference_once and kwargs.get("reference") is not None:
+            fail_reference_once = False
+            raise RuntimeError("400 Bad Request (error code: 10008): Unknown Message")
+        message_id = 9000 + len(calls)
+        return SimpleNamespace(
+            id=message_id,
+            to_reference=lambda **_kwargs: SimpleNamespace(message_id=message_id),
+        )
+
+    channel = SimpleNamespace(id=555, send=send)
+    thread = SimpleNamespace(id=777, send=send)
+    setattr(
+        adapter,
+        "_client",
+        SimpleNamespace(
+            get_channel=lambda channel_id: thread if channel_id == 777 else channel,
+            fetch_channel=AsyncMock(),
+        ),
+    )
+    setattr(adapter, "truncate_message", lambda _content, _limit, _len_fn=None: ["one"])
+
+    # Reasoning, tool activity, commentary, lifecycle text, and ordinary status
+    # remain visible but silent. The content label is not used for classification.
+    for label, metadata in (
+        ("reasoning", {"_interim_send": True}),
+        ("tool progress", {"non_conversational": True}),
+        ("commentary", {"_interim_send": True}),
+        ("lifecycle status", {"non_conversational": True}),
+        ("progress", {}),
+    ):
+        before = len(calls)
+        original = dict(metadata)
+        result = await adapter.send("555", label, metadata=metadata)
+        assert result.success is True
+        assert calls[before].get("silent") is True
+        assert metadata == original
+        assert "notify" not in calls[before]
+        assert "_interim_send" not in calls[before]
+
+    # A runtime-marked user-attention event is notification-worthy even if it is
+    # not ordinary final-answer prose.
+    before = len(calls)
+    result = await adapter.send(
+        "555",
+        "Approval required",
+        metadata={"notify": True, "_interim_send": True, "kind": "approval"},
+    )
+    assert result.success is True
+    assert "silent" not in calls[before]
+
+    # A one-message completed response is notification-capable.
+    before = len(calls)
+    result = await adapter.send(
+        "555", "single-message final", metadata={"notify": True, "turn_id": "turn-0"}
+    )
+    assert result.success is True
+    assert "silent" not in calls[before]
+
+    # Finality is runtime metadata plus physical chunk position, never prose.
+    calls.clear()
+    final_metadata = {"notify": True, "turn_id": "turn-1"}
+    setattr(
+        adapter,
+        "truncate_message",
+        lambda _content, _limit, _len_fn=None: ["one", "two", "three"],
+    )
+    result = await adapter.send("555", "not parsed for finality", metadata=final_metadata)
+    assert result.success is True
+    assert _silent_values(calls) == [True, True, None]
+    assert final_metadata == {"notify": True, "turn_id": "turn-1"}
+
+    # Thread routing and a deleted-reference retry retain the same policy and
+    # reply anchoring. The retry cannot turn a silent chunk into a loud one.
+    calls.clear()
+    reference = object()
+    setattr(adapter, "_reply_reference_for_send", lambda reply_to, channel: reference)
+    fail_reference_once = True
+    thread_metadata = {"notify": True, "thread_id": "777"}
+    result = await adapter.send(
+        "555", "thread final", reply_to="99", metadata=thread_metadata
+    )
+    assert result.success is True
+    assert _silent_values(calls) == [True, True, True, None]
+    assert [call.get("reference") for call in calls] == [reference, None, None, None]
+    assert thread_metadata == {"notify": True, "thread_id": "777"}
+
+    # Explicit legacy mode preserves the pre-feature wire shape for every chunk.
+    legacy = _adapter("all")
+    legacy_calls: list[dict] = []
+
+    async def legacy_send(**kwargs):
+        legacy_calls.append(dict(kwargs))
+        return SimpleNamespace(id=10000 + len(legacy_calls))
+
+    legacy_channel = SimpleNamespace(id=888, send=legacy_send)
+    setattr(
+        legacy,
+        "_client",
+        SimpleNamespace(
+            get_channel=lambda _channel_id: legacy_channel,
+            fetch_channel=AsyncMock(),
+        ),
+    )
+    setattr(legacy, "truncate_message", lambda _content, _limit, _len_fn=None: ["one"])
+    await legacy.send("888", "legacy interim", metadata={"_interim_send": True})
+    await legacy.send("888", "legacy final", metadata={"notify": True})
+    setattr(legacy, "truncate_message", lambda _content, _limit, _len_fn=None: ["one", "two", "three"])
+    result = await legacy.send(
+        "888", "legacy split final", metadata={"notify": True}
+    )
+    assert result.success is True
+    assert _silent_values(legacy_calls) == [None, None, None, None, None]
+
+    # Interactive prompts are already user-attention egress and bypass routine
+    # turn-progress suppression.
+    calls.clear()
+    setattr(adapter, "truncate_message", lambda _content, _limit, _len_fn=None: ["one"])
+    await adapter._send_prompt(
+        "555",
+        None,
+        lambda _channel: ({"content": "Choose an option"}, None),
+    )
+    assert len(calls) == 1
+    assert "silent" not in calls[0]
+
+    # The plain-text dangerous-command fallback is an interim boundary but an
+    # actionable prompt. Its producer must set notify=True before sealing the
+    # metadata as an interim send.
+    approval_calls: list[dict] = []
+
+    class PlainApprovalAdapter:
+        typed_command_prefix = "/"
+
+        def pause_typing_for_chat(self, _chat_id):
+            return None
+
+        def send(self, chat_id, content, metadata=None):
+            approval_calls.append(
+                {"chat_id": chat_id, "content": content, "metadata": metadata}
+            )
+            return "scheduled approval"
+
+    approval_ctx = SimpleNamespace(
+        _status_adapter=PlainApprovalAdapter(),
+        _status_chat_id="555",
+        _status_thread_metadata={"thread_id": "777"},
+        session_key="approval-session",
+    )
+    approval_runner = TurnRunner(
+        cast(Any, SimpleNamespace()), cast(Any, approval_ctx)
+    )
+    setattr(approval_runner, "_close_native_stream_boundary", lambda _reason: None)
+
+    def schedule_approval(operation, _label):
+        assert operation == "scheduled approval"
+        return SimpleNamespace(result=lambda timeout=None: None)
+
+    setattr(approval_runner, "_schedule", schedule_approval)
+    approval_runner._approval_notify_sync(
+        {"command": "printf safe", "description": "test approval"}
+    )
+    assert approval_calls[0]["metadata"] == {
+        "thread_id": "777",
+        "is_approval_prompt": True,
+        "notify": True,
+        "_interim_send": True,
+    }
+
+    # Fatal turn errors are also explicit user-attention events.
+    calls.clear()
+    error_event = MessageEvent(
+        text="trigger",
+        source=adapter.build_source("555", chat_type="channel"),
+    )
+    error_metadata = await adapter._notify_turn_error(
+        error_event, RuntimeError("test failure")
+    )
+    assert error_metadata == {"notify": True}
+    assert len(calls) == 1
+    assert "silent" not in calls[0]
+
+    # Routine thread infrastructure is also visible but silent. User-attention
+    # prompts and failure warnings remain on their dedicated loud paths.
+    thread_seed_calls: list[dict] = []
+
+    async def thread_seed_send(content, **kwargs):
+        thread_seed_calls.append({"content": content, **kwargs})
+        return SimpleNamespace(id=12001)
+
+    created_thread = SimpleNamespace(
+        id=12000,
+        name="test thread",
+        send=thread_seed_send,
+    )
+    thread_parent = SimpleNamespace(
+        create_thread=AsyncMock(return_value=created_thread),
+    )
+    interaction = SimpleNamespace(
+        channel=thread_parent,
+        user=SimpleNamespace(display_name="Tester"),
+    )
+    result = await adapter._create_thread(
+        cast(Any, interaction),
+        name="test thread",
+        message="starter message",
+    )
+    assert result["success"] is True
+    assert _silent_values(thread_seed_calls) == [True]
+
+    auto_seed_calls: list[dict] = []
+    auto_thread = SimpleNamespace(id=13000, name="auto thread")
+    auto_seed = SimpleNamespace(
+        create_thread=AsyncMock(return_value=auto_thread),
+    )
+
+    async def auto_seed_send(content, **kwargs):
+        auto_seed_calls.append({"content": content, **kwargs})
+        return auto_seed
+
+    auto_message = SimpleNamespace(
+        content="auto thread",
+        author=SimpleNamespace(display_name="Tester"),
+        create_thread=AsyncMock(side_effect=RuntimeError("direct create rejected")),
+        channel=SimpleNamespace(send=auto_seed_send),
+    )
+    assert await adapter._auto_create_thread(auto_message) is auto_thread
+    assert _silent_values(auto_seed_calls) == [True]
+
+    handoff_seed_calls: list[dict] = []
+    handoff_thread = SimpleNamespace(id=14000)
+    handoff_seed = SimpleNamespace(
+        create_thread=AsyncMock(return_value=handoff_thread),
+    )
+
+    async def handoff_seed_send(content, **kwargs):
+        handoff_seed_calls.append({"content": content, **kwargs})
+        return handoff_seed
+
+    handoff_parent = SimpleNamespace(
+        create_thread=AsyncMock(side_effect=RuntimeError("direct create rejected")),
+        send=handoff_seed_send,
+    )
+    previous_client = adapter._client
+    setattr(
+        adapter,
+        "_client",
+        SimpleNamespace(
+            get_channel=lambda _channel_id: handoff_parent,
+            fetch_channel=AsyncMock(),
+        ),
+    )
+    assert await adapter.create_handoff_thread("555", "handoff") == "14000"
+    adapter._client = previous_client
+    assert _silent_values(handoff_seed_calls) == [True]
+
+    # Discord edits cannot create a push notification. For a finalized overflow,
+    # only continuation sends can notify, and only the last continuation does.
+    calls.clear()
+    setattr(
+        adapter,
+        "truncate_message",
+        lambda _content, _limit, _len_fn=None: ["one", "two", "three"],
+    )
+    original_message = SimpleNamespace(
+        id=42,
+        edit=AsyncMock(),
+        to_reference=MagicMock(return_value=object()),
+    )
+    result = await adapter._edit_overflow_split(  # pyright: ignore[reportCallIssue]
+        channel,
+        original_message,
+        "42",
+        "oversized final",
+        metadata={"notify": True},
+    )
+    assert result.success is True
+    assert _silent_values(calls) == [True, None]
+
+    # A segment-boundary edit stays interim. A turn-final edit receives the
+    # same authoritative notify metadata as a fresh final send, allowing its
+    # overflow continuations to select only the last notification candidate.
+    edit_calls: list[dict] = []
+
+    async def edit_message(**kwargs):
+        edit_calls.append(dict(kwargs))
+        return SendResult(success=True, message_id=kwargs["message_id"])
+
+    setattr(adapter, "edit_message", edit_message)
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "555",
+        StreamConsumerConfig(),
+        metadata={"thread_id": "777"},
+    )
+    await consumer._edit_message(
+        message_id="42", content="segment", finalize=True, notify=False
+    )
+    await consumer._edit_message(
+        message_id="42", content="completed", finalize=True, notify=True
+    )
+    assert edit_calls[0]["metadata"] == {"thread_id": "777"}
+    assert edit_calls[1]["metadata"] == {"thread_id": "777", "notify": True}
+
+    # Edit-based streaming starts with a visible silent preview. Because an edit
+    # cannot create a Discord push, important mode replaces that preview with one
+    # fresh, notification-capable completed message and removes the stale preview.
+    streaming = _adapter("important")
+    streaming_calls: list[dict] = []
+    preview_landed = asyncio.Event()
+
+    async def streaming_send(**kwargs):
+        streaming_calls.append(dict(kwargs))
+        preview_landed.set()
+        message_id = 15000 + len(streaming_calls)
+        return SimpleNamespace(
+            id=message_id,
+            to_reference=lambda **_kwargs: SimpleNamespace(message_id=message_id),
+        )
+
+    streaming_channel = SimpleNamespace(id=555, send=streaming_send)
+    setattr(
+        streaming,
+        "_client",
+        SimpleNamespace(
+            get_channel=lambda _channel_id: streaming_channel,
+            fetch_channel=AsyncMock(),
+        ),
+    )
+    setattr(streaming, "truncate_message", lambda text, _limit, _len_fn=None: [text])
+    delete_preview = AsyncMock(return_value=True)
+    setattr(streaming, "delete_message", delete_preview)
+    stream_consumer = GatewayStreamConsumer(
+        streaming,
+        "555",
+        StreamConsumerConfig(
+            transport="edit",
+            chat_type="channel",
+            edit_interval=0.01,
+            buffer_threshold=1,
+            cursor="",
+            fresh_final_after_seconds=0.0,
+        ),
+    )
+    stream_consumer.on_delta("streamed final")
+    stream_task = asyncio.create_task(stream_consumer.run())
+    await asyncio.wait_for(preview_landed.wait(), timeout=1)
+    stream_consumer.finish()
+    await asyncio.wait_for(stream_task, timeout=1)
+    assert _silent_values(streaming_calls) == [True, None]
+    delete_preview.assert_awaited_once_with("555", "15001")
+    assert stream_consumer.final_response_sent is True
+
+    # The same guarantee holds after streaming overflow has sealed earlier
+    # chunks. Those heads stay visible and silent; only the fresh tail notifies,
+    # and cleanup deletes only the active tail preview.
+    overflow_streaming = _adapter("important")
+    overflow_calls: list[dict] = []
+    overflow_heads_landed = asyncio.Event()
+    overflow_tail_preview_landed = asyncio.Event()
+
+    async def overflow_send(**kwargs):
+        overflow_calls.append(dict(kwargs))
+        if len(overflow_calls) == 2:
+            overflow_heads_landed.set()
+        elif len(overflow_calls) == 3:
+            overflow_tail_preview_landed.set()
+        message_id = 16000 + len(overflow_calls)
+        return SimpleNamespace(
+            id=message_id,
+            to_reference=lambda **_kwargs: SimpleNamespace(message_id=message_id),
+        )
+
+    overflow_channel = SimpleNamespace(id=556, send=overflow_send)
+    setattr(
+        overflow_streaming,
+        "_client",
+        SimpleNamespace(
+            get_channel=lambda _channel_id: overflow_channel,
+            fetch_channel=AsyncMock(),
+        ),
+    )
+    delete_overflow_preview = AsyncMock(return_value=True)
+    setattr(overflow_streaming, "delete_message", delete_overflow_preview)
+    overflow_consumer = GatewayStreamConsumer(
+        overflow_streaming,
+        "556",
+        StreamConsumerConfig(
+            transport="edit",
+            chat_type="channel",
+            edit_interval=0.01,
+            buffer_threshold=1,
+            cursor="",
+            fresh_final_after_seconds=0.0,
+        ),
+    )
+    overflow_consumer.on_delta("x" * 4500)
+    overflow_task = asyncio.create_task(overflow_consumer.run())
+    await asyncio.wait_for(overflow_heads_landed.wait(), timeout=1)
+    overflow_consumer.on_delta("y")
+    await asyncio.wait_for(overflow_tail_preview_landed.wait(), timeout=1)
+    overflow_consumer.finish()
+    await asyncio.wait_for(overflow_task, timeout=1)
+    assert len(overflow_calls) >= 3
+    assert _silent_values(overflow_calls[:-1]) == [True] * (
+        len(overflow_calls) - 1
+    ), overflow_calls
+    assert "silent" not in overflow_calls[-1]
+    deleted_overflow_ids = {
+        call.args[1] for call in delete_overflow_preview.await_args_list
+    }
+    assert deleted_overflow_ids == {str(16000 + len(overflow_calls) - 1)}
+    assert overflow_consumer.final_response_sent is True
+
+    # A tool-boundary segment can finalize its transport without finalizing the
+    # turn. A first physical send at that boundary must remain silent.
+    segment_adapter = _adapter("important")
+    segment_sends: list[dict] = []
+
+    async def segment_send(**kwargs):
+        segment_sends.append(dict(kwargs))
+        return SendResult(success=True, message_id="segment-1")
+
+    setattr(segment_adapter, "send", segment_send)
+    segment_consumer = GatewayStreamConsumer(
+        segment_adapter,
+        "555",
+        StreamConsumerConfig(transport="edit", cursor=""),
+    )
+    assert await segment_consumer._send_or_edit(
+        "tool preamble", finalize=True, is_turn_final=False
+    ) is True
+    assert not segment_sends[0]["metadata"] or (
+        "notify" not in segment_sends[0]["metadata"]
+    )
+    assert segment_consumer.final_response_sent is False
+
+    # Discord important mode explicitly needs a fresh final because edits cannot
+    # create a push. If that send fails, do not downgrade to a successful edit
+    # and falsely complete the turn without a notification.
+    failed_fresh_adapter = _adapter("important")
+    setattr(
+        failed_fresh_adapter,
+        "send",
+        AsyncMock(return_value=SendResult(success=False, error="send rejected")),
+    )
+    edit_after_failure = AsyncMock(
+        return_value=SendResult(success=True, message_id="preview-1")
+    )
+    setattr(failed_fresh_adapter, "edit_message", edit_after_failure)
+    failed_fresh_consumer = GatewayStreamConsumer(
+        failed_fresh_adapter,
+        "555",
+        StreamConsumerConfig(transport="edit", cursor=""),
+    )
+    failed_fresh_consumer._message_id = "preview-1"
+    failed_fresh_consumer._last_sent_text = "preview"
+    assert await failed_fresh_consumer._edit_existing(
+        "completed", finalize=True, is_turn_final=True
+    ) is False
+    edit_after_failure.assert_not_awaited()
+    assert failed_fresh_consumer.final_response_sent is False
+    assert failed_fresh_consumer._fallback_final_send is True
+
+
+@pytest.mark.asyncio
+async def test_notification_contract_for_forums_and_media(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _adapter("important")
+    forum_starters: list[dict] = []
+    forum_followups: list[list[dict]] = []
+
+    async def create_thread(**kwargs):
+        forum_starters.append(dict(kwargs))
+        followup_calls: list[dict] = []
+        forum_followups.append(followup_calls)
+
+        async def followup_send(**send_kwargs):
+            followup_calls.append(dict(send_kwargs))
+            message_id = 8000 + len(followup_calls)
+            return SimpleNamespace(
+                id=message_id,
+                to_reference=lambda **_kwargs: SimpleNamespace(message_id=message_id),
+            )
+
+        attachments = []
+        if kwargs.get("file") is not None:
+            attachments = [kwargs["file"]]
+        elif kwargs.get("files"):
+            attachments = list(kwargs["files"])
+        return SimpleNamespace(
+            id=7000 + len(forum_starters),
+            thread=SimpleNamespace(
+                id=7000 + len(forum_starters),
+                send=followup_send,
+            ),
+            message=SimpleNamespace(
+                id=6000 + len(forum_starters),
+                attachments=attachments,
+            ),
+        )
+
+    forum = SimpleNamespace(id=666, create_thread=create_thread)
+    setattr(adapter, "_is_forum_parent", lambda channel: channel is forum)
+    setattr(
+        adapter,
+        "_client",
+        SimpleNamespace(
+            get_channel=lambda _channel_id: forum,
+            fetch_channel=AsyncMock(),
+        ),
+    )
+
+    def forum_chunks(content, _limit):
+        if content == "final single":
+            return ["single"]
+        return ["one", "two", "three"]
+
+    setattr(adapter, "truncate_message", forum_chunks)
+
+    progress_metadata = {"_interim_send": True, "phase": "tool"}
+    result = await adapter.send("666", "progress", metadata=progress_metadata)
+    assert result.success is True
+    assert forum_starters[-1].get("silent") is True
+    assert _silent_values(forum_followups[-1]) == [True, True]
+    assert progress_metadata == {"_interim_send": True, "phase": "tool"}
+
+    result = await adapter.send("666", "final single", metadata={"notify": True})
+    assert result.success is True
+    assert "silent" not in forum_starters[-1]
+    assert forum_followups[-1] == []
+
+    result = await adapter.send("666", "final split", metadata={"notify": True})
+    assert result.success is True
+    assert forum_starters[-1].get("silent") is True
+    assert _silent_values(forum_followups[-1]) == [True, None]
+
+    # Forum attachments use the same starter-message policy.
+    media_path = tmp_path / "report.txt"
+    media_path.write_text("evidence", encoding="utf-8")
+    monkeypatch.setattr(
+        discord_adapter_module.discord,
+        "File",
+        lambda path, filename=None, **_kwargs: SimpleNamespace(
+            path=path, filename=filename
+        ),
+    )
+    result = await adapter.send_document(
+        "666", str(media_path), metadata={"_interim_send": True}
+    )
+    assert result.success is True
+    assert forum_starters[-1].get("silent") is True
+
+    # Multi-image batches are physical Discord messages. A notify-worthy batch
+    # sequence emits at most one push, on its final batch.
+    regular_calls: list[dict] = []
+
+    async def regular_send(**kwargs):
+        regular_calls.append(dict(kwargs))
+        return SimpleNamespace(
+            id=5000 + len(regular_calls),
+            attachments=list(kwargs.get("files") or []),
+        )
+
+    regular = SimpleNamespace(id=555, send=regular_send)
+    client = SimpleNamespace(
+        get_channel=lambda _channel_id: regular,
+        fetch_channel=AsyncMock(),
+        http=SimpleNamespace(request=AsyncMock(return_value={"id": "4444"})),
+    )
+    setattr(adapter, "_client", client)
+    setattr(adapter, "_is_forum_parent", lambda channel: False)
+
+    # An unsafe or failed remote image falls back to the base URL send without
+    # dropping the notification metadata.
+    url_fallbacks: list[dict] = []
+
+    async def base_send_image(
+        self, chat_id, image_url, caption=None, reply_to=None, metadata=None
+    ):
+        url_fallbacks.append(
+            {
+                "chat_id": chat_id,
+                "image_url": image_url,
+                "caption": caption,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id="fallback")
+
+    with monkeypatch.context() as media_patch:
+        media_patch.setattr(BasePlatformAdapter, "send_image", base_send_image)
+        fallback_metadata = {"notify": True, "thread_id": "777"}
+        result = await adapter.send_image(
+            "555",
+            "http://127.0.0.1/image.png",
+            caption="fallback",
+            metadata=fallback_metadata,
+        )
+    assert result.success is True
+    assert url_fallbacks[0]["metadata"] == fallback_metadata
+
+    # A completed response containing both text and an attachment emits exactly
+    # one notification candidate: the attachment is silent and sent first, then
+    # the completed text is loud.
+    regular_calls.clear()
+    attachment = tmp_path / "final-report.txt"
+    attachment.write_text("report", encoding="utf-8")
+    adapter.config.typing_indicator = False
+    setattr(adapter, "truncate_message", lambda _content, _limit, _len_fn=None: ["Final body"])
+    setattr(adapter, "on_processing_start", AsyncMock())
+    setattr(adapter, "on_processing_complete", AsyncMock())
+
+    async def final_with_attachment(_event):
+        return f"Final body\nMEDIA: {attachment}"
+
+    adapter.set_message_handler(final_with_attachment)
+    final_event = MessageEvent(
+        text="request",
+        source=adapter.build_source("555", chat_type="channel"),
+    )
+    await adapter._process_message_background(
+        final_event, build_session_key(final_event.source)
+    )
+    assert len(regular_calls) == 2
+    assert regular_calls[0].get("files")
+    assert regular_calls[1].get("content") == "Final body"
+    assert _silent_values(regular_calls) == [True, None]
+
+    regular_calls.clear()
+    images = []
+    for index in range(11):
+        path = tmp_path / f"image-{index}.png"
+        path.write_bytes(b"png")
+        images.append((path.as_uri(), f"image {index}"))
+    await adapter.send_multiple_images(
+        "555", images, metadata={"notify": True}, human_delay=0
+    )
+    assert _silent_values(regular_calls) == [True, None]
+
+    # A skipped planned tail must not consume the final notification: the last
+    # actual batch remains loud.
+    regular_calls.clear()
+    missing = tmp_path / "missing-tail.png"
+    await adapter.send_multiple_images(
+        "555",
+        [*images[:10], (missing.as_uri(), "missing")],
+        metadata={"notify": True},
+        human_delay=0,
+    )
+    assert _silent_values(regular_calls) == [None]
+
+    # If a native image batch fails, the per-image fallback preserves the same
+    # last-actual-message invariant.
+    fallback_image_metadata: list[dict] = []
+
+    async def base_send_multiple_images(
+        self, chat_id, fallback_images, metadata=None, human_delay=0.0
+    ):
+        fallback_image_metadata.append(dict(metadata or {}))
+
+    async def fail_batch_send(**_kwargs):
+        raise RuntimeError("native batch rejected")
+
+    previous_client = adapter._client
+    failing_channel = SimpleNamespace(id=555, send=fail_batch_send)
+    setattr(
+        adapter,
+        "_client",
+        SimpleNamespace(
+            get_channel=lambda _channel_id: failing_channel,
+            fetch_channel=AsyncMock(),
+        ),
+    )
+    with monkeypatch.context() as fallback_patch:
+        fallback_patch.setattr(
+            BasePlatformAdapter,
+            "send_multiple_images",
+            base_send_multiple_images,
+        )
+        await adapter.send_multiple_images(
+            "555", images[:3], metadata={"notify": True}, human_delay=0
+        )
+    adapter._client = previous_client
+    assert [metadata.get("notify") for metadata in fallback_image_metadata] == [
+        None,
+        None,
+        True,
+    ]
+
+    # Native voice messages use a raw Discord payload. Preserve the voice flag
+    # and add SUPPRESS_NOTIFICATIONS only for non-notify delivery.
+    audio_path = tmp_path / "voice.ogg"
+    audio_path.write_bytes(b"not-real-ogg")
+    await adapter.send_voice(
+        "555", str(audio_path), metadata={"_interim_send": True}
+    )
+    form = client.http.request.await_args.kwargs["form"]
+    payload = json.loads(next(part["value"] for part in form if part["name"] == "payload_json"))
+    assert payload["flags"] & _SUPPRESS_NOTIFICATIONS
+
+    await adapter.send_voice("555", str(audio_path), metadata={"notify": True})
+    form = client.http.request.await_args.kwargs["form"]
+    payload = json.loads(next(part["value"] for part in form if part["name"] == "payload_json"))
+    assert not payload["flags"] & _SUPPRESS_NOTIFICATIONS
+
+    # Fallback final chunking assigns notification intent per physical message,
+    # so only the last fallback chunk can produce a Discord push.
+    fallback_adapter = _adapter("important")
+    fallback_chunk_metadata: list[dict] = []
+
+    async def fallback_send(**kwargs):
+        fallback_chunk_metadata.append(dict(kwargs.get("metadata") or {}))
+        return SendResult(
+            success=True, message_id=f"fallback-{len(fallback_chunk_metadata)}"
+        )
+
+    setattr(fallback_adapter, "send", fallback_send)
+    fallback_consumer = GatewayStreamConsumer(
+        fallback_adapter,
+        "555",
+        StreamConsumerConfig(transport="edit", cursor=""),
+    )
+    setattr(
+        fallback_consumer,
+        "_split_text_chunks",
+        lambda _text, _limit, len_fn=None: ["one", "two", "three"],
+    )
+    await fallback_consumer._send_fallback_final("completed response")
+    assert [metadata.get("notify") for metadata in fallback_chunk_metadata] == [
+        None,
+        None,
+        True,
+    ]
+
+    # A failed attachment warning is itself actionable. It must restore notify
+    # intent even when the failed non-last attachment had that marker removed.
+    media_failure_adapter = _adapter("important")
+    media_failure_sends: list[dict] = []
+
+    async def media_failure_send(**kwargs):
+        media_failure_sends.append(dict(kwargs))
+        return SendResult(success=True, message_id="warning-1")
+
+    setattr(media_failure_adapter, "send", media_failure_send)
+    original_failure_metadata = {"notify": False, "thread_id": "777"}
+    await media_failure_adapter._notify_media_delivery_failure(
+        "555", "/tmp/report.txt", metadata=original_failure_metadata
+    )
+    assert media_failure_sends[0]["metadata"] == {
+        "notify": True,
+        "thread_id": "777",
+    }
+    assert original_failure_metadata == {"notify": False, "thread_id": "777"}

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -590,6 +590,24 @@ display:
       reasoning_style: subtext   # code | blockquote | subtext
 ```
 
+#### `display.platforms.discord.notifications`
+
+**Type:** string — **Default:** `"all"` — **Values:** `all`, `important`
+
+Controls native Discord push notifications without hiding Hermes activity:
+
+- `all` — Legacy behavior. Every Discord message is sent normally and can generate a push notification.
+- `important` — Reasoning, tool activity, progress, status, and other intermediate messages remain visible but are sent with Discord's silent-message flag. A completed response can generate one normal notification, from its last Discord message only. If Discord splits the response, all earlier chunks are silent.
+
+```yaml
+display:
+  platforms:
+    discord:
+      notifications: important
+```
+
+Hermes uses runtime delivery metadata to distinguish intermediate activity from notification-worthy output. It does not infer finality from message text. Interactive approval, clarification, and picker prompts remain notification-capable because they use Discord's dedicated prompt path.
+
 ## Slash Command Access Control
 
 By default, every allowed user can run every slash command. To split your allowlist into **admins** (full slash command access) and **regular users** (only commands you explicitly enable), add `allow_admin_from` and `user_allowed_commands` to the Discord platform's `extra` block:


### PR DESCRIPTION
## What does this PR do?

Adds Discord native silent-message delivery while keeping all Hermes activity visible. With `display.platforms.discord.notifications: important`, intermediate activity is sent with `silent=True`; only the last physical message of a completed response generates a normal notification. The default remains `all`, preserving legacy behavior.

## Related Issue

Related: #38028 is the original implementation salvaged here with attribution preserved. #47004 is a competing Discord-only implementation, while #20463 proposes a broaderpriority-aware model for Telegram and Discord. This PR is the most complete implementation aligned with the current plugin architecture and current delivery contracts. These approachesoverlap, so maintainers should select one.

## Provenance / salvage

This PR salvages and completes #38028 by @BenceBertalan. Original commit `999afebdae2bfcf8a4e25875004dca7f67464f66` was cherry-picked with `-x` and conflict-resolved against current `main`. Its original Author identity, author date, and source SHA remain in Git history. Later commits reconcile current architecture, address review findings, add final-chunk and forum semantics, tests, and documentation.

#47004 independently proposes overlapping Discord behavior. #20463 proposes a broader priority framework. This PR stays focused on Discord `all|important` and existing `notify` metadata. No code was copied from either competing PR.

## Type of Change

- ☐ 🐛 Bug fix (non-breaking change that fixes an issue)
- ☑ ✨ New feature (non-breaking change that adds functionality)
- ☐ 🔒 Security fix
- ☑ 📝 Documentation update
- ☑ ✅ Tests (adding or improving test coverage)
- ☐ ♻️ Refactor (no behavior change)
- ☐ 🎯 New skill (bundled or hub)

## Changes Made

- Resolve `all|important` configuration inside the Discord plugin.
- Apply notification policy per physical message across channels, threads, forums, split replies, retries, edit overflow, media, and fallback delivery.
- Keep approvals, clarification, picker, fatal-error, and other actionable sends notification-capable.
- Notify only from the last chunk of a completed response.
- Document the setting and retain `all` as the default.

## How to Test

1. Focused notification-contract tests: `2 passed`.
2. Discord, streaming, media, forum/thread, and display/config regression selection: `644 passed, 0 failed` across 71 files.
3. Ruff, Windows-footgun, compatibility-pointer, contributor-attribution, and diff checks: passed. The advisory type check exited successfully with existing repository diagnostics under `--exit-zero`.

Coverage includes legacy mode, important mode, ordinary channels, threads, forums, split finals, actionable sends, deleted-reference fallback, media, fallback chunking, and metadata isolation.

## Checklist

### Code

- ☑ I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- ☑ My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- ☑ I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- ☑ My PR contains **only** changes related to this fix/feature (no unrelated commits)
- ☐ I've run `pytest tests/ -q` and all tests pass
- ☑ I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- ☑ I've tested on my platform: Linux

### Documentation & Housekeeping

- ☑ I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- ☑ I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- ☑ I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- ☑ I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific process or filesystem behavior changed
- ☑ I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

No live Discord-server smoke test was performed. Adapter and gateway tests cover the supported discord.py interface.

## Infographic

<img src="https://v3b.fal.media/files/b/0aa91ef0/lPcm2D-f3Lnggs7KdpOXE_v3ZU5UEN.png" alt="Discord notification behavior: all activity remains visible while only the final chunk notifies" width="1024" height="768">

