### PR TITLE
Fix/whatsapp self chat guard

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -43,6 +43,8 @@ import {
   extractBridgeEvent,
   inboundReadReceiptKeys,
   inferMediaType,
+  isBotInteractionMessage,
+  isCanonicalSelfChat,
   mediaPayloadForFile,
   pollCreationMessageFromPayload,
   pollUpdateForAggregation,
@@ -555,6 +557,16 @@ async function startSocket() {
         messageKeys: Object.keys(msg.message || {}),
       });
 
+      if (WHATSAPP_MODE === 'self-chat' && isBotInteractionMessage(msg)) {
+        emitDebugEvent({
+          stage: 'ignored',
+          reason: 'self_chat_bot_interaction',
+          chatId: redactWhatsAppId(chatId),
+          senderId: redactWhatsAppId(senderId),
+        });
+        continue;
+      }
+
       // Handle fromMe messages based on mode
       let fromOwner = false;
       if (msg.key.fromMe) {
@@ -606,10 +618,11 @@ async function startSocket() {
           // WhatsApp now uses LID (Linked Identity Device) format: 67427329167522@lid
           // AND classic format: 34652029134@s.whatsapp.net
           // sock.user has both: { id: "number:10@s.whatsapp.net", lid: "lid_number:10@lid" }
-          const myNumber = (sock.user?.id || '').replace(/:.*@/, '@').replace(/@.*/, '');
-          const myLid = (sock.user?.lid || '').replace(/:.*@/, '@').replace(/@.*/, '');
-          const chatNumber = chatId.replace(/@.*/, '');
-          const isSelfChat = (myNumber && chatNumber === myNumber) || (myLid && chatNumber === myLid);
+          const isSelfChat = isCanonicalSelfChat({
+            chatId,
+            accountId: sock.user?.id,
+            accountLid: sock.user?.lid,
+          });
           emitDebugEvent({
             stage: 'self_chat_check',
             matched: !!isSelfChat,

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -19,6 +19,8 @@ import {
   appendMediaFailureNote,
   extractBridgeEvent,
   inboundReadReceiptKeys,
+  isBotInteractionMessage,
+  isCanonicalSelfChat,
   mediaPayloadForFile,
   pollCreationMessageFromPayload,
   pollUpdateForAggregation,
@@ -43,6 +45,43 @@ import {
   assert.equal(receiptKeys[0], groupKey);
   assert.equal(receiptKeys[0].participant, groupKey.participant);
   console.log('  ✓ inbound read receipts preserve the original group message key');
+}
+
+// -- self-chat bot isolation ---------------------------------------------
+{
+  assert.equal(isBotInteractionMessage({
+    key: { remoteJid: '15551234567@s.whatsapp.net', fromMe: true },
+    message: { conversation: 'ordinary self-chat message' },
+  }), false);
+  assert.equal(isBotInteractionMessage({
+    key: { remoteJid: '15551234567@s.whatsapp.net', fromMe: true },
+    message: { botInvokeMessage: { message: { conversation: 'ask Meta AI' } } },
+  }), true);
+  assert.equal(isBotInteractionMessage({
+    key: { remoteJid: '15551234567@s.whatsapp.net', fromMe: true },
+    botTargetId: '13135550002@bot',
+    message: { conversation: 'ask a bot' },
+  }), true);
+  assert.equal(isBotInteractionMessage({
+    key: { remoteJid: '13135550002@bot', fromMe: true },
+    message: { conversation: 'direct bot chat' },
+  }), true);
+  console.log('  ✓ self-chat bot interactions are isolated from Hermes');
+}
+
+{
+  const account = {
+    accountId: '1555010:12@s.whatsapp.net',
+    accountLid: '155501234567890:12@lid',
+  };
+  assert.equal(isCanonicalSelfChat({ chatId: '155501234567890@lid', ...account }), true);
+  assert.equal(isCanonicalSelfChat({ chatId: '1555010@s.whatsapp.net', ...account }), false);
+  assert.equal(isCanonicalSelfChat({
+    chatId: '1555010@s.whatsapp.net',
+    accountId: account.accountId,
+    accountLid: '',
+  }), true);
+  console.log('  ✓ LID self-chat identity takes precedence over legacy PN mirrors');
 }
 
 // -- quoted outbound text -------------------------------------------------

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -506,6 +506,50 @@ export function inboundReadReceiptKeys({ key, enabled }) {
   return [key];
 }
 
+// Meta AI and other WhatsApp bots can surface owner prompts as fromMe events
+// in the account's own PN chat. Reject explicit bot metadata before the
+// self-chat gate mistakes those prompts for messages sent to Hermes.
+export function isBotInteractionMessage(msg) {
+  const key = msg?.key || {};
+  const message = msg?.message || {};
+  const jids = [
+    key.remoteJid,
+    key.remoteJidAlt,
+    key.participant,
+    key.participantAlt,
+    msg?.botMessageInvokerJid,
+    msg?.botTargetId,
+  ];
+  const hasBotJid = jids.some(jid => typeof jid === 'string' && jid.endsWith('@bot'));
+
+  return Boolean(
+    hasBotJid
+    || msg?.botMessageInvokerJid
+    || msg?.botTargetId
+    || msg?.is1PBizBotMessage
+    || msg?.isSupportAiMessage
+    || message.botInvokeMessage
+    || message.botTaskMessage
+    || message.botForwardedMessage
+    || message.richResponseMessage
+  );
+}
+
+// Modern WhatsApp accounts expose a Linked Identity (LID) for the real
+// self-chat. Prefer it exclusively when available: Meta AI owner prompts can
+// be mirrored under the account's legacy phone-number JID and must not cross
+// into Hermes. Older accounts without a LID retain the PN fallback.
+export function isCanonicalSelfChat({ chatId, accountId, accountLid }) {
+  const chatNumber = String(chatId || '').replace(/@.*/, '');
+  const lidNumber = String(accountLid || '').replace(/:.*@/, '@').replace(/@.*/, '');
+  if (lidNumber) {
+    return String(chatId || '').endsWith('@lid') && chatNumber === lidNumber;
+  }
+
+  const accountNumber = String(accountId || '').replace(/:.*@/, '@').replace(/@.*/, '');
+  return Boolean(accountNumber && chatNumber === accountNumber);
+}
+
 export function mediaPayloadForFile({ buffer, filePath, mediaType, caption, fileName }) {
   const ext = filePath.toLowerCase().split('.').pop();
   const type = mediaType || inferMediaType(ext);


### PR DESCRIPTION
## What does this PR do?

Self-chat detection used a loose OR-comparison against both the account
LID and the legacy phone-number JID, so non-self chats reached via the
PN identity (Meta AI interactions) were misclassified as self-chat and
ingested as agent commands.

This PR solves unintended Hermes API calls, agent interruption, and message loops when whatsapp gateway user sends a message to Meta's new "Meta AI" tool in Whatsapp, with self-chat mode.

## Related Issue

[https://github.com/NousResearch/hermes-agent/issues/103281]

## Fixes:

**Primary fix:** `isCanonicalSelfChat()` — when the account has a LID,
only LID chatIds match; older accounts without a LID keep the PN fallback.

**Second layer:** `isBotInteractionMessage()` — bot-interaction messages
(bot JIDs, `botInvokeMessage`, `isSupportAiMessage`) are ignored in
self-chat mode before the gate, so prompts the user sends to WhatsApp
bots are never treated as commands.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- Implemented fixes with new methods in /scripts/whatsapp-bridge/bridge_helpers.js
- Connected 'isBotInteractionMessage' and 'isCanonicalSelfChat' to the main bridge script: scripts/whatsapp-bridge/bridge.js 
- Updated tests to verify fix: scripts/whatsapp-bridge/bridge.native.test.mjs

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Setup whatsapp gateway for hermes, in self-chat mode
2. Navigate to the "Meta AI" tool in Whatsapp. Send a test message.
3. Check Hermes session in whatsapp for test message bleed-thru.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [Yes] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [Yes - whatsapp gateway same on all platforms)] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A