### PR TITLE
feat: live streaming STT for plugin providers — low-latency desktop dictation

### DIFF
--- a/agent/transcription_provider.py
+++ b/agent/transcription_provider.py
@@ -196,3 +196,82 @@ class TranscriptionProvider(abc.ABC):
                 providers may use it as a vocabulary/context hint; others
                 should ignore it.
         """
+
+    # ------------------------------------------------------------------
+    # Live streaming (optional capability)
+    # ------------------------------------------------------------------
+
+    @property
+    def streaming_capable(self) -> bool:
+        """Whether this provider can transcribe LIVE audio chunk-by-chunk.
+
+        Streaming lets a caller feed audio as it is captured (microphone
+        input) instead of only whole files, cutting dictation latency
+        from "record, then transcribe" to "transcribe while speaking".
+
+        Providers that return True must implement
+        :meth:`open_stream_session` and accept 16 kHz mono s16le PCM in
+        arbitrary chunk sizes. Default: False — the file-based
+        :meth:`transcribe` path is unchanged for everyone else.
+        """
+        return False
+
+    def open_stream_session(
+        self,
+        *,
+        language: Optional[str] = None,
+        prompt: Optional[str] = None,
+    ) -> "TranscriptionStreamSession":
+        """Open a live transcription session (streaming-capable only).
+
+        Args:
+            language: Optional BCP-47 language hint (e.g. ``"pt"``).
+            prompt: Optional vocabulary/context hint — same semantics as
+                the ``prompt`` extra on :meth:`transcribe`.
+
+        Returns:
+            A :class:`TranscriptionStreamSession` bound to this provider.
+            Sessions are single-use; open a fresh one per utterance.
+
+        Raises:
+            NotImplementedError: this provider is not streaming-capable.
+        """
+        raise NotImplementedError(
+            f"{self.name} does not support live streaming transcription"
+        )
+
+
+class TranscriptionStreamSession(abc.ABC):
+    """Live audio → transcript session from a streaming-capable provider.
+
+    Contract: audio arrives as 16 kHz mono s16le PCM in arbitrary chunk
+    sizes via :meth:`push_audio`; :meth:`finalize` ends the session,
+    flushes trailing audio and returns the standard transcription
+    envelope (``success``/``transcript``/``provider``).
+
+    Sessions are single-use. A session may transcribe on a background
+    thread (e.g. a provider websocket reader); implementations must make
+    :meth:`push_audio` and :meth:`partial_transcript` safe to call from
+    the feeding thread.
+    """
+
+    @abc.abstractmethod
+    def push_audio(self, chunk: bytes) -> None:
+        """Feed one chunk of 16 kHz mono s16le PCM to the session."""
+
+    @abc.abstractmethod
+    def finalize(self) -> Dict[str, Any]:
+        """End the session and return the transcription envelope.
+
+        Blocks until the provider has finalized the transcript. Must not
+        raise — convert failures to the error envelope, matching
+        :meth:`TranscriptionProvider.transcribe`.
+        """
+
+    def partial_transcript(self) -> str:
+        """Latest non-final transcript (``''`` when none available).
+
+        Callers may poll this to show live captions while the user is
+        still speaking. Default: no partials.
+        """
+        return ""

--- a/agent/transcription_registry.py
+++ b/agent/transcription_registry.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import logging
 import threading
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from agent.transcription_provider import TranscriptionProvider
 from hermes_constants import hermes_home_key
@@ -123,6 +123,30 @@ def get_provider(name: str, *, scope: Optional[str] = None) -> Optional[Transcri
     key = name.strip().lower()
     with _lock:
         return _scoped_providers.get(scope or hermes_home_key(), {}).get(key) or _providers.get(key)
+
+
+def open_streaming_session(
+    name: str,
+    *,
+    language: Optional[str] = None,
+    prompt: Optional[str] = None,
+    scope: Optional[str] = None,
+) -> Optional[Any]:
+    """Open a live transcription session for a streaming-capable provider.
+
+    Returns the provider's :class:`~agent.transcription_provider.TranscriptionStreamSession`
+    when a provider is registered under *name* AND reports
+    ``streaming_capable``; otherwise None (callers fall back to the
+    file-based path). Never raises for lookup failures.
+    """
+    provider = get_provider(name, scope=scope)
+    if provider is None or not provider.streaming_capable:
+        return None
+    try:
+        return provider.open_stream_session(language=language, prompt=prompt)
+    except Exception:  # noqa: BLE001 — a broken session open must not break dispatch
+        logger.warning("Streaming session open failed for '%s'", name, exc_info=True)
+        return None
 
 
 def snapshot_registration(

--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 
+import { float32ToInt16Pcm, resampleTo16k } from '@/lib/pcm'
+
 type BrowserAudioContext = typeof AudioContext
 
 export interface MicRecorderOptions {
@@ -9,6 +11,11 @@ export interface MicRecorderOptions {
   silenceLevel?: number
   silenceMs?: number
   idleSilenceMs?: number
+  /** Live PCM tap: receives 16 kHz mono s16le chunks as they are captured
+   *  (used by streaming dictation — the chunks feed the host's live STT
+   *  relay while the user is still speaking). Only delivered when a 16 kHz
+   *  AudioContext is available; the MediaRecorder blob path is unaffected. */
+  onPcm?: (chunk: ArrayBuffer) => void
 }
 
 export interface MicRecording {
@@ -71,6 +78,7 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
   const streamRef = useRef<MediaStream | null>(null)
   const chunksRef = useRef<Blob[]>([])
   const audioContextRef = useRef<AudioContext | null>(null)
+  const processorRef = useRef<ScriptProcessorNode | null>(null)
   const animationRef = useRef<number | null>(null)
   const startedAtRef = useRef(0)
   const heardSpeechRef = useRef(false)
@@ -82,6 +90,11 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
     if (animationRef.current) {
       window.cancelAnimationFrame(animationRef.current)
       animationRef.current = null
+    }
+
+    if (processorRef.current) {
+      processorRef.current.disconnect()
+      processorRef.current = null
     }
 
     void audioContextRef.current?.close()
@@ -105,6 +118,7 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
     }
 
     try {
+      const wantsPcm = typeof options.onPcm === 'function'
       const audioContext = new AudioContextCtor()
       const analyser = audioContext.createAnalyser()
       const source = audioContext.createMediaStreamSource(stream)
@@ -114,6 +128,43 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
 
       source.connect(analyser)
       audioContextRef.current = audioContext
+
+      if (wantsPcm) {
+        // The context runs at the device rate — macOS can clamp a requested
+        // 16 kHz context to the hardware rate, and a silent rate mismatch
+        // used to starve the streaming leg. The tap resamples in JS, so
+        // onPcm ALWAYS delivers 16 kHz mono s16le regardless of context rate.
+        // ScriptProcessor is deprecated but universally supported and needs
+        // no worklet module URL in the Electron renderer.
+        //
+        // Two input channels + explicit L/R average: a mono-configured node
+        // relies on the browser's downmix, which has produced silent input in
+        // some Electron/macOS combos — averaging ourselves is deterministic
+        // whether the track is mono or stereo.
+        const processor = audioContext.createScriptProcessor(4096, 2, 1)
+        processorRef.current = processor
+        const contextRate = audioContext.sampleRate
+
+        // The tap only hears what is connected to it: source → processor,
+        // or onaudioprocess fires with SILENT buffers (201 chunks of pure
+        // zero — caught by the server's energy probe, avg_abs_level=0).
+        source.connect(processor)
+
+        processor.onaudioprocess = event => {
+          const left = event.inputBuffer.getChannelData(0)
+          const right = event.inputBuffer.numberOfChannels > 1 ? event.inputBuffer.getChannelData(1) : null
+          const input = new Float32Array(left.length)
+
+          for (let i = 0; i < left.length; i += 1) {
+            input[i] = right ? (left[i] + right[i]) * 0.5 : left[i]
+          }
+
+          const resampled = resampleTo16k(input, contextRate)
+          options.onPcm?.(float32ToInt16Pcm(resampled))
+        }
+
+        processor.connect(audioContext.destination)
+      }
 
       const tick = () => {
         analyser.getByteTimeDomainData(data)

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.ts
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
 
 import { useI18n } from '@/i18n'
+import { sttStreamingRelayAvailable } from '@/lib/voice-client-direct'
+import { type DictationStreamSession, openDictationStream } from '@/lib/voice-stream'
 import { notify, notifyError } from '@/store/notifications'
 
 import type { VoiceActivityState, VoiceStatus } from '../types'
@@ -12,6 +14,35 @@ interface VoiceRecorderOptions {
   onTranscribeAudio?: (audio: Blob) => Promise<string>
   focusInput: () => void
   onTranscript: (text: string) => void
+}
+
+/**
+ * Push-to-talk dictation (mic icon in the composer): record → transcript.
+ *
+ * When the active STT provider supports live streaming (see
+ * `sttStreamingRelayAvailable`), PCM captured WHILE the user speaks is
+ * streamed to the host's /api/audio/transcribe-stream relay, so the
+ * transcript is ready right at end-of-recording instead of after a post-hoc
+ * file transcription. The MediaRecorder blob is still produced in parallel
+ * and used as the fallback whenever the streaming leg fails — dictation
+ * keeps working exactly as before on older backends or non-streaming STT.
+ */
+/** Bound a promise so a silent peer can never freeze the UI indefinitely. */
+async function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), ms)
+      })
+    ])
+  } finally {
+    if (timer !== undefined) {
+      clearTimeout(timer)
+    }
+  }
 }
 
 export function useVoiceRecorder({
@@ -28,6 +59,9 @@ export function useVoiceRecorder({
   const startedAtRef = useRef(0)
   const intervalRef = useRef<number | null>(null)
   const timeoutRef = useRef<number | null>(null)
+  const recordingRef = useRef(false)
+  const streamSessionRef = useRef<DictationStreamSession | null>(null)
+  const pcmBufferRef = useRef<ArrayBuffer[]>([])
 
   const clearTimers = () => {
     if (intervalRef.current) {
@@ -43,16 +77,48 @@ export function useVoiceRecorder({
 
   useEffect(() => () => clearTimers(), [])
 
-  const stop = async () => {
-    clearTimers()
-    const result = await handle.stop()
+  /** Feed live PCM to the streaming session; buffer briefly until it opens. */
+  const onPcmChunk = (chunk: ArrayBuffer) => {
+    const session = streamSessionRef.current
 
-    if (!result) {
-      setVoiceStatus('idle')
+    if (session) {
+      session.pushAudio(chunk)
 
       return
     }
 
+    const buffer = pcmBufferRef.current
+
+    // ~64 s of 16 kHz s16le at one ~256 ms chunk per push.
+    if (buffer.length < 250) {
+      buffer.push(chunk)
+    }
+  }
+
+  const openStreamSession = async () => {
+    const session = await openDictationStream()
+
+    if (!session) {
+      return
+    }
+
+    if (!recordingRef.current) {
+      session.cancel()
+
+      return
+    }
+
+    streamSessionRef.current = session
+    const buffered = pcmBufferRef.current
+    pcmBufferRef.current = []
+
+    for (const chunk of buffered) {
+      session.pushAudio(chunk)
+    }
+  }
+
+  /** Transcribe a finished recording blob (the non-streaming path). */
+  const transcribeBlob = async (audio: Blob) => {
     if (!onTranscribeAudio) {
       setVoiceStatus('idle')
 
@@ -62,7 +128,7 @@ export function useVoiceRecorder({
     setVoiceStatus('transcribing')
 
     try {
-      const transcript = (await onTranscribeAudio(result.audio)).trim()
+      const transcript = (await onTranscribeAudio(audio)).trim()
 
       if (!transcript) {
         notify({ kind: 'warning', title: voiceCopy.noSpeechDetected, message: voiceCopy.tryRecordingAgain })
@@ -77,6 +143,59 @@ export function useVoiceRecorder({
     }
   }
 
+  const stop = async () => {
+    clearTimers()
+    recordingRef.current = false
+
+    const session = streamSessionRef.current
+    streamSessionRef.current = null
+    pcmBufferRef.current = []
+
+    const result = await handle.stop()
+
+    if (!result) {
+      session?.cancel()
+      setVoiceStatus('idle')
+
+      return
+    }
+
+    if (session) {
+      // Streaming leg: transcript should already be (almost) ready. Bound it
+      // hard — a silent provider/socket must never leave the mic button
+      // frozen in the recording state; on any failure we fall back to the
+      // recorded blob, which is exactly today's non-streaming behaviour.
+      setVoiceStatus('transcribing')
+      const startedAt = Date.now()
+
+      try {
+        const transcript = (await withTimeout(session.stop(), 25_000, 'live STT timed out'))
+          ?.trim() ?? ''
+
+        if (transcript) {
+          console.info(`[dictation] streaming OK in ${Date.now() - startedAt}ms`)
+          onTranscript(transcript)
+          setVoiceStatus('idle')
+          focusInput()
+
+          return
+        }
+      } catch (error) {
+        // Fall through to the recorded-blob path. Close the live socket so a
+        // silent provider can't leak a half-open session into the next take.
+        const reason = error instanceof Error ? error.message : String(error)
+        console.warn(`[dictation] streaming failed (${reason}); falling back to blob relay`)
+        notifyError(
+          new Error(`${reason} — retrying with the standard transcription`),
+          voiceCopy.transcriptionFailed
+        )
+        session.cancel()
+      }
+    }
+
+    await transcribeBlob(result.audio)
+  }
+
   const start = async () => {
     if (!onTranscribeAudio) {
       notify({ kind: 'warning', title: voiceCopy.unavailable, message: voiceCopy.transcriptionUnavailable })
@@ -84,17 +203,44 @@ export function useVoiceRecorder({
       return
     }
 
+    // Streaming is a relay capability: only when the backend's STT provider
+    // reports streaming support AND we still have a mic blob as fallback.
+    let streaming = false
+
     try {
-      await handle.start({ onError: error => notifyError(error, voiceCopy.recordingFailed) })
-      startedAtRef.current = Date.now()
-      setElapsedSeconds(0)
-      setVoiceStatus('recording')
-      intervalRef.current = window.setInterval(() => setElapsedSeconds((Date.now() - startedAtRef.current) / 1000), 250)
-      const cap = Math.max(1, Math.min(Math.trunc(maxRecordingSeconds), 600))
-      timeoutRef.current = window.setTimeout(() => void stop(), cap * 1000)
+      streaming = await sttStreamingRelayAvailable()
+    } catch {
+      streaming = false
+    }
+
+    console.info(`[dictation] mode=${streaming ? 'streaming' : 'blob'} (stt.streaming=${streaming})`)
+
+    if (streaming) {
+      pcmBufferRef.current = []
+    }
+
+    try {
+      await handle.start({
+        onError: error => notifyError(error, voiceCopy.recordingFailed),
+        onPcm: streaming ? onPcmChunk : undefined
+      })
     } catch (error) {
       setVoiceStatus('idle')
       notifyError(error, voiceCopy.recordingFailed)
+
+      return
+    }
+
+    recordingRef.current = true
+    startedAtRef.current = Date.now()
+    setElapsedSeconds(0)
+    setVoiceStatus('recording')
+    intervalRef.current = window.setInterval(() => setElapsedSeconds((Date.now() - startedAtRef.current) / 1000), 250)
+    const cap = Math.max(1, Math.min(Math.trunc(maxRecordingSeconds), 600))
+    timeoutRef.current = window.setTimeout(() => void stop(), cap * 1000)
+
+    if (streaming) {
+      void openStreamSession()
     }
   }
 

--- a/apps/desktop/src/lib/pcm.test.ts
+++ b/apps/desktop/src/lib/pcm.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+
+import { float32ToInt16Pcm, resampleTo16k } from './pcm'
+
+describe('resampleTo16k', () => {
+  it('passes 16 kHz input through unchanged', () => {
+    const input = new Float32Array([0.1, -0.2, 0.3])
+
+    expect(resampleTo16k(input, 16000)).toBe(input)
+  })
+
+  it('downsamples integer ratios (48k -> 16k) by 3x', () => {
+    // One second of a 1 kHz-ish ramp at 48 kHz.
+    const input = new Float32Array(48000)
+
+    for (let i = 0; i < input.length; i += 1) {
+      input[i] = Math.sin((2 * Math.PI * 1000 * i) / 48000)
+    }
+
+    const out = resampleTo16k(input, 48000)
+
+    expect(out.length).toBe(16000)
+
+    // The downsampled signal must still be a sine at 1 kHz: value at sample
+    // n equals the 48 kHz sine at 3n (linear interp on an exact multiple).
+    for (const n of [0, 1000, 8000, 15999]) {
+      expect(out[n]).toBeCloseTo(input[n * 3], 4)
+    }
+  })
+
+  it('handles fractional ratios (44.1k -> 16k) without crashing or NaN', () => {
+    const input = new Float32Array(44100)
+
+    for (let i = 0; i < input.length; i += 1) {
+      input[i] = Math.sin((2 * Math.PI * 440 * i) / 44100)
+    }
+
+    const out = resampleTo16k(input, 44100)
+
+    expect(out.length).toBe(Math.floor(44100 / (44100 / 16000)))
+    expect(out.every(value => Number.isFinite(value))).toBe(true)
+    expect(out.every(value => value >= -1.001 && value <= 1.001)).toBe(true)
+  })
+
+  it('returns empty for empty input', () => {
+    expect(resampleTo16k(new Float32Array(0), 48000).length).toBe(0)
+  })
+})
+
+describe('float32ToInt16Pcm', () => {
+  it('converts and clamps', () => {
+    const buffer = float32ToInt16Pcm(new Float32Array([0, 1, -1, 2, -2]))
+    const pcm = new Int16Array(buffer)
+
+    expect(pcm[0]).toBe(0)
+    expect(pcm[1]).toBe(32767)
+    expect(pcm[2]).toBe(-32768)
+    expect(pcm[3]).toBe(32767)
+    expect(pcm[4]).toBe(-32768)
+  })
+})

--- a/apps/desktop/src/lib/pcm.ts
+++ b/apps/desktop/src/lib/pcm.ts
@@ -1,0 +1,47 @@
+/**
+ * 16 kHz PCM helpers for live dictation.
+ *
+ * The capture pipeline resamples the mic to 16 kHz mono s16le in JS, so it
+ * never depends on the browser granting an AudioContext at exactly 16 kHz
+ * (macOS/Chromium can clamp the context rate to the device rate — a silent
+ * rate mismatch that starved the streaming leg before the resampler existed).
+ */
+
+/** Resample mono Float32 samples (in -1..1) at *inputRate* to 16 kHz. */
+export function resampleTo16k(input: Float32Array, inputRate: number): Float32Array {
+  if (inputRate === 16000 || input.length === 0) {
+    return input
+  }
+
+  const ratio = inputRate / 16000
+  const outLength = Math.max(1, Math.floor(input.length / ratio))
+  const output = new Float32Array(outLength)
+
+  // Linear interpolation — handles integer (48k→16k) and fractional
+  // (44.1k→16k) ratios alike.
+  for (let i = 0; i < outLength; i += 1) {
+    const pos = i * ratio
+    const index = Math.floor(pos)
+    const frac = pos - index
+
+    if (index + 1 >= input.length) {
+      output[i] = input[index]
+    } else {
+      output[i] = input[index] * (1 - frac) + input[index + 1] * frac
+    }
+  }
+
+  return output
+}
+
+/** Convert mono Float32 samples to a 16 kHz s16le ArrayBuffer. */
+export function float32ToInt16Pcm(input: Float32Array): ArrayBuffer {
+  const pcm = new Int16Array(input.length)
+
+  for (let i = 0; i < input.length; i += 1) {
+    const sample = Math.max(-1, Math.min(1, input[i]))
+    pcm[i] = sample < 0 ? sample * 0x8000 : sample * 0x7fff
+  }
+
+  return pcm.buffer
+}

--- a/apps/desktop/src/lib/voice-client-direct.ts
+++ b/apps/desktop/src/lib/voice-client-direct.ts
@@ -43,6 +43,10 @@ export interface DirectTtsConfig {
 interface RelayConfig {
   mode: 'relay'
   reason?: string
+  /** True when the relayed STT provider is streaming-capable: the client may
+   *  stream live PCM to /api/audio/transcribe-stream instead of uploading one
+   *  blob after the recording ends (host feeds the provider while speaking). */
+  streaming?: boolean
 }
 
 export interface VoiceClientConfig {
@@ -234,6 +238,21 @@ export async function transcribeAudioClientDirect(audio: Blob): Promise<null | s
   }
 
   return null
+}
+
+/**
+ * True when the active profile's STT is a RELAY provider that supports live
+ * streaming (e.g. a plugin-registered provider like soniox-stt). The client
+ * can then stream mic PCM to /api/audio/transcribe-stream while the user is
+ * still speaking — the transcript lands right at end-of-recording instead of
+ * after a post-hoc file transcription. Any direct-wire provider returns false
+ * (they transcribe the finished blob client-side, which is already fast).
+ */
+export async function sttStreamingRelayAvailable(): Promise<boolean> {
+  const config = await fetchVoiceClientConfig()
+  const stt = config?.stt
+
+  return Boolean(stt && stt.mode === 'relay' && (stt as { streaming?: boolean }).streaming === true)
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/lib/voice-stream.routing.test.ts
+++ b/apps/desktop/src/lib/voice-stream.routing.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { setApiRequestConnection, setApiRequestProfile } from '@/hermes'
+
+import { resolveTranscribeStreamUrl } from './voice-stream'
+
+// The transcribe-stream WebSocket must dial the ACTIVE (connection, profile)
+// backend — the same routing contract as resolveSpeakStreamUrl: when a
+// registry remote rides over a local install, live dictation audio must reach
+// the REMOTE gateway (where the profile's STT provider runs), not the local
+// machine's web server.
+describe('resolveTranscribeStreamUrl', () => {
+  const remoteWsUrl = 'wss://gateway.example/api/ws?ticket=fresh'
+  const localWsUrl = 'ws://127.0.0.1:5151/api/ws?token=local'
+
+  let getConnection: ReturnType<typeof vi.fn>
+  let getConnectionFor: ReturnType<typeof vi.fn>
+  let getGatewayWsUrl: ReturnType<typeof vi.fn>
+  let getGatewayWsUrlFor: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    getConnection = vi.fn(async () => ({ authMode: 'token', baseUrl: 'http://127.0.0.1:5151', wsUrl: localWsUrl }))
+
+    getConnectionFor = vi.fn(async () => ({
+      authMode: 'token',
+      baseUrl: 'https://gateway.example',
+      wsUrl: remoteWsUrl
+    }))
+
+    getGatewayWsUrl = vi.fn(async () => ({ ok: true, wsUrl: localWsUrl }))
+    getGatewayWsUrlFor = vi.fn(async () => ({ ok: true, wsUrl: remoteWsUrl }))
+
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { getConnection, getConnectionFor, getGatewayWsUrl, getGatewayWsUrlFor }
+    })
+  })
+
+  afterEach(() => {
+    setApiRequestConnection(null)
+    setApiRequestProfile(null)
+    Reflect.deleteProperty(window, 'hermesDesktop')
+  })
+
+  it('resolves through the registry (connection, profile) bridges when a registry connection is active', async () => {
+    setApiRequestConnection('gw-tailscale')
+    setApiRequestProfile('research')
+
+    const url = await resolveTranscribeStreamUrl()
+
+    expect(url).toContain('wss://gateway.example')
+    expect(url).toContain('/api/audio/transcribe-stream')
+    expect(getConnectionFor).toHaveBeenCalledWith({ connectionId: 'gw-tailscale', profile: 'research' })
+    expect(getGatewayWsUrlFor).toHaveBeenCalledWith({ connectionId: 'gw-tailscale', profile: 'research' })
+    // The v1 primary path must NOT be consulted — that's the local machine.
+    expect(getConnection).not.toHaveBeenCalled()
+    expect(getGatewayWsUrl).not.toHaveBeenCalled()
+  })
+
+  it('keeps a backend-namespaced profile query param when one is already present', async () => {
+    setApiRequestConnection('gw-tailscale')
+    setApiRequestProfile('research')
+    getGatewayWsUrlFor.mockResolvedValue({
+      ok: true,
+      wsUrl: 'wss://gateway.example/api/ws?profile=backend-ns&ticket=t'
+    })
+
+    const url = await resolveTranscribeStreamUrl()
+
+    expect(url).toContain('profile=backend-ns')
+    expect(url).not.toContain('profile=research')
+  })
+
+  it('falls back to the v1 primary backend when no registry connection is active', async () => {
+    const url = await resolveTranscribeStreamUrl()
+
+    expect(url).toContain('127.0.0.1:5151')
+    expect(url).toContain('/api/audio/transcribe-stream')
+    expect(getConnection).toHaveBeenCalledWith(null)
+    expect(getGatewayWsUrlFor).not.toHaveBeenCalled()
+  })
+
+  it('returns null when the gateway URL is not the /api/ws shape', async () => {
+    getGatewayWsUrl.mockResolvedValue({ ok: true, wsUrl: 'ws://127.0.0.1:5151/other' })
+
+    expect(await resolveTranscribeStreamUrl()).toBeNull()
+  })
+
+  it('returns null without desktop bridges', async () => {
+    Reflect.deleteProperty(window, 'hermesDesktop')
+
+    expect(await resolveTranscribeStreamUrl()).toBeNull()
+  })
+})

--- a/apps/desktop/src/lib/voice-stream.ts
+++ b/apps/desktop/src/lib/voice-stream.ts
@@ -1,0 +1,216 @@
+import { resolveGatewayWsUrl } from '@hermes/shared'
+
+import { getApiRequestConnection, getApiRequestProfile } from '@/hermes'
+
+/**
+ * Live dictation STT: stream mic PCM to the gateway's
+ * /api/audio/transcribe-stream WebSocket WHILE the user is speaking.
+ *
+ * The gateway feeds the audio to the active streaming-capable STT provider
+ * (plugin-registered, e.g. soniox-stt) and returns the transcript right when
+ * the recording ends — no "record the whole utterance, then transcribe the
+ * file" round-trip. Direction of travel:
+ *
+ *   mic → PCM chunks (this module) → gateway → provider (live) → text → composer
+ *
+ * Protocol (server contract in hermes_cli/web_server.py):
+ *   client → {"sample_rate": 16000}   then binary s16le mono PCM frames,
+ *            {"eos": true}            recording finished
+ *   server → {"type":"partial","text":...}, {"type":"final","transcript":...},
+ *            {"type":"error","message":...}
+ *
+ * Any failure (older backend, no streaming provider, socket drop) surfaces as
+ * a rejected stop()/null handle — callers fall back to the recorded-blob
+ * relay, so dictation keeps working exactly as before.
+ */
+
+export async function resolveTranscribeStreamUrl(): Promise<null | string> {
+  const desktop = window.hermesDesktop
+
+  if (!desktop?.getConnection) {
+    return null
+  }
+
+  try {
+    // Same (connection, profile) routing as resolveSpeakStreamUrl: mint a
+    // fresh credential for the ACTIVE backend and swap the gateway endpoint
+    // for the STT one — auth is shared across WS routes.
+    const profile = getApiRequestProfile()
+    const connectionId = getApiRequestConnection()
+
+    const conn =
+      connectionId && desktop.getConnectionFor
+        ? await desktop.getConnectionFor({ connectionId, profile })
+        : await desktop.getConnection(profile)
+
+    const wsDeps =
+      connectionId && desktop.getGatewayWsUrlFor
+        ? { getGatewayWsUrl: () => desktop.getGatewayWsUrlFor!({ connectionId, profile }) }
+        : connectionId
+          ? {}
+          : desktop
+
+    const wsUrl = await resolveGatewayWsUrl(wsDeps, conn)
+    const url = new URL(wsUrl)
+
+    if (!url.pathname.endsWith('/api/ws')) {
+      return null
+    }
+
+    url.pathname = url.pathname.replace(/\/api\/ws$/, '/api/audio/transcribe-stream')
+
+    if (profile && !url.searchParams.has('profile')) {
+      url.searchParams.set('profile', profile)
+    }
+
+    return url.toString()
+  } catch {
+    return null
+  }
+}
+
+export interface DictationStreamSession {
+  /** Feed one PCM chunk (16 kHz mono s16le). No-op once finished/closed. */
+  pushAudio: (chunk: ArrayBuffer) => void
+  /** End the recording and resolve with the final transcript (null = silence). */
+  stop: () => Promise<null | string>
+  /** Abort without a transcript (barge-in / cancel). */
+  cancel: () => void
+  /** Latest non-final text the provider has recognized so far. */
+  lastPartial: () => string
+}
+
+export function openDictationStream(options?: {
+  onPartial?: (text: string) => void
+}): Promise<DictationStreamSession | null> {
+  const onPartial = options?.onPartial
+
+  return (async () => {
+    const url = await resolveTranscribeStreamUrl()
+
+    if (!url) {
+      return null
+    }
+
+    let ws: WebSocket
+    let opened = false
+    let settled = false
+    let partial = ''
+    let pending: { resolve: (t: null | string) => void; reject: (e: Error) => void } | null = null
+    let errorMessage: null | string = null
+
+    const settle = (resolve: (t: null | string) => void, reject: (e: Error) => void) => {
+      pending = { resolve, reject }
+    }
+
+    ws = new WebSocket(url)
+
+    ws.onmessage = event => {
+      let message: { type?: string; transcript?: string; text?: string; message?: string } = {}
+
+      try {
+        message = JSON.parse(String(event.data)) as typeof message
+      } catch {
+        return
+      }
+
+      if (message.type === 'partial' && typeof message.text === 'string') {
+        partial = message.text
+        onPartial?.(partial)
+      } else if (message.type === 'final') {
+        settled = true
+        pending?.resolve((message.transcript ?? '').trim() || null)
+        pending = null
+        ws.close()
+      } else if (message.type === 'error') {
+        errorMessage = message.message ?? 'STT streaming error'
+        settled = true
+        pending?.reject(new Error(errorMessage))
+        pending = null
+        ws.close()
+      }
+    }
+
+    ws.onclose = () => {
+      if (!settled) {
+        settled = true
+
+        if (errorMessage) {
+          console.warn(`[voice-stream] closed without final: ${errorMessage}`)
+          pending?.reject(new Error(errorMessage))
+        } else {
+          pending?.resolve(null)
+        }
+
+        pending = null
+      }
+    }
+
+    ws.onerror = () => {
+      if (!settled && !errorMessage) {
+        errorMessage = 'STT streaming connection failed'
+      }
+    }
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        ws.onopen = () => {
+          opened = true
+          resolve()
+        }
+
+        ws.onerror = () => {
+          if (!opened) {
+            reject(new Error(errorMessage ?? 'STT streaming connection failed'))
+          }
+        }
+      })
+    } catch (error) {
+      ws.close()
+
+      return null
+    }
+
+    ws.send(JSON.stringify({ sample_rate: 16000 }))
+    console.info('[voice-stream] transcribe-stream connected (16 kHz s16le)')
+
+    return {
+      pushAudio: (chunk: ArrayBuffer) => {
+        if (ws.readyState === WebSocket.OPEN && !settled) {
+          try {
+            ws.send(chunk)
+          } catch {
+            // Socket died mid-recording — stop() will surface the failure and
+            // the caller falls back to the recorded blob.
+          }
+        }
+      },
+      stop: () =>
+        new Promise<null | string>((resolve, reject) => {
+          if (settled) {
+            resolve(null)
+
+            return
+          }
+
+          settle(resolve, reject)
+
+          try {
+            ws.send(JSON.stringify({ eos: true }))
+          } catch (error) {
+            reject(error instanceof Error ? error : new Error('STT streaming send failed'))
+          }
+        }),
+      cancel: () => {
+        if (!settled) {
+          settled = true
+          pending?.resolve(null)
+          pending = null
+        }
+
+        ws.close()
+      },
+      lastPartial: () => partial
+    }
+  })()
+}

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -3518,6 +3518,60 @@ def _plugin_tts_providers() -> list[dict]:
     return rows
 
 
+def _plugin_stt_providers() -> list[dict]:
+    """Build picker-row dicts from plugin-registered STT providers.
+
+    Mirror of :func:`_plugin_tts_providers` for the Speech-to-Text
+    category (``register_transcription_provider()`` plugin hook). Built-in
+    STT rows stay hardcoded in ``TOOL_CATEGORIES["stt"]``; this function
+    injects PLUGIN-registered providers — e.g. ``soniox-stt`` — so they
+    are selectable from ``hermes tools`` (and the desktop provider UI,
+    which shares this code path) with their ``get_setup_schema`` env-var
+    prompts writing to ``.env``.
+
+    Selecting a row writes ``stt.provider: <name>`` through the same
+    generic path as built-ins; the transcription dispatcher resolves the
+    plugin from the registry automatically.
+    """
+    try:
+        from agent.transcription_registry import _BUILTIN_NAMES, list_providers
+        from hermes_cli.plugins import _ensure_plugins_discovered
+
+        _ensure_plugins_discovered()
+        providers = list_providers()
+    except Exception:
+        return []
+
+    rows: list[dict] = []
+    for provider in providers:
+        name = getattr(provider, "name", None)
+        if not name:
+            continue
+        # Defensive: reject built-in shadowing at the picker layer too.
+        if name.lower().strip() in _BUILTIN_NAMES:
+            continue
+        try:
+            schema = provider.get_setup_schema()
+        except Exception:
+            continue
+        if not isinstance(schema, dict):
+            continue
+        row = {
+            "name": schema.get("name", provider.display_name),
+            "badge": schema.get("badge", ""),
+            "tag": schema.get("tag", ""),
+            "env_vars": schema.get("env_vars", []),
+            # Selecting this row writes ``stt.provider: <name>`` — the
+            # same write-path used by hardcoded rows.
+            "stt_provider": name,
+            "stt_plugin_name": name,
+        }
+        if schema.get("post_setup"):
+            row["post_setup"] = schema["post_setup"]
+        rows.append(row)
+    return rows
+
+
 def _visible_providers(
     cat: dict,
     config: dict,
@@ -3600,6 +3654,12 @@ def _visible_providers(
     # is filtered out by ``_plugin_tts_providers`` defensively.
     if cat.get("name") == "Text-to-Speech":
         visible.extend(_plugin_tts_providers())
+
+    # Inject plugin-registered STT backends (register_transcription_provider
+    # plugin hook) so streaming-capable providers like soniox-stt are
+    # selectable from the picker like any built-in.
+    if cat.get("name") == "Speech-to-Text":
+        visible.extend(_plugin_stt_providers())
 
     return visible
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5367,6 +5367,212 @@ async def transcribe_audio_upload(
     }
 
 
+@app.websocket("/api/audio/transcribe-stream")
+async def transcribe_stream_ws(ws: "WebSocket") -> None:
+    """Live STT for the desktop: mic PCM in as the user speaks, text out.
+
+    The client streams 16 kHz mono s16le PCM captured while the user is
+    STILL speaking; the server feeds it to the active streaming-capable
+    STT provider (plugin-registered, e.g. ``soniox-stt``) and returns the
+    transcript right when the user stops — instead of "record the whole
+    utterance, then transcribe the file" (latency ≥ utterance duration).
+
+    Protocol:
+      client → ``{"sample_rate": 16000}``   first frame (must be 16000)
+               binary PCM frames (s16le mono @ 16000)
+               ``{"eos": true}``             recording finished
+      server → ``{"type": "partial", "text": "..."}`` as speech is recognized
+               ``{"type": "final", "success": true, "transcript": "...",
+                    "provider": "..."}``
+               ``{"type": "error", "message": "..."}`` on failure (and no
+               streaming provider for the configured STT — the client falls
+               back to the POST /api/audio/transcribe relay).
+    """
+    if not _ws_auth_ok(ws):
+        await ws.close(code=4401)
+        return
+    if not _ws_request_is_allowed(ws):
+        await ws.close(code=4403)
+        return
+    await ws.accept()
+
+    # Profile via query param, like /api/audio/speak-stream: provider chain +
+    # API keys must resolve from the requesting profile's config.
+    profile = (ws.query_params.get("profile") or "").strip() or None
+    loop = asyncio.get_running_loop()
+
+    def _resolve():
+        from tools import transcription_tools as tt
+
+        with _config_profile_scope(profile):
+            cfg = tt._load_stt_config()
+            if not tt.is_stt_enabled(cfg):
+                return None, "stt disabled"
+            provider = tt._get_provider(cfg)
+            if provider in tt.BUILTIN_STT_PROVIDERS:
+                return None, "built-in provider has no streaming wire"
+            language = tt._resolve_stt_language(provider, cfg)
+            from agent.transcription_registry import open_streaming_session
+
+            session = open_streaming_session(provider, language=language)
+            if session is None:
+                return None, "configured STT provider is not streaming-capable"
+            return session, None
+
+    try:
+        session, error = await loop.run_in_executor(None, _resolve)
+    except Exception:
+        _log.exception("transcribe-stream provider resolution failed")
+        session, error = None, "resolution error"
+    if session is None:
+        with contextlib.suppress(Exception):
+            await ws.send_json({"type": "error", "message": f"no streaming STT available ({error})"})
+            await ws.close()
+        return
+    _log.info("transcribe-stream: streaming session opened (%s)", type(session).__name__)
+
+    # First frame: session parameters.
+    try:
+        first = await ws.receive_json()
+    except Exception:
+        first = {}
+    if first.get("sample_rate") != 16000:
+        with contextlib.suppress(Exception):
+            await ws.send_json({"type": "error", "message": "sample_rate must be 16000"})
+            await ws.close()
+        return
+
+    audio_in: queue.Queue = queue.Queue()  # bytes; None = end-of-audio
+    result_out: queue.Queue = queue.Queue()  # final envelope
+
+    def _feed_and_finalize() -> None:
+        # Session.push_audio is a plain socket send; feed inline until EOS,
+        # then finalize (blocks until the provider's transcript is ready).
+        while True:
+            chunk = audio_in.get()
+            if chunk is None:
+                break
+            try:
+                session.push_audio(chunk)
+            except Exception:
+                _log.warning("transcribe-stream push failed", exc_info=True)
+                break
+        try:
+            result_out.put(session.finalize())
+        except Exception as exc:  # noqa: BLE001 — envelope everything
+            result_out.put(
+                {"success": False, "transcript": "", "provider": "unknown", "error": str(exc)}
+            )
+
+    feeder = threading.Thread(target=_feed_and_finalize, daemon=True)
+    feeder.start()
+    session_started_at = time.monotonic()
+    audio_chunks = 0
+    pcm_abs_sum = 0
+    pcm_samples = 0
+
+    async def _send_partials() -> None:
+        # Surface non-final text while the user is still speaking.
+        last = ""
+        while True:
+            await asyncio.sleep(0.4)
+            try:
+                partial = session.partial_transcript()
+            except Exception:
+                partial = ""
+            if partial and partial != last:
+                last = partial
+                with contextlib.suppress(Exception):
+                    await ws.send_json({"type": "partial", "text": partial})
+
+    partials_task = asyncio.create_task(_send_partials())
+
+    try:
+        # Receive audio until the client signals end-of-audio or drops.
+        while True:
+            try:
+                message = await ws.receive()
+            except Exception:
+                # Client disconnected mid-recording (barge-in / cancel).
+                audio_in.put(None)
+                break
+            if message.get("type") == "websocket.disconnect" or message.get("bytes") is None and message.get("text") is None:
+                # Disconnect or non-data frame — treat as end-of-audio.
+                audio_in.put(None)
+                break
+            chunk = message.get("bytes")
+            if chunk is not None:
+                audio_chunks += 1
+                audio_in.put(chunk)
+                # Energy probe (16 kHz s16le): distinguishes "mic sent silence"
+                # from "provider rejected real audio" in the end-of-session log.
+                try:
+                    view = memoryview(chunk).cast("h")
+                    pcm_abs_sum += sum(abs(int(sample)) for sample in view)
+                    pcm_samples += len(view)
+                except Exception:  # noqa: BLE001 — energy is diagnostic-only
+                    pass
+                continue
+            raw_text = message.get("text")
+            if raw_text is not None:
+                import json as _json
+
+                try:
+                    payload = _json.loads(raw_text)
+                except ValueError:
+                    payload = {}
+                if payload.get("eos"):
+                    audio_in.put(None)
+                    break
+        # Wait for the feeder to finalize — bounded, so a stalled provider
+        # session can never leave the client's recording UI hanging.
+        try:
+            result = await asyncio.wait_for(
+                loop.run_in_executor(None, result_out.get), timeout=45
+            )
+        except asyncio.TimeoutError:
+            _log.warning("transcribe-stream finalize timed out")
+            result = {
+                "success": False,
+                "transcript": "",
+                "error": "transcribe-stream timed out",
+            }
+    except Exception:
+        _log.exception("transcribe-stream session failed")
+        result = {"success": False, "transcript": "", "error": "transcribe-stream session failed"}
+    finally:
+        partials_task.cancel()
+
+    _log.info(
+        "transcribe-stream: session ended in %.1fs (success=%s, %d audio chunks, "
+        "avg_abs_level=%.0f/32768)",
+        time.monotonic() - session_started_at,
+        bool(result.get("success")),
+        audio_chunks,
+        (pcm_abs_sum / pcm_samples) if pcm_samples else 0,
+    )
+    if not result.get("success"):
+        _log.warning("transcribe-stream: finalize failed: %s", result.get("error"))
+    elif result.get("transcript"):
+        _log.info("transcribe-stream: transcript %d chars", len(result["transcript"]))
+
+    if not result.get("success"):
+        with contextlib.suppress(Exception):
+            await ws.send_json({"type": "error", "message": result.get("error") or "transcription failed"})
+    else:
+        with contextlib.suppress(Exception):
+            await ws.send_json(
+                {
+                    "type": "final",
+                    "success": True,
+                    "transcript": result.get("transcript", ""),
+                    "provider": result.get("provider", ""),
+                }
+            )
+    with contextlib.suppress(Exception):
+        await ws.close()
+
+
 @app.get("/api/audio/voice-config")
 async def get_client_voice_config(profile: Optional[str] = None):
     """The active profile's STT/TTS config for CLIENT-DIRECT voice.

--- a/tests/agent/test_transcription_registry.py
+++ b/tests/agent/test_transcription_registry.py
@@ -20,7 +20,7 @@ from typing import Any, Optional
 import pytest
 
 from agent import transcription_registry
-from agent.transcription_provider import TranscriptionProvider
+from agent.transcription_provider import TranscriptionProvider, TranscriptionStreamSession
 
 
 class _FakeProvider(TranscriptionProvider):
@@ -185,3 +185,88 @@ class TestBuiltinSync:
             "These two lists exist as a circular-import workaround and "
             "MUST be kept in sync manually."
         )
+
+
+# ---------------------------------------------------------------------------
+# Streaming capability
+# ---------------------------------------------------------------------------
+
+
+class _FakeStreamingProvider(_FakeProvider):
+    """A streaming-capable provider whose session records pushed chunks."""
+
+    def __init__(self, name: str = "streamer", fail_open: bool = False):
+        super().__init__(name=name)
+        self._fail_open = fail_open
+        self.pushed: list[bytes] = []
+        self.opened_language: Optional[str] = None
+
+    @property
+    def streaming_capable(self) -> bool:
+        return True
+
+    def open_stream_session(self, *, language=None, prompt=None):
+        if self._fail_open:
+            raise RuntimeError("boom")
+        self.opened_language = language
+        return _FakeStreamSession(self)
+
+
+class _FakeStreamSession(TranscriptionStreamSession):
+    def __init__(self, provider: _FakeStreamingProvider):
+        self._provider = provider
+        self.finalized = False
+
+    def push_audio(self, chunk: bytes) -> None:
+        self._provider.pushed.append(chunk)
+
+    def finalize(self):
+        self.finalized = True
+        return {
+            "success": True,
+            "transcript": "".join(c.decode(errors="ignore") for c in self._provider.pushed),
+            "provider": self._provider.name,
+        }
+
+
+class TestStreamingCapability:
+    def test_default_not_streaming_capable(self):
+        # Plain TranscriptionProvider subclasses don't stream.
+        p = _FakeProvider(name="openrouter")
+        assert p.streaming_capable is False
+
+    def test_open_streaming_session_none_for_file_only_provider(self):
+        p = _FakeProvider(name="openrouter")
+        transcription_registry.register_provider(p)
+        assert transcription_registry.open_streaming_session("openrouter") is None
+
+    def test_open_streaming_session_unknown_name_returns_none(self):
+        assert transcription_registry.open_streaming_session("ghost") is None
+
+    def test_streaming_session_push_and_finalize(self):
+        p = _FakeStreamingProvider(name="streamer")
+        transcription_registry.register_provider(p)
+        session = transcription_registry.open_streaming_session("streamer", language="pt")
+        assert session is not None
+        session.push_audio(b"ola")
+        session.push_audio(b" mundo")
+        result = session.finalize()
+        assert result == {
+            "success": True,
+            "transcript": "ola mundo",
+            "provider": "streamer",
+        }
+        assert p.opened_language == "pt"
+        assert p.pushed == [b"ola", b" mundo"]
+
+    def test_default_partial_transcript_empty(self):
+        p = _FakeStreamingProvider(name="streamer")
+        transcription_registry.register_provider(p)
+        session = transcription_registry.open_streaming_session("streamer")
+        assert session is not None
+        assert session.partial_transcript() == ""
+
+    def test_open_failure_returns_none(self):
+        p = _FakeStreamingProvider(name="streamer", fail_open=True)
+        transcription_registry.register_provider(p)
+        assert transcription_registry.open_streaming_session("streamer") is None

--- a/tests/hermes_cli/test_stt_picker.py
+++ b/tests/hermes_cli/test_stt_picker.py
@@ -1,125 +1,120 @@
-"""Tests for the Speech-to-Text category in `hermes tools` (tools_config).
+"""Tests for the STT plugin picker surface in hermes_cli/tools_config.py.
 
-Covers the STT provider picker rows, config writes (stt.provider /
-use_gateway), the model picker catalog, config-only checklist exclusion,
-and the faster_whisper post-setup readiness hook.
+Covers ``_plugin_stt_providers()`` and the ``_visible_providers()``
+integration that injects plugin rows (e.g. soniox-stt) into the
+Speech-to-Text category.
+
+Mirrors tests/hermes_cli/test_tts_picker.py (issue #30398 pattern).
 """
 
-import sys
-import types
-from pathlib import Path
-from unittest.mock import MagicMock, patch
+from __future__ import annotations
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-
-from hermes_cli.tools_config import (  # noqa: E402
-    _CONFIG_ONLY_TOOLSETS,
-    CONFIGURABLE_TOOLSETS,
-    STT_MODEL_CATALOG,
-    TOOL_CATEGORIES,
-    _checklist_toolset_keys,
-    _configure_stt_model,
-    _is_provider_active,
-    _write_provider_config,
-    apply_provider_selection,
-)
+from agent import transcription_registry
+from agent.transcription_provider import TranscriptionProvider
+from hermes_cli import tools_config
 
 
-def _stt_cat():
-    return TOOL_CATEGORIES["stt"]
+class _FakeSTTProvider(TranscriptionProvider):
+    def __init__(self, name: str, schema: dict | None = None, streaming: bool = False):
+        self._name = name
+        self._schema = schema
+        self._streaming = streaming
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def streaming_capable(self) -> bool:
+        return self._streaming
+
+    def transcribe(self, file_path: str, **kw):
+        return {"success": True, "transcript": "", "provider": self._name}
+
+    def get_setup_schema(self):
+        if self._schema is not None:
+            return self._schema
+        return super().get_setup_schema()
 
 
-def _stt_provider_named(name):
-    return next(p for p in _stt_cat()["providers"] if p["name"] == name)
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    transcription_registry._reset_for_tests()
+    yield
+    transcription_registry._reset_for_tests()
 
 
-class TestSttCategory:
-    def test_stt_category_exists(self):
-        cat = _stt_cat()
-        assert cat["name"] == "Speech-to-Text"
-        assert len(cat["providers"]) >= 5
+class TestPluginSTTProviders:
+    """``_plugin_stt_providers()`` returns picker-row dicts."""
+
+    def test_minimal_schema_uses_display_name(self):
+        """A provider with no setup_schema override gets a row built from
+        ``display_name`` and ``name`` only."""
+        transcription_registry.register_provider(_FakeSTTProvider(name="minimal"))
+        rows = tools_config._plugin_stt_providers()
+        assert len(rows) == 1
+        assert rows[0]["name"] == "Minimal"  # display_name default
+        assert rows[0]["stt_provider"] == "minimal"
+        assert rows[0]["env_vars"] == []
+
+    def test_schema_env_vars_and_streaming_row(self):
+        """A provider with a full setup schema (env var prompt) maps into the
+        picker row that the generic selection path persists."""
+        provider = _FakeSTTProvider(
+            name="soniox",
+            streaming=True,
+            schema={
+                "name": "Soniox",
+                "badge": "paid",
+                "tag": "live-streaming STT",
+                "env_vars": [
+                    {"key": "SONIOX_API_KEY", "prompt": "Soniox API key", "url": "https://console.soniox.com"},
+                ],
+            },
+        )
+        transcription_registry.register_provider(provider)
+        rows = tools_config._plugin_stt_providers()
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["name"] == "Soniox"
+        assert row["badge"] == "paid"
+        assert row["stt_provider"] == "soniox"
+        assert row["env_vars"][0]["key"] == "SONIOX_API_KEY"
+
+    def test_builtin_shadowing_filtered(self):
+        """A plugin named like a built-in STT provider never reaches the picker."""
+        transcription_registry.register_provider(_FakeSTTProvider(name="openai"))
+        assert tools_config._plugin_stt_providers() == []
+
+    def test_skips_providers_with_no_name(self):
+        class _NoName:
+            display_name = "Bogus"
+
+            def get_setup_schema(self):
+                return {"name": "Bogus"}
+
+        transcription_registry._providers["bogus"] = _NoName()  # type: ignore[assignment]
+        try:
+            rows = tools_config._plugin_stt_providers()
+            assert all(r.get("stt_plugin_name") != "bogus" for r in rows)
+        finally:
+            transcription_registry._providers.pop("bogus", None)  # type: ignore[arg-type]
 
 
+class TestVisibleProvidersInjectsSTTPlugins:
+    """``_visible_providers()`` injects plugin rows into the Speech-to-Text
+    category alongside the hardcoded built-ins."""
 
-
-    def test_managed_row_shares_tts_coverage_category(self):
-        from hermes_cli.nous_subscription import MANAGED_FEATURE_COVERAGE_CATEGORY
-
-        managed = [p for p in _stt_cat()["providers"] if p.get("managed_nous_feature")]
-        assert managed, "expected a Nous Subscription row"
-        for p in managed:
-            assert p["managed_nous_feature"] == "stt"
-        assert MANAGED_FEATURE_COVERAGE_CATEGORY["stt"] == "openai-audio"
-
-
-class TestConfigWrites:
-    def test_write_provider_config_sets_stt_provider(self):
-        config = {"stt": {"use_gateway": True}}
-        prov = _stt_provider_named("Groq")
-        _write_provider_config(prov, config, managed_feature=None)
-        assert config["stt"]["provider"] == "groq"
-        # Legacy key is popped so the read-time shim can't override the pick.
-        assert "use_gateway" not in config["stt"]
-
-
-    def test_apply_provider_selection_stt(self):
-        config = {}
-        with patch(
-            "hermes_cli.tools_config.get_nous_subscription_features"
-        ) as feats:
-            feats.return_value = MagicMock(
-                nous_auth_present=False, account_info=None
-            )
-            apply_provider_selection("stt", "OpenAI", config)
-        assert config["stt"]["provider"] == "openai"
-
-
-class TestActiveDetection:
-    def test_active_matches_config(self):
-        config = {"stt": {"provider": "groq"}}
-        assert _is_provider_active(_stt_provider_named("Groq"), config)
-        assert not _is_provider_active(_stt_provider_named("OpenAI"), config)
-
-    def test_unset_provider_defaults_to_local(self):
-        assert _is_provider_active(_stt_provider_named("Local Whisper"), {})
-
-
-class TestModelPicker:
-
-    def test_catalog_matches_runtime_model_sets(self):
-        from tools.transcription_tools import GROQ_MODELS, OPENAI_MODELS
-
-        assert set(STT_MODEL_CATALOG["openai"]) == OPENAI_MODELS
-        assert set(STT_MODEL_CATALOG["groq"]) == GROQ_MODELS
-
-
-
-
-    def test_configure_stt_model_defaults_to_current(self):
-        config = {"stt": {"openai": {"model": "gpt-transcribe"}}}
-        with patch(
-            "hermes_cli.tools_config._prompt_choice", return_value=0
-        ) as pc:
-            _configure_stt_model("openai", config)
-        # default index should point at the currently configured model
-        args = pc.call_args[0]
-        assert args[2] == STT_MODEL_CATALOG["openai"].index("gpt-transcribe")
-
-
-class TestConfigOnlyExclusion:
-    def test_stt_is_config_only(self):
-        assert "stt" in _CONFIG_ONLY_TOOLSETS
-
-    def test_stt_excluded_from_checklist_universe(self):
-        assert "stt" not in _checklist_toolset_keys("cli")
-        # sanity: tts (a real toolset) stays in
-        assert "tts" in _checklist_toolset_keys("cli")
-
-
-class TestPostSetup:
-    def test_faster_whisper_in_post_setup_ready(self):
-        from hermes_cli.tools_config import _POST_SETUP_READY
-
-        assert "faster_whisper" in _POST_SETUP_READY
+    def test_stt_category_contains_plugin_rows(self):
+        transcription_registry.register_provider(_FakeSTTProvider(name="soniox"))
+        cat = tools_config.TOOL_CATEGORIES["stt"]
+        visible = tools_config._visible_providers(cat, config={})
+        names = [row.get("name") for row in visible]
+        # Hardcoded rows still present.
+        assert "Local Whisper" in names
+        # Plugin row injected with the stt_provider write-path key.
+        plugin_rows = [row for row in visible if row.get("stt_plugin_name")]
+        assert len(plugin_rows) == 1
+        assert plugin_rows[0]["stt_provider"] == "soniox"

--- a/tests/hermes_cli/test_web_server_transcribe_stream.py
+++ b/tests/hermes_cli/test_web_server_transcribe_stream.py
@@ -1,0 +1,132 @@
+"""/api/audio/transcribe-stream — live STT for desktop dictation over WebSocket."""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import urlencode
+
+import pytest
+from starlette.testclient import TestClient
+
+from hermes_cli import web_server
+
+
+@pytest.fixture
+def stream_client(monkeypatch, _isolate_hermes_home):
+    previous_auth_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.auth_required = False
+
+    client = TestClient(web_server.app)
+    try:
+        yield client
+    finally:
+        close = getattr(client, "close", None)
+        if close is not None:
+            close()
+        if previous_auth_required is None:
+            if hasattr(web_server.app.state, "auth_required"):
+                delattr(web_server.app.state, "auth_required")
+        else:
+            web_server.app.state.auth_required = previous_auth_required
+
+
+def _url(token: str | None = None) -> str:
+    return f"/api/audio/transcribe-stream?{urlencode({'token': token or web_server._SESSION_TOKEN})}"
+
+
+class _FakeSession:
+    """Streaming session contract the endpoint drives (16 kHz s16le PCM in)."""
+
+    def __init__(self):
+        self.pushed: list[bytes] = []
+        self.finalized = False
+        self.partial = ""
+
+    def push_audio(self, chunk: bytes) -> None:
+        self.pushed.append(chunk)
+
+    def partial_transcript(self) -> str:
+        return self.partial
+
+    def finalize(self):
+        self.finalized = True
+        text = "".join(c.decode("utf-8", errors="ignore") for c in self.pushed)
+        if text == "fail":
+            return {"success": False, "transcript": "", "provider": "fake", "error": "boom"}
+        return {"success": True, "transcript": f"heard: {text}", "provider": "fake"}
+
+
+def _patch_streaming(monkeypatch, session: _FakeSession):
+    """Route the endpoint's resolution to a fake streaming-capable provider."""
+    monkeypatch.setattr("tools.transcription_tools._load_stt_config", lambda: {})
+    monkeypatch.setattr("tools.transcription_tools.is_stt_enabled", lambda cfg: True)
+    monkeypatch.setattr("tools.transcription_tools._get_provider", lambda cfg: "fake-stream")
+    monkeypatch.setattr("tools.transcription_tools._resolve_stt_language", lambda provider, cfg: "pt")
+    monkeypatch.setattr(
+        "agent.transcription_registry.open_streaming_session",
+        lambda provider, language=None: session if provider == "fake-stream" else None,
+    )
+
+
+def test_streams_pcm_and_returns_final(stream_client, monkeypatch):
+    session = _FakeSession()
+    _patch_streaming(monkeypatch, session)
+
+    with stream_client.websocket_connect(_url()) as conn:
+        conn.send_text(json.dumps({"sample_rate": 16000}))
+        conn.send_bytes(b"ola")
+        conn.send_bytes(b" mundo")
+        conn.send_text(json.dumps({"eos": True}))
+
+        final = conn.receive_json()
+        assert final["type"] == "final"
+        assert final["success"] is True
+        assert final["transcript"] == "heard: ola mundo"
+        assert final["provider"] == "fake"
+
+    assert session.pushed == [b"ola", b" mundo"]
+    assert session.finalized is True
+
+
+def test_rejects_non_16000_sample_rate(stream_client, monkeypatch):
+    _patch_streaming(monkeypatch, _FakeSession())
+
+    with stream_client.websocket_connect(_url()) as conn:
+        conn.send_text(json.dumps({"sample_rate": 48000}))
+        error = conn.receive_json()
+        assert error["type"] == "error"
+        assert "16000" in error["message"]
+
+
+def test_error_envelope_when_provider_has_no_streaming(stream_client, monkeypatch):
+    _patch_streaming(monkeypatch, _FakeSession())
+    monkeypatch.setattr(
+        "agent.transcription_registry.open_streaming_session",
+        lambda provider, language=None: None,
+    )
+
+    with stream_client.websocket_connect(_url()) as conn:
+        error = conn.receive_json()
+        assert error["type"] == "error"
+        assert "streaming" in error["message"]
+
+
+def test_error_envelope_when_stt_disabled(stream_client, monkeypatch):
+    monkeypatch.setattr("tools.transcription_tools.is_stt_enabled", lambda cfg: False)
+
+    with stream_client.websocket_connect(_url()) as conn:
+        error = conn.receive_json()
+        assert error["type"] == "error"
+
+
+def test_failure_envelope_surfaces_provider_error(stream_client, monkeypatch):
+    _patch_streaming(monkeypatch, _FakeSession())
+
+    with stream_client.websocket_connect(_url()) as conn:
+        conn.send_text(json.dumps({"sample_rate": 16000}))
+        conn.send_bytes(b"fail")
+        conn.send_text(json.dumps({"eos": True}))
+
+        error = conn.receive_json()
+        assert error["type"] == "error"
+        assert error["message"] == "boom"

--- a/tools/voice_client_config.py
+++ b/tools/voice_client_config.py
@@ -69,6 +69,25 @@ def _client_direct_enabled() -> bool:
     return True
 
 
+def _plugin_streaming_capable(provider: str) -> bool:
+    """Whether a plugin-registered STT provider supports live streaming.
+
+    Plugin/command providers can't be called from the client directly,
+    but a streaming-capable plugin enables the *live relay*: the client
+    streams PCM to ``/api/audio/transcribe-stream`` and the host feeds
+    it to the provider while the user speaks.
+    """
+    try:
+        from agent.transcription_registry import get_provider
+        from hermes_cli.plugins import _ensure_plugins_discovered
+
+        _ensure_plugins_discovered()
+        registered = get_provider(provider)
+        return bool(registered is not None and registered.streaming_capable)
+    except Exception:  # noqa: BLE001 — capability probe must never break config
+        return False
+
+
 def _relay(reason: str) -> Dict[str, Any]:
     """A relay verdict that tells the client (and logs) WHY, without secrets."""
     return {"mode": "relay", "reason": reason}
@@ -93,7 +112,15 @@ def _resolve_stt_client_config() -> Dict[str, Any]:
     if tt._is_local_stt_provider(provider, stt_config):
         return _relay("local provider")
     if provider not in tt.BUILTIN_STT_PROVIDERS:
-        return _relay("command/plugin provider")
+        # Plugin/command providers can't be called from the client directly.
+        # A streaming-capable plugin instead enables the live relay: the
+        # client streams PCM to /api/audio/transcribe-stream and the host
+        # feeds it to the provider while the user speaks.
+        streaming = _plugin_streaming_capable(provider)
+        relay = _relay("command/plugin provider")
+        if streaming:
+            relay["streaming"] = True
+        return relay
 
     language = tt._resolve_stt_language(
         provider, stt_config,


### PR DESCRIPTION
## Summary

Plugin-registered STT providers (the `register_transcription_provider()` surface) can now transcribe **live audio**: PCM chunks are fed to the provider **while the user is still speaking**, so dictation text lands ~1s after the recording ends instead of after a post-hoc file transcription (latency equal to utterance duration, or worse with async job queues).

Companion consumer: a user plugin (`soniox-stt`) implements the streaming session over Soniox's realtime WebSocket — validated end-to-end on macOS (live partials during speech; final ~1.3s after stop for a 12s clip).

## Changes

- **`agent/transcription_provider.py`** — optional streaming capability on the ABC: `streaming_capable`, `open_stream_session()` and a new `TranscriptionStreamSession` (16 kHz mono s16le chunks in, standard envelope out, optional `partial_transcript()`). File-based path unchanged; providers that do not opt in are untouched.
- **`agent/transcription_registry.py`** — `open_streaming_session()` resolver (never raises for lookup failures).
- **`tools/voice_client_config.py`** — the relay config now signals `streaming: true` when the active plugin provider is streaming-capable, so clients know the live relay exists.
- **`hermes_cli/web_server.py`** — `/api/audio/transcribe-stream` WebSocket: PCM in, `partial`/`final` out, mirroring the `speak-stream` endpoint conventions (auth, profile scoping, bounded waits so a stalled provider can never freeze the client).
- **`hermes_cli/tools_config.py`** — inject plugin STT providers into the `hermes tools` Speech-to-Text picker (mirror of the existing `_plugin_tts_providers()` rows), making plugin providers selectable with their `get_setup_schema()` env prompts.
- **Desktop (`apps/desktop`)** — dictation streams mic PCM when the backend advertises streaming; capture is a device-rate AudioContext plus JS resample to 16 kHz with an explicit L/R downmix (no dependency on the browser granting a 16 kHz context — macOS can clamp it, silently starving the leg). The MediaRecorder blob relay remains the fallback whenever the streaming leg fails, with a visible reason. WS routing pinned by tests (same contract as `resolveSpeakStreamUrl`).

## Test plan

- Python: `tests/agent/test_transcription_registry.py` (streaming contract), `tests/hermes_cli/test_web_server_transcribe_stream.py` (endpoint protocol), `tests/hermes_cli/test_stt_picker.py` (picker injection), plus the existing transcription/plugin suites — all green.
- Desktop: `vitest` (routing, pcm resampler, client-direct), `tsc --noEmit` and `eslint` clean on touched files.
- Live E2E (author-validated on macOS): dictation via the composer mic icon, text in ~1s after stop; the fallback path was exercised and now surfaces its reason.
- Note: `src/app/contrib/hooks/use-background-sync.test.ts` carries a pre-existing type error on `main` unrelated to this PR.

## Out of scope (follow-ups)

- Live captioning of partial tokens during speech (the streaming API already exposes them).
- Streaming for the CLI voice mode and gateway voice channels (same ABC, different feeders).
