### PR TITLE
fix(dashboard): read the session token at request time in mount_spa

### DIFF
--- a/hermes_cli/web_server_dashboard.py
+++ b/hermes_cli/web_server_dashboard.py
@@ -102,7 +102,16 @@ def mount_spa(application: FastAPI):
     with a missing dist per-request (404 JSON / ``check_dir=False``), so a long-lived
     ``--skip-build`` process recovers the moment a build appears on disk — no restart.
     """
-    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, _SESSION_TOKEN, app
+    from hermes_cli import web_server as _web_server
+    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, app
+
+    # Read ``_SESSION_TOKEN`` through the module object at request time. A
+    # ``from ... import`` binding would freeze the random boot-time token:
+    # ``start_server`` later rebinds ``web_server._SESSION_TOKEN`` to the
+    # Desktop SSH spawn token (_apply_ssh_session_token), and the API
+    # middleware validates against the rebound value — so a frozen copy here
+    # would inject a token the API itself rejects (401 on every sensitive
+    # endpoint).
 
     # `hermes serve` is the headless backend: it must NEVER serve the browser SPA, even if a
     # dist is lying around, so only the JSON-RPC/WS/API surface is reachable.
@@ -120,7 +129,7 @@ def mount_spa(application: FastAPI):
             if full_path == "" and not gated:
                 return HTMLResponse(
                     "<!doctype html><html><head><script>"
-                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(_SESSION_TOKEN)};"
+                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(_web_server._SESSION_TOKEN)};"
                     "window.__HERMES_AUTH_REQUIRED__=false;"
                     f"</script></head><body>{_HEADLESS_MSG}</body></html>",
                     headers=_NO_STORE,
@@ -151,7 +160,7 @@ def mount_spa(application: FastAPI):
             return JSONResponse({"error": "Frontend not built. Run: cd web && npm run build"}, status_code=404)
         chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
         gated = bool(getattr(app.state, "auth_required", False))
-        token_js = "" if gated else f'window.__HERMES_SESSION_TOKEN__="{_SESSION_TOKEN}";'
+        token_js = "" if gated else f'window.__HERMES_SESSION_TOKEN__="{_web_server._SESSION_TOKEN}";'
         bootstrap_script = (
             f"<script>{token_js}"
             f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -247,6 +247,62 @@ class TestSessionTokenInjection:
         assert ws._SESSION_TOKEN == original_token
 
 
+class TestMountSpaSessionTokenLookup:
+    """Regression guard for the Desktop SSH 401 loop.
+
+    ``mount_spa`` runs at ``web_server`` module-import time, but
+    ``start_server`` rebinds ``web_server._SESSION_TOKEN`` to the Desktop SSH
+    spawn token afterwards (``_apply_ssh_session_token``). The injected
+    ``window.__HERMES_SESSION_TOKEN__`` must therefore be read through the
+    module object at request time — a ``from ... import _SESSION_TOKEN``
+    capture inside ``mount_spa`` freezes the boot-time random token, and the
+    API middleware (which validates against the rebound value) then 401s
+    every sensitive endpoint with the very token the page itself served.
+    """
+
+    def test_headless_root_injects_token_applied_after_mount(self, monkeypatch):
+        pytest.importorskip("fastapi")
+        import hermes_cli.web_server as ws
+        from fastapi import FastAPI
+        from starlette.testclient import TestClient
+
+        from hermes_cli.web_server_dashboard import mount_spa
+
+        monkeypatch.setenv("HERMES_SERVE_HEADLESS", "1")
+        app = FastAPI()
+        mount_spa(app)
+        # Simulate start_server adopting the Desktop SSH spawn token AFTER mount.
+        monkeypatch.setattr(ws, "_SESSION_TOKEN", "spawned-after-mount")
+
+        response = TestClient(app).get("/")
+
+        assert response.status_code == 200
+        assert 'window.__HERMES_SESSION_TOKEN__="spawned-after-mount";' in response.text
+
+    def test_spa_index_injects_token_applied_after_mount(self, monkeypatch):
+        pytest.importorskip("fastapi")
+        import hermes_cli.web_server as ws
+        from fastapi import FastAPI
+        from starlette.testclient import TestClient
+
+        from hermes_cli.web_server_dashboard import mount_spa
+
+        # mount_spa captures WEB_DIST by value at mount time (static config,
+        # never rebound in production), so this test needs the real built SPA.
+        if not (ws.WEB_DIST / "index.html").is_file():
+            pytest.skip("web SPA build (web_dist/index.html) not present")
+
+        monkeypatch.delenv("HERMES_SERVE_HEADLESS", raising=False)
+        app = FastAPI()
+        mount_spa(app)
+        monkeypatch.setattr(ws, "_SESSION_TOKEN", "spawned-after-mount")
+
+        response = TestClient(app).get("/")
+
+        assert response.status_code == 200
+        assert 'window.__HERMES_SESSION_TOKEN__="spawned-after-mount";' in response.text
+
+
 # ---------------------------------------------------------------------------
 # web_server tests (FastAPI endpoints)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Desktop SSH remote mode is broken on current main: every sensitive API call (`/api/profiles`, …) 401s with the very token the backend injected into its own handshake page, and the desktop latches onto the "SSH connection failed" boot screen while SSH itself is fine.

Regression from 5f1feb5344: `mount_spa` moved to `web_server_dashboard.py` and now captures `_SESSION_TOKEN` via `from hermes_cli.web_server import …` at mount time (module import). `start_server()` later rebinds `web_server._SESSION_TOKEN` to the Desktop SSH spawn token (`_apply_ssh_session_token`), and the API middleware validates against the rebound value — so the frozen copy injected into `window.__HERMES_SESSION_TOKEN__` never matches.

Full evidence chain in the linked issue, including live verification that the injected token's fingerprint matches the desktop lockfile while the API rejects it.

Closes #103313.

## Fix

Read the token through the module object at request time in both injection sites (headless root handshake page and SPA `_serve_index`), so the injected value always tracks the rebound token. No behavior change for the non-SSH path (env-seeded token is already in place before `start_server` runs; reading through the module object returns the same value).

## Testing

- New `TestMountSpaSessionTokenLookup` regression tests: token applied to `web_server._SESSION_TOKEN` AFTER `mount_spa()` must be the one injected — covers both the headless root handshake and the SPA index. Both tests **fail on current main** (reproducing the 401 mismatch) and pass with this fix.
- `pytest tests/hermes_cli/test_web_server.py`: 183 passed, 4 skipped; the single failure (`test_custom_endpoint_save_scopes_to_the_requested_profile`) fails identically on unmodified main (pre-existing, unrelated).
- Live-verified end-to-end: with this patch applied on the remote host, the desktop boots clean — no more 401s, profiles load, remote terminal works.
