### PR TITLE
fix(discord): explain auto-thread rate limits

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -81,9 +81,10 @@ class _Snowflake:
 class _AutoThreadRateLimited(Exception):
     """Discord refused auto-thread creation and supplied a retry delay."""
 
-    def __init__(self, retry_after: float) -> None:
-        self.retry_after_seconds = max(1, math.ceil(retry_after))
-        super().__init__(f"Discord rate-limited thread creation for {self.retry_after_seconds}s")
+    def __init__(self, retry_after: Optional[float]) -> None:
+        self.retry_after_seconds = None if retry_after is None else max(1, math.ceil(retry_after))
+        detail = "an unknown duration" if self.retry_after_seconds is None else f"{self.retry_after_seconds}s"
+        super().__init__(f"Discord rate-limited thread creation for {detail}")
 
 
 def _format_retry_delay(seconds: int) -> str:
@@ -102,6 +103,7 @@ _DISCORD_NONCONVERSATIONAL_STATE_FILENAME = "discord_nonconversational_messages.
 
 _DISCORD_COMMAND_SYNC_MUTATION_INTERVAL_SECONDS = 4.5
 _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS = 30.0
+_DISCORD_MAX_RATE_LIMIT_WAIT_SECONDS = 30.0
 # Discord caps global slash commands at 100/app; exceeding it fails the ENTIRE sync (error 30032).
 _DISCORD_MAX_APP_COMMANDS = 100
 # Native slash commands (registered before COMMAND_REGISTRY/plugins so they survive the 100 cap):
@@ -1232,6 +1234,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 command_prefix="!",  # Not really used, we handle raw messages
                 intents=intents,
                 allowed_mentions=_build_allowed_mentions(),
+                max_ratelimit_timeout=_DISCORD_MAX_RATE_LIMIT_WAIT_SECONDS,
                 **proxy_kwargs_for_bot(proxy_url),
             )
             adapter_self = self  # capture for closure
@@ -5353,12 +5356,13 @@ class DiscordAdapter(BasePlatformAdapter):
             except Exception as direct_error:
                 last_direct_error = direct_error
                 if self._is_discord_rate_limit(direct_error):
-                    retry_after = self._extract_discord_retry_after(direct_error) or 60.0
+                    retry_after = self._extract_discord_retry_after(direct_error)
                     logger.warning(
-                        "[%s] Discord rate-limited auto-thread creation; retry after %.2fs",
-                        self.name, retry_after,
+                        "[%s] Discord rate-limited auto-thread creation; retry after %s",
+                        self.name, f"{retry_after:.2f}s" if retry_after is not None else "unknown delay",
                     )
                     raise _AutoThreadRateLimited(retry_after) from direct_error
+                seed_msg = None
                 try:
                     seed_msg = await message.channel.send(
                         f"\U0001f9f5 Thread created by Hermes: **{thread_name}**"
@@ -5368,10 +5372,22 @@ class DiscordAdapter(BasePlatformAdapter):
                 except Exception as fallback_error:
                     last_fallback_error = fallback_error
                     if self._is_discord_rate_limit(fallback_error):
-                        retry_after = self._extract_discord_retry_after(fallback_error) or 60.0
+                        retry_after = self._extract_discord_retry_after(fallback_error)
+                        delete_seed = getattr(seed_msg, "delete", None)
+                        if callable(delete_seed):
+                            try:
+                                delete_result = delete_seed()
+                                if inspect.isawaitable(delete_result):
+                                    await delete_result
+                            except Exception:
+                                logger.debug(
+                                    "[%s] Failed to remove auto-thread fallback seed after rate limit",
+                                    self.name,
+                                    exc_info=True,
+                                )
                         logger.warning(
-                            "[%s] Discord rate-limited fallback auto-thread creation; retry after %.2fs",
-                            self.name, retry_after,
+                            "[%s] Discord rate-limited fallback auto-thread creation; retry after %s",
+                            self.name, f"{retry_after:.2f}s" if retry_after is not None else "unknown delay",
                         )
                         raise _AutoThreadRateLimited(retry_after) from fallback_error
                     if attempt == 0:
@@ -6055,10 +6071,14 @@ class DiscordAdapter(BasePlatformAdapter):
                         # channel. Surface a short visible error so the user can retry once Discord
                         # recovers, and skip agent invocation for this message. See #20243.
                         if rate_limit_error is not None:
-                            retry_delay = _format_retry_delay(rate_limit_error.retry_after_seconds)
+                            if rate_limit_error.retry_after_seconds is None:
+                                retry_instruction = "Try again later"
+                            else:
+                                retry_delay = _format_retry_delay(rate_limit_error.retry_after_seconds)
+                                retry_instruction = f"Try again in {retry_delay}"
                             notice = (
                                 "⚠️ Discord is temporarily rate-limiting Hermes from creating another "
-                                f"thread. This message was not processed. Try again in {retry_delay}, "
+                                f"thread. This message was not processed. {retry_instruction}, "
                                 "or continue in an existing thread."
                             )
                         else:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -77,6 +77,23 @@ class _Snowflake:
     def __init__(self, id: int) -> None:  # noqa: A002 - matches discord API
         self.id = id
 
+
+class _AutoThreadRateLimited(Exception):
+    """Discord refused auto-thread creation and supplied a retry delay."""
+
+    def __init__(self, retry_after: float) -> None:
+        self.retry_after_seconds = max(1, math.ceil(retry_after))
+        super().__init__(f"Discord rate-limited thread creation for {self.retry_after_seconds}s")
+
+
+def _format_retry_delay(seconds: int) -> str:
+    minutes, remaining_seconds = divmod(max(1, seconds), 60)
+    if not minutes:
+        return f"{remaining_seconds}s"
+    if not remaining_seconds:
+        return f"{minutes}m"
+    return f"{minutes}m {remaining_seconds}s"
+
 VALID_THREAD_AUTO_ARCHIVE_MINUTES = {60, 1440, 4320, 10080}
 _DISCORD_COMMAND_SYNC_POLICIES = {"safe", "bulk", "off"}
 _DISCORD_COMMAND_SYNC_STATE_SUBDIR = "gateway"
@@ -5335,6 +5352,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 return self._stamp_auto_thread_name(thread, thread_name)
             except Exception as direct_error:
                 last_direct_error = direct_error
+                if self._is_discord_rate_limit(direct_error):
+                    retry_after = self._extract_discord_retry_after(direct_error) or 60.0
+                    logger.warning(
+                        "[%s] Discord rate-limited auto-thread creation; retry after %.2fs",
+                        self.name, retry_after,
+                    )
+                    raise _AutoThreadRateLimited(retry_after) from direct_error
                 try:
                     seed_msg = await message.channel.send(
                         f"\U0001f9f5 Thread created by Hermes: **{thread_name}**"
@@ -5343,6 +5367,13 @@ class DiscordAdapter(BasePlatformAdapter):
                     return self._stamp_auto_thread_name(thread, thread_name)
                 except Exception as fallback_error:
                     last_fallback_error = fallback_error
+                    if self._is_discord_rate_limit(fallback_error):
+                        retry_after = self._extract_discord_retry_after(fallback_error) or 60.0
+                        logger.warning(
+                            "[%s] Discord rate-limited fallback auto-thread creation; retry after %.2fs",
+                            self.name, retry_after,
+                        )
+                        raise _AutoThreadRateLimited(retry_after) from fallback_error
                     if attempt == 0:
                         # Brief backoff: most failures here are transient connect errors.
                         await asyncio.sleep(0.75)
@@ -6001,7 +6032,12 @@ class DiscordAdapter(BasePlatformAdapter):
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:
-                thread = await self._auto_create_thread(message)
+                rate_limit_error = None
+                try:
+                    thread = await self._auto_create_thread(message)
+                except _AutoThreadRateLimited as error:
+                    thread = None
+                    rate_limit_error = error
                 if thread:
                     parent_channel_id = str(message.channel.id)
                     is_thread = True
@@ -6018,10 +6054,19 @@ class DiscordAdapter(BasePlatformAdapter):
                         # That breaks thread-first Discord workflows by dumping a new task into a shared
                         # channel. Surface a short visible error so the user can retry once Discord
                         # recovers, and skip agent invocation for this message. See #20243.
-                        await message.channel.send(
-                            "⚠️ Hermes could not create a Discord thread for "
-                            "this message, so the request was not processed. Please retry."
-                        )
+                        if rate_limit_error is not None:
+                            retry_delay = _format_retry_delay(rate_limit_error.retry_after_seconds)
+                            notice = (
+                                "⚠️ Discord is temporarily rate-limiting Hermes from creating another "
+                                f"thread. This message was not processed. Try again in {retry_delay}, "
+                                "or continue in an existing thread."
+                            )
+                        else:
+                            notice = (
+                                "⚠️ Hermes could not create a Discord thread for this message, so the "
+                                "request was not processed. Please retry."
+                            )
+                        await message.channel.send(notice)
                     except Exception as notify_error:
                         logger.warning(
                             "[%s] Failed to notify user of auto-thread failure: %s", self.name,

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -10,6 +10,18 @@ import pytest
 from gateway.config import PlatformConfig
 
 
+class FakeRateLimited(Exception):
+    def __init__(self, retry_after):
+        self.retry_after = retry_after
+        super().__init__(f"Too many requests. Retry in {retry_after:.2f} seconds.")
+
+
+class FakeHTTP429(Exception):
+    def __init__(self):
+        self.response = SimpleNamespace(status=429, headers={})
+        super().__init__("HTTP 429")
+
+
 def _ensure_discord_mock():
     """Install a mock discord module when discord.py isn't available."""
     if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
@@ -228,9 +240,7 @@ async def test_auto_thread_rate_limit_notice_includes_retry_delay_without_fallba
     monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
     monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
 
-    rate_limit = RuntimeError("Too many requests")
-    monkeypatch.setattr(adapter, "_is_discord_rate_limit", lambda error: error is rate_limit)
-    monkeypatch.setattr(adapter, "_extract_discord_retry_after", lambda error: 286.02)
+    rate_limit = FakeRateLimited(286.02)
 
     channel = FakeTextChannel(channel_id=800)
 
@@ -267,11 +277,12 @@ async def test_auto_thread_fallback_rate_limit_stops_retries_and_explains_delay(
     monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
 
     direct_error = RuntimeError("temporary connection failure")
-    rate_limit = RuntimeError("Too many requests")
-    monkeypatch.setattr(adapter, "_is_discord_rate_limit", lambda error: error is rate_limit)
-    monkeypatch.setattr(adapter, "_extract_discord_retry_after", lambda error: 60.0)
+    rate_limit = FakeRateLimited(60.0)
 
-    seed_message = SimpleNamespace(create_thread=AsyncMock(side_effect=rate_limit))
+    seed_message = SimpleNamespace(
+        create_thread=AsyncMock(side_effect=rate_limit),
+        delete=AsyncMock(),
+    )
     channel = FakeTextChannel(channel_id=800)
     channel.send.side_effect = [seed_message, None]
     message = make_message(channel=channel, content="hello")
@@ -282,11 +293,37 @@ async def test_auto_thread_fallback_rate_limit_stops_retries_and_explains_delay(
     adapter.handle_message.assert_not_awaited()
     message.create_thread.assert_awaited_once()
     seed_message.create_thread.assert_awaited_once()
+    seed_message.delete.assert_awaited_once()
     assert channel.send.await_count == 2
     notice = channel.send.await_args_list[-1].args[0]
     assert "discord is temporarily rate-limiting" in notice.lower()
     assert "1m" in notice
     assert "not processed" in notice.lower()
+
+
+@pytest.mark.asyncio
+async def test_auto_thread_rate_limit_without_retry_after_does_not_invent_delay(
+    adapter, monkeypatch,
+):
+    """A 429 without retry metadata should say 'later' rather than fabricate a wait."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    channel = FakeTextChannel(channel_id=800)
+    message = make_message(channel=channel, content="hello")
+    message.create_thread = AsyncMock(side_effect=FakeHTTP429())
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+    channel.send.assert_awaited_once()
+    assert channel.send.await_args is not None
+    notice = channel.send.await_args.args[0]
+    assert "try again later" in notice.lower()
+    assert "1m" not in notice
 
 
 # ── config.py bridging ───────────────────────────────────────────────

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -61,6 +61,7 @@ class FakeTextChannel:
         self.name = name
         self.guild = SimpleNamespace(name=guild_name)
         self.topic = None
+        self.send = AsyncMock()
 
 
 class FakeThread:
@@ -214,6 +215,78 @@ async def test_auto_thread_failure_skips_agent_and_notifies_user(adapter, monkey
     sent_text = channel.send.await_args.args[0]
     assert "could not create" in sent_text.lower()
     assert "thread" in sent_text.lower()
+
+
+@pytest.mark.asyncio
+async def test_auto_thread_rate_limit_notice_includes_retry_delay_without_fallback_spam(
+    adapter, monkeypatch,
+):
+    """A Discord 429 should explain when to retry and must not emit seed-message fallbacks."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    rate_limit = RuntimeError("Too many requests")
+    monkeypatch.setattr(adapter, "_is_discord_rate_limit", lambda error: error is rate_limit)
+    monkeypatch.setattr(adapter, "_extract_discord_retry_after", lambda error: 286.02)
+
+    channel = FakeTextChannel(channel_id=800)
+
+    async def send(content):
+        if content.startswith("🧵"):
+            raise AssertionError("rate limits must not trigger fallback seed messages")
+        return None
+
+    channel.send.side_effect = send
+    message = make_message(channel=channel, content="hello")
+    message.create_thread = AsyncMock(side_effect=rate_limit)
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+    message.create_thread.assert_awaited_once()
+    channel.send.assert_awaited_once()
+    sent_text = channel.send.await_args.args[0]
+    assert "discord is temporarily rate-limiting" in sent_text.lower()
+    assert "4m 47s" in sent_text
+    assert "not processed" in sent_text.lower()
+    assert "existing thread" in sent_text.lower()
+
+
+@pytest.mark.asyncio
+async def test_auto_thread_fallback_rate_limit_stops_retries_and_explains_delay(
+    adapter, monkeypatch,
+):
+    """A fallback-path 429 should stop retries and retain Discord's retry delay."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    direct_error = RuntimeError("temporary connection failure")
+    rate_limit = RuntimeError("Too many requests")
+    monkeypatch.setattr(adapter, "_is_discord_rate_limit", lambda error: error is rate_limit)
+    monkeypatch.setattr(adapter, "_extract_discord_retry_after", lambda error: 60.0)
+
+    seed_message = SimpleNamespace(create_thread=AsyncMock(side_effect=rate_limit))
+    channel = FakeTextChannel(channel_id=800)
+    channel.send.side_effect = [seed_message, None]
+    message = make_message(channel=channel, content="hello")
+    message.create_thread = AsyncMock(side_effect=direct_error)
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+    message.create_thread.assert_awaited_once()
+    seed_message.create_thread.assert_awaited_once()
+    assert channel.send.await_count == 2
+    notice = channel.send.await_args_list[-1].args[0]
+    assert "discord is temporarily rate-limiting" in notice.lower()
+    assert "1m" in notice
+    assert "not processed" in notice.lower()
 
 
 # ── config.py bridging ───────────────────────────────────────────────

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -184,6 +184,37 @@ async def test_resolve_allowed_usernames_preserves_wildcard(monkeypatch, initial
 
 
 @pytest.mark.asyncio
+async def test_connect_caps_long_discord_rate_limit_waits(monkeypatch):
+    """Long REST cooldowns must surface as RateLimited instead of blocking message handling."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+
+    intents = SimpleNamespace(
+        message_content=False, dm_messages=False, guild_messages=False,
+        members=False, voice_states=False,
+    )
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+    captured_kwargs = {}
+
+    def fake_bot_factory(**kwargs):
+        captured_kwargs.update(kwargs)
+        return FakeBot(
+            intents=kwargs["intents"],
+            proxy=kwargs.get("proxy"),
+            allowed_mentions=kwargs.get("allowed_mentions"),
+        )
+
+    monkeypatch.setattr(discord_platform.commands, "Bot", fake_bot_factory)
+    monkeypatch.setattr(adapter, "_resolve_allowed_usernames", AsyncMock())
+
+    assert await adapter.connect() is True
+    assert captured_kwargs["max_ratelimit_timeout"] == 30.0
+
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
 async def test_reconnect_closes_previous_client_to_prevent_zombie_websocket(monkeypatch):
     """Regression for #18187: calling connect() twice without disconnect() in
     between (e.g. during an in-process reconnect attempt) must close the old


### PR DESCRIPTION
Summary

- Detect Discord HTTP 429 responses during automatic thread creation.
- Configure discord.py to surface REST cooldowns longer than 30 seconds instead of silently sleeping for minutes.
- Show an actionable parent-channel notice containing Discord’s retry delay.
- State explicitly that the original message was not processed and suggest using an existing thread.
- Skip futile seed-message fallback and short retry attempts while Discord’s rate-limit bucket is active.
- Remove a misleading fallback seed message if its thread creation is rate-limited.
- Preserve the existing generic failure notice for non-rate-limit errors.

Motivation

Discord can apply dynamic per-route limits to thread creation. The existing adapter could let discord.py sleep for the full cooldown, retry after 0.75 seconds once an error surfaced, emit misleading duplicate “Thread created by Hermes” seed messages, and finally ask the user to retry without saying when. This change does not queue or process the failed request.

Trade-off

`max_ratelimit_timeout` is a discord.py client-wide setting. Cooldowns longer than 30 seconds on any Discord REST endpoint will now fail fast rather than silently block the gateway; normal short send/global rate limits continue to wait and retry. In practice, thread creation is the endpoint observed returning multi-minute cooldowns. The adapter already contains delivery failures without crashing the gateway.

Test plan

- `scripts/run_tests.sh -j 2 tests/gateway/test_discord_channel_controls.py tests/gateway/test_discord_connect.py tests/gateway/test_discord_slash_commands.py tests/gateway/test_discord_double_dispatch.py`
- 42 tests passed.
- `ruff check plugins/platforms/discord/adapter.py tests/gateway/test_discord_channel_controls.py tests/gateway/test_discord_connect.py`
- Real discord.py 2.7.1 smoke check confirmed `RateLimited(286.02)` is detected and its retry delay is extracted.