### PR TITLE
fix(dashboard): honor profile display_name in the profile switcher

### DIFF
--- a/hermes_cli/web_server_profiles.py
+++ b/hermes_cli/web_server_profiles.py
@@ -109,6 +109,7 @@ def _fallback_profile_entry(profiles_mod, name: str, home: Path, *, is_default: 
         "skill_count": _safe(lambda: profiles_mod._count_skills(home), 0),
         "gateway_running": _safe(gateway_running, False),
         "description": meta("description", ""), "description_auto": meta("description_auto", False),
+        "display_name": meta("display_name", ""),
         "distribution_name": None, "distribution_version": None, "distribution_source": None,
         "has_alias": False}
 

--- a/tests/hermes_cli/test_web_profiles_fallback_display_name.py
+++ b/tests/hermes_cli/test_web_profiles_fallback_display_name.py
@@ -1,0 +1,49 @@
+"""Regression tests: the ``/api/profiles`` fallback payload keeps ``display_name``.
+
+``list_profiles_endpoint`` serves ``_profile_to_dict`` rows on the happy path,
+which have carried ``display_name`` since the payload grew one. When
+``profiles_mod.list_profiles`` raises, it falls back to
+``_fallback_profile_dicts`` — a directory scan whose entries previously
+omitted ``display_name``, so a renamed profile (``hermes profile rename
+default "Legal writing"``) would lose its label in the dashboard profile
+switcher exactly when the server was already degraded (#103251).
+
+These tests pin the fallback entry's contract: ``display_name`` is read from
+``profile.yaml`` via the same ``read_profile_meta`` the CLI uses, and is an
+empty string (not a missing key) when unset.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from hermes_cli.profiles import read_profile_meta
+from hermes_cli.web_server_profiles import _fallback_profile_entry
+
+
+def _fake_profiles_mod():
+    return SimpleNamespace(
+        _read_config_model=lambda home: (None, None),
+        read_profile_meta=read_profile_meta,
+        _count_skills=lambda home: 0,
+        _check_gateway_running=lambda home: False,
+    )
+
+
+def test_fallback_entry_reads_display_name_from_profile_yaml(tmp_path: Path) -> None:
+    (tmp_path / "profile.yaml").write_text("display_name: Legal writing\n")
+
+    entry = _fallback_profile_entry(
+        _fake_profiles_mod(), "default", tmp_path,
+        is_default=True, has_env=False, gateway_running=lambda: False,
+    )
+
+    assert entry["display_name"] == "Legal writing"
+
+
+def test_fallback_entry_defaults_display_name_to_empty_string(tmp_path: Path) -> None:
+    entry = _fallback_profile_entry(
+        _fake_profiles_mod(), "work", tmp_path,
+        is_default=False, has_env=False, gateway_running=lambda: False,
+    )
+
+    assert entry["display_name"] == ""

--- a/web/src/components/ProfileSwitcher.test.tsx
+++ b/web/src/components/ProfileSwitcher.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiMocks = vi.hoisted(() => ({
+  getProfiles: vi.fn(),
+  getActiveProfile: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: apiMocks,
+  // ProfileProvider mirrors its selection into the api module.
+  setManagementProfile: vi.fn(),
+  getManagementProfile: vi.fn(() => ""),
+}));
+
+function profileFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    name: "default",
+    path: "/tmp/hermes-home/default",
+    is_default: true,
+    model: null,
+    provider: null,
+    has_env: false,
+    skill_count: 0,
+    gateway_running: false,
+    description: "",
+    description_auto: false,
+    display_name: "",
+    distribution_name: null,
+    distribution_version: null,
+    distribution_source: null,
+    has_alias: false,
+    ...overrides,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function waitFor(cond: () => boolean, timeoutMs = 5000) {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor: condition never became true");
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+  }
+}
+
+const trigger = () => document.querySelector('button[role="combobox"]');
+
+async function renderSwitcher() {
+  const [{ ProfileSwitcher }, { I18nProvider }, { ProfileProvider }] = await Promise.all([
+    import("./ProfileSwitcher"),
+    import("@/i18n"),
+    import("@/contexts/ProfileProvider"),
+  ]);
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () =>
+    root.render(
+      <I18nProvider>
+        <MemoryRouter>
+          <ProfileProvider>
+            <ProfileSwitcher />
+          </ProfileProvider>
+        </MemoryRouter>
+      </I18nProvider>,
+    ),
+  );
+}
+
+function click(el: Element | null) {
+  if (!el) throw new Error("element not rendered");
+  el.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+}
+
+const optionTexts = () =>
+  Array.from(document.querySelectorAll('[role="option"]')).map((el) =>
+    el.textContent?.replace("✓", "").trim(),
+  );
+
+describe("ProfileSwitcher display_name labels (#103251)", () => {
+  beforeEach(() => {
+    for (const fn of Object.values(apiMocks)) fn.mockReset();
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 500 })));
+    vi.stubGlobal("ResizeObserver", class { disconnect() {} observe() {} unobserve() {} });
+    // The listbox scroll path touches Element.prototype.scrollIntoView, absent in jsdom.
+    Element.prototype.scrollIntoView = () => {};
+  });
+
+  afterEach(async () => {
+    await act(async () => root?.unmount());
+    container?.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("labels the dashboard's own profile with its display name, not the raw id", async () => {
+    apiMocks.getProfiles.mockResolvedValue({
+      profiles: [
+        profileFixture({ name: "default", display_name: "Legal writing" }),
+        profileFixture({ name: "work", is_default: false }),
+      ],
+    });
+    apiMocks.getActiveProfile.mockResolvedValue({ current: "default", active: "default" });
+    await renderSwitcher();
+    await waitFor(() => Boolean(trigger()));
+
+    expect(trigger()?.textContent).toContain("this dashboard (Legal writing (default))");
+  });
+
+  it("falls back to the bare id when the current profile has no display name", async () => {
+    apiMocks.getProfiles.mockResolvedValue({
+      profiles: [profileFixture(), profileFixture({ name: "work", is_default: false })],
+    });
+    apiMocks.getActiveProfile.mockResolvedValue({ current: "default", active: "default" });
+    await renderSwitcher();
+    await waitFor(() => Boolean(trigger()));
+
+    expect(trigger()?.textContent).toContain("this dashboard (default)");
+  });
+
+  it("labels other profiles' listbox options with their display names", async () => {
+    apiMocks.getProfiles.mockResolvedValue({
+      profiles: [
+        profileFixture(),
+        profileFixture({ name: "work", is_default: false, display_name: "Work", path: "/tmp/hermes-home/work" }),
+      ],
+    });
+    apiMocks.getActiveProfile.mockResolvedValue({ current: "default", active: "default" });
+    await renderSwitcher();
+    await waitFor(() => Boolean(trigger()));
+
+    await act(async () => {
+      click(trigger());
+    });
+    expect(optionTexts()).toContain("Work (work)");
+  });
+});

--- a/web/src/components/ProfileSwitcher.tsx
+++ b/web/src/components/ProfileSwitcher.tsx
@@ -16,16 +16,18 @@ import { cn } from "@/lib/utils";
  * fetchJSON ?profile= injection. Hidden when only one profile exists.
  */
 export function ProfileSwitcher({ collapsed }: ProfileSwitcherProps) {
-  const { profile, currentProfile, profiles, setProfile } = useProfileScope();
+  const { profile, currentProfile, profiles, profileLabels, setProfile } =
+    useProfileScope();
   const { t } = useI18n();
 
+  const currentId = currentProfile || "default";
   const currentDashboardLabel = useMemo(
     () =>
       (t.app.currentProfileOption ?? "this dashboard ({name})").replace(
         "{name}",
-        currentProfile || "default",
+        profileLabels[currentId] ?? currentId,
       ),
-    [currentProfile, t.app.currentProfileOption],
+    [currentId, profileLabels, t.app.currentProfileOption],
   );
 
   if (profiles.length < 2) return null;
@@ -70,7 +72,7 @@ export function ProfileSwitcher({ collapsed }: ProfileSwitcherProps) {
           .filter((name) => name !== currentProfile)
           .map((name) => (
             <SelectOption key={name} value={name}>
-              {name}
+              {profileLabels[name] ?? name}
             </SelectOption>
           ))}
       </Select>

--- a/web/src/contexts/ProfileProvider.tsx
+++ b/web/src/contexts/ProfileProvider.tsx
@@ -37,6 +37,7 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
   const [searchParams, setSearchParams] = useSearchParams();
   const { pathname } = useLocation();
   const [profiles, setProfiles] = useState<string[]>([]);
+  const [profileLabels, setProfileLabels] = useState<Record<string, string>>({});
   const [currentProfile, setCurrentProfile] = useState("default");
 
   // Initial value comes from the URL (deep link / refresh / unified-launch
@@ -87,6 +88,16 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
         if (cancelled) return;
 
         setProfiles(profilesRes.profiles.map((p) => p.name));
+        // "display_name (id)" when set, else the bare id — same label shape
+        // as `hermes profile list` and the Profiles page.
+        setProfileLabels(
+          Object.fromEntries(
+            profilesRes.profiles.map((p) => [
+              p.name,
+              p.display_name?.trim() ? `${p.display_name.trim()} (${p.name})` : p.name,
+            ]),
+          ),
+        );
 
         const current = info.current || "default";
         const active = info.active || "default";
@@ -127,8 +138,8 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
   );
 
   const value = useMemo(
-    () => ({ profile, currentProfile, profiles, setProfile }),
-    [profile, currentProfile, profiles, setProfile],
+    () => ({ profile, currentProfile, profiles, profileLabels, setProfile }),
+    [profile, currentProfile, profiles, profileLabels, setProfile],
   );
 
   return (

--- a/web/src/contexts/profile-context.ts
+++ b/web/src/contexts/profile-context.ts
@@ -8,6 +8,9 @@ export interface ProfileContextValue {
   currentProfile: string;
   /** Known profile names (includes "default"). */
   profiles: string[];
+  /** Display label per profile id — `display_name (id)` when a display name
+   *  is set, else the bare id (mirrors `hermes profile list`). */
+  profileLabels: Record<string, string>;
   setProfile: (name: string) => void;
 }
 
@@ -15,5 +18,6 @@ export const ProfileContext = createContext<ProfileContextValue>({
   profile: "",
   currentProfile: "default",
   profiles: [],
+  profileLabels: {},
   setProfile: () => {},
 });


### PR DESCRIPTION
## What does this PR do?

`hermes profile rename default "Legal writing"` sets a display name the CLI honors in `hermes profile list`, but the web dashboard's profile switcher always rendered the canonical id — the root profile (permanently `default`) was therefore unlabelable from the browser.

The `/api/profiles` payload already carries `display_name`, but `ProfileProvider` kept only the ids (`profiles.map((p) => p.name)`), so the switcher never saw the display name. This PR threads a `profileLabels` map (`display_name (id)` when set, else the bare id — the same label shape as `hermes profile list` and the Profiles page) through the profile context, and uses it for both the current-dashboard label and the other profiles' listbox options. The `/api/profiles` fallback path (served when `list_profiles` raises) also now reports `display_name` so the label survives a degraded server instead of silently regressing to the raw id.

## Related Issue

Fixes #103251

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `web/src/contexts/profile-context.ts` — add `profileLabels: Record<string, string>` to the context contract (default `{}`).
- `web/src/contexts/ProfileProvider.tsx` — build the id → label map from the `/api/profiles` payload (`display_name (id)` when set, bare id otherwise) and expose it via the context.
- `web/src/components/ProfileSwitcher.tsx` — render the label for the current-dashboard option and the other profiles' listbox options; values stay canonical ids so `?profile=` params and API calls are unchanged.
- `hermes_cli/web_server_profiles.py` — `_fallback_profile_entry` now includes `display_name` (read via the same `read_profile_meta` the CLI uses), aligning the degraded-path payload with `_profile_to_dict`.
- `tests/hermes_cli/test_web_profiles_fallback_display_name.py` — pin the fallback contract (reads `profile.yaml`, empty string when unset).
- `web/src/components/ProfileSwitcher.test.tsx` — regression tests: display name shown for the dashboard's own profile, bare-id fallback when unset, and labeled listbox options for other profiles.

## How to Test

1. `hermes profile rename default "Legal writing"`, then open the dashboard with ≥2 profiles — the switcher's first option now reads `this dashboard (Legal writing (default))`; before the fix it read `this dashboard (default)`.
2. A profile without a display name still renders its bare id (`this dashboard (default)`, `work`).
3. Run the automated suites:
   - `python -m pytest tests/hermes_cli/test_web_profiles_fallback_display_name.py tests/hermes_cli/test_web_server_skills_profiles.py tests/hermes_cli/test_web_profiles_off_loop.py -q` — Observed result: 26 passed.
   - `cd web && npx vitest run src/components/ProfileSwitcher.test.tsx src/pages/SessionsPage.test.tsx src/pages/ChatPage.test.tsx` — Observed result: 13 passed (10 existing + 3 new).
   - `cd web && npx tsc -p . --noEmit` and `npx eslint <changed files>` — Observed result: clean (the single `set-state-in-effect` warning in `ProfileProvider.tsx` pre-exists on `main`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted suites for the touched modules; full-suite CI will run on the PR)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple silicon)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-ability) — or N/A (label rendering is platform-neutral)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — not a skill.