### PR TITLE
fix(secrets): forward OP_BIOMETRIC_UNLOCK_ENABLED to the op child env

### DIFF
--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -40,9 +40,11 @@ _OP_ENV_ALLOWLIST = (
     "PATH", "HOME", "USERPROFILE", "APPDATA", "LOCALAPPDATA", "SystemRoot",
     "TMPDIR", "TMP", "TEMP", "XDG_CONFIG_HOME", "XDG_RUNTIME_DIR",
     "OP_ACCOUNT", "OP_CONNECT_HOST", "OP_CONNECT_TOKEN",
-    # Lets a user skip op's desktop-app integration probe (which can hang with
-    # no timeout on a wedged desktop container) and go straight to token auth.
-    "OP_LOAD_DESKTOP_APP_SETTINGS",
+    # Both let a user skip op's desktop-app integration probe (which can hang
+    # with no timeout on a wedged desktop container) and go straight to token
+    # auth. OP_BIOMETRIC_UNLOCK_ENABLED is the one 1Password documents; without
+    # it here the documented lever is silently dropped before op ever runs.
+    "OP_LOAD_DESKTOP_APP_SETTINGS", "OP_BIOMETRIC_UNLOCK_ENABLED",
 )
 
 # L1 key folds in str(home_path) so a HERMES_HOME switch inside one long-lived

--- a/tests/test_onepassword_secrets.py
+++ b/tests/test_onepassword_secrets.py
@@ -43,6 +43,8 @@ def _clean_op_env(monkeypatch):
     monkeypatch.delenv("OP_ACCOUNT", raising=False)
     monkeypatch.delenv("OP_CONNECT_HOST", raising=False)
     monkeypatch.delenv("OP_CONNECT_TOKEN", raising=False)
+    monkeypatch.delenv("OP_LOAD_DESKTOP_APP_SETTINGS", raising=False)
+    monkeypatch.delenv("OP_BIOMETRIC_UNLOCK_ENABLED", raising=False)
     yield
 
 
@@ -297,5 +299,41 @@ def test_apply_never_overrides_token_var(monkeypatch, tmp_path):
     assert calls["n"] == 0
 
 
+# ---------------------------------------------------------------------------
+# Child environment allowlist
+# ---------------------------------------------------------------------------
 
 
+def test_op_child_env_forwards_desktop_integration_switches(monkeypatch):
+    """Both documented ways to bypass op's desktop-app probe must reach the child.
+
+    OP_BIOMETRIC_UNLOCK_ENABLED is the switch 1Password documents; when it is
+    missing from the allowlist it is dropped with no warning, so a user who
+    follows the vendor docs sees no effect at all.
+    """
+    monkeypatch.setenv("OP_LOAD_DESKTOP_APP_SETTINGS", "false")
+    monkeypatch.setenv("OP_BIOMETRIC_UNLOCK_ENABLED", "false")
+
+    env = op._op_child_env("")
+
+    assert env["OP_LOAD_DESKTOP_APP_SETTINGS"] == "false"
+    assert env["OP_BIOMETRIC_UNLOCK_ENABLED"] == "false"
+
+
+def test_op_child_env_still_withholds_unrelated_credentials(monkeypatch):
+    """Guards the reason the allowlist exists, so widening it can't pass unnoticed."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-must-not-reach-op")
+    monkeypatch.setenv("OP_BIOMETRIC_UNLOCK_ENABLED", "false")
+
+    env = op._op_child_env("ops-token")
+
+    assert "OPENAI_API_KEY" not in env
+    assert env["OP_SERVICE_ACCOUNT_TOKEN"] == "ops-token"
+
+
+def test_op_child_env_omits_switches_when_user_did_not_set_them(monkeypatch):
+    """An allowlist entry must forward a value, never invent one."""
+    env = op._op_child_env("")
+
+    assert "OP_BIOMETRIC_UNLOCK_ENABLED" not in env
+    assert "OP_LOAD_DESKTOP_APP_SETTINGS" not in env


### PR DESCRIPTION
## What does this PR do?

`_OP_ENV_ALLOWLIST` did not carry `OP_BIOMETRIC_UNLOCK_ENABLED`, so the one switch [1Password documents](https://developer.1password.com/docs/cli/app-integration/#optional-set-the-biometric-unlock-environment-variable) for toggling the desktop-app integration was dropped before `op` was spawned — silently, with no warning or debug line. A user who follows the vendor docs sees no effect at all, and the only lever that actually works is `OP_LOAD_DESKTOP_APP_SETTINGS` (allowlisted in #62829), which 1Password documents nowhere: it is absent from both `op --help` and the CLI reference. So today the documented lever is unreachable and the undocumented one is mandatory.

This adds one allowlist entry. It deliberately does **not** widen the allowlist mechanism — the minimal-env design is the right call and the new test below pins it.

**Why it matters on macOS.** `op`'s desktop-app integration probe reads the 1Password group container, which the OS protects with `kTCCServiceSystemPolicyAppData`. From a launchd-started process holding no AppData grant, that read raises an authorization dialog and `op` blocks until it is answered. Measured here with a live `tccd` capture, runs interleaved so a cold-start effect can't explain it:

```
run1  probe skipped    0.68 s   no TCC request
run2  probe enabled  120 s      AllFiles denied (authValue=0), then AppData -> AUTHREQ_PROMPTING
run3  probe skipped    0.72 s   no TCC request
```

In production (seven gateway processes starting together, four resolving secrets) that was 6 authorization dialogs at every boot; with the probe skipped, 0 — with a positive control on the same capture (5,430 `AUTHREQ` lines present, so the query was live and the zero is a real absence). Detail in #60674.

## Related Issue

Fixes #103221

Context on the macOS symptom: #60674

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/secret_sources/onepassword.py` — add `OP_BIOMETRIC_UNLOCK_ENABLED` to `_OP_ENV_ALLOWLIST`, and reword the neighbouring comment to cover both switches and say which one the vendor documents.
- `tests/test_onepassword_secrets.py` — three tests around `_op_child_env`, plus two `delenv` lines in the existing `_clean_op_env` fixture so the suite starts from a known state for both switches (without them, a developer whose own shell exports either variable gets a non-deterministic run).

## How to Test

1. `scripts/run_tests.sh tests/test_onepassword_secrets.py` → passes.
2. Revert only the `agent/secret_sources/onepassword.py` hunk, keep the tests, run again → `test_op_child_env_forwards_desktop_integration_switches` fails with `KeyError: 'OP_BIOMETRIC_UNLOCK_ENABLED'`. That check was run before opening this PR: the test is falsifiable, it is not green by construction.
3. End to end on macOS: with a service-account token, `export OP_BIOMETRIC_UNLOCK_ENABLED=false` and resolve a secret — `op` no longer probes the desktop container.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs and issues to make sure this isn't a duplicate (`gh search issues/prs` on `OP_BIOMETRIC_UNLOCK_ENABLED`, `OP_ENV_ALLOWLIST`, `onepassword allowlist` — only #62829, which added the *other* switch, and #60674)
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **not the full suite.** Run: `scripts/run_tests.sh tests/secret_sources/` (44 passed), `scripts/run_tests.sh tests/test_onepassword_secrets.py tests/test_env_loader_secret_sources.py` (34 passed). I did not run all ~4k test files locally; flagging that rather than ticking the box. CI will cover the rest.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6.2 (25G83), arm64, Python 3.11, 1Password CLI 2.39.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the allowlist comment is the documentation for this constant; no user-facing doc references the variable list.
- [x] `cli-config.yaml.example` — N/A, no config key added or changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture or workflow change.
- [x] Cross-platform impact considered: the entry is inert where the desktop-app integration isn't in play. `_op_child_env` copies by exact key from the source environment, so on Windows and Linux the behaviour is unchanged unless the user sets the variable, which is exactly the documented intent.
- [x] Tool descriptions/schemas — N/A, no tool behaviour changed.

## Screenshots / Logs

Falsifiability check, tests kept and only the source hunk reverted:

```
>       assert env["OP_BIOMETRIC_UNLOCK_ENABLED"] == "false"
E       KeyError: 'OP_BIOMETRIC_UNLOCK_ENABLED'

FAILED tests/test_onepassword_secrets.py::test_op_child_env_forwards_desktop_integration_switches
1 failed, 2 passed
```

With the fix applied:

```
=== Summary: 2 files, 34 tests passed, 0 failed (100% complete) ===
```
