### PR TITLE
Lock host-managed channels in the dashboard

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -169,7 +169,10 @@ _ENV_VAR_NAME_DENYLIST: frozenset[str] = frozenset({
     "HERMES_YOLO_MODE", "HERMES_ACCEPT_HOOKS", "HERMES_REDACT_SECRETS",
     "HERMES_INTERACTIVE", "HERMES_EXEC_ASK", "HERMES_GATEWAY_SESSION",
     "HERMES_CRON_SESSION", "HERMES_SINGLE_QUERY_SESSION",
-    "HERMES_SESSION_KEY", "HERMES_SESSION_PLATFORM"})
+    "HERMES_SESSION_KEY", "HERMES_SESSION_PLATFORM",
+    # Host-declared channel ownership stamps (hermes_cli.managed_platforms): a user write
+    # here would switch the dashboard lock off.
+    "HERMES_MANAGED_PLATFORMS", "HERMES_MANAGED_PLATFORMS_LABEL"})
 
 
 def _env_var_policy_name(key: str, *, is_windows: Optional[bool] = None) -> str:

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -45,6 +45,16 @@ _PROFILE_MANAGED_ENV_KEYS: frozenset[str] = frozenset({
     "HERMES_COPILOT_ACP_ARGS", "COPILOT_CLI_PATH", "COPILOT_ACP_BASE_URL",
 })
 
+# Channel ownership stamps a hosting layer injects into the process env (hermes_cli.managed_platforms).
+# The launch value is the authority: a user .env assigning one of these would otherwise win on the next
+# override=True load and switch the dashboard lock off, so it is re-asserted after every load. The portal
+# URL joins the host-owned record only while a declaration exists; without one it stays a user setting
+# (self-hosted dashboard registration writes it).
+_HOST_DECLARATION_KEY = "HERMES_MANAGED_PLATFORMS"
+_HOST_STAMP_KEYS: tuple[str, ...] = (_HOST_DECLARATION_KEY, "HERMES_MANAGED_PLATFORMS_LABEL")
+_HOST_LINK_KEY = "HERMES_DASHBOARD_PORTAL_URL"
+_HOST_STAMPS_AT_LAUNCH: dict[str, str | None] | None = None
+
 
 def _env_keys_defined_in_dotenv(path: Path) -> set[str]:
     """KEY names assigned in a dotenv file (including empty ``KEY=``). A fast line scanner (works in early
@@ -65,6 +75,31 @@ def _env_keys_defined_in_dotenv(path: Path) -> set[str]:
         if key:
             keys.add(key)
     return keys
+
+
+def _snapshot_host_stamps() -> None:
+    """Capture the host stamps from the process env once, before the first user .env load."""
+    global _HOST_STAMPS_AT_LAUNCH
+    if _HOST_STAMPS_AT_LAUNCH is None:
+        _HOST_STAMPS_AT_LAUNCH = {key: os.environ.get(key) for key in (*_HOST_STAMP_KEYS, _HOST_LINK_KEY)}
+
+
+def _reassert_host_stamps(*paths: Path) -> None:
+    """Restore the launch value of every host stamp a loaded dotenv file assigned (absent at launch: removed)."""
+    if _HOST_STAMPS_AT_LAUNCH is None:
+        return
+    owned = list(_HOST_STAMP_KEYS)
+    if _HOST_STAMPS_AT_LAUNCH[_HOST_DECLARATION_KEY]:
+        owned.append(_HOST_LINK_KEY)
+    assigned = set().union(*(_env_keys_defined_in_dotenv(path) for path in paths))
+    for key in owned:
+        if key not in assigned:
+            continue
+        launch_value = _HOST_STAMPS_AT_LAUNCH[key]
+        if launch_value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = launch_value
 
 
 def _clear_known_keys_missing_from_dotenv(path: Path) -> None:
@@ -317,6 +352,7 @@ def load_hermes_dotenv(
     """Load Hermes env files: ``~/.hermes/.env`` overrides stale shell exports; project ``.env`` is a dev
     fallback that only fills gaps when the user env exists (and overrides shell vars when it does not)."""
     home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+    _snapshot_host_stamps()
 
     # Multiplex gateway: while a routed profile-home override is active, copying that profile's .env
     # into os.environ would expose its credentials to sibling turns and every spawned child. Unscoped
@@ -361,6 +397,7 @@ def load_hermes_dotenv(
     if project_env_path and project_env_path.exists():
         _load_dotenv_with_fallback(project_env_path, override=not loaded)
         loaded.append(project_env_path)
+    _reassert_host_stamps(*loaded)
 
     # External sources are skipped for the updater (dotenv + managed env still load): ``update`` must not
     # import optional secret-manager libs (Bitwarden → cryptography → _rust.pyd) into the process replacing

--- a/hermes_cli/managed_platforms.py
+++ b/hermes_cli/managed_platforms.py
@@ -1,0 +1,117 @@
+"""Host-declared ownership of messaging channels.
+
+A hosting layer that configures channels on the operator's behalf (the Nous
+Portal for hosted agents) stamps the container with two deployment values:
+
+    HERMES_MANAGED_PLATFORMS=telegram:native,discord:relay
+    HERMES_MANAGED_PLATFORMS_LABEL=Nous Portal
+
+The dashboard renders the listed channels read-only and refuses writes to
+them. ``native`` means the host supplies the platform's own credentials;
+``relay`` means the platform is fronted by the host's connector and the native
+adapter is off by design. The link back to the host is
+``HERMES_DASHBOARD_PORTAL_URL``, which hosted deployments already set.
+
+These are internal deployment stamps, not user settings. Absent means no
+channel is managed and every surface behaves as before.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from functools import lru_cache
+from typing import Dict, Mapping, Optional
+from urllib.parse import urlsplit
+
+logger = logging.getLogger(__name__)
+
+PLATFORMS_ENV = "HERMES_MANAGED_PLATFORMS"
+LABEL_ENV = "HERMES_MANAGED_PLATFORMS_LABEL"
+URL_ENV = "HERMES_DASHBOARD_PORTAL_URL"
+
+KINDS = ("native", "relay")
+DEFAULT_KIND = "native"
+DEFAULT_LABEL = "your hosting provider"
+MAX_LABEL_LENGTH = 64
+
+
+@dataclass(frozen=True)
+class ManagedPlatforms:
+    """Platform ids owned by the host, keyed to their kind, plus display data."""
+
+    platforms: Dict[str, str] = field(default_factory=dict)
+    label: str = DEFAULT_LABEL
+    url: Optional[str] = None
+
+    def __bool__(self) -> bool:
+        return bool(self.platforms)
+
+    def kind_of(self, platform_id: str) -> Optional[str]:
+        return self.platforms.get(platform_id)
+
+    def manages_relay(self) -> bool:
+        return "relay" in self.platforms.values()
+
+    def record_for(self, platform_id: str) -> Optional[dict]:
+        kind = self.platforms.get(platform_id)
+        if kind is None:
+            return None
+        return {"kind": kind, "label": self.label, "url": self.url}
+
+
+def load_managed_platforms(environ: Optional[Mapping[str, str]] = None) -> ManagedPlatforms:
+    env = os.environ if environ is None else environ
+    return _parse(env.get(PLATFORMS_ENV, ""), env.get(LABEL_ENV, ""), env.get(URL_ENV, ""))
+
+
+@lru_cache(maxsize=16)
+def _parse(raw_platforms: str, raw_label: str, raw_url: str) -> ManagedPlatforms:
+    """Cached per distinct stamp so a malformed value is logged once, not per request."""
+    platforms = _parse_platforms(raw_platforms)
+    if not platforms:
+        return ManagedPlatforms()
+    return ManagedPlatforms(
+        platforms=platforms, label=_parse_label(raw_label), url=_parse_url(raw_url)
+    )
+
+
+def _parse_platforms(raw: str) -> Dict[str, str]:
+    platforms: Dict[str, str] = {}
+    for entry in raw.split(","):
+        entry = entry.strip().lower()
+        if not entry:
+            continue
+        platform_id, _, kind = entry.partition(":")
+        platform_id = platform_id.strip()
+        kind = kind.strip() or DEFAULT_KIND
+        if not platform_id:
+            continue
+        if kind not in KINDS:
+            logger.warning(
+                "%s: unknown kind %r for platform %r, treating it as %s",
+                PLATFORMS_ENV, kind, platform_id, DEFAULT_KIND,
+            )
+            kind = DEFAULT_KIND
+        platforms.setdefault(platform_id, kind)
+    return platforms
+
+
+def _parse_label(raw: str) -> str:
+    label = " ".join(raw.split())
+    if not label:
+        return DEFAULT_LABEL
+    return label[:MAX_LABEL_LENGTH]
+
+
+def _parse_url(raw: str) -> Optional[str]:
+    candidate = raw.strip()
+    if not candidate:
+        return None
+    try:
+        parts = urlsplit(candidate)
+    except ValueError:
+        return None
+    if parts.scheme not in ("http", "https") or not parts.netloc:
+        return None
+    return candidate

--- a/hermes_cli/web_routers/analytics.py
+++ b/hermes_cli/web_routers/analytics.py
@@ -17,6 +17,7 @@ from hermes_cli.web_server_profiles import (
     _approval_mode_of, _aux_task_summary, _aux_usage_rows, _broadcast_gateway_session_info, _is_other_profile, _merge_aux_into_by_model,
 )
 from hermes_cli.web_models import RawConfigUpdate
+from hermes_cli.web_server_messaging import _refuse_if_managed_platform_config_changed
 
 router = APIRouter()
 
@@ -57,7 +58,9 @@ async def update_config_raw(body: RawConfigUpdate, profile: Optional[str] = None
             # Full-document replacement: the editor owns the whole file; never
             # merge omitted sections back from disk.
             # See #62723.
-            approvals_mode_changed = _approval_mode_of(parsed) != _approval_mode_of(read_raw_config())
+            existing = read_raw_config()
+            _refuse_if_managed_platform_config_changed(existing, parsed)
+            approvals_mode_changed = _approval_mode_of(parsed) != _approval_mode_of(existing)
             save_config(parsed, merge_existing=False)
         # Same indicator refresh as the schema-driven save.
         if approvals_mode_changed and not _is_other_profile(body.profile or profile):

--- a/hermes_cli/web_routers/config_env.py
+++ b/hermes_cli/web_routers/config_env.py
@@ -22,6 +22,7 @@ from hermes_cli.web_server_profiles import (
 from fastapi import HTTPException, Request
 from hermes_cli.config import DEFAULT_CONFIG, OPTIONAL_ENV_VARS, read_raw_config, custom_endpoint_key_env, coerce_provider_id, find_provider_entry, redact_key, _deep_merge
 from hermes_cli.web_models import ConfigUpdate, EnvVarUpdate, EnvVarDelete, EnvVarReveal, CustomEndpointUpdate
+from hermes_cli.web_server_messaging import _refuse_if_env_key_managed, _refuse_if_managed_platform_config_changed
 from typing import Any, Dict, List, Optional, Tuple
 
 _log = logging.getLogger("hermes_cli.web_server")
@@ -119,6 +120,7 @@ async def update_config(body: ConfigUpdate, profile: Optional[str] = None):
                 existing = read_raw_config()
                 incoming = _denormalize_config_from_web(body.config)
                 merged = _deep_merge(existing, incoming)
+                _refuse_if_managed_platform_config_changed(existing, merged)
                 # Compare normalized approvals.mode across the in-memory
                 # documents, not config blocks and not cache re-reads: the page
                 # PUTs the defaulted GET record while disk holds sparse YAML (a
@@ -273,6 +275,7 @@ def _get_env_vars_sync(profile: Optional[str] = None):
 
 @router.put("/api/env")
 async def set_env_var(body: EnvVarUpdate, profile: Optional[str] = None):
+    _refuse_if_env_key_managed(body.key)
     # Unified credential lifecycle: writes .env AND reconciles any config.yaml
     # mirror still holding the previous value of this var (model.api_key /
     # auxiliary.*.api_key / custom_providers[*]), so a rotation can't leave a
@@ -697,6 +700,7 @@ async def validate_provider_credential(body: EnvVarUpdate, request: Request):
 
 @router.delete("/api/env")
 async def remove_env_var(body: EnvVarDelete, profile: Optional[str] = None):
+    _refuse_if_env_key_managed(body.key)
     # Unified credential lifecycle: clears the .env entry AND every mirror of
     # the credential — env-seeded credential_pool entries in auth.json (stale
     # ones kept providers alive in the model picker), the affected providers'

--- a/hermes_cli/web_routers/messaging.py
+++ b/hermes_cli/web_routers/messaging.py
@@ -27,7 +27,7 @@ from hermes_cli.config import OPTIONAL_ENV_VARS, get_env_path, redact_key
 from hermes_cli.web_deps import LateState, late
 from hermes_cli.web_server_gateway import _restart_gateway_after
 from hermes_cli.web_server_messaging import (
-    _TelegramOnboardingPairing, _WhatsAppOnboardingSession, _messaging_platform_catalog, _telegram_onboarding_error_message, _telegram_onboarding_lock, _telegram_onboarding_pairings, _whatsapp_onboarding_payload, _whatsapp_onboarding_sessions,
+    _TelegramOnboardingPairing, _WhatsAppOnboardingSession, _managed_platform_record, _managed_platforms, _messaging_platform_catalog, _refuse_if_platform_managed, _telegram_onboarding_error_message, _telegram_onboarding_lock, _telegram_onboarding_pairings, _whatsapp_onboarding_payload, _whatsapp_onboarding_sessions,
 )
 from hermes_cli.web_routers._common import http_failure
 from hermes_cli.web_models import (
@@ -260,6 +260,9 @@ def _messaging_platform_payload(
             "allowed_users_set": bool(env_value("WHATSAPP_ALLOWED_USERS").strip()),
             "home_channel_set": bool(home_channel),
         }
+    managed = _managed_platforms()
+    if managed:
+        payload["managed"] = managed.record_for(platform_id)
     return payload
 
 
@@ -521,6 +524,7 @@ def _register_whatsapp_session(session_path: Path, record) -> str:
 
 @router.post("/api/messaging/whatsapp/onboarding/start")
 async def start_whatsapp_onboarding(body: WhatsAppOnboardingStart):
+    _refuse_if_platform_managed("whatsapp")
     mode = _normalize_whatsapp_onboarding_mode(body.mode)
     allowed_users = _normalize_whatsapp_allowed_users(body.allowed_users)
 
@@ -564,6 +568,7 @@ async def get_whatsapp_onboarding_status(pairing_id: str):
 
 @router.post("/api/messaging/whatsapp/onboarding/{pairing_id}/apply")
 async def apply_whatsapp_onboarding(pairing_id: str, body: WhatsAppOnboardingApply, profile: Optional[str] = None):
+    _refuse_if_platform_managed("whatsapp")
     with _whatsapp_onboarding_lock:
         record = _whatsapp_record_or_404(pairing_id)
         if record.status != "connected":
@@ -652,6 +657,7 @@ async def _telegram_onboarding_request(method: str, path: str, *, body=None, bea
 
 @router.post("/api/messaging/telegram/onboarding/start")
 async def start_telegram_onboarding(body: TelegramOnboardingStart):
+    _refuse_if_platform_managed("telegram")
     bot_name = (body.bot_name or "Hermes Agent").strip() or "Hermes Agent"
     payload = await _telegram_onboarding_request("POST", "/v1/telegram/pairings", body={"bot_name": bot_name})
 
@@ -714,6 +720,7 @@ async def get_telegram_onboarding_status(pairing_id: str):
 
 @router.post("/api/messaging/telegram/onboarding/{pairing_id}/apply")
 async def apply_telegram_onboarding(pairing_id: str, body: TelegramOnboardingApply, profile: Optional[str] = None):
+    _refuse_if_platform_managed("telegram")
     normalized_ids = [_normalize_telegram_user_id(raw_id) for raw_id in body.allowed_user_ids]
     if not all(normalized_ids):
         raise HTTPException(status_code=400, detail="Allowed Telegram user IDs must be numeric.")
@@ -771,11 +778,15 @@ async def get_messaging_platforms(profile: Optional[str] = None):
         # the gateway status readers do NOT (they resolve process-level paths), so the profile directory is
         # passed explicitly for those (#71211).
         with _profile_scope(profile) as scoped_dir:
-            return {
+            result = {
                 "env_path": str(get_env_path()),
                 "gateway_start_command": " ".join(["hermes", *_gateway_subcommand(profile, "start")]),
                 "platforms": _platform_payloads(scoped_dir, _messaging_platform_catalog()),
             }
+            managed = _managed_platforms()
+            if managed:
+                result["managed_by"] = {"label": managed.label, "url": managed.url}
+            return result
 
     return await asyncio.to_thread(_run)
 
@@ -826,6 +837,7 @@ def _multiplex_port_binding_conflict(platform_id: str, requested_profile: Option
 @router.put("/api/messaging/platforms/{platform_id}")
 async def update_messaging_platform(platform_id: str, body: MessagingPlatformUpdate, profile: Optional[str] = None):
     entry = _require_platform(platform_id)
+    _refuse_if_platform_managed(platform_id)
 
     target_profile = body.profile or profile
     if body.enabled:
@@ -876,6 +888,12 @@ async def update_messaging_platform(platform_id: str, body: MessagingPlatformUpd
 @router.post("/api/messaging/platforms/{platform_id}/test")
 async def test_messaging_platform(platform_id: str, profile: Optional[str] = None):
     entry = _require_platform(platform_id)
+    record = _managed_platform_record(platform_id)
+    if record is not None and record["kind"] == "relay":
+        raise HTTPException(
+            status_code=409,
+            detail=f"{entry['name']} runs through {record['label']}; the native connection test does not apply.",
+        )
 
     def _run():
         with _profile_scope(profile) as scoped_dir:

--- a/hermes_cli/web_server_messaging.py
+++ b/hermes_cli/web_server_messaging.py
@@ -11,7 +11,7 @@ from fastapi import HTTPException
 from pathlib import Path
 from typing import Any, Optional
 from hermes_cli import __version__
-from hermes_cli.config import OPTIONAL_ENV_VARS, write_platform_config_field
+from hermes_cli.config import DEFAULT_CONFIG, OPTIONAL_ENV_VARS, _deep_merge, write_platform_config_field
 from hermes_cli.setup_hidden_env import is_setup_hidden_env as _is_setup_hidden_env
 
 # Same logger the code used before extraction (record parity).
@@ -304,6 +304,98 @@ def _discover_platform_env_vars(platform_id: str) -> tuple[str, ...]:
         and name not in _MESSAGING_KEYS_PAGE_KEYS
         and not _is_setup_hidden_env(name)
         and any(name.startswith(prefix) for prefix in prefixes)}))
+
+
+def _managed_platforms():
+    """Host-declared channel ownership (see hermes_cli.managed_platforms)."""
+    from hermes_cli.managed_platforms import load_managed_platforms
+
+    return load_managed_platforms()
+
+
+def _managed_platform_record(platform_id: str) -> Optional[dict]:
+    return _managed_platforms().record_for(platform_id)
+
+
+def _managed_platform_name(platform_id: str) -> str:
+    try:
+        entry = next((e for e in _messaging_platform_catalog() if e["id"] == platform_id), None)
+    except Exception:
+        entry = None
+    return entry["name"] if entry else platform_id.replace("_", " ").title()
+
+
+def _refuse_if_platform_managed(platform_id: str) -> None:
+    """409 when the host owns ``platform_id``: the dashboard must not write it."""
+    record = _managed_platform_record(platform_id)
+    if record is None:
+        return
+    raise HTTPException(
+        status_code=409,
+        detail=f"{_managed_platform_name(platform_id)} is managed by {record['label']}.",
+    )
+
+
+_RELAY_DIRECT_PLATFORMS_ENV = "GATEWAY_RELAY_ALLOW_DIRECT_PLATFORMS"
+_PORTAL_URL_ENV = "HERMES_DASHBOARD_PORTAL_URL"
+
+
+def _managed_platform_owning_env_key(key: str, managed) -> Optional[str]:
+    """Managed platform whose env namespace holds ``key``. Matched by the platform prefix, so the
+    knobs the setup card hides (``TELEGRAM_ALLOW_ALL_USERS``, ``TELEGRAM_HOME_CHANNEL``, ...) count
+    too, then by the card's explicit env_vars for plugin platforms with their own names."""
+    for platform_id in managed.platforms:
+        if any(key.startswith(prefix) for prefix in _platform_env_prefixes(platform_id)):
+            return platform_id
+    try:
+        for entry in _messaging_platform_catalog():
+            if entry["id"] in managed.platforms and key in entry.get("env_vars", ()):
+                return entry["id"]
+    except Exception:
+        _log.debug("could not build the messaging catalog for the managed env guard", exc_info=True)
+    return None
+
+
+def _refuse_if_env_key_managed(key: str) -> None:
+    """409 when ``key`` belongs to a host-owned platform. ``GATEWAY_RELAY_ALLOW_DIRECT_PLATFORMS``
+    counts as owned whenever a relay platform is managed: it is the one switch that would bring
+    native adapters back beside the host's connector. ``HERMES_DASHBOARD_PORTAL_URL`` counts as
+    owned whenever anything is managed: the locked cards link to it."""
+    managed = _managed_platforms()
+    if not managed:
+        return
+    if key == _PORTAL_URL_ENV or (key == _RELAY_DIRECT_PLATFORMS_ENV and managed.manages_relay()):
+        raise HTTPException(status_code=409, detail=f"{key} is managed by {managed.label}.")
+    owner = _managed_platform_owning_env_key(key, managed)
+    if owner is not None:
+        _refuse_if_platform_managed(owner)
+
+
+def _platform_block_views(doc: Any, platform_id: str) -> tuple:
+    """The four places gateway/config_loader.py reads a platform block from:
+    ``gateway.platforms.<id>``, ``platforms.<id>``, ``gateway.<id>`` and a root ``<id>``."""
+    doc = doc if isinstance(doc, dict) else {}
+    gateway = doc.get("gateway") if isinstance(doc.get("gateway"), dict) else {}
+    nested = gateway.get("platforms") if isinstance(gateway.get("platforms"), dict) else {}
+    top = doc.get("platforms") if isinstance(doc.get("platforms"), dict) else {}
+    return (nested.get(platform_id), top.get(platform_id), gateway.get(platform_id), doc.get(platform_id))
+
+
+def _effective_config(doc: Any) -> dict:
+    """``doc`` as load_config() reads it, defaults filled in: the settings form echoes the defaulted
+    record back over a sparse config.yaml, and a default block is not a change."""
+    return _deep_merge(DEFAULT_CONFIG, doc if isinstance(doc, dict) else {})
+
+
+def _refuse_if_managed_platform_config_changed(before: Any, after: Any) -> None:
+    """409 when a config write alters a host-owned platform block in any of its locations."""
+    managed = _managed_platforms()
+    if not managed:
+        return
+    before, after = _effective_config(before), _effective_config(after)
+    for platform_id in managed.platforms:
+        if _platform_block_views(before, platform_id) != _platform_block_views(after, platform_id):
+            _refuse_if_platform_managed(platform_id)
 
 
 def _merge_platform_env_vars(platform_id: str, override: dict[str, Any], plugin_entry: Any | None) -> tuple[str, ...]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -333,6 +333,11 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     # these, so production tests must not see them either.
     "HERMES_DASHBOARD_OAUTH_CLIENT_ID",
     "HERMES_DASHBOARD_PORTAL_URL",
+    # Host-declared channel ownership (hermes_cli.managed_platforms). Set only
+    # by hosting layers; a developer box carrying it would lock Channels cards
+    # in every dashboard test.
+    "HERMES_MANAGED_PLATFORMS",
+    "HERMES_MANAGED_PLATFORMS_LABEL",
     "TERMINAL_CWD",
     "TERMINAL_ENV",
     "TERMINAL_VERCEL_RUNTIME",

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -3,6 +3,8 @@ import importlib
 import os
 import sys
 
+import pytest
+
 from hermes_cli.env_loader import load_hermes_dotenv
 
 
@@ -461,6 +463,39 @@ def test_export_prefixed_known_key_in_user_env_is_kept(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_ACP_AUTH_METHOD", "cursor_login")
     load_hermes_dotenv(hermes_home=home)
     assert os.getenv("HERMES_ACP_AUTH_METHOD") == "claude_code_cli"
+
+
+@pytest.mark.parametrize("launch_platforms", ["telegram:native,discord:relay", None])
+def test_host_channel_stamps_keep_their_launch_value_over_user_env(tmp_path, monkeypatch, launch_platforms):
+    """A hosting layer injects HERMES_MANAGED_PLATFORMS into the process env. The user .env loads with
+    override, so a line assigning the stamp there would switch the dashboard lock off (or invent one):
+    the value the process launched with is re-asserted after the load. The portal URL the locked cards
+    link to gets the same treatment only under a declaration; without one it stays a user setting."""
+    from hermes_cli import env_loader
+
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_text(
+        "HERMES_MANAGED_PLATFORMS=\nHERMES_MANAGED_PLATFORMS_LABEL=Elsewhere\n"
+        "HERMES_DASHBOARD_PORTAL_URL=https://elsewhere.example\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(env_loader, "_HOST_STAMPS_AT_LAUNCH", None)
+    monkeypatch.delenv("HERMES_MANAGED_PLATFORMS_LABEL", raising=False)
+    monkeypatch.setenv("HERMES_DASHBOARD_PORTAL_URL", "https://portal.example")
+    if launch_platforms is None:
+        monkeypatch.delenv("HERMES_MANAGED_PLATFORMS", raising=False)
+    else:
+        monkeypatch.setenv("HERMES_MANAGED_PLATFORMS", launch_platforms)
+
+    load_hermes_dotenv(hermes_home=home)
+
+    assert os.environ.get("HERMES_MANAGED_PLATFORMS") == launch_platforms
+    assert "HERMES_MANAGED_PLATFORMS_LABEL" not in os.environ
+    host_owned = launch_platforms is not None
+    assert os.environ["HERMES_DASHBOARD_PORTAL_URL"] == (
+        "https://portal.example" if host_owned else "https://elsewhere.example"
+    )
 
 
 def test_shell_exported_credentials_survive_cleanup(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_managed_platforms.py
+++ b/tests/hermes_cli/test_managed_platforms.py
@@ -1,0 +1,100 @@
+"""Parsing of the host-declared channel ownership stamps."""
+import logging
+
+import pytest
+
+from hermes_cli import managed_platforms
+from hermes_cli.managed_platforms import (
+    DEFAULT_LABEL,
+    LABEL_ENV,
+    PLATFORMS_ENV,
+    URL_ENV,
+    load_managed_platforms,
+)
+
+
+def test_unset_means_nothing_managed():
+    managed = load_managed_platforms({})
+    assert not managed
+    assert managed.platforms == {}
+    assert managed.record_for("telegram") is None
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("telegram:native,discord:relay", {"telegram": "native", "discord": "relay"}),
+        ("telegram", {"telegram": "native"}),
+        (" Telegram:Native , DISCORD:relay ", {"telegram": "native", "discord": "relay"}),
+        ("telegram:relay,telegram:native", {"telegram": "relay"}),
+        ("telegram:bogus", {"telegram": "native"}),
+        (",, :relay ,", {}),
+    ],
+)
+def test_platform_entries(raw, expected):
+    assert load_managed_platforms({PLATFORMS_ENV: raw}).platforms == expected
+
+
+def test_record_carries_kind_label_and_url():
+    managed = load_managed_platforms(
+        {
+            PLATFORMS_ENV: "telegram:native,discord:relay",
+            LABEL_ENV: "Nous Portal",
+            URL_ENV: "https://portal.example.com",
+        }
+    )
+    assert managed.record_for("discord") == {
+        "kind": "relay",
+        "label": "Nous Portal",
+        "url": "https://portal.example.com",
+    }
+    assert managed.manages_relay() is True
+    assert managed.kind_of("slack") is None
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("", DEFAULT_LABEL),
+        ("   ", DEFAULT_LABEL),
+        ("  Nous   Portal ", "Nous Portal"),
+        ("x" * 100, "x" * 64),
+    ],
+)
+def test_label_fallback_and_cap(raw, expected):
+    managed = load_managed_platforms({PLATFORMS_ENV: "telegram", LABEL_ENV: raw})
+    assert managed.label == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("https://portal.example.com/agents", "https://portal.example.com/agents"),
+        ("http://localhost:3000", "http://localhost:3000"),
+        ("ftp://portal.example.com", None),
+        ("http://[", None),
+        ("javascript:alert(1)", None),
+        ("portal.example.com", None),
+        ("", None),
+    ],
+)
+def test_url_accepts_only_http_and_https(raw, expected):
+    managed = load_managed_platforms({PLATFORMS_ENV: "telegram", URL_ENV: raw})
+    assert managed.url == expected
+
+
+def test_label_and_url_do_not_unlock_when_no_platforms_listed():
+    managed = load_managed_platforms(
+        {LABEL_ENV: "Nous Portal", URL_ENV: "https://portal.example.com"}
+    )
+    assert not managed
+    assert managed.label == DEFAULT_LABEL
+    assert managed.url is None
+
+
+def test_unknown_kind_is_logged_once_per_stamp_value(caplog):
+    managed_platforms._parse.cache_clear()
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.managed_platforms"):
+        for _ in range(3):
+            load_managed_platforms({PLATFORMS_ENV: "telegram:weird"})
+    assert sum("unknown kind" in r.getMessage() for r in caplog.records) == 1

--- a/tests/hermes_cli/test_web_server_managed_platforms.py
+++ b/tests/hermes_cli/test_web_server_managed_platforms.py
@@ -1,0 +1,288 @@
+"""Host-declared channel ownership on the dashboard Channels surface.
+
+A hosting layer stamps ``HERMES_MANAGED_PLATFORMS``; the dashboard then reports
+those channels as managed and refuses every write path that could change them.
+Without the stamp nothing changes, down to the payload shape.
+"""
+import pytest
+import yaml
+
+
+VALID_TOKEN = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ_1234"
+PORTAL_URL = "https://portal.example.com"
+
+
+@pytest.fixture
+def homes(tmp_path, monkeypatch, _isolate_hermes_home):
+    from hermes_constants import get_hermes_home
+    from hermes_cli import profiles
+
+    default_home = get_hermes_home()
+    profiles_root = default_home / "profiles"
+    worker_home = profiles_root / "worker_alpha"
+    for home in (default_home, worker_home):
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text("{}\n", encoding="utf-8")
+        (home / ".env").write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(profiles, "_get_default_hermes_home", lambda: default_home)
+    monkeypatch.setattr(profiles, "_get_profiles_root", lambda: profiles_root)
+    return {"default": default_home, "worker_alpha": worker_home}
+
+
+@pytest.fixture
+def client(monkeypatch, homes):
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+
+    import hermes_state
+    from hermes_constants import get_hermes_home
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    c = TestClient(app)
+    c.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+    return c
+
+
+@pytest.fixture
+def managed(monkeypatch):
+    monkeypatch.setenv("HERMES_MANAGED_PLATFORMS", "telegram:native,discord:relay")
+    monkeypatch.setenv("HERMES_MANAGED_PLATFORMS_LABEL", "Nous Portal")
+    monkeypatch.setenv("HERMES_DASHBOARD_PORTAL_URL", PORTAL_URL)
+
+
+def _platform(payload, platform_id):
+    return next(p for p in payload["platforms"] if p["id"] == platform_id)
+
+
+def _files_unchanged(home):
+    return (
+        (home / ".env").read_text(encoding="utf-8") == ""
+        and yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8")) == {}
+    )
+
+
+class TestReads:
+    def test_payload_shape_is_unchanged_without_the_stamp(self, client):
+        payload = client.get("/api/messaging/platforms").json()
+        assert "managed_by" not in payload
+        assert all("managed" not in p for p in payload["platforms"])
+
+    def test_declared_platforms_carry_their_record(self, client, managed):
+        payload = client.get("/api/messaging/platforms").json()
+        assert payload["managed_by"] == {"label": "Nous Portal", "url": PORTAL_URL}
+        assert _platform(payload, "telegram")["managed"] == {
+            "kind": "native",
+            "label": "Nous Portal",
+            "url": PORTAL_URL,
+        }
+        assert _platform(payload, "discord")["managed"]["kind"] == "relay"
+        assert _platform(payload, "slack")["managed"] is None
+
+
+class TestChannelWrites:
+    def test_platform_update_is_refused_before_any_write(self, client, managed, homes):
+        resp = client.put(
+            "/api/messaging/platforms/telegram",
+            json={"enabled": True, "env": {"TELEGRAM_BOT_TOKEN": VALID_TOKEN}},
+        )
+        assert resp.status_code == 409
+        assert resp.json()["detail"] == "Telegram is managed by Nous Portal."
+        assert _files_unchanged(homes["default"])
+
+    def test_unmanaged_platform_still_writable(self, client, managed, homes):
+        resp = client.put("/api/messaging/platforms/slack", json={"enabled": False})
+        assert resp.status_code == 200
+        cfg = yaml.safe_load((homes["default"] / "config.yaml").read_text())
+        assert cfg["platforms"]["slack"]["enabled"] is False
+
+    def test_lock_applies_to_every_profile(self, client, managed, homes):
+        resp = client.put(
+            "/api/messaging/platforms/telegram",
+            params={"profile": "worker_alpha"},
+            json={"enabled": True, "env": {"TELEGRAM_BOT_TOKEN": VALID_TOKEN}},
+        )
+        assert resp.status_code == 409
+        assert _files_unchanged(homes["worker_alpha"])
+
+    def test_telegram_onboarding_refused_without_side_effects(
+        self, client, managed, monkeypatch
+    ):
+        import hermes_cli.web_routers.messaging as messaging_router
+        from hermes_cli import web_server_messaging
+
+        async def _no_network(*args, **kwargs):
+            raise AssertionError("the setup service must not be contacted")
+
+        monkeypatch.setattr(messaging_router, "_telegram_onboarding_request", _no_network)
+
+        start = client.post("/api/messaging/telegram/onboarding/start", json={})
+        assert start.status_code == 409
+        assert web_server_messaging._telegram_onboarding_pairings == {}
+
+        apply = client.post(
+            "/api/messaging/telegram/onboarding/some-id/apply",
+            json={"allowed_user_ids": ["123"]},
+        )
+        assert apply.status_code == 409
+
+    def test_whatsapp_onboarding_refused_without_side_effects(self, client, monkeypatch):
+        from hermes_cli import web_server_messaging
+
+        monkeypatch.setenv("HERMES_MANAGED_PLATFORMS", "whatsapp:native")
+
+        start = client.post(
+            "/api/messaging/whatsapp/onboarding/start", json={"mode": "bot"}
+        )
+        assert start.status_code == 409
+        assert web_server_messaging._whatsapp_onboarding_sessions == {}
+
+        apply = client.post(
+            "/api/messaging/whatsapp/onboarding/some-id/apply", json={}
+        )
+        assert apply.status_code == 409
+
+
+class TestConnectionTest:
+    def test_native_test_still_runs(self, client, managed):
+        resp = client.post("/api/messaging/platforms/telegram/test")
+        assert resp.status_code == 200
+
+    def test_relay_test_is_refused(self, client, managed):
+        resp = client.post("/api/messaging/platforms/discord/test")
+        assert resp.status_code == 409
+        assert "Nous Portal" in resp.json()["detail"]
+
+
+class TestGenericWriters:
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "TELEGRAM_BOT_TOKEN",
+            "TELEGRAM_ALLOWED_USERS",
+            # Hidden from the setup card but honoured by the gateway.
+            "TELEGRAM_ALLOW_ALL_USERS",
+            "TELEGRAM_HOME_CHANNEL",
+        ],
+    )
+    def test_env_routes_refuse_the_managed_platform_namespace(
+        self, client, managed, homes, key
+    ):
+        put = client.put("/api/env", json={"key": key, "value": "anything"})
+        assert put.status_code == 409
+        delete = client.request("DELETE", "/api/env", json={"key": key})
+        assert delete.status_code == 409
+        assert _files_unchanged(homes["default"])
+
+    def test_env_routes_leave_other_keys_alone(self, client, managed, homes):
+        resp = client.put(
+            "/api/env", json={"key": "SLACK_BOT_TOKEN", "value": "xoxb-not-managed"}
+        )
+        assert resp.status_code == 200
+        assert "SLACK_BOT_TOKEN=xoxb-not-managed" in (
+            homes["default"] / ".env"
+        ).read_text(encoding="utf-8")
+
+    def test_env_routes_refuse_the_portal_link_while_channels_are_managed(
+        self, client, managed, homes
+    ):
+        put = client.put(
+            "/api/env",
+            json={"key": "HERMES_DASHBOARD_PORTAL_URL", "value": "https://elsewhere.example"},
+        )
+        assert put.status_code == 409
+        delete = client.request(
+            "DELETE", "/api/env", json={"key": "HERMES_DASHBOARD_PORTAL_URL"}
+        )
+        assert delete.status_code == 409
+        assert _files_unchanged(homes["default"])
+
+    def test_portal_link_stays_a_user_setting_without_a_declaration(self, client, homes):
+        put = client.put(
+            "/api/env",
+            json={"key": "HERMES_DASHBOARD_PORTAL_URL", "value": "https://portal.example"},
+        )
+        assert put.status_code == 200
+        assert "HERMES_DASHBOARD_PORTAL_URL=https://portal.example" in (
+            homes["default"] / ".env"
+        ).read_text(encoding="utf-8")
+
+    def test_direct_platforms_switch_is_owned_only_with_a_relay_platform(
+        self, client, monkeypatch, homes
+    ):
+        monkeypatch.setenv("HERMES_MANAGED_PLATFORMS", "telegram:native,discord:relay")
+        refused = client.put(
+            "/api/env",
+            json={"key": "GATEWAY_RELAY_ALLOW_DIRECT_PLATFORMS", "value": "true"},
+        )
+        assert refused.status_code == 409
+
+        monkeypatch.setenv("HERMES_MANAGED_PLATFORMS", "telegram:native")
+        allowed = client.put(
+            "/api/env",
+            json={"key": "GATEWAY_RELAY_ALLOW_DIRECT_PLATFORMS", "value": "true"},
+        )
+        assert allowed.status_code == 200
+
+    @pytest.mark.parametrize(
+        "key", ["HERMES_MANAGED_PLATFORMS", "HERMES_MANAGED_PLATFORMS_LABEL"]
+    )
+    def test_the_stamps_themselves_cannot_be_set(self, client, homes, key):
+        put = client.put("/api/env", json={"key": key, "value": ""})
+        assert put.status_code == 400
+        assert "denylist" in put.json()["detail"]
+        assert _files_unchanged(homes["default"])
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            {"platforms": {"telegram": {"enabled": False}}},
+            {"gateway": {"platforms": {"telegram": {"enabled": False}}}},
+            {"gateway": {"telegram": {"enabled": False}}},
+            {"telegram": {"enabled": False}},
+        ],
+    )
+    def test_config_form_refuses_every_managed_platform_location(
+        self, client, managed, homes, config
+    ):
+        refused = client.put("/api/config", json={"config": config})
+        assert refused.status_code == 409
+        assert _files_unchanged(homes["default"])
+
+    def test_config_form_leaves_other_platforms_alone(self, client, managed):
+        allowed = client.put(
+            "/api/config",
+            json={"config": {"platforms": {"slack": {"enabled": False}}}},
+        )
+        assert allowed.status_code == 200
+
+    def test_config_form_round_trip_of_the_defaulted_record_is_allowed(self, client, managed):
+        record = client.get("/api/config").json()
+        assert client.put("/api/config", json={"config": record}).status_code == 200
+
+    @pytest.mark.parametrize(
+        "yaml_text",
+        [
+            "platforms:\n  telegram:\n    enabled: false\n",
+            "gateway:\n  platforms:\n    telegram:\n      enabled: false\n",
+            "gateway:\n  telegram:\n    enabled: false\n",
+            "telegram:\n  enabled: false\n",
+        ],
+    )
+    def test_raw_editor_refuses_every_managed_platform_location(
+        self, client, managed, homes, yaml_text
+    ):
+        refused = client.put("/api/config/raw", json={"yaml_text": yaml_text})
+        assert refused.status_code == 409
+        assert _files_unchanged(homes["default"])
+
+    def test_raw_editor_leaves_other_platforms_alone(self, client, managed):
+        allowed = client.put(
+            "/api/config/raw",
+            json={"yaml_text": "platforms:\n  slack:\n    enabled: false\n"},
+        )
+        assert allowed.status_code == 200

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1556,6 +1556,13 @@ export interface MessagingPlatformEnvVar {
   advanced: boolean;
 }
 
+/** Set when a hosting layer owns this channel (HERMES_MANAGED_PLATFORMS). */
+export interface ManagedPlatformInfo {
+  kind: "native" | "relay";
+  label: string;
+  url: string | null;
+}
+
 export interface MessagingPlatform {
   id: string;
   name: string;
@@ -1579,12 +1586,15 @@ export interface MessagingPlatform {
     home_channel_set?: boolean;
   } | null;
   env_vars: MessagingPlatformEnvVar[];
+  /** Present only when the server has a host ownership declaration. */
+  managed?: ManagedPlatformInfo | null;
 }
 
 export interface MessagingPlatformsResponse {
   env_path: string;
   gateway_start_command: string;
   platforms: MessagingPlatform[];
+  managed_by?: { label: string; url: string | null };
 }
 
 export interface MessagingPlatformUpdate {

--- a/web/src/lib/managed-channels.test.ts
+++ b/web/src/lib/managed-channels.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import type { ManagedPlatformInfo } from "./api";
+import { managedChannelControls } from "./managed-channels";
+
+const native: ManagedPlatformInfo = { kind: "native", label: "Nous Portal", url: null };
+const relay: ManagedPlatformInfo = { kind: "relay", label: "Nous Portal", url: null };
+
+describe("managedChannelControls", () => {
+  it.each([
+    ["older server without the field", { configured: true }],
+    ["explicit null", { managed: null, configured: false }],
+  ])("keeps every control for an unmanaged card (%s)", (_label, platform) => {
+    expect(managedChannelControls(platform)).toEqual({
+      managed: null,
+      showToggle: true,
+      showConfigure: true,
+      showOnboarding: true,
+      showTest: true,
+      showNativeState: true,
+    });
+  });
+
+  it.each([
+    ["configured", true],
+    ["not configured", false],
+  ])("native: hides setup, keeps state, tests only when %s", (_label, configured) => {
+    expect(managedChannelControls({ managed: native, configured })).toEqual({
+      managed: native,
+      showToggle: false,
+      showConfigure: false,
+      showOnboarding: false,
+      showTest: configured,
+      showNativeState: true,
+    });
+  });
+
+  it("relay: hides everything native, including the state badge", () => {
+    expect(managedChannelControls({ managed: relay, configured: true })).toEqual({
+      managed: relay,
+      showToggle: false,
+      showConfigure: false,
+      showOnboarding: false,
+      showTest: false,
+      showNativeState: false,
+    });
+  });
+});

--- a/web/src/lib/managed-channels.ts
+++ b/web/src/lib/managed-channels.ts
@@ -1,0 +1,47 @@
+import type { ManagedPlatformInfo, MessagingPlatform } from "./api";
+
+/** Which controls a Channels card renders once a host declares ownership. */
+export interface ManagedChannelControls {
+  managed: ManagedPlatformInfo | null;
+  showToggle: boolean;
+  showConfigure: boolean;
+  showOnboarding: boolean;
+  showTest: boolean;
+  /** False when the native adapter is off by design (relay), so its
+   * Disabled / Not configured badge would contradict a working channel. */
+  showNativeState: boolean;
+}
+
+const UNMANAGED: ManagedChannelControls = {
+  managed: null,
+  showToggle: true,
+  showConfigure: true,
+  showOnboarding: true,
+  showTest: true,
+  showNativeState: true,
+};
+
+export function managedChannelControls(
+  platform: Pick<MessagingPlatform, "managed" | "configured">,
+): ManagedChannelControls {
+  const managed = platform.managed ?? null;
+  if (!managed) return UNMANAGED;
+  if (managed.kind === "relay") {
+    return {
+      managed,
+      showToggle: false,
+      showConfigure: false,
+      showOnboarding: false,
+      showTest: false,
+      showNativeState: false,
+    };
+  }
+  return {
+    managed,
+    showToggle: false,
+    showConfigure: false,
+    showOnboarding: false,
+    showTest: platform.configured,
+    showNativeState: true,
+  };
+}

--- a/web/src/pages/ChannelsPage.tsx
+++ b/web/src/pages/ChannelsPage.tsx
@@ -6,6 +6,7 @@ import {
   CheckCircle2,
   ExternalLink,
   Info,
+  Lock,
   PlugZap,
   QrCode,
   Radio,
@@ -26,6 +27,7 @@ import { Switch } from "@nous-research/ui/ui/components/switch";
 import { Toast } from "@nous-research/ui/ui/components/toast";
 import { useToast } from "@nous-research/ui/hooks/use-toast";
 import { api } from "@/lib/api";
+import { managedChannelControls } from "@/lib/managed-channels";
 import type {
   MessagingPlatform,
   MessagingPlatformEnvVar,
@@ -135,6 +137,9 @@ export default function ChannelsPage() {
   const [gatewayStartCommand, setGatewayStartCommand] = useState(
     "hermes gateway start",
   );
+  const [managedBy, setManagedBy] = useState<{ label: string; url: string | null } | null>(
+    null,
+  );
   const [loading, setLoading] = useState(true);
   const { toast, showToast } = useToast();
   const { setEnd } = usePageHeader();
@@ -165,6 +170,7 @@ export default function ChannelsPage() {
         setPlatforms(res.platforms);
         setEnvPath(res.env_path || "~/.hermes/.env");
         setGatewayStartCommand(res.gateway_start_command || "hermes gateway start");
+        setManagedBy(res.managed_by ?? null);
       })
       .catch((e) => showToast(`Error: ${e}`, "error"));
   }, [showToast]);
@@ -290,9 +296,10 @@ export default function ChannelsPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [setEnd, restarting]);
 
+  const unmanaged = useMemo(() => platforms.filter((p) => !p.managed), [platforms]);
   const configured = useMemo(
-    () => platforms.filter((p) => p.configured).length,
-    [platforms],
+    () => unmanaged.filter((p) => p.configured).length,
+    [unmanaged],
   );
 
   if (loading) {
@@ -343,11 +350,35 @@ export default function ChannelsPage() {
         </Card>
       )}
 
-      <p className="text-xs text-muted-foreground">
-        {configured} of {platforms.length} channels configured. Credentials are
-        written to <code className="font-courier">{envPath}</code>; the
-        gateway connects each enabled channel on its next restart.
-      </p>
+      {managedBy && (
+        <Card className="border-border">
+          <CardContent className="flex flex-wrap items-center gap-2 p-4 text-sm text-muted-foreground">
+            <Lock className="h-4 w-4 shrink-0" />
+            <span>
+              Some channels are managed in {managedBy.label} and can only be changed there.
+            </span>
+            {managedBy.url && (
+              <a
+                href={managedBy.url}
+                target="_blank"
+                rel="noreferrer"
+                className="ml-auto inline-flex items-center gap-1 text-primary hover:underline"
+              >
+                Open {managedBy.label}
+                <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {unmanaged.length > 0 && (
+        <p className="text-xs text-muted-foreground">
+          {configured} of {unmanaged.length} channels configured. Credentials are
+          written to <code className="font-courier">{envPath}</code>; the
+          gateway connects each enabled channel on its next restart.
+        </p>
+      )}
 
       {/* Config modal */}
       {editing && (
@@ -528,10 +559,14 @@ export default function ChannelsPage() {
       {/* Platform list */}
       <div className="grid gap-3">
         {platforms.map((platform) => {
-          const badge = stateBadge(platform.state);
+          const controls = managedChannelControls(platform);
+          const badge = controls.showNativeState
+            ? stateBadge(platform.state)
+            : { tone: "secondary" as const, label: "Managed" };
           const busy = togglingId === platform.id;
-          const StateIcon =
-            platform.state === "connected"
+          const StateIcon = !controls.showNativeState
+            ? Lock
+            : platform.state === "connected"
               ? CheckCircle2
               : platform.state === "fatal" || platform.state === "startup_failed"
                 ? AlertTriangle
@@ -562,42 +597,63 @@ export default function ChannelsPage() {
                       <span className="text-xs text-muted-foreground">
                         {platform.description}
                       </span>
-                      {platform.error_message && (
+                      {controls.showNativeState && platform.error_message && (
                         <span className="text-xs text-destructive">
                           {platform.error_message}
+                        </span>
+                      )}
+                      {controls.managed && (
+                        <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                          <Lock className="h-3 w-3 shrink-0" />
+                          Managed in {controls.managed.label}
+                          {controls.managed.url && (
+                            <a
+                              href={controls.managed.url}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="inline-flex items-center gap-1 text-primary hover:underline"
+                            >
+                              Open
+                              <ExternalLink className="h-3 w-3" />
+                            </a>
+                          )}
                         </span>
                       )}
                     </div>
                   </div>
 
                   <div className="flex items-center gap-2 shrink-0 self-start sm:self-center">
-                    <div className="flex items-center gap-1.5">
-                      {busy ? (
-                        <Spinner className="text-sm" />
-                      ) : (
-                        <Switch
-                          checked={platform.enabled}
-                          onCheckedChange={() => void handleToggle(platform)}
-                          aria-label={`Enable ${platform.name}`}
-                        />
-                      )}
-                    </div>
-                    <Button
-                      ghost
-                      size="sm"
-                      onClick={() => handleTest(platform)}
-                      disabled={testingId === platform.id}
-                      prefix={
-                        testingId === platform.id ? (
-                          <Spinner />
+                    {controls.showToggle && (
+                      <div className="flex items-center gap-1.5">
+                        {busy ? (
+                          <Spinner className="text-sm" />
                         ) : (
-                          <PlugZap className="h-4 w-4" />
-                        )
-                      }
-                    >
-                      Test
-                    </Button>
-                    {platform.id !== "telegram" && (
+                          <Switch
+                            checked={platform.enabled}
+                            onCheckedChange={() => void handleToggle(platform)}
+                            aria-label={`Enable ${platform.name}`}
+                          />
+                        )}
+                      </div>
+                    )}
+                    {controls.showTest && (
+                      <Button
+                        ghost
+                        size="sm"
+                        onClick={() => handleTest(platform)}
+                        disabled={testingId === platform.id}
+                        prefix={
+                          testingId === platform.id ? (
+                            <Spinner />
+                          ) : (
+                            <PlugZap className="h-4 w-4" />
+                          )
+                        }
+                      >
+                        Test
+                      </Button>
+                    )}
+                    {controls.showConfigure && platform.id !== "telegram" && (
                       <Button
                         size="sm"
                         className="uppercase"
@@ -609,7 +665,7 @@ export default function ChannelsPage() {
                     )}
                   </div>
                 </div>
-                {platform.id === "telegram" && (
+                {controls.showOnboarding && platform.id === "telegram" && (
                   <TelegramOnboardingPanel
                     onManualSetup={() => openConfig(platform)}
                     onChanged={load}
@@ -619,7 +675,7 @@ export default function ChannelsPage() {
                     showToast={showToast}
                   />
                 )}
-                {platform.id === "whatsapp" && (
+                {controls.showOnboarding && platform.id === "whatsapp" && (
                   <WhatsAppOnboardingPanel
                     onChanged={load}
                     onRestartNeeded={() => setRestartNeeded(true)}

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -161,6 +161,10 @@ An unauthenticated public dashboard was the entry point for the June 2026 MCP-co
 
 Running the dashboard as a separate container **is** supported when that container shares the host PID and network namespace (e.g. `network_mode: host`, as the repo's own `docker-compose.yml` does — see its `dashboard` service). Its gateway-liveness detection requires a shared PID namespace with the gateway process, so the limitation only applies to dashboards run in isolated bridge-network containers without a shared PID namespace.
 
+### Host-managed channels
+
+A hosting layer that configures messaging channels for the operator (the Nous Portal does this for hosted agents) can stamp the container with `HERMES_MANAGED_PLATFORMS`, a comma-separated list of `platform:kind` entries such as `telegram:native,discord:relay`, plus an optional `HERMES_MANAGED_PLATFORMS_LABEL`. The dashboard then shows those channels read-only, links back to the host through `HERMES_DASHBOARD_PORTAL_URL`, and refuses writes to them from the Channels page, the Keys page and the config editor. `native` means the host supplies the platform credentials; `relay` means the host's connector fronts the platform and the native adapter stays off. These are deployment stamps set by the host, not settings for your own `.env`: the value the container was launched with wins over any assignment there, and while channels are managed the same holds for `HERMES_DASHBOARD_PORTAL_URL`. Without them nothing changes.
+
 ## Running interactively (CLI chat)
 
 To open an interactive chat session against a running data directory:


### PR DESCRIPTION
On hosted agents the portal configures messaging channels, but the dashboard Channels page still offers Configure, the QR setup and the enable switch for them. Edits made there land in $HERMES_HOME/.env and silently beat the value the host injected, and the switch disables a channel the portal still reports as configured.

A hosting layer can now stamp the channels it owns:

    HERMES_MANAGED_PLATFORMS=telegram:native,discord:relay
    HERMES_MANAGED_PLATFORMS_LABEL=Nous Portal

The dashboard shows those channels read only with a link back to the host, and every write path that could change them answers 409: platform update, Telegram and WhatsApp onboarding, env PUT and DELETE for the platform namespace, and the config form and raw editor for the platform block in any of its locations. relay marks channels fronted by the host connector, whose card shows Managed instead of the native Disabled state. The stamp names themselves are on the env writer denylist. Without the stamp nothing changes.

Not covered here: the desktop app has its own channel controls and will surface the 409 as an error, and a value already sitting in the agent's .env before the lock keeps winning until it is cleared on the box.
