### PR TITLE
fix(windows): default cua-driver to on-demand; add autostart management

### DIFF
--- a/hermes_cli/subcommands/computer_use.py
+++ b/hermes_cli/subcommands/computer_use.py
@@ -55,6 +55,17 @@ def _cu_status(args) -> int:
             print("    Run: hermes computer-use install")
         return 1
     try:
+        from hermes_cli.tools_config_cua import _cua_driver_autostart_state_windows
+        _auto = _cua_driver_autostart_state_windows()
+        if _auto["supported"]:
+            if _auto["registered"]:
+                print(f"  Autostart: logon task present ({_auto['task_state']}) — disable with: "
+                      "hermes computer-use autostart disable")
+            else:
+                print("  Autostart: off (starts on demand)")
+    except Exception:
+        pass
+    try:
         st = cua_driver_update_check()
         if st and st.get("update_available"):
             latest = st.get("latest_version") or "?"
@@ -76,6 +87,29 @@ def _cu_doctor(args) -> None:
         include=list(getattr(args, "include", []) or []),
         skip=list(getattr(args, "skip", []) or []),
         json_output=bool(getattr(args, "json", False))))
+
+
+def _cu_autostart(args) -> int:
+    from hermes_cli import tools_config_cua as _tools_config_cua
+    sub = getattr(args, "computer_use_autostart_action", None) or "status"
+    if sub == "enable":
+        ok = _tools_config_cua._repair_cua_driver_autostart_windows(
+            _tools_config_cua._cua_driver_cmd(), verbose=True)
+        return 0 if ok else 1
+    if sub == "disable":
+        return 0 if _tools_config_cua._disable_cua_driver_autostart_windows() else 1
+    state = _tools_config_cua._cua_driver_autostart_state_windows()
+    if not state["supported"]:
+        print("Autostart logon task: Windows-only concept.")
+        print("  macOS: ~/Library/LaunchAgents/com.trycua.cua-driver.plist")
+        print("  Linux: systemctl --user cua-driver.service")
+        return 0
+    if not state["registered"]:
+        print("Autostart: off (cua-driver starts on demand).")
+    else:
+        print(f"Autostart: logon task registered ({state['task_state']}).")
+        print("  Disable with: hermes computer-use autostart disable")
+    return 0
 
 
 def _cu_perms_status(args) -> None:
@@ -140,6 +174,23 @@ def build_computer_use_parser(subparsers) -> None:
             "PATH. The upstream install.sh always pulls the latest release, "
             "so this performs an in-place upgrade.")
     computer_use_sub.add_parser("status", help="Print whether cua-driver is installed and on PATH")
+    computer_use_autostart = computer_use_sub.add_parser(
+        "autostart", help="Manage the Windows cua-driver logon task (opt-in autostart)",
+        description="Inspect or change whether cua-driver starts at Windows login.\n"
+            "Since #95372/#97389 Hermes defaults to on-demand (no logon task): the driver "
+            "is spawned per session over stdio, so the `cua-driver-serve` Scheduled Task is "
+            "unnecessary for normal Computer Use — and removing it also removes the brief "
+            "login console flash (trycua/cua#1645).\n\n"
+            "`status` is read-only; `enable` registers the task (UAC prompt); `disable` "
+            "disables it (reversible, deletes nothing).")
+    computer_use_autostart_sub = computer_use_autostart.add_subparsers(
+        dest="computer_use_autostart_action")
+    computer_use_autostart_sub.add_parser(
+        "status", help="Report whether the logon task is registered (read-only)")
+    computer_use_autostart_sub.add_parser(
+        "enable", help="Register the logon task (explicit opt-in, UAC prompt)")
+    computer_use_autostart_sub.add_parser(
+        "disable", help="Disable the logon task (reversible, deletes nothing)")
     computer_use_doctor = computer_use_sub.add_parser(
         "doctor", help="Run cua-driver `health_report` and surface the check matrix",
         description="Drive cua-driver's stable `health_report` MCP tool and render\n"
@@ -181,7 +232,7 @@ def build_computer_use_parser(subparsers) -> None:
         computer_use_perms.print_help()
 
     _actions = {"install": _cu_install, "status": _cu_status, "doctor": _cu_doctor,
-                "permissions": _cu_permissions}
+                "permissions": _cu_permissions, "autostart": _cu_autostart}
 
     def cmd_computer_use(args):
         handler = _actions.get(getattr(args, "computer_use_action", None))

--- a/hermes_cli/tools_config_cua.py
+++ b/hermes_cli/tools_config_cua.py
@@ -137,9 +137,14 @@ def _cua_driver_contract_status(binary: Optional[str] = None) -> dict:
 
 
 def _cua_driver_install_ready() -> bool:
-    """Return whether an existing driver needs no install-time repair."""
-    return bool(_cua_driver_contract_status().get("ready")) and (
-        sys.platform != "win32" or _cua_driver_autostart_registered_windows())
+    """Return whether an existing driver needs no install-time repair.
+
+    Readiness is the runtime contract only. The Windows logon-task autostart is an
+    explicit opt-in (``hermes computer-use autostart enable``) since #95372/#97389 —
+    Hermes spawns its own per-session stdio bridge (``cua-driver mcp``), so a missing
+    ``cua-driver-serve`` task must not count as "not ready".
+    """
+    return bool(_cua_driver_contract_status().get("ready"))
 
 
 def _pip_install(args: List[str], *, timeout: int = 300, capture_output: bool = True):
@@ -302,8 +307,17 @@ def install_cua_driver(upgrade: bool = False, require_confirmed_update: bool = F
         version = _cua_driver_version(binary)
         suffix = "" if version is None else f": {version or 'unknown version'}"
         _print_success(f"    {driver_cmd} already installed{suffix}.")
-        if is_windows and not _repair_cua_driver_autostart_windows(binary, verbose=False):
-            return _fail("    cua-driver is compatible, but Windows autostart repair failed.")
+        if is_windows:
+            # Autostart is opt-in (#95372, #97389): never (re-)register the logon task
+            # here. A missing task is the expected on-demand default; a present one is a
+            # legacy of older installers.
+            if not _cua_driver_autostart_registered_windows():
+                _print_info("    cua-driver starts on demand (no logon task registered).")
+                _print_info("    To start it at Windows login instead, run: "
+                            "hermes computer-use autostart enable")
+            else:
+                _print_info("    A legacy cua-driver-serve logon task is still registered;")
+                _print_info("    remove it with: hermes computer-use autostart disable")
         _print_cua_platform_notes(is_windows, is_linux, fresh_install=False)
         return True
     if repair_existing:
@@ -512,7 +526,12 @@ def _repair_cua_driver_autostart_windows(driver_cmd: str, *, verbose: bool) -> b
     """Best-effort repair for Windows installer autostart quoting failures.
     Older install.ps1 builds interpolated the binary path into a PowerShell command string, which
     split at the first space. If the scheduled task is missing, retry via Start-Process's
-    structured ``-FilePath`` / ``-ArgumentList`` parameters instead."""
+    structured ``-FilePath`` / ``-ArgumentList`` parameters instead.
+
+    Since #95372/#97389 this is ONLY the engine behind the explicit opt-in
+    (``hermes computer-use autostart enable``). Hermes' own install/refresh paths must
+    not call it unprompted: autostart is opt-in and the driver starts on demand.
+    """
     if sys.platform != "win32" or _cua_driver_autostart_registered_windows():
         return True
     binary = shutil.which(driver_cmd)
@@ -536,6 +555,69 @@ def _repair_cua_driver_autostart_windows(driver_cmd: str, *, verbose: bool) -> b
     _print_warning("    cua-driver autostart registration failed.")
     _print_output_tail(result)
     _print_info("    From an elevated shell, run: cua-driver autostart enable")
+    return False
+
+
+def _cua_driver_autostart_state_windows() -> dict:
+    """Read-only probe of the ``cua-driver-serve`` logon task.
+
+    Never mutates, never prompts, and never flashes a console of its own
+    (no-window creation flags — it would be ironic otherwise). Returns
+    ``{"supported", "registered", "task_state"}`` where ``task_state`` is the
+    scheduler state (``Ready``/``Disabled``/``Running``/...) or ``""`` when no
+    task is registered.
+    """
+    state = {"supported": sys.platform == "win32", "registered": False, "task_state": ""}
+    if sys.platform != "win32":
+        return state
+    ps = shutil.which("powershell") or shutil.which("powershell.exe") or "powershell"
+    try:
+        result = _run_text(
+            [ps, "-NoProfile", "-NonInteractive", "-Command",
+             "try { (Get-ScheduledTask -TaskName 'cua-driver-serve' "
+             "-ErrorAction Stop).State.ToString() } catch { 'missing' }"],
+            timeout=20, stdin=subprocess.DEVNULL, env=_cua_driver_env(),
+            creationflags=_post_setup_no_window_flags())
+    except Exception:
+        return state
+    task_state = (result.stdout or "").strip()
+    if result.returncode == 0 and task_state and task_state != "missing":
+        state["registered"] = True
+        state["task_state"] = task_state
+    return state
+
+
+def _disable_cua_driver_autostart_windows() -> bool:
+    """Best-effort disable of the legacy ``cua-driver-serve`` logon task.
+
+    Disable (not delete) is deliberate: it stops the per-login launch and the console
+    flash, stays reversible via ``hermes computer-use autostart enable``, and never
+    destroys anything the user might have configured by hand. Returns True when no task
+    remains active.
+    """
+    if sys.platform != "win32":
+        _print_info("    Logon-task management here is Windows-only.")
+        _print_info("    macOS: remove ~/Library/LaunchAgents/com.trycua.cua-driver.plist")
+        _print_info("    Linux: systemctl --user disable --now cua-driver.service")
+        return False
+    if not _cua_driver_autostart_registered_windows():
+        _print_success("    No cua-driver-serve logon task registered — already on-demand.")
+        return True
+    try:
+        result = _run_text(["schtasks.exe", "/Change", "/TN", "cua-driver-serve", "/Disable"],
+                           timeout=30, stdin=subprocess.DEVNULL,
+                           creationflags=_post_setup_no_window_flags())
+    except Exception as exc:
+        return _fail(f"    Could not disable the logon task: {exc}")
+    if result.returncode == 0:
+        _print_success("    Disabled the cua-driver-serve logon task.")
+        _print_info("    No more per-login launch or console flash; "
+                    "Computer Use still works on demand.")
+        return True
+    _print_warning("    Could not disable the cua-driver-serve logon task.")
+    _print_output_tail(result)
+    _print_info("    Try from an elevated shell, or disable it in Task Scheduler > "
+                "Task Scheduler Library.")
     return False
 
 
@@ -627,9 +709,20 @@ def _reap_after_timeout(proc, *, is_windows: bool) -> None:
 def _cua_installer_command(is_windows: bool):
     """Return ``(install_cmd, manual_hint, script_path)``; all None if the POSIX download fails."""
     if is_windows:
-        ps_oneliner = f"irm {_CUA_INSTALL_PS1_URL} | iex"  # mirrors cua_driver_install_hint()
-        return (["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", ps_oneliner],
-                f'powershell -NoProfile -ExecutionPolicy Bypass -Command "{ps_oneliner}"', None)
+        # Always the scriptblock form with -NoAutoStart: install.ps1 then skips
+        # Register-CuaDriverAutostart (its only UAC self-elevation branch, which creates
+        # the logon-triggered cua-driver-serve task). Fresh installs must not opt the
+        # user into a per-boot daemon (#95372, #97389); Hermes spawns its own per-session
+        # stdio bridge, so the task is unnecessary for normal Computer Use. The plain
+        # `irm … | iex` one-liner cannot receive parameters, hence scriptblock
+        # invocation. (Fresh-install half first proposed in #98505 by salch-cred.) The
+        # manual hint uses the same form so a copy-pasted retry cannot silently recreate
+        # the task either.
+        ps_scriptblock = (f"$sc = irm {_CUA_INSTALL_PS1_URL}; "
+                          "& ([scriptblock]::Create($sc)) -NoAutoStart")
+        return (["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command",
+                ps_scriptblock],
+                f'powershell -NoProfile -ExecutionPolicy Bypass -Command "{ps_scriptblock}"', None)
 
     # Download-then-exec instead of `bash -c "$(curl …)"`: no shell=True, no command substitution,
     # and the script lands in a mkstemp file (unpredictable name, 0600) rather than a fixed /tmp
@@ -657,7 +750,11 @@ def _unattended_installer_preflight(install_cmd: list, is_windows: bool):
     LOCK_STALE_AFTER_SECONDS=600 before probing the holder (the 11-minute silent hang class);
     (2) release host unreachable — the installer dies slowly inside its own retries; a 5s HEAD
     answers. Returns the (possibly rewritten) install command, or None to skip this refresh.
-    Explicit `install --upgrade` runs never come here and keep upstream's full lock-recovery."""
+    Explicit `install --upgrade` runs never come here and keep upstream's full lock-recovery.
+
+    No command rewrite here: the installer command already carries -NoAutoStart on Windows
+    (see _cua_installer_command), so autostart stays opt-in on every path (#95372, #97389).
+    """
     if _cua_install_lock_held():
         _fail("    Another cua-driver install is in progress (upstream install lock is held) — "
               "skipping this refresh.",
@@ -667,14 +764,6 @@ def _unattended_installer_preflight(install_cmd: list, is_windows: bool):
         _print_info("    github.com is unreachable — skipping cua-driver refresh "
                     "(will retry on the next update).")
         return None
-    if is_windows:
-        # -NoAutoStart skips Register-CuaDriverAutostart — the ONLY branch of install.ps1 that
-        # self-elevates (UAC). Cost: an existing cua-driver-serve task keeps pointing at the
-        # previous binary until the next interactive upgrade. Scriptblock invocation (not `| iex`)
-        # is what lets us pass the parameter.
-        install_cmd = [
-            "powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command",
-            f"$sc = irm {_CUA_INSTALL_PS1_URL}; & ([scriptblock]::Create($sc)) -NoAutoStart"]
     return install_cmd
 
 
@@ -762,9 +851,13 @@ def _run_cua_driver_installer(label: str = "Installing", verbose: bool = True,
             _record_installer_output(out, proc.returncode)
         installed_binary = _resolved_cua_driver_cmd()
         if proc.returncode == 0 and installed_binary:
-            if is_windows and not _repair_cua_driver_autostart_windows(installed_binary,
-                                                                        verbose=verbose):
-                _print_warning("    cua-driver installed, but auto-start was not registered.")
+            # The installer above always runs with -NoAutoStart, so a missing task is the
+            # expected outcome — do NOT re-register it here (the post-install repair path
+            # flagged on #95372). A present task is a legacy of an older installer; surface
+            # the opt-out instead of touching it.
+            if is_windows and _cua_driver_autostart_registered_windows():
+                _print_warning("    A pre-existing cua-driver-serve logon task is still registered.")
+                _print_info("    Remove it with: hermes computer-use autostart disable")
             if verbose:
                 _print_success(f"    {driver_cmd} installed.")
                 _print_cua_platform_notes(is_windows, is_linux, fresh_install=True)

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -1542,10 +1542,9 @@ class TestWindowsAutostartRepair:
         which.assert_not_called()
 
     @pytest.mark.windows_only
-    def test_windows_installer_runs_autostart_repair_after_success(self):
-        """``windows_only``: the PowerShell install argv and the autostart
-        repair hook are both inside the ``is_windows`` branch, so on Linux the
-        fake selected a branch whose `powershell` doesn't exist on PATH."""
+    def test_windows_installer_uses_no_autostart_and_skips_repair(self):
+        """``windows_only``: fresh installs pass ``-NoAutoStart`` and must
+        NOT re-register the logon task post-install (#95372, #97389)."""
         from unittest.mock import MagicMock
         from hermes_cli import tools_config_cua as tools_config
 
@@ -1569,10 +1568,11 @@ class TestWindowsAutostartRepair:
              patch("subprocess.Popen", side_effect=fake_popen), \
              patch.object(tools_config, "_clear_stale_cua_install_lock"), \
              patch.object(tools_config, "_repair_cua_driver_autostart_windows", return_value=True) as repair, \
+             patch.object(tools_config, "_cua_driver_autostart_registered_windows", return_value=False), \
              patch.object(tools_config, "_print_warning"), \
              patch.object(tools_config, "_print_info"), \
              patch.object(tools_config, "_print_success"):
-            ok = tools_config._run_cua_driver_installer(label="Refreshing", verbose=False)
+            ok = tools_config._run_cua_driver_installer(label="Installing", verbose=False)
 
         assert ok is True
         assert captured["kwargs"].get("shell") is False
@@ -1580,10 +1580,9 @@ class TestWindowsAutostartRepair:
         assert captured["cmd"][:4] == [
             "powershell", "-NoProfile", "-ExecutionPolicy", "Bypass",
         ]
-        repair.assert_called_once_with(
-            r"C:\Users\Ha Trung\AppData\Local\Programs\Cua\cua-driver\bin\cua-driver.exe",
-            verbose=False,
-        )
+        assert "-NoAutoStart" in captured["cmd"][-1]
+        assert "| iex" not in captured["cmd"][-1]
+        repair.assert_not_called()
 
     @pytest.mark.windows_only
     def test_autostart_repair_quotes_username_space_path_via_file_path(self):
@@ -1749,12 +1748,213 @@ class TestUnattendedRefreshPreflights:
         assert "-NoAutoStart" in joined
         assert "scriptblock" in joined
 
-    def test_windows_explicit_command_keeps_plain_oneliner(self):
-        """Explicit installs keep upstream's documented `irm | iex` shape
-        (autostart re-registration included — human present for UAC)."""
+    def test_windows_explicit_command_passes_noautostart(self):
+        """Explicit installs also invoke install.ps1 with -NoAutoStart:
+        autostart is opt-in since #95372/#97389, and the post-install
+        repair path no longer re-registers the task."""
         ok, popen, _, _, _ = self._run(None, system="Windows")
         assert ok is True
         cmd = popen.call_args.args[0]
         joined = " ".join(cmd)
-        assert "-NoAutoStart" not in joined
-        assert "| iex" in joined
+        assert "-NoAutoStart" in joined
+        assert "| iex" not in joined
+
+
+class TestCuaDriverAutostartOptIn:
+    """Autostart is opt-in since #95372/#97389: installs never register
+    the logon task, readiness ignores it, and ``hermes computer-use
+    autostart`` manages the legacy task left by older installers."""
+
+    def test_install_ready_ignores_missing_logon_task(self):
+        from hermes_cli import tools_config_cua as tools_config
+
+        with patch.object(
+            tools_config, "_cua_driver_contract_status",
+            return_value={"ready": True, "version": "0.20.0", "reason": ""},
+        ), patch.object(
+            tools_config, "_cua_driver_autostart_registered_windows",
+            return_value=False,
+        ) as registered:
+            assert tools_config._cua_driver_install_ready() is True
+            registered.assert_not_called()
+
+    def test_install_not_ready_when_contract_broken(self):
+        from hermes_cli import tools_config_cua as tools_config
+
+        with patch.object(
+            tools_config, "_cua_driver_contract_status",
+            return_value={"ready": False, "version": "0.19.4", "reason": "too old"},
+        ), patch.object(
+            tools_config, "_cua_driver_autostart_registered_windows",
+            return_value=True,
+        ):
+            assert tools_config._cua_driver_install_ready() is False
+
+    def test_compatible_existing_install_skips_autostart_repair(self):
+        """A compatible driver stays untouched: no reinstall, no repair
+        registration — just the on-demand note. Deterministic on every
+        lane via the platform seam."""
+        from hermes_cli import tools_config_cua as tools_config
+
+        with patch("platform.system", return_value="Windows"), \
+             patch.object(
+                 tools_config.shutil, "which",
+                 side_effect=lambda n: "/usr/local/bin/" + n
+                 if n in {"cua-driver", "curl"} else None,
+             ), \
+             patch.object(
+                 tools_config, "_run_cua_driver_installer"
+             ) as runner, \
+             patch.object(
+                 tools_config, "_cua_driver_contract_status",
+                 return_value={"ready": True, "version": "0.20.0", "reason": ""},
+             ), \
+             patch.object(
+                 tools_config, "_repair_cua_driver_autostart_windows",
+                 return_value=True,
+             ) as repair, \
+             patch.object(
+                 tools_config, "_cua_driver_autostart_registered_windows",
+                 return_value=False,
+             ), \
+             patch.object(
+                 tools_config, "_print_info"
+             ) as info, \
+             patch("subprocess.run"):
+            assert tools_config.install_cua_driver(upgrade=False) is True
+            runner.assert_not_called()
+            repair.assert_not_called()
+            assert any("on demand" in c.args[0] for c in info.call_args_list)
+
+    @pytest.mark.windows_only
+    def test_disable_reports_already_on_demand_when_missing(self):
+        from hermes_cli import tools_config_cua as tools_config
+
+        with patch.object(
+            tools_config, "_cua_driver_autostart_registered_windows",
+            return_value=False,
+        ), patch(
+            "subprocess.run"
+        ) as run, patch.object(
+            tools_config, "_print_success"
+        ):
+            assert tools_config._disable_cua_driver_autostart_windows() is True
+            run.assert_not_called()
+
+    @pytest.mark.windows_only
+    def test_disable_issues_schtasks_change_disable(self):
+        from hermes_cli import tools_config_cua as tools_config
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with patch.object(
+            tools_config, "_cua_driver_autostart_registered_windows",
+            return_value=True,
+        ), patch(
+            "subprocess.run", side_effect=fake_run
+        ), patch.object(
+            tools_config, "_print_success"
+        ), patch.object(
+            tools_config, "_print_info"
+        ):
+            assert tools_config._disable_cua_driver_autostart_windows() is True
+
+        assert calls == [
+            ["schtasks.exe", "/Change", "/TN", "cua-driver-serve", "/Disable"]
+        ]
+
+    @pytest.mark.windows_only
+    def test_disable_failure_points_at_elevation(self):
+        from hermes_cli import tools_config_cua as tools_config
+
+        def fake_run(cmd, **kwargs):
+            return SimpleNamespace(
+                returncode=1, stdout="", stderr="ERROR: Access is denied."
+            )
+
+        with patch.object(
+            tools_config, "_cua_driver_autostart_registered_windows",
+            return_value=True,
+        ), patch(
+            "subprocess.run", side_effect=fake_run
+        ), patch.object(
+            tools_config, "_print_warning"
+        ) as warning, patch.object(
+            tools_config, "_print_info"
+        ) as info:
+            assert tools_config._disable_cua_driver_autostart_windows() is False
+            warning.assert_called_once()
+            assert any("elevated" in c.args[0] for c in info.call_args_list)
+
+    @pytest.mark.windows_only
+    def test_state_probe_parses_scheduler_state(self):
+        from hermes_cli import tools_config_cua as tools_config
+
+        def fake_run(cmd, **kwargs):
+            return SimpleNamespace(returncode=0, stdout="Disabled\n", stderr="")
+
+        with patch.object(
+            tools_config.shutil, "which",
+            return_value=r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+        ), patch(
+            "subprocess.run", side_effect=fake_run
+        ):
+            state = tools_config._cua_driver_autostart_state_windows()
+
+        assert state == {"supported": True, "registered": True, "task_state": "Disabled"}
+
+    @pytest.mark.windows_only
+    def test_state_probe_missing_task_is_unregistered(self):
+        from hermes_cli import tools_config_cua as tools_config
+
+        def fake_run(cmd, **kwargs):
+            return SimpleNamespace(returncode=0, stdout="missing\n", stderr="")
+
+        with patch.object(
+            tools_config.shutil, "which", return_value="powershell"
+        ), patch(
+            "subprocess.run", side_effect=fake_run
+        ):
+            state = tools_config._cua_driver_autostart_state_windows()
+
+        assert state == {"supported": True, "registered": False, "task_state": ""}
+
+    @pytest.mark.windows_only
+    def test_failed_install_hint_keeps_no_autostart(self):
+        """A failed install's copy-paste retry hint must not silently
+        recreate the task (#97389 repro step)."""
+        from unittest.mock import MagicMock
+        from hermes_cli import tools_config_cua as tools_config
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 1
+        fake_proc.returncode = 1
+        fake_proc.communicate.return_value = ("boom", None)
+
+        with patch.object(
+            tools_config.shutil, "which", return_value=None
+        ), patch(
+            "subprocess.Popen", return_value=fake_proc
+        ), patch.object(
+            tools_config, "_clear_stale_cua_install_lock"
+        ), patch.object(
+            tools_config, "_cua_driver_autostart_registered_windows",
+            return_value=False,
+        ), patch.object(
+            tools_config, "_print_warning"
+        ) as warning, patch.object(
+            tools_config, "_print_info"
+        ) as info, patch.object(
+            tools_config, "_print_success"
+        ):
+            ok = tools_config._run_cua_driver_installer(label="Installing", verbose=False)
+
+        assert ok is False
+        assert any("Re-run manually" in c.args[0] for c in warning.call_args_list)
+        joined = "\n".join(c.args[0] for c in info.call_args_list)
+        assert "-NoAutoStart" in joined
+        assert "| iex" not in joined

--- a/website/docs/user-guide/features/computer-use.md
+++ b/website/docs/user-guide/features/computer-use.md
@@ -96,6 +96,24 @@ hermes -t computer_use chat
 
 or add `computer_use` to your enabled toolsets in `~/.hermes/config.yaml`.
 
+## Autostart (Windows) — on-demand by default
+
+Hermes does **not** start cua-driver at Windows login. The
+`cua-driver-serve` Scheduled Task is never created by Hermes installs or
+updates — the driver is spawned per session over stdio when you actually
+use Computer Use, so a per-boot daemon (and the brief login console
+flash it caused, trycua/cua#1645) is unnecessary.
+
+- `hermes computer-use status` shows the autostart state on Windows.
+- `hermes computer-use autostart status|enable|disable` manages the task:
+  `enable` is the explicit opt-in (UAC prompt); `disable` stops the
+  per-login launch without deleting anything (reversible).
+- Upgraded from an older Hermes that created the task? One command
+  cleans it up: `hermes computer-use autostart disable`.
+
+(Driving over SSH is the exception — that setup needs the autostart
+pattern; see the Windows row in the prereqs table above.)
+
 ## Permission modes and logged-in browser profiles
 
 Hermes maps its existing approval UX onto cua-driver's immutable runtime


### PR DESCRIPTION
## Problem

On Windows, enabling the Computer Use toolset silently registers a
`cua-driver-serve` Scheduled Task (logon trigger, `RunLevel: Highest`)
with no opt-out in the UI or `config.yaml`. Every login then flashes a
2–3s blue PowerShell console — the residual of trycua/cua#1645, whose
fix (#1654) hid the *long-lived* window but cannot prevent the brief
flash for a console-subsystem binary at process startup.

Issue map (same root behavior, different entry points):

- #95372 — fresh installs should not enable autostart
- #97389 — desktop entry point + console-flash detail (triaged as duplicate of #95372)
- #98052 (related, **not** fixed here) — the elevated autostart daemon can leave an unclosable overlay behind after Hermes exits; removing the default task shrinks that blast radius but the orphan case still needs its own watchdog
- trycua/cua#1645 → trycua/cua#1654 (upstream console fix; brief flash remains by design there)
- #98505 by @salch-cred — fresh-install `-NoAutoStart` (1 file, still open); this PR includes that change with credit and completes it
- Supersedes #102774 (same change, conflicted by the #102117 refactor; rebased onto the decomposed `tools_config_cua.py` / `subcommands/computer_use.py` layout)

Why the task is unnecessary for Hermes at all: Hermes talks to
cua-driver over its **own per-session stdio bridge** (`cua-driver mcp`;
see the resolver in `tools/computer_use/`), not via the logon-task
`serve` daemon on the named pipe. The task only matters for
out-of-band consumers (e.g. driving over SSH, per the cua.ai
windows-ssh guide). Pre-warming it on every boot saves ~1–3s on first
use at the cost of a startup entry, a background process, and a
console flash — a trade the user was never asked about.

## Fix — autostart is now opt-in, default is on-demand

`hermes_cli/tools_config_cua.py`:

- `_cua_installer_command` — Windows installs (fresh **and**
  unattended) use the `-NoAutoStart` scriptblock form, so
  `install.ps1` skips `Register-CuaDriverAutostart` entirely. The
  manual copy-paste retry hint uses the same form, so a pasted retry
  cannot silently recreate the task. (`_unattended_installer_preflight`
  keeps its lock/network fast-fail checks; its command rewrite is now
  redundant and removed.)
- Compatible-existing and post-install paths **no longer (re-)register
  the task** — this is the post-install repair path @huklaa flagged on
  #95372. They print the opt-in/opt-out hint instead. Existing tasks
  are never touched by install/update (preserves the #95129/#95345
  unattended-update behavior).
- `_cua_driver_install_ready` — readiness is the runtime contract
  only. A missing task no longer counts as "not ready" (previously it
  re-triggered the UAC repair loop on every enable/update).
- New `_cua_driver_autostart_state_windows` (read-only probe,
  no-window spawn) and `_disable_cua_driver_autostart_windows`
  (disables, never deletes — reversible via `enable`).
- `_repair_cua_driver_autostart_windows` is kept as the engine behind
  the explicit opt-in.

New `hermes computer-use autostart status|enable|disable`
(`hermes_cli/subcommands/computer_use.py`): `status` is read-only,
`enable` is the explicit opt-in (UAC prompt), `disable` stops the
per-login launch and the flash. `hermes computer-use status` shows the
autostart state on Windows (probe failures never fail the command).

Docs: new “Autostart (Windows) — on-demand by default” section in
`website/docs/user-guide/features/computer-use.md`.

## Testing

- `tests/hermes_cli/test_install_cua_driver.py`: **62 passed,
  19 skipped**. New `TestCuaDriverAutostartOptIn` (9 tests); updated 2
  tests that asserted the old register-by-default behavior.
- 5 failures in the same file are **pre-existing on clean `main` on a
  Windows host** (verified via `git stash` before/after on this tree):
  4 assume the `curl`/POSIX fetch path, 1 asserts a POSIX timeout
  default. Unrelated to this change.
- `test_post_setup_gating.py` +
  `test_web_routers_tools_install_on_enable.py` (mock
  `_cua_driver_install_ready`): **9 passed**.
- `ruff check` on all touched Python files: clean.
- Live-verified on Windows 11 24H2 (this checkout, cua-driver 0.23.2):
  `computer-use autostart status` correctly reports the real registered
  task; `computer-use status` shows the new autostart line.

Fixes #95372
Fixes #97389
