### PR TITLE
fix(cron): intersect job toolsets with origin platform (fail-closed)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1719,6 +1719,9 @@ def create_job(
 
     raw = locals()
     f = {key: norm(raw[key]) for key, norm in _CREATE_FIELD_NORMALIZERS.items()}
+    from cron.scheduler import clamp_cron_enabled_toolsets_to_origin
+    f["enabled_toolsets"] = clamp_cron_enabled_toolsets_to_origin(
+        f["enabled_toolsets"], origin)
     normalized_skills = _normalize_skill_list(skill, skills)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
     normalized_reasoning_effort = _normalize_reasoning_effort(reasoning_effort)
@@ -1923,6 +1926,10 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
         _normalize_job_updates(job, updates)
         previous_inference_axes = _normalized_inference_axes(job)
         updated = _apply_skill_fields({**job, **updates})
+        if "enabled_toolsets" in updates:
+            from cron.scheduler import clamp_cron_enabled_toolsets_to_origin
+            updated["enabled_toolsets"] = clamp_cron_enabled_toolsets_to_origin(
+                updated.get("enabled_toolsets"), updated.get("origin"))
         _reject_terminal_activation(job, updated, job_id)
         # Re-check on the MERGED record; scoped to changed fields so legacy records keep loading.
         if {"monitor_script", "monitor_url", "no_agent", "script"}.intersection(updates):

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -431,29 +431,114 @@ def _merge_mcp_into_per_job_toolsets(per_job: list[str], cfg: dict) -> list[str]
     return result
 
 
-def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
-    """Toolset list for a cron job. Precedence: per-job ``enabled_toolsets`` (+ MCP merge) >
-    ``cron`` platform config (``_get_platform_tools``, which strips _DEFAULT_OFF_TOOLSETS so fresh
-    installs run without ``moa``) > ``None`` on any failure (full default set).
+def _job_origin_platform(job: dict | None) -> str | None:
+    """``origin.platform`` when it is a non-blank string; else None.
 
-    1. Per-job ``enabled_toolsets`` (set via ``cronjob`` tool on create/update). Keeps the agent's
-    job-scoped toolset override intact — #6130. Enabled MCP servers are layered on per
-    ``_merge_mcp_into_per_job_toolsets`` so a native-toolset allowlist does not silently strip MCP tools. 2.
-    Mirrors gateway behavior (``_get_platform_tools(cfg, platform_key)``) so users can gate cron toolsets
-    globally without recreating every job. 3. ``None`` on any lookup failure — AIAgent loads the full
-    default set (legacy behavior before this change, preserved as the safety net).
+    Non-dict origins (legacy provenance strings) are missing, matching
+    ``_resolve_origin``.
     """
-    per_job = job.get("enabled_toolsets")
-    if per_job:
-        return _merge_mcp_into_per_job_toolsets(list(per_job), cfg or {})
+    if not isinstance(job, dict):
+        return None
+    origin = job.get("origin")
+    if not isinstance(origin, dict):
+        return None
+    plat = origin.get("platform")
+    if isinstance(plat, str) and plat.strip():
+        return plat.strip()
+    return None
+
+
+def _cfg_for_platform_tools(cfg: dict | None) -> dict:
+    """``_get_platform_tools`` reads top-level ``platform_toolsets``.
+
+    Promote a non-empty ``tools.platform_toolsets`` map when the top-level key
+    is missing so a hermetic config (and any wrapped shape) still intersects.
+    """
+    cfg = cfg or {}
+    pts = cfg.get("platform_toolsets")
+    if isinstance(pts, dict) and pts:
+        return cfg
+    tools = cfg.get("tools")
+    nested = tools.get("platform_toolsets") if isinstance(tools, dict) else None
+    if isinstance(nested, dict) and nested:
+        return {**cfg, "platform_toolsets": nested}
+    return cfg
+
+
+def clamp_cron_enabled_toolsets_to_origin(
+    enabled_toolsets: list[str] | None,
+    origin: dict | None,
+    cfg: dict | None = None,
+) -> list[str] | None:
+    """Create/update choke: never persist more toolsets than the origin platform.
+
+    Missing origin (CLI/dashboard) leaves the list unchanged. Lookup failure
+    refuses to persist the unclamped grant (returns None → inherit at fire).
+    """
+    requested = [str(t).strip() for t in (enabled_toolsets or []) if str(t).strip()]
+    if not requested:
+        return None
+    plat = None
+    if isinstance(origin, dict):
+        raw = origin.get("platform")
+        if isinstance(raw, str) and raw.strip():
+            plat = raw.strip()
+    if not plat:
+        return requested
     try:
-        from hermes_cli.tools_config import _get_platform_tools  # lazy: avoid heavy import at cron module load
-        return sorted(_get_platform_tools(cfg or {}, "cron"))
+        from hermes_cli.tools_config import _get_platform_tools  # lazy
+        if cfg is None:
+            cfg = load_config() or {}
+        origin_tools = set(_get_platform_tools(_cfg_for_platform_tools(cfg), plat))
     except Exception as exc:
         logger.warning(
-            "Cron toolset resolution failed, falling back to full default toolset: %s",
-            exc)
+            "Cron toolset clamp at persist failed; not storing unclamped list: %s",
+            exc,
+        )
         return None
+    clamped = [t for t in requested if t in origin_tools]
+    return clamped or None
+
+
+def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str]:
+    """Toolset list for a cron job. A cron never has more permissions than who created it.
+
+    Precedence:
+    1. Origin platform (``job.origin.platform``) when present. Missing origin
+       (CLI/dashboard) falls back to the ``cron`` platform.
+    2. If per-job ``enabled_toolsets`` is set, INTERSECT with that platform
+       list, then layer MCP via ``_merge_mcp_into_per_job_toolsets``. Without
+       an origin the per-job list still wins outright (#6130 for CLI jobs).
+    3. If no per-job list, use the origin platform list (or ``cron`` when
+       origin is missing).
+    4. Any lookup failure → ``[]`` (fail-closed). Never ``None``: that used
+       to load the full default set, including terminal.
+    """
+    try:
+        from hermes_cli.tools_config import _get_platform_tools  # lazy: avoid heavy import at cron module load
+        cfg = _cfg_for_platform_tools(cfg)
+        origin_plat = _job_origin_platform(job)
+        per_job = job.get("enabled_toolsets")
+
+        origin_tools = None
+        if origin_plat:
+            origin_tools = set(_get_platform_tools(cfg, origin_plat))
+
+        if per_job:
+            requested = [str(t).strip() for t in per_job if str(t).strip()]
+            if origin_tools is not None:
+                requested = [t for t in requested if t in origin_tools]
+            return _merge_mcp_into_per_job_toolsets(requested, cfg)
+
+        if origin_tools is not None:
+            return sorted(origin_tools)
+        return sorted(_get_platform_tools(cfg, "cron"))
+    except Exception as exc:
+        logger.warning(
+            "Cron toolset resolution failed, failing closed (empty toolset, no terminal): %s",
+            exc,
+        )
+        return []
 
 
 def _resolve_job_reasoning_config(job: dict, cfg: dict, model: str) -> dict | None:

--- a/tests/cron/test_cron_toolset_origin_clamp.py
+++ b/tests/cron/test_cron_toolset_origin_clamp.py
@@ -1,0 +1,41 @@
+"""Create/update clamp for H3: a persisted job never stores more toolsets than origin."""
+
+from cron.scheduler import clamp_cron_enabled_toolsets_to_origin, _resolve_cron_enabled_toolsets
+
+
+CFG = {
+    "platform_toolsets": {
+        "whatsapp_cloud": ["web", "file", "memory"],
+        "telegram": ["web", "file", "memory"],
+    }
+}
+
+
+def test_clamp_strips_terminal_when_origin_lacks_it():
+    out = clamp_cron_enabled_toolsets_to_origin(
+        ["terminal", "file", "web"],
+        {"platform": "whatsapp_cloud"},
+        CFG,
+    )
+    assert out is not None
+    assert "terminal" not in out
+    assert "file" in out and "web" in out
+
+
+def test_clamp_leaves_cli_list_when_origin_missing():
+    out = clamp_cron_enabled_toolsets_to_origin(
+        ["web", "terminal"],
+        None,
+        CFG,
+    )
+    assert out == ["web", "terminal"]
+
+
+def test_resolver_no_origin_keeps_per_job_list():
+    """CLI jobs (retro_chase) keep an explicit terminal pin."""
+    result = _resolve_cron_enabled_toolsets(
+        {"enabled_toolsets": ["terminal", "file"]},
+        {"mcp_servers": {}},
+    )
+    assert "terminal" in result
+    assert "file" in result

--- a/tests/cron/test_cron_toolset_origin_intersect.py
+++ b/tests/cron/test_cron_toolset_origin_intersect.py
@@ -1,0 +1,104 @@
+"""Known-bad control para H3 (sin dependencia de pytest: corre igual en 3.11 y 3.12)
+
+Original doc:
+Known-bad control para H3: un cron nunca tiene mas permisos que quien lo creo.
+
+Debe correr ROJO contra el codigo de hoy (`_resolve_cron_enabled_toolsets` da
+precedencia absoluta a `job['enabled_toolsets']` sin mirar `origin.platform`) y
+VERDE con el fix B4-8 (b). Hermetico: no lee configs de la maquina.
+
+Destino con el fix: tests/cron/test_cron_toolset_origin_intersect.py
+"""
+from cron.scheduler import _resolve_cron_enabled_toolsets
+
+# Config minima: whatsapp_cloud sin terminal / code_execution, como la flota.
+CFG = {
+    "tools": {
+        "platform_toolsets": {
+            "whatsapp_cloud": ["web", "file", "memory"],
+            "telegram": ["web", "file", "memory"],
+        }
+    }
+}
+
+
+def _job(**kw):
+    job = {
+        "id": "test0001",
+        "enabled": True,
+        "origin": {"platform": "whatsapp_cloud"},
+    }
+    job.update(kw)
+    return job
+
+
+def test_job_no_puede_darse_terminal_desde_una_plataforma_sin_terminal():
+    """El agente pide terminal en un cron creado desde WhatsApp: no debe resolverlo."""
+    resolved = _resolve_cron_enabled_toolsets(
+        _job(enabled_toolsets=["terminal", "file", "web"]), CFG
+    ) or []
+    assert "terminal" not in resolved, (
+        "un cron creado desde whatsapp_cloud resolvio terminal: "
+        f"{sorted(resolved)}"
+    )
+
+
+def test_job_conserva_lo_que_su_plataforma_si_permite():
+    """La interseccion no debe vaciar el job: lo permitido sobrevive."""
+    resolved = _resolve_cron_enabled_toolsets(
+        _job(enabled_toolsets=["terminal", "file", "web"]), CFG
+    ) or []
+    assert "file" in resolved and "web" in resolved, sorted(resolved)
+
+
+def test_sin_lista_hereda_de_su_plataforma_de_origen_no_de_cron():
+    """58/60 jobs de Mia no traen lista. Hoy caen a `cron` (28 toolsets con terminal)."""
+    resolved = _resolve_cron_enabled_toolsets(_job(), CFG) or []
+    assert "terminal" not in resolved, (
+        f"job sin lista heredo terminal: {sorted(resolved)}"
+    )
+
+
+def _terminal_no_se_gana_por_cron(plataforma):
+    resolved = _resolve_cron_enabled_toolsets(
+        _job(origin={"platform": plataforma}, enabled_toolsets=["terminal"]), CFG
+    ) or []
+    assert "terminal" not in resolved, f"{plataforma}: {sorted(resolved)}"
+
+
+def test_whatsapp_cloud_no_gana_terminal_por_cron():
+    _terminal_no_se_gana_por_cron("whatsapp_cloud")
+
+
+def test_telegram_no_gana_terminal_por_cron():
+    _terminal_no_se_gana_por_cron("telegram")
+
+
+def test_resolver_que_falla_es_fail_closed_no_default_completo():
+    """(d) de Fable: si el resolver revienta, el job NO debe recibir terminal.
+
+    Hoy `_resolve_cron_enabled_toolsets` devuelve None en el `except`, y None
+    significa 'AIAgent carga el set default completo' — con terminal,
+    code_execution, browser y computer_use. Es la fuente
+    `full_default_on_resolve_fail` que Fable vio en los 7 jobs de arq-staging.
+
+    Sin `monkeypatch` a proposito: asi este caso tambien corre en el
+    interprete real del gateway (3.11, sin pytest), no solo bajo pytest.
+    """
+    import hermes_cli.tools_config as tc
+
+    def _boom(*a, **kw):
+        raise RuntimeError("config ilegible")
+
+    original = tc._get_platform_tools
+    tc._get_platform_tools = _boom
+    try:
+        resolved = _resolve_cron_enabled_toolsets(_job(), CFG)
+    finally:
+        tc._get_platform_tools = original
+
+    assert resolved is not None, (
+        "el resolver fallo y devolvio None = set default completo con terminal "
+        "(fail-open); debe ser fail-closed"
+    )
+    assert "terminal" not in resolved, sorted(resolved)

--- a/tests/cron/test_cronjob_schema.py
+++ b/tests/cron/test_cronjob_schema.py
@@ -19,3 +19,14 @@ def test_cronjob_schema_action_description_flags_create_requirements():
     assert "REQUIRED" in action_desc
 
 
+def test_cronjob_schema_does_not_suggest_terminal():
+    """H3 (c): the schema must not prompt the model to request terminal."""
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    desc = CRONJOB_SCHEMA["parameters"]["properties"]["enabled_toolsets"]["description"]
+    lowered = desc.lower()
+    assert "use \"terminal\"" not in lowered
+    assert '"terminal"' not in lowered
+    assert "never receives more toolsets than the platform" in lowered
+
+

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -63,6 +63,12 @@ from tools.cronjob_job_args import (
 from tools.registry import registry, tool_error
 
 
+def _clamp_enabled_toolsets_for_origin(enabled_toolsets, origin):
+    """Persist-time intersect: a cron never stores more toolsets than its origin platform."""
+    from cron.scheduler import clamp_cron_enabled_toolsets_to_origin
+    return clamp_cron_enabled_toolsets_to_origin(enabled_toolsets, origin)
+
+
 def _dumps(payload: Dict[str, Any]) -> str:
     return json.dumps(payload, indent=2)
 
@@ -566,7 +572,9 @@ def _action_create(a: Dict[str, Any]) -> str:
             model=_normalize_optional_job_value(a["model"]), provider=_normalize_optional_job_value(a["provider"]),
             base_url=_normalize_optional_job_value(a["base_url"], strip_trailing_slash=True),
             script=_normalize_optional_job_value(script), context_from=context_from,
-            enabled_toolsets=a["enabled_toolsets"] or None, workdir=_normalize_optional_job_value(a["workdir"]),
+            enabled_toolsets=_clamp_enabled_toolsets_for_origin(
+                a["enabled_toolsets"] or None, _origin_from_env()),
+            workdir=_normalize_optional_job_value(a["workdir"]),
             no_agent=_no_agent, attach_to_session=a["attach_to_session"],
             monitor_script=_normalize_optional_job_value(a["monitor_script"]),
             monitor_url=_normalize_optional_job_value(a["monitor_url"]),
@@ -766,7 +774,8 @@ def _update_context_from(job: Dict[str, Any], a: Dict[str, Any], updates: Dict[s
 def _update_run_fields(job: Dict[str, Any], a: Dict[str, Any], updates: Dict[str, Any]) -> Optional[str]:
     """enabled_toolsets / attach_to_session / workdir / no_agent / repeat / schedule."""
     if a["enabled_toolsets"] is not None:
-        updates["enabled_toolsets"] = a["enabled_toolsets"] or None
+        updates["enabled_toolsets"] = _clamp_enabled_toolsets_for_origin(
+            a["enabled_toolsets"] or None, job.get("origin"))
     if a["attach_to_session"] is not None:
         updates["attach_to_session"] = bool(a["attach_to_session"])
     if a["workdir"] is not None:
@@ -967,7 +976,7 @@ Jobs run in a fresh session with no current-chat context, so prompts must be sel
             "enabled_toolsets": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": "Optional toolset names to restrict the job's agent to (e.g. [\"web\", \"terminal\"]) — cuts token overhead. Infer from the prompt. Omit for all default tools. On update, [] clears."
+                "description": "Optional toolset names to restrict the job's agent to (e.g. [\"web\", \"file\"]). Infer from the prompt. A cron never receives more toolsets than the platform that created it. Omit to inherit that platform's tools. On update, [] clears."
             },
             "workdir": {
                 "type": "string",


### PR DESCRIPTION
## Summary

A cron job created from a chat platform (WhatsApp, Telegram, …) must not receive more tools than that platform. Today `_resolve_cron_enabled_toolsets` gives per-job `enabled_toolsets` outright precedence, so an agent that asks for `terminal` from WhatsApp stores and runs with it. On resolver exception the function returned `None`, and `None` loads the full default set (terminal, code_execution, browser, computer_use).

This PR:

- **(b)** Intersects the job's `enabled_toolsets` with the origin platform toolset at **create**, **update**, and **resolve**. Jobs with no origin (CLI/dashboard) keep the previous per-job / `cron` platform behavior.
- **(c)** Removes the schema hint that told the model to request `"terminal"`.
- **(d)** Fail-closed: resolver exceptions return `[]`, never `None`.

Known-bad control (copied unchanged, sha `751dfaf6`): `tests/cron/test_cron_toolset_origin_intersect.py`.

## Known limitation (follow-up)

This does **not** close the cron→cron hop. `_CronRunScope` sets `platform=""` on purpose, so `_origin_from_env()` returns `None` inside a cron tick. The persist clamp then leaves the requested list intact, and the resolver gives that list absolute precedence. A job whose origin platform still has `cronjob` (and not `terminal`) can therefore create a **child** with `terminal` in one hop.

That path already existed; this PR does not regress it. Closing it means publishing the parent's already-resolved toolset onto the child so a child never exceeds its parent — not inferring origin from deliver env. Tracked as a follow-up, not this commit.

## Test plan

- [x] Control `751dfaf6`: 5 previously-red cases green, 6th (`conserva lo que su plataforma sí permite`) still green.
- [x] Python 3.12.13 + pytest: those 6 + clamp/schema tests pass at `fa9735ca`.
- [x] Python 3.11.15 gateway interpreter, no pytest (plain runner): 6/6 pass at the same commit.
- [x] Full `tests/cron`: 1224 passed, 3 skipped (pre-commit working tree; same diff).

Zero deploy. This is code only.
