### PR TITLE
feat(cron): add prompt_file, no_cron_hint, and --attach-to-session for cron jobs

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -430,9 +430,11 @@ def job_payload_is_empty(job: Dict[str, Any]) -> bool:
     least one payload field is explicitly present. ``no_agent`` already requires a script."""
     if _coerce_job_text(job.get("prompt")).strip() or _coerce_job_text(job.get("script")).strip():
         return False
+    if _coerce_job_text(job.get("prompt_file")).strip():
+        return False
     if _normalize_skill_list(job.get("skill"), job.get("skills")):
         return False
-    return any(k in job for k in ("prompt", "script", "skill", "skills"))
+    return any(k in job for k in ("prompt", "script", "skill", "skills", "prompt_file"))
 
 
 def _schedule_display_for_job(job: Dict[str, Any]) -> str:
@@ -1705,6 +1707,8 @@ def create_job(
     failure_deliver: Optional[str] = None,
     paused: bool = False,
     paused_reason: Optional[str] = None,
+    prompt_file: Optional[str] = None,
+    no_cron_hint: Optional[bool] = None,
 ) -> Dict[str, Any]:
     """Create a new cron job and return the stored record.
 
@@ -1737,10 +1741,28 @@ def create_job(
     normalized_skills = _normalize_skill_list(skill, skills)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
     normalized_reasoning_effort = _normalize_reasoning_effort(reasoning_effort)
+    normalized_prompt_file = str(prompt_file).strip() if isinstance(prompt_file, str) else None
+    normalized_prompt_file = normalized_prompt_file or None
+    normalized_no_cron_hint = no_cron_hint if isinstance(no_cron_hint, bool) else None
+    # prompt_file must resolve to a readable file at create time so a typo fails
+    # fast here instead of silently at every fire. It is read fresh each run (see
+    # scheduler_prompt._build_job_prompt), so it stays the single source of truth for a
+    # routine that lives in a git-backed file.
+    if normalized_prompt_file is not None:
+        _pf = Path(normalized_prompt_file).expanduser()
+        if not _pf.is_file():
+            raise ValueError(
+                f"prompt_file does not exist or is not a readable file: {normalized_prompt_file}"
+            )
+        # Store the resolved absolute path so create-time validation and the
+        # fire-time read (scheduler runs under its own cwd) refer to the same
+        # file -- a relative path would resolve differently at each. Mirrors
+        # _normalize_workdir's expand+resolve contract.
+        normalized_prompt_file = str(_pf.resolve())
 
     _validate_job_mode_invariants(f["monitor_script"], f["monitor_url"], f["no_agent"], f["script"])
     prompt_text = _coerce_job_text(prompt).strip()
-    if not prompt_text and not f["script"] and not normalized_skills:
+    if not prompt_text and not f["script"] and not normalized_skills and not normalized_prompt_file:
         raise ValueError(EMPTY_PAYLOAD_ERROR)
     # Reject gateway-lifecycle commands (respawn loops) here, not just in the CLI: covers the tool.
     from cron.lifecycle_guard import check_gateway_lifecycle
@@ -1801,6 +1823,7 @@ def create_job(
     for key, value in (
         ("attach_to_session", normalized_attach), ("reasoning_effort", normalized_reasoning_effort),
         ("failure_deliver", f["failure_deliver"]),
+        ("prompt_file", normalized_prompt_file), ("no_cron_hint", normalized_no_cron_hint),
     ):
         if value is not None:
             job[key] = value

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -389,6 +389,14 @@ class CronPromptInjectionBlocked(Exception):
     """
 
 
+class CronPromptFileError(Exception):
+    """Raised by _build_job_prompt when a job's prompt_file (its sole payload)
+    cannot be read at fire time. Caught in run_job so the operator sees a clean
+    error delivery instead of the job firing with an empty prompt (burning an
+    unattended model call on a no-op).
+    """
+
+
 def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
     """Toolsets a cron-spawned agent must never receive: ``messaging``/``clarify`` always
     (interactive); ``cronjob`` by default (loop prevention, not a security boundary —
@@ -2087,6 +2095,21 @@ def _prepare_job_prompt(
             "the threat pattern (`tools/cronjob_tools.py::_CRON_THREAT_PATTERNS`)."
         )
         return (False, blocked_doc, "", str(block_exc)), None
+    except CronPromptFileError as pf_exc:
+        # prompt_file was the sole payload and could not be read at fire time.
+        # Fail the run loudly instead of firing an empty prompt.
+        logger.warning(
+            "Job '%s' (ID: %s): prompt_file unreadable at fire time -- %s",
+            job_name, job_id, pf_exc,
+        )
+        pf_doc = (
+            f"# Cron Job: {job_name}\n\n"
+            f"**Job ID:** {job_id}\n"
+            f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+            f"**Status:** ERROR\n\n"
+            f"{pf_exc}\n"
+        )
+        return (False, pf_doc, "", str(pf_exc)), None
     if prompt is None:
         logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
         return (True, "", SILENT_MARKER, None), None

--- a/cron/scheduler_prompt.py
+++ b/cron/scheduler_prompt.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+from pathlib import Path
 from hermes_time import now as _hermes_now
 from typing import Optional
 
@@ -212,6 +213,19 @@ def _build_job_prompt(
     ``cronjob(action='run')``, 57331 — salvaged from #57342 by @liuhao1024).
     """
     user_prompt = str(job.get("prompt") or "")
+    # prompt_file fallback: when there is no inline prompt, read the file fresh
+    # each fire so edits to a routine file land on the next run without
+    # re-creating the job (single source of truth). An inline prompt wins.
+    # A read failure raises rather than firing an empty prompt (the file IS the
+    # payload) -- run_job catches it and records the run as an error.
+    if not user_prompt.strip() and job.get("prompt_file"):
+        pf = Path(str(job["prompt_file"])).expanduser()
+        try:
+            user_prompt = pf.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise _sched.CronPromptFileError(
+                f"prompt_file {pf} could not be read at fire time: {exc}"
+            ) from exc
     if extra_prompt:
         user_prompt = f"{user_prompt}\n\n## Run Context\n{extra_prompt}"
     prompt = user_prompt
@@ -244,7 +258,7 @@ def _build_job_prompt(
         prompt = f"{notepad_section}{prompt}"
         has_injected_data = True
 
-    prompt = _CRON_HINT + prompt
+    prompt = _CRON_HINT + prompt if not job.get("no_cron_hint") else prompt
     skill_names = _job_skill_names(job)
     if not skill_names:
         return _scan_assembled_cron_prompt(

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -580,6 +580,7 @@ def cron_create(args):
            if getattr(args, "paused", False) or getattr(args, "paused_reason", None) is not None else {}),
         prompt_file=getattr(args, "prompt_file", None),
         no_cron_hint=getattr(args, "no_cron_hint", None),
+        attach_to_session=getattr(args, "attach_to_session", None),
         **_job_api_kwargs(args))
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -578,6 +578,8 @@ def cron_create(args):
         no_agent=getattr(args, "no_agent", False) or None,
         **({"paused": args.paused, "paused_reason": getattr(args, "paused_reason", None)}
            if getattr(args, "paused", False) or getattr(args, "paused_reason", None) is not None else {}),
+        prompt_file=getattr(args, "prompt_file", None),
+        no_cron_hint=getattr(args, "no_cron_hint", None),
         **_job_api_kwargs(args))
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -81,6 +81,19 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
             "reported and continue where the last run left off (scouts, "
             "monitors, incremental digests). First run is unchanged.")
     cron_create.add_argument(
+        "--attach-to-session",
+        dest="attach_to_session",
+        action="store_const",
+        const=True,
+        default=None,
+        help=(
+            "Make the job's delivery a continuable session: the report arrives "
+            "as a real message the user can reply to, with the run's context in "
+            "scope (briefings, routines that ask follow-up questions). Absent = "
+            "one-way delivery."
+        ),
+    )
+    cron_create.add_argument(
         "--prompt-file",
         dest="prompt_file",
         help=(

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -80,6 +80,30 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
             "into its prompt, so it can dedupe against what was already "
             "reported and continue where the last run left off (scouts, "
             "monitors, incremental digests). First run is unchanged.")
+    cron_create.add_argument(
+        "--prompt-file",
+        dest="prompt_file",
+        help=(
+            "Path to a file whose contents ARE the prompt, read fresh on every "
+            "run so edits to the file land on the next fire (single source of "
+            "truth for a routine file). Stored as an absolute path. An inline "
+            "prompt argument, if given, wins over this. Create-only; not "
+            "editable via `cron edit`."
+        ),
+    )
+    cron_create.add_argument(
+        "--no-cron-hint",
+        dest="no_cron_hint",
+        action="store_const",
+        const=True,
+        default=None,
+        help=(
+            "Suppress the execution-guidance banner normally prepended to a "
+            "cron job's prompt (delivery + [SILENT] convention). Use for jobs "
+            "that always deliver via an attached session and manage their own "
+            "output."
+        ),
+    )
 
     _flag(cron_create, "--paused", default=False,
         help="Create disabled in one write; resume to schedule, or explicitly run now.")

--- a/tests/cron/test_cron_create_attach_to_session.py
+++ b/tests/cron/test_cron_create_attach_to_session.py
@@ -1,0 +1,71 @@
+"""`hermes cron create --attach-to-session` CLI flag.
+
+The cronjob() tool and jobs.json already support attach_to_session (a
+continuable-session delivery), but there was no `hermes cron create` flag for
+it -- it could only be set from the model tool or by hand-editing jobs.json.
+This wires the flag through the create parser and dispatch.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+
+@pytest.fixture
+def hermes_env(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "scripts").mkdir()
+    (home / "cron").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import importlib
+    import hermes_constants
+    importlib.reload(hermes_constants)
+    import cron.jobs
+    importlib.reload(cron.jobs)
+    import cron.scheduler
+    importlib.reload(cron.scheduler)
+
+    return home
+
+
+def _create_parser():
+    from hermes_cli.subcommands.cron import build_cron_parser
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers()
+    build_cron_parser(sub, cmd_cron=lambda args: 0)
+    return parser
+
+
+def test_cli_create_parser_accepts_attach_to_session():
+    args = _create_parser().parse_args(
+        ["cron", "create", "every day at 08:00", "hi", "--attach-to-session"]
+    )
+    assert args.attach_to_session is True
+
+
+def test_cli_create_defaults_attach_to_session_to_none():
+    """Absent flag = None, so create_job leaves the key off (byte-identical)."""
+    args = _create_parser().parse_args(["cron", "create", "every 5m", "hi"])
+    assert args.attach_to_session is None
+
+
+def test_cli_create_forwards_attach_to_session(hermes_env):
+    """End-to-end: the flag lands on the persisted job record."""
+    from hermes_cli.cron import cron_create
+    from cron.jobs import load_jobs
+
+    args = _create_parser().parse_args(
+        ["cron", "create", "every day at 08:00", "run it",
+         "--attach-to-session", "--deliver", "local"]
+    )
+    rc = cron_create(args)
+    assert rc == 0
+
+    jobs = load_jobs()
+    assert len(jobs) == 1
+    assert jobs[0]["attach_to_session"] is True

--- a/tests/cron/test_cron_prompt_file_and_hint.py
+++ b/tests/cron/test_cron_prompt_file_and_hint.py
@@ -1,0 +1,302 @@
+"""Cron ``prompt_file`` and ``no_cron_hint`` (per-job opt-outs).
+
+Two small, user-owned (CLI/programmatic) knobs:
+
+* ``prompt_file`` -- point a job at a file whose contents ARE the prompt, read
+  fresh at each fire so edits to the file are picked up (single source of
+  truth for a routine that lives in a git-backed vault). Makes an
+  otherwise-promptless job runnable.
+* ``no_cron_hint`` -- suppress the always-prepended cron execution-guidance
+  banner for a job that does not want it (e.g. one that always delivers via an
+  attached session and never uses the [SILENT] convention).
+
+Both follow the ``reasoning_effort`` precedent: conditional-persist (absent =
+byte-identical to pre-feature jobs) and deliberately NOT model-settable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def hermes_env(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "scripts").mkdir()
+    (home / "cron").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import importlib
+    import hermes_constants
+    importlib.reload(hermes_constants)
+    import cron.jobs
+    importlib.reload(cron.jobs)
+    import cron.scheduler
+    importlib.reload(cron.scheduler)
+
+    return home
+
+
+# ---------------------------------------------------------------------------
+# prompt_file: create-time
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_file_makes_a_promptless_job_valid(hermes_env):
+    from cron.jobs import create_job
+
+    routine = hermes_env / "routine.md"
+    routine.write_text("Run the daily round.\n")
+
+    job = create_job(
+        prompt=None, schedule="every 5m", prompt_file=str(routine), deliver="local"
+    )
+    assert job["prompt_file"] == str(routine)
+
+
+def test_prompt_file_missing_is_rejected_at_create(hermes_env):
+    from cron.jobs import create_job
+
+    with pytest.raises(ValueError, match="prompt_file"):
+        create_job(
+            prompt=None,
+            schedule="every 5m",
+            prompt_file=str(hermes_env / "does-not-exist.md"),
+            deliver="local",
+        )
+
+
+def test_prompt_file_absent_when_unset(hermes_env):
+    """Byte-identical to pre-feature jobs: no key when not provided."""
+    from cron.jobs import create_job
+
+    job = create_job(prompt="hi", schedule="every 5m", deliver="local")
+    assert "prompt_file" not in job
+
+
+def test_prompt_file_is_stored_as_an_absolute_path(hermes_env, monkeypatch):
+    """A relative path validated at create must resolve to the same file at
+    fire time (scheduler runs under its own cwd), so it is stored absolute."""
+    from cron.jobs import create_job
+
+    routine = hermes_env / "routine.md"
+    routine.write_text("do it\n")
+    # Create with a RELATIVE path from inside the file's directory.
+    monkeypatch.chdir(hermes_env)
+    job = create_job(
+        prompt=None, schedule="every 5m", prompt_file="routine.md", deliver="local"
+    )
+    assert job["prompt_file"] == str(routine.resolve())
+
+
+def test_prompt_file_only_job_is_not_treated_as_empty(hermes_env):
+    """The run-time empty-payload guard (job_payload_is_empty) must count
+    prompt_file as payload, or a prompt_file-only job gets auto-paused."""
+    from cron.jobs import create_job, job_payload_is_empty
+
+    routine = hermes_env / "routine.md"
+    routine.write_text("run the round\n")
+    job = create_job(
+        prompt=None, schedule="every 5m", prompt_file=str(routine), deliver="local"
+    )
+    assert job_payload_is_empty(job) is False
+
+
+# ---------------------------------------------------------------------------
+# prompt_file: read at FIRE time (picks up edits)
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_file_content_is_used_as_the_prompt(hermes_env):
+    from cron.jobs import create_job
+    from cron.scheduler import _build_job_prompt
+
+    routine = hermes_env / "routine.md"
+    routine.write_text("Execute step one.\n")
+    job = create_job(
+        prompt=None, schedule="every 5m", prompt_file=str(routine), deliver="local"
+    )
+
+    built = _build_job_prompt(job)
+    assert "Execute step one." in built
+
+
+def test_prompt_file_is_reread_each_fire(hermes_env):
+    """Edits to the file land on the next run without re-creating the job."""
+    from cron.jobs import create_job
+    from cron.scheduler import _build_job_prompt
+
+    routine = hermes_env / "routine.md"
+    routine.write_text("first version\n")
+    job = create_job(
+        prompt=None, schedule="every 5m", prompt_file=str(routine), deliver="local"
+    )
+    assert "first version" in _build_job_prompt(job)
+
+    routine.write_text("second version\n")
+    assert "second version" in _build_job_prompt(job)
+
+
+def test_inline_prompt_wins_over_prompt_file(hermes_env):
+    """An explicit prompt takes precedence; prompt_file is the fallback."""
+    from cron.jobs import create_job
+    from cron.scheduler import _build_job_prompt
+
+    routine = hermes_env / "routine.md"
+    routine.write_text("from file\n")
+    job = create_job(
+        prompt="from inline",
+        schedule="every 5m",
+        prompt_file=str(routine),
+        deliver="local",
+    )
+
+    built = _build_job_prompt(job)
+    assert "from inline" in built
+    assert "from file" not in built
+
+
+# ---------------------------------------------------------------------------
+# no_cron_hint: suppress the execution-guidance banner
+# ---------------------------------------------------------------------------
+
+_HINT_MARK = "running as a scheduled cron job"
+
+
+def test_cron_hint_is_present_by_default(hermes_env):
+    from cron.jobs import create_job
+    from cron.scheduler import _build_job_prompt
+
+    job = create_job(prompt="do the thing", schedule="every 5m", deliver="local")
+    assert _HINT_MARK in _build_job_prompt(job)
+    assert "prompt_file" not in job  # unrelated defaults untouched
+
+
+def test_no_cron_hint_suppresses_the_banner(hermes_env):
+    from cron.jobs import create_job
+    from cron.scheduler import _build_job_prompt
+
+    job = create_job(
+        prompt="do the thing",
+        schedule="every 5m",
+        no_cron_hint=True,
+        deliver="local",
+    )
+    assert job["no_cron_hint"] is True
+    built = _build_job_prompt(job)
+    assert _HINT_MARK not in built
+    assert "do the thing" in built
+
+
+def test_no_cron_hint_absent_when_unset(hermes_env):
+    from cron.jobs import create_job
+
+    job = create_job(prompt="hi", schedule="every 5m", deliver="local")
+    assert "no_cron_hint" not in job
+
+
+# ---------------------------------------------------------------------------
+# Not model-settable (reasoning_effort precedent)
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_file_and_no_cron_hint_are_not_in_the_model_schema():
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    props = CRONJOB_SCHEMA["parameters"]["properties"]
+    assert "prompt_file" not in props
+    assert "no_cron_hint" not in props
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through the tool boundary (the CLI create path)
+# ---------------------------------------------------------------------------
+
+
+def test_tool_create_with_prompt_file_and_no_cron_hint(hermes_env):
+    import json
+    from tools.cronjob_tools import cronjob
+    from cron.scheduler import _build_job_prompt
+    from cron.jobs import get_job
+
+    routine = hermes_env / "routine.md"
+    routine.write_text("Run the vault round.\n")
+
+    result = json.loads(
+        cronjob(
+            action="create",
+            schedule="every day at 08:00",
+            prompt_file=str(routine),
+            no_cron_hint=True,
+            deliver="local",
+        )
+    )
+    assert result["success"] is True
+
+    job = get_job(result["job_id"])
+    assert job["prompt_file"] == str(routine)
+    assert job["no_cron_hint"] is True
+
+    built = _build_job_prompt(job)
+    assert "Run the vault round." in built
+    assert _HINT_MARK not in built
+
+
+def test_tool_create_rejects_missing_prompt_file(hermes_env):
+    import json
+    from tools.cronjob_tools import cronjob
+
+    result = json.loads(
+        cronjob(
+            action="create",
+            schedule="every 5m",
+            prompt_file=str(hermes_env / "nope.md"),
+            deliver="local",
+        )
+    )
+    assert result["success"] is False
+    assert "prompt_file" in result["error"]
+
+
+def test_cli_create_parser_accepts_the_new_flags():
+    """The argparse wiring exists and maps to the right dests."""
+    import argparse
+    from hermes_cli.subcommands.cron import build_cron_parser
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers()
+    build_cron_parser(sub, cmd_cron=lambda args: 0)
+
+    args = parser.parse_args(
+        ["cron", "create", "every 5m", "--prompt-file", "/tmp/r.md", "--no-cron-hint"]
+    )
+    assert args.prompt_file == "/tmp/r.md"
+    assert args.no_cron_hint is True
+
+
+def test_run_job_errors_when_prompt_file_vanishes_before_fire(hermes_env):
+    """A prompt_file-only job whose file is deleted after create must fail the
+    run loudly, not fire an empty prompt (wasted unattended model call)."""
+    from unittest.mock import patch
+
+    import cron.scheduler as scheduler
+    from cron.jobs import create_job
+
+    routine = hermes_env / "routine.md"
+    routine.write_text("run the round\n")
+    job = create_job(
+        prompt=None, schedule="every 5m", prompt_file=str(routine), deliver="local"
+    )
+    routine.unlink()  # gone before the next fire
+
+    class _Boom:
+        def __init__(self, *a, **kw):  # pragma: no cover - must never run
+            raise AssertionError("agent must not be constructed on unreadable prompt_file")
+
+    with patch("run_agent.AIAgent", _Boom):
+        success, doc, final, error = scheduler.run_job(job)
+
+    assert success is False
+    assert "prompt_file" in error
+    assert "ERROR" in doc

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -538,8 +538,8 @@ def _action_create(a: Dict[str, Any]) -> str:
                 "non-empty stdout is delivered verbatim, empty stdout "
                 "sends nothing (watchdog pattern), and a non-zero exit or timeout sends an error alert.",
                 success=False)
-    elif not prompt and not canonical_skills:
-        return tool_error("create requires either prompt or at least one skill", success=False)
+    elif not prompt and not canonical_skills and not a["prompt_file"]:
+        return tool_error("create requires either prompt, prompt_file, or at least one skill", success=False)
     error = (
         (prompt and _scan_cron_prompt(prompt))
         or (script and _validate_cron_script_path(script))
@@ -575,6 +575,7 @@ def _action_create(a: Dict[str, Any]) -> str:
             # CLI-only lane: absent from CRONJOB_SCHEMA and the model dispatch (models don't pick models).
             reasoning_effort=a["reasoning_effort"],
             failure_deliver=_resolve_cron_context_deliver(_normalize_deliver_param(a["failure_deliver"])),
+            prompt_file=a["prompt_file"], no_cron_hint=a["no_cron_hint"],
             **({"paused": a["paused"], "paused_reason": a["paused_reason"]}
                if a["paused"] is not False or a["paused_reason"] is not None else {}))
     except CronSchedulerRegistrationError as exc:
@@ -877,6 +878,8 @@ def cronjob(
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
     failure_deliver: Optional[Union[str, List[str]]] = None,
+    prompt_file: Optional[str] = None,
+    no_cron_hint: Optional[bool] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
     paused: bool = False,


### PR DESCRIPTION
## What does this PR do?

Adds three user-owned cron job options (CLI + programmatic). Each follows an existing precedent so that an absent option leaves a job record byte-identical to a pre-feature job, and each is deliberately **not** model-settable (absent from `CRONJOB_SCHEMA`, not forwarded by the model dispatch handler) because these are operator knobs, not agent-facing ones.

- **`prompt_file`** - point a job at a file whose contents *are* the prompt, read fresh at each fire so editing the file lands on the next run without re-creating the job (single source of truth for a routine file). Chosen over an inline-prompt-only model because a routine's prompt is often a maintained document; re-reading at fire time keeps the job and the file as one fact instead of a stale copy.
- **`no_cron_hint`** - suppress the always-prepended cron execution-guidance banner for jobs that always deliver via an attached session and manage their own output.
- **`--attach-to-session` flag** - `attach_to_session` already existed in the `cronjob()` tool and `jobs.json` but had no CLI flag; this wires it through `hermes cron create`.

## Related Issue

<!-- No tracking issue. -->
Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/jobs.py` - persist `prompt_file` / `no_cron_hint` conditionally (absent = unchanged record); validate `prompt_file` exists at create time and store it resolved-absolute; count `prompt_file` as payload in `job_payload_is_empty` so a `prompt_file`-only job isn't auto-paused as empty.
- `cron/scheduler_prompt.py` - read `prompt_file` fresh at fire time (inline prompt wins); raise `CronPromptFileError` on a read failure.
- `cron/scheduler.py` - in `run_job`, catch `CronPromptFileError` and record an error run instead of firing an empty prompt; honor `no_cron_hint` when building the banner.
- `hermes_cli/subcommands/cron.py`, `hermes_cli/cron.py` - add `--prompt-file`, `--no-cron-hint`, and `--attach-to-session` to the `create` parser and dispatch (`--attach-to-session` follows the `--continuity` `store_const`/`default=None` pattern).
- `tools/cronjob_tools.py` - keep `prompt_file` / `no_cron_hint` out of the model-facing schema/dispatch.
- Tests: `tests/cron/test_cron_prompt_file_and_hint.py`, `tests/cron/test_cron_create_attach_to_session.py`.

## How to Test

1. `hermes cron create --name routine --schedule "every 1h" --prompt-file /path/to/prompt.txt` - job is created; editing `prompt.txt` changes the next run's prompt with no re-create. A missing path is rejected at create time.
2. `hermes cron create … --no-cron-hint --attach-to-session` - the run delivers into a continuable session without the cron guidance banner.
3. Delete the `prompt_file` between runs → the fire records an error run (not an empty prompt).
4. Confirm the model tool cannot set `prompt_file` / `no_cron_hint` (absent from `CRONJOB_SCHEMA`).
5. Automated: `pytest tests/cron/test_cron_prompt_file_and_hint.py tests/cron/test_cron_create_attach_to_session.py -q`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(cron):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run the affected tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Ubuntu, Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A (no docs page for CLI cron flags; docstrings cover behavior)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A (per-job options, not global config)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` - N/A
- [x] I've considered cross-platform impact - `prompt_file` stored resolved-absolute via `pathlib`; no OS-specific primitives
- [x] I've updated tool descriptions/schemas - N/A by design (these knobs are intentionally excluded from the model tool schema)

## Screenshots / Logs

<!-- N/A -->