### PR TITLE
feat(discord): per-user toolset roles (toolset_roles + user_roles)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1369,6 +1369,12 @@ platform_toolsets:
 #   reactions: true                  # Show processing reactions (default: true)
 #   history_backfill: true           # Recover missed channel messages on mention (default: true)
 #   history_backfill_limit: 50       # Max messages to scan backwards (default: 50)
+#   toolset_roles:                   # Named toolset bundles (roles)
+#     research: [web, skills]
+#     full: [hermes-discord]
+#   user_roles:                      # Per-DM-peer assignment; unlisted users keep the platform default
+#     "123456789012345678": research
+#     "876543210987654321": [research, full]   # multiple roles are additive
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Available toolsets (use these names in platform_toolsets or the toolsets list)

--- a/gateway/config_loader.py
+++ b/gateway/config_loader.py
@@ -210,6 +210,8 @@ _SHARED_KEYS: tuple = (
     ),
     ("channel_skill_bindings", _DISCORD_SLACK, None),
     ("channel_prompts", None, _str_keyed),
+    ("toolset_roles", None, _str_keyed),
+    ("user_roles", None, _str_keyed),
     *_plain("gateway_restart_notification", "typing_indicator", "typing_status_text"),
 )
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4823,6 +4823,51 @@ class DiscordAdapter(BasePlatformAdapter):
         from gateway.platforms.base import resolve_channel_prompt
         return resolve_channel_prompt(self.config.extra, channel_id, parent_id)
 
+    def toolsets_for_source(self, source) -> Optional[List[str]]:
+        """Per-user toolset role resolution.
+
+        Config format (in platform extra):
+            toolset_roles:
+              research: [web, skills]   # named toolset bundles
+            user_roles:
+              "<numeric Discord user ID>": research         # single role
+              "<other numeric user ID>": [research, admin]  # multiple, additive
+
+        A user's configured role (or roles, unioned and deduped) REPLACES the
+        platform-level ``platform_toolsets.discord`` resolution for this run
+        only. Resolution is validated through the same ``_get_platform_tools``
+        path as all other toolset config, so unknown or platform-restricted
+        toolset names are dropped rather than trusted. Users without an entry
+        — or whose roles resolve to nothing (missing ``toolset_roles``,
+        unknown role names, empty bundles) — keep the platform default.
+        """
+        user_id = str(getattr(source, "user_id", "") or "")
+        if not user_id:
+            return None
+        extra = self.config.extra if isinstance(getattr(self.config, "extra", None), dict) else {}
+        user_roles = extra.get("user_roles")
+        assigned = user_roles.get(user_id) if isinstance(user_roles, dict) else None
+        if isinstance(assigned, str):
+            assigned = [assigned]
+        if not isinstance(assigned, list) or not assigned:
+            return None
+        roles = extra.get("toolset_roles")
+        if not isinstance(roles, dict):
+            return None
+        toolsets: List[str] = []
+        for role in assigned:
+            role_name = str(role).strip()
+            if not role_name:
+                continue
+            bundle = roles.get(role_name)
+            if not isinstance(bundle, list):
+                continue  # unknown role: nothing added, defaults apply
+            for toolset in bundle:
+                name = str(toolset).strip()
+                if name and name not in toolsets:
+                    toolsets.append(name)
+        return toolsets or None
+
     def _extra_or_env_flag(self, key: str, env_key: str, env_default: str, *, truthy: bool) -> bool:
         """Boolean from ``config.extra[key]`` (str parsed permissively) else ``env_key``.
         ``truthy=True`` env values must be in {true,1,yes,on}; ``truthy=False`` env values are on

--- a/tests/gateway/test_discord_toolset_roles.py
+++ b/tests/gateway/test_discord_toolset_roles.py
@@ -1,0 +1,212 @@
+"""Per-user Discord toolset roles (adapter.toolsets_for_source).
+
+A Discord platform config may carry ``toolset_roles`` (named toolset
+bundles) and ``user_roles`` (numeric Discord user ID -> role name or
+list of role names). For runs triggered by an assigned user, the union
+of their roles' toolsets REPLACES the platform-level
+``platform_toolsets.discord`` resolution. Unassigned users — and users
+whose roles are unknown, missing, or resolve to nothing — keep the
+platform default. The gateway validates the override through the same
+``_get_platform_tools`` path as platform config, so restricted/unknown
+toolset names behave identically to a manually configured list.
+
+Models tests/gateway/test_webhook_route_toolsets.py: webhook's per-route
+``toolsets`` is the same extension point scoped to routes; this scopes it to
+users (use case: a shared Discord bot where the operator wants a second
+allowed DM peer to have web access but no terminal/file/config tools).
+"""
+
+from types import SimpleNamespace
+
+from gateway.platforms.base import BasePlatformAdapter
+from gateway.run import GatewayRunner
+from hermes_cli.tools_config import _get_platform_tools
+
+
+def _ensure_discord_sdk():
+    import sys
+    import types
+    from unittest.mock import MagicMock
+
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+    discord_mod = types.ModuleType("discord")
+    discord_mod.Intents = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.Interaction = object
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+_ensure_discord_sdk()
+
+from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+
+ROLE_USER_ID = "100000000000000001"     # fake numeric Discord user ID
+UNASSIGNED_ID = "100000000000000002"    # fake numeric Discord user ID
+ROLES = {
+    "research": ["web", "skills"],
+    "full": ["terminal", "file"],
+}
+
+
+class _Src:
+    def __init__(self, user_id):
+        self.user_id = user_id
+        self.chat_id = f"dm:{user_id}"
+
+
+def _make_adapter(toolset_roles=None, user_roles=None):
+    adapter = object.__new__(DiscordAdapter)
+    adapter.config = SimpleNamespace(
+        extra={"toolset_roles": toolset_roles, "user_roles": user_roles}
+    )
+    return adapter
+
+
+def _make_runner(adapter):
+    gr = object.__new__(GatewayRunner)
+    gr._adapter_for_source = lambda source: adapter
+    return gr
+
+
+BASE_CONFIG = {
+    "platform_toolsets": {"discord": ["hermes-discord"]},
+}
+
+
+class TestDiscordAdapterToolsetsForSource:
+    def test_single_role_string_returns_bundle(self):
+        adapter = _make_adapter(ROLES, {ROLE_USER_ID: "research"})
+        assert adapter.toolsets_for_source(_Src(ROLE_USER_ID)) == ["web", "skills"]
+
+    def test_multiple_roles_union_with_dedupe(self):
+        # Overlapping toolsets across roles are additive with one copy.
+        adapter = _make_adapter(
+            {"a": [" web ", "x"], "b": ["x", "y"]},
+            {ROLE_USER_ID: ["a", "b"]},
+        )
+        assert adapter.toolsets_for_source(_Src(ROLE_USER_ID)) == ["web", "x", "y"]
+
+    def test_unlisted_user_returns_none(self):
+        adapter = _make_adapter(ROLES, {ROLE_USER_ID: "research"})
+        assert adapter.toolsets_for_source(_Src(UNASSIGNED_ID)) is None
+
+    def test_missing_user_id_returns_none(self):
+        adapter = _make_adapter(ROLES, {ROLE_USER_ID: "research"})
+        assert adapter.toolsets_for_source(_Src("")) is None
+
+    def test_no_user_roles_config_returns_none(self):
+        adapter = _make_adapter(ROLES, None)
+        assert adapter.toolsets_for_source(_Src(ROLE_USER_ID)) is None
+
+    def test_unknown_role_returns_none(self):
+        # Unknown role names contribute nothing; user keeps platform default.
+        adapter = _make_adapter(ROLES, {ROLE_USER_ID: "does_not_exist"})
+        assert adapter.toolsets_for_source(_Src(ROLE_USER_ID)) is None
+
+    def test_partial_unknown_roles_still_resolve_known_ones(self):
+        adapter = _make_adapter(ROLES, {ROLE_USER_ID: ["ghost", "research"]})
+        assert adapter.toolsets_for_source(_Src(ROLE_USER_ID)) == ["web", "skills"]
+
+    def test_missing_toolset_roles_returns_none(self):
+        adapter = _make_adapter(None, {ROLE_USER_ID: "research"})
+        assert adapter.toolsets_for_source(_Src(ROLE_USER_ID)) is None
+
+    def test_empty_or_non_list_entries_return_none(self):
+        adapter = _make_adapter(
+            {
+                "empty": [],
+                "weird": "notalist",
+                "blank": ["  "],
+            },
+            {
+                "1": "empty",
+                "2": "weird",
+                "3": "blank",
+                "4": [],
+                "5": " ",
+            },
+        )
+        for uid in ("1", "2", "3", "4", "5"):
+            assert adapter.toolsets_for_source(_Src(uid)) is None
+
+    def test_missing_extra_returns_none(self):
+        adapter = object.__new__(DiscordAdapter)
+        adapter.config = SimpleNamespace(extra=None)
+        assert adapter.toolsets_for_source(_Src(ROLE_USER_ID)) is None
+
+    def test_base_adapter_default_is_none(self):
+        # Adapters without the override (telegram, slack, ...) inherit None.
+        adapter = _make_adapter(ROLES, {ROLE_USER_ID: "research"})
+        assert (
+            BasePlatformAdapter.toolsets_for_source(adapter, _Src(ROLE_USER_ID)) is None
+        )
+
+
+class TestGatewayResolveEnabledToolsetsForSource:
+    def test_role_override_replaces_platform_resolution(self):
+        adapter = _make_adapter({"research": ["web"]}, {ROLE_USER_ID: "research"})
+        gr = _make_runner(adapter)
+        res = GatewayRunner._resolve_enabled_toolsets_for_source(
+            gr, BASE_CONFIG, _Src(ROLE_USER_ID), "discord"
+        )
+        assert "web" in res
+        # The platform's full-access composite must be gone, not merged.
+        for forbidden in ("terminal", "file", "code_execution", "browser",
+                          "memory", "skills", "vision", "discord", "discord_admin"):
+            assert forbidden not in res, f"unexpected toolset in restricted run: {forbidden}"
+
+    def test_unlisted_user_keeps_platform_default(self):
+        adapter = _make_adapter({"research": ["web"]}, {ROLE_USER_ID: "research"})
+        gr = _make_runner(adapter)
+        res = GatewayRunner._resolve_enabled_toolsets_for_source(
+            gr, BASE_CONFIG, _Src(UNASSIGNED_ID), "discord"
+        )
+        assert res == sorted(_get_platform_tools(BASE_CONFIG, "discord"))
+        assert "terminal" in res
+
+    def test_unknown_role_keeps_platform_default(self):
+        # Spec: a user assigned a role that doesn't exist gets default perms.
+        adapter = _make_adapter({"research": ["web"]}, {ROLE_USER_ID: "no_such_role"})
+        gr = _make_runner(adapter)
+        res = GatewayRunner._resolve_enabled_toolsets_for_source(
+            gr, BASE_CONFIG, _Src(ROLE_USER_ID), "discord"
+        )
+        assert res == sorted(_get_platform_tools(BASE_CONFIG, "discord"))
+        assert "terminal" in res
+
+    def test_role_override_does_not_mutate_caller_config(self):
+        adapter = _make_adapter({"research": ["web"]}, {ROLE_USER_ID: "research"})
+        gr = _make_runner(adapter)
+        cfg = dict(BASE_CONFIG)
+        cfg["platform_toolsets"] = dict(BASE_CONFIG["platform_toolsets"])
+        GatewayRunner._resolve_enabled_toolsets_for_source(
+            gr, cfg, _Src(ROLE_USER_ID), "discord"
+        )
+        assert cfg["platform_toolsets"]["discord"] == ["hermes-discord"]
+
+    def test_validation_matches_platform_config_path(self):
+        # Same-shape invariant as the webhook per-route tests: the per-user
+        # role resolution resolves identically to manually saving that list
+        # as the platform's toolset config.
+        adapter = _make_adapter({"research": ["web"]}, {ROLE_USER_ID: "research"})
+        gr = _make_runner(adapter)
+        override_res = GatewayRunner._resolve_enabled_toolsets_for_source(
+            gr, BASE_CONFIG, _Src(ROLE_USER_ID), "discord"
+        )
+        manual = sorted(
+            _get_platform_tools(
+                {**BASE_CONFIG, "platform_toolsets": {**BASE_CONFIG["platform_toolsets"], "discord": ["web"]}},
+                "discord",
+            )
+        )
+        assert override_res == manual


### PR DESCRIPTION
**Summary**

This PR adds role-based access control to Hermes's Discord. Its intended to be used when bots are shared, so granular tool permissions assignments can be made to different Discord UIDs.

**What Changed**
`plugins/platforms/discord/adapter.py` - added `DiscordAdapter.toolsets_for_source()` which overrides the no-op hook on `BasePlatformAdapter` to resolve a user's configured roles into a list of tools.

`gateway/config_loader.py` - added capability for two new config keys to be ingested and passed along.

`cli-config.yaml.example` - updated to include two new config keys in the existing `discord` block; `toolset_roles` and `user_roles`.

'tests/gateway/test_discord_toolset_roles.py` - Additional positive-pass and/or negative-pass tests:

- bundle passthrough with whitespace stripped
- additive roles with dedupe
- `None` for unlisted user
- empty Discord user ID
- missing `user_roles`
- `user_roles` with a mix of known and unknown role entries
- missing `toolset_roles`
- unknown role
- unknown role keeps default tools
- malformed config entries
- missing `extra config`
- Base class inheritance
- restricted role defs actually exclude full access toolset
- unlisted user keeps platform default tools
- caller config dict unmutated
- resolved identity is invariant

**Testing**
Define as role bundle in `toolset_roles`:
```
discord:
  toolset_roles:
    research: [web, skills]
  user_roles:
    "<123456789012345678>": research  # or [research, other] 
```
Assign roles to a Discord user ID in `user_roles`.

DM as the defined user and ask the agent to do something disallowed; it should be denied.
DM as the defined user and attempt a tool call to an allowed tool, it should be allowed.

I was unable to run the full `pytest` suite due to my local platform. `pytest tests/gateway/test_discord_toolset_roles.py` passes; tests for Discord roles, access policy, toolset isolation, and allowed channels are also passing 84/84(100).

Platform: Win 10 w/Python 3.12

**Backwards compatibility**
This change is fully backwards compat; there are no behavioral changes if users don't set the new keys.

**Note**

This PR has related functionality to:

- PR #96087 (admin/user tool-tier, RFC #20744): This one is a binary admin-or-not with a platform-wide `user_toolsets` intersection; my change is per-user with no admin list. No config conflict.
- PR #3995 `gateway.user_roles`: This limits tools-per-user on all platforms. It uses list of tools per user; there is functional overlap here but hasn't been updated for a while. No config conflict. If this PR is accepted along with 3995, the set of tools permitted to a Discord user is the intersection of both limits.
- PR #26716 gates tools in the API server via the role derived from the API key hash.
