### PR TITLE
fix(stt): auto-detect language by default; confidence-gated fallback replaces the forced "en"

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1561,7 +1561,9 @@ stt:
     # no_speech_prob_threshold: 0.6  # drop a segment only if no_speech_prob > this...
     # logprob_threshold: -1.0       # ...AND avg_logprob < this (both must hit — quiet real speech survives)
     # unload_after_idle_seconds: 0  # 0=never unload (default); e.g. 300 releases the model after 5min idle (frees VRAM on GPU; next voice message reloads it)
-  language: "en"               # GLOBAL language hint for every STT provider (per-provider language wins). Set "" for auto-detect.
+    # fallback_language: "en"       # re-transcribe with this language when auto-detect is not confident (short/accented clips); "" = never
+    # language_confidence_threshold: 0.6  # faster-whisper language_probability below this triggers the fallback
+  language: ""                 # GLOBAL language hint for every STT provider (per-provider language wins). "" = auto-detect (default); a set value is forced.
   # groq:
   #   model: "whisper-large-v3-turbo"
   #   language: ""             # blank = stt.language > HERMES_LOCAL_STT_LANGUAGE > auto-detect

--- a/contributors/emails/ries@vriend.com
+++ b/contributors/emails/ries@vriend.com
@@ -1,0 +1,1 @@
+riesvriend

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1058,9 +1058,12 @@ DEFAULT_CONFIG = {
         "echo_transcripts": True,
         # No seeded "provider": a stored value counts as an explicit user pick; unset = autodetect
         # ladder. Valid: "local" (faster-whisper) | "groq" | "openai" | "mistral" | "elevenlabs" |
-        # "deepinfra". Global language hint unless a per-provider language overrides it. "en"
-        # because Whisper auto-detect misreads short/accented clips; "" = auto; or "es", "zh", ...
-        "language": "en",
+        # "deepinfra". Global language hint unless a per-provider language overrides it.
+        # "" = auto-detect (the default). A set value is FORCED on every provider, so a
+        # seeded "en" turned every non-English voice note into English nonsense; pin
+        # "es", "zh", ... only for a single-language install. The short/accented clips
+        # that auto-detect misreads are caught by local.fallback_language below.
+        "language": "",
         # Client-side ffmpeg silence trim before cloud upload (local whisper uses VAD): silence
         # inflates upload time, billing and hallucinations. Failure = raw upload.
         "cloud_trim_silence": True,
@@ -1069,6 +1072,11 @@ DEFAULT_CONFIG = {
         "local": {
             "model": "base",  # tiny, base, small, medium, large-v3
             "language": "",  # auto-detect; set "en", "es", ... to force
+            # Auto-detect confidence gate: when faster-whisper's language guess scores
+            # below the threshold (short or accented clips), the clip is re-transcribed
+            # with fallback_language. "" disables the fallback.
+            "fallback_language": "en",
+            "language_confidence_threshold": 0.6,
             "initial_prompt": "",
             # Anti-hallucination (faster-whisper decodes junk from silence). vad: Silero filter
             # (false = raw audio, for music/ambient). A segment is dropped only if no_speech_prob

--- a/tests/tools/test_stt_default_language.py
+++ b/tests/tools/test_stt_default_language.py
@@ -1,22 +1,120 @@
 """Default STT language contract.
 
-Teknium (July 2026): the global ``stt.language`` DEFAULTS to "en" because
-Whisper auto-detection frequently misidentifies short/accented clips
-("STT transcribed the wrong language" class). Users opt back into
-auto-detect with ``stt.language: ""``.
+The global ``stt.language`` defaults to ``""`` (auto-detect). A set value is FORCED on
+every provider, and the seeded ``"en"`` (July 2026) turned every non-English voice note
+into English nonsense — a 17 s Dutch Telegram voice note came back as
+"This is an interview with Fabian Pinkhash for OXP … he will be 20 years old" (85 %
+word error rate) while auto-detect on the same ``base`` model heard Dutch.
+
+The reason the forced default existed — Whisper misreads short/accented clips — is
+covered by the local provider's confidence gate instead: an auto-detected language
+with ``language_probability`` below ``stt.local.language_confidence_threshold`` is
+re-transcribed with ``stt.local.fallback_language``.
 """
 
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
 from hermes_cli.config import DEFAULT_CONFIG
+from tools.transcription_local import low_confidence_fallback_language
 from tools.transcription_tools import _resolve_stt_language
 
 
 class TestDefaultSttLanguage:
-    def test_default_config_pins_english(self):
-        assert DEFAULT_CONFIG["stt"]["language"] == "en"
+    def test_default_config_auto_detects(self):
+        assert DEFAULT_CONFIG["stt"]["language"] == ""
+        assert DEFAULT_CONFIG["stt"]["local"]["language"] == ""
 
+    def test_default_config_keeps_an_english_fallback_for_the_local_gate(self):
+        local = DEFAULT_CONFIG["stt"]["local"]
+        assert local["fallback_language"] == "en"
+        assert local["language_confidence_threshold"] == 0.6
 
-    def test_per_provider_still_wins_over_default(self, monkeypatch):
+    def test_nothing_is_forced_by_default(self, monkeypatch):
+        monkeypatch.delenv("HERMES_LOCAL_STT_LANGUAGE", raising=False)
+        assert _resolve_stt_language("local", dict(DEFAULT_CONFIG["stt"])) is None
+        assert _resolve_stt_language("xai", dict(DEFAULT_CONFIG["stt"])) is None
+
+    def test_per_provider_still_wins_over_global(self, monkeypatch):
         monkeypatch.delenv("HERMES_LOCAL_STT_LANGUAGE", raising=False)
         stt = dict(DEFAULT_CONFIG["stt"])
+        stt["language"] = "en"
         stt["groq"] = {"language": "he"}
         assert _resolve_stt_language("groq", stt) == "he"
+        assert _resolve_stt_language("local", stt) == "en"
+
+
+def _info(language, probability):
+    return SimpleNamespace(language=language, language_probability=probability, duration=17.2)
+
+
+class TestLowConfidenceFallback:
+    CFG = {"fallback_language": "en", "language_confidence_threshold": 0.6}
+
+    def test_low_confidence_guess_falls_back(self):
+        assert low_confidence_fallback_language(_info("nl", 0.54), self.CFG) == "en"
+
+    def test_confident_guess_is_kept(self):
+        assert low_confidence_fallback_language(_info("nl", 0.71), self.CFG) is None
+        assert low_confidence_fallback_language(_info("nl", 0.6), self.CFG) is None
+
+    def test_guess_equal_to_the_fallback_needs_no_second_pass(self):
+        assert low_confidence_fallback_language(_info("en", 0.2), self.CFG) is None
+
+    def test_disabled_fallback_and_unknown_shapes(self):
+        assert low_confidence_fallback_language(_info("nl", 0.1), {"fallback_language": ""}) is None
+        assert low_confidence_fallback_language(_info("nl", 0.1), {}) is None
+        no_prob = SimpleNamespace(language="nl")
+        assert low_confidence_fallback_language(no_prob, self.CFG) is None
+
+    def test_threshold_is_configurable(self):
+        cfg = {"fallback_language": "de", "language_confidence_threshold": 0.9}
+        assert low_confidence_fallback_language(_info("nl", 0.85), cfg) == "de"
+
+
+def _segment(text):
+    return SimpleNamespace(text=text, no_speech_prob=0.0, avg_logprob=-0.2)
+
+
+def _run_local(model, stt_config):
+    from tools import transcription_tools as tt
+
+    with patch.object(tt, "_HAS_FASTER_WHISPER", True), \
+         patch.object(tt, "_load_stt_config", return_value=stt_config), \
+         patch.object(tt, "_get_or_load_local_model", return_value=model), \
+         patch("tools.transcription_local._load_stt_config", return_value=stt_config, create=True):
+        return tt._transcribe_local("/tmp/clip.ogg", "base")
+
+
+class TestLocalTranscribeGate:
+    STT = {"language": "", "local": {"language": "", "fallback_language": "en",
+                                     "language_confidence_threshold": 0.6}}
+
+    def test_low_confidence_auto_detect_retries_with_the_fallback(self):
+        model = MagicMock()
+        model.transcribe.side_effect = [
+            ([_segment("Dit is een lied")], _info("nl", 0.54)),
+            ([_segment("This is a lead")], _info("en", 1.0)),
+        ]
+        result = _run_local(model, self.STT)
+        assert result["success"] and result["transcript"] == "This is a lead"
+        assert model.transcribe.call_count == 2
+        first, second = model.transcribe.call_args_list
+        assert "language" not in first.kwargs
+        assert second.kwargs["language"] == "en"
+
+    def test_confident_auto_detect_transcribes_once(self):
+        model = MagicMock()
+        model.transcribe.return_value = ([_segment("Noteer Fabien als een lead")], _info("nl", 0.71))
+        result = _run_local(model, self.STT)
+        assert result["transcript"] == "Noteer Fabien als een lead"
+        assert model.transcribe.call_count == 1
+        assert "language" not in model.transcribe.call_args.kwargs
+
+    def test_forced_language_never_hits_the_gate(self):
+        model = MagicMock()
+        model.transcribe.return_value = ([_segment("hoi")], _info("nl", 0.1))
+        forced = {"language": "nl", "local": dict(self.STT["local"])}
+        _run_local(model, forced)
+        assert model.transcribe.call_count == 1
+        assert model.transcribe.call_args.kwargs["language"] == "nl"

--- a/tools/transcription_local.py
+++ b/tools/transcription_local.py
@@ -157,6 +157,9 @@ def _load_local_whisper_model(model_name: str, device: str = "auto", compute_typ
 _VAD_MIN_SILENCE_MS_DEFAULT = 500
 _NO_SPEECH_PROB_THRESHOLD_DEFAULT = 0.6
 _LOGPROB_THRESHOLD_DEFAULT = -1.0
+# Auto-detect confidence gate: faster-whisper's language_probability below this on an
+# auto-detected clip triggers a second pass with ``stt.local.fallback_language``.
+_LANGUAGE_CONFIDENCE_THRESHOLD_DEFAULT = 0.6
 
 
 def build_local_transcribe_kwargs(stt_config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
@@ -186,6 +189,34 @@ def build_local_transcribe_kwargs(stt_config: Optional[Dict[str, Any]] = None) -
     if isinstance(initial_prompt, str) and initial_prompt.strip():
         kwargs["initial_prompt"] = initial_prompt
     return kwargs
+
+
+def low_confidence_fallback_language(info: Any, local_cfg: Dict[str, Any]) -> Optional[str]:
+    """The language to re-transcribe with when faster-whisper AUTO-detected one at low
+    confidence, else None.
+
+    Whisper's language detection misreads short or accented clips, which users see as a
+    voice note transcribed in the wrong language. Forcing one language for everyone
+    (the pre-2026-09 default ``stt.language: "en"``) fixed that for English speakers and
+    turned every non-English voice note into nonsense. This gate keeps auto-detect as
+    the default and reserves the forced language for the low-confidence case only:
+    ``stt.local.fallback_language`` (``""`` = never) and
+    ``stt.local.language_confidence_threshold`` (faster-whisper's ``language_probability``).
+    A forced language (config, env or a pre_transcription hook) never reaches here.
+    """
+    fallback = str(local_cfg.get("fallback_language") or "").strip().lower()
+    if not fallback:
+        return None
+    try:
+        probability = float(getattr(info, "language_probability"))
+    except (AttributeError, TypeError, ValueError):
+        return None
+    threshold = _config_number(
+        local_cfg, "language_confidence_threshold", _LANGUAGE_CONFIDENCE_THRESHOLD_DEFAULT)
+    detected = str(getattr(info, "language", "") or "").strip().lower()
+    if detected == fallback or probability >= threshold:
+        return None
+    return fallback
 
 
 def _confidence_thresholds(local_cfg: Dict[str, Any]) -> tuple[float, float]:

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -30,7 +30,8 @@ from tools.transcription_audio import (
 from tools.transcription_local import (
     _get_idle_unload_seconds, _has_local_command, _join_confident_segments,
     _load_local_whisper_model, _looks_like_cuda_lib_error, _normalize_local_model,
-    _transcribe_local_command, _try_lazy_install_stt, build_local_transcribe_kwargs)
+    _transcribe_local_command, _try_lazy_install_stt, build_local_transcribe_kwargs,
+    low_confidence_fallback_language)
 # The ``_transcribe_<provider>`` handlers are looked up in this module's globals by _dispatch_stt_provider.
 from tools.transcription_cloud import (  # noqa: F401  (handlers dispatched via globals())
     _has_xai_stt_credentials, _resolve_openai_audio_client_config, _transcribe_deepinfra,
@@ -379,6 +380,17 @@ def _transcribe_local(
                            "evicting cached model and retrying on CPU (int8).", exc)
             model = _replace_cached_model_on_cpu(model_name)
             segments, info = model.transcribe(file_path, **transcribe_kwargs)
+        # A forced language (config, env or hook) is honoured as-is. An auto-detected one
+        # gets a confidence gate: a low-probability guess (short/accented clips) is redone
+        # with stt.local.fallback_language instead of forcing one language for everyone.
+        if "language" not in transcribe_kwargs:
+            fallback = low_confidence_fallback_language(info, local_cfg)
+            if fallback:
+                logger.info("Local whisper auto-detected %s at p=%.2f (below the confidence "
+                            "threshold) — retrying with fallback language %r",
+                            info.language, info.language_probability, fallback)
+                segments, info = model.transcribe(
+                    file_path, **{**transcribe_kwargs, "language": fallback})
         transcript = _join_confident_segments(segments, local_cfg)
         logger.info("Transcribed %s via local whisper (%s, lang=%s, %.1fs audio)",
                     Path(file_path).name, model_name, info.language, info.duration)

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2152,7 +2152,7 @@ stt:
   enabled: true                # Auto-transcribe inbound voice messages (default: true)
   echo_transcripts: true       # Post raw transcripts back to the chat as 🎙️ "..." (default: true)
   provider: "local"            # "local" | "groq" | "openai" | "mistral" | "xai" | "elevenlabs" | "deepinfra" | ...
-  language: "en"               # GLOBAL language hint for every provider (per-provider language wins); set "" for auto-detect
+  language: ""                 # GLOBAL language hint for every provider (per-provider language wins); "" = auto-detect (default), a set value is forced
   cloud_trim_silence: true     # trim long pauses with ffmpeg before uploading to a cloud provider (default: true)
   cloud_trim_threshold_db: -40 # audio quieter than this counts as silence
   cloud_trim_keep_ms: 300      # how much of each pause survives the trim (keeps natural pacing)
@@ -2174,7 +2174,7 @@ stt:
   # model: "whisper-1"         # Legacy fallback key still respected
 ```
 
-Language resolution is the same for **every** STT provider (local, groq, openai, mistral, xai, elevenlabs, deepinfra, command providers, and plugins): `stt.<provider>.language` → `stt.language` → `HERMES_LOCAL_STT_LANGUAGE` env var → provider auto-detect. **The default is `stt.language: "en"`** — Whisper auto-detection frequently misidentifies short or accented clips, which shows up as voice notes transcribed in the wrong language. Non-English speakers should set `stt.language` to their language code once (e.g. `"es"`, `"zh"`, `"uk"`); set it to `""` to restore auto-detection for multilingual use.
+Language resolution is the same for **every** STT provider (local, groq, openai, mistral, xai, elevenlabs, deepinfra, command providers, and plugins): `stt.<provider>.language` → `stt.language` → `HERMES_LOCAL_STT_LANGUAGE` env var → provider auto-detect. **The default is auto-detect (`stt.language: ""`).** A set value is *forced* on every provider, so pin a code (e.g. `"es"`, `"zh"`, `"uk"`) only when every voice note is in that one language. Whisper's auto-detection can misread short or accented clips; the local provider covers that case with a confidence gate instead of a forced language: when faster-whisper's language guess scores below `stt.local.language_confidence_threshold` (default `0.6`), the clip is transcribed again with `stt.local.fallback_language` (default `"en"`; `""` disables the fallback).
 
 Set `stt.echo_transcripts: false` when the gateway should transcribe voice notes for the agent but must not post the raw transcript back to the chat (for example, customer-facing WhatsApp bots).
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -475,10 +475,12 @@ Local transcription works out of the box when `faster-whisper` is installed. If 
 # In ~/.hermes/config.yaml
 stt:
   provider: "local"           # "local" | "groq" | "openai" | "mistral" | "xai" | "elevenlabs" | "deepinfra"
-  language: "en"              # Global language hint applied to every provider unless a per-provider language overrides it; set "" to restore auto-detect
+  language: ""                # Global language hint applied to every provider unless a per-provider language overrides it; "" = auto-detect (default), a set value is forced
   local:
     model: "base"             # tiny, base, small, medium, large-v3
     language: ""              # optional ISO-639-1 hint; blank = use HERMES_LOCAL_STT_LANGUAGE if set, else auto-detect
+    fallback_language: "en"   # re-transcribe with this language when auto-detect is not confident (short/accented clips); "" = never
+    language_confidence_threshold: 0.6  # faster-whisper language_probability below this triggers the fallback
   groq:
     language: ""              # optional ISO-639-1 hint; blank = use HERMES_LOCAL_STT_LANGUAGE if set, else auto-detect
   openai:


### PR DESCRIPTION
## What does this PR do?

Makes `stt.language` default to auto-detect (`""`) again, and moves the reason the forced `"en"` existed (#73100 — Whisper misreads short or accented clips) into a **confidence gate on the local provider**: when faster-whisper auto-detects a language with `language_probability` below `stt.local.language_confidence_threshold` (default `0.6`), the clip is transcribed a second time with `stt.local.fallback_language` (default `"en"`, `""` disables it).

**Why.** The global hint is *forced* on every provider (`build_local_transcribe_kwargs` passes it as `language=` to faster-whisper), so a seeded `"en"` turns every non-English voice note into English nonsense, out of the box, with no error anywhere. Measured on a real 17 s Dutch Telegram voice note with the stock `base` model:

| Setting | Transcript | Word error rate |
| --- | --- | --- |
| `stt.language: "en"` (current default) | "This is an interview with Fabian Pinkhash for OXP, not here Fabian as a lead. Fabian is CEO of ODO. He will be released after the show. And he will be 20 years old." | 85 % |
| auto-detect (this PR) | "Dit is een interview met Fabian Pinkhage voor OXP … Hij wil graag de Ries gebeld worden na de show en hij wil 20 bots." (detected `nl`, p = 0.71) | 35 % |

The same `base` model auto-detected a clean 15 s **English** clip as `nl` at p = 0.54 — the short-clip misread #73100 was about. With the gate, that clip falls back to `en` and comes out right, while the Dutch clip (p = 0.71) stays Dutch. So the gate serves both cases the forced default could only trade off against each other. A user who really wants one language everywhere still sets `stt.language` (or a per-provider `language`), and a forced language never reaches the gate.

Deep-merge gives existing configs the new defaults automatically; an explicit `stt.language: "en"` in a user's config keeps forcing English exactly as before.

## Related Issue

Refines #73100 (the forced default) on top of #73067 (unified language resolution). No open issue; the failure was found on a hosted fleet where every non-English voice note came back in English after picking up the July default.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config_defaults.py` — `stt.language` defaults to `""`; new `stt.local.fallback_language` (`"en"`) and `stt.local.language_confidence_threshold` (`0.6`).
- `tools/transcription_local.py` — `low_confidence_fallback_language(info, local_cfg)`: the gate, config-driven, never raises.
- `tools/transcription_tools.py` — `_transcribe_local` applies the gate only when no language was forced (config, env or `pre_transcription` hook), and re-runs `model.transcribe` with the fallback language on a low-confidence guess.
- `tests/tools/test_stt_default_language.py` — the new default contract, the gate's decision table, and `_transcribe_local` retrying with the fallback / transcribing once when confident / never gating a forced language.
- `cli-config.yaml.example`, `website/docs/user-guide/configuration.md`, `website/docs/user-guide/features/tts.md` — the default and the two new keys.
- `contributors/emails/ries@vriend.com` — first-time contributor mapping.

Out of scope, deliberately: the `local_command` (whisper.cpp) provider keeps its own explicit `DEFAULT_LOCAL_STT_LANGUAGE = "en"`, because CLI templates differ in how they spell auto-detect.

## How to Test

1. `pytest tests/tools/test_stt_default_language.py tests/tools/test_stt_language_resolution.py tests/tools/test_stt_silence_hallucinations.py tests/tools/test_transcription.py tests/gateway/test_stt_config.py -q` → 71 passed.
2. With a stock config (no `stt.language` set) and `provider: local`, send a non-English voice note on any gateway platform: the transcript is in the spoken language, and the log line reads `Transcribed … via local whisper (base, lang=<code> …)`.
3. Send a very short English clip: the log shows `auto-detected <x> at p=<low> … retrying with fallback language 'en'` when the guess was weak, and the transcript is English.
4. Set `stt.language: "en"` explicitly: behaviour is identical to before this PR (one pass, forced).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the STT test modules listed above and they pass (the full `pytest tests/ -q` was not run on this machine)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (unit tests); the measurements above ran on Linux (Ubuntu 24.04, faster-whisper 1.2.1, `base`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python, no platform calls
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
