### PR TITLE
fix(agent): annotate naive Beijing-time 'reset at' timestamps with local time

### DIFF
--- a/agent/api_error_summary.py
+++ b/agent/api_error_summary.py
@@ -6,6 +6,7 @@ Extracted from ``run_agent.py``; every method resolves through ``AIAgent``'s MRO
 """
 import json
 import re
+from datetime import datetime
 from typing import Any, Dict, Optional
 
 from agent.redact import redact_sensitive_text
@@ -28,6 +29,23 @@ _XAI_ENTITLEMENT_HINT = (
     "which, or run `/model` to switch providers."
 )
 _ERROR_DETAIL_KEYS = ("message", "detail", "error", "code", "type")
+
+# Z.AI / Zhipu quota walls return a 429 body phrased "Usage limit reached for
+# 5 hour. Your limit will reset at 2026-09-04 19:01:25" — the timestamp is a
+# *naive* Beijing-time (UTC+8) value with no zone marker. Rendering it verbatim
+# misleads users in other zones by the offset (6h for Europe/Warsaw in summer).
+_RESET_AT_PATTERN = re.compile(
+    r"reset at (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})", re.IGNORECASE
+)
+# Z.AI's quota window is ~5h, so a genuine Beijing interpretation of the
+# timestamp lands minutes-to-hours ahead of now. The window is deliberately
+# generous (up to 6h) to absorb clock drift, and one-sided (strictly future):
+# if the provider ever switches to UTC or already-local timestamps, the
+# Beijing interpretation falls outside the window and the text passes through
+# unchanged — no wrong annotation is ever added.
+_RESET_AT_SANITY_WINDOW_SECONDS = 6 * 3600
+# Must match the annotation text emitted below — checked for idempotence.
+_ANNOTATION_MARKER = "Beijing time, UTC+8; local:"
 
 
 def _is_xai_entitlement_text(lower: str) -> bool:
@@ -123,6 +141,54 @@ class ApiErrorSummaryMixin:
         return str(value)
 
     @staticmethod
+    def _annotate_naive_beijing_reset_timestamp(text: str) -> str:
+        """Append a local-time conversion to naive Beijing reset timestamps.
+
+        Z.AI / Zhipu usage-limit 429 bodies say "Your limit will reset at
+        2026-09-04 19:01:25" — a naive Beijing-time (UTC+8) timestamp with no
+        zone marker. Shown verbatim to a user in another timezone it misleads
+        by the zone offset (6h for Europe/Warsaw in summer). This annotates
+        the timestamp with the user's local equivalent.
+
+        Guarded by a one-sided sanity window: the annotation is added only
+        when interpreting the timestamp as Beijing time lands strictly in the
+        future and within ``_RESET_AT_SANITY_WINDOW_SECONDS``. If the provider
+        ever switches to UTC or already-local timestamps, the Beijing reading
+        falls outside the window and the text passes through unchanged — the
+        guard makes a wrong annotation impossible rather than merely unlikely.
+        Idempotent: already-annotated text is returned as-is.
+        """
+        if _ANNOTATION_MARKER in text:
+            return text
+        m = _RESET_AT_PATTERN.search(text)
+        if not m:
+            return text
+        try:
+            from zoneinfo import ZoneInfo
+
+            naive = datetime.strptime(m.group(1), "%Y-%m-%d %H:%M:%S")
+            try:
+                from hermes_time import get_timezone
+
+                local_tz = get_timezone() or datetime.now().astimezone().tzinfo
+            except Exception:
+                local_tz = datetime.now().astimezone().tzinfo
+            if local_tz is None:
+                return text
+            now_local = datetime.now(local_tz)
+            local = naive.replace(tzinfo=ZoneInfo("Asia/Shanghai")).astimezone(local_tz)
+            if not 0 < (local - now_local).total_seconds() <= _RESET_AT_SANITY_WINDOW_SECONDS:
+                return text
+            return text.replace(
+                m.group(0),
+                f"{m.group(0)} (Beijing time, UTC+8; local: "
+                f"{local.strftime('%Y-%m-%d %H:%M:%S')})",
+                1,
+            )
+        except Exception:
+            return text
+
+    @staticmethod
     def _summarize_api_error(error: Exception) -> str:
         """Extract a human-readable one-liner from an API error.
 
@@ -167,6 +233,7 @@ class ApiErrorSummaryMixin:
             msg = body.get("error", {}).get("message") if isinstance(body.get("error"), dict) else body.get("message")
             if msg:
                 msg = ApiErrorSummaryMixin._coerce_api_error_detail(msg)
+                msg = ApiErrorSummaryMixin._annotate_naive_beijing_reset_timestamp(msg)
                 return ApiErrorSummaryMixin._decorate_xai_entitlement_error(f"{prefix}{msg[:300]}")
 
         # SDK may leave body empty while httpx has the payload. Redact: the body is attacker-influenced
@@ -188,9 +255,15 @@ class ApiErrorSummaryMixin:
                 if isinstance(payload, dict):
                     err = payload.get("error")
                     if isinstance(err, dict) and err.get("message"):
-                        return redact_sensitive_text(f"{prefix}{str(err['message'])[:300]}")
+                        _msg = ApiErrorSummaryMixin._annotate_naive_beijing_reset_timestamp(
+                            str(err["message"])
+                        )
+                        return redact_sensitive_text(f"{prefix}{_msg[:300]}")
                     if payload.get("message"):
-                        return redact_sensitive_text(f"{prefix}{str(payload['message'])[:300]}")
+                        _msg = ApiErrorSummaryMixin._annotate_naive_beijing_reset_timestamp(
+                            str(payload["message"])
+                        )
+                        return redact_sensitive_text(f"{prefix}{_msg[:300]}")
                 return redact_sensitive_text(f"{prefix}{snippet[:300]}")
 
         # Fallback: truncate the raw string but give more room than 200 chars

--- a/tests/agent/test_annotate_beijing_reset_timestamps.py
+++ b/tests/agent/test_annotate_beijing_reset_timestamps.py
@@ -1,0 +1,121 @@
+"""Annotate naive Beijing-time "reset at" timestamps in provider error summaries.
+
+Z.AI / Zhipu usage-limit 429 bodies phrase the quota reset as "Your limit will
+reset at 2026-09-04 19:01:25" — a *naive* Beijing-time (UTC+8) timestamp with no
+zone marker. Rendered verbatim to a user in another timezone it misleads by the
+zone offset (6h for Europe/Warsaw in summer). These tests lock the contract:
+
+* when the Beijing interpretation lands in the sanity window (strictly future,
+  ≤ 6h ahead), the timestamp gains "(Beijing time, UTC+8; local: …)";
+* outside the window (a UTC or already-local timestamp would land there), the
+  text passes through unchanged — the guard makes a wrong annotation
+  impossible, so a provider switch to UTC/local silently disables the feature;
+* no "reset at" phrase, no annotation;
+* already-annotated text is never annotated twice (idempotence);
+* the annotation survives the JSON-body and httpx-fallback summary paths, not
+  just the direct-message path.
+
+Timestamps are computed relative to ``datetime.now()`` so the tests never go
+stale (behavior contracts, not frozen snapshots).
+"""
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from zoneinfo import ZoneInfo
+
+from run_agent import AIAgent
+
+_BEIJING = ZoneInfo("Asia/Shanghai")
+
+
+def _beijing_ts_ahead(hours: float) -> str:
+    """A naive Beijing-time timestamp ``hours`` ahead of now, as Z.AI sends it."""
+    ts = datetime.now(_BEIJING) + timedelta(hours=hours)
+    return ts.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _zai_body(hours: float) -> str:
+    return (
+        "Usage limit reached for 5 hour. "
+        f"Your limit will reset at {_beijing_ts_ahead(hours)}"
+    )
+
+
+def test_reset_timestamp_in_window_is_annotated_with_local_time():
+    text = _zai_body(2)
+
+    result = AIAgent._annotate_naive_beijing_reset_timestamp(text)
+
+    assert "(Beijing time, UTC+8; local:" in result
+    # The original verbatim timestamp is preserved (annotation is additive).
+    assert "reset at 20" in result or "reset at 1" in result or "reset at 0" in result
+
+
+def test_reset_timestamp_outside_window_passes_through_unchanged():
+    # A UTC or already-local timestamp interprets as ~6-8h AHEAD when read as
+    # Beijing (outside the 6h window) or BEHIND now — both must pass through.
+    for hours in (-2, 8):
+        text = _zai_body(hours)
+
+        assert AIAgent._annotate_naive_beijing_reset_timestamp(text) == text
+
+
+def test_no_reset_at_phrase_is_untouched():
+    text = "Usage limit reached for 5 hour. Try again later."
+
+    assert AIAgent._annotate_naive_beijing_reset_timestamp(text) == text
+
+
+def test_already_annotated_text_is_idempotent():
+    text = AIAgent._annotate_naive_beijing_reset_timestamp(_zai_body(2))
+    assert "(Beijing time, UTC+8; local:" in text  # sanity: first pass annotated
+
+    assert AIAgent._annotate_naive_beijing_reset_timestamp(text) == text
+
+
+def test_local_conversion_is_arithmetically_correct(monkeypatch):
+    # Pin the zone the method resolves: the annotated local time must be the
+    # SAME instant as the Beijing timestamp, expressed in the pinned zone —
+    # regardless of the machine's container zone.
+    import hermes_time
+
+    warsaw = ZoneInfo("Europe/Warsaw")
+    monkeypatch.setattr(hermes_time, "get_timezone", lambda: warsaw)
+
+    ts = datetime.now(_BEIJING) + timedelta(hours=2)
+    text = (
+        "Usage limit reached for 5 hour. "
+        f"Your limit will reset at {ts.strftime('%Y-%m-%d %H:%M:%S')}"
+    )
+    result = AIAgent._annotate_naive_beijing_reset_timestamp(text)
+
+    local_str = result.split("local: ")[-1].rstrip(")")
+    annotated_local = datetime.strptime(local_str, "%Y-%m-%d %H:%M:%S").replace(
+        tzinfo=warsaw
+    )
+    expected = ts.astimezone(warsaw)
+    assert abs((annotated_local - expected).total_seconds()) < 5  # same instant
+
+
+def test_json_body_error_message_is_annotated():
+    err = Exception("")
+    err.status_code = 429
+    err.body = {"error": {"message": _zai_body(1), "type": "rate_limit_exceeded"}}
+
+    summary = AIAgent._summarize_api_error(err)
+
+    assert "HTTP 429" in summary
+    assert "(Beijing time, UTC+8; local:" in summary
+
+
+def test_httpx_fallback_payload_is_annotated():
+    payload = '{"error": {"message": "%s"}}' % _zai_body(1)
+    err = Exception("")
+    err.status_code = 429
+    err.body = {}  # empty — forces the httpx response.text fallback (#36109 path)
+    err.response = SimpleNamespace(text=payload)
+
+    summary = AIAgent._summarize_api_error(err)
+
+    assert "HTTP 429" in summary
+    assert "(Beijing time, UTC+8; local:" in summary


### PR DESCRIPTION
## What does this PR do?

Z.AI / Zhipu usage-limit 429 bodies phrase the quota reset as:

> Usage limit reached for 5 hour. Your limit will reset at 2026-09-04 19:01:25

That timestamp is a **naive Beijing-time (UTC+8) value with no zone marker**. Rendered verbatim to a user in another timezone it misleads by the full zone offset — 6h for Europe/Warsaw in summer: the user reads a reset time six hours later than reality and waits half a day for nothing.

This annotates the timestamp with the user's local equivalent on **all three provider-message summary paths** in `_summarize_api_error` (SDK `body.error.message`, and the httpx `response.text` fallback for both structured payload shapes — the #36109 path):

> Your limit will reset at 2026-09-04 19:01:25 (Beijing time, UTC+8; local: 2026-09-04 13:01:25)

## Why this approach

- **The guard makes a wrong annotation impossible, not merely unlikely.** The annotation fires only when interpreting the timestamp as Beijing time lands strictly in the future and within 6h (Z.AI's quota window is ~5h). If the provider ever switches to UTC or already-local timestamps, the Beijing reading falls outside the one-sided window and the text passes through unchanged — the feature silently disables itself instead of lying.
- **Idempotent** via a marker check — an already-annotated message is never annotated twice (the summary can pass through multiple call sites).
- **Never raises**: any failure in zone resolution/parsing returns the original text; this only ever *adds* information on an error-display path.
- **Local zone resolves through `hermes_time.get_timezone()`** (the configured user timezone) with a system-local fallback — consistent with the cron/session timezone work.
- Output is still redacted downstream as before; annotation happens before redaction/truncation on each path.

## Related Issue

Related to #103181 and #103038 — those fix the *classification* of these Z.AI 429s ("will reset at" must be a transient rate limit, not non-retryable billing). This PR fixes the *display*: once the session survives the 429, the message the user finally sees must not carry a misleading wall-clock time.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes a bug)

## Changes Made

- `agent/api_error_summary.py`: new `ApiErrorSummaryMixin._annotate_naive_beijing_reset_timestamp()` (module-level compiled regex + sanity-window constants), hooked into the three message-returning paths of `_summarize_api_error`.
- `tests/agent/test_annotate_beijing_reset_timestamps.py`: 8 behavior-contract tests (annotation in window; pass-through outside window for both UTC-like and past timestamps; no-phrase untouched; idempotence; arithmetic correctness of the zone conversion against a pinned zone; annotation present on the SDK-body and httpx-fallback summary paths).

## How to Test

1. `.venv/bin/python -m pytest tests/agent/test_annotate_beijing_reset_timestamps.py tests/run_agent/test_summarize_api_error.py -q` → 16 passed (8 new + 8 existing unchanged).
2. Full `tests/agent/` + `tests/run_agent/` sweep (43 min): 8313 passed / 76 failed / 35 skipped. A/B attribution: re-running failing files on a clean `origin/main` worktree reproduces the same failures (e.g. `test_auxiliary_client.py` fails 6/6 identically on both trees; `test_turn_liveness_watchdog.py` is green in isolation on both) — they are environmental to this local container venv (exact-pinned deps resolved for linux-aarch64, no CI credentials), not regressions from this change. CI remains the authoritative full-suite gate; the touched surface (`api_error_summary`) and its sibling summary-path tests are green locally.
3. Manual: with `timezone: Europe/Warsaw`, a synthetic Z.AI-shaped 429 whose Beijing reset lands ~2h ahead summarizes to `... reset at 2026-09-05 08:13:09 (Beijing time, UTC+8; local: 2026-09-05 02:13:09)`; the same body with a UTC-style timestamp (8h ahead as Beijing) passes through unannotated.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (closest: #94765 — timezone-aware *session_search* timestamps, different surface; no existing PR touches provider-error timestamp zones)
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant `pytest` suites and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Docker, aarch64)

### Documentation & Housekeeping

- [x] Docstrings added for the new method and constants — or N/A
- [ ] N/A: no config keys, no architecture changes, no tool schema changes
- [x] Cross-platform: uses only stdlib `zoneinfo` (Python ≥3.9) and `datetime`; no new dependencies