### PR TITLE
fix(desktop): recover profile wakes from saturated backend pool

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -284,7 +284,7 @@ import {
   localRouteFallbackProfiles,
   undialedSshRouteSeeds
 } from './plugin-profile-routes'
-import { selectPoolEvictions } from './pool-eviction'
+import { evictPoolEntries } from './pool-eviction'
 import { clampPoolLimits, parsePoolLimits, POOL_LIMITS_DEFAULTS } from './pool-limits'
 import {
   LocalBackendSpawnCoordinator,
@@ -1505,7 +1505,7 @@ function setPoolLimits(raw) {
   poolLimits = clampPoolLimits(raw)
   persistPoolLimits(poolLimits)
   localBackendSpawnCoordinator.setLimit(poolLimits.maxBackends)
-  evictLruPoolBackends(poolMaxBackends())
+  void evictLruPoolBackends(poolMaxBackends())
   startPoolIdleReaper()
 
   return { ...poolLimits }
@@ -11407,7 +11407,10 @@ async function ensureBackend(profile) {
     return connection
   }
 
-  evictLruPoolBackends(poolMaxBackends() - 1)
+  // The hard slot is released only after the evicted child exits. Wait for
+  // that teardown before entering the spawn queue; otherwise a successful
+  // LRU choice still leaves this wake racing the old child for 30 seconds.
+  await evictLruPoolBackends(poolMaxBackends() - 1)
 
   const entry = {
     process: null,
@@ -11573,7 +11576,7 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
       return existingLocal.connectionPromise
     }
 
-    evictLruPoolBackends(poolMaxBackends() - 1)
+    await evictLruPoolBackends(poolMaxBackends() - 1)
 
     const localEntry = {
       process: null,
@@ -11644,7 +11647,7 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
     )
   }
 
-  evictLruPoolBackends(poolMaxBackends() - 1)
+  await evictLruPoolBackends(poolMaxBackends() - 1)
 
   const entry = {
     process: null,
@@ -12295,13 +12298,17 @@ function touchPoolBackend(profile) {
 // across N registered remote connections LRU-evict a REAL local backend that
 // was merely idle past the keepalive window. Descriptors are still reclaimed
 // by the idle reaper.
-function evictLruPoolBackends(keep) {
-  const evictions = selectPoolEvictions(backendPool.entries(), Math.max(0, keep), Date.now(), POOL_KEEPALIVE_FRESH_MS)
-
-  for (const profile of evictions) {
-    rememberLog(`Evicting idle profile backend "${profile}" (LRU cap ${poolMaxBackends()})`)
-    stopPoolBackend(profile)
-  }
+async function evictLruPoolBackends(keep) {
+  return evictPoolEntries(
+    backendPool.entries(),
+    Math.max(0, keep),
+    Date.now(),
+    POOL_KEEPALIVE_FRESH_MS,
+    async profile => {
+      rememberLog(`Evicting idle profile backend "${profile}" (LRU cap ${poolMaxBackends()})`)
+      await stopPoolBackend(profile)
+    }
+  )
 }
 
 function startPoolIdleReaper() {

--- a/apps/desktop/electron/pool-eviction.test.ts
+++ b/apps/desktop/electron/pool-eviction.test.ts
@@ -11,7 +11,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { selectPoolEvictions } from './pool-eviction'
+import { evictPoolEntries, selectPoolEvictions } from './pool-eviction'
 
 const NOW = 1_000_000
 // Mirrors main.ts POOL_KEEPALIVE_FRESH_MS (4 minutes — see #95189).
@@ -83,6 +83,39 @@ test('descriptor-only pools never evict', () => {
   ]
 
   assert.deepEqual(selectPoolEvictions(entries, 2, NOW, FRESH_MS), [])
+})
+
+test('making room waits for every selected backend to finish stopping', async () => {
+  let releaseStop!: () => void
+
+  const stopGate = new Promise<void>(resolve => {
+    releaseStop = resolve
+  })
+
+  const stopped: string[] = []
+  let settled = false
+
+  const entries: [string, ReturnType<typeof spawned>][] = [
+    ['oldest', spawned(500_000)],
+    ['fresh', spawned(1_000)]
+  ]
+
+  const eviction = evictPoolEntries(entries, 1, NOW, FRESH_MS, async key => {
+    stopped.push(key)
+    await stopGate
+  }).then(keys => {
+    settled = true
+
+    return keys
+  })
+
+  await Promise.resolve()
+  assert.deepEqual(stopped, ['oldest'])
+  assert.equal(settled, false, 'a replacement must not race the exiting child for its slot')
+
+  releaseStop()
+  assert.deepEqual(await eviction, ['oldest'])
+  assert.equal(settled, true)
 })
 
 // ── #95189 — Keepalive-fresh window must tolerate transient missed pings ──

--- a/apps/desktop/electron/pool-eviction.ts
+++ b/apps/desktop/electron/pool-eviction.ts
@@ -56,3 +56,26 @@ export function selectPoolEvictions<K>(
 
   return evictions
 }
+
+/**
+ * Evict enough stale spawned backends to make room, and do not report the
+ * room as available until every selected child has actually exited.
+ *
+ * Selection and teardown deliberately live in one helper: callers that fire
+ * stopBackend() without awaiting it can enqueue a replacement while the old
+ * child still owns its hard spawn slot. Under a restore stampede that race
+ * turns successful LRU selection into a 30-second queue timeout.
+ */
+export async function evictPoolEntries<K>(
+  entries: Iterable<[K, PoolEvictionEntry]>,
+  keep: number,
+  now: number,
+  freshMs: number,
+  stopBackend: (key: K) => Promise<void>
+): Promise<K[]> {
+  const evictions = selectPoolEvictions(entries, keep, now, freshMs)
+
+  await Promise.all(evictions.map(key => stopBackend(key)))
+
+  return evictions
+}

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -1066,16 +1066,16 @@ export const host = {
         }
       }
     } catch (error) {
-      if (
-        options.awaitHydration &&
-        openingStillCurrent() &&
-        error instanceof Error &&
-        error.message.startsWith('Timed out loading ')
-      ) {
+      const wakeFailedWhileCurrent = options.awaitHydration && openingStillCurrent() && error instanceof Error
+
+      const hydrationTimedOut = wakeFailedWhileCurrent && error.message.startsWith('Timed out loading ')
+
+      if (wakeFailedWhileCurrent && (wakePhase === 'activation' || hydrationTimedOut)) {
         const timedOutAt = Date.now()
 
-        console.warn('[bot-wake] hydration timed out', {
+        console.warn(hydrationTimedOut ? '[bot-wake] hydration timed out' : '[bot-wake] activation failed', {
           attempts: wakePhase === 'hydration' ? maxAttempts : 1,
+          error: error.message,
           hydrationWaitMs: wakePhase === 'hydration' ? timedOutAt - profileActiveAt : 0,
           phase: wakePhase,
           profile: targetProfile,
@@ -1085,8 +1085,12 @@ export const host = {
           storedSessionId,
           transcriptPainted: $messages.get().length > 0
         })
-        // Reuse the core stranded-session surface: it renders the explicit
-        // error and Retry button, and the normal resume path clears the latch.
+        // Reuse the core stranded-session surface for BOTH deadline and direct
+        // activation failures (including a saturated local-backend pool). It
+        // renders an explicit failure and Retry button; the normal resume path
+        // clears the latch. Previously only the synthetic hydration timeout
+        // reached this surface, so a real slot rejection cleared neither the
+        // apparent terminal wake state nor a path forward.
         setResumeExhaustedSessionId(storedSessionId)
       }
 

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -1234,6 +1234,26 @@ describe('profile-aware plugin session opens', () => {
     expect($gatewaySwapTarget.get()).toBeNull()
   })
 
+  it('surfaces a direct pool-slot activation failure with the same Retry path', async () => {
+    vi.mocked(ensureGatewayProfile).mockRejectedValueOnce(
+      new Error('Local backend start for "research" timed out while waiting for a free slot.')
+    )
+
+    await expect(
+      host.openSession('queued-chat', {
+        profile: 'research',
+        intent: 'main',
+        awaitHydration: true,
+        expectHistory: true,
+        keepAllProfilesScope: false,
+        hydrationTimeoutMs: 100
+      })
+    ).rejects.toThrow('timed out while waiting for a free slot')
+
+    expect(setResumeExhaustedSessionId).toHaveBeenCalledWith('queued-chat')
+    expect($gatewaySwapTarget.get()).toBeNull()
+  })
+
   it('names the phase in the wake log so a stuck dial is not read as a slow transcript', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
 


### PR DESCRIPTION
## What does this PR do?

Prevents profile wakes from getting stranded when the local backend pool is saturated.

The pool already selects stale LRU backends before starting a replacement, but teardown was fire-and-forget. The replacement could therefore enter the bounded spawn queue while the evicted child still owned its hard slot and time out despite a successful eviction choice.

This change:

- waits for selected LRU backend processes to exit before queueing their replacements;
- applies that ordering to local, forced-local, and registry-scoped pooled backends;
- routes direct profile-activation failures, including slot timeout errors, into the existing stranded-session error and Retry surface;
- preserves the keepalive safety rule that prevents active backends from being force-evicted.

## Related Issue

Fixes #103230

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added an awaited LRU eviction helper that resolves only after all selected backends finish stopping.
- Awaited room-making before each pooled backend creation path enters the spawn queue.
- Reused the existing retryable stranded-session UI for direct activation failures.
- Added regression coverage for teardown ordering and direct pool-slot activation failures.

## How to Test

1. From `apps/desktop`, run:
   `npx vitest run electron/pool-eviction.test.ts src/sdk/profile-routing.test.ts electron/pool-spawn-coordinator.test.ts --testTimeout=15000`
2. Run `npm run typecheck`.
3. Run ESLint and Prettier checks for the five changed files.

Verified locally: 74/74 focused tests passed; renderer, Electron, and E2E TypeScript typechecks passed; ESLint and Prettier passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, Desktop TypeScript-only change; focused Vitest suites and all Desktop TypeScript projects were checked
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux test environment; the process-pool and renderer paths are platform-neutral

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior-only bug fix with inline rationale
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific process behavior added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A — covered by deterministic process-pool and renderer-state regression tests.