### PR TITLE
feat(mcp): add Pilot Protocol catalog entry

### DIFF
--- a/optional-mcps/pilot/manifest.yaml
+++ b/optional-mcps/pilot/manifest.yaml
@@ -1,0 +1,31 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: pilot
+description: Discover specialist agents and message trusted peers.
+source: https://github.com/pilot-protocol/pilot-mcp
+
+transport:
+  type: stdio
+  command: npx
+  args:
+    - -y
+    - pilotprotocol-mcp
+
+auth:
+  type: none
+
+suggest:
+  keywords:
+    - pilot protocol
+    - agent messaging
+    - agent discovery
+  hosts:
+    - pilotprotocol.network
+
+post_install: |
+  Initialize the local Pilot runtime and Hermes hooks once:
+  `npx -y pilotprotocol-mcp setup --hermes`
+
+  Restart Hermes, then call `pilot_search` or `pilot_peers`.


### PR DESCRIPTION
## What does this PR do?

Adds Pilot Protocol to Hermes' optional MCP catalog. The entry launches the published stdio server and gives the required one-time runtime setup command.

## How to test

1. `hermes mcp install official/pilot`
2. Run the displayed setup command
3. Restart Hermes and call `pilot_search`

The manifest parses successfully as YAML.

Disclosure: I contribute to Pilot Protocol.