### PR TITLE
GPT-6 Astra + Astra Pro (standard/fast/flex) pickable on Nous Portal and OpenRouter

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -331,6 +331,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     # OpenAI — direct-API windows (Codex OAuth caps gpt-5.4+/5.5/5.6 at 272K, resolved by
     # its own branch). 5.4-nano/-mini are 400k, not 1.05M; gpt-5.3-codex-spark is
     # Codex-OAuth-only and listed so "gpt-5" (400k) doesn't win.
+    "gpt-6-astra": 1050000,  # also matches -pro (verified live on OpenRouter)
     "gpt-5.6-luna": 1050000, "gpt-5.6-terra": 1050000, "gpt-5.6-sol": 1050000, "gpt-5.5": 1050000,
     "gpt-5.4-nano": 400000, "gpt-5.4-mini": 400000, "gpt-5.4": 1050000,
     "gpt-5.3-codex-spark": 128000, "gpt-5.1-chat": 128000, "gpt-5": 400000,

--- a/hermes_cli/models_catalog_static.py
+++ b/hermes_cli/models_catalog_static.py
@@ -19,13 +19,19 @@ _OPENROUTER_DESCRIPTIONS = {
     "moonshotai/kimi-k3": "recommended",
     "z-ai/glm-5.2": "default",
     "openrouter/pareto-code": "auto-routes to cheapest coder meeting openrouter.min_coding_score",
+    "openai/gpt-6-astra-fast": "2x price, priority tier",
+    "openai/gpt-6-astra-flex": "0.5x price, flex tier",
+    "openai/gpt-6-astra-pro-fast": "2x price, priority tier",
+    "openai/gpt-6-astra-pro-flex": "0.5x price, flex tier",
 }
 OPENROUTER_MODELS: list[tuple[str, str]] = [
     (mid, _OPENROUTER_DESCRIPTIONS.get(mid, "free" if mid.endswith(":free") else ""))
     for mid in (
         "anthropic/claude-fable-5.1", "anthropic/claude-fable-5", "anthropic/claude-opus-5",
         "anthropic/claude-opus-5-fast", "anthropic/claude-opus-4.8", "anthropic/claude-opus-4.8-fast",
-        "anthropic/claude-sonnet-5", "anthropic/claude-haiku-4.5", "openai/gpt-5.6-sol", "openai/gpt-5.6-sol-pro",
+        "anthropic/claude-sonnet-5", "anthropic/claude-haiku-4.5", "openai/gpt-6-astra", "openai/gpt-6-astra-fast",
+        "openai/gpt-6-astra-flex", "openai/gpt-6-astra-pro", "openai/gpt-6-astra-pro-fast", "openai/gpt-6-astra-pro-flex",
+        "openai/gpt-5.6-sol", "openai/gpt-5.6-sol-pro",
         "openai/gpt-5.6-terra", "openai/gpt-5.6-terra-pro", "openai/gpt-5.6-luna", "openai/gpt-5.6-luna-pro",
         "openai/gpt-5.5", "openai/gpt-5.5-pro", "openai/gpt-5.4-mini", "google/gemini-3.1-pro-preview",
         "google/gemini-3.8-flash", "google/gemini-3.7-flash", "x-ai/grok-4.6", "deepseek/deepseek-v4-pro",

--- a/plugins/model-providers/openrouter/__init__.py
+++ b/plugins/model-providers/openrouter/__init__.py
@@ -42,6 +42,19 @@ def _sticky_key(session_id: str | None) -> str | None:
     return _cache_scope_from_session_id(get_affinity_scope() or get_conversation_context() or session_id)
 
 
+# OpenAI speed tiers. Nous Portal serves them as distinct slugs (``-fast``/``-flex``); OpenRouter
+# serves them as ENDPOINTS of the base model (tags ``openai/fast``, ``openai/flex``) and silently
+# routes an unknown suffix to the standard tier at standard price. So the picker carries the Nous
+# slugs for both providers, and here the wire model becomes the base slug with ``provider.only``
+# pinned to that tier's endpoints; the base slug is pinned to the standard endpoints so default
+# routing never lands on flex/fast.
+_SPEED_TIER_ENDPOINTS = {"": ("openai", "azure", "azure/us"), "-fast": ("openai/fast",), "-flex": ("openai/flex",)}
+_SPEED_TIERED_BASES = ("openai/gpt-6-astra", "openai/gpt-6-astra-pro")
+OPENROUTER_ENDPOINT_PINS: dict[str, tuple[str, tuple[str, ...]]] = {
+    base + suffix: (base, tags) for base in _SPEED_TIERED_BASES for suffix, tags in _SPEED_TIER_ENDPOINTS.items()
+}
+
+
 class OpenRouterProfile(ProviderProfile):
     """OpenRouter aggregator — provider preferences, reasoning config passthrough."""
 
@@ -113,6 +126,10 @@ class OpenRouterProfile(ProviderProfile):
         if sticky_key:
             body["session_id"] = sticky_key
         prefs = context.get("provider_preferences")
+        pin = OPENROUTER_ENDPOINT_PINS.get(context.get("model") or "")
+        if pin:
+            # The tier pin owns ``only``; the user's other routing prefs (ignore/sort/...) still apply.
+            prefs = {**(prefs or {}), "only": list(pin[1])}
         if prefs:
             body["provider"] = prefs
         # Pareto Code router plugin is only meaningful for openrouter/pareto-code.
@@ -130,9 +147,13 @@ class OpenRouterProfile(ProviderProfile):
         self, *, reasoning_config: dict | None = None, supports_reasoning: bool = False,
         model: str | None = None, session_id: str | None = None, **context: Any,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
-        """Pass reasoning_config as extra_body.reasoning; pin Grok's cache via x-grok-conv-id."""
+        """Pass reasoning_config as extra_body.reasoning; pin Grok's cache via x-grok-conv-id;
+        rewrite speed-tier slugs to their OpenRouter base model."""
         extra_body: dict[str, Any] = {}
         top_level: dict[str, Any] = {}
+        pin = OPENROUTER_ENDPOINT_PINS.get(model or "")
+        if pin and pin[0] != model:
+            top_level["model"] = pin[0]
         if supports_reasoning:
             # Reasoning-mandatory Anthropic models use adaptive thinking: any
             # ``reasoning`` field (disable, or an enabled form on a tool-continuation

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -190,6 +190,25 @@ class TestOpenRouterProfile:
         )
         assert tl == {"verbosity": "high"}
 
+    def test_speed_tier_slugs_pin_endpoints_and_rewrite_wire_model(self):
+        """Nous-style ``-fast``/``-flex`` slugs are OpenRouter ENDPOINTS of the base model: the wire
+        model must be the base slug and ``provider.only`` must select exactly that tier, while the
+        user's other routing prefs survive. The base slug itself is pinned off the flex/fast tiers."""
+        import inspect
+        p = get_provider_profile("openrouter")
+        pins = inspect.getmodule(type(p)).OPENROUTER_ENDPOINT_PINS
+        for slug, (base, tags) in pins.items():
+            _, tl = p.build_api_kwargs_extras(model=slug)
+            body = p.build_extra_body(model=slug, provider_preferences={"ignore": ["deepinfra"]})
+            assert tl.get("model", slug) == base
+            assert body["provider"] == {"ignore": ["deepinfra"], "only": list(tags)}
+            tiered = [t for t in tags if t.endswith(("/fast", "/flex"))]
+            assert tiered == ([] if slug == base else list(tags))
+        # Unpinned model: no rewrite, prefs pass through untouched.
+        _, tl = p.build_api_kwargs_extras(model="openai/gpt-5.6-sol")
+        assert "model" not in tl
+        assert p.build_extra_body(model="openai/gpt-5.6-sol", provider_preferences={"ignore": ["x"]})["provider"] == {"ignore": ["x"]}
+
 
 class TestNousProfile:
     def test_tags(self):

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-09-03T07:08:39Z",
+  "updated_at": "2026-09-04T22:47:22Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -43,6 +43,30 @@
         {
           "id": "anthropic/claude-haiku-4.5",
           "description": ""
+        },
+        {
+          "id": "openai/gpt-6-astra",
+          "description": ""
+        },
+        {
+          "id": "openai/gpt-6-astra-fast",
+          "description": "2x price, priority tier"
+        },
+        {
+          "id": "openai/gpt-6-astra-flex",
+          "description": "0.5x price, flex tier"
+        },
+        {
+          "id": "openai/gpt-6-astra-pro",
+          "description": ""
+        },
+        {
+          "id": "openai/gpt-6-astra-pro-fast",
+          "description": "2x price, priority tier"
+        },
+        {
+          "id": "openai/gpt-6-astra-pro-flex",
+          "description": "0.5x price, flex tier"
         },
         {
           "id": "openai/gpt-5.6-sol",
@@ -246,6 +270,24 @@
         },
         {
           "id": "anthropic/claude-haiku-4.5"
+        },
+        {
+          "id": "openai/gpt-6-astra"
+        },
+        {
+          "id": "openai/gpt-6-astra-fast"
+        },
+        {
+          "id": "openai/gpt-6-astra-flex"
+        },
+        {
+          "id": "openai/gpt-6-astra-pro"
+        },
+        {
+          "id": "openai/gpt-6-astra-pro-fast"
+        },
+        {
+          "id": "openai/gpt-6-astra-pro-flex"
         },
         {
           "id": "openai/gpt-5.6-sol"


### PR DESCRIPTION
GPT-6 Astra and GPT-6 Astra Pro are pickable on Nous Portal and OpenRouter, in all three OpenAI speed tiers (standard / fast / flex), from the curated catalogs.

## Changes

- `hermes_cli/models_catalog_static.py`: six slugs in `OPENROUTER_MODELS` (nous derives from it), above the gpt-5.6 line: `openai/gpt-6-astra{,-fast,-flex}`, `openai/gpt-6-astra-pro{,-fast,-flex}`. Tier descriptions `2x price, priority tier` / `0.5x price, flex tier`.
- `plugins/model-providers/openrouter/__init__.py`: `OPENROUTER_ENDPOINT_PINS`. OpenRouter has no tier slugs; the tiers are **endpoints** of the base model (`openai/fast`, `openai/flex`), and an unknown suffix silently routes to the standard tier at standard price. The profile rewrites a tier slug to the base wire model and pins `provider.only` to that tier's endpoint. The base slug is pinned to `openai` / `azure` / `azure/us` so default routing never lands on flex or fast. The user's other routing prefs (`ignore`, `sort`, ...) still merge in.
- `agent/model_metadata.py`: `gpt-6-astra: 1,050,000` (substring-matches `-pro` and the tier suffixes; verified live on OpenRouter for both models).
- `website/static/api/model-catalog.json` regenerated.

Deliberately not touched (scoped rollout): `_PROVIDER_MODELS["openai-api"]`, codex lists, copilot aliases, setup defaults. Pricing snapshot skipped: both routes bill via `official_models_api`. #103057 (direct OpenAI/Codex Astra baseline) is a different surface and stays independent.

## Validation

| Check | Result |
|---|---|
| Nous Portal live, all six slugs | 200; each echoes its own id; `service_tier` default / priority / flex; cost 1x / 2x / 0.5x (`gpt-6-astra` 0.00036 / 0.00072 / 0.00018 for the same 16-token call) |
| Nous Portal `provider` prefs | 400 "routing decided centrally" — pins are OpenRouter-only by construction |
| OpenRouter `/models/{id}/endpoints` | astra: `openai`, `azure`, `openai/flex`, `openai/fast`; astra-pro adds `azure/us`; flex 0.5x, fast 2x |
| OpenRouter live, full `AIAgent` path | `openai/gpt-6-astra` → wire `openai/gpt-6-astra` + `only:[openai,azure,azure/us]` → "ok" (Azure, std price). `openai/gpt-6-astra-pro-flex` → wire `openai/gpt-6-astra-pro` + `only:[openai/flex]` (request shape correct; the OpenAI-direct endpoints reject this account with an upstream "Policy Violation" 502 — account-side, also fires for `gpt-5.6-sol` with `only:[openai]`, so the flex/fast tiers could not be billed-verified on OpenRouter from here) |
| Control: unpinned `openai/gpt-6-astra:flex` on OpenRouter | routes to Azure at standard price — the silent-downgrade this PR prevents |
| Curated fallback (network denied, temp `HERMES_HOME`) | both providers list exactly the six slugs, in order, no dupes; context 1,050,000 |
| Tests | `tests/providers/ + 8 catalog suites`: 424 passed. New invariant test: every pin rewrites to its base and pins exactly its tier; unpinned models untouched |

## Infographic

![Nous Portal added support for GPT-6 Astra](https://v3b.fal.media/files/b/0aa92124/PYimvz0F-dt6VnAr8scrd_dhIDdjgc.png)
