### PR TITLE
fix(cron): tolerate epoch start-time drift in reaper

### DIFF
--- a/cron/executions.py
+++ b/cron/executions.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import sqlite3
+import sys
 import threading
 import time
 import uuid
@@ -26,6 +27,12 @@ EXECUTIONS_FILE: Optional[Path] = None
 MAX_TERMINAL_EXECUTIONS = 1000
 HANDOFF_ADOPTION_GRACE_SECONDS = 30.0
 _TERMINAL_STATES = ("completed", "failed", "unknown")
+# On macOS/Windows, psutil exposes process creation time as an epoch timestamp.
+# A wall-clock correction can shift a live process's re-read fingerprint slightly,
+# so dead-owner recovery treats a narrow near-match as live rather than rewrite a
+# durable execution record on uncertain evidence. Linux /proc start ticks remain
+# exact and retain the strongest PID-reuse guard.
+_EPOCH_START_TIME_DRIFT_TOLERANCE_CENTISECONDS = 200
 _lock = threading.RLock()
 _PROCESS_ID = uuid.uuid4().hex
 
@@ -158,7 +165,11 @@ def _owner_is_live(pid: int, started_at: Optional[int]) -> bool:
     if started_at is None:
         return pid == os.getpid()
     current = _process_start_time(pid)
-    return current is not None and current == started_at
+    if current is None:
+        return True  # fail safe: a live PID without a readable fingerprint is not dead
+    if sys.platform == "linux":
+        return current == started_at
+    return abs(current - started_at) <= _EPOCH_START_TIME_DRIFT_TOLERANCE_CENTISECONDS
 
 
 def _prune_unlocked(conn: sqlite3.Connection) -> None:

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -9,6 +9,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 
 def _point_ledger(monkeypatch, tmp_path):
     import cron.executions as executions
@@ -244,6 +246,80 @@ def test_recovery_does_not_mark_live_process_execution_unknown(monkeypatch, tmp_
 
     assert executions.recover_interrupted_executions() == 0
     assert executions.latest_execution("still-live")["status"] == "running"
+
+
+@pytest.mark.macos_only
+def test_recovery_keeps_live_owner_when_psutil_start_time_drifts_one_second(
+    monkeypatch, tmp_path
+):
+    """Wall-clock correction must not make a live macOS owner look recycled."""
+    executions = _point_ledger(monkeypatch, tmp_path)
+    record = executions.create_execution("clock-skew-live", source="builtin")
+    executions.mark_execution_running(record["id"])
+    recorded_start = record["process_started_at"]
+    assert isinstance(recorded_start, int)
+
+    # A second scheduler process sees this process as an external owner. macOS
+    # psutil create_time is epoch-derived and can shift by a second after NTP
+    # correction even though this PID is still alive.
+    with executions._transaction() as conn:
+        conn.execute(
+            "UPDATE executions SET process_id='other-scheduler' WHERE id=?",
+            (record["id"],),
+        )
+    monkeypatch.setattr(
+        executions, "_process_start_time", lambda _pid: recorded_start - 100
+    )
+
+    assert executions.recover_interrupted_executions() == 0
+    latest = executions.latest_execution("clock-skew-live")
+    assert latest is not None
+    assert latest["status"] == "running"
+
+
+def test_recovery_keeps_live_owner_when_start_fingerprint_is_unavailable(
+    monkeypatch, tmp_path
+):
+    """A transient process-inspection failure is not proof that a PID died."""
+    executions = _point_ledger(monkeypatch, tmp_path)
+    record = executions.create_execution("unreadable-live", source="builtin")
+    executions.mark_execution_running(record["id"])
+    with executions._transaction() as conn:
+        conn.execute(
+            "UPDATE executions SET process_id='other-scheduler' WHERE id=?",
+            (record["id"],),
+        )
+    monkeypatch.setattr(executions, "_process_start_time", lambda _pid: None)
+
+    assert executions.recover_interrupted_executions() == 0
+    latest = executions.latest_execution("unreadable-live")
+    assert latest is not None
+    assert latest["status"] == "running"
+
+
+def test_recovery_reaps_owner_when_start_identity_differs_outside_tolerance(
+    monkeypatch, tmp_path
+):
+    """The macOS tolerance must not erase the recycled-PID identity guard."""
+    executions = _point_ledger(monkeypatch, tmp_path)
+    record = executions.create_execution("recycled-pid", source="builtin")
+    executions.mark_execution_running(record["id"])
+    recorded_start = record["process_started_at"]
+    assert isinstance(recorded_start, int)
+
+    with executions._transaction() as conn:
+        conn.execute(
+            "UPDATE executions SET process_id='other-scheduler' WHERE id=?",
+            (record["id"],),
+        )
+    monkeypatch.setattr(
+        executions, "_process_start_time", lambda _pid: recorded_start + 1000
+    )
+
+    assert executions.recover_interrupted_executions() == 1
+    latest = executions.latest_execution("recycled-pid")
+    assert latest is not None
+    assert latest["status"] == "unknown"
 
 
 def test_restart_marks_interrupted_execution_unknown_without_requeue(tmp_path):


### PR DESCRIPTION
## Summary
- keep a live macOS/Windows execution owner from being reaped after a small epoch-based creation-time drift
- keep Linux process-tick matching exact and fail safe when a live PID fingerprint cannot be read
- cover drift, unreadable fingerprints, and recycled-PID boundaries

## Validation
- `HERMES_PYTHON=/Users/georgeteifel/.hermes/hermes-agent/.venv/bin/python scripts/run_tests.sh tests/cron/test_execution_ledger.py tests/cron/test_dead_owner_claim_reclaim.py`