### PR TITLE
fix(tools): snapshot-scoped element actions + zero-delivery type verdict (computer_use)

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -2272,6 +2272,182 @@ class TestElementTokenAttachment:
         assert backend._snapshot_tokens == {1: "snap2:1", 2: "snap2:2"}
 
 
+class TestSnapshotIdAttachment:
+    """Snapshot-scoped element addressing (trycua/cua element_token gate):
+    newer cua-driver builds refuse a bare `element_index` — the call must
+    carry `element_token`, or `snapshot_id` next to the index. The wrapper
+    learns the snapshot handle from `get_window_state`'s structuredContent
+    and attaches it schema-gated, so pre-snapshot drivers never see an
+    unknown property (additionalProperties=false rejects those)."""
+
+    def _backend_with_session(self, capabilities, input_properties):
+        from unittest.mock import MagicMock
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        backend = CuaDriverBackend()
+        backend._session = MagicMock()
+        backend._session.call_tool.return_value = {
+            "data": "ok", "images": [], "image_mime_types": [],
+            "structuredContent": None, "isError": False,
+        }
+        backend._session.supports_capability = lambda cap, tool=None: (
+            cap in capabilities.get(tool or "", set())
+        )
+        backend._session.supports_input_property = lambda tool, prop: (
+            prop in input_properties.get(tool, set())
+        )
+        backend._active_pid = 111
+        backend._active_window_id = 222
+        return backend
+
+    def test_snapshot_id_attached_when_schema_accepts(self):
+        backend = self._backend_with_session(
+            capabilities={"click": set()},
+            input_properties={
+                "click": {"element_index", "element_token", "snapshot_id"}
+            },
+        )
+        backend._snapshot_tokens = {}
+        backend._last_snapshot_id = "s0000beef"
+        backend.click(element=5, button="left")
+        name, args = backend._session.call_tool.call_args.args
+        assert name == "click"
+        assert args["element_index"] == 5
+        assert args["snapshot_id"] == "s0000beef"
+
+    def test_token_wins_over_snapshot_id(self):
+        """When the per-element token is attachable it already pins the
+        snapshot — sending the handle too is redundant."""
+        backend = self._backend_with_session(
+            capabilities={"click": {"accessibility.element_tokens"}},
+            input_properties={
+                "click": {"element_index", "element_token", "snapshot_id"}
+            },
+        )
+        backend._snapshot_tokens = {5: "s0000beef:5"}
+        backend._last_snapshot_id = "s0000beef"
+        backend.click(element=5, button="left")
+        _, args = backend._session.call_tool.call_args.args
+        assert args["element_token"] == "s0000beef:5"
+        assert "snapshot_id" not in args
+
+    def test_snapshot_id_not_sent_to_pre_snapshot_drivers(self):
+        backend = self._backend_with_session(
+            capabilities={"click": set()}, input_properties={"click": {"element_index"}}
+        )
+        backend._snapshot_tokens = {}
+        backend._last_snapshot_id = "s0000beef"
+        backend.click(element=5, button="left")
+        _, args = backend._session.call_tool.call_args.args
+        assert args["element_index"] == 5
+        assert "snapshot_id" not in args
+        assert "element_token" not in args
+
+    def test_no_snapshot_handle_means_bare_index(self):
+        """Old structured shape without snapshot_id: nothing to attach, the
+        call keeps its pre-existing form."""
+        backend = self._backend_with_session(
+            capabilities={"click": set()},
+            input_properties={"click": {"element_index", "snapshot_id"}},
+        )
+        backend._snapshot_tokens = {}
+        backend._last_snapshot_id = None
+        backend.click(element=5, button="left")
+        _, args = backend._session.call_tool.call_args.args
+        assert args["element_index"] == 5
+        assert "snapshot_id" not in args
+
+    def test_capture_parses_snapshot_handle(self):
+        from unittest.mock import MagicMock
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        backend = CuaDriverBackend()
+        backend._session = MagicMock()
+        backend._session.supports_capability = lambda cap, tool=None: True
+        backend._last_snapshot_id = "sdeadbeef"  # stale handle from a prior capture
+
+        def fake_call_tool(name, args):
+            if name == "list_windows":
+                return {"data": "", "images": [], "image_mime_types": [], "isError": False,
+                        "structuredContent": {"windows": [{
+                            "app_name": "Demo", "pid": 9, "window_id": 1,
+                            "is_on_screen": True, "title": "", "z_index": 0}]}}
+            if name == "get_window_state":
+                return {
+                    "data": "Demo tree", "images": [], "image_mime_types": [],
+                    "isError": False,
+                    "structuredContent": {
+                        "snapshot_id": "s0000beef",
+                        "elements": [{"element_index": 1, "role": "AXButton",
+                                      "label": "OK", "element_token": "s0000beef:1"}],
+                    },
+                }
+            return {"data": "", "images": [], "image_mime_types": [],
+                    "structuredContent": None, "isError": False}
+
+        backend._session.call_tool.side_effect = fake_call_tool
+        cap = backend.capture(mode="ax")
+        assert backend._last_snapshot_id == "s0000beef"
+        assert cap.snapshot_id == "s0000beef"
+
+    def test_capture_without_snapshot_handle_clears_stale_one(self):
+        from unittest.mock import MagicMock
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        backend = CuaDriverBackend()
+        backend._session = MagicMock()
+        backend._session.supports_capability = lambda cap, tool=None: False
+        backend._last_snapshot_id = "sdeadbeef"
+
+        def fake_call_tool(name, args):
+            if name == "list_windows":
+                return {"data": "", "images": [], "image_mime_types": [], "isError": False,
+                        "structuredContent": {"windows": [{
+                            "app_name": "Demo", "pid": 9, "window_id": 1,
+                            "is_on_screen": True, "title": "", "z_index": 0}]}}
+            if name == "get_window_state":
+                return {"data": "Demo tree", "images": [], "image_mime_types": [],
+                        "isError": False,
+                        "structuredContent": {"elements": [
+                            {"element_index": 1, "role": "AXButton", "label": "OK"}]}}
+            return {"data": "", "images": [], "image_mime_types": [],
+                    "structuredContent": None, "isError": False}
+
+        backend._session.call_tool.side_effect = fake_call_tool
+        cap = backend.capture(mode="ax")
+        assert backend._last_snapshot_id is None
+        assert cap.snapshot_id is None
+
+
+class TestZeroDeliveryTypeVerdict:
+    """Zero-delivery `type` verdict: web inputs behind trusted-event checks
+    swallow synthetic keystrokes entirely (delivered 0 of N). Retrying the
+    same delivery rung cannot help; the actionable next step is the AX
+    set_value path, which bypasses synthetic-event filtering."""
+
+    def _result(self, delivered):
+        from tools.computer_use.backend import ActionResult
+        return ActionResult(
+            ok=True,
+            action="type",
+            message="type_text incomplete",
+            code="type_text_incomplete",
+            meta={"delivered_chars": delivered, "requested_chars": 11},
+        )
+
+    def test_zero_delivery_recommends_set_value(self):
+        from tools.computer_use.tool import _classify_action_result
+        verdict = _classify_action_result(self._result(0))
+        assert verdict["decision"] == "escalate"
+        assert verdict["recommended"] == "set_value"
+        assert "set_value" in verdict["hint"]
+
+    def test_partial_delivery_keeps_generic_ladder(self):
+        from tools.computer_use.tool import _classify_action_result
+        verdict = _classify_action_result(self._result(7))
+        assert verdict.get("recommended") != "set_value"
+
+
 class TestSessionLifecycle:
     """Surface gap (audit June 2026): Hermes never declared a cua-driver
     session, so the agent-cursor overlay was inert and per-run state

--- a/tools/computer_use/backend.py
+++ b/tools/computer_use/backend.py
@@ -77,6 +77,10 @@ class CaptureResult:
     # part). None → consumers fall back to base64-prefix sniffing (older drivers).
     # See #1961, #47072.
     image_mime_type: Optional[str] = None
+    # Snapshot handle (`s` + 8 hex) this capture's element indices are scoped to; newer cua-driver
+    # builds refuse a bare element_index and want this handle (or the per-element token) alongside it.
+    # None on pre-snapshot drivers — indices from those builds are standalone.
+    snapshot_id: Optional[str] = None
     # Guidance appended to the summary by capture lanes that intentionally return no elements (e.g.
     # full-screen composited grabs) to point the model at an interactive lane.
     note: str = ""

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -309,11 +309,16 @@ class CuaDriverBackend(_CaptureMixin, _InputMixin, ComputerUseBackend):
         # re-resolving to a different element. Cleared whenever a fresh capture overwrites the snapshot
         # context.
         self._snapshot_tokens: Dict[int, str] = {}
+        # Snapshot handle the current `_snapshot_tokens` map belongs to (same lifetime as the map).
+        # Snapshot-gated drivers accept `element_index` only with this handle (or an element_token)
+        # attached; pre-snapshot drivers never receive it.
+        self._last_snapshot_id: Optional[str] = None
 
     def _set_active_target(self, target: Dict[str, Any]) -> None:
         self._active_pid = target["pid"]
         self._active_window_id = target["window_id"]
         self._snapshot_tokens = {}  # prior snapshot's tokens: disarm before any capture so an exception can't pair them
+        self._last_snapshot_id = None  # same disarming for the snapshot handle
         self._last_target = {"pid": self._active_pid, "window_id": self._active_window_id}
 
     def launch_app(self, *, bundle_id: Optional[str] = None, name: Optional[str] = None,
@@ -359,6 +364,14 @@ class CuaDriverBackend(_CaptureMixin, _InputMixin, ComputerUseBackend):
         token = self._snapshot_tokens.get(idx) if isinstance(idx, int) else None
         if token and self._session.supports_capability("accessibility.element_tokens", tool=name):
             args["element_token"] = token
+        elif (
+            isinstance(idx, int)
+            and self._last_snapshot_id
+            and self._session.supports_input_property(name, "snapshot_id")
+        ):
+            # Snapshot-gated drivers (trycua/cua element_token gate) refuse a bare element_index; the
+            # token is preferable but this capture carried none, so pin the index to its snapshot handle.
+            args["snapshot_id"] = self._last_snapshot_id
         if inject_session:  # setdefault preserves any explicit session a caller already supplied
             args.setdefault("session", self._session_id)
         try:

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -366,7 +366,7 @@ class CuaDriverBackend(_CaptureMixin, _InputMixin, ComputerUseBackend):
             args["element_token"] = token
         elif (
             isinstance(idx, int)
-            and self._last_snapshot_id
+            and getattr(self, "_last_snapshot_id", None)
             and self._session.supports_input_property(name, "snapshot_id")
         ):
             # Snapshot-gated drivers (trycua/cua element_token gate) refuse a bare element_index; the

--- a/tools/computer_use/cua_backend_capture.py
+++ b/tools/computer_use/cua_backend_capture.py
@@ -230,8 +230,8 @@ class _CaptureMixin:
     def _gws_args(self) -> Dict[str, Any]:
         return {"pid": self._active_pid, "window_id": self._active_window_id, "session": self._session_id}
 
-    def _capture_vision(self) -> Tuple[Optional[str], Optional[str], List[UIElement], str]:
-        """Pixels only, ``elements`` always empty: ``(png_b64, mime, [], window_title)``. Drivers advertising the
+    def _capture_vision(self) -> Tuple[Optional[str], Optional[str], List[UIElement], str, Optional[str]]:
+        """Pixels only, ``elements`` always empty: ``(png_b64, mime, [], window_title, snapshot_id)``. Drivers advertising the
         cheaper standalone ``screenshot`` tool use it; current drivers folded PNG capture into ``get_window_state``
         (tree DISCARDED here). Before discovery ran we still try ``screenshot`` first and fall back, so the path
         self-heals on any driver version."""
@@ -251,10 +251,10 @@ class _CaptureMixin:
                 self._active_window_id) or {}
             if cli_out.get("images"):
                 png_b64, image_mime_type = cli_out["images"][0], "image/png"
-        return png_b64, image_mime_type, [], window_title
+        return png_b64, image_mime_type, [], window_title, None
 
-    def _capture_window_state(self) -> Tuple[Optional[str], Optional[str], List[UIElement], str]:
-        """AX tree + screenshot. Returns ``(png_b64, mime, elements, window_title)``."""
+    def _capture_window_state(self) -> Tuple[Optional[str], Optional[str], List[UIElement], str, Optional[str]]:
+        """AX tree + screenshot. Returns ``(png_b64, mime, elements, window_title, snapshot_id)``."""
         # A flaky bridge can return a degenerate result (no screenshot AND no parseable tree) WITHOUT raising
         # — a silent 0x0 to the model. Distinct from the EAGAIN path handled in call_tool: here MCP "succeeded".
         gws_out = self._fetch_or_refetch(
@@ -273,7 +273,20 @@ class _CaptureMixin:
                     else _parse_elements_from_tree(tree) if tree else [])
         # Tokens are tied to this snapshot: overwrite the whole map (and clear it when the new capture carries none).
         self._snapshot_tokens = {e.index: e.element_token for e in elements if e.element_token}
-        return *_image_from_tool_result(gws_out), elements, window_title
+        # Same lifetime for the snapshot handle: the driver publishes it next to `elements` (absent on
+        # pre-snapshot builds and on snapshots that registered none, e.g. unresolved window scope).
+        raw_snapshot_id = (gws_out.get("structuredContent") or {}).get("snapshot_id")
+        self._last_snapshot_id = (
+            raw_snapshot_id
+            if isinstance(raw_snapshot_id, str) and raw_snapshot_id
+            else None
+        )
+        return (
+            *_image_from_tool_result(gws_out),
+            elements,
+            window_title,
+            self._last_snapshot_id,
+        )
 
     def capture(self, mode: str = "som", app: Optional[str] = None, pid: Optional[int] = None,
                 window_id: Optional[int] = None) -> CaptureResult:
@@ -296,11 +309,21 @@ class _CaptureMixin:
         # to the frontmost window.
         if app or not self._last_app:
             self._last_app = app_name or app or ""
-        png_b64, image_mime_type, elements, window_title = (
+        png_b64, image_mime_type, elements, window_title, snapshot_id = (
             self._capture_vision() if mode == "vision" else self._capture_window_state())
         png_bytes_len, width, height = _png_metrics(png_b64, 0, 0) if png_b64 else (0, 0, 0)
-        return CaptureResult(mode=mode, width=width, height=height, png_b64=png_b64, elements=elements, app=app_name,
-                             window_title=window_title, png_bytes_len=png_bytes_len, image_mime_type=image_mime_type)
+        return CaptureResult(
+            mode=mode,
+            width=width,
+            height=height,
+            png_b64=png_b64,
+            elements=elements,
+            app=app_name,
+            window_title=window_title,
+            png_bytes_len=png_bytes_len,
+            image_mime_type=image_mime_type,
+            snapshot_id=snapshot_id,
+        )
 
     def _capture_full_screen(self, mode: str) -> CaptureResult:
         """Composited PrtScn-style grab via `get_desktop_state` (the shell window would only show wallpaper + icons).

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -415,6 +415,27 @@ def _classify_action_result(res: ActionResult) -> Dict[str, Any]:
         return {"decision": "verify_fresh_state", "hint": ("Input was delivered but not confirmed. Re-capture and check the "
                 "result BEFORE any retry — do not repeat the input on an escalation recommendation alone.")}
     if res.effect == "suspected_noop" or not res.ok or res.code is not None:
+        meta = res.meta if isinstance(res.meta, dict) else {}
+        delivered, requested = meta.get("delivered_chars"), meta.get("requested_chars")
+        if (
+            res.action in ("type", "type_text")
+            and isinstance(delivered, int)
+            and isinstance(requested, int)
+            and requested > 0
+            and delivered <= 0
+        ):
+            # Zero delivery: the field swallowed every synthetic keystroke (trusted-event checks on web
+            # inputs do this). Neither rung of the delivery ladder can fix a target that drops events at
+            # the source — the AX set_value path writes the value directly and bypasses event filtering.
+            return {
+                "decision": "escalate",
+                "recommended": "set_value",
+                "hint": (
+                    "0 characters landed: this input drops synthetic keystrokes, so no delivery rung will fix it. "
+                    "Use set_value on the field's element index instead — it sets the value through the "
+                    "accessibility API and bypasses event filtering. Re-capture first if the index is stale."
+                ),
+            }
         return {"decision": "escalate", **({"recommended": res.escalation.get("recommended")}
                                            if isinstance(res.escalation, dict) else {}), "hint": (
             "The input likely did not land. Climb one rung following `recommended`: 'px' → re-issue by coordinate; "
@@ -508,11 +529,21 @@ def _capture_view(cap: CaptureResult, max_elements: int) -> SimpleNamespace:
     lost_detail = len(cap.elements) > len(visible) or any(len(e.label) > _MAX_ELEMENT_LABEL_CHARS for e in visible)
     too_small = bool(dims) and min(dims) < _MIN_PROVIDER_IMAGE_DIMENSION
     has_image = bool(cap.png_b64) and cap.mode != "ax" and not too_small
-    return SimpleNamespace(cap=cap, visible=visible, total=len(cap.elements), width=width, height=height,
-                           truncated=len(cap.elements) - len(visible), bounds_scale=scale, bounds_note=note,
-                           elements_file=_spill_elements_to_file(cap) if lost_detail else None,
-                           screenshot_path=_persist_capture_image(cap) if has_image else None,
-                           dims_omitted=dims if too_small else None, has_image=has_image)
+    return SimpleNamespace(
+        cap=cap,
+        visible=visible,
+        total=len(cap.elements),
+        width=width,
+        height=height,
+        truncated=len(cap.elements) - len(visible),
+        bounds_scale=scale,
+        bounds_note=note,
+        elements_file=_spill_elements_to_file(cap) if lost_detail else None,
+        screenshot_path=_persist_capture_image(cap) if has_image else None,
+        dims_omitted=dims if too_small else None,
+        has_image=has_image,
+        snapshot_id=getattr(cap, "snapshot_id", None),
+    )
 
 def _capture_summary_lines(v: SimpleNamespace) -> List[str]:
     """Human-readable capture summary; line ORDER is contract. Lists only what `elements` surfaces, otherwise the
@@ -542,8 +573,13 @@ def _text_capture_payload(v: SimpleNamespace, summary: str, extra: Optional[Dict
         "mode": v.cap.mode, "width": v.width, "height": v.height, "app": v.cap.app, "window_title": v.cap.window_title,
         "elements": [_element_to_dict(e) for e in v.visible], "total_elements": v.total, "summary": summary,
         **(extra or {}),
-        **_present(truncated_elements=v.truncated, elements_file=v.elements_file, screenshot_path=v.screenshot_path,
-                   bounds_scale=v.bounds_scale),
+        **_present(
+            truncated_elements=v.truncated,
+            elements_file=v.elements_file,
+            screenshot_path=v.screenshot_path,
+            bounds_scale=v.bounds_scale,
+            snapshot_id=getattr(v, "snapshot_id", None),
+        ),
     })
 
 def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEMENTS) -> Any:


### PR DESCRIPTION
### What

Three fixes to the `computer_use` wrapper for snapshot-scoped element addressing and zero-delivery typing, both reported in #103157:

1. **`snapshot_id` learned and attached.** `get_window_state`'s structuredContent publishes a `snapshot_id` next to `elements[]` (trycua/cua element_token gate), and newer cua-driver builds refuse a bare `element_index` (`snapshot_id_required`) — the call must carry an `element_token`, or the snapshot handle next to the index. The wrapper now:
   - parses `structuredContent.snapshot_id` in `_capture_window_state` and keeps it with the same lifetime as `_snapshot_tokens` (cleared on capture/target-change/transport reset),
   - attaches `snapshot_id` to `element_index` actions when the live tool schema accepts it (`supports_input_property`, the same fail-closed gate as `delivery_mode`) and the per-element token was not attachable — pre-snapshot drivers never see the new property,
   - surfaces `snapshot_id` in the `capture` tool response so the model can pass it explicitly when needed.
2. **Zero-delivery `type` verdict.** When `delivered_chars == 0` the escalation now recommends `set_value` (the AX path writes the value directly and bypasses synthetic-event filtering) instead of the generic px/foreground ladder — web inputs behind trusted-event checks drop CGEvent keystrokes at the source, so no delivery rung can fix them.
3. **`set_value` element actions** ride the same snapshot attach (they carry `element_index` too).

The CGEvent trust filtering itself and the TCC grant divergence live in cua-driver, not this repo — this PR is scoped to what the wrapper can do: make element-index acting work against snapshot-gated drivers and make the zero-delivery failure mode point at the one path that still works.

### Testing

- 8 new unit tests: snapshot-id attach (schema-gated), token-precedence, pre-snapshot drivers unaffected, no-handle captures, snapshot-handle parsing/clearing, zero-delivery verdict, partial-delivery unaffected.
- Mutation-checked: killing the attach branch or the verdict branch turns the matching tests red.
- `tests/tools/test_computer_use.py` — 108 passed. `ruff check` clean; `ruff format` produces no new complaints on changed lines (pre-existing repo drift untouched).