### PR TITLE
fix(desktop): use shared tooltip for listing gallery

### DIFF
--- a/apps/desktop/src/components/assistant-ui/embeds/listing-embed.tsx
+++ b/apps/desktop/src/components/assistant-ui/embeds/listing-embed.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react'
 import { WIDGET_SHELL_CLASS } from '@/components/chat/widget-shell'
 import { ImageLightbox } from '@/components/chat/zoomable-image'
 import { Codicon } from '@/components/ui/codicon'
+import { Tip } from '@/components/ui/tooltip'
 import { useImageDownload } from '@/hooks/use-image-download'
 import { useI18n } from '@/i18n'
 import { ExternalLink } from '@/lib/external-link'
@@ -190,11 +191,11 @@ function ListingGallery({ address, images }: { address: string; images: string[]
             // photos every frame is equal.
             className={cn(mosaic && tile === 0 && 'col-span-2 row-span-2')}
             key={src}
+            label={t.desktop.openImage}
             more={tile === visible.length - 1 ? live.length - visible.length : 0}
             onError={() => setBroken(prev => (prev.includes(src) ? prev : [...prev, src]))}
             onOpen={() => setOpenAt(tile)}
             src={src}
-            title={t.desktop.openImage}
           />
         ))}
       </span>
@@ -219,7 +220,7 @@ function GalleryTile({
   onError,
   onOpen,
   src,
-  title
+  label
 }: {
   address: string
   className?: string
@@ -228,33 +229,34 @@ function GalleryTile({
   onError: () => void
   onOpen: () => void
   src: string
-  title: string
+  label: string
 }) {
   return (
-    <button
-      className={cn('relative block size-full cursor-zoom-in overflow-hidden bg-muted/55', className)}
-      onClick={onOpen}
-      title={title}
-      type="button"
-    >
-      <img
-        alt={address}
-        className="size-full object-cover transition-opacity hover:opacity-90"
-        loading="lazy"
-        onError={onError}
-        referrerPolicy="no-referrer"
-        src={src}
-      />
-      {more > 0 && (
-        <span
-          className={cn(
-            TEXT_CLASS,
-            'absolute inset-0 grid place-items-center bg-background/55 font-medium tabular-nums text-foreground backdrop-blur-[2px]'
-          )}
-        >
-          +{more}
-        </span>
-      )}
-    </button>
+    <Tip label={label}>
+      <button
+        className={cn('relative block size-full cursor-zoom-in overflow-hidden bg-muted/55', className)}
+        onClick={onOpen}
+        type="button"
+      >
+        <img
+          alt={address}
+          className="size-full object-cover transition-opacity hover:opacity-90"
+          loading="lazy"
+          onError={onError}
+          referrerPolicy="no-referrer"
+          src={src}
+        />
+        {more > 0 && (
+          <span
+            className={cn(
+              TEXT_CLASS,
+              'absolute inset-0 grid place-items-center bg-background/55 font-medium tabular-nums text-foreground backdrop-blur-[2px]'
+            )}
+          >
+            +{more}
+          </span>
+        )}
+      </button>
+    </Tip>
   )
 }


### PR DESCRIPTION
## What does this PR do?

Replaces the native `title` tooltip on property-listing gallery buttons with the Desktop shared `Tip` component. This restores the no-native-title UI invariant while keeping the existing localized label and lightbox behavior.

## How to test

- `npm run test:ui --workspace apps/desktop -- src/components/ui/__tests__/no-native-title.test.ts`
- `npm run typecheck --workspace apps/desktop`
- `npm exec --workspace apps/desktop eslint -- src/components/assistant-ui/embeds/listing-embed.tsx`