### PR TITLE
fix(cli): drain LSP subprocess transports before event loop shutdown

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -793,12 +793,23 @@ def _shutdown_cached_aux_clients() -> None:
     shutdown_cached_clients()
 
 
+def _shutdown_lsp_service() -> None:
+    """Tear down the LSP service so its asyncio subprocess transports are cleaned up
+    before the event loop closes.  Prevents ``RuntimeError: Event loop is closed`` from
+    ``BaseSubprocessTransport.__del__`` during interpreter shutdown when an LSP server
+    (e.g. pyright) was spawned during the session.
+    """
+    from agent.lsp import shutdown_service
+    shutdown_service()
+
+
 # Ordered teardown steps (attribute names, resolved at call time so tests can patch them)
 # and the exception class each swallows.
 _CLEANUP_STEPS = (
     ("_stop_cli_wake_word", Exception), ("_cleanup_all_terminals", Exception),
     ("_interrupt_async_delegations", Exception), ("_cleanup_all_browsers", Exception),
     ("_shutdown_mcp_servers", BaseException), ("_shutdown_cached_aux_clients", Exception),
+    ("_shutdown_lsp_service", Exception),
 )
 
 


### PR DESCRIPTION
## Summary

- Wire `agent.lsp.shutdown_service` into the CLI `_run_cleanup` sequence so the LSP client's asyncio subprocess transports are explicitly terminated before the event loop closes on `/exit` or interpreter shutdown.
- Without this, `BaseSubprocessTransport.__del__` fires during GC after the loop is already closed and CPython logs `RuntimeError: Event loop is closed` as an ignored exception on exit.
- The LSP service already had an idempotent `shutdown_service()` and an `atexit` handler; this patch closes the gap for the interactive TUI `/exit` path.

## Motivation

When starting and stopping Hermes, the console printed:

```
Exception ignored in: <function BaseSubprocessTransport.__del__ ...>
RuntimeError: Event loop is closed
```

This is a benign cleanup race: CPython finalizes alive asyncio subprocess transports after the loop has shut down. The LSP client (e.g. pyright/gopls) is the most common source in an interactive TUI session. Explicitly draining it in `_run_cleanup` before the loop teardown eliminates the noise.

## Test plan

- [ ] Start Hermes TUI, trigger at least one LSP diagnostics request so a server subprocess is spawned, then type `/exit`.
- [ ] Confirm the `RuntimeError: Event loop is closed` trace no longer appears on exit.
- [ ] Confirm normal shutdown still works when no LSP server was ever spawned (function is idempotent).

