### PR TITLE
fix(approvals): retry Bedrock temperature rejection

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3088,7 +3088,7 @@ def _is_unsupported_parameter_error(exc: Exception, param: str) -> bool:
         return False
     err_lower = str(exc).lower()
     return param_lower in err_lower and _contains_any(err_lower, (
-        "unsupported parameter", "unsupported_parameter", "not supported", "does not support",
+        "unsupported parameter", "unsupported_parameter", "not supported", "does not support", "doesn't support",
         "unknown parameter", "unrecognized request argument", "unrecognized parameter", "invalid parameter",
     ))
 

--- a/tests/agent/test_unsupported_parameter_retry.py
+++ b/tests/agent/test_unsupported_parameter_retry.py
@@ -34,6 +34,7 @@ class TestIsUnsupportedParameterError:
         ("temperature", "HTTP 400: Unsupported parameter: temperature"),
         ("temperature", "Error code: 400 - {'error': {'code': 'unsupported_parameter', 'param': 'temperature'}}"),
         ("temperature", "this model does not support temperature"),
+        ("temperature", "This model doesn't support the temperature field. Remove temperature and try again."),
         # max_tokens phrasings
         ("max_tokens", "HTTP 400: Unsupported parameter: max_tokens"),
         ("max_tokens", "Unknown parameter: max_tokens — use max_completion_tokens"),


### PR DESCRIPTION
## Summary
Recognize Bedrock’s `doesn't support ... temperature` validation wording so the auxiliary client retries without the unsupported parameter instead of escalating smart approval to manual.

## Root cause
The unsupported-parameter classifier handled `does not support` but not the contraction used by Bedrock.

## Verification
- `scripts/run_tests.sh tests/agent/test_unsupported_parameter_retry.py tests/agent/test_unsupported_temperature_retry.py -q` — 31 tests passed