### PR TITLE
docs: Omarchy integration guide (Quattro desktop widgets)

### DIFF
--- a/website/docs/integrations/omarchy.md
+++ b/website/docs/integrations/omarchy.md
@@ -1,0 +1,38 @@
+---
+title: "Omarchy Integration"
+sidebar_label: "Omarchy"
+sidebar_position: 5
+---
+
+# Omarchy
+
+[Omarchy](https://omarchy.org) is an opinionated Arch + Hyprland desktop built around a Quickshell-based shell ("Quattro"). Its bar has a plugin system, and community plugins already exist for Hermes. This page describes what a desktop integration can rely on and what it should avoid.
+
+## What a desktop shell integration typically uses
+
+- `hermes status` and `hermes doctor` for health checks. Both are safe to run periodically; a cold `hermes` process costs seconds of Python startup, so cache results; the interval is an integration choice (30 minutes is a reasonable ceiling for a version string).
+- `hermes gateway start | stop | restart | status` for the messaging gateway's systemd user service. This is the supported control path; do not manage the unit with raw `systemctl` writes.
+- `hermes pause` / `hermes resume`, the emergency stop. Pause writes a JSON sentinel at `$HERMES_HOME/ESTOP` (profile-aware: a profile gateway reads its own `HERMES_HOME/ESTOP` first, then the fleet root). Third-party integrations can read that sentinel directly to display the paused state and reason without shelling out.
+- `hermes kanban boards list --json` returns machine-readable board summaries for task widgets.
+- `hermes send` for one-shot deliveries to configured messaging platforms from scripts and desktop actions.
+
+## Reading local state
+
+The SQLite store at `~/.hermes/state.db` (set `HERMES_HOME` per profile) answers most status questions read-only:
+
+- `sessions`: recent conversations with title, source (cli, telegram, discord, ...), model, message counts, timestamps, git workspace, and per-session cost fields.
+- `messages`: per-message timestamps and roles, enough for an activity estimate such as "a message arrived recently" and today's prompt counts.
+- `session_model_usage`: per-model token totals and estimated cost, already computed by Hermes.
+
+Open the database with `sqlite3.connect("file:...?mode=ro", uri=True)`. Remember that SQLite columns are dynamically typed: coerce values defensively, because a schema change in a fast-moving codebase should degrade a widget, not crash it. The schema is internal and can change between releases; pin your integration's expectations and fail soft.
+
+## What to avoid
+
+- Do not read `auth.json`, `.env`, or credential stores. If you need provider names, `hermes auth list` prints them; retain only names and counts.
+- Do not hand-parse `config.yaml` with regexes for anything beyond simple scalars. `hermes config get <path>` prints resolved values and handles nested structures. A `model:` key can be a scalar, a mapping with a `default:` child, or a dict-format custom-endpoint block; guessing produces wrong answers.
+- Do not spawn a Hermes CLI call on a fast refresh timer. Each cold call costs seconds of Python startup. Cache aggressively (TTLs of minutes) and read the database for the frequent path.
+- Do not write to `$HERMES_HOME` except through documented commands. Third-party state belongs in `$XDG_STATE_HOME`.
+
+## An example: the Omarchy bar plugin ecosystem
+
+[Hermes Deck](https://github.com/mbot11/omarchy-hermes-deck) is an open-source Quattro plugin that implements the read-only database polling, the action dispatcher with validated arguments, the ESTOP notifications, and the special-workspace TUI modal described above. a persistent state daemon polling the database read-only, an action dispatcher wrapping `hermes pause`/`resume`/`gateway restart` with validated arguments, desktop notifications on emergency-stop and gateway transitions, and a drop-down TUI modal on a Hyprland special workspace. Its `docs/SECURITY.md` documents one concrete trust boundary for desktop shells.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -703,6 +703,7 @@ const sidebars: SidebarsConfig = {
         'integrations/nous-portal',
         'integrations/providers',
         'integrations/buzz',
+        'integrations/omarchy',
         'user-guide/features/mcp',
         'user-guide/features/acp',
         'user-guide/features/provider-routing',


### PR DESCRIPTION
## Summary

Adds `website/docs/integrations/omarchy.md`, registered in `sidebars.ts`, aimed at the growing set of Omarchy/Quickshell bar widgets that surface Hermes state.

It documents what a desktop integration can rely on:

- Cheap vs expensive status surfaces: cache `hermes --version`/`doctor` results (a cold CLI call costs seconds of Python startup); read `state.db` read-only for the frequent path.
- Supported control paths: `hermes gateway start|stop|restart|status` (not raw systemctl writes) and `hermes pause`/`resume`, including the profile-aware `$HERMES_HOME/ESTOP` JSON sentinel that third-party code can read to display paused state and reason.
- Machine-readable surfaces that already work: `hermes kanban boards list --json`, `hermes config get <path>`, `hermes send`.
- What to avoid: credential stores, regex-parsing `config.yaml` (the `model:` key can be scalar, mapping-with-default, or dict-format), and CLI calls on fast refresh timers.

[Hermes Deck](https://github.com/mbot11/omarchy-hermes-deck), an MIT Quattro plugin, is linked as the worked example; its `docs/SECURITY.md` documents the trust boundary in concrete terms.

## Motivation

Filed issue #103176 separately: third-party integrations currently hand-roll `state.db` schema expectations because no read-only status contract exists. This guide captures today's stable patterns without committing upstream to anything.

## Testing

Docs-only change (one new page + sidebar entry). Renders as standard Docusaurus markdown; no code changes.