### PR TITLE
Fix unified-memory budgeting on Apple Silicon and other shared pools

### DIFF
--- a/hermes_cli/local_runtime/context_policy.py
+++ b/hermes_cli/local_runtime/context_policy.py
@@ -64,7 +64,10 @@ def initial_window(profile: ModelProfile, budget: HardwareBudget, *, flash_atten
     everywhere, capped at native. ``overhead_bytes`` is runtime cost beyond weights+KV; zero keeps
     this pure physics for decision-table tests, production callers pass it.
     """
-    refusal = physics_check(profile, budget, FLOOR, flash_attention=flash_attention)
+    # Pass overhead into the gate too: refusing on weights+KV alone under-priced
+    # every decision by the runtime overhead the rung loop already accounts for.
+    refusal = physics_check(profile, budget, FLOOR, flash_attention=flash_attention,
+                            overhead_bytes=overhead_bytes)
     if refusal:
         return refusal
 

--- a/hermes_cli/local_runtime/estimator.py
+++ b/hermes_cli/local_runtime/estimator.py
@@ -131,17 +131,61 @@ class PhysicsRefusal:
     message: str
 
 
+# OS free-memory floor for UNIFIED-memory machines. On a shared pool the model's
+# working set comes out of the same physical RAM the OS lives in, so "it fits the
+# budget" is not the same as "the machine still works". The reserve in
+# hardware.py shapes the budget; this is the hard admission gate that refuses a
+# load which would leave the OS too little to run.
+#
+# Shape is min(cap, max(floor, fraction)) — the same idiom the discrete path
+# already uses. Justified per tier: a single constant is wrong (3 GiB of a 512 GiB
+# Mac Pro is 0.6%), and an UNCAPPED max(3 GiB, 10%) is also wrong — it would newly
+# refuse a 240 GiB model on a 256 GiB machine, a regression. The cap is
+# load-bearing, not decoration.
+_OS_FLOOR_FRACTION = 0.10
+_OS_FLOOR_MIN = 3 << 30            # 3 GiB — binds up to 32 GiB of RAM
+_OS_FLOOR_CAP = 16 << 30           # 16 GiB — binds from 160 GiB of RAM up
+
+
+def os_free_floor_bytes(total_ram: int) -> int:
+    """Bytes that must remain free for the OS after a model is resident."""
+    return int(min(_OS_FLOOR_CAP, max(_OS_FLOOR_MIN, total_ram * _OS_FLOOR_FRACTION)))
+
+
 def physics_check(profile: ModelProfile, budget: HardwareBudget,
-                  floor: int, *, flash_attention: bool = True) -> PhysicsRefusal | None:
+                  floor: int, *, flash_attention: bool = True,
+                  overhead_bytes: int = 0) -> PhysicsRefusal | None:
+    """Refuse a model that cannot physically run.
+
+    ``overhead_bytes`` is runtime cost beyond weights+KV. It defaults to 0 so the
+    pure-physics decision-table tests are unchanged, but production callers pass
+    it: without it every refusal decision was under-priced by that amount.
+    """
     needed = (profile.weights_bytes
               + ctx_bytes(profile, min(floor, profile.n_ctx_train or floor),
-                          flash_attention=flash_attention))
+                          flash_attention=flash_attention)
+              + overhead_bytes)
     available = budget.usable_vram_bytes + budget.ram_available_bytes
-    if needed <= available:
-        return None
     gib = 1 << 30
-    return PhysicsRefusal(
-        needed_bytes=needed, available_bytes=available,
-        message=(f"{profile.name}: needs ~{needed / gib:.1f} GiB at the "
-                 f"{floor // 1024}K floor but only ~{available / gib:.1f} GiB "
-                 "of VRAM+RAM exist — try a smaller quant (UD-Q3/Q2)"))
+    if needed > available:
+        return PhysicsRefusal(
+            needed_bytes=needed, available_bytes=available,
+            message=(f"{profile.name}: needs ~{needed / gib:.1f} GiB at the "
+                     f"{floor // 1024}K floor but only ~{available / gib:.1f} GiB "
+                     "of VRAM+RAM exist — try a smaller quant (UD-Q3/Q2)"))
+
+    # Unified memory only: on a discrete card the weights live in VRAM and do not
+    # consume host RAM, so the OS floor does not apply there.
+    if budget.uma:
+        total_ram = budget.total_device_bytes
+        os_floor = os_free_floor_bytes(total_ram)
+        left_for_os = total_ram - needed
+        if left_for_os < os_floor:
+            return PhysicsRefusal(
+                needed_bytes=needed, available_bytes=available,
+                message=(f"{profile.name}: needs ~{needed / gib:.1f} GiB of the "
+                         f"~{total_ram / gib:.1f} GiB shared pool, leaving only "
+                         f"~{left_for_os / gib:.1f} GiB for the OS (floor is "
+                         f"~{os_floor / gib:.1f} GiB) — the machine would swap; "
+                         "try a smaller quant (UD-Q3/Q2) or a shorter context"))
+    return None

--- a/hermes_cli/local_runtime/hardware.py
+++ b/hermes_cli/local_runtime/hardware.py
@@ -31,8 +31,25 @@ _GIB = 1 << 30
 _MARGIN_FLOOR = 2 << 30
 _MARGIN_FRACTION = 0.09
 # UMA headroom: on unified-memory machines the model shares physical memory with the OS and every
-# app, so budget from RAM minus this fraction.
-_UMA_HEADROOM_FRACTION = 0.20
+# app, so budget from the pool minus a reserve: clamp(pool * 10%, 1.5 GiB, 12 GiB).
+#
+# It is a clamp, not a flat fraction, because the OS working set is roughly CONSTANT, not
+# proportional to installed memory. The previous flat 20% held back ~51 GiB on a 256 GiB Mac
+# Studio for an OS that will never use a fraction of that — computing 204.8 GiB usable and so
+# REFUSING a 405B-Q4 model that in fact fits. The cap fixes that end. The floor fixes the other:
+# turbofit's sibling implementation capped flat at 8 GiB, which saturates at 160 GiB and leaves a
+# 192 GiB+ machine reserving no more than a 160 GiB one — unsafe on exactly the hardware where an
+# OOM costs most. 12 GiB keeps growing past that point.
+#
+# The clamp is a strict middle: it never reserves more than the old 20% (so it refuses nothing
+# that used to load) and never less than turbofit's (so each change there trims an over-fit).
+#
+# Clamped in whole MiB, matching apple_unified_budget.py exactly so the two cannot drift by
+# sub-MiB rounding. This MUST stay in sync with that shared module — change it there and
+# re-vendor; do not fork the formula.
+_UMA_RESERVE_FRACTION = 0.10
+_UMA_RESERVE_FLOOR_MB = 1536       # 1.5 GiB — binds at 8 GiB
+_UMA_RESERVE_CAP_MB = 12 * 1024    # 12 GiB — binds from 128 GiB up
 
 # Engine-fallback gates for the unified-pool quirk — BOTH must hold, and no discrete card can
 # meet either: (1) the allocator's pool exceeds the smi report by well past rounding/ECC slack
@@ -244,8 +261,27 @@ def _unified_pool_bytes(smi_total: int, ram_total: int) -> int | None:
     return None
 
 
+def _uma_reserve_bytes(total: int) -> int:
+    """Bytes held back from the shared pool for the OS: clamp(total * 10%, 1.5 GiB, 12 GiB).
+
+    Sized from ``total`` — the pool's physical extent — never from a live-free reading. The OS's
+    working set does not shrink because a model is already resident, so scaling the reserve off
+    live-free would shrink it exactly when memory is tightest, and would make one machine report
+    a different reserve minute to minute.
+
+    Clamped in whole MiB to match apple_unified_budget.py bit-for-bit.
+    """
+    total_mb = max(0, total) // (1 << 20)
+    scaled = total_mb * _UMA_RESERVE_FRACTION
+    reserve_mb = int(min(float(_UMA_RESERVE_CAP_MB), max(float(_UMA_RESERVE_FLOOR_MB), scaled)))
+    return reserve_mb << 20
+
+
 def _uma_budget(base: int, total: int) -> HardwareBudget:
-    usable = max(0, int(base * (1 - _UMA_HEADROOM_FRACTION)))
+    """``base`` is what may be claimed now (live-free, or ``total`` when planning); ``total`` is
+    the pool's physical extent. The reserve is sized from ``total`` and subtracted from ``base``,
+    so planning and live differ in available headroom, not in what the OS is owed."""
+    usable = max(0, base - _uma_reserve_bytes(total))
     return HardwareBudget(usable_vram_bytes=usable, total_device_bytes=total,
                           ram_available_bytes=0, uma=True)
 

--- a/tests/hermes_cli/test_unified_pool_quirk.py
+++ b/tests/hermes_cli/test_unified_pool_quirk.py
@@ -108,7 +108,7 @@ def test_budget_unified_pool_planning(monkeypatch):
     assert b.uma is True
     assert b.ram_available_bytes == 0
     assert b.total_device_bytes == UMA_POOL
-    assert b.usable_vram_bytes == int(UMA_POOL * (1 - hw._UMA_HEADROOM_FRACTION))
+    assert b.usable_vram_bytes == UMA_POOL - hw._uma_reserve_bytes(UMA_POOL)
     # The whole point: the budget must dwarf the carve-out.
     assert b.usable_vram_bytes > 2 * UMA_SMI_TOTAL
 
@@ -120,8 +120,9 @@ def test_budget_unified_pool_live_counts_dedicated_free_plus_os_available(monkey
     b = hw.probe_budget(planning=False)
     assert b.uma is True
     live = (14848 << 20) + 32 * GIB
-    assert b.usable_vram_bytes == int(min(UMA_POOL, live)
-                                      * (1 - hw._UMA_HEADROOM_FRACTION))
+    # Reserve is sized from the pool's physical extent, not from the live figure:
+    # what the OS is owed does not shrink just because memory got tight.
+    assert b.usable_vram_bytes == min(UMA_POOL, live) - hw._uma_reserve_bytes(UMA_POOL)
 
 
 def test_budget_unified_no_smi_still_classifies(monkeypatch):
@@ -135,10 +136,12 @@ def test_budget_unified_no_smi_still_classifies(monkeypatch):
     planning = hw.probe_budget(planning=True)
     assert planning.uma is True
     assert planning.total_device_bytes == UMA_POOL
-    assert planning.usable_vram_bytes == int(
-        UMA_POOL * (1 - hw._UMA_HEADROOM_FRACTION))
+    assert planning.usable_vram_bytes == UMA_POOL - hw._uma_reserve_bytes(UMA_POOL)
     live = hw.probe_budget(planning=False)
-    assert live.usable_vram_bytes == int(32 * GIB * (1 - hw._UMA_HEADROOM_FRACTION))
+    # Was: 32 GiB * 0.8 — the old code took the reserve out of FREE ram, so the
+    # reserve shrank precisely as the machine ran out of memory. Now the reserve
+    # is sized from the pool total and subtracted from what is claimable now.
+    assert live.usable_vram_bytes == 32 * GIB - hw._uma_reserve_bytes(UMA_POOL)
 
 
 def test_budget_discrete_unchanged_when_probe_says_discrete(monkeypatch):


### PR DESCRIPTION
Fixes #102619.

That report is this bug seen from the UI: an M5 Max with 128 GiB of unified memory tags a
27B Q4 (~16 GB) as "Too big for this machine". The reporter's diagnosis is right — the
budget was not accounting for unified memory correctly — and their suggested threshold
("unified size minus OS overhead, ~16 GB on a typical macOS install") is close to what this
PR implements: a reserve of `clamp(RAM * 10%, 1.5 GiB, 12 GiB)`, which on their 128 GiB
machine holds back 12 GiB and leaves 116 GiB usable, so a 16 GB model is admitted with
room to spare.

Related, not fixed here:
- #102110 "Local Model not working" — may share a root cause; worth re-testing against this branch.
- #102503 fixed nvidia-smi discovery in the same `local_runtime` area; this PR touches the
  no-NVIDIA fallback path that sits next to it.

---

# Fix unified-memory budgeting on Apple Silicon and other shared pools

Branch: `fix/apple-unified-memory-budget` (4 files, +105 / -19)
Target: `NousResearch/hermes-agent`

## The problem

`_uma_budget` reserved a flat 20% of the pool, sized from whatever `base` happened to be
at the call site. Three distinct bugs fall out of that.

**1. The reserve shrank as the machine ran out of memory.** On the no-smi path, `base` is
live-free RAM, so the reserve was 20% *of what was left*. The tighter memory got, the less
was held back for the OS — exactly backwards. The same Mac reported a different budget
minute to minute.

**2. A flat fraction is wrong at both ends.** The OS working set is roughly constant, not
proportional to RAM:

| RAM | old reserve (20%) | new reserve | effect |
|---|---|---|---|
| 8 GiB | 1.6 GiB | 1.5 GiB | ~same |
| 32 GiB | 6.4 GiB | 3.2 GiB | mid-range was squeezed |
| 256 GiB | 51.2 GiB | 12 GiB | **wrongly refused a 240 GiB model** |
| 512 GiB | 102.4 GiB | 12 GiB | a fifth of the machine thrown away |

**3. `physics_check` never received `overhead_bytes`.** `initial_window` already computed
it for the rung loop but did not pass it to the refusal gate, so every refusal decision was
under-priced by that amount (≥1.5 GiB — the same order as the bug being fixed).

## The changes

**Reserve is now `clamp(total * 10%, 1.5 GiB, 12 GiB)`**, sized from the pool's *physical
extent* and subtracted from what is claimable now. Planning and live budgets therefore
differ in available headroom, not in what the OS is owed.

The clamp is deliberately a strict middle: it never reserves more than the old 20% (so it
refuses nothing that previously loaded) and never less than a 5%/8 GiB rule (so every
difference trims an over-fit rather than creating one).

Note `total` is the *pool's* extent, not system RAM — on the unified-NVIDIA carve-out path
those differ, and clamping to OS RAM would discard exactly the carved capacity the existing
comments warn about.

**`physics_check` accepts `overhead_bytes`** (default 0, so pure-physics decision-table
tests are unchanged) and `initial_window` passes the value it already had.

**New OS free-memory floor**, applied only when `budget.uma`: refuse a load that would
leave the OS less than `min(16 GiB, max(3 GiB, 10% RAM))` free. On a shared pool, "it fits
the budget" is not the same as "the machine still works" — an 8 GiB Mac would previously
admit a ~6 GiB model and thrash.

The 16 GiB cap is load-bearing rather than cosmetic: an uncapped `max(3 GiB, 10%)` newly
refuses a 240 GiB model on a 256 GiB machine, which is a regression.

## Discrete GPUs are untouched

`_uma_budget` is unreachable for discrete cards (they return via the separate
`_MARGIN_FLOOR`/`_MARGIN_FRACTION` path), and the OS floor is gated on `budget.uma` because
a discrete card's weights do not consume host RAM.
`test_budget_discrete_unchanged_when_probe_says_discrete` guards this.

## Tests

46 pass across `tests/hermes_cli/test_unified_pool_quirk.py` and `test_context_policy.py`.

Four assertions in `test_unified_pool_quirk.py` referenced the removed
`_UMA_HEADROOM_FRACTION`. Three are mechanical. The fourth asserted the live budget equalled
`32 GiB * 0.8` — it encoded the shrink-when-tight bug above, and has been rewritten to
assert the reserve is sized from the pool total, with a comment explaining why the old
expectation was wrong.

## How to verify

```sh
git checkout fix/apple-unified-memory-budget
python -m pytest tests/hermes_cli/test_unified_pool_quirk.py \
                 tests/hermes_cli/test_context_policy.py -q
```

Behavioural spot-checks worth running on real hardware, which I could **not** do:

- A 256 GiB Mac should now load a ~240 GiB model that `main` refuses.
- An 8 GiB Mac should now *refuse* an ~8B-Q4 model at 8K context with a message naming the
  OS floor, rather than loading and swapping.
- A Mac under memory pressure should report a stable budget across repeated probes.

## What has not been validated

- **No Apple hardware was used.** The analysis is arithmetic over estimated model
  footprints; the footprints are estimates, not measurements.
- The OS floor's constants (3 GiB / 10% / 16 GiB) are justified per RAM tier against those
  estimates, not measured against real macOS pressure behaviour.
- `select_variant` in `catalog.py` was **not** given the mirrored floor check, so the
  catalog can still advertise a model the launch gate will refuse. That is a deliberate
  scope cut, not an oversight.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
