### PR TITLE
fix(cron): route every desktop cron action through the job-owning profile

### DIFF
--- a/apps/desktop/src/api/cron.ts
+++ b/apps/desktop/src/api/cron.ts
@@ -39,6 +39,16 @@ export function getCronJob(jobId: string): Promise<CronJob> {
   })
 }
 
+// Cron mutations target ONE per-profile store. The list aggregator stamps each
+// job's owning profile (CronJob.profile); pass it here so the backend resolves
+// the right store instead of falling back to the caller's ambient profile,
+// which from a cross-profile view triggers/pauses/deletes the wrong store or
+// 404s with "Job not found". A concrete profile becomes ?profile=<name>; omit
+// it to keep the legacy ambient-profile behavior for single-profile callers.
+function profileQuery(profile?: string): string {
+  return profile ? `?profile=${encodeURIComponent(profile)}` : ''
+}
+
 export async function getCronJobRuns(jobId: string, limit = 20): Promise<SessionInfo[]> {
   const { runs } = await hermesApi<{ runs: SessionInfo[] }>({
     ...profileScoped(),
@@ -72,49 +82,49 @@ export function createCronJob(body: CronJobCreatePayload): Promise<CronJob> {
   })
 }
 
-export function updateCronJob(jobId: string, updates: CronJobUpdates): Promise<CronJob> {
+export function updateCronJob(jobId: string, updates: CronJobUpdates, profile?: string): Promise<CronJob> {
   return hermesApi<CronJob>({
     ...profileScoped(),
     ...connectionScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}`,
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}${profileQuery(profile)}`,
     method: 'PUT',
     body: { updates }
   })
 }
 
-export function pauseCronJob(jobId: string): Promise<CronJob> {
+export function pauseCronJob(jobId: string, profile?: string): Promise<CronJob> {
   return hermesApi<CronJob>({
     ...profileScoped(),
     ...connectionScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/pause`,
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/pause${profileQuery(profile)}`,
     method: 'POST'
   })
 }
 
-export function resumeCronJob(jobId: string): Promise<CronJob> {
+export function resumeCronJob(jobId: string, profile?: string): Promise<CronJob> {
   return hermesApi<CronJob>({
     ...profileScoped(),
     ...connectionScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/resume`,
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/resume${profileQuery(profile)}`,
     method: 'POST'
   })
 }
 
-export function triggerCronJob(jobId: string): Promise<CronJob> {
+export function triggerCronJob(jobId: string, profile?: string): Promise<CronJob> {
   return hermesApi<CronJob>({
     ...profileScoped(),
     ...connectionScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/trigger`,
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/trigger${profileQuery(profile)}`,
     method: 'POST',
     timeoutMs: CRON_TRIGGER_REQUEST_TIMEOUT_MS
   })
 }
 
-export function deleteCronJob(jobId: string): Promise<{ ok: boolean }> {
+export function deleteCronJob(jobId: string, profile?: string): Promise<{ ok: boolean }> {
   return hermesApi<{ ok: boolean }>({
     ...profileScoped(),
     ...connectionScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}`,
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}${profileQuery(profile)}`,
     method: 'DELETE'
   })
 }

--- a/apps/desktop/src/api/cron.ts
+++ b/apps/desktop/src/api/cron.ts
@@ -49,11 +49,13 @@ function profileQuery(profile?: string): string {
   return profile ? `?profile=${encodeURIComponent(profile)}` : ''
 }
 
-export async function getCronJobRuns(jobId: string, limit = 20): Promise<SessionInfo[]> {
+export async function getCronJobRuns(jobId: string, limit = 20, profile?: string): Promise<SessionInfo[]> {
+  const query = profile ? `?profile=${encodeURIComponent(profile)}&limit=${limit}` : `?limit=${limit}`
+
   const { runs } = await hermesApi<{ runs: SessionInfo[] }>({
     ...profileScoped(),
     ...connectionScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/runs?limit=${limit}`
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/runs${query}`
   })
 
   return runs ?? []

--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -377,12 +377,20 @@ function CronJobSidebarRow({
           </Tip>
         </SidebarRowShell>
       </ActionsContextMenu>
-      {expanded && <CronJobSidebarRuns jobId={job.id} onOpenRun={onOpenRun} />}
+      {expanded && <CronJobSidebarRuns jobId={job.id} jobProfile={job.profile} onOpenRun={onOpenRun} />}
     </div>
   )
 }
 
-function CronJobSidebarRuns({ jobId, onOpenRun }: { jobId: string; onOpenRun: (sessionId: string) => void }) {
+function CronJobSidebarRuns({
+  jobId,
+  jobProfile,
+  onOpenRun
+}: {
+  jobId: string
+  jobProfile?: string
+  onOpenRun: (sessionId: string) => void
+}) {
   const { t } = useI18n()
   const c = t.cron
   const selectedSessionId = useStore($selectedStoredSessionId)
@@ -395,7 +403,7 @@ function CronJobSidebarRuns({ jobId, onOpenRun }: { jobId: string; onOpenRun: (s
     let cancelled = false
 
     const load = () =>
-      getCronJobRuns(jobId, PEEK_RUN_LIMIT)
+      getCronJobRuns(jobId, PEEK_RUN_LIMIT, jobProfile)
         .then(result => {
           if (!cancelled) {
             setRuns(result)
@@ -432,7 +440,7 @@ function CronJobSidebarRuns({ jobId, onOpenRun }: { jobId: string; onOpenRun: (s
       window.clearInterval(intervalId)
     }
     // cronChangeTick: a fired run reloads the peek immediately.
-  }, [changeEventsAvailable, cronChangeTick, jobId, visible])
+  }, [changeEventsAvailable, cronChangeTick, jobId, jobProfile, visible])
 
   return (
     <div className="mb-1 ml-[1.375rem] flex flex-col gap-px">

--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -252,7 +252,7 @@ function CronJobSidebarRow({
   // row updates in place.
   const togglePause = async () => {
     try {
-      const updated = isPaused ? await resumeCronJob(job.id) : await pauseCronJob(job.id)
+      const updated = isPaused ? await resumeCronJob(job.id, job.profile) : await pauseCronJob(job.id, job.profile)
       updateCronJobs(rows => rows.map(row => (row.id === job.id ? updated : row)))
       notify({ kind: 'success', title: isPaused ? c.resumed : c.paused, message: label })
     } catch (err) {
@@ -273,7 +273,7 @@ function CronJobSidebarRow({
     }
 
     try {
-      await deleteCronJob(job.id)
+      await deleteCronJob(job.id, job.profile)
       updateCronJobs(rows => rows.filter(row => row.id !== job.id))
       notify({ kind: 'success', title: c.deleted, message: label })
     } catch (err) {

--- a/apps/desktop/src/app/cron/cron-actions.test.ts
+++ b/apps/desktop/src/app/cron/cron-actions.test.ts
@@ -31,9 +31,22 @@ describe('triggerAndRefreshCronJobs', () => {
 
     const result = await triggerAndRefreshCronJobs('deleted-one-shot', 'work')
 
-    expect(triggerCronJob).toHaveBeenCalledWith('deleted-one-shot')
+    expect(triggerCronJob).toHaveBeenCalledWith('deleted-one-shot', undefined)
     expect(getCronJobs).toHaveBeenCalledWith('work')
     expect(result).toEqual({ jobs: authoritative, refreshError: null, stale: false })
+  })
+
+  it('targets the job-owning profile so an aggregated view hits the right store', async () => {
+    // Regression: the cross-profile ("all") view refreshes with 'all', but the
+    // trigger itself must go to the job's OWN profile. Without the third arg the
+    // backend fell back to the ambient profile and 404'd with "Job not found".
+    triggerCronJob.mockResolvedValue({ id: 'j', state: 'scheduled' })
+    getCronJobs.mockResolvedValue([])
+
+    await triggerAndRefreshCronJobs('j', 'all', 'tommy')
+
+    expect(triggerCronJob).toHaveBeenCalledWith('j', 'tommy')
+    expect(getCronJobs).toHaveBeenCalledWith('all')
   })
 
   it('reports refresh failure separately after a successful trigger', async () => {

--- a/apps/desktop/src/app/cron/cron-actions.ts
+++ b/apps/desktop/src/app/cron/cron-actions.ts
@@ -89,9 +89,10 @@ export async function mutateAndRefreshCronJobs<T>(
  */
 export async function triggerAndRefreshCronJobs(
   jobId: string,
-  profile: 'all' | string
+  profile: 'all' | string,
+  jobProfile?: string
 ): Promise<CronTriggerRefreshResult> {
-  const { value: _value, ...result } = await mutateAndRefreshCronJobs(profile, () => triggerCronJob(jobId))
+  const { value: _value, ...result } = await mutateAndRefreshCronJobs(profile, () => triggerCronJob(jobId, jobProfile))
 
   return result
 }

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -467,7 +467,7 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
       const isPaused = jobState(job) === 'paused'
 
       const { refreshError, stale } = await mutateAndRefreshCronJobs(profile, () =>
-        isPaused ? resumeCronJob(job.id) : pauseCronJob(job.id)
+        isPaused ? resumeCronJob(job.id, job.profile) : pauseCronJob(job.id, job.profile)
       )
 
       if (stale) {
@@ -502,7 +502,7 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
     try {
       const run = await controller.run(
         key,
-        () => triggerAndRefreshCronJobs(job.id, viewProfile),
+        () => triggerAndRefreshCronJobs(job.id, viewProfile, job.profile),
         () => notify({ kind: 'info', title: c.triggerNow, message: truncate(jobTitle(job), 60) })
       )
 
@@ -539,7 +539,9 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
       return
     }
 
-    const { refreshError, stale } = await mutateAndRefreshCronJobs(profile, () => deleteCronJob(pendingDelete.id))
+    const { refreshError, stale } = await mutateAndRefreshCronJobs(profile, () =>
+      deleteCronJob(pendingDelete.id, pendingDelete.profile)
+    )
 
     if (stale) {
       return
@@ -585,7 +587,7 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
         refreshError,
         stale
       } = await mutateAndRefreshCronJobs(profile, () =>
-        updateCronJob(editor.job.id, cronEditorUpdates(values, { scriptOnlyJob }))
+        updateCronJob(editor.job.id, cronEditorUpdates(values, { scriptOnlyJob }), editor.job.profile)
       )
 
       if (stale || !updated) {

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -843,7 +843,7 @@ function CronJobDetail({
         </section>
       ) : null}
 
-      <CronJobRuns c={c} jobId={job.id} onOpenSession={onOpenSession} />
+      <CronJobRuns c={c} jobId={job.id} jobProfile={job.profile} onOpenSession={onOpenSession} />
     </PanelDetail>
   )
 }
@@ -868,10 +868,12 @@ const RUNS_BACKSTOP_INTERVAL_MS = 60_000
 function CronJobRuns({
   c,
   jobId,
+  jobProfile,
   onOpenSession
 }: {
   c: Translations['cron']
   jobId: string
+  jobProfile?: string
   onOpenSession?: (sessionId: string) => void
 }) {
   const [runs, setRuns] = useState<null | SessionInfo[]>(null)
@@ -882,7 +884,7 @@ function CronJobRuns({
     let cancelled = false
 
     const load = () =>
-      getCronJobRuns(jobId)
+      getCronJobRuns(jobId, undefined, jobProfile)
         .then(result => {
           if (!cancelled) {
             setRuns(result)
@@ -919,7 +921,7 @@ function CronJobRuns({
       document.removeEventListener('visibilitychange', onVisible)
     }
     // cronChangeTick: a fired run moves jobs.json bookkeeping → reload now.
-  }, [changeEventsAvailable, cronChangeTick, jobId])
+  }, [changeEventsAvailable, cronChangeTick, jobId, jobProfile])
 
   return (
     <div>

--- a/apps/desktop/src/hermes-cron-scope.test.ts
+++ b/apps/desktop/src/hermes-cron-scope.test.ts
@@ -104,4 +104,37 @@ describe('cron helpers are profile-scoped', () => {
     void getCronJobs()
     expect(api.mock.calls.at(-1)?.[0].path).toBe('/api/cron/jobs')
   })
+
+  // Contract: mutations and run-history target ONE per-profile store. The
+  // list aggregator stamps each job's owning profile; passing it here as
+  // ?profile= makes the backend resolve the right store instead of the
+  // caller's ambient profile. Without it, a cross-profile view 404'd on
+  // trigger ("Job not found") and run history read the wrong store (empty).
+  it('threads an explicit job profile into the endpoint query for runs and mutations', () => {
+    const path = () => api.mock.calls.at(-1)?.[0].path
+
+    void getCronJobRuns('job-1', 20, 'tommy')
+    expect(path()).toBe('/api/cron/jobs/job-1/runs?profile=tommy&limit=20')
+
+    void triggerCronJob('job-1', 'tommy')
+    expect(path()).toBe('/api/cron/jobs/job-1/trigger?profile=tommy')
+
+    void pauseCronJob('job-1', 'tommy')
+    expect(path()).toBe('/api/cron/jobs/job-1/pause?profile=tommy')
+
+    void resumeCronJob('job-1', 'tommy')
+    expect(path()).toBe('/api/cron/jobs/job-1/resume?profile=tommy')
+
+    void updateCronJob('job-1', { enabled: false } as never, 'tommy')
+    expect(path()).toBe('/api/cron/jobs/job-1?profile=tommy')
+
+    void deleteCronJob('job-1', 'tommy')
+    expect(path()).toBe('/api/cron/jobs/job-1?profile=tommy')
+
+    // Omitting the job profile keeps the legacy ambient-profile path.
+    void getCronJobRuns('job-1')
+    expect(path()).toBe('/api/cron/jobs/job-1/runs?limit=20')
+    void triggerCronJob('job-1')
+    expect(path()).toBe('/api/cron/jobs/job-1/trigger')
+  })
 })

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -890,6 +890,10 @@ export interface CronJob {
   name?: null | string
   next_run_at?: null | string
   no_agent?: boolean
+  /** Owning profile name, stamped by the cross-profile list aggregator so
+   *  mutations (trigger/pause/resume/delete/update) can target the right
+   *  per-profile store. Absent on legacy single-profile responses. */
+  profile?: string
   prompt?: null | string
   provider?: null | string
   schedule?: CronJobSchedule

--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -724,8 +724,15 @@ def _deliver_to_bot_chat(job: dict, content: str, profile: str) -> Optional[str]
     env = delegated_child_subprocess_env(os.environ)
     if profile:
         argv += ["-p", profile]
-        # -p owns profile resolution; this scheduler's HERMES_HOME must not shadow it.
-        env.pop("HERMES_HOME", None)
+        # -p resolves the target profile, but only against the deployment root
+        # (HERMES_HOME/profiles/ in Docker/custom layouts, ~/.hermes/profiles/
+        # in standard ones). Popping HERMES_HOME entirely makes the child fall
+        # back to ~/.hermes, so in a Docker deployment (HERMES_HOME=/opt/data)
+        # `-p tommy` looks under ~/.hermes/profiles and fails with "profile does
+        # not exist". Point HERMES_HOME at the resolved root instead of dropping
+        # it, so -p finds the profile in every layout.
+        from hermes_constants import get_default_hermes_root
+        env["HERMES_HOME"] = str(get_default_hermes_root())
     else:
         # Multiplex workers carry the profile in a ContextVar, not os.environ.
         env["HERMES_HOME"] = str(source_home)

--- a/hermes_cli/web_routers/cron.py
+++ b/hermes_cli/web_routers/cron.py
@@ -83,7 +83,10 @@ def _found(job):
 def _list_cron_jobs_sync(profile: str = "all"):
     requested = (profile or "all").strip()
     if requested.lower() != "all":
-        return _call_cron_for_profile(requested, "list_jobs", True)
+        jobs = _call_cron_for_profile(requested, "list_jobs", True)
+        for j in jobs:
+            j["profile"] = requested
+        return jobs
 
     jobs: List[Dict[str, Any]] = []
     for item in _cron_profile_dicts():
@@ -91,7 +94,16 @@ def _list_cron_jobs_sync(profile: str = "all"):
         if not name:
             continue
         try:
-            jobs.extend(_call_cron_for_profile(name, "list_jobs", True))
+            owned = _call_cron_for_profile(name, "list_jobs", True)
+            # Stamp the owning profile so mutation endpoints (trigger/pause/
+            # resume/delete/update) can target the right per-profile store. In
+            # the aggregated 'all' view the caller has no other way to know
+            # which profile a row belongs to, and the trigger endpoint's
+            # profile=None scan resolves to the WRONG store the moment two
+            # profiles share a job name.
+            for j in owned:
+                j["profile"] = name
+            jobs.extend(owned)
         except Exception:
             _log.exception("Failed to list cron jobs for profile %s", name)
     return jobs

--- a/tests/cron/test_cron_bot_chat_delivery.py
+++ b/tests/cron/test_cron_bot_chat_delivery.py
@@ -145,7 +145,7 @@ def test_deliver_runs_canonical_bot_chat_lane():
     assert not any("the output" in str(a) for a in argv)
 
 
-def test_deliver_named_profile_uses_p_flag_and_clears_home():
+def test_deliver_named_profile_uses_p_flag_and_points_home_at_root():
     calls = {}
 
     def fake_run(argv, **kwargs):
@@ -155,14 +155,20 @@ def test_deliver_named_profile_uses_p_flag_and_clears_home():
 
     with mock.patch.object(sched.subprocess, "run", side_effect=fake_run), \
          mock.patch.object(sched_delivery.shutil, "which", return_value="/usr/bin/hermes"), \
-         mock.patch.dict(sched.os.environ, {"HERMES_HOME": "/tmp/other-profile"}):
+         mock.patch.dict(sched.os.environ, {"HERMES_HOME": "/tmp/other-profile"}), \
+         mock.patch("hermes_constants.get_default_hermes_root",
+                    return_value=sched.Path("/opt/data")):
         err = _deliver_to_bot_chat({"id": "j1", "name": "n"}, "out", "research")
 
     assert err is None
     argv = calls["argv"]
     assert argv[1:3] == ["-p", "research"]
-    # -p owns resolution; the scheduler's own HERMES_HOME must not leak in.
-    assert "HERMES_HOME" not in calls["kwargs"]["env"]
+    # -p resolves the profile, but only against the deployment root. HERMES_HOME
+    # must be SET to that root (not dropped): dropping it makes the child fall
+    # back to ~/.hermes, so a Docker deployment (HERMES_HOME=/opt/data) fails to
+    # find /opt/data/profiles/research. Regression for the "profile does not
+    # exist" bot-chat delivery failure.
+    assert calls["kwargs"]["env"]["HERMES_HOME"] == "/opt/data"
 
 
 def test_deliver_failure_returns_error_string():

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -823,6 +823,38 @@ async def test_cron_profile_scan_runs_off_event_loop(isolated_profiles, monkeypa
 
 
 @pytest.mark.asyncio
+async def test_list_cron_jobs_stamps_owning_profile(isolated_profiles):
+    """Each listed job carries its owning profile so mutation endpoints can
+    target the right per-profile store. Without this, the desktop's trigger/
+    pause/delete fall back to the ambient profile and 404 ("Job not found") or
+    hit the wrong store in the aggregated view."""
+    _web_server_cron._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="owned by worker",
+        schedule="every 1h",
+        name="owned-job",
+    )
+    _web_server_cron._call_cron_for_profile(
+        "default",
+        "create_job",
+        prompt="owned by default",
+        schedule="every 1h",
+        name="default-job",
+    )
+
+    aggregated = await _rt_cron.list_cron_jobs(profile="all")
+    by_name = {j.get("name"): j for j in aggregated}
+    assert by_name["owned-job"]["profile"] == "worker_alpha"
+    assert by_name["default-job"]["profile"] == "default"
+
+    # The single-profile view stamps it too, so the row is self-describing
+    # regardless of how it was fetched.
+    scoped = await _rt_cron.list_cron_jobs(profile="worker_alpha")
+    assert all(j["profile"] == "worker_alpha" for j in scoped)
+
+
+@pytest.mark.asyncio
 async def test_cron_dashboard_io_rejects_async_callables():
     from hermes_cli import web_server
 


### PR DESCRIPTION
## What does this PR do?

The desktop cron UI listed jobs with `?profile=<name>` (via `getCronJobs`) but did not thread that profile through the rest of the surface. Every other interaction resolved the store from the *caller's ambient profile* instead of the job's owner, so any job owned by a different profile than the active window broke in three ways - same root cause:

- **Mutations** (trigger / pause / resume / delete / update) fired without a profile -> "Run now" 404'd with "Job not found" from a cross-profile view, and pause/resume/delete/update silently hit the wrong per-profile store.
- **Run history** (`getCronJobRuns`) fired without a profile -> the cron overlay and sidebar peek read an empty store and showed "No runs yet" even though the run had executed and delivered.
- **bot-chat delivery** popped `HERMES_HOME` before spawning `hermes -p <profile> chat …`, assuming `-p` owns profile resolution. It doesn't: `-p` resolves against the deployment root that `get_default_hermes_root()` derives from `HERMES_HOME`. Dropped, the child falls back to `~/.hermes`, so in a Docker/custom deployment (`HERMES_HOME=/opt/data`) `-p tommy` looks under `~/.hermes/profiles` and fails with "Profile 'tommy' does not exist" - every scheduled `bot-chat:<profile>` delivery silently failed there.

The right approach makes the job's owning profile a single server-stamped fact (`CronJob.profile`) that every read and write threads back through, so store resolution can never diverge from the profile that owns the job.

## Related Issue

<!-- No tracking issue; happy to open one if preferred. -->
Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_routers/cron.py` - stamp each job's owning profile in `_list_cron_jobs_sync` (both the scoped and aggregated `all` branches).
- `apps/desktop/src/types/hermes.ts` - expose `CronJob.profile`.
- `apps/desktop/src/api/cron.ts` - thread `?profile=<owner>` through `getCronJobRuns` and every mutation helper.
- `apps/desktop/src/app/cron/index.tsx`, `apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx` - pass the job profile from both call sites (cron overlay + sidebar), including effect deps so a profile change reloads.
- `apps/desktop/src/app/cron/cron-actions.ts` - target the job profile on mutations while the refresh stays scoped to the view.
- `cron/scheduler_delivery.py` - set `HERMES_HOME` to the resolved deployment root instead of popping it, so `-p` finds the profile in standard and Docker layouts.
- Tests: `tests/hermes_cli/test_web_server_cron_profiles.py`, `apps/desktop/src/app/cron/cron-actions.test.ts`, `apps/desktop/src/hermes-cron-scope.test.ts`, `tests/cron/test_cron_bot_chat_delivery.py`.

## How to Test

1. Run two profiles (e.g. `default` and `tommy`), create a cron job under `tommy`.
2. From a `default` window's cron overlay: "Run now" on the tommy job succeeds (previously 404 "Job not found"); pause/resume/delete hit tommy's store; the run-history panel shows the run (previously "No runs yet").
3. In a Docker/custom deployment (`HERMES_HOME=/opt/data`), a scheduled `bot-chat:tommy` delivery resolves the profile and delivers (previously failed silently with "Profile 'tommy' does not exist").
4. Automated: `pytest tests/hermes_cli/test_web_server_cron_profiles.py tests/cron/test_cron_bot_chat_delivery.py -q` and the desktop `cron-actions` / `hermes-cron-scope` unit tests.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(cron):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the affected tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Ubuntu, Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A (no user-facing docs affected)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` - N/A
- [x] I've considered cross-platform impact - no OS-specific primitives touched; the fix hardens the Docker/custom `HERMES_HOME` layout
- [x] I've updated tool descriptions/schemas - N/A (no tool behavior change)

## Screenshots / Logs

<!-- N/A -->