### PR TITLE
fix(skills): keyboard activation rung for React/Polaris controls that ignore background clicks

### DIFF
--- a/skills/autonomous-ai-agents/computer-use/SKILL.md
+++ b/skills/autonomous-ai-agents/computer-use/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: computer-use
 description: "Drive the desktop in the background without stealing focus."
-version: 2.1.0
+version: 2.2.0
 author: Francesco Bonacci (f-trycua), Hermes Agent
 license: MIT
 platforms: [macos, windows, linux]
@@ -247,7 +247,46 @@ recipe — focus lands on the visible button either way.
 Windows / Linux), standalone Edge, and Electron builds. Arc, Dia, Brave,
 Firefox, Safari and similar are rejected — drive their page content with the
 native ladder + keyboard activation, or use the separate headless `browser_*`
-tools when the user's session isn't required.
+tools when the user's session isn't required. Note: Arc/Dia tabs have been
+observed crash-looping React-heavy admin SPAs (Shopify admin "Code 5" error
+pages) — prefer a certified engine for long UI sessions.
+
+### Buried windows eat your clicks (z-order)
+
+Mouse clicks are delivered by the OS to the **topmost window at that screen
+point** — the target app's identity never matters. If the window you're
+driving sits *under* another window (e.g. the Hermes desktop app is z-above
+the browser), every click — AX hit-test, background CGEvent, even foreground
+delivery when the raise doesn't stick — lands on the window above it, and the
+target sees nothing. Keyboard events are the exception: they're targeted by
+PID and reach buried windows fine. Symptoms: keys work, clicks never do;
+click responses say "pressed the background element" or "not driver-verified"
+and nothing changes.
+
+Fix: bring the target genuinely to the front and **verify it stayed there**:
+
+```
+focus_app(app="Dia", raise_window=true)   # requires approval; check response
+# → frontmost_pid: 996, frontmost_ordinary_window_id: 130  ← verify these
+click(element=…, delivery_mode="foreground")
+```
+
+Because foreground delivery *restores the previously-frontmost app after
+acting*, the window sinks again between calls — re-run `focus_app` (and
+verify `frontmost_pid`) before **every** foreground action in a sequence.
+Check `list_windows` for z-order if the target's window vanishes from
+`focus_app` results (the user may have closed it, or it moved Spaces).
+
+### Coordinates are screen points; capture images are scaled
+
+Element bounds in the AX JSON are **screen coordinates** (the AXWindow entry
+carries the menu-bar/taskbar offset, e.g. `AXWindow @ (0, 34, 1175, 1028)` on
+macOS). Coordinate clicks expect the same screen-point space. The capture
+screenshot, by contrast, is a **scaled image** (window points × a Retina/zoom
+factor, e.g. 1.334×) — do NOT multiply AX bounds by the capture scale before
+clicking, and do NOT read element positions off a vision screenshot in pixels.
+When bounds and reality disagree, click the center of the element's stated
+bounds and verify with a fresh capture.
 
 ### Key shortcuts vary per platform
 
@@ -360,6 +399,8 @@ in your conversation context.
 | `cua_browser_state` refuses the browser (Arc, Dia, Firefox, Safari) | Unsupported engine for the typed route — native ladder + keyboard activation only, or headless `browser_*` tools when the user's session isn't needed |
 | `AXUIElementPerformAction(AXPress) returned -25206` | `kAXErrorFailure` — transient macOS AX failure. Retry once; if it persists, use a coordinate click or the keyboard rung |
 | Clicks land off-target or "the coordinates were right but nothing happened" | Capture scale drifts between captures (observed 1.33× → 1.24× on the same window; Retina scaling varies). Re-capture before every click, prefer `element=N` over pixel math, and validate a pixel target with a probe click that has a visible effect |
+| All mouse clicks do nothing, but keyboard input works | The target window is **buried under another window** (z-order). Clicks go to the topmost window at that point. `focus_app(raise_window=true)`, verify `frontmost_pid` in the response, then click — and re-focus before every foreground action (foreground delivery restores the previous frontmost after acting) |
+| `type` delivers 0 characters in a browser (Arc/Dia) | Printable-char CGEvent synthesis can be dropped by the engine; non-printable keys (return/escape) still deliver. Don't fight it: click the address bar and pick a suggestion with Enter (keyboard-activated), or switch to a certified engine with the typed route |
 | Anything else weird | **First action: ask the user to run `hermes computer-use doctor`.** It runs the cua-driver `health_report` MCP tool and prints a structured per-check matrix. Their output tells you (and them) exactly what's wrong |
 
 ## When NOT to use `computer_use`

--- a/skills/autonomous-ai-agents/computer-use/SKILL.md
+++ b/skills/autonomous-ai-agents/computer-use/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: computer-use
 description: "Drive the desktop in the background without stealing focus."
-version: 2.0.0
+version: 2.1.0
 author: Francesco Bonacci (f-trycua), Hermes Agent
 license: MIT
 platforms: [macos, windows, linux]
@@ -129,10 +129,18 @@ Walk it in order:
 3. **Pixel, background.** After `effect:"suspected_noop"` or a structured
    refusal recommends `"px"` (or a `degraded` capture has no elements), click
    by `coordinate=[x,y]` instead of `element`.
-4. **Typed page.** When `escalation.recommended == "page"` and the exact
+4. **Keyboard activation (web content).** When an element click keeps
+   "succeeding" without effect on a web page — React/Polaris tables and ⋮
+   popover triggers are the classic case — focus the element with one click,
+   then activate it with a trusted keystroke: `key(keys="return")` (or
+   `"space"` for checkboxes/switches). Keystrokes are trusted at the DOM
+   level; background clicks on macOS are AX-mediated and apps can ignore
+   them. `key(keys="escape")` closes popovers so you can retry cleanly. Full
+   recipe below in "Web controls that ignore clicks".
+5. **Typed page.** When `escalation.recommended == "page"` and the exact
    browser-page contract below is available, use the namespaced typed route
    before native foreground. This is not the legacy `page` workflow.
-5. **Foreground.** After `effect:"suspected_noop"`,
+6. **Foreground.** After `effect:"suspected_noop"`,
    `code:"background_unavailable"`, or a verified pixel no-op,
    re-issue the SAME action with `delivery_mode="foreground"`. This briefly
    raises the window and restores focus after; pair with `bring_to_front=True`
@@ -190,6 +198,56 @@ Use the native capture/AX/pixel/foreground ladder for browser chrome, browser
 permission UI, OS prompts, native dialogs, extension surfaces, unsupported
 engines, and any typed route that cannot prove exact binding or mutation
 permission. `cua_browser_dialog` covers page JavaScript dialogs only.
+
+## Web controls that ignore clicks (trusted events & aria-hidden duplicates)
+
+Web apps built on React-style synthetic events — Shopify's Polaris admin is
+the canonical example — sometimes ignore background clicks that *report
+success*: the app receives events whose `isTrusted` is false, or none at all,
+and its handler never fires. Three facts make this predictable:
+
+- **Background "pixel" clicks on macOS are AX-mediated, not raw mouse
+  events.** A background coordinate click runs an AX hit-test at the point
+  and AXPresses whatever it finds; it is not a CGEvent mouse click. Controls
+  with custom pointer logic (popover triggers, drag handles, color pickers)
+  can ignore it.
+- **Foreground CGEvent is the only true hardware-level mouse path.** And even
+  certified Chromium on macOS refuses *trusted CDP pointer* input
+  (`browser_input_trust_unavailable`), so some engines have no trusted mouse
+  route at all.
+- **Keystrokes ARE trusted.** CGEvent key synthesis lands in the browser as
+  trusted input, so keyboard activation works where clicks fail. This is also
+  why typing a URL into an address bar always works.
+
+### The click→Enter recipe (validated on Polaris ⋮ menus)
+
+1. `click(element=N)` on the control. If the press no-ops, it still moves
+   focus onto the button.
+2. `key(keys="return")` — the trusted key event fires the app's real handler
+   and the popover opens. (Use `"space"` for checkboxes/switches.)
+3. Re-capture: Polaris popovers appear in the AX tree as `AXMenu` +
+   `AXMenuItem` elements — activate menu items directly with
+   `click(element=N)`.
+4. Close stray popovers with `key(keys="escape")` before retrying; focus
+   stays on the trigger button, so a bare Enter reopens the menu.
+
+### aria-hidden duplicate nodes
+
+Web tables frequently expose **two AX nodes with identical bounds** for one
+visible control (the DOM renders the table twice, one copy `aria-hidden` for
+a11y). cua-driver can resolve the click to the *unlabeled* duplicate — the
+click response shows `AXButton ""` — which is a silent no-op. When the click
+response has an empty label, or a table button ignores clicks, suspect a
+duplicate: re-capture and pick the labeled node, or use the click→Enter
+recipe — focus lands on the visible button either way.
+
+### Certified engines only for the typed route
+
+`cua_browser_state` binds only certified engines: standalone Chrome (macOS /
+Windows / Linux), standalone Edge, and Electron builds. Arc, Dia, Brave,
+Firefox, Safari and similar are rejected — drive their page content with the
+native ladder + keyboard activation, or use the separate headless `browser_*`
+tools when the user's session isn't required.
 
 ### Key shortcuts vary per platform
 
@@ -298,6 +356,10 @@ in your conversation context.
 | Click had no effect | Read the structured verdict. `effect:"unverifiable"` → fresh capture/state before retry, even with an escalation hint. `effect:"suspected_noop"` or a structured refusal → climb the recommended ladder: coordinate (px), typed page route when exact, then foreground. Browser chrome/native prompts remain native. Don't conclude the app is undrivable |
 | Type text disappears into a terminal emulator | cua-driver detects terminals (Ghostty, iTerm2, Terminal.app, Windows Terminal, mintty, etc.) and routes through key-event synthesis — should "just work" on a recent cua-driver. If it doesn't, ask the user to run `hermes computer-use doctor` |
 | `blocked pattern in type text` | You tried to `type` a shell command matching the dangerous-pattern block list (`curl ... \| bash`, `sudo rm -rf`, etc.). Break the command up or reconsider |
+| Web button click "succeeds" but nothing happens (React/Polaris tables, ⋮ menus) | Likely an aria-hidden duplicate (click response shows `AXButton ""`) or an untrusted-event ignore. Use the click→Enter recipe: `click(element=N)` to focus, then `key(keys="return")`. Close popovers with `escape` |
+| `cua_browser_state` refuses the browser (Arc, Dia, Firefox, Safari) | Unsupported engine for the typed route — native ladder + keyboard activation only, or headless `browser_*` tools when the user's session isn't needed |
+| `AXUIElementPerformAction(AXPress) returned -25206` | `kAXErrorFailure` — transient macOS AX failure. Retry once; if it persists, use a coordinate click or the keyboard rung |
+| Clicks land off-target or "the coordinates were right but nothing happened" | Capture scale drifts between captures (observed 1.33× → 1.24× on the same window; Retina scaling varies). Re-capture before every click, prefer `element=N` over pixel math, and validate a pixel target with a probe click that has a visible effect |
 | Anything else weird | **First action: ask the user to run `hermes computer-use doctor`.** It runs the cua-driver `health_report` MCP tool and prints a structured per-check matrix. Their output tells you (and them) exactly what's wrong |
 
 ## When NOT to use `computer_use`


### PR DESCRIPTION
## Problem

On macOS, `computer_use` background clicks are AX-mediated (hit-test + AXPress), not raw mouse events. React-style web apps — Shopify's Polaris admin is the canonical case — can silently ignore them: the app receives events whose `isTrusted` is false, or none at all, and its handler never fires. Observed live: the Polaris "More actions" (⋮) popover never opened via AXPress element clicks, background pixel clicks, or foreground CGEvent mouse input. Keystrokes, however, are trusted at the DOM level.

Two compounding factors made this hard to diagnose:

- **aria-hidden duplicate nodes**: Polaris tables expose two AX nodes with identical bounds for one visible control (the DOM renders the table twice, one copy `aria-hidden`). The click response can show `AXButton ""` — the unlabeled duplicate — a silent no-op.
- **Capture scale drift**: Retina capture scale drifted between captures on the same window (observed 1.33× → 1.24×), so pixel-math clicks land off-target.

## Fix

Add a **keyboard activation rung** to the escalate ladder, plus a dedicated section documenting the trusted-events mechanics:

1. New ladder rung #4: focus the element with one click, then activate with `key(keys="return")` (or `"space"` for checkboxes/switches). Escape closes popovers for clean retries.
2. New section "Web controls that ignore clicks": the validated click→Enter recipe, aria-hidden duplicate detection (empty-label click responses), and the certified-engine list for the typed browser route (`cua_browser_state` rejects Arc/Dia/Firefox/Safari — only standalone Chrome/Edge/Electron bind).
3. New failure-mode rows: React/Polaris no-ops, unsupported engines, `AXUIElementPerformAction -25206` (`kAXErrorFailure`), capture scale drift.

## Validation

Recipe proven live on Shopify Polaris (Languages page, macOS, Dia/Arc-core Chromium):

```
click(element=N)   → AXPress succeeds, no menu (focus lands on button)
key(keys="return") → popover opens (AXMenu + AXMenuItem in tree)
key(keys="escape") → popover closes
key(keys="return") → reopens (bare Enter suffices once focused)
```

Menu items then activate directly via `click(element=N)`.
