### PR TITLE
fix(desktop): prevent bridge timeouts across profiles and connections

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -41,6 +41,7 @@ import {
   setSelectedStoredSessionId
 } from '@/store/session'
 import { $sessionTiles, $workingSessionIds, clearAllSessionStates, publishSessionState } from '@/store/session-states'
+import type { RpcEvent } from '@/types/hermes'
 
 import { deferred } from '../../../test/deferred'
 
@@ -164,6 +165,10 @@ class FakeWebSocket {
     // 'silent': swallow — a healthy socket answers, a half-open one never does.
   }
 
+  receiveEvent(params: RpcEvent) {
+    this.emit('message', { data: JSON.stringify({ jsonrpc: '2.0', method: 'event', params }) })
+  }
+
   private emit(type: string, ev: unknown) {
     for (const fn of this.listeners[type] ?? []) {
       fn(ev)
@@ -244,16 +249,18 @@ function fakeDesktop() {
 
 function Harness({
   beforeConnectionSwitch = () => undefined,
+  handleGatewayEvent = () => undefined,
   refreshHermesConfig = async () => undefined,
   refreshSessions
 }: {
   beforeConnectionSwitch?: () => void
+  handleGatewayEvent?: (event: RpcEvent) => void
   refreshHermesConfig?: (force?: boolean, shouldPublish?: () => boolean) => Promise<void>
   refreshSessions?: (shouldPublish?: () => boolean) => Promise<void>
 } = {}) {
   useGatewayBoot({
     beforeConnectionSwitch,
-    handleGatewayEvent: () => undefined,
+    handleGatewayEvent,
     onConnectionReady: () => undefined,
     onGatewayReady: () => undefined,
     refreshHermesConfig,
@@ -898,6 +905,45 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
 
     await expect(requestGatewayForAgent('primary-vps', 'default', 'ping')).resolves.toEqual({ pong: true })
     expect(FakeWebSocket.instances).toHaveLength(1)
+  })
+
+  it('tags primary requests with the primary connection while a secondary is foreground', async () => {
+    const desktop = {
+      ...fakeDesktop(),
+      getConnectionFor: vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) => ({
+        ...coderConn,
+        connectionId,
+        profile,
+        wsUrl: `wss://${connectionId}.example.com/api/ws?token=r`
+      }))
+    }
+
+    Object.assign(window, { hermesDesktop: desktop })
+    const handleGatewayEvent = vi.fn()
+    render(<Harness handleGatewayEvent={handleGatewayEvent} />)
+    await flushAsync()
+    const primarySocket = FakeWebSocket.instances[0]
+    let opening!: Promise<boolean>
+    act(() => {
+      opening = ensureGatewayForAgent('cloud', 'default')
+    })
+    await flushAsync()
+    await opening
+    expect(isActivePrimary()).toBe(false)
+    act(() =>
+      primarySocket.receiveEvent({
+        type: 'window.read.request',
+        session_id: 'primary-runtime',
+        payload: { request_id: 'primary-request' }
+      })
+    )
+    expect(handleGatewayEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'window.read.request',
+        connectionId: 'primary-vps',
+        profile: 'default'
+      })
+    )
   })
 
   it('keeps registered source sockets alive during a legacy mode apply', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -20,7 +20,6 @@ import {
 import { resetBackgroundPollingGuard } from '@/store/composer-status'
 import {
   $gateway,
-  activeGatewayConnectionId,
   closeLegacySecondaryGateways,
   closeSecondaryGateways,
   configureGatewayRegistry,
@@ -29,6 +28,7 @@ import {
   gatewayActivationEpoch,
   isActivePrimary,
   liveSecondaryConnectionIds,
+  primaryGatewayConnectionId,
   pruneSecondaryGateways,
   reconnectSecondaryGateways,
   reportPrimaryGatewayState,
@@ -838,7 +838,7 @@ export function useGatewayBoot({
     const sourceProfile = normalizeProfileKey($activeGatewayProfile.get())
 
     const offEvent = gateway.onEvent(event => {
-      const connectionId = activeGatewayConnectionId()
+      const connectionId = primaryGatewayConnectionId()
 
       const scopedEvent = {
         ...event,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+
+import type { GatewayEventContext } from './types'
+
+const sent: { method: string; params: Record<string, unknown>; url: string }[] = []
+
+class FakeGateway {
+  connectionState = 'closed'
+  url = 'ws://default'
+  async connect(url: string) {
+    this.url = url
+    this.connectionState = 'open'
+  }
+  async request(method: string, params: Record<string, unknown> = {}) {
+    sent.push({ method, params, url: this.url })
+
+    return { status: 'ok' }
+  }
+  close() {
+    this.connectionState = 'closed'
+  }
+  onEvent() {
+    return () => undefined
+  }
+  onState() {
+    return () => undefined
+  }
+}
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  HermesGateway: FakeGateway,
+  setApiRequestConnection: vi.fn()
+}))
+vi.mock('@/store/session', () => ({ setConnection: vi.fn(), setGatewayState: vi.fn(), setMessages: vi.fn() }))
+vi.mock('@/store/notify-baseline', () => ({ markNativeNotifyBaseline: vi.fn() }))
+vi.mock('@/app/chat/right-rail/preview-reader', () => ({
+  readActivePreview: vi.fn(async () => ({ text: 'public page' }))
+}))
+vi.mock('@/app/right-sidebar/terminal/agent-terminal-stream', () => ({ writeAgentTerminalChunk: vi.fn() }))
+vi.mock('@/app/right-sidebar/terminal/buffer', () => ({ readActiveTerminal: vi.fn(() => ({ text: 'terminal' })) }))
+vi.mock('@/app/right-sidebar/terminal/terminals', () => ({ closeAgentTerminalByProc: vi.fn() }))
+vi.mock('@/store/pane-focus', () => ({ applyDesktopLayoutPreset: vi.fn(), revealDesktopPane: vi.fn() }))
+vi.mock('@/store/reactions-local', () => ({ recordAgentReaction: vi.fn() }))
+vi.mock('@/store/tips', () => ({ $tipsEnabled: { get: () => false }, showTip: vi.fn() }))
+vi.mock('@/store/tours', () => ({ $toursEnabled: { get: () => false } }))
+const { handleDesktopBridgeEvent } = await import('./desktop-bridge')
+
+const { $gateway, closeSecondaryGateways, configureGatewayRegistry, setPrimaryGateway } =
+  await import('@/store/gateway')
+
+function request(type: string, profile = 'juststoreit', connectionId = 'local') {
+  const payload = { request_id: 'probe-request', action: 'elements' }
+
+  return {
+    event: { type, profile, connectionId, session_id: 'jsi-runtime' },
+    payload,
+    isActiveEvent: false
+  } as GatewayEventContext
+}
+
+beforeEach(() => {
+  sent.length = 0
+  configureGatewayRegistry({ onEvent: vi.fn() })
+  const primary = new FakeGateway()
+  primary.connectionState = 'open'
+  setPrimaryGateway(primary as never, 'default')
+  $gateway.set(primary as never)
+  Object.assign(window, {
+    hermesDesktop: {
+      getConnection: async () => ({ mode: 'local' }),
+      getConnectionFor: async ({ connectionId, profile }: { connectionId: string; profile: string }) => ({
+        connectionId,
+        profile,
+        mode: 'local'
+      }),
+      getGatewayWsUrlFor: async ({ connectionId, profile }: { connectionId: string; profile: string }) =>
+        `ws://${connectionId}/${profile}`,
+      touchBackend: async () => undefined,
+      readWindowBelow: async () => ({ window: { app: 'Hermes' } })
+    }
+  })
+})
+afterEach(() => {
+  closeSecondaryGateways()
+  vi.restoreAllMocks()
+})
+it.each(['preview.act', 'preview.read', 'window.read', 'terminal.read', 'tour'])(
+  'answers %s on the requesting profile socket, even when default is active',
+  async kind => {
+    expect(handleDesktopBridgeEvent(request(`${kind}.request`))).toBe(true)
+    await vi.waitFor(() => expect(sent.some(call => call.method === `${kind}.respond`)).toBe(true))
+    expect(sent.find(call => call.method === `${kind}.respond`)).toMatchObject({
+      url: 'ws://local/juststoreit',
+      params: { request_id: 'probe-request' }
+    })
+  }
+)
+it('keeps an asynchronous reply on its original connection when foreground changes', async () => {
+  let finish!: (value: null) => void
+  vi.spyOn(window.hermesDesktop!, 'readWindowBelow').mockImplementation(
+    () =>
+      new Promise(resolve => {
+        finish = resolve
+      })
+  )
+  handleDesktopBridgeEvent(request('window.read.request', 'default', 'source-a'))
+  const other = new FakeGateway()
+  other.url = 'ws://source-b/default'
+  $gateway.set(other as never)
+  finish(null)
+  await vi.waitFor(() => expect(sent.some(call => call.method === 'window.read.respond')).toBe(true))
+  expect(sent.find(call => call.method === 'window.read.respond')?.url).toBe('ws://source-a/default')
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
@@ -4,7 +4,7 @@ import { readActiveTerminal } from '@/app/right-sidebar/terminal/buffer'
 import { closeAgentTerminalByProc } from '@/app/right-sidebar/terminal/terminals'
 import type { PreviewActAction } from '@/lib/preview-act/act-in-page'
 import type { TourAction, TourStep } from '@/lib/tour'
-import { $gateway } from '@/store/gateway'
+import { $gateway, requestGatewayForAgent } from '@/store/gateway'
 import { applyDesktopLayoutPreset, revealDesktopPane } from '@/store/pane-focus'
 import { recordAgentReaction } from '@/store/reactions-local'
 import { setMessages } from '@/store/session'
@@ -46,6 +46,14 @@ const loadPreviewEngine = () => {
  *  message reactions. */
 export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
   const { event, payload, isActiveEvent } = ctx
+  // Replies belong to the socket that issued the request. The foreground
+  // gateway may be another profile, or may change during an async page read.
+  const legacyGateway = $gateway.get()
+
+  const respond = (method: string, params: Record<string, unknown>) =>
+    event.profile || event.connectionId
+      ? requestGatewayForAgent(event.connectionId ?? null, event.profile ?? 'default', method, params)
+      : legacyGateway?.request(method, params)
 
   if (event.type === 'terminal.read.request') {
     // read_terminal tool: serialize the renderer's xterm buffer and answer
@@ -57,7 +65,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
       const count = typeof payload?.count === 'number' ? payload.count : undefined
       const result = readActiveTerminal({ start, count })
 
-      void $gateway.get()?.request('terminal.read.respond', {
+      void respond('terminal.read.respond', {
         request_id: requestId,
         text: result ? JSON.stringify(result) : ''
       })
@@ -76,7 +84,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
       const count = typeof payload?.count === 'number' ? payload.count : undefined
 
       void readActivePreview({ count, start }).then(result => {
-        void $gateway.get()?.request('preview.read.respond', {
+        void respond('preview.read.respond', {
           request_id: requestId,
           text: result ? JSON.stringify(result) : ''
         })
@@ -96,7 +104,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
 
     if (requestId) {
       const answer = (result: unknown) =>
-        $gateway.get()?.request('preview.act.respond', {
+        respond('preview.act.respond', {
           request_id: requestId,
           text: result ? JSON.stringify(result) : ''
         })
@@ -140,7 +148,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
       const read = window.hermesDesktop?.readWindowBelow
 
       const answer = (result: unknown) =>
-        $gateway.get()?.request('window.read.respond', {
+        respond('window.read.respond', {
           request_id: requestId,
           text: result ? JSON.stringify(result) : ''
         })
@@ -180,7 +188,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
 
     if (requestId) {
       const answer = (result: unknown) =>
-        $gateway.get()?.request('tour.respond', {
+        respond('tour.respond', {
           request_id: requestId,
           text: result ? JSON.stringify(result) : ''
         })

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -376,6 +376,11 @@ export function activeGateway(): HermesGateway | null {
   return g.secondaries.get(g.activeKey)?.gateway ?? null
 }
 
+/** The window-owned primary identity, independent of the foreground route. */
+export function primaryGatewayConnectionId(): null | string {
+  return g.primaryConnectionId
+}
+
 /**
  * The registry connection serving the gateway the user is currently looking
  * at. A registry-backed primary takes its identity from the published primary


### PR DESCRIPTION
## What does this PR do?

Desktop can execute a profile's browser request but send the reply to the foreground gateway, leaving the requesting backend to time out. Return all five response-bearing bridge families to the event's connection and profile, including replies that finish after a foreground switch.

Primary socket events must also carry the primary connection identity. The boot hook currently tags them with the foreground connection, which can be a secondary. This PR corrects that producer as well as the reply path. Existing action gates and response payloads remain unchanged.

## Related Issue

Related to #94272.

Overlaps #102883 and #102935, which route replies through session-owner lookup. This is an alternative using the incoming event's connection/profile directly, and also fixes primary event tagging while a secondary is foreground. Those PRs do not change that producer. These alternatives should be reconciled before merge.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts`: use `requestGatewayForAgent` for tagged requests; capture the existing gateway for untagged legacy requests. Apply to terminal, preview read/action, window read, and tour responses.
- `apps/desktop/src/store/gateway.ts` and `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts`: read the registry's primary connection identity when tagging primary events.
- Colocated tests exercise the real registry with fake transport and the real boot hook with a fake WebSocket. Cover each reply family, asynchronous foreground changes, and primary events while a secondary is foreground.

## How to Test

1. Open Desktop with a non-default profile and a public preview page while the ambient gateway belongs to another profile. Run `drive_preview` with `action=elements`. Before the fix, diagnostics showed the reply reaching the default backend immediately while the requesting profile timed out after 45 seconds. With the rebuilt macOS arm64 app, the requesting profile received the element inventory successfully.
2. From `apps/desktop`, run `npx vitest run src/app/gateway/hooks/use-gateway-boot.test.tsx src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts`: **49 passed**. The new routing cases and primary-tag case were observed failing before their respective fixes.
3. `npx tsc -p . --noEmit`, ESLint on all five changed files, and Prettier checks pass. `npm run build` and macOS arm64 directory packaging passed. The installed package passed `codesign --verify --deep --strict`; its 285 JS/CSS/HTML files matched the build.

The installed live probe covered `drive_preview(action=elements)` and `read_window_below`. Both replies reached the requesting profile within 0.1 seconds of the recorded tool calls. Window enumeration returned `Could not enumerate windows: the window enumerator failed: spawn ENOTDIR`. That separate native helper failure remains unresolved and is outside this routing fix. No login, page mutation, or operational data writes were performed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs. Overlapping alternatives are disclosed above.
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass. Not run: this is a Desktop TypeScript-only change; focused Vitest, TypeScript, lint, build, and installed-client checks are listed above.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS arm64

### Documentation & Housekeeping

- [x] Relevant documentation updated or N/A: no public interface change; ownership comments explain the routing rule.
- [x] `cli-config.yaml.example`: N/A, no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A, no workflow change.
- [x] Cross-platform impact considered: renderer routing uses existing platform-independent gateway APIs. Live validation was macOS only.
- [x] Tool descriptions/schemas: N/A, unchanged.

## Screenshots / Logs

No visual layout, styling, or control changes. The installed client was inspected after the probe; the completed successful browser result and native window error were visible in the conversation. Sanitized response evidence:

```text
drive_preview(action=elements): returned the public page element inventory, including Sign In.
read_window_below: returned the native spawn ENOTDIR error immediately.
Before: preview reply reached the wrong backend; requester timed out.
After: both responses reached the requesting profile within 0.1 seconds of recorded calls.
```

Raw conversation screenshots and logs are omitted because they contain unrelated private workspace/session data. Temporary diagnostic logging was removed before building; no backend logging changes are included. The previous app is retained locally for rollback. Code review completed before the live probe, with no remaining routing findings.

---
🤖 **Authored by GPT-6 for Jeremy**
