### PR TITLE
fix(anthropic): keep the newest screenshots when a batch shares one message

### DIFF
--- a/agent/anthropic_message_convert.py
+++ b/agent/anthropic_message_convert.py
@@ -591,11 +591,15 @@ def _manage_thinking_signatures(result: List[Dict[str, Any]], base_url: str | No
 
 def _evict_old_screenshots(result: List[Dict[str, Any]]) -> None:
     """Keep only the 3 most recent computer-use screenshots (~1,465 tokens each); older images
-    become a placeholder text block. Mutates ``result`` in place."""
+    become a placeholder text block. Mutates ``result`` in place.
+
+    Both loops walk newest -> oldest: parallel tool calls land as sibling ``tool_result`` blocks
+    inside ONE user message (_convert_tool_message_to_result merges them), so a forward inner walk
+    would count a batch oldest-first and evict the newest screenshot of the batch instead."""
     image_count = 0
     for msg in reversed(result):
         content = msg.get("content")
-        for block in content if isinstance(content, list) else []:
+        for block in reversed(content) if isinstance(content, list) else []:
             inner = block.get("content") if _block_type(block) == "tool_result" else None
             if not isinstance(inner, list) or not _has_block_type(inner, {"image"}):
                 continue

--- a/tests/agent/test_anthropic_screenshot_eviction_recency.py
+++ b/tests/agent/test_anthropic_screenshot_eviction_recency.py
@@ -1,0 +1,107 @@
+"""Screenshot eviction must keep the three NEWEST screenshots.
+
+``_evict_old_screenshots`` (agent/anthropic_message_convert.py) walks messages
+newest -> oldest, replacing every image past the third with
+``[screenshot removed to save context]``.  Its block-level loop used to walk the
+blocks *inside* one message oldest -> newest while sharing the outer counter, so
+recency was inconsistent as soon as one message held more than one screenshot.
+
+That is the normal shape for parallel tool calls: sibling ``tool_result`` blocks
+are appended into the same user message by
+``_convert_tool_message_to_result``.  A batch of four screenshots therefore had
+blocks 1-3 kept and block 4 — the most recent view of the screen — evicted.
+
+These tests assert the docstring's contract directly: whichever way the
+screenshots arrived, the surviving images are the last three in wire order.
+"""
+
+from typing import Any, Dict, List
+
+from agent.anthropic_message_convert import convert_messages_to_anthropic
+
+PLACEHOLDER = "[screenshot removed to save context]"
+
+
+def _screenshot_call(call_id: str) -> Dict[str, Any]:
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": "computer", "arguments": '{"action": "screenshot"}'},
+    }
+
+
+def _assistant_turn(call_ids: List[str]) -> Dict[str, Any]:
+    return {"role": "assistant", "content": "", "tool_calls": [_screenshot_call(c) for c in call_ids]}
+
+
+def _screenshot_result(call_id: str) -> Dict[str, Any]:
+    """A tool message carrying one screenshot, tagged by ``call_id`` in its image URL."""
+    return {
+        "role": "tool",
+        "tool_call_id": call_id,
+        "content": [
+            {"type": "text", "text": f"screenshot {call_id}"},
+            {"type": "image_url", "image_url": {"url": f"https://shots.test/{call_id}.png"}},
+        ],
+    }
+
+
+def _screenshot_tags(converted: List[Dict[str, Any]]) -> List[str]:
+    """Call ids of the surviving images, in wire order."""
+    tags = []
+    for msg in converted:
+        content = msg.get("content")
+        for block in content if isinstance(content, list) else []:
+            inner = block.get("content") if block.get("type") == "tool_result" else None
+            for b in inner if isinstance(inner, list) else []:
+                if b.get("type") == "image":
+                    tags.append(b["source"]["url"].rsplit("/", 1)[-1].removesuffix(".png"))
+    return tags
+
+
+def _evicted_tags(converted: List[Dict[str, Any]]) -> List[str]:
+    """Call ids of the tool_results whose image became a placeholder, in wire order."""
+    tags = []
+    for msg in converted:
+        content = msg.get("content")
+        for block in content if isinstance(content, list) else []:
+            inner = block.get("content") if block.get("type") == "tool_result" else None
+            blocks = inner if isinstance(inner, list) else []
+            if any(b.get("type") == "text" and b.get("text") == PLACEHOLDER for b in blocks):
+                tags.append(block["tool_use_id"])
+    return tags
+
+
+def test_parallel_screenshot_batch_keeps_the_newest_three():
+    """Five screenshots in ONE merged user message: the last three survive."""
+    call_ids = [f"call_{i}" for i in range(1, 6)]
+    messages = [{"role": "user", "content": "look at the screen"}, _assistant_turn(call_ids)]
+    messages += [_screenshot_result(c) for c in call_ids]
+
+    _system, converted = convert_messages_to_anthropic(messages)
+
+    # The batch really did merge into a single user turn — the case the bug needs.
+    tool_result_msgs = [
+        m for m in converted
+        if m.get("role") == "user" and isinstance(m.get("content"), list)
+        and any(b.get("type") == "tool_result" for b in m["content"])
+    ]
+    assert len(tool_result_msgs) == 1
+    assert len(tool_result_msgs[0]["content"]) == len(call_ids)
+
+    assert _screenshot_tags(converted) == call_ids[-3:]
+    assert _evicted_tags(converted) == call_ids[:-3]
+
+
+def test_screenshots_split_across_messages_keep_the_newest_three():
+    """Screenshots arriving in separate turns AND in a batch share one recency order."""
+    first, second, batch = ["call_1"], ["call_2"], ["call_3", "call_4", "call_5"]
+    messages: List[Dict[str, Any]] = [{"role": "user", "content": "watch the screen"}]
+    for group in (first, second, batch):
+        messages.append(_assistant_turn(group))
+        messages += [_screenshot_result(c) for c in group]
+
+    _system, converted = convert_messages_to_anthropic(messages)
+
+    assert _screenshot_tags(converted) == ["call_3", "call_4", "call_5"]
+    assert _evicted_tags(converted) == ["call_1", "call_2"]


### PR DESCRIPTION
## Problem

`_evict_old_screenshots` in `agent/anthropic_message_convert.py` promises to "keep only the 3 most recent computer-use screenshots". It walks messages newest → oldest, but the loop over the blocks *inside* a message walked them oldest → newest while sharing the single `image_count`. The two orders only agree when every message holds at most one screenshot.

## Failure scenario

Parallel tool calls violate that assumption by design. `_convert_tool_message_to_result` appends sibling `tool_result`s into the **same** user message:

```python
last_content = last.get("content") if last.get("role") == "user" else None
if isinstance(last_content, list) and last_content and last_content[0].get("type") == "tool_result":
    last_content.append(tool_result)
```

So a batch of N screenshot calls lands as N `tool_result` blocks in one user turn. The inner loop counted them oldest-first, so blocks 1–3 were kept and every later block — including the most recent view of the screen — was replaced with `[screenshot removed to save context]`. The eviction inverted its own contract in exactly the multi-screenshot case it exists for, leaving the model reasoning from three stale frames after the current one had been dropped.

Observed on `main` with five screenshot tool results merged into one user turn:

```
AssertionError: assert ['call_1', 'call_2', 'call_3'] == ['call_3', 'call_4', 'call_5']
```

## What changed

- `agent/anthropic_message_convert.py` — iterate the inner blocks in reverse so both loops agree on recency. Each block still reads its own `inner` list, so the placeholder rewrite is unchanged and the retention count stays at 3. One-line change plus a docstring note on why the direction is load-bearing.
- `tests/agent/test_anthropic_screenshot_eviction_recency.py` — two invariant tests through the public `convert_messages_to_anthropic`: whichever way the screenshots arrived, the surviving images are the last three in wire order and the placeholders sit on the earlier ones. Asserted on positions and identity (tagged image URLs), not on counts or a structure snapshot.

## Bug-class sweep

Checked every pass in the module that walks nested content or carries a recency assumption:

- `_apply_assistant_cache_control_to_last_cacheable_block` — `reversed(blocks)` + `break`; consistent.
- `_split_blank_text_blocks` / `_replay_ordered_blocks` — forward walks that take the *last* dropped `cache_control`; that is the most recent one. Consistent.
- `_manage_thinking_signatures` / `_keep_valid_latest_thinking` — reverse scan for the latest assistant index, then a per-turn forward block walk with no cross-block counter. Consistent.
- `_strip_orphaned_tool_blocks`, `_scrub_blank_text_blocks`, `_merge_consecutive_roles` — order-independent filters.
- `context_compressor._retire_stale_tool_result_images` (the other keep-newest image pass) — message-level only, walks `range(len(result) - 1, -1, -1)` and counts whole image-bearing tool messages, so it has no inner/outer mismatch.

`_evict_old_screenshots` was the only site sharing a counter between a reverse outer walk and a forward inner walk.

## Testing

Red on base — fix stashed:

```
$ scripts/run_tests.sh tests/agent/test_anthropic_screenshot_eviction_recency.py
tests/agent/test_anthropic_screenshot_eviction_recency.py F.             [100%]
>       assert _screenshot_tags(converted) == call_ids[-3:]
E       AssertionError: assert ['call_1', 'call_2', 'call_3'] == ['call_3', 'call_4', 'call_5']
========================= 1 failed, 1 passed in 0.16s =========================
```

(The across-messages case passes before the fix — it pins the ordering that was already correct.)

Green after:

```
$ scripts/run_tests.sh tests/agent/test_anthropic_screenshot_eviction_recency.py
=== Summary: 1 files, 2 tests passed, 0 failed (100% complete) in 2.0s (20 workers) ===
```

Every test file touching the converter:

```
$ scripts/run_tests.sh $(grep -rl "anthropic_message_convert\|convert_messages_to_anthropic" tests/)
=== Summary: 15 files, 329 tests passed, 0 failed (100% complete) in 23.5s (20 workers) ===
```

Full agent suite:

```
$ scripts/run_tests.sh tests/agent/
=== Summary: 491 files, 6300 tests passed, 2 failed, 23 skipped (100% complete) in 299.0s (20 workers) ===
  tests/agent/test_compression_stall_fallback_78981.py  (1 test failed)
  tests/agent/test_compression_attempt_lifecycle.py  (1 test failed)
```

Both failures are pre-existing timing flakes under a loaded 20-worker run, unrelated to this change. On a clean checkout of `main` the same two files fail and pass on retry (`⚠ FLAKY: failed on attempt 1, passed on retry`), and with this change applied they pass in isolation:

```
$ scripts/run_tests.sh tests/agent/test_compression_stall_fallback_78981.py tests/agent/test_compression_attempt_lifecycle.py
=== Summary: 2 files, 23 tests passed, 0 failed (100% complete) in 4.6s (20 workers) ===
```

`ruff check` clean on both touched files.
