### PR TITLE
fix(session-search): stop hydrating inline base64 images into results

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -17,6 +17,7 @@ import pytest
 from hermes_state import SessionDB
 from tools.session_search_tool import (
     SESSION_SEARCH_SCHEMA,
+    _flatten_search_content,
     _format_timestamp,
     _is_compacted_message,
     _resolve_to_parent,
@@ -1156,3 +1157,51 @@ class TestNewResetLineageBrowse:
         sids = [r["session_id"] for r in result["results"]]
         assert "s_legacy_child" in sids
 
+
+
+# --- multimodal content: inline images must not be hydrated verbatim --------
+
+_JPEG_DATA_URI = "data:image/jpeg;base64," + ("/9j/4AAQ" * 200_000)  # ~1.6 MB, like one phone photo
+
+
+def test_flatten_search_content_replaces_inline_images_with_placeholder():
+    blocks = [
+        {"type": "text", "text": "Add this bottle to my cellar."},
+        {"type": "image_url", "image_url": {"url": _JPEG_DATA_URI}},
+        {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "A" * 5000}},
+    ]
+    flat = _flatten_search_content(blocks)
+    assert flat.startswith("Add this bottle to my cellar.")
+    assert "[image/jpeg omitted:" in flat and "KB inline data]" in flat
+    assert "[image/png omitted:" in flat
+    assert len(flat) < 300
+    # Strings and None pass through unchanged.
+    assert _flatten_search_content("plain") == "plain"
+    assert _flatten_search_content(None) is None
+    # A short http(s) image reference is kept, not hidden behind a placeholder.
+    ref = _flatten_search_content([{"type": "image_url", "image_url": {"url": "https://x/y.png"}}])
+    assert ref == "[image_url: https://x/y.png]"
+
+
+def test_session_search_full_detail_does_not_return_inline_image_payloads(db):
+    """A hit in a session with a photo used to hydrate the whole base64 image
+    (multi-MB per result); the result must stay text-sized with a placeholder."""
+    now = int(time.time())
+    db.create_session("s_photo", source="discord")
+    db._conn.execute("UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+                     (now - 600, "Wine cellar", "s_photo"))
+    db.append_message("s_photo", role="user", content=[
+        {"type": "text", "text": "Add this Barolo to the cellar, rack 3."},
+        {"type": "image_url", "image_url": {"url": _JPEG_DATA_URI}},
+    ])
+    db.append_message("s_photo", role="assistant", content="Added the Barolo to rack 3.")
+    db.append_message("s_photo", role="user", content="Thanks, Barolo it is.")
+    db.end_session("s_photo", "completed")
+    db._conn.commit()
+
+    result = json.loads(session_search(query="Barolo", detail="full", db=db))
+    assert result.get("success") is True and result.get("count", 0) >= 1
+    raw = json.dumps(result)
+    assert "base64,/9j/" not in raw
+    assert "[image/jpeg omitted:" in raw
+    assert len(raw) < 20_000

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -10,6 +10,7 @@ No LLM calls — every shape returns actual DB messages.
 
 import json
 import logging
+import re
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
@@ -144,10 +145,58 @@ def _is_compacted_message(db, message_id) -> bool:
     return _is_compacted_state(_get_message_storage_state(db, message_id))
 
 
+_DATA_URI_RE = re.compile(r"data:([\w.+-]+/[\w.+-]+)?;base64,", re.IGNORECASE)
+
+
+def _flatten_search_content(raw: Any) -> Any:
+    """Collapse multimodal (list) content into text for a search result.
+
+    User turns with an attached photo are stored as OpenAI-style blocks whose
+    ``image_url`` carries the whole picture inline (``data:image/jpeg;base64,…``,
+    5-10 MB each). Hydrating those verbatim made a single hit spill the entire
+    session_search response to disk (14 MB for 12 KB of text) and hid the text
+    the model asked for. Text blocks are kept; media blocks become a short
+    placeholder that names the mime type and the size that was dropped. String
+    content passes through untouched.
+    """
+    if not isinstance(raw, list):
+        return raw
+    parts: List[str] = []
+    for block in raw:
+        if isinstance(block, str):
+            parts.append(block)
+            continue
+        if not isinstance(block, dict):
+            continue
+        btype = block.get("type") or ""
+        if btype == "text" and isinstance(block.get("text"), str):
+            parts.append(block["text"])
+            continue
+        payload, mime_hint = "", ""  # largest string under image_url.url / source.data / url / data
+        for holder in (block.get("image_url"), block.get("source"), block):
+            if isinstance(holder, dict):
+                mime_hint = mime_hint or holder.get("media_type") or holder.get("mime_type") or ""
+                for key in ("url", "data"):
+                    val = holder.get(key)
+                    if isinstance(val, str) and len(val) > len(payload):
+                        payload = val
+            elif isinstance(holder, str) and len(holder) > len(payload):
+                payload = holder
+        m = _DATA_URI_RE.match(payload)
+        mime = (m.group(1) if m else None) or mime_hint or btype or "media"
+        if m or len(payload) > 2000:
+            parts.append(f"[{mime} omitted: {len(payload) // 1024} KB inline data]")
+        elif payload:
+            parts.append(f"[{mime}: {payload[:200]}]")
+        else:
+            parts.append(f"[{btype or 'block'} omitted]")
+    return "\n".join(parts)
+
+
 def _shape_message(m: Dict[str, Any], anchor_id: Optional[int] = None,
                    max_content_len: Optional[int] = None) -> Dict[str, Any]:
     """Slim a message row; keeps ``content`` even when empty (tool-call-only turns)."""
-    content = m.get("content")
+    content = _flatten_search_content(m.get("content"))
     if isinstance(content, str) and "\x1b" in content:  # archived terminal output carries ANSI
         from tools.ansi_strip import strip_ansi
         content = strip_ansi(content)


### PR DESCRIPTION
## What does this PR do?

`session_search` hydrates message rows into its results through `_shape_message`, which only bounds **string** content. User turns that carry an attached photo are stored as OpenAI-style content blocks whose `image_url` holds the whole picture inline (`data:image/jpeg;base64,…`, 5–10 MB per photo). Any hit in such a session therefore returned every image verbatim.

Observed on a real install (Discord, gpt-5.5 via openai-codex): one `session_search` call for a common word returned **13,999,152 characters** — 12 KB of it text, the rest two inline JPEGs from a single user message. The result was spilled to `cache/spillover/`, the model had to page through the file with `execute_code` to find the text, and a second query with `detail="adaptive"` did the same again (another 14 MB).

The fix flattens list content before shaping: text blocks are kept, media blocks become a short placeholder that names the mime type and the size that was dropped, e.g. `[image/jpeg omitted: 7208 KB inline data]`. Short `http(s)` image references are kept as-is. String content passes through untouched, and the existing `max_content_len` truncation now applies to the flattened text too. Same query after the fix: **44,542 characters**.

## Related Issue

No issue filed; happy to open one if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/session_search_tool.py`: new `_flatten_search_content()` (handles `text`, OpenAI `image_url`, Anthropic `image`/`source` blocks, bare strings); `_shape_message` runs content through it first.
- `tests/tools/test_session_search.py`: unit test for the flattener (placeholder text, passthrough of strings/`None`, short http refs kept) and an end-to-end test that seeds a session with an inline ~1.6 MB JPEG, runs `session_search(detail="full")`, and asserts no base64 payload comes back and the response stays under 20 KB.

## How to Test

1. `pytest tests/tools/test_session_search.py -q` — 55 passed (2 new).
2. On a live install: send a message with an attached photo through any platform, then ask the agent to `session_search` a word from that message with `detail="full"`. Before: multi-MB result, "This tool result was too large … saved to cache/spillover". After: text-sized result with an `[image/jpeg omitted: … KB inline data]` line where the photo was.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_session_search.py -q` and all tests pass (full `tests/` not run locally)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.7 (Apple Silicon), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring on the new helper; N/A otherwise
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure Python string handling, N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
