### PR TITLE
fix(secrets): forward 1Password biometric switch

### DIFF
--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -43,6 +43,8 @@ _OP_ENV_ALLOWLIST = (
     # Lets a user skip op's desktop-app integration probe (which can hang with
     # no timeout on a wedged desktop container) and go straight to token auth.
     "OP_LOAD_DESKTOP_APP_SETTINGS",
+    # 1Password's documented switch for toggling desktop-app integration.
+    "OP_BIOMETRIC_UNLOCK_ENABLED",
 )
 
 # L1 key folds in str(home_path) so a HERMES_HOME switch inside one long-lived

--- a/tests/test_onepassword_secrets.py
+++ b/tests/test_onepassword_secrets.py
@@ -75,6 +75,14 @@ def test_validate_references_filters_bad_names_and_refs():
     assert len(warnings) == 3
 
 
+def test_op_child_env_forwards_biometric_unlock_switch(monkeypatch):
+    monkeypatch.setenv("OP_BIOMETRIC_UNLOCK_ENABLED", "false")
+
+    child_env = op._op_child_env("")
+
+    assert child_env["OP_BIOMETRIC_UNLOCK_ENABLED"] == "false"
+
+
 # ---------------------------------------------------------------------------
 # fetch_onepassword_secrets
 # ---------------------------------------------------------------------------

--- a/tests/test_onepassword_secrets.py
+++ b/tests/test_onepassword_secrets.py
@@ -43,6 +43,8 @@ def _clean_op_env(monkeypatch):
     monkeypatch.delenv("OP_ACCOUNT", raising=False)
     monkeypatch.delenv("OP_CONNECT_HOST", raising=False)
     monkeypatch.delenv("OP_CONNECT_TOKEN", raising=False)
+    monkeypatch.delenv("OP_LOAD_DESKTOP_APP_SETTINGS", raising=False)
+    monkeypatch.delenv("OP_BIOMETRIC_UNLOCK_ENABLED", raising=False)
     yield
 
 
@@ -75,12 +77,33 @@ def test_validate_references_filters_bad_names_and_refs():
     assert len(warnings) == 3
 
 
-def test_op_child_env_forwards_biometric_unlock_switch(monkeypatch):
+def test_op_child_env_forwards_desktop_integration_switches(monkeypatch):
+    """Both desktop-integration switches must reach the child process."""
+    monkeypatch.setenv("OP_LOAD_DESKTOP_APP_SETTINGS", "false")
     monkeypatch.setenv("OP_BIOMETRIC_UNLOCK_ENABLED", "false")
 
     child_env = op._op_child_env("")
 
+    assert child_env["OP_LOAD_DESKTOP_APP_SETTINGS"] == "false"
     assert child_env["OP_BIOMETRIC_UNLOCK_ENABLED"] == "false"
+
+
+def test_op_child_env_still_withholds_unrelated_credentials(monkeypatch):
+    """Keep provider credentials out of the minimal child environment."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-must-not-reach-op")
+    monkeypatch.setenv("OP_BIOMETRIC_UNLOCK_ENABLED", "false")
+
+    child_env = op._op_child_env("ops-token")
+
+    assert "OPENAI_API_KEY" not in child_env
+    assert child_env["OP_SERVICE_ACCOUNT_TOKEN"] == "ops-token"
+
+
+def test_op_child_env_omits_switches_when_user_did_not_set_them():
+    child_env = op._op_child_env("")
+
+    assert "OP_BIOMETRIC_UNLOCK_ENABLED" not in child_env
+    assert "OP_LOAD_DESKTOP_APP_SETTINGS" not in child_env
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #103221.

## Summary
- forward 1Password's documented `OP_BIOMETRIC_UNLOCK_ENABLED` setting through the minimal `op` child-process environment
- preserve the existing allowlist model rather than widening environment inheritance
- add focused regression coverage for `_op_child_env()`

## Tests
- focused GitHub Actions behavior check for `OP_BIOMETRIC_UNLOCK_ENABLED` forwarding
- `python -m py_compile agent/secret_sources/onepassword.py tests/test_onepassword_secrets.py`
- `git diff --check`

All focused checks passed on the contribution branch.