### PR TITLE
fix(desktop): keep a working profile backend alive and deliver its parked subagent results

### DIFF
--- a/apps/desktop/electron/backend-activity.test.ts
+++ b/apps/desktop/electron/backend-activity.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Tests for electron/backend-activity.ts — the "is this pooled backend doing
+ * work?" gate in front of the idle reaper and the LRU cap eviction.
+ *
+ * Incident: the renderer's 60s keepalive stopped for a profile the user had
+ * switched away from; ten minutes later the idle reaper SIGTERM'd a backend
+ * that was running three agent turns plus an hour-long in-process
+ * delegate_task subagent. The keepalive proves a renderer socket is open, not
+ * that the backend is idle — so the reaper now asks the backend itself via
+ * GET /api/activity and spares anything busy. Older runtimes 404 on that
+ * route and wedged processes time out; both are UNKNOWN and keep the legacy
+ * reap-on-idle behaviour so stale backends are still reclaimed.
+ */
+
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  decideIdleReap,
+  DEFAULT_BUSY_GRACE_MS,
+  formatSparedBusyBackendLog,
+  parseBackendActivity,
+  probeBackendActivity,
+  withinBusyGrace
+} from './backend-activity'
+
+const NOW = 1_000_000
+const IDLE_LIMIT_MS = 10 * 60_000
+
+const busyBody = { ok: true, busy: true, running_turns: 3, active_subagents: 1, background_processes: 0 }
+const idleBody = { ok: true, busy: false, running_turns: 0, active_subagents: 0, background_processes: 0 }
+
+// ── parseBackendActivity ─────────────────────────────────────────────────────
+
+test('parse accepts the documented payload and maps counters', () => {
+  assert.deepEqual(parseBackendActivity(busyBody), {
+    busy: true,
+    runningTurns: 3,
+    activeSubagents: 1,
+    backgroundProcesses: 0
+  })
+  assert.deepEqual(parseBackendActivity(idleBody), {
+    busy: false,
+    runningTurns: 0,
+    activeSubagents: 0,
+    backgroundProcesses: 0
+  })
+})
+
+test('parse rejects unrecognised shapes as unknown (null)', () => {
+  const rejected: unknown[] = [
+    null,
+    undefined,
+    'busy',
+    42,
+    [],
+    {},
+    { ok: true },
+    { ok: false, busy: true, running_turns: 1, active_subagents: 0, background_processes: 0 },
+    { ok: true, busy: 'yes', running_turns: 0, active_subagents: 0, background_processes: 0 },
+    { ok: true, busy: false, running_turns: -1, active_subagents: 0, background_processes: 0 },
+    { ok: true, busy: false, running_turns: '0', active_subagents: 0, background_processes: 0 },
+    { ok: true, busy: false, running_turns: 0, active_subagents: 0 },
+    // /api/status-like body from a backend that does not know the route.
+    { ok: true, status: 'ready', version: '1.2.3' }
+  ]
+
+  for (const body of rejected) {
+    assert.equal(parseBackendActivity(body), null, `expected null for ${JSON.stringify(body)}`)
+  }
+})
+
+// ── decideIdleReap — decision table ──────────────────────────────────────────
+
+const past = (overrides: Partial<Parameters<typeof decideIdleReap>[0]> = {}) => ({
+  idleMs: IDLE_LIMIT_MS + 1,
+  idleLimitMs: IDLE_LIMIT_MS,
+  activity: null,
+  busyGraceMs: DEFAULT_BUSY_GRACE_MS,
+  now: NOW,
+  lastBusyAt: null,
+  ...overrides
+})
+
+test('idle keepalive + busy backend → keep, and hand back a busy stamp', () => {
+  const decision = decideIdleReap(past({ activity: parseBackendActivity(busyBody) }))
+
+  assert.equal(decision.reap, false)
+  assert.equal(decision.reason, 'busy')
+  assert.equal(decision.lastBusyAt, NOW)
+})
+
+test('idle keepalive + provably idle backend → reap', () => {
+  const decision = decideIdleReap(past({ activity: parseBackendActivity(idleBody) }))
+
+  assert.equal(decision.reap, true)
+  assert.equal(decision.reason, 'idle')
+})
+
+test('idle keepalive + unknown activity (404 / timeout) → reap, legacy behaviour', () => {
+  const decision = decideIdleReap(past({ activity: null }))
+
+  assert.equal(decision.reap, true)
+  assert.equal(decision.reason, 'unknown-activity')
+})
+
+test('seen busy within the grace window → keep even if this probe says idle or unknown', () => {
+  const recentlyBusy = NOW - DEFAULT_BUSY_GRACE_MS / 2
+
+  for (const activity of [null, parseBackendActivity(idleBody)]) {
+    const decision = decideIdleReap(past({ activity, lastBusyAt: recentlyBusy }))
+
+    assert.equal(decision.reap, false)
+    assert.equal(decision.reason, 'busy-grace')
+  }
+})
+
+test('a busy stamp older than the grace window no longer protects the backend', () => {
+  const decision = decideIdleReap(past({ activity: null, lastBusyAt: NOW - DEFAULT_BUSY_GRACE_MS }))
+
+  assert.equal(decision.reap, true)
+})
+
+test('within the idle window nothing is reaped, whatever the probe says', () => {
+  for (const activity of [null, parseBackendActivity(idleBody), parseBackendActivity(busyBody)]) {
+    const decision = decideIdleReap(past({ idleMs: IDLE_LIMIT_MS, activity }))
+
+    assert.equal(decision.reap, false)
+    assert.equal(decision.reason, 'keepalive-fresh')
+  }
+})
+
+test('withinBusyGrace treats a missing stamp as never busy', () => {
+  assert.equal(withinBusyGrace(null, NOW, DEFAULT_BUSY_GRACE_MS), false)
+  assert.equal(withinBusyGrace(undefined, NOW, DEFAULT_BUSY_GRACE_MS), false)
+  assert.equal(withinBusyGrace(NOW - 1, NOW, DEFAULT_BUSY_GRACE_MS), true)
+})
+
+// ── probeBackendActivity — fetch outcome mapping ─────────────────────────────
+
+const spawnedEntry = { process: { pid: 4242 }, port: 51234, token: 'tok-secret' }
+
+test('probe hits /api/activity on the entry port with its token and parses a good body', async () => {
+  const calls: { url: string; token: string; timeoutMs: number }[] = []
+
+  const fetch = async (url: string, token: string, options: { timeoutMs: number }) => {
+    calls.push({ url, token, timeoutMs: options.timeoutMs })
+
+    return busyBody
+  }
+
+  const activity = await probeBackendActivity(fetch, spawnedEntry, 3_000)
+
+  assert.deepEqual(activity, parseBackendActivity(busyBody))
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].url, `http://127.0.0.1:${spawnedEntry.port}/api/activity`)
+  assert.equal(calls[0].token, spawnedEntry.token)
+  assert.equal(calls[0].timeoutMs, 3_000)
+})
+
+test('probe maps 404 (older runtime), timeout and network errors to unknown without throwing', async () => {
+  const failures = [
+    new Error('404: Not Found'),
+    new Error('Timed out connecting to Hermes backend after 3000ms'),
+    Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:51234'), { code: 'ECONNREFUSED' }),
+    new Error('Expected JSON from http://127.0.0.1:51234/api/activity but got HTML (status 200).')
+  ]
+
+  for (const failure of failures) {
+    const fetch = async () => {
+      throw failure
+    }
+
+    assert.equal(await probeBackendActivity(fetch, spawnedEntry, 3_000), null, failure.message)
+  }
+})
+
+test('probe maps an unrecognised 2xx body to unknown', async () => {
+  const fetch = async () => ({ ok: true, status: 'ready' })
+
+  assert.equal(await probeBackendActivity(fetch, spawnedEntry, 3_000), null)
+})
+
+test('probe never dials a descriptor entry or a backend without a known port/token', async () => {
+  let dialed = 0
+
+  const fetch = async () => {
+    dialed += 1
+
+    return busyBody
+  }
+
+  assert.equal(await probeBackendActivity(fetch, { process: null, port: 51234, token: 'tok' }, 3_000), null)
+  assert.equal(await probeBackendActivity(fetch, { process: { pid: 1 }, port: null, token: 'tok' }, 3_000), null)
+  assert.equal(await probeBackendActivity(fetch, { process: { pid: 1 }, port: 51234, token: null }, 3_000), null)
+  assert.equal(dialed, 0)
+})
+
+// ── desktop.log line ─────────────────────────────────────────────────────────
+
+test('the spared-busy log line names the backend and carries every counter', () => {
+  const line = formatSparedBusyBackendLog('conn:local::coder', parseBackendActivity(busyBody)!)
+
+  assert.equal(
+    line,
+    'Sparing busy profile backend "conn:local::coder" (running_turns=3, active_subagents=1, background_processes=0) despite idle keepalive'
+  )
+})

--- a/apps/desktop/electron/backend-activity.ts
+++ b/apps/desktop/electron/backend-activity.ts
@@ -1,0 +1,184 @@
+/**
+ * backend-activity.ts
+ *
+ * "Is this pooled backend actually doing work?" — the question the idle reaper
+ * and the LRU cap eviction in main.ts must answer before SIGTERM'ing a child.
+ *
+ * The renderer's 60s `hermes:backend:touch` keepalive only proves a renderer
+ * socket is open for that profile. It says nothing about the backend itself:
+ * when the user switches to another profile the pings stop, `lastActiveAt`
+ * ages past the idle window, and the reaper killed a backend that was running
+ * three agent turns plus an hour-long in-process `delegate_task` subagent.
+ *
+ * Every local backend now exposes `GET /api/activity` (same auth as
+ * `/api/status`) reporting its own work in progress. Older backends 404 on it,
+ * and a wedged process times out — both map to UNKNOWN, and unknown keeps
+ * today's behaviour (reap on idle) so the app still reclaims backends from old
+ * runtimes and hung processes.
+ *
+ * Dependency-free (same pattern as pool-eviction.ts / pool-stop.ts) so the
+ * decision table is asserted directly instead of grepping main.ts.
+ */
+
+export interface BackendActivity {
+  busy: boolean
+  runningTurns: number
+  activeSubagents: number
+  backgroundProcesses: number
+}
+
+/**
+ * A backend seen busy within this window is spared even if a later probe
+ * blips (transient 404 from a restarting server, a timeout under load, or a
+ * single idle sample between two turns). Two idle-reaper ticks (60s each).
+ */
+export const DEFAULT_BUSY_GRACE_MS = 120_000
+
+function nonNegativeCount(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    return null
+  }
+
+  return value
+}
+
+/**
+ * Validate the `/api/activity` payload. Anything that does not carry the full
+ * documented shape is null (= unknown): a partially recognised body must not
+ * be trusted to prove idleness.
+ */
+export function parseBackendActivity(json: unknown): BackendActivity | null {
+  if (!json || typeof json !== 'object' || Array.isArray(json)) {
+    return null
+  }
+
+  const body = json as Record<string, unknown>
+
+  if (body.ok === false || typeof body.busy !== 'boolean') {
+    return null
+  }
+
+  const runningTurns = nonNegativeCount(body.running_turns)
+  const activeSubagents = nonNegativeCount(body.active_subagents)
+  const backgroundProcesses = nonNegativeCount(body.background_processes)
+
+  if (runningTurns === null || activeSubagents === null || backgroundProcesses === null) {
+    return null
+  }
+
+  return { busy: body.busy, runningTurns, activeSubagents, backgroundProcesses }
+}
+
+export type IdleReapReason = 'keepalive-fresh' | 'busy' | 'busy-grace' | 'idle' | 'unknown-activity'
+
+export interface IdleReapInput {
+  /** Milliseconds since the entry's last keepalive touch. */
+  idleMs: number
+  /** The pool idle window (poolIdleMs()). */
+  idleLimitMs: number
+  /** Probe result; null when the backend could not tell us (404 / timeout / network). */
+  activity: BackendActivity | null
+  /** How long a busy sighting protects the backend. */
+  busyGraceMs: number
+  now: number
+  /** Last time this backend was seen busy, if ever. */
+  lastBusyAt?: number | null
+}
+
+export interface IdleReapDecision {
+  reap: boolean
+  reason: IdleReapReason
+  /** New busy stamp for the caller to record on the pool entry. */
+  lastBusyAt?: number
+}
+
+/**
+ * Decision table for one pool entry:
+ *
+ *   not past the idle window         → keep  (keepalive-fresh)
+ *   idle + probe says busy           → keep  (busy; remember the stamp)
+ *   idle + seen busy within grace    → keep  (busy-grace)
+ *   idle + probe unknown             → reap  (unknown-activity — legacy path)
+ *   idle + probe says not busy       → reap  (idle)
+ */
+export function decideIdleReap(input: IdleReapInput): IdleReapDecision {
+  if (input.idleMs <= input.idleLimitMs) {
+    return { reap: false, reason: 'keepalive-fresh' }
+  }
+
+  if (input.activity?.busy) {
+    return { reap: false, reason: 'busy', lastBusyAt: input.now }
+  }
+
+  if (withinBusyGrace(input.lastBusyAt, input.now, input.busyGraceMs)) {
+    return { reap: false, reason: 'busy-grace' }
+  }
+
+  if (input.activity === null) {
+    return { reap: true, reason: 'unknown-activity' }
+  }
+
+  return { reap: true, reason: 'idle' }
+}
+
+export function withinBusyGrace(lastBusyAt: number | null | undefined, now: number, busyGraceMs: number): boolean {
+  return typeof lastBusyAt === 'number' && now - lastBusyAt < busyGraceMs
+}
+
+/** The pool-entry fields the probe needs; descriptor entries have process === null. */
+export interface ActivityProbeEntry {
+  process?: unknown
+  port?: number | null
+  token?: string | null
+}
+
+/** Shape of main.ts fetchJson(url, token, { timeoutMs }). */
+export type ActivityFetch = (url: string, token: string, options: { timeoutMs: number }) => Promise<unknown>
+
+/**
+ * Ask a spawned local backend for its activity. Never throws: a missing
+ * process/port/token, a 404 from an older runtime, a timeout, a network error
+ * or an unrecognised body all resolve to null (unknown).
+ */
+export async function probeBackendActivity(
+  fetch: ActivityFetch,
+  entry: ActivityProbeEntry,
+  timeoutMs: number
+): Promise<BackendActivity | null> {
+  if (!entry.process || !entry.port || !entry.token) {
+    return null
+  }
+
+  try {
+    const body = await fetch(`http://127.0.0.1:${entry.port}/api/activity`, entry.token, { timeoutMs })
+
+    return parseBackendActivity(body)
+  } catch {
+    return null
+  }
+}
+
+export function describeBackendActivity(activity: BackendActivity): string {
+  return (
+    `running_turns=${activity.runningTurns}, active_subagents=${activity.activeSubagents}, ` +
+    `background_processes=${activity.backgroundProcesses}`
+  )
+}
+
+/** desktop.log line for a backend the idle reaper left alone because it was busy. */
+export function formatSparedBusyBackendLog(key: string, activity: BackendActivity): string {
+  return `Sparing busy profile backend "${key}" (${describeBackendActivity(activity)}) despite idle keepalive`
+}
+
+/** desktop.log line for a backend spared by the LRU cap because it was busy. */
+export function formatSparedBusyEvictionLog(key: string, activity: BackendActivity, cap: number): string {
+  return `Sparing busy profile backend "${key}" (${describeBackendActivity(activity)}) from LRU cap ${cap}`
+}
+
+/** desktop.log line for a backend spared because it was seen busy within the grace window. */
+export function formatSparedRecentlyBusyLog(key: string, lastBusyAt: number, now: number, busyGraceMs: number): string {
+  return (
+    `Sparing recently busy profile backend "${key}" ` +
+    `(busy ${Math.round((now - lastBusyAt) / 1000)}s ago, within ${Math.round(busyGraceMs / 1000)}s grace)`
+  )
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -33,6 +33,15 @@ import {
 import { classifyActiveRuntime } from './active-runtime-state'
 import { destroyKeepaliveAgents, downloadAgentFor, jsonAgentFor, withRetry } from './api-transport'
 import { appIconCandidates, resolveAppIcon } from './app-icon'
+import {
+  decideIdleReap,
+  DEFAULT_BUSY_GRACE_MS,
+  formatSparedBusyBackendLog,
+  formatSparedBusyEvictionLog,
+  formatSparedRecentlyBusyLog,
+  probeBackendActivity,
+  withinBusyGrace
+} from './backend-activity'
 import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } from './backend-child'
 import {
   type BackendOutputTail,
@@ -1505,7 +1514,7 @@ function setPoolLimits(raw) {
   poolLimits = clampPoolLimits(raw)
   persistPoolLimits(poolLimits)
   localBackendSpawnCoordinator.setLimit(poolLimits.maxBackends)
-  evictLruPoolBackends(poolMaxBackends())
+  void evictLruPoolBackends(poolMaxBackends())
   startPoolIdleReaper()
 
   return { ...poolLimits }
@@ -1538,6 +1547,16 @@ const POOL_KEEPALIVE_FRESH_MS = Math.max(
 )
 
 let poolIdleReaper = null
+// One reaper tick may be waiting on activity probes (≤ POOL_ACTIVITY_PROBE_TIMEOUT_MS)
+// when the next fires; the interval must not overlap itself.
+let poolIdleReapInFlight = false
+// Before killing a pooled backend the reaper / LRU cap ask it `GET /api/activity`.
+// Short timeout: a wedged process must still be reclaimed, so "no answer"
+// degrades to the legacy reap-on-idle path rather than sparing it forever.
+const POOL_ACTIVITY_PROBE_TIMEOUT_MS = 3_000
+// A backend seen busy within this window is spared even if a later probe
+// blips (two idle-reaper ticks).
+const POOL_BUSY_GRACE_MS = DEFAULT_BUSY_GRACE_MS
 let backendOrphanReapPromise = null
 // Auto-reload budget for renderer crashes, shared by EVERY window (primary,
 // secondary session, instance) so a crash loop anywhere is suppressed after
@@ -5363,7 +5382,7 @@ function fetchJson(url, token, options: any = {}) {
 
         req.end()
       }),
-    { method: options.method || 'GET' }
+    { method: options.method || 'GET', maxRetries: options.maxRetries }
   )
 }
 
@@ -11407,7 +11426,7 @@ async function ensureBackend(profile) {
     return connection
   }
 
-  evictLruPoolBackends(poolMaxBackends() - 1)
+  void evictLruPoolBackends(poolMaxBackends() - 1)
 
   const entry = {
     process: null,
@@ -11415,6 +11434,7 @@ async function ensureBackend(profile) {
     token: null,
     connectionPromise: null,
     lastActiveAt: Date.now(),
+    lastBusyAt: null,
     remoteBaseUrl: null,
     releaseLocalBackendSlot: null,
     localBackendSlotKey: null,
@@ -11573,7 +11593,7 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
       return existingLocal.connectionPromise
     }
 
-    evictLruPoolBackends(poolMaxBackends() - 1)
+    void evictLruPoolBackends(poolMaxBackends() - 1)
 
     const localEntry = {
       process: null,
@@ -11581,6 +11601,7 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
       token: null,
       connectionPromise: null,
       lastActiveAt: Date.now(),
+      lastBusyAt: null,
       remoteBaseUrl: null,
       releaseLocalBackendSlot: null,
       localBackendSlotKey: null,
@@ -11644,7 +11665,7 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
     )
   }
 
-  evictLruPoolBackends(poolMaxBackends() - 1)
+  void evictLruPoolBackends(poolMaxBackends() - 1)
 
   const entry = {
     process: null,
@@ -11652,6 +11673,7 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
     token: null,
     connectionPromise: null,
     lastActiveAt: Date.now(),
+    lastBusyAt: null,
     remoteBaseUrl: null
   }
 
@@ -11786,6 +11808,7 @@ async function ensureManagedSshBackendAtKey(source, profile, key, correlationId,
     token: null,
     connectionPromise: null,
     lastActiveAt: Date.now(),
+    lastBusyAt: null,
     remoteBaseUrl: null
   }
 
@@ -12285,23 +12308,125 @@ function touchPoolBackend(profile) {
   }
 }
 
+// Ask a spawned local backend whether it is doing work (GET /api/activity).
+// Resolves null (unknown) for descriptor entries, older runtimes (404), and
+// wedged processes (timeout); a busy answer stamps `entry.lastBusyAt`.
+async function probePoolBackendActivity(entry: any) {
+  const activity = await probeBackendActivity(
+    (url, token, options) => fetchJson(url, token, { ...options, maxRetries: 0 }),
+    entry,
+    POOL_ACTIVITY_PROBE_TIMEOUT_MS
+  )
+
+  if (activity?.busy) {
+    entry.lastBusyAt = Date.now()
+  }
+
+  return activity
+}
+
 // Evict least-recently-used SPAWNED pool backends until at most `keep` remain —
 // but only ever evict backends without a live renderer socket (stale beyond the
-// keepalive window). When every backend is actively kept alive we let the pool
-// exceed the soft cap rather than kill a running session. Process-less
-// descriptor entries (remote/cloud registry sources, per-profile remote
-// overrides — `entry.process === null`) are excluded from the cap entirely:
-// they hold no local process, so counting them used to let a roster refresh
-// across N registered remote connections LRU-evict a REAL local backend that
-// was merely idle past the keepalive window. Descriptors are still reclaimed
-// by the idle reaper.
-function evictLruPoolBackends(keep) {
-  const evictions = selectPoolEvictions(backendPool.entries(), Math.max(0, keep), Date.now(), POOL_KEEPALIVE_FRESH_MS)
+// keepalive window) that are not doing work. When every backend is actively
+// kept alive or busy we let the pool exceed the soft cap rather than kill a
+// running agent turn. Process-less descriptor entries (remote/cloud registry
+// sources, per-profile remote overrides — `entry.process === null`) are
+// excluded from the cap entirely: they hold no local process, so counting them
+// used to let a roster refresh across N registered remote connections
+// LRU-evict a REAL local backend that was merely idle past the keepalive
+// window. Descriptors are still reclaimed by the idle reaper.
+//
+// The keepalive only proves a renderer socket is open; a backend running turns
+// or an in-process delegate_task subagent for a profile the user switched away
+// from looks "stale" to it. Each LRU candidate is therefore probed for
+// activity before it is stopped. Callers do not await this (the stop itself was
+// already fire-and-forget): sparing a busy backend means the spawn coordinator
+// may hold the incoming spawn until a slot frees or its wait times out — the
+// deliberate trade-off, since the alternative is aborting an hour of agent work.
+async function evictLruPoolBackends(keep) {
+  const now = Date.now()
+  const evictions = selectPoolEvictions(backendPool.entries(), Math.max(0, keep), now, POOL_KEEPALIVE_FRESH_MS)
 
-  for (const profile of evictions) {
-    rememberLog(`Evicting idle profile backend "${profile}" (LRU cap ${poolMaxBackends()})`)
-    stopPoolBackend(profile)
-  }
+  await Promise.all(
+    evictions.map(async profile => {
+      const entry = backendPool.get(profile)
+
+      if (!entry) {
+        return
+      }
+
+      if (withinBusyGrace(entry.lastBusyAt, now, POOL_BUSY_GRACE_MS)) {
+        rememberLog(formatSparedRecentlyBusyLog(profile, entry.lastBusyAt, now, POOL_BUSY_GRACE_MS))
+
+        return
+      }
+
+      const activity = await probePoolBackendActivity(entry)
+
+      if (activity?.busy) {
+        rememberLog(formatSparedBusyEvictionLog(profile, activity, poolMaxBackends()))
+
+        return
+      }
+
+      // The entry may have been stopped or replaced while the probe ran.
+      if (backendPool.get(profile) !== entry) {
+        return
+      }
+
+      rememberLog(`Evicting idle profile backend "${profile}" (LRU cap ${poolMaxBackends()})`)
+      await stopPoolBackend(profile)
+    })
+  )
+}
+
+// One idle-reaper tick: every entry past the idle window is probed for activity
+// (concurrently) and only provably-idle or unknown backends are stopped. A
+// backend still running turns / subagents / background processes is spared and
+// its busy stamp refreshed so a later probe blip cannot reap it either.
+async function reapIdlePoolBackends() {
+  const now = Date.now()
+  const idleLimitMs = poolIdleMs()
+
+  await Promise.all(
+    [...backendPool.entries()].map(async ([profile, entry]) => {
+      const idleMs = now - (entry.lastActiveAt || 0)
+
+      if (idleMs <= idleLimitMs) {
+        return
+      }
+
+      const activity = entry.process ? await probePoolBackendActivity(entry) : null
+
+      const decision = decideIdleReap({
+        idleMs,
+        idleLimitMs,
+        activity,
+        busyGraceMs: POOL_BUSY_GRACE_MS,
+        now,
+        lastBusyAt: entry.lastBusyAt
+      })
+
+      if (decision.reason === 'busy' && activity) {
+        rememberLog(formatSparedBusyBackendLog(profile, activity))
+
+        return
+      }
+
+      if (decision.reason === 'busy-grace') {
+        rememberLog(formatSparedRecentlyBusyLog(profile, entry.lastBusyAt, now, POOL_BUSY_GRACE_MS))
+
+        return
+      }
+
+      if (!decision.reap || backendPool.get(profile) !== entry) {
+        return
+      }
+
+      rememberLog(`Reaping idle profile backend "${profile}" (idle > ${Math.round(idleLimitMs / 1000)}s)`)
+      await stopPoolBackend(profile)
+    })
+  )
 }
 
 function startPoolIdleReaper() {
@@ -12310,19 +12435,24 @@ function startPoolIdleReaper() {
   }
 
   poolIdleReaper = setInterval(() => {
-    const now = Date.now()
-
-    for (const [profile, entry] of [...backendPool.entries()]) {
-      if (now - (entry.lastActiveAt || 0) > poolIdleMs()) {
-        rememberLog(`Reaping idle profile backend "${profile}" (idle > ${Math.round(poolIdleMs() / 1000)}s)`)
-        stopPoolBackend(profile)
-      }
+    if (poolIdleReapInFlight) {
+      return
     }
 
-    if (backendPool.size === 0 && poolIdleReaper) {
-      clearInterval(poolIdleReaper)
-      poolIdleReaper = null
-    }
+    poolIdleReapInFlight = true
+
+    void reapIdlePoolBackends()
+      .catch(error => {
+        rememberLog(`Pool idle reaper tick failed: ${error instanceof Error ? error.message : String(error)}`)
+      })
+      .finally(() => {
+        poolIdleReapInFlight = false
+
+        if (backendPool.size === 0 && poolIdleReaper) {
+          clearInterval(poolIdleReaper)
+          poolIdleReaper = null
+        }
+      })
   }, 60_000)
 
   if (typeof poolIdleReaper.unref === 'function') {

--- a/hermes_cli/web_routers/activity.py
+++ b/hermes_cli/web_routers/activity.py
@@ -1,0 +1,65 @@
+"""``GET /api/activity`` — the backend's busy signal for supervisors that reap idle
+``hermes serve`` processes (the desktop app runs one per profile).
+
+Wall-clock idleness of the RPC transport is not idleness of the process: a running turn,
+a detached ``delegate_task`` subagent (a thread in this process) or a background terminal
+process is live work with no request traffic. Reaping on transport idleness alone killed a
+backend mid-delegation; this endpoint is what the reaper must consult first.
+
+Answers in milliseconds from in-memory counters only: no DB, no threadpool, no imports of
+the TUI gateway (a process that never opened a chat has no running turns by definition).
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Callable
+
+from fastapi import APIRouter, Request
+from hermes_cli.web_deps import late
+
+router = APIRouter()
+
+_require_token = late("_require_token")
+
+
+def activity_snapshot(running_turns: int | Callable[[], int], active_subagents: int | Callable[[], int],
+                      background_processes: int | Callable[[], int]) -> dict:
+    """Aggregate the three live-work counters into the endpoint payload. ``busy`` is true iff any
+    counter is positive; a counter whose source fails counts as 0 (the reaper falls back to its
+    own idle policy rather than being told a healthy backend is stuck busy)."""
+    counts = {}
+    for name, source in (("running_turns", running_turns), ("active_subagents", active_subagents),
+                         ("background_processes", background_processes)):
+        try:
+            value = int(source() if callable(source) else source)
+        except Exception:
+            value = 0
+        counts[name] = max(0, value)
+    return {"ok": True, "busy": any(counts.values()), **counts}
+
+
+def _count_running_turns() -> int:
+    """Live TUI/desktop sessions with a turn in flight. Read through ``sys.modules`` so the
+    probe never imports the gateway (and its threads) into a process that never needed it."""
+    server = sys.modules.get("tui_gateway.server")
+    if server is None:
+        return 0
+    with server._sessions_lock:
+        return sum(1 for s in server._sessions.values() if s.get("running") and not s.get("_finalized"))
+
+
+def _count_active_subagents() -> int:
+    from tools.async_delegation import active_count
+    return active_count()
+
+
+def _count_background_processes() -> int:
+    from tools.process_registry import process_registry
+    return process_registry.count_running()
+
+
+@router.get("/api/activity")
+async def get_activity(request: Request):
+    _require_token(request)
+    return activity_snapshot(_count_running_turns, _count_active_subagents, _count_background_processes)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -917,6 +917,7 @@ from hermes_cli.web_routers import (  # noqa: E402
     git as _git_routes,
     local_models as _local_models_routes,
     status as _status_routes,
+    activity as _activity_routes,
     actions as _actions_routes,
     audio as _audio_routes,
     sessions as _sessions_routes,
@@ -940,6 +941,7 @@ app.include_router(_files_routes.router)
 app.include_router(_git_routes.router)
 app.include_router(_local_models_routes.router)
 app.include_router(_status_routes.router)
+app.include_router(_activity_routes.router)
 app.include_router(_actions_routes.router)
 app.include_router(_audio_routes.router)
 app.include_router(_actions_routes.status_router)

--- a/tests/hermes_cli/test_web_activity.py
+++ b/tests/hermes_cli/test_web_activity.py
@@ -1,0 +1,79 @@
+"""``GET /api/activity`` — the busy signal an idle reaper must consult before killing a backend.
+
+Contracts: ``busy`` relates to the three counters (true iff any is positive); the route is
+token-gated like the other non-public dashboard endpoints; ``running_turns`` counts live
+``tui_gateway`` sessions with a turn in flight and ignores finalized ones.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from hermes_cli.web_routers.activity import activity_snapshot
+
+
+@pytest.mark.parametrize("turns,subagents,procs", [(1, 0, 0), (0, 2, 0), (0, 0, 1), (3, 1, 4)])
+def test_busy_when_any_counter_is_positive(turns, subagents, procs):
+    snap = activity_snapshot(turns, subagents, procs)
+    assert snap["busy"] is True
+    assert (snap["running_turns"], snap["active_subagents"], snap["background_processes"]) == (turns, subagents, procs)
+
+
+def test_idle_when_every_counter_is_zero():
+    snap = activity_snapshot(lambda: 0, lambda: 0, lambda: 0)
+    assert snap == {"ok": True, "busy": False, "running_turns": 0, "active_subagents": 0, "background_processes": 0}
+
+
+def test_failing_counter_source_reads_as_zero_not_busy():
+    def boom():
+        raise RuntimeError("registry unavailable")
+    snap = activity_snapshot(boom, 0, boom)
+    assert snap["busy"] is False
+    assert snap["running_turns"] == snap["background_processes"] == 0
+
+
+class TestActivityEndpoint:
+    @pytest.fixture(autouse=True)
+    def _client(self):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        self.anon = TestClient(app)
+        self.client = TestClient(app)
+        self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+
+    def test_requires_the_dashboard_token(self):
+        assert self.anon.get("/api/activity").status_code == 401
+        resp = self.client.get("/api/activity")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["busy"] == any(body[k] > 0 for k in ("running_turns", "active_subagents", "background_processes"))
+
+    def test_running_turns_counts_live_running_sessions_and_ignores_finalized(self):
+        """E2E against the real ``tui_gateway.server._sessions`` registry."""
+        from tui_gateway import server
+
+        def _rec(running: bool, finalized: bool = False) -> dict:
+            return {"session_key": "k", "history_lock": threading.Lock(), "running": running,
+                    "_finalized": finalized}
+
+        fake = {"act-running": _rec(True), "act-running-2": _rec(True), "act-idle": _rec(False),
+                "act-finalized-running": _rec(True, finalized=True)}
+        with server._sessions_lock:
+            server._sessions.update(fake)
+        try:
+            body = self.client.get("/api/activity").json()
+        finally:
+            with server._sessions_lock:
+                for sid in fake:
+                    server._sessions.pop(sid, None)
+        assert body["running_turns"] >= 2
+        assert body["busy"] is True
+
+        after = self.client.get("/api/activity").json()
+        assert after["running_turns"] == body["running_turns"] - 2

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -946,3 +946,76 @@ def test_batch_model_rejection_notice_requires_configured_model_in_text(monkeypa
     text = format_process_notification(evt)
     assert text is not None
     assert "SUBAGENT MODEL REJECTED" not in text
+
+
+# ── Parked completions replayed for the owning session ──────────────────────
+def _park_dead_owner_row(tmp_path, monkeypatch, delegation_id, session_key, *, dispatched_at=None):
+    """Durable ``unknown``/``pending`` row: dispatched by a process that died before finishing."""
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    ad._persist_dispatch({
+        "delegation_id": delegation_id, "goal": "parked goal", "context": None, "toolsets": None,
+        "role": "leaf", "model": "m", "session_key": session_key, "origin_ui_session_id": "dead-ui-sid",
+        "parent_session_id": session_key, "status": "running",
+        "dispatched_at": dispatched_at if dispatched_at is not None else time.time() - 2.0,
+        "completed_at": None, "interrupt_fn": None})
+    monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
+    assert ad.recover_abandoned_delegations() == 1
+    if dispatched_at is not None:  # recovery stamps completed_at=now; pin the age basis
+        with ad._transaction() as conn:
+            conn.execute("UPDATE async_delegations SET completed_at=? WHERE delegation_id=?",
+                         (dispatched_at, delegation_id))
+
+
+def test_restore_pending_for_session_replays_only_the_owning_key(tmp_path, monkeypatch):
+    _park_dead_owner_row(tmp_path, monkeypatch, "d-parked", "owner-key")
+
+    unrelated = queue.Queue()
+    assert ad.restore_pending_for_session({"someone-else", ""}, unrelated) == 0
+    assert unrelated.empty()
+    assert ad.get_durable_delegation("d-parked")["delivery_state"] == "pending"
+
+    owner = queue.Queue()
+    assert ad.restore_pending_for_session({"owner-key"}, owner) == 1
+    evt = owner.get_nowait()
+    assert evt["delegation_id"] == "d-parked"
+    assert evt["session_key"] == "owner-key"
+    assert evt["status"] == "unknown"
+    assert evt["restored"] is True
+
+
+def test_restore_pending_for_session_drops_rows_past_the_replay_age_cap(tmp_path, monkeypatch):
+    stale = time.time() - ad._MAX_COMPLETION_REPLAY_AGE_S - 60
+    _park_dead_owner_row(tmp_path, monkeypatch, "d-stale", "owner-key", dispatched_at=stale)
+
+    q = queue.Queue()
+    assert ad.restore_pending_for_session({"owner-key"}, q) == 0
+    assert q.empty()
+    assert ad.get_durable_delegation("d-stale")["delivery_state"] == "dropped"
+
+
+def test_restore_pending_for_session_skips_rows_under_a_fresh_claim(tmp_path, monkeypatch):
+    """A row a consumer is delivering right now is not handed to a second consumer."""
+    _park_dead_owner_row(tmp_path, monkeypatch, "d-claimed", "owner-key")
+    assert ad.claim_completion_delivery("d-claimed", "poller:live")
+
+    q = queue.Queue()
+    assert ad.restore_pending_for_session({"owner-key"}, q) == 0
+    assert q.empty()
+
+
+def test_second_in_memory_copy_cannot_be_claimed_twice(tmp_path, monkeypatch):
+    """Process-start replay + session replay may both enqueue one row; only one copy claims."""
+    _park_dead_owner_row(tmp_path, monkeypatch, "d-twice", "owner-key")
+
+    q = queue.Queue()
+    assert ad.restore_undelivered_completions(q) == 1
+    assert ad.restore_pending_for_session({"owner-key"}, q) == 1
+    first, second = q.get_nowait(), q.get_nowait()
+    assert first["delegation_id"] == second["delegation_id"] == "d-twice"
+
+    first_claim = ad.claim_event_delivery(first, "tui-poller")
+    assert first_claim
+    assert ad.claim_event_delivery(second, "tui-poller") is None
+    ad.complete_event_delivery(first, first_claim)
+    assert ad.get_durable_delegation("d-twice")["delivery_state"] == "delivered"
+    assert ad.claim_event_delivery(second, "tui-poller") is None

--- a/tests/tui_gateway/test_delegation_session_lifecycle.py
+++ b/tests/tui_gateway/test_delegation_session_lifecycle.py
@@ -156,3 +156,139 @@ class TestFinalizeInterruptsOwnDelegations:
         kwargs = mock_int.call_args.kwargs
         assert kwargs["session_key"] == ""
         assert kwargs["origin_ui_session_id"] == "tab9"
+
+
+# ---------------------------------------------------------------------------
+# 3. Parked completions reach the owning session when it comes back
+#
+# Incident: the backend was reaped mid-delegation; on restart the recovered row was replayed
+# onto the shared queue while only an UNRELATED chat was open, whose poller dropped the
+# in-memory copy. The durable row stayed pending and nothing ever delivered it to the owner.
+# ---------------------------------------------------------------------------
+
+import queue as _queue
+import time as _time
+
+from tui_gateway import server as _server
+
+
+def _wait_for(predicate, timeout: float = 5.0) -> bool:
+    deadline = _time.monotonic() + timeout
+    while _time.monotonic() < deadline:
+        if predicate():
+            return True
+        _time.sleep(0.02)
+    return False
+
+
+@pytest.fixture
+def _poller_harness(monkeypatch):
+    """Real poller threads against the temp HERMES_HOME ledger; pollers + sessions are reaped after."""
+    from tools.process_registry import process_registry
+
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+    submits: list = []
+
+    def _fake_submit(rid, sid, session, text, **kwargs):
+        submits.append({"sid": sid, "text": text, **kwargs})
+        session["running"] = False  # the turn finished
+
+    monkeypatch.setattr(_server, "_emit", lambda event, sid, payload=None: None)
+    monkeypatch.setattr(_server, "_run_prompt_submit", _fake_submit)
+    monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
+    registered: list = []
+
+    def start(sid: str, session_key: str) -> dict:
+        session = {"session_key": session_key, "history_lock": threading.Lock(), "running": False,
+                   "_finalized": False}
+        with _server._sessions_lock:
+            _server._sessions[sid] = session
+        registered.append(sid)
+        session["_notif_stop"] = _server._start_notification_poller(sid, session)
+        return session
+
+    yield start, submits
+    pollers = [(stop, th) for stop, th in list(_server._notification_pollers) if th.is_alive()]
+    for stop, _th in pollers:
+        stop.set()
+    deadline = _time.time() + 3.0
+    for _stop, th in pollers:
+        th.join(timeout=max(0.0, deadline - _time.time()))
+    _server._notification_pollers[:] = [(s, th) for s, th in _server._notification_pollers if th.is_alive()]
+    with _server._sessions_lock:
+        for sid in registered:
+            _server._sessions.pop(sid, None)
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+
+def _park_row_from_dead_backend(delegation_id: str, session_key: str) -> None:
+    """The incident's durable state: dispatched by a backend that died, recovered as ``unknown``."""
+    ad._persist_dispatch({
+        "delegation_id": delegation_id, "goal": "reaped mid-work", "context": None, "toolsets": None,
+        "role": "leaf", "model": "m", "session_key": session_key, "origin_ui_session_id": "dead-ui-sid",
+        "parent_session_id": session_key, "status": "running", "dispatched_at": _time.time() - 5.0,
+        "completed_at": None, "interrupt_fn": None})
+    assert ad.recover_abandoned_delegations() == 1
+
+
+def test_parked_completion_is_delivered_when_the_owning_session_resumes(_poller_harness):
+    from tools.process_registry import process_registry
+    start, submits = _poller_harness
+    _park_row_from_dead_backend("d-incident", "owner-key")
+
+    # Process start: the recovered row is replayed onto the shared queue...
+    assert ad.restore_undelivered_completions(process_registry.completion_queue) == 1
+    # ...while only an unrelated chat is open: its poller must not deliver it (fail-closed drop).
+    start("sid-unrelated", "unrelated-key")
+    assert _wait_for(lambda: process_registry.completion_queue.empty())
+    _time.sleep(0.3)
+    assert submits == []
+    assert ad.get_durable_delegation("d-incident")["delivery_state"] == "pending"
+
+    # The owner comes back (session_key == the row's origin_session): its poller must deliver it.
+    start("sid-owner", "owner-key")
+    assert _wait_for(lambda: len(submits) == 1), "parked completion never reached the owning session"
+    assert submits[0]["sid"] == "sid-owner"
+    assert submits[0]["display_kind"] == "async_delegation_complete"
+    assert "d-incident" in submits[0]["text"]
+    assert _wait_for(lambda: ad.get_durable_delegation("d-incident")["delivery_state"] == "delivered")
+
+
+def test_parked_completion_is_not_replayed_to_a_session_that_does_not_own_it(_poller_harness):
+    start, submits = _poller_harness
+    _park_row_from_dead_backend("d-foreign", "owner-key")
+
+    start("sid-unrelated", "unrelated-key")
+    _time.sleep(0.5)
+    assert submits == []
+    assert ad.get_durable_delegation("d-foreign")["delivery_state"] == "pending"
+
+
+def test_replay_does_not_double_deliver_a_copy_still_queued_from_process_start(_poller_harness):
+    """Process-start copy still in memory + session-resume copy: exactly one turn, session left idle."""
+    from tools.process_registry import process_registry
+    start, submits = _poller_harness
+    _park_row_from_dead_backend("d-twice", "owner-key")
+    assert ad.restore_undelivered_completions(process_registry.completion_queue) == 1
+
+    session = start("sid-owner", "owner-key")
+    assert _wait_for(lambda: process_registry.completion_queue.empty()
+                     and ad.get_durable_delegation("d-twice")["delivery_state"] == "delivered")
+    _time.sleep(0.5)  # give a second copy every chance to be (wrongly) injected
+    assert len(submits) == 1
+    assert session["running"] is False
+
+
+class TestOwnershipAcrossCompressionLineage:
+    def test_row_stamped_with_tip_is_owned_by_a_session_resumed_at_an_ancestor(self):
+        """Resume at the root id while the delegation was dispatched under the compressed continuation."""
+        evt = {"type": "async_delegation", "origin_ui_session_id": "dead-ui-sid", "session_key": "tip_key"}
+        db = MagicMock()
+        db.resolve_resume_session_id.side_effect = lambda k: k
+        db.get_compression_lineage.side_effect = lambda k: ["root_key", "tip_key"] if k == "root_key" else [k]
+        with patch("tui_gateway.server._get_db", return_value=db):
+            assert _session_owns_notification_event("tabX", {"session_key": "root_key", "_finalized": False}, evt)
+            assert not _session_owns_notification_event(
+                "tabY", {"session_key": "other_key", "_finalized": False}, evt)

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -47,6 +47,8 @@ _MAX_DELIVERY_ATTEMPTS = 8
 # Pending completions older than this are dropped on restart replay instead of
 # re-run as a full-context turn; 48h keeps weekend results deliverable.
 _MAX_COMPLETION_REPLAY_AGE_S = 48 * 3600.0
+# A delivery claim older than this is stale (consumer died mid-turn) and may be re-claimed.
+_DELIVERY_CLAIM_WINDOW_S = 300.0
 _DB_LOCK = threading.Lock()
 
 # ── Stale-delegation detection (progress-based, on by default) ──────────────
@@ -268,29 +270,66 @@ def restore_undelivered_completions(target_queue) -> int:
     (#64484).
     """
     recover_abandoned_delegations()
-    now, restored = time.time(), 0
     with _DB_LOCK, _transaction() as conn:
-        rows = conn.execute("""SELECT delegation_id, event_json, completed_at, dispatched_at
-               FROM async_delegations
-               WHERE state != 'running' AND delivery_state='pending' AND event_json IS NOT NULL
-               ORDER BY completed_at, delegation_id""").fetchall()
-        for delegation_id, payload, completed_at, dispatched_at in rows:
-            age_basis = completed_at or dispatched_at
-            if age_basis and (now - age_basis) > _MAX_COMPLETION_REPLAY_AGE_S:
-                conn.execute("""UPDATE async_delegations SET delivery_state='dropped',
-                              delivery_claim=NULL, delivery_claimed_at=NULL,
-                              updated_at=?
-                       WHERE delegation_id=? AND delivery_state='pending'""", (now, delegation_id))
-                logger.warning("Async delegation %s: pending completion is %.1fh old "
-                               "(cap %.1fh); terminally dropping the replay (result remains queryable).",
-                               delegation_id, (now - age_basis) / 3600.0, _MAX_COMPLETION_REPLAY_AGE_S / 3600.0)
-                continue
-            evt = json.loads(payload)
-            if isinstance(evt, dict):
-                evt["restored"] = True
-            target_queue.put(evt)
-            restored += 1
+        rows = conn.execute(f"{_PENDING_REPLAY_SELECT} ORDER BY completed_at, delegation_id").fetchall()
+        return _replay_pending_rows(conn, rows, target_queue)
+
+
+_PENDING_REPLAY_SELECT = """SELECT delegation_id, event_json, completed_at, dispatched_at
+       FROM async_delegations
+       WHERE state != 'running' AND delivery_state='pending' AND event_json IS NOT NULL"""
+
+
+def _replay_pending_rows(conn: sqlite3.Connection, rows, target_queue) -> int:
+    """Re-enqueue pending completion rows as ``restored=True`` events (in memory only);
+    rows past the replay age cap are terminally dropped instead. Returns the enqueued count."""
+    now, restored = time.time(), 0
+    for delegation_id, payload, completed_at, dispatched_at in rows:
+        age_basis = completed_at or dispatched_at
+        if age_basis and (now - age_basis) > _MAX_COMPLETION_REPLAY_AGE_S:
+            conn.execute("""UPDATE async_delegations SET delivery_state='dropped',
+                          delivery_claim=NULL, delivery_claimed_at=NULL,
+                          updated_at=?
+                   WHERE delegation_id=? AND delivery_state='pending'""", (now, delegation_id))
+            logger.warning("Async delegation %s: pending completion is %.1fh old "
+                           "(cap %.1fh); terminally dropping the replay (result remains queryable).",
+                           delegation_id, (now - age_basis) / 3600.0, _MAX_COMPLETION_REPLAY_AGE_S / 3600.0)
+            continue
+        evt = json.loads(payload)
+        if isinstance(evt, dict):
+            evt["restored"] = True
+        target_queue.put(evt)
+        restored += 1
     return restored
+
+
+def restore_pending_for_session(session_keys, target_queue) -> int:
+    """Re-enqueue the parked completions whose ``origin_session`` is one of ``session_keys``
+    (a session's key plus its compression lineage), for the session that just started or resumed.
+
+    The process-start replay puts every pending row on the shared queue once; when the owning
+    session is not open at that moment the poller that dequeues it drops the in-memory copy
+    (never adopt an orphan) while the durable row stays ``pending``. Without this call the
+    result would only ever be replayed at the next backend start and dropped again.
+
+    A row whose ``delivery_claim`` is younger than the claim window is being delivered right
+    now and is skipped. A row still queued in memory from the process-start replay CAN be
+    enqueued a second time here; that is harmless because ``claim_completion_delivery``
+    succeeds for exactly one copy — the other copy's claim finds the row already delivered (or
+    freshly claimed) and is discarded without a turn.
+    """
+    keys = sorted({str(k or "") for k in session_keys} - {""})
+    if not keys:
+        return 0
+    placeholders = ",".join("?" for _ in keys)
+    with _DB_LOCK, _transaction() as conn:
+        rows = conn.execute(
+            f"""{_PENDING_REPLAY_SELECT}
+                 AND origin_session IN ({placeholders})
+                 AND (delivery_claim IS NULL OR delivery_claimed_at < ?)
+               ORDER BY completed_at, delegation_id""",
+            (*keys, time.time() - _DELIVERY_CLAIM_WINDOW_S)).fetchall()
+        return _replay_pending_rows(conn, rows, target_queue)
 
 
 def _update_delivery(sql: str, params: tuple) -> bool:
@@ -319,7 +358,7 @@ def claim_completion_delivery(delegation_id: str, claim_id: str) -> bool:
                       delivery_attempts=delivery_attempts+1, updated_at=?
                WHERE delegation_id=? AND delivery_state='pending'
                  AND (delivery_claim IS NULL OR delivery_claimed_at < ?)""",
-            (claim_id, now, now, delegation_id, now - 300))
+            (claim_id, now, now, delegation_id, now - _DELIVERY_CLAIM_WINDOW_S))
         return cur.rowcount == 1
 
 

--- a/tui_gateway/session_notifications.py
+++ b/tui_gateway/session_notifications.py
@@ -22,6 +22,38 @@ def _notif_current_keys(sid: str, session: dict) -> set:
     return {str(session.get("session_key") or ""), _session_lookup_key(session, fallback=sid)}
 
 
+def _notif_lineage_keys(keys) -> set:
+    """``keys`` plus every id on their compression lineage (root through tip): a delegation dispatched
+    under a pre-compression session id must still match the session now keyed by the continuation, and a
+    resume at an ancestor id must still match a row stamped with the tip. Falls back to ``keys`` alone
+    when the store is unavailable."""
+    out = {str(k or "") for k in keys} - {""}
+    try:
+        db = _get_db()
+        if db is not None:
+            for key in list(out):
+                out.update(db.get_compression_lineage(key) or ())
+    except Exception:
+        pass
+    return out
+
+
+def _replay_parked_delegations(sid: str, session: dict) -> int:
+    """Re-enqueue durable delegation completions parked for this session (its keys + compression lineage)
+    onto the shared queue the poller just started draining. A ledger failure must never break session start."""
+    try:
+        from tools.async_delegation import restore_pending_for_session
+        from tools.process_registry import process_registry
+        keys = _notif_lineage_keys(_notif_current_keys(sid, session))
+        replayed = restore_pending_for_session(keys, process_registry.completion_queue)
+    except Exception as exc:
+        logger.debug("Parked delegation replay skipped for session %s: %s", sid, exc)
+        return 0
+    if replayed:
+        logger.info("Re-enqueued %d parked async delegation completion(s) for session %s", replayed, sid)
+    return replayed
+
+
 def _notif_session_matches(s: dict, keys) -> bool:
     return str(s.get("session_key") or "") in keys or _session_lookup_key(s, fallback="") in keys
 
@@ -81,8 +113,13 @@ def _session_owns_notification_event(sid: str, session: dict, evt: dict) -> bool
     if str(evt.get("origin_ui_session_id") or "") == str(sid or ""):
         return True
     evt_key = str(evt.get("session_key") or "")
+    if not evt_key:
+        return False
     current_keys = _notif_current_keys(sid, session)
-    return bool(evt_key) and (evt_key in current_keys or _notif_resolve_event_key(evt_key) in current_keys)
+    if evt_key in current_keys or _notif_resolve_event_key(evt_key) in current_keys:
+        return True
+    # A parked completion stamped with the lineage TIP while this session resumed at an ancestor id.
+    return evt_key in _notif_lineage_keys(current_keys)
 
 
 def _notification_event_requires_owner(evt: dict) -> bool:
@@ -344,6 +381,9 @@ def _notif_dispatch_event(sid: str, session: dict, evt: dict, text: str) -> None
     """Run the claimed (running=True) agent turn for one notification event."""
     from tools.async_delegation import claim_event_delivery, complete_event_delivery, release_event_delivery
     if (claim := claim_event_delivery(evt, "tui-poller")) is None:
+        # Another copy of this completion already claimed or delivered it (process-start replay +
+        # session-resume replay can both enqueue one row): give the turn back, no second injection.
+        _notif_release_turn(session)
         return
     kwargs = ({"display_kind": "async_delegation_complete", "display_metadata": _async_delegation_display_metadata(evt)}
               if evt.get("type") == "async_delegation" else {})
@@ -373,7 +413,8 @@ def _notif_handle_event(sid, session, evt, emitted, registry, fmt, deferred) -> 
         origin, key = str(evt.get("origin_ui_session_id") or ""), str(evt.get("session_key") or "")
         if deferred is None:
             (logger.warning if is_delegation else logger.debug)(
-                "Dropping unowned %s notification (origin=%r key=%r) instead of delivering to session %s",
+                "Dropping unowned %s notification (origin=%r key=%r) instead of delivering to session %s; "
+                "the payload stays parked in the durable ledger and is delivered when its own session is resumed",
                 evt_type, origin, key, sid)
         elif is_delegation:
             deferred.append(evt)
@@ -503,6 +544,7 @@ def _start_notification_poller(sid: str, session: dict) -> threading.Event:
     t = threading.Thread(target=_notification_poller_loop, args=(stop, sid, session), daemon=True, name=f"tui-notif-poller-{sid}")
     _notification_pollers[:] = [(s, th) for (s, th) in _notification_pollers if th.is_alive()] + [(stop, t)]
     t.start()
+    _replay_parked_delegations(sid, session)
     return stop
 
 


### PR DESCRIPTION
## What does this PR do?

The desktop app runs one `hermes serve` backend per profile and reaps a pooled backend once its renderer keepalive has been silent past the idle window. That keepalive only proves a renderer socket is open for the profile — it says nothing about the process. Switching to another profile stops the pings, so a backend still running agent turns and an hour-long in-process `delegate_task` subagent looked idle and was SIGTERM'd mid-work:

```text
Reaping idle profile backend "<profile>" (idle > 600s)
Hermes backend for profile "<profile>" exited (SIGTERM)
```

A second, latent bug made the loss silent. On the next backend start the abandoned delegation is recovered as `unknown` and replayed onto the shared completion queue once. If the owning chat is not open at that moment, whichever session's poller dequeues it drops the in-memory copy (correctly — never adopt an orphan) while the durable row stays `pending`. Nothing ever re-delivered it: every later backend start replayed and dropped it again, and resuming the owning chat found nothing queued. The user only learned the subagent had died by asking the agent.

Three focused commits:

1. **`fix(tui_gateway)`** — when a session's notification poller starts (new or resumed), re-enqueue the pending completions addressed to it (its keys plus compression lineage), so resuming the owner delivers the parked result. Ownership also matches a row stamped with the lineage tip when the session resumed at an ancestor id. A duplicate in-memory copy is harmless (the delivery claim succeeds for exactly one), and the losing copy now releases the turn it claimed — previously a failed claim left the session marked `running` forever. The drop warning now says the payload is parked and will be delivered on resume.
2. **`feat(web)`** — `GET /api/activity` (token-gated like `/api/status`, in-memory counters only, answers in milliseconds): `{busy, running_turns, active_subagents, background_processes}`. `busy` is true iff any counter is positive.
3. **`fix(desktop)`** — the pool idle reaper and the LRU cap probe `/api/activity` before stopping a spawned backend and spare it while busy; a backend seen busy within a short grace window (2 reaper ticks) survives a single probe blip. Older runtimes (404) and wedged processes (timeout) read as *unknown* and keep today's reap-on-idle path, so they are still reclaimed. The decision table and probe live in a dependency-free `electron/backend-activity.ts`; LRU eviction becomes async for the probe (sparing a busy backend may make an incoming spawn wait for a slot — the intended trade-off over aborting hours of agent work). Reaper ticks no longer overlap.

## Related Issue

No existing issue; observed on a real installation. Same family as #55578 / #64484 (delegation ownership), in the opposite direction — the event was lost rather than misdelivered.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (`/api/activity`, needed by the fix)

## Changes Made

- `tools/async_delegation.py`: shared `_replay_pending_rows`; new `restore_pending_for_session(session_keys, queue)`; named claim window constant.
- `tui_gateway/session_notifications.py`: `_replay_parked_delegations` on poller start; lineage-aware ownership; release the turn on a lost claim; clearer drop log.
- `hermes_cli/web_routers/activity.py` (new) + 2-line mount in `hermes_cli/web_server.py`.
- `apps/desktop/electron/backend-activity.ts` (new): `parseBackendActivity`, `decideIdleReap`, `withinBusyGrace`, `probeBackendActivity`, log formatters.
- `apps/desktop/electron/main.ts`: reaper/LRU wiring, `lastBusyAt` on pool entries, in-flight guard, `fetchJson` `maxRetries` passthrough (probe runs with 0 retries).
- Tests: `tests/tools/test_async_delegation.py`, `tests/tui_gateway/test_delegation_session_lifecycle.py` (real poller threads against the temp-home ledger: unrelated session must not deliver, owner resume must, no double delivery), `tests/hermes_cli/test_web_activity.py`, `apps/desktop/electron/backend-activity.test.ts`.

## How to Test

1. In the desktop app, open a chat on a secondary profile, have it dispatch a long `delegate_task`, then switch to another profile and wait past the pool idle window (`HERMES_DESKTOP_POOL_IDLE_MS=60000` shortens it). `logs/desktop.log` should show `Sparing busy profile backend "<profile>" (running_turns=…, active_subagents=1, …)` each tick, and the backend pid must survive until the subagent finishes; afterwards it is reaped normally.
2. `curl -H "<dashboard token header>" http://127.0.0.1:<port>/api/activity` on a backend running a turn → `busy: true`.
3. Backend-only: dispatch a background delegation, SIGKILL the backend, restart it, open an unrelated chat (must receive nothing; row stays `pending`), then resume the owning chat → it receives the `[ASYNC DELEGATION …]` turn and the ledger row becomes `delivered`.

Verification actually run (Linux):

```text
scripts/run_tests.sh tests/tools/test_async_delegation.py tests/tui_gateway/test_delegation_session_lifecycle.py tests/hermes_cli/test_web_activity.py
=== Summary: 3 files, 55 tests passed, 0 failed, 1 skipped ===

scripts/run_tests.sh tests/tui_gateway/  (plus the above)
=== 109 files, 1025 passed, 2 failed ===   # both in test_projects_rpc.py, identical failures on unmodified upstream/main

cd apps/desktop && npx vitest run --project electron
Test Files  150 passed | 2 skipped   Tests  2124 passed | 6 skipped
npx tsc --build tsconfig.electron.json   # clean
eslint on touched files, ruff on touched files   # clean
```

End-to-end, both against real processes in a throwaway `HERMES_HOME`:

- Real `hermes serve` driven over `/api/ws` with the step-3 scenario. Unfixed: the owner resumes with nothing delivered and the row stays `pending` (same `Dropping unowned async_delegation notification …` line as the incident). Fixed: `/api/activity` reports `active_subagents: 1` during work; the unrelated session receives nothing; on owner resume the log shows `Re-enqueued 1 parked async delegation completion(s)`, the notification turn runs, and the row ends `delivered`.
- Real Electron dev app, pooled second profile, subagent running a 7-minute command, renderer keepalive dropped, 60s idle window. Unfixed: `Reaping idle profile backend` + `exited (SIGTERM)` after ~2 minutes with the subagent still running. Fixed: `Sparing busy profile backend …` on seven consecutive ticks, then `Sparing recently busy … within 120s grace`, then `Reaping idle profile backend` only after the delegation completed (`completed | delivered` in the ledger); the backend pid was unchanged throughout.

Not run: macOS/Windows, `npm run check` (renderer/e2e typecheck — no renderer files changed), the full Python suite.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass — targeted suites above via `scripts/run_tests.sh`; full suite not run
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Arch), real Electron dev app + real backend

### Documentation & Housekeeping

- [x] Docstrings updated — N/A beyond that
- [x] No config keys added — N/A
- [x] No architecture/workflow change — N/A
- [x] Cross-platform: the probe uses the existing loopback `fetchJson`; no platform-specific code
- [x] No tool schema change — N/A
