### PR TITLE
feat(gateway): return non-push wake completions

### DIFF
--- a/gateway/wake.py
+++ b/gateway/wake.py
@@ -35,11 +35,14 @@ def adapter_supports_push(adapter: Any) -> bool:
     return bool(getattr(adapter, "supports_async_delivery", True))
 
 
-async def deliver_wake(adapter: Any, *, text: str, session_id: str = "", source: Any = None) -> None:
+async def deliver_wake(
+    adapter: Any, *, text: str, session_id: str = "", source: Any = None
+) -> Optional[dict[str, Any]]:
     """Deliver a wake turn to the session behind ``adapter``. ``session_id`` is the RAW session id
     (``X-Hermes-Session-Id`` / state.db key) — required for non-push adapters. ``source`` is the
     ``SessionSource`` for the synthetic event — required for push-capable adapters. Raises on
-    failure so the caller can rewind/retry."""
+    failure so the caller can rewind/retry. Non-push delivery returns the parsed completion plus
+    requested/effective session ids; push delivery retains its historical ``None`` result."""
     if adapter_supports_push(adapter):
         if source is None:
             raise ValueError("deliver_wake: push-capable adapter requires a SessionSource")
@@ -50,7 +53,7 @@ async def deliver_wake(adapter: Any, *, text: str, session_id: str = "", source:
     if not session_id:
         raise ValueError("deliver_wake: non-push adapter (supports_async_delivery=False) "
                          "requires the raw session id to self-post the wake turn")
-    await _self_post_chat_completion(adapter, text=text, session_id=session_id)
+    return await _self_post_chat_completion(adapter, text=text, session_id=session_id)
 
 
 def _delegation_display_metadata(evt: dict) -> dict:
@@ -101,7 +104,9 @@ async def persist_delegation_delivery(adapter: Any, *, text: str, session_id: st
     )
 
 
-async def _self_post_chat_completion(adapter: Any, *, text: str, session_id: str) -> None:
+async def _self_post_chat_completion(
+    adapter: Any, *, text: str, session_id: str
+) -> dict[str, Any]:
     """POST the wake text to the in-pod API server as a normal session turn, using the adapter's
     own bind host/port/key. Session continuation via ``X-Hermes-Session-Id`` is 403-gated on
     ``API_SERVER_KEY``, so a missing key is a hard error rather than a wake in a fresh session
@@ -142,9 +147,20 @@ async def _self_post_chat_completion(adapter: Any, *, text: str, session_id: str
                         raise RuntimeError(
                             f"wake self-post failed for session {session_id}: HTTP {resp.status}: {body}"
                         )
-                    await resp.read()
+                    completion = await resp.json(content_type=None)
+                    if not isinstance(completion, dict):
+                        raise RuntimeError(
+                            f"wake self-post returned a non-object completion for session {session_id}"
+                        )
+                    effective_session_id = str(
+                        resp.headers.get("X-Hermes-Session-Id") or session_id
+                    )
                     logger.info("wake self-post delivered for session %s (attempt %d)", session_id, attempt + 1)
-                    return
+                    return {
+                        "requested_session_id": session_id,
+                        "effective_session_id": effective_session_id,
+                        "completion": completion,
+                    }
         except (aiohttp.ClientError, asyncio.TimeoutError, OSError) as exc:
             last_err = exc
             logger.warning("wake self-post transient failure for session %s (attempt %d/%d): %s",

--- a/tests/gateway/test_wake_delivery.py
+++ b/tests/gateway/test_wake_delivery.py
@@ -79,23 +79,119 @@ def test_deliver_wake_non_push_self_posts_raw_session_id(monkeypatch):
         seen["session_id"] = request.headers.get("X-Hermes-Session-Id")
         seen["auth"] = request.headers.get("Authorization")
         seen["body"] = await request.json()
-        return web.json_response({"choices": [{"message": {"content": "ok"}}]})
+        return web.json_response(
+            {"choices": [{"message": {"content": "ok"}}]},
+            headers={"X-Hermes-Session-Id": "rotated-sid-43"},
+        )
 
     async def run():
         runner, port = await _serve(handler)
         try:
             adapter = ApiServerLikeAdapter(host="0.0.0.0", port=port, key="sekrit")
-            await deliver_wake(adapter, text="task done — wake", session_id="raw-sid-42")
+            return await deliver_wake(
+                adapter, text="task done — wake", session_id="raw-sid-42"
+            )
         finally:
             await runner.cleanup()
 
-    asyncio.run(run())
+    result = asyncio.run(run())
     assert seen["session_id"] == "raw-sid-42"
     assert seen["auth"] == "Bearer sekrit"
     assert seen["body"]["stream"] is False
     assert seen["body"]["messages"] == [
         {"role": "user", "content": "task done — wake"}
     ]
+    assert result == {
+        "requested_session_id": "raw-sid-42",
+        "effective_session_id": "rotated-sid-43",
+        "completion": {"choices": [{"message": {"content": "ok"}}]},
+    }
+
+
+def test_deliver_wake_push_result_remains_none():
+    result = asyncio.run(deliver_wake(PushAdapter(), text="wake", source=_source()))
+    assert result is None
+
+
+def test_deliver_wake_propagates_non_transient_http_error():
+    from aiohttp import web
+
+    async def handler(request):
+        return web.json_response({"error": "denied"}, status=403)
+
+    async def run():
+        runner, port = await _serve(handler)
+        try:
+            adapter = ApiServerLikeAdapter(port=port)
+            with pytest.raises(RuntimeError, match="HTTP 403"):
+                await deliver_wake(adapter, text="x", session_id="sid")
+        finally:
+            await runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_filesystem_plugin_consumes_wake_completion(tmp_path, monkeypatch):
+    """A user-installed plugin can consume both the completion and rotated session id."""
+    from aiohttp import web
+    import yaml
+
+    from hermes_cli.plugins import PluginManager
+
+    home = tmp_path / "hermes-home"
+    plugin_dir = home / "plugins" / "wake-consumer"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        yaml.safe_dump({
+            "name": "wake-consumer",
+            "version": "0.1.0",
+            "description": "Consumes the generic wake completion result",
+        }),
+        encoding="utf-8",
+    )
+    (plugin_dir / "__init__.py").write_text(
+        "from gateway.wake import deliver_wake\n\n"
+        "async def consume(adapter, *, text, session_id):\n"
+        "    result = await deliver_wake(adapter, text=text, session_id=session_id)\n"
+        "    return {\n"
+        "        'session_id': result['effective_session_id'],\n"
+        "        'answer': result['completion']['choices'][0]['message']['content'],\n"
+        "    }\n\n"
+        "def register(ctx):\n"
+        "    ctx.register_hook('post_api_request', lambda **kwargs: None)\n",
+        encoding="utf-8",
+    )
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"enabled": ["wake-consumer"]}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    manager = PluginManager()
+    manager.discover_and_load()
+    loaded = manager._plugins["wake-consumer"]
+    assert loaded.enabled is True
+    assert loaded.module is not None
+
+    async def handler(request):
+        return web.json_response(
+            {"choices": [{"message": {"content": "validated"}}]},
+            headers={"X-Hermes-Session-Id": "session-after-compression"},
+        )
+
+    async def run():
+        runner, port = await _serve(handler)
+        try:
+            return await loaded.module.consume(
+                ApiServerLikeAdapter(port=port), text="wake", session_id="session-before"
+            )
+        finally:
+            await runner.cleanup()
+
+    assert asyncio.run(run()) == {
+        "session_id": "session-after-compression",
+        "answer": "validated",
+    }
 
 
 def test_deliver_wake_retries_429_then_succeeds(monkeypatch):
@@ -180,5 +276,3 @@ def test_persist_delegation_delivery_raises_without_db():
         asyncio.run(persist_delegation_delivery(
             NoDbAdapter(), text="x", session_id="sid",
         ))
-
-


### PR DESCRIPTION
## Summary

- return the parsed non-streaming completion payload from non-push `deliver_wake()` calls
- include requested and effective session ids so callers can follow session rotation
- preserve the existing `None` result for push-capable adapters
- cover the additive contract with a filesystem-loaded plugin consumer

## Provenance

- base: `5a0b1ba766956a1a16bc2f17dc3b83eb63633402`
- result: `04a0636e14f398557d2ab7294cd15bd9b4aba90c`
- scope: generic gateway wake behavior only; no SupportPortal or AgentRelay special cases

## Verification

- targeted canonical gateway/plugin suites: 183 passed
- full `scripts/run_tests.sh`: completed with 53 failures and one per-file timeout, all outside the two modified files; observed failures were platform/environment/timing cases including macOS `/tmp` canonicalization, unavailable systemd/launchd behavior, local port/proxy behavior, and external-tool assumptions
- no wake-related failure was present in the full run

This PR is additive. Existing callers that ignore the return value are unchanged.
