### PR TITLE
fix(fallback): consult host_mandated_api_mode so Kimi Coding fallback…

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1801,6 +1801,15 @@ def _is_anthropic_wire_url(url: str) -> bool:
     return url.rstrip("/").lower().endswith("/anthropic") or base_url_hostname(url) == "api.anthropic.com"
 
 
+def _host_mandated_api_mode_cached(url: str):
+    """host_mandated_api_mode() with ImportError/exception tolerance (None = not mandated)."""
+    try:
+        from hermes_cli.providers import host_mandated_api_mode
+        return host_mandated_api_mode(url)
+    except Exception:
+        return None
+
+
 def _fallback_api_mode_hint(fb: dict, fb_provider: str, fb_base_url_hint: Optional[str]) -> tuple[bool, str]:
     """(explicit, api_mode) for a fallback entry from its ORIGINAL base_url: resolve_provider_client()
     rewrites a dual-surface /anthropic base to /v1, losing the Anthropic wire signal. An explicit
@@ -1811,12 +1820,34 @@ def _fallback_api_mode_hint(fb: dict, fb_provider: str, fb_base_url_hint: Option
         return True, explicit
     if fb_provider == "anthropic" or (fb_base_url_hint and _is_anthropic_wire_url(fb_base_url_hint)):
         return False, "anthropic_messages"
+    # Host-mandated wire protocols: some endpoints accept exactly one protocol
+    # (Kimi Coding api.kimi.com/coding speaks native Anthropic Messages).
+    # resolve_provider_client() routes the hint through _to_openai_base_url(),
+    # which APPENDS /v1 for Kimi (/coding → /coding/v1), so the pre-resolve
+    # pass must consult host_mandated_api_mode() — the same source of truth the
+    # primary path uses — or a named kimi-coding entry (no explicit base_url)
+    # still resolves to chat_completions here. Explicit api_mode above always wins.
+    if fb_base_url_hint:
+        mandated = _host_mandated_api_mode_cached(fb_base_url_hint)
+        if mandated is not None:
+            return False, mandated
     return False, "chat_completions"
 
 
 def _fallback_api_mode_resolved(agent, fb_provider: str, fb_model: str, fb_base_url: str) -> str:
     """Re-detect api_mode from provider / resolved base URL / model when the hint pass
     landed on the chat_completions default (never called for an explicit api_mode)."""
+    # Host-mandated wire protocols first: the resolved client base_url for Kimi
+    # Coding has already been rewritten to .../coding/v1 by _to_openai_base_url(),
+    # so the /anthropic-suffix and api.anthropic.com checks below never fire for it.
+    # Ask the same host_mandated_api_mode() the primary path consults, or a
+    # kimi-coding fallback is driven over the OpenAI wire
+    # (POST /coding/chat/completions → 404). Also covers entries whose base_url
+    # is resolved from provider config rather than the fallback entry (the
+    # pre-resolve hint pass never saw it).
+    mandated = _host_mandated_api_mode_cached(fb_base_url)
+    if mandated is not None:
+        return mandated
     if fb_provider == "openai-codex":
         return "codex_responses"
     if fb_provider in {"nous", "nous-portal", "nousresearch"}:

--- a/tests/run_agent/test_fallback_host_mandated_api_mode.py
+++ b/tests/run_agent/test_fallback_host_mandated_api_mode.py
@@ -1,0 +1,131 @@
+"""Regression tests: fallback entries on host-mandated single-protocol
+endpoints (Kimi Coding api.kimi.com/coding) must resolve to the correct
+api_mode, not the OpenAI chat_completions default.
+
+Bug: ``try_activate_fallback()`` determined api_mode with its own provider
+list and never consulted ``host_mandated_api_mode()``. A named
+``kimi-coding`` fallback entry (no explicit base_url) resolved its client
+to ``https://api.kimi.com/coding/v1`` (via ``_to_openai_base_url()``), the
+/anthropic-suffix and api.anthropic.com checks did not match, and the swap
+drove the session over the OpenAI wire — POST /coding/chat/completions →
+HTTP 404 on every attempt (6 retries), then the chain skipped the entry.
+The primary path was unaffected (it consults host_mandated_api_mode()).
+"""
+
+from unittest.mock import MagicMock, patch
+
+from agent import chat_completion_helpers
+from run_agent import AIAgent
+
+from tests.run_agent.test_provider_fallback import _make_agent, _mock_client
+
+
+class TestKimiFallbackApiMode:
+    """kimi-coding fallback must land on anthropic_messages."""
+
+    @staticmethod
+    def _kimi_fb_client():
+        # What resolve_provider_client() returns for kimi-coding after
+        # _to_openai_base_url() rewrites /coding → /coding/v1.
+        return _mock_client(base_url="https://api.kimi.com/coding/v1")
+
+    def test_resolved_client_url_consults_host_mandated_mode(self):
+        """Post-resolve pass: .../coding/v1 must map to anthropic_messages."""
+        agent = _make_agent(
+            fallback_model=[{"provider": "kimi-coding", "model": "kimi-k3"}]
+        )
+        agent._fallback_chain = [
+            {"provider": "kimi-coding", "model": "kimi-k3"}
+        ]
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(self._kimi_fb_client(), "kimi-k3"),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.provider == "kimi-coding"
+        assert agent.api_mode == "anthropic_messages"
+
+    def test_pre_resolve_hint_consults_host_mandated_mode(self):
+        """Pre-resolve pass: explicit base_url hint .../coding wins too."""
+        agent = _make_agent(
+            fallback_model=[
+                {
+                    "provider": "kimi-coding",
+                    "model": "kimi-k3",
+                    "base_url": "https://api.kimi.com/coding",
+                }
+            ]
+        )
+        agent._fallback_chain = [
+            {
+                "provider": "kimi-coding",
+                "model": "kimi-k3",
+                "base_url": "https://api.kimi.com/coding",
+            }
+        ]
+
+        captured = {}
+
+        def fake_resolve(provider, model=None, raw_codex=True,
+                         explicit_base_url=None, explicit_api_key=None,
+                         api_mode=None):
+            captured["api_mode"] = api_mode
+            return _mock_client(base_url="https://api.kimi.com/coding/v1"), model
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            side_effect=fake_resolve,
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert captured["api_mode"] == "anthropic_messages"
+        assert agent.api_mode == "anthropic_messages"
+
+    def test_explicit_api_mode_entry_not_overridden(self):
+        """An explicit fb.api_mode (even chat_completions) stays pinned."""
+        agent = _make_agent(
+            fallback_model=[
+                {
+                    "provider": "kimi-coding",
+                    "model": "kimi-k3",
+                    "api_mode": "chat_completions",
+                }
+            ]
+        )
+        agent._fallback_chain = [
+            {
+                "provider": "kimi-coding",
+                "model": "kimi-k3",
+                "api_mode": "chat_completions",
+            }
+        ]
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(self._kimi_fb_client(), "kimi-k3"),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.api_mode == "chat_completions"
+
+    def test_openai_wire_provider_unchanged(self):
+        """Regression guard: plain OpenAI-wire fallbacks stay chat_completions."""
+        agent = _make_agent(
+            fallback_model=[{"provider": "deepseek", "model": "deepseek-chat"}]
+        )
+        agent._fallback_chain = [
+            {"provider": "deepseek", "model": "deepseek-chat"}
+        ]
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(
+                _mock_client(base_url="https://api.deepseek.com/v1"),
+                "deepseek-chat",
+            ),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.api_mode == "chat_completions"


### PR DESCRIPTION
Supersedes #96904 (same fix, rebased onto current `main` after the b2b0e340/0e1875e8 helpers refactor — the fix now lives inside `_fallback_api_mode_hint()` / `_fallback_api_mode_resolved()`).

## Summary

A named `kimi-coding` fallback entry (no explicit `base_url`) always failed with `HTTP 404: The requested resource was not found` — all 6 retries, then the chain skipped the entry.

### Root cause

`try_activate_fallback()` resolved the client for `kimi-coding` to `https://api.kimi.com/coding/v1` (via `_to_openai_base_url()`), but both api_mode detection passes missed the endpoint:

- the **pre-resolve pass** only checked `/anthropic` suffixes and `api.anthropic.com` on the user-supplied `base_url` hint (absent for a named provider entry);
- the **post-resolve pass** checked the same shapes on the resolved client URL — but Kimi's rewritten URL ends in `/coding/v1`, not `/anthropic`, and its host is `api.kimi.com`.

Kimi's `/coding` endpoint only speaks the Anthropic Messages wire, so the swap drove the session over OpenAI `chat_completions` → `POST /coding/chat/completions` → 404 on every attempt.

The primary path was unaffected: it consults `host_mandated_api_mode()` (`hermes_cli/providers.py`), which already knows about `api.kimi.com/coding`, `api.anthropic.com`, `api.openai.com`, and Bedrock runtime hosts. This is the third sibling of the same bug class (#32243, #49247 fixed two earlier shape-detection gaps by extending the heuristics by hand).

### Fix

Both passes in `try_activate_fallback()` now ask `host_mandated_api_mode()` first — the same source of truth the primary path uses — and fall back to the existing shape heuristics only when it returns `None`:

- pre-resolve pass: consults it on the `base_url` hint (when present);
- post-resolve pass: consults it on the resolved client URL (covers named provider entries whose base_url comes from the provider config — the pre-resolve pass never sees those).

An explicit `fb.api_mode` on the fallback entry still wins and is never overridden.

## Reproduction

Config:

```yaml
fallback_providers:
- model: kimi-k3
  provider: kimi-coding
```

Kill the primary provider (e.g. point it at a dead port). Pre-fix logs:

```
WARNING agent.conversation_loop: API call failed (attempt N/6) error_type=NotFoundError provider=kimi-coding base_url=https://api.kimi.com/coding model=kimi-k3 summary=HTTP 404: The requested resource was not found
```

The same model works fine as the primary (`hermes chat -m kimi-k3 --provider kimi-coding`), which is what made this confusing to diagnose.

## Test plan

- [x] New regression tests: `tests/run_agent/test_fallback_host_mandated_api_mode.py` (4 tests — resolved-URL pass, pre-resolve hint pass, explicit `api_mode` pin respected, plain OpenAI-wire provider unchanged)
- [x] Existing fallback suite green: `test_provider_fallback.py` + `test_fallback_credential_isolation.py` + `test_24996_fallback_exhaustion_cooldown.py` — 41 passed
- [x] E2E on Windows against the live endpoint: primary pointed at a dead port, `kimi-coding` fallback answered through the Anthropic wire

Follows the repo's "extend, don't duplicate" rule: no new heuristics list — the fallback chain now consumes the same mandate table the primary path already maintains.