### PR TITLE
fix(desktop): preserve gateway route in HUD mode

### DIFF
--- a/apps/desktop/electron/hud-ipc.ts
+++ b/apps/desktop/electron/hud-ipc.ts
@@ -18,7 +18,7 @@ export interface HudIpcDeps {
   /** Main's authoritative translucency state (Settings → Appearance). */
   getTranslucencyState: () => TranslucencyState
   getHudWindow: () => BrowserWindow | null
-  openHudWindow: (sessionId: null | string, profile: null | string) => void
+  openHudWindow: (sessionId: null | string, profile: null | string, connectionId: null | string) => void
   closeHudWindow: () => void
   resetHudLayout: () => boolean
   setHudSessionId: (sessionId: null | string) => void
@@ -137,7 +137,8 @@ export function registerHudIpc({
   ipcMain.handle('hermes:hud:open', async (_event, request) => {
     openHudWindow(
       typeof request?.sessionId === 'string' ? request.sessionId : null,
-      typeof request?.profile === 'string' ? request.profile : null
+      typeof request?.profile === 'string' ? request.profile : null,
+      typeof request?.connectionId === 'string' ? request.connectionId : null
     )
 
     return { ok: true }

--- a/apps/desktop/electron/hud-url.test.ts
+++ b/apps/desktop/electron/hud-url.test.ts
@@ -11,11 +11,16 @@ test('buildHudWindowUrl puts win=hud before the hash route (dev server)', () => 
   assert.ok(url.indexOf('?win=hud') < url.indexOf('#'))
 })
 
-test('buildHudWindowUrl carries the handoff profile in the query before the hash', () => {
-  const url = buildHudWindowUrl('sess-1', { devServer: 'http://localhost:5173', profile: 'work' })
+test('buildHudWindowUrl carries the handoff route in the query before the hash', () => {
+  const url = buildHudWindowUrl('sess-1', {
+    connectionId: 'remote gateway',
+    devServer: 'http://localhost:5173',
+    profile: 'work'
+  })
 
-  assert.equal(url, 'http://localhost:5173/?win=hud&profile=work#/sess-1')
+  assert.equal(url, 'http://localhost:5173/?win=hud&profile=work&connectionId=remote%20gateway#/sess-1')
   assert.ok(url.indexOf('profile=work') < url.indexOf('#'))
+  assert.ok(url.indexOf('connectionId=remote%20gateway') < url.indexOf('#'))
 })
 
 test('buildHudWindowUrl encodes the profile and the session id', () => {

--- a/apps/desktop/electron/hud-url.ts
+++ b/apps/desktop/electron/hud-url.ts
@@ -8,7 +8,7 @@ import { pathToFileURL } from 'node:url'
  * Build the renderer URL for the HUD window.
  *
  * Same query-before-hash contract as `buildSessionWindowUrl`: `?win=hud` and
- * the optional `profile=` MUST sit in the search string before the '#', or
+ * the optional route fields MUST sit in the search string before the '#', or
  * HashRouter swallows them as part of the route.
  *
  * The profile is what the HUD renderer adopts at boot. Session ids are scoped
@@ -21,12 +21,19 @@ export function buildHudWindowUrl(
   sessionId: null | string | undefined,
   {
     devServer,
+    connectionId,
     profile,
     rendererIndexPath
-  }: { devServer?: null | string; profile?: null | string; rendererIndexPath?: string } = {}
+  }: {
+    devServer?: null | string
+    connectionId?: null | string
+    profile?: null | string
+    rendererIndexPath?: string
+  } = {}
 ): string {
+  const connectionKey = typeof connectionId === 'string' ? connectionId.trim() : ''
   const profileKey = typeof profile === 'string' ? profile.trim() : ''
-  const query = `?win=hud${profileKey ? `&profile=${encodeURIComponent(profileKey)}` : ''}`
+  const query = `?win=hud${profileKey ? `&profile=${encodeURIComponent(profileKey)}` : ''}${connectionKey ? `&connectionId=${encodeURIComponent(connectionKey)}` : ''}`
   const route = sessionId ? `#/${encodeURIComponent(sessionId)}` : '#/'
 
   if (devServer) {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -13749,11 +13749,12 @@ let hudRestoreMainWindow = false
 // the id and hands it over in the close broadcast.
 let hudSessionId = null
 
-// The profile the live HUD renderer booted against (rides hudUrl's query
+// The route the live HUD renderer booted against (rides hudUrl's query
 // string). A renderer adopts its backend once at boot, so a retarget onto a
-// session from a DIFFERENT profile cannot be a same-window `goto` — the HUD
-// must be respawned against the new profile's backend (see openHudWindow).
+// session from a DIFFERENT connection/profile cannot be a same-window `goto` —
+// the HUD must be respawned against the new backend (see openHudWindow).
 let hudProfile = null
+let hudConnectionId = null
 
 // A wide, short bar parked near the bottom of the active display — the shape
 // of a game chat frame, and where one belongs. Defaults only: once the user
@@ -14011,7 +14012,7 @@ function hudBounds() {
   return defaultHudBounds(area)
 }
 
-function hudUrl(sessionId, profile) {
+function hudUrl(sessionId, profile, connectionId) {
   // The profile rides the query string next to `win=hud` (BEFORE the '#', so
   // HashRouter never sees it). The HUD renderer's gateway boot reads it and
   // adopts that backend instead of the primary — without it, a HUD opened on a
@@ -14019,6 +14020,7 @@ function hudUrl(sessionId, profile) {
   // wrong backend and falls back to the default profile's last session.
   return buildHudWindowUrl(sessionId, {
     devServer: DEV_SERVER,
+    connectionId,
     profile,
     rendererIndexPath: DEV_SERVER ? undefined : resolveRendererIndex()
   })
@@ -14038,7 +14040,7 @@ function broadcastHudState(open) {
   }
 }
 
-function spawnHudWindow(sessionId, profile) {
+function spawnHudWindow(sessionId, profile, connectionId) {
   const win = new BrowserWindow({
     ...hudBounds(),
     minWidth: 380,
@@ -14145,7 +14147,7 @@ function spawnHudWindow(sessionId, profile) {
   // Log-only lifecycle (#81290): the HUD is a compact auxiliary surface the
   // user can re-toggle; a dead renderer should be diagnosable, not resurrected.
   installWindowRendererLifecycle(win, { kind: 'hud', callbacks: { log: rememberLog } })
-  loadWindowUrl(win, hudUrl(sessionId, profile), 'HUD')
+  loadWindowUrl(win, hudUrl(sessionId, profile, connectionId), 'HUD')
 
   return win
 }
@@ -14163,15 +14165,16 @@ function restoreMainWindowFromHud() {
   }
 }
 
-function openHudWindow(sessionId, profile) {
+function openHudWindow(sessionId, profile, connectionId) {
   const profileKey = typeof profile === 'string' && profile.trim() ? profile.trim() : null
+  const connectionKey = typeof connectionId === 'string' && connectionId.trim() ? connectionId.trim() : null
 
   if (hudWindow && !hudWindow.isDestroyed()) {
-    // Pointed at another PROFILE: the live renderer is bound to the old
-    // profile's backend, and a renderer adopts its backend exactly once at
+    // Pointed at another ROUTE: the live renderer is bound to the old
+    // connection/profile backend, and a renderer adopts its backend exactly once at
     // boot — an in-place goto would resolve the id against the wrong backend
     // (the #82285 fallback). Respawn against the right one.
-    if (profileKey && hudProfile !== profileKey) {
+    if ((profileKey || connectionKey) && (hudProfile !== profileKey || hudConnectionId !== connectionKey)) {
       const win = hudWindow
       hudWindow = null
       win.removeAllListeners('closed')
@@ -14179,7 +14182,8 @@ function openHudWindow(sessionId, profile) {
 
       hudSessionId = sessionId || null
       hudProfile = profileKey
-      hudWindow = spawnHudWindow(sessionId, profileKey)
+      hudConnectionId = connectionKey
+      hudWindow = spawnHudWindow(sessionId, profileKey, connectionKey)
       broadcastHudState(true)
       registerHudSnapShortcut()
 
@@ -14205,7 +14209,8 @@ function openHudWindow(sessionId, profile) {
   hudRestoreMainWindow = Boolean(mainWindow && !mainWindow.isDestroyed() && mainWindow.isVisible())
   hudSessionId = sessionId || null
   hudProfile = profileKey
-  hudWindow = spawnHudWindow(sessionId, profileKey)
+  hudConnectionId = connectionKey
+  hudWindow = spawnHudWindow(sessionId, profileKey, connectionKey)
   broadcastHudState(true)
   registerHudSnapShortcut()
 

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -78,7 +78,7 @@ import {
   recordSessionEventScope,
   resetTileRuntimeBindings
 } from '@/store/session-states'
-import { windowProfileOverride } from '@/store/windows'
+import { getWindowConnection, windowProfileOverride } from '@/store/windows'
 import type { RpcEvent } from '@/types/hermes'
 
 import { stashGatewaySurvivor, survivorIsStale, takeGatewaySurvivor } from './gateway-hmr-survivor'
@@ -325,7 +325,7 @@ export function useGatewayBoot({
         // this primary socket at a secondary profile's backend after a live swap.
         // Secondaries reconnect via reconnectSecondaryGateways().
         const conn = await withTimeout(
-          desktop.getConnection(),
+          getWindowConnection(desktop),
           RECONNECT_ATTEMPT_TIMEOUT_MS,
           'Timed out reconnecting to Hermes backend'
         )
@@ -607,7 +607,7 @@ export function useGatewayBoot({
         // shared backend-boot budget rather than the reconnect budget because
         // ensureBackend may cold-spawn a pooled helper backend here.
         const conn = await withTimeout(
-          desktop.getConnection(windowProfileOverride() ?? undefined),
+          getWindowConnection(desktop),
           BACKEND_BOOT_WAIT_TIMEOUT_MS,
           'Timed out reconnecting to Hermes backend'
         )
@@ -789,7 +789,7 @@ export function useGatewayBoot({
         // must not latch the profile atom to a connection that never resolves
         // if the main-process IPC round-trip wedges.
         void withTimeout(
-          desktop.getConnection(fallbackProfile),
+          getWindowConnection(desktop, { profile: fallbackProfile }),
           RECONNECT_ATTEMPT_TIMEOUT_MS,
           'Timed out resolving the fallback gateway connection'
         )
@@ -989,7 +989,7 @@ export function useGatewayBoot({
         // rides out a full backend cold spawn, so it gets the shared 45s
         // backend-boot budget, not the 20s reconnect budget.
         const conn = await withTimeout(
-          desktop.getConnection(windowProfileOverride() ?? undefined),
+          getWindowConnection(desktop),
           BACKEND_BOOT_WAIT_TIMEOUT_MS,
           'Timed out connecting to Hermes backend'
         )

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -117,7 +117,11 @@ declare global {
           solid: boolean
           workspaceTransfer: boolean
         }
-        open: (request?: { sessionId?: null | string; profile?: null | string }) => Promise<{ ok: boolean }>
+        open: (request?: {
+          connectionId?: null | string
+          sessionId?: null | string
+          profile?: null | string
+        }) => Promise<{ ok: boolean }>
         close: () => Promise<{ ok: boolean }>
         setIgnoreMouse: (ignore: boolean) => void
         beginMove: () => void

--- a/apps/desktop/src/store/hud.test.ts
+++ b/apps/desktop/src/store/hud.test.ts
@@ -79,6 +79,16 @@ describe('openHud profile targeting (#82285)', () => {
     expect(open).toHaveBeenCalledWith({ connectionId: 'vultr-gateway', sessionId: null, profile: 'thanos' })
   })
 
+  it('carries the active gateway route for a legacy profile-only session', () => {
+    $sessions.set([session({ id: 'abc', profile: 'thanos' })])
+    $activeGatewayProfile.set('thanos')
+    setPrimaryGatewayConnectionId('vultr-gateway')
+
+    openHud('abc')
+
+    expect(open).toHaveBeenCalledWith({ connectionId: 'vultr-gateway', sessionId: 'abc', profile: 'thanos' })
+  })
+
   it('normalizes to default for single-profile users', () => {
     openHud()
 

--- a/apps/desktop/src/store/hud.test.ts
+++ b/apps/desktop/src/store/hud.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { setPrimaryGateway, setPrimaryGatewayConnectionId } from '@/store/gateway'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $sessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
@@ -30,6 +31,8 @@ beforeEach(() => {
   $hudSession.set(null)
   $sessions.set([])
   $activeGatewayProfile.set('default')
+  setPrimaryGateway({ connectionState: 'open' } as never, 'default')
+  setPrimaryGatewayConnectionId(null)
 })
 
 afterEach(() => {
@@ -67,12 +70,13 @@ describe('openHud profile targeting (#82285)', () => {
     expect(open).toHaveBeenCalledWith({ sessionId: 'abc', profile: 'work' })
   })
 
-  it('uses the active gateway profile when opening without a session', () => {
-    $activeGatewayProfile.set('research')
+  it('carries the active gateway route when opening without a session', () => {
+    $activeGatewayProfile.set('thanos')
+    setPrimaryGatewayConnectionId('vultr-gateway')
 
     openHud()
 
-    expect(open).toHaveBeenCalledWith({ sessionId: null, profile: 'research' })
+    expect(open).toHaveBeenCalledWith({ connectionId: 'vultr-gateway', sessionId: null, profile: 'thanos' })
   })
 
   it('normalizes to default for single-profile users', () => {

--- a/apps/desktop/src/store/hud.ts
+++ b/apps/desktop/src/store/hud.ts
@@ -16,8 +16,8 @@
 import { atom } from 'nanostores'
 
 import { requestComposerDraftSync } from '@/store/composer'
-import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
-import { $sessions, rememberedSessionProfile } from '@/store/session'
+import { $activeGatewayProfile, normalizeProfileKey, resolveNewChatOwnerRoute } from '@/store/profile'
+import { $sessions, knownSessionOwner, rememberedSessionProfile } from '@/store/session'
 import { isHudWindow } from '@/store/windows'
 
 /** Whether a HUD window is currently up. In the HUD's own renderer this is
@@ -56,19 +56,23 @@ export function openHud(sessionId?: null | string): void {
   requestComposerDraftSync('flush')
 
   // Which backend the HUD must boot against. The HUD is a full renderer that
-  // adopts the PRIMARY backend's profile by default, so handing it a session
-  // from a non-primary profile without saying so resolves the id against the
+  // adopts the PRIMARY backend route by default, so handing it a session from
+  // another connection/profile without saying so resolves the id against the
   // wrong backend — the lookup misses and the HUD falls back to the default
   // profile's last session (#82285). Same ladder the remembered-navigation key
   // uses: the session's stamped owner wins, and a fresh/unstamped/uncached
   // target inherits the profile the user is looking at.
-  const profile = normalizeProfileKey(
-    rememberedSessionProfile($sessions.get(), sessionId ?? null, $activeGatewayProfile.get())
-  )
+  const targetSessionId = sessionId ?? null
+  const sessions = $sessions.get()
+  const owner = knownSessionOwner(sessions, targetSessionId)
+  const profile = normalizeProfileKey(rememberedSessionProfile(sessions, targetSessionId, $activeGatewayProfile.get()))
+
+  const connectionId =
+    typeof owner === 'object' && owner ? owner.connectionId : (resolveNewChatOwnerRoute(profile)?.connectionId ?? null)
 
   $hudActive.set(true)
-  $hudSession.set(sessionId ?? null)
-  void api.open({ sessionId: sessionId ?? null, profile })
+  $hudSession.set(targetSessionId)
+  void api.open({ sessionId: targetSessionId, profile, ...(connectionId ? { connectionId } : {}) })
 }
 
 /** Leave HUD mode. Callable from either window — main closes the child, the

--- a/apps/desktop/src/store/windows.ts
+++ b/apps/desktop/src/store/windows.ts
@@ -133,12 +133,40 @@ export function isPeerInstanceWindow(search = typeof window === 'undefined' ? ''
 // before, so ordinary windows and single-profile users are untouched.
 // Not cached: it is read a handful of times per boot and staying cache-free
 // keeps it honest under test.
-export function windowProfileOverride(): null | string {
+function windowRouteOverride(
+  name: string,
+  search = typeof window === 'undefined' ? '' : window.location.search
+): null | string {
   try {
-    return new URLSearchParams(window.location.search).get('profile')?.trim() || null
+    return new URLSearchParams(search).get(name)?.trim() || null
   } catch {
     return null
   }
+}
+
+export function windowProfileOverride(search?: string): null | string {
+  return windowRouteOverride('profile', search)
+}
+
+export function windowConnectionIdOverride(search?: string): null | string {
+  return windowRouteOverride('connectionId', search)
+}
+
+/** Resolve the backend this renderer was opened for. Helper windows carry an
+ * exact registry source; ordinary and older windows keep the legacy profile
+ * route unchanged. */
+export function getWindowConnection(
+  desktop: Pick<Window['hermesDesktop'], 'getConnection' | 'getConnectionFor'>,
+  {
+    connectionId = windowConnectionIdOverride(),
+    profile = windowProfileOverride()
+  }: { connectionId?: null | string; profile?: null | string } = {}
+) {
+  if (connectionId && desktop.getConnectionFor) {
+    return desktop.getConnectionFor({ connectionId, profile })
+  }
+
+  return profile ? desktop.getConnection(profile) : desktop.getConnection()
 }
 
 // True when running inside the Electron desktop shell (the preload bridge is

--- a/apps/desktop/src/store/windows.ts
+++ b/apps/desktop/src/store/windows.ts
@@ -133,23 +133,20 @@ export function isPeerInstanceWindow(search = typeof window === 'undefined' ? ''
 // before, so ordinary windows and single-profile users are untouched.
 // Not cached: it is read a handful of times per boot and staying cache-free
 // keeps it honest under test.
-function windowRouteOverride(
-  name: string,
-  search = typeof window === 'undefined' ? '' : window.location.search
-): null | string {
+function windowRouteOverride(name: string): null | string {
   try {
-    return new URLSearchParams(search).get(name)?.trim() || null
+    return new URLSearchParams(window.location.search).get(name)?.trim() || null
   } catch {
     return null
   }
 }
 
-export function windowProfileOverride(search?: string): null | string {
-  return windowRouteOverride('profile', search)
+export function windowProfileOverride(): null | string {
+  return windowRouteOverride('profile')
 }
 
-export function windowConnectionIdOverride(search?: string): null | string {
-  return windowRouteOverride('connectionId', search)
+export function windowConnectionIdOverride(): null | string {
+  return windowRouteOverride('connectionId')
 }
 
 /** Resolve the backend this renderer was opened for. Helper windows carry an


### PR DESCRIPTION
## Summary

- Carry the selected gateway `connectionId` through HUD IPC and the window URL.
- Resolve HUD boot and reconnect against the exact connection/profile route.
- Respawn an open HUD when the gateway changes, including the same profile name on another gateway.

## Reproduction

On current `main`, selecting remote `Thanos` and then opening HUD gives the new window only `profile=thanos`. The HUD falls back to local profile lookup and reports `Profile "thanos" no longer exists`.

## Test plan

- [x] UI routing tests: 72 passed
- [x] Electron HUD URL tests: 6 passed
- [x] TypeScript type-check
- [x] ESLint on changed files
- [x] Prettier check on changed files
- [x] Production build