### PR TITLE
test(gateway): pin event timestamps in byte-bounded replay page test

### DIFF
--- a/tests/gateway/test_hosted_rooms.py
+++ b/tests/gateway/test_hosted_rooms.py
@@ -740,6 +740,10 @@ def test_room_log_pages_are_bounded_by_serialized_event_bytes(tmp_path, monkeypa
             kind="message.user",
             actor=USER,
             payload={"text": "x" * 180, "index": index},
+            # Fixed timestamps: the page budget below is derived from one event's
+            # serialized length, and time.time()'s float repr alternates between
+            # 16 and 17 significant digits, which shifts sibling pages by ±1 byte.
+            now=100.0 + index,
         )
 
     one_event = rooms.read_events(db, room_id="room-1", limit=1)


### PR DESCRIPTION
## What does this PR do?

Makes `test_room_log_pages_are_bounded_by_serialized_event_bytes` deterministic by pinning the appended events' `created_at` timestamps. The test derives its page budget from the **first** event's serialized page length + 1, but the events were appended with wall-clock `now`, and `time.time()`'s shortest float repr alternates between 16 and 17 significant digits. When the second event's `created_at` repr happens to be one byte longer than the first's, the second page (which starts at that event) exceeds the budget by exactly 1 byte and `read_events` raises `HostedRoomError: hosted room event exceeds replay page limit` at `gateway/hosted_rooms.py:1159`.

This is the flake that failed the `Python tests / Run tests` lane twice on #103192 (changes unrelated to hosted rooms). Root cause verified locally by dumping the failing page budget:

```
budget=525 first_page_len=524
seq=2 evlen=422 created_at=1788564061.9030132   # 17-sig-digit repr
seq=3 evlen=421 created_at=1788564061.904404    # 16-sig-digit repr
single-page-len=526 vs budget=525               # +1 byte -> raise
```

## Related Issue

No dedicated issue; the flake was diagnosed in the CI evidence comment on #103192 (this is the "happy to send that one-liner as a separate PR" follow-up promised there).

Fixes #N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/gateway/test_hosted_rooms.py` — pass `now=100.0 + index` to the four `_append` calls in `test_room_log_pages_are_bounded_by_serialized_event_bytes` so every event's `created_at` repr has identical length (matches the file's existing style of pinning `now=` in `_create`/`_disband` helpers). No production code changes.

Not touched (already immune): `test_room_log_pages_bound_multibyte_utf8_and_advance_cursor` derives its budget from `max()` across per-event pages; `test_room_log_page_bound_includes_json_structure_overhead` uses a fixed 1_000-byte budget with ~400-byte events.

## How to Test

1. Before the fix, loop the test on clean `upstream/main`: `for i in $(seq 1 300); do python -m pytest tests/gateway/test_hosted_rooms.py::test_room_log_pages_are_bounded_by_serialized_event_bytes -q; done` — observed **8/300 failures (~2.7%)**, each with `HostedRoomError: hosted room event exceeds replay page limit`.
2. After the fix, same loop — observed **0/300 failures**.
3. Full file: `python -m pytest tests/gateway/test_hosted_rooms.py -q` — observed result: **44 passed**.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A