### PR TITLE
fix(slack): stop mixing markdown_text into native task-card appendStream; cards now say WHY they failed

### DIFF
--- a/contributors/emails/admin@foundationoperations.com
+++ b/contributors/emails/admin@foundationoperations.com
@@ -1,0 +1,2 @@
+FoundationOperations
+# PR #103197 fix(slack): native task-card appendStream

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -300,7 +300,15 @@ class TurnRunner:
 
         def fallback_text(self) -> str:
             labels = {"in_progress": "running", "complete": "complete", "error": "error"}
-            lines = [f"- {t['title']} - {labels.get(t['status'], t['status'])}" for t in self.visible_tasks()]
+            lines = []
+            for t in self.visible_tasks():
+                line = f"- {t['title']} - {labels.get(t['status'], t['status'])}"
+                # Surface the failure reason inline (risk text) so the
+                # fallback rail carries the same signal as the card.
+                detail = str(t.get("details") or "").strip()
+                if t["status"] == "error" and detail:
+                    line += f" ({detail})"
+                lines.append(line)
             return "Hermes is working\n" + "\n".join(lines)
 
         def _upsert(self, call_id: str, title: str) -> Dict[str, str]:
@@ -325,7 +333,18 @@ class TurnRunner:
             # Completion-only events are rare but valid on some runtimes; keep their real ID instead
             # of guessing a same-name pending call.
             task = self.tasks.get(call_id) or self._upsert(call_id, tool_name)
-            task["status"] = "error" if raw.get("is_error") else "complete"
+            is_error = bool(raw.get("is_error"))
+            task["status"] = "error" if is_error else "complete"
+            # Failure suffix (the concrete "risk text": exit codes, error
+            # messages) rides the details field of the task_update chunk.
+            # Only present while failed: a retried call id that now succeeds
+            # must not keep a stale failure reason on the card, and clean
+            # tasks carry no details key at all.
+            detail = self._compact(raw.get("details"), 256)
+            if is_error and detail:
+                task["details"] = detail
+            else:
+                task.pop("details", None)
             return True
 
     async def _task_card_send_or_edit_fallback(self, st) -> None:
@@ -683,9 +702,14 @@ class TurnRunner:
             return
         from agent.display import _detect_tool_failure
         name = str(tool_name or "tool")
-        is_error, _ = _detect_tool_failure(name, result)
+        is_error, suffix = _detect_tool_failure(name, result)
+        # The failure suffix is the "risk text": the concrete reason a tool
+        # failed ("exit 1", "File not found: ..."). Surface it on the card
+        # (details field) instead of hiding it behind a bare "error" badge.
+        details = suffix.strip().strip("[]").strip() if is_error else ""
         self._ctx.progress_queue.put({
-            "type": "tool.completed", "tool_call_id": str(call_id or ""), "tool_name": name, "is_error": bool(is_error),
+            "type": "tool.completed", "tool_call_id": str(call_id or ""), "tool_name": name,
+            "is_error": bool(is_error), "details": details,
         })
 
     def combined_tool_start_callback(self, call_id, tool_name, args):

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1865,7 +1865,14 @@ class SlackAdapter(BasePlatformAdapter):
         self, chat_id: str, tasks: List[Dict[str, str]], *, title: str = "Hermes is working",
         reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None,
         fallback_text: Optional[str] = None) -> SendResult:
-        """Start or update a Slack-native plan/task progress stream."""
+        """Start or update a Slack-native plan/task progress stream.
+
+        ``fallback_text`` is accepted for caller compatibility but must never
+        be mixed into the chunk payload — Slack rejects appendStream calls
+        that carry both top-level ``markdown_text`` and ``chunks``. The text
+        fallback belongs to the editable-text fallback rail only.
+        """
+        del fallback_text
         if not self._app:
             return SendResult(success=False, error="Not connected")
         if not tasks:
@@ -1904,8 +1911,13 @@ class SlackAdapter(BasePlatformAdapter):
                 chunks.extend(self._task_update_chunk(task) for task in tasks)
                 append_payload: Dict[str, Any] = {
                     "channel": chat_id, "ts": stream.stream_ts, "chunks": chunks}
-                if fallback_text:
-                    append_payload["markdown_text"] = fallback_text
+                # Slack rejects appendStream calls that carry both top-level
+                # ``markdown_text`` and ``chunks``
+                # (``cannot_provide_both_markdown_text_and_chunks``). The
+                # plan/task chunks are the primary payload here; the text
+                # fallback belongs to the gateway's editable-text fallback
+                # rail for when the native rail fails, so it must not be
+                # sent alongside the chunks.
                 await client.api_call("chat.appendStream", json=append_payload)
                 return SendResult(success=True, message_id=stream.stream_ts)
             except Exception as exc:  # pragma: no cover - defensive logging
@@ -1918,9 +1930,20 @@ class SlackAdapter(BasePlatformAdapter):
         status = str(task.get("status") or "in_progress")
         status = status if status in {"in_progress", "complete", "error"} else "in_progress"
         task_id = str(task.get("id") or task.get("task_id") or "task")
-        return {
-            "type": "task_update", "id": task_id, "title": str(task.get("title") or task_id)[:256],
-            "status": status}
+        chunk: Dict[str, Any] = {
+            "type": "task_update", "id": task_id,
+            "title": str(task.get("title") or task_id)[:256], "status": status}
+        # Rich card fields: ``details`` carries the concrete failure reason
+        # (exit codes, error messages) so a red card says WHY; ``output``
+        # carries a result summary when the caller provides one. Slack caps
+        # both at 256 chars.
+        details = str(task.get("details") or "").strip()
+        if details:
+            chunk["details"] = details[:256]
+        output = str(task.get("output") or "").strip()
+        if output:
+            chunk["output"] = output[:256]
+        return chunk
 
     async def _stop_native_task_card_stream(
         self, key: Tuple[str, str, str], stream: _NativeTaskCardStream) -> None:
@@ -1931,7 +1954,15 @@ class SlackAdapter(BasePlatformAdapter):
             try:
                 if self._app and stream.stream_ts:
                     await self._get_client(stream.channel, team_id=stream.team_id).api_call(
-                        "chat.stopStream", json={"channel": stream.channel, "ts": stream.stream_ts})
+                        "chat.stopStream",
+                        json={
+                            "channel": stream.channel,
+                            "ts": stream.stream_ts,
+                            # Mark the card's session closed once the turn is
+                            # done — otherwise Slack keeps the card in a
+                            # live/typing session state after we stop appending.
+                            "session_status": "closed",
+                        })
             except Exception as exc:  # pragma: no cover - defensive logging
                 logger.debug("[Slack] Native task-card stopStream failed: %s", exc)
             finally:

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -308,6 +308,33 @@ class DuplicateNativeToolsAgent:
         return {"final_response": "done", "messages": [], "api_calls": 1}
 
 
+class RetryNativeToolsAgent:
+    """Fails a call once, then retries the same call id to success — the
+    stale failure reason must clear off the card."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tool_start_callback = kwargs.get("tool_start_callback")
+        self.tool_complete_callback = kwargs.get("tool_complete_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None, **kwargs):
+        self.tool_start_callback("call-1", "web_search", {"query": "alpha"})
+        time.sleep(0.15)
+        self.tool_complete_callback(
+            "call-1", "web_search", {"query": "alpha"}, '{"error": "rate limited"}'
+        )
+        time.sleep(0.15)
+        # Retry under the same call id; success must drop the stale reason.
+        self.tool_start_callback("call-1", "web_search", {"query": "alpha"})
+        time.sleep(0.15)
+        self.tool_complete_callback(
+            "call-1", "web_search", {"query": "alpha"}, '{"success": true}'
+        )
+        time.sleep(0.15)
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
 class ThinkingAgent:
     """Agent that emits _thinking scratch text (no tool calls).
 
@@ -1097,6 +1124,9 @@ async def test_slack_native_progress_correlates_concurrent_duplicate_tools_by_id
             "id": "call-b",
             "title": "web_search - beta",
             "status": "error",
+            # Failed tools carry the concrete failure reason (risk text) so
+            # the red card says WHY, not just THAT.
+            "details": "boom",
         },
     ]
     assert adapter.sent == []
@@ -1126,9 +1156,48 @@ async def test_slack_native_failure_keeps_editing_one_live_text_fallback(
     assert adapter.sent[0]["content"].endswith("web_search - alpha - running")
     assert len(adapter.edits) >= 2
     assert {edit["message_id"] for edit in adapter.edits} == {"progress-1"}
-    assert adapter.edits[-1]["content"].endswith("web_search - beta - error")
+    # The fallback rail carries the same failure reason (risk text) as the
+    # native card would.
+    assert adapter.edits[-1]["content"].endswith("web_search - beta - error (boom)")
     assert "web_search - alpha - complete" in adapter.edits[-1]["content"]
     assert adapter.native_stops == 1
+
+
+@pytest.mark.asyncio
+async def test_slack_native_retry_clears_stale_failure_details(
+    monkeypatch, tmp_path
+):
+    """A retried call id that now succeeds must not keep the stale failure
+    reason on the card — details ride the failure, not the call id."""
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        RetryNativeToolsAgent,
+        session_id="sess-native-retry",
+        platform=Platform.SLACK,
+        chat_id="C1",
+        thread_id="thread-1",
+        adapter_cls=NativeTaskCardAdapter,
+        user_id="U1",
+        scope_id="T1",
+    )
+
+    assert result["final_response"] == "done"
+    # Mid-turn the failed attempt surfaces its reason on the card...
+    failed = next(
+        update
+        for update in adapter.native_updates
+        if update["tasks"] and update["tasks"][-1].get("details") == "rate limited"
+    )
+    assert failed["tasks"][-1]["status"] == "error"
+    # ...and the final snapshot shows the successful retry with no stale reason.
+    assert adapter.native_updates[-1]["tasks"] == [
+        {
+            "id": "call-1",
+            "title": "web_search - alpha",
+            "status": "complete",
+        },
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -5143,6 +5143,92 @@ class TestNativeTaskCardProgress:
         ]
         assert adapter._native_task_card_streams == {}
 
+    @pytest.mark.asyncio
+    async def test_append_stream_never_mixes_markdown_text_and_chunks(self, adapter):
+        """Slack rejects appendStream payloads carrying both top-level
+        ``markdown_text`` and ``chunks``
+        (``cannot_provide_both_markdown_text_and_chunks``). The fallback text
+        belongs to the editable-text fallback rail only."""
+        team_client = AsyncMock()
+
+        async def api_call(method, *, json):
+            if method == "chat.startStream":
+                return {"ts": "stream-1"}
+            return {"ok": True}
+
+        team_client.api_call.side_effect = api_call
+        adapter._team_clients["T1"] = team_client
+        tasks = [{"id": "call-1", "title": "terminal", "status": "in_progress"}]
+
+        result = await adapter.send_native_task_card_progress(
+            "C1", tasks, metadata={"thread_id": "thread-1", "slack_team_id": "T1"},
+            fallback_text="Hermes is working\n- terminal - running",
+        )
+
+        assert result.success
+        appends = [
+            call.kwargs["json"]
+            for call in team_client.api_call.await_args_list
+            if call.args[0] == "chat.appendStream"
+        ]
+        assert appends, "expected an appendStream call"
+        for payload in appends:
+            assert "chunks" in payload
+            assert "markdown_text" not in payload
+
+    @pytest.mark.asyncio
+    async def test_stop_stream_marks_session_closed(self, adapter):
+        """stopStream must carry ``session_status: closed`` so the card's
+        session closes with the turn instead of lingering in a live/typing
+        state after we stop appending."""
+        team_client = AsyncMock()
+
+        async def api_call(method, *, json):
+            if method == "chat.startStream":
+                return {"ts": "stream-1"}
+            return {"ok": True}
+
+        team_client.api_call.side_effect = api_call
+        adapter._team_clients["T1"] = team_client
+        metadata = {"thread_id": "thread-1", "slack_team_id": "T1"}
+        await adapter.send_native_task_card_progress(
+            "C1",
+            [{"id": "call-1", "title": "terminal", "status": "in_progress"}],
+            metadata=metadata,
+        )
+
+        await adapter.stop_native_task_card_progress("C1", metadata=metadata)
+
+        stop_call = team_client.api_call.await_args
+        assert stop_call.args[0] == "chat.stopStream"
+        assert stop_call.kwargs["json"]["session_status"] == "closed"
+
+    def test_task_update_chunk_carries_failure_details_and_caps(self):
+        """Failed tools render WHY on the card: ``details`` carries the
+        concrete failure reason and ``output`` a result summary, both capped
+        at the 256-char spec limit."""
+        chunk = SlackAdapter._task_update_chunk(
+            {
+                "id": "call-1",
+                "title": "terminal - ls",
+                "status": "error",
+                "details": "ls: cannot access: No such file or directory",
+            }
+        )
+        assert chunk["details"] == "ls: cannot access: No such file or directory"
+        assert "output" not in chunk
+
+        long_reason = "x" * 300
+        capped = SlackAdapter._task_update_chunk(
+            {"id": "call-2", "title": "t", "status": "error", "details": long_reason}
+        )
+        assert capped["details"] == "x" * 256
+
+        clean = SlackAdapter._task_update_chunk(
+            {"id": "call-3", "title": "t", "status": "complete"}
+        )
+        assert "details" not in clean and "output" not in clean
+
 
 # ---------------------------------------------------------------------------
 # TestSlackAuthoredTextDeduplication


### PR DESCRIPTION
## Symptom

Slack native task cards (the "Hermes is working" plan cards behind `platforms.slack.extra.native_task_cards`) fail every update and the gateway silently falls back to the plain editable-text rail. When they do render, failed tools show a bare red "error" badge with no reason, and finished cards linger in a live/typing session state after the turn ends.

## Root cause (three related defects)

1. **Mixed appendStream payload.** `send_native_task_card_progress` sent the gateway's fallback text as top-level `markdown_text` alongside `chunks` in every `chat.appendStream` call. Slack rejects that combination (`cannot_provide_both_markdown_text_and_chunks`), so the native rail never worked. The fallback text belongs to the editable-text fallback rail only — chunks are the primary payload.
2. **Failure reason discarded.** `_detect_tool_failure` already computes the concrete "risk text" (`exit 1`, `File not found: x.py`), but `native_tool_complete_callback` threw it away (`is_error, _`). The card said THAT a step failed, never WHY.
3. **Unclosed stream session.** `chat.stopStream` never sent `session_status`, leaving the card session open after the turn.

## Fix

- `plugins/platforms/slack/adapter.py` — drop `markdown_text` from the chunk payload (kept in the signature for caller compat, documented + `del`'d); `_task_update_chunk` now carries `details` (failure reason) and `output` (result summary), both capped at the 256-char spec limit; `stopStream` sends `session_status: "closed"`.
- `gateway/run_turn_runner.py` — the completion callback forwards the failure suffix as `details` on the `tool.completed` event; `_TaskCardState.apply_event` stores it on the task and clears it when the same call id retries to success (no stale reason); `fallback_text()` carries the reason inline (`- terminal - error (exit 1)`) so the editable-text rail has the same signal as the card.

## Verification

Reproduced on current `main` (`b0ab2e163a`): the mixed payload is unconditional at the appendStream call site; the suffix discard is at `native_tool_complete_callback`.

Tests (301 passing across the touched suites):
- appendStream payloads never mix `markdown_text` with `chunks`
- stopStream marks `session_status: closed`
- `details` survive to chunks and the fallback rail, cap at 256
- a retried call id that succeeds clears the stale failure reason

```
tests/gateway/test_run_progress_topics.py
tests/gateway/test_slack.py
tests/gateway/test_slack_native_streaming.py
tests/agent/test_display_tool_failure.py
tests/gateway/relay/test_relay_task_card_failures.py
301 passed
ruff check — clean
```

Also live-verified against a real Slack workspace: a run with a deliberately failing tool rendered the reason on the red card and closed the session cleanly.


Fixes #87743