### PR TITLE
fix(mcp): serialize rotating OAuth refresh tokens across processes

### DIFF
--- a/tests/tools/test_mcp_oauth_refresh_processes.py
+++ b/tests/tools/test_mcp_oauth_refresh_processes.py
@@ -1,0 +1,134 @@
+"""Real SDK flows and token files, with deterministic local token responses."""
+import asyncio
+import os
+from pathlib import Path
+import sys
+from urllib.parse import parse_qs
+
+import pytest
+
+pytest.importorskip("mcp.client.auth.oauth2")
+
+
+async def _provider(home):
+    from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthMetadata
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import HermesMCPOAuthProvider
+
+    storage = HermesTokenStorage("shared", hermes_home=home)
+    metadata = OAuthClientMetadata(redirect_uris=["http://localhost/callback"])
+    if await storage.get_client_info() is None:
+        await storage.set_client_info(OAuthClientInformationFull(
+            client_id="test-client", redirect_uris=metadata.redirect_uris,
+            token_endpoint_auth_method="none",
+        ))
+
+    async def unused(*args):
+        raise AssertionError("Interactive authorization must not run")
+
+    provider = HermesMCPOAuthProvider(
+        server_name="shared", server_url="https://resource.example/mcp",
+        client_metadata=metadata, storage=storage,
+        redirect_handler=unused, callback_handler=unused,
+    )
+    provider.context.oauth_metadata = OAuthMetadata(
+        issuer="https://auth.example", authorization_endpoint="https://auth.example/authorize",
+        token_endpoint="https://auth.example/token", response_types_supported=["code"],
+    )
+    await provider._initialize()
+    return provider, storage
+
+
+async def _worker(home, label):
+    from tools.mcp_tool import sdk_httpx
+    httpx = sdk_httpx()
+    provider, _ = await _provider(home)
+    print("ready", flush=True)
+    await asyncio.to_thread(sys.stdin.readline)
+    flow = provider.async_auth_flow(httpx.Request("POST", "https://resource.example/mcp"))
+    try:
+        request = await flow.__anext__()
+        print(parse_qs(request.content.decode())["refresh_token"][0], flush=True)
+        await asyncio.to_thread(sys.stdin.readline)
+        resource = await flow.asend(httpx.Response(200, request=request, json={
+            "access_token": f"access-{label}", "token_type": "Bearer",
+            "refresh_token": f"refresh-{label}", "expires_in": 3600,
+        }))
+        assert resource.headers["Authorization"] == f"Bearer access-{label}"
+    finally:
+        await flow.aclose()
+
+
+@pytest.mark.asyncio
+async def test_processes_refresh_serially_using_the_latest_persisted_token(tmp_path):
+    from mcp.shared.auth import OAuthToken
+    _, storage = await _provider(tmp_path)
+    await storage.set_tokens(OAuthToken(
+        access_token="expired", refresh_token="original", token_type="Bearer", expires_in=0,
+    ))
+    workers = []
+    try:
+        for label in ("first", "second"):
+            worker = await asyncio.create_subprocess_exec(
+                sys.executable, __file__, str(tmp_path), label,
+                stdin=asyncio.subprocess.PIPE, stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env={**os.environ, "PYTHONPATH": str(Path.cwd()), "HERMES_HOME": str(tmp_path)},
+            )
+            workers.append(worker)
+            assert await asyncio.wait_for(worker.stdout.readline(), 15) == b"ready\n"
+        first, second = workers
+        first.stdin.write(b"go\n")
+        await first.stdin.drain()
+        assert await asyncio.wait_for(first.stdout.readline(), 15) == b"original\n"
+        second.stdin.write(b"go\n")
+        await second.stdin.drain()
+        # Keep the first token response pending. No second refresh may be built.
+        with pytest.raises(TimeoutError):
+            await asyncio.wait_for(second.stdout.readline(), 2)
+        first.stdin.write(b"finish\n")
+        await first.stdin.drain()
+        assert await asyncio.wait_for(second.stdout.readline(), 15) == b"refresh-first\n"
+        second.stdin.write(b"finish\n")
+        await second.stdin.drain()
+        for worker in workers:
+            assert await asyncio.wait_for(worker.wait(), 15) == 0, (await worker.stderr.read()).decode()
+        assert (await storage.get_tokens()).refresh_token == "refresh-second"
+    finally:
+        for worker in workers:
+            if worker.returncode is None:
+                worker.kill()
+            await worker.wait()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("outcome", ["close", "cancel-waiter", "invalid-response"])
+async def test_failed_or_cancelled_refresh_releases_the_file_lock(tmp_path, outcome):
+    from mcp.shared.auth import OAuthToken
+    from tools.mcp_tool import sdk_httpx
+    httpx = sdk_httpx()
+    _, storage = await _provider(tmp_path)
+    await storage.set_tokens(OAuthToken(
+        access_token="expired", refresh_token="original", token_type="Bearer", expires_in=0,
+    ))
+    provider, _ = await _provider(tmp_path)
+    flow = provider.async_auth_flow(httpx.Request("POST", "https://resource.example/mcp"))
+    request = await flow.__anext__()
+    try:
+        if outcome == "cancel-waiter":
+            waiter = asyncio.create_task(storage.acquire_refresh_lock())
+            await asyncio.sleep(0)
+            waiter.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await waiter
+        elif outcome == "invalid-response":
+            await flow.asend(httpx.Response(200, request=request, content=b"invalid-json"))
+    finally:
+        await flow.aclose()
+    handle = await storage.acquire_refresh_lock(timeout=2)
+    storage.release_refresh_lock(handle)
+    assert (await storage.get_tokens()).refresh_token == "original"
+
+
+if __name__ == "__main__":
+    asyncio.run(_worker(sys.argv[1], sys.argv[2]))

--- a/tests/tools/test_mcp_oauth_user_agent.py
+++ b/tests/tools/test_mcp_oauth_user_agent.py
@@ -91,6 +91,8 @@ def _ready_for_token_requests(provider):
         "token_type": "Bearer",
         "refresh_token": "rt",
     })
+    # Refresh re-reads the shared store after taking its cross-process lock.
+    asyncio.run(provider.context.storage.set_tokens(provider.context.current_tokens))
 
 
 def _build_provider_via(builder, monkeypatch, tmp_path, cfg):
@@ -122,7 +124,10 @@ def test_token_requests_carry_the_configured_user_agent(
     exchange = asyncio.run(
         provider._exchange_token_authorization_code("code", "verifier")
     )
-    refresh = asyncio.run(provider._refresh_token())
+    try:
+        refresh = asyncio.run(provider._refresh_token())
+    finally:
+        provider._release_refresh_lock()
 
     assert exchange.headers["User-Agent"] == "My-MCP-Client/1.0"
     assert refresh.headers["User-Agent"] == "My-MCP-Client/1.0"
@@ -144,7 +149,10 @@ def test_unconfigured_user_agent_leaves_the_default_header(
     exchange = asyncio.run(
         provider._exchange_token_authorization_code("code", "verifier")
     )
-    refresh = asyncio.run(provider._refresh_token())
+    try:
+        refresh = asyncio.run(provider._refresh_token())
+    finally:
+        provider._release_refresh_lock()
 
     default_ua = httpx.Request("POST", "https://x.example/").headers.get("User-Agent")
     assert exchange.headers.get("User-Agent") == default_ua

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -286,6 +286,43 @@ class HermesTokenStorage:
     _meta_path = partialmethod(_path, ".meta.json")
     _cimd_rejected_path = partialmethod(_path, ".cimd-off")
 
+    async def acquire_refresh_lock(self, timeout: float = 30.0):
+        """Serialize rotating-token refreshes across processes sharing this token file."""
+        path = self._tokens_path().resolve().with_suffix(".refresh.lock")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        handle = os.fdopen(os.open(path, os.O_RDWR | os.O_CREAT, 0o600), "r+b", buffering=0)
+        deadline = time.monotonic() + timeout
+        try:
+            if sys.platform == "win32" and os.fstat(handle.fileno()).st_size == 0:
+                handle.write(b"\0")
+            while True:
+                try:
+                    if sys.platform == "win32":
+                        import msvcrt
+                        handle.seek(0)
+                        msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                    else:
+                        import fcntl
+                        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    return handle
+                except OSError as exc:
+                    import errno
+                    if exc.errno not in (errno.EACCES, errno.EAGAIN):
+                        raise
+                    if time.monotonic() >= deadline:
+                        raise TimeoutError("Timed out waiting for MCP OAuth refresh") from None
+                    # No executor thread can outlive cancellation and acquire an orphaned lock.
+                    await asyncio.sleep(0.05)
+        except BaseException:
+            handle.close()
+            raise
+
+    @staticmethod
+    def release_refresh_lock(handle) -> None:
+        if handle is not None:
+            # Closing the file releases flock / the Windows byte-range lock.
+            handle.close()
+
     def _state_paths(self) -> tuple[Path, Path, Path]:
         return self._tokens_path(), self._client_info_path(), self._meta_path()
 

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -256,6 +256,10 @@ class HermesMCPOAuthProvider(HermesProviderMixin, *_SDK_BASES):
                 import anyio
                 with anyio.CancelScope(shield=True):
                     await self.context.lock.acquire()
+            # Propagate close/transport failure to the shared provider's lock cleanup.
+            import anyio
+            with anyio.CancelScope(shield=True):
+                await inner.aclose()
         if retry_after_concurrent_auth:
             yield request
             self._persist_oauth_metadata_if_changed()

--- a/tools/mcp_oauth_provider.py
+++ b/tools/mcp_oauth_provider.py
@@ -34,6 +34,33 @@ class HermesProviderMixin:
         # oauth.user_agent — stamped onto token-endpoint requests only; some authorization servers/WAFs
         # reject httpx's default (#75576).
         self._hermes_token_user_agent = token_user_agent
+        self._hermes_refresh_lock = None
+
+    def _release_refresh_lock(self) -> None:
+        handle = getattr(self, "_hermes_refresh_lock", None)
+        self._hermes_refresh_lock = None
+        if handle is not None:
+            handle.close()
+
+    async def async_auth_flow(self, request):
+        # Preserve httpx's bidirectional generator protocol for both the legacy
+        # provider and the manager. A transport failure may close it before the
+        # refresh-response handler gets a chance to release the file lock.
+        inner = super().async_auth_flow(request)
+        try:
+            outgoing = await inner.__anext__()
+            while True:
+                incoming = yield outgoing
+                outgoing = await inner.asend(incoming)
+        except StopAsyncIteration:
+            return
+        finally:
+            import anyio
+            try:
+                with anyio.CancelScope(shield=True):
+                    await inner.aclose()
+            finally:
+                self._release_refresh_lock()
 
     def _prepare_token_request(self, request):
         """Stamp the configured User-Agent onto a token/refresh request."""
@@ -59,8 +86,19 @@ class HermesProviderMixin:
         return self._prepare_token_request(await super()._exchange_token_authorization_code(*args, **kwargs))
 
     async def _refresh_token(self):
-        self._coerce_client_secret_post()
-        return self._prepare_token_request(await super()._refresh_token())
+        from tools.mcp_oauth import HermesTokenStorage
+        storage = self.context.storage
+        try:
+            if isinstance(storage, HermesTokenStorage):
+                # The SDK already holds its in-process context lock here.
+                self._hermes_refresh_lock = await storage.acquire_refresh_lock()
+                # A different process may have rotated the token while we waited.
+                self.context.current_tokens = await storage.get_tokens()
+            self._coerce_client_secret_post()
+            return self._prepare_token_request(await super()._refresh_token())
+        except BaseException:
+            self._release_refresh_lock()
+            raise
 
     async def _store_tokens(self, token_response) -> None:
         self.context.current_tokens = token_response
@@ -82,6 +120,12 @@ class HermesProviderMixin:
 
     async def _handle_refresh_response(self, response) -> bool:
         """Accept any 2xx refresh response; never log the body."""
+        try:
+            return await self._store_refresh_response(response)
+        finally:
+            self._release_refresh_lock()
+
+    async def _store_refresh_response(self, response) -> bool:
         if not (200 <= response.status_code < 300):
             self._hermes_logger.warning("Token refresh failed: %s", response.status_code)
             self.context.clear_tokens()


### PR DESCRIPTION
## What does this PR do?

Two Hermes processes sharing an MCP token store can load the same expired access token and refresh it concurrently. For providers that rotate refresh tokens, one request then uses an already-consumed token and fails even though the other process successfully renewed access.

Hold a per-token-file OS lock from refresh-request construction through persistence of the response. After acquiring it, reload the token from disk so a waiting process uses the latest refresh token. The existing SDK lock still serializes requests within each provider. Both the managed and legacy provider paths use the shared implementation.

The wait polls nonblocking OS locks asynchronously, without a worker thread that could acquire a lock after its caller was cancelled. Generator closure and failed refresh responses release the lock. No dependencies, configuration keys, or background services are added. Waiting processes may still perform a sequential refresh using the new token; this change does not attempt to eliminate that extra request.

## Type of Change

- [x] Bug fix (OAuth concurrency and cleanup)

## How to Test

`scripts/run_tests.sh tests/tools/test_mcp_oauth_refresh_processes.py tests/tools/test_mcp_oauth_manager.py tests/tools/test_mcp_oauth_bidirectional.py tests/tools/test_mcp_oauth.py tests/tools/test_mcp_oauth_user_agent.py tests/tools/test_mcp_oauth_integration.py tests/tools/test_mcp_oauth_cold_load_expiry.py tests/tools/test_mcp_oauth_metadata.py -q -j 2 --file-retries 0`

Linux: **106 tests passed across these files in targeted runs**. The new reproduction uses two real Python processes, the real SDK auth generators and real temporary token files; responses are supplied locally without contacting an OAuth server. On base `71f8c60f6a6ab8f2fab1e4d5c22d6dd9c856b63e`, the second process builds a refresh before the first response is persisted. With this change it waits and reads the rotated token. Additional cases cover closing an in-flight flow, cancelling a lock waiter and an invalid token response. The User-Agent test fixtures now persist their synthetic tokens to exercise the disk-reload contract.

Ruff and whitespace checks pass. Windows uses a native byte-range lock; Windows/macOS execution, live external OAuth and the full repository suite remain unverified for this draft.

## Checklist

- [x] Searched upstream PRs for duplicate MCP cross-process refresh fixes
- [x] Focused regression coverage and Conventional Commit
- [x] No credentials or user-specific configuration included
- [ ] Full suite and remaining platform CI

Adapted from a local M-Lietz fix, with cancellation-safe acquisition and shared provider coverage, using LietzTech Agent assistance.
