### PR TITLE
fix(agent): count skill_manage patch and write_file results in the review completion log

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -616,7 +616,10 @@ def _action_lines(data: Dict, detail: Dict, verbose: bool) -> List[str]:
     target = data.get("target", "") or detail.get("target", "")
     is_skill = detail.get("tool") == "skill_manage"
     lower = message.lower()
-    if not verbose and ("created" in lower or "updated" in lower or (is_skill and "patched" in lower)):
+    if not verbose and (
+        "created" in lower or "updated" in lower
+        or (is_skill and ("patched" in lower or "written to skill" in lower))
+    ):
         return [message]
     if not is_skill and not target:
         return []
@@ -720,10 +723,12 @@ def _record_review_usage_to_parent(parent_agent: Any, usage: Dict[str, Any]) -> 
 def _classify_review_result(actions: List[str]) -> str:
     """Map a review action summary to ``none`` / ``skill`` / ``memory`` / ``skill+memory``.
     Prefix-based on the formats :func:`summarize_background_review_actions` emits (``Skill …``,
-    ``📝 Skill …``, ``Memory …``, ``User profile …``), so a free-text line like ``Skipped: no
-    skill worth saving`` stays ``none``."""
+    ``📝 Skill …``, ``Memory …``, ``User profile …``), plus the raw ``skill_manage`` messages the
+    non-verbose fast path passes through verbatim — ``Patched …`` (patch) and ``File '…' written
+    to skill …`` (write_file) — so a free-text line like ``Skipped: no skill worth saving`` stays
+    ``none``."""
     lowers = [str(action).lstrip().removeprefix("📝").lstrip().lower() for action in actions or []]
-    has_skill = any(t.startswith("skill") for t in lowers)
+    has_skill = any(t.startswith(("skill", "patched ", "file '")) for t in lowers)
     has_memory = any(t.startswith(("memory", "user profile")) for t in lowers)
     return "+".join(kind for kind, hit in (("skill", has_skill), ("memory", has_memory)) if hit) or "none"
 

--- a/tests/agent/test_background_review_usage.py
+++ b/tests/agent/test_background_review_usage.py
@@ -153,6 +153,26 @@ def test_classify_review_result():
         background_review._classify_review_result(["User profile ➕ prefers terse"])
         == "memory"
     )
+    # Raw skill_manage messages passed through verbatim by the non-verbose fast path
+    # (issue #103235): patch starts with "Patched", write_file with "File '…'".
+    assert (
+        background_review._classify_review_result(
+            ["Patched SKILL.md in skill 'deploy' (3 replacements)."]
+        )
+        == "skill"
+    )
+    assert (
+        background_review._classify_review_result(
+            ["File 'references/api.md' written to skill 'deploy'."]
+        )
+        == "skill"
+    )
+    assert (
+        background_review._classify_review_result(
+            ["📝 File 'references/api.md' written to skill 'deploy'."]
+        )
+        == "skill"
+    )
 
 
 def test_enabled_config_failure_logs_warning(caplog):

--- a/tests/run_agent/test_background_review_summary.py
+++ b/tests/run_agent/test_background_review_summary.py
@@ -110,3 +110,41 @@ def test_removed_or_replaced_relabels_by_target():
 
     assert "User profile updated" in actions
     assert "Memory updated" in actions
+
+
+def _skill_manage_call(call_id, action, **extra):
+    return {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": call_id,
+                "type": "function",
+                "function": {
+                    "name": "skill_manage",
+                    "arguments": json.dumps({"action": action, "name": "deploy", **extra}),
+                },
+            }
+        ],
+    }
+
+
+def test_patch_and_write_file_results_surface_and_classify_as_skill():
+    """Issue #103235: the non-verbose fast path passes skill_manage's patch and
+    write_file messages through verbatim ("Patched ...", "File '...' written to skill ..."),
+    and write_file must enter the action list at all — otherwise a review that
+    patched a skill or added support files logs result=none."""
+    from agent.background_review import _classify_review_result
+
+    review_messages = [
+        _skill_manage_call("c1", "patch", old_string="a", new_string="b"),
+        _tool_msg("c1", {"success": True, "message": "Patched SKILL.md in skill 'deploy' (3 replacements)."}),
+        _skill_manage_call("c2", "write_file", file_path="references/api.md", file_content="x"),
+        _tool_msg("c2", {"success": True, "message": "File 'references/api.md' written to skill 'deploy'."}),
+    ]
+
+    actions = _summarize(review_messages, prior_snapshot=[])
+
+    assert "Patched SKILL.md in skill 'deploy' (3 replacements)." in actions
+    assert "File 'references/api.md' written to skill 'deploy'." in actions
+    assert _classify_review_result(actions) == "skill"


### PR DESCRIPTION
## What does this PR do?

The background-review completion log line (`Background review complete: … result=…`) under-reports skill work. `_classify_review_result` prefix-matches the action summary lines, but the non-verbose fast path in `_action_lines` passes `skill_manage` messages through verbatim — and two of them violate the `Skill …` prefix convention:

- **patch** → `Patched SKILL.md in skill 'x' (N replacements).` — enters `actions` but starts with `Patched`, so `has_skill` misses it.
- **write_file** → `File 'y' written to skill 'x'.` — contains none of the fallback keywords (`added`/`replaced`/`removed`/`applied`), so it never enters `actions` at all.

A review that patched a skill or added support files therefore logs `result=none`. In the reporter's profile, 27 curator mutations (2 create, 17 patch, 8 write_file) over 54 reviews produced `result=skill` **zero** times (#103235).

Fix (keeps the existing prefix-based design instead of re-plumbing classification through tool calls):

- `agent/background_review.py` — `_action_lines`: the non-verbose fast path also passes through `write_file`'s `written to skill` message, so it surfaces like create/edit/patch instead of being dropped. `_classify_review_result`: extend the skill prefix set with the two raw `skill_manage` message prefixes the fast path emits (`patched `, `file '`). Free-text lines like `Skipped: no skill worth saving` still classify as `none`; the verbose `📝 …` unwrap path is unchanged and now also classifies `📝 File '…' written …` / `📝 Patched …` fallback lines correctly.

## Related Issue

Fixes #103235

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/background_review.py` — `_classify_review_result`: skill prefixes now include `patched ` and `file '` (the raw `skill_manage` patch/write_file message shapes); docstring updated.
- `agent/background_review.py` — `_action_lines`: non-verbose fast path passes `skill_manage` `write_file` messages through verbatim (`written to skill`), so they enter the action list.
- `tests/agent/test_background_review_usage.py` — regression assertions in `test_classify_review_result` for the patch / write_file raw messages (non-verbose and verbose forms).
- `tests/run_agent/test_background_review_summary.py` — end-to-end regression: a review whose tool results are one patch + one write_file surfaces both messages and classifies as `skill`.

## How to Test

1. `pytest tests/agent/test_background_review_usage.py tests/run_agent/test_background_review_summary.py -q` — Observed result: 17 passed.
2. Fail-on-main check: with the source change reverted (tests kept), both new regression tests fail on unmodified `main`; with the fix applied they pass.
3. Adjacent suites: `pytest tests/run_agent/test_background_review.py tests/run_agent/test_background_review_cache_parity.py tests/agent/test_background_review_tool_call_guard.py tests/agent/test_skip_background_review.py tests/test_background_review_list_shapes.py -q` — Observed result: 34 passed. Full skill tool domain — Observed result: 607 passed, 1 skipped.
4. `ruff check` on the three touched files — Observed result: All checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstring updated in place)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure string classification, no platform surface)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (tool messages unchanged)
