### PR TITLE
fix(mcp): open OAuth browser once per flow

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -352,6 +352,27 @@ class TestUtilities:
         assert _can_open_browser() is True
 
 
+class TestRedirectHandlerBrowserOpen:
+    def test_browser_opens_once_per_handler(self, monkeypatch, capsys):
+        import tools.mcp_oauth as mod
+
+        monkeypatch.setattr(mod, "_is_interactive", lambda: True)
+        monkeypatch.setattr(mod, "_can_open_browser", lambda: True)
+        opened = MagicMock(return_value=False)
+        monkeypatch.setattr(mod.webbrowser, "open", opened)
+
+        first_handler = _make_redirect_handler(49199)
+        asyncio.run(first_handler("https://example.com/auth?attempt=1"))
+        asyncio.run(first_handler("https://example.com/auth?attempt=2"))
+        asyncio.run(_make_redirect_handler(49198)("https://example.com/auth?attempt=3"))
+
+        assert [args.args[0] for args in opened.call_args_list] == [
+            "https://example.com/auth?attempt=1",
+            "https://example.com/auth?attempt=3",
+        ]
+        assert "https://example.com/auth?attempt=2" in capsys.readouterr().err
+
+
 class TestRedirectHandlerSshHint:
     """_make_redirect_handler must print an SSH tunnel hint on remote sessions."""
 

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -536,15 +536,23 @@ _SSH_HINT_LOOPBACK = (
     "  See: https://hermes-agent.nousresearch.com/docs/guides/oauth-over-ssh\n")
 
 
-def _announce_authorization_url(authorization_url: str, port: int, redirect_uri: str | None) -> None:
-    """Print the URL (always, as the fallback) and open the browser when possible."""
+def _announce_authorization_url(
+    authorization_url: str,
+    port: int,
+    redirect_uri: str | None,
+    *,
+    auto_open: bool = True,
+) -> None:
+    """Print the URL (always, as the fallback) and open the browser when allowed."""
     print(f"\n  MCP OAuth: authorization required.\n  Open this URL in your browser:\n\n    {authorization_url}\n", file=sys.stderr)
     if os.getenv("SSH_CLIENT") or os.getenv("SSH_TTY"):
         if redirect_uri:
             print(_SSH_HINT_PROXY.format(redirect_uri=redirect_uri), file=sys.stderr)
         elif port:
             print(_SSH_HINT_LOOPBACK.format(port=port), file=sys.stderr)
-    if not _can_open_browser():
+    if not auto_open:
+        note = "Automatic browser open is limited to the first URL for this login — open the updated URL manually."
+    elif not _can_open_browser():
         note = "Headless environment detected — open the URL manually."
     else:
         opened = False
@@ -558,10 +566,13 @@ def _make_redirect_handler(port: int, redirect_uri: str | None = None):
     """Redirect handler closing over this flow's port (a closure, not ``_oauth_port``, keeps concurrent
     flows isolated). ``redirect_uri`` is a configured proxy callback (None for loopback) and only tailors the hint.
 
-    Using a closure instead of reading the module-level ``_oauth_port`` avoids cross-server state pollution
-    when multiple MCP servers run OAuth concurrently (fixes #44588).
+    The closure also limits automatic browser opening to one attempt while still printing any updated URL
+    supplied by an SDK retry. A new handler represents a new OAuth flow and gets its own browser-open attempt.
     """
+    auto_open_allowed = True
+
     async def _redirect_handler(authorization_url: str) -> None:
+        nonlocal auto_open_allowed
         dashboard_flow = get_dashboard_oauth_flow()
         if dashboard_flow is not None:
             await dashboard_flow.publish_authorization_url(authorization_url)
@@ -577,7 +588,14 @@ def _make_redirect_handler(port: int, redirect_uri: str | None = None):
         _raise_if_non_interactive(
             "MCP OAuth requires browser authorization but no interactive session is available (non-interactive/background context)."
         )
-        _announce_authorization_url(authorization_url, port, redirect_uri)
+        auto_open = auto_open_allowed
+        auto_open_allowed = False
+        _announce_authorization_url(
+            authorization_url,
+            port,
+            redirect_uri,
+            auto_open=auto_open,
+        )
 
     return _redirect_handler
 


### PR DESCRIPTION
## Problem

The MCP SDK can invoke one OAuth `redirect_handler` repeatedly after callback timeouts, each time with a fresh authorization URL. The handler currently calls `webbrowser.open()` on every invocation, so one `hermes mcp login notion` attempt can create hundreds of browser pages while waiting for consent.

Reproduction: create one `_make_redirect_handler(...)`, invoke it two or more times in an interactive/browser-capable context, and observe one `webbrowser.open()` call per invocation.

## Fix

- Keep the guard inside the redirect-handler closure, so one OAuth flow can attempt automatic browser opening only once.
- Consume that one-shot allowance before the browser call, including when `webbrowser.open()` returns false or raises.
- Continue printing every updated authorization URL and the existing SSH/manual fallback guidance.
- Leave dashboard URL publishing and non-interactive fail-closed behavior unchanged.

Both the legacy `build_oauth_auth` path and the manager used by `login`/`reauth` construct handlers through shared `build_provider_kwargs`, so the fix applies without call-site duplication.

This is intentionally narrower than the module-global/explicit-flow gate proposed in #96358: it preserves normal interactive browser opening and scopes deduplication to exactly one handler/login attempt.

## Changed files

- `tools/mcp_oauth.py` — add the per-handler one-shot browser-open allowance.
- `tests/tools/test_mcp_oauth.py` — prove repeated calls on one handler open once, a new handler opens once, and the later URL is still printed.

## Verification

- Regression test on unmodified `main`: failed with 3 browser-open calls instead of 2.
- `scripts/run_tests.sh tests/tools/test_mcp_oauth*.py tests/tools/test_mcp_dashboard_oauth.py` — 107 passed.
- `scripts/run_tests.sh tests/tools/test_mcp*.py` — 664 passed.
- `python -m ruff check tools/mcp_oauth.py tests/tools/test_mcp_oauth.py` — passed.
- `scripts/run_tests.sh tests/tools/` — broader run reached 18 unrelated failing files; the same 18 files also fail on clean `main` (83 baseline failures vs. 82 on this branch), while all MCP tests pass.

Refs #96320
