### PR TITLE
fix(terminal): block Windows-style NUL redirection under Git Bash (#103244)

### DIFF
--- a/tests/tools/test_windows_nul_guard.py
+++ b/tests/tools/test_windows_nul_guard.py
@@ -1,0 +1,74 @@
+"""Tests for Windows-style NUL device redirection guard under Git Bash (Issue #103244)."""
+
+import json
+import sys
+import unittest
+from unittest.mock import patch
+
+from tools.terminal_tool_guards import (
+    detect_windows_nul_redirection,
+    windows_nul_redirection_block,
+)
+
+
+class TestWindowsNulRedirectionDetection(unittest.TestCase):
+    """Test suite for detecting unquoted Windows NUL device redirections."""
+
+    def test_blocks_common_agent_redirections(self):
+        payloads = [
+            'rg foo "C:/definitely-does-not-exist" 2>NUL || true',
+            'gh issue comment 123 --body "done" && del /q "temp.txt" 2>nul || true',
+            'gh issue view 456 2>NUL || echo "unavailable"',
+            'gh issue view 789 2>NUL | tail -220',
+            'gh pr diff 101 --stat 2>NUL || true',
+            "printf 'x' 2>NUL",
+            "cmd.exe /c dir > NUL",
+            "process_data >> nul",
+            "build_artifact &> NUL",
+            "compile_code 1>nul 2>&1",
+            "run_check >& NUL",
+        ]
+        for cmd in payloads:
+            hit, msg = detect_windows_nul_redirection(cmd)
+            self.assertTrue(hit, f"Expected command to be detected: {cmd}")
+            self.assertIsNotNone(msg)
+            self.assertIn("/dev/null", msg)
+            self.assertIn("Git Bash", msg)
+
+    def test_allows_posix_null_and_quoted_occurrences(self):
+        safe_commands = [
+            "rg foo test 2>/dev/null || true",
+            "cmd > /dev/null 2>&1",
+            'echo "Notice: 2>NUL is invalid on bash"',
+            "git commit -m 'fix: resolve 2>NUL issue in script'",
+            "python -c 'x = None'",
+            "cat <<'EOF'\n2>NUL is inside heredoc\nEOF",
+            "grep --null -r pattern .",
+            "echo $NUL",
+            "npm run build",
+        ]
+        for cmd in safe_commands:
+            hit, msg = detect_windows_nul_redirection(cmd)
+            self.assertFalse(hit, f"Command should NOT be blocked: {cmd}")
+            self.assertIsNone(msg)
+
+    def test_windows_nul_redirection_block_platform_behavior(self):
+        test_cmd = "rg foo 2>NUL"
+
+        # When platform is simulated as win32
+        with patch.object(sys, "platform", "win32"):
+            res = windows_nul_redirection_block(test_cmd)
+            self.assertIsNotNone(res)
+            data = json.loads(res)
+            self.assertEqual(data.get("exit_code"), 1)
+            self.assertEqual(data.get("status"), "blocked")
+            self.assertIn("Use POSIX '/dev/null'", data.get("error", ""))
+
+        # When platform is simulated as linux/darwin
+        with patch.object(sys, "platform", "linux"):
+            res = windows_nul_redirection_block(test_cmd)
+            self.assertIsNone(res)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -728,7 +728,7 @@ def _command_requires_pipe_stdin(command: str) -> bool:
 
 from tools.terminal_tool_guards import (
     _foreground_background_guidance, _safe_command_preview, _validate_workdir,
-    gateway_lifecycle_block, self_repo_block,
+    gateway_lifecycle_block, self_repo_block, windows_nul_redirection_block,
 )
 from tools.terminal_tool_background import spawn_background_process
 from tools.terminal_tool_result import finalize_foreground_result
@@ -1074,6 +1074,9 @@ def _pre_exec_block(
             raise _Rejected(_error_json(workdir_error, status="blocked"))
     if env_type == "local":
         blocked = self_repo_block(command=command, cwd=cwd, workdir=workdir, session_key=session_key)
+        if blocked:
+            raise _Rejected(blocked)
+        blocked = windows_nul_redirection_block(command)
         if blocked:
             raise _Rejected(blocked)
 

--- a/tools/terminal_tool_guards.py
+++ b/tools/terminal_tool_guards.py
@@ -267,3 +267,49 @@ def self_repo_block(
         return None
     logger.warning("Blocked self-repo git mutation (command: %s)", _safe_command_preview(command))
     return _blocked_json(msg, "blocked")
+
+
+_WINDOWS_NUL_REDIRECTION_RE = re.compile(
+    r"(?:^|[\s;&|])(?:>>|>&|&>|[0-9]*>(?:&)?)\s*nul\b(?!/)",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def detect_windows_nul_redirection(command: str) -> tuple[bool, Optional[str]]:
+    """Detect Windows-style NUL device redirection in a shell command.
+
+    In Git Bash on native Windows, 'NUL' is not recognized as the Windows null
+    device; Bash treats it as a normal relative filename, creating a literal
+    'NUL' / 'nul' file in the workspace directory.
+    Quotes, backticks, and inert heredocs are stripped so keyword mentions inside
+    echo strings or script bodies do not trigger false positives.
+    """
+    unquoted = _strip_quotes(command)
+    if _WINDOWS_NUL_REDIRECTION_RE.search(unquoted):
+        return (
+            True,
+            "Blocked: Windows-style null device redirection ('>NUL', '2>NUL') detected. "
+            "On native Windows, Hermes executes commands through Git Bash, which treats 'NUL' "
+            "as a literal file and pollutes the workspace. Use POSIX '/dev/null' (e.g. '2>/dev/null' "
+            "or '>/dev/null 2>&1') instead.",
+        )
+    return False, None
+
+
+def windows_nul_redirection_block(command: str) -> Optional[str]:
+    """Pre-execution block for Windows-style NUL redirection under Git Bash.
+
+    Returns a structured JSON error string when blocked on Windows, else None.
+    """
+    import sys
+
+    if sys.platform != "win32":
+        return None
+    hit, msg = detect_windows_nul_redirection(command)
+    if hit and msg:
+        logger.warning(
+            "Blocked Windows NUL redirection under Git Bash (command: %s)",
+            _safe_command_preview(command),
+        )
+        return _blocked_json(msg, "blocked")
+    return None


### PR DESCRIPTION
## Summary of Changes

Fixes #103244

On native Windows, Hermes executes terminal tool commands via Git Bash / MSYS. When an agent or command emits Windows-style null redirection such as 2>NUL, >NUL, or 2>nul, Bash does not recognize NUL as the Windows null device; instead, it treats it as a standard relative filename and creates a literal NUL file in the current working directory.

This PR implements a preflight guard windows_nul_redirection_block in tools/terminal_tool_guards.py wired into _pre_exec_block in tools/terminal_tool.py:
- **Selective & Platform-Gated:** Active only on native Windows (sys.platform == 'win32').
- **Quote-Safe & Heredoc-Aware:** Uses _strip_quotes(command) so keyword mentions inside strings (e.g. echo '2>NUL' or commit messages) and inert heredocs are not falsely blocked.
- **Actionable Guidance:** Returns a structured blocked response (exit_code: 1, status: 'blocked') instructing the caller to use POSIX /dev/null (e.g. 2>/dev/null or >/dev/null 2>&1).

## Verification
- Added comprehensive unit tests in tests/tools/test_windows_nul_guard.py covering:
  - Common agent redirection payloads (2>NUL, del ... 2>nul, > NUL, &> NUL, 1>nul 2>&1).
  - Safe POSIX commands and quoted occurrences (echo '2>NUL', heredocs, commit messages).
  - Platform behavior on Windows vs Linux/macOS.
- All tests pass: Ran 3 tests in 0.001s - OK.