### PR TITLE
fix(tools): disclose same-lineage FTS hits hidden as live context; hydrate discovery metadata from the matched session

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -1156,3 +1156,101 @@ class TestNewResetLineageBrowse:
         sids = [r["session_id"] for r in result["results"]]
         assert "s_legacy_child" in sids
 
+
+class TestSameLineageHiddenDisclosure:
+    """#103184: same-lineage hits dropped by the live-context skip must be
+    disclosed in the payload instead of silently vanishing."""
+
+    def test_unended_predecessor_hits_disclosed_not_silent(self, db):
+        """A gateway predecessor whose end-write was lost (unended, same
+        lineage) is still hidden, but the payload must say so instead of
+        returning 0 results with no signal."""
+        db.create_session("s_root", source="telegram", session_key="tg:user:1")
+        db.end_session("s_root", "session_reset")
+        db.create_session(
+            "s_lost", source="telegram",
+            parent_session_id="s_root", session_key="tg:user:1",
+            model_config={"_reset_from": "s_root"},
+        )
+        db.append_message(
+            "s_lost", role="user", content="published the zephyrwidgets repo link"
+        )
+        db.create_session(
+            "s_cur", source="telegram",
+            parent_session_id="s_lost", session_key="tg:user:1",
+            model_config={"_reset_from": "s_lost"},
+        )
+        db._conn.commit()
+        result = json.loads(session_search(
+            query="zephyrwidgets", db=db, current_session_id="s_cur",
+        ))
+        assert result["success"] is True
+        assert result["count"] == 0  # still hidden: unended == treated as live
+        hidden = result["hidden_same_lineage"]
+        assert hidden["count"] >= 1
+        sessions = [s["session_id"] for s in hidden["sessions"]]
+        assert "s_lost" in sessions
+        lost = next(s for s in hidden["sessions"] if s["session_id"] == "s_lost")
+        assert lost["end_reason"] is None  # the tell-tale of the lost end-write
+
+    def test_current_session_live_rows_not_disclosed_as_hidden(self, db):
+        """The current session's own live rows are already in context —
+        skipping them is expected and must NOT light up hidden_same_lineage."""
+        db.create_session("s_root", source="telegram", session_key="tg:user:1")
+        db.end_session("s_root", "session_reset")
+        db.create_session(
+            "s_cur", source="telegram",
+            parent_session_id="s_root", session_key="tg:user:1",
+            model_config={"_reset_from": "s_root"},
+        )
+        db.append_message("s_cur", role="user", content="zephyrwidgets note to self")
+        db._conn.commit()
+        result = json.loads(session_search(
+            query="zephyrwidgets", db=db, current_session_id="s_cur",
+        ))
+        assert result["count"] == 0
+        assert "hidden_same_lineage" not in result
+
+    def test_ended_predecessor_surfaces_without_disclosure(self, db):
+        """The normal /new path (ended predecessor) keeps returning results and
+        never grows a hidden_same_lineage note."""
+        _seed_gateway_new_reset_chain(db)
+        result = json.loads(session_search(
+            query="ibuprofen", db=db, current_session_id="s_today",
+        ))
+        assert result["count"] >= 1
+        assert "hidden_same_lineage" not in result
+
+
+class TestDiscoveryMetadataFromMatchedSession:
+    """#103184: when/title must describe the matched conversation, not the
+    (possibly months older) lineage root of a long-lived gateway chain."""
+
+    def _age_the_root(self, db):
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+            (1754956800, "MCP root servers", "s_aug12"),
+        )
+        db._conn.commit()
+
+    def test_fts_hit_metadata_from_matching_session(self, db):
+        _seed_gateway_new_reset_chain(db)
+        self._age_the_root(db)
+        result = json.loads(session_search(
+            query="ibuprofen", db=db, current_session_id="s_today",
+        ))
+        hit = next(r for r in result["results"] if r["session_id"] == "s_night")
+        assert hit["title"] == "Night ibuprofen plan"
+        assert "2025" not in hit["when"]  # not the root's August-2025 started_at
+        assert hit["parent_session_id"] == "s_aug12"  # lineage still exposed
+
+    def test_title_match_metadata_from_matched_session(self, db):
+        _seed_gateway_new_reset_chain(db)
+        self._age_the_root(db)
+        result = json.loads(session_search(
+            query="Night ibuprofen plan", db=db, current_session_id="s_today",
+        ))
+        assert result["count"] >= 1
+        hit = next(r for r in result["results"] if r["session_id"] == "s_night")
+        assert hit["title"] == "Night ibuprofen plan"
+        assert "2025" not in hit["when"]

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -195,7 +195,8 @@ def _title_match_result(db, query: str, current_lineage_root: Optional[str]) -> 
     # /new-reset and compression-ended parents are not.
     if current_lineage_root and lineage_root == current_lineage_root and not _session_left_live_context(db, session_id):
         return None
-    session_meta = _quiet(lambda: db.get_session(lineage_root) or db.get_session(session_id), None,
+    # Title-hit metadata also comes from the matched session, not the lineage root (#103184).
+    session_meta = _quiet(lambda: db.get_session(session_id) or db.get_session(lineage_root), None,
                           "get_session failed for title match %s", session_id) or {}
     if session_meta.get("source") in _HIDDEN_SESSION_SOURCES:
         return None
@@ -242,7 +243,10 @@ def _hydrate_hit(db, lineage_root: str, match_info: Dict[str, Any], result_detai
     except Exception as e:
         logging.warning("get_anchored_view failed for %s/%s: %s", hit_sid, msg_id, e, exc_info=True)
         return None
-    session_meta, full = _get_session_meta(db, lineage_root), result_detail == "full"
+    # Hydrate when/title from the session that owns the hit — a long-lived gateway
+    # lineage's root can be months older than the matched conversation (#103184).
+    session_meta, full = (_get_session_meta(db, hit_sid) or _get_session_meta(db, lineage_root),
+                          result_detail == "full")
     return _discovery_entry(
         lineage_root, session_id=hit_sid,
         when=_format_timestamp(session_meta.get("started_at") or match_info.get("session_started")),
@@ -283,6 +287,10 @@ def _discover(db, query: str, role_filter: Optional[List[str]], limit: int, sort
     results = [title_result] if title_result else []
     if title_result and (title_lineage := title_result.pop("_lineage_root", None)):
         seen_sessions[title_lineage] = {"_title_only": True}
+    # Same-lineage rows dropped by the live-context skip below (#103184): counted per
+    # FTS row and deduped per session so the payload can disclose the hiding instead of
+    # returning 0 results with no signal.
+    hidden_rows, hidden_sessions = 0, {}
     # Dedupe by lineage (lineage_root -> first surviving FTS row) up to `limit`. The raw
     # owning session_id stays on the row — only it pairs validly with the FTS match id.
     # Current-lineage hits are skipped UNLESS the transcript left live context
@@ -305,6 +313,18 @@ def _discover(db, query: str, role_filter: Optional[List[str]], limit: int, sort
         is_compacted_hit = _is_compacted_message(db, r.get("id"))
         if current_lineage_root and resolved_sid == current_lineage_root and not (
                 _session_left_live_context(db, raw_sid) or is_compacted_hit):
+            # An unended same-lineage row (e.g. a gateway predecessor whose end-write was
+            # lost across a restart) is dropped here with no signal, so the agent
+            # concludes the conversation never existed (#103184). Disclose it; the
+            # current session's own live rows are not counted — they are already in
+            # context (the same-session skip below) and hiding them is expected.
+            if raw_sid != current_session_id:
+                hidden_rows += 1
+                if raw_sid not in hidden_sessions:
+                    meta = _get_session_meta(db, raw_sid)
+                    hidden_sessions[raw_sid] = {"session_id": raw_sid,
+                                                "end_reason": meta.get("end_reason"),
+                                                "last_activity": _format_timestamp(meta.get("last_activity_at"))}
             continue
         if current_session_id and raw_sid == current_session_id and not is_compacted_hit:
             continue
@@ -318,7 +338,13 @@ def _discover(db, query: str, role_filter: Optional[List[str]], limit: int, sort
             results.append(entry)
     for entry in results:
         entry["link"] = _session_link(entry["session_id"], link_profile)
-    return _discover_payload(db, query, detail, results, sessions_searched=len(seen_sessions), link_hint=(
+    return _discover_payload(db, query, detail, results, sessions_searched=len(seen_sessions),
+        **({"hidden_same_lineage": {"count": hidden_rows, "sessions": list(hidden_sessions.values()),
+            "note": f"{hidden_rows} matching message(s) in {len(hidden_sessions)} same-lineage session(s) "
+            "were hidden because they are still treated as live context (unended). This can be a gateway "
+            "session whose end-write was lost. To read one anyway, scroll it directly: "
+            "session_search(session_id=..., around_message_id=...)."}} if hidden_rows else {}),
+        link_hint=(
         "When referring the user to a session, write its `link` value "
         "verbatim inline mid-sentence (it renders as a titled link) — never "
         "as markdown, in backticks, on its own line, or next to the "


### PR DESCRIPTION
## What does this PR do?

`session_search` discovery could silently return `results: [], sessions_searched: 0` even when the FTS index had exact-phrase matches, and the entries it did return carried the **lineage root's** `when`/`title` instead of the matched conversation's. Both problems live in the discovery lineage handling of `tools/session_search_tool.py` and are fixed here:

1. **No more silent hiding.** `_discover()`'s same-lineage live-context skip dropped FTS rows with no signal whenever an owning session was unended — in practice a messaging-gateway predecessor whose end-write was lost across a restart. The drop itself is kept (an unended session may genuinely still be live context, e.g. a delegation child), but dropped rows are now counted and disclosed in the payload as `hidden_same_lineage: {count, sessions: [{session_id, end_reason, last_activity}], note}` — symmetric to the existing `index_rebuild` annotation. The note tells the agent it can scroll a listed session directly (`session_search(session_id=..., around_message_id=...)`), turning "the conversation doesn't exist" into an actionable pointer. The current session's own live rows are deliberately **not** counted: they are already in context and skipping them is expected.
2. **Metadata from the matched conversation.** `_hydrate_hit()` and `_title_match_result()` now hydrate `when`/`title`/`source`/`model` from the session that owns the matched message, falling back to the lineage root when that row is missing. In a long-lived gateway lineage (root months older than the matched child) results previously showed the root's date/title; `parent_session_id` still exposes the lineage relationship.

## Related Issue

Fixes #103184

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/session_search_tool.py` — `_discover()`: count/disclose same-lineage rows dropped by the live-context skip as `hidden_same_lineage` (current-session rows excluded); `_hydrate_hit()`: hydrate session metadata from the hit's owning session first, lineage root as fallback; `_title_match_result()`: same fallback-order swap for title hits.
- `tests/tools/test_session_search.py` — 5 regression tests: unended predecessor disclosed (with `end_reason: None` tell-tale), current-session live rows do not light up the disclosure, ended `/new` predecessor still surfaces without disclosure, and FTS/title-hit metadata comes from the matched session rather than an aged lineage root.

## How to Test

1. `pytest tests/tools/test_session_search.py -q` — Observed result: `58 passed` (53 pre-existing + 5 new).
2. `ruff check tools/session_search_tool.py tests/tools/test_session_search.py` — Observed result: `All checks passed!`.
3. New test `test_unended_predecessor_hits_disclosed_not_silent` reproduces the issue shape (root → unended gateway child with an FTS match → current session): the hit stays hidden but `hidden_same_lineage.count >= 1` and the session is listed — should pass.
4. New test `test_fts_hit_metadata_from_matching_session` ages the lineage root to August 2025 with a distinct title and asserts the September child's own `when`/`title` are used — should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure Python, no platform-specific code)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

The issue's reproduction (single Telegram DM, gateway auto-reset lineage `20260812_… → 20260903_…` with the predecessor never ended) now returns:

```json
{
  "success": true, "mode": "discover", "results": [], "count": 0,
  "hidden_same_lineage": {
    "count": 6,
    "sessions": [{"session_id": "20260903_032324_…", "end_reason": null, "last_activity": "…"}],
    "note": "6 matching message(s) in 1 same-lineage session(s) were hidden because they are still treated as live context (unended). … scroll it directly …"
  }
}
```
