### PR TITLE
fix(whatsapp): match self-chat by LID exclusively when exposed (#103281)

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -606,10 +606,19 @@ async function startSocket() {
           // WhatsApp now uses LID (Linked Identity Device) format: 67427329167522@lid
           // AND classic format: 34652029134@s.whatsapp.net
           // sock.user has both: { id: "number:10@s.whatsapp.net", lid: "lid_number:10@lid" }
-          const myNumber = (sock.user?.id || '').replace(/:.*@/, '@').replace(/@.*/, '');
           const myLid = (sock.user?.lid || '').replace(/:.*@/, '@').replace(/@.*/, '');
           const chatNumber = chatId.replace(/@.*/, '');
-          const isSelfChat = (myNumber && chatNumber === myNumber) || (myLid && chatNumber === myLid);
+          // When the account exposes a LID, self-chat must match LID exclusively.
+          // The legacy PN identity also surfaces Meta AI conversations; an OR
+          // comparison would misclassify those as self-chat and ingest them as
+          // agent commands (#103281).
+          let isSelfChat;
+          if (myLid) {
+            isSelfChat = chatNumber === myLid;
+          } else {
+            const myNumber = (sock.user?.id || '').replace(/:.*@/, '@').replace(/@.*/, '');
+            isSelfChat = !!(myNumber && chatNumber === myNumber);
+          }
           emitDebugEvent({
             stage: 'self_chat_check',
             matched: !!isSelfChat,


### PR DESCRIPTION
Fixes #103281

Self-chat detection compared `chatId` loosely against both the account's LID and its legacy PN JID (`myNumber || myLid`). Meta AI interactions surface under the legacy PN identity, so they were misclassified as self-chat and ingested as agent commands, causing loops and unauthorized API activity.

**Change**
`scripts/whatsapp-bridge/bridge.js`: when `sock.user.lid` is present, self-chat matches LID exclusively; legacy PN is only used as fallback when no LID exists. Adds debug comment linking to #103281.

**Verification**
`node --check bridge.js` passes. Manual logic test: LID present + PN chat → false (ignored), LID present + LID chat → true, no LID + PN chat → true.