### PR TITLE
fix(cli): propagate exit status codes for cron and webhook subcommands (#103257)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1739,7 +1739,7 @@ def cmd_gateway(args):
 
     from hermes_cli.gateway import gateway_command
 
-    gateway_command(args)
+    return gateway_command(args)
 
 
 def cmd_proxy(args):
@@ -1752,12 +1752,12 @@ def cmd_proxy(args):
         raise SystemExit(rc)
 
 
-def _forward_command(name: str, module: str, attr: str, *, forward_return: bool = False, doc: str = ""):
+def _forward_command(name: str, module: str, attr: str, *, forward_return: bool = True, doc: str = ""):
     """A ``hermes <cmd>`` handler that hands ``args`` to ``<module>.<attr>``.
 
     Imports at CALL time so fast paths never pay for it and
     ``patch("<module>.<attr>")`` keeps intercepting. ``forward_return``
-    surfaces the return code to ``main()`` (only kanban/project propagate).
+    surfaces the return code to ``main()``.
     """
 
     def _cmd(args):

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -95,20 +95,21 @@ def webhook_command(args):
     if not sub:
         print("Usage: hermes webhook {subscribe|list|remove|test}")
         print("Run 'hermes webhook --help' for details.")
-        return
+        return 1
     if not _is_webhook_enabled():
         print(_setup_hint())
-        return
+        return 1
     handler = _ACTIONS.get(sub)
     if handler is not None:
-        handler(args)
+        return handler(args) or 0
+    return 1
 
 
 def _cmd_subscribe(args):
     name = args.name.strip().lower().replace(" ", "-")
     if not re.match(r'^[a-z0-9][a-z0-9_-]*$', name):
         print(f"Error: Invalid name '{name}'. Use lowercase alphanumeric with hyphens/underscores.")
-        return
+        return 1
 
     subs = _load_subscriptions()
     is_update = name in subs
@@ -128,7 +129,7 @@ def _cmd_subscribe(args):
             print(
                 "Error: --deliver-only requires --deliver to be a real target "
                 "(telegram, discord, slack, github_comment, etc.) — not 'log'.")
-            return
+            return 1
         route["deliver_only"] = True
     script = (getattr(args, "script", "") or "").strip()
     if script:
@@ -153,6 +154,7 @@ def _cmd_subscribe(args):
     print("\n  Configure your service to POST to the URL above.")
     print("  Use the secret for HMAC-SHA256 signature validation.")
     print("  The gateway must be running to receive events (hermes gateway run).\n")
+    return 0
 
 
 def _cmd_list(args):
@@ -160,7 +162,7 @@ def _cmd_list(args):
     if not subs:
         print("  No dynamic webhook subscriptions.")
         print("  Create one with: hermes webhook subscribe <name>")
-        return
+        return 0
 
     base_url = _get_webhook_base_url()
     print(f"\n  {len(subs)} webhook subscription(s):\n")
@@ -179,6 +181,7 @@ def _cmd_list(args):
         if route.get("script"):
             print(f"    Script:  {route['script']}")
         print()
+    return 0
 
 
 def _cmd_remove(args):
@@ -187,10 +190,11 @@ def _cmd_remove(args):
     if name not in subs:
         print(f"  No subscription named '{name}'.")
         print("  Note: Static routes from config.yaml cannot be removed here.")
-        return
+        return 1
     del subs[name]
     _save_subscriptions(subs)
     print(f"  Removed webhook subscription: {name}")
+    return 0
 
 
 def _cmd_test(args):
@@ -199,7 +203,7 @@ def _cmd_test(args):
     subs = _load_subscriptions()
     if name not in subs:
         print(f"  No subscription named '{name}'.")
-        return
+        return 1
     secret = subs[name].get("secret", "")
     url = f"{_get_webhook_base_url()}/webhooks/{name}"
     payload = args.payload or '{"test": true, "event_type": "test", "message": "Hello from hermes webhook test"}'
@@ -214,9 +218,13 @@ def _cmd_test(args):
         with urllib.request.urlopen(req, timeout=10) as resp:
             body = resp.read().decode()
             print(f"  Response ({resp.status}): {body}")
+            if resp.status >= 400:
+                return 1
+            return 0
     except Exception as e:
         print(f"  Error: {e}")
         print("  Is the gateway running? (hermes gateway run)")
+        return 1
 
 
 _ACTIONS = {

--- a/tests/hermes_cli/test_cli_exit_codes.py
+++ b/tests/hermes_cli/test_cli_exit_codes.py
@@ -1,0 +1,169 @@
+"""Process-level and dispatcher-level exit status tests for CLI commands (#103257)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).parents[2]
+
+
+def _run_hermes(home: Path, *args: str, extra_env: dict | None = None) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(home)
+    env["PYTHONPATH"] = str(ROOT) + os.pathsep + env.get("PYTHONPATH", "")
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", *args],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+
+# ---------------------------------------------------------------------------
+# hermes cron mutation failure exit codes (#103257)
+# ---------------------------------------------------------------------------
+
+
+def test_cron_create_invalid_schedule_exits_nonzero(tmp_path):
+    """An invalid schedule string must fail the command with a non-zero exit code."""
+    res = _run_hermes(tmp_path, "cron", "create", "not a schedule", "do something")
+    assert res.returncode == 1
+    assert "Failed to create job" in res.stdout
+
+
+def test_cron_edit_missing_job_exits_nonzero(tmp_path):
+    """Editing a non-existent job must exit with code 1."""
+    res = _run_hermes(tmp_path, "cron", "edit", "nope000000", "--name=x")
+    assert res.returncode == 1
+    assert "Job not found" in res.stdout
+
+
+def test_cron_pause_missing_job_exits_nonzero(tmp_path):
+    """Pausing a non-existent job must exit with code 1."""
+    res = _run_hermes(tmp_path, "cron", "pause", "nope000000")
+    assert res.returncode == 1
+    assert "Failed to pause job" in res.stdout
+
+
+def test_cron_remove_missing_job_exits_nonzero(tmp_path):
+    """Removing a non-existent job must exit with code 1."""
+    res = _run_hermes(tmp_path, "cron", "remove", "nope000000")
+    assert res.returncode == 1
+    assert "Failed to remove job" in res.stdout
+
+
+def test_cron_run_missing_job_exits_nonzero(tmp_path):
+    """Running a non-existent job must exit with code 1."""
+    res = _run_hermes(tmp_path, "cron", "run", "nope000000")
+    assert res.returncode == 1
+    assert "Failed to run job" in res.stdout
+
+
+# ---------------------------------------------------------------------------
+# hermes webhook subcommand exit codes (#103257)
+# ---------------------------------------------------------------------------
+
+
+def test_webhook_subscribe_disabled_exits_nonzero(tmp_path):
+    """Subscribing when webhook is disabled must exit with code 1."""
+    res = _run_hermes(tmp_path, "webhook", "subscribe", "my-route")
+    assert res.returncode == 1
+    assert "Webhook platform is not enabled" in res.stdout
+
+
+def test_webhook_remove_disabled_exits_nonzero(tmp_path):
+    """Removing when webhook is disabled must exit with code 1."""
+    res = _run_hermes(tmp_path, "webhook", "remove", "my-route")
+    assert res.returncode == 1
+    assert "Webhook platform is not enabled" in res.stdout
+
+
+def test_webhook_remove_missing_route_exits_nonzero(tmp_path):
+    """Removing a non-existent route when enabled must exit with code 1."""
+    cfg = {"platforms": {"webhook": {"enabled": True, "extra": {"port": 8644, "secret": "sec"}}}}
+    (tmp_path / "config.yaml").write_text(yaml.dump(cfg), encoding="utf-8")
+
+    res = _run_hermes(tmp_path, "webhook", "remove", "nope-route")
+    assert res.returncode == 1
+    assert "No subscription named 'nope-route'" in res.stdout
+
+
+def test_webhook_test_missing_route_exits_nonzero(tmp_path):
+    """Testing a non-existent route when enabled must exit with code 1."""
+    cfg = {"platforms": {"webhook": {"enabled": True, "extra": {"port": 8644, "secret": "sec"}}}}
+    (tmp_path / "config.yaml").write_text(yaml.dump(cfg), encoding="utf-8")
+
+    res = _run_hermes(tmp_path, "webhook", "test", "nope-route")
+    assert res.returncode == 1
+    assert "No subscription named 'nope-route'" in res.stdout
+
+
+def test_webhook_subscribe_invalid_name_exits_nonzero(tmp_path):
+    """Subscribing with an invalid route name must exit with code 1."""
+    cfg = {"platforms": {"webhook": {"enabled": True, "extra": {"port": 8644, "secret": "sec"}}}}
+    (tmp_path / "config.yaml").write_text(yaml.dump(cfg), encoding="utf-8")
+
+    res = _run_hermes(tmp_path, "webhook", "subscribe", "Invalid Name With Spaces!")
+    assert res.returncode == 1
+    assert "Invalid name" in res.stdout
+
+
+def test_webhook_subscribe_invalid_deliver_only_exits_nonzero(tmp_path):
+    """Subscribing with --deliver-only and deliver=log must exit with code 1."""
+    cfg = {"platforms": {"webhook": {"enabled": True, "extra": {"port": 8644, "secret": "sec"}}}}
+    (tmp_path / "config.yaml").write_text(yaml.dump(cfg), encoding="utf-8")
+
+    res = _run_hermes(tmp_path, "webhook", "subscribe", "log-route", "--deliver-only", "--deliver", "log")
+    assert res.returncode == 1
+    assert "--deliver-only requires --deliver to be a real target" in res.stdout
+
+
+def test_webhook_lifecycle_success_exits_zero(tmp_path):
+    """A valid subscribe -> list -> remove lifecycle must all exit with code 0."""
+    cfg = {"platforms": {"webhook": {"enabled": True, "extra": {"port": 8644, "secret": "sec"}}}}
+    (tmp_path / "config.yaml").write_text(yaml.dump(cfg), encoding="utf-8")
+
+    # 1. Subscribe
+    sub_res = _run_hermes(tmp_path, "webhook", "subscribe", "test-route")
+    assert sub_res.returncode == 0
+    assert "Created webhook subscription: test-route" in sub_res.stdout
+
+    # 2. List
+    list_res = _run_hermes(tmp_path, "webhook", "list")
+    assert list_res.returncode == 0
+    assert "test-route" in list_res.stdout
+
+    # 3. Remove
+    rm_res = _run_hermes(tmp_path, "webhook", "remove", "test-route")
+    assert rm_res.returncode == 0
+    assert "Removed webhook subscription: test-route" in rm_res.stdout
+
+
+# ---------------------------------------------------------------------------
+# _forward_command return propagation tests (#103257)
+# ---------------------------------------------------------------------------
+
+
+def test_forward_command_propagates_handler_exit_status(monkeypatch):
+    """_forward_command must return the handler's status code so main() can exit with it."""
+    from types import SimpleNamespace
+    import hermes_cli.main as main_mod
+
+    fake_module = SimpleNamespace(fake_action=lambda args: 42)
+    monkeypatch.setitem(sys.modules, "hermes_cli.fake_subcommand", fake_module)
+
+    forwarded = main_mod._forward_command("cmd_fake", "hermes_cli.fake_subcommand", "fake_action")
+    assert forwarded(None) == 42
+


### PR DESCRIPTION
## Overview
This PR resolves issue #103257, fixing a critical defect where CLI subcommands such as `hermes cron` and `hermes webhook` printed failure messages but exited with status `0`.

## Root Cause Analysis
An end-to-end trace of the CLI execution lifecycle revealed two distinct root causes responsible for swallowing failure status codes:

1. **Discarded Return Values in `_forward_command()` (`hermes_cli/main.py`)**:
   During the whole-codebase decomposition (#102117), CLI subcommands were wrapped in lazy loaders via `_forward_command()`. However, `_forward_command()` defaulted to `forward_return: bool = False`, with only `kanban` and `project` explicitly opting into return propagation. Consequently, subcommands like `cmd_cron` and `cmd_webhook` had their return status codes discarded and replaced with `None`. Because the CLI entrypoint `main()` treats `None` as success, any failure within these subcommands exited `0`.

2. **Missing Status Returns in `hermes_cli/webhook.py`**:
   `webhook_command()` and its action handlers (`_cmd_subscribe`, `_cmd_remove`, `_cmd_test`) printed errors to stdout/stderr but lacked explicit return codes on failure paths, returning `None` by default.

3. **Unreturned Handler in `cmd_gateway()` (`hermes_cli/main.py`)**:
   `cmd_gateway()` called `gateway_command(args)` without returning its status code.

## Canonical Fix (Zero Duplication)

- **Default Forwarding in `_forward_command()`**: Changed default parameter `forward_return: bool = True` in `_forward_command()`. This single change at the root abstraction ensures that all 22 forwarded CLI subcommands naturally propagate their integer status codes to `main()` without duplicate wrapper logic.
- **Explicit Webhook Status Codes**: Standardized `webhook_command()` and all handlers in `hermes_cli/webhook.py` to return `0` on success and `1` on failure (matching the established pattern in `cron_command()`).
- **Gateway Status Return**: Added `return gateway_command(args)` in `cmd_gateway()`.

## Test Coverage
Added 13 automated tests in `tests/hermes_cli/test_cli_exit_codes.py`:
- **Cron Mutations (#103257)**:
  - `cron create "not a schedule"` exits `1`
  - `cron edit nope000000 --name=x` exits `1`
  - `cron pause nope000000` exits `1`
  - `cron remove nope000000` exits `1`
  - `cron run nope000000` exits `1`
- **Webhook Subcommands (#103257)**:
  - `webhook subscribe` when disabled exits `1`
  - `webhook remove` when disabled exits `1`
  - `webhook remove` non-existent route exits `1`
  - `webhook test` non-existent route exits `1`
  - `webhook subscribe` invalid route name exits `1`
  - `webhook subscribe` invalid deliver target (`--deliver-only` with `deliver=log`) exits `1`
  - `webhook` valid lifecycle `subscribe -> list -> remove` exits `0`
- **Abstraction Unit Test**:
  - `_forward_command` propagates handler status code to caller.

Fixes #103257
