### PR TITLE
fix(cron): pass job workdir to agent-path wake-gate scripts

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2043,7 +2043,10 @@ def _prepare_job_prompt(
     prerun_script = None
     script_path = job.get("script")
     if script_path:
-        prerun_script = _run_job_script_with_claim_heartbeat(job, script_path, cancel_event=cancel_event)
+        # Pass workdir as subprocess cwd, mirroring the no_agent path: scripts get no arguments,
+        # so cwd is the only per-job context a gate script has.
+        prerun_script = _run_job_script_with_claim_heartbeat(
+            job, script_path, workdir=_resolve_job_workdir(job, job_id), cancel_event=cancel_event)
         _ran_ok, _script_output = prerun_script
         if _ran_ok and not _parse_wake_gate(_script_output):
             logger.info("Job '%s' (ID: %s): wakeAgent=false, skipping agent run", job_name, job_id)

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -320,3 +320,58 @@ class TestRunJobTerminalCwd:
         assert observed["terminal_cwd_during_run"] == baseline
         assert os.environ["TERMINAL_CWD"] == baseline
         assert get_session_cwd(observed["task_id"]) is None
+
+
+# ---------------------------------------------------------------------------
+# scheduler.run_job: agent-path wake-gate script honours workdir
+# ---------------------------------------------------------------------------
+
+class TestAgentPathWakeGateWorkdir:
+    """The pre-run wake-gate script on the agent path must run with the job's
+    workdir as its cwd, exactly as the no_agent path already does.
+
+    Scripts receive no arguments, so cwd is the only per-job context a gate
+    script gets. Launched without the workdir it runs from the scripts dir,
+    cannot find the data it was written against, and fails open.
+    """
+
+    def test_wake_gate_script_runs_in_job_workdir(self, tmp_path, monkeypatch):
+        from pathlib import Path
+        from unittest.mock import patch
+        import cron.scheduler as sched
+        from hermes_cli import env_loader
+
+        monkeypatch.setattr(sched, "_get_hermes_home", lambda: tmp_path)
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        workdir = tmp_path / "job-data"
+        workdir.mkdir()
+        seen_cwd = tmp_path / "seen-cwd"
+        (scripts_dir / "gate.py").write_text(
+            "import json, os\n"
+            f"open({str(seen_cwd)!r}, 'w').write(os.getcwd())\n"
+            "print(json.dumps({'wakeAgent': False}))\n",
+            encoding="utf-8",
+        )
+
+        job = {
+            "id": "gate-workdir",
+            "name": "gate-workdir",
+            "prompt": "hello",
+            "schedule": "*/5 * * * *",
+            "script": "gate.py",
+            "workdir": str(workdir),
+        }
+
+        with patch("cron.scheduler_delivery._resolve_origin", return_value=None), \
+             patch.object(env_loader, "load_hermes_dotenv"), \
+             patch.object(env_loader, "reset_secret_source_cache"), \
+             patch("run_agent.AIAgent") as agent_cls:
+            success, _doc, final, err = sched.run_job(job)
+
+        assert success is True
+        assert err is None
+        assert final == sched.SILENT_MARKER
+        agent_cls.assert_not_called()
+        assert seen_cwd.exists(), "gate script did not run"
+        assert Path(seen_cwd.read_text()).resolve() == workdir.resolve()


### PR DESCRIPTION
## Problem

A cron job can set `workdir`. On the `no_agent` path the script is launched with `workdir=_resolve_job_workdir(job, job_id)`, so it runs with the job's directory as its cwd. On the agent path the pre-run wake-gate script (`_prepare_job_prompt` in `cron/scheduler.py`) was launched without the workdir, so it ran with cwd set to the scripts directory instead.

Scripts receive no arguments, so cwd is the only per-job context a gate script has. A gate that reads its per-job data relative to cwd cannot find it on the agent path. In production this made a date-window gate fail open and fire a reminder outside its window.

## Related issue

Fixes #21721. That report covers two halves: `_run_job_script` ignoring `workdir` entirely, and the agent path never passing it. The first half has since landed (the `workdir` kwarg on `_run_job_script`, used by the `no_agent` path; see #69396 in its docstring). This PR closes the remaining agent-path half. #21397 addressed both halves against the pre-split scheduler and is now stale.

## Fix

Pass `workdir=_resolve_job_workdir(job, job_id)` to `_run_job_script_with_claim_heartbeat` on the agent path, mirroring the `no_agent` path's existing behaviour. No new helpers; the existing resolver already handles unset and stale directories.

## Test

`tests/cron/test_cron_workdir.py::TestAgentPathWakeGateWorkdir` runs a real gate script through `run_job` on the agent path with a `workdir` set. The script writes `os.getcwd()` to a file and returns `wakeAgent: false` so no agent is constructed. On unpatched main the recorded cwd is the scripts directory; with the fix it is the job's workdir.

Ran the new test, all of `tests/cron/test_cron_workdir.py`, `test_script_claim_heartbeat.py`, `test_sessiondb_init_hang.py`, `test_cron_no_agent.py`, and `test_scheduler.py -k wake` (63 passed). I did not run the full suite on this machine.

## Type of change

Bug fix (non-breaking change that fixes an issue).

## Checklist

- Read the Contributing Guide; commit follows Conventional Commits.
- Searched existing PRs for a duplicate.
- PR contains only changes related to this fix.
- Regression test added; targeted cron tests pass (full suite not run locally, see above).
- Tested on Ubuntu 26.04, Python 3.14.
- Documentation, config example, CONTRIBUTING/AGENTS, tool schemas: N/A. Cross-platform: cwd is passed through the existing `workdir` kwarg, no platform-specific code.

