### PR TITLE
fix(mcp): consume in-dial reconnect request so it cannot tear down the session it produced

### DIFF
--- a/tests/tools/test_mcp_in_dial_reconnect.py
+++ b/tests/tools/test_mcp_in_dial_reconnect.py
@@ -1,0 +1,90 @@
+"""A reconnect requested mid-dial must not tear down the session it produced.
+
+`_signal_reconnect_and_wait` clears `_ready` and sets `_reconnect_event`, then
+polls for a fresh session. When the lifecycle loop is ALREADY rebuilding, that
+request lands mid-dial: the dial completes, publishes the new session and sets
+`_ready`, and `_wait_for_lifecycle_event()` is entered with the event still set
+-- so `asyncio.wait` returns "reconnect" immediately and destroys the session
+that was established microseconds earlier.
+
+Meanwhile `_wait_for_server_session_ready()` only checks
+`session is not old_session and _ready.is_set()`, so it certifies that same
+doomed session and the single session-expired retry is spent on a transport
+that is already unwinding. Observed in production as, milliseconds apart:
+
+    reconnect requested - tearing down HTTP session
+    retry after session reconnect failed: Connection closed
+
+The request is satisfied BY that dial, so it must be consumed when the session
+becomes ready rather than left to fire against it.
+"""
+import asyncio
+
+import pytest
+
+from tools.mcp_tool import MCPServerTask
+
+
+def _ready_server(name: str = "test") -> MCPServerTask:
+    """A task in the state a dial leaves behind: session published, _ready set."""
+    srv = MCPServerTask(name)
+    srv._config = {"keepalive_interval": 300}
+    srv.session = object()
+    srv._ready.set()
+    return srv
+
+
+@pytest.mark.asyncio
+async def test_in_dial_reconnect_does_not_tear_down_the_new_session():
+    """An event set BEFORE readiness is consumed, not acted on."""
+    srv = _ready_server()
+    srv._reconnect_event.set()          # requested while the dial was in flight
+
+    task = asyncio.ensure_future(srv._wait_for_lifecycle_event())
+    await asyncio.sleep(0.1)
+
+    assert not task.done(), (
+        "brand-new session torn down by the reconnect request that built it"
+    )
+    assert not srv._reconnect_event.is_set(), (
+        "the in-dial request must be consumed so it cannot fire later either"
+    )
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_reconnect_requested_after_ready_still_reconnects():
+    """The real signal path (keepalive failure, OAuth recovery) still works."""
+    srv = _ready_server()
+
+    task = asyncio.ensure_future(srv._wait_for_lifecycle_event())
+    await asyncio.sleep(0.05)           # let it enter the wait
+    srv._reconnect_event.set()
+
+    assert await asyncio.wait_for(task, timeout=3.0) == "reconnect"
+
+
+@pytest.mark.asyncio
+async def test_shutdown_after_ready_still_shuts_down():
+    srv = _ready_server()
+
+    task = asyncio.ensure_future(srv._wait_for_lifecycle_event())
+    await asyncio.sleep(0.05)
+    srv._shutdown_event.set()
+
+    assert await asyncio.wait_for(task, timeout=3.0) == "shutdown"
+
+
+@pytest.mark.asyncio
+async def test_shutdown_still_wins_when_both_set_after_ready():
+    srv = _ready_server()
+
+    task = asyncio.ensure_future(srv._wait_for_lifecycle_event())
+    await asyncio.sleep(0.05)
+    srv._reconnect_event.set()
+    srv._shutdown_event.set()
+
+    assert await asyncio.wait_for(task, timeout=3.0) == "shutdown"

--- a/tools/mcp_tool_server_run.py
+++ b/tools/mcp_tool_server_run.py
@@ -61,6 +61,17 @@ class MCPServerRunMixin:
         that don't implement the optional ping utility — see :meth:`_keepalive_probe`) to prevent
         TCP/session state from going stale during idle periods (#17003).
         """
+        # LOCAL PATCH: in-dial reconnect coalescing.
+        # Reaching this point means a session was just established and ``_ready`` is set. A
+        # ``_reconnect_event`` STILL set here was raised *during* the dial that produced this
+        # very session (e.g. a tool call failing with a server-expired session signals a
+        # reconnect while the lifecycle loop is already rebuilding). Leaving it set makes the
+        # wait below return "reconnect" instantly and tear down the brand-new session -- while
+        # _wait_for_server_session_ready() has simultaneously certified that same session as
+        # fresh+ready and spent the one session-expired retry on it ("Connection closed").
+        # The request has already been satisfied by this dial, so consume it.
+        self._reconnect_event.clear()
+
         keepalive_interval = max(
             _core._MIN_KEEPALIVE_INTERVAL,
             float(self._config.get("keepalive_interval", _core._DEFAULT_KEEPALIVE_INTERVAL)))


### PR DESCRIPTION
Fixes #103211.

## The bug

A reconnect requested **while a dial is already in flight** is not deduplicated — it is consumed by the connection it was meant to produce.

`_wait_for_lifecycle_event()` builds its `reconnect_task` from `_reconnect_event.wait()`. If the event is already set on entry, `asyncio.wait` returns immediately and the session established microseconds earlier — `self.session` assigned, `_discover_tools()` done, `_ready` set — is torn straight back down.

That alone would only cost a wasted reconnect cycle. What makes it user-visible is that `_wait_for_server_session_ready()` guards on `session is not old_session and _ready.is_set()`, which the doomed session satisfies. So `_handle_session_expired_and_retry` believes the transport is healthy and spends its **single** retry on a transport that is already unwinding — the one mechanism meant to make server-side session expiry invisible fails precisely when it is needed.

Measured against Composio at ~1 failed call in 28; the tool error reaches the model and the in-flight work is lost.

## The fix

```python
async def _wait_for_lifecycle_event(self) -> str:
    ...
    self._reconnect_event.clear()
```

Reaching that point means a session is established and `_ready` is set, so a still-pending request was raised *during* the dial that produced this session. It has been satisfied; consume it.

Hardening the waiter instead does not work: there is a ~350 ms window between the lifecycle loop clearing the event on its way into teardown and `_ready` being cleared, during which the waiter would still certify the dying session. Consuming the request at the point it is satisfied closes the race at its source.

## Tests

`tests/tools/test_mcp_in_dial_reconnect.py`:

- `test_in_dial_reconnect_does_not_tear_down_the_new_session` — the regression. On unpatched `main` it fails with `_wait_for_lifecycle_event` returning `'reconnect'` immediately; it also asserts the event is consumed so it cannot fire later instead.
- `test_reconnect_requested_after_ready_still_reconnects` — the real signal path (keepalive failure, OAuth recovery) is untouched.
- `test_shutdown_after_ready_still_shuts_down`
- `test_shutdown_still_wins_when_both_set_after_ready`

The last three pass both with and without the fix — they exist to pin that the clear does not swallow legitimate lifecycle events.

Full related suite: `pytest tests/tools/ -k "mcp and (reconnect or oauth or lifecycle or session or transport or health)"` → **172 passed**.

## Notes

Found in production on a long-lived gateway after a separate OAuth wedge (#101756) was worked around locally; that wedge was masking this one. The two are independent: #101756 is a permanent park, this is an intermittent per-call failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
