### PR TITLE
fix(agent): propagate tool-call timeout to delegated children

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -29,6 +29,7 @@ from agent.display import (
     redact_tool_args_for_display as _redact_tool_args_for_display,
     _detect_tool_failure,
 )
+from agent.interrupt_compat import request_hard_interrupt
 from agent.message_sanitization import coalesce_tool_call_id
 from agent.inline_tool_executors import (
     INLINE_TOOL_EXECUTORS,
@@ -545,6 +546,26 @@ def _interrupt_worker_tids(agent, tids, *, reason=_NO_REASON) -> None:
             _ra()._set_interrupt(True, tid, **kwargs)
 
 
+def _interrupt_active_children(agent) -> None:
+    """Stop delegated children of a timed-out tool call. The worker-tid signal raised
+    by ``_interrupt_worker_tids`` never reaches them: each delegate child runs on its
+    own daemon worker and only observes its own interrupt state, so mirror
+    ``agent.interrupt()``'s child propagation (see interrupt_control) here."""
+    lock = getattr(agent, "_active_children_lock", None)
+    try:
+        if lock is not None:
+            with lock:
+                children = list(agent._active_children)
+        else:
+            children = list(getattr(agent, "_active_children", None) or ())
+    except Exception:
+        return
+    for child in children:
+        with contextlib.suppress(Exception):
+            if not request_hard_interrupt(child) and hasattr(child, "_interrupt_requested"):
+                child._interrupt_requested = True
+
+
 def _set_worker_activity_callback(agent) -> None:
     """The activity callback is thread-local: bind it on THIS thread so tool-layer heartbeats fire."""
     with contextlib.suppress(Exception):
@@ -870,6 +891,7 @@ def _run_sequential_tool_execution_middleware(
         future.cancel()
         if state == "timeout":
             _interrupt_worker_tids(agent, worker_tid)
+            _interrupt_active_children(agent)
         return _abandoned_sequential_result(agent, ref, message, result_cls, **outcome)
     finally:
         # Never join a wedged worker (daemon pool also keeps it out of the atexit join).
@@ -1295,6 +1317,7 @@ class _ConcurrentBatch:
                 with agent._tool_worker_threads_lock:
                     worker_tids = list(agent._tool_worker_threads)
                 _interrupt_worker_tids(agent, worker_tids)
+                _interrupt_active_children(agent)
             else:
                 # Give running tools a moment to notice the per-thread interrupt and exit gracefully.
                 concurrent.futures.wait(not_done, timeout=3.0)

--- a/tests/agent/test_timeout_stops_delegate_children.py
+++ b/tests/agent/test_timeout_stops_delegate_children.py
@@ -1,0 +1,162 @@
+"""Regression tests for #103301: a timed-out tool call must stop its delegated children.
+
+The sequential and concurrent timeout paths only raised the worker thread's interrupt
+bit (``tools.interrupt`` is per-thread); a ``delegate_task`` child runs on its own
+daemon worker and only observes its own interrupt state, so after the parent reported
+"timed out" the child kept running — issuing tool calls and git commits — with no stop
+signal. ``agent.interrupt()`` already propagates to ``_active_children`` (see
+``interrupt_control``); these tests pin the same propagation on both timeout paths.
+"""
+
+import concurrent.futures
+import threading
+import time
+
+import pytest
+
+import agent.tool_executor as tool_executor
+from agent.tool_executor import (
+    _ConcurrentBatch,
+    _ManagedToolResult,
+    _ParsedCall,
+    _ToolTimeoutResult,
+    _interrupt_active_children,
+    _run_sequential_tool_execution_middleware,
+)
+
+
+class _FakeChild:
+    """Delegate-child double recording the stop signals it received."""
+
+    def __init__(self) -> None:
+        self.hard_interrupt_calls = []
+        self._interrupt_requested = False
+
+    def hard_interrupt(self, message=None, **kwargs):
+        self.hard_interrupt_calls.append(message)
+        self._interrupt_requested = True
+
+
+class _LegacyChild:
+    """Third-party/legacy child exposing only ``interrupt(message=None)``."""
+
+    def __init__(self) -> None:
+        self.interrupt_calls = []
+
+    def interrupt(self, message=None, **kwargs):
+        self.interrupt_calls.append(message)
+
+
+class _BareChild:
+    """Child double with no interrupt ABI at all (fallback flag path)."""
+
+    def __init__(self) -> None:
+        self._interrupt_requested = False
+
+
+class _FakeAgent:
+    def __init__(self, children=None):
+        self._tool_worker_threads = set()
+        self._tool_worker_threads_lock = threading.Lock()
+        self._active_children = list(children or [])
+        self._active_children_lock = threading.Lock()
+        self._interrupt_requested = False
+        self.activity = []
+
+    def _touch_activity(self, msg):
+        self.activity.append(msg)
+
+
+@pytest.fixture()
+def fake_agent():
+    return _FakeAgent()
+
+
+@pytest.fixture(autouse=True)
+def _quiet_emits(monkeypatch):
+    monkeypatch.setattr(tool_executor, "_SEQUENTIAL_INTERRUPT_POLL_SECONDS", 0.05)
+    monkeypatch.setattr(
+        tool_executor,
+        "_emit_terminal_post_tool_call",
+        lambda agent, **kw: None,
+    )
+
+
+def test_sequential_timeout_stops_delegate_children(monkeypatch, fake_agent):
+    """The sequential deadline path must propagate the stop to active children."""
+
+    child = _FakeChild()
+    fake_agent._active_children.append(child)
+
+    def _blocking_middleware(agent_arg, **kwargs):
+        time.sleep(30)  # non-cooperative: never returns on its own
+        return _ManagedToolResult(result="late", args={}, middleware_trace=[], blocked=False, dispatched=True)
+
+    monkeypatch.setattr(tool_executor, "_run_agent_tool_execution_middleware", _blocking_middleware)
+    monkeypatch.setattr(tool_executor, "_resolve_sequential_tool_timeout", lambda: 0.2)
+
+    managed = _run_sequential_tool_execution_middleware(
+        fake_agent,
+        function_name="delegate_task",
+        function_args={"goal": "x"},
+        effective_task_id="t",
+        tool_call_id="call_1",
+        execute=lambda a: "unused",
+    )
+
+    assert isinstance(managed.result, _ToolTimeoutResult)
+    assert "timed out after 0.2s" in str(managed.result)
+    # The child saw the stop signal even though the tool itself never cooperated.
+    assert child.hard_interrupt_calls == [None]
+    assert child._interrupt_requested is True
+
+
+def test_concurrent_batch_timeout_stops_delegate_children(fake_agent):
+    """The concurrent batch deadline path must propagate the stop to active children."""
+
+    child = _FakeChild()
+    fake_agent._active_children.append(child)
+
+    parsed = _ParsedCall(
+        tool_call=None, name="delegate_task", args={}, middleware_trace=[],
+        parse_error=None, scope_block=None,
+    )
+    batch = _ConcurrentBatch(fake_agent, [], "t", [parsed], 0.1)
+
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    try:
+        future = executor.submit(lambda: time.sleep(30))
+        # Deadline already elapsed: the wait loop must take the timed_out branch.
+        abandoned = batch.await_completion({future}, {future: 0}, time.monotonic() - 1.0)
+    finally:
+        executor.shutdown(wait=False, cancel_futures=True)
+
+    assert abandoned is True
+    assert batch.timed_out_indices == {0}
+    assert child.hard_interrupt_calls == [None]
+
+
+def test_helper_covers_all_child_abis():
+    """hard_interrupt children get the new ABI; legacy children get interrupt();
+    ABI-less children still get the cooperative flag."""
+
+    agent = _FakeAgent(children=[])
+    hard, legacy, bare = _FakeChild(), _LegacyChild(), _BareChild()
+    agent._active_children = [hard, legacy, bare]
+
+    _interrupt_active_children(agent)
+
+    assert hard.hard_interrupt_calls == [None]
+    assert legacy.interrupt_calls == [None]
+    assert bare._interrupt_requested is True
+
+
+def test_helper_safe_without_children():
+    """Agents without the delegation registry (or with no active children) are a no-op."""
+
+    _interrupt_active_children(_FakeAgent(children=[]))
+
+    class _Minimal:
+        pass
+
+    _interrupt_active_children(_Minimal())  # no _active_children attribute at all


### PR DESCRIPTION
## What does this PR do?

When a `delegate_task` tool call hits its deadline, the executor raised the parent tool-worker thread's per-thread interrupt bit (`tools.interrupt` is thread-scoped), cancelled the `Future` (a no-op once the worker started), and returned the "timed out" result without joining. But a delegated child runs on its **own** daemon worker and only observes its **own** interrupt state — the parent-side bit never reached it, so children kept running (tool calls, git commits) for minutes after the parent had already reported `timed out` (#103301).

`agent.interrupt()` already propagates a user stop to `_active_children` (`agent/interrupt_control.py`); this PR mirrors that same propagation on both executor timeout paths, so a timed-out delegation stops its children through the existing, well-tested cooperative stop chain (`hard_interrupt` → `_interrupt_requested` flag → thread-bit fan-out, recursively for nested delegates).

## Related Issue

Fixes #103301

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/tool_executor.py`: add `_interrupt_active_children(agent)` helper — snapshots `_active_children` under its lock and requests a hard interrupt on each child (falling back to the cooperative `_interrupt_requested` flag for children without the interrupt ABI, matching `_signal_child_stop` in `tools/delegate_tool_child_run.py`).
- `agent/tool_executor.py`: call it from the sequential deadline branch (`state == "timeout"`) and the concurrent batch `timed_out` branch, right next to the existing `_interrupt_worker_tids` fan-out.
- `tests/agent/test_timeout_stops_delegate_children.py`: regression coverage for both timeout paths plus the helper's child-ABI variants.

## How to Test

1. `pytest tests/agent/test_timeout_stops_delegate_children.py -q` — 4 passed: the sequential timeout path and the concurrent batch timeout path both stop registered children; the helper covers `hard_interrupt`, legacy `interrupt`, and bare-flag children, and is a safe no-op without the delegation registry.
2. `pytest tests/agent/test_sequential_tool_interrupt.py tests/agent/test_deadline.py -q` — 60 passed (existing interrupt/deadline semantics unchanged).
3. `pytest tests/tools/test_delegate.py tests/tools/test_async_delegation.py tests/tools/test_delegate_timeout_cleanup.py -q` — 116 passed; one unrelated pre-existing local failure (`test_child_dedicated_db_follows_parents_db_path`, macOS `/var` vs `/private/var` symlink path mismatch) reproduces on clean upstream/main and is not touched by this PR.

Observed result: a timed-out delegation now receives the same cooperative stop signal as a user `/stop`, so children exit at their next check point instead of outliving the "timed out" report.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-architecture) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A