### PR TITLE
fix(tui): allow disabling terminal title to preserve tmux/zellij pane names (#102608)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -895,6 +895,7 @@ DEFAULT_CONFIG = {
         "status_bar": {
             "fields": [],
         },
+        "terminal_title": True,  # TUI terminal tab/window title (OSC 0/1/2); False leaves tmux/zellij titles alone (#102608)
         "copy_shortcut": "auto",  # "auto" (platform default) | ctrl_c | ctrl_shift_c | disabled
         # Petdex animated mascot (github.com/crafter-station/petdex): cosmetic sprite across
         # CLI/TUI/desktop, managed with `hermes pets`. No effect on prompt caching.

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -355,6 +355,7 @@ export interface UiState {
   // `display.timestamps` — dim [HH:MM] labels on user/assistant transcript
   // rows, the same config key the classic CLI honors (#41531).
   timestamps: boolean
+  terminalTitle: boolean
   usage: Usage
 }
 

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -36,6 +36,7 @@ const buildUiState = (): UiState => ({
   statusBarFields: null,
   streaming: true,
   timestamps: false,
+  terminalTitle: true,
   // Last session's resolved theme paints frame one (flash-free boot, like
   // the desktop's hermes-boot-* keys); DEFAULT_THEME only on first launch.
   theme: bootTheme ?? DEFAULT_THEME,

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -311,7 +311,8 @@ export const applyDisplay = (
     streaming: d.streaming !== false,
     // The SAME key that stamps [HH:MM] on classic-CLI labels (#41531) —
     // no separate TUI knob.
-    timestamps: d.timestamps === true
+    timestamps: d.timestamps === true,
+    terminalTitle: d.terminal_title !== false
   })
 }
 

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -638,12 +638,14 @@ export function useMainApp(gw: GatewayClient) {
   const tabCwd = ui.info?.cwd
 
   useTerminalTitle(
-    model
-      ? {
-          tab: composeTabTitle(marker, ui.sessionTitle, '', ''),
-          window: composeTabTitle(marker, ui.sessionTitle, model, tabCwd ? shortCwd(tabCwd, 24) : '')
-        }
-      : 'Hermes'
+    ui.terminalTitle === false
+      ? null
+      : model
+        ? {
+            tab: composeTabTitle(marker, ui.sessionTitle, '', ''),
+            window: composeTabTitle(marker, ui.sessionTitle, model, tabCwd ? shortCwd(tabCwd, 24) : '')
+          }
+        : 'Hermes'
   )
 
   useEffect(() => {

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -97,6 +97,7 @@ export interface ConfigDisplayConfig {
   thinking_mode?: string
   /** Show [HH:MM] timestamps on transcript rows — same key the classic CLI
    *  honors on its user/assistant labels (#41531). */
+  terminal_title?: boolean
   timestamps?: boolean
   /**
    * Nudge the user toward the /agents spawn-tree dashboard the first time a


### PR DESCRIPTION
Fixes #102608

The Ink TUI always wrote OSC 0/1/2 terminal titles (useTerminalTitle in useMainApp.ts), overwriting tmux/zellij pane/tab names. This adds a config key `display.terminal_title` (default `true`) that is fanned to `UiState.terminalTitle` via `useConfigSync`. When set to `false` the hook receives `null` and leaves the terminal title untouched.

**Changes**
- `hermes_cli/config_defaults.py`: add `display.terminal_title: True`
- `ui-tui/src/gatewayTypes.ts`: extend ConfigDisplayConfig
- `ui-tui/src/app/uiStore.ts` / `interfaces.ts`: add `terminalTitle` state
- `ui-tui/src/app/useConfigSync.ts`: map `display.terminal_title !== false`
- `ui-tui/src/app/useMainApp.ts`: gate `useTerminalTitle` with null when disabled

Test: `npx tsc --noEmit --project ui-tui/tsconfig.json` passes, `vitest run useConfigSync.test.ts` 42/42 passes.