### PR TITLE
fix(desktop): name Hermes Cloud connections by instance, not dashboard URL

### DIFF
--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -15,6 +15,7 @@ import {
   backendScopeKey,
   backendScopePrefix,
   buildAgentRoster,
+  cloudLabelIsDerived,
   connectionDialFieldsChanged,
   connectionIdForLabel,
   labelKey,
@@ -26,6 +27,7 @@ import {
   normalizeRegistry,
   parseRemoteProfileListing,
   reconcileAppliedGlobalConnection,
+  reconcileCloudInstanceNames,
   reconcileRegistryDrift,
   REGISTRY_VERSION,
   registrySourceOwnsPrimaryBackend,
@@ -1503,6 +1505,152 @@ test('Apply remote preserves an existing URL identity and label without duplicat
   assert.equal(matches[0].authMode, 'oauth')
   assert.equal(applied.primary, 'hermes-alex')
   assert.equal(applied.lastUsed, 'hermes-alex')
+})
+
+// --- Hermes Cloud instance names ---
+
+const CLOUD_URL = 'https://agent-7f3a.hermes.nousresearch.com'
+
+function appliedCloud(registry: ConnectionRegistry, name?: string): ConnectionRegistry {
+  return reconcileAppliedGlobalConnection(registry, {
+    mode: 'cloud',
+    remote: { url: CLOUD_URL, authMode: 'oauth', org: 'nous', ...(name === undefined ? {} : { name }) }
+  })
+}
+
+test('Apply cloud labels the connection with the instance name, not the dashboard host', () => {
+  const registry = appliedCloud(emptyRegistry(), 'Research Bot')
+  const cloud = registry.connections.find(connection => connection.kind === 'cloud')
+
+  assert.ok(cloud)
+  assert.equal(cloud.label, 'Research Bot')
+  assert.equal(cloud.cloudName, 'Research Bot')
+  assert.equal(cloud.url, CLOUD_URL)
+})
+
+test('Apply cloud still falls back to the host when the instance has no name', () => {
+  const cloud = appliedCloud(emptyRegistry()).connections.find(connection => connection.kind === 'cloud')
+
+  assert.ok(cloud)
+  assert.equal(cloud.label, 'agent-7f3a.hermes.nousresearch.com')
+  assert.equal(cloud.cloudName, undefined)
+})
+
+test('Apply cloud replaces a host-derived label once the instance name is known', () => {
+  const registry = appliedCloud(emptyRegistry())
+  const renamed = appliedCloud(registry, 'Research Bot')
+  const cloud = renamed.connections.find(connection => connection.kind === 'cloud')
+
+  assert.ok(cloud)
+  assert.equal(cloud.label, 'Research Bot')
+  // Same entry, not a second registration for the same gateway.
+  assert.equal(renamed.connections.filter(connection => connection.kind === 'cloud').length, 1)
+})
+
+test('Apply cloud never overwrites a device name the user typed here', () => {
+  let registry = appliedCloud(emptyRegistry(), 'Research Bot')
+  const cloudId = registry.connections.find(connection => connection.kind === 'cloud')!.id
+
+  registry = upsertConnection(registry, {
+    ...registry.connections.find(connection => connection.id === cloudId)!,
+    label: 'Work bot'
+  })
+
+  const cloud = appliedCloud(registry, 'Renamed In Portal').connections.find(connection => connection.id === cloudId)
+
+  assert.ok(cloud)
+  assert.equal(cloud.label, 'Work bot')
+  assert.equal(cloud.cloudName, 'Renamed In Portal')
+})
+
+test('cloudLabelIsDerived tells our label apart from a user-typed one', () => {
+  assert.equal(cloudLabelIsDerived({ cloudName: 'Research Bot', label: 'Research Bot', url: CLOUD_URL }), true)
+  assert.equal(cloudLabelIsDerived({ cloudName: 'Research Bot', label: 'Work bot', url: CLOUD_URL }), false)
+  // Registered before names were stored: the host label is ours too.
+  assert.equal(cloudLabelIsDerived({ label: 'agent-7f3a.hermes.nousresearch.com', url: CLOUD_URL }), true)
+  assert.equal(cloudLabelIsDerived({ label: 'Work bot', url: CLOUD_URL }), false)
+})
+
+test('discovery folds a portal rename into the registry label', () => {
+  const registry = appliedCloud(emptyRegistry(), 'Research Bot')
+  const result = reconcileCloudInstanceNames(registry, [{ dashboardUrl: `${CLOUD_URL}/`, name: 'Renamed In Portal' }])
+  const cloud = result.registry.connections.find(connection => connection.kind === 'cloud')
+
+  assert.equal(result.changed, true)
+  assert.ok(cloud)
+  assert.equal(cloud.label, 'Renamed In Portal')
+  assert.equal(cloud.cloudName, 'Renamed In Portal')
+})
+
+test('discovery leaves an unchanged roster (and unrelated sources) alone', () => {
+  const registry = appliedCloud(emptyRegistry(), 'Research Bot')
+
+  const same = reconcileCloudInstanceNames(registry, [{ dashboardUrl: CLOUD_URL, name: 'Research Bot' }])
+
+  assert.equal(same.changed, false)
+  assert.equal(same.registry, registry)
+
+  const unrelated = reconcileCloudInstanceNames(registry, [
+    { dashboardUrl: 'https://other.hermes.nousresearch.com', name: 'Other Bot' }
+  ])
+
+  assert.equal(unrelated.changed, false)
+  assert.equal(unrelated.registry.connections.find(connection => connection.kind === 'cloud')!.label, 'Research Bot')
+})
+
+test('discovery keeps a user-typed device name while still tracking the portal name', () => {
+  let registry = appliedCloud(emptyRegistry(), 'Research Bot')
+  const cloudId = registry.connections.find(connection => connection.kind === 'cloud')!.id
+
+  registry = upsertConnection(registry, {
+    ...registry.connections.find(connection => connection.id === cloudId)!,
+    label: 'Work bot'
+  })
+
+  const result = reconcileCloudInstanceNames(registry, [{ dashboardUrl: CLOUD_URL, name: 'Renamed In Portal' }])
+  const cloud = result.registry.connections.find(connection => connection.id === cloudId)
+
+  assert.equal(result.changed, true)
+  assert.ok(cloud)
+  assert.equal(cloud.label, 'Work bot')
+  assert.equal(cloud.cloudName, 'Renamed In Portal')
+})
+
+test('discovery suffixes rather than colliding when another source owns the name', () => {
+  let registry = appliedCloud(emptyRegistry(), 'Research Bot')
+
+  registry = upsertConnection(registry, {
+    id: 'hermes-alex',
+    kind: 'remote',
+    label: 'Renamed In Portal',
+    url: 'https://gateway.example.com',
+    authMode: 'oauth'
+  })
+
+  const result = reconcileCloudInstanceNames(registry, [{ dashboardUrl: CLOUD_URL, name: 'Renamed In Portal' }])
+  const cloud = result.registry.connections.find(connection => connection.kind === 'cloud')
+
+  assert.ok(cloud)
+  assert.equal(cloud.label, 'Renamed In Portal 2')
+  assert.equal(cloud.cloudName, 'Renamed In Portal')
+})
+
+test('a cloud rename survives normalizeRegistry and a label-only edit', () => {
+  const registry = appliedCloud(emptyRegistry(), 'Research Bot')
+  const reloaded = normalizeRegistry(JSON.parse(JSON.stringify(registry)))
+  const cloud = reloaded.connections.find(connection => connection.kind === 'cloud')
+
+  assert.ok(cloud)
+  assert.equal(cloud.cloudName, 'Research Bot')
+
+  const edited = normalizeConnectionInput(
+    mergeConnectionInput({ id: cloud.id, kind: 'cloud', label: 'Work bot' }, cloud),
+    reloaded
+  )
+
+  assert.equal(edited.cloudName, 'Research Bot')
+  assert.equal(edited.url, CLOUD_URL)
+  assert.equal(edited.org, 'nous')
 })
 
 test('Apply local moves primary/current to This device without deleting registered remotes', () => {

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -64,6 +64,12 @@ export interface RegistryConnection {
   headers?: Record<string, unknown>
   /** cloud: portal org slug/id the instance was discovered under. */
   org?: string
+  /** cloud: the instance name as the portal knows it. The dashboard URL is
+   * machine-assigned and immutable, so it makes a poor device name; the portal
+   * name is the one users actually set and rename. Kept alongside `label` so a
+   * later rename in the portal can be told apart from a rename the user typed
+   * HERE — see cloudLabelIsDerived / reconcileCloudInstanceNames. */
+  cloudName?: string
   /** ssh fields (normalizeSshConfig shapes). */
   host?: string
   user?: string
@@ -822,6 +828,7 @@ export interface ConnectionInput {
   token?: unknown
   headers?: Record<string, unknown>
   org?: string
+  cloudName?: string
   host?: string
   user?: string
   port?: number | string
@@ -955,6 +962,14 @@ export function normalizeConnectionInput(input: ConnectionInput, registry: Conne
       entry.org = org
     }
 
+    const cloudName = String(input.cloudName || '')
+      .trim()
+      .slice(0, LABEL_MAX)
+
+    if (kind === 'cloud' && cloudName) {
+      entry.cloudName = cloudName
+    }
+
     return entry
   }
 
@@ -986,6 +1001,7 @@ export function mergeConnectionInput(input: ConnectionInput, existing?: null | R
   inherit('url')
   inherit('authMode')
   inherit('org')
+  inherit('cloudName')
   inherit('host')
   inherit('keyPath')
   inherit('remoteHermesPath')
@@ -1133,7 +1149,9 @@ export function normalizeRegistry(raw: unknown): ConnectionRegistry {
         // Defensive: registry entries are always written with labels, but a
         // hand-edited file may drop one. Derive rather than discard.
         label =
-          kind === 'ssh' ? String(entry.host || 'ssh') : hostLabelFromBaseUrl(String(entry.url || '')) || String(kind)
+          kind === 'ssh'
+            ? String(entry.host || 'ssh')
+            : String(entry.cloudName || '').trim() || hostLabelFromBaseUrl(String(entry.url || '')) || String(kind)
       }
 
       label = uniqueLabel(label, seenLabels)
@@ -1179,6 +1197,14 @@ export function normalizeRegistry(raw: unknown): ConnectionRegistry {
 
         if (kind === 'cloud' && org) {
           clean.org = org
+        }
+
+        const cloudName = String(entry.cloudName || '')
+          .trim()
+          .slice(0, LABEL_MAX)
+
+        if (kind === 'cloud' && cloudName) {
+          clean.cloudName = cloudName
         }
       } else if (kind === 'ssh') {
         const ssh = normalizeSshConfig({ ...entry, mode: 'ssh' })
@@ -1252,8 +1278,10 @@ export function migrateV1ToRegistry(v1: unknown): ConnectionRegistry {
       return existing
     }
 
+    const cloudName = kind === 'cloud' ? String(block.name || '').trim() : ''
+
     const label = uniqueLabel(
-      hostLabelFromBaseUrl(url) || (kind === 'cloud' ? 'Hermes Cloud' : 'Remote gateway'),
+      cloudName || hostLabelFromBaseUrl(url) || (kind === 'cloud' ? 'Hermes Cloud' : 'Remote gateway'),
       connections.map(c => c.label)
     )
 
@@ -1282,6 +1310,10 @@ export function migrateV1ToRegistry(v1: unknown): ConnectionRegistry {
 
     if (kind === 'cloud' && org) {
       entry.org = org
+    }
+
+    if (cloudName) {
+      entry.cloudName = cloudName
     }
 
     connections.push(entry)
@@ -1418,6 +1450,104 @@ export function setLastUsedConnection(registry: ConnectionRegistry, id: string):
 }
 
 /**
+ * Whether a cloud entry's label is still one WE derived (the portal instance
+ * name, or — for entries registered before names were stored — the dashboard
+ * host) rather than a device name the user typed in Settings → Connections.
+ *
+ * This is the whole arbitration rule for cloud labels: a rename in the portal
+ * must reach the desktop, because the dashboard URL is machine-assigned and
+ * immutable and nobody wants `agent-7f3a….hermes.nousresearch.com` in the
+ * sidebar. But a name the user typed HERE is theirs and outranks the portal.
+ */
+export function cloudLabelIsDerived(connection: Pick<RegistryConnection, 'cloudName' | 'label' | 'url'>): boolean {
+  const label = labelKey(connection.label)
+
+  if (connection.cloudName) {
+    return label === labelKey(connection.cloudName)
+  }
+
+  // No stored name: the entry predates this field (or was migrated from v1),
+  // so the only label we could have given it is the host one.
+  return label === labelKey(hostLabelFromBaseUrl(connection.url || '') || '') || label === labelKey('Hermes Cloud')
+}
+
+/** Comparison key for a gateway URL: trimmed, trailing slashes dropped, lowercased. */
+function gatewayUrlKey(value: string): string {
+  return String(value || '')
+    .trim()
+    .replace(/\/+$/, '')
+    .toLowerCase()
+}
+
+/** A discovered Hermes Cloud instance, trimmed to what naming needs. */
+export interface CloudInstanceName {
+  dashboardUrl?: null | string
+  name?: null | string
+}
+
+/**
+ * Fold the instance names from a Hermes Cloud discovery pass into the registry
+ * so a rename in the portal shows up in the desktop's sidebar and Connections
+ * list. Matches on the dashboard URL (the immutable identity); updates the
+ * stored `cloudName` always, and the visible `label` only while it is still
+ * derived (see cloudLabelIsDerived), so a user-typed device name survives.
+ *
+ * Returns the same registry object when nothing moved, so callers can skip the
+ * disk write on the common no-change refresh.
+ */
+export function reconcileCloudInstanceNames(
+  registry: ConnectionRegistry,
+  instances: readonly CloudInstanceName[]
+): { changed: boolean; registry: ConnectionRegistry } {
+  const byUrl = new Map<string, string>()
+
+  for (const instance of instances || []) {
+    const url = gatewayUrlKey(String(instance?.dashboardUrl || ''))
+    const name = String(instance?.name || '')
+      .trim()
+      .slice(0, LABEL_MAX)
+
+    if (url && name && !byUrl.has(url)) {
+      byUrl.set(url, name)
+    }
+  }
+
+  if (byUrl.size === 0) {
+    return { changed: false, registry }
+  }
+
+  let changed = false
+  const connections = registry.connections.map(connection => {
+    if (connection.kind !== 'cloud') {
+      return connection
+    }
+
+    const name = byUrl.get(gatewayUrlKey(connection.url || ''))
+
+    if (!name || (connection.cloudName === name && labelKey(connection.label) === labelKey(name))) {
+      return connection
+    }
+
+    const next: RegistryConnection = { ...connection, cloudName: name }
+
+    if (cloudLabelIsDerived(connection)) {
+      // Another source may already answer to this name; uniqueLabel suffixes
+      // rather than throwing a collision at a background refresh.
+      next.label = uniqueLabel(
+        name,
+        registry.connections.filter(c => c.id !== connection.id).map(c => c.label)
+      )
+    }
+
+    changed = true
+
+    return next
+  })
+
+  return changed ? { changed, registry: { ...registry, connections } } : { changed: false, registry }
+}
+
+/**
  * Reconcile a successfully-coerced global v1 connection config into the v2
  * registry. Settings still writes connection.json for compatibility, but an
  * Apply must publish the same primary identity to connections.json in the
@@ -1425,9 +1555,10 @@ export function setLastUsedConnection(registry: ConnectionRegistry, id: string):
  *
  * Remote-shaped entries are matched by normalized URL across remote/cloud so
  * changing provenance never duplicates a gateway. Existing identity and
- * user-chosen label win; a new entry derives both from the host. Switching to
- * local keeps registered remotes available while moving primary/last-used
- * back to This device.
+ * user-chosen label win; a new entry derives both from the Hermes Cloud
+ * instance name, or the host when there is none. Switching to local keeps
+ * registered remotes available while moving primary/last-used back to This
+ * device.
  */
 export function reconcileAppliedGlobalConnection(
   registry: ConnectionRegistry,
@@ -1462,12 +1593,18 @@ export function reconcileAppliedGlobalConnection(
 
   const kind: ConnectionKind = mode === 'cloud' ? 'cloud' : 'remote'
 
+  // Hermes Cloud carries the instance name the portal knows it by. Prefer it
+  // over the dashboard host — the host is machine-assigned and immutable, the
+  // name is what the user set — and let a portal rename replace a label we
+  // derived ourselves, while a device name the user typed here is preserved.
+  const cloudName = kind === 'cloud' ? String(block.name || existing?.cloudName || '').trim() : ''
   const label =
-    existing?.label ||
-    uniqueLabel(
-      hostLabelFromBaseUrl(url) || (kind === 'cloud' ? 'Hermes Cloud' : 'Remote gateway'),
-      registry.connections.map(connection => connection.label)
-    )
+    existing && (!cloudName || !cloudLabelIsDerived(existing))
+      ? existing.label
+      : uniqueLabel(
+          cloudName || hostLabelFromBaseUrl(url) || (kind === 'cloud' ? 'Hermes Cloud' : 'Remote gateway'),
+          registry.connections.filter(connection => connection.id !== existing?.id).map(connection => connection.label)
+        )
 
   const entry = normalizeConnectionInput(
     {
@@ -1478,7 +1615,8 @@ export function reconcileAppliedGlobalConnection(
       authMode: block.authMode,
       token: block.token,
       headers: block.headers,
-      org: block.org
+      org: block.org,
+      cloudName
     },
     registry
   )

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -138,6 +138,7 @@ import {
   normalizeRegistry,
   parseBackendScopeKey,
   reconcileAppliedGlobalConnection,
+  reconcileCloudInstanceNames,
   reconcileRegistryDrift,
   registrySourceOwnsPrimaryBackend,
   rememberSshEnumeration,
@@ -8768,6 +8769,83 @@ function trimCloudAgents(body) {
     }))
 }
 
+// Fold the names from a discovery pass into both connection stores so a rename
+// in the portal reaches the desktop. The registry drives every label the user
+// sees (sidebar switcher, Connections list); connection.json holds the same
+// name so a later Apply re-derives from a fresh value instead of resurrecting
+// the one captured at connect time. Best effort — discovery must still return
+// its agents if either write fails.
+function refreshCloudInstanceNames(agents) {
+  const named = (Array.isArray(agents) ? agents : []).filter(agent => agent?.dashboardUrl && agent?.name)
+
+  if (named.length === 0) {
+    return
+  }
+
+  try {
+    const previous = readDesktopConnectionsRegistry()
+    const result = reconcileCloudInstanceNames(previous, named)
+
+    if (result.changed) {
+      writeDesktopConnectionsRegistry(result.registry)
+
+      // 'saved' — a rename moves no endpoint, so windows re-pull the registry
+      // snapshot without disposing or re-dialing the connection's sockets.
+      for (const connection of result.registry.connections) {
+        const before = previous.connections.find(candidate => candidate.id === connection.id)
+
+        if (before?.label !== connection.label) {
+          broadcastConnectionsChanged({ connectionId: connection.id, reason: 'saved' })
+        }
+      }
+    }
+  } catch (error) {
+    rememberLog(`[cloud] could not refresh instance names in the registry: ${error.message}`)
+  }
+
+  try {
+    // Clone: readDesktopConnectionConfig hands back the CACHED object, and a
+    // failed write must not leave an unsaved name behind in memory. Round-trip
+    // through JSON — the same projection writeDesktopConnectionConfig applies —
+    // so the clone can never differ from what would land on disk.
+    const config = JSON.parse(JSON.stringify(readDesktopConnectionConfig()))
+    const byUrl = new Map(named.map(agent => [cloudUrlKey(agent.dashboardUrl), String(agent.name).trim()]))
+
+    // Every cloud-mode block in the v1 config: the global route plus any
+    // per-profile override pinned to a Hermes Cloud instance.
+    const blocks = [
+      config.mode === 'cloud' ? config.remote : null,
+      ...Object.values(config.profiles || {}).filter((entry: any) => entry?.mode === 'cloud')
+    ].filter(Boolean) as Record<string, any>[]
+
+    let changed = false
+
+    for (const block of blocks) {
+      const name = byUrl.get(cloudUrlKey(block.url))
+
+      if (name && block.name !== name) {
+        block.name = name
+        changed = true
+      }
+    }
+
+    if (changed) {
+      writeDesktopConnectionConfig(config)
+    }
+  } catch (error) {
+    rememberLog(`[cloud] could not refresh instance names in connection.json: ${error.message}`)
+  }
+}
+
+// Comparison key for a dashboard URL: NAS returns it raw, our stores hold the
+// normalizeRemoteBaseUrl form, so both sides get trimmed/lowercased alike.
+function cloudUrlKey(url) {
+  return String(url || '')
+    .trim()
+    .replace(/\/+$/, '')
+    .toLowerCase()
+}
+
 // Silent per-agent sign-in: open the selected agent dashboard's /login in the
 // SAME OAuth partition. Because the user already holds a live portal session
 // there, the agent's /oauth/authorize auto-approves (org member) and 302s back,
@@ -9755,6 +9833,9 @@ async function sanitizeDesktopConnectionConfig(config = readDesktopConnectionCon
     // The persisted Hermes Cloud org (slug/id) for a cloud connection, or '' for
     // remote/local. Lets Settings → Gateway reopen into the same org.
     cloudOrg: mode === 'cloud' ? String(block.org || '') : '',
+    // The instance name the portal knows this cloud agent by — what the desktop
+    // shows instead of the machine-assigned dashboard host.
+    cloudName: mode === 'cloud' ? String(block.name || '') : '',
     remoteTokenPreview: tokenPreview(remoteToken),
     remoteTokenSet: Boolean(remoteToken),
     // Whether the OS keyring can encrypt a token; drives the plain-text opt-in
@@ -9779,13 +9860,16 @@ async function sanitizeDesktopConnectionConfig(config = readDesktopConnectionCon
 // resolveRemoteBackend), so only token-auth remotes require a saved token.
 // `org` (optional) is the Hermes Cloud org slug/id the instance was discovered
 // under — persisted so Settings can reopen into the same org; omitted from the
-// block when empty so plain remote connections stay unchanged.
-function buildRemoteBlock(remoteUrl, authMode, token, org?: string, headers?: object) {
+// block when empty so plain remote connections stay unchanged. `name` is the
+// Hermes Cloud instance name (the portal's own display name), persisted so the
+// registry can label the connection with it instead of the immutable
+// dashboard host.
+function buildRemoteBlock(remoteUrl, authMode, token, org?: string, headers?: object, name?: string) {
   if (authMode !== 'oauth' && !decryptDesktopSecret(token)) {
     throw new Error('Remote gateway session token is required.')
   }
 
-  const block: { url: string; authMode: string; token: object; headers?: object; org?: string } = {
+  const block: { url: string; authMode: string; token: object; headers?: object; org?: string; name?: string } = {
     url: normalizeRemoteBaseUrl(remoteUrl),
     authMode,
     token
@@ -9801,6 +9885,12 @@ function buildRemoteBlock(remoteUrl, authMode, token, org?: string, headers?: ob
 
   if (orgValue) {
     block.org = orgValue
+  }
+
+  const nameValue = typeof name === 'string' ? name.trim() : ''
+
+  if (nameValue) {
+    block.name = nameValue
   }
 
   return block
@@ -9834,6 +9924,10 @@ function coerceDesktopConnectionConfig(input: any = {}, existing = readDesktopCo
   // inherit the saved org. A plain 'remote' connection never carries an org
   // (switching cloud→remote drops it), so it stays unset unless mode is cloud.
   const cloudOrg = mode === 'cloud' ? String(input.cloudOrg ?? existingBlock.org ?? '').trim() : ''
+  // Cloud instance name: same inheritance rule as the org — an explicit value
+  // (the agent the user just picked) wins, an omitted field keeps the saved
+  // name, and a non-cloud mode carries none.
+  const cloudName = mode === 'cloud' ? String(input.cloudName ?? existingBlock.name ?? '').trim() : ''
   const incomingToken = typeof input.remoteToken === 'string' ? input.remoteToken.trim() : ''
 
   const remoteHeaders =
@@ -9877,7 +9971,7 @@ function coerceDesktopConnectionConfig(input: any = {}, existing = readDesktopCo
     if (remoteLike) {
       profiles[key] = {
         mode,
-        ...buildRemoteBlock(remoteUrl, authMode, nextToken, cloudOrg, remoteHeaders)
+        ...buildRemoteBlock(remoteUrl, authMode, nextToken, cloudOrg, remoteHeaders, cloudName)
       }
     } else {
       const localEntry = localProfileEntry(rawExistingBlock)
@@ -9897,7 +9991,7 @@ function coerceDesktopConnectionConfig(input: any = {}, existing = readDesktopCo
   }
 
   const nextRemote = remoteLike
-    ? buildRemoteBlock(remoteUrl, authMode, nextToken, cloudOrg, remoteHeaders)
+    ? buildRemoteBlock(remoteUrl, authMode, nextToken, cloudOrg, remoteHeaders, cloudName)
     : existingMode === 'ssh'
       ? rawExistingBlock
       : { url: remoteUrl ? normalizeRemoteBaseUrl(remoteUrl) : remoteUrl, authMode, token: nextToken }
@@ -15956,7 +16050,15 @@ ipcMain.handle('hermes:cloud:logout', async () => {
 ipcMain.handle('hermes:cloud:discover', async (_event, org) => {
   // Returns { agents } or { needsOrgSelection: true, orgs }. `org` (optional)
   // scopes discovery to a chosen org for multi-org users.
-  return discoverCloudAgents(typeof org === 'string' && org ? org : undefined)
+  const result = await discoverCloudAgents(typeof org === 'string' && org ? org : undefined)
+
+  // Discovery is the only moment the desktop hears an instance's current name,
+  // so it is also where a portal rename lands on already-registered cloud
+  // connections. Refreshing here (not in the renderer) means any surface that
+  // triggers discovery keeps the labels honest.
+  refreshCloudInstanceNames(result?.agents)
+
+  return result
 })
 ipcMain.handle('hermes:cloud:agent-sign-in', async (_event, dashboardUrl) => {
   // Silent per-agent sign-in via the shared portal session. Returns the agent's

--- a/apps/desktop/src/app/settings/gateway-settings.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.tsx
@@ -53,6 +53,10 @@ export interface GatewaySettingsState {
   remoteTokenPlainText: boolean
   remoteUrl: string
   cloudOrg: string
+  // The Hermes Cloud instance name (the portal's own display name for this
+  // agent). Shown wherever the connection is named, so a rename in the portal
+  // reaches the desktop instead of the fixed dashboard host.
+  cloudName: string
   sshHost: string
   sshUser: string
   sshPort: number | null
@@ -74,6 +78,7 @@ const EMPTY_STATE: GatewaySettingsState = {
   remoteTokenPlainText: false,
   remoteUrl: '',
   cloudOrg: '',
+  cloudName: '',
   sshHost: '',
   sshUser: '',
   sshPort: null,
@@ -911,7 +916,11 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
         mode: 'cloud',
         remoteAuthMode: 'oauth',
         remoteUrl: agent.dashboardUrl,
-        cloudOrg: cloudOrgRef.current ?? undefined
+        cloudOrg: cloudOrgRef.current ?? undefined,
+        // Name the connection after the instance, not its dashboard host: the
+        // host is machine-assigned and immutable, the name is what the user
+        // set in the portal (and can rename there later).
+        cloudName: agent.name
       })
 
       if (seq !== contextSeq.current) {

--- a/apps/desktop/src/components/boot-failure-reauth.test.ts
+++ b/apps/desktop/src/components/boot-failure-reauth.test.ts
@@ -25,6 +25,7 @@ function config(overrides: Partial<DesktopConnectionConfig> = {}): DesktopConnec
     remoteTokenPlainText: false,
     remoteUrl: 'https://box:9119',
     cloudOrg: '',
+    cloudName: '',
     sshHost: '',
     sshUser: '',
     sshPort: null,

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -834,6 +834,11 @@ export interface DesktopConnectionConfig {
   // connected instance was discovered under, so Settings → Gateway can reopen
   // into that org. Empty string for remote/local.
   cloudOrg: string
+  // For a 'cloud' connection: the instance name the portal knows this agent by.
+  // It — not the machine-assigned, immutable dashboard host — is what the
+  // desktop shows, and a rename in the portal lands here on the next discovery.
+  // Empty string for remote/local.
+  cloudName: string
   sshHost: string
   sshUser: string
   sshPort: number | null
@@ -857,6 +862,10 @@ export interface DesktopConnectionConfigInput {
   // For a 'cloud' connection: the selected Hermes Cloud org (slug or id) to
   // persist so Settings can reopen into it. Ignored for remote/local modes.
   cloudOrg?: string
+  // For a 'cloud' connection: the selected instance's portal name, persisted so
+  // the registry can label the connection with it. Omit to keep the saved name;
+  // ignored for remote/local modes.
+  cloudName?: string
   sshHost?: string
   sshUser?: string
   sshPort?: number | null
@@ -901,6 +910,9 @@ export interface DesktopRegistryConnection {
   url?: string
   authMode?: 'oauth' | 'token'
   org?: string
+  // cloud: the instance name the portal knows it by. `label` follows this until
+  // the user types their own device name here, after which theirs wins.
+  cloudName?: string
   host?: string
   user?: string
   port?: number


### PR DESCRIPTION
## What does this PR do?

NAS already returns each instance's `name`, but the desktop dropped it and labelled the connection from the URL.
This carries the name through to the registry label, and refreshes it on every discovery so a rename in the portal reaches the desktop. A device name the user typed in Settings → Connections still wins. The URL stays as the endpoint detail and the matching identity.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `electron/connection-registry.ts`: optional `cloudName` on registry entries; `cloudLabelIsDerived()` (portal name vs. user-typed name); `reconcileCloudInstanceNames()` folds a discovery pass into the registry; `reconcileAppliedGlobalConnection` labels cloud entries by name, not host.
- `electron/main.ts`: persists the name as `remote.name`; `refreshCloudInstanceNames()` wired into the `hermes:cloud:discover` handler, broadcasting `reason: 'saved'` (no reconnect).
- `src/app/settings/gateway-settings.tsx`: passes `cloudName: agent.name` on connect.
- `src/global.d.ts`: `cloudName` on the config/registry renderer types.
- Tests: 9 new in `connection-registry.test.ts`; fixture update in `boot-failure-reauth.test.ts`.

Both JSON stores gain one optional string field; old files load unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (desktop-only, no Python touched)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings): doc comments at the new definitions
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys: N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows: N/A
- [x] I've considered cross-platform impact (Windows, macOS): no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior: N/A
