### PR TITLE
fix(desktop): gate picker defaultPath on local readability

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -274,6 +274,7 @@ import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
 import { LEGACY_OAUTH_PARTITION, resolveOauthPartition } from './oauth-partition'
 import { createParentStartMarkerResolver, parentWatchdogEnv } from './parent-process-identity'
 import { registerPetOverlayIpc } from './pet-overlay-ipc'
+import { locallyReadable } from './picker-default-path'
 import {
   pendingNotice as pendingPluginCompatNotice,
   recordDismissed as recordPluginCompatDismissed
@@ -16823,6 +16824,14 @@ ipcMain.handle('hermes:selectPaths', async (_event, options: any = {}) => {
     } catch {
       resolvedDefaultPath = undefined
     }
+
+    // The picker browses THIS machine, but defaultPath may come from another
+    // one (a remote gateway's cwd, a backend running as another user) — e.g.
+    // a remote session rooted at /root is unreadable locally and made GTK
+    // fail the whole dialog with "Could not read the contents of root".
+    // Seed the dialog only when a local process can actually read the path;
+    // otherwise drop the hint and let the dialog open at its native default.
+    resolvedDefaultPath = locallyReadable(resolvedDefaultPath)
   }
 
   const result = await dialog.showOpenDialog(mainWindow, {

--- a/apps/desktop/electron/picker-default-path.test.ts
+++ b/apps/desktop/electron/picker-default-path.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Regression: the native picker's defaultPath must be validated against the
+ * LOCAL filesystem before the dialog is seeded with it.
+ *
+ * `hermes:selectPaths` receives the backend session's cwd as defaultPath. In
+ * remote mode that backend is another machine (often as another user), so the
+ * path can be unreadable here — a remote gateway running as root yields
+ * `/root`, and a dialog seeded with it failed wholesale on Linux with
+ * "Could not read the contents of root: Permission denied". The renderer-side
+ * file-read path is already local-first; the picker never validated, so the
+ * gate lives at the Electron boundary (picker-default-path.ts) and covers
+ * every picker caller at once.
+ */
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { locallyReadable } from './picker-default-path'
+
+describe('picker defaultPath local-readability gate', () => {
+  const scratch = path.join(os.tmpdir(), 'hermes-picker-gate-test')
+
+  beforeAll(() => {
+    fs.mkdirSync(scratch, { recursive: true })
+  })
+
+  afterAll(() => {
+    fs.rmSync(scratch, { recursive: true, force: true })
+  })
+
+  test('keeps a locally readable directory', () => {
+    expect(locallyReadable(scratch)).toBe(scratch)
+  })
+
+  test('drops a path this process cannot read (chmod 000)', () => {
+    const sealed = path.join(scratch, 'sealed')
+    fs.mkdirSync(sealed, { recursive: true })
+    fs.chmodSync(sealed, 0o000)
+
+    try {
+      expect(locallyReadable(sealed)).toBeNull()
+    } finally {
+      fs.chmodSync(sealed, 0o700)
+    }
+  })
+
+  test('drops a path that does not exist locally (remote cwd)', () => {
+    const absent = path.join(scratch, 'only-on-the-remote-backend')
+    expect(locallyReadable(absent)).toBeNull()
+  })
+
+  test('empty and nullish hints stay null (dialog opens at its native default)', () => {
+    expect(locallyReadable(undefined)).toBeNull()
+    expect(locallyReadable(null)).toBeNull()
+    expect(locallyReadable('')).toBeNull()
+  })
+
+  // The bug report's exact shape: a superuser-owned, 0700 home directory
+  // (e.g. a remote root backend's cwd rendered on a non-root laptop). Skipped
+  // only when the test runner itself has root privileges, where the dialog
+  // would not have failed in the first place.
+  test.skipIf(process.getuid?.() === 0)('drops a foreign 0700 home like /root', () => {
+    expect(locallyReadable('/root')).toBeNull()
+  })
+})

--- a/apps/desktop/electron/picker-default-path.ts
+++ b/apps/desktop/electron/picker-default-path.ts
@@ -1,0 +1,30 @@
+import fs from 'node:fs'
+
+/**
+ * Gate the native file dialog's `defaultPath` on local readability.
+ *
+ * The picker browses THIS machine, but `defaultPath` is usually the backend
+ * session's cwd — and in remote mode the backend is another machine (often
+ * running as a different user). Its `/root` exists locally only as a path
+ * this process cannot read, and a dialog seeded with it fails wholesale:
+ * GTK shows "Could not read the contents of root: Permission denied" and
+ * Linux/Windows pickers fall back to a broken or empty view. Existing local
+ * read paths ("local-first") already validate; the picker never did.
+ *
+ * Returns the path unchanged when a local process can read it, and `null`
+ * when it cannot (absent, permission-denied, or any other stat failure) so
+ * the caller drops the hint and the dialog opens at its native default.
+ */
+export function locallyReadable(defaultPath: null | string | undefined): null | string {
+  if (!defaultPath) {
+    return null
+  }
+
+  try {
+    fs.accessSync(String(defaultPath), fs.constants.R_OK)
+
+    return String(defaultPath)
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Bug Description

Every attach/context file-picker open in Hermes Desktop fails with a GTK error while the app is connected to a remote gateway:

> Could not read the contents of root
> Error opening directory '/root': Permission denied

Fixes #103216

## Root Cause

`hermes:selectPaths` seeds the LOCAL native dialog with the backend session's cwd as `defaultPath`. In remote mode that cwd belongs to the remote machine (a root-operated gateway yields `/root`), so the hint is unreadable or absent locally, and GTK fails the whole dialog instead of ignoring it. The renderer's file-read path (`readDesktopFileDataUrlLocalFirst`) is already local-first; the picker's hint was never validated against the local filesystem.

## Fix

Gate the hint at the Electron boundary: after WSL bridging and `path.resolve`, keep `defaultPath` only when a local process can read it (`fs.accessSync(path, R_OK)`); otherwise drop it and let the dialog open at its native default. One seam covers every picker caller (composer file/image attach, plugins, future call sites) — no renderer changes.

## How to Verify

1. Connect Desktop to a remote gateway whose backend runs as root (session cwd `/root`) from a non-root Linux account.
2. On main: opening the attach picker shows the GTK permission-denied dialog every time.
3. On this branch: the picker opens at its native default (last-used/home); no error dialog.

## Test Plan

- [x] Added regression test (`electron/picker-default-path.test.ts`): real-filesystem behavior contract — keeps a readable dir, drops chmod-000, drops absent remote cwd, drops foreign 0700 home (`/root`), nullish stays null.
- [x] `vitest run --project electron` — 150 files / 2115 tests pass (6 skipped: Windows-only).
- [x] `tsc -p tsconfig.electron.json --noEmit` + eslint + prettier clean.

## Risk Assessment

Low — the gate only ever removes a hint the dialog would have failed on; a readable local defaultPath behaves exactly as before. `locallyReadable` is a pure `fs` check extracted to `picker-default-path.ts` (no Electron imports), so it is unit-testable without booting the app.