### PR TITLE
fix(gateway): restart after startup SIGTERM

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2045,7 +2045,8 @@ from gateway.restart import (
     DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT,
     DEFAULT_GATEWAY_RESTART_AFTER_TURN_TIMEOUT,
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
-    DEFAULT_GATEWAY_SIGNAL_INTERRUPT_GRACE_TIMEOUT)
+    DEFAULT_GATEWAY_SIGNAL_INTERRUPT_GRACE_TIMEOUT,
+    GATEWAY_SERVICE_RESTART_EXIT_CODE as _GATEWAY_SERVICE_RESTART_EXIT_CODE)
 
 
 logger = logging.getLogger(__name__)
@@ -5094,14 +5095,26 @@ def _exit_with_failure_verdict(runner) -> bool:
     return True
 
 
-def _unexpected_signal_requires_restart(runner, signal_initiated_shutdown: bool) -> bool:
-    """True when an unplanned signal should make the supervisor revive the gateway."""
-    if not signal_initiated_shutdown or runner._restart_requested:
+def _resolve_gateway_exit_verdict(runner, signal_initiated_shutdown: bool) -> bool:
+    """Resolve the process verdict after either startup abort or normal shutdown."""
+    if _exit_with_failure_verdict(runner):
         return False
-    logger.info(
-        "Exiting with code 1 (signal-initiated shutdown without restart "
-        "request) so the service manager can revive the gateway."
-    )
+    if runner.exit_code is not None:
+        raise SystemExit(runner.exit_code)
+    if signal_initiated_shutdown and not runner._restart_requested:
+        logger.info(
+            "Exiting with code 1 (signal-initiated shutdown without restart "
+            "request) so the service manager can revive the gateway."
+        )
+        return False
+    # Older restart paths may not set ``runner.exit_code``; retain the service-restart fallback.
+    if runner._restart_via_service:
+        logger.info(
+            "Exiting with code %d (service-restart requested) so the service "
+            "manager relaunches the gateway.",
+            _GATEWAY_SERVICE_RESTART_EXIT_CODE,
+        )
+        raise SystemExit(_GATEWAY_SERVICE_RESTART_EXIT_CODE)
     return True
 
 
@@ -5124,8 +5137,6 @@ async def _start_gateway_shutdown_tail(
         stop_nous_auth_keepalive()
 
     _best_effort(_stop_keepalive)
-    if _exit_with_failure_verdict(runner):
-        return False
 
     # Never join(): an in-flight cron delivery is a coroutine on THIS loop; a sync join would drop it.
     # Stop cron scheduler + housekeeping cleanly. These MUST be awaited cooperatively, not join()ed. A cron
@@ -5148,20 +5159,7 @@ async def _start_gateway_shutdown_tail(
     with suppress(Exception):
         await _shutdown_mcp_servers_nonblocking()
 
-    if runner.exit_code is not None:
-        raise SystemExit(runner.exit_code)
-
-    # Unplanned SIGTERM exits non-zero so the service manager revives us; planned stops must not.
-    if _unexpected_signal_requires_restart(runner, _signal_initiated_shutdown[0]):
-        return False  # → sys.exit(1) in the caller
-
-    # Older restart paths may reach here without ``runner.exit_code``; keep the non-zero fallback.
-    if runner._restart_via_service:
-        logger.info("Exiting with code 75 (service-restart requested) so the service "
-                    "manager relaunches the gateway.")
-        raise SystemExit(75)
-
-    return True
+    return _resolve_gateway_exit_verdict(runner, _signal_initiated_shutdown[0])
 
 
 async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = False, verbosity: Optional[int] = 0) -> bool:
@@ -5302,15 +5300,9 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         # Startup aborted by restart/shutdown before running mode; preserve that path without starting cron.
         try:
             await runner.wait_for_shutdown()
-            if _exit_with_failure_verdict(runner):
-                return False
             with suppress(Exception):
                 await _shutdown_mcp_servers_nonblocking()
-            if runner.exit_code is not None:
-                raise SystemExit(runner.exit_code)
-            if _unexpected_signal_requires_restart(runner, _signal_initiated_shutdown[0]):
-                return False
-            return True
+            return _resolve_gateway_exit_verdict(runner, _signal_initiated_shutdown[0])
         finally:
             _shutdown_gateway_health_export(runner)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5094,6 +5094,17 @@ def _exit_with_failure_verdict(runner) -> bool:
     return True
 
 
+def _unexpected_signal_requires_restart(runner, signal_initiated_shutdown: bool) -> bool:
+    """True when an unplanned signal should make the supervisor revive the gateway."""
+    if not signal_initiated_shutdown or runner._restart_requested:
+        return False
+    logger.info(
+        "Exiting with code 1 (signal-initiated shutdown without restart "
+        "request) so the service manager can revive the gateway."
+    )
+    return True
+
+
 async def _start_gateway_shutdown_tail(
     runner, _control_server, cron_stop: threading.Event, cron_provider,
     cron_thread: threading.Thread, housekeeping_thread: threading.Thread,
@@ -5140,10 +5151,8 @@ async def _start_gateway_shutdown_tail(
     if runner.exit_code is not None:
         raise SystemExit(runner.exit_code)
 
-    # Unplanned SIGTERM exits non-zero so systemd Restart=on-failure revives us; planned stops must not.
-    if _signal_initiated_shutdown[0] and not runner._restart_requested:
-        logger.info("Exiting with code 1 (signal-initiated shutdown without restart "
-                    "request) so systemd Restart=on-failure can revive the gateway.")
+    # Unplanned SIGTERM exits non-zero so the service manager revives us; planned stops must not.
+    if _unexpected_signal_requires_restart(runner, _signal_initiated_shutdown[0]):
         return False  # → sys.exit(1) in the caller
 
     # Older restart paths may reach here without ``runner.exit_code``; keep the non-zero fallback.
@@ -5299,6 +5308,8 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 await _shutdown_mcp_servers_nonblocking()
             if runner.exit_code is not None:
                 raise SystemExit(runner.exit_code)
+            if _unexpected_signal_requires_restart(runner, _signal_initiated_shutdown[0]):
+                return False
             return True
         finally:
             _shutdown_gateway_health_export(runner)

--- a/tests/gateway/test_startup_restart_race.py
+++ b/tests/gateway/test_startup_restart_race.py
@@ -216,3 +216,67 @@ async def test_start_gateway_does_not_start_cron_after_aborted_startup(tmp_path,
     assert exc.value.code == GATEWAY_SERVICE_RESTART_EXIT_CODE
     assert cron_started is False
     assert export_shutdown_calls == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("unexpected_signal", "expected_success"),
+    [(True, False), (False, True)],
+    ids=["unexpected-sigterm", "planned-stop"],
+)
+async def test_start_gateway_classifies_startup_signal_exit(
+    tmp_path, monkeypatch, unexpected_signal, expected_success
+):
+    """A startup SIGTERM is restartable unless a planned-stop marker classified it as intentional."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    signal_state = None
+    cron_started = False
+
+    class AbortedStartupRunner:
+        def __init__(self, config):
+            self.config = config
+            self.adapters = {}
+            self._running = False
+            self._restart_requested = False
+            self.should_exit_cleanly = False
+            self.should_exit_with_failure = False
+            self.exit_reason = None
+            self.exit_code = None
+
+        async def start(self):
+            if unexpected_signal:
+                signal_state[0] = True
+            return True
+
+        async def wait_for_shutdown(self):
+            return None
+
+    def capture_signal_state(runner, state):
+        nonlocal signal_state
+        signal_state = state
+        return lambda received_signal=None: None
+
+    def fail_if_cron_starts(*args, **kwargs):
+        nonlocal cron_started
+        cron_started = True
+
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr("gateway.status.acquire_gateway_runtime_lock", lambda: True)
+    monkeypatch.setattr("gateway.status.write_pid_file", lambda: None)
+    monkeypatch.setattr("gateway.status.remove_pid_file", lambda: None)
+    monkeypatch.setattr("gateway.status.release_gateway_runtime_lock", lambda: None)
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
+    monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: None)
+    monkeypatch.setattr("gateway.run.GatewayRunner", AbortedStartupRunner)
+    monkeypatch.setattr(
+        "gateway.run._start_gateway_make_shutdown_signal_handler", capture_signal_state
+    )
+    monkeypatch.setattr("gateway.run._start_cron_ticker", fail_if_cron_starts)
+    monkeypatch.setattr("tools.mcp_tool_lifecycle.shutdown_mcp_servers", lambda: None)
+
+    result = await gateway_run.start_gateway(
+        config=GatewayConfig(), replace=False, verbosity=None
+    )
+
+    assert result is expected_success
+    assert cron_started is False

--- a/tests/gateway/test_startup_restart_race.py
+++ b/tests/gateway/test_startup_restart_race.py
@@ -219,6 +219,56 @@ async def test_start_gateway_does_not_start_cron_after_aborted_startup(tmp_path,
 
 
 @pytest.mark.asyncio
+async def test_start_gateway_preserves_service_restart_fallback_after_aborted_startup(
+    tmp_path, monkeypatch
+):
+    """A legacy service restart without an explicit exit code still exits with EX_TEMPFAIL."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    cron_started = False
+
+    class AbortedStartupRunner:
+        def __init__(self, config):
+            self.config = config
+            self.adapters = {}
+            self._running = False
+            self._restart_requested = True
+            self._restart_via_service = True
+            self.should_exit_cleanly = False
+            self.should_exit_with_failure = False
+            self.exit_reason = None
+            self.exit_code = None
+
+        async def start(self):
+            return True
+
+        async def wait_for_shutdown(self):
+            return None
+
+    def fail_if_cron_starts(*args, **kwargs):
+        nonlocal cron_started
+        cron_started = True
+
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr("gateway.status.acquire_gateway_runtime_lock", lambda: True)
+    monkeypatch.setattr("gateway.status.write_pid_file", lambda: None)
+    monkeypatch.setattr("gateway.status.remove_pid_file", lambda: None)
+    monkeypatch.setattr("gateway.status.release_gateway_runtime_lock", lambda: None)
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
+    monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: None)
+    monkeypatch.setattr("gateway.run.GatewayRunner", AbortedStartupRunner)
+    monkeypatch.setattr("gateway.run._start_cron_ticker", fail_if_cron_starts)
+    monkeypatch.setattr("tools.mcp_tool_lifecycle.shutdown_mcp_servers", lambda: None)
+
+    with pytest.raises(SystemExit) as exc:
+        await gateway_run.start_gateway(
+            config=GatewayConfig(), replace=False, verbosity=None
+        )
+
+    assert exc.value.code == GATEWAY_SERVICE_RESTART_EXIT_CODE
+    assert cron_started is False
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("unexpected_signal", "expected_success"),
     [(True, False), (False, True)],
@@ -238,6 +288,7 @@ async def test_start_gateway_classifies_startup_signal_exit(
             self.adapters = {}
             self._running = False
             self._restart_requested = False
+            self._restart_via_service = False
             self.should_exit_cleanly = False
             self.should_exit_with_failure = False
             self.exit_reason = None


### PR DESCRIPTION
## Summary

- classify an unexpected SIGTERM during gateway startup with the same restartable failure verdict used after the gateway reaches running state
- resolve failure, explicit-code, unplanned-signal, service-restart, and clean-stop outcomes in one private helper shared by both shutdown paths
- preserve the legacy service-restart fallback when a startup abort has no explicit exit code

## Root cause

When SIGTERM arrived after signal handlers were installed but before `GatewayRunner.start()` set `_running`, the early-abort branch waited for teardown and returned `True`. `main()` translated that into exit 0, while the generated s6 finish policy maps exit 0 to 125 (intentional stop, no restart). A duplicate dashboard restart could therefore leave the hosted gateway down indefinitely.

The startup-abort and running-shutdown paths previously resolved process exit state independently. The early path omitted both the unexpected-signal verdict and the older `_restart_via_service` fallback, so the two paths could drift. Both paths now use `_resolve_gateway_exit_verdict()` after their applicable cleanup. An unplanned signal returns `False` and becomes exit 1, an explicit code still wins, a legacy service restart exits 75, and a planned operator stop remains successful.

This is distinct from #103185: that PR covers signals arriving before the asyncio handlers are installed; this change covers a signal that was received and handled during adapter startup.

## Tests

- `scripts/run_tests.sh tests/test_plugin_compat_warning.py tests/gateway/test_startup_restart_race.py tests/gateway/test_runner_startup_failures.py tests/hermes_cli/test_service_manager.py -q` — 35 passed, 1 skipped
- `.venv/bin/ruff check gateway/run.py tests/gateway/test_startup_restart_race.py`
- `.venv/bin/python scripts/check-windows-footguns.py gateway/run.py tests/gateway/test_startup_restart_race.py`

The behavior tests exercise the production `start_gateway()` early-abort path for an unexpected startup SIGTERM, a planned stop, an explicit service-restart code, and the service-restart fallback without an explicit code. Existing coverage continues to pin fatal configuration (78) and s6 finish mappings.

Fixes #103191

## Collaboration credit

The shared exit-verdict resolver and legacy service-restart fallback were adapted from JoaoMarcos44’s implementation in f77586ef7683c17d5890e63e38604a68d5ea11ce (#103248) after the sibling-path review. Commit 7b3e336121d2c7d9d754fac4161ed3b21c738371 records Joao as co-author; b80ae94b6f95688beb62cd5b0af2cc0d0906d4b2 remains the original focused startup-SIGTERM fix.