### PR TITLE
fix(desktop): allow spaces when renaming sessions

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1,4 +1,4 @@
-import { KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core'
+import { PointerSensor, useSensor, useSensors } from '@dnd-kit/core'
 import { sortableKeyboardCoordinates } from '@dnd-kit/sortable'
 import { useStore } from '@nanostores/react'
 import type * as React from 'react'
@@ -27,6 +27,7 @@ import { searchSessions, type SessionInfo, type SessionSearchResult } from '@/he
 import { useI18n } from '@/i18n'
 import { comboTokens } from '@/lib/keybinds/combo'
 import { resolveProfileColor } from '@/lib/profile-color'
+import { ReorderKeyboardSensor } from '@/lib/reorder-keyboard-sensor'
 import { sessionMatchesSearch } from '@/lib/session-search'
 import { normalizeSessionSource, sessionSourceLabel } from '@/lib/session-source'
 import { cn } from '@/lib/utils'
@@ -483,7 +484,7 @@ export function ChatSidebar({
 
   const dndSensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+    useSensor(ReorderKeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   )
 
   // Profile scope = the "workspace switcher" context. Concrete scope shows only

--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -4,7 +4,6 @@ import {
   type DragEndEvent,
   type DragOverEvent,
   type DragStartEvent,
-  KeyboardSensor,
   type Modifier,
   PointerSensor,
   useSensor,
@@ -56,6 +55,7 @@ import {
   reorderCommitHaptic,
   reorderStepHaptic
 } from '@/lib/reorder'
+import { ReorderKeyboardSensor } from '@/lib/reorder-keyboard-sensor'
 import { cn } from '@/lib/utils'
 import {
   $activeConnectionId,
@@ -278,7 +278,7 @@ export function ProfileRail() {
   // distance constraint: a small drag reorders, a tap still selects the profile.
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+    useSensor(ReorderKeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   )
 
   // Tick a haptic each time the drag crosses into a new cell, and a satisfying

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
@@ -1,7 +1,12 @@
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { useSensor, useSensors } from '@dnd-kit/core'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { atom } from 'nanostores'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { ReorderKeyboardSensor } from '@/lib/reorder-keyboard-sensor'
+
+import { SidebarRowGrab, SidebarRowShell } from './chrome'
+import { ReorderableList, useSortableBindings } from './reorderable-list'
 import { SessionActionsMenu, SessionContextMenu } from './session-actions-menu'
 
 afterEach(cleanup)
@@ -122,7 +127,74 @@ function renderMenu() {
   )
 }
 
+function SortableRenameRow() {
+  const { ref, dragHandleProps } = useSortableBindings('s1')
+
+  return (
+    <SidebarRowShell
+      actions={
+        <SessionActionsMenu sessionId="s1" title="My session">
+          <button aria-label="Session actions" type="button">
+            ⋮
+          </button>
+        </SessionActionsMenu>
+      }
+      ref={ref}
+      {...dragHandleProps}
+    >
+      <SidebarRowGrab ariaLabel="Reorder session" dragHandleProps={dragHandleProps}>
+        <span>My session</span>
+      </SidebarRowGrab>
+    </SidebarRowShell>
+  )
+}
+
+function SortableRenameList() {
+  const sensors = useSensors(useSensor(ReorderKeyboardSensor))
+
+  return (
+    <ReorderableList ids={['s1']} onReorder={() => {}} sensors={sensors}>
+      <SortableRenameRow />
+    </ReorderableList>
+  )
+}
+
 describe('SessionActionsMenu', () => {
+  it('leaves Space in the focused rename input instead of starting a row reorder', async () => {
+    render(<SortableRenameList />)
+    const trigger = screen.getByRole('button', { name: 'Session actions' })
+    fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.pointerUp(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.click(trigger)
+    fireEvent.click(await screen.findByRole('menuitem', { name: /rename/i }))
+    const input = within(await screen.findByRole('dialog')).getByRole('textbox')
+    await waitFor(() => expect(input.ownerDocument.activeElement).toBe(input))
+
+    const space = new KeyboardEvent('keydown', { key: ' ', code: 'Space', bubbles: true, cancelable: true })
+    fireEvent(input, space)
+    // Let a mistakenly activated sensor attach its document listener, then
+    // cancel it even on failure so it cannot leak into the next test.
+    await act(() => new Promise(resolve => setTimeout(resolve, 0)))
+    fireEvent.keyDown(input.ownerDocument, { key: 'Escape', code: 'Escape' })
+
+    expect(space.defaultPrevented).toBe(false)
+  })
+
+  it('still starts keyboard reordering from the focused grab handle and row', async () => {
+    const { container } = render(<SortableRenameList />)
+    const handle = screen.getByRole('button', { name: 'Reorder session' })
+    const row = container.querySelector<HTMLElement>('[aria-roledescription="sortable"]')!
+
+    for (const activator of [handle, row]) {
+      activator.focus()
+      fireEvent.keyDown(activator, { key: ' ', code: 'Space' })
+      expect(activator.getAttribute('aria-pressed')).toBe('true')
+      await act(() => new Promise(resolve => setTimeout(resolve, 0)))
+      fireEvent.keyDown(activator.ownerDocument, { key: 'Escape', code: 'Escape' })
+      expect(activator.getAttribute('aria-pressed')).not.toBe('true')
+    }
+  })
+
   it('opens the dropdown on click without a tooltip on the kebab', async () => {
     renderMenu()
 

--- a/apps/desktop/src/lib/keybinds/composer-focus-keys.test.ts
+++ b/apps/desktop/src/lib/keybinds/composer-focus-keys.test.ts
@@ -177,6 +177,21 @@ describe('composerFocusKeysAllowed', () => {
     expect(composerFocusKeysAllowed(keydown({ key: 'a', code: 'KeyA', target: button }), 'type')).toBe(true)
   })
 
+  it('leaves Space with focused controls, including keyboard reorder handles', () => {
+    const button = document.createElement('button')
+    const handle = document.createElement('span')
+    handle.setAttribute('role', 'button')
+    handle.tabIndex = 0
+    document.body.append(button, handle)
+
+    for (const target of [button, handle]) {
+      expect(composerFocusKeysAllowed(keydown({ key: ' ', code: 'Space', target }), 'type')).toBe(false)
+      expect(composerFocusKeysAllowed(keydown({ key: 'a', code: 'KeyA', target }), 'type')).toBe(true)
+    }
+
+    expect(composerFocusKeysAllowed(keydown({ key: ' ', code: 'Space', target: document.body }), 'type')).toBe(true)
+  })
+
   it('refuses when a dialog is open', () => {
     const dialog = document.createElement('div')
     dialog.setAttribute('role', 'dialog')

--- a/apps/desktop/src/lib/keybinds/composer-focus-keys.ts
+++ b/apps/desktop/src/lib/keybinds/composer-focus-keys.ts
@@ -189,5 +189,7 @@ export function composerFocusKeysAllowed(event: KeyboardEvent, combo: string): b
     return false
   }
 
-  return !(combo === 'enter' && isActivateOnEnterTarget(event.target))
+  // Space belongs to the focused control too (native activation or keyboard
+  // reordering). Other printable keys can still hand typing to the composer.
+  return !((combo === 'enter' || event.key === ' ') && isActivateOnEnterTarget(event.target))
 }

--- a/apps/desktop/src/lib/reorder-keyboard-sensor.ts
+++ b/apps/desktop/src/lib/reorder-keyboard-sensor.ts
@@ -1,0 +1,12 @@
+import { KeyboardSensor } from '@dnd-kit/core'
+
+// A sortable row also owns menus and portaled dialogs. Their React key events
+// still bubble through the row: only the focused activator owns reorder keys.
+// Keep the stock sensor's key codes, movement, cancellation and focus restore.
+export class ReorderKeyboardSensor extends KeyboardSensor {
+  static activators = KeyboardSensor.activators.map(activator => ({
+    ...activator,
+    handler: (...args: Parameters<typeof activator.handler>) =>
+      args[0].target === args[0].currentTarget && activator.handler(...args)
+  }))
+}


### PR DESCRIPTION
## What does this PR do?

Fixes Space being swallowed while renaming a session from the sidebar. The input can already have focus: the portaled dialog's React key event bubbles through its owning sortable row, whose dnd-kit keyboard activator cancels Space before the browser inserts it.

Keyboard activation now belongs only to the element carrying the listener. A small shared sensor checks the React event's `target === currentTarget` before delegating to dnd-kit's stock activator. This preserves focused-row and grab-handle keyboard reordering, stock movement/cancellation, and row-wide pointer dragging while excluding nested controls and portaled dialogs.

Live verification also exposed the global composer type-to-focus handler consuming Space from focused drag handles. It now yields Space to activation controls, just as it already yields Enter. Ordinary printable-character type-to-focus remains unchanged.

## Related Issue

Refs #83617.

Related open approaches: #83618, #101625, and #94099. This is an alternative shared-activator fix rather than an additional focus trap, rename-only propagation boundary, or removal of keyboard activation from the row. It also covers the virtual-list/shared-sidebar and profile-rail sensor configurations and the composer capture-phase conflict.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/reorder-keyboard-sensor.ts`: guard keyboard activation while retaining the stock sensor behavior.
- `apps/desktop/src/app/chat/sidebar/index.tsx` and `profile-switcher.tsx`: use the guarded sensor; pointer sensors and thresholds are unchanged.
- `apps/desktop/src/lib/keybinds/composer-focus-keys.ts`: leave Space with focused activation controls.
- Regression coverage in `session-actions-menu.test.tsx` and `composer-focus-keys.test.ts`.

## How to Test

1. Open a session's **⋯ → Rename…**, then type a multi-word title using Space. Spaces should appear, including when inserting one in the middle of the title.
2. Save with the button, reload, and confirm the title persists.
3. Repeat via the right-click menu; Enter saves and Escape cancels without changing the original title.
4. Focus a row/grab handle, then use Space → ArrowDown → Space to reorder. Confirm mouse dragging still reorders too.

Verification after rebasing onto upstream `b0ab2e163a`:

```text
cd apps/desktop
npm run test:ui -- src/app/chat/sidebar/ src/lib/keybinds/
Test Files  31 passed (31)
     Tests  291 passed (291)

npm run typecheck
Passed: renderer, Electron, and E2E TypeScript projects
```

ESLint on all six changed files and `git diff --check` also passed. The new bug regressions were observed failing before their respective fixes. Independent review found no blocking logic or security issues.

Repeated the behavior checks above in the real Electron dev app with a real local backend and an isolated temporary profile on Linux. Playwright sent actual Space key events, not direct input-value assignments. Both saved multi-word titles survived reload and were read back from the backend database. Keyboard and pointer reordering changed the visible order. No model request was needed. Other host platforms and the full Python suite were not run.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs; related alternatives are linked above.
- [x] This PR contains only changes related to the fix.
- [ ] I've run `pytest tests/ -q` and all tests pass — not run; renderer-only change, relevant suites listed above.
- [x] I've added regression tests.
- [x] I've tested on my platform: Linux, real Electron dev app.

### Documentation & Housekeeping

- [x] Relevant documentation updated or N/A — rationale is documented beside the guards.
- [x] Config example updates or N/A — no configuration changes.
- [x] Architecture/workflow documentation updates or N/A — no architectural changes.
- [x] Cross-platform impact considered — platform-independent event handling; runtime validation was on Linux only.
- [x] Tool descriptions/schemas updated or N/A — no tool changes.

## Screenshots / Logs

Only the sanitized test summary above is included. Local screenshots, raw logs, machine paths, profile contents, and real conversation data are intentionally not published.
