### PR TITLE
fix(gateway): /new banner reports channel-override model, not global default

### DIFF
--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2024,12 +2024,29 @@ class GatewayTurnMixin:
         Call via ``asyncio.to_thread``: resolution can block (credential refresh, context-length
         probes), and the scope is entered here so contextvars behave in the worker thread."""
         with self._profile_scope_for_source(source):
-            return self._format_session_info()
+            return self._format_session_info(source)
 
-    def _format_session_info(self) -> str:
-        """Model / provider / context-length / endpoint block so users can spot bad context detection."""
-        from gateway.run import _resolve_gateway_model_context
-        resolved = _resolve_gateway_model_context()
+    def _format_session_info(self, source: Optional[SessionSource] = None) -> str:
+        """Model / provider / context-length / endpoint block so users can spot bad context detection.
+
+        ``source`` (when given) resolves the effective channel override (model/provider) so the
+        /new and auto-reset banners report the model the turn will actually use. Those banners run
+        before any turn, so the turn resolver's override path never ran and the global default
+        leaked in."""
+        from gateway.run import _get_channel_override, _resolve_gateway_model_context
+        override_model = override_provider = None
+        if source is not None:
+            cfg = getattr(self, "config", None)
+            if cfg is not None:
+                ch = _get_channel_override(
+                    cfg, source.platform, str(source.chat_id) if source.chat_id else "",
+                    thread_id=str(source.thread_id) if getattr(source, "thread_id", None) else None,
+                    parent_id=str(source.parent_chat_id) if getattr(source, "parent_chat_id", None) else None,
+                )
+                if ch is not None:
+                    override_model = ch.model
+                    override_provider = ch.provider
+        resolved = _resolve_gateway_model_context(override_model or None)
         context_length = resolved.context_length
         ctx_source = {
             "config": "config",
@@ -2041,7 +2058,7 @@ class GatewayTurnMixin:
         )
         lines = [
             f"◆ Model: `{resolved.model}`",
-            f"◆ Provider: {resolved.provider or 'openrouter'}",
+            f"◆ Provider: {override_provider or resolved.provider or 'openrouter'}",
             f"◆ Context: {ctx_display} tokens ({ctx_source})",
         ]
         base_url = resolved.base_url

--- a/tests/gateway/test_session_info.py
+++ b/tests/gateway/test_session_info.py
@@ -116,6 +116,60 @@ class TestFormatSessionInfo:
         assert "config" in info
         assert "131K" not in info
 
+    def test_channel_override_model_wins_over_global_default(self, runner, tmp_path):
+        """The /new (and auto-reset) banner must report the channel override model, not the
+        global default — the turn would use the override, so the banner must not lie."""
+        from gateway.config import Platform, ChannelOverride, PlatformConfig
+        from gateway.session import SessionSource
+        from types import SimpleNamespace
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM, chat_id="14930030", user_id="u1",
+            thread_id="624616",
+        )
+        runner.config = SimpleNamespace(
+            platforms={
+                Platform.TELEGRAM: SimpleNamespace(
+                    channel_overrides={"624616": ChannelOverride(model="deepseek/deepseek-v4-pro", provider="commandcode")},
+                )
+            }
+        )
+        p1, p2, p3 = _patch_info(
+            tmp_path,
+            "model:\n  default: xiaomi/mimo-v2.5\n  provider: commandcode\n",
+            "xiaomi/mimo-v2.5",
+            {"provider": "commandcode", "base_url": "", "api_key": ""},
+        )
+        with p1, p2, p3:
+            info = runner._format_session_info(source)
+        assert "deepseek-v4-pro" in info
+        assert "mimo-v2.5" not in info
+        assert "commandcode" in info
+
+    def test_no_override_falls_back_to_global(self, runner, tmp_path):
+        """No matching channel override → the global default still surfaces."""
+        from gateway.config import Platform, PlatformConfig
+        from gateway.session import SessionSource
+        from types import SimpleNamespace
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM, chat_id="14930030", user_id="u1",
+            thread_id="999999",
+        )
+        runner.config = SimpleNamespace(
+            platforms={Platform.TELEGRAM: SimpleNamespace(channel_overrides={})}
+        )
+        p1, p2, p3 = _patch_info(
+            tmp_path,
+            "model:\n  default: xiaomi/mimo-v2.5\n  provider: commandcode\n",
+            "xiaomi/mimo-v2.5",
+            {"provider": "commandcode", "base_url": "", "api_key": ""},
+        )
+        with p1, p2, p3:
+            info = runner._format_session_info(source)
+        assert "mimo-v2.5" in info
+        assert "commandcode" in info
+
 
 class TestResetNoticeSessionInfo:
     """#59003: the auto-reset banner must report the serving profile's config,

--- a/tests/gateway/test_session_info.py
+++ b/tests/gateway/test_session_info.py
@@ -170,6 +170,52 @@ class TestFormatSessionInfo:
         assert "mimo-v2.5" in info
         assert "commandcode" in info
 
+    def test_plain_dm_chat_no_thread_id_no_override(self, runner, tmp_path):
+        """A normal Telegram DM/group chat has no thread_id and no override: the banner must
+        render exactly as before the fix — global model, no crash, no override leakage."""
+        from gateway.config import Platform, PlatformConfig
+        from gateway.session import SessionSource
+        from types import SimpleNamespace
+
+        # Plain private DM: chat_id set, thread_id=None, no channel_overrides at all.
+        source = SessionSource(
+            platform=Platform.TELEGRAM, chat_id="14930030", user_id="u1",
+        )
+        runner.config = SimpleNamespace(
+            platforms={Platform.TELEGRAM: SimpleNamespace(channel_overrides={})}
+        )
+        p1, p2, p3 = _patch_info(
+            tmp_path,
+            "model:\n  default: xiaomi/mimo-v2.5\n  provider: commandcode\n",
+            "xiaomi/mimo-v2.5",
+            {"provider": "commandcode", "base_url": "", "api_key": ""},
+        )
+        with p1, p2, p3:
+            info = runner._format_session_info(source)
+        assert "mimo-v2.5" in info
+        assert "commandcode" in info
+        assert "◆ Model:" in info
+        assert "◆ Provider:" in info
+
+    def test_plain_dm_without_config_attr_does_not_crash(self, runner, tmp_path):
+        """A bare runner with no `.config` attribute (test/double edge case) must still render
+        the global model — the override lookup is guarded by getattr."""
+        from gateway.config import Platform
+        from gateway.session import SessionSource
+
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="14930030", user_id="u1")
+        # Deliberately no runner.config set.
+        p1, p2, p3 = _patch_info(
+            tmp_path,
+            "model:\n  default: xiaomi/mimo-v2.5\n  provider: commandcode\n",
+            "xiaomi/mimo-v2.5",
+            {"provider": "commandcode", "base_url": "", "api_key": ""},
+        )
+        with p1, p2, p3:
+            info = runner._format_session_info(source)
+        assert "mimo-v2.5" in info
+        assert "commandcode" in info
+
 
 class TestResetNoticeSessionInfo:
     """#59003: the auto-reset banner must report the serving profile's config,


### PR DESCRIPTION
## Problem

In Telegram DM topics (and any channel with a `channel_override`), the `/new` and auto-reset banners showed the **global** `model.default` instead of the override model. Example: a topic pinned to `deepseek/deepseek-v4-pro` displayed `xiaomi/mimo-v2.5`.

The runtime footer was correct (it reads the model the agent *actually* used), but only after a real turn had run — so the very first thing a user sees after `/new` was wrong.

## Root cause

`_format_session_info()` (used by both `/new` and the auto-reset notice) was called without a `SessionSource`. It delegated to `_resolve_gateway_model_context()`, which resolves only `model.default` — the `channel_overrides` are applied in a *separate* path (`_resolve_session_agent_runtime()`), which only runs during an actual agent turn.

## Fix

Thread `SessionSource` through `_reset_notice_session_info(source)` → `_format_session_info(source)`, and resolve the effective channel override (via `_get_channel_override`, thread_id/parent_id-aware) before context-window resolution. The provider line prefers the override provider too. `source` defaults to `None`, so the existing callers without a source keep the exact prior behavior.

## Why this is safe for normal chats

- `_get_channel_override` is already defensive: missing platform / empty `channel_overrides` → returns `None`.
- The override lookup is a 1:1 replica of the proven call in `_resolve_session_agent_runtime()` (same `getattr(self, "config", None)` guard).
- With no override, `_resolve_gateway_model_context(None)` is byte-identical to the old `_resolve_gateway_model_context()`.

## Tests

- `test_channel_override_model_wins_over_global_default` — override model/prov surfaces in the banner.
- `test_no_override_falls_back_to_global` — fallback path.
- `test_plain_dm_chat_no_thread_id_no_override` — normal DM (no thread_id, no overrides) renders exactly as before.
- `test_plain_dm_without_config_attr_does_not_crash` — bare runner edge case.

Full `tests/gateway/` suite: **7657 passed, 0 failed**.