### PR TITLE
fix(telegram): drop status-cache ids when the bubble is deleted

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -12,7 +12,7 @@ import re
 import time
 from contextvars import ContextVar
 from datetime import datetime, timezone
-from typing import Any, Awaitable, Callable, Dict, Iterator, List, Optional, Set
+from typing import Any, Awaitable, Callable, Dict, Iterator, List, Optional, Set, Union
 from hermes_cli import setup_platforms
 
 logger = logging.getLogger(__name__)
@@ -367,6 +367,33 @@ class _PollingLifecycleAbort(RuntimeError):
     """Internal control flow for polling startup fenced by teardown."""
 
 
+def telegram_chat_id_key(chat_id: Union[str, int]) -> str:
+    """Stable string key for a chat_id (for dict keys / persisted state)."""
+    return str(normalize_telegram_chat_id(chat_id))
+
+
+def _is_stale_telegram_edit_target(error: object) -> bool:
+    """True when this message_id cannot be edited or deleted again.
+
+    Covers gone ids (deleted / inaccessible) and Bot API permanent refusals
+    to mutate that id. Does not match ``message is not modified`` (success),
+    flood-control, or transient network errors.
+    """
+    text = str(error or "").lower().replace("’", "'")
+    if "not modified" in text:
+        return False
+    return (
+        "message to edit not found" in text
+        or "message to delete not found" in text
+        or "message can't be edited" in text
+        or "message cannot be edited" in text
+        or "message can't be deleted" in text
+        or "message cannot be deleted" in text
+        or "message_id_invalid" in text
+        or "message identifier is not specified" in text
+    )
+
+
 class TelegramAdapter(BasePlatformAdapter):
     """Telegram bot adapter: users/groups, MarkdownV2 replies, forum topics, media."""
 
@@ -528,6 +555,18 @@ class TelegramAdapter(BasePlatformAdapter):
         # Last truncated mid-stream preview per (chat_id, message_id): past the 4096 cap every edit
         # truncates to the SAME text, and resending burns flood budget. Dropped on finalize.
         self._last_overflow_preview: Dict[tuple, str] = {}
+
+    def _forget_status_message_id(self, chat_id: Union[str, int], message_id: str) -> None:
+        """Drop status-cache rows that point at a deleted/missing Telegram message."""
+        chat = telegram_chat_id_key(chat_id)
+        mid = str(message_id)
+        stale = [
+            key
+            for key, cached in self._status_message_ids.items()
+            if telegram_chat_id_key(key[0]) == chat and str(cached) == mid
+        ]
+        for key in stale:
+            self._status_message_ids.pop(key, None)
 
     @property
     def send_path_degraded(self) -> bool:
@@ -3403,7 +3442,7 @@ class TelegramAdapter(BasePlatformAdapter):
         append a fresh bubble on every call. With this method, the first call sends and the message id is
         remembered; subsequent calls with the same (chat_id, status_key) edit that same message in place.
         """
-        key = (str(chat_id), str(status_key))
+        key = (telegram_chat_id_key(chat_id), str(status_key))
         cached_id = self._status_message_ids.get(key)
         if cached_id is not None:
             result = await self.edit_message(chat_id, cached_id, content, finalize=True, metadata=metadata)
@@ -3432,6 +3471,9 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception as fmt_err:
             if "not modified" in str(fmt_err).lower():
                 return True
+            if _is_stale_telegram_edit_target(fmt_err):
+                self._forget_status_message_id(chat_id, message_id)
+                raise
             logger.warning(warn_fmt, self.name, _redact_telegram_error_text(fmt_err))
             await self._edit_text(chat_id, message_id, plain)
         return False
@@ -3542,6 +3584,10 @@ class TelegramAdapter(BasePlatformAdapter):
             if any(m in err_str for m in _transient_markers):
                 logger.warning("[%s] Transient network error editing message %s (will retry): %s", self.name, message_id, safe_error)
                 return SendResult(success=False, error=safe_error, retryable=True)
+            if _is_stale_telegram_edit_target(e):
+                self._forget_status_message_id(chat_id, message_id)
+                logger.debug("[%s] Edit target %s is gone; cache dropped: %s", self.name, message_id, safe_error)
+                return SendResult(success=False, error=safe_error)
             logger.error("[%s] Failed to edit Telegram message %s: %s", self.name, message_id, safe_error)
             return SendResult(success=False, error=safe_error)
 
@@ -3651,8 +3697,11 @@ class TelegramAdapter(BasePlatformAdapter):
             return False
         try:
             await self._bot.delete_message(chat_id=normalize_telegram_chat_id(chat_id), message_id=int(message_id))
+            self._forget_status_message_id(chat_id, message_id)
             return True
         except Exception as e:
+            if _is_stale_telegram_edit_target(e):
+                self._forget_status_message_id(chat_id, message_id)
             logger.debug("[%s] Failed to delete Telegram message %s: %s", self.name, message_id, _redact_telegram_error_text(e))
             return False
 

--- a/tests/gateway/test_telegram_status_update.py
+++ b/tests/gateway/test_telegram_status_update.py
@@ -105,4 +105,168 @@ async def test_distinct_status_keys_do_not_collide(adapter):
     assert adapter._status_message_ids[("chat-1", "lifecycle")] == "100"
     assert adapter._status_message_ids[("chat-1", "model-switch")] == "200"
 
+@pytest.mark.asyncio
+async def test_delete_message_drops_cached_status_id(adapter):
+    """cleanup_progress deletes the bubble; the status cache must not keep that id."""
+    adapter._status_message_ids[("chat-1", "lifecycle")] = "3202"
+    adapter._bot.delete_message = AsyncMock(return_value=True)
+
+    ok = await adapter.delete_message("chat-1", "3202")
+
+    assert ok is True
+    assert ("chat-1", "lifecycle") not in adapter._status_message_ids
+
+
+@pytest.mark.asyncio
+async def test_status_after_delete_sends_fresh_instead_of_editing_tombstone(adapter):
+    """Next status emit after cleanup must send, not edit the deleted id."""
+    adapter.send.side_effect = [
+        SendResult(success=True, message_id="3202"),
+        SendResult(success=True, message_id="3203"),
+    ]
+    adapter._bot.delete_message = AsyncMock(return_value=True)
+
+    first = await adapter.send_or_update_status("chat-1", "lifecycle", "starting")
+    assert first.message_id == "3202"
+    await adapter.delete_message("chat-1", "3202")
+
+    second = await adapter.send_or_update_status("chat-1", "lifecycle", "still working")
+
+    assert second.message_id == "3203"
+    adapter.edit_message.assert_not_awaited()
+    assert adapter.send.await_count == 2
+    assert adapter._status_message_ids[("chat-1", "lifecycle")] == "3203"
+
+
+@pytest.mark.asyncio
+async def test_finalize_missing_message_does_not_retry_plain_text(monkeypatch):
+    """A gone message is not a MarkdownV2 format failure (no second plain-text edit)."""
+    _install_fake_telegram(monkeypatch)
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
+    adapter._bot = MagicMock()
+    gone = Exception("Bad Request: message to edit not found")
+    adapter._bot.edit_message_text = AsyncMock(side_effect=gone)
+    adapter._status_message_ids[("123", "lifecycle")] = "456"
+
+    result = await adapter.edit_message("123", "456", "still working", finalize=True)
+
+    assert result.success is False
+    assert "not found" in (result.error or "").lower()
+    assert adapter._bot.edit_message_text.await_count == 1
+    assert ("123", "lifecycle") not in adapter._status_message_ids
+
+@pytest.mark.asyncio
+async def test_delete_invalidates_equivalent_chat_id_forms(adapter):
+    """Whitespace / int / str chat ids must share one status-cache key."""
+    adapter._bot.delete_message = AsyncMock(return_value=True)
+    adapter._status_message_ids[("-100123", "lifecycle")] = "100"
+    adapter._status_message_ids[("-100123", "other")] = "200"
+    adapter._status_message_ids[("chat-2", "lifecycle")] = "100"
+
+    deleted = await adapter.delete_message("  -100123  ", "100")
+
+    assert deleted is True
+    assert ("-100123", "lifecycle") not in adapter._status_message_ids
+    assert adapter._status_message_ids[("-100123", "other")] == "200"
+    assert adapter._status_message_ids[("chat-2", "lifecycle")] == "100"
+
+    adapter.send.return_value = SendResult(success=True, message_id="300")
+    result = await adapter.send_or_update_status(-100123, "lifecycle", "next status")
+
+    assert result.success is True
+    adapter.send.assert_awaited_once()
+    adapter.edit_message.assert_not_awaited()
+    assert adapter._status_message_ids[("-100123", "lifecycle")] == "300"
+
+@pytest.mark.parametrize(
+    "err",
+    [
+        "Bad Request: message to edit not found",
+        "Bad Request: message to delete not found",
+        "Bad Request: message can't be edited",
+        "Bad Request: message cannot be edited",
+        "Bad Request: message can’t be edited",
+        "Bad Request: message can't be deleted",
+        "Bad Request: MESSAGE_ID_INVALID",
+        "Bad Request: message identifier is not specified",
+    ],
+)
+def test_stale_target_classifier_matches_bot_api_refusals(monkeypatch, err):
+    _install_fake_telegram(monkeypatch)
+    from plugins.platforms.telegram.adapter import _is_stale_telegram_edit_target
+
+    assert _is_stale_telegram_edit_target(Exception(err)) is True
+
+
+@pytest.mark.parametrize(
+    "err",
+    [
+        "Bad Request: message is not modified",
+        "httpx.ConnectError: Connection refused",
+        "flood_control:30.0",
+        "Forbidden: bot was blocked by the user",
+        "Bad Request: not enough rights to edit the message",
+        "Method not found",
+        "Message thread not found",
+    ],
+)
+def test_stale_target_classifier_ignores_non_tombstone_errors(monkeypatch, err):
+    _install_fake_telegram(monkeypatch)
+    from plugins.platforms.telegram.adapter import _is_stale_telegram_edit_target
+
+    assert _is_stale_telegram_edit_target(Exception(err)) is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "err",
+    [
+        "Bad Request: message to edit not found",
+        "Bad Request: message can't be edited",
+        "Bad Request: MESSAGE_ID_INVALID",
+    ],
+)
+async def test_finalize_uneditable_target_does_not_retry_plain_text(monkeypatch, err):
+    """Gone or uneditable ids must not get a second plain-text edit."""
+    _install_fake_telegram(monkeypatch)
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
+    adapter._bot = MagicMock()
+    adapter._bot.edit_message_text = AsyncMock(side_effect=Exception(err))
+    adapter._status_message_ids[("123", "lifecycle")] = "456"
+
+    result = await adapter.edit_message("123", "456", "still working", finalize=True)
+
+    assert result.success is False
+    assert adapter._bot.edit_message_text.await_count == 1
+    assert ("123", "lifecycle") not in adapter._status_message_ids
+
+
+@pytest.mark.asyncio
+async def test_delete_already_gone_still_drops_cache(adapter):
+    adapter._status_message_ids[("chat-1", "lifecycle")] = "3202"
+    adapter._bot.delete_message = AsyncMock(
+        side_effect=Exception("Bad Request: message to delete not found")
+    )
+
+    ok = await adapter.delete_message("chat-1", "3202")
+
+    assert ok is False
+    assert ("chat-1", "lifecycle") not in adapter._status_message_ids
+
+
+@pytest.mark.asyncio
+async def test_delete_failure_that_is_not_stale_keeps_cache(adapter):
+    adapter._status_message_ids[("chat-1", "lifecycle")] = "3202"
+    adapter._bot.delete_message = AsyncMock(
+        side_effect=Exception("httpx.ReadTimeout: timed out")
+    )
+
+    ok = await adapter.delete_message("chat-1", "3202")
+
+    assert ok is False
+    assert adapter._status_message_ids[("chat-1", "lifecycle")] == "3202"
 


### PR DESCRIPTION
## Summary
`cleanup_progress=true` deletes the Telegram status bubble, but `_status_message_ids` kept the old id. The next `send_or_update_status` edited a tombstone (`Message to edit not found`). `finalize=True` then treated that as a MarkdownV2 format failure and retried the same dead id as plain text.

## Fix
- Forget cached status ids on successful delete and on already-gone delete/edit targets.
- Do not fall back to a plain-text edit when the target cannot be mutated; callers already send-fresh on failure.
- Cache keys use `telegram_chat_id_key` so equivalent chat-id forms (int / str / whitespace) hit the same slot (same approach as #99905).
- Stale-target matcher also covers Bot API permanent refusals: `message can't be edited`, `message can't be deleted`, `MESSAGE_ID_INVALID`. It does **not** match `message is not modified`, flood-control, rights errors, or transient network errors.

## Relation to #99905
#99905 (open, earlier) covers delete-time invalidation + canonical chat-id keys. This PR keeps that keying and also covers stale edit/delete targets and the finalize plain-text retry.

## Test plan
```
scripts/run_tests.sh tests/gateway/test_telegram_status_update.py tests/gateway/test_telegram_progress_edit_transient.py -q --tb=line
```
**42 passed** (26 status-cache + 16 progress-edit-transient).