### PR TITLE
fix(curator): skip the LLM review fork when there is nothing to review

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -811,11 +811,14 @@ def _render_report_markdown(p: Dict[str, Any]) -> str:
 
 # --- Orchestrator — spawn a forked AIAgent for the LLM review pass ---
 
-def _render_candidate_list() -> str:
-    """Human/agent-readable list of curator-managed skills with usage stats."""
+def _render_candidate_list() -> Optional[str]:
+    """Human/agent-readable list of curator-managed skills with usage stats, or ``None`` when there are none.
+
+    ``None`` — not a "nothing to review" sentence — is the empty signal on purpose: the caller has to skip the fork,
+    and a rendered string invites a substring test that silently stops matching the day the wording is edited."""
     rows = skill_usage.curated_report()
     if not rows:
-        return "No curator-managed skills to review."
+        return None
     cron_referenced = _cron_referenced_skills()
     return "\n".join([f"Curator-managed skills ({len(rows)}):\n"] + [
         f"- {r['name']}  provenance={r.get('provenance', 'agent')}  state={r['state']}  "
@@ -848,7 +851,7 @@ def _consolidation_pass(prefix: str, auto_summary: str, dry_run: bool, before_na
     needn't dig into REPORT.md. Returns ``(final_summary, llm_meta)``; never raises."""
     try:
         candidate_list = _render_candidate_list()
-        if "No agent-created skills" in candidate_list:
+        if candidate_list is None:
             final_summary = f"{prefix}{auto_summary}; llm: skipped (no candidates)"
             llm_meta = _llm_meta("skipped (no candidates)")
         else:

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -462,6 +462,41 @@ def test_run_review_synchronous_invokes_llm_stub(curator_env, monkeypatch):
     assert any("stubbed-summary" in s for s in captured)
 
 
+def test_llm_review_is_not_forked_when_there_is_nothing_to_review(curator_env, monkeypatch):
+    """An empty candidate list must skip the LLM consolidation fork.
+
+    The fork is an auxiliary-model run with a high iteration cap and a prompt
+    that pushes the reviewer to keep archiving; pointed at zero candidates it
+    burns tokens on nothing, once per ``curator.interval_hours`` tick. The
+    second half of this test pins the other direction — one candidate still
+    forks — so the guard cannot be "fixed" by skipping unconditionally.
+    """
+    c = curator_env["curator"]
+    u = curator_env["usage"]
+
+    calls = []
+    def _stub(prompt):
+        calls.append(prompt)
+        return {"final": "", "summary": "s", "model": "", "provider": "",
+                "tool_calls": [], "error": None}
+    monkeypatch.setattr(c, "_run_llm_review", _stub)
+
+    assert c._safe_curated_report() == []  # precondition: nothing to review
+    c.run_curator_review(synchronous=True, consolidate=True)
+    assert calls == [], (
+        "the LLM review fork was spawned with no curator-managed skills to "
+        "review"
+    )
+    # The pass must have been skipped deliberately, not aborted by an error
+    # before it reached the fork.
+    assert "error" not in c.load_state()["last_run_summary"]
+
+    _write_skill(curator_env["home"] / "skills", "a")
+    u.mark_agent_created("a")
+    c.run_curator_review(synchronous=True, consolidate=True)
+    assert len(calls) == 1, "a real candidate must still reach the review fork"
+
+
 
 
 


### PR DESCRIPTION
## Problem

`_consolidation_pass` in `agent/curator.py` gates the auxiliary-model consolidation fork on:

```python
candidate_list = _render_candidate_list()
if "No agent-created skills" in candidate_list:
```

The only producer of that value, `_render_candidate_list`, returns a different string when
there is nothing to review:

```python
return "No curator-managed skills to review."
```

`grep -rn "No agent-created skills"` over the tree matched exactly one line — the guard itself.
Nothing has ever emitted that substring, so the test was always `False` and the guard was dead.

## Failure

With `curator.consolidate: true` and zero curator-managed skills — a fresh install, or
`prune_builtins: false` with nothing agent-created — the guard did not trip and
`_run_llm_review()` was spawned anyway: an auxiliary-model fork with `max_iterations=9999`,
pointed at an empty candidate list, under a prompt that ends *"If you end the pass with fewer
than 10 archives, you stopped too early — go back and look at the clusters you left"*. It
repeated on every `curator.interval_hours` tick.

This is bounded rather than critical: `curator.consolidate` defaults **off**, so it only costs
users who deliberately turned consolidation on. Worth fixing, not worth alarm.

## What changed

`_render_candidate_list()` now returns `Optional[str]` — `None` when
`skill_usage.curated_report()` has no rows — and the caller tests `if candidate_list is None`.
The rendered listing for the non-empty case is byte-for-byte unchanged.

Why `None` rather than a shared sentinel constant: a module-level constant would keep the two
sites in sync today, but it still expresses an emptiness decision as prose that a later wording
edit has to remember to route through. Returning `None` moves the decision into the one function
that actually reads `curated_report()`, so producer and consumer cannot drift apart again — the
drift becomes unrepresentable rather than merely discouraged.

## Bug-class sweep

The reported defect is "a guard that substring-tests prose produced somewhere else". I swept
`agent/`, `tools/` and `hermes_cli/` for the same shape (`if "<prose>" in x`,
`x.startswith("<prose>")`) and checked every in-repo hit against its producer. All of them still
match live producers — `"File not found:"`, `"compaction complete"`,
`"compression is currently blocked"`, `"X Premium+ does NOT include"`, `"Could not find"`,
`"Path not found:"`, `"Run 'hermes doctor'"` and the rest. `agent/curator.py` was the only dead
one. The remaining hits of that grep are dict-key membership tests or classification of
*provider* error text, which is legitimately fuzzy and not producer/consumer drift.

## Follow-up questions for maintainers (not touched here)

Two neighbouring inconsistencies of the same family turned up. Both look like product decisions
rather than obvious bugs, so I left them alone rather than guess:

1. **`prune_builtins` is authorised in the prompt but refused by the enforcement layer.**
   `CURATOR_PRUNE_BUILTINS_NOTE` (`agent/curator.py`) tells the review fork that bundled built-ins
   "MAY be archived… overriding hard rule #1 for bundled skills ONLY", and `curated_report()` does
   list them when `prune_builtins` is on. But `_background_review_write_guard`
   (`tools/skill_manager_guards.py`) refuses any background-review `skill_manage` against
   `skill_usage.is_bundled(name)` unconditionally, with no `prune_builtins` awareness — and the
   `_is_curator_managed_record` check right below it would refuse them a second time, since
   bundled skills carry no `created_by: "agent"`. `curator.prune_builtins` defaults **True**, so
   the fork is routinely told to do something the guard always blocks. Meanwhile the
   *deterministic* prune path (`tools/skill_usage.py`) does honour `prune_builtins` for bundled
   skills. Is the LLM fork meant to be able to archive bundled built-ins (gate the `is_bundled`
   and record checks on `prune_builtins`), or is the deterministic path deliberately the only one
   allowed to (drop the prompt note)? `git log` gave no signal — both sites were last touched by
   whole-module refactors.

2. **`skills/AGENTS.md`** ("Curator (skill lifecycle)") still states the invariant as *"touches
   only `created_by: "agent"` skills (bundled + hub-installed are off-limits)"*, which no longer
   describes the deterministic prune path when `prune_builtins` is on. I have not edited it,
   since the right wording depends on the answer to (1).

## Testing

Added `test_llm_review_is_not_forked_when_there_is_nothing_to_review` to
`tests/agent/test_curator.py`. It asserts the behaviour — `_run_llm_review` is not called — not
the sentinel string, and it pins both directions so the guard cannot be satisfied by skipping
unconditionally.

Before the fix (`git stash` of the `agent/curator.py` change):

```
$ python -m pytest tests/agent/test_curator.py::test_llm_review_is_not_forked_when_there_is_nothing_to_review -q
        assert c._safe_curated_report() == []  # precondition: nothing to review
        c.run_curator_review(synchronous=True, consolidate=True)
>       assert calls == [], (
            "the LLM review fork was spawned with no curator-managed skills to "
            "review"
        )
E       AssertionError: the LLM review fork was spawned with no curator-managed skills to review
E       assert ['You are run...s to review.'] == []
E         Left contains one more item: "You are running as Hermes' background skill CURATOR. ... \n\nNo curator-managed skills to review."

1 failed in 0.20s
```

After:

```
$ python -m pytest tests/agent/test_curator.py tests/agent/test_curator_activity.py \
    tests/agent/test_curator_backup.py tests/agent/test_curator_classification.py \
    tests/agent/test_curator_reports.py tests/tools/test_skill_usage.py \
    tests/tools/test_skill_manager_tool.py tests/test_background_review_session_isolation.py -q
159 passed in 8.08s

$ python -m pytest tests/hermes_cli/test_curator_run.py tests/hermes_cli/test_curator_archive_prune.py \
    tests/hermes_cli/test_curator_usage.py tests/hermes_cli/test_curator_status.py \
    tests/hermes_cli/test_curator_pin_unmanaged.py tests/hermes_cli/test_curator_pin_visibility.py \
    tests/hermes_cli/test_curator_recent_run_notice.py -q
18 passed in 0.78s
```

Run on CPython 3.11.15 in a throwaway venv built from this repo's `pyproject.toml` dependencies.
