### PR TITLE
fix(mcp): honor SDK read-only annotations

### DIFF
--- a/tests/tools/test_mcp_trust_gating.py
+++ b/tests/tools/test_mcp_trust_gating.py
@@ -247,3 +247,12 @@ class TestAnnotationCaptureAtDiscovery:
         assert _mcp_registration._annotation_read_only_hint(
             SimpleNamespace()
         ) is False
+
+    def test_sdk_annotations_supported(self):
+        """MCP SDK models expose the wire-format hint as snake_case."""
+        assert _mcp_registration._annotation_read_only_hint(
+            SimpleNamespace(annotations=SimpleNamespace(read_only_hint=True))
+        ) is True
+        assert _mcp_registration._annotation_read_only_hint(
+            SimpleNamespace(annotations=SimpleNamespace(read_only_hint=False))
+        ) is False

--- a/tools/mcp_tool_registration.py
+++ b/tools/mcp_tool_registration.py
@@ -41,9 +41,19 @@ def _normalize_server_trust(value: Any) -> str:
 
 
 def _annotation_read_only_hint(mcp_tool: Any) -> bool:
-    """True only when annotations (SDK object or cache dict) carry ``readOnlyHint is True``; unknown = write-capable."""
+    """Return the exact read-only hint from an SDK object or cached JSON.
+
+    MCP's Pydantic models expose ``readOnlyHint`` as ``read_only_hint`` while
+    cache payloads retain the wire-format camelCase key. Unknown or non-boolean
+    values remain write-capable.
+    """
     annotations = getattr(mcp_tool, "annotations", None)
-    hint = annotations.get("readOnlyHint") if isinstance(annotations, dict) else getattr(annotations, "readOnlyHint", None)
+    if isinstance(annotations, dict):
+        hint = annotations.get("readOnlyHint")
+    else:
+        hint = getattr(annotations, "read_only_hint", None)
+        if hint is None:
+            hint = getattr(annotations, "readOnlyHint", None)
     return hint is True
 
 


### PR DESCRIPTION
## Problem

Hermes trust gating reads `annotations.readOnlyHint`, but the MCP Python SDK maps that wire field to `annotations.read_only_hint`. A live server can correctly advertise `readOnlyHint: true` while Hermes caches `false` and requires write approval for a read-only tool.

Measured reproduction: Docker MCP Gateway advertised `readOnlyHint=true` for Context7 `resolve-library-id` and `query-docs`; Hermes cached both as `false` and blocked the resolver as write-capable on an untrusted server.

## Change

Read the SDK's snake_case attribute first, retain camelCase compatibility for older objects and cached JSON, and keep unknown/non-boolean values fail-closed.

## Verification

`scripts/run_tests.sh tests/tools/test_mcp_trust_gating.py` — 12 passed.

Co-Authored-By: OpenAI Codex <noreply@openai.com>