### PR TITLE
fix(browser): own and reap real-profile attach daemons (#100855)

### DIFF
--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -223,6 +223,22 @@ class TestRealProfileCdpLaunch:
         assert cdp is None
         assert err and "boom" in err
 
+    def test_legacy_unowned_daemon_state_blocks_snapshot(self, tmp_path):
+        """Never overlay the credential copy while a pre-fix daemon may still own it."""
+        import tools.browser_tool as bt
+        from tools import browser_tool_real_profile_daemon as daemon
+
+        self._reset()
+        legacy = tmp_path / ".agent-browser" / f"{bt._REAL_PROFILE_SESSION}.pid"
+        with patch.object(bt_cloud, "_use_real_profile", return_value=True), \
+             patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
+             patch.object(daemon, "legacy_state_path", return_value=legacy), \
+             patch("hermes_cli.browser_connect.snapshot_real_profile") as snapshot:
+            cdp, err = bt_real_profile._real_profile_cdp()
+
+        assert cdp is None and err and "unowned pre-upgrade" in err
+        snapshot.assert_not_called()
+
     def test_launch_returns_http_cdp(self, tmp_path):
         import tools.browser_tool as bt
         self._reset()
@@ -275,6 +291,7 @@ class TestRealProfileCdpLaunch:
 
         def fake_run(argv, **kw):
             captured["argv"] = argv
+            captured["env"] = kw["env"]
             return proc
 
         class FakeChrome:
@@ -295,6 +312,7 @@ class TestRealProfileCdpLaunch:
                           side_effect=[None, "http://127.0.0.1:41000"]), \
              patch.object(bt_install, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
              patch.object(bt.subprocess, "run", side_effect=fake_run), \
+             patch.object(bt, "_socket_safe_tmpdir", return_value=str(tmp_path)), \
              patch.object(bt_cloud, "_is_headed_mode", return_value=False):
             bt_real_profile._real_profile_cdp()
         # The chrome launch itself is headless (no window, no focus steal).
@@ -303,6 +321,11 @@ class TestRealProfileCdpLaunch:
         assert "--headless" not in captured["argv"]
         assert "--profile" not in captured["argv"]
         assert "--cdp" in captured["argv"]
+        socket_dir = captured["env"]["AGENT_BROWSER_SOCKET_DIR"]
+        assert os.path.basename(socket_dir) == f"agent-browser-{bt._REAL_PROFILE_SESSION}"
+        assert captured["env"]["AGENT_BROWSER_IDLE_TIMEOUT_MS"]
+        assert os.path.isfile(os.path.join(socket_dir, f"{bt._REAL_PROFILE_SESSION}.owner_pid"))
+        assert os.path.isfile(os.path.join(socket_dir, f"{bt._REAL_PROFILE_SESSION}.owners.json"))
         self._reset()
 
     def test_reuses_only_session_on_our_copy_dir(self, tmp_path):
@@ -330,7 +353,7 @@ class TestRealProfileCdpLaunch:
              patch.object(bt_real_profile, "_cdp_http_ready", return_value=True), \
              patch.object(bt_real_profile, "_cdp_on_data_dir", return_value=False), \
              patch.object(bt_real_profile, "_agent_browser_close_session",
-                          side_effect=lambda s: closed.__setitem__("n", closed["n"] + 1)), \
+                          side_effect=lambda s: (closed.__setitem__("n", closed["n"] + 1), True)[1]), \
              patch.object(bt_install, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
              patch.object(bt.subprocess, "run", return_value=proc), \
              patch.object(bt_cloud, "_is_headed_mode", return_value=False):
@@ -338,6 +361,40 @@ class TestRealProfileCdpLaunch:
         assert closed["n"] == 1  # stale wrong-dir session was closed
         assert cdp == "http://127.0.0.1:41000"
         self._reset()
+
+    def test_get_close_and_attach_share_reapable_lifecycle_env(self, tmp_path):
+        """Stale-endpoint refresh commands must address the same owned daemon state."""
+        import tools.browser_tool as bt
+        from tools import browser_tool_lifecycle as bt_lifecycle
+
+        calls = []
+        proc = Mock(returncode=0, stdout="", stderr="")
+
+        def fake_run(argv, **kwargs):
+            calls.append((argv, kwargs["env"]))
+            return proc
+
+        with patch.object(bt, "_socket_safe_tmpdir", return_value=str(tmp_path)), \
+             patch.object(bt_install, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
+             patch.object(bt.subprocess, "run", side_effect=fake_run), \
+             patch.object(bt_lifecycle, "_start_browser_cleanup_thread"), \
+             patch.object(bt_real_profile, "_agent_browser_get_cdp",
+                          return_value="http://127.0.0.1:41000"):
+            bt_real_profile._agent_browser_session_cmd(
+                bt._REAL_PROFILE_SESSION, "get", "cdp-url", log_label="test get"
+            )
+            bt_real_profile._agent_browser_close_session(bt._REAL_PROFILE_SESSION)
+            cdp, err = bt_real_profile._attach_agent_browser_to_real_profile(41000, str(tmp_path))
+
+        assert err is None and cdp == "http://127.0.0.1:41000"
+        assert len(calls) == 3
+        socket_dirs = {env["AGENT_BROWSER_SOCKET_DIR"] for _, env in calls}
+        assert socket_dirs == {str(tmp_path / f"agent-browser-{bt._REAL_PROFILE_SESSION}")}
+        assert all(env["AGENT_BROWSER_IDLE_TIMEOUT_MS"] for _, env in calls)
+        assert all(argv[argv.index("--session") + 1] == bt._REAL_PROFILE_SESSION for argv, _ in calls)
+        owner_path = next(iter(socket_dirs)) + f"/{bt._REAL_PROFILE_SESSION}.owners.json"
+        owners = json.loads(open(owner_path, encoding="utf-8").read())["owners"]
+        assert owners == [{"pid": os.getpid(), "start_time": owners[0]["start_time"]}]
 
     def test_cdp_on_data_dir_matches_devtoolsactiveport(self, tmp_path):
         (tmp_path / "DevToolsActivePort").write_text("41000\n/devtools/browser/x\n")

--- a/tests/tools/test_browser_real_profile_daemon.py
+++ b/tests/tools/test_browser_real_profile_daemon.py
@@ -1,0 +1,380 @@
+"""Lifecycle tests for the real-profile agent-browser attach daemon."""
+
+import json
+import os
+from unittest.mock import Mock
+
+import pytest
+
+
+def _state(tmp_path, session, *, owner_pid, owner_start, daemon_pid=None, owners=None):
+    socket_dir = tmp_path / f"agent-browser-{session}"
+    socket_dir.mkdir()
+    (socket_dir / f"{session}.owners.json").write_text(
+        json.dumps(
+            {
+                "session_name": session,
+                "owners": owners or [{"pid": owner_pid, "start_time": owner_start}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    if daemon_pid is not None:
+        (socket_dir / f"{session}.pid").write_text(str(daemon_pid), encoding="utf-8")
+    return socket_dir
+
+
+def _scope(tmp_path, monkeypatch, session="hermes-real-profile-testowner"):
+    import tools.browser_tool as bt
+
+    monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: str(tmp_path))
+    monkeypatch.setattr(bt, "_REAL_PROFILE_SESSION", session)
+    return session
+
+
+def test_registers_exact_owner_incarnation(tmp_path, monkeypatch):
+    from tools import browser_tool_real_profile_daemon as daemon
+
+    session = _scope(tmp_path, monkeypatch)
+    socket_dir = tmp_path / f"agent-browser-{session}"
+    socket_dir.mkdir()
+    monkeypatch.setattr(daemon, "_process_start_time", lambda pid: 123456)
+
+    assert daemon.register(str(socket_dir), session)
+
+    owner = json.loads((socket_dir / f"{session}.owners.json").read_text(encoding="utf-8"))
+    assert owner == {
+        "session_name": session,
+        "owners": [{"pid": os.getpid(), "start_time": 123456}],
+    }
+
+
+def test_register_refuses_existing_daemon_without_owner_manifest(tmp_path, monkeypatch):
+    from tools import browser_tool_real_profile_daemon as daemon
+
+    session = _scope(tmp_path, monkeypatch)
+    socket_dir = tmp_path / f"agent-browser-{session}"
+    socket_dir.mkdir()
+    (socket_dir / f"{session}.pid").write_text("222", encoding="utf-8")
+    monkeypatch.setattr(daemon, "_process_start_time", lambda pid: 44)
+
+    assert not daemon.register(str(socket_dir), session)
+    assert not (socket_dir / f"{session}.owners.json").exists()
+
+
+def test_register_preserves_another_live_owner(tmp_path, monkeypatch):
+    from tools import browser_tool_real_profile_daemon as daemon
+
+    session = _scope(tmp_path, monkeypatch)
+    other = {"pid": 777, "start_time": 77}
+    socket_dir = _state(tmp_path, session, owner_pid=777, owner_start=77, owners=[other])
+    monkeypatch.setattr(
+        daemon,
+        "_process_start_time",
+        lambda pid: 44 if pid == os.getpid() else 77,
+    )
+    monkeypatch.setattr("gateway.status._pid_exists", lambda pid: True)
+
+    assert daemon.register(str(socket_dir), session)
+
+    stored = json.loads((socket_dir / f"{session}.owners.json").read_text(encoding="utf-8"))
+    assert stored["owners"] == [other, {"pid": os.getpid(), "start_time": 44}]
+
+
+def test_reaper_removes_dead_owner_generation_and_exact_daemon(tmp_path, monkeypatch):
+    from tools import browser_tool_real_profile_daemon as daemon
+    from tools import browser_tool_lifecycle as lifecycle
+    from tools.process_registry import ProcessRegistry
+
+    session = _scope(tmp_path, monkeypatch)
+    socket_dir = _state(tmp_path, session, owner_pid=111, owner_start=11, daemon_pid=222)
+    live = {222}
+    terminated = []
+    monkeypatch.setattr(daemon, "_owner_alive", lambda owner: False)
+    monkeypatch.setattr(daemon, "_process_start_time", lambda pid: 22 if pid == 222 else None)
+    monkeypatch.setattr(lifecycle, "_verify_reapable_browser_daemon", lambda *args: True)
+    monkeypatch.setattr("gateway.status._pid_exists", lambda pid: pid in live)
+
+    def terminate(pid, expected_start=None):
+        terminated.append((pid, expected_start))
+        live.discard(pid)
+
+    monkeypatch.setattr(ProcessRegistry, "_terminate_host_pid", terminate)
+
+    assert daemon.reap_orphans() == 1
+    assert terminated == [(222, 22)]
+    assert not socket_dir.exists()
+
+
+def test_reaper_preserves_live_owner(tmp_path, monkeypatch):
+    from tools import browser_tool_real_profile_daemon as daemon
+    from tools.process_registry import ProcessRegistry
+
+    session = _scope(tmp_path, monkeypatch)
+    socket_dir = _state(tmp_path, session, owner_pid=111, owner_start=11, daemon_pid=222)
+    terminate = Mock()
+    monkeypatch.setattr(daemon, "_owner_alive", lambda owner: True)
+    monkeypatch.setattr(ProcessRegistry, "_terminate_host_pid", terminate)
+
+    assert daemon.reap_orphans() == 0
+    terminate.assert_not_called()
+    assert socket_dir.exists()
+
+
+def test_reaper_refuses_pid_reuse_between_verify_and_signal(tmp_path, monkeypatch):
+    from tools import browser_tool_real_profile_daemon as daemon
+    from tools import browser_tool_lifecycle as lifecycle
+    from tools.process_registry import ProcessRegistry
+
+    session = _scope(tmp_path, monkeypatch)
+    socket_dir = _state(tmp_path, session, owner_pid=111, owner_start=11, daemon_pid=222)
+    starts = iter((22, 23))
+    terminate = Mock()
+    monkeypatch.setattr(daemon, "_owner_alive", lambda owner: False)
+    monkeypatch.setattr(daemon, "_process_start_time", lambda pid: next(starts))
+    monkeypatch.setattr(lifecycle, "_verify_reapable_browser_daemon", lambda *args: True)
+    monkeypatch.setattr("gateway.status._pid_exists", lambda pid: True)
+    monkeypatch.setattr(ProcessRegistry, "_terminate_host_pid", terminate)
+
+    assert daemon.reap_orphans() == 0
+    terminate.assert_not_called()
+    assert socket_dir.exists()
+
+
+def test_reaper_refuses_identity_mismatch_including_user_chrome(tmp_path, monkeypatch):
+    from tools import browser_tool_real_profile_daemon as daemon
+    from tools import browser_tool_lifecycle as lifecycle
+    from tools.process_registry import ProcessRegistry
+
+    session = _scope(tmp_path, monkeypatch)
+    socket_dir = _state(tmp_path, session, owner_pid=111, owner_start=11, daemon_pid=222)
+    terminate = Mock()
+    monkeypatch.setattr(daemon, "_owner_alive", lambda owner: False)
+    monkeypatch.setattr(daemon, "_process_start_time", lambda pid: 22)
+    monkeypatch.setattr(lifecycle, "_verify_reapable_browser_daemon", lambda *args: False)
+    monkeypatch.setattr("gateway.status._pid_exists", lambda pid: True)
+    monkeypatch.setattr(ProcessRegistry, "_terminate_host_pid", terminate)
+
+    assert daemon.reap_orphans() == 0
+    terminate.assert_not_called()
+    assert socket_dir.exists()
+
+
+@pytest.mark.linux_only
+def test_controlled_orphan_daemon_is_reaped_end_to_end(tmp_path, monkeypatch):
+    import shutil
+    import subprocess
+
+    from tools import browser_tool_real_profile_daemon as daemon
+
+    session = _scope(tmp_path, monkeypatch)
+    socket_dir = tmp_path / f"agent-browser-{session}"
+    fixture = tmp_path / "agent-browser-fixture"
+    shutil.copy2("/bin/sleep", fixture)
+    env = dict(os.environ)
+    env["AGENT_BROWSER_SOCKET_DIR"] = str(socket_dir)
+    proc = subprocess.Popen([str(fixture), "60"], env=env)
+    try:
+        _state(tmp_path, session, owner_pid=999_999_999, owner_start=1, daemon_pid=proc.pid)
+        assert daemon.reap_orphans() == 1
+        proc.wait(timeout=5)
+        assert proc.poll() is not None
+        assert not socket_dir.exists()
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)
+
+
+def test_strict_identity_guard_spares_chrome_and_other_daemons(tmp_path, monkeypatch):
+    import psutil
+    from tools import browser_tool_lifecycle as lifecycle
+
+    session = _scope(tmp_path, monkeypatch)
+    socket_dir = str(tmp_path / f"agent-browser-{session}")
+
+    visible_chrome = Mock()
+    visible_chrome.name.return_value = "Google Chrome"
+    visible_chrome.cmdline.return_value = ["Google Chrome", socket_dir, "agent-browser"]
+    visible_chrome.environ.return_value = {"AGENT_BROWSER_SOCKET_DIR": socket_dir}
+    monkeypatch.setattr(psutil, "Process", lambda pid: visible_chrome)
+    assert not lifecycle._verify_reapable_browser_daemon(222, socket_dir, session)
+
+    other_daemon = Mock()
+    other_daemon.name.return_value = "agent-browser-linux-x64"
+    other_daemon.cmdline.return_value = ["agent-browser-linux-x64", "daemon"]
+    other_daemon.environ.return_value = {"AGENT_BROWSER_SOCKET_DIR": f"{socket_dir}-other"}
+    monkeypatch.setattr(psutil, "Process", lambda pid: other_daemon)
+    assert not lifecycle._verify_reapable_browser_daemon(222, socket_dir, session)
+
+    exact_daemon = Mock()
+    exact_daemon.name.return_value = "agent-browser-linux-x64"
+    exact_daemon.cmdline.return_value = ["agent-browser-linux-x64", "daemon"]
+    exact_daemon.environ.return_value = {"AGENT_BROWSER_SOCKET_DIR": socket_dir}
+    monkeypatch.setattr(psutil, "Process", lambda pid: exact_daemon)
+    assert lifecycle._verify_reapable_browser_daemon(222, socket_dir, session)
+
+
+def test_pid_record_replacement_preserves_new_state(tmp_path, monkeypatch):
+    from tools import browser_tool_real_profile_daemon as daemon
+    from tools import browser_tool_lifecycle as lifecycle
+    from tools.process_registry import ProcessRegistry
+
+    session = _scope(tmp_path, monkeypatch)
+    socket_dir = _state(tmp_path, session, owner_pid=111, owner_start=11, daemon_pid=222)
+    live = {222}
+    monkeypatch.setattr(daemon, "_owner_alive", lambda owner: False)
+    monkeypatch.setattr(daemon, "_process_start_time", lambda pid: 22)
+    monkeypatch.setattr(lifecycle, "_verify_reapable_browser_daemon", lambda *args: True)
+    monkeypatch.setattr("gateway.status._pid_exists", lambda pid: pid in live)
+
+    def terminate(pid, expected_start=None):
+        live.discard(pid)
+        (socket_dir / f"{session}.pid").write_text("333", encoding="utf-8")
+
+    monkeypatch.setattr(ProcessRegistry, "_terminate_host_pid", terminate)
+
+    assert daemon.reap_orphans() == 0
+    assert socket_dir.exists()
+    assert (socket_dir / f"{session}.pid").read_text(encoding="utf-8") == "333"
+
+
+def test_ambiguous_owner_metadata_fails_closed(tmp_path, monkeypatch):
+    from tools import browser_tool_real_profile_daemon as daemon
+
+    session = _scope(tmp_path, monkeypatch)
+    socket_dir = tmp_path / f"agent-browser-{session}"
+    socket_dir.mkdir()
+    (socket_dir / f"{session}.owners.json").write_text("{}", encoding="utf-8")
+
+    assert daemon.reap_orphans() == 0
+    assert socket_dir.exists()
+
+
+def test_ambiguous_daemon_pid_fails_closed(tmp_path, monkeypatch):
+    from tools import browser_tool_real_profile_daemon as daemon
+
+    session = _scope(tmp_path, monkeypatch)
+    socket_dir = _state(tmp_path, session, owner_pid=111, owner_start=11)
+    (socket_dir / f"{session}.pid").write_text("not-a-pid", encoding="utf-8")
+    monkeypatch.setattr(daemon, "_owner_alive", lambda owner: False)
+
+    assert daemon.reap_orphans() == 0
+    assert socket_dir.exists()
+
+
+def test_close_refuses_while_another_live_owner_exists(tmp_path, monkeypatch):
+    import tools.browser_tool as bt
+    from tools import browser_tool_lifecycle as lifecycle
+    from tools import browser_tool_real_profile as real_profile
+    from tools import browser_tool_real_profile_daemon as daemon
+    from tools import browser_tool_install as install
+
+    session = _scope(tmp_path, monkeypatch)
+    other = {"pid": 777, "start_time": 77}
+    _state(tmp_path, session, owner_pid=777, owner_start=77, owners=[other])
+    monkeypatch.setattr(daemon, "_process_start_time", lambda pid: 44 if pid == os.getpid() else 77)
+    monkeypatch.setattr("gateway.status._pid_exists", lambda pid: True)
+    monkeypatch.setattr(install, "_find_agent_browser", lambda: "/usr/bin/agent-browser")
+    monkeypatch.setattr(lifecycle, "_start_browser_cleanup_thread", lambda: None)
+    run = Mock()
+    monkeypatch.setattr(bt.subprocess, "run", run)
+
+    assert not real_profile._agent_browser_close_session(session)
+    run.assert_not_called()
+
+
+def test_cleanup_owned_preserves_another_live_hermes_owner(tmp_path, monkeypatch):
+    from tools import browser_tool_real_profile_daemon as daemon
+    from tools.process_registry import ProcessRegistry
+
+    session = _scope(tmp_path, monkeypatch)
+    current = {"pid": os.getpid(), "start_time": 44}
+    other = {"pid": 777, "start_time": 77}
+    socket_dir = _state(
+        tmp_path,
+        session,
+        owner_pid=current["pid"],
+        owner_start=current["start_time"],
+        daemon_pid=222,
+        owners=[current, other],
+    )
+    terminate = Mock()
+    monkeypatch.setattr(daemon, "_process_start_time", lambda pid: 44 if pid == os.getpid() else 77)
+    monkeypatch.setattr(daemon, "_owner_alive", lambda owner: owner == other)
+    monkeypatch.setattr(ProcessRegistry, "_terminate_host_pid", terminate)
+
+    assert daemon.cleanup_owned() is False
+    terminate.assert_not_called()
+    stored = json.loads((socket_dir / f"{session}.owners.json").read_text(encoding="utf-8"))
+    assert stored["owners"] == [other]
+
+
+def test_cleanup_owned_preserves_pidless_startup_state(tmp_path, monkeypatch):
+    from tools import browser_tool_real_profile_daemon as daemon
+
+    session = _scope(tmp_path, monkeypatch)
+    socket_dir = _state(tmp_path, session, owner_pid=os.getpid(), owner_start=44)
+    monkeypatch.setattr(daemon, "_process_start_time", lambda pid: 44)
+
+    assert daemon.cleanup_owned() is False
+    assert socket_dir.exists()
+
+
+def test_cleanup_owned_is_idempotent_and_owner_bound(tmp_path, monkeypatch):
+    from tools import browser_tool_lifecycle as lifecycle
+    from tools import browser_tool_real_profile_daemon as daemon
+    from tools.process_registry import ProcessRegistry
+
+    session = _scope(tmp_path, monkeypatch)
+    socket_dir = _state(
+        tmp_path, session, owner_pid=os.getpid(), owner_start=44, daemon_pid=222
+    )
+    live = {222}
+    monkeypatch.setattr(daemon, "_process_start_time", lambda pid: 44 if pid == os.getpid() else 22)
+    monkeypatch.setattr(lifecycle, "_verify_reapable_browser_daemon", lambda *args: True)
+    monkeypatch.setattr("gateway.status._pid_exists", lambda pid: pid in live)
+    monkeypatch.setattr(
+        ProcessRegistry,
+        "_terminate_host_pid",
+        lambda pid, expected_start=None: live.discard(pid),
+    )
+
+    assert daemon.cleanup_owned() is True
+    assert daemon.cleanup_owned() is False
+    assert not socket_dir.exists()
+
+
+def test_public_orphan_reaper_routes_real_profile_to_dedicated_owner_logic(tmp_path, monkeypatch):
+    from tools import browser_tool_lifecycle as lifecycle
+    from tools import browser_tool_real_profile_daemon as daemon
+
+    session = _scope(tmp_path, monkeypatch)
+    _state(tmp_path, session, owner_pid=111, owner_start=11, daemon_pid=222)
+    calls = []
+    monkeypatch.setattr(daemon, "reap_orphans", lambda: calls.append(True) or 0)
+    monkeypatch.setattr(
+        lifecycle,
+        "_reap_socket_dir",
+        lambda *args: (_ for _ in ()).throw(AssertionError("legacy reaper handled real-profile state")),
+    )
+    monkeypatch.setattr("tools.browser_lightpanda.reap_orphaned_lightpanda", lambda: None)
+
+    lifecycle._reap_orphaned_browser_sessions()
+
+    assert calls == [True]
+
+
+def test_cleanup_all_browsers_closes_attach_daemon(tmp_path, monkeypatch):
+    import tools.browser_tool as bt
+    from tools import browser_tool_lifecycle as lifecycle
+    from tools import browser_tool_real_profile_daemon as daemon
+
+    _scope(tmp_path, monkeypatch)
+    monkeypatch.setattr(bt, "_active_sessions", {})
+    cleaned = []
+    monkeypatch.setattr(daemon, "cleanup_owned", lambda: cleaned.append(True))
+
+    lifecycle.cleanup_all_browsers()
+
+    assert cleaned == [True]

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -228,8 +228,9 @@ from tools import browser_tool_cloud as _cloud
 from tools import browser_tool_lightpanda_fallback as _lp
 
 
-# Single shared real-profile copy-browser session: concurrent tasks reuse it
-# instead of each launching a rival Chromium on the same copied user-data-dir.
+# Single shared real-profile copy-browser session: concurrent tasks and Hermes
+# process generations reuse it instead of launching rival Chromium processes on
+# the same copied user-data-dir. Durable owners live beside its socket state.
 _REAL_PROFILE_SESSION = "hermes-real-profile"
 _real_profile_cdp_lock = threading.Lock()
 _real_profile_cdp_cache: dict = {}

--- a/tools/browser_tool_lifecycle.py
+++ b/tools/browser_tool_lifecycle.py
@@ -80,6 +80,8 @@ def _emergency_cleanup_all_sessions():
     # Real-profile Chrome is launched directly (not by agent-browser), so the
     # session cleanup never reaps it.
     _best_effort("Real-profile chrome cleanup on exit", _real_profile._terminate_real_profile_chrome)
+    from tools import browser_tool_real_profile_daemon as _real_profile_daemon
+    _best_effort("Real-profile attach daemon cleanup on exit", _real_profile_daemon.cleanup_owned)
     if _bt._active_sessions:
         _bt.logger.info("Emergency cleanup: closing %s active session(s)...", len(_bt._active_sessions))
         try:
@@ -219,6 +221,22 @@ def _verify_reapable_browser_daemon(daemon_pid: int, socket_dir: str,
     except (psutil.AccessDenied, OSError) as exc:
         return refuse("could not read process identity (%s)", exc)
 
+    real_profile_daemon = session_name == _bt._REAL_PROFILE_SESSION or session_name.startswith("hermes-real-profile-")
+    if real_profile_daemon:
+        # This session is security-sensitive: its directory stores durable owner
+        # authority and it attaches to a copy carrying real login state. Require
+        # exact daemon-name and environment binding; argv substring/basename
+        # matches are insufficient authority to signal a user's visible Chrome.
+        if not name.startswith("agent-browser"):
+            return refuse("not an agent-browser daemon executable (name=%r)", name)
+        try:
+            env_dir = (proc.environ() or {}).get("AGENT_BROWSER_SOCKET_DIR", "")
+        except (psutil.AccessDenied, psutil.NoSuchProcess, OSError) as exc:
+            return refuse("could not read daemon environment binding (%s)", exc)
+        if not env_dir or os.path.normcase(os.path.realpath(env_dir)) != os.path.normcase(os.path.realpath(socket_dir)):
+            return refuse("not exactly bound to real-profile socket dir %s", socket_dir)
+        return True
+
     if "agent-browser" not in name and "agent-browser" not in cmdline:
         return refuse("not an agent-browser process (name=%r)", name)
 
@@ -357,6 +375,8 @@ def _reap_orphaned_browser_sessions():
         from tools.browser_lightpanda import reap_orphaned_lightpanda
         reap_orphaned_lightpanda()
     _best_effort("Lightpanda orphan reap", _reap_lp)
+    from tools import browser_tool_real_profile_daemon as _real_profile_daemon
+    _best_effort("Real-profile attach daemon orphan reap", _real_profile_daemon.reap_orphans)
 
     tmpdir = _bt._socket_safe_tmpdir()
     socket_dirs = []
@@ -371,6 +391,8 @@ def _reap_orphaned_browser_sessions():
     reaped = 0
     for socket_dir in socket_dirs:
         session_name = os.path.basename(socket_dir).removeprefix("agent-browser-")
+        if session_name == _bt._REAL_PROFILE_SESSION or session_name.startswith("hermes-real-profile-"):
+            continue  # dedicated owner-incarnation lifecycle above; never fall back to legacy PID-only rules
         if session_name and _reap_socket_dir(socket_dir, session_name, tracked_names):
             reaped += 1
 
@@ -681,6 +703,8 @@ def cleanup_all_browsers() -> None:
     except Exception:
         pass
 
+    from tools import browser_tool_real_profile_daemon as _real_profile_daemon
+    _best_effort("Real-profile attach daemon cleanup", _real_profile_daemon.cleanup_owned)
     _install._discover_homebrew_node_dirs.cache_clear()
     # Each resolved flag flips BEFORE its cache is nulled so a concurrent reader never
     # sees ``resolved=True`` with ``cache=None``.

--- a/tools/browser_tool_real_profile.py
+++ b/tools/browser_tool_real_profile.py
@@ -36,6 +36,21 @@ def _cdp_http_ready(http_cdp: str) -> bool:
     return _cdp_ready(http_cdp, timeout=1.0)
 
 
+def _real_profile_daemon_env() -> dict[str, str]:
+    """Reaper-visible lifecycle environment for this Hermes process's attach daemon."""
+    _bt = _origin()
+    socket_dir = os.path.join(_bt._socket_safe_tmpdir(), f"agent-browser-{_bt._REAL_PROFILE_SESSION}")
+    os.makedirs(socket_dir, mode=0o700, exist_ok=True)
+    from tools import browser_tool_lifecycle as _lifecycle
+    from tools import browser_tool_real_profile_daemon as _daemon
+
+    if not _daemon.register(socket_dir, _bt._REAL_PROFILE_SESSION):
+        raise OSError("could not publish real-profile daemon ownership")
+    _lifecycle._write_owner_pid(socket_dir, _bt._REAL_PROFILE_SESSION)
+    _lifecycle._start_browser_cleanup_thread()
+    return _session._agent_browser_command_env(socket_dir)
+
+
 def _agent_browser_session_cmd(session_name: str, *cmd: str, log_label: str) -> Optional[subprocess.CompletedProcess]:
     """Run ``agent-browser --session <name> <cmd...>``; None when agent-browser is missing or the run fails."""
     _bt = _origin()
@@ -44,9 +59,19 @@ def _agent_browser_session_cmd(session_name: str, *cmd: str, log_label: str) -> 
     except FileNotFoundError:
         return None
     try:
-        return subprocess.run([*_session._agent_browser_argv(browser_cmd), "--session", session_name, *cmd],
-                              capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=15,
-                              env=_bt._build_browser_env(), stdin=subprocess.DEVNULL)
+        env = _real_profile_daemon_env()
+        argv = [*_session._agent_browser_argv(browser_cmd), "--session", session_name, *cmd]
+        if cmd == ("close",):
+            from tools import browser_tool_real_profile_daemon as _daemon
+
+            with _daemon.exclusive_current_owner(env["AGENT_BROWSER_SOCKET_DIR"], session_name) as exclusive:
+                if not exclusive:
+                    _bt.logger.warning("Refusing to close shared real-profile daemon while another owner may be live")
+                    return None
+                return subprocess.run(argv, capture_output=True, text=True, encoding="utf-8", errors="replace",
+                                      timeout=15, env=env, stdin=subprocess.DEVNULL)
+        return subprocess.run(argv, capture_output=True, text=True, encoding="utf-8", errors="replace",
+                              timeout=15, env=env, stdin=subprocess.DEVNULL)
     except (subprocess.SubprocessError, OSError) as e:
         _bt.logger.debug("real-profile %s failed: %s", log_label, e)
         return None
@@ -75,9 +100,10 @@ def _cdp_on_data_dir(http_cdp: str, data_dir: str) -> bool:
     return bool(m) and _read_devtools_port(data_dir) == m.group(1)
 
 
-def _agent_browser_close_session(session_name: str) -> None:
-    """Best-effort close of an agent-browser session (stale/wrong-dir cleanup)."""
-    _agent_browser_session_cmd(session_name, "close", log_label="session close")
+def _agent_browser_close_session(session_name: str) -> bool:
+    """Close a stale session only when this is its sole provably live Hermes owner."""
+    proc = _agent_browser_session_cmd(session_name, "close", log_label="session close")
+    return proc is not None and proc.returncode == 0
 
 
 _REAL_PROFILE_CHROME_FLAGS = (
@@ -169,7 +195,7 @@ def _attach_agent_browser_to_real_profile(port: int, copy_dir: str) -> Tuple[Opt
             "--cdp", str(port), "open", "about:blank"]
     try:
         proc = subprocess.run(argv, capture_output=True, text=True, encoding="utf-8", errors="replace",
-                              timeout=_bt._get_open_command_timeout(first_open=True), env=_bt._build_browser_env(),
+                              timeout=_bt._get_open_command_timeout(first_open=True), env=_real_profile_daemon_env(),
                               stdin=subprocess.DEVNULL)
     except subprocess.TimeoutExpired:
         return None, _RP + "the real-profile browser took too long to start. Retry, or turn the toggle off."
@@ -230,13 +256,20 @@ def _real_profile_cdp() -> tuple:
         # Reuse BEFORE writing anything. CRITICAL: the snapshot overlay (truncates/rewrites
         # Cookies / Login Data) must NOT run while a live copy-browser (maybe from a previous
         # hermes process) holds the user-data-dir open — that corrupts the databases.
+        from tools import browser_tool_real_profile_daemon as _daemon
+
+        legacy_state = _daemon.legacy_state_path()
+        if legacy_state is not None:
+            return None, (_RP + "unowned pre-upgrade agent-browser state is still present at "
+                          f"{legacy_state}; close that hermes-real-profile session before retrying.")
         copy_dir = real_profile_copy_dir(browser)
         existing = _agent_browser_get_cdp(_bt._REAL_PROFILE_SESSION)
         if existing and _cdp_http_ready(existing) and _cdp_on_data_dir(existing, copy_dir):
             _bt._real_profile_cdp_cache["cdp"] = existing
             return existing, None
         if existing:  # stale/wrong-dir session: close it so nothing holds the dir open
-            _agent_browser_close_session(_bt._REAL_PROFILE_SESSION)
+            if not _agent_browser_close_session(_bt._REAL_PROFILE_SESSION):
+                return None, _RP + "the stale browser session is still owned by another live Hermes process; retry later."
 
         copy_dir, err = snapshot_real_profile(browser)
         if err or not copy_dir:

--- a/tools/browser_tool_real_profile_daemon.py
+++ b/tools/browser_tool_real_profile_daemon.py
@@ -1,0 +1,401 @@
+"""Durable ownership and cleanup for the shared real-profile attach daemon."""
+
+import json
+import os
+import shutil
+import time
+from contextlib import contextmanager, suppress
+from pathlib import Path
+from typing import Optional
+
+from tools.browser_tool_origin import origin as _bt
+
+_OWNER_SUFFIX = ".owners.json"
+_LOCK_SUFFIX = ".owners.lock"
+
+
+def _socket_dir() -> str:
+    return os.path.join(_bt._socket_safe_tmpdir(), f"agent-browser-{_bt._REAL_PROFILE_SESSION}")
+
+
+def _owner_path(socket_dir: str, session_name: str) -> Path:
+    return Path(socket_dir) / f"{session_name}{_OWNER_SUFFIX}"
+
+
+def _lock_path(socket_dir: str, session_name: str) -> Path:
+    del session_name
+    return Path(f"{socket_dir}{_LOCK_SUFFIX}")
+
+
+def _process_start_time(pid: int) -> Optional[int]:
+    from gateway.status import get_process_start_time
+
+    return get_process_start_time(pid)
+
+
+@contextmanager
+def _locked(socket_dir: str, session_name: str):
+    """Serialize owner read-modify-write and cleanup across Hermes processes."""
+    path = _lock_path(socket_dir, session_name)
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    handle = path.open("a+b")
+    locked = False
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            handle.seek(0, os.SEEK_END)
+            if handle.tell() == 0:
+                handle.write(b"\n")
+                handle.flush()
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        locked = True
+        yield
+    finally:
+        if locked:
+            with suppress(OSError):
+                if os.name == "nt":
+                    import msvcrt
+
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        handle.close()
+
+
+def legacy_state_path() -> Optional[Path]:
+    """Return pre-fix real-profile state outside the managed socket directory, if any."""
+    env = _bt._build_browser_env()
+    explicit = str(env.get("AGENT_BROWSER_SOCKET_DIR") or "").strip()
+    xdg_runtime = str(env.get("XDG_RUNTIME_DIR") or "").strip()
+    home = str(env.get("HOME") or "").strip()
+    if explicit:
+        legacy_dir = Path(explicit)
+    elif xdg_runtime:
+        legacy_dir = Path(xdg_runtime) / "agent-browser"
+    elif home:
+        legacy_dir = Path(home) / ".agent-browser"
+    else:
+        import tempfile
+
+        legacy_dir = Path(tempfile.gettempdir()) / "agent-browser"
+    if os.path.normcase(os.path.realpath(legacy_dir)) == os.path.normcase(os.path.realpath(_socket_dir())):
+        return None
+    session_name = _bt._REAL_PROFILE_SESSION
+    for suffix in ("pid", "sock", "port", "engine", "stream", "version"):
+        candidate = legacy_dir / f"{session_name}.{suffix}"
+        if candidate.exists() or candidate.is_symlink():
+            return candidate
+    return None
+
+
+def _owner_identity() -> Optional[dict[str, int]]:
+    owner_start = _process_start_time(os.getpid())
+    if owner_start is None:
+        return None
+    return {"pid": os.getpid(), "start_time": owner_start}
+
+
+def _read_owners(socket_dir: str, session_name: str) -> Optional[list[dict[str, int]]]:
+    path = _owner_path(socket_dir, session_name)
+    try:
+        if path.is_symlink():
+            return None
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if payload.get("session_name") != session_name or not isinstance(payload.get("owners"), list):
+            return None
+        owners = []
+        for value in payload["owners"]:
+            pid, started = int(value["pid"]), int(value["start_time"])
+            if pid <= 0 or started <= 0:
+                return None
+            owners.append({"pid": pid, "start_time": started})
+        return owners
+    except FileNotFoundError:
+        return []
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError, OSError):
+        return None
+
+
+def _write_legacy_owner_pid(socket_dir: str, session_name: str, owner_pid: int) -> bool:
+    """Keep the existing reaper marker on a live owner for mixed-version safety."""
+    try:
+        from utils import atomic_write_text
+
+        atomic_write_text(
+            Path(socket_dir) / f"{session_name}.owner_pid",
+            str(owner_pid),
+            create_mode=0o600,
+        )
+        return True
+    except OSError:
+        return False
+
+
+def _write_owners(socket_dir: str, session_name: str, owners: list[dict[str, int]]) -> bool:
+    try:
+        from utils import atomic_json_write
+
+        atomic_json_write(
+            _owner_path(socket_dir, session_name),
+            {"session_name": session_name, "owners": owners},
+            mode=0o600,
+        )
+        return True
+    except OSError as exc:
+        _bt.logger.warning("Cannot publish real-profile daemon owners for %s: %s", session_name, exc)
+        return False
+
+
+def _owner_alive(owner: dict[str, int]) -> Optional[bool]:
+    """True for the recorded incarnation, False when dead/reused, None if ambiguous."""
+    from gateway.status import _pid_exists
+
+    pid = owner["pid"]
+    if not _pid_exists(pid):
+        return False
+    current_start = _process_start_time(pid)
+    if current_start is None:
+        return None
+    return current_start == owner["start_time"]
+
+
+def _classify_owners(owners: list[dict[str, int]]) -> tuple[list[dict[str, int]], bool]:
+    live = []
+    ambiguous = False
+    for owner in owners:
+        state = _owner_alive(owner)
+        if state is True:
+            live.append(owner)
+        elif state is None:
+            ambiguous = True
+    return live, ambiguous
+
+
+def register(socket_dir: str, session_name: str) -> bool:
+    """Add this process incarnation as an owner; fail closed on ambiguous state."""
+    current = _owner_identity()
+    if current is None:
+        _bt.logger.warning("Cannot register real-profile daemon owner: process start time unavailable")
+        return False
+    try:
+        with _locked(socket_dir, session_name):
+            owners = _read_owners(socket_dir, session_name)
+            if owners is None:
+                _bt.logger.warning("Cannot register real-profile daemon owner: owner metadata is ambiguous")
+                return False
+            if not owners and (Path(socket_dir) / f"{session_name}.pid").exists():
+                _bt.logger.warning("Cannot adopt real-profile daemon without durable owner metadata")
+                return False
+            live, ambiguous = _classify_owners(owners)
+            if ambiguous:
+                _bt.logger.warning("Cannot register real-profile daemon owner: owner identity is unreadable")
+                return False
+            if current not in live:
+                live.append(current)
+            return _write_owners(socket_dir, session_name, live)
+    except OSError as exc:
+        _bt.logger.warning("Cannot lock real-profile daemon ownership for %s: %s", session_name, exc)
+        return False
+
+
+@contextmanager
+def exclusive_current_owner(socket_dir: str, session_name: str):
+    """Yield whether this process is the sole provably live owner, while holding the owner lock."""
+    current = _owner_identity()
+    if current is None:
+        yield False
+        return
+    try:
+        with _locked(socket_dir, session_name):
+            owners = _read_owners(socket_dir, session_name)
+            if owners is None or current not in owners:
+                yield False
+                return
+            live, ambiguous = _classify_owners(owners)
+            if not ambiguous and live != owners:
+                _write_owners(socket_dir, session_name, live)
+            yield not ambiguous and live == [current]
+    except OSError:
+        yield False
+
+
+def _daemon_pid(socket_dir: str, session_name: str) -> tuple[Optional[int], bool]:
+    """Return ``(pid, trustworthy)``; a missing file is trustworthy absence, junk is ambiguous."""
+    path = Path(socket_dir) / f"{session_name}.pid"
+    try:
+        if path.is_symlink():
+            return None, False
+        raw = path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return None, True
+    except OSError:
+        return None, False
+    try:
+        pid = int(raw)
+    except ValueError:
+        return None, False
+    return (pid, True) if pid > 0 else (None, False)
+
+
+def _stable_file(path: Path) -> Optional[tuple[str, os.stat_result]]:
+    try:
+        before = path.stat()
+        text = path.read_text(encoding="utf-8")
+        after = path.stat()
+    except OSError:
+        return None
+    if (before.st_dev, before.st_ino, before.st_mtime_ns, before.st_size) != (
+        after.st_dev,
+        after.st_ino,
+        after.st_mtime_ns,
+        after.st_size,
+    ):
+        return None
+    return text, after
+
+
+def _file_still_matches(path: Path, expected_text: str, expected_stat: os.stat_result) -> bool:
+    current = _stable_file(path)
+    if current is None:
+        return False
+    text, stat = current
+    return text == expected_text and (
+        stat.st_dev,
+        stat.st_ino,
+        stat.st_mtime_ns,
+        stat.st_size,
+    ) == (
+        expected_stat.st_dev,
+        expected_stat.st_ino,
+        expected_stat.st_mtime_ns,
+        expected_stat.st_size,
+    )
+
+
+def _claim_and_remove(
+    socket_dir: str,
+    evidence_name: str,
+    expected_text: str,
+    expected_stat: os.stat_result,
+) -> bool:
+    """Rename the inspected directory and delete only that exact state generation."""
+    claim = f"{socket_dir}.reap-{os.getpid()}-{time.time_ns()}"
+    try:
+        os.rename(socket_dir, claim)
+    except OSError:
+        return False
+    if not _file_still_matches(Path(claim) / evidence_name, expected_text, expected_stat):
+        return False
+    shutil.rmtree(claim, ignore_errors=True)
+    return not os.path.exists(claim)
+
+
+def _terminate_exact_daemon(socket_dir: str, session_name: str, daemon_pid: int) -> bool:
+    """Terminate only the verified daemon incarnation bound to this socket directory."""
+    from gateway.status import _pid_exists
+    from tools.browser_tool_lifecycle import _verify_reapable_browser_daemon
+    from tools.process_registry import ProcessRegistry
+
+    daemon_start = _process_start_time(daemon_pid)
+    if daemon_start is None:
+        _bt.logger.warning(
+            "Refusing to reap real-profile daemon PID %d: no process-start fingerprint", daemon_pid
+        )
+        return False
+    if not _verify_reapable_browser_daemon(daemon_pid, socket_dir, session_name):
+        return False
+    if _process_start_time(daemon_pid) != daemon_start:
+        _bt.logger.warning(
+            "Refusing to reap real-profile daemon PID %d: process incarnation changed", daemon_pid
+        )
+        return False
+    try:
+        ProcessRegistry._terminate_host_pid(daemon_pid, expected_start=daemon_start)
+    except (ProcessLookupError, PermissionError, OSError):
+        return False
+    return not _pid_exists(daemon_pid)
+
+
+def _remove_dead_state(socket_dir: str, session_name: str, *, allow_pidless: bool) -> bool:
+    """Remove state only when no live daemon can still reference it."""
+    from gateway.status import _pid_exists
+
+    daemon_pid, pid_trustworthy = _daemon_pid(socket_dir, session_name)
+    if not pid_trustworthy:
+        _bt.logger.warning("Preserving real-profile daemon state %s: daemon PID is ambiguous", socket_dir)
+        return False
+    if daemon_pid is None and not allow_pidless:
+        return False
+    evidence_name = f"{session_name}.pid" if daemon_pid is not None else f"{session_name}{_OWNER_SUFFIX}"
+    evidence = _stable_file(Path(socket_dir) / evidence_name)
+    if evidence is None:
+        return False
+    expected_text, expected_stat = evidence
+    if daemon_pid is not None and _pid_exists(daemon_pid):
+        if not _terminate_exact_daemon(socket_dir, session_name, daemon_pid):
+            return False
+    if not _file_still_matches(Path(socket_dir) / evidence_name, expected_text, expected_stat):
+        return False
+    return _claim_and_remove(socket_dir, evidence_name, expected_text, expected_stat)
+
+
+def cleanup_owned() -> bool:
+    """Release this owner and stop the daemon only when no other live owner remains."""
+    session_name, socket_dir = _bt._REAL_PROFILE_SESSION, _socket_dir()
+    if not os.path.isdir(socket_dir):
+        return False
+    current = _owner_identity()
+    if current is None:
+        _bt.logger.warning("Refusing real-profile daemon cleanup: current owner identity is unavailable")
+        return False
+    try:
+        with _locked(socket_dir, session_name):
+            owners = _read_owners(socket_dir, session_name)
+            if owners is None or current not in owners:
+                _bt.logger.warning("Refusing real-profile daemon cleanup: ownership is ambiguous")
+                return False
+            remaining, ambiguous = _classify_owners([owner for owner in owners if owner != current])
+            if ambiguous:
+                _bt.logger.warning("Preserving real-profile daemon: another owner identity is unreadable")
+                return False
+            if remaining:
+                if _write_owners(socket_dir, session_name, remaining):
+                    _write_legacy_owner_pid(socket_dir, session_name, remaining[0]["pid"])
+                return False
+            return _remove_dead_state(socket_dir, session_name, allow_pidless=False)
+    except OSError as exc:
+        _bt.logger.warning("Cannot lock real-profile daemon cleanup: %s", exc)
+        return False
+
+
+def reap_orphans() -> int:
+    """Stop the shared daemon only after every recorded Hermes owner is provably gone."""
+    session_name, socket_dir = _bt._REAL_PROFILE_SESSION, _socket_dir()
+    if not os.path.isdir(socket_dir):
+        return 0
+    try:
+        with _locked(socket_dir, session_name):
+            owners = _read_owners(socket_dir, session_name)
+            if owners is None or not owners:
+                _bt.logger.warning("Preserving real-profile daemon state %s: owner metadata is ambiguous", socket_dir)
+                return 0
+            live, ambiguous = _classify_owners(owners)
+            if ambiguous:
+                return 0
+            if live:
+                if live != owners and _write_owners(socket_dir, session_name, live):
+                    _write_legacy_owner_pid(socket_dir, session_name, live[0]["pid"])
+                return 0
+            return int(_remove_dead_state(socket_dir, session_name, allow_pidless=False))
+    except OSError as exc:
+        _bt.logger.warning("Cannot lock real-profile daemon orphan cleanup: %s", exc)
+        return 0


### PR DESCRIPTION
## What does this PR do?

Completes the distinct `hermes-real-profile` agent-browser attach-daemon lifecycle portion of #100855.

The attach lane starts a shared agent-browser daemon whose state was previously outside Hermes' lifecycle ownership and orphan-reaper contract. This could leave a wedged daemon and headless Chrome alive across gateway restarts, while the existing Browser Harness and directly-launched signed-Chrome fixes cover different producers.

This PR adds durable, cross-process owner metadata and cleanup for the attach daemon. It uses exact process-incarnation fingerprints, daemon identity and socket-directory binding checks, locked owner read/modify/write, atomic state-generation claiming, and conservative fail-closed behavior for ambiguous or legacy state. Multiple live Hermes owners are preserved; the daemon is stopped only after the final provable owner releases it. Legacy pre-upgrade state is not snapshotted into the credential copy.

## Scope boundary

- PR #100865 remains the Browser Harness / `browser_exec` carrier.
- PR #100998 remains the directly-launched signed Chrome carrier.
- This PR is only the shared agent-browser daemon/session created by the real-profile attach lane.

Refs #100855

## Validation performed

- Focused real-profile/daemon suite: 94 passed, 3 failures reproduced byte-identically on pristine `origin/main` as pre-existing baseline failures.
- Orphan-reaper, cleanup, process-registry, timeout, Lightpanda and snapshot suites: 194 passed, 4 skipped.
- `test_browser_use_cli.py`: 116 passed; Browser Harness lane untouched.
- Gateway shutdown suites: 22 passed.
- Ruff, Ty, `git diff --check`, and Windows footgun checks passed; four pre-existing Ty diagnostics were unchanged.
- Two independent review rounds covered lifecycle/concurrency, Chrome-kill safety, and test coverage; actionable findings were addressed.