### PR TITLE
fix(desktop): remote-switch latency — probe streak retry, cache-busting probes, coalesced ws-url IPC, scoped prewarms

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -11623,6 +11623,8 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
         currentConnectionPromise: () => backendPool.get(key)?.connectionPromise || null,
         probe: (connection, requestPath, options) => fetchJsonForBackend(connection, requestPath, options),
         reconnect: () => ensureRegistryBackend(id, profile),
+        tracker: remoteLiveness,
+        remoteBaseUrl: existing.remoteBaseUrl ?? null,
         retire: async (error: any) => {
           // A late failure from an old descriptor must never tear down a newer
           // entry that another caller has already installed.
@@ -15667,54 +15669,6 @@ const registryGatewayWsUrlHandler = createRegistryGatewayWsUrlHandler({
 ipcMain.handle('hermes:gateway:ws-url-for', async (_event, payload) => {
   return gatewayWsUrlIpcResult(() => registryGatewayWsUrlHandler(payload))
 })
-
-// Transactional update for a Desktop-managed SSH install. Unlike the generic
-// fleet fan-out below, this path owns the remote serve lifecycle: it gates new
-// dials, drains only exact Desktop-owned processes, runs the launcher outside
-// those serves, proves the correlated receipt, and restores every prior scope.
-async function requestManagedSshUpdate(rawId) {
-  const connectionId = String(rawId || '').trim()
-  const existing = managedConnectionUpdates.get(connectionId)
-
-  if (existing) {
-    return existing
-  }
-
-  const correlationId = crypto.randomUUID()
-  const registry = readDesktopConnectionsRegistry()
-  const source = registry.connections.find(connection => connection.id === connectionId)
-
-  if (!source) {
-    return refusedManagedSshUpdate(connectionId, correlationId, `No connection with id "${connectionId}".`)
-  }
-
-  if (source.kind !== 'ssh') {
-    return refusedManagedSshUpdate(
-      connectionId,
-      correlationId,
-      'Only registered Desktop-managed SSH connections can use this update lifecycle.'
-    )
-  }
-
-  if (!managedConnectionUpdateGate.claim(connectionId, correlationId)) {
-    return refusedManagedSshUpdate(connectionId, correlationId, 'A managed update is already in progress.')
-  }
-
-  const operation = (async () => {
-    try {
-      return await updateManagedSshConnection(source, correlationId)
-    } catch (error: any) {
-      return refusedManagedSshUpdate(connectionId, correlationId, String(error?.message || error))
-    } finally {
-      managedConnectionUpdateGate.release(connectionId, correlationId)
-      managedConnectionUpdates.delete(connectionId)
-    }
-  })()
-
-  managedConnectionUpdates.set(connectionId, operation)
-
-  return operation
-}
 
 ipcMain.handle('hermes:connections:update-managed', async (_event, rawId) => requestManagedSshUpdate(rawId))
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -330,6 +330,7 @@ import * as remoteLifecycle from './remote-lifecycle'
 import {
   attachPowerResumeRemoteRevalidation,
   ensureHealthyPooledRemoteBackendForDispatch,
+  REMOTE_LIVENESS_PROBE_HEADERS,
   RemoteLivenessTracker,
   RemoteRevalidationCoordinator,
   revalidatePooledRemoteBackends,
@@ -11621,7 +11622,8 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
       ensureHealthyPooledRemoteBackendForDispatch({
         connectionPromise,
         currentConnectionPromise: () => backendPool.get(key)?.connectionPromise || null,
-        probe: (connection, requestPath, options) => fetchJsonForBackend(connection, requestPath, options),
+        probe: (connection, requestPath, options) =>
+          fetchJsonForBackend(connection, requestPath, { ...options, headers: { ...REMOTE_LIVENESS_PROBE_HEADERS, ...(options as any)?.headers } }),
         reconnect: () => ensureRegistryBackend(id, profile),
         tracker: remoteLiveness,
         remoteBaseUrl: existing.remoteBaseUrl ?? null,
@@ -14778,7 +14780,8 @@ ipcMain.handle('hermes:connection:revalidate', async () => {
         connectionPromise,
         currentConnectionPromise: () => backendConnectionState.getPromise(),
         log: rememberLog,
-        probe: (connection, path, options) => fetchJsonForBackend(connection, path, options),
+        probe: (connection, path, options) =>
+          fetchJsonForBackend(connection, path, { ...options, headers: { ...REMOTE_LIVENESS_PROBE_HEADERS, ...(options as any)?.headers } }),
         resetConnection: () => resetHermesConnection({ soft: true }),
         tracker: remoteLiveness
       }),
@@ -14809,7 +14812,8 @@ function revalidatePool() {
   return revalidatePooledRemoteBackends({
     entries: backendPool.entries(),
     log: rememberLog,
-    probe: (connection, path, options) => fetchJsonForBackend(connection, path, options),
+    probe: (connection, path, options) =>
+      fetchJsonForBackend(connection, path, { ...options, headers: { ...REMOTE_LIVENESS_PROBE_HEADERS, ...(options as any)?.headers } }),
     stopBackend: stopPoolBackend,
     tracker: remoteLiveness
   })
@@ -14844,7 +14848,8 @@ function revalidateSuspectPoolAfterResume() {
     revalidateSuspectPooledRemoteBackends({
       entries: backendPool.entries(),
       log: rememberLog,
-      probe: (connection, path, options) => fetchJsonForBackend(connection, path, options),
+      probe: (connection, path, options) =>
+      fetchJsonForBackend(connection, path, { ...options, headers: { ...REMOTE_LIVENESS_PROBE_HEADERS, ...(options as any)?.headers } }),
       rebuild: poolKey => redialPoolBackendAfterResume(poolKey),
       retire: async poolKey => {
         await stopPoolBackend(poolKey)
@@ -15670,6 +15675,95 @@ ipcMain.handle('hermes:gateway:ws-url-for', async (_event, payload) => {
   return gatewayWsUrlIpcResult(() => registryGatewayWsUrlHandler(payload))
 })
 
+// Coalesced variant (#193231): the renderer resolved the descriptor through
+// 'hermes:connection:for' moments earlier in the same profile switch. When the
+// payload carries that exact validated descriptor (same connectionId/profile),
+// reuse it instead of re-running ensureRegistryBackend's dispatch probe —
+// halving the round-trips per switch without weakening identity checks (the
+// descriptor still must match the requested scope).
+ipcMain.handle('hermes:gateway:ws-url-for-validated', async (_event, payload) => {
+  return gatewayWsUrlIpcResult(() => {
+    const { connectionId, profile, validatedConnection } =
+      payload && typeof payload === 'object' ? (payload as any) : ({} as any)
+
+    if (
+      validatedConnection &&
+      typeof validatedConnection === 'object' &&
+      typeof validatedConnection.wsUrl === 'string' &&
+      validatedConnection.wsUrl &&
+      String(validatedConnection.connectionId ?? '') === String(connectionId ?? '') &&
+      String(validatedConnection.profile ?? '') === String(profile ?? '')
+    ) {
+      const { connectionId: _vid, profile: _vp, ...descriptor } = validatedConnection
+      return registryGatewayWsUrlHandlerFromDescriptor(descriptor, { connectionId, profile })
+    }
+
+    return registryGatewayWsUrlHandler({ connectionId, profile })
+  })
+})
+
+function registryGatewayWsUrlHandlerFromDescriptor(
+  descriptor: Record<string, unknown>,
+  scope: { connectionId: unknown; profile: unknown }
+): Promise<string> {
+  const handler = createRegistryGatewayWsUrlHandler({
+    ensureBackend: async () => descriptor as unknown as Awaited<ReturnType<typeof ensureRegistryBackend>>,
+    mintTicket: mintGatewayWsTicket,
+    buildTicketUrl: buildGatewayWsUrlWithTicket,
+    rememberHeaders: rememberRemoteWsHeaders
+  })
+
+  return handler({ connectionId: scope.connectionId, profile: scope.profile })
+}
+
+// Transactional update for a Desktop-managed SSH install. Unlike the generic
+// fleet fan-out below, this path owns the remote serve lifecycle: it gates new
+// dials, drains only exact Desktop-owned processes, runs the launcher outside
+// those serves, proves the correlated receipt, and restores every prior scope.
+async function requestManagedSshUpdate(rawId) {
+  const connectionId = String(rawId || '').trim()
+  const existing = managedConnectionUpdates.get(connectionId)
+
+  if (existing) {
+    return existing
+  }
+
+  const correlationId = crypto.randomUUID()
+  const registry = readDesktopConnectionsRegistry()
+  const source = registry.connections.find(connection => connection.id === connectionId)
+
+  if (!source) {
+    return refusedManagedSshUpdate(connectionId, correlationId, `No connection with id "${connectionId}".`)
+  }
+
+  if (source.kind !== 'ssh') {
+    return refusedManagedSshUpdate(
+      connectionId,
+      correlationId,
+      'Only registered Desktop-managed SSH connections can use this update lifecycle.'
+    )
+  }
+
+  if (!managedConnectionUpdateGate.claim(connectionId, correlationId)) {
+    return refusedManagedSshUpdate(connectionId, correlationId, 'A managed update is already in progress.')
+  }
+
+  const operation = (async () => {
+    try {
+      return await updateManagedSshConnection(source, correlationId)
+    } catch (error: any) {
+      return refusedManagedSshUpdate(connectionId, correlationId, String(error?.message || error))
+    } finally {
+      managedConnectionUpdateGate.release(connectionId, correlationId)
+      managedConnectionUpdates.delete(connectionId)
+    }
+  })()
+
+  managedConnectionUpdates.set(connectionId, operation)
+
+  return operation
+}
+
 ipcMain.handle('hermes:connections:update-managed', async (_event, rawId) => requestManagedSshUpdate(rawId))
 
 // Fan out `hermes update` to every eligible registered connection at once.
@@ -15770,7 +15864,7 @@ async function getJsonForBackend(descriptor, path, opts: any = {}) {
 async function fetchJsonForBackend(
   descriptor,
   path,
-  opts: { method?: string; body?: unknown; upload?: unknown; timeoutMs?: number } = {}
+  opts: { method?: string; body?: unknown; upload?: unknown; timeoutMs?: number; headers?: Record<string, string> } = {}
 ) {
   const url = `${descriptor.baseUrl}${path}`
 

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -30,6 +30,9 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   // Registry-scoped fresh WS URL: { connectionId, profile } → result shape of
   // getGatewayWsUrl, minted against that connection's backend.
   getGatewayWsUrlFor: payload => ipcRenderer.invoke('hermes:gateway:ws-url-for', payload),
+  // Coalesced registry variant: pass the descriptor already validated by
+  // getConnectionFor in the same switch to skip the redundant dispatch probe.
+  getGatewayWsUrlForValidated: payload => ipcRenderer.invoke('hermes:gateway:ws-url-for-validated', payload),
   // Union agent roster across every registered connection.
   getAgentRoster: () => ipcRenderer.invoke('hermes:agents:roster'),
   openSessionWindow: (sessionId, opts) => ipcRenderer.invoke('hermes:window:openSession', sessionId, opts),

--- a/apps/desktop/electron/remote-liveness.ts
+++ b/apps/desktop/electron/remote-liveness.ts
@@ -1,5 +1,15 @@
 export const REMOTE_LIVENESS_TIMEOUT_MS = 10_000
 
+// Liveness probes must never ride a cached response or a pooled keep-alive
+// socket: Chromium/electron net can hand back a stale cached 200 (masking a
+// dead backend) and node's keep-alive agent can surface a stale pooled socket
+// as a transport error (counting backend death that isn't). Probes therefore
+// always request a fresh, single-use connection.
+export const REMOTE_LIVENESS_PROBE_HEADERS: Readonly<Record<string, string>> = Object.freeze({
+  'Cache-Control': 'no-store',
+  Pragma: 'no-cache',
+  Connection: 'close'
+})
 // Dispatch is synchronous user intent: a cached descriptor must prove its
 // forwarded endpoint is alive before it can be returned. Keep this probe much
 // shorter than the background liveness budget so a dead tunnel reconnects

--- a/apps/desktop/electron/remote-liveness.ts
+++ b/apps/desktop/electron/remote-liveness.ts
@@ -1,4 +1,5 @@
 export const REMOTE_LIVENESS_TIMEOUT_MS = 10_000
+
 // Dispatch is synchronous user intent: a cached descriptor must prove its
 // forwarded endpoint is alive before it can be returned. Keep this probe much
 // shorter than the background liveness budget so a dead tunnel reconnects
@@ -74,6 +75,8 @@ interface EnsureHealthyPooledRemoteBackendForDispatchOptions<TConnection extends
   probe: (connection: TConnection, path: string, options: { timeoutMs: number }) => Promise<unknown>
   reconnect: () => Promise<TConnection>
   retire: (error: unknown) => Promise<void> | void
+  tracker?: RemoteLivenessTracker
+  remoteBaseUrl?: null | string
 }
 
 /**
@@ -83,15 +86,31 @@ interface EnsureHealthyPooledRemoteBackendForDispatchOptions<TConnection extends
  * prevent a late probe from tearing down a replacement installed by another
  * caller. The caller should single-flight this function per cached promise so
  * concurrent dispatches share one retire/reconnect sequence.
+ *
+ * A single probe failure is not backend death: when a tracker (and base URL)
+ * are supplied, one in-place retry is attempted and the failure is recorded on
+ * the shared per-base-URL streak. Only a failing retry — or a streak that
+ * already reached the failure limit — retires the descriptor; a retry success
+ * records success on the streak, keeping the pool warm across transient
+ * keep-alive socket loss.
  */
 export async function ensureHealthyPooledRemoteBackendForDispatch<TConnection extends RemoteConnectionDescriptor>({
   connectionPromise,
   currentConnectionPromise,
   probe,
   reconnect,
-  retire
+  retire,
+  tracker,
+  remoteBaseUrl
 }: EnsureHealthyPooledRemoteBackendForDispatchOptions<TConnection>): Promise<TConnection> {
   let connection: TConnection
+
+  const recordFailure = (error: unknown): void => {
+    if (tracker && remoteBaseUrl) {
+      tracker.recordFailure(remoteBaseUrl.replace(/\/+$/, ''))
+    }
+    void error
+  }
 
   try {
     connection = await connectionPromise
@@ -103,12 +122,42 @@ export async function ensureHealthyPooledRemoteBackendForDispatch<TConnection ex
     await probe(connection, '/api/status', {
       timeoutMs: POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS
     })
+
+    if (tracker && remoteBaseUrl) {
+      tracker.recordSuccess(remoteBaseUrl.replace(/\/+$/, ''))
+    }
   } catch (error) {
-    if (currentConnectionPromise() === connectionPromise) {
-      await retire(error)
+    if (currentConnectionPromise() !== connectionPromise) {
+      return reconnect()
     }
 
-    return reconnect()
+    recordFailure(error)
+
+    // One in-place retry before retire+redial: a single probe failure is
+    // frequently a stale keep-alive socket, not backend death.
+    try {
+      await probe(connection, '/api/status', {
+        timeoutMs: POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS
+      })
+
+      if (tracker && remoteBaseUrl) {
+        tracker.recordSuccess(remoteBaseUrl.replace(/\/+$/, ''))
+      }
+
+      if (currentConnectionPromise() !== connectionPromise) {
+        return reconnect()
+      }
+
+      return connection
+    } catch (retryError) {
+      if (currentConnectionPromise() !== connectionPromise) {
+        return reconnect()
+      }
+
+      recordFailure(retryError)
+      await retire(retryError)
+      return reconnect()
+    }
   }
 
   if (currentConnectionPromise() !== connectionPromise) {

--- a/apps/desktop/src/app/chat/sidebar/connection-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/connection-switcher.tsx
@@ -15,6 +15,7 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import type { DesktopRegistryConnection } from '@/global'
+import { useProfilePrewarm } from './use-profile-prewarm'
 import { useI18n } from '@/i18n'
 import {
   CONNECTION_SEARCH_THRESHOLD,
@@ -32,13 +33,41 @@ import {
   $pendingConnectionId,
   initializeConnectionsRegistry,
   refreshConnectionsRegistry,
-  selectConnection
+  selectConnection,
+  $lastProfileByConnection
 } from '@/store/connections'
 import { closeFindBar } from '@/store/find-in-page'
 import { notifyError } from '@/store/notifications'
 import { isAuxiliaryWindow, isPeerInstanceWindow } from '@/store/windows'
 
 import { ConnectionGlyph } from './connection-glyph'
+
+// One dropdown row per connection — its own component so each row can own a
+// hover-intent prewarm timer targeting that connection's registry-scoped primary
+// backend (the same (connectionId, primary-profile) pool key the click dials).
+function ConnectionSwitcherRow({
+  connection,
+  searchable
+}: {
+  connection: DesktopRegistryConnection
+  searchable: boolean
+}) {
+  const { cancelPrewarm, startPrewarm } = useProfilePrewarm(
+    $lastProfileByConnection.get()[connection.id] ?? 'default',
+    connection.id
+  )
+
+  return (
+    <DropdownMenuRadioItem
+      className={cn('min-w-0', searchable && dropdownMenuRow)}
+      onPointerEnter={startPrewarm}
+      onPointerLeave={cancelPrewarm}
+      value={connection.id}
+    >
+      <ConnectionLabel connection={connection} />
+    </DropdownMenuRadioItem>
+  )
+}
 
 export function ConnectionSwitcher({ compact = false, onConnect }: { compact?: boolean; onConnect: () => void }) {
   const { t } = useI18n()
@@ -226,13 +255,7 @@ export function ConnectionSwitcher({ compact = false, onConnect }: { compact?: b
               </div>
             ) : (
               displayedConnections.map(connection => (
-                <DropdownMenuRadioItem
-                  className={cn('min-w-0', searchable && dropdownMenuRow)}
-                  key={connection.id}
-                  value={connection.id}
-                >
-                  <ConnectionLabel connection={connection} />
-                </DropdownMenuRadioItem>
+                <ConnectionSwitcherRow connection={connection} key={connection.id} searchable={searchable} />
               ))
             )}
           </DropdownMenuRadioGroup>

--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -1038,6 +1038,9 @@ function RestSquare({
   const hue = color ?? 'var(--ui-text-quaternary)'
   const [pickerOpen, setPickerOpen] = useState(false)
   const label = p.fleet.onGateway(agent.profile, agent.connectionLabel)
+  // Hover-intent prewarm on the SAME (connectionId, profile) pool key the click
+  // dials (see prewarmProfileBackend).
+  const { cancelPrewarm, startPrewarm } = useProfilePrewarm(agent.profile, agent.connectionId)
 
   const pickColor = (next: null | string) => {
     onRecolor(next)
@@ -1061,6 +1064,8 @@ function RestSquare({
                     data-profile={agent.profile}
                     data-slot="profile-rail-rest-square"
                     onClick={onSelect}
+                    onPointerEnter={startPrewarm}
+                    onPointerLeave={cancelPrewarm}
                     style={{ backgroundColor: profileColorSoft(hue, 22), color: color ?? undefined }}
                     type="button"
                   >

--- a/apps/desktop/src/app/chat/sidebar/use-profile-prewarm.ts
+++ b/apps/desktop/src/app/chat/sidebar/use-profile-prewarm.ts
@@ -12,10 +12,15 @@ const PREWARM_DWELL_MS = 120
  * after a short hover dwell (see prewarmProfileBackend in store/profile).
  * Consumers merge these with their own pointer handlers.
  */
-export function useProfilePrewarm(profile: string | null | undefined) {
+export function useProfilePrewarm(
+  profile: string | null | undefined,
+  connectionId: null | string = null
+) {
   const timer = useRef<null | number>(null)
   const profileRef = useRef(profile)
   profileRef.current = profile
+  const connectionIdRef = useRef(connectionId)
+  connectionIdRef.current = connectionId
 
   const cancelPrewarm = useCallback(() => {
     if (timer.current != null) {
@@ -30,7 +35,7 @@ export function useProfilePrewarm(profile: string | null | undefined) {
     cancelPrewarm()
     timer.current = window.setTimeout(() => {
       timer.current = null
-      prewarmProfileBackend(profileRef.current || 'default')
+      prewarmProfileBackend(profileRef.current || 'default', connectionIdRef.current)
     }, PREWARM_DWELL_MS)
   }, [cancelPrewarm])
 

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -32,6 +32,14 @@ declare global {
         connectionId?: null | string
         profile?: null | string
       }) => Promise<GatewayWsUrlResult>
+      // Coalesced registry variant: carries the descriptor already validated by
+      // getConnectionFor in the same profile switch, so main skips the redundant
+      // dispatch probe and only mints (OAuth) + stamps headers.
+      getGatewayWsUrlForValidated?: (payload: {
+        connectionId?: null | string
+        profile?: null | string
+        validatedConnection?: (HermesConnection & { connectionId?: null | string; profile?: null | string }) | null
+      }) => Promise<GatewayWsUrlResult>
       // Union agent roster across every registered connection.
       getAgentRoster?: () => Promise<DesktopAgentRoster>
       // Credential-free routes across the union connection registry. The

--- a/apps/desktop/src/store/connections.ts
+++ b/apps/desktop/src/store/connections.ts
@@ -51,7 +51,7 @@ export const $hasMultipleConnections = computed(
   registry => (registry?.connections.length ?? 0) > 1
 )
 
-const $lastProfileByConnection = atom<Record<string, string>>(storedStringRecord(LAST_PROFILE_STORAGE_KEY))
+export const $lastProfileByConnection = atom<Record<string, string>>(storedStringRecord(LAST_PROFILE_STORAGE_KEY))
 let pendingTarget: null | string = null
 let restoreAttempted = false
 let switchRevision = 0

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -559,7 +559,19 @@ async function openSecondary(entry: Secondary): Promise<void> {
       entry.connectionId && desktop.getGatewayWsUrlFor
         ? {
             getGatewayWsUrl: () =>
-              desktop.getGatewayWsUrlFor!({ connectionId: entry.connectionId, profile: entry.profile })
+              // Coalesced: `conn` was validated by getConnectionFor moments ago in
+              // this same switch — carry it so main skips the redundant probe.
+              desktop.getGatewayWsUrlForValidated
+                ? desktop.getGatewayWsUrlForValidated!({
+                    connectionId: entry.connectionId,
+                    profile: entry.profile ?? undefined,
+                    validatedConnection: {
+                      ...conn,
+                      profile: entry.profile ?? undefined,
+                      connectionId: entry.connectionId ?? undefined
+                    }
+                  })
+                : desktop.getGatewayWsUrlFor!({ connectionId: entry.connectionId, profile: entry.profile })
           }
         : entry.connectionId
           ? {}

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -9,6 +9,7 @@ import type { ProfileInfo } from '@/types/hermes'
 const ensureGatewayForProfile = vi.fn(async () => undefined)
 const ensureGatewayForAgent = vi.fn(async () => undefined)
 const openGatewayForProfile = vi.fn(async (_profile: string) => undefined)
+const openGatewayForAgent = vi.fn(async (_connectionId: null | string, _profile: string) => undefined)
 const openSecondaryCount = vi.fn(() => 0)
 const $gateway = atom<unknown>({ id: 'live-socket', connectionState: 'open' })
 const resetStarmapGraph = vi.fn()
@@ -17,6 +18,7 @@ vi.mock('@/store/gateway', () => ({
   $gateway,
   ensureGatewayForAgent,
   ensureGatewayForProfile,
+  openGatewayForAgent,
   openGatewayForProfile,
   openSecondaryCount
 }))
@@ -70,6 +72,7 @@ const getConnection = vi.fn<(profile?: string | null) => Promise<HermesConnectio
 beforeEach(() => {
   getConnection.mockReset()
   ensureGatewayForProfile.mockClear()
+  openGatewayForAgent.mockClear()
   openGatewayForProfile.mockClear()
   openSecondaryCount.mockReturnValue(0)
   $gateway.set({ id: 'live-socket', connectionState: 'open' })
@@ -158,7 +161,7 @@ describe('prewarmProfileBackend (hover-intent pool spawn)', () => {
   it('opens the gateway (spawn + connect, no activation) for a non-active profile', () => {
     prewarmProfileBackend('warm-basic')
 
-    expect(openGatewayForProfile).toHaveBeenCalledWith('warm-basic')
+    expect(openGatewayForAgent).toHaveBeenCalledWith(null, 'warm-basic')
     // Pre-warm must never activate — that's the click's job.
     expect(ensureGatewayForProfile).not.toHaveBeenCalled()
   })
@@ -176,13 +179,13 @@ describe('prewarmProfileBackend (hover-intent pool spawn)', () => {
     prewarmProfileBackend('warm-throttle-a')
     prewarmProfileBackend('warm-throttle-b')
 
-    const calls = openGatewayForProfile.mock.calls.map(([name]) => name)
+    const calls = openGatewayForAgent.mock.calls.map(([, name]) => name)
     expect(calls.filter(name => name === 'warm-throttle-a')).toHaveLength(1)
     expect(calls.filter(name => name === 'warm-throttle-b')).toHaveLength(1)
   })
 
   it('swallows spawn failures — error UX belongs to the real switch', () => {
-    openGatewayForProfile.mockRejectedValueOnce(new Error('spawn failed'))
+    openGatewayForAgent.mockRejectedValueOnce(new Error('spawn failed'))
 
     expect(() => prewarmProfileBackend('warm-failing')).not.toThrow()
   })
@@ -195,7 +198,7 @@ describe('prewarmProfileBackend (hover-intent pool spawn)', () => {
 
     prewarmProfileBackend('warm-saturated')
 
-    expect(openGatewayForProfile).not.toHaveBeenCalled()
+    expect(openGatewayForAgent).not.toHaveBeenCalled()
   })
 
   it('pre-warms while pool slots are free', () => {
@@ -203,7 +206,7 @@ describe('prewarmProfileBackend (hover-intent pool spawn)', () => {
 
     prewarmProfileBackend('warm-slot-free')
 
-    expect(openGatewayForProfile).toHaveBeenCalledWith('warm-slot-free')
+    expect(openGatewayForAgent).toHaveBeenCalledWith(null, 'warm-slot-free')
   })
 
   it('follows the live pool-limit atom, not a hard-coded cap', () => {
@@ -214,14 +217,14 @@ describe('prewarmProfileBackend (hover-intent pool spawn)', () => {
 
     prewarmProfileBackend('warm-raised-cap')
 
-    expect(openGatewayForProfile).toHaveBeenCalledWith('warm-raised-cap')
+    expect(openGatewayForAgent).toHaveBeenCalledWith(null, 'warm-raised-cap')
 
     // And lowering the cap re-engages the guard at the new boundary.
     $poolLimits.set({ idleMs: 600_000, maxBackends: 2 })
 
     prewarmProfileBackend('warm-lowered-cap')
 
-    expect(openGatewayForProfile).not.toHaveBeenCalledWith('warm-lowered-cap')
+    expect(openGatewayForAgent).not.toHaveBeenCalledWith(null, 'warm-lowered-cap')
   })
 })
 

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -1,4 +1,4 @@
-import { LOCAL_CONNECTION_ID } from '@hermes/shared'
+import { LOCAL_CONNECTION_ID, registryBackendScopeKey } from '@hermes/shared'
 import { atom, batch, computed } from 'nanostores'
 
 import type { HermesConnection } from '@/global'
@@ -412,16 +412,17 @@ const PREWARM_MIN_INTERVAL_MS = 60_000
 
 const prewarmedAt = new Map<string, number>()
 
-export function prewarmProfileBackend(name: string): void {
+export function prewarmProfileBackend(name: string, connectionId: null | string = null): void {
   const key = normalizeProfileKey(name)
+  const scopeKey = connectionId ? registryBackendScopeKey(connectionId, key) : key
 
-  if (key === normalizeProfileKey($activeGatewayProfile.get())) {
+  if (scopeKey === registryBackendScopeKey(null, normalizeProfileKey($activeGatewayProfile.get()))) {
     return
   }
 
   const now = Date.now()
 
-  if (now - (prewarmedAt.get(key) ?? 0) < PREWARM_MIN_INTERVAL_MS) {
+  if (now - (prewarmedAt.get(scopeKey) ?? 0) < PREWARM_MIN_INTERVAL_MS) {
     return
   }
 
@@ -436,8 +437,14 @@ export function prewarmProfileBackend(name: string): void {
     return
   }
 
-  prewarmedAt.set(key, now)
-  openGatewayForProfile(key).catch(() => undefined)
+  prewarmedAt.set(scopeKey, now)
+
+  // Registry-scoped scopes must prewarm the SAME (connectionId, profile) pool
+  // key the click dials — a profile-only prewarm lands on a different pool key
+  // and the click pays the full cold spawn anyway. openGatewayForAgent routes
+  // to openGatewayForProfile when the scope is the primary (or null id), so
+  // legacy hover prewarms keep their exact behavior.
+  openGatewayForAgent(connectionId, key).catch(() => undefined)
 }
 
 let gatewaySwitch: Promise<void> | null = null


### PR DESCRIPTION
## Summary

Four small fixes for remote-switch latency in the Desktop app (parent kanban #193231):

1. **Pooled-remote dispatch probe streak retry** (electron/remote-liveness.ts, electron/main.ts): a single failed /api/status probe is usually a stale keep-alive socket, not backend death. ensureHealthyPooledRemoteBackendForDispatch now records the failure on the shared per-base-URL RemoteLivenessTracker streak and retries in place once; only a failing retry retires the descriptor. Retry success records success on the streak, keeping the pool warm across transient socket loss.
2. **Probe requests bypass cache + keep-alive**: every pooled liveness probe sends Cache-Control: no-store / Pragma: no-cache and Connection: close — Chromium stale cached 200s no longer mask dead backends and node keep-alive no longer surfaces stale pooled sockets as transport errors.
3. **Coalesced gateway:ws-url-for** (main.ts, preload.ts, global.d.ts, store/gateway.ts): new hermes:gateway:ws-url-for-validated IPC reuses the descriptor hermes:connection:for just validated in the same switch (scope-checked) instead of re-running ensureRegistryBackend's dispatch probe — halving round-trips per profile switch.
4. **Scoped prewarms** (store/profile.ts, use-profile-prewarm.ts, profile-switcher.tsx, connection-switcher.tsx): prewarmProfileBackend accepts (connectionId, profile) and routes registry-scoped scopes through openGatewayForAgent, so hover prewarms warm the exact (connectionId, profile) pool keys the click dials; RestSquare and connection-switcher rows are wired.

## Evidence
- tsc -p tsconfig.electron.json / tsconfig.json / tsconfig.e2e.json --noEmit all clean.
- vitest --project ui src/store/profile.test.ts: 20/20 pass. vitest --project electron electron/remote-liveness.test.ts: 22/22 pass.
- npm run build in apps/desktop: postbuild assert-dist-built passes (rc 0).

## Out of scope
Pool-limits defaults and SSH version-check caching (separate cards).