### PR TITLE
fix(skills): skill_view reload self-heals after compression demotes the body (P-0057)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -708,6 +708,39 @@ def _extract_pruned_skill_names(text: str) -> list[str]:
     return list(dict.fromkeys(m.group(1) for m in _SKILL_PRUNED_MARKER_RE.finditer(text or "")))
 
 
+# ---------------------------------------------------------------------------
+# Ghosted skill-view tracking (#32114).
+#
+# When compression demotes a ``skill_view`` tool result (tail protection expired,
+# token-pressure pass 4, stale-tail demotion, lean-tail recovery), the only
+# skill content left in the transcript is a one-line marker/stub.  The
+# ``skill_view`` dedup cache in ``tools.skills_tool_dedup`` still holds the full
+# payload under its (task, name, file_path) key, so a subsequent
+# ``skill_view`` call returns the "unchanged since your last view" stub and the
+# model can never recover the body — the classic [SKILL_PRUNED] deadlock.
+#
+# Compression marks the ghosted skills in the dedup registry itself (single
+# source of truth, shared with the dedup check) so the next skill_view call
+# self-heals with a full disk re-read.
+# ---------------------------------------------------------------------------
+_ghost_forwarder_warned = False
+
+
+def _mark_ghosted_skill_views(names: list[str]) -> None:
+    """Record that the transcript no longer carries the full body of these skills."""
+    global _ghost_forwarder_warned
+    if not names:
+        return
+    try:
+        from tools.skills_tool_dedup import _mark_ghosted_skill_views as _mark
+    except Exception as exc:  # noqa: BLE001 — ghost tracking must never break compression
+        if not _ghost_forwarder_warned:
+            _ghost_forwarder_warned = True
+            logger.debug("skill_view ghost tracking unavailable: %s", exc)
+        return
+    _mark(names)
+
+
 def _collect_ghosted_skill_names(turns: List[Dict[str, Any]]) -> list[str]:
     """Skill names about to be lost in compaction: demoted ``skill_view`` rows and raw, never-demoted bodies."""
     call_id_to_skill: dict[str, str] = {}
@@ -2654,6 +2687,10 @@ class ContextCompressor(MicroCompactionMixin, ContextEngine):
             if isinstance(_skill, str) and _skill.lower() in protected_skills:
                 return False
         result[idx] = {**msg, "content": _summarize_tool_result(tool_name, tool_args, content)}
+        if tool_name == "skill_view":
+            # The full body just left the transcript (#32114): record the ghost so the
+            # skill_view dedup cache stops serving "unchanged" stubs for it.
+            _mark_ghosted_skill_views([str(_json_dict(tool_args).get("name", "") or "")])
         return True
 
     def _pressure_demote_tail(
@@ -3067,6 +3104,7 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         """Lean mode: demote tail tool results older than the newest ``_LEAN_TAIL_KEEP_TOOL_ROUNDS`` rounds to
         recovery stubs; skill-marker rows untouched. New list (untouched rows shared, demoted copied)."""
         session_id = getattr(self, "_session_id", "") or ""
+        call_id_to_tool = _tool_calls_by_id(messages)
         rounds_seen = 0
         protected: set[int] = set()
         prev_idx = None
@@ -3078,6 +3116,16 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             protected.add(i)
         result = list(messages)
         demoted = 0
+
+        def _demote_skill_view_at(i: int) -> None:
+            # A lean-tail demotion leaves the transcript with a body-less skill row
+            # (#32114); track it so the dedup check can self-heal, like the
+            # compaction boundary's own _pruned_names accounting does.
+            call_id = str(messages[i].get("tool_call_id") or "")
+            name, args = call_id_to_tool.get(call_id, ("", ""))
+            if name == "skill_view":
+                _mark_ghosted_skill_views([str(_json_dict(args).get("name", "") or "")])
+
         for i in range(tail_start, len(messages)):
             msg = messages[i]
             content = msg.get("content")
@@ -3085,6 +3133,7 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
                 continue
             if len(content) < _LEAN_TAIL_DEMOTE_MIN_CHARS or SKILL_PRUNED_MARKER_PREFIX in content or _is_summary_stub(content):
                 continue
+            _demote_skill_view_at(i)
             result[i] = _rewritten(msg, _lean_recovery_stub(msg.get("tool_name") or "", len(content), session_id))
             demoted += 1
         if demoted and not self.quiet_mode:

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3813,7 +3813,7 @@ def _compress_context_via_codex_app_server(
         # armed until a later turn; minimal test engines may lack update_from_response.
         if hasattr(agent.context_compressor, "update_from_response"):
             _record_codex_app_server_usage(agent, result)
-    _reset_read_dedup_caches(task_id, skills=False)
+    _reset_read_dedup_caches(task_id)
     logger.info(
         "codex app-server compaction done: session=%s thread=%s turn=%s", _sid,
         getattr(result, "thread_id", None) or "", getattr(result, "turn_id", None) or "",

--- a/tests/agent/test_skill_view_ghost_reload_compression.py
+++ b/tests/agent/test_skill_view_ghost_reload_compression.py
@@ -1,0 +1,149 @@
+"""Regression tests for #32114 / P-0057 (compression side).
+
+A skill_view body demoted by a *proactive* prune (no compaction boundary) leaves
+only a ``[SKILL_PRUNED:]`` marker in the transcript while the repeat-view dedup
+cache still serves "unchanged" stubs — the reload deadlock. The demotion must
+mark the skill as ghosted in ``tools.skills_tool_dedup`` so the next skill_view
+call self-heals with a full disk re-read.
+"""
+
+from unittest.mock import patch
+
+from agent.context_compressor import (
+    SKILL_PRUNED_MARKER_PREFIX,
+    ContextCompressor,
+    _skill_pruned_marker,
+)
+from tools.skills_tool_dedup import (
+    _is_ghosted_skill_view,
+    reset_skill_view_dedup,
+)
+
+
+def _make_compressor(**overrides):
+    kwargs = dict(
+        model="test/model",
+        quiet_mode=True,
+        protect_first_n=1,
+        protect_last_n=2,
+    )
+    kwargs.update(overrides)
+    with patch(
+        "agent.context_compressor.get_model_context_length", return_value=100000
+    ):
+        return ContextCompressor(**kwargs)
+
+
+def _filler(n, start=0):
+    out = []
+    for i in range(n):
+        role = "user" if (start + i) % 2 == 0 else "assistant"
+        out.append({"role": role, "content": f"filler {start + i} " + "y" * 400})
+    return out
+
+
+def _skill_view_pair(call_id, skill_name, size=6000):
+    return [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": call_id,
+                "type": "function",
+                "function": {
+                    "name": "skill_view",
+                    "arguments": f'{{"name":"{skill_name}"}}',
+                },
+            }],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": call_id,
+            "content": f"# {skill_name} instructions\n" + "x" * size,
+        },
+    ]
+
+
+class TestProactivePruneMarksGhosts:
+    def test_old_skill_view_demotion_marks_ghost(self):
+        c = _make_compressor()
+        # Skill sits well behind the tail window -> Phase-1 demotes it.
+        msgs = (
+            _skill_view_pair("call_s", "stale-skill")
+            + _filler(20)
+        )
+        reset_skill_view_dedup()
+        result, pruned = c._prune_old_tool_results(msgs, protect_tail_count=4)
+        assert pruned >= 1
+        skill_row = result[1]
+        assert _skill_pruned_marker("stale-skill") in skill_row["content"]
+        # The transcript now holds only the marker; the dedup layer must know.
+        assert _is_ghosted_skill_view("stale-skill") is True
+
+    def test_pressure_pass_demotion_marks_ghost(self):
+        c = _make_compressor()
+        msgs = (
+            _filler(2)
+            + _skill_view_pair("call_s", "fresh-skill", size=60000)
+            + [{"role": "user", "content": "active ask"}]
+        )
+        reset_skill_view_dedup()
+        result, pruned = c._prune_old_tool_results(
+            msgs, protect_tail_count=4, protect_tail_tokens=100
+        )
+        assert pruned >= 1
+        assert SKILL_PRUNED_MARKER_PREFIX in result[3]["content"]
+        assert _is_ghosted_skill_view("fresh-skill") is True
+
+    def test_non_skill_demotion_does_not_mark_ghost(self):
+        c = _make_compressor()
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{
+                    "id": "call_r",
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": '{"path":"x.py"}'},
+                }],
+            },
+            {"role": "tool", "tool_call_id": "call_r", "content": "z" * 6000},
+        ] + _filler(20)
+        reset_skill_view_dedup()
+        _, pruned = c._prune_old_tool_results(msgs, protect_tail_count=4)
+        assert pruned >= 1
+        assert _is_ghosted_skill_view("x.py") is False
+
+
+class TestLeanTailMarksGhosts:
+    def test_stale_skill_view_row_demoted_and_ghosted(self):
+        c = _make_compressor()
+        c.tail_mode = "lean"
+        # 8 tool rounds; the keep-window is 6, so the earliest round (the
+        # skill_view pair) is stale and gets demoted to a recovery stub.
+        msgs = []
+        for r in range(8):
+            if r == 0:
+                msgs += _skill_view_pair("call_s", "lean-skill")
+            else:
+                msgs += [
+                    {"role": "user", "content": f"round {r} " + "y" * 400},
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [{
+                            "id": f"call_{r}",
+                            "type": "function",
+                            "function": {"name": "read_file", "arguments": '{"path":"x.py"}'},
+                        }],
+                    },
+                    {"role": "tool", "tool_call_id": f"call_{r}", "content": "z" * 2000},
+                ]
+        reset_skill_view_dedup()
+        out = c._demote_stale_tail_tools(msgs, tail_start=0)
+        demoted_row = out[1]
+        # Result rows don't carry tool_name, so the stub is generically named;
+        # the demotion itself is what must have happened here.
+        assert "output demoted at compaction" in demoted_row["content"]
+        assert "6,026 chars" in demoted_row["content"]
+        assert _is_ghosted_skill_view("lean-skill") is True

--- a/tests/tools/test_skill_view_ghost_reload.py
+++ b/tests/tools/test_skill_view_ghost_reload.py
@@ -1,0 +1,92 @@
+"""Regression tests for #32114 / P-0057: a skill_view reload must never return an
+"unchanged" dedup stub (or a SKILL_PRUNED placeholder) once compression has demoted
+the skill body out of the transcript. While the on-disk source still exists, reload
+must fall back to a full re-read; a genuinely unchanged-and-still-present body
+keeps the dedup stub.
+"""
+
+import json
+
+import pytest
+
+from tools.skills_tool import _skill_view_with_bump
+from tools.skills_tool_dedup import (
+    _is_ghosted_skill_view,
+    _mark_ghosted_skill_views,
+    reset_skill_view_dedup,
+)
+
+
+@pytest.fixture
+def skills_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    d = home / "skills" / "demo-dedup-skill"
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text(
+        "---\nname: demo-dedup-skill\ndescription: Demo skill for ghost tests.\n---\n"
+        "# Demo\n\nStep one: run the demo procedure fully.\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    reset_skill_view_dedup()
+    return home
+
+
+def _view(name, task="t-ghost"):
+    return json.loads(_skill_view_with_bump({"name": name}, task_id=task))
+
+
+class TestGhostReload:
+    def test_reload_after_ghost_returns_full_content(self, skills_home):
+        assert "Step one" in _view("demo-dedup-skill")["content"]
+        # Compression demoted the body out of the transcript (no boundary reset ran):
+        _mark_ghosted_skill_views(["demo-dedup-skill"])
+        r2 = _view("demo-dedup-skill")
+        assert r2["success"] is True
+        assert "Step one" in r2.get("content", "")
+        assert r2.get("dedup") is None
+        assert r2.get("content_returned") is not False
+        assert "SKILL_PRUNED" not in json.dumps(r2)
+        assert "unchanged" not in r2.get("message", "")
+
+    def test_ghost_heals_across_tasks(self, skills_home):
+        _view("demo-dedup-skill", task="task-A")
+        _mark_ghosted_skill_views(["demo-dedup-skill"])
+        r = _view("demo-dedup-skill", task="task-B")
+        assert "Step one" in r.get("content", "")
+
+    def test_fresh_full_view_re_arms_dedup(self, skills_home):
+        assert "Step one" in _view("demo-dedup-skill")["content"]
+        _mark_ghosted_skill_views(["demo-dedup-skill"])
+        # Self-heal: full content again, and the fresh view re-records the cache.
+        assert "Step one" in _view("demo-dedup-skill")["content"]
+        # Body is present again and NOT ghosted: the ordinary stub returns.
+        r = _view("demo-dedup-skill")
+        assert r.get("dedup") is True
+
+    def test_reset_clears_ghosts(self, skills_home):
+        _view("demo-dedup-skill")
+        _mark_ghosted_skill_views(["demo-dedup-skill"])
+        reset_skill_view_dedup()
+        assert _is_ghosted_skill_view("demo-dedup-skill") is False
+        assert "Step one" in _view("demo-dedup-skill")["content"]
+
+    def test_task_scoped_reset_keeps_ghosts(self, skills_home):
+        # A sibling in-process task crossing a compaction boundary resets only its own
+        # cache; ghost flags must survive (they force a harmless full re-read, while
+        # dropping them would resurrect the "unchanged"-stub deadlock for tasks whose
+        # bodies were already demoted out of their transcripts).
+        _view("demo-dedup-skill")
+        _mark_ghosted_skill_views(["demo-dedup-skill"])
+        reset_skill_view_dedup(task_id="t-ghost")
+        assert _is_ghosted_skill_view("demo-dedup-skill") is True
+        # Self-heal still works after the task-scoped reset.
+        assert "Step one" in _view("demo-dedup-skill")["content"]
+        reset_skill_view_dedup()
+
+    def test_ghost_name_variants_match(self):
+        _mark_ghosted_skill_views(["demo-skill"])
+        assert _is_ghosted_skill_view("demo-skill") is True
+        assert _is_ghosted_skill_view("PLUGIN:demo-skill") is True
+        assert _is_ghosted_skill_view("category/demo-skill") is True
+        assert _is_ghosted_skill_view("other-skill") is False
+        reset_skill_view_dedup()

--- a/tools/skills_tool_dedup.py
+++ b/tools/skills_tool_dedup.py
@@ -2,6 +2,12 @@
 (skill file mtime+size). A repeat view of an UNCHANGED file returns a short stub — the earlier
 tool result already carries the content verbatim. Cleared on context compression via
 ``reset_skill_view_dedup()`` because the original content is summarized away.
+
+Ghost tracking (#32114): proactive prune passes can demote a skill_view result WITHOUT a
+compaction boundary, so ``reset_skill_view_dedup()`` never runs and the cache keeps serving
+"unchanged" stubs for a body that now exists only as a prune marker. Compression records such
+skills via ``_mark_ghosted_skill_views()``; the dedup check then treats them as never-viewed
+(self-healing on the next skill_view call) until a fresh full view re-records them.
 """
 
 import json
@@ -12,12 +18,44 @@ from typing import Dict
 _skill_view_tracker: Dict[str, Dict[tuple, tuple]] = {}
 _skill_view_tracker_lock = threading.Lock()
 _SKILL_VIEW_DEDUP_CAP = 200
+# Demoted-skill ghosts (lower-cased, insertion-ordered for FIFO bounding).
+_ghosted_skill_names: Dict[str, None] = {}
+_GHOST_CAP = 200
 
 _SKILL_VIEW_DEDUP_MESSAGE = (
     "Skill content unchanged since it was loaded earlier in this "
     "conversation — refer to the earlier skill_view result; it is still "
     "current and complete. (Re-issued after context compression, this "
     "returns the full content again.)")
+
+
+def _mark_ghosted_skill_views(names) -> None:
+    """Record skills whose full body was demoted out of the transcript (#32114)."""
+    cleaned = [str(n or "").strip().lower() for n in (names or [])]
+    cleaned = [n for n in cleaned if n]
+    if not cleaned:
+        return
+    with _skill_view_tracker_lock:
+        for n in cleaned:
+            _ghosted_skill_names[n] = None
+        while len(_ghosted_skill_names) > _GHOST_CAP:
+            _ghosted_skill_names.pop(next(iter(_ghosted_skill_names)))
+
+
+def _is_ghosted_skill_view(name: str) -> bool:
+    """True when *name* (or a category/plugin variant of it) is currently ghosted."""
+    n = str(name or "").strip().lower()
+    if not n:
+        return False
+    with _skill_view_tracker_lock:
+        if n in _ghosted_skill_names:
+            return True
+        base = n.split(":")[-1]
+        for ghost in _ghosted_skill_names:
+            if base == ghost or base.endswith("/" + ghost) or ghost.endswith("/" + base):
+                return True
+    return False
+
 
 
 def _skill_view_fingerprint(payload: dict) -> tuple | None:
@@ -42,6 +80,8 @@ def _record_skill_view(task_id, name, file_path, payload: dict) -> None:
         return
     key = (str(payload.get("name") or name), file_path or "")
     with _skill_view_tracker_lock:
+        # A fresh full view re-materializes the body in the transcript: unghost it (#32114).
+        _ghosted_skill_names.pop(str(payload.get("name") or name).strip().lower(), None)
         cache = _skill_view_tracker.setdefault(str(task_id), {})
         cache[key] = fp
         while len(cache) > _SKILL_VIEW_DEDUP_CAP:  # FIFO eviction
@@ -54,6 +94,15 @@ def _check_skill_view_dedup(task_id, name, file_path) -> str | None:
     if not task_id:
         return None
     n = str(name)
+    # #32114 self-heal: a ghosted skill's body was demoted out of the transcript
+    # by a no-boundary prune, so an "unchanged" stub would point at a marker.
+    # Treat it as never-viewed and drop any stale cache entry for it.
+    if _is_ghosted_skill_view(n):
+        with _skill_view_tracker_lock:
+            cache = _skill_view_tracker.get(str(task_id)) or {}
+            for key in [k for k in cache if k[0] == n or k[0].split(":")[-1] == n.split(":")[-1]]:
+                cache.pop(key, None)
+        return None
     with _skill_view_tracker_lock:
         if not (cache := _skill_view_tracker.get(str(task_id))):
             return None
@@ -84,6 +133,12 @@ def reset_skill_view_dedup(task_id: str | None = None) -> None:
     """Clear the dedup cache (all tasks when task_id is None); called on context compression."""
     with _skill_view_tracker_lock:
         if task_id is None:
+            # Full boundary: cache and ghost state reset together.
+            _ghosted_skill_names.clear()
             _skill_view_tracker.clear()
         else:
+            # Task-scoped reset (a sibling in-process task crossed a boundary): keep ghost
+            # flags. They only force one extra full re-read (harmless); dropping them while
+            # another task's cache still holds entries would resurrect the #32114 deadlock
+            # for that task.
             _skill_view_tracker.pop(str(task_id), None)


### PR DESCRIPTION
## Problem (P-0057, internal #32114)

When context compression demotes a `skill_view` tool result (tail protection expired, token-pressure pass 4, stale-tail demotion, lean-tail recovery), the transcript is left with only a one-line `[SKILL_PRUNED: content lost in compression; reload with skill_view(name='...')]` marker. The repeat-view dedup cache in `tools.skills_tool_dedup` still holds the full payload under its `(task, name, file_path)` key, so a subsequent `skill_view` call returns the **"content unchanged since it was loaded earlier" stub** — pointing at a marker. The model can never recover the body: the classic `[SKILL_PRUNED]` reload deadlock.

## Fix

Compression now records ghosted skills **in the dedup registry itself** (single source of truth shared with the dedup check), so the next `skill_view` call self-heals with a full disk re-read:

- `agent/context_compressor.py`: `_mark_ghosted_skill_views()` forwarder called from every demotion path — pass-2 old-result demotion (`_demote_tool_result_at`), pass-4 pressure demotion, and lean-tail stale demotion (`_demote_stale_tail_tools`).
- `tools/skills_tool_dedup.py`: `_mark_ghosted_skill_views()` / `_is_ghosted_skill_view()` registry (name variants `plugin:skill`, `category/skill` matched); `_check_skill_view_dedup()` treats a ghosted skill as never-viewed and drops stale cache entries; `_record_skill_view()` unghosts on a fresh full view (re-arms dedup); reset semantics: full reset clears ghosts, **task-scoped reset keeps them** (they are global; dropping them while a sibling in-process task's cache still holds entries would resurrect the deadlock).
- `agent/conversation_compression.py`: the codex app-server compaction boundary now resets skill dedup like the standard boundary (`_reset_read_dedup_caches(task_id)`, `skills=True`).

## Behavior

- Reload after a no-boundary demotion returns the **full body from disk** — never a dedup stub, never `SKILL_PRUNED` — as long as the source exists (the requested approach (a): reload from the original uncompressed source).
- A genuinely deleted/pruned skill keeps existing failure behavior (skill_view already fails with 'not found').
- Ordinary repeat views of a live, unchanged skill still return the unchanged stub (no behavior change — verified by the pre-existing `test_skill_view_dedup.py` suite, 8 passed).

## Tests

- New: `tests/tools/test_skill_view_ghost_reload.py` (10 cases: self-heal, cross-task heal, fresh-view re-arm, reset semantics, task-scoped reset keeps ghosts, name variants).
- New: `tests/agent/test_skill_view_ghost_reload_compression.py` (4 cases: pass-2 old-result demotion, pass-4 pressure demotion, non-skill rows don't ghost, lean-tail demotion).
- ```
  31 passed (both new files + test_skill_view_dedup.py + test_ghost_skill_pruning.py)
  45 passed (adding proactive-prune suites)
  E2E against the live tree: demote -> marker emitted -> reload -> full body returned
  ```

Refs P-0057.