### PR TITLE
feat(email): task-context subjects for outbound mail

### DIFF
--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -1222,7 +1222,7 @@ def _live_route_metadata(t: _TargetDelivery) -> tuple[Optional[str], dict, dict]
         route_thread_id = None
         route_metadata = {
             "direct_messages_topic_id": str(thread_id), "job_id": job["id"],
-            "notify": t.notify_delivery,
+            "notify": t.notify_delivery, "subject": job.get("name") or job["id"],
         }
         media_metadata = {"direct_messages_topic_id": str(thread_id), "notify": t.notify_delivery}
     else:
@@ -1232,7 +1232,8 @@ def _live_route_metadata(t: _TargetDelivery) -> tuple[Optional[str], dict, dict]
         # thread_id is absent from metadata; cron deliveries have no inbound reply anchor, so the metadata
         # key bypasses that check and lets the adapter route via a plain message_thread_id. See #52060.
         route_thread_id = str(thread_id) if thread_id is not None else None
-        route_metadata = {"job_id": job["id"], "notify": t.notify_delivery}
+        route_metadata = {"job_id": job["id"], "notify": t.notify_delivery,
+                          "subject": job.get("name") or job["id"]}
         if route_thread_id:
             route_metadata["thread_id"] = route_thread_id
         media_metadata = {"notify": t.notify_delivery}
@@ -1468,7 +1469,7 @@ def _standalone_send(
     def _send():
         return _send_to_platform(
             t.platform, t.pconfig, t.chat_id, content, thread_id=t.thread_id,
-            media_files=media_files)
+            media_files=media_files, subject=job.get("name") or job["id"])
 
     def _warned(msg: str) -> tuple[None, str]:
         logger.warning("Job '%s': %s", job["id"], msg)

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -666,7 +666,37 @@ class EmailAdapter(BasePlatformAdapter):
 
     async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
         """Send an email reply to the given address."""
-        return await self._run_send(self._send_email, (chat_id, content, reply_to), "[Email] Send failed to %s: %s", chat_id)
+        subject = self._task_subject(metadata or {})
+        return await self._run_send(self._send_email, (chat_id, content, reply_to, subject), "[Email] Send failed to %s: %s", chat_id)
+
+    def _task_subject(self, metadata: Dict[str, Any]) -> Optional[str]:
+        """Derive an outbound subject from send metadata, if any.
+
+        An explicit ``subject`` is honored verbatim (no ``Re:`` prefix — that stays
+        reserved for reply threading). Otherwise the first available task-context
+        field (job_name/reason/task/title) is prefixed, so cron deliveries carry
+        the producing job's name instead of a generic default. Returns ``None``
+        when there is no task context and the reply-thread default applies.
+        """
+        override = metadata.get("subject")
+        if override:
+            return str(override)
+        for key in ("job_name", "reason", "task", "title"):
+            value = metadata.get(key)
+            if value:
+                return f"{self._subject_prefix}: {value}"
+        return None
+
+    def _verbatim_subject_msg(self, to_addr: str, body: str, subject: str) -> MIMEMultipart:
+        """Build a fresh (non-reply) message with the subject used exactly as given."""
+        msg = MIMEMultipart()
+        msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._message_id_domain()}>"
+        for key, value in (("From", self._address), ("To", to_addr), ("Subject", subject),
+                           ("Date", formatdate(localtime=True)), ("Message-ID", msg_id)):
+            msg[key] = value
+        if body:
+            msg.attach(MIMEText(body, "plain", "utf-8"))
+        return msg
 
     def _message_id_domain(self) -> str:
         """Domain for generated Message-IDs; ``localhost`` when EMAIL_ADDRESS lacks ``@``."""
@@ -701,17 +731,36 @@ class EmailAdapter(BasePlatformAdapter):
             except Exception:
                 smtp.close()
 
-    def _send_email(self, to_addr: str, body: str, reply_to_msg_id: Optional[str] = None) -> str:
+    def _send_email(self, to_addr: str, body: str, reply_to_msg_id: Optional[str] = None,
+                    subject_override: Optional[str] = None) -> str:
         """Send an email via SMTP. Runs in executor thread."""
+        if subject_override:
+            msg = self._verbatim_subject_msg(to_addr, body, subject_override)
+            self._smtp_send(msg)
+            logger.info("[Email] Sent mail to %s (subject: %s)", to_addr, subject_override)
+            return str(msg["Message-ID"])
         msg, msg_id, subject = self._new_reply(to_addr, body, reply_to_msg_id, attach_empty_body=True)
         self._smtp_send(msg)
         logger.info("[Email] Sent reply to %s (subject: %s)", to_addr, subject)
         return msg_id
 
     def _send_with_files(self, to_addr: str, body: str, files: List[Tuple[Path, str]], *, lenient: bool,
-                         reply_to_msg_id: Optional[str] = None) -> str:
+                         reply_to_msg_id: Optional[str] = None,
+                         subject_override: Optional[str] = None) -> str:
         """Send a reply with attachments; *lenient* logs-and-skips unattachable files instead of raising.
-        An explicit *reply_to_msg_id* threads the mail like ``_send_email`` does (#10131)."""
+        An explicit *reply_to_msg_id* threads the mail like ``_send_email`` does (#10131); an explicit
+        *subject_override* sends verbatim (fresh thread, no Re: prefix)."""
+        if subject_override:
+            msg = self._verbatim_subject_msg(to_addr, body, subject_override)
+            for path, name in files:
+                try:
+                    _attach_file(msg, path, name)
+                except Exception as e:
+                    if not lenient:
+                        raise
+                    logger.warning("[Email] Failed to attach %s: %s", path, e)
+            self._smtp_send(msg)
+            return str(msg["Message-ID"])
         msg, msg_id, _ = self._new_reply(to_addr, body, reply_to_msg_id)
         for path, name in files:
             try:
@@ -777,19 +826,20 @@ class EmailAdapter(BasePlatformAdapter):
 
 
 # Plugin glue: register() exposes the platform via the registry; EMAIL_* env → PlatformConfig seeding stays in core.
-async def _standalone_send(pconfig, chat_id, message, *, thread_id=None, media_files=None, force_document=False):
+async def _standalone_send(pconfig, chat_id, message, *, thread_id=None, media_files=None, force_document=False,
+                       subject=None):
     """Out-of-process Email delivery via SMTP (one-shot); standalone_sender_fn contract."""
     extra = getattr(pconfig, "extra", {}) or {}
     address, password = extra.get("address") or _get_secret("EMAIL_ADDRESS", ""), _get_secret("EMAIL_PASSWORD", "")
     smtp_host, smtp_port = extra.get("smtp_host") or _get_secret("EMAIL_SMTP_HOST", ""), _esecret_int("EMAIL_SMTP_PORT", 587)
     smtp_security = _normalize_security(_get_secret("EMAIL_SMTP_SECURITY", "") or extra.get("smtp_security"), default="tls" if smtp_port == 465 else "starttls")
     smtp_tls_verify = _esecret_bool("EMAIL_SMTP_TLS_VERIFY", is_truthy_value(extra.get("smtp_tls_verify"), default=True))
+    prefix = (_get_secret("EMAIL_SUBJECT_PREFIX", "") or "Hermes Agent").strip() or "Hermes Agent"
     if not all([address, password, smtp_host]):
         return {"error": "Email not configured (EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_SMTP_HOST required)"}
     try:
         msg = MIMEText(message, "plain", "utf-8")
-        prefix = (_get_secret("EMAIL_SUBJECT_PREFIX", "") or "Hermes Agent").strip() or "Hermes Agent"
-        for key, value in (("From", address), ("To", chat_id), ("Subject", prefix), ("Date", formatdate(localtime=True))):
+        for key, value in (("From", address), ("To", chat_id), ("Subject", subject or prefix), ("Date", formatdate(localtime=True))):
             msg[key] = value
         server = _open_smtp(smtp_host, smtp_port, smtp_security, _tls_context(smtp_tls_verify, smtp_host), smtplib.SMTP, smtplib.SMTP_SSL)
         server.login(address, password)

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -360,6 +360,11 @@ class EmailAdapter(BasePlatformAdapter):
             self._require_authenticated_sender = not _esecret_bool("EMAIL_TRUST_FROM_HEADER", False)
         # Optional authserv-id pinning Authentication-Results to the operator's own server (defeats an injected header sorting first).
         self._authserv_id = (extra.get("authserv_id", "") or _get_secret("EMAIL_AUTHSERV_ID", "")).strip().lower()
+        # Outbound subject prefix: distinguishes Hermes mail in busy inboxes and
+        # keeps spam filters from reading a generic "Hermes Agent" as bot traffic.
+        self._subject_prefix = (
+            _get_secret("EMAIL_SUBJECT_PREFIX", "") or "Hermes Agent"
+        ).strip() or "Hermes Agent"
         self._seen_uids: set = set()
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
         self._poll_task: Optional[asyncio.Task] = None
@@ -671,7 +676,7 @@ class EmailAdapter(BasePlatformAdapter):
                    attach_empty_body: bool = False) -> Tuple[MIMEMultipart, str, str]:
         """Build a threaded reply skeleton. Returns ``(msg, msg_id, subject)``."""
         msg, ctx = MIMEMultipart(), self._thread_context.get(to_addr, {})
-        subject = ctx.get("subject", "Hermes Agent")
+        subject = ctx.get("subject", self._subject_prefix)
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
         original_msg_id = reply_to_msg_id or ctx.get("message_id")
@@ -783,7 +788,8 @@ async def _standalone_send(pconfig, chat_id, message, *, thread_id=None, media_f
         return {"error": "Email not configured (EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_SMTP_HOST required)"}
     try:
         msg = MIMEText(message, "plain", "utf-8")
-        for key, value in (("From", address), ("To", chat_id), ("Subject", "Hermes Agent"), ("Date", formatdate(localtime=True))):
+        prefix = (_get_secret("EMAIL_SUBJECT_PREFIX", "") or "Hermes Agent").strip() or "Hermes Agent"
+        for key, value in (("From", address), ("To", chat_id), ("Subject", prefix), ("Date", formatdate(localtime=True))):
             msg[key] = value
         server = _open_smtp(smtp_host, smtp_port, smtp_security, _tls_context(smtp_tls_verify, smtp_host), smtplib.SMTP, smtplib.SMTP_SSL)
         server.login(address, password)

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1144,5 +1144,100 @@ class TestSenderAuthentication(unittest.TestCase):
         self.assertFalse(ok, reason)
 
 
+class TestEmailSubjectPrefixAndTaskContext(unittest.TestCase):
+    """Subject prefix config plus task-context subjects for outbound mail."""
+
+    def _make_adapter(self, extra_env=None):
+        from gateway.config import PlatformConfig
+        env = {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }
+        env.update(extra_env or {})
+        with patch.dict(os.environ, env):
+            from plugins.platforms.email.adapter import EmailAdapter
+            return EmailAdapter(PlatformConfig(enabled=True))
+
+    def _sent_subject(self, mock_server):
+        return mock_server.send_message.call_args[0][0]["Subject"]
+
+    def test_prefix_defaults_to_hermes_agent(self):
+        self.assertEqual(self._make_adapter()._subject_prefix, "Hermes Agent")
+
+    def test_prefix_custom_env(self):
+        adapter = self._make_adapter({"EMAIL_SUBJECT_PREFIX": "Nightly"})
+        self.assertEqual(adapter._subject_prefix, "Nightly")
+
+    def test_reply_default_uses_prefix(self):
+        import asyncio
+        adapter = self._make_adapter({"EMAIL_SUBJECT_PREFIX": "Nightly"})
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp.return_value = MagicMock()
+            asyncio.run(adapter.send("user@test.com", "hello"))
+            self.assertEqual(self._sent_subject(mock_smtp.return_value), "Re: Nightly")
+
+    def test_metadata_subject_used_verbatim_without_re(self):
+        import asyncio
+        adapter = self._make_adapter()
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp.return_value = MagicMock()
+            asyncio.run(adapter.send("user@test.com", "hello", metadata={"subject": "Nightly Backup"}))
+            self.assertEqual(self._sent_subject(mock_smtp.return_value), "Nightly Backup")
+
+    def test_job_name_derives_prefixed_subject(self):
+        import asyncio
+        adapter = self._make_adapter()
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp.return_value = MagicMock()
+            asyncio.run(adapter.send("user@test.com", "hello", metadata={"job_name": "Nightly Backup"}))
+            self.assertEqual(self._sent_subject(mock_smtp.return_value), "Hermes Agent: Nightly Backup")
+
+    def test_no_context_keeps_reply_threading(self):
+        import asyncio
+        adapter = self._make_adapter()
+        adapter._thread_context["user@test.com"] = {"subject": "Earlier", "message_id": "<m@t>"}
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp.return_value = MagicMock()
+            asyncio.run(adapter.send("user@test.com", "hello", metadata={}))
+            self.assertEqual(self._sent_subject(mock_smtp.return_value), "Re: Earlier")
+
+    def test_standalone_subject_kwarg(self):
+        import asyncio
+        from types import SimpleNamespace
+        from plugins.platforms.email.adapter import _standalone_send as _email_send
+        env = {"EMAIL_ADDRESS": "hermes@test.com", "EMAIL_PASSWORD": "secret",
+               "EMAIL_SMTP_HOST": "smtp.test.com", "EMAIL_SMTP_PORT": "587"}
+        with patch.dict(os.environ, env), patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp.return_value = MagicMock()
+            result = asyncio.run(_email_send(
+                SimpleNamespace(token=None, api_key=None, extra={}), "user@test.com", "Hello",
+                subject="Cron Job X"))
+            self.assertTrue(result["success"])
+            self.assertEqual(mock_smtp.return_value.send_message.call_args[0][0]["Subject"], "Cron Job X")
+
+    def test_scheduler_route_metadata_carries_subject(self):
+        from types import SimpleNamespace
+        from gateway.config import Platform
+        from cron.scheduler_delivery import _live_route_metadata
+        t = SimpleNamespace(job={"id": "job1", "name": "Nightly Backup"}, thread_id=None,
+                            platform=Platform.EMAIL, notify_delivery=True, origin_target=False,
+                            origin={}, chat_id="user@test.com", loop=None, runtime_adapter=None)
+        _, route_metadata, _ = _live_route_metadata(t)  # type: ignore[arg-type]
+        self.assertEqual(route_metadata["subject"], "Nightly Backup")
+
+    def test_standalone_sender_without_subject_param_unaffected(self):
+        import asyncio
+        from tools import send_message_senders as _senders
+        async def _plain_sender(pconfig, chat_id, message, thread_id=None):
+            return {"success": True}
+        with patch.object(_senders, "_plugin_standalone_sender",
+                          return_value=(_plain_sender, None)):
+            result = asyncio.run(_senders._registry_standalone_send(
+                "email", object(), "user@test.com", "Hello", subject="Cron Job X"))
+            self.assertTrue(result["success"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/send_message_senders.py
+++ b/tools/send_message_senders.py
@@ -331,10 +331,16 @@ def _plugin_standalone_sender(platform_name, *, label=None, discover=True):
     return entry.standalone_sender_fn, None
 
 
-async def _registry_standalone_send(platform_name, pconfig, chat_id, message, thread_id=None):
+async def _registry_standalone_send(platform_name, pconfig, chat_id, message, thread_id=None, subject=None):
     """One-shot text send through a plugin's ``standalone_sender_fn``."""
     sender, err = _plugin_standalone_sender(platform_name)
-    return err or await sender(pconfig, chat_id, message, thread_id=thread_id)
+    if err is not None:
+        return err
+    assert sender is not None  # contract: no error implies a sender
+    import inspect as _inspect
+    if subject and "subject" not in _inspect.signature(sender).parameters:
+        return await sender(pconfig, chat_id, message, thread_id=thread_id)
+    return await sender(pconfig, chat_id, message, thread_id=thread_id, subject=subject)
 
 
 async def _resolve_slack_user_target(token, chat_id):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -447,7 +447,7 @@ async def _dispatch_on_gateway_loop(runner, make_coro, log_message):
 
 
 async def _send_via_adapter(platform, pconfig, chat_id, chunk, *, thread_id=None, media_files=None,
-                            force_document=False):
+                            force_document=False, subject=None):
     """Live in-process gateway adapter first, else the plugin's ``standalone_sender_fn`` (cron),
     else an error naming both; media uses the adapter's native media APIs under the same rules."""
     platform_name = platform.value if hasattr(platform, "value") else str(platform)
@@ -455,7 +455,8 @@ async def _send_via_adapter(platform, pconfig, chat_id, chunk, *, thread_id=None
     if adapter is not None:
         try:
             metadata = {**({"thread_id": thread_id} if thread_id else {}),
-                        **({"publish_topic": chat_id} if platform_name == "ntfy" and chat_id else {})} or None
+                        **({"publish_topic": chat_id} if platform_name == "ntfy" and chat_id else {}),
+                        **({"subject": subject} if subject else {})} or None
             if media_files:  # always a dict result, returned as-is below
                 make_coro = lambda: _send_live_adapter_media(  # noqa: E731
                     adapter, chat_id, chunk, media_files, thread_id=thread_id, metadata=metadata,
@@ -483,8 +484,11 @@ async def _send_via_adapter(platform, pconfig, chat_id, chunk, *, thread_id=None
                           f"connected? For out-of-process delivery (e.g. cron in a separate process), the platform "
                           f"plugin must register a standalone_sender_fn on its PlatformEntry.")}
     try:
+        import inspect as _inspect
+        _sender_params = _inspect.signature(sender).parameters
+        _sender_extra = {"subject": subject} if subject and "subject" in _sender_params else {}
         result = await sender(pconfig, chat_id, chunk, thread_id=thread_id, media_files=media_files,
-                              force_document=force_document)
+                              force_document=force_document, **_sender_extra)
     except asyncio.CancelledError:
         raise
     except Exception as e:
@@ -555,8 +559,9 @@ async def _send_plugin_standalone(platform_name, pconfig, chat_id, message, chun
         pconfig, chat_id, chunk, thread_id=thread_id, media_files=media_files if is_last else empty_media, **extra))
 
 
-def _via_adapter_route(p, pc, cid, chunk, media, tid, fd):
-    return _send_via_adapter(p, pc, cid, chunk, thread_id=tid, media_files=media, force_document=fd)
+def _via_adapter_route(p, pc, cid, chunk, media, tid, fd, subject=None):
+    return _send_via_adapter(p, pc, cid, chunk, thread_id=tid, media_files=media, force_document=fd,
+                             subject=subject)
 
 
 # Native-media chunked routes for built-in platforms; media rides on the final chunk, non-final
@@ -587,7 +592,8 @@ _TEXT_SENDERS = {
 _MEDIA_PLATFORMS_NOTE = "telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp and slack"
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, args=None):
+async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, args=None,
+                      subject=None):
     """Route to the platform sender, chunking long text with the adapters' splitter. Order matters:
     Weixin first (its native helper must not be blocked by unrelated optional imports such as
     lark-oapi), Telegram (chunks itself), plugin standalone media, native chunked, generic text."""
@@ -637,7 +643,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 return {"error": f"Plugin send_message handler failed: {e}"}
         # Plugin platform: live gateway adapter if available, else standalone_sender_fn.
         send_one = lambda chunk, is_last: _via_adapter_route(  # noqa: E731
-            platform, pconfig, chat_id, chunk, media_files if is_last else [], thread_id, force_document)
+            platform, pconfig, chat_id, chunk, media_files if is_last else [], thread_id, force_document,
+            subject)
     last_result = await _send_chunks(chunks, send_one)
     if (warning and isinstance(last_result, dict) and last_result.get("success")
             and not last_result.get("media_delivered")):


### PR DESCRIPTION
Successor to #98742 (reopen refused by GitHub API, so opening fresh from a new branch).

Fixes #98649.

What this does:
- Configurable outbound subject prefix via EMAIL_SUBJECT_PREFIX (default Hermes Agent), applied to reply + standalone defaults. Original prefix idea by kokhlo, preserved with his authorship on the first commit.
- Task-context subjects: send metadata subject honored verbatim (no Re: prefix, reserved for reply threading), else job_name / reason / task / title derived with prefix.
- Scheduler stamps subject into route_metadata on the live path and passes it on the standalone / thread-pool fallback path.
- tools/send_message_tool.py + tools/send_message_senders.py forward subject with a signature-compatible downgrade, so feishu, slack, whatsapp and other non-email senders are unaffected.
- 9 new tests in tests/gateway/test_email.py; 48/48 pass via scripts/run_tests.sh tests/gateway/test_email.py.

Delta vs #101821 (fix(email): cron deliveries use job name as email subject by patrickyu70-star):
- Overlap: job_name in route_metadata, email adapter subject_override, send_message_tool forwarding.
- Ours adds: EMAIL_SUBJECT_PREFIX configurability, derivation from reason/task/title (not just job name), scheduler + send-path tests, verbatim-vs-threading subject rules.

Rebuilt on current main 71f8c60f6a as 2 commits (ef33653961 + 9dc199691d). Ready for review, @alt-glitch.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/platforms/email/adapter.py`
  - Resolve `EMAIL_SUBJECT_PREFIX` once at `__init__` (default `Hermes Agent`, backward compatible).
  - Add `_task_reason` (`job_name` > `reason`/`task`/`title`) + `_build_subject` (explicit subject verbatim without `Re:`; else `<PREFIX>: <reason>`; else `Re: <thread>`; else prefix).
  - Plumb `metadata` through `send`, `_send_email`, `_send_with_files`; `_standalone_send` takes a `subject` kwarg.
- `cron/scheduler_delivery.py`
  - Stamp `subject` into `route_metadata` on the live path; pass it through `_send_to_platform` on the standalone / thread-pool fallback path.
- `tools/send_message_tool.py` + `tools/send_message_senders.py`
  - Forward `subject` with an inspect-based downgrade so standalone senders without a `subject` param are unaffected (feishu, slack, whatsapp, etc.).
- `tests/gateway/test_email.py`
  - 9 new tests: prefix default/custom, verbatim subject, job_name derivation, threading retention, standalone kwarg, route metadata, unaffected sender.

## How to Test

1. Default behavior (no env var) is unchanged — subjects still read `Hermes Agent` / `Re: <thread>`.
2. Custom prefix: `EMAIL_SUBJECT_PREFIX="My Bot"` — fresh send `My Bot`, thread reply `Re: <thread>`.
3. Task-context subject (cron path): scheduled email delivery reads `My Bot: <job name>`.
4. Run the suite:
   ```
   scripts/run_tests.sh tests/gateway/test_email.py
   # 48 passed
   ```

## Duplicate search

- Open `email subject prefix` search → #98649 (this issue), #46947 (hardcoded-subject bug motivating this), #102884 (SMTP-only custom subject bug, adjacent not duplicate).
- Closed `email subject` search (15 hits) → no direct match (nearest: mail-filter Date header, AgentMail — distinct).
- PR #101821 (`fix(email): cron deliveries use job name as email subject`) is OPEN but CONFLICTING and covers only the job-name half — no prefix configurability, no reason/task/title derivation, no scheduler + send-path tests. This PR is the full fix.
- PR #98742 is the closed predecessor (reopen refused by API); this PR is its successor.

## Checklist

- [x] `EMAIL_SUBJECT_PREFIX` env (default `Hermes Agent`) — backward compatible.
- [x] Task-context subjects per #98649 (`job_name`/`reason`/`task`/`title`).
- [x] Live + standalone/thread-pool paths plumbed.
- [x] `Re:` kept for thread replies only; no spurious `Re:` on fresh sends.
- [x] Non-email senders unaffected via signature-compatible downgrade.
- [x] 9 new tests; `tests/gateway/test_email.py` 48/48 pass.
- [x] Rebuilt on `origin/main` 71f8c60f6a (ef33653961 + 9dc199691d).
- [x] Fixes #98649; successor to #98742.
