### PR TITLE
feat(models): add GPT-6 Astra to Codex picker

### DIFF
--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -17,6 +17,10 @@ logger = logging.getLogger(__name__)
 # when using Codex with a ChatGPT account"), so listing them leaked dead picker choices. If
 # OpenAI re-enables any, live discovery (_fetch_models_from_api) picks them up automatically.
 DEFAULT_CODEX_MODELS: List[str] = [
+    # Live-verified against the ChatGPT Codex OAuth route on 2026-09-04.
+    # Keep the configured regular-Hermes default first in `/model`.
+    "gpt-6-astra-pro",
+    "gpt-6-astra",
     "gpt-5.6-sol",
     "gpt-5.6-terra",
     "gpt-5.6-luna",
@@ -54,6 +58,8 @@ def _dedupe(model_ids) -> List[str]:
     """Order-preserving dedupe."""
     return list(dict.fromkeys(model_ids))
 
+_CODEX_CURATED_HEAD: List[str] = ["gpt-6-astra-pro", "gpt-6-astra"]
+
 
 def _add_forward_compat_models(model_ids: List[str]) -> List[str]:
     """Surface newer Codex slugs missing from live discovery when an older compatible template is
@@ -89,8 +95,9 @@ def _add_context_variants(model_ids: List[str]) -> List[str]:
 
 
 def _finalize_codex_models(model_ids: List[str]) -> List[str]:
-    """Forward-compat synthesis + large-context variant synthesis."""
-    return _add_context_variants(_add_forward_compat_models(model_ids))
+    """Curated head + forward-compat and large-context synthesis."""
+    merged = _CODEX_CURATED_HEAD + [model for model in model_ids if model not in _CODEX_CURATED_HEAD]
+    return _add_context_variants(_add_forward_compat_models(merged))
 
 
 def _extract_chatgpt_account_id(access_token: str) -> Optional[str]:

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -15,6 +15,11 @@ CHATGPT_REJECTED_CODEX_PRO_SLUGS = {
 }
 
 
+def test_curated_codex_picker_leads_with_live_verified_astra_aliases():
+    model_ids = get_codex_model_ids()
+    assert model_ids[:2] == ["gpt-6-astra-pro", "gpt-6-astra"]
+
+
 def test_curated_codex_fallback_excludes_chatgpt_rejected_pro_slugs(monkeypatch):
     """OAuth fallback retains real models but never synthesizes rejected ones."""
     retained_models = {"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"}


### PR DESCRIPTION
## Summary

- surface the live-verified `gpt-6-astra-pro` and `gpt-6-astra` aliases at the top of the OpenAI Codex picker
- merge the curated head in the common finalization path so it survives live API, local cache, and offline fallback resolution
- do not synthesize unverified `-900k` Astra variants

## Why

Both aliases route successfully through the ChatGPT Codex OAuth backend, and regular Hermes can already be configured with `gpt-6-astra-pro`. They were absent from `/model` because cached/live catalogs took precedence over the fallback list and the picker truncates before appended defaults.

## Verification

Live regular/default Hermes calls:

- `gpt-6-astra-pro` → `ASTRA-OK`
- `gpt-6-astra` → `ASTRA-BASE-OK`

Focused tests on exact commit `94d6cb41034316546664d7f3c5ab768bec7973f6`:

```text
13 passed in 7.16s
```

Picker order verified:

```text
0: gpt-6-astra-pro
1: gpt-6-astra
2: gpt-5.6-sol
3: gpt-5.6-sol-900k
```
