### PR TITLE
fix(gateway): persist active_agents when a cron job starts or ends, not only at chat-turn boundaries

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -9,6 +9,7 @@ import contextvars
 import errno
 import json
 import logging
+import weakref
 import os
 import re
 import subprocess
@@ -582,6 +583,47 @@ def get_running_job_ids() -> "frozenset[str]":
         return frozenset(_running_job_ids | _running_fire_owners.keys())
 
 
+# Listeners the gateway attaches so a cron job's start and end persist its active-work
+# count (``gateway_state.json``) the way a chat turn boundary does. Without them a cron
+# that outlives the last chat turn leaves ``active_agents`` stale — a fleet converge then
+# reads "mid-turn" for days — and a cron that runs with no chat turn open is invisible to
+# the file. Bound methods are held weakly so a gone runner drops out; notification runs
+# OUTSIDE ``_running_lock`` (a listener may read ``get_running_job_ids``) and a raising
+# listener never reaches the scheduler.
+_running_jobs_listeners: List[Any] = []
+
+
+def add_running_jobs_listener(listener: Callable[[], None]) -> None:
+    """Call ``listener()`` after every running-job register/release (cron start/end)."""
+    ref = weakref.WeakMethod(listener) if hasattr(listener, "__self__") else listener
+    with _running_lock:
+        if ref not in _running_jobs_listeners:
+            _running_jobs_listeners.append(ref)
+
+
+def remove_running_jobs_listener(listener: Callable[[], None]) -> None:
+    """Detach ``listener`` (idempotent)."""
+    ref = weakref.WeakMethod(listener) if hasattr(listener, "__self__") else listener
+    with _running_lock:
+        _running_jobs_listeners[:] = [r for r in _running_jobs_listeners if r != ref]
+
+
+def _notify_running_jobs_changed() -> None:
+    with _running_lock:
+        snapshot = list(_running_jobs_listeners)
+    for ref in snapshot:
+        fn = ref() if isinstance(ref, weakref.WeakMethod) else ref
+        if fn is None:
+            with _running_lock:
+                if ref in _running_jobs_listeners:
+                    _running_jobs_listeners.remove(ref)
+            continue
+        try:
+            fn()
+        except Exception:
+            logger.debug("running-jobs listener failed", exc_info=True)
+
+
 def try_register_running_job(job_id: str) -> bool:
     """Atomically add ``job_id`` to the in-flight set; False (caller must skip) if already mid-run.
     Single dedupe owner for ticker + manual runs (the fire claim's 300s TTL is outlived by real
@@ -602,7 +644,8 @@ def try_register_running_job(job_id: str) -> bool:
         # can bound. Sentinel is replaced by the real future once ``pool.submit`` returns.
         _running_since[job_id] = time.time()
         _running_futures[job_id] = _FUTURE_PENDING
-        return True
+    _notify_running_jobs_changed()
+    return True
 
 
 def release_running_job(job_id: str) -> None:
@@ -611,6 +654,7 @@ def release_running_job(job_id: str) -> None:
         _running_job_ids.discard(job_id)
         _running_since.pop(job_id, None)
         _running_futures.pop(job_id, None)
+    _notify_running_jobs_changed()
 
 
 def _inflight_min_allowance_minutes() -> float:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3333,6 +3333,7 @@ class GatewayRunner(
         except Exception:
             logger.debug("could not set multiplex-active flag", exc_info=True)
         self.adapters: Dict[Platform, BasePlatformAdapter] = {}
+        self._attach_cron_persist_listener()
         # Non-None means SessionDB init failed — the gateway broadcasts a one-time warning to the home
         # channel(s) after connecting so the user learns persistence is broken before /resume fails.
         # See #88235.
@@ -3845,6 +3846,18 @@ class GatewayRunner(
         Passes ONLY ``active_agents`` so the read-merge-write keeps lifecycle state (gateway_state=None
         would clobber it). Best-effort: a failed write must never disrupt a turn."""
         _write_runtime_status_quiet(active_agents=self._active_work_count())
+
+    def _attach_cron_persist_listener(self) -> None:
+        """Make a cron job's start and end a persist boundary too. Cron work counts in
+        ``_active_work_count`` but runs outside the chat-turn boundaries that call
+        ``_persist_active_agents``, so a cron that outlived the last chat turn left
+        ``active_agents`` stale in ``gateway_state.json`` (a fleet's polite restart probe then
+        read "mid-turn" for a day), and a cron with no chat turn open was invisible to it."""
+        try:
+            from cron.scheduler import add_running_jobs_listener
+            add_running_jobs_listener(self._persist_active_agents)
+        except Exception:
+            logger.debug("cron running-jobs listener not attached", exc_info=True)
 
     def _running_agent_ids(self) -> set:
         """``id()`` of every agent mid-turn — identity-keyed so the lookup is O(1) and independent of

--- a/tests/cron/test_running_jobs_listener.py
+++ b/tests/cron/test_running_jobs_listener.py
@@ -1,0 +1,85 @@
+"""The running-jobs listener: a cron job's start and end notify the gateway so it can
+persist ``active_agents`` the way a chat turn boundary does.
+
+Without this, a cron job that outlives the last chat turn leaves ``gateway_state.json``
+at the count it had when that turn ended (a fleet's polite restart probe then read
+"mid-turn" for 26 hours on an idle box), and a cron job with no chat turn open is
+invisible to the file.
+"""
+
+import gc
+
+import pytest
+
+import cron.scheduler as sched
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    sched._running_job_ids.clear()
+    sched._running_fire_owners.clear()
+    sched._running_jobs_listeners.clear()
+    yield
+    sched._running_job_ids.clear()
+    sched._running_fire_owners.clear()
+    sched._running_jobs_listeners.clear()
+
+
+def test_register_and_release_notify_the_listener():
+    calls = []
+    sched.add_running_jobs_listener(lambda: calls.append(len(sched.get_running_job_ids())))
+    assert sched.try_register_running_job("job-a") is True
+    assert calls == [1]
+    sched.release_running_job("job-a")
+    assert calls == [1, 0]
+
+
+def test_a_refused_duplicate_register_does_not_notify():
+    calls = []
+    sched.add_running_jobs_listener(lambda: calls.append("x"))
+    assert sched.try_register_running_job("job-a") is True
+    assert sched.try_register_running_job("job-a") is False
+    assert calls == ["x"]
+
+
+def test_a_raising_listener_never_breaks_the_scheduler():
+    calls = []
+
+    def boom():
+        raise RuntimeError("listener bug")
+
+    sched.add_running_jobs_listener(boom)
+    sched.add_running_jobs_listener(lambda: calls.append("ok"))
+    assert sched.try_register_running_job("job-a") is True
+    sched.release_running_job("job-a")
+    assert calls == ["ok", "ok"]
+    assert "job-a" not in sched.get_running_job_ids()
+
+
+def test_remove_listener_is_idempotent():
+    calls = []
+    fn = lambda: calls.append("x")  # noqa: E731
+    sched.add_running_jobs_listener(fn)
+    sched.add_running_jobs_listener(fn)  # a second add is a no-op
+    sched.remove_running_jobs_listener(fn)
+    sched.remove_running_jobs_listener(fn)
+    sched.try_register_running_job("job-a")
+    assert calls == []
+
+
+def test_a_bound_method_is_held_weakly():
+    calls = []
+
+    class Runner:
+        def persist(self):
+            calls.append("persisted")
+
+    runner = Runner()
+    sched.add_running_jobs_listener(runner.persist)
+    sched.try_register_running_job("job-a")
+    assert calls == ["persisted"]
+    del runner
+    gc.collect()
+    sched.release_running_job("job-a")
+    assert calls == ["persisted"]  # the dead reference was dropped, not called
+    assert sched._running_jobs_listeners == []

--- a/tests/gateway/test_cron_active_work_drain.py
+++ b/tests/gateway/test_cron_active_work_drain.py
@@ -118,3 +118,28 @@ class TestKillToolSubprocessesMarksCronInterrupted:
         assert marked_calls, "mark_running_jobs_interrupted was never called during shutdown"
         assert any(result == ["job-1"] for _reason, result in marked_calls)
 
+
+
+# --- a cron job's start and end persist active_agents (the stale-flag fix) ------ #
+
+def test_cron_start_and_end_persist_active_agents_without_a_chat_turn(monkeypatch):
+    """A cron job that runs with no chat turn open, or that outlives the last chat turn,
+    must move ``active_agents`` in gateway_state.json itself. Before the listener the file
+    only moved at chat-turn boundaries, so a cron ending after the last turn left it at 1
+    (an idle box read as mid-turn for 26 hours) and a cron with no turn open read as 0."""
+    import cron.scheduler as sched
+    from gateway import run as gateway_run
+
+    persisted = []
+    monkeypatch.setattr(gateway_run, "_write_runtime_status_quiet",
+                        lambda **fields: persisted.append(fields.get("active_agents")))
+    sched._running_jobs_listeners.clear()
+    runner, _adapter = make_restart_runner()
+    runner._attach_cron_persist_listener()
+    try:
+        assert sched.try_register_running_job("evening-log") is True
+        assert persisted == [1]
+        sched.release_running_job("evening-log")
+        assert persisted == [1, 0]
+    finally:
+        sched._running_jobs_listeners.clear()


### PR DESCRIPTION
## What does this PR do?

Makes a cron job's start and end a persist boundary for `active_agents` in `gateway_state.json`, the same way a chat turn's claim and release already are.

**The bug.** `_active_work_count()` counts running cron jobs, and `_persist_active_agents()` writes that total to `gateway_state.json` — but only at chat-turn boundaries (`_persist_active_agents` is called when a running-agent slot is claimed or released) and on lifecycle transitions. The cron scheduler registers and releases its jobs in its own thread pool (`try_register_running_job` / `release_running_job`) and never asks the gateway to persist. Two failures follow, in opposite directions:

- A cron job that **ends after** the last chat turn leaves the file at the count it had when that turn ended. Observed on a hosted box: a group reply released its slot at 18:03:20 while a daily cron was still running, so the file was written with `active_agents: 1`; the cron ended at 18:03:21 and nothing wrote a 0. The file stayed at `1` for 26 hours on an idle gateway, and the host's polite restart probe (which honours `gateway_state == running ∧ active_agents > 0`) refused to restart it that whole time.
- A cron job that **runs while no chat turn is open** never reaches the file, which still says `0`, so an external busy probe reads idle and may restart the gateway mid-cron.

Both are the same root: cron work is in the count but not in the persist path. The in-process drain (`_drain_active_agents`) is unaffected, because it reads `get_running_job_ids()` live; only readers of the persisted file were blind.

**The fix.** `cron/scheduler.py` gains a small listener registry beside the running-job set: `add_running_jobs_listener` / `remove_running_jobs_listener`, and `try_register_running_job` / `release_running_job` notify after the change, outside `_running_lock` (a listener may read `get_running_job_ids()`). A raising listener is logged at debug and never reaches the scheduler; a bound method is held through `weakref.WeakMethod` so a gone runner drops out on its own. `GatewayRunner.__init__` attaches `_persist_active_agents` through `_attach_cron_persist_listener()`. The persist is best-effort (`_write_runtime_status_quiet`) and the status file write is atomic (`atomic_json_write`), so a persist from the scheduler's thread and one from the event loop cannot corrupt the file; the last writer wins with the count that was true at its moment.

## Related Issue

Follows #60432 (the in-process shutdown drain was blind to cron work). This is the persisted-file half of the same blind spot. No open issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py` — `_running_jobs_listeners`, `add_running_jobs_listener`, `remove_running_jobs_listener`, `_notify_running_jobs_changed`; notification after a successful register and after a release.
- `gateway/run.py` — `GatewayRunner._attach_cron_persist_listener()` (called from `__init__`) registering `_persist_active_agents`.
- `tests/cron/test_running_jobs_listener.py` — register/release notify, a refused duplicate does not, a raising listener never breaks the scheduler, idempotent remove, a bound method is held weakly.
- `tests/gateway/test_cron_active_work_drain.py` — a cron start persists `active_agents: 1` and its end persists `0` with no chat turn open.

## How to Test

1. `pytest tests/cron/test_running_jobs_listener.py tests/gateway/test_cron_active_work_drain.py tests/cron/test_inflight_stale_guard.py tests/cron/test_shutdown_interrupt.py tests/cron/test_cleanup_timeout.py -q` → 64 passed.
2. Run a gateway with a cron job scheduled and no chat activity; watch `~/.hermes/gateway_state.json`: `active_agents` goes to `1` when the job starts and back to `0` when it ends. Before this PR the file does not move.
3. Send a chat message while a cron job is running and let the chat turn finish first: the file ends at `0` once the cron finishes. Before this PR it stayed at `1`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the cron and gateway-drain test modules listed above and they pass (the full `pytest tests/ -q` was not run on this machine)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (unit tests); the failure was observed on Linux (Ubuntu 24.04, gateway 0.20.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings; no user-facing config changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python, no platform calls
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
