### PR TITLE
feat(hindsight): add opt-in automatic recall controls

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -102,6 +102,42 @@ Config file: `~/.hermes/hindsight/config.json`
 | `retain_user_prefix` | `User` | Label used before user turns in auto-retained transcripts |
 | `retain_assistant_prefix` | `Assistant` | Label used before assistant turns in auto-retained transcripts |
 
+### Optional auto-recall controls
+
+These controls are disabled by default. They affect automatic context injection,
+not explicit `hindsight_recall` / `hindsight_reflect` tool calls, retained facts or
+the active bank. They are available in the generic provider configuration panel
+and in `hindsight/config.json`.
+
+| Key | Default | Effect when enabled |
+|-----|---------|---------------------|
+| `recall_max_results` | `0` | Keep only the first N ranked recall results; 0 keeps all. This caps injected results, not server retrieval cost. |
+| `recall_live_status_bypass` | `false` | Skip automatic recall when both a time phrase and an operational-status phrase match. |
+| `recall_simple_budget` | `""` | Budget (`low`, `mid`, `high`) for short queries; empty disables. |
+| `recall_simple_max_words` | `0` | Word limit for the short-query budget; 0 disables. |
+| `recall_document_tags` | `[]` | Base tags for document-filtered recall; requires matching document terms. |
+| `recall_document_terms` | `[]` | Case-insensitive phrases that activate document filtering. |
+| `recall_document_tag_routes` | `{}` | Additional tag -> phrase-list mapping, e.g. `{"topic:network": ["router", "network"]}`. |
+| `recall_document_types` | `["world", "observation"]` | Fact types used when document filtering matches. |
+
+The live-status and short-query classifiers are simple English/German phrase
+heuristics, not intent detection: they can skip useful context or miss a live
+question. Short queries containing known analysis/comparison phrases keep the
+normal budget. Classification uses the full query before truncation. For
+current-message routing, combine with the existing `recall_sync: true`; the
+default asynchronous mode still prefetches from the preceding turn.
+
+Document filtering searches **already retained** facts in the current bank. It
+does not watch folders, synchronize, import, tag or alter documents. A matching
+query replaces the configured recall tags/types with the document scope;
+base tags and all matching route tags use `tags_match: "all"`. Overly restrictive
+tags can produce no useful matches, and filters are not an access-control
+boundary. Nonmatching queries keep the normal scope.
+
+With `prefetch_method: "reflect"`, only bypass and short-query budget apply;
+document filters and the result cap are recall-only. No Mental Models setting
+is changed by these controls.
+
 ### Integration
 
 | Key | Default | Description |

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -41,6 +41,7 @@ from .settings import (
     _DEFAULT_API_URL, _DEFAULT_IDLE_TIMEOUT, _DEFAULT_LOCAL_URL, _DEFAULT_RETAIN_SOURCE,
     _DEFAULT_TIMEOUT, _HINDSIGHT_GLYPH, _MIN_CLIENT_VERSION, _MIN_VERSION_FOR_UPDATE_MODE_APPEND,
     _PROVIDER_DEFAULT_MODELS, _VALID_BUDGETS, _daemon_llm_provider,
+    _contains_term, _is_live_status_query, _is_simple_recall_query,
     _normalize_observation_scopes, _normalize_retain_tags, _parse_int_setting,
     _resolve_bank_id_template,
 )
@@ -433,6 +434,14 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "prefetch_retain_drain_timeout", "description": "Max seconds the background prefetch waits for the retain to become recall-visible (queue drain + server-side completion) before recalling anyway", "default": 10.0},
             {"key": "retain_context", "description": "Context label for retained memories", "default": "conversation between Hermes Agent and the User"},
             {"key": "recall_max_tokens", "description": "Maximum tokens for recall results", "default": 4096},
+            {"key": "recall_max_results", "description": "Ranked auto-recall result cap (0 keeps all)", "default": 0},
+            {"key": "recall_live_status_bypass", "description": "Opt-in English/German phrase heuristic to skip live-status auto-recall", "default": False},
+            {"key": "recall_simple_budget", "description": "Optional budget for short auto-recall queries", "default": "", "choices": ["", "low", "mid", "high"]},
+            {"key": "recall_simple_max_words", "description": "Short-query word limit (0 disables)", "default": 0},
+            {"key": "recall_document_tags", "description": "Base tags for optional document filtering", "default": []},
+            {"key": "recall_document_terms", "description": "Phrases enabling document filtering", "default": []},
+            {"key": "recall_document_tag_routes", "description": "Additional document tag to phrase-list mapping", "default": {}},
+            {"key": "recall_document_types", "description": "Fact types for document-filtered auto-recall", "default": ["world", "observation"]},
             {"key": "recall_max_input_chars", "description": "Maximum input query length for auto-recall", "default": 800},
             {"key": "recall_prompt_preamble", "description": "Custom preamble for recalled memories in context"},
             {"key": "timeout", "description": "API request timeout in seconds", "default": _DEFAULT_TIMEOUT},
@@ -765,6 +774,20 @@ class HindsightMemoryProvider(MemoryProvider):
         self._auto_recall = cfg.get("auto_recall", True)
         self._recall_sync = bool(cfg.get("recall_sync", False))
         self._recall_max_tokens = int(cfg.get("recall_max_tokens", 4096))
+        self._recall_max_results = max(0, _parse_int_setting(cfg.get("recall_max_results"), 0))
+        self._recall_live_status_bypass = cfg.get("recall_live_status_bypass") is True
+        simple_budget = cfg.get("recall_simple_budget", "")
+        self._recall_simple_budget = simple_budget if isinstance(simple_budget, str) and simple_budget in _VALID_BUDGETS else ""
+        self._recall_simple_max_words = max(0, _parse_int_setting(cfg.get("recall_simple_max_words"), 0))
+        self._recall_document_tags = _normalize_retain_tags(cfg.get("recall_document_tags"))
+        self._recall_document_terms = _normalize_retain_tags(cfg.get("recall_document_terms"))
+        routes = cfg.get("recall_document_tag_routes", {})
+        self._recall_document_tag_routes = {
+            tag.strip(): _normalize_retain_tags(terms) for tag, terms in routes.items()
+            if isinstance(tag, str) and tag.strip()
+        } if isinstance(routes, dict) else {}
+        types = _normalize_retain_tags(cfg.get("recall_document_types", ["world", "observation"]))
+        self._recall_document_types = [t for t in types if t in ("world", "observation", "experience")] or ["world", "observation"]
         self._recall_max_input_chars = int(cfg.get("recall_max_input_chars", 800))
         # None -> observation-only (Hindsight's consolidated, deduplicated layer; raw
         # world/experience facts re-ship the evidence they summarize and burn the
@@ -841,33 +864,52 @@ class HindsightMemoryProvider(MemoryProvider):
             logger.debug("Prefetch: skipped (%s)", why)
         return why is not None
 
-    def _recall(self, query: str) -> list:
+    def _recall(self, query: str, **overrides) -> list:
         kwargs: dict = {"bank_id": self._bank_id, "query": query, "budget": self._budget, "max_tokens": self._recall_max_tokens}
         if self._recall_tags:
             kwargs.update(tags=self._recall_tags, tags_match=self._recall_tags_match)
         if self._recall_types:
             kwargs["types"] = self._recall_types
+        kwargs.update(overrides)
         resp = self._run_hindsight_operation(lambda client: client.arecall(**kwargs))
         return resp.results or []
 
-    def _reflect(self, query: str) -> str | None:
+    def _reflect(self, query: str, *, budget: str | None = None) -> str | None:
         resp = self._run_hindsight_operation(
-            lambda client: client.areflect(bank_id=self._bank_id, query=query, budget=self._budget)
+            lambda client: client.areflect(bank_id=self._bank_id, query=query, budget=budget or self._budget)
         )
         return resp.text
 
     def _do_recall(self, query: str) -> tuple[str, int]:
         """One recall/reflect for *query* (background prefetch and ``recall_sync`` paths)
         -> (text, memory count); the count is 0 for reflect (synthesis) and on error."""
+        if self._recall_live_status_bypass and _is_live_status_query(query):
+            logger.debug("Recall: skipped by opt-in live-status phrase heuristic")
+            return "", 0
+        # Classify before truncation: a long/complex question must not become simple
+        # merely because its context-injection query is clipped.
+        overrides = {}
+        if self._recall_simple_budget and _is_simple_recall_query(query, self._recall_simple_max_words):
+            overrides["budget"] = self._recall_simple_budget
+        document_query = bool(self._recall_document_tags and self._recall_document_terms
+                              and _contains_term(query, self._recall_document_terms))
         if self._recall_max_input_chars:
             query = query[:self._recall_max_input_chars]
         try:
             if self._prefetch_method == "reflect":
                 logger.debug("Recall: calling reflect (bank=%s, query_len=%d)", self._bank_id, len(query))
-                return self._reflect(query) or "", 0
+                return self._reflect(query, **overrides) or "", 0
+            if document_query:
+                tags = list(self._recall_document_tags)
+                for tag, terms in self._recall_document_tag_routes.items():
+                    if _contains_term(query, terms) and tag not in tags:
+                        tags.append(tag)
+                overrides.update(tags=tags, tags_match="all", types=self._recall_document_types)
             logger.debug("Recall: calling recall (bank=%s, query_len=%d, budget=%s)",
                          self._bank_id, len(query), self._budget)
-            results = self._recall(query)
+            results = self._recall(query, **overrides)
+            if self._recall_max_results:
+                results = results[:self._recall_max_results]
             logger.debug("Recall: returned %d results", len(results))
             return "\n".join(f"- {r.text}" for r in results if r.text), len(results)
         except Exception as e:

--- a/plugins/memory/hindsight/config_schema.py
+++ b/plugins/memory/hindsight/config_schema.py
@@ -1,7 +1,8 @@
 """Hindsight's declared config surface — rendered by the generic desktop panel."""
 
 from plugins.memory.config_schema import (
-    KIND_SECRET, KIND_SELECT, KIND_TEXT, ProviderConfigSchema, ProviderField, ProviderFieldOption,
+    KIND_BOOL, KIND_JSON, KIND_NUMBER, KIND_SECRET, KIND_SELECT, KIND_TEXT,
+    ProviderConfigSchema, ProviderField, ProviderFieldOption,
 )
 
 CONFIG_SCHEMA = ProviderConfigSchema(
@@ -32,5 +33,22 @@ CONFIG_SCHEMA = ProviderConfigSchema(
             options=tuple(ProviderFieldOption(b, b) for b in ("low", "mid", "high")),
             inline=True,
         ),
+        ProviderField(key="recall_max_results", label="Auto-recall result cap", kind=KIND_NUMBER, default="0",
+                      group="Optional auto-recall controls", description="0 keeps all ranked results; recall method only."),
+        ProviderField(key="recall_live_status_bypass", label="Skip live-status questions", kind=KIND_BOOL, default="false",
+                      group="Optional auto-recall controls", description="Opt-in English/German phrase heuristic; may miss or misclassify questions."),
+        ProviderField(key="recall_simple_budget", label="Short-query budget", kind=KIND_SELECT, default="",
+                      group="Optional auto-recall controls", options=(ProviderFieldOption("", "Disabled"),
+                      *(ProviderFieldOption(b, b) for b in ("low", "mid", "high")))),
+        ProviderField(key="recall_simple_max_words", label="Short-query word limit", kind=KIND_NUMBER, default="0",
+                      group="Optional auto-recall controls", description="0 disables short-query classification."),
+        ProviderField(key="recall_document_tags", label="Document base tags", kind=KIND_JSON, default="[]",
+                      group="Optional document filtering", description="Filters existing memories; never imports or syncs documents."),
+        ProviderField(key="recall_document_terms", label="Document trigger phrases", kind=KIND_JSON, default="[]",
+                      group="Optional document filtering", description="Requires base tags and a matching phrase; recall method only."),
+        ProviderField(key="recall_document_tag_routes", label="Additional document tag routes", kind=KIND_JSON, default="{}",
+                      group="Optional document filtering", description="Map each additional tag to a list of trigger phrases. Matched tags must all apply."),
+        ProviderField(key="recall_document_types", label="Document fact types", kind=KIND_JSON, default='["world", "observation"]',
+                      group="Optional document filtering", description="Fact types used only for document-filtered auto-recall."),
     ),
 )

--- a/plugins/memory/hindsight/settings.py
+++ b/plugins/memory/hindsight/settings.py
@@ -28,6 +28,16 @@ _HINDSIGHT_GLYPH = "👁️"
 # (vectorize-io/hindsight#932).
 _MIN_VERSION_FOR_UPDATE_MODE_APPEND = "0.5.0"
 _VALID_BUDGETS = {"low", "mid", "high"}
+_LIVE_TIME_TERMS = ("right now", "currently", "at the moment", "live now",
+                    "gerade", "jetzt", "momentan", "derzeit", "aktuell live")
+_LIVE_STATE_TERMS = ("active", "available", "connected", "healthy", "online", "reachable",
+                     "running", "status", "aktiv", "erreichbar", "fehler", "gesund",
+                     "läuft", "laufend", "verbunden", "verfügbar")
+_COMPLEX_QUERY_TERMS = ("analyse", "analyze", "compare", "evaluate", "explain why", "investigate",
+                        "relationship", "synthesize", "what do you know", "what have we",
+                        "vergleiche", "bewerte", "erkläre warum", "erinnerst du dich",
+                        "recherchiere", "untersuche", "was weißt du", "wie hängt",
+                        "zusammenhang", "zusammenfassen", "über meine", "über unser")
 _PROVIDER_DEFAULT_MODELS = {
     "openai": "gpt-4o-mini",
     "anthropic": "claude-haiku-4-5",
@@ -57,6 +67,20 @@ def _parse_int_setting(value: Any, default: int) -> int:
 
 def _daemon_llm_provider(provider: str) -> str:
     return "openai" if provider in _OPENAI_WIRE_PROVIDERS else provider
+
+
+def _contains_term(text: str, terms: list[str] | tuple[str, ...]) -> bool:
+    """Case-insensitive phrase matching, not a semantic intent classifier."""
+    folded = text.casefold()
+    return any(term.casefold() in folded for term in terms if term)
+
+
+def _is_live_status_query(query: str) -> bool:
+    return _contains_term(query, _LIVE_TIME_TERMS) and _contains_term(query, _LIVE_STATE_TERMS)
+
+
+def _is_simple_recall_query(query: str, max_words: int) -> bool:
+    return 0 < len(query.split()) <= max_words and not _contains_term(query, _COMPLEX_QUERY_TERMS)
 
 
 def _normalize_retain_tags(value: Any) -> List[str]:

--- a/tests/plugins/memory/test_hindsight_config_schema.py
+++ b/tests/plugins/memory/test_hindsight_config_schema.py
@@ -18,16 +18,28 @@ def test_hindsight_is_declared():
         "api_url",
         "bank_id",
         "recall_budget",
+        "recall_max_results", "recall_live_status_bypass", "recall_simple_budget",
+        "recall_simple_max_words", "recall_document_tags", "recall_document_terms",
+        "recall_document_tag_routes", "recall_document_types",
     }
 
 
-def test_fields_are_all_inline():
+def test_basic_fields_stay_inline_and_optional_controls_use_full_config():
     provider = get_provider_config_schema("hindsight")
     assert provider is not None
 
-    # Hindsight is simple enough to render fully in the compact panel, so it
-    # never grows a Full config… modal.
-    assert all(field.inline for field in provider.fields)
+    # Keep the normal panel compact; opt-in controls belong in the existing modal.
+    assert {field.key for field in provider.inline_fields()} == {
+        "mode", "api_key", "api_url", "bank_id", "recall_budget",
+    }
+    advanced = {field.key: field for field in provider.fields if not field.inline}
+    assert all(field.group for field in advanced.values())
+    assert advanced["recall_max_results"].default == "0"
+    assert advanced["recall_live_status_bypass"].default == "false"
+    assert advanced["recall_simple_budget"].default == ""
+    assert advanced["recall_simple_max_words"].default == "0"
+    assert advanced["recall_document_tags"].default == "[]"
+    assert advanced["recall_document_terms"].default == "[]"
 
 
 def test_mode_gating_is_expressed_as_select_options():

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -554,6 +554,67 @@ class TestToolHandlers:
 
 
 class TestPrefetch:
+    @pytest.mark.parametrize("config,query,count,budget,tags,types", [
+        ({}, "Is the gateway running right now?", 2, "mid", ["normal"], ["observation"]),
+        ({"recall_live_status_bypass": True}, "Is the gateway running right now?", 0, None, None, None),
+        ({"recall_live_status_bypass": True}, "Läuft der Gateway gerade?", 0, None, None, None),
+        ({"recall_live_status_bypass": "false"}, "Is the gateway running right now?", 2, "mid", ["normal"], ["observation"]),
+        ({"recall_max_results": 1}, "Remember our plan", 1, "mid", ["normal"], ["observation"]),
+        ({"recall_max_results": "bad", "recall_document_tag_routes": []}, "Remember our plan", 2, "mid", ["normal"], ["observation"]),
+        ({"recall_simple_budget": "low", "recall_simple_max_words": 8}, "My favorite color?", 2, "low", ["normal"], ["observation"]),
+        ({"recall_simple_budget": "low", "recall_simple_max_words": 8}, "Compare our options", 2, "mid", ["normal"], ["observation"]),
+        ({"recall_simple_budget": "low", "recall_simple_max_words": 3, "recall_max_input_chars": 5}, "Tell me more about that project", 2, "mid", ["normal"], ["observation"]),
+        ({"recall_document_tags": ["docs"], "recall_document_terms": ["document"],
+          "recall_document_tag_routes": {"topic:network": ["router"]}}, "Find ROUTER document", 2, "mid", ["docs", "topic:network"], ["world", "observation"]),
+        ({"recall_document_tags": ["docs"], "recall_document_terms": ["document"]}, "My favorite color?", 2, "mid", ["normal"], ["observation"]),
+        ({"recall_document_tags": ["docs"]}, "Find document", 2, "mid", ["normal"], ["observation"]),
+    ])
+    def test_optional_auto_recall_controls_leave_explicit_tools_unchanged(
+        self, provider_with_config, config, query, count, budget, tags, types,
+    ):
+        p = provider_with_config(recall_sync=True, recall_tags=["normal"], **config)
+        injected = p.prefetch(query)
+        if count == 0:
+            assert injected == ""
+            assert p.recall_status() is None
+            p._client.arecall.assert_not_called()
+        else:
+            assert p.recall_status().count == count
+            assert ("Memory 2" in injected) == (count == 2)
+            kwargs = p._client.arecall.call_args.kwargs
+            assert (kwargs["budget"], kwargs["tags"], kwargs["types"]) == (budget, tags, types)
+            assert kwargs["tags_match"] == ("all" if tags[0] == "docs" else "any")
+        # Same query through the explicit tool must still use normal scope/budget
+        # and return both facts, even when automatic recall skipped or capped it.
+        result = p._tool_recall({"query": query})
+        assert "Memory 1" in result and "Memory 2" in result
+        kwargs = p._client.arecall.call_args.kwargs
+        assert (kwargs["budget"], kwargs["tags"], kwargs["types"]) == ("mid", ["normal"], ["observation"])
+
+    @pytest.mark.parametrize("query,expected_budget", [("Favorite document?", "low"), ("Compare documents", "mid"), ("Running right now?", None)])
+    def test_reflect_auto_controls_and_declared_configuration(self, provider_with_config, query, expected_budget):
+        from plugins.memory.hindsight.config_schema import CONFIG_SCHEMA
+
+        config = dict(recall_max_results=1, recall_live_status_bypass=True,
+                      recall_simple_budget="low", recall_simple_max_words=8,
+                      recall_document_tags=["docs"], recall_document_terms=["document"],
+                      recall_document_tag_routes={}, recall_document_types=["world"])
+        p = provider_with_config(prefetch_method="reflect", recall_sync=True, **config)
+        assert set(config) <= {f.key for f in CONFIG_SCHEMA.fields}
+        assert set(config) <= {f["key"] for f in p.get_config_schema()}
+        injected = p.prefetch(query)
+        p._client.arecall.assert_not_called()
+        if expected_budget is None:
+            assert injected == ""
+            p._client.areflect.assert_not_called()
+        else:
+            assert "Synthesized answer" in injected
+            assert p._client.areflect.call_args.kwargs == {
+                "bank_id": "test-bank", "query": query, "budget": expected_budget,
+            }
+        assert p._tool_reflect({"query": query}) == "Synthesized answer"
+        assert p._client.areflect.call_args.kwargs["budget"] == "mid"
+
     def test_prefetch_returns_empty_when_no_result(self, provider):
         assert provider.prefetch("test") == ""
 


### PR DESCRIPTION
## Summary

Add optional controls to the existing Hindsight provider's automatic recall: a ranked-result cap, a live-status phrase bypass, a short-query budget, and term-based tag/type filtering for already retained documents. All controls default off, leaving native behavior unchanged. Explicit recall/reflect tools keep their configured scope and budget.

Use the existing provider configuration schema/full-config modal; keep its compact connection panel unchanged. No new service, dependency, provider, document import/synchronization or bank mutation is introduced. No Mental Models setting is modified.

## Tradeoffs / feedback requested

- English/German phrase matching is deliberately an **opt-in heuristic**, not semantic intent detection or a freshness guarantee. It can skip useful context or misclassify a question. Classification happens before query truncation.
- For current-message routing, use the existing native `recall_sync`; asynchronous prefetch timing is not changed or claimed as a new feature.
- A cap limits injected results, not server retrieval cost. Document tags replace the usual scope only on matching queries, use `tags_match: all`, and are not authorization boundaries. Broad/mismatched tags may return unhelpful/no results.
- Reflect uses only bypass and short-query budget; result caps and document filters are recall-only.
- This focused provider-level proposal adapts an existing user customization. If maintainers prefer fewer controls or a different routing extension point, feedback on that scope is welcome before moving out of Draft.

## Validation

- Two new parametrized behavior test functions (15 cases): native defaults, enabled controls, malformed optional settings, truncation, unchanged explicit tools, reflect behavior and declared config fields. Eight cases fail on unmodified main; seven preserve existing defaults.
- Existing configuration assertions updated to cover advanced controls while retaining the compact panel.
- `scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py tests/plugins/memory/test_hindsight_config_schema.py tests/plugins/memory/test_config_schema.py -q -j 2 --file-retries 0`: **110 passed** in an isolated Linux checkout.
- Ruff for changed Python files and `git diff --check`: passed.
- Full suite, rendered desktop UI, Windows/macOS and live-bank validation have not been run. Draft for review.

Based on `71f8c60f6a6ab8f2fab1e4d5c22d6dd9c856b63e`, independently of the provenance proposal #103269. Both touch recall helpers and may need integration adjustments when one merges. Original M-Lietz authorship is credited in the commit; no production installation was changed.
