### PR TITLE
fix(telegram): scope editable status messages to each turn

### DIFF
--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -772,8 +772,13 @@ class TurnRunner:
                 _redact_gateway_user_facing_secrets(str(message or ""))[:160],
             )
             return
+        # Adapters keep editable-message IDs across turns. A bare event type
+        # would make this turn edit an earlier turn's bubble (or another topic's).
+        status_key = event_type
+        if ctx.session_key and ctx.run_generation is not None:
+            status_key = f"{ctx.session_key}:run:{ctx.run_generation}:{event_type}"
         fut = self._schedule(
-            _send_or_update_status_coro(ctx._status_adapter, ctx._status_chat_id, event_type, prepared, ctx._status_thread_metadata),
+            _send_or_update_status_coro(ctx._status_adapter, ctx._status_chat_id, status_key, prepared, ctx._status_thread_metadata),
             f"status_callback ({event_type}) scheduling error",
         )
         if fut is not None and ctx._cleanup_progress:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -13,6 +13,7 @@ import time
 from contextvars import ContextVar
 from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable, Dict, Iterator, List, Optional, Set
+from weakref import WeakValueDictionary
 from hermes_cli import setup_platforms
 
 logger = logging.getLogger(__name__)
@@ -523,6 +524,9 @@ class TelegramAdapter(BasePlatformAdapter):
         # bubbles owned by this adapter so subsequent calls with the same key edit the same message instead
         # of appending new ones (#30045).
         self._status_message_ids: Dict[tuple, str] = {}
+        self._STATUS_MESSAGE_IDS_MAX = 2000
+        # Locks live only while an update is active or waiting for the same key.
+        self._status_locks: WeakValueDictionary[tuple, asyncio.Lock] = WeakValueDictionary()
         # Last truncated mid-stream preview per (chat_id, message_id): past the 4096 cap every edit
         # truncates to the SAME text, and resending burns flood budget. Dropped on finalize.
         self._last_overflow_preview: Dict[tuple, str] = {}
@@ -3393,18 +3397,27 @@ class TelegramAdapter(BasePlatformAdapter):
         remembered; subsequent calls with the same (chat_id, status_key) edit that same message in place.
         """
         key = (str(chat_id), str(status_key))
-        cached_id = self._status_message_ids.get(key)
-        if cached_id is not None:
-            result = await self.edit_message(chat_id, cached_id, content, finalize=True, metadata=metadata)
-            if result.success:
-                if result.message_id:
-                    self._status_message_ids[key] = str(result.message_id)
-                return result
-            self._status_message_ids.pop(key, None)
-        result = await self.send(chat_id, content, metadata=metadata)
-        if result.success and result.message_id:
-            self._status_message_ids[key] = str(result.message_id)
-        return result
+        lock = self._status_locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._status_locks[key] = lock
+        async with lock:
+            cached_id = self._status_message_ids.get(key)
+            if cached_id is not None:
+                result = await self.edit_message(chat_id, cached_id, content, finalize=True, metadata=metadata)
+                if result.success:
+                    if result.message_id:
+                        self._status_message_ids[key] = str(result.message_id)
+                    return result
+                self._status_message_ids.pop(key, None)
+            result = await self.send(chat_id, content, metadata=metadata)
+            if result.success and result.message_id:
+                # Per-turn keys accumulate in a long-running gateway.
+                if len(self._status_message_ids) >= self._STATUS_MESSAGE_IDS_MAX:
+                    for stale in list(self._status_message_ids)[:self._STATUS_MESSAGE_IDS_MAX // 2]:
+                        self._status_message_ids.pop(stale, None)
+                self._status_message_ids[key] = str(result.message_id)
+            return result
 
     async def _edit_text(self, chat_id: str, message_id: str, text: str, parse_mode: Any = None) -> None:
         """``editMessageText`` with normalized ids; ``parse_mode=None`` sends plain text."""

--- a/tests/gateway/test_telegram_status_update.py
+++ b/tests/gateway/test_telegram_status_update.py
@@ -9,6 +9,7 @@ The status-update path must:
 
 from __future__ import annotations
 
+import asyncio
 import sys
 import types
 from types import SimpleNamespace
@@ -16,8 +17,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.config import PlatformConfig
+from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import SendResult
+from gateway.run_turn_runner import TurnRunner
+from gateway.turn_context import TurnContext
 
 
 def _install_fake_telegram(monkeypatch):
@@ -106,3 +109,61 @@ async def test_distinct_status_keys_do_not_collide(adapter):
     assert adapter._status_message_ids[("chat-1", "model-switch")] == "200"
 
 
+@pytest.mark.asyncio
+async def test_gateway_statuses_edit_only_within_their_turn(adapter, monkeypatch):
+    pending = []
+    monkeypatch.setattr(
+        "gateway.run.safe_schedule_threadsafe",
+        lambda coro, *args, **kwargs: pending.append(coro),
+    )
+    # Exercise gateway routing and the real adapter send/edit path; only the
+    # Telegram network transport is replaced.
+    del adapter.send
+    del adapter.edit_message
+    adapter._bot.send_message = AsyncMock(side_effect=[SimpleNamespace(message_id=i) for i in range(3)])
+    adapter._bot.edit_message_text = AsyncMock()
+    for session, generation in [("topic-a", 1), ("topic-a", 2), ("topic-b", 1)]:
+        ctx = TurnContext(
+            source=SimpleNamespace(platform=Platform.TELEGRAM),
+            session_key=session, run_generation=generation,
+            _status_adapter=adapter, _status_chat_id="123",
+            _run_still_current=lambda: True,
+        )
+        turn = TurnRunner(MagicMock(), ctx)
+        turn._status_callback_sync("lifecycle", "Starting")
+        turn._status_callback_sync("lifecycle", "Continuing")
+        for coro in pending:
+            await coro
+        pending.clear()
+
+    assert adapter._bot.send_message.await_count == 3
+    assert [call.kwargs["message_id"] for call in adapter._bot.edit_message_text.await_args_list] == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_overlapping_statuses_send_once_and_old_turn_cache_is_bounded(adapter):
+    started, release = asyncio.Event(), asyncio.Event()
+
+    async def delayed_send(*args, **kwargs):
+        started.set()
+        await release.wait()
+        return SendResult(success=True, message_id="first")
+
+    adapter.send.side_effect = delayed_send
+    adapter.edit_message.return_value = SendResult(success=True)
+    first = asyncio.create_task(adapter.send_or_update_status("chat-1", "turn-1", "Starting"))
+    await asyncio.wait_for(started.wait(), timeout=5)
+    second = asyncio.create_task(adapter.send_or_update_status("chat-1", "turn-1", "Continuing"))
+    await asyncio.sleep(0)
+    release.set()
+    await asyncio.wait_for(asyncio.gather(first, second), timeout=5)
+    assert adapter.send.await_count == 1
+    adapter.edit_message.assert_awaited_once()
+
+    adapter._STATUS_MESSAGE_IDS_MAX = 4
+    adapter.send.side_effect = None
+    adapter.send.return_value = SendResult(success=True, message_id="next")
+    for i in range(10):
+        await adapter.send_or_update_status("chat-1", f"later-{i}", "Starting")
+    assert len(adapter._status_message_ids) <= adapter._STATUS_MESSAGE_IDS_MAX
+    assert adapter._status_message_ids[("chat-1", "later-9")] == "next"


### PR DESCRIPTION
## What does this PR do?

Gateway status callbacks currently use the event type (for example `lifecycle`) as the editable-message key. Telegram retains that key across turns, so a later turn can edit an earlier turn's status bubble, including a bubble belonging to another topic in the same chat. Overlapping first updates can also both send a new bubble.

Scope gateway status keys to the session and run generation, serialize Telegram updates for the same key, and bound the retained message-ID cache. Calls without a complete turn identity preserve their existing key. No new dependency or user setting is introduced.

## Type of Change

- [x] Bug fix

## Changes Made

- Add turn identity at the gateway's existing status callback.
- Keep one active lock per Telegram status key, with weak references after callers finish.
- Add two behavior tests for cross-turn/topic ownership and overlapping updates/cache growth.

## How to Test

`scripts/run_tests.sh tests/gateway/test_telegram_status_update.py tests/gateway/test_memory_status.py tests/gateway/test_telegram_progress_edit_transient.py -q -j 2 --file-retries 0`

Linux: **36 passed**. The regression tests failed against base `71f8c60f6a6ab8f2fab1e4d5c22d6dd9c856b63e`: a later turn reused the old bubble and overlapping updates sent twice. The gateway regression exercises the actual adapter send/edit methods with a fake Telegram transport; no real user messages were sent. The full repository suite and live Telegram delivery have not been run for this draft.

## Checklist

- [x] Focused change with regression coverage and Conventional Commit
- [x] Searched existing upstream PRs for duplicate Telegram turn/status fixes
- [x] No private configuration, credentials, or new dependencies
- [ ] Full repository suite and additional platform CI

Adapted from a locally used fix by M-Lietz to the current upstream module layout, with LietzTech Agent assistance.
