### PR TITLE
feat(hindsight): expose recall provenance and per-call scope

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -86,7 +86,7 @@ Config file: `~/.hermes/hindsight/config.json`
 >
 > Per [Hindsight's docs](https://hindsight.vectorize.io/developer/observations), observations are the **consolidated** knowledge layer Hindsight builds on top of raw facts: deduplicated beliefs grounded in evidence, refined as new facts arrive, with proof counts and freshness signals. Raw `world` / `experience` facts are the individual supporting evidence that feeds them. For per-turn context injection, observations are denser per token and avoid feeding the model multiple raw facts that one observation already summarizes.
 >
-> Restore the broad recall with `"recall_types": "observation,world,experience"` (string or JSON list) in `~/.hermes/hindsight/config.json`. This applies to **both** auto-recall and the `hindsight_recall` tool — both read the same `recall_types` setting (the tool schema has no per-call `types` argument), so narrowing the default narrows both paths.
+> Restore broad recall globally with `"recall_types": "observation,world,experience"` (string or JSON list) in `~/.hermes/hindsight/config.json`. Auto-recall uses this setting. Explicit `hindsight_recall` calls default to it but can override `types` for one evidence-oriented search without changing subsequent auto-recall.
 
 ### Retain
 
@@ -130,8 +130,17 @@ Available in `hybrid` and `tools` memory modes:
 | Tool | Description |
 |------|-------------|
 | `hindsight_retain` | Store information with auto entity extraction; supports optional per-call `tags` |
-| `hindsight_recall` | Multi-strategy search (semantic + entity graph) |
+| `hindsight_recall` | Multi-strategy search with source metadata; optional per-call `budget`, `max_tokens`, `types`, `tags`, `tags_match`, and `include_source_facts` |
 | `hindsight_reflect` | Cross-memory synthesis (LLM-powered) |
+
+Explicit recall reports available fact IDs, types, document IDs, timestamps, tags,
+and observation source-fact IDs. Supporting source metadata is requested by default;
+set `include_source_facts: false` to omit that additional lookup. Returned timestamps
+describe recorded events/mentions and do not prove that an operational fact is still
+current. Automatic context injection keeps its existing text-only format and budget.
+Per-call `max_tokens` accepts 128..8192; the source-fact token budget uses the same
+value in addition to the result budget. An explicit `tags: []` clears the configured
+tag filter for that call only.
 
 ## Environment Variables
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -218,9 +218,63 @@ RECALL_SCHEMA = {
         "Search long-term memory. Returns memories ranked by relevance using "
         "semantic search, keyword matching, entity graph traversal, and reranking."
     ),
-    "parameters": {"type": "object", "required": ["query"],
-                   "properties": {"query": {"type": "string", "description": "What to search for."}}},
+    "parameters": {"type": "object", "required": ["query"], "properties": {
+        "query": {"type": "string", "description": "What to search for."},
+        "budget": {"type": "string", "enum": ["low", "mid", "high"],
+                   "description": "Search thoroughness for this call; defaults to configured budget."},
+        "max_tokens": {"type": "integer", "minimum": 128, "maximum": 8192,
+                       "description": "Result token budget for this call."},
+        "types": {"type": "array", "minItems": 1, "uniqueItems": True,
+                  "items": {"type": "string", "enum": ["observation", "world", "experience"]},
+                  "description": "Override the configured fact types for this search."},
+        "tags": {"type": "array", "items": {"type": "string"},
+                 "description": "Override configured search tags for this call; [] clears the filter."},
+        "tags_match": {"type": "string", "enum": ["any", "all", "any_strict", "all_strict"]},
+        "include_source_facts": {"type": "boolean",
+                                 "description": "Include observation source-fact metadata. Defaults to true."},
+    }},
 }
+
+
+def _recall_overrides(args: dict) -> dict:
+    """Validate only explicit overrides; existing global settings keep their semantics."""
+    result = {}
+    for key, allowed in (("budget", ("low", "mid", "high")),
+                         ("tags_match", ("any", "all", "any_strict", "all_strict"))):
+        if key in args:
+            if args[key] not in allowed:
+                raise ValueError(f"Invalid {key}: choose {', '.join(allowed)}")
+            result[key] = args[key]
+    if "max_tokens" in args:
+        value = args["max_tokens"]
+        if type(value) is not int or not 128 <= value <= 8192:
+            raise ValueError("Invalid max_tokens: expected integer 128..8192")
+        result["max_tokens"] = value
+    for key in ("types", "tags"):
+        if key in args:
+            value = args[key]
+            if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+                raise ValueError(f"Invalid {key}: expected a list of strings")
+            if key == "types" and (not value or any(item not in ("observation", "world", "experience") for item in value)):
+                raise ValueError("Invalid types: use observation, world, and/or experience")
+            result[key] = list(dict.fromkeys(value))
+    include = args.get("include_source_facts", True)
+    if not isinstance(include, bool):
+        raise ValueError("Invalid include_source_facts: expected a boolean")
+    result["include_source_facts"] = include
+    return result
+
+
+def _recall_provenance(item: Any) -> str:
+    """Expose the source metadata the client returned, without inferring freshness."""
+    parts = []
+    for key in ("id", "type", "document_id", "occurred_start", "mentioned_at", "tags", "source_fact_ids"):
+        value = getattr(item, key, None)
+        if value:
+            if isinstance(value, (list, tuple)):
+                value = ",".join(str(part) for part in value)
+            parts.append(f"{key}={value}")
+    return "; ".join(parts)
 
 REFLECT_SCHEMA = {
     "name": "hindsight_reflect",
@@ -841,12 +895,16 @@ class HindsightMemoryProvider(MemoryProvider):
             logger.debug("Prefetch: skipped (%s)", why)
         return why is not None
 
-    def _recall(self, query: str) -> list:
+    def _recall_kwargs(self, query: str) -> dict:
         kwargs: dict = {"bank_id": self._bank_id, "query": query, "budget": self._budget, "max_tokens": self._recall_max_tokens}
         if self._recall_tags:
             kwargs.update(tags=self._recall_tags, tags_match=self._recall_tags_match)
         if self._recall_types:
             kwargs["types"] = self._recall_types
+        return kwargs
+
+    def _recall(self, query: str) -> list:
+        kwargs = self._recall_kwargs(query)
         resp = self._run_hindsight_operation(lambda client: client.arecall(**kwargs))
         return resp.results or []
 
@@ -1068,9 +1126,23 @@ class HindsightMemoryProvider(MemoryProvider):
         query = args["query"]
         logger.debug("Tool hindsight_recall: bank=%s, query_len=%d, budget=%s",
                      self._bank_id, len(query), self._budget)
-        results = self._recall(query)
+        kwargs = self._recall_kwargs(query)
+        kwargs.update(_recall_overrides(args))
+        if kwargs["include_source_facts"]:
+            kwargs["max_source_facts_tokens"] = kwargs["max_tokens"]
+        response = self._run_hindsight_operation(lambda client: client.arecall(**kwargs))
+        results = response.results or []
         logger.debug("Tool hindsight_recall: %d results", len(results))
-        return "\n".join(f"{i}. {r.text}" for i, r in enumerate(results, 1)) or "No relevant memories found."
+        lines = []
+        for i, item in enumerate(results, 1):
+            lines.append(f"{i}. {item.text}")
+            if provenance := _recall_provenance(item):
+                lines.append(f"   provenance: {provenance}")
+        sources = getattr(response, "source_facts", None)
+        if kwargs["include_source_facts"] and isinstance(sources, dict) and sources:
+            lines.append("Source facts:")
+            lines.extend(f"- source_id={source_id}; {_recall_provenance(fact)}" for source_id, fact in sources.items())
+        return "\n".join(lines) or "No relevant memories found."
 
     def _tool_reflect(self, args: dict) -> str:
         query = args["query"]

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -444,6 +444,48 @@ class TestPostSetup:
 
 
 class TestToolHandlers:
+    def test_recall_scope_and_sources_do_not_change_auto_recall(self, provider):
+        provider._client.arecall.return_value = SimpleNamespace(
+            results=[SimpleNamespace(
+                text="Recorded maintenance window", id="observation-1", type="observation",
+                mentioned_at="2026-01-01T12:00:00Z", source_fact_ids=["fact-1"],
+            )],
+            source_facts={"fact-1": SimpleNamespace(
+                type="world", document_id="maintenance-note", tags=["source:note"],
+            )},
+        )
+        args = {"query": "maintenance", "types": ["world"], "budget": "high",
+                "max_tokens": 800, "tags": ["source:note"], "tags_match": "all_strict"}
+        result = json.loads(provider.handle_tool_call("hindsight_recall", args))["result"]
+        kwargs = provider._client.arecall.call_args.kwargs
+        assert kwargs["types"] == ["world"] and kwargs["budget"] == "high"
+        assert kwargs["tags"] == args["tags"] and kwargs["tags_match"] == "all_strict"
+        assert kwargs["include_source_facts"] is True and kwargs["max_source_facts_tokens"] == 800
+        assert "source_fact_ids=fact-1" in result and "document_id=maintenance-note" in result
+        assert "mentioned_at=2026-01-01T12:00:00Z" in result
+        provider._do_recall("maintenance")
+        automatic = provider._client.arecall.call_args.kwargs
+        assert automatic["types"] == provider._recall_types
+        assert automatic["budget"] == provider._budget
+        assert "include_source_facts" not in automatic
+        provider._recall_tags = ["default-tag"]
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall", {"query": "maintenance", "tags": [], "include_source_facts": False},
+        ))["result"]
+        assert provider._client.arecall.call_args.kwargs["tags"] == []
+        assert "Source facts:" not in result
+        assert provider._recall_tags == ["default-tag"]
+
+    @pytest.mark.parametrize("override", [
+        {"budget": "maximum"}, {"max_tokens": True}, {"max_tokens": 64},
+        {"types": ["unknown"]}, {"types": "world"}, {"types": []},
+        {"tags": [12]}, {"tags_match": "unknown"}, {"include_source_facts": "yes"},
+    ])
+    def test_recall_invalid_overrides_do_not_reach_the_client(self, provider, override):
+        result = json.loads(provider.handle_tool_call("hindsight_recall", {"query": "test", **override}))
+        assert "error" in result
+        provider._client.arecall.assert_not_called()
+
     def test_retain_success(self, provider):
         result = json.loads(provider.handle_tool_call(
             "hindsight_retain", {"content": "user likes dark mode"}


### PR DESCRIPTION
## Summary

Extend the existing Hindsight recall tool with validated per-call budget, token, fact-type and tag overrides, and expose source identifiers and timestamps returned by Hindsight. Automatic recall keeps its existing configured scope and text-only output.

Observation text alone can obscure which original facts support it. The explicit tool now includes available result metadata and observation source-fact metadata. These timestamps describe stored facts, not proof of current live state. No new memory provider, bank mutation, document import or additional dependency is introduced.

Source facts default on for the explicit tool and use an additional token budget equal to the result budget; callers can disable them. `tags: []` clears filtering for one call only. This response-size/default choice is open for maintainer feedback.

## Validation

- Added two invariant test functions (one parametrized), using the existing provider fixture and mocked client transport: per-call scope/provenance with unchanged automatic-recall defaults, and rejected invalid overrides without a client request.
- The ten new cases fail against the unmodified base.
- `scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py -q -j 1 --file-retries 0`: **96 passed** in an isolated Linux checkout.
- Ruff on changed Python files and `git diff --check`: passed.
- Not yet tested against a live Hindsight bank or on Windows/macOS; full repository suite not run. Draft for review.

Prepared against `71f8c60f6a6ab8f2fab1e4d5c22d6dd9c856b63e`. This is an adaptation of an earlier M-Lietz customization; original authorship is credited in the commit. No production installation was changed.
