### PR TITLE
fix(gateway): re-stamp gateway_state.json from the loop heartbeat

### DIFF
--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -358,11 +358,42 @@ async def loop_heartbeat_forever(
                        "loop-scheduling witness and will not escalate on a stale heartbeat",
                        exc_info=True)
     extra = {"loop_tick_socket": tick_server is not None, "loop_tick_tcp_port": tick_tcp_port}
+    def _write_heartbeat_and_runtime_status() -> None:
+        """Refresh the heartbeat file, and re-stamp ``gateway_state.json`` behind it.
+
+        The second write is here because nothing else moves that file on a cadence: the gateway runner writes it
+        on lifecycle transitions (running / draining / stopped) and at in-process turn boundaries, so an
+        idle gateway -- or one whose only work is spawning kanban WORKERS, which are separate processes
+        rather than turns -- stops touching it, and its ``updated_at`` ages without bound while the
+        gateway is perfectly alive. Every consumer that reads recency off that field then concludes the
+        opposite: measured against hermes-webui, whose cross-container liveness check treats
+        ``updated_at`` as a heartbeat with a 120s window, ``gateway_stale_running_state`` was reported
+        ("health metadata has gone stale", with the Scheduled Jobs panel warning that cron would not
+        tick) against a gateway with ``updated_at`` 2h16m old, ``active_agents: 0`` and pid 1 =
+        ``hermes gateway run``.
+
+        This loop is the right owner: it already ticks at ``DEFAULT_HEARTBEAT_INTERVAL_S``, well inside
+        that window, and it is already the signal that ages when the loop freezes -- so both files keep
+        the same liveness meaning and a wedged loop still ages both. ``write_runtime_status()`` with no
+        arguments is read-merge-write, so the lifecycle state cannot be clobbered.
+
+        Skipped when ``home`` is overridden (only tests do): the runtime-status path comes from the
+        ambient HERMES_HOME and takes no ``home`` argument, so honouring the override is impossible and
+        ignoring it would write into the developer's real home.
+        """
+        write_loop_heartbeat(start_time=start_time, home=home, extra=extra)
+        if home is not None:
+            return
+        try:
+            from gateway.status import write_runtime_status
+            write_runtime_status()
+        except Exception:
+            logger.debug("gateway_state.json re-stamp failed", exc_info=True)
+
     try:
         while True:  # first write is immediate so monitors see a fresh file at once
             try:
-                await asyncio.to_thread(write_loop_heartbeat, start_time=start_time, home=home,
-                                        extra=extra)
+                await asyncio.to_thread(_write_heartbeat_and_runtime_status)
             except Exception:  # write_loop_heartbeat never raises: executor problem, keep the task
                 logger.debug("Loop heartbeat write failed off-loop", exc_info=True)
             if should_continue is not None and not should_continue():

--- a/tests/gateway/test_loop_heartbeat_restamps_runtime_status.py
+++ b/tests/gateway/test_loop_heartbeat_restamps_runtime_status.py
@@ -1,0 +1,90 @@
+"""The loop heartbeat must also re-stamp ``gateway_state.json`` (#*).
+
+``run.py`` writes that file on lifecycle transitions and at in-process turn boundaries, and nowhere
+else. An idle gateway therefore stops touching it -- and so does a busy one whose work is spawning
+kanban *workers*, since those are separate processes rather than gateway turns. Its ``updated_at`` then
+ages without bound while the gateway is alive, and every consumer that reads recency off that field
+concludes the opposite. Measured against hermes-webui, which uses it as the cross-container liveness
+signal with a 120s window: ``gateway_stale_running_state`` reported against a gateway whose
+``updated_at`` was 2h16m old, with ``active_agents: 0`` and pid 1 = ``hermes gateway run``.
+
+The heartbeat loop is the right owner because it already ticks well inside that window and already ages
+when the loop freezes, so both files keep the same liveness meaning.
+"""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import patch
+
+from gateway.shutdown_watchdog import loop_heartbeat_forever
+
+
+def _run_one_tick(**kwargs):
+    """Drive the loop for a single write, then cancel it."""
+    async def main():
+        task = asyncio.create_task(loop_heartbeat_forever(interval_s=1.0, **kwargs))
+        for _ in range(200):                      # the first write is immediate; give it a moment
+            await asyncio.sleep(0.01)
+            if calls["heartbeat"]:
+                break
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    calls = {"heartbeat": 0, "runtime": 0}
+
+    def _heartbeat(**_kw):
+        calls["heartbeat"] += 1
+
+    def _runtime(*_a, **_kw):
+        calls["runtime"] += 1
+
+    with patch("gateway.shutdown_watchdog.write_loop_heartbeat", side_effect=_heartbeat), \
+         patch("gateway.status.write_runtime_status", side_effect=_runtime):
+        asyncio.run(main())
+    return calls
+
+
+def test_heartbeat_tick_also_restamps_runtime_status():
+    calls = _run_one_tick()
+    assert calls["heartbeat"] >= 1
+    assert calls["runtime"] >= 1, "gateway_state.json was not re-stamped by the heartbeat tick"
+
+
+def test_home_override_skips_the_runtime_status_write(tmp_path: Path):
+    """The runtime-status path comes from the ambient HERMES_HOME and takes no ``home`` argument.
+
+    A caller that redirects ``home`` (only tests do) must not have its heartbeat write into one place
+    and its runtime status into another -- the developer's real Hermes home.
+    """
+    calls = _run_one_tick(home=tmp_path)
+    assert calls["heartbeat"] >= 1
+    assert calls["runtime"] == 0, "a home override still wrote to the ambient runtime status path"
+
+
+def test_a_failing_runtime_status_write_does_not_kill_the_heartbeat():
+    """Liveness reporting must never be able to stop liveness reporting."""
+    calls = {"heartbeat": 0}
+
+    async def main():
+        task = asyncio.create_task(loop_heartbeat_forever(interval_s=0.05))
+        for _ in range(200):
+            await asyncio.sleep(0.01)
+            if calls["heartbeat"] >= 2:
+                break
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    def _heartbeat(**_kw):
+        calls["heartbeat"] += 1
+
+    with patch("gateway.shutdown_watchdog.write_loop_heartbeat", side_effect=_heartbeat), \
+         patch("gateway.status.write_runtime_status", side_effect=RuntimeError("disk full")):
+        asyncio.run(main())
+
+    assert calls["heartbeat"] >= 2, "the heartbeat stopped after a runtime-status write failed"


### PR DESCRIPTION
An idle gateway stops touching `gateway_state.json`, so its `updated_at` ages without bound while the process is perfectly alive — and every consumer that reads recency off that field concludes the opposite.

The gateway runner (`run.py`, with the lifecycle writes now living in `run_startup.py` / `run_shutdown.py` behind `_write_runtime_status_quiet`) writes the file on lifecycle transitions (`starting` / `running` / `draining` / `stopped`) and at in-process turn boundaries; adapters and the session-store recovery path write it on their own state changes. None of those writers is periodic. That also means a *busy* gateway stops touching it when its work is spawning kanban **workers**, because those are separate processes rather than gateway turns. `gateway/status.py` still documents this itself: `derive_gateway_busy` notes that "an idle gateway never advances `updated_at`".

### Measured

Against hermes-webui, which cannot use a PID check across containers and so uses `updated_at` as its cross-container liveness signal with a 120s window (`api/agent_health.py`, `GATEWAY_FRESHNESS_THRESHOLD_S = 120.0`):

- reported reason: `gateway_stale_running_state`
- UI: *"GATEWAY METADATA STALE — the gateway is marked as configured, but its health metadata has gone stale. In Docker, scheduled jobs require a live gateway daemon"*, in the Scheduled Jobs panel
- the file at that moment: `updated_at` **2h16m** old, `gateway_state: "running"`, `active_agents: 0`
- the process at that moment: pid 1 in the container was `hermes gateway run`, and `state/gateway.heartbeat` was 3s old

Nothing was wrong except the file.

### Why the loop heartbeat is the right owner

`loop_heartbeat_forever` already ticks at `DEFAULT_HEARTBEAT_INTERVAL_S` (30s), comfortably inside that 120s window, and it is already the signal that ages when the loop freezes. Re-stamping from there gives both files the same liveness meaning, and a wedged loop still ages both.

- The write joins the existing `to_thread` hop rather than adding another, so the docstring's guarantee (initiated by the loop, awaited, one in flight at a time) still holds.
- `write_runtime_status()` with no arguments is read-merge-write, so the lifecycle state cannot be clobbered — the same call `_persist_active_agents` already makes.
- Skipped when `home` is overridden, which only tests do: the runtime-status path comes from the ambient `HERMES_HOME` and takes no `home` argument, so honouring the override is impossible and ignoring it would write into the developer's real home.
- A failing re-stamp is logged and swallowed. Liveness reporting must not be able to stop liveness reporting.

### Tests

`tests/gateway/test_loop_heartbeat_restamps_runtime_status.py` — 3 cases: the tick re-stamps, a `home` override does not, and a raising `write_runtime_status` does not stop the heartbeat. Neighbour suites `tests/gateway/test_shutdown_watchdog.py`, `tests/gateway/test_loop_liveness_watchdog.py` and `tests/hermes_cli/test_update_wedged_gateway.py` pass on the rebased branch.

### Alternative considered and rejected

Pointing the consumer at the HTTP health endpoint instead. `build_agent_health_payload()` probes `GATEWAY_HEALTH_URL` before any file signal and `/health` answers 200, so it looked like a configuration-only fix. Sampled 12 times 4s apart, **4 of 12** came back `remote_gateway_unreachable` (the probe allows 2.0s per path across three paths) — trading a permanent false "stale" for an intermittent false "your URL is wrong", which is a worse message. Making the file honest fixes it for every consumer instead of one.

### Related

#32887 (issue), #32958 and #33777 are alternative approaches to the same idle-staleness (a new `status_heartbeat.py` module and a `run.py` patch respectively); this PR touches only `gateway/shutdown_watchdog.py` and shares no files with either.
