### PR TITLE
Add privacy-safe Langfuse telemetry and feedback hooks

### DIFF
--- a/agent/turn_api_request.py
+++ b/agent/turn_api_request.py
@@ -9,6 +9,8 @@ the ``pre_api_request`` hook and the debug dump. Nothing here imports
 from __future__ import annotations
 
 from dataclasses import dataclass
+import hashlib
+import json
 import logging
 from typing import Any
 
@@ -57,6 +59,25 @@ def _fire_pre_api_request_hook(
                 request_messages = api_kwargs.get("input")
             if not isinstance(request_messages, list):
                 request_messages = api_messages
+            tool_schema_bytes = None
+            tool_policy_fingerprint = None
+            wire_tools = api_kwargs.get("tools")
+            enabled_tool_count = len(wire_tools) if isinstance(wire_tools, list) else None
+            if isinstance(wire_tools, list):
+                try:
+                    encoded_tools = json.dumps(
+                        wire_tools,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                        ensure_ascii=False,
+                        default=str,
+                    ).encode("utf-8")
+                    tool_schema_bytes = len(encoded_tools)
+                    tool_policy_fingerprint = "sha256:" + hashlib.sha256(encoded_tools).hexdigest()
+                except Exception:
+                    # Omit unavailable measurements rather than estimating from
+                    # the sanitized hook payload.
+                    pass
             # Shallow copies: plugins may retain the lists; deepcopy is costly.
             # ``request_messages``/``conversation_history`` are raw langfuse passthroughs.
             # Anthropic (``system``) and Responses/Codex (``instructions``) move the system
@@ -80,6 +101,9 @@ def _fire_pre_api_request_hook(
                 system_prompt=_system_prompt_for_hooks(api_kwargs, request_messages),
                 message_count=len(api_messages),
                 tool_count=len(agent.tools or []),
+                enabled_tool_count=enabled_tool_count,
+                tool_schema_bytes=tool_schema_bytes,
+                tool_policy_fingerprint=tool_policy_fingerprint,
                 approx_input_tokens=approx_tokens,
                 request_char_count=total_chars,
                 max_tokens=agent.max_tokens,

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -535,6 +535,7 @@ def finalize_turn(
 
     result = {
         "final_response": final_response,
+        "turn_id": turn_id,
         "last_reasoning": _last_turn_reasoning(messages),
         "messages": messages,
         "api_calls": api_call_count,

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -230,6 +230,70 @@ are intentionally excluded.
 Observers can use these hooks to model nested trajectories while keeping child
 agent execution linked to the parent turn that spawned it.
 
+### Gateway delivery and Discord feedback
+
+Gateway adapters expose two backend-neutral observer boundaries. The runner is
+the security boundary: it performs central actor authorization. For Discord
+feedback it additionally validates the reaction envelope and constructs a new
+subscriber payload rather than forwarding adapter data verbatim. Other
+platforms retain their existing normalized `gateway_platform_event` contracts.
+
+| Hook | When it fires |
+| --- | --- |
+| `gateway_outbound_response` | Once for every successfully delivered response message ID (including every Discord split chunk) correlated to its originating turn/trace. |
+| `gateway_platform_event` | For an authorized Discord reaction added to or removed from a message verified as bot-authored. No edit, delete, thread-create, or thread-update events are registered or published. |
+
+Discord actor/chat/thread/message IDs are never sent raw to subscriber hooks.
+Set the dedicated profile-scoped secret
+`HERMES_GATEWAY_HOOK_PSEUDONYM_KEY` (at least 16 UTF-8 bytes, normally in the
+profile `.env` or process environment). Each ID is replaced by a deterministic,
+field-separated `hmac-sha256:<hex>` value. The same key must be available when
+outbound and reaction hooks run for their message pseudonyms to correlate. If
+the key is absent, too short, or unavailable in the active profile scope, all
+platform ID fields are omitted. The outbound `trace_id` and `turn_id` remain so
+trace correlation fails closed without losing non-platform operational metadata.
+
+The exact `gateway_outbound_response` subscriber kwargs are:
+
+```text
+platform: str
+target_chat_id: str              # optional HMAC pseudonym
+target_thread_id: str            # optional HMAC pseudonym
+target_message_id: str           # optional HMAC pseudonym
+turn_id: str
+trace_id: str
+observation_id: str              # optional
+timestamp: timezone-aware ISO 8601 str
+```
+
+The exact Discord reaction `gateway_platform_event` subscriber kwargs are:
+
+```text
+platform: "discord"
+event_type: "reaction"
+payload:
+  target_chat_id: str            # optional HMAC pseudonym
+  target_thread_id: str          # optional HMAC pseudonym
+  target_message_id: str         # optional HMAC pseudonym
+  actor_id: str                  # optional HMAC pseudonym
+  emoji: str
+  action: "add" | "remove"
+  timestamp: timezone-aware ISO 8601 str
+  bot_authored_target: true
+```
+
+The envelopes contain no message text, display names, raw platform objects, or
+raw Discord IDs and assign no sentiment to emoji. Hermes drops malformed events,
+bot actors, unauthorized actors, and reactions whose target was not verified as
+a message authored by the connected bot. Hook failures are best-effort and
+cannot fail message delivery or the Discord event loop. Consumers must treat
+duplicate notifications as harmless.
+
+These hooks are correlation and notification primitives only. Platform
+adapters do not write scores or credentials to an observability backend;
+deployments that convert feedback into scores should use a separate,
+least-privilege consumer.
+
 ## Payload Safety
 
 Observer payloads are designed for telemetry consumers, not raw object access.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1529,6 +1529,7 @@ class MessageEvent:
     # May this event resolve gateway commands / control prompts? Proactive plugin events set False
     # so untrusted payload text stays conversational. Kept last for positional compat.
     allow_gateway_control: bool = True
+    _hermes_turn_correlation: Optional[Dict[str, str]] = None
 
     def is_command(self) -> bool:
         """Check if this is a command message (e.g., /new, /reset)."""
@@ -1620,6 +1621,22 @@ class SendResult:
     # SEND_ERROR_KINDS member (failures only) via :func:`classify_send_error`, so consumers
     # branch without substring-matching ``error``.
     error_kind: Optional[str] = None
+
+
+def _delivery_message_ids(result: Any) -> List[str]:
+    """Return every successfully delivered message ID, in send order."""
+    if result is None or not getattr(result, "success", False):
+        return []
+    candidates: List[Any] = [getattr(result, "message_id", None)]
+    continuation_ids = getattr(result, "continuation_message_ids", None)
+    if isinstance(continuation_ids, (list, tuple)):
+        candidates.extend(continuation_ids)
+    raw_response = getattr(result, "raw_response", None)
+    if isinstance(raw_response, dict):
+        split_ids = raw_response.get("message_ids")
+        if isinstance(split_ids, (list, tuple)):
+            candidates.extend(split_ids)
+    return list(dict.fromkeys(str(item) for item in candidates if item))
 
 
 # Platform-neutral send-failure kinds for ``SendResult.error_kind``: too_long (size cap),
@@ -1863,6 +1880,7 @@ class BasePlatformAdapter(ABC):
         self._reaction_handler: Optional[Callable[[Dict[str, Any]], Awaitable[None]]] = None
         # Runner-owned boundary for normalized events: auth/profile state never lives in an adapter.
         self._platform_event_handler: Optional[Callable[[Dict[str, Any], Any], Awaitable[None]]] = None
+        self._outbound_response_handler: Optional[Callable[[Dict[str, Any], Any], Any]] = None
         # Rewrites ``event.source.thread_id`` before session keying (Telegram DM topics).
         self._topic_recovery_fn: Optional[Callable[[Any], Optional[str]]] = None
         self._running, self._fatal_error_retryable = False, True
@@ -2212,6 +2230,40 @@ class BasePlatformAdapter(ABC):
         ``SessionSource``); the runner owns authorization and plugin dispatch: no callback = fail
         closed."""
         self._platform_event_handler = handler
+
+    def set_outbound_response_handler(
+        self, handler: Optional[Callable[[Dict[str, Any], Any], Any]],
+    ) -> None:
+        """Install the post-success, content-free outbound observer boundary."""
+        self._outbound_response_handler = handler
+
+    async def _fire_outbound_response(self, event: MessageEvent, message_ids: List[str]) -> None:
+        handler = getattr(self, "_outbound_response_handler", None)
+        correlation = event._hermes_turn_correlation
+        if not callable(handler) or not isinstance(correlation, dict):
+            return
+        trace_id = str(correlation.get("trace_id") or "")
+        turn_id = str(correlation.get("turn_id") or "")
+        if not trace_id or not turn_id:
+            return
+        for message_id in dict.fromkeys(str(item) for item in message_ids if item):
+            envelope = {
+                "platform": str(getattr(event.source.platform, "value", event.source.platform)),
+                "target_chat_id": str(event.source.chat_id),
+                "target_thread_id": str(event.source.thread_id) if event.source.thread_id else None,
+                "target_message_id": message_id,
+                "turn_id": turn_id,
+                "trace_id": trace_id,
+                "timestamp": datetime.now().astimezone().isoformat(),
+            }
+            if correlation.get("observation_id"):
+                envelope["observation_id"] = str(correlation["observation_id"])
+            try:
+                result = handler(envelope, event.source)
+                if inspect.isawaitable(result):
+                    await result
+            except Exception:
+                logger.debug("outbound response hook failed", exc_info=True)
 
     def set_topic_recovery_fn(self, fn: Optional[Callable[[Any], Optional[str]]]) -> None:
         """Install a thread_id-recovery hook (Telegram DM topic mode): called with ``event.source``
@@ -3875,12 +3927,14 @@ class BasePlatformAdapter(ABC):
     async def _process_message_background(self, event: MessageEvent, session_key: str) -> None:
         """Background task that actually processes the message."""
         delivery_attempted = delivery_succeeded = False  # feeds the processing-complete hook
+        delivered_message_ids: List[str] = []
 
         def _record_delivery(result):
             nonlocal delivery_attempted, delivery_succeeded
             if result is not None:
                 delivery_attempted = True
                 delivery_succeeded = delivery_succeeded or bool(getattr(result, "success", False))
+                delivered_message_ids.extend(_delivery_message_ids(result))
         # Reuse the interrupt event handle_message() installed; new Event only if removed externally.
         interrupt_event = self._active_sessions.get(session_key) or asyncio.Event()
         self._active_sessions[session_key] = interrupt_event
@@ -3889,6 +3943,15 @@ class BasePlatformAdapter(ABC):
         try:
             await self._run_processing_hook("on_processing_start", event)
             response = await self._message_handler(event)
+            streamed_ids = getattr(event, "_hermes_streamed_message_ids", None)
+            if isinstance(streamed_ids, (list, tuple)):
+                normalized_streamed_ids = [
+                    str(message_id) for message_id in streamed_ids
+                    if message_id and str(message_id) != "__no_edit__"
+                ]
+                if normalized_streamed_ids:
+                    delivery_attempted = delivery_succeeded = True
+                    delivered_message_ids.extend(normalized_streamed_ids)
             is_ephemeral_response = isinstance(response, EphemeralReply)
             # Unwrap EphemeralReply for downstream text processing; TTL applies after send.
             response, _ephemeral_ttl = self._unwrap_ephemeral(response)
@@ -3937,6 +4000,8 @@ class BasePlatformAdapter(ABC):
             await self._run_processing_hook(
                 "on_processing_complete", event,
                 ProcessingOutcome.SUCCESS if processing_ok else ProcessingOutcome.FAILURE)
+            if delivery_succeeded:
+                await self._fire_outbound_response(event, delivered_message_ids)
             # Force-flush an unfired debounce timer so this task hands off to a fresh drain task.
             # Clear the Event BEFORE the stop-typing await so concurrent inbound sees a live guard.
             await self._flush_text_debounce_now(session_key)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12,6 +12,8 @@ except ModuleNotFoundError:
 import asyncio
 import concurrent.futures
 import dataclasses
+import hashlib
+import hmac
 import json
 import logging
 import os
@@ -63,6 +65,26 @@ _STALL_NOTIFY_SEND_TIMEOUT_SECONDS = 15.0
 _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS = 16 * 1024 * 1024
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 _GATEWAY_HYGIENE_PLATFORM = "gateway_hygiene"
+_GATEWAY_HOOK_PSEUDONYM_ENV = "HERMES_GATEWAY_HOOK_PSEUDONYM_KEY"
+_GATEWAY_HOOK_PSEUDONYM_MIN_BYTES = 16
+
+
+def _gateway_hook_pseudonym_key() -> Optional[bytes]:
+    """Resolve the profile-scoped hook pseudonym key, failing closed."""
+    try:
+        from agent.secret_scope import get_secret
+        value = get_secret(_GATEWAY_HOOK_PSEUDONYM_ENV)
+    except Exception:
+        return None
+    if not isinstance(value, str):
+        return None
+    encoded = value.encode("utf-8")
+    return encoded if len(encoded) >= _GATEWAY_HOOK_PSEUDONYM_MIN_BYTES else None
+
+
+def _pseudonymize_gateway_id(kind: str, value: str, key: bytes) -> str:
+    digest = hmac.new(key, f"{kind}:{value}".encode("utf-8"), hashlib.sha256)
+    return f"hmac-sha256:{digest.hexdigest()}"
 
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not gateway chats

--- a/gateway/run_adapters.py
+++ b/gateway/run_adapters.py
@@ -1048,6 +1048,9 @@ class GatewayAdapterLifecycleMixin:
             authorization_check or self._make_adapter_auth_check(adapter.platform)
         )
         adapter.set_platform_event_handler(platform_event_handler or self._primary_platform_event_handler())
+        _set_outbound = getattr(adapter, "set_outbound_response_handler", None)
+        if callable(_set_outbound):
+            _set_outbound(self._handle_gateway_outbound_response)
         adapter._busy_text_mode = (self._busy_text_mode if busy_text_mode is None else busy_text_mode)
 
     def _configure_profile_adapter(
@@ -1353,13 +1356,119 @@ class GatewayAdapterLifecycleMixin:
     def _multiplex_on(self) -> bool:
         return bool(getattr(self.config, "multiplex_profiles", False))
 
+    def _handle_gateway_outbound_response(self, event: Dict[str, Any], source: SessionSource) -> None:
+        """Dispatch one authorized post-success correlation envelope."""
+        with _log_suppressed(logging.DEBUG, "[Gateway] outbound response hook failed", exc_info=True):
+            if not self._is_user_authorized_for_source(source, allow_adapter_delegation=False):
+                return
+            required = (
+                "platform", "target_chat_id", "target_message_id", "turn_id", "trace_id", "timestamp",
+            )
+            if not isinstance(event, dict) or "target_thread_id" not in event or any(
+                key not in event for key in required
+            ):
+                return
+
+            def _bounded(value: Any) -> Optional[str]:
+                if not isinstance(value, str) or not 0 < len(value) <= 256:
+                    return None
+                return None if any(ord(char) < 32 or ord(char) == 127 for char in value) else value
+
+            source_platform = str(getattr(source.platform, "value", source.platform))
+            if _bounded(event["platform"]) != source_platform:
+                return
+            if any(_bounded(event[key]) is None for key in (
+                "target_chat_id", "target_message_id", "turn_id", "trace_id",
+            )):
+                return
+            observation_id = event.get("observation_id")
+            if observation_id is not None and _bounded(observation_id) is None:
+                return
+            timestamp = event["timestamp"]
+            if not isinstance(timestamp, str) or len(timestamp) > 64:
+                return
+            parsed_timestamp = datetime.fromisoformat(timestamp)
+            if parsed_timestamp.tzinfo is None:
+                return
+            if event["target_chat_id"] != str(source.chat_id):
+                return
+            expected_thread_id = str(source.thread_id) if source.thread_id else None
+            if event["target_thread_id"] != expected_thread_id:
+                return
+            payload = {
+                "platform": event["platform"], "turn_id": event["turn_id"],
+                "trace_id": event["trace_id"], "timestamp": event["timestamp"],
+            }
+            if observation_id is not None:
+                payload["observation_id"] = observation_id
+            from gateway.run import _gateway_hook_pseudonym_key, _pseudonymize_gateway_id
+            pseudonym_key = _gateway_hook_pseudonym_key()
+            if pseudonym_key is not None:
+                payload["target_chat_id"] = _pseudonymize_gateway_id("chat", event["target_chat_id"], pseudonym_key)
+                payload["target_message_id"] = _pseudonymize_gateway_id(
+                    "message", event["target_message_id"], pseudonym_key
+                )
+                if event["target_thread_id"] is not None:
+                    payload["target_thread_id"] = _pseudonymize_gateway_id(
+                        "thread", event["target_thread_id"], pseudonym_key
+                    )
+            from hermes_cli import lifecycle
+            lifecycle.invoke_hook("gateway_outbound_response", **payload)
+
     async def _handle_gateway_platform_event(self, event: dict, source) -> None:
-        """Authorize and publish one normalized adapter event to plugin hooks."""
+        """Authorize and publish normalized events; Discord exposes reactions only."""
         # Observer failures must never break the adapter's update loop.
         with _log_suppressed(logging.DEBUG, "gateway_platform_event hook dispatch failed", exc_info=True):
             from hermes_cli.lifecycle import has_hook, invoke_hook
-            if has_hook("gateway_platform_event") and self._is_user_authorized_for_source(source):
+            if not has_hook("gateway_platform_event") or not self._is_user_authorized_for_source(source):
+                return
+            if not isinstance(event, dict):
+                return
+            if event.get("platform") != "discord":
                 invoke_hook("gateway_platform_event", **event)
+                return
+            if event.get("event_type") != "reaction" or not isinstance(event.get("payload"), dict):
+                return
+            raw_payload = event["payload"]
+
+            def _bounded(value: Any, *, maximum: int = 256) -> Optional[str]:
+                if not isinstance(value, str) or not 0 < len(value) <= maximum:
+                    return None
+                return None if any(ord(char) < 32 or ord(char) == 127 for char in value) else value
+
+            target_chat_id = _bounded(raw_payload.get("target_chat_id"))
+            target_message_id = _bounded(raw_payload.get("target_message_id"))
+            actor_id = _bounded(raw_payload.get("actor_id"))
+            target_thread_id = raw_payload.get("target_thread_id")
+            if target_thread_id is not None:
+                target_thread_id = _bounded(target_thread_id)
+            emoji = _bounded(raw_payload.get("emoji"), maximum=128)
+            action = raw_payload.get("action")
+            timestamp = raw_payload.get("timestamp")
+            if (
+                target_chat_id is None or target_message_id is None or actor_id is None or emoji is None
+                or action not in {"add", "remove"} or raw_payload.get("bot_authored_target") is not True
+                or not isinstance(timestamp, str) or len(timestamp) > 64
+            ):
+                return
+            parsed_timestamp = datetime.fromisoformat(timestamp)
+            if parsed_timestamp.tzinfo is None or target_chat_id != str(source.chat_id):
+                return
+            expected_thread_id = str(source.thread_id) if source.thread_id else None
+            if target_thread_id != expected_thread_id or actor_id != str(source.user_id):
+                return
+            payload: Dict[str, Any] = {
+                "emoji": emoji, "action": action, "timestamp": timestamp, "bot_authored_target": True,
+            }
+            from gateway.run import _gateway_hook_pseudonym_key, _pseudonymize_gateway_id
+            pseudonym_key = _gateway_hook_pseudonym_key()
+            if pseudonym_key is not None:
+                payload["target_chat_id"] = _pseudonymize_gateway_id("chat", target_chat_id, pseudonym_key)
+                payload["target_message_id"] = _pseudonymize_gateway_id("message", target_message_id, pseudonym_key)
+                payload["actor_id"] = _pseudonymize_gateway_id("actor", actor_id, pseudonym_key)
+                if target_thread_id is not None:
+                    payload["target_thread_id"] = _pseudonymize_gateway_id("thread", target_thread_id, pseudonym_key)
+            invoke_hook("gateway_platform_event", platform="discord", event_type="reaction", payload=payload)
 
     def _make_profile_platform_event_handler(self, profile_name: str):
         """Bind platform-event auth and hook dispatch to one multiplex profile."""

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1340,7 +1340,7 @@ class GatewayTurnMixin:
                 await _typing_adapter.stop_typing(source.chat_id)
 
     async def _hmwa_shape_agent_response(
-        self, agent_result, source, history, session_entry, session_key,
+        self, event, agent_result, source, history, session_entry, session_key,
         _quick_key, run_generation, _run_start_session_id, _platform_name, _msg_start_time,
     ):
         """Turn the raw agent result into the outbound text: sentinel/silence handling, response
@@ -1351,6 +1351,13 @@ class GatewayTurnMixin:
             _is_gateway_hidden_reasoning_incomplete_turn, _normalize_empty_agent_response,
             _sanitize_gateway_final_response, _should_clear_resume_pending_after_turn,
         )
+        turn_id = str(agent_result.get("turn_id") or "")
+        if turn_id:
+            try:
+                from hermes_cli.lifecycle import take_turn_correlation
+                event._hermes_turn_correlation = take_turn_correlation(turn_id)
+            except Exception:
+                logger.debug("turn correlation lookup failed", exc_info=True)
         response = agent_result.get("final_response") or ""
         # Hidden-reasoning-only retry exhaustion: the loop's sentinel text doubles as final_response
         # and would be delivered verbatim (peer agents would ingest it as a completed turn).
@@ -1729,6 +1736,12 @@ class GatewayTurnMixin:
         # Streamed responses still need MEDIA: files delivered (chunks carry the tags verbatim). Never
         # skip when the agent failed: the error text is new content streaming didn't show.
         if agent_result.get("already_sent") and not agent_result.get("failed"):
+            streamed_message_ids = agent_result.get("delivered_message_ids")
+            if isinstance(streamed_message_ids, (list, tuple)):
+                event._hermes_streamed_message_ids = [
+                    str(message_id) for message_id in streamed_message_ids
+                    if message_id and str(message_id) != "__no_edit__"
+                ]
             if response and adapter:
                 await self._deliver_media_from_response(response, event, adapter)
             # Streaming delivered the body, but the footer was held back (`not already_sent` gate).
@@ -1974,7 +1987,7 @@ class GatewayTurnMixin:
                 return None
 
             response, _intentional_silence, agent_messages = await self._hmwa_shape_agent_response(
-                agent_result, source, history, session_entry, session_key,
+                event, agent_result, source, history, session_entry, session_key,
                 _quick_key, run_generation, _run_start_session_id, _platform_name, _msg_start_time,
             )
             response = self._hmwa_prepend_reasoning(agent_result, response, source, _intentional_silence)
@@ -3557,6 +3570,8 @@ class GatewayTurnMixin:
             logger.warning(fail_result, _sk, getattr(_res, "error", None))
             return
         response["already_sent"] = True
+        if _sc.message_id and _sc.message_id != "__no_edit__":
+            response["delivered_message_ids"] = [str(_sc.message_id)]
         logger.info(*ok)
 
     async def _run_agent_mark_streamed_delivery(self, response: Any, turn_ctx: TurnContext) -> None:
@@ -3847,4 +3862,10 @@ class GatewayTurnMixin:
 
         await self._run_agent_mark_streamed_delivery(response, turn_ctx)
         self._run_agent_schedule_bubble_cleanup(response, _cleanup_adapter, turn_ctx)
+        _sc = turn_ctx.stream_consumer_holder[0]
+        if (
+            isinstance(response, dict) and response.get("already_sent")
+            and _sc is not None and _sc.message_id and _sc.message_id != "__no_edit__"
+        ):
+            response["delivered_message_ids"] = [str(_sc.message_id)]
         return response

--- a/hermes_cli/lifecycle.py
+++ b/hermes_cli/lifecycle.py
@@ -3,9 +3,76 @@
 from __future__ import annotations
 
 import logging
+import threading
+import time
+from collections import OrderedDict
 from typing import Any, List
 
 logger = logging.getLogger(__name__)
+
+MAX_TURN_CORRELATIONS = 2048
+_TURN_CORRELATION_TTL_S = 3600.0
+_TURN_CORRELATION_LOCK = threading.Lock()
+_TURN_CORRELATIONS: OrderedDict[str, tuple[float, dict[str, str]]] = OrderedDict()
+
+
+def _bounded_correlation_id(value: Any) -> str | None:
+    """Accept opaque identifiers only; never retain arbitrary content blobs."""
+    if not isinstance(value, str) or not 0 < len(value) <= 256:
+        return None
+    if any(ord(char) < 32 or ord(char) == 127 for char in value):
+        return None
+    return value
+
+
+def publish_turn_correlation(
+    *, turn_id: str, trace_id: str, observation_id: str | None = None, **kwargs: Any
+) -> bool:
+    """Publish a bounded, content-free turn correlation envelope."""
+    bounded_turn_id = _bounded_correlation_id(turn_id)
+    bounded_trace_id = _bounded_correlation_id(trace_id)
+    bounded_observation_id = (
+        _bounded_correlation_id(observation_id) if observation_id is not None else None
+    )
+    if (
+        kwargs
+        or bounded_turn_id is None
+        or bounded_trace_id is None
+        or (observation_id is not None and bounded_observation_id is None)
+    ):
+        return False
+    envelope = {"turn_id": bounded_turn_id, "trace_id": bounded_trace_id}
+    if bounded_observation_id:
+        envelope["observation_id"] = bounded_observation_id
+    now = time.monotonic()
+    with _TURN_CORRELATION_LOCK:
+        _TURN_CORRELATIONS[bounded_turn_id] = (now, envelope)
+        _TURN_CORRELATIONS.move_to_end(bounded_turn_id)
+        cutoff = now - _TURN_CORRELATION_TTL_S
+        while _TURN_CORRELATIONS:
+            first_key, (created_at, _) = next(iter(_TURN_CORRELATIONS.items()))
+            if len(_TURN_CORRELATIONS) <= MAX_TURN_CORRELATIONS and created_at >= cutoff:
+                break
+            _TURN_CORRELATIONS.pop(first_key, None)
+    return True
+
+
+def take_turn_correlation(turn_id: str) -> dict[str, str] | None:
+    """Consume one correlation envelope after the originating turn returns."""
+    bounded_turn_id = _bounded_correlation_id(turn_id)
+    if bounded_turn_id is None:
+        return None
+    with _TURN_CORRELATION_LOCK:
+        item = _TURN_CORRELATIONS.pop(bounded_turn_id, None)
+    if item is None or item[0] < time.monotonic() - _TURN_CORRELATION_TTL_S:
+        return None
+    return dict(item[1])
+
+
+def clear_turn_correlations() -> None:
+    """Clear transient state (primarily for process teardown and tests)."""
+    with _TURN_CORRELATION_LOCK:
+        _TURN_CORRELATIONS.clear()
 
 
 def _observe(hook_name: str, **kwargs: Any) -> None:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -177,6 +177,10 @@ VALID_HOOKS: Set[str] = {
     # hooks.md). Other event types and hook names land here only together with real fire-sites and payload
     # contracts; no inert VALID_HOOKS surface is registered ahead of implementation.
     "gateway_platform_event",
+    # Post-delivery, content-free correlation envelope for successfully sent
+    # gateway responses. Carries only pseudonymized target IDs and turn/trace
+    # identifiers; observer-only and isolated by invoke_hook.
+    "gateway_outbound_response",
     # pre_command: BEFORE a recognized slash command's handler on CLI and gateway canonical dispatch;
     # returns IGNORED in v1. Deliberately NOT fired for the gateway's running-agent intercept path
     # (/stop, /approve, busy_policy) — a slow/hostile plugin must not touch the operator's escape

--- a/plugins/observability/langfuse/README.md
+++ b/plugins/observability/langfuse/README.md
@@ -45,7 +45,9 @@ child span to inspect `role: system` (truncated via `HERMES_LANGFUSE_MAX_CHARS`)
 ```bash
 HERMES_LANGFUSE_ENV=production       # environment tag
 HERMES_LANGFUSE_RELEASE=v1.0.0       # release tag
-HERMES_LANGFUSE_SAMPLE_RATE=0.5      # sample 50% of traces
+HERMES_LANGFUSE_SAMPLE_RATE=0.5      # capture content for 50% of turns
+HERMES_LANGFUSE_PSEUDONYM_KEY=...    # dedicated HMAC key for exported IDs
+HERMES_LANGFUSE_PSEUDONYM_KEY_VERSION=v1  # rotation/version label
 HERMES_LANGFUSE_MAX_CHARS=12000      # max chars per field (default: 12000)
 HERMES_LANGFUSE_CAPTURE=sanitized    # content capture mode (see below)
 HERMES_LANGFUSE_DEBUG=true           # verbose plugin logging
@@ -61,12 +63,56 @@ names, token usage, cost, timing — is always captured in every mode.
 |------|----------|
 | `metadata` | No content. Each content field is replaced by a shape/size stub (`{"omitted": true, "type": "text", "chars": N}`). |
 | `sanitized` | **(default)** Content is exported after secret-pattern redaction (API keys, tokens, JWTs, private keys, `password=`-style assignments) and truncation. Redaction runs *before* truncation. |
-| `full` | Raw content, truncated only. Explicit opt-in — traces will contain whatever passed through the conversation, including injected memory and file contents. |
+| `full` | Content without the plugin's pattern sanitization, truncated and still subject to the mandatory SDK export mask. Explicit opt-in. |
 
 The active mode is recorded on every trace as `metadata.capture_mode`.
+Sampling applies only to content. Every turn can still export operational
+metadata, including failures, token/cost usage, counts, statuses, and retry
+outcomes, when its content is not sampled. A non-sampled turn is an absolute
+content boundary: prompts, responses, tool arguments/results, merged tool-call
+records, MoA advisor outputs, subagent goals/summaries, and subagent tool
+history payloads are replaced by content-free shape/size stubs. This keeps
+failure and feedback correlation visible without forcing content capture.
 
 Note: `sanitized` is pattern-based defense in depth, not a DLP guarantee.
 For personal sessions or shared Langfuse projects, prefer `metadata`.
+
+## Telemetry contract and privacy
+
+Root traces carry `telemetry_schema_version = "hermes.telemetry.v1"` plus the
+Hermes release when available. The v1 metadata contract includes stable
+configuration, prompt, and tool-policy fingerprints; enabled-tool count and
+serialized tool-schema bytes when tools are present; exact context character
+counts; provider-reported token-source buckets; and route/retry/fallback/quota
+outcomes when their lifecycle payloads provide those values. Missing values
+are omitted rather than estimated.
+
+Session/task/turn/request and platform-native identifiers are never exported raw. Set a
+dedicated `HERMES_LANGFUSE_PSEUDONYM_KEY` of at least 16 UTF-8 bytes to export
+keyed, domain-separated HMAC pseudonyms, and set
+`HERMES_LANGFUSE_PSEUDONYM_KEY_VERSION` to a rotation label understood by your
+downstream consumers. When the key is absent or too short, these identifier
+fields are omitted; Hermes does not fall back to unsalted hashes.
+The key itself is never attached to trace metadata.
+
+All capture modes use the strongest masking boundary supported by the installed
+Langfuse SDK. Newer SDKs use the OpenTelemetry export-stage
+`mask_otel_spans` callback, which masks final span attributes including those
+from third-party instrumentation. If masking fails, the callback returns the
+SDK's explicit `drop=True` result instead of exporting the original content.
+SDKs without that API use their supported synchronous `mask` callback; failures
+there return a fixed redacted sentinel rather than the original value.
+Observability failures remain non-blocking for agent serving.
+
+### Trace-ID migration
+
+Trace IDs created by this version include immutable `turn_id` identity even
+when `task_id` is present. Consecutive turns in one gateway session therefore
+appear as separate backend traces. Historical traces created by older Hermes
+versions may already contain multiple turns merged under one trace ID; this
+change does not split or rewrite those records. Dashboards and exports that
+assumed one trace per session/task must use `session_id` grouping (when keyed
+pseudonyms are enabled) and treat the deployment boundary as a migration cut.
 
 ## Error + shutdown coverage
 

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -10,10 +10,14 @@ from __future__ import annotations
 
 import atexit
 import contextlib
+import hashlib
+import hmac
+import importlib.metadata
 import json
 import logging
 import os
 import re
+import secrets
 import threading
 import time
 from dataclasses import dataclass, field
@@ -27,12 +31,19 @@ except Exception:  # pragma: no cover - fail-open when optional dep is missing
     Langfuse = None
     propagate_attributes = None
 
+try:
+    from langfuse.types import MaskOtelSpansResult, OtelSpanPatch
+except Exception:  # pragma: no cover - legacy SDK compatibility
+    MaskOtelSpansResult = None
+    OtelSpanPatch = None
+
 
 @dataclass
 class TraceState:
     trace_id: str
     root_ctx: Any
     root_span: Any
+    content_sampled: bool = True
     generations: Dict[str, Any] = field(default_factory=dict)
     tools: Dict[str, Any] = field(default_factory=dict)
     pending_tools_by_name: Dict[str, list] = field(default_factory=dict)
@@ -120,14 +131,333 @@ def _capture_mode() -> str:
     return _DEFAULT_CAPTURE_MODE
 
 
+_TELEMETRY_SCHEMA_VERSION = "hermes.telemetry.v1"
+_MASK_VERSION = "hermes-mask.v1"
+_SAMPLE_POLICY_VERSION = "hermes-content-sample.v1"
+_EMAIL_RE = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE)
+_PHONE_RE = re.compile(r"(?<!\w)(?:\+?\d[\d .()\-]{7,}\d)(?!\w)")
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=str,
+    )
+
+
+def _fingerprint(value: Any) -> str:
+    digest = hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _hermes_release() -> Optional[str]:
+    configured = _env("HERMES_LANGFUSE_RELEASE") or _env("LANGFUSE_RELEASE")
+    if configured:
+        return configured
+    try:
+        return importlib.metadata.version("hermes-agent")
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _pseudonymize_identifier(kind: str, value: Any) -> Optional[str]:
+    """Return a keyed, domain-separated identifier or omit it fail-closed."""
+    if value is None or value == "":
+        return None
+    key = _env("HERMES_LANGFUSE_PSEUDONYM_KEY")
+    if not key or len(key.encode("utf-8")) < 16:
+        return None
+    digest = hmac.new(
+        key.encode("utf-8"),
+        f"{kind}:{value}".encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return f"hmac-sha256:{digest}"
+
+
+def _text_chars(value: Any) -> int:
+    """Count actual text characters without estimating tokens or media bytes."""
+    if isinstance(value, str):
+        return len(value)
+    if isinstance(value, dict):
+        return sum(_text_chars(item) for item in value.values())
+    if isinstance(value, (list, tuple)):
+        return sum(_text_chars(item) for item in value)
+    return 0
+
+
+def _message_content_chars(messages: Any) -> int:
+    """Count message payload text without counting structural keys/roles."""
+    if not isinstance(messages, list):
+        return _text_chars(messages)
+    total = 0
+    for message in messages:
+        if isinstance(message, dict):
+            total += _text_chars(message.get("content"))
+        else:
+            total += _text_chars(getattr(message, "content", None))
+    return total
+
+
+def _telemetry_metadata(
+    *,
+    task_id: str,
+    session_id: str,
+    provider: str,
+    model: str,
+    api_mode: str,
+    messages: Any,
+    system_prompt: Any,
+    request: Any,
+    enabled_tool_count: Any = None,
+    tool_schema_bytes: Any = None,
+    tool_policy_fingerprint: Any = None,
+) -> Dict[str, Any]:
+    """Build the stable, content-free Hermes telemetry v1 root contract."""
+    metadata: Dict[str, Any] = {
+        "source": "hermes",
+        "telemetry_schema_version": _TELEMETRY_SCHEMA_VERSION,
+        "capture_mode": _capture_mode(),
+        "mask_version": _MASK_VERSION,
+        "sample_policy_version": _SAMPLE_POLICY_VERSION,
+        "config_fingerprint": _fingerprint(
+            {"provider": provider, "model": model, "api_mode": api_mode}
+        ),
+    }
+    release = _hermes_release()
+    if release:
+        metadata["hermes_release"] = release
+
+    pseudonym_key_version = _env("HERMES_LANGFUSE_PSEUDONYM_KEY_VERSION", "v1")
+    pseudonymous_session = _pseudonymize_identifier("session", session_id)
+    pseudonymous_task = _pseudonymize_identifier("task", task_id)
+    if pseudonymous_session or pseudonymous_task:
+        metadata["pseudonym_key_version"] = pseudonym_key_version
+    if pseudonymous_session:
+        metadata["session_id"] = pseudonymous_session
+    if pseudonymous_task:
+        metadata["task_id"] = pseudonymous_task
+
+    if system_prompt is not None:
+        metadata["prompt_fingerprint"] = _fingerprint(system_prompt)
+
+    if isinstance(enabled_tool_count, int) and not isinstance(enabled_tool_count, bool):
+        metadata["enabled_tool_count"] = max(0, enabled_tool_count)
+    if isinstance(tool_schema_bytes, int) and not isinstance(tool_schema_bytes, bool):
+        metadata["tool_schema_bytes"] = max(0, tool_schema_bytes)
+    if isinstance(tool_policy_fingerprint, str) and re.fullmatch(
+        r"sha256:[0-9a-f]{64}", tool_policy_fingerprint
+    ):
+        metadata["tool_policy_fingerprint"] = tool_policy_fingerprint
+
+    context_chars: Dict[str, int] = {}
+    if system_prompt is not None:
+        context_chars["system_prompt"] = _text_chars(system_prompt)
+    if messages is not None:
+        context_chars["conversation"] = _message_content_chars(messages)
+    if context_chars:
+        metadata["context_source_chars"] = context_chars
+    return metadata
+
+
+def _content_sample_rate() -> float:
+    raw = (
+        _env("HERMES_LANGFUSE_CONTENT_SAMPLE_RATE")
+        or _env("HERMES_LANGFUSE_SAMPLE_RATE")
+        or "1.0"
+    )
+    try:
+        rate = float(raw)
+    except ValueError:
+        logger.warning("Invalid Langfuse content sample rate %r; using 0.0", raw)
+        return 0.0
+    if not 0.0 <= rate <= 1.0:
+        logger.warning(
+            "Langfuse content sample rate outside 0..1: %r; using 0.0", raw
+        )
+        return 0.0
+    return rate
+
+
+def _content_is_sampled(trace_id: str, rate: Optional[float] = None) -> bool:
+    if _capture_mode() == "metadata":
+        return False
+    probability = _content_sample_rate() if rate is None else rate
+    if probability <= 0:
+        return False
+    if probability >= 1:
+        return True
+    sample = int(hashlib.sha256(trace_id.encode("utf-8")).hexdigest()[:16], 16)
+    return sample / float(0xFFFFFFFFFFFFFFFF) < probability
+
+
+def _mask_text(value: str) -> str:
+    from agent.redact import redact_sensitive_text
+
+    masked = redact_sensitive_text(value, force=True)
+    masked = _EMAIL_RE.sub("[EMAIL_REDACTED]", masked)
+    return _PHONE_RE.sub("[PHONE_REDACTED]", masked)
+
+
+def _mask_export_value(value: Any) -> Any:
+    """Recursively mask an export attribute; exceptions intentionally escape."""
+    if isinstance(value, str):
+        return _mask_text(value)
+    if isinstance(value, dict):
+        return {key: _mask_export_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_mask_export_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_mask_export_value(item) for item in value)
+    return value
+
+
+def _mask_otel_spans(*, params: Any) -> Any:
+    """Langfuse export-stage mask; masking failure drops the whole batch."""
+    if MaskOtelSpansResult is None:
+        raise RuntimeError("Langfuse MaskOtelSpansResult type unavailable")
+    try:
+        patches = {}
+        for identifier, span in params.spans.items():
+            replacements: Dict[str, Any] = {}
+            for key, value in (getattr(span, "attributes", None) or {}).items():
+                masked = _mask_export_value(value)
+                if masked != value:
+                    replacements[key] = masked
+            if replacements:
+                if OtelSpanPatch is None:
+                    raise RuntimeError("Langfuse OtelSpanPatch type unavailable")
+                patches[identifier] = OtelSpanPatch(set_attributes=replacements)
+        return MaskOtelSpansResult(span_patches=patches)
+    except Exception as exc:
+        # The SDK's explicit drop signal is the only acceptable fallback: a
+        # masking failure must never cause the original attributes to export.
+        _debug(f"export masking failed; dropping span batch: {exc}")
+        return MaskOtelSpansResult(drop=True)
+
+
+def _legacy_mask(*, data: Any, **_: Any) -> Any:
+    """Fail-closed fallback for Langfuse SDKs predating export-stage masking."""
+    try:
+        return _mask_export_value(data)
+    except Exception:
+        logger.error("Langfuse SDK masking failed; replacing content", exc_info=True)
+        return "<redacted:mask-failed>"
+
+
+def _token_source_buckets(usage: Any) -> Dict[str, int]:
+    """Map only provider-reported token buckets; never manufacture estimates."""
+    if not isinstance(usage, dict):
+        return {}
+    names = {
+        "input": "input",
+        "output": "output",
+        "input_tokens": "input",
+        "output_tokens": "output",
+        "cache_read_tokens": "cache_read",
+        "cache_write_tokens": "cache_write",
+        "cache_read_input_tokens": "cache_read",
+        "cache_creation_input_tokens": "cache_write",
+        "reasoning_tokens": "reasoning",
+    }
+    buckets: Dict[str, int] = {}
+    for source, target in names.items():
+        value = usage.get(source)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            buckets[target] = int(value)
+    return buckets
+
+
+def _tool_policy_decision(middleware_trace: Any) -> Optional[str]:
+    if not isinstance(middleware_trace, list):
+        return None
+    normalized = {
+        "allow": "allowed",
+        "allowed": "allowed",
+        "approve": "allowed",
+        "approved": "allowed",
+        "deny": "denied",
+        "denied": "denied",
+        "block": "denied",
+        "blocked": "denied",
+        "prompt": "approval_required",
+        "approval_required": "approval_required",
+    }
+    for entry in reversed(middleware_trace):
+        if not isinstance(entry, dict):
+            continue
+        for key in ("decision", "policy", "outcome", "status"):
+            value = str(entry.get(key) or "").lower()
+            if value in normalized:
+                return normalized[value]
+    return None
+
+
+def _middleware_route_reason(middleware_trace: Any) -> Optional[str]:
+    """Report the existing middleware route signal without exporting free text."""
+    if not isinstance(middleware_trace, list):
+        return None
+    for entry in reversed(middleware_trace):
+        if not isinstance(entry, dict):
+            continue
+        if isinstance(entry.get("reason"), str) and entry["reason"]:
+            return "middleware_rewrite"
+    return None
+
+
+def _structured_code(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    return value if re.fullmatch(r"[a-z][a-z0-9_.:-]{0,63}", value) else None
+
+
+def _structured_outcome_metadata(
+    *,
+    route_reason_code: Any = None,
+    fallback_count: Any = None,
+    retry_count: Any = None,
+    quota_result_code: Any = None,
+) -> Dict[str, Any]:
+    """Accept only bounded codes/counts, never arbitrary provider text."""
+    metadata: Dict[str, Any] = {}
+    for key, value in (
+        ("route_reason_code", route_reason_code),
+        ("quota_result_code", quota_result_code),
+    ):
+        code = _structured_code(value)
+        if code is not None:
+            metadata[key] = code
+    for key, value in (
+        ("fallback_count", fallback_count),
+        ("retry_count", retry_count),
+    ):
+        if (
+            isinstance(value, int)
+            and not isinstance(value, bool)
+            and 0 <= value <= 1_000_000
+        ):
+            metadata[key] = value
+    return metadata
+
+
+# Secret redaction in ``sanitized`` mode reuses the project-wide
+# ``agent.redact.redact_sensitive_text(force=True)`` — which covers 50+ credential
+# patterns, private keys, JWTs, auth headers, DB connection strings, and env
+# assignments with pre-check-gated regex. The ``force=True`` flag ensures
+# redaction runs even if the user has ``security.redact_secrets: false`` set —
+# appropriate for an observability plugin exporting to an external service.
+
+
 def _redact_secrets(value: str) -> str:
     # force=True: redact even if the user disabled security.redact_secrets —
     # this content is exported to an external service.
     try:
-        from agent.redact import redact_sensitive_text
-        return redact_sensitive_text(value, force=True)
+        return _mask_text(value)
     except Exception:
-        return value
+        return "[CONTENT OMITTED: MASKING FAILED]"
 
 
 # (types, shape builder) for _describe_content; first match wins (bool handled before).
@@ -140,15 +470,22 @@ _CONTENT_SHAPES = (
 )
 
 
-def _describe_content(value: Any) -> Any:
+def _describe_content(value: Any, *, include_keys: bool = True) -> Any:
     """Metadata-mode stand-in for content: shape and size, never payload."""
     if value is None or isinstance(value, bool):
         return value
     shape = next((build(value) for types, build in _CONTENT_SHAPES if isinstance(value, types)), None)
+    if isinstance(value, dict) and shape is not None:
+        shape["items"] = len(value)
+        if not include_keys:
+            shape.pop("keys", None)
     return {"omitted": True, **(shape or {"type": type(value).__name__})}
 
 
-def _capture_content(value: Any, *, parse_json_strings: bool = False, tool_result_of: Optional[tuple] = None) -> Any:
+def _capture_content(
+    value: Any, *, parse_json_strings: bool = False,
+    tool_result_of: Optional[tuple] = None, content_sampled: bool = True,
+) -> Any:
     """Apply the active capture mode to a CONTENT value.
 
     Only prompt/response text, tool arguments and tool results are content;
@@ -157,6 +494,12 @@ def _capture_content(value: Any, *, parse_json_strings: bool = False, tool_resul
     parsed first so a read_file payload can be collapsed to a preview keyed by
     the call's ``args``.
     """
+    if not content_sampled:
+        if value is None:
+            return {"omitted": True, "type": "null"}
+        if isinstance(value, bool):
+            return {"omitted": True, "type": "boolean"}
+        return _describe_content(value, include_keys=False)
     if _capture_mode() == "metadata":
         return _describe_content(value)
     if tool_result_of is not None:
@@ -237,12 +580,12 @@ def _build_client() -> Optional[Langfuse]:
         value = _env(f"HERMES_LANGFUSE_{name}") or _env(f"LANGFUSE_{name}") or default
         if value:
             kwargs[key] = value
-    sample_rate = _env("HERMES_LANGFUSE_SAMPLE_RATE")
-    if sample_rate:
-        try:
-            kwargs["sample_rate"] = float(sample_rate)
-        except ValueError:
-            logger.warning("Invalid HERMES_LANGFUSE_SAMPLE_RATE=%r", sample_rate)
+    # Retain operational spans and sample only content. Mandatory SDK masking is
+    # still applied in full-capture mode.
+    if MaskOtelSpansResult is not None and OtelSpanPatch is not None:
+        kwargs["mask_otel_spans"] = _mask_otel_spans
+    else:
+        kwargs["mask"] = _legacy_mask
 
     try:
         return Langfuse(**kwargs)
@@ -507,42 +850,95 @@ def _usage_and_cost(response: Any, *, provider: str, model: str, base_url: str, 
         return {}, {}
 
 
-def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform: str, provider: str, model: str,
-                      api_mode: str, messages: Any, client: Langfuse,
-                      turn_id: str = "", api_request_id: str = "") -> TraceState:
-    trace_id = client.create_trace_id(seed=f"{session_id or 'sessionless'}::{task_id or task_key}")
-    last_user = next((m for m in reversed(messages) if isinstance(m, dict) and m.get("role") == "user"), None) \
-        if isinstance(messages, list) else None
-    trace_input = None if last_user is None else {"role": "user", "content": _capture_content(last_user.get("content"))}
-    metadata = {
-        "source": "hermes", "task_id": task_id, "turn_id": turn_id, "api_request_id": api_request_id,
-        "platform": platform, "provider": provider, "model": model, "api_mode": api_mode,
-        "capture_mode": _capture_mode(),
+def _start_root_trace(
+    task_key: str, *, task_id: str, session_id: str, platform: str,
+    provider: str, model: str, api_mode: str, messages: Any, client: Any,
+    turn_id: str = "", api_request_id: str = "", system_prompt: Any = None,
+    request: Any = None, route_reason_code: Any = None,
+    fallback_count: Any = None, retry_count: Any = None,
+    quota_result_code: Any = None, enabled_tool_count: Any = None,
+    tool_schema_bytes: Any = None, tool_policy_fingerprint: Any = None,
+) -> TraceState:
+    raw_trace_seed = (
+        f"{session_id or 'sessionless'}::"
+        f"{task_id or task_key}::{turn_id or api_request_id or task_key}"
+    )
+    trace_seed = _pseudonymize_identifier("trace", raw_trace_seed)
+    if trace_seed is None:
+        trace_seed = f"random-v1:{secrets.token_hex(32)}"
+    trace_id = client.create_trace_id(seed=trace_seed)
+    content_sampled = _content_is_sampled(trace_id)
+    last_user = next(
+        (m for m in reversed(messages) if isinstance(m, dict) and m.get("role") == "user"),
+        None,
+    ) if isinstance(messages, list) else None
+    raw_trace_input = None if last_user is None else {
+        "role": "user", "content": last_user.get("content"),
     }
-    # session_id must be in trace_context for Langfuse session grouping.
-    trace_ctx: Dict[str, Any] = {"trace_id": trace_id, **({"session_id": session_id} if session_id else {})}
+    trace_input = _capture_content(raw_trace_input, content_sampled=content_sampled)
+    metadata = _telemetry_metadata(
+        task_id=task_id, session_id=session_id, provider=provider, model=model,
+        api_mode=api_mode, messages=messages, system_prompt=system_prompt,
+        request=request, enabled_tool_count=enabled_tool_count,
+        tool_schema_bytes=tool_schema_bytes,
+        tool_policy_fingerprint=tool_policy_fingerprint,
+    )
+    metadata.update({
+        "platform": platform, "provider": provider, "model": model,
+        "api_mode": api_mode, "sample_probability": _content_sample_rate(),
+        "content_sampled": content_sampled,
+    })
+    pseudonymous_turn = _pseudonymize_identifier("turn", turn_id)
+    pseudonymous_request = _pseudonymize_identifier("api_request", api_request_id)
+    if pseudonymous_turn:
+        metadata["turn_id"] = pseudonymous_turn
+    if pseudonymous_request:
+        metadata["api_request_id"] = pseudonymous_request
+    metadata.update(_structured_outcome_metadata(
+        route_reason_code=route_reason_code, fallback_count=fallback_count,
+        retry_count=retry_count, quota_result_code=quota_result_code,
+    ))
+
+    pseudonymous_session = _pseudonymize_identifier("session", session_id)
+    trace_ctx: Dict[str, Any] = {"trace_id": trace_id}
+    if pseudonymous_session:
+        trace_ctx["session_id"] = pseudonymous_session
 
     def open_root():
-        ctx = client.start_as_current_observation(trace_context=trace_ctx, name="Hermes turn", as_type="chain",
-                                                  input=trace_input, metadata=metadata, end_on_exit=False)
+        ctx = client.start_as_current_observation(
+            trace_context=trace_ctx, name="Hermes turn", as_type="chain",
+            input=trace_input, metadata=metadata, end_on_exit=False,
+        )
         return ctx, ctx.__enter__()
 
     root_ctx = root_span = None
     if propagate_attributes is not None:
         try:
-            with propagate_attributes(session_id=session_id or task_key, trace_name="Hermes turn",
-                                      tags=["hermes", "langfuse"]):
+            with propagate_attributes(
+                session_id=pseudonymous_session, trace_name="Hermes turn",
+                tags=["hermes", "langfuse"],
+            ):
                 root_ctx, root_span = open_root()
         except Exception:
             root_ctx = None
     if root_ctx is None:
         root_ctx, root_span = open_root()
 
-    with _failsafe("update_trace(input)"):  # SDK v3 uses update_trace()
+    with _failsafe("update_trace(input)"):
         root_span.update_trace(input=trace_input)
-
+    if turn_id:
+        with _failsafe("turn correlation publish"):
+            from hermes_cli.lifecycle import publish_turn_correlation
+            observation_id = getattr(root_span, "id", None)
+            publish_turn_correlation(
+                turn_id=turn_id, trace_id=trace_id,
+                observation_id=str(observation_id) if observation_id else None,
+            )
     _debug(f"started trace {trace_id} for {task_key}")
-    return TraceState(trace_id=trace_id, root_ctx=root_ctx, root_span=root_span)
+    return TraceState(
+        trace_id=trace_id, root_ctx=root_ctx, root_span=root_span,
+        content_sampled=content_sampled,
+    )
 
 
 def _start_child_observation(state: TraceState, *, name: str, as_type: str, input_value: Any,
@@ -605,6 +1001,15 @@ def _flush(client: Any) -> None:
             client.flush()
 
 
+def _merge_trace_output(output: Any, state: TraceState) -> Any:
+    """Attach tool calls only when the trace's content sample is enabled."""
+    if not state.content_sampled or not state.turn_tool_calls:
+        return output
+    merged = dict(output) if isinstance(output, dict) else {"content": output}
+    merged["tool_calls"] = list(state.turn_tool_calls)
+    return merged
+
+
 def _finish_trace(task_key: str, *, output: Any = None) -> None:
     client = _get_langfuse()
     with _STATE_LOCK:
@@ -614,10 +1019,7 @@ def _finish_trace(task_key: str, *, output: Any = None) -> None:
 
     try:
         _end_children(state)
-        final_output = output
-        if state.turn_tool_calls:
-            final_output = dict(output) if isinstance(output, dict) else {"content": output}
-            final_output["tool_calls"] = list(state.turn_tool_calls)
+        final_output = _merge_trace_output(output, state)
         if final_output is not None:
             # update_trace sets TRACE-level I/O (SDK v3); root I/O via update().
             # Neither may prevent end(), else children export without a root.
@@ -717,7 +1119,9 @@ def _emit_moa_reference_generations(state: TraceState, *, client: Langfuse, refe
 
         observation = _start_child_observation(state, name=f"MoA advisor: {label}", as_type="generation", input_value=None,
                                                metadata=metadata, model=ref.get("model"))
-        _end_observation(observation, output=_capture_content(ref.get("output")), usage_details=usage_details,
+        _end_observation(observation, output=_capture_content(
+            ref.get("output"), content_sampled=state.content_sampled,
+        ), usage_details=usage_details,
                          cost_details=cost_details, metadata=metadata)
 
 
@@ -726,7 +1130,12 @@ def on_pre_llm_request(*, task_id: str = "", session_id: str = "", platform: str
                        request_messages: Any = None, messages: Any = None, message_count: int = 0,
                        approx_input_tokens: int = 0, conversation_history: Any = None,
                        user_message: Any = None, turn_id: str = "", api_request_id: str = "",
-                       request: Any = None, system_prompt: Any = None, **_: Any) -> None:
+                       request: Any = None, system_prompt: Any = None,
+                       enabled_tool_count: Any = None, route_reason_code: Any = None,
+                       fallback_count: Any = None, retry_count: Any = None,
+                       quota_result_code: Any = None, middleware_trace: Any = None,
+                       tool_schema_bytes: Any = None,
+                       tool_policy_fingerprint: Any = None, **_: Any) -> None:
     client, task_key = _client_and_key(task_id, session_id, turn_id, api_request_id)
     if client is None:
         return
@@ -736,6 +1145,8 @@ def on_pre_llm_request(*, task_id: str = "", session_id: str = "", platform: str
     body_model = request["body"].get("model") if isinstance(request, dict) and isinstance(request.get("body"), dict) else None
     if isinstance(body_model, str) and body_model:
         model = body_model
+    if route_reason_code is None:
+        route_reason_code = _middleware_route_reason(middleware_trace)
 
     input_messages = _coerce_request_messages(request_messages=request_messages, messages=messages,
                                               conversation_history=conversation_history, user_message=user_message)
@@ -747,7 +1158,12 @@ def on_pre_llm_request(*, task_id: str = "", session_id: str = "", platform: str
     with _STATE_LOCK:
         state = _get_or_start_state_locked(
             task_key, task_id=task_id, session_id=session_id, platform=platform, provider=provider, model=model,
-            api_mode=api_mode, messages=input_messages, client=client, turn_id=turn_id, api_request_id=api_request_id)
+            api_mode=api_mode, messages=input_messages, client=client, turn_id=turn_id,
+            api_request_id=api_request_id, system_prompt=system_prompt, request=request,
+            route_reason_code=route_reason_code, fallback_count=fallback_count,
+            retry_count=retry_count, quota_result_code=quota_result_code,
+            enabled_tool_count=enabled_tool_count, tool_schema_bytes=tool_schema_bytes,
+            tool_policy_fingerprint=tool_policy_fingerprint)
         previous = state.generations.pop(req_key, None)
         if previous is not None:
             _end_observation(previous)
@@ -756,9 +1172,15 @@ def on_pre_llm_request(*, task_id: str = "", session_id: str = "", platform: str
             "message_count": message_count, "approx_input_tokens": approx_input_tokens,
             **({"system_prompt_chars": system_chars} if system_chars else {}),
         }
+        gen_metadata.update(_structured_outcome_metadata(
+            route_reason_code=route_reason_code, fallback_count=fallback_count,
+            retry_count=retry_count, quota_result_code=quota_result_code,
+        ))
         state.generations[req_key] = _start_child_observation(
             state, name=f"LLM call {api_call_count}", as_type="generation",
-            input_value=langfuse_input, metadata=gen_metadata, model=model,
+            input_value=_capture_content(
+                langfuse_input, content_sampled=state.content_sampled,
+            ), metadata=gen_metadata, model=model,
             model_parameters={"api_mode": api_mode, "provider": provider},
         )
 
@@ -768,7 +1190,9 @@ def on_post_llm_call(*, task_id: str = "", session_id: str = "", provider: str =
                      response: Any = None, api_duration: float = 0.0, finish_reason: str = "", usage: Any = None,
                      assistant_content_chars: int = 0, assistant_tool_call_count: int = 0,
                      assistant_response: Any = None, turn_id: str = "", api_request_id: str = "",
-                     response_model: Any = None, moa_references: Any = None, **_: Any) -> None:
+                     response_model: Any = None, moa_references: Any = None,
+                     route_reason_code: Any = None, fallback_count: Any = None,
+                     retry_count: Any = None, quota_result_code: Any = None, **_: Any) -> None:
     client, task_key = _client_and_key(task_id, session_id, turn_id, api_request_id)
     if client is None:
         return
@@ -789,12 +1213,14 @@ def on_post_llm_call(*, task_id: str = "", session_id: str = "", provider: str =
     if assistant_message is not None:
         output = _serialize_assistant_message(assistant_message)
     elif assistant_response is not None:
-        output = {"content": _capture_content(assistant_response), "reasoning": None, "tool_calls": []}
+        output = {"content": _capture_content(
+            assistant_response, content_sampled=state.content_sampled,
+        ), "reasoning": None, "tool_calls": []}
     else:
         output = {"content": f"[{assistant_content_chars} chars]" if assistant_content_chars else None, "reasoning": None,
                   "tool_calls": [{"id": f"tc_{i}"} for i in range(assistant_tool_call_count or 0)]}
 
-    if output.get("tool_calls"):
+    if output.get("tool_calls") and state.content_sampled:
         state.turn_tool_calls.extend(output["tool_calls"])
 
     # post_api_request's ``response`` is a sanitized dict with no ``.usage``;
@@ -808,11 +1234,25 @@ def on_post_llm_call(*, task_id: str = "", session_id: str = "", provider: str =
 
     gen_metadata = {"tool_call_count": len(output.get("tool_calls", [])) or assistant_tool_call_count,
                     **_duration_meta(api_duration), **({"finish_reason": finish_reason} if finish_reason else {})}
-    _end_observation(generation, output=output, usage_details=usage_details, cost_details=cost_details, metadata=gen_metadata)
+    token_bucket_source = usage if isinstance(usage, dict) else usage_details
+    token_buckets = _token_source_buckets(token_bucket_source)
+    if token_buckets:
+        gen_metadata["token_source_buckets"] = token_buckets
+        if "input" in token_buckets:
+            gen_metadata["context_total_tokens"] = token_buckets["input"]
+    gen_metadata.update(_structured_outcome_metadata(
+        route_reason_code=route_reason_code, fallback_count=fallback_count,
+        retry_count=retry_count, quota_result_code=quota_result_code,
+    ))
+    export_output = output if state.content_sampled else _capture_content(
+        output, content_sampled=False,
+    )
+    _end_observation(generation, output=export_output, usage_details=usage_details,
+                     cost_details=cost_details, metadata=gen_metadata)
 
     has_tools = bool(getattr(assistant_message, "tool_calls", None)) if assistant_message else assistant_tool_call_count > 0
     if not has_tools and output.get("content"):
-        _finish_trace(task_key, output=output)
+        _finish_trace(task_key, output=export_output)
 
 
 def on_pre_tool_call(*, tool_name: str = "", args: Any = None, task_id: str = "",
@@ -825,7 +1265,9 @@ def on_pre_tool_call(*, tool_name: str = "", args: Any = None, task_id: str = ""
         state = _TRACE_STATE.get(task_key)
         if state is None:
             return
-        observation = _start_child_observation(state, name=f"Tool: {tool_name}", as_type="tool", input_value=_capture_content(args),
+        observation = _start_child_observation(state, name=f"Tool: {tool_name}", as_type="tool", input_value=_capture_content(
+            args, content_sampled=state.content_sampled,
+        ),
                                                metadata={"tool_name": tool_name, "tool_call_id": tool_call_id})
         if tool_call_id:
             state.tools[tool_call_id] = observation
@@ -835,7 +1277,10 @@ def on_pre_tool_call(*, tool_name: str = "", args: Any = None, task_id: str = ""
 
 def on_post_tool_call(*, tool_name: str = "", args: Any = None, result: Any = None,
                       task_id: str = "", session_id: str = "", tool_call_id: str = "",
-                      turn_id: str = "", api_request_id: str = "", **_: Any) -> None:
+                      turn_id: str = "", api_request_id: str = "",
+                      status: Any = None, error_type: Any = None,
+                      duration_ms: Any = None, middleware_trace: Any = None,
+                      **_: Any) -> None:
     task_key = _trace_key(task_id, session_id, turn_id=turn_id, api_request_id=api_request_id)
     with _STATE_LOCK:
         state = _TRACE_STATE.get(task_key)
@@ -850,7 +1295,10 @@ def on_post_tool_call(*, tool_name: str = "", args: Any = None, result: Any = No
     if observation is None:
         return
 
-    safe_result_value = _capture_content(result, tool_result_of=(tool_name, args))
+    safe_result_value = _capture_content(
+        result, tool_result_of=(tool_name, args),
+        content_sampled=state.content_sampled,
+    )
 
     # Backfill so the generation's tool_call record carries the result alongside arguments.
     if tool_call_id:
@@ -862,8 +1310,19 @@ def on_post_tool_call(*, tool_name: str = "", args: Any = None, result: Any = No
                 if isinstance(target, dict):
                     target["output"] = safe_result_value
 
-    _end_observation(observation, output=safe_result_value,
-                     metadata={"tool_name": tool_name, "args": _capture_content(args, parse_json_strings=True)})
+    tool_metadata: Dict[str, Any] = {"tool_name": tool_name}
+    if tool_call_id:
+        tool_metadata["tool_call_id"] = tool_call_id
+    if status is not None:
+        tool_metadata["outcome_code"] = str(status)
+    if error_type:
+        tool_metadata["error_type"] = str(error_type)
+    if isinstance(duration_ms, (int, float)) and not isinstance(duration_ms, bool):
+        tool_metadata["duration_ms"] = duration_ms
+    policy_decision = _tool_policy_decision(middleware_trace)
+    if policy_decision:
+        tool_metadata["tool_policy_decision"] = policy_decision
+    _end_observation(observation, output=safe_result_value, metadata=tool_metadata)
 
 
 def on_api_request_error(*, task_id: str = "", session_id: str = "", api_call_count: int = 0,
@@ -885,11 +1344,21 @@ def on_api_request_error(*, task_id: str = "", session_id: str = "", api_call_co
 
     # Error messages can embed request fragments (URLs w/ keys, prompt echoes) — capture-pipeline them.
     error_metadata: Dict[str, Any] = {
-        "error": True, "error_type": error_type, "error_message": _capture_content(error_message),
-        **{k: v for k, v in (("status_code", status_code), ("retry_count", retry_count), ("max_retries", max_retries),
-                             ("retryable", retryable), ("reason", str(reason) if reason else None)) if v is not None},
-        **_duration_meta(api_duration),
+        "error": True, "error_type": error_type,
+        "error_message": _capture_content(
+            error_message, content_sampled=state.content_sampled,
+        ), **_duration_meta(api_duration),
     }
+    if isinstance(status_code, int) and not isinstance(status_code, bool) and 0 <= status_code <= 999:
+        error_metadata["status_code"] = status_code
+    error_metadata.update(_structured_outcome_metadata(retry_count=retry_count))
+    if isinstance(max_retries, int) and not isinstance(max_retries, bool) and 0 <= max_retries <= 1_000_000:
+        error_metadata["max_retries"] = max_retries
+    if isinstance(retryable, bool):
+        error_metadata["retryable"] = retryable
+    reason_code = _structured_code(reason)
+    if reason_code:
+        error_metadata["reason_code"] = reason_code
 
     if generation is not None:
         with _failsafe("error-level update"):
@@ -942,11 +1411,20 @@ def on_subagent_start(*, parent_turn_id: str = "", parent_subagent_id: Any = Non
         state = _state_for_turn(parent_turn_id)
         if state is None:
             return
-        metadata = {"child_session_id": child_session_id, "child_subagent_id": child_subagent_id, "child_role": child_role,
-                    **({"parent_subagent_id": parent_subagent_id} if parent_subagent_id else {})}
+        metadata = {"child_role": child_role}
+        for field, kind, value in (
+            ("child_session_id", "subagent_session", child_session_id),
+            ("child_subagent_id", "subagent", child_subagent_id),
+            ("parent_subagent_id", "parent_subagent", parent_subagent_id),
+        ):
+            pseudonym = _pseudonymize_identifier(kind, value)
+            if pseudonym is not None:
+                metadata[field] = pseudonym
         state.subagents[str(child_session_id)] = _start_child_observation(
             state, name=f"Subagent: {child_role or 'delegate'}", as_type="span",
-            input_value=_capture_content(child_goal), metadata=metadata)
+            input_value=_capture_content(
+                child_goal, content_sampled=state.content_sampled,
+            ), metadata=metadata)
 
 
 def on_subagent_stop(*, parent_turn_id: str = "", child_session_id: Any = None, child_role: str = "",
@@ -963,10 +1441,16 @@ def on_subagent_stop(*, parent_turn_id: str = "", child_session_id: Any = None, 
     if observation is None:
         return
 
-    metadata = {"child_role": child_role, **{k: v for k, v in (("status", child_status), ("duration_ms", duration_ms)) if v},
-                **({"tool_call_count": len(tool_call_history), "tool_calls": _capture_content(tool_call_history)}
-                   if isinstance(tool_call_history, list) else {})}
-    _end_observation(observation, output=_capture_content(child_summary), metadata=metadata)
+    metadata = {"child_role": child_role,
+                **{k: v for k, v in (("status", child_status), ("duration_ms", duration_ms)) if v}}
+    if isinstance(tool_call_history, list):
+        metadata["tool_call_count"] = len(tool_call_history)
+        metadata["tool_calls"] = _capture_content(
+            tool_call_history, content_sampled=state.content_sampled,
+        )
+    _end_observation(observation, output=_capture_content(
+        child_summary, content_sampled=state.content_sampled,
+    ), metadata=metadata)
 
 
 def register(ctx) -> None:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1237,20 +1237,12 @@ class DiscordAdapter(BasePlatformAdapter):
                 await adapter_self._dispatch_discord_message(message)
 
             @self._client.event
-            async def on_message_edit(before: DiscordMessage, after: DiscordMessage):
-                await adapter_self._on_platform_message_edit(before, after)
+            async def on_raw_reaction_add(payload):
+                await adapter_self._on_platform_reaction(payload, action="add")
 
             @self._client.event
-            async def on_message_delete(message: DiscordMessage):
-                await adapter_self._on_platform_message_delete(message)
-
-            @self._client.event
-            async def on_thread_create(thread):
-                await adapter_self._on_platform_thread_create(thread)
-
-            @self._client.event
-            async def on_thread_update(before, after):
-                await adapter_self._on_platform_thread_update(before, after)
+            async def on_raw_reaction_remove(payload):
+                await adapter_self._on_platform_reaction(payload, action="remove")
 
             @self._client.event
             async def on_voice_state_update(member, before, after):
@@ -1571,6 +1563,91 @@ class DiscordAdapter(BasePlatformAdapter):
                 "new_name": new_name[:256],
             })
         await self._emit_platform_event("thread_renamed", _build)
+
+    async def _on_platform_reaction(self, payload, *, action: str) -> None:
+        """Normalize a reaction to this bot's own message without content."""
+        if not self._platform_events_subscribed() or action not in {"add", "remove"}:
+            return
+        try:
+            actor_id = getattr(payload, "user_id", None)
+            channel_id = getattr(payload, "channel_id", None)
+            message_id = getattr(payload, "message_id", None)
+            emoji = getattr(payload, "emoji", None)
+            bot_user = getattr(getattr(self, "_client", None), "user", None)
+            bot_id = getattr(bot_user, "id", None)
+            snowflakes = (actor_id, channel_id, message_id, bot_id)
+            if any(
+                not isinstance(value, int)
+                or isinstance(value, bool)
+                or value <= 0
+                for value in snowflakes
+            ):
+                return
+            emoji_text = str(emoji).strip() if emoji is not None else ""
+            if not emoji_text:
+                return
+            if str(actor_id) == str(bot_id):
+                return
+
+            actor = getattr(payload, "member", None)
+            if actor is None:
+                actor = self._client.get_user(actor_id)
+            if actor is None:
+                actor = await self._client.fetch_user(actor_id)
+            if (
+                actor is None
+                or getattr(actor, "bot", False)
+                or getattr(actor, "id", None) != actor_id
+            ):
+                return
+
+            channel = self._client.get_channel(channel_id)
+            if channel is None:
+                channel = await self._client.fetch_channel(channel_id)
+            if channel is None or not callable(getattr(channel, "fetch_message", None)):
+                return
+            target = await channel.fetch_message(message_id)
+            target_author = getattr(target, "author", None)
+            if (
+                getattr(target, "id", None) != message_id
+                or target_author is None
+                or not getattr(target_author, "bot", False)
+                or str(getattr(target_author, "id", "")) != str(bot_id)
+            ):
+                return
+
+            thread_id, chat_id = self._thread_id_and_chat_for_channel(channel)
+            if not chat_id:
+                return
+            guild_id = getattr(payload, "guild_id", None)
+            event = {
+                "platform": "discord",
+                "event_type": "reaction",
+                "payload": {
+                    "target_chat_id": str(chat_id)[:128],
+                    "target_thread_id": thread_id[:128] if thread_id else None,
+                    "target_message_id": str(message_id)[:128],
+                    "actor_id": str(actor_id)[:128],
+                    "emoji": emoji_text[:128],
+                    "action": action,
+                    "timestamp": dt.datetime.now(dt.timezone.utc).isoformat(),
+                    "bot_authored_target": True,
+                },
+            }
+            source = self._source_for_platform_event(
+                chat_id=str(chat_id),
+                user_id=str(actor_id),
+                user_name=None,
+                thread_id=thread_id,
+                guild_id=str(guild_id) if guild_id is not None else None,
+                message_id=str(message_id),
+            )
+        except Exception:
+            logger.debug(
+                "[%s] reaction normalize error", self.name, exc_info=True,
+            )
+            return
+        await self._fire_platform_event(event, source)
 
     async def _cancel_bot_task(self) -> None:
         """Cancel and await the background client.start() task, if running."""

--- a/tests/gateway/test_discord_platform_events.py
+++ b/tests/gateway/test_discord_platform_events.py
@@ -1,18 +1,16 @@
-"""Discord ``gateway_platform_event`` fire-sites (#64176 remaining scope).
+"""Discord platform-event normalization and feedback security boundaries.
 
-Covers the Discord half of the normalized-envelope pipeline:
-* ``message_edited`` / ``message_deleted`` / ``thread_created`` /
-  ``thread_renamed`` normalize to stable plain-dict envelopes (no raw SDK
-  objects) and dispatch through the gateway-owned post-auth boundary
-* bot-authored events are dropped at the fire-site (streaming edits are noise)
-* malformed events (missing ids / identities) drop, fail closed
-* no installed gateway callback means no fire (no trusted auth boundary)
-* the has_hook no-subscriber fast-path skips all normalization work
+Legacy edit/delete/thread normalizers are exercised directly as inert helpers,
+but Discord does not register their SDK listeners and the runner rejects their
+events. Only reaction add/remove is active for feedback. Reaction tests cover
+bot-target verification, malformed-event fail-closed behavior, central gateway
+authorization, content-free envelopes, and listener-surface restriction.
 """
 
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import sys
 from pathlib import Path
@@ -364,7 +362,7 @@ class TestRunnerBoundaryIntegration:
 
         invoked.assert_not_called()
 
-    def test_authorized_discord_event_reaches_hooks(self):
+    def test_authorized_non_reaction_event_still_never_reaches_hooks(self):
         from gateway.run import GatewayRunner
 
         runner = object.__new__(GatewayRunner)
@@ -381,8 +379,133 @@ class TestRunnerBoundaryIntegration:
         finally:
             lifecycle.invoke_hook = orig_invoke
 
-        invoked.assert_called_once()
-        args, kwargs = invoked.call_args
-        assert args == ("gateway_platform_event",)
-        assert kwargs["platform"] == "discord"
-        assert kwargs["event_type"] == "message_edited"
+        invoked.assert_not_called()
+
+
+class TestReactionFeedbackEvents:
+    def test_connect_registers_only_reaction_feedback_listeners(self):
+        source = inspect.getsource(DiscordAdapter.connect)
+        assert "async def on_raw_reaction_add" in source
+        assert "async def on_raw_reaction_remove" in source
+        for unrelated_listener in (
+            "async def on_message_edit",
+            "async def on_message_delete",
+            "async def on_thread_create",
+            "async def on_thread_update",
+        ):
+            assert unrelated_listener not in source
+
+    @staticmethod
+    def _configured_adapter(*, target_bot=True, actor_bot=False):
+        a = _adapter()
+        actor = SimpleNamespace(id=777, bot=actor_bot, display_name="private-name")
+        target = _message(author_id=999, bot=target_bot, content="private-target-text")
+        channel = _channel()
+        channel.fetch_message = AsyncMock(return_value=target)
+        target.channel = channel
+        a._client = SimpleNamespace(
+            user=SimpleNamespace(id=999, bot=True),
+            get_channel=lambda _channel_id: channel,
+            fetch_channel=AsyncMock(return_value=channel),
+            get_user=lambda _user_id: actor,
+            fetch_user=AsyncMock(return_value=actor),
+        )
+        return a, actor, target
+
+    @staticmethod
+    def _payload(**overrides):
+        values = {
+            "user_id": 777,
+            "channel_id": 555,
+            "message_id": 456,
+            "guild_id": 999,
+            "emoji": "👍",
+            "member": None,
+        }
+        values.update(overrides)
+        return SimpleNamespace(**values)
+
+    def test_add_and_remove_normalize_without_content_or_names(self):
+        a, actor, _target = self._configured_adapter()
+        seen = _capture(a)
+        payload = self._payload(member=actor)
+
+        asyncio.run(a._on_platform_reaction(payload, action="add"))
+        asyncio.run(a._on_platform_reaction(payload, action="remove"))
+
+        assert len(seen) == 2
+        for index, action in enumerate(("add", "remove")):
+            event, source = seen[index]
+            assert event["platform"] == "discord"
+            assert event["event_type"] == "reaction"
+            assert event["payload"] == {
+                "target_chat_id": "555",
+                "target_thread_id": None,
+                "target_message_id": "456",
+                "actor_id": "777",
+                "emoji": "👍",
+                "action": action,
+                "timestamp": event["payload"]["timestamp"],
+                "bot_authored_target": True,
+            }
+            assert source.user_id == "777"
+            serialized = json.dumps(event)
+            assert "private-name" not in serialized
+            assert "private-target-text" not in serialized
+            assert "content" not in event["payload"]
+
+    def test_bot_actor_non_bot_target_and_malformed_events_drop(self):
+        a, actor, _target = self._configured_adapter()
+        seen = _capture(a)
+        asyncio.run(a._on_platform_reaction(self._payload(user_id=999), action="add"))
+        assert seen == []
+
+        a, actor, _target = self._configured_adapter(target_bot=False)
+        seen = _capture(a)
+        asyncio.run(
+            a._on_platform_reaction(self._payload(member=actor), action="add")
+        )
+        assert seen == []
+
+        a, actor, _target = self._configured_adapter()
+        seen = _capture(a)
+        for malformed in (
+            self._payload(member=actor, message_id=None),
+            self._payload(member=actor, user_id=""),
+            self._payload(member=actor, emoji=""),
+        ):
+            asyncio.run(a._on_platform_reaction(malformed, action="add"))
+        assert seen == []
+
+    def test_runner_authorization_fails_closed_and_duplicates_are_notifications(
+        self, monkeypatch
+    ):
+        from gateway.run import GatewayRunner
+
+        a, actor, _target = self._configured_adapter()
+        payload = self._payload(member=actor)
+        invoked = MagicMock()
+        monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", invoked)
+        runner = object.__new__(GatewayRunner)
+        runner._is_user_authorized = (
+            lambda source, *, allow_adapter_delegation=True: False
+        )
+        a.set_platform_event_handler(runner._handle_gateway_platform_event)
+        asyncio.run(a._on_platform_reaction(payload, action="add"))
+        invoked.assert_not_called()
+
+        runner._is_user_authorized = (
+            lambda source, *, allow_adapter_delegation=True: source.user_id == "777"
+        )
+        asyncio.run(a._on_platform_reaction(payload, action="add"))
+        asyncio.run(a._on_platform_reaction(payload, action="add"))
+        assert invoked.call_count == 2
+        first = dict(invoked.call_args_list[0].kwargs)
+        second = dict(invoked.call_args_list[1].kwargs)
+        first_payload = dict(first["payload"])
+        second_payload = dict(second["payload"])
+        assert isinstance(first_payload.pop("timestamp"), str)
+        assert isinstance(second_payload.pop("timestamp"), str)
+        first["payload"] = first_payload
+        second["payload"] = second_payload
+        assert first == second

--- a/tests/gateway/test_discord_reactions.py
+++ b/tests/gateway/test_discord_reactions.py
@@ -140,3 +140,76 @@ async def test_reactions_disabled_via_env(adapter, monkeypatch):
     adapter.send.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_outbound_hook_fires_only_after_success_without_content(adapter):
+    async def handler(_event):
+        return "private response body"
+
+    outbound = AsyncMock()
+    adapter.set_message_handler(handler)
+    adapter.set_outbound_response_handler(outbound)
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="999"))
+    event = _make_event(
+        "5",
+        SimpleNamespace(add_reaction=AsyncMock(), remove_reaction=AsyncMock()),
+    )
+    event._hermes_turn_correlation = {
+        "turn_id": "turn-1",
+        "trace_id": "trace-1",
+        "observation_id": "observation-1",
+    }
+
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    outbound.assert_awaited_once()
+    assert outbound.await_args is not None
+    envelope, source = outbound.await_args.args
+    assert envelope["target_message_id"] == "999"
+    assert envelope["trace_id"] == "trace-1"
+    assert source is event.source
+    assert "private response body" not in repr(envelope)
+    assert not ({"content", "text", "response"} & set(envelope))
+
+
+@pytest.mark.asyncio
+async def test_outbound_hook_does_not_fire_for_failed_delivery(adapter):
+    async def handler(_event):
+        return "private response body"
+
+    outbound = AsyncMock()
+    adapter.set_message_handler(handler)
+    adapter.set_outbound_response_handler(outbound)
+    adapter.send = AsyncMock(return_value=SendResult(success=False, error="offline"))
+    event = _make_event(
+        "6",
+        SimpleNamespace(add_reaction=AsyncMock(), remove_reaction=AsyncMock()),
+    )
+    event._hermes_turn_correlation = {"turn_id": "turn-1", "trace_id": "trace-1"}
+
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    outbound.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_outbound_hook_observes_confirmed_streamed_delivery(adapter):
+    async def handler(event):
+        event._hermes_turn_correlation = {
+            "turn_id": "turn-stream",
+            "trace_id": "trace-stream",
+        }
+        event._hermes_streamed_message_ids = ["stream-message-1"]
+        return None
+
+    outbound = AsyncMock()
+    adapter.set_message_handler(handler)
+    adapter.set_outbound_response_handler(outbound)
+    event = _make_event(
+        "7",
+        SimpleNamespace(add_reaction=AsyncMock(), remove_reaction=AsyncMock()),
+    )
+
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    outbound.assert_awaited_once()
+    assert outbound.await_args.args[0]["target_message_id"] == "stream-message-1"

--- a/tests/gateway/test_feedback_correlation_hooks.py
+++ b/tests/gateway/test_feedback_correlation_hooks.py
@@ -31,6 +31,12 @@ def _pseudonym(kind: str, value: str) -> str:
 
 
 class TestTurnCorrelationState:
+    def test_feedback_hooks_are_declared_plugin_surfaces(self):
+        from hermes_cli.plugins import VALID_HOOKS
+
+        assert "gateway_outbound_response" in VALID_HOOKS
+        assert "gateway_platform_event" in VALID_HOOKS
+
     def test_publish_take_is_one_shot_and_thread_safe(self):
         from hermes_cli import lifecycle
 

--- a/tests/gateway/test_feedback_correlation_hooks.py
+++ b/tests/gateway/test_feedback_correlation_hooks.py
@@ -1,0 +1,353 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, SendResult
+from gateway.session import SessionSource
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="chat-1",
+        chat_type="thread",
+        user_id="actor-1",
+        user_name="internal-only-name",
+        thread_id="thread-1",
+    )
+
+
+def _pseudonym(kind: str, value: str) -> str:
+    key = b"gateway-hook-test-key-at-least-16-bytes"
+    digest = hmac.new(key, f"{kind}:{value}".encode(), hashlib.sha256).hexdigest()
+    return f"hmac-sha256:{digest}"
+
+
+class TestTurnCorrelationState:
+    def test_publish_take_is_one_shot_and_thread_safe(self):
+        from hermes_cli import lifecycle
+
+        lifecycle.clear_turn_correlations()
+
+        def publish(index: int) -> None:
+            lifecycle.publish_turn_correlation(
+                turn_id=f"turn-{index}",
+                trace_id=f"trace-{index}",
+                observation_id=f"observation-{index}",
+            )
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            list(pool.map(publish, range(100)))
+
+        seen = {
+            lifecycle.take_turn_correlation(f"turn-{index}")["trace_id"]
+            for index in range(100)
+        }
+        assert seen == {f"trace-{index}" for index in range(100)}
+        assert lifecycle.take_turn_correlation("turn-0") is None
+
+    def test_rejects_content_and_bounds_retained_entries(self, monkeypatch):
+        from hermes_cli import lifecycle
+
+        lifecycle.clear_turn_correlations()
+        assert lifecycle.publish_turn_correlation(
+            turn_id="turn-content",
+            trace_id="trace-content",
+            content="must not be accepted",
+        ) is False
+        assert lifecycle.publish_turn_correlation(
+            turn_id="x" * 257, trace_id="trace-too-long"
+        ) is False
+        assert lifecycle.publish_turn_correlation(
+            turn_id="turn-control\ntext", trace_id="trace-control"
+        ) is False
+
+        monkeypatch.setattr(lifecycle.time, "monotonic", lambda: 100.0)
+        assert lifecycle.publish_turn_correlation(
+            turn_id="turn-expired", trace_id="trace-expired"
+        )
+        monkeypatch.setattr(
+            lifecycle.time,
+            "monotonic",
+            lambda: 100.0 + lifecycle._TURN_CORRELATION_TTL_S + 1.0,
+        )
+        assert lifecycle.take_turn_correlation("turn-expired") is None
+
+        for index in range(lifecycle.MAX_TURN_CORRELATIONS + 1):
+            assert lifecycle.publish_turn_correlation(
+                turn_id=f"turn-{index}", trace_id=f"trace-{index}"
+            )
+        assert lifecycle.take_turn_correlation("turn-0") is None
+
+
+class TestOutboundRunnerBoundary:
+    @staticmethod
+    def _runner(authorized: bool):
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner._is_user_authorized = (
+            lambda source, *, allow_adapter_delegation=True: authorized
+        )
+        return runner
+
+    @staticmethod
+    def _event() -> dict:
+        return {
+            "platform": "discord",
+            "target_chat_id": "chat-1",
+            "target_thread_id": "thread-1",
+            "target_message_id": "message-1",
+            "turn_id": "turn-1",
+            "trace_id": "trace-1",
+            "observation_id": "observation-1",
+            "timestamp": "2026-09-04T12:00:00+00:00",
+        }
+
+    def test_authorized_envelope_pseudonymizes_discord_ids(self, monkeypatch):
+        key = "gateway-hook-test-key-at-least-16-bytes"
+        monkeypatch.setenv("HERMES_GATEWAY_HOOK_PSEUDONYM_KEY", key)
+        invoked = MagicMock()
+        monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", invoked)
+
+        self._runner(True)._handle_gateway_outbound_response(self._event(), _source())
+
+        def pseudonym(kind: str, value: str) -> str:
+            digest = hmac.new(
+                key.encode(), f"{kind}:{value}".encode(), hashlib.sha256
+            ).hexdigest()
+            return f"hmac-sha256:{digest}"
+
+        invoked.assert_called_once_with(
+            "gateway_outbound_response",
+            platform="discord",
+            target_chat_id=pseudonym("chat", "chat-1"),
+            target_thread_id=pseudonym("thread", "thread-1"),
+            target_message_id=pseudonym("message", "message-1"),
+            turn_id="turn-1",
+            trace_id="trace-1",
+            observation_id="observation-1",
+            timestamp="2026-09-04T12:00:00+00:00",
+        )
+        forbidden = {"content", "text", "response", "display_name", "user_name"}
+        assert not (forbidden & set(invoked.call_args.kwargs))
+        serialized = json.dumps(invoked.call_args.kwargs)
+        assert "chat-1" not in serialized
+        assert "thread-1" not in serialized
+        assert "message-1" not in serialized
+
+    def test_missing_pseudonym_key_omits_platform_ids_but_retains_trace(
+        self, monkeypatch
+    ):
+        monkeypatch.delenv("HERMES_GATEWAY_HOOK_PSEUDONYM_KEY", raising=False)
+        invoked = MagicMock()
+        monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", invoked)
+
+        self._runner(True)._handle_gateway_outbound_response(self._event(), _source())
+
+        invoked.assert_called_once()
+        payload = invoked.call_args.kwargs
+        assert payload["trace_id"] == "trace-1"
+        assert payload["turn_id"] == "turn-1"
+        assert not {
+            "target_chat_id",
+            "target_thread_id",
+            "target_message_id",
+        } & set(payload)
+
+    def test_unauthorized_or_malformed_event_fails_closed(self, monkeypatch):
+        invoked = MagicMock()
+        monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", invoked)
+        self._runner(False)._handle_gateway_outbound_response(self._event(), _source())
+        malformed = self._event()
+        malformed.pop("trace_id")
+        self._runner(True)._handle_gateway_outbound_response(malformed, _source())
+        wrong_platform = self._event()
+        wrong_platform["platform"] = "telegram"
+        self._runner(True)._handle_gateway_outbound_response(wrong_platform, _source())
+        missing_thread = self._event()
+        missing_thread.pop("target_thread_id")
+        self._runner(True)._handle_gateway_outbound_response(missing_thread, _source())
+        oversized = self._event()
+        oversized["target_message_id"] = "x" * 257
+        self._runner(True)._handle_gateway_outbound_response(oversized, _source())
+        invoked.assert_not_called()
+
+    def test_duplicate_delivery_notifications_are_harmless_at_hook_layer(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv(
+            "HERMES_GATEWAY_HOOK_PSEUDONYM_KEY",
+            "gateway-hook-test-key-at-least-16-bytes",
+        )
+        invoked = MagicMock()
+        monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", invoked)
+        runner = self._runner(True)
+        event = self._event()
+        runner._handle_gateway_outbound_response(event, _source())
+        runner._handle_gateway_outbound_response(event, _source())
+        assert invoked.call_count == 2
+        assert invoked.call_args_list[0] == invoked.call_args_list[1]
+
+    def test_hook_failure_never_escapes_runner(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.lifecycle.invoke_hook",
+            MagicMock(side_effect=RuntimeError("observer unavailable")),
+        )
+        self._runner(True)._handle_gateway_outbound_response(self._event(), _source())
+
+
+class TestSplitOutboundCorrelation:
+    def test_raw_response_message_ids_all_reach_outbound_hook(self, monkeypatch):
+        from gateway.platforms import base
+
+        monkeypatch.setenv(
+            "HERMES_GATEWAY_HOOK_PSEUDONYM_KEY",
+            "gateway-hook-test-key-at-least-16-bytes",
+        )
+        result = SendResult(
+            success=True,
+            message_id="chunk-1",
+            raw_response={"message_ids": ["chunk-1", "chunk-2", "chunk-3"]},
+        )
+        assert base._delivery_message_ids(result) == [
+            "chunk-1",
+            "chunk-2",
+            "chunk-3",
+        ]
+
+        invoked = MagicMock()
+        monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", invoked)
+        runner = TestOutboundRunnerBoundary._runner(True)
+        adapter = SimpleNamespace(
+            _outbound_response_handler=runner._handle_gateway_outbound_response
+        )
+        event = MessageEvent(
+            text="request",
+            source=_source(),
+            _hermes_turn_correlation={"turn_id": "turn-1", "trace_id": "trace-1"},
+        )
+        asyncio.run(
+            base.BasePlatformAdapter._fire_outbound_response(
+                adapter, event, base._delivery_message_ids(result)
+            )
+        )
+        assert invoked.call_count == 3
+        assert [
+            item.kwargs["target_message_id"] for item in invoked.call_args_list
+        ] == [
+            _pseudonym("message", "chunk-1"),
+            _pseudonym("message", "chunk-2"),
+            _pseudonym("message", "chunk-3"),
+        ]
+        assert {
+            item.kwargs["trace_id"] for item in invoked.call_args_list
+        } == {"trace-1"}
+
+
+class TestReactionRunnerBoundary:
+    @staticmethod
+    def _event() -> dict:
+        return {
+            "platform": "discord",
+            "event_type": "reaction",
+            "payload": {
+                "target_chat_id": "chat-1",
+                "target_thread_id": "thread-1",
+                "target_message_id": "message-1",
+                "actor_id": "actor-1",
+                "emoji": "👍",
+                "action": "add",
+                "timestamp": "2026-09-04T12:00:00+00:00",
+                "bot_authored_target": True,
+            },
+        }
+
+    @staticmethod
+    def _runner(authorized: bool):
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner._is_user_authorized = (
+            lambda source, *, allow_adapter_delegation=True: authorized
+        )
+        return runner
+
+    def test_reaction_hook_pseudonymizes_all_discord_ids(self, monkeypatch):
+        monkeypatch.setenv(
+            "HERMES_GATEWAY_HOOK_PSEUDONYM_KEY",
+            "gateway-hook-test-key-at-least-16-bytes",
+        )
+        invoked = MagicMock()
+        monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda _name: True)
+        monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", invoked)
+
+        asyncio.run(
+            self._runner(True)._handle_gateway_platform_event(self._event(), _source())
+        )
+
+        invoked.assert_called_once()
+        payload = invoked.call_args.kwargs["payload"]
+        serialized = json.dumps(payload)
+        for raw_id in ("chat-1", "thread-1", "message-1", "actor-1"):
+            assert raw_id not in serialized
+        assert all(
+            payload[field].startswith("hmac-sha256:")
+            for field in (
+                "target_chat_id",
+                "target_thread_id",
+                "target_message_id",
+                "actor_id",
+            )
+        )
+        assert payload["emoji"] == "👍"
+        assert payload["action"] == "add"
+        assert payload["bot_authored_target"] is True
+
+    def test_missing_key_omits_reaction_ids(self, monkeypatch):
+        monkeypatch.delenv("HERMES_GATEWAY_HOOK_PSEUDONYM_KEY", raising=False)
+        invoked = MagicMock()
+        monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda _name: True)
+        monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", invoked)
+
+        asyncio.run(
+            self._runner(True)._handle_gateway_platform_event(self._event(), _source())
+        )
+
+        invoked.assert_called_once()
+        payload = invoked.call_args.kwargs["payload"]
+        assert not {
+            "target_chat_id",
+            "target_thread_id",
+            "target_message_id",
+            "actor_id",
+        } & set(payload)
+
+    def test_non_reaction_platform_events_never_reach_subscriber_hooks(
+        self, monkeypatch
+    ):
+        invoked = MagicMock()
+        monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda _name: True)
+        monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", invoked)
+        event = {
+            "platform": "discord",
+            "event_type": "message_edited",
+            "payload": {
+                "chat_id": "chat-1",
+                "message_id": "message-1",
+                "text": "ordinary-edit-content-canary-93a2",
+            },
+        }
+
+        asyncio.run(
+            self._runner(True)._handle_gateway_platform_event(event, _source())
+        )
+
+        invoked.assert_not_called()

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -321,6 +321,9 @@ class TestTurnTraceIsolation:
         """A turn that never finalizes must not absorb the following turn."""
         mod = self._fresh_plugin()
         started: list = []
+        monkeypatch.setenv(
+            "HERMES_LANGFUSE_PSEUDONYM_KEY", "unit-test-turn-isolation-key"
+        )
         monkeypatch.setattr(mod, "_get_langfuse", lambda: self._fake_client(started))
         monkeypatch.setattr(mod, "_end_observation", lambda *a, **k: None)
         mod._TRACE_STATE.clear()
@@ -333,6 +336,8 @@ class TestTurnTraceIsolation:
         # Each turn opened its OWN root trace.  On the pre-fix code the second
         # turn reused turn 1's lingering state and only one trace was opened.
         assert len(started) == 2
+        assert started[0] != started[1]
+        assert all("sess-iso" not in trace_id for trace_id in started)
 
         # Turn 2 finalized and was popped by _finish_trace; only turn 1's
         # (non-finalizing) state lingers.  Assert the surviving key is turn 1's
@@ -1334,6 +1339,38 @@ class TestApiRequestErrorHook:
             error={"type": "X", "message": "y"}, retryable=False,
         )
 
+    def test_unsampled_failure_keeps_metadata_without_error_content(
+        self, monkeypatch
+    ):
+        mod = self._fresh_plugin()
+        monkeypatch.setenv("HERMES_LANGFUSE_CAPTURE", "sanitized")
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: object())
+        mod._TRACE_STATE.clear()
+        turn_id = "s:t:turn-unsampled"
+        task_key = mod._trace_key("t", "s", turn_id=turn_id)
+        gen, _root = self._seed_state(mod, task_key)
+        mod._TRACE_STATE[task_key].content_sampled = False
+
+        mod.on_api_request_error(
+            task_id="t",
+            session_id="s",
+            api_call_count=1,
+            turn_id=turn_id,
+            status_code=429,
+            retry_count=1,
+            retryable=True,
+            error={"type": "RateLimitError", "message": "private prompt echo"},
+        )
+
+        metadata = [u["metadata"] for u in gen.updates if "metadata" in u][0]
+        assert metadata["status_code"] == 429
+        assert metadata["retry_count"] == 1
+        assert metadata["error_message"] == {
+            "omitted": True,
+            "type": "text",
+            "chars": len("private prompt echo"),
+        }
+
     def test_error_message_respects_capture_mode(self, monkeypatch):
         mod = self._fresh_plugin()
         monkeypatch.setenv("HERMES_LANGFUSE_CAPTURE", "metadata")
@@ -1508,6 +1545,7 @@ class TestSubagentTracing:
 
     def test_start_attaches_span_despite_task_scoped_key(self, monkeypatch):
         mod = self._fresh_plugin()
+        monkeypatch.setenv("HERMES_LANGFUSE_PSEUDONYM_KEY", "p" * 32)
         spans = []
         # Key minted by the LLM hooks with a task id — a naive rebuild from
         # session_id alone would not match this.
@@ -1524,8 +1562,31 @@ class TestSubagentTracing:
 
         assert len(spans) == 1
         assert spans[0].kw["name"] == "Subagent: researcher"
-        assert spans[0].kw["metadata"]["child_subagent_id"] == "sub-1"
+        metadata = spans[0].kw["metadata"]
+        assert metadata["child_subagent_id"].startswith("hmac-sha256:")
+        assert metadata["child_session_id"].startswith("hmac-sha256:")
+        assert "sub-1" not in repr(metadata)
+        assert "child-sess-1" not in repr(metadata)
         assert "child-sess-1" in state.subagents
+
+    def test_start_omits_exported_child_ids_without_pseudonym_key(self, monkeypatch):
+        mod = self._fresh_plugin()
+        monkeypatch.delenv("HERMES_LANGFUSE_PSEUDONYM_KEY", raising=False)
+        spans = []
+        self._state(mod, monkeypatch, "task:task-9:turn:turn-7", spans)
+
+        mod.on_subagent_start(
+            parent_turn_id="turn-7",
+            parent_subagent_id="parent-1",
+            child_session_id="child-sess-1",
+            child_subagent_id="sub-1",
+            child_role="researcher",
+        )
+
+        metadata = spans[0].kw["metadata"]
+        assert "child_session_id" not in metadata
+        assert "child_subagent_id" not in metadata
+        assert "parent_subagent_id" not in metadata
 
     def test_stop_ends_span_and_records_outcome(self, monkeypatch):
         mod = self._fresh_plugin()
@@ -2387,3 +2448,547 @@ class TestCanonicalCostExport:
         # explicit zeros are treated as authoritative by Langfuse and block
         # its own model-based estimation (#43129).
         assert response_cost == {}
+
+
+class TestTelemetryV1Contract:
+    def _fresh_plugin(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        return importlib.import_module("plugins.observability.langfuse")
+
+    def test_root_metadata_is_versioned_fingerprinted_and_pseudonymous(
+        self, monkeypatch
+    ):
+        mod = self._fresh_plugin()
+        monkeypatch.setenv("HERMES_LANGFUSE_RELEASE", "test-release")
+        monkeypatch.setenv(
+            "HERMES_LANGFUSE_PSEUDONYM_KEY",
+            "unit-test-non-credential-hmac-material",
+        )
+        monkeypatch.setenv("HERMES_LANGFUSE_PSEUDONYM_KEY_VERSION", "test-v2")
+        started = []
+
+        class Span:
+            id = "root-observation"
+
+            def update_trace(self, **kwargs):
+                started.append(("trace", kwargs))
+
+        class Context:
+            def __enter__(self):
+                return Span()
+
+        class Client:
+            def create_trace_id(self, seed):
+                return f"trace::{seed}"
+
+            def start_as_current_observation(self, **kwargs):
+                started.append(("root", kwargs))
+                return Context()
+
+        raw_session = "discord:raw-chat-123456789"
+        raw_task = "raw-task-123456789"
+        request = {
+            "body": {
+                "messages": [{"role": "user", "content": "hello"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {"name": "read_file", "parameters": {}},
+                    }
+                ],
+            }
+        }
+        mod._start_root_trace(
+            "turn:one",
+            task_id=raw_task,
+            session_id=raw_session,
+            platform="discord",
+            provider="unit-provider",
+            model="unit-model",
+            api_mode="chat_completions",
+            messages=request["body"]["messages"],
+            request=request,
+            system_prompt="system contract",
+            client=Client(),
+            turn_id="turn-one",
+            enabled_tool_count=7,
+            tool_schema_bytes=1234,
+            tool_policy_fingerprint="sha256:" + "a" * 64,
+        )
+
+        root_kwargs = next(value for kind, value in started if kind == "root")
+        metadata = root_kwargs["metadata"]
+        rendered = repr(started)
+        assert metadata["telemetry_schema_version"] == "hermes.telemetry.v1"
+        assert metadata["hermes_release"] == "test-release"
+        assert metadata["pseudonym_key_version"] == "test-v2"
+        assert metadata["session_id"].startswith("hmac-sha256:")
+        assert metadata["task_id"].startswith("hmac-sha256:")
+        assert metadata["config_fingerprint"].startswith("sha256:")
+        assert metadata["prompt_fingerprint"].startswith("sha256:")
+        assert metadata["tool_policy_fingerprint"] == "sha256:" + "a" * 64
+        assert metadata["enabled_tool_count"] == 7
+        assert metadata["tool_schema_bytes"] == 1234
+        assert metadata["context_source_chars"] == {
+            "system_prompt": len("system contract"),
+            "conversation": len("hello"),
+        }
+        assert raw_session not in rendered
+        assert raw_task not in rendered
+
+    def test_raw_session_and_task_ids_are_omitted_without_hmac_key(self, monkeypatch):
+        mod = self._fresh_plugin()
+        monkeypatch.delenv("HERMES_LANGFUSE_PSEUDONYM_KEY", raising=False)
+        metadata = mod._telemetry_metadata(
+            task_id="raw-task-id",
+            session_id="discord:raw-session-id",
+            provider="provider",
+            model="model",
+            api_mode="chat_completions",
+            messages=[],
+            system_prompt=None,
+            request=None,
+        )
+        assert "task_id" not in metadata
+        assert "session_id" not in metadata
+        assert "raw-task-id" not in repr(metadata)
+        assert "raw-session-id" not in repr(metadata)
+
+    def test_short_pseudonym_key_omits_identifiers(self, monkeypatch):
+        mod = self._fresh_plugin()
+        monkeypatch.setenv("HERMES_LANGFUSE_PSEUDONYM_KEY", "too-short")
+        metadata = mod._telemetry_metadata(
+            task_id="raw-task-id",
+            session_id="discord:raw-session-id",
+            provider="provider",
+            model="model",
+            api_mode="chat_completions",
+            messages=[],
+            system_prompt=None,
+            request=None,
+        )
+        assert "task_id" not in metadata
+        assert "session_id" not in metadata
+        assert "pseudonym_key_version" not in metadata
+
+    def test_sdk_sampling_is_content_only_and_export_mask_is_installed(
+        self, monkeypatch
+    ):
+        mod = self._fresh_plugin()
+        captured = {}
+        monkeypatch.setenv(
+            "HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-unit-test-not-a-credential"
+        )
+        monkeypatch.setenv(
+            "HERMES_LANGFUSE_SECRET_KEY", "sk-lf-unit-test-not-a-credential"
+        )
+        monkeypatch.setenv("HERMES_LANGFUSE_SAMPLE_RATE", "0.25")
+
+        class Client:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr(mod, "Langfuse", Client)
+        monkeypatch.setattr(mod, "MaskOtelSpansResult", object)
+        monkeypatch.setattr(mod, "OtelSpanPatch", object)
+        monkeypatch.setattr(mod, "_LANGFUSE_CLIENT", None)
+        monkeypatch.setattr(mod, "_INIT_FAILED", False)
+        assert mod._get_langfuse() is not None
+        assert "sample_rate" not in captured
+        assert callable(captured["mask_otel_spans"])
+        assert mod._content_sample_rate() == 0.25
+
+    def test_sdk_without_span_mask_uses_fail_closed_mask_callback(
+        self, monkeypatch
+    ):
+        mod = self._fresh_plugin()
+        captured = {}
+        monkeypatch.setenv(
+            "HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-unit-public"
+        )
+        monkeypatch.setenv(
+            "HERMES_LANGFUSE_SECRET_KEY", "sk-lf-unit-secret"
+        )
+
+        class Client:
+            def __init__(
+                self,
+                *,
+                public_key=None,
+                secret_key=None,
+                base_url=None,
+                mask=None,
+                environment=None,
+                release=None,
+            ):
+                captured.update(
+                    public_key=public_key,
+                    secret_key=secret_key,
+                    base_url=base_url,
+                    mask=mask,
+                    environment=environment,
+                    release=release,
+                )
+
+        monkeypatch.setattr(mod, "Langfuse", Client)
+        monkeypatch.setattr(mod, "_LANGFUSE_CLIENT", None)
+        monkeypatch.setattr(mod, "_INIT_FAILED", False)
+        assert mod._get_langfuse() is not None
+        assert callable(captured["mask"])
+
+    def test_legacy_sdk_mask_failure_returns_redacted_sentinel(self, monkeypatch):
+        mod = self._fresh_plugin()
+        monkeypatch.setattr(
+            mod,
+            "_mask_text",
+            lambda _value: (_ for _ in ()).throw(RuntimeError("mask failed")),
+        )
+        assert mod._legacy_mask(data="do not export") == "<redacted:mask-failed>"
+
+    def test_export_mask_failure_drops_batch_instead_of_returning_original(
+        self, monkeypatch
+    ):
+        mod = self._fresh_plugin()
+        params = SimpleNamespace(
+            spans={
+                "span": SimpleNamespace(
+                    attributes={"langfuse.observation.input": "private"}
+                )
+            }
+        )
+
+        class Result:
+            def __init__(self, *, span_patches=None, drop=False):
+                self.span_patches = span_patches
+                self.drop = drop
+
+        monkeypatch.setattr(mod, "MaskOtelSpansResult", Result)
+        monkeypatch.setattr(
+            mod,
+            "_mask_export_value",
+            lambda _value: (_ for _ in ()).throw(RuntimeError("mask failed")),
+        )
+        masked = mod._mask_otel_spans(params=params)
+        assert masked.drop is True
+        assert not masked.span_patches
+
+    def test_unsampled_content_becomes_metadata_stub(self, monkeypatch):
+        mod = self._fresh_plugin()
+        monkeypatch.setenv("HERMES_LANGFUSE_CAPTURE", "sanitized")
+        assert mod._capture_content("private body", content_sampled=False) == {
+            "omitted": True,
+            "type": "text",
+            "chars": len("private body"),
+        }
+
+    def test_invalid_content_sample_rate_disables_content(self, monkeypatch):
+        mod = self._fresh_plugin()
+        monkeypatch.setenv("HERMES_LANGFUSE_SAMPLE_RATE", "not-a-rate")
+        assert mod._content_sample_rate() == 0.0
+
+    def test_unvalidated_fingerprint_is_omitted(self):
+        mod = self._fresh_plugin()
+        metadata = mod._telemetry_metadata(
+            provider="unit",
+            model="model",
+            api_mode="chat",
+            task_id="",
+            session_id="",
+            messages=[],
+            system_prompt=None,
+            request={},
+            tool_policy_fingerprint="raw-private-value",
+        )
+
+        assert "tool_policy_fingerprint" not in metadata
+
+    def test_outcome_fields_are_bounded_structured_values(self):
+        mod = self._fresh_plugin()
+        assert mod._structured_outcome_metadata(
+            route_reason_code="quota_fallback",
+            fallback_count=1,
+            retry_count=2,
+            quota_result_code="exhausted",
+        ) == {
+            "route_reason_code": "quota_fallback",
+            "fallback_count": 1,
+            "retry_count": 2,
+            "quota_result_code": "exhausted",
+        }
+        assert mod._structured_outcome_metadata(
+            route_reason_code="private free-form reason!",
+            fallback_count=-1,
+            retry_count="two",
+            quota_result_code="token=private",
+        ) == {}
+
+    def test_route_reason_uses_existing_middleware_reason_without_payload_leakage(self):
+        mod = self._fresh_plugin()
+        trace = [{"source": "router", "reason": "Quota Fallback", "private": "do-not-export"}]
+        assert mod._middleware_route_reason(trace) == "middleware_rewrite"
+
+    def test_usage_source_buckets_only_include_provider_reported_values(self):
+        mod = self._fresh_plugin()
+        usage = {
+            "input_tokens": 100,
+            "output_tokens": 20,
+            "cache_read_input_tokens": 30,
+            "reasoning_tokens": None,
+        }
+        assert mod._token_source_buckets(usage) == {
+            "input": 100,
+            "output": 20,
+            "cache_read": 30,
+        }
+
+    def test_tool_outcome_metadata_does_not_capture_result_content(self, monkeypatch):
+        mod = self._fresh_plugin()
+        updates = []
+        observation = SimpleNamespace(update=lambda **kwargs: updates.append(kwargs))
+        state = mod.TraceState(
+            trace_id="trace",
+            root_ctx=None,
+            root_span=SimpleNamespace(),
+            tools={"call": observation},
+        )
+        mod._TRACE_STATE[mod._trace_key("turn:call", "")] = state
+        monkeypatch.setattr(
+            mod,
+            "_end_observation",
+            lambda _observation, **kwargs: updates.append(kwargs),
+        )
+        mod.on_post_tool_call(
+            tool_name="terminal",
+            tool_call_id="call",
+            result="private command output",
+            status="error",
+            error_type="TimeoutError",
+            duration_ms=12,
+            middleware_trace=[{"policy": "deny", "private": "not-exported"}],
+            task_id="turn:call",
+        )
+        metadata = updates[-1]["metadata"]
+        assert metadata == {
+            "tool_name": "terminal",
+            "tool_call_id": "call",
+            "outcome_code": "error",
+            "error_type": "TimeoutError",
+            "duration_ms": 12,
+            "tool_policy_decision": "denied",
+        }
+        assert "private command output" not in repr(metadata)
+        assert "not-exported" not in repr(metadata)
+
+
+class TestUnsampledContentBoundary:
+    """sample_rate=0 is an absolute content boundary, not pattern redaction."""
+
+    @staticmethod
+    def _fresh_plugin(monkeypatch):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+        monkeypatch.setenv("HERMES_LANGFUSE_SAMPLE_RATE", "0")
+        monkeypatch.setenv("HERMES_LANGFUSE_CAPTURE", "sanitized")
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: object())
+        return mod
+
+    def test_trace_output_never_reintroduces_arbitrary_tool_content(self, monkeypatch):
+        mod = self._fresh_plugin(monkeypatch)
+        canary = "ordinary-tool-canary-7f7c6f"
+        state = mod.TraceState(
+            trace_id="trace-unsampled",
+            root_ctx=None,
+            root_span=None,
+            content_sampled=mod._content_is_sampled("trace-unsampled"),
+        )
+        state.turn_tool_calls.append(
+            {
+                "id": "call-1",
+                "name": "terminal",
+                "arguments": {"command": canary},
+                "output": {"stdout": canary},
+            }
+        )
+
+        merged = mod._merge_trace_output(
+            {"content": {"omitted": True, "type": "text", "chars": 4}}, state
+        )
+
+        assert state.content_sampled is False
+        assert canary not in repr(merged)
+        assert "tool_calls" not in merged
+        assert canary not in repr(
+            mod._capture_content({canary: True}, content_sampled=False)
+        )
+        assert mod._capture_content(True, content_sampled=False) == {
+            "omitted": True,
+            "type": "boolean",
+        }
+
+    def test_unsampled_post_llm_does_not_retain_raw_tool_arguments(
+        self, monkeypatch
+    ):
+        mod = self._fresh_plugin(monkeypatch)
+
+        class Observation:
+            def __init__(self):
+                self.updates = []
+
+            def update(self, **kwargs):
+                self.updates.append(kwargs)
+
+            def end(self):
+                pass
+
+        generation = Observation()
+        state = mod.TraceState(
+            trace_id="trace-unsampled",
+            root_ctx=None,
+            root_span=SimpleNamespace(),
+            content_sampled=mod._content_is_sampled("trace-unsampled"),
+            generations={"0": generation},
+        )
+        task_key = mod._trace_key("task-unsampled", "")
+        mod._TRACE_STATE[task_key] = state
+        canary = "ordinary-tool-argument-canary-2b76"
+        assistant_message = SimpleNamespace(
+            content="tool call pending",
+            tool_calls=[
+                SimpleNamespace(
+                    id="call-1",
+                    type="function",
+                    function=SimpleNamespace(name="terminal", arguments=canary),
+                )
+            ],
+        )
+
+        mod.on_post_llm_call(
+            task_id="task-unsampled",
+            assistant_message=assistant_message,
+            api_call_count=0,
+        )
+
+        assert state.turn_tool_calls == []
+        assert canary not in repr(generation.updates)
+        assert generation.updates[-1]["metadata"]["tool_call_count"] == 1
+
+    def test_unsampled_moa_output_is_omitted_but_usage_and_cost_remain(
+        self, monkeypatch
+    ):
+        mod = self._fresh_plugin(monkeypatch)
+        generations = []
+
+        class Observation:
+            def __init__(self, kwargs):
+                self.kwargs = kwargs
+                self.updates = {}
+
+            def update(self, **kwargs):
+                self.updates.update(kwargs)
+
+            def end(self):
+                pass
+
+        class Root:
+            def start_observation(self, **kwargs):
+                observation = Observation(kwargs)
+                generations.append(observation)
+                return observation
+
+        state = mod.TraceState(
+            trace_id="trace-unsampled",
+            root_ctx=None,
+            root_span=Root(),
+            content_sampled=mod._content_is_sampled("trace-unsampled"),
+        )
+        canary = "ordinary-moa-output-canary-c375"
+
+        mod._emit_moa_reference_generations(
+            state,
+            client=object(),
+            references=[
+                {
+                    "label": "advisor",
+                    "model": "model",
+                    "provider": "provider",
+                    "output": canary,
+                    "usage": {"input_tokens": 100, "output_tokens": 50},
+                    "cost_usd": 0.001,
+                }
+            ],
+        )
+
+        assert state.content_sampled is False
+        assert canary not in repr([generation.updates for generation in generations])
+        assert generations[0].updates["usage_details"] == {
+            "input": 100,
+            "output": 50,
+        }
+        assert generations[0].updates["cost_details"]["total"] == pytest.approx(
+            0.001
+        )
+
+    def test_unsampled_subagent_content_is_omitted_but_metadata_remains(
+        self, monkeypatch
+    ):
+        mod = self._fresh_plugin(monkeypatch)
+        spans = []
+
+        class Observation:
+            def __init__(self, kwargs):
+                self.kwargs = kwargs
+                self.updates = {}
+
+            def update(self, **kwargs):
+                self.updates.update(kwargs)
+
+            def end(self):
+                pass
+
+        class Root:
+            def start_observation(self, **kwargs):
+                observation = Observation(kwargs)
+                spans.append(observation)
+                return observation
+
+        state = mod.TraceState(
+            trace_id="trace-unsampled",
+            root_ctx=None,
+            root_span=Root(),
+            content_sampled=mod._content_is_sampled("trace-unsampled"),
+        )
+        mod._TRACE_STATE["task:t:turn:turn-unsampled"] = state
+        goal_canary = "ordinary-goal-canary-28d6"
+        summary_canary = "ordinary-summary-canary-56ad"
+        history_canary = "ordinary-history-canary-92bc"
+
+        mod.on_subagent_start(
+            parent_session_id="sess-1",
+            parent_turn_id="turn-unsampled",
+            child_session_id="child-sess-1",
+            child_role="researcher",
+            child_goal=goal_canary,
+        )
+        mod.on_subagent_stop(
+            parent_session_id="sess-1",
+            parent_turn_id="turn-unsampled",
+            child_session_id="child-sess-1",
+            child_role="researcher",
+            child_summary=summary_canary,
+            child_status="ok",
+            tool_call_history=[
+                {"name": "read_file", "side_effect_target": history_canary}
+            ],
+            duration_ms=42,
+        )
+
+        exported = repr([span.kwargs for span in spans]) + repr(
+            [span.updates for span in spans]
+        )
+        assert state.content_sampled is False
+        assert goal_canary not in exported
+        assert summary_canary not in exported
+        assert history_canary not in exported
+        assert spans[0].updates["metadata"]["status"] == "ok"
+        assert spans[0].updates["metadata"]["tool_call_count"] == 1
+        assert spans[0].updates["metadata"]["duration_ms"] == 42

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3264,6 +3264,12 @@ class TestRunConversation:
         ]
         assert all("message_count" in c and isinstance(c.get("request_messages"), list) for c in pre_request_calls)
         assert all("request" in c and "messages" in c["request"]["body"] for c in pre_request_calls)
+        assert all(c["enabled_tool_count"] == 1 for c in pre_request_calls)
+        assert all(c["tool_schema_bytes"] > 0 for c in pre_request_calls)
+        assert all(
+            re.fullmatch(r"sha256:[0-9a-f]{64}", c["tool_policy_fingerprint"])
+            for c in pre_request_calls
+        )
         assert any(msg.get("role") == "user" and msg.get("content") == "search something" for msg in pre_request_calls[0]["request_messages"])
         assert all("usage" in c and "response" in c for c in post_request_calls)
         assert all("assistant_message" in c["response"] for c in post_request_calls)


### PR DESCRIPTION
## Summary
- add a versioned content-free Hermes telemetry contract with HMAC-pseudonymous identifiers and content-independent sampling
- add fail-closed export masking and per-turn trace identity
- add authorization-gated Discord reaction/outbound hooks with split-message correlation and pseudonymous platform IDs
- restrict the Discord event surface to reactions only

## Verification
- affected suites: 569 passed, 1 skipped
- Langfuse plugin suite after final privacy fix: 109 passed
- independent adversarial re-review: PASS
- ruff, py_compile, and git diff --check: passed

## Notes
The one warning in the broad suite is the pre-existing `_BarrierDB.flush_token_counts` test-double warning.