### PR TITLE
feat(kanban): add reopen_task() to undo a completion (done -> blocked/todo/ready)

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -940,6 +940,27 @@ def _cmd_unblock(args: argparse.Namespace) -> int:
                            lambda tid: f"cannot unblock {tid} (not blocked/scheduled?)")
 
 
+def _cmd_reopen(args: argparse.Namespace) -> int:
+    ids, rc = _require_ids(args)
+    if rc:
+        return rc
+    reason = _stripped_or_none(getattr(args, "reason", None))
+    landing = getattr(args, "landing", "ready") or "ready"
+    kind = getattr(args, "kind", None)
+    author = _profile_author() if reason else None
+    suffix = f": {reason}" if reason else ""
+    with kbc.connect_closing() as conn:
+        op = _commented(conn, reason, author, "REOPENED", lambda tid: kb.reopen_task(
+            conn, tid, reason=reason, landing=landing, kind=kind, author=author or "operator",
+        ))
+        def ok_msg(tid):
+            landed = kb.get_task(conn, tid)
+            where = landed.status if landed else landing
+            return f"Reopened {tid} -> {where}{suffix}"
+        return _bulk_apply(ids, op, ok_msg,
+                           lambda tid: f"cannot reopen {tid} (not done? landing={landing}?)")
+
+
 def _cmd_request_review(args: argparse.Namespace) -> int:
     tid = args.task_id
     summary = _stripped_or_none(getattr(args, "summary", None))
@@ -1227,6 +1248,7 @@ _HANDLERS = {
     "attachments": _cmd_attachments, "attach-rm": _cmd_attach_rm,
     "complete": _cmd_complete, "edit": _cmd_edit, "block": _cmd_block,
     "schedule": _cmd_schedule, "unblock": _cmd_unblock,
+    "reopen": _cmd_reopen,
     "request-review": _cmd_request_review, "request-changes": _cmd_request_changes,
     "reopen-review": _cmd_reopen_review, "promote": _cmd_promote,
     "archive": _cmd_archive, "tail": _cmd_tail, "dispatch": _cmd_dispatch,
@@ -1254,6 +1276,7 @@ Common subcommands:
   `complete <id>…`      Mark task(s) done
   `request-review <id>` Enter first-class review; `request-changes <id> <reason>` returns an active review to its implementer
   `block <id> [reason]` Mark blocked; `schedule <id> [reason]` parks time-delay work; `unblock <id>` to revive
+  `reopen <id> [--landing ready|todo|blocked] [reason]` Undo a completion (verify-gate veto / wrongly closed)
   `assign <id> <profile>`  Reassign
   `boards list`         Show all boards
   `assignees`           Known profiles + counts

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3429,6 +3429,134 @@ def invalidate_descendants_for_parent_reopen(
     return {"invalidated": invalidated, "terminations": terminations}
 
 
+_REOPEN_LANDINGS = {"blocked", "todo", "ready"}
+
+
+def reopen_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reason: Optional[str] = None,
+    landing: str = "ready",
+    kind: Optional[str] = None,
+    author: str = "operator",
+) -> bool:
+    """Reopen a completed task: ``done`` -> ``landing`` (``blocked``/``todo``/``ready``).
+
+    The single domain implementation for undoing a completion. ``complete_task``
+    commits before any observer can react (kanban hooks are observer-only), so
+    nothing else in the public API can take a done card backward; verify/scratch
+    gates, operator "wrongly closed" corrections, and future dashboard reopen
+    surfaces all route here instead of hand-rolling raw SQL.
+
+    All changes commit in one write txn:
+
+    * Source must be ``done`` (idempotent CAS — rowcount 1 or no-op False). An
+      ``archived`` card is deliberately excluded: un-archiving is a board move,
+      not a completion undo.
+    * ``completed_at`` and ``result`` are cleared: the card no longer claims to
+      have completed.
+    * ``landing='ready'`` is parent-gated via ``_landing_status_after_parents``
+      and falls back to ``todo`` when a parent is still open, so the dispatcher
+      never spawns a child whose upstream is unfinished.
+    * ``landing='blocked'`` records a sticky ``blocked`` event (newest
+      blocked/unblocked event wins) so ``recompute_ready`` cannot auto-promote
+      it back into the pool; ``kind`` (default ``needs_input``) seeds a fresh
+      block-loop recurrence just like :func:`block_task`. The blocked event also
+      feeds watcher notify subscriptions.
+    * ``landing='todo'``/``'ready'`` record a ``status`` event with the reason.
+    * Descendants that were promoted or completed on the strength of this card's
+      result are invalidated through
+      :func:`invalidate_descendants_for_parent_reopen` (demoted to ``todo``,
+      comments naming the ancestor); any running descendants are terminated
+      strictly post-commit.
+    * ``consecutive_failures`` resets and ``block_kind``/``block_recurrences``
+      clear — a deliberate reopen is a fresh start (mirrors unblock).
+
+    Fires ``kanban_task_blocked`` post-commit when ``landing='blocked'`` so
+    observers see the veto exactly like a :func:`block_task` block.
+    """
+    if landing not in _REOPEN_LANDINGS:
+        raise ValueError(f"landing must be one of {sorted(_REOPEN_LANDINGS)}")
+    if kind is not None and kind not in VALID_BLOCK_KINDS:
+        raise ValueError(f"kind must be one of {sorted(VALID_BLOCK_KINDS)} or None")
+    now = int(time.time())
+    effective_kind = kind if landing == "blocked" else None
+    if landing == "blocked" and effective_kind is None:
+        effective_kind = "needs_input"
+    terminations: list[tuple[Optional[int], Optional[str]]] = []
+    with write_txn(conn):
+        prev = conn.execute(
+            "SELECT status, completed_at, result, block_kind, block_recurrences, "
+            "consecutive_failures, assignee FROM tasks WHERE id = ?", (task_id,),
+        ).fetchone()
+        if prev is None or prev["status"] != "done":
+            return False
+        # Never put a card back into the pool while a parent is still open.
+        target = _landing_status_after_parents(conn, task_id)
+        new_status = landing
+        if landing == "ready":
+            new_status = "ready" if target == "ready" else "todo"
+        # Status columns, completion evidence, and the retry/loop breakers all
+        # reset: a reopen is a deliberate operator/veto action.
+        cur = conn.execute(
+            """
+            UPDATE tasks
+               SET status             = ?,
+                   completed_at       = NULL,
+                   result             = NULL,
+                   block_kind         = NULL,
+                   block_recurrences  = 0,
+                   consecutive_failures = 0,
+                   claim_lock         = NULL,
+                   claim_expires      = NULL,
+                   worker_pid         = NULL
+             WHERE id = ?
+               AND status = 'done'
+            """,
+            (new_status, task_id),
+        )
+        if cur.rowcount != 1:
+            return False
+        if new_status == "blocked":
+            # Sticky + notify + block-loop bookkeeping, mirroring
+            # block_task/_route_block for a needs_input-style veto.
+            conn.execute(
+                "UPDATE tasks SET block_kind = ?, block_recurrences = 1 WHERE id = ?",
+                (effective_kind, task_id),
+            )
+            conn.execute(
+                "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
+                "VALUES (?, NULL, 'blocked', ?, ?)",
+                (task_id, _json_or_null(
+                    {"reason": reason, "kind": effective_kind, "recurrences": 1,
+                     "source_status": "done"}),
+                 now),
+            )
+        else:
+            conn.execute(
+                "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
+                "VALUES (?, NULL, 'status', ?, ?)",
+                (task_id, _json_or_null(
+                    {"status": new_status, "reason": reason,
+                     "requested_status": landing, "source_status": "done"}),
+                 now),
+            )
+        # Retract everything that assumed this card's completion.
+        result = invalidate_descendants_for_parent_reopen(
+            conn, task_id, author=author,
+        )
+        terminations.extend(result["terminations"])
+    for pid, claim_lock in terminations:
+        _terminate_reclaimed_worker(pid, claim_lock)
+    if new_status == "blocked":
+        _done_task = get_task(conn, task_id)
+        _fire_task_hook(
+            "kanban_task_blocked", _done_task, task_id, None, reason=reason,
+        )
+    return True
+
+
 def specify_triage_task(
     conn: sqlite3.Connection, task_id: str, *, title: Optional[str] = None,
     body: Optional[str] = None, assignee: Optional[str] = None, author: Optional[str] = None,

--- a/hermes_cli/kanban_parser.py
+++ b/hermes_cli/kanban_parser.py
@@ -307,6 +307,16 @@ _SPECS = [
         _reason("Optional reason/note — recorded as a comment before unblocking. Quote multi-word reasons."),
         _TASK_IDS,
     ], help="Return blocked/scheduled tasks to ready, or todo while parents remain open"),
+    _cmd("reopen", [
+        _TASK_IDS,
+        _reason("Optional reason/note — recorded as a comment before reopening. Quote multi-word reasons."),
+        _arg("--landing", choices=sorted(kb._REOPEN_LANDINGS), default="ready",
+             help="Where the reopened task lands: 'blocked' (verify/scratch-gate veto — waits for an "
+                  "operator, sticky to the dispatcher), 'todo' (re-queued behind dependencies), or "
+                  "'ready' (back in the pool now; default)."),
+        _arg("--kind", choices=sorted(kb.VALID_BLOCK_KINDS),
+             help="Typed block kind when --landing blocked (default: needs_input). Ignored otherwise."),
+    ], help="Undo a completion: reopen a done task (done -> blocked/todo/ready)"),
     _cmd("request-review", [
         _TASK_ID,
         _arg("--summary", help="What was implemented and how it was verified — shown to the reviewer."),

--- a/tests/hermes_cli/test_kanban_reopen_task.py
+++ b/tests/hermes_cli/test_kanban_reopen_task.py
@@ -1,0 +1,232 @@
+"""Tests for ``kanban_db.reopen_task`` — the done -> blocked/todo/ready undo primitive.
+
+``complete_task`` commits before any observer can react (kanban hooks are
+observer-only; ``block_task``/``request_review`` only transition running/ready),
+so a completed card cannot be taken backward through the public API. These
+tests pin the domain implementation that fills the gap (M-reopen):
+
+* a done card reopens to ``blocked``/``todo``/``ready`` in one txn,
+* ``completed_at`` and ``result`` are cleared — the card no longer claims done,
+* ``landing='blocked'`` is STICKY (newest blocked/unblocked event is blocked)
+  so ``recompute_ready`` never auto-promotes the veto back into the pool,
+* descendants promoted/completed on the card's result are invalidated
+  (demoted to ``todo`` with an ancestor-naming comment), running descendants
+  terminate strictly post-commit (audit trail first),
+* ``consecutive_failures`` resets (deliberate operator/veto action), and
+* non-done sources are refused (idempotent CAS); invalid landings/kinds raise.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban_db_dispatch as kbd
+
+
+@pytest.fixture
+def conn(tmp_path: Path):
+    db = kbc.connect(tmp_path / "kanban.db")
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _done_parent_with_done_child(conn, *, parent_title="ancestor"):
+    parent_id = kb.create_task(conn, title=parent_title, assignee="planner")
+    assert kb.complete_task(conn, parent_id)
+    child_id = kb.create_task(
+        conn, title="child", assignee="builder", parents=[parent_id],
+    )
+    assert kb.complete_task(conn, child_id)
+    return parent_id, child_id
+
+
+def _blocked_events(conn, task_id):
+    return [
+        e for e in kb.list_events(conn, task_id)
+        if e.kind in ("blocked", "unblocked")
+    ]
+
+
+def _status_events(conn, task_id):
+    return [e for e in kb.list_events(conn, task_id) if e.kind == "status"]
+
+
+def test_veto_landing_blocked_is_sticky_and_clears_completion(conn):
+    parent_id, child_id = _done_parent_with_done_child(conn)
+
+    assert kb.reopen_task(
+        conn, parent_id, reason="verify-gate: tests failed",
+        landing="blocked", kind="needs_input", author="verify-gate",
+    ) is True
+
+    task = kb.get_task(conn, parent_id)
+    assert task is not None and task.status == "blocked"
+    assert task.completed_at is None
+    assert task.result is None
+    assert task.block_kind == "needs_input"
+    assert task.block_recurrences == 1
+    assert task.consecutive_failures == 0
+
+    # Sticky: newest blocked/unblocked event is 'blocked', so recompute_ready
+    # must NOT promote the veto back into the pool.
+    events = _blocked_events(conn, parent_id)
+    assert events and events[-1].kind == "blocked"
+    payload = events[-1].payload or {}
+    assert payload.get("reason") == "verify-gate: tests failed"
+    assert payload.get("kind") == "needs_input"
+    assert payload.get("source_status") == "done"
+    kb.recompute_ready(conn)
+    assert kb.get_task(conn, parent_id).status == "blocked"
+
+    # The child that completed on this card's result is retracted.
+    child = kb.get_task(conn, child_id)
+    assert child is not None and child.status == "todo"
+    assert child.completed_at is None
+
+
+def test_reopen_ready_returns_to_pool_with_status_event(conn):
+    parent_id, _child_id = _done_parent_with_done_child(conn)
+
+    assert kb.reopen_task(
+        conn, parent_id, reason="wrongly closed; redo", landing="ready",
+        author="operator",
+    ) is True
+
+    task = kb.get_task(conn, parent_id)
+    assert task is not None and task.status == "ready"
+    assert task.completed_at is None
+    assert task.result is None
+    assert task.block_kind is None
+
+    st = _status_events(conn, parent_id)
+    assert st and st[-1].kind == "status"
+    payload = st[-1].payload or {}
+    assert payload.get("status") == "ready"
+    assert payload.get("requested_status") == "ready"
+    assert payload.get("source_status") == "done"
+    assert payload.get("reason") == "wrongly closed; redo"
+
+
+def test_reopen_landing_todo(conn):
+    task_id = kb.create_task(conn, title="leaf", assignee="builder")
+    assert kb.complete_task(conn, task_id)
+
+    assert kb.reopen_task(conn, task_id, landing="todo") is True
+    task = kb.get_task(conn, task_id)
+    assert task is not None and task.status == "todo"
+    # A dependency-free reopened card is promoted by the next recompute.
+    assert kb.recompute_ready(conn) == 1
+    assert kb.get_task(conn, task_id).status == "ready"
+
+
+def test_reopen_refuses_non_done_and_unknown(conn):
+    ready_id = kb.create_task(conn, title="not done", assignee="builder")
+    assert kb.reopen_task(conn, ready_id, landing="blocked") is False
+    assert kb.get_task(conn, ready_id).status == "ready"
+
+    assert kb.reopen_task(conn, "t_no_such_task", landing="blocked") is False
+
+    done_id = kb.create_task(conn, title="done once", assignee="builder")
+    assert kb.complete_task(conn, done_id)
+    assert kb.reopen_task(conn, done_id, landing="blocked") is True
+    # Idempotent CAS: a second veto is a no-op, not an error.
+    assert kb.reopen_task(conn, done_id, landing="blocked") is False
+
+
+def test_reopen_clears_prior_failure_counter(conn):
+    task_id = kb.create_task(conn, title="flaky card", assignee="builder")
+    assert kb.complete_task(conn, task_id)
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET consecutive_failures = 4 WHERE id = ?", (task_id,),
+        )
+
+    assert kb.reopen_task(conn, task_id, landing="ready") is True
+    assert kb.get_task(conn, task_id).consecutive_failures == 0
+
+
+def test_running_descendant_event_precedes_termination(tmp_path, monkeypatch):
+    db = kbc.connect(tmp_path / "kanban.db")
+    try:
+        parent_id = kb.create_task(conn=db, title="ancestor", assignee="planner")
+        assert kb.complete_task(db, parent_id)
+        child_id = kb.create_task(
+            db, title="running child", assignee="builder", parents=[parent_id],
+        )
+        claimed = kb.claim_task(db, child_id)
+        assert claimed is not None and claimed.status == "running"
+        kbd._set_worker_pid(db, child_id, 424242)
+
+        kills: list[tuple] = []
+
+        def fake_terminate(pid, claim_lock, **kwargs):
+            # The audit trail must already be durable when the kill fires:
+            # standalone calls commit before terminating.
+            side = kbc.connect(tmp_path / "kanban.db")
+            try:
+                kinds = [e.kind for e in kb.list_events(side, child_id)]
+            finally:
+                side.close()
+            assert "descendant_invalidated" in kinds
+            kills.append((pid, claim_lock))
+            return {"terminated": True}
+
+        monkeypatch.setattr(kb, "_terminate_reclaimed_worker", fake_terminate)
+
+        assert kb.reopen_task(
+            db, parent_id, reason="veto", landing="blocked", author="verify-gate",
+        ) is True
+
+        assert kills and kills[0][0] == 424242
+        child = kb.get_task(db, child_id)
+        assert child is not None
+        assert child.status == "todo"
+        assert child.current_run_id is None
+        run = kb.latest_run(db, child_id)
+        assert run is not None and run.outcome == "reclaimed"
+    finally:
+        db.close()
+
+
+def test_reopen_invalid_arguments_raise(conn):
+    task_id = kb.create_task(conn, title="any", assignee="builder")
+    assert kb.complete_task(conn, task_id)
+    with pytest.raises(ValueError):
+        kb.reopen_task(conn, task_id, landing="archived")
+    with pytest.raises(ValueError):
+        kb.reopen_task(conn, task_id, landing="blocked", kind="not-a-kind")
+    # Failed validation must not mutate the task.
+    assert kb.get_task(conn, task_id).status == "done"
+
+
+def test_reopen_fires_blocked_lifecycle_hook_when_landing_blocked(conn, monkeypatch):
+    fired: list[tuple] = []
+
+    def fake_fire_hook(event, task, task_id, run_id, **fields):
+        fired.append((event, task_id, run_id, fields))
+
+    monkeypatch.setattr(kb, "_fire_task_hook", fake_fire_hook)
+
+    task_id = kb.create_task(conn, title="gate card", assignee="builder")
+    assert kb.complete_task(conn, task_id)
+    assert kb.reopen_task(
+        conn, task_id, reason="veto", landing="blocked", author="verify-gate",
+    ) is True
+    assert any(
+        ev == "kanban_task_blocked" and tid == task_id and rid is None
+        for ev, tid, rid, _f in fired
+    ), fired
+
+    # Non-blocked landings fire no blocked lifecycle hook (they are not blocks);
+    # the completion hook from complete_task is unrelated.
+    fired.clear()
+    task2 = kb.create_task(conn, title="redo card", assignee="builder")
+    assert kb.complete_task(conn, task2)
+    assert kb.reopen_task(conn, task2, landing="ready") is True
+    assert [x for x in fired if x[0] == "kanban_task_blocked"] == []


### PR DESCRIPTION
## Summary

Adds a single domain primitive — `kanban_db.reopen_task()` — for undoing a completion (`done` -> `blocked`/`todo`/`ready`), plus a `kanban reopen` CLI verb.

**Why this gap exists:** `complete_task` commits before any observer can react (kanban lifecycle hooks are observer-only), and `block_task`/`request_review` only transition `running`/`ready`. There is currently **no public API that takes a done card backward**. External verify/scratch gates and operators working around it must hand-roll raw SQL (the dashboard plugin already does exactly that in `_set_status_direct`, without block bookkeeping or completion-evidence clearing).

## Semantics (one write txn)

- CAS-guards on `status = 'done'` — idempotent, and `archived` is deliberately excluded (un-archiving is a board move, not a completion undo).
- Clears `completed_at`/`result`, resets `consecutive_failures`, `block_kind`, `block_recurrences` — a reopen is a deliberate operator/veto action.
- `landing='blocked'` (the gate-veto case): writes a **sticky** `blocked` event (newest blocked/unblocked event wins) so `recompute_ready` never auto-promotes the veto back into the pool; `kind` bookkeeping mirrors `block_task`; fires `kanban_task_blocked` post-commit so observers see the veto exactly like a normal block.
- `landing='ready'` is parent-gated via `_landing_status_after_parents` and falls back to `todo`.
- Invalidates descendants that were promoted or completed on the strength of this card's result via `invalidate_descendants_for_parent_reopen` — running descendants terminate strictly post-commit with the audit trail durable first.

## CLI

`kanban reopen <id>… [--landing ready|todo|blocked] [--kind ...] [reason]` — defaults to `ready` (back in the pool); `--landing blocked` is the explicit veto shape used by gates.

## Tests

`tests/hermes_cli/test_kanban_reopen_task.py` (9 tests) pins: sticky blocked veto that survives `recompute_ready`, completion-evidence clearing, status-event payloads for todo/ready, idempotent refusal of non-done sources, failure-counter reset, post-commit running-descendant termination with durable audit trail, invalid-argument validation, and the blocked lifecycle-hook fire. Full run: `test_kanban_reopen_task.py` + `test_kanban_parent_reopen_invalidation.py` + `test_kanban_blocked_sticky.py` = 14 passed; broader kanban CLI/lifecycle/core suites = 65 passed, 1 skipped.

## Follow-ups (not in this PR)

- Route the dashboard plugin's `_set_status_direct` reopen path through `reopen_task()` so all reopen surfaces share one implementation (would also fix its missing `completed_at`/`result` clearing on done->todo drags).
- Verify/scratch gate plugins switch from their raw-flip stopgap to this primitive once merged.

## Attribution

Authored for the NousResearch/hermes-agent upstream. Relates to the Sep-2026 decomposition follow-up of keeping kanban lifecycle verbs typed and transactional.
