### PR TITLE
fix: bound FIFO startup loading and avoid credential discovery rereads

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2398,6 +2398,11 @@ def load_env() -> Dict[str, str]:
 
     try:
         st = env_path.stat()
+        # Secret-provider mounts may be FIFOs. Bootstrap owns consuming those;
+        # discovery must use the loaded secret scope rather than block on another
+        # reader. Keep this result uncached so a later regular file is noticed.
+        if not stat.S_ISREG(st.st_mode):
+            return {}
         cache_key = (str(env_path), st.st_mtime, st.st_size)
     except FileNotFoundError:
         cache_key = (str(env_path), None, None)

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -6,6 +6,7 @@ import codecs
 import io
 import logging
 import os
+import stat
 import sys
 import threading
 from pathlib import Path
@@ -50,6 +51,8 @@ def _env_keys_defined_in_dotenv(path: Path) -> set[str]:
     """KEY names assigned in a dotenv file (including empty ``KEY=``). A fast line scanner (works in early
     bootstrap without python-dotenv); decode errors fall back to latin-1 like ``_load_dotenv_with_fallback``."""
     keys: set[str] = set()
+    if not path.is_file():
+        return keys
     try:
         text = path.read_text(encoding="utf-8", errors="replace")
     except Exception:
@@ -67,16 +70,17 @@ def _env_keys_defined_in_dotenv(path: Path) -> set[str]:
     return keys
 
 
-def _clear_known_keys_missing_from_dotenv(path: Path) -> None:
+def _clear_known_keys_missing_from_dotenv(path: Path, *, defined: set[str] | None = None) -> None:
     """After ``.env`` loaded with override, delete inherited ``_PROFILE_MANAGED_ENV_KEYS`` it does not
     define. Deliberately NARROW: only keys that change *which provider path* is used.
 
     Does **not** run when the ``.env`` file does not exist (bare-profile case, which follows ``#66930`` /
     ``#67027`` semantics).
     """
-    if not path.exists():
-        return
-    defined = _env_keys_defined_in_dotenv(path)
+    if defined is None:
+        if not path.is_file():
+            return
+        defined = _env_keys_defined_in_dotenv(path)
     for key in _PROFILE_MANAGED_ENV_KEYS:
         if key not in defined and key in os.environ:
             del os.environ[key]
@@ -224,7 +228,60 @@ def _sanitize_loaded_credentials() -> None:
         )
 
 
-def _load_dotenv_with_fallback(path: Path, *, override: bool) -> None:
+def _read_credential_fifo(path: Path) -> str:
+    """Read one complete provider response; never persist it or wait indefinitely.
+
+    EOF after data completes a response. An absent writer, a writer that never
+    closes, or an oversized response fails before any environment is changed.
+    """
+    import select
+    import time
+
+    deadline = time.monotonic() + 5.0
+    fd = os.open(path, os.O_RDONLY | os.O_NONBLOCK)
+    payload = bytearray()
+    try:
+        if not stat.S_ISFIFO(os.fstat(fd).st_mode):
+            raise OSError("credential FIFO changed type before loading")
+        while time.monotonic() < deadline:
+            ready, _, _ = select.select([fd], [], [], min(0.05, max(0, deadline - time.monotonic())))
+            if not ready:
+                continue
+            try:
+                chunk = os.read(fd, 65536)
+            except BlockingIOError:
+                continue
+            if chunk:
+                payload.extend(chunk)
+                if len(payload) > 1024 * 1024:
+                    raise ValueError("credential FIFO provider response exceeds 1 MiB")
+            elif payload:
+                break
+            else:
+                # A writerless FIFO can report EOF immediately. Avoid spinning
+                # while waiting for its provider to open the write end.
+                time.sleep(0.01)
+        else:
+            raise TimeoutError("credential FIFO provider did not supply a complete response within 5 seconds; check that the credential provider is running and unlocked")
+    finally:
+        os.close(fd)
+    try:
+        return bytes(payload).decode("utf-8-sig")
+    except UnicodeDecodeError:
+        return bytes(payload).removeprefix(codecs.BOM_UTF8).decode("latin-1")
+
+
+def _load_dotenv_with_fallback(path: Path, *, override: bool) -> set[str] | None:
+    if stat.S_ISFIFO(path.stat().st_mode):
+        from dotenv import dotenv_values
+
+        text = _read_credential_fifo(path)
+        defined = set(dotenv_values(stream=io.StringIO(text), interpolate=False))
+        load_dotenv(stream=io.StringIO(text), override=override)
+        _sanitize_loaded_credentials()
+        return defined
+    if not path.is_file():
+        raise OSError("credential path must be a regular file or provider FIFO")
     try:
         # utf-8-sig strips a leading BOM (PowerShell 5.1 / Notepad); plain utf-8 would keep U+FEFF on the
         # first key name and silently drop it from os.environ under its canonical name.
@@ -241,7 +298,7 @@ def _sanitize_env_file_if_needed(path: Path) -> None:
     """Pre-sanitize a .env file before python-dotenv reads it. Sniffs a leading BOM *before* any text
     decode: UTF-16 (Notepad "Unicode") is rewritten as clean UTF-8; UTF-32 is refused (left untouched) so
     we never fall through to the errors=replace corruption path."""
-    if not path.exists():
+    if not path.is_file():
         return
     try:
         from hermes_cli.config import _sanitize_env_lines
@@ -347,9 +404,9 @@ def load_hermes_dotenv(
         _sanitize_env_file_if_needed(project_env_path)
 
     if user_env.exists():
-        _load_dotenv_with_fallback(user_env, override=True)
+        defined = _load_dotenv_with_fallback(user_env, override=True)
         loaded.append(user_env)
-        _clear_known_keys_missing_from_dotenv(user_env)  # mirrors reload_env(): inherited keys must not leak
+        _clear_known_keys_missing_from_dotenv(user_env, defined=defined)  # mirrors reload_env(): inherited keys must not leak
 
     # .op.env AFTER .env so .env wins, but the bootstrap OP_SERVICE_ACCOUNT_TOKEN reaches
     # apply_onepassword_secrets() even in cron with no shell state; gitignored so the token never enters

--- a/tests/hermes_cli/test_fifo_credential_discovery.py
+++ b/tests/hermes_cli/test_fifo_credential_discovery.py
@@ -1,0 +1,48 @@
+"""Credential discovery must not consume a mounted secret-provider FIFO."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize("host", [
+    pytest.param("linux", marks=pytest.mark.linux_only),
+    pytest.param("macos", marks=pytest.mark.macos_only),
+])
+def test_fifo_discovery_returns_inherited_credentials_without_a_writer(tmp_path, host):
+    fifo = tmp_path / ".env"
+    os.mkfifo(fifo, 0o600)
+    before = fifo.stat()
+    env = dict(os.environ, HERMES_HOME=str(tmp_path), OPENAI_API_KEY="inherited-test-key")
+    code = """
+import signal
+signal.alarm(5)
+from hermes_cli.config import get_env_value_prefer_dotenv, load_env
+assert load_env() == {}
+assert get_env_value_prefer_dotenv('OPENAI_API_KEY') == 'inherited-test-key'
+"""
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", code], env=env,
+            cwd=Path(__file__).resolve().parents[2],
+            capture_output=True, text=True, timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail("credential discovery blocked opening the writerless FIFO")
+    assert result.returncode == 0, "credential discovery did not finish before the FIFO watchdog: " + result.stderr
+    assert fifo.stat().st_ino == before.st_ino
+    assert fifo.stat().st_mode == before.st_mode
+
+
+def test_regular_dotenv_still_overrides_inherited_credentials(tmp_path, monkeypatch):
+    from hermes_cli.config import get_env_value_prefer_dotenv, invalidate_env_cache, load_env
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "inherited-test-key")
+    (tmp_path / ".env").write_text("OPENAI_API_KEY=stored-test-key\n", encoding="utf-8")
+    invalidate_env_cache()
+    assert load_env()["OPENAI_API_KEY"] == "stored-test-key"
+    assert get_env_value_prefer_dotenv("OPENAI_API_KEY") == "stored-test-key"

--- a/tests/hermes_cli/test_fifo_startup.py
+++ b/tests/hermes_cli/test_fifo_startup.py
@@ -1,0 +1,118 @@
+"""Full startup regressions: no real credentials or installation mutations."""
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+# --help exits before dispatch; this checkout and HOME are disposable.
+@pytest.mark.live_system_guard_bypass
+@pytest.mark.parametrize("platform", [pytest.param("linux", marks=pytest.mark.linux_only), pytest.param("darwin", marks=pytest.mark.macos_only)])
+@pytest.mark.parametrize("arguments", [["skills", "install", "official/creative/kanban-video-orchestrator", "--help"], ["update", "--help"]])
+def test_writerless_fifo_cli_startup_is_bounded(tmp_path, platform, arguments):
+    home = tmp_path / "home"
+    profile = home / ".hermes"
+    profile.mkdir(parents=True)
+    fifo = profile / ".env"
+    os.mkfifo(fifo, 0o600)
+    before = fifo.stat()
+    env = {"HOME": str(home), "HERMES_HOME": str(profile), "PATH": os.defpath,
+           "PYTHONDONTWRITEBYTECODE": "1", "PYTHONPATH": str(ROOT)}
+    started = time.monotonic()
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", "import faulthandler; faulthandler.dump_traceback_later(8, exit=True); from hermes_cli.main import main; main()", *arguments],
+            cwd=ROOT, env=env, capture_output=True, text=True, timeout=12,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail("CLI startup exceeded watchdog")
+    assert "Timeout (0:00:08)" not in result.stderr, result.stderr
+    assert result.returncode != 0
+    assert "credential FIFO" in result.stderr
+    assert "provider" in result.stderr
+    assert time.monotonic() - started < 12
+    after = fifo.stat()
+    assert (before.st_ino, before.st_mode) == (after.st_ino, after.st_mode)
+
+
+@pytest.mark.parametrize("platform", [pytest.param("linux", marks=pytest.mark.linux_only), pytest.param("darwin", marks=pytest.mark.macos_only)])
+@pytest.mark.parametrize("location", ["user", "project", "op", "managed"])
+def test_single_writer_supplies_complete_load(tmp_path, monkeypatch, platform, location):
+    import threading
+    from hermes_cli import env_loader, managed_scope
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "inherited-synthetic")
+    monkeypatch.delenv("OP_SERVICE_ACCOUNT_TOKEN", raising=False)
+    monkeypatch.setenv("HERMES_ACP_AUTH_METHOD", "inherited-route")
+    fifo = tmp_path / (".op.env" if location == "op" else ".env")
+    project = None
+    if location == "project":
+        fifo = tmp_path / "project.env"
+        project = fifo
+    if location == "managed":
+        directory = tmp_path / "managed"
+        directory.mkdir()
+        fifo = directory / ".env"
+        monkeypatch.setattr(managed_scope, "get_managed_dir", lambda: directory)
+    else:
+        monkeypatch.setattr(managed_scope, "get_managed_dir", lambda: None)
+    os.mkfifo(fifo, 0o600)
+    before = fifo.stat()
+    completed = threading.Event()
+
+    def writer():
+        with fifo.open("wb") as stream:
+            stream.write(b"\xef\xbb\xbfOPENAI_API_KEY=writer-synthetic\nHERMES_ACP_AUTH_METHOD=synthetic-route\n")
+        completed.set()
+
+    thread = threading.Thread(target=writer, daemon=True)
+    thread.start()
+    # Kill a blocked reread without leaving the test runner stuck.
+    import signal
+    old = signal.signal(signal.SIGALRM, lambda *_: (_ for _ in ()).throw(TimeoutError("independent FIFO reread")))
+    signal.alarm(10)
+    try:
+        env_loader.load_hermes_dotenv(hermes_home=tmp_path, project_env=project, load_external_secrets=False)
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, old)
+    assert completed.wait(2)
+    thread.join(2)
+    assert os.environ["OPENAI_API_KEY"] == ("inherited-synthetic" if location == "op" else "writer-synthetic")
+    assert os.environ["HERMES_ACP_AUTH_METHOD"] == ("inherited-route" if location == "op" else "synthetic-route")
+    after = fifo.stat()
+    assert (before.st_ino, before.st_mode) == (after.st_ino, after.st_mode)
+
+
+@pytest.mark.parametrize("platform", [pytest.param("linux", marks=pytest.mark.linux_only), pytest.param("darwin", marks=pytest.mark.macos_only)])
+def test_unfinished_provider_does_not_apply_partial_credentials(tmp_path, monkeypatch, platform):
+    import threading
+    from hermes_cli.env_loader import _load_dotenv_with_fallback
+
+    fifo = tmp_path / "synthetic.env"
+    os.mkfifo(fifo, 0o600)
+    monkeypatch.setenv("OPENAI_API_KEY", "inherited-synthetic")
+    release = threading.Event()
+
+    def writer():
+        with fifo.open("wb", buffering=0) as stream:
+            stream.write(b"OPENAI_API_KEY=partial-synthetic\n")
+            release.wait(10)
+
+    thread = threading.Thread(target=writer, daemon=True)
+    thread.start()
+    try:
+        with pytest.raises(TimeoutError, match="credential FIFO provider"):
+            _load_dotenv_with_fallback(fifo, override=True)
+        assert os.environ["OPENAI_API_KEY"] == "inherited-synthetic"
+    finally:
+        release.set()
+        thread.join(2)
+    assert not thread.is_alive()

--- a/tests/hermes_cli/test_fifo_startup.py
+++ b/tests/hermes_cli/test_fifo_startup.py
@@ -12,9 +12,10 @@ ROOT = Path(__file__).resolve().parents[2]
 
 # --help exits before dispatch; this checkout and HOME are disposable.
 @pytest.mark.live_system_guard_bypass
+@pytest.mark.parametrize("writer_present", [False, True])
 @pytest.mark.parametrize("platform", [pytest.param("linux", marks=pytest.mark.linux_only), pytest.param("darwin", marks=pytest.mark.macos_only)])
 @pytest.mark.parametrize("arguments", [["skills", "install", "official/creative/kanban-video-orchestrator", "--help"], ["update", "--help"]])
-def test_writerless_fifo_cli_startup_is_bounded(tmp_path, platform, arguments):
+def test_fifo_cli_startup_is_bounded(tmp_path, platform, arguments, writer_present):
     home = tmp_path / "home"
     profile = home / ".hermes"
     profile.mkdir(parents=True)
@@ -23,6 +24,15 @@ def test_writerless_fifo_cli_startup_is_bounded(tmp_path, platform, arguments):
     before = fifo.stat()
     env = {"HOME": str(home), "HERMES_HOME": str(profile), "PATH": os.defpath,
            "PYTHONDONTWRITEBYTECODE": "1", "PYTHONPATH": str(ROOT)}
+    if writer_present:
+        import threading
+
+        def writer():
+            with fifo.open("wb") as stream:
+                stream.write(b"OPENAI_API_KEY=synthetic-only\n")
+
+        thread = threading.Thread(target=writer, daemon=True)
+        thread.start()
     started = time.monotonic()
     try:
         result = subprocess.run(
@@ -32,9 +42,15 @@ def test_writerless_fifo_cli_startup_is_bounded(tmp_path, platform, arguments):
     except subprocess.TimeoutExpired:
         pytest.fail("CLI startup exceeded watchdog")
     assert "Timeout (0:00:08)" not in result.stderr, result.stderr
-    assert result.returncode != 0
-    assert "credential FIFO" in result.stderr
-    assert "provider" in result.stderr
+    if writer_present:
+        thread.join(2)
+        assert not thread.is_alive()
+        assert result.returncode == 0, result.stderr
+        assert "usage:" in result.stdout.lower()
+    else:
+        assert result.returncode != 0
+        assert "credential FIFO" in result.stderr
+        assert "provider" in result.stderr
     assert time.monotonic() - started < 12
     after = fifo.stat()
     assert (before.st_ino, before.st_mode) == (after.st_ino, after.st_mode)

--- a/tests/tools/test_skill_fifo_discovery.py
+++ b/tests/tools/test_skill_fifo_discovery.py
@@ -1,0 +1,54 @@
+"""Exercise skill readiness through the registry with an externally owned FIFO."""
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.parametrize("host", [
+    pytest.param("linux", marks=pytest.mark.linux_only),
+    pytest.param("macos", marks=pytest.mark.macos_only),
+])
+@pytest.mark.parametrize("credentials", ["none_required", "inherited", "scoped", "other_profile"])
+def test_skill_dispatch_does_not_reread_fifo(tmp_path, host, credentials):
+    skill = tmp_path / "skills" / "fifo-probe"
+    skill.mkdir(parents=True)
+    required = "" if credentials == "none_required" else "required_environment_variables: [OPENAI_API_KEY]\n"
+    (skill / "SKILL.md").write_text(
+        "---\nname: fifo-probe\ndescription: Synthetic skill.\n" + required + "---\nProbe body.\n",
+        encoding="utf-8",
+    )
+    fifo = tmp_path / ".env"
+    os.mkfifo(fifo, 0o600)
+    before = fifo.stat()
+    env = dict(os.environ, HERMES_HOME=str(tmp_path), HOME=str(tmp_path))
+    env.pop("OPENAI_API_KEY", None)
+    if credentials in {"inherited", "other_profile"}:
+        env["OPENAI_API_KEY"] = "synthetic-inherited-key"
+    code = """
+import json, signal, sys
+signal.alarm(5)
+from agent import secret_scope
+import tools.skills_tool
+from tools.registry import registry
+case = sys.argv[1]
+if case in {'scoped', 'other_profile'}:
+    secret_scope.set_multiplex_active(True)
+    secret_scope.set_secret_scope({'OPENAI_API_KEY': 'synthetic-scoped-key'} if case == 'scoped' else {})
+result = registry.dispatch('skill_view', {'name': 'fifo-probe'})
+result = json.loads(result) if isinstance(result, str) else result
+assert result.get('success'), result.get('error')
+expected = ['OPENAI_API_KEY'] if case == 'other_profile' else []
+assert result['missing_required_environment_variables'] == expected
+assert 'Probe body.' in result['content']
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code, credentials], env=env,
+        cwd=Path(__file__).resolve().parents[2], capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode == 0, "skill discovery failed or hit the FIFO watchdog: " + result.stderr
+    assert fifo.stat().st_ino == before.st_ino
+    assert fifo.stat().st_mode == before.st_mode

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -7,6 +7,7 @@ linked files. Sibling modules (skills_tool_setup / _plugin / _dedup) re-export h
 import json
 import logging
 import os
+import stat
 import time
 from contextlib import suppress
 from pathlib import Path, PurePosixPath, PureWindowsPath
@@ -92,6 +93,10 @@ def load_env() -> Dict[str, str]:
     env_path = get_hermes_home() / ".env"
     env_vars: Dict[str, str] = {}
     if env_path.exists():
+        # Bootstrap owns secret-provider streams. Readiness must not consume a
+        # FIFO again; missing file values fall back to the active secret scope.
+        if not stat.S_ISREG(env_path.stat().st_mode):
+            return env_vars
         # utf-8-sig: a Notepad BOM would otherwise glue U+FEFF onto the first key.
         with env_path.open(encoding="utf-8-sig", errors="replace") as f:
             for line in map(str.strip, f):

--- a/tools/skills_tool_setup.py
+++ b/tools/skills_tool_setup.py
@@ -126,8 +126,10 @@ def _is_gateway_surface() -> bool:
 
 
 def _is_env_var_persisted(var_name: str, env_snapshot: Dict[str, str]) -> bool:
-    """Set (non-empty) in the .env snapshot, else in the process environment."""
-    return bool(env_snapshot[var_name] if var_name in env_snapshot else os.getenv(var_name))
+    """Set in a regular-file snapshot, else in the active profile's loaded secrets."""
+    from agent.secret_scope import get_secret
+
+    return bool(env_snapshot[var_name] if var_name in env_snapshot else get_secret(var_name))
 
 
 def _build_setup_note(


### PR DESCRIPTION
## What does this PR do?

A provider-backed .env FIFO blocks CLI startup during sanitization, before skill-install or updater dispatch. Independent discovery readers can also hang. This correction covers both paths while preserving regular-file precedence and active-profile credential scope.

FIFO startup loading consumes one bounded response and parses it in memory. Routing-key cleanup uses the same response. A missing or non-closing writer fails within five seconds before modifying the environment; responses are capped at 1 MiB. FIFOs are never sanitized on disk or replaced.

## Related Issue

No linked issue.

## Type of Change

- [x] Bug fix

## Changes Made

- `hermes_cli/env_loader.py`: bounded FIFO loading, stream parsing, and no independent sanitizer/key-scanner reads.
- `hermes_cli/config.py`, `tools/skills_tool.py`, `tools/skills_tool_setup.py`: regular-file discovery guards and scoped credential fallback.
- `tests/hermes_cli/test_fifo_startup.py`: real CLI startup with --help to prevent install/update dispatch; missing/present writers, user/project/bootstrap/managed paths, metadata preservation and incomplete-response atomicity.
- Discovery regressions cover credential-free skills, inherited/scoped credentials and cross-profile isolation.

## How to Test

```sh
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh \
  tests/hermes_cli/test_fifo_startup.py \
  tests/hermes_cli/test_fifo_credential_discovery.py \
  tests/hermes_cli/test_config.py \
  tests/hermes_cli/test_env_loader.py \
  tests/tools/test_skill_fifo_discovery.py \
  tests/tools/test_skills_tool.py \
  tests/tools/test_skill_env_passthrough.py \
  tests/agent/test_secret_scope.py \
  --file-timeout 90 -q
```

At `63cf417396960e6eec15d2481d2a323abe179d8a`: macOS **232 passed, 0 failed, 18 skipped**. Nine native startup cases executed. Linux cases were skipped locally. The exact revision also passed on GitHub-hosted Linux and macOS: **232 passed, 0 failed, 18 skipped on each platform**, with nine native startup cases, two model discovery cases and four skill FIFO cases executed on each. [Workflow and job logs](https://github.com/Referralconsequently/hermes-agent-upstream/actions/runs/33992601437). Fork evidence does not substitute for required upstream CI or the full suite.

Before correction, both actual CLI startup paths reached the watchdog in the sanitizer's read_bytes call. The local runner used synthetic HOME/profile trees and OS denial of production profile access. No real credential mounts were read. Ruff and git diff --check pass.

## Checklist

### Code

- [x] Contributing Guide read.
- [x] Conventional commits.
- [x] Existing PR search performed.
- [x] Only related changes included.
- [ ] Full suite passes. (Not run; focused results above.)
- [x] Regressions added.
- [x] Tested on macOS.

### Documentation & Housekeeping

- [x] Behavior documented in code.
- [x] Configuration-key changes: N/A.
- [x] Cross-platform behavior considered; native FIFO markers used.
- [x] Tool schema changes: N/A.

## Screenshots / Logs

Recovery remains unresolved: ordinary `hermes update` imports this same failing loader before updater dispatch. Please confirm the maintainer-supported recovery/bootstrap procedure for an existing installer-managed checkout with a protected provider FIFO. Installed core, update branch and FIFO have not been modified; no credential-preloading workaround was used. The recovery procedure must be validated in isolation before production use.
