### PR TITLE
fix(tools): harden file search roots and rg diagnostics

### DIFF
--- a/agent/search_policy.py
+++ b/agent/search_policy.py
@@ -25,6 +25,8 @@ SEARCH_PRUNE_DIR_NAMES = frozenset({
     "__pycache__", ".cache", ".Trash", ".tox", ".nox", ".mypy_cache",
     ".pytest_cache", ".ruff_cache", ".npm", ".yarn", ".pnpm-store",
     ".gradle", ".m2", ".nuget",
+    # Toolchain and editor caches (multi-GB source trees on developer hosts).
+    ".cargo", ".rustup", ".cursor", ".vscode-server",
     # Backup copies.
     "backups", "backup", ".backups",
 })

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -454,6 +454,159 @@ class TestSearchPathValidation:
         assert result.error is not None
         assert "search failed" in result.error.lower() or "Search error" in result.error
 
+    def test_dangling_symlink_root_is_classified_before_existence_check(self, mock_env):
+        commands = []
+
+        def side_effect(command, **kwargs):
+            commands.append(command)
+            if command.startswith("if test -L"):
+                return {"output": "symlink", "returncode": 0}
+            if command.startswith("if test -e"):
+                return {"output": "dangling", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        result = ShellFileOperations(mock_env).search("*.py", path="/offline-link", target="files")
+
+        assert result.error is not None
+        assert "dangling symlink" in result.error.lower()
+        assert commands[0].startswith("if test -L")
+        assert "test -e" not in commands[0].split("then", 1)[0]
+        assert not any("command -v" in command for command in commands)
+
+    def test_unresponsive_symlink_root_fails_before_search_engine(self, mock_env):
+        commands = []
+
+        def side_effect(command, **kwargs):
+            commands.append((command, kwargs.get("timeout")))
+            if command.startswith("if test -L"):
+                return {"output": "symlink", "returncode": 0}
+            if command.startswith("if test -e"):
+                return {"output": "[Command timed out after 5s]", "returncode": 124}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        result = ShellFileOperations(mock_env).search("*.py", path="/project/external", target="files")
+
+        assert result.error is not None
+        assert "symlink" in result.error.lower()
+        assert "unresponsive" in result.error.lower()
+        assert commands[-1][1] == 5
+        assert not any("command -v" in command for command, _timeout in commands)
+
+    def test_unresponsive_initial_probe_fails_before_search_engine(self, mock_env):
+        commands = []
+
+        def side_effect(command, **kwargs):
+            commands.append((command, kwargs.get("timeout")))
+            if command.startswith("if test -L"):
+                return {"output": "[Command timed out after 5s]", "returncode": 124}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        result = ShellFileOperations(mock_env).search(
+            "*.py", path="/project/unresponsive", target="files")
+
+        assert result.error is not None
+        assert "unresponsive" in result.error.lower()
+        assert commands[0][1] == 5
+        assert not any("command -v" in command for command, _timeout in commands)
+
+    def test_multi_path_reports_skipped_unresponsive_root(self, mock_env, monkeypatch):
+        ops = ShellFileOperations(mock_env)
+        monkeypatch.setattr(
+            ops,
+            "_path_exists_probe",
+            lambda path: "exists" if path == "/project" else "unresponsive",
+        )
+        monkeypatch.setattr(
+            ops,
+            "_search_files",
+            lambda *_args, **_kwargs: SearchResult(files=["/project/a.py"], total_count=1),
+        )
+
+        result = ops._try_multi_path_search(
+            "*.py", "/project /offline", "files", None, 10, 0, "content", 0)
+
+        assert result is not None
+        assert result.files == ["/project/a.py"]
+        assert "skipped unavailable" in (result.warning or "").lower()
+        assert "/offline (unresponsive root)" in (result.warning or "")
+
+    def test_broad_root_is_rejected_before_probe_or_engine_discovery(self, mock_env):
+        result = ShellFileOperations(mock_env).search("*.py", path="/", target="files")
+
+        assert result.error is not None
+        assert "too broad" in result.error.lower()
+        mock_env.execute.assert_not_called()
+
+    def test_project_below_home_is_not_rejected_as_broad(self, mock_env):
+        mock_env.cwd = "/Users/tester/project"
+        mock_env.execute.side_effect = [
+            {"output": "exists", "returncode": 0},
+            {"output": "yes", "returncode": 0},
+            {"output": "/Users/tester/project/main.py", "returncode": 0},
+        ]
+
+        result = ShellFileOperations(mock_env).search(
+            "*.py", path="/Users/tester/project", target="files")
+
+        assert result.error is None
+
+
+class TestFileSearchRipgrepDiagnostics:
+    def test_file_enumeration_surfaces_pure_rg_error(self, mock_env, monkeypatch):
+        monkeypatch.setattr(
+            "tools.file_operations_search.secrets.token_hex", lambda _size: "testmarker")
+        mock_env.execute.return_value = {
+            "output": "__HERMES_RG_DIAGNOSTIC_testmarker__rg: /offline: Interrupted system call (os error 4)\n",
+            "returncode": 2,
+        }
+
+        ops = ShellFileOperations(mock_env)
+        monkeypatch.setattr(ops, "_resolve_command", lambda _cmd: "rg")
+        result = ops._search_files_rg("*.py", "/offline", limit=10, offset=0)
+
+        assert result.files == []
+        assert result.error is not None
+        assert "Interrupted system call" in result.error
+
+    def test_file_enumeration_keeps_partial_results_and_diagnostics(self, mock_env, monkeypatch):
+        monkeypatch.setattr(
+            "tools.file_operations_search.secrets.token_hex", lambda _size: "testmarker")
+        mock_env.execute.return_value = {
+            "output": "/project/good.py\n__HERMES_RG_DIAGNOSTIC_testmarker__rg: /project/offline: Interrupted system call (os error 4)\n",
+            "returncode": 2,
+        }
+
+        ops = ShellFileOperations(mock_env)
+        monkeypatch.setattr(ops, "_resolve_command", lambda _cmd: "rg")
+        result = ops._search_files_rg("*.py", "/project", limit=10, offset=0)
+
+        assert result.error is None
+        assert result.files == ["/project/good.py"]
+        assert result.warning is not None
+        assert "Interrupted system call" in result.warning
+
+    def test_rg_prefixed_filename_is_not_misclassified_as_diagnostic(self, mock_env, monkeypatch):
+        monkeypatch.setattr(
+            "tools.file_operations_search.secrets.token_hex", lambda _size: "testmarker")
+        mock_env.execute.return_value = {
+            "output": (
+                "__HERMES_RG_DIAGNOSTIC__.py\n"
+                "__HERMES_RG_DIAGNOSTIC_testmarker__rg: /offline: I/O error\n"
+            ),
+            "returncode": 2,
+        }
+
+        ops = ShellFileOperations(mock_env)
+        monkeypatch.setattr(ops, "_resolve_command", lambda _cmd: "rg")
+        result = ops._search_files_rg("*.py", "/project", limit=10, offset=0)
+
+        assert result.error is None
+        assert result.files == ["__HERMES_RG_DIAGNOSTIC__.py"]
+        assert "I/O error" in (result.warning or "")
+
 
 class TestSearchFilesFallbackHiddenPaths:
     def _make_env(self):

--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -235,7 +235,7 @@ class TestPaginationBounds:
 
         def fake_exec(command, *args, **kwargs):
             commands.append(command)
-            if command.startswith("test -e"):
+            if command.startswith(("test -e ", "if test -L ")):
                 return MagicMock(exit_code=0, stdout="exists")
             if "--files" in command:
                 return MagicMock(exit_code=0, stdout="a.py\n")

--- a/tests/tools/test_macos_protected_search.py
+++ b/tests/tools/test_macos_protected_search.py
@@ -3,6 +3,8 @@
 import re
 from pathlib import Path
 
+import pytest
+
 import tools.file_operations as file_operations
 from tools.environments.local import LocalEnvironment
 from tools.file_operations import ShellFileOperations
@@ -382,3 +384,46 @@ def test_real_ripgrep_does_not_descend_into_protected_folder(tmp_path, monkeypat
     paths = [match.path for match in result.matches]
     assert any("visible.txt" in path for path in paths)
     assert all("protected.txt" not in path for path in paths)
+
+
+def test_protected_globs_survive_shell_cwd_outside_search_root(tmp_path, monkeypatch):
+    """rg anchors --glob to the shell cwd, not the search root. With cwd at
+    ~/workspace and the search rooted at ~, the root-relative ``!Library/**``
+    never matches, so the walk descends into ~/Library. The ``**/`` form must
+    also be emitted, on the main pass and on every zero-match probe."""
+    import shutil
+    if not shutil.which("rg"):
+        pytest.skip("ripgrep not installed")
+    home = tmp_path / "Users" / "alice"
+    workspace = home / "workspace"
+    workspace.mkdir(parents=True)
+    (workspace / "notes.txt").write_text("needle here\n")
+    library = home / "Library" / "App"
+    library.mkdir(parents=True)
+    (library / "secret.txt").write_text("needle protected\n")
+    monkeypatch.setattr(file_operations, "_HOME", str(home))
+    monkeypatch.setattr(file_operations.sys, "platform", "darwin")
+    ops = ShellFileOperations(LocalEnvironment(cwd=str(workspace)))
+
+    result = ops.search("needle", path=str(home), target="content")
+
+    matched_paths = [m.path for m in (result.matches or [])]
+    assert any(str(workspace / "notes.txt") in p for p in matched_paths)
+    assert not any(str(library / "secret.txt") in p for p in matched_paths)
+
+
+def test_zero_match_probes_carry_protected_globs(tmp_path, monkeypatch):
+    home = tmp_path / "Users" / "alice"
+    home.mkdir(parents=True)
+    env = RecordingEnvironment(home / "workspace")
+    ops = ShellFileOperations(env)
+    monkeypatch.setattr(file_operations, "_HOME", str(home))
+    monkeypatch.setattr(file_operations.sys, "platform", "darwin")
+
+    ops.search("needle", path=str(home), target="content")
+
+    probes = [c for c in env.commands if "--count-matches" in c]
+    assert probes, "zero-match probes should run on an empty result"
+    for command in probes:
+        for dirname in PROTECTED_NAMES:
+            assert f"!**/{dirname}/**" in command

--- a/tests/tools/test_macos_protected_search.py
+++ b/tests/tools/test_macos_protected_search.py
@@ -16,7 +16,7 @@ class RecordingEnvironment:
 
     def execute(self, command, cwd=None, **kwargs):
         self.commands.append(command)
-        if command.startswith("test -e"):
+        if command.startswith(("test -e", "if test -L")):
             return {"output": "exists\n", "returncode": 0}
         if command.startswith("command -v"):
             return {"output": "yes\n", "returncode": 0}
@@ -219,7 +219,7 @@ def _multi_root_protected_search(tmp_path, monkeypatch, engine):
     def execute(command, cwd=None, **kwargs):
         nonlocal path_checks
         env.commands.append(command)
-        if command.startswith("test -e"):
+        if command.startswith(("test -e", "if test -L")):
             path_checks += 1
             output = "not_found\n" if path_checks == 1 else "exists\n"
             return {"output": output, "returncode": 0}
@@ -243,7 +243,7 @@ def test_rg_multi_root_keeps_explicit_protected_root_and_reports_actual_skips(
     absolute_operand = downloads.as_posix() in command
     anchored_operand = (
         f"cd {ops._escape_shell_arg(downloads.parent.as_posix())} &&" in command
-        and " -- '.' 'Downloads' 2>/dev/null" in command
+        and " -- '.' 'Downloads'" in command
     )
     assert absolute_operand or anchored_operand
     assert "!Downloads/**" not in command
@@ -279,7 +279,7 @@ def test_rg_multi_root_scopes_protected_globs_and_restores_absolute_paths(monkey
 
     def execute(command, cwd=None, **kwargs):
         env.commands.append(command)
-        if command.startswith("test -e"):
+        if command.startswith(("test -e", "if test -L")):
             output = "not_found\n" if "'/Users/alice /repo'" in command else "exists\n"
             return {"output": output, "returncode": 0}
         if command.startswith("command -v rg"):
@@ -301,7 +301,7 @@ def test_rg_multi_root_scopes_protected_globs_and_restores_absolute_paths(monkey
     commands = _rg_files_commands(env.commands)
     assert len(commands) == 1
     command = commands[0]
-    assert command.startswith("set -o pipefail; cd '/' && ")
+    assert "cd '/' && " in command
     assert "--sortr=modified" in command
     assert "'!Users/alice/Downloads/**'" in command
     assert "'!repo/Downloads/**'" not in command
@@ -320,7 +320,7 @@ def test_rg_scoped_multi_root_handles_dot_spaces_and_overlapping_roots(monkeypat
 
     def execute(command, cwd=None, **kwargs):
         env.commands.append(command)
-        if command.startswith("test -e"):
+        if command.startswith(("test -e", "if test -L")):
             output = "not_found\n" if "'., /Users/alice'" in command else "exists\n"
             return {"output": output, "returncode": 0}
         if command.startswith("command -v rg"):
@@ -347,7 +347,7 @@ def test_rg_scoped_multi_root_terminates_options_before_dash_prefixed_root(monke
 
     def execute(command, cwd=None, **kwargs):
         env.commands.append(command)
-        if command.startswith("test -e"):
+        if command.startswith(("test -e", "if test -L")):
             output = "not_found\n" if "'., --version'" in command else "exists\n"
             return {"output": output, "returncode": 0}
         if command.startswith("command -v rg"):
@@ -361,7 +361,7 @@ def test_rg_scoped_multi_root_terminates_options_before_dash_prefixed_root(monke
 
     command = _rg_files_commands(env.commands)[0]
     assert "cd '/Users/alice' &&" in command
-    assert " -- '.' '--version' 2>/dev/null" in command
+    assert " -- '.' '--version'" in command
     assert result.error is None
 
 

--- a/tests/tools/test_search_budget_truncation.py
+++ b/tests/tools/test_search_budget_truncation.py
@@ -107,7 +107,7 @@ class FindRecordingEnvironment:
 class MultiRootFindEnvironment(FindRecordingEnvironment):
     def execute(self, command, **kwargs):
         self.commands.append((command, kwargs))
-        if command.startswith("test -e "):
+        if command.startswith(("test -e ", "if test -L ")):
             output = "not_found\n" if "'/one/.hidden /two/.cache'" in command else "exists\n"
             return {"output": output, "returncode": 0}
         if command.startswith("command -v find"):

--- a/tests/tools/test_search_files_engine_selection.py
+++ b/tests/tools/test_search_files_engine_selection.py
@@ -21,7 +21,7 @@ class RecordingEnvironment:
 
     def execute(self, command, **kwargs):
         self.commands.append(command)
-        if command.startswith("test -e "):
+        if command.startswith(("test -e ", "if test -L ")):
             return {"output": "exists\n", "returncode": 0}
         if command.startswith("command -v rg"):
             return {"output": "/opt/Rip Grep/rg\n", "returncode": 0}
@@ -65,7 +65,7 @@ def test_bounded_filename_total_is_serialized_as_a_lower_bound(engine, monkeypat
 
     def execute(command, **kwargs):
         env.commands.append(command)
-        if command.startswith("test -e "):
+        if command.startswith(("test -e ", "if test -L ")):
             return {"output": "exists\n", "returncode": 0}
         if command.startswith("command -v rg"):
             return {
@@ -138,7 +138,7 @@ def test_modified_requires_parseable_ripgrep_14_before_search(version):
 
     def execute(command, **kwargs):
         env.commands.append(command)
-        if command.startswith("test -e "):
+        if command.startswith(("test -e ", "if test -L ")):
             return {"output": "exists\n", "returncode": 0}
         if command.startswith("command -v rg"):
             return {"output": "/opt/Rip Grep/rg\n", "returncode": 0}
@@ -222,15 +222,17 @@ def test_modified_capability_failure_is_actionable_and_not_downgraded():
 
 
 @pytest.mark.parametrize("order", ["discovery", "modified"])
-def test_rg_partial_output_with_error_exit_fails_closed(order):
+def test_rg_partial_output_with_error_exit_preserves_results_and_warns(order):
     env = RecordingEnvironment(rg_output="/repo/partial.py\n", rg_code=2)
 
     result = ShellFileOperations(env).search(
         "*.py", path="/repo", target="files", order=order
     )
 
-    assert result.error is not None
-    assert result.files == []
+    assert result.error is None
+    assert result.files == ["/repo/partial.py"]
+    assert "partial results" in (result.warning or "").lower()
+    assert "status 2" in (result.warning or "").lower()
     assert len(env.rg_commands) == 1
 
 
@@ -308,7 +310,7 @@ def test_repeated_search_key_distinguishes_order(monkeypatch):
 class RipgrepInvocationEnvironment(RecordingEnvironment):
     def execute(self, command, **kwargs):
         self.commands.append(command)
-        if command.startswith("test -e "):
+        if command.startswith(("test -e ", "if test -L ")):
             return {"output": "exists\n", "returncode": 0}
         if command.startswith("command -v rg"):
             return {"output": "/opt/Rip Grep/rg\n", "returncode": 0}
@@ -401,7 +403,7 @@ def test_remote_msys_shaped_executable_is_not_rewritten_as_controller_path():
 
     def execute(command, **kwargs):
         env.commands.append(command)
-        if command.startswith("test -e "):
+        if command.startswith(("test -e ", "if test -L ")):
             return {"output": "exists\n", "returncode": 0}
         if command.startswith("command -v rg"):
             return {"output": "/c/remote-tools/rg\n", "returncode": 0}
@@ -436,7 +438,7 @@ def test_modified_multi_path_search_preserves_exact_order_request():
 
     def execute(command, **kwargs):
         env.commands.append(command)
-        if command.startswith("test -e "):
+        if command.startswith(("test -e ", "if test -L ")):
             if "'/one /two'" in command:
                 return {"output": "not_found\n", "returncode": 0}
             return {"output": "exists\n", "returncode": 0}
@@ -469,7 +471,7 @@ def test_comma_delimited_file_roots_preserve_internal_spaces_in_one_search():
     def execute(command, **kwargs):
         nonlocal path_checks
         env.commands.append(command)
-        if command.startswith("test -e "):
+        if command.startswith(("test -e ", "if test -L ")):
             path_checks += 1
             output = "not_found\n" if path_checks == 1 else "exists\n"
             return {"output": output, "returncode": 0}
@@ -496,7 +498,7 @@ def test_multi_path_modified_capability_error_propagates():
 
     def execute(command, **kwargs):
         env.commands.append(command)
-        if command.startswith("test -e "):
+        if command.startswith(("test -e ", "if test -L ")):
             output = "not_found\n" if "'/one /two'" in command else "exists\n"
             return {"output": output, "returncode": 0}
         if command.startswith("command -v rg"):

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1357,13 +1357,33 @@ class ShellFileOperations(LintMixin, SearchMixin, FileOperations):
                 error=(f"Invalid file search order {order!r}; expected "
                        "'discovery' or 'modified'."))
         path = self._expand_path(path)
-        if "not_found" in self._path_exists_probe(path):
+        broad_root = self._unbounded_search_root(path)
+        if broad_root:
+            return SearchResult(
+                error=(f"Search root is too broad for recursive traversal: {broad_root}. "
+                       "Narrow path to a project, workspace, or known artifact directory."),
+                total_count=0)
+        path_status = self._path_exists_probe(path)
+        if "unresponsive" in path_status:
+            return SearchResult(error=(
+                f"Search root is unresponsive: {path}. "
+                "The bounded existence probe timed out; narrow the root or retry."))
+        if "not_found" in path_status:
             # Models often pass several paths in one string: search the parts that exist.
             multi = self._try_multi_path_search(
                 pattern, path, target, file_glob, limit, offset, output_mode, context, order)
             if multi is not None:
                 return multi
             return self._path_not_found_result(path)
+        if "symlink" in path_status:
+            target_status = self._symlink_target_status(path)
+            if target_status == "dangling":
+                return SearchResult(error=(
+                    f"Search root is a dangling symlink: {path}. Repair the link target before retrying."))
+            if target_status == "unresponsive":
+                return SearchResult(error=(
+                    f"Search root is a symlink whose target is unresponsive: {path}. "
+                    "Repair or remount the target filesystem before retrying."))
         result = self._dispatch_search(pattern, path, target, file_glob, limit, offset,
                                        output_mode, context, order)
         exclusions = self._macos_search_exclusions(path)

--- a/tools/file_operations_search.py
+++ b/tools/file_operations_search.py
@@ -7,6 +7,7 @@
 import os
 import posixpath
 import re
+import secrets
 import sys
 import threading
 from pathlib import Path
@@ -139,6 +140,20 @@ def _split_tool_diagnostics(output: str) -> tuple[str, str]:
         else:
             diagnostics.append(line)
     return '\n'.join(diagnostics), '\n'.join(payload)
+
+
+def _split_file_search_diagnostics(output: str, marker: str) -> tuple[str, str]:
+    """Separate tagged ``rg --files`` diagnostics without guessing path syntax."""
+    diagnostics: list[str] = []
+    files: list[str] = []
+    for line in output.split("\n"):
+        if not line:
+            continue
+        if line.startswith(marker):
+            diagnostics.append(line.removeprefix(marker))
+            continue
+        files.append(line)
+    return "\n".join(diagnostics), "\n".join(files)
 
 
 def _parse_search_context_line(line: str) -> tuple[str, int, str] | None:
@@ -392,8 +407,49 @@ class SearchMixin:
         return out
 
     def _path_exists_probe(self, path: str) -> str:
-        """Stdout of the existence probe: contains "exists" or "not_found"."""
-        return self._exec(f"test -e {self._escape_shell_arg(path)} && echo exists || echo not_found").stdout
+        """Classify a search root without dereferencing symlink targets."""
+        quoted = self._escape_shell_arg(path)
+        result = self._exec(
+            f"if test -L {quoted}; then echo symlink; "
+            f"elif test -e {quoted}; then echo exists; else echo not_found; fi",
+            timeout=5,
+        )
+        if result.exit_code == 124:
+            return "unresponsive"
+        return result.stdout
+
+    def _symlink_target_status(self, path: str) -> str:
+        """Return reachable, dangling, or unresponsive for a symlink target."""
+        quoted = self._escape_shell_arg(path)
+        probe = self._exec(
+            f"if test -e {quoted}; then echo reachable; else echo dangling; fi",
+            timeout=5,
+        )
+        if probe.exit_code == 124:
+            return "unresponsive"
+        return "reachable" if "reachable" in probe.stdout else "dangling"
+
+    def _unbounded_search_root(self, path: str) -> Optional[str]:
+        """Return an account/filesystem root unsafe for recursive traversal."""
+        effective_cwd = getattr(self.env, "cwd", None) or self.cwd
+        raw = (path or ".").strip()
+        if not os.path.isabs(raw) and not re.match(r"^[A-Za-z]:[\\/]", raw):
+            raw = os.path.join(effective_cwd, raw)
+        normalized = os.path.normpath(raw)
+        posix = normalized.replace("\\", "/")
+        filesystem_root = posix == "/" or re.fullmatch(r"[A-Za-z]:/?", posix)
+        account_root = (
+            posix in {"/home", "/Users", "/root"}
+            or re.fullmatch(r"/(?:home|Users)/[^/]+", posix)
+            or re.fullmatch(r"[A-Za-z]:/Users/[^/]+", posix, re.IGNORECASE)
+        )
+        if filesystem_root:
+            return normalized
+        if account_root and not self._macos_search_exclusions(path):
+            return normalized
+        if self._is_broad_local_search_root(path) and not self._macos_search_exclusions(path):
+            return normalized
+        return None
 
     def _dispatch_search(self, pattern: str, path: str, target: str,
                          file_glob: Optional[str], limit: int, offset: int,
@@ -433,11 +489,37 @@ class SearchMixin:
             parts = path.split()
         if len(parts) < 2:
             return None
-        existing, missing = [], []
+        existing, missing, unavailable, broad_roots = [], [], [], []
         for p in parts:
             expanded = self._expand_path(p)
-            (existing if "exists" in self._path_exists_probe(expanded) else missing).append(expanded)
+            broad_root = self._unbounded_search_root(expanded)
+            if broad_root:
+                broad_roots.append(broad_root)
+                continue
+            status = self._path_exists_probe(expanded)
+            if "symlink" in status:
+                target_status = self._symlink_target_status(expanded)
+                if target_status == "reachable":
+                    existing.append(expanded)
+                else:
+                    unavailable.append(f"{expanded} ({target_status} symlink target)")
+            elif "unresponsive" in status:
+                unavailable.append(f"{expanded} (unresponsive root)")
+            else:
+                (existing if "exists" in status else missing).append(expanded)
         if not existing:
+            if unavailable:
+                return SearchResult(
+                    error=("Every candidate search root is unavailable: "
+                           + ", ".join(unavailable[:3])
+                           + ". Narrow the path or retry."),
+                    total_count=0)
+            if broad_roots:
+                return SearchResult(
+                    error=("Every existing path is too broad for recursive traversal: "
+                           + ", ".join(broad_roots[:3])
+                           + ". Narrow path to a project, workspace, or known artifact directory."),
+                    total_count=0)
             return None
         if target == "files":
             # One global traversal across roots so modified ordering and pagination
@@ -461,6 +543,14 @@ class SearchMixin:
             note += "; skipped missing: " + ", ".join(missing[:3])
             if len(missing) > 3:
                 note += f" (+{len(missing) - 3} more)"
+        if unavailable:
+            note += "; skipped unavailable: " + ", ".join(unavailable[:3])
+            if len(unavailable) > 3:
+                note += f" (+{len(unavailable) - 3} more)"
+        if broad_roots:
+            note += "; skipped broad roots: " + ", ".join(broad_roots[:3])
+            if len(broad_roots) > 3:
+                note += f" (+{len(broad_roots) - 3} more)"
         warning_parts = [note]
         if not merged.error:
             protected_paths = [absolute for _r, _rel, absolute in self._effective_macos_search_exclusions(existing)]
@@ -693,26 +783,47 @@ class SearchMixin:
         sort_arg = " --sortr=modified" if order == "modified" else ""
         root_args = " ".join(self._escape_native_tool_arg(root) for root in command_roots)
         cd_prefix = f"cd {self._escape_shell_arg(scoped_common)} && " if scoped_common else ""
+        diagnostic_marker = f"__HERMES_RG_DIAGNOSTIC_{secrets.token_hex(16)}__"
         # ``--`` terminates options so a dash-prefixed root is never parsed as a flag.
-        cmd = (f"set -o pipefail; {cd_prefix}{rg} --files{sort_arg} -g {self._escape_shell_arg(glob_pattern)}"
-               f"{exclusion_args} -- {root_args} 2>/dev/null | head -n {fetch_limit}")
+        cmd = (
+            "set -o pipefail; "
+            "diagnostics_file=$(mktemp \"${TMPDIR:-/tmp}/hermes-rg-files.XXXXXX\") || exit 1; "
+            "trap 'rm -f \"$diagnostics_file\"' EXIT; "
+            f"{cd_prefix}{rg} --files{sort_arg} -g {self._escape_shell_arg(glob_pattern)}"
+            f"{exclusion_args} -- {root_args} 2>\"$diagnostics_file\" "
+            f"| head -n {fetch_limit}; "
+            "rg_status=${PIPESTATUS[0]}; "
+            f"sed 's/^/{diagnostic_marker}/' \"$diagnostics_file\"; "
+            "exit \"$rg_status\""
+        )
         result = self._exec(cmd, timeout=60)
         stdout, limit_reason = _search_stdout_and_limit(result)
-        all_files = [f for f in stdout.splitlines() if f]
+        diagnostics, payload = _split_file_search_diagnostics(stdout, diagnostic_marker)
+        all_files = [f for f in payload.splitlines() if f]
         if scoped_common:
             all_files = [
                 f if posixpath.isabs(f) else posixpath.normpath(posixpath.join(scoped_common, f))
                 for f in all_files]
         bounded_sigpipe = result.exit_code == 141 and len(all_files) >= fetch_limit
-        if result.exit_code not in {0, 1, 124} and not bounded_sigpipe:
+        partial_rg_error = result.exit_code == 2 and bool(all_files)
+        if result.exit_code not in {0, 1, 124} and not bounded_sigpipe and not partial_rg_error:
             if order == "modified":
                 return SearchResult(error=(
                     "Exact modification-time order failed; ripgrep 14+ is "
                     "required. Upgrade ripgrep or use order='discovery'."))
+            if result.exit_code == 2:
+                error_msg = diagnostics.strip() or result.stdout.strip() or "File search error"
+                return SearchResult(error=f"File search failed: {error_msg}", total_count=0)
             return SearchResult(error="File search failed while running ripgrep.")
         return SearchResult(
             files=all_files[offset:offset + limit], total_count=len(all_files),
-            truncated=len(all_files) > offset + limit or bool(limit_reason), limit_reason=limit_reason)
+            truncated=len(all_files) > offset + limit or bool(limit_reason), limit_reason=limit_reason,
+            warning=(
+                "File search returned partial results; ripgrep "
+                + (f"reported: {diagnostics.strip()}" if diagnostics.strip()
+                   else f"exited with status {result.exit_code}.")
+                if partial_rg_error else None),
+        )
 
     def _search_content(self, pattern: str, path: str, file_glob: Optional[str],
                         limit: int, offset: int, output_mode: str, context: int) -> SearchResult:

--- a/tools/file_operations_search.py
+++ b/tools/file_operations_search.py
@@ -401,9 +401,14 @@ class SearchMixin:
 
     def _rg_exclusion_globs(self, path: str) -> List[str]:
         """``--glob '!<dir>/**'`` pairs excluding protected dirs from an rg run."""
+        # rg anchors --glob to the shell cwd, not the search root, so the
+        # root-relative form only matches when cwd == root. Emit the ``**/``
+        # form too (same trade-off as _search_prune_glob_args) so a search
+        # rooted at $HOME from ~/workspace still skips ~/Library & co.
         out: List[str] = []
         for item in self._macos_search_exclusions(path):
-            out.extend(["--glob", self._escape_shell_arg(f"!{item}/**")])
+            for prefix in ("", "**/"):
+                out.extend(["--glob", self._escape_shell_arg(f"!{prefix}{item}/**")])
         return out
 
     def _path_exists_probe(self, path: str) -> str:
@@ -593,6 +598,11 @@ class SearchMixin:
         rg = self._quote_executable(rg_executable)
         has_meta = bool(re.search(r"[.\[\](){}?*+^$\\|]", pattern))
         glob_expr = f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else ""
+        # Probes must honour the same protected-dir pruning as the main pass;
+        # --hidden --no-ignore otherwise walks all of ~/Library.
+        exclusion_expr = " ".join(self._rg_exclusion_globs(path))
+        if exclusion_expr:
+            glob_expr = f"{glob_expr} {exclusion_expr}"
         for flags, template in self._ZERO_MATCH_PROBES:
             if flags == "-F" and not has_meta:
                 continue
@@ -768,8 +778,9 @@ class SearchMixin:
                 for _r, _rel, absolute in effective_exclusions]
         else:
             exclusion_terms = [
-                f"--glob {self._escape_shell_arg(f'!{relative}/**')}"
-                for _r, relative, _abs in effective_exclusions]
+                f"--glob {self._escape_shell_arg(f'!{prefix}{relative}/**')}"
+                for _r, relative, _abs in effective_exclusions
+                for prefix in ("", "**/")]
         exclusion_globs = " ".join(dict.fromkeys(exclusion_terms))
         exclusion_args = f" {exclusion_globs}" if exclusion_globs else ""
         rg_executable = rg_executable or self._resolve_command("rg")


### PR DESCRIPTION
## What does this PR do?

Hardens `search_files` against roots that make `rg --files` hang, blow past the result budget, or hide the reason a root yielded nothing.

- Roots that are the filesystem root, an account root (`/Users/<name>`, `/home/<name>`, `C:/Users/<name>`), or a broad local root are rejected before any probe runs, with a message telling the caller to narrow the path. On macOS an account root is still allowed when the protected-location exclusions apply to it, so the existing macOS home-directory behaviour is unchanged.
- The root existence probe and the symlink resolution probe are bounded to 5 seconds each, so an unreachable network mount or a stalled protected location no longer stalls the tool call.
- `rg --files` stderr is captured through a `mktemp` file and tagged with a per-run randomised marker (`__HERMES_RG_DIAGNOSTIC_<token>__`). A real file whose name happens to start with the bare prefix is never misclassified as a diagnostic. `PIPESTATUS` is preserved so rg's own exit code survives the pipeline.
- Multi-root searches label roots that were unavailable, missing, or too broad in the result summary instead of silently returning fewer matches.

This started as local changes that `hermes update` autostashed; it was rebased onto current `main` and re-verified before opening.

### Second and third commits: macOS protected-folder globs never applied when the shell cwd differs from the search root

ripgrep matches `--glob` patterns relative to the shell's current working directory, not the search root. The macOS TCC exclusions were emitted as root-relative `!Library/**`, so they only worked when the terminal cwd happened to equal the search root. With `terminal.cwd` set to a project directory (or `hermes` launched from one), a search rooted at `$HOME` walked all of `~/Library` (663k files on the reporting machine), hit the 60 s budget, and then both zero-match probes, which carried no exclusions at all, burned their 30 s budgets too. Every home-rooted `search_files` call cost 120 s and returned `search_timeout` with zero results; 70 such timeouts in 30 days of one user's `state.db`.

The existing test passed because it builds `LocalEnvironment(cwd=str(home))`, the one configuration where the root-relative glob works.

- Emit the `**/<dir>/**` form of each protected-folder glob alongside the root-relative one, on the main content pass, on `rg --files`, and on every zero-match probe. Same trade-off `_search_prune_glob_args` already makes. Explicit roots inside a protected folder are unaffected because exclusions are only computed for ancestor roots.
- Add `.cargo`, `.rustup`, `.cursor`, `.vscode-server` to `SEARCH_PRUNE_DIR_NAMES`. They behave like `.npm`, `.gradle`, `.m2`, which are already pruned: multi-GB toolchain and editor caches that never hold user work. The hidden/no-ignore probe over `$HOME` read 3.7 GB from the two Rust caches alone.

Measured through `search_tool` on the reporting machine: home-rooted content miss 120.6 s (timeout) to 19.8 s; home-rooted content hit from timeout with no results to 2.7 s; `rg --files` rooted at home from timeouts to 0.6 s.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_operations_search.py`: root rejection, bounded probes, diagnostic capture with randomised marker, `PIPESTATUS` handling, per-root labels.
- `tools/file_operations.py`: threads the new root diagnostics into the tool result.
- `tests/tools/test_file_operations.py`: new tests for root rejection, probe timeouts, diagnostic separation (including a file literally named `__HERMES_RG_DIAGNOSTIC__.py`), and multi-root labels.
- `tests/tools/test_macos_protected_search.py`, `test_search_files_engine_selection.py`, `test_file_operations_edge_cases.py`, `test_search_budget_truncation.py`: updated for the new call shape.
- `tools/file_operations_search.py` (`_rg_exclusion_globs`, `_zero_match_probe`, `_search_files_rg`): emit `**/`-prefixed protected-folder globs so they match from any shell cwd, and pass them to the zero-match probes.
- `agent/search_policy.py`: prune `.cargo`, `.rustup`, `.cursor`, `.vscode-server`.
- `tests/tools/test_macos_protected_search.py`: two regression tests, both fail without the fix. One runs real `rg` with cwd at `~/workspace` and the search rooted at `~` and asserts the `~/Library` file is not returned; the other captures the probe commands and asserts they carry the globs.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_subdirectory_hints.py tests/tools/test_file_operations.py tests/tools/test_macos_protected_search.py tests/tools/test_search_files_engine_selection.py tests/tools/test_file_operations_edge_cases.py -q` (217 passed, 5 skipped, on macOS 15).
4. Glob fix, on macOS: set `terminal.cwd` to a project directory (anything other than `$HOME`), then ask the agent to content-search `~` for a string that does not exist. Before: 120 s and `limit_reason: search_timeout`. After: completes in seconds, and the result `warning` lists the skipped protected folders. A search rooted at `~/Library/LaunchAgents` still returns results.
2. Ask the agent to search `/` or your home directory; it should refuse with a narrowing hint instead of running `rg` over the whole disk.
3. Search a directory containing an unreachable subtree (an unmounted network path or a macOS protected folder without Full Disk Access); the result should list matches from the good roots and label the bad one.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (ran the affected `tests/tools/` files via `scripts/run_tests.sh`; full suite not run)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the `rg --files` command already ran as a bash pipeline (`set -o pipefail … | head`) on every platform, including Git Bash on Windows. This change adds `mktemp`, `trap`, `sed`, and `PIPESTATUS` to that same pipeline; all are available in Git Bash. Not exercised on a Windows machine, so reviewer eyes on that path are welcome.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

https://claude.ai/code/session_0172F8vLzidVpiYUjzRYxu2m
https://claude.ai/code/session_01JdCStfk1ANLJzur4DXdyTV

