### PR TITLE
fix(desktop): invalidate warm-cache runtime bindings on connection switch (#93888)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -14,6 +14,7 @@ import {
   $turnStartedAt,
   setActiveSessionId,
   setActiveSessionStoredIdRotation,
+  setConnection,
   setCurrentFastMode,
   setCurrentModel,
   setCurrentProvider,
@@ -688,5 +689,35 @@ describe('useSessionStateCache — reconnect busy reconcile (#93059)', () => {
     expect(cache.sessionStateByRuntimeIdRef.current.get('runtime-1')?.busy).toBe(false)
     expect(cache.sessionStateByRuntimeIdRef.current.get('runtime-1')?.awaitingResponse).toBe(false)
     expect($sessionStates.get()['runtime-1']?.busy).toBe(false)
+  })
+})
+
+describe('useSessionStateCache — warm-cache invalidation on connection switch (#93888)', () => {
+  afterEach(() => {
+    setConnection(null)
+    cleanup()
+  })
+
+  it('clears stale stored→runtime bindings when the connection changes', () => {
+    let cache!: Cache
+
+    setConnection({ connectionId: 'local', mode: 'local' } as never)
+    render(<Harness activeSessionId="runtime-local" onReady={value => (cache = value)} selectedStoredSessionId="stored-local" />)
+
+    // Populate the warm cache under the local backend.
+    act(() => {
+      cache.ensureSessionState('runtime-local', 'stored-local')
+    })
+    expect(cache.runtimeIdByStoredSessionIdRef.current.get('stored-local')).toBe('runtime-local')
+
+    // Switch to a remote gateway: the previous backend's runtime ids are
+    // meaningless to it, so they must not survive (a stale local runtime id
+    // sent to a remote gateway is rejected as "Session not found").
+    act(() => {
+      setConnection({ connectionId: 'remote', mode: 'remote' } as never)
+    })
+
+    expect(cache.runtimeIdByStoredSessionIdRef.current.size).toBe(0)
+    expect(cache.sessionStateByRuntimeIdRef.current.size).toBe(0)
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -9,6 +9,7 @@ import { persistInFlightTurnState } from '@/lib/inflight-turn-journal'
 import { setMutableRef } from '@/lib/mutable-ref'
 import {
   $activeSessionId,
+  $connection,
   $messages,
   setActiveSessionStoredIdRotation,
   setCurrentFastMode,
@@ -127,6 +128,30 @@ export function useSessionStateCache({
   // Runtime id whose transcript currently occupies `$messages` — lets the
   // flush below tell a same-session refresh from a thread switch.
   const viewSessionIdRef = useRef<string | null>(null)
+
+  // A runtime id is owned by the backend that minted it. Switching the active
+  // connection (local ↔ remote gateway, or one remote to another) changes
+  // which backend owns every stored session, so the cached stored→runtime
+  // bindings from the PREVIOUS backend must not survive the switch: sending a
+  // stale local runtime id to a remote gateway makes it reject the resume as
+  // "Session not found" (#93888). Wipe both warm-cache refs on connection
+  // change so the next resume resolves a fresh runtime from the new backend
+  // (the cold `session.resume` path, which correctly uses the durable stored
+  // id, repopulates them).
+  const connection = useStore($connection)
+  const connectionScopeKey = connection?.connectionId ?? connection?.mode ?? 'default'
+  const prevConnectionScopeKeyRef = useRef(connectionScopeKey)
+
+  // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
+  useEffect(() => {
+    if (prevConnectionScopeKeyRef.current === connectionScopeKey) {
+      return
+    }
+
+    prevConnectionScopeKeyRef.current = connectionScopeKey
+    runtimeIdByStoredSessionIdRef.current.clear()
+    sessionStateCache.clear()
+  }, [connectionScopeKey, sessionStateCache])
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {


### PR DESCRIPTION
## Summary

Switching the active gateway connection (local ↔ remote gateway, or one
remote to another) did **not** invalidate the warm-cache's
stored→runtime ID bindings. The previous backend's runtime IDs are
meaningless to the new gateway — sending a stale local runtime ID to a
remote gateway makes it reject the resume as "Session not found"
(#93888).

## Fix

Added a `useEffect` in `useSessionStateCache` that watches the
connection scope key (`connection.connectionId` || `connection.mode`).
On any change, it clears both warm-cache refs:
- `runtimeIdByStoredSessionIdRef.current.clear()`
- `sessionStateCache.clear()`

The next resume then resolves a fresh runtime from the new backend
(via the cold `session.resume` path, which correctly uses the durable
stored ID), repopulating the warm cache with valid bindings.

## Tests

New test suite in
`apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx`:

```typescript
describe('useSessionStateCache — warm-cache invalidation on connection switch (#93888)', () => {
  it('clears stale stored→runtime bindings when the connection changes', () => {
    // Populate warm cache under local backend
    // Switch to remote gateway
    // Expect warm cache to be cleared (size === 0)
  })
})
```

## Verification

- New test: **1 passed** (fails without the `useEffect` change)
- `src/lib` full dir: **1243 passed**
- `tsc --build tsconfig.json`: clean

Fixes #93888