### PR TITLE
fix(desktop): probe for a working ssh binary on Windows

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -361,6 +361,7 @@ import {
   SESSION_WINDOW_MIN_WIDTH
 } from './session-windows'
 import { ensureLoginShellPath } from './shell-path'
+import { getSshBinary } from './ssh-binary'
 import { createBootstrapCoordinator, sshConfigFingerprint } from './ssh-bootstrap-coordinator'
 import { collectSshConfigHosts, parseSshGOutput } from './ssh-config'
 import { createSshProbeConnection, pickLocalPort, redactSecrets, SshConnection } from './ssh-connection'
@@ -10435,10 +10436,10 @@ async function reachablePreviewUrl(webContentsId: number, rawUrl: string): Promi
 }
 
 async function effectiveSshConfigFingerprint(sshConfig) {
-  const ssh =
-    process.platform === 'win32'
-      ? path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'OpenSSH', 'ssh.exe')
-      : 'ssh'
+  // Health-checked ssh executable — on Windows the inbox OpenSSH client can
+  // be present but broken, so probe candidates instead of trusting one
+  // hardcoded path (#103288).
+  const ssh = await getSshBinary(sshRememberLog)
 
   const args = ['-G']
 
@@ -15197,10 +15198,9 @@ ipcMain.handle('hermes:ssh-config:resolve', async (_event, host) => {
     throw new Error('SSH host is required.')
   }
 
-  const ssh =
-    process.platform === 'win32'
-      ? path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'OpenSSH', 'ssh.exe')
-      : 'ssh'
+  // Same health-checked resolution as effectiveSshConfigFingerprint — the
+  // hardcoded System32 OpenSSH path cannot be trusted on Windows (#103288).
+  const ssh = await getSshBinary(sshRememberLog)
 
   return new Promise((resolve, reject) => {
     const child = spawn(ssh, ['-G', '--', value], hiddenWindowsChildOptions({ stdio: ['ignore', 'pipe', 'pipe'] }))

--- a/apps/desktop/electron/ssh-binary.test.ts
+++ b/apps/desktop/electron/ssh-binary.test.ts
@@ -1,0 +1,264 @@
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+
+import { test } from 'vitest'
+
+import { getSshBinary, probeSshBinary, resolveSshBinary, sshBinaryCandidates } from './ssh-binary'
+
+type FakeBehavior = {
+  code?: number
+  output?: string
+  spawnError?: boolean
+}
+
+// A spawnFn that scripts each candidate's `ssh -V` outcome. Emissions are
+// queued so the probe can attach its listeners first.
+function scriptedSpawn(behaviors: Record<string, FakeBehavior>) {
+  const calls: string[] = []
+
+  const spawnFn = (command: string) => {
+    calls.push(command)
+
+    const behavior = behaviors[command] ?? { spawnError: true }
+    const child: any = new EventEmitter()
+
+    child.stdout = new EventEmitter()
+    child.stderr = new EventEmitter()
+    child.kill = () => {}
+
+    queueMicrotask(() => {
+      if (behavior.spawnError) {
+        child.emit('error', new Error(`spawn ${command} ENOENT`))
+
+        return
+      }
+
+      if (behavior.output) {
+        child.stderr.emit('data', Buffer.from(behavior.output))
+      }
+
+      child.emit('close', behavior.code ?? 0)
+    })
+
+    return child
+  }
+
+  return { calls, spawnFn }
+}
+
+const nothingExists = () => false
+
+const existsOnly =
+  (...files: string[]) =>
+  (p: string) =>
+    files.includes(p)
+
+const WIN_ENV = {
+  SystemRoot: 'C:\\Windows',
+  LOCALAPPDATA: 'C:\\Users\\test\\AppData\\Local',
+  ProgramFiles: 'C:\\Program Files',
+  'ProgramFiles(x86)': 'C:\\Program Files (x86)'
+}
+
+const SYSTEM32_SSH = 'C:\\Windows\\System32\\OpenSSH\\ssh.exe'
+const GIT_SSH = 'C:\\Program Files\\Git\\usr\\bin\\ssh.exe'
+const PORTABLE_GIT_SSH = 'C:\\Users\\test\\AppData\\Local\\hermes\\git\\usr\\bin\\ssh.exe'
+const HEALTHY = { code: 0, output: 'OpenSSH_for_Windows_9.5p1, LibreSSL 3.8.2' }
+
+test('win32 candidates: env override first, deduped against the inbox path', () => {
+  const candidates = sshBinaryCandidates({ ...WIN_ENV, HERMES_SSH_PATH: SYSTEM32_SSH }, nothingExists)
+
+  assert.deepEqual(candidates, [SYSTEM32_SSH, 'ssh'])
+})
+
+test('win32 candidates: no override and no Git install leaves inbox + bare ssh', () => {
+  const candidates = sshBinaryCandidates({ SystemRoot: 'D:\\Win' }, nothingExists)
+
+  assert.deepEqual(candidates, ['D:\\Win\\System32\\OpenSSH\\ssh.exe', 'ssh'])
+})
+
+test('win32 candidates: Git for Windows ssh comes from the shared Git discovery', () => {
+  // System-wide install (ProgramFiles\Git\bin\bash.exe) -> sibling usr/bin ssh.
+  const candidates = sshBinaryCandidates(WIN_ENV, existsOnly('C:\\Program Files\\Git\\bin\\bash.exe'))
+
+  assert.deepEqual(candidates, [SYSTEM32_SSH, 'ssh', GIT_SSH])
+})
+
+test('win32 candidates: Hermes PortableGit and HERMES_GIT_BASH_PATH are covered', () => {
+  const portable = sshBinaryCandidates(
+    WIN_ENV,
+    existsOnly('C:\\Users\\test\\AppData\\Local\\hermes\\git\\usr\\bin\\bash.exe')
+  )
+
+  assert.deepEqual(portable, [SYSTEM32_SSH, 'ssh', PORTABLE_GIT_SSH])
+
+  const viaEnv = sshBinaryCandidates(
+    { ...WIN_ENV, HERMES_GIT_BASH_PATH: 'D:\\tools\\git\\bin\\bash.exe' },
+    existsOnly('D:\\tools\\git\\bin\\bash.exe')
+  )
+
+  assert.deepEqual(viaEnv, [SYSTEM32_SSH, 'ssh', 'D:\\tools\\git\\usr\\bin\\ssh.exe'])
+})
+
+test('win32 candidates: a PATH-resolved ssh identical to the inbox binary is deduped', () => {
+  const env = { ...WIN_ENV, Path: 'C:\\Windows\\System32\\OpenSSH;C:\\tools' }
+  const candidates = sshBinaryCandidates(env, existsOnly(SYSTEM32_SSH))
+
+  assert.deepEqual(candidates, [SYSTEM32_SSH])
+})
+
+test('non-Windows platforms keep the bare ssh and never probe', async () => {
+  const spawnFn = () => {
+    throw new Error('must not be called')
+  }
+
+  assert.equal(await resolveSshBinary({ platform: 'darwin', env: {}, spawnFn, fileExists: nothingExists }), 'ssh')
+  assert.equal(await resolveSshBinary({ platform: 'linux', env: {}, spawnFn, fileExists: nothingExists }), 'ssh')
+})
+
+test('a healthy HERMES_SSH_PATH override wins', async () => {
+  const { calls, spawnFn } = scriptedSpawn({ 'D:\\tools\\ssh.exe': HEALTHY })
+  const binary = await resolveSshBinary({
+    platform: 'win32',
+    env: { ...WIN_ENV, HERMES_SSH_PATH: 'D:\\tools\\ssh.exe' },
+    spawnFn,
+    fileExists: nothingExists
+  })
+
+  assert.equal(binary, 'D:\\tools\\ssh.exe')
+  assert.deepEqual(calls, ['D:\\tools\\ssh.exe'])
+})
+
+test('a broken HERMES_SSH_PATH override is skipped, not fatal', async () => {
+  // The #103288 failure mode on the override, with a healthy inbox binary.
+  const { calls, spawnFn } = scriptedSpawn({
+    'D:\\tools\\ssh.exe': { code: 255 },
+    [SYSTEM32_SSH]: HEALTHY
+  })
+  const warnings: string[] = []
+  const binary = await resolveSshBinary({
+    platform: 'win32',
+    env: { ...WIN_ENV, HERMES_SSH_PATH: 'D:\\tools\\ssh.exe' },
+    spawnFn,
+    fileExists: nothingExists,
+    log: line => warnings.push(line)
+  })
+
+  assert.equal(binary, SYSTEM32_SSH)
+  assert.deepEqual(calls, ['D:\\tools\\ssh.exe', SYSTEM32_SSH])
+  assert.ok(warnings.some(line => line.includes('D:\\tools\\ssh.exe')))
+})
+
+test('a broken inbox OpenSSH falls back to the Git for Windows bundle', async () => {
+  // Exactly the reporter's machine: System32 ssh dies instantly with no
+  // output, bare ssh is not on the app PATH, Git's MSYS OpenSSH works.
+  const { spawnFn } = scriptedSpawn({
+    [SYSTEM32_SSH]: { code: 255 },
+    [GIT_SSH]: { code: 0, output: 'OpenSSH_10.3p1, OpenSSL 3.5.2 5 Aug 2025' }
+  })
+  const binary = await resolveSshBinary({
+    platform: 'win32',
+    env: WIN_ENV,
+    spawnFn,
+    fileExists: existsOnly('C:\\Program Files\\Git\\bin\\bash.exe')
+  })
+
+  assert.equal(binary, GIT_SSH)
+})
+
+test('when nothing is healthy, fall back to bare ssh for the original error', async () => {
+  const { spawnFn } = scriptedSpawn({})
+  const binary = await resolveSshBinary({ platform: 'win32', env: WIN_ENV, spawnFn, fileExists: nothingExists })
+
+  assert.equal(binary, 'ssh')
+})
+
+test('a chain of hanging binaries cannot starve the final Git fallback probe', async () => {
+  // Three hanging candidates (override, inbox, PATH) would eat a naive total
+  // budget before the Git fallback is ever tried; the resolver reserves a
+  // full probe for the final candidate instead.
+  const calls: string[] = []
+  const spawnFn = (command: string) => {
+    calls.push(command)
+
+    const child: any = new EventEmitter()
+
+    child.stdout = new EventEmitter()
+    child.stderr = new EventEmitter()
+
+    if (command === GIT_SSH) {
+      queueMicrotask(() => {
+        child.stderr.emit('data', Buffer.from(HEALTHY.output))
+        child.emit('close', 0)
+      })
+    } else {
+      child.kill = () => queueMicrotask(() => child.emit('close', null))
+    }
+
+    return child
+  }
+
+  const binary = await resolveSshBinary({
+    platform: 'win32',
+    env: { ...WIN_ENV, HERMES_SSH_PATH: 'D:\\bad\\ssh.exe', Path: 'C:\\tools' },
+    spawnFn,
+    fileExists: existsOnly('C:\\tools\\ssh.exe', 'C:\\Program Files\\Git\\bin\\bash.exe'),
+    probeTimeoutMs: 50,
+    budgetMs: 130
+  })
+
+  assert.equal(binary, GIT_SSH)
+  assert.ok(calls.includes(GIT_SSH), 'final fallback candidate must always be probed')
+})
+
+test('probe rejects a zero-exit binary that is not OpenSSH', async () => {
+  const { spawnFn } = scriptedSpawn({ 'ssh': { code: 0, output: 'usage: ssh ...' } })
+
+  assert.equal(await probeSshBinary('ssh', spawnFn), false)
+})
+
+test('probe rejects a binary that cannot be spawned', async () => {
+  const { spawnFn } = scriptedSpawn({})
+
+  assert.equal(await probeSshBinary('ssh', spawnFn), false)
+})
+
+test('probe accepts a healthy binary reporting on stdout or stderr', async () => {
+  const { spawnFn } = scriptedSpawn({ 'ssh': HEALTHY })
+
+  assert.equal(await probeSshBinary('ssh', spawnFn), true)
+})
+
+test('probe kills a hanging binary and settles on its close', async () => {
+  const child: any = new EventEmitter()
+
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+
+  let killed = false
+
+  child.kill = () => {
+    killed = true
+    queueMicrotask(() => child.emit('close', null))
+  }
+
+  assert.equal(await probeSshBinary('ssh', () => child, 30), false)
+  assert.ok(killed)
+})
+
+test('probe still settles within a grace period when the kill never reaps the child', async () => {
+  const child: any = new EventEmitter()
+
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  child.kill = () => {} // close never arrives
+
+  const started = Date.now()
+
+  assert.equal(await probeSshBinary('ssh', () => child, 30), false)
+  assert.ok(Date.now() - started < 5_000, 'grace-settled probe must not hang the resolver')
+})
+
+test('getSshBinary memoizes the resolution for the process', () => {
+  assert.equal(getSshBinary(), getSshBinary())
+})

--- a/apps/desktop/electron/ssh-binary.ts
+++ b/apps/desktop/electron/ssh-binary.ts
@@ -1,0 +1,247 @@
+// Picks a working ssh executable on Windows. The Win32 OpenSSH client under
+// System32 is the usual choice, but on some machines that binary is broken —
+// it dies instantly (exit 255, no output, no console) even though the file
+// exists and the "OpenSSH Client" capability reports Installed (#103288).
+// Rather than trusting the path, each candidate is health-checked with
+// `ssh -V` and the first one that actually runs wins. Non-Windows platforms
+// keep the historical bare `ssh` (PATH resolution) untouched.
+import { spawn } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { findGitBash } from './find-git-bash'
+
+// Per-probe ceiling, and a total budget for the whole resolution so a chain
+// of hanging binaries cannot stall boot indefinitely. The final candidate
+// (the Git for Windows fallback when present) always gets probed — earlier
+// candidates are skipped once the budget can no longer cover them AND the
+// reserved final probe.
+const PROBE_TIMEOUT_MS = 4_000
+const TOTAL_PROBE_BUDGET_MS = 12_000
+const PROBE_KILL_GRACE_CAP_MS = 1_000
+
+export interface SshBinaryDeps {
+  platform?: NodeJS.Platform | string
+  env?: Record<string, string | undefined>
+  spawnFn?: any
+  fileExists?: (filePath: string) => boolean
+  log?: (line: string) => void
+  probeTimeoutMs?: number
+  budgetMs?: number
+}
+
+// Candidate paths are Windows paths regardless of host platform (unit tests
+// exercise this on POSIX CI hosts too), so always join with win32 semantics —
+// plain path.join would produce mixed forward-slash paths off Windows.
+const joinWin = path.win32.join
+
+// Resolve `ssh` against PATH so a bare-ssh candidate that points at the same
+// binary as an earlier candidate can be deduped instead of probed twice.
+function resolveSshOnPath(env: Record<string, string | undefined>, fileExists: (p: string) => boolean): string | null {
+  for (const dir of String(env.Path || env.PATH || '').split(';')) {
+    if (!dir.trim()) {
+      continue
+    }
+
+    const candidate = joinWin(dir, 'ssh.exe')
+
+    if (fileExists(candidate)) {
+      return candidate
+    }
+  }
+
+  return null
+}
+
+// Git for Windows bundles a full MSYS OpenSSH. Reuse the repo's existing Git
+// discovery (HERMES_GIT_BASH_PATH, PortableGit under %LOCALAPPDATA%\hermes\git,
+// ProgramFiles / ProgramFiles(x86), user-scoped install) and take the sibling
+// usr/bin/ssh.exe from the same install root.
+function gitSshCandidates(env: Record<string, string | undefined>, fileExists: (p: string) => boolean): string[] {
+  const bash = findGitBash({ isWindows: true, env, fileExists })
+
+  if (!bash) {
+    return []
+  }
+
+  const binDir = path.win32.dirname(bash)
+  const parent = path.win32.dirname(binDir)
+  const root =
+    path.win32.basename(binDir).toLowerCase() === 'bin'
+      ? path.win32.basename(parent).toLowerCase() === 'usr'
+        ? path.win32.dirname(parent) // <root>\usr\bin\bash.exe -> <root>
+        : parent // <root>\bin\bash.exe -> <root>
+      : binDir // custom layout: best effort, the probe decides
+
+  return [joinWin(root, 'usr', 'bin', 'ssh.exe')]
+}
+
+// Candidate order: explicit override, the Windows inbox OpenSSH client,
+// whatever PATH resolves, then the Git for Windows bundled MSYS OpenSSH.
+// Dedupe is case/separator-insensitive so e.g. a PATH-resolved ssh that IS
+// the System32 binary is not probed twice.
+export function sshBinaryCandidates(
+  env: Record<string, string | undefined>,
+  fileExists: (p: string) => boolean = fs.existsSync
+): string[] {
+  const candidates = [
+    env.HERMES_SSH_PATH,
+    joinWin(env.SystemRoot || 'C:\\Windows', 'System32', 'OpenSSH', 'ssh.exe'),
+    resolveSshOnPath(env, fileExists) || 'ssh',
+    ...gitSshCandidates(env, fileExists)
+  ]
+
+  const seen = new Set<string>()
+
+  return candidates.filter((c): c is string => {
+    if (!c || !c.trim()) {
+      return false
+    }
+
+    const key = c.replace(/\//g, '\\').toLowerCase()
+
+    if (seen.has(key)) {
+      return false
+    }
+
+    seen.add(key)
+
+    return true
+  })
+}
+
+// A candidate is healthy when `candidate -V` exits 0 and reports an OpenSSH
+// version string. A binary that is missing (spawn error), hangs, or dies
+// instantly with no output — the #103288 failure mode — is unhealthy. On
+// timeout the child is SIGKILLed and the probe waits for the close event (or
+// a short grace period) before settling, so a failed kill cannot leave a
+// zombie probe running in parallel with the next candidate.
+export function probeSshBinary(candidate: string, spawnFn: any, timeoutMs: number = PROBE_TIMEOUT_MS): Promise<boolean> {
+  return new Promise(resolve => {
+    let child
+
+    try {
+      child = spawnFn(candidate, ['-V'], { stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true })
+    } catch {
+      resolve(false)
+
+      return
+    }
+
+    let output = ''
+    let settled = false
+    let timedOut = false
+    let graceTimer: any = null
+
+    const finish = (healthy: boolean) => {
+      if (settled) {
+        return
+      }
+
+      settled = true
+      clearTimeout(timer)
+
+      if (graceTimer) {
+        clearTimeout(graceTimer)
+      }
+
+      resolve(healthy)
+    }
+
+    const timer = setTimeout(() => {
+      timedOut = true
+
+      try {
+        child.kill('SIGKILL')
+      } catch {
+        // already gone
+      }
+
+      // A successful kill reaps the child and `close` settles the probe; this
+      // grace timer only covers the kill having silently failed. The grace
+      // never exceeds the probe timeout itself, keeping short-timeout (test)
+      // probes fast.
+      graceTimer = setTimeout(() => finish(false), Math.min(PROBE_KILL_GRACE_CAP_MS, timeoutMs))
+      graceTimer.unref?.()
+    }, timeoutMs)
+
+    timer.unref?.()
+
+    // `ssh -V` prints to stdout on newer OpenSSH and stderr on older builds.
+    child.stdout?.on('data', d => {
+      output += d.toString()
+    })
+    child.stderr?.on('data', d => {
+      output += d.toString()
+    })
+    child.on('error', () => finish(false))
+    child.on('close', code => finish(!timedOut && code === 0 && /openssh/i.test(output)))
+  })
+}
+
+export async function resolveSshBinary({
+  platform = process.platform,
+  env = process.env,
+  spawnFn = spawn,
+  fileExists = fs.existsSync,
+  log = () => {},
+  probeTimeoutMs = PROBE_TIMEOUT_MS,
+  budgetMs = TOTAL_PROBE_BUDGET_MS
+}: SshBinaryDeps = {}): Promise<string> {
+  if (platform !== 'win32') {
+    return 'ssh'
+  }
+
+  const deadline = Date.now() + budgetMs
+  // The final candidate (the Git for Windows fallback when one was
+  // discovered) is guaranteed a full probe: earlier candidates only get
+  // budget that still leaves a complete final probe in reserve. A chain of
+  // hanging binaries therefore degrades to "skip the middle, still try the
+  // bundled fallback" instead of never reaching it.
+  const reserveMs = probeTimeoutMs + Math.min(PROBE_KILL_GRACE_CAP_MS, probeTimeoutMs)
+  const candidates = sshBinaryCandidates(env, fileExists)
+
+  for (let i = 0; i < candidates.length; i++) {
+    const candidate = candidates[i]
+    const isFinal = i === candidates.length - 1
+    const remaining = deadline - reserveMs - Date.now()
+
+    if (!isFinal && remaining <= 0) {
+      log(`[ssh] probe budget exhausted; skipping ${candidate} to preserve the final fallback probe`)
+
+      continue
+    }
+
+    const timeoutMs = isFinal ? probeTimeoutMs : Math.min(probeTimeoutMs, remaining)
+
+    // An explicit HERMES_SSH_PATH override that fails the health check is
+    // warned about but not fatal — the chain below may still find a working
+    // binary, which is strictly better than refusing to connect.
+    if (await probeSshBinary(candidate, spawnFn, timeoutMs)) {
+      log(`[ssh] using ssh binary: ${candidate}`)
+
+      return candidate
+    }
+
+    log(`[ssh] ssh candidate failed its health check: ${candidate}`)
+  }
+
+  // Nothing probed clean. Return the bare command so downstream errors read
+  // exactly like they did before this fallback existed.
+  log('[ssh] no working ssh binary found; falling back to bare "ssh"')
+
+  return 'ssh'
+}
+
+// The resolved binary cannot change while the app is running, so probe once
+// per process. The first caller's logger wins; later callers share the
+// cached result.
+let cachedSshBinary: Promise<string> | null = null
+
+export function getSshBinary(log?: (line: string) => void): Promise<string> {
+  if (!cachedSshBinary) {
+    cachedSshBinary = resolveSshBinary({ log })
+  }
+
+  return cachedSshBinary
+}

--- a/apps/desktop/electron/ssh-connection.ts
+++ b/apps/desktop/electron/ssh-connection.ts
@@ -36,6 +36,8 @@ import net from 'node:net'
 import os from 'node:os'
 import path from 'node:path'
 
+import { getSshBinary } from './ssh-binary'
+
 const DEFAULT_CONNECT_TIMEOUT_MS = 15_000
 const DEFAULT_EXEC_TIMEOUT_MS = 20_000
 const DEFAULT_FORWARD_TIMEOUT_MS = 15_000
@@ -404,7 +406,40 @@ function sshErrorMessage(kind, conn, stderr?) {
 
 // Resolves { code, stdout, stderr }. On timeout the child is SIGKILLed and the
 // promise rejects with err.kind = TIMEOUT. `spawnFn` is injectable for tests.
-function runSsh(args, { timeoutMs, spawnFn = spawn, stdin = 'ignore', stdinData, signal }: any = {}) {
+async function runSsh(args, { timeoutMs, spawnFn = spawn, stdin = 'ignore', stdinData, signal }: any = {}) {
+  // A custom spawnFn means the caller (tests) controls spawning entirely, so
+  // keep the literal 'ssh' and let injected children see unchanged argv. In
+  // production, resolve a binary that actually runs on this machine (#103288).
+  let sshBinary = 'ssh'
+
+  if (spawnFn === spawn) {
+    // The first resolution health-checks candidates (bounded by a total
+    // budget in ssh-binary). Race it against the caller's abort signal so a
+    // cancelled connect does not have to wait out the probe chain; the
+    // memoized resolution itself continues in the background.
+    let abortResolution: any
+    const aborted = new Promise<string>((_, reject) => {
+      abortResolution = reject
+    })
+    const onAbort = () => {
+      const error: any = new Error('SSH operation was cancelled.')
+      error.kind = 'superseded'
+      abortResolution(error)
+    }
+
+    if (signal?.aborted) {
+      onAbort()
+    } else {
+      signal?.addEventListener('abort', onAbort, { once: true })
+    }
+
+    try {
+      sshBinary = await Promise.race([getSshBinary(), aborted])
+    } finally {
+      signal?.removeEventListener('abort', onAbort)
+    }
+  }
+
   return new Promise((resolve, reject) => {
     if (signal?.aborted) {
       const error: any = new Error('SSH operation was cancelled.')
@@ -418,7 +453,7 @@ function runSsh(args, { timeoutMs, spawnFn = spawn, stdin = 'ignore', stdinData,
     let child
 
     try {
-      child = spawnFn('ssh', args, { stdio: [useStdinPipe ? 'pipe' : 'ignore', 'pipe', 'pipe'] })
+      child = spawnFn(sshBinary, args, { stdio: [useStdinPipe ? 'pipe' : 'ignore', 'pipe', 'pipe'] })
     } catch (error) {
       reject(error)
 
@@ -815,9 +850,22 @@ class SshConnection {
   // _handleNoMuxTunnelFlap (bounded restart) instead of poisoning isAlive()
   // outright — the old instant-poison path is how a ~10s local tunnel blip
   // cascaded into SIGTERM of a healthy backend (#96266).
-  _startNoMuxTunnelChild(tunnel: any, spec: string, args: string[], localPort: number | string) {
+  async _startNoMuxTunnelChild(tunnel: any, spec: string, args: string[], localPort: number | string) {
+    // Same rule as runSsh: an injected _spawnFn (tests) keeps the literal
+    // 'ssh'; production resolves a binary that runs on this machine (#103288).
+    const sshBinary = this._spawnFn === spawn ? await getSshBinary() : 'ssh'
+
+    // The await above opens a window where cancelForward/close can tear this
+    // tunnel down; spawning now would leak an ssh child nothing manages.
+    if (tunnel.stopping || this._tunnels.get(spec) !== tunnel) {
+      const error: any = new Error('tunnel was cancelled while resolving the ssh binary')
+      error.kind = 'superseded'
+      error.tunnelStderr = ''
+      throw error
+    }
+
     return new Promise<void>((resolve, reject) => {
-      const child = this._spawnFn('ssh', args, { stdio: ['ignore', 'ignore', 'pipe'] })
+      const child = this._spawnFn(sshBinary, args, { stdio: ['ignore', 'ignore', 'pipe'] })
       tunnel.child = child
       let stderr = ''
       let readyConfirmed = false
@@ -974,7 +1022,12 @@ class SshConnection {
       } catch (error: any) {
         try {
           await stopTunnelChild(tunnel.child)
-          this._tunnels.delete(spec)
+          // A newer forward() for the same spec may already have replaced
+          // the map entry while this one awaited the ssh-binary resolution;
+          // only delete the entry if it still belongs to this tunnel.
+          if (this._tunnels.get(spec) === tunnel) {
+            this._tunnels.delete(spec)
+          }
         } catch (stopError) {
           throw this._fail(stopError, SSH_ERROR.UNKNOWN)
         }
@@ -1017,7 +1070,13 @@ class SshConnection {
         }
 
         await stopTunnelChild(tunnel.child)
-        this._tunnels.delete(spec)
+
+        // Same ownership guard as forward(): a same-spec re-forward may have
+        // replaced the entry while the stop was awaited.
+        if (this._tunnels.get(spec) === tunnel) {
+          this._tunnels.delete(spec)
+        }
+
         this._logLine(`cancelled forward 127.0.0.1:${localPort}`)
       }
 

--- a/apps/desktop/electron/terminal-ipc.ts
+++ b/apps/desktop/electron/terminal-ipc.ts
@@ -12,6 +12,7 @@ import nodePty from 'node-pty'
 
 import { resolveTerminalConnectionForSender } from './connection-apply'
 import { ensureSpawnHelperExecutable } from './spawn-helper-perms'
+import { getSshBinary } from './ssh-binary'
 import { buildInteractiveSshArgs } from './ssh-connection'
 import { createTerminalOutputGate } from './terminal-output-gate'
 import { buildWindowsInteractiveCommand } from './windows-remote-lifecycle'
@@ -305,9 +306,9 @@ export function registerTerminalIpc({
 
     const ptyProcess = remote
       ? nodePty.spawn(
-          process.platform === 'win32'
-            ? path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'OpenSSH', 'ssh.exe')
-            : 'ssh',
+          // Health-checked ssh executable — the hardcoded System32 OpenSSH
+          // path can exist yet be unusable on Windows (#103288).
+          await getSshBinary(rememberLog),
           buildInteractiveSshArgs(sshTarget.ssh, String(payload?.cwd || '').trim(), undefined, remoteCommand),
           { cols, cwd: app.getPath('home'), env: terminalShellEnv(), name: 'xterm-256color', rows }
         )


### PR DESCRIPTION
## Problem

On some Windows machines the inbox OpenSSH client (`System32\OpenSSH\ssh.exe`) exists but is broken: it dies instantly with exit 255 and no output, no event-log entry, even for `ssh -V` — while the "OpenSSH Client" Windows capability still reports **Installed**. The desktop app hardcoded that path, so every SSH operation (connect, tunnel, remote terminal, `ssh -G` config resolution) failed and remote mode was unusable. Reinstalling the capability can fail too (`Add-WindowsCapability` error `0x800f0950`), leaving users with no working inbox binary at all. Affected machine confirmed on Windows 11 with both the inbox binary and the official Microsoft portable OpenSSH build dead, while Git for Windows' bundled MSYS OpenSSH works fine.

Closes #103288.

## Fix

Stop trusting any hardcoded path. At first use, health-check candidates with `ssh -V` (exit 0 + OpenSSH version string, 4s timeout) and use the first one that actually runs:

1. `HERMES_SSH_PATH` override — kept as the explicit escape hatch; if it fails the probe we warn and fall through instead of hard-failing
2. The inbox Windows OpenSSH client (`%SystemRoot%\System32\OpenSSH\ssh.exe`)
3. Bare `ssh` (PATH resolution)
4. Git for Windows bundled OpenSSH (`C:\Program Files\Git\usr\bin\ssh.exe`, then per-user `%LOCALAPPDATA%\Programs\Git\...`)

The resolution lives in a new shared `ssh-binary.ts` module, is memoized per process, and is used by **all** ssh spawn sites:

- `ssh-connection.ts` — `runSsh()` (every exec/forward/mux op) and the no-mux `-N -L` tunnel child (this is the site the original env-var-only patch missed, since it resolves `ssh` from PATH)
- `main.ts` — `hermes:ssh-config:resolve` and `effectiveSshConfigFingerprint`
- `terminal-ipc.ts` — the embedded remote terminal PTY spawn

If nothing probes clean, fall back to bare `ssh` so downstream errors read exactly as before this change. Non-Windows platforms keep the bare `ssh` untouched (no probing, zero behavior change), and tests injecting a custom `spawnFn` keep the literal `ssh` argv, so existing SSH-connection tests stay hermetic.

Each probe decision is logged (`[ssh] using ssh binary: ...` / `failed its health check`) to the desktop log for support diagnosis.

## Testing

- New `electron/ssh-binary.test.ts` (11 tests): candidate ordering/dedup, env override wins when healthy, broken override falls through, broken inbox binary falls back to Git for Windows, all-broken falls back to bare `ssh`, probe rejects non-OpenSSH/unspawnable binaries, non-Windows never probes, memoization.
- `npm run typecheck` clean.
- `vitest run --project electron`: new tests all pass; the pre-existing Windows-platform failures in `ssh-connection.test.ts` are byte-identical before/after this change (verified via `git stash` A/B runs).
- Live-verified on the originally broken machine: the built desktop app now auto-detects the Git for Windows ssh and connects to the remote backend with no env var set.
