### PR TITLE
test: silence system audio players under pytest on macOS

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ import importlib
 import os
 import shutil
 import sqlite3
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -1079,11 +1080,89 @@ def _wal_is_usable() -> bool:
 #    available to the tests that legitimately exercise it with a mocked
 #    audio backend (``tests/tools/test_voice_mode.py``).
 #
+#  • ``tools.voice_mode._spawn_system_player`` — the one place voice_mode
+#    starts ``afplay`` / ``ffplay`` / ``aplay``. Second incident (2026-09-04):
+#    a macOS run played beeps and spoke "Hello world." through the speakers.
+#    Neither route passed through the two bindings above:
+#      - ``tools.tts_tool.stream_tts_to_speaker`` does its own late
+#        ``from tools.voice_mode import play_audio_file`` (the "Hello world."
+#        fixture in ``tests/gateway/test_voice_command.py``, synthesised by
+#        the keyless ``edge`` provider);
+#      - ``play_beep`` on macOS skips sounddevice (TCC prompt) and writes a
+#        temp WAV that goes through the same ``play_audio_file``.
+#    Every one of them ends in this spawn, so that is where it is stopped.
+#    The stub hands the call through when a test has stubbed
+#    ``subprocess.Popen`` itself (such a test is asserting on argv/env, not
+#    making noise), and otherwise returns a finished no-op process.
+#
 # Config cannot re-open this hole: the ``tts:`` section of ``config.yaml``
 # only selects *which* provider speaks, never *whether* to speak — that gate
 # is the env var alone.
 
 _AUDIO_GUARD_BYPASS_MARK = "real_audio_playback"
+
+# Captured at import, before any fixture wraps it. ``_live_system_guard``
+# installs a *subclass* of the real ``Popen`` for every test (so isinstance
+# checks keep working); a test that stubs ``Popen`` itself installs a plain
+# function or a Mock. That is the distinction the spawn guard relies on.
+_REAL_POPEN = subprocess.Popen
+
+
+def _popen_would_really_spawn() -> bool:
+    """True when ``subprocess.Popen`` is the real class or a subclass of it
+    (the live-system guard's wrapper) — i.e. calling it starts a process."""
+    cur = subprocess.Popen
+    return isinstance(cur, type) and issubclass(cur, _REAL_POPEN)
+
+
+class _SilentPlayer:
+    """Stand-in for an already-finished system-player process."""
+
+    returncode = 0
+    pid = -1
+
+    def wait(self, timeout=None):
+        return 0
+
+    def poll(self):
+        return 0
+
+    def terminate(self):
+        pass
+
+    def kill(self):
+        pass
+
+
+def _make_silent_spawn(real_spawn):
+    def _silent_spawn_system_player(cmd, env):
+        if not _popen_would_really_spawn():
+            # The test stubbed the primitive itself — honour its stub so
+            # argv/env assertions keep working (it makes no noise).
+            return real_spawn(cmd, env)
+        return _SilentPlayer()
+
+    return _silent_spawn_system_player
+
+
+@pytest.fixture(scope="session")
+def _audio_playback_spawn_guard_session():
+    """Session-lived state for the system-player spawn guard.
+
+    The silent spawn is installed by the per-test guard on first use (so
+    ``tools.voice_mode`` is first imported under the hermetic environment,
+    exactly as before) but through *this* session-scoped MonkeyPatch, so it
+    stays in place between tests. That matters: the 2026-09-04 incident
+    included a beep fired from a daemon thread *after* its test had finished,
+    i.e. after a function-scoped monkeypatch would have restored the real
+    spawn. ``state["real"]`` is the real spawn, handed back to tests marked
+    ``real_audio_playback`` for their duration only.
+    """
+    state = {"real": None, "mp": pytest.MonkeyPatch()}
+    try:
+        yield state
+    finally:
+        state["mp"].undo()
 _ALLOW_MACOS_KEYCHAIN_MARK = "allow_macos_keychain"
 
 # ---------------------------------------------------------------------------
@@ -1657,7 +1736,7 @@ def _live_system_guard(request, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def _audio_playback_guard(request, monkeypatch):
+def _audio_playback_guard(request, monkeypatch, _audio_playback_spawn_guard_session):
     """Stub TTS synthesis + speaker playback for every test.
 
     See the block comment above for the incident this closes. Defence in
@@ -1672,14 +1751,13 @@ def _audio_playback_guard(request, monkeypatch):
     surface. Silence is the whole point. Tests that genuinely want real audio
     can opt out with ``@pytest.mark.real_audio_playback``.
     """
-    if request.node.get_closest_marker(_AUDIO_GUARD_BYPASS_MARK):
-        yield
-        return
+    spawn_state = _audio_playback_spawn_guard_session
 
-    try:
-        import hermes_cli.voice as _voice
-    except Exception:
-        # Optional audio deps missing — nothing importable to speak with.
+    if request.node.get_closest_marker(_AUDIO_GUARD_BYPASS_MARK):
+        if spawn_state["real"] is not None:
+            import tools.voice_mode as _vm
+
+            monkeypatch.setattr(_vm, "_spawn_system_player", spawn_state["real"])
         yield
         return
 
@@ -1689,10 +1767,37 @@ def _audio_playback_guard(request, monkeypatch):
     def _blocked_play_audio_file(path, *args, **kwargs):
         return False
 
-    if hasattr(_voice, "speak_text"):
-        monkeypatch.setattr(_voice, "speak_text", _blocked_speak_text)
-    if hasattr(_voice, "play_audio_file"):
-        monkeypatch.setattr(_voice, "play_audio_file", _blocked_play_audio_file)
+    try:
+        import hermes_cli.voice as _voice
+    except Exception:
+        # Optional audio deps missing — nothing importable to speak with.
+        _voice = None
+
+    if _voice is not None:
+        if hasattr(_voice, "speak_text"):
+            monkeypatch.setattr(_voice, "speak_text", _blocked_speak_text)
+        if hasattr(_voice, "play_audio_file"):
+            monkeypatch.setattr(_voice, "play_audio_file", _blocked_play_audio_file)
+
+    # Third route: the system-player spawn itself (see the comment block
+    # above). Installed through the session-scoped MonkeyPatch so it persists
+    # between tests; re-checked every test in case one reloaded
+    # ``tools.voice_mode`` and got the real spawn back.
+    try:
+        import tools.voice_mode as _vm
+    except Exception:
+        _vm = None
+
+    current = getattr(_vm, "_spawn_system_player", None)
+    if (
+        current is not None
+        and current.__name__ != "_silent_spawn_system_player"
+    ):
+        if spawn_state["real"] is None:
+            spawn_state["real"] = current
+        spawn_state["mp"].setattr(
+            _vm, "_spawn_system_player", _make_silent_spawn(spawn_state["real"])
+        )
 
     yield
 

--- a/tests/test_audio_playback_guard.py
+++ b/tests/test_audio_playback_guard.py
@@ -29,8 +29,10 @@ test from re-setting the variable mid-test.
 """
 
 import os
+import subprocess
 import sys
 import types
+import wave
 
 import pytest
 
@@ -124,3 +126,83 @@ def test_bypass_marker_restores_the_real_speak_text():
     import hermes_cli.voice as voice
 
     assert voice.speak_text.__name__ == "speak_text"
+
+
+def _write_silent_wav(path):
+    with wave.open(str(path), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(16000)
+        wf.writeframes(b"\x00\x00" * 160)
+
+
+def _force_system_player_path(monkeypatch, vm, which_result):
+    """Steer ``play_audio_file`` to the afplay spawn regardless of host."""
+    monkeypatch.setattr(vm, "_sounddevice_output_allowed", lambda: False)
+    monkeypatch.setattr(vm.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(vm.shutil, "which", lambda name: which_result)
+
+
+def test_system_player_spawn_is_neutralised(tmp_path, monkeypatch):
+    """Third route (2026-09-04 incident): beeps and "Hello world." on macOS.
+
+    ``play_beep`` and ``tools.tts_tool.stream_tts_to_speaker`` never touch
+    ``hermes_cli.voice`` — both end in ``tools.voice_mode.play_audio_file``,
+    which on macOS spawns ``afplay``. Drive that exact path with
+    ``subprocess.Popen`` replaced by a *subclass* of the real one (so the
+    guard still classes it as a real spawn, exactly like the live-system
+    guard's wrapper) whose constructor raises. Unguarded, that raise is
+    swallowed by the player loop and ``play_audio_file`` reports ``False``;
+    guarded, the spawn never happens and it reports ``True``.
+    """
+    import tools.voice_mode as vm
+
+    assert vm._spawn_system_player.__name__ == "_silent_spawn_system_player"
+
+    class _ExplodingPopen(subprocess.Popen):
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("real system-player spawn reached subprocess.Popen")
+
+    monkeypatch.setattr(subprocess, "Popen", _ExplodingPopen)
+
+    wav = tmp_path / "silent.wav"
+    _write_silent_wav(wav)
+    _force_system_player_path(monkeypatch, vm, "/usr/bin/afplay")
+
+    assert vm.play_audio_file(str(wav)) is True
+
+
+def test_system_player_guard_hands_through_to_a_test_stubbed_popen(tmp_path, monkeypatch):
+    """Tests that stub ``subprocess.Popen`` to assert on argv/env must keep
+    seeing the spawn — the guard defers to them instead of swallowing it."""
+    import tools.voice_mode as vm
+
+    seen = []
+
+    class _Done:
+        returncode = 0
+
+        def wait(self, timeout=None):
+            return 0
+
+    def _recording_popen(cmd, **kwargs):
+        seen.append((list(cmd), kwargs))
+        return _Done()
+
+    monkeypatch.setattr(subprocess, "Popen", _recording_popen)
+
+    wav = tmp_path / "silent.wav"
+    _write_silent_wav(wav)
+    _force_system_player_path(monkeypatch, vm, "/usr/bin/afplay")
+
+    assert vm.play_audio_file(str(wav)) is True
+    assert seen and seen[0][0][0] == "afplay"
+    assert "env" in seen[0][1]
+
+
+@pytest.mark.real_audio_playback
+def test_bypass_marker_restores_the_real_system_player_spawn():
+    """Identity only — calling it would start a real player."""
+    import tools.voice_mode as vm
+
+    assert vm._spawn_system_player.__name__ == "_spawn_system_player"

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -695,8 +695,14 @@ class TestCleanupTempRecordings:
 # ============================================================================
 
 class TestPlayBeep:
-    def test_beep_calls_sounddevice_play(self, mock_sd):
+    def test_beep_calls_sounddevice_play(self, mock_sd, monkeypatch):
         np = pytest.importorskip("numpy")
+
+        # This test covers the sounddevice branch. On macOS play_beep routes
+        # through the tempfile/afplay path instead (covered by
+        # TestMacOSAudioOutputPolicy), so pin the policy to the branch under
+        # test rather than the host's.
+        monkeypatch.setattr("tools.voice_mode._sounddevice_output_allowed", lambda: True)
 
         from tools.voice_mode import play_beep
 

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -59,6 +59,25 @@ def _sounddevice_output_allowed() -> bool:
     return platform.system() != "Darwin"
 
 
+def _spawn_system_player(cmd: List[str], env: Dict[str, str]) -> "subprocess.Popen":
+    """Spawn a system audio player (``afplay`` / ``ffplay`` / ``aplay`` / the
+    WSL2 PowerShell pipeline).
+
+    This is the only place voice_mode starts a process that reaches the
+    speakers. It is a module attribute rather than an inline ``Popen`` so the
+    test suite's audio-playback guard (``tests/conftest.py``) can neutralise
+    real speaker output at exactly this point without stubbing ``subprocess``
+    for everything else.
+    """
+    return subprocess.Popen(
+        cmd,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        stdin=subprocess.DEVNULL,
+        env=env,
+    )
+
+
 def _play_int16_via_tempfile(audio, sample_rate: int) -> None:
     """Play int16 mono PCM via a temp WAV + play_audio_file (macOS: afplay, no TCC prompt)."""
     tmp_path = None
@@ -1061,8 +1080,7 @@ def _run_system_player(cmd: List[str]) -> bool:
         # Sibling of the TTS/STT credential scrub: players must not inherit tokens/keys.
         # See #56332, #70342.
         from tools.environments.local import hermes_subprocess_env
-        proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, stdin=subprocess.DEVNULL,
-                                env=hermes_subprocess_env(inherit_credentials=False))
+        proc = _spawn_system_player(cmd, hermes_subprocess_env(inherit_credentials=False))
         _set_active_playback(proc)
         proc.wait(timeout=300)
         rc = proc.returncode


### PR DESCRIPTION
## What does this PR do?

Stops the test suite from playing real audio on macOS.

On macOS `_sounddevice_output_allowed()` is False, so every playback path in `tools/voice_mode.py` ends in an `afplay` subprocess. The existing audio guard in `tests/conftest.py` only stubbed `hermes_cli.voice`, so two paths still reached the speakers:

- `play_beep` → `tools.voice_mode` → `afplay` (the `TestPlayBeep` cases, plus one beep fired from a daemon thread after its test had finished).
- `tools.tts_tool.stream_tts_to_speaker`, which does its own late `from tools.voice_mode import play_audio_file`, so the `"Hello world."` fixture in `tests/gateway/test_voice_command.py` was spoken aloud on every run.

The fix adds a `_spawn_system_player(cmd, env)` choke point in `voice_mode.py` (the only place a process that reaches the speakers is started) and a session-lived silent spawn in `conftest.py` that replaces it. The guard:

- returns a `_SilentPlayer` (exit code 0) instead of spawning, so playback code paths run to completion silently;
- hands through to the real spawn when a test has replaced `subprocess.Popen` with a plain function or `Mock`, so existing tests that assert on `afplay` argv keep working;
- treats a `Popen` *subclass* as a real spawn, because `_live_system_guard` wraps `Popen` in one per test and that must not disable the audio guard;
- lives for the whole session (a `pytest.MonkeyPatch` undone at session end) so a leaked daemon thread cannot beep after its test;
- steps aside for tests marked `real_audio_playback`.

`TestPlayBeep::test_beep_calls_sounddevice_play` now pins `_sounddevice_output_allowed` to True so it exercises the sounddevice path on every platform. On macOS that test currently fails on `main`; it passes with this change.

## Related Issue

Fixes #

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tools/voice_mode.py`: add `_spawn_system_player`; `_run_system_player` calls it instead of an inline `subprocess.Popen`. No behaviour change outside tests.
- `tests/conftest.py`: `_popen_would_really_spawn`, `_SilentPlayer`, `_make_silent_spawn`, session fixture `_audio_playback_spawn_guard_session`, and the extended `_audio_playback_guard` autouse fixture; comment block documents the third playback route.
- `tests/test_audio_playback_guard.py`: three regression tests — an exploding `Popen` subclass proves the spawn is neutralised, a plain-function stub proves hand-through (sees `afplay` argv and the scrubbed env), and a `real_audio_playback`-marked test proves the bypass restores the real spawn.
- `tests/tools/test_voice_mode.py`: beep test pins `_sounddevice_output_allowed`.

## How to Test

1. On macOS, on `main`: `scripts/run_tests.sh tests/gateway/test_voice_command.py tests/tools/test_voice_mode.py -q` with speakers on. You hear "Hello world." and beeps.
2. On this branch, same command: silence.
3. `scripts/run_tests.sh tests/test_audio_playback_guard.py tests/tools/test_voice_mode.py tests/gateway/test_voice_command.py tests/tools/test_voice_cli_integration.py -q` → 172 passed, 4 failed, 1 skipped on macOS 15. The 4 failures (`TestPulseSocketReachable` ×2, `TestWSL2PowerShellFallback` ×2) fail identically on `main` on macOS; they exercise Linux-only sockets and the WSL2 PowerShell pipeline and are not touched here.
4. To find any future audio-emitting test without hearing it: put a logging `afplay` shim first on `PATH` and run `venv/bin/python -m pytest` directly (the repo runner's `env -i` drops `PATH`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (ran the four audio-related files listed above; full suite not run)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstrings and the conftest comment block)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the guard is platform-neutral; it only intercepts the one spawn site.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

https://claude.ai/code/session_0172F8vLzidVpiYUjzRYxu2m
