### PR TITLE
feat: support generic external-process providers

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -788,7 +788,16 @@ def _explicit_client_kwargs(agent, api_key, base_url, _provider_timeout) -> Dict
         client_kwargs["default_query"] = {k: v[0] for k, v in parse_qs(_parsed_url.query).items()}
     if _provider_timeout is not None:
         client_kwargs["timeout"] = _provider_timeout
-    if agent.provider == "copilot-acp":
+    _process_backed = agent.provider == "copilot-acp"
+    if not _process_backed:
+        with suppress(Exception):
+            from providers import get_provider_profile as _get_process_profile
+
+            _process_profile = _get_process_profile(agent.provider)
+            _process_backed = bool(
+                _process_profile and _process_profile.auth_type == "external_process"
+            )
+    if _process_backed:
         client_kwargs["command"] = agent.acp_command
         client_kwargs["args"] = agent.acp_args
     # OpenCode Zen free tier is served ANONYMOUSLY and 401s any bearer (incl. our keyless

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1289,6 +1289,22 @@ def _plugin_aliases() -> Dict[str, str]:
     return aliases
 
 
+def _reconcile_plugin_provider(provider: str) -> str:
+    """Resolve plugin aliases and lazily add a provider discovered after module import."""
+    canonical = _plugin_aliases().get(provider, provider)
+    if canonical in PROVIDER_REGISTRY:
+        return canonical
+    try:
+        import providers as providers_module
+
+        profile = getattr(providers_module, "get_provider_profile")(canonical)
+        if profile is not None:
+            _register_plugin_provider(profile)
+    except Exception as exc:
+        logger.debug("Could not reconcile provider plugin %r: %s", canonical, exc)
+    return canonical
+
+
 def _scoped_key_env_reader() -> Callable[[str], str]:
     """Scope-aware key reader for provider auto-detection.
 
@@ -1350,6 +1366,8 @@ def _config_model_provider() -> Tuple[Any, Optional[str]]:
         model_cfg = (load_config() or {}).get("model")
         provider = model_cfg.get("provider") if isinstance(model_cfg, dict) else None
         provider = provider.strip().lower() if isinstance(provider, str) else ""
+        if provider:
+            provider = _reconcile_plugin_provider(provider)
         return model_cfg, (provider if provider in PROVIDER_REGISTRY else None)
     except Exception as e:
         logger.debug("Could not read config.yaml model.provider for auto-resolution: %s", e)
@@ -1402,7 +1420,7 @@ def resolve_provider(
     provider configured) See #29285.
     """
     normalized = (requested or "auto").strip().lower()
-    normalized = _plugin_aliases().get(normalized, normalized)
+    normalized = _reconcile_plugin_provider(normalized)
 
     if normalized in ("openrouter", "custom") or normalized in PROVIDER_REGISTRY:
         return normalized
@@ -1874,6 +1892,7 @@ def _external_process_spec(
         command = configured_command.strip()
     command = command or str(getattr(profile, "process_command", "") or "")
 
+    args: List[str]
     try:
         if raw_args:
             args = shlex.split(raw_args)
@@ -1882,9 +1901,16 @@ def _external_process_spec(
             if isinstance(configured_args, str):
                 args = shlex.split(configured_args)
             elif isinstance(configured_args, (list, tuple)):
-                args = [str(value) for value in configured_args]
+                if not all(isinstance(value, str) for value in configured_args):
+                    raise ValueError("process argv must contain strings")
+                args = list(configured_args)
             else:
-                args = [str(value) for value in (getattr(profile, "process_args", ()) or ())]
+                profile_args = getattr(profile, "process_args", ()) or ()
+                if not all(isinstance(value, str) for value in profile_args):
+                    raise ValueError("process argv must contain strings")
+                args = list(profile_args)
+        if "\0" in command or any("\0" in value for value in args):
+            raise ValueError("process command and argv cannot contain NUL bytes")
     except ValueError as exc:
         raise AuthError(
             f"Invalid process arguments for provider '{pconfig.id}'.",
@@ -1895,6 +1921,8 @@ def _external_process_spec(
 
 
 _EXTERNAL_PROCESS_PROBE_JOIN_TIMEOUT = 9.0
+_EXTERNAL_PROCESS_PROBE_LOCK = threading.Lock()
+_EXTERNAL_PROCESS_PROBES: Dict[str, Dict[str, Any]] = {}
 
 
 def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
@@ -1928,29 +1956,55 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
         pass
     probe = getattr(profile, "external_process_auth_status", None) if profile else None
     if configured and callable(probe):
-        probe_result: list[Any] = []
-        probe_error: list[Exception] = []
+        with _EXTERNAL_PROCESS_PROBE_LOCK:
+            state = _EXTERNAL_PROCESS_PROBES.get(provider_id)
+            if state is None:
+                probe_result: list[Any] = []
+                probe_error: list[Exception] = []
 
-        def invoke_probe() -> None:
-            try:
-                probe_result.append(
-                    probe(command=resolved_command or command, args=args, timeout=8.0)
+                def invoke_probe() -> None:
+                    try:
+                        probe_result.append(
+                            probe(
+                                command=resolved_command or command,
+                                args=args,
+                                timeout=8.0,
+                            )
+                        )
+                    except Exception as exc:
+                        probe_error.append(exc)
+
+                worker = threading.Thread(
+                    target=invoke_probe,
+                    name=f"external-process-auth-{provider_id}",
+                    daemon=True,
                 )
-            except Exception as exc:
-                probe_error.append(exc)
-
-        worker = threading.Thread(target=invoke_probe, daemon=True)
-        worker.start()
+                state = {
+                    "worker": worker,
+                    "result": probe_result,
+                    "error": probe_error,
+                }
+                _EXTERNAL_PROCESS_PROBES[provider_id] = state
+                worker.start()
+            worker = state["worker"]
+            probe_result = state["result"]
+            probe_error = state["error"]
         worker.join(timeout=_EXTERNAL_PROCESS_PROBE_JOIN_TIMEOUT)
         if worker.is_alive():
             auth_verified = False
             auth_source = "provider_probe_timeout"
             auth_evidence = "provider authentication probe timed out"
         elif probe_error:
+            with _EXTERNAL_PROCESS_PROBE_LOCK:
+                if _EXTERNAL_PROCESS_PROBES.get(provider_id) is state:
+                    _EXTERNAL_PROCESS_PROBES.pop(provider_id, None)
             auth_verified = False
             auth_source = "provider_probe_error"
             auth_evidence = "provider authentication probe unavailable"
         elif probe_result:
+            with _EXTERNAL_PROCESS_PROBE_LOCK:
+                if _EXTERNAL_PROCESS_PROBES.get(provider_id) is state:
+                    _EXTERNAL_PROCESS_PROBES.pop(provider_id, None)
             probed = probe_result[0]
             if isinstance(probed, dict) and isinstance(probed.get("logged_in"), bool):
                 logged_in = bool(probed["logged_in"])

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1841,11 +1841,9 @@ def _external_process_auth_evidence(provider_id: str) -> tuple[bool, Optional[st
 
 
 def _external_process_spec(
-    pconfig: ProviderConfig) -> tuple[str, List[str], str, Optional[str], tuple[str, ...]]:
-    """``(command, args, base_url, resolved_command, command_env_vars)`` for an ACP provider.
-
-    Launch details come from the provider's own profile (copilot-acp: HERMES_COPILOT_ACP_COMMAND /
-    COPILOT_CLI_PATH / HERMES_COPILOT_ACP_ARGS), so out-of-tree providers describe their binary."""
+    pconfig: ProviderConfig,
+) -> tuple[str, List[str], str, Optional[str], tuple[str, ...]]:
+    """Resolve process launch settings as env override > config > profile defaults."""
     base_url = _provider_env_base_url(pconfig) or pconfig.inference_base_url
     try:
         from providers import get_provider_profile as _get_provider_profile
@@ -1854,28 +1852,119 @@ def _external_process_spec(
         profile = None
     command_env_vars = tuple(getattr(profile, "process_command_env_vars", ()) or ())
     args_env_var = str(getattr(profile, "process_args_env_var", "") or "")
-    command = (next((v for v in (os.getenv(var, "").strip() for var in command_env_vars) if v), "")
-               or str(getattr(profile, "process_command", "") or ""))
+    command = next(
+        (value for value in (os.getenv(var, "").strip() for var in command_env_vars) if value),
+        "",
+    )
     raw_args = os.getenv(args_env_var, "").strip() if args_env_var else ""
-    args = shlex.split(raw_args) if raw_args else list(getattr(profile, "process_args", ()) or [])
+
+    settings: Dict[str, Any] = {}
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        providers_cfg = cfg.get("providers") if isinstance(cfg, dict) else None
+        candidate = providers_cfg.get(pconfig.id) if isinstance(providers_cfg, dict) else None
+        if isinstance(candidate, dict):
+            settings = candidate
+    except Exception:
+        pass
+
+    configured_command = settings.get("command")
+    if not command and isinstance(configured_command, str):
+        command = configured_command.strip()
+    command = command or str(getattr(profile, "process_command", "") or "")
+
+    try:
+        if raw_args:
+            args = shlex.split(raw_args)
+        else:
+            configured_args = settings.get("args")
+            if isinstance(configured_args, str):
+                args = shlex.split(configured_args)
+            elif isinstance(configured_args, (list, tuple)):
+                args = [str(value) for value in configured_args]
+            else:
+                args = [str(value) for value in (getattr(profile, "process_args", ()) or ())]
+    except ValueError as exc:
+        raise AuthError(
+            f"Invalid process arguments for provider '{pconfig.id}'.",
+            provider=pconfig.id,
+            code="invalid_external_process_args",
+        ) from exc
     return command, args, base_url, shutil.which(command) if command else None, command_env_vars
 
 
-def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
-    """Status snapshot for providers that run a local subprocess.
+_EXTERNAL_PROCESS_PROBE_JOIN_TIMEOUT = 9.0
 
-    ``configured``/``logged_in`` are structural (executable resolves or TCP endpoint set): the
-    subprocess owns real auth. ``auth_verified``/``auth_source`` carry positive evidence only."""
+
+def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
+    """Status for a local subprocess, with an optional bounded provider-owned auth probe."""
     pconfig = PROVIDER_REGISTRY.get(provider_id)
     if not pconfig or pconfig.auth_type != "external_process":
         return {"configured": False}
-    command, args, base_url, resolved_command, _ = _external_process_spec(pconfig)
-    available = bool(resolved_command or base_url.startswith("acp+tcp://"))
+    try:
+        command, args, base_url, resolved_command, _ = _external_process_spec(pconfig)
+    except AuthError as exc:
+        return {
+            "configured": False,
+            "provider": provider_id,
+            "name": pconfig.name,
+            "logged_in": False,
+            "auth_verified": False,
+            "auth_source": "invalid_configuration",
+            "auth_evidence": str(exc),
+            "error": exc.code,
+        }
+    configured = bool(resolved_command or base_url.startswith("acp+tcp://"))
     auth_verified, auth_source = _external_process_auth_evidence(provider_id)
+    logged_in = configured
+    auth_evidence = "process command resolved" if configured else "process command not found"
+
+    profile = None
+    try:
+        from providers import get_provider_profile
+        profile = get_provider_profile(provider_id)
+    except Exception:
+        pass
+    probe = getattr(profile, "external_process_auth_status", None) if profile else None
+    if configured and callable(probe):
+        probe_result: list[Any] = []
+        probe_error: list[Exception] = []
+
+        def invoke_probe() -> None:
+            try:
+                probe_result.append(
+                    probe(command=resolved_command or command, args=args, timeout=8.0)
+                )
+            except Exception as exc:
+                probe_error.append(exc)
+
+        worker = threading.Thread(target=invoke_probe, daemon=True)
+        worker.start()
+        worker.join(timeout=_EXTERNAL_PROCESS_PROBE_JOIN_TIMEOUT)
+        if worker.is_alive():
+            auth_verified = False
+            auth_source = "provider_probe_timeout"
+            auth_evidence = "provider authentication probe timed out"
+        elif probe_error:
+            auth_verified = False
+            auth_source = "provider_probe_error"
+            auth_evidence = "provider authentication probe unavailable"
+        elif probe_result:
+            probed = probe_result[0]
+            if isinstance(probed, dict) and isinstance(probed.get("logged_in"), bool):
+                logged_in = bool(probed["logged_in"])
+                auth_verified = logged_in
+                auth_source = "provider_probe"
+                evidence = probed.get("auth_evidence")
+                if isinstance(evidence, str) and evidence.strip():
+                    auth_evidence = evidence.strip()
+
     return {
-        "configured": available, "provider": provider_id, "name": pconfig.name, "command": command,
-        "args": args, "resolved_command": resolved_command, "base_url": base_url,
-        "logged_in": available, "auth_verified": auth_verified, "auth_source": auth_source}
+        "configured": configured, "provider": provider_id, "name": pconfig.name,
+        "command": command, "args": args, "resolved_command": resolved_command,
+        "base_url": base_url, "logged_in": logged_in, "auth_verified": auth_verified,
+        "auth_source": auth_source, "auth_evidence": auth_evidence}
 
 
 def _get_aws_sdk_auth_status(target: str) -> Dict[str, Any]:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -662,6 +662,7 @@ from hermes_cli.model_setup_flows import (
     _model_flow_named_custom,
     _model_flow_copilot,
     _model_flow_copilot_acp,
+    _model_flow_external_process,
     _model_flow_kimi,
     _model_flow_stepfun,
     _model_flow_bedrock,
@@ -706,6 +707,7 @@ from hermes_cli.main_provider_setup import (
     _build_provider_picker_rows,
     _clear_stale_openai_base_url,
     _is_profile_api_key_provider,
+    _is_profile_external_process_provider,
     _named_custom_provider_map,
     _prompt_provider_choice,
     _remove_custom_provider,
@@ -1996,6 +1998,8 @@ def select_provider_and_model(args=None):
         or _is_profile_api_key_provider(selected_provider)
     ):
         _model_flow_api_key_provider(config, selected_provider, current_model)
+    elif _is_profile_external_process_provider(selected_provider):
+        _model_flow_external_process(config, selected_provider, current_model)
 
     # Post-switch cleanup: switching to a named provider (anything except
     # "custom") leaves a stale OPENAI_BASE_URL in ~/.hermes/.env that poisons

--- a/hermes_cli/main_provider_setup.py
+++ b/hermes_cli/main_provider_setup.py
@@ -21,6 +21,16 @@ def _is_profile_api_key_provider(provider_id: str) -> bool:
         return False
 
 
+def _is_profile_external_process_provider(provider_id: str) -> bool:
+    """True for plugin providers that delegate inference to a local process."""
+    try:
+        from providers import get_provider_profile
+        profile = get_provider_profile(provider_id)
+        return profile is not None and profile.auth_type == "external_process"
+    except Exception:
+        return False
+
+
 _GENERIC_API_KEY_PROVIDERS = frozenset({
     "openai-api", "gemini", "deepseek", "xai", "zai", "kimi-coding-cn",
     "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go",

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -9,6 +9,7 @@ own ``model_setup_flows_*`` modules.
 from __future__ import annotations
 
 import contextlib
+import inspect
 import argparse
 import os
 
@@ -577,7 +578,9 @@ def _model_flow_copilot(config, current_model=""):
             print(f"Reasoning effort set to: {selected_effort}")
 
 
-def _external_process_model_choices(provider_id: str) -> list[str]:
+def _external_process_model_choices(
+    provider_id: str, *, status: dict | None = None,
+) -> list[str]:
     """Return a subprocess provider's live catalog, or its declared fallback."""
     from hermes_cli.auth import get_external_process_provider_status
     from providers import get_provider_profile
@@ -585,17 +588,24 @@ def _external_process_model_choices(provider_id: str) -> list[str]:
     profile = get_provider_profile(provider_id)
     if profile is None or profile.auth_type != "external_process":
         return []
-    status = get_external_process_provider_status(provider_id)
+    status = status or get_external_process_provider_status(provider_id)
     discovered = None
     try:
-        discovered = profile.fetch_models(
-            api_key="", base_url=profile.base_url,
-            command=status.get("resolved_command") or status.get("command"),
-            args=status.get("args") or (),
+        fetch = profile.fetch_models
+        parameters = inspect.signature(fetch).parameters.values()
+        supports_context = any(
+            parameter.kind == inspect.Parameter.VAR_KEYWORD
+            for parameter in parameters
+        ) or {"command", "args"}.issubset(
+            {parameter.name for parameter in parameters}
         )
-    except TypeError:
-        with contextlib.suppress(Exception):
-            discovered = profile.fetch_models(api_key="", base_url=profile.base_url)
+        kwargs = {"api_key": "", "base_url": profile.base_url}
+        if supports_context:
+            kwargs.update(
+                command=status.get("resolved_command") or status.get("command"),
+                args=status.get("args") or (),
+            )
+        discovered = fetch(**kwargs)
     except Exception:
         pass
     candidates = discovered or profile.fallback_models or ()
@@ -632,7 +642,7 @@ def _model_flow_external_process(config, provider_id: str, current_model=""):
         print(f"  ⚠ {exc}")
         return
 
-    models = _external_process_model_choices(provider_id)
+    models = _external_process_model_choices(provider_id, status=status)
     selected = _pick_model_or_prompt(
         models, "Model name: ", current_model=current_model,
         confirm_provider=provider_id, confirm_base_url=effective_base,

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -577,6 +577,71 @@ def _model_flow_copilot(config, current_model=""):
             print(f"Reasoning effort set to: {selected_effort}")
 
 
+def _external_process_model_choices(provider_id: str) -> list[str]:
+    """Return a subprocess provider's live catalog, or its declared fallback."""
+    from hermes_cli.auth import get_external_process_provider_status
+    from providers import get_provider_profile
+
+    profile = get_provider_profile(provider_id)
+    if profile is None or profile.auth_type != "external_process":
+        return []
+    status = get_external_process_provider_status(provider_id)
+    discovered = None
+    try:
+        discovered = profile.fetch_models(
+            api_key="", base_url=profile.base_url,
+            command=status.get("resolved_command") or status.get("command"),
+            args=status.get("args") or (),
+        )
+    except TypeError:
+        with contextlib.suppress(Exception):
+            discovered = profile.fetch_models(api_key="", base_url=profile.base_url)
+    except Exception:
+        pass
+    candidates = discovered or profile.fallback_models or ()
+    return list(dict.fromkeys(str(model).strip() for model in candidates if str(model).strip()))
+
+
+def _model_flow_external_process(config, provider_id: str, current_model=""):
+    """Generic picker for standalone subprocess-backed model providers."""
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY, get_external_process_provider_status,
+        resolve_external_process_provider_credentials)
+    from providers import get_provider_profile
+
+    del config
+    pconfig = PROVIDER_REGISTRY.get(provider_id)
+    profile = get_provider_profile(provider_id)
+    if pconfig is None or profile is None or profile.auth_type != "external_process":
+        print(f"No external-process provider named {provider_id!r} is registered.")
+        return
+
+    status = get_external_process_provider_status(provider_id)
+    command = status.get("resolved_command") or status.get("command") or profile.process_command
+    effective_base = status.get("base_url") or pconfig.inference_base_url or profile.base_url
+    _say(
+        f"  {profile.display_name or profile.name} runs through a local subprocess.",
+        f"  Command: {command or '(not configured)'}", "")
+    if status.get("auth_source") == "provider_probe" and not status.get("logged_in"):
+        evidence = str(status.get("auth_evidence") or "provider authentication failed")
+        print(f"  ⚠ Authentication unavailable: {evidence}")
+        return
+    try:
+        creds = resolve_external_process_provider_credentials(provider_id)
+    except Exception as exc:
+        print(f"  ⚠ {exc}")
+        return
+
+    models = _external_process_model_choices(provider_id)
+    selected = _pick_model_or_prompt(
+        models, "Model name: ", current_model=current_model,
+        confirm_provider=provider_id, confirm_base_url=effective_base,
+        confirm_api_key=creds.get("api_key", ""))
+    _finish_model(
+        selected, provider_id, f"Default model set to: {selected} (via {pconfig.name})",
+        base_url=effective_base, api_mode=profile.api_mode or "chat_completions")
+
+
 def _model_flow_copilot_acp(config, current_model=""):
     """GitHub Copilot ACP flow using the local Copilot CLI."""
     from hermes_cli.auth import (

--- a/hermes_cli/models_catalog_static.py
+++ b/hermes_cli/models_catalog_static.py
@@ -350,13 +350,14 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [ProviderEntry(*row) for row in (
 
 # Auto-extend CANONICAL_PROVIDERS with providers registered under plugins/model-providers/<name>/
 # so a new provider reaches the picker, /model and every downstream consumer without edits here.
-# Non-api-key flows need bespoke picker UX and are skipped.
+# Auth flows with dedicated picker UX are skipped; generic external-process
+# providers use the shared subprocess setup flow.
 _canonical_slugs = {p.slug for p in CANONICAL_PROVIDERS}
 try:
     from providers import list_providers as _list_providers_for_canonical
     for _pp in _list_providers_for_canonical():
         if _pp.name in _canonical_slugs or _pp.auth_type in {
-            "oauth_device_code", "oauth_external", "external_process", "aws_sdk", "copilot", "vertex",
+            "oauth_device_code", "oauth_external", "aws_sdk", "copilot", "vertex",
         }:
             continue
         _label = _pp.display_name or _pp.name

--- a/tests/hermes_cli/test_external_process_provider_seam.py
+++ b/tests/hermes_cli/test_external_process_provider_seam.py
@@ -57,9 +57,9 @@ def test_an_out_of_tree_external_process_provider_resolves_end_to_end(fake_cli, 
     from hermes_cli.auth import PROVIDER_REGISTRY, resolve_external_process_provider_credentials, resolve_provider
     from hermes_cli.runtime_provider import resolve_runtime_provider
 
+    assert resolve_provider("acme") == "acme-acp"
     assert PROVIDER_REGISTRY["acme"] is PROVIDER_REGISTRY["acme-acp"]
     assert PROVIDER_REGISTRY["acme-acp"].auth_type == "external_process"
-    assert resolve_provider("acme") == "acme-acp"
 
     creds = resolve_external_process_provider_credentials("acme-acp")
     assert (creds["command"], creds["args"], creds["api_key"]) == (str(fake_cli / "acme-cli"), ["--acp"], "acme-acp")
@@ -84,3 +84,17 @@ def test_copilot_acp_launch_details_are_unchanged(fake_cli, monkeypatch):
     monkeypatch.setenv("COPILOT_CLI_PATH", str(fake_cli / "custom-acme"))
     assert resolve_external_process_provider_credentials("copilot-acp")["command"] == str(fake_cli / "custom-acme")
     assert resolve_runtime_provider(requested="copilot-acp", target_model="x")["base_url"] == "acp://copilot"
+
+
+def test_auto_resolution_reconciles_a_late_configured_plugin(monkeypatch):
+    from hermes_cli import auth
+
+    monkeypatch.delitem(auth.PROVIDER_REGISTRY, "acme-acp", raising=False)
+    monkeypatch.delitem(auth.PROVIDER_REGISTRY, "acme", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"provider": "acme"}},
+    )
+
+    assert auth.resolve_provider("auto") == "acme-acp"
+    assert auth.PROVIDER_REGISTRY["acme"] is auth.PROVIDER_REGISTRY["acme-acp"]

--- a/tests/hermes_cli/test_generic_external_process_provider.py
+++ b/tests/hermes_cli/test_generic_external_process_provider.py
@@ -1,0 +1,277 @@
+"""Behavior contracts for standalone external-process model providers."""
+from __future__ import annotations
+
+import importlib
+import os
+import stat
+import threading
+import time
+from types import SimpleNamespace
+
+
+def _profile(**overrides):
+    from providers.base import ProviderProfile
+
+    values = {
+        "name": "test-process",
+        "display_name": "Test Process",
+        "description": "Test subprocess provider",
+        "base_url": "process://test",
+        "auth_type": "external_process",
+        "process_command": "test-process-cli",
+        "process_args": ("serve", "--stdio"),
+        "process_command_env_vars": ("TEST_PROCESS_COMMAND",),
+        "process_args_env_var": "TEST_PROCESS_ARGS",
+        "fallback_models": ("test-model-a", "test-model-b"),
+    }
+    values.update(overrides)
+    return ProviderProfile(**values)
+
+
+def test_external_process_status_uses_the_selected_profile_not_copilot_defaults(
+    tmp_path, monkeypatch
+):
+    from hermes_cli import auth
+
+    executable = tmp_path / "test-process-cli"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(executable.stat().st_mode | stat.S_IEXEC)
+    profile = _profile(process_command=str(executable))
+
+    monkeypatch.setitem(
+        auth.PROVIDER_REGISTRY,
+        profile.name,
+        auth.ProviderConfig(
+            id=profile.name,
+            name=profile.display_name,
+            auth_type="external_process",
+            inference_base_url=profile.base_url,
+        ),
+    )
+    monkeypatch.setattr("providers.get_provider_profile", lambda name: profile)
+
+    status = auth.get_external_process_provider_status(profile.name)
+
+    assert status["configured"] is True
+    assert status["resolved_command"] == str(executable)
+    assert status["args"] == ["serve", "--stdio"]
+    assert status["base_url"] == "process://test"
+
+
+def test_configured_command_and_args_override_profile_defaults(tmp_path, monkeypatch):
+    from hermes_cli import auth
+    from hermes_cli import config as config_mod
+
+    executable = tmp_path / "configured-agent"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(executable.stat().st_mode | stat.S_IEXEC)
+    profile = _profile(process_command="missing-profile-default")
+    monkeypatch.setitem(
+        auth.PROVIDER_REGISTRY,
+        profile.name,
+        auth.ProviderConfig(
+            id=profile.name,
+            name=profile.display_name,
+            auth_type="external_process",
+            inference_base_url=profile.base_url,
+        ),
+    )
+    monkeypatch.setattr("providers.get_provider_profile", lambda name: profile)
+    monkeypatch.setattr(
+        config_mod,
+        "load_config",
+        lambda: {
+            "providers": {
+                profile.name: {
+                    "command": str(executable),
+                    "args": ["--tenant", "test"],
+                }
+            }
+        },
+    )
+
+    status = auth.get_external_process_provider_status(profile.name)
+    creds = auth.resolve_external_process_provider_credentials(profile.name)
+
+    assert status["resolved_command"] == str(executable)
+    assert status["args"] == ["--tenant", "test"]
+    assert creds["command"] == str(executable)
+    assert creds["args"] == ["--tenant", "test"]
+
+
+def test_status_honors_optional_profile_auth_probe(tmp_path, monkeypatch):
+    from hermes_cli import auth
+
+    executable = tmp_path / "test-agent"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(executable.stat().st_mode | stat.S_IEXEC)
+    profile = _profile(process_command=str(executable))
+    profile.external_process_auth_status = lambda **_: {
+        "logged_in": False,
+        "auth_evidence": "provider probe reported authentication required",
+    }
+    monkeypatch.setitem(
+        auth.PROVIDER_REGISTRY,
+        profile.name,
+        auth.ProviderConfig(
+            id=profile.name,
+            name=profile.display_name,
+            auth_type="external_process",
+            inference_base_url=profile.base_url,
+        ),
+    )
+    monkeypatch.setattr("providers.get_provider_profile", lambda name: profile)
+
+    status = auth.get_external_process_provider_status(profile.name)
+
+    assert status["configured"] is True
+    assert status["logged_in"] is False
+    assert status["auth_verified"] is False
+    assert status["auth_evidence"] == "provider probe reported authentication required"
+
+
+def test_status_hard_bounds_a_probe_that_ignores_timeout(tmp_path, monkeypatch):
+    from hermes_cli import auth
+
+    executable = tmp_path / "test-agent"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(executable.stat().st_mode | stat.S_IEXEC)
+    blocked = threading.Event()
+    profile = _profile(process_command=str(executable))
+    profile.external_process_auth_status = lambda **_: blocked.wait(5)
+    monkeypatch.setitem(
+        auth.PROVIDER_REGISTRY,
+        profile.name,
+        auth.ProviderConfig(
+            id=profile.name,
+            name=profile.display_name,
+            auth_type="external_process",
+            inference_base_url=profile.base_url,
+        ),
+    )
+    monkeypatch.setattr("providers.get_provider_profile", lambda name: profile)
+    monkeypatch.setattr(auth, "_EXTERNAL_PROCESS_PROBE_JOIN_TIMEOUT", 0.02)
+
+    started = time.monotonic()
+    status = auth.get_external_process_provider_status(profile.name)
+
+    assert time.monotonic() - started < 0.5
+    assert status["configured"] is True
+    assert status["logged_in"] is True
+    assert status["auth_verified"] is False
+    assert status["auth_source"] == "provider_probe_timeout"
+
+
+def test_status_reports_malformed_configured_args(tmp_path, monkeypatch):
+    from hermes_cli import auth
+
+    executable = tmp_path / "test-agent"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(executable.stat().st_mode | stat.S_IEXEC)
+    profile = _profile(process_command=str(executable))
+    monkeypatch.setitem(
+        auth.PROVIDER_REGISTRY,
+        profile.name,
+        auth.ProviderConfig(
+            id=profile.name,
+            name=profile.display_name,
+            auth_type="external_process",
+            inference_base_url=profile.base_url,
+        ),
+    )
+    monkeypatch.setattr("providers.get_provider_profile", lambda name: profile)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"providers": {profile.name: {"args": "\""}}},
+    )
+
+    status = auth.get_external_process_provider_status(profile.name)
+
+    assert status["configured"] is False
+    assert status["auth_source"] == "invalid_configuration"
+    assert status["error"] == "invalid_external_process_args"
+
+
+def test_external_process_profile_is_listed_as_a_canonical_model_provider(monkeypatch):
+    import providers
+    import hermes_cli.models_catalog_static as models
+
+    profile = _profile()
+    original = providers.list_providers
+    monkeypatch.setattr(providers, "list_providers", lambda: [profile])
+    try:
+        reloaded = importlib.reload(models)
+        matching = [entry for entry in reloaded.CANONICAL_PROVIDERS if entry.slug == profile.name]
+        assert len(matching) == 1
+        assert matching[0].label == profile.display_name
+    finally:
+        monkeypatch.setattr(providers, "list_providers", original)
+        importlib.reload(models)
+
+
+def test_external_process_model_choices_prefer_live_catalog_and_fall_back(monkeypatch):
+    from hermes_cli.model_setup_flows import _external_process_model_choices
+
+    profile = _profile()
+    monkeypatch.setattr("providers.get_provider_profile", lambda name: profile)
+    seen = {}
+
+    def fetch_models(**kwargs):
+        seen.update(kwargs)
+        return ["live-b", "live-a", "live-b"]
+    monkeypatch.setattr(profile, "fetch_models", fetch_models)
+    assert _external_process_model_choices(profile.name) == ["live-b", "live-a"]
+    assert "command" in seen
+    assert "args" in seen
+
+    monkeypatch.setattr(profile, "fetch_models", lambda **kwargs: None)
+    assert _external_process_model_choices(profile.name) == ["test-model-a", "test-model-b"]
+
+
+def test_external_process_setup_stops_on_failed_provider_auth_probe(monkeypatch, capsys):
+    from hermes_cli import auth
+    from hermes_cli.model_setup_flows import _model_flow_external_process
+
+    profile = _profile()
+    monkeypatch.setitem(
+        auth.PROVIDER_REGISTRY,
+        profile.name,
+        auth.ProviderConfig(
+            id=profile.name,
+            name=profile.display_name,
+            auth_type="external_process",
+            inference_base_url=profile.base_url,
+        ),
+    )
+    monkeypatch.setattr("providers.get_provider_profile", lambda name: profile)
+    monkeypatch.setattr(
+        auth,
+        "get_external_process_provider_status",
+        lambda provider_id: {
+            "configured": True,
+            "logged_in": False,
+            "auth_source": "provider_probe",
+            "auth_evidence": "provider probe reported authentication required",
+            "command": profile.process_command,
+            "base_url": profile.base_url,
+        },
+    )
+    monkeypatch.setattr(
+        auth,
+        "resolve_external_process_provider_credentials",
+        lambda provider_id: (_ for _ in ()).throw(AssertionError("must not continue")),
+    )
+
+    _model_flow_external_process({}, profile.name)
+
+    assert "authentication" in capsys.readouterr().out.lower()
+
+
+def test_main_classifies_profile_external_process_providers(monkeypatch):
+    from hermes_cli.main_provider_setup import _is_profile_external_process_provider
+
+    profile = _profile()
+    monkeypatch.setattr("providers.get_provider_profile", lambda name: profile if name == profile.name else None)
+
+    assert _is_profile_external_process_provider(profile.name) is True
+    assert _is_profile_external_process_provider("missing") is False

--- a/tests/hermes_cli/test_generic_external_process_provider.py
+++ b/tests/hermes_cli/test_generic_external_process_provider.py
@@ -137,8 +137,15 @@ def test_status_hard_bounds_a_probe_that_ignores_timeout(tmp_path, monkeypatch):
     executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     executable.chmod(executable.stat().st_mode | stat.S_IEXEC)
     blocked = threading.Event()
+    calls = 0
     profile = _profile(process_command=str(executable))
-    profile.external_process_auth_status = lambda **_: blocked.wait(5)
+
+    def blocked_probe(**_):
+        nonlocal calls
+        calls += 1
+        return blocked.wait(5)
+
+    setattr(profile, "external_process_auth_status", blocked_probe)
     monkeypatch.setitem(
         auth.PROVIDER_REGISTRY,
         profile.name,
@@ -154,12 +161,69 @@ def test_status_hard_bounds_a_probe_that_ignores_timeout(tmp_path, monkeypatch):
 
     started = time.monotonic()
     status = auth.get_external_process_provider_status(profile.name)
+    for _ in range(3):
+        auth.get_external_process_provider_status(profile.name)
 
-    assert time.monotonic() - started < 0.5
+    assert time.monotonic() - started < 1.5
+    assert calls == 1
     assert status["configured"] is True
     assert status["logged_in"] is True
     assert status["auth_verified"] is False
     assert status["auth_source"] == "provider_probe_timeout"
+    blocked.set()
+    state = auth._EXTERNAL_PROCESS_PROBES.pop(profile.name)
+    state["worker"].join(timeout=1)
+
+
+def test_status_concurrent_callers_share_one_started_probe(tmp_path, monkeypatch):
+    from hermes_cli import auth
+
+    executable = tmp_path / "test-agent"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(executable.stat().st_mode | stat.S_IEXEC)
+    release = threading.Event()
+    calls = 0
+    profile = _profile(process_command=str(executable))
+
+    def blocked_probe(**_):
+        nonlocal calls
+        calls += 1
+        release.wait(1)
+        return {"logged_in": True}
+
+    setattr(profile, "external_process_auth_status", blocked_probe)
+    monkeypatch.setitem(
+        auth.PROVIDER_REGISTRY,
+        profile.name,
+        auth.ProviderConfig(
+            id=profile.name,
+            name=profile.display_name,
+            auth_type="external_process",
+            inference_base_url=profile.base_url,
+        ),
+    )
+    monkeypatch.setattr("providers.get_provider_profile", lambda name: profile)
+    monkeypatch.setattr(auth, "_EXTERNAL_PROCESS_PROBE_JOIN_TIMEOUT", 0.05)
+    errors = []
+
+    def status_call():
+        try:
+            auth.get_external_process_provider_status(profile.name)
+        except Exception as exc:
+            errors.append(exc)
+
+    callers = [threading.Thread(target=status_call) for _ in range(6)]
+    for caller in callers:
+        caller.start()
+    for caller in callers:
+        caller.join(timeout=1)
+    release.set()
+
+    assert not errors
+    assert all(not caller.is_alive() for caller in callers)
+    assert calls == 1
+    state = auth._EXTERNAL_PROCESS_PROBES.pop(profile.name)
+    state["worker"].join(timeout=1)
 
 
 def test_status_reports_malformed_configured_args(tmp_path, monkeypatch):
@@ -189,6 +253,35 @@ def test_status_reports_malformed_configured_args(tmp_path, monkeypatch):
 
     assert status["configured"] is False
     assert status["auth_source"] == "invalid_configuration"
+    assert status["error"] == "invalid_external_process_args"
+
+
+def test_status_rejects_nul_in_structured_argv(tmp_path, monkeypatch):
+    from hermes_cli import auth
+
+    executable = tmp_path / "test-agent"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(executable.stat().st_mode | stat.S_IEXEC)
+    profile = _profile(process_command=str(executable))
+    monkeypatch.setitem(
+        auth.PROVIDER_REGISTRY,
+        profile.name,
+        auth.ProviderConfig(
+            id=profile.name,
+            name=profile.display_name,
+            auth_type="external_process",
+            inference_base_url=profile.base_url,
+        ),
+    )
+    monkeypatch.setattr("providers.get_provider_profile", lambda name: profile)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"providers": {profile.name: {"args": ["--ok", "\0"]}}},
+    )
+
+    status = auth.get_external_process_provider_status(profile.name)
+
+    assert status["configured"] is False
     assert status["error"] == "invalid_external_process_args"
 
 
@@ -226,6 +319,41 @@ def test_external_process_model_choices_prefer_live_catalog_and_fall_back(monkey
 
     monkeypatch.setattr(profile, "fetch_models", lambda **kwargs: None)
     assert _external_process_model_choices(profile.name) == ["test-model-a", "test-model-b"]
+
+
+def test_model_catalog_internal_type_error_is_not_retried(monkeypatch):
+    from hermes_cli.model_setup_flows import _external_process_model_choices
+
+    profile = _profile()
+    calls = 0
+
+    def broken_fetch(**kwargs):
+        nonlocal calls
+        calls += 1
+        raise TypeError("provider implementation defect")
+
+    monkeypatch.setattr("providers.get_provider_profile", lambda name: profile)
+    monkeypatch.setattr(profile, "fetch_models", broken_fetch)
+
+    assert _external_process_model_choices(profile.name) == ["test-model-a", "test-model-b"]
+    assert calls == 1
+
+
+def test_runtime_client_kwargs_include_generic_process_launch_settings(monkeypatch):
+    from agent.agent_init import _explicit_client_kwargs
+
+    profile = _profile()
+    monkeypatch.setattr("providers.get_provider_profile", lambda name: profile)
+    agent = SimpleNamespace(
+        provider=profile.name,
+        acp_command="/configured/process-cli",
+        acp_args=["--tenant", "test"],
+    )
+
+    kwargs = _explicit_client_kwargs(agent, "process-provider", profile.base_url, 30)
+
+    assert kwargs["command"] == "/configured/process-cli"
+    assert kwargs["args"] == ["--tenant", "test"]
 
 
 def test_external_process_setup_stops_on_failed_provider_auth_probe(monkeypatch, capsys):

--- a/website/docs/developer-guide/model-provider-plugin.md
+++ b/website/docs/developer-guide/model-provider-plugin.md
@@ -154,9 +154,9 @@ class AcmeProfile(ProviderProfile):
         return None
 ```
 
-## External-process (ACP) providers
+## External-process providers
 
-An agent CLI driven over stdio is not an HTTP endpoint. Set `auth_type="external_process"`, describe how to launch the binary, and supply the client with `create_client`. No core edits are needed — `hermes -m <name>`, `/model`, credential resolution, runtime resolution and the auxiliary client (compression, vision) all key on `auth_type`, not on the provider name. `plugins/model-providers/copilot-acp/` is the in-tree example.
+An agent CLI driven over stdio is not an HTTP endpoint. Set `auth_type="external_process"`, describe how to launch the binary, and supply the client with `create_client`. Hermes then includes the provider in its normal model picker and routes setup, credential resolution, runtime resolution, and auxiliary clients by `auth_type` rather than by vendor name. `plugins/model-providers/copilot-acp/` is the in-tree ACP example.
 
 | Field | Purpose |
 |---|---|
@@ -164,8 +164,22 @@ An agent CLI driven over stdio is not an HTTP endpoint. Set `auth_type="external
 | `process_args` | Default argv tail, e.g. `("--acp", "--stdio")` |
 | `process_command_env_vars` | Env vars that override the binary, checked in order |
 | `process_args_env_var` | Env var that overrides argv (shlex-split) |
+| `fallback_models` | Models shown when `fetch_models()` cannot retrieve a live catalog |
 
-The client your `create_client` returns receives `command` and `args` in `client_kwargs`. If it is already complete and async-safe, declare `HERMES_SKIP_TRANSPORT_WRAP = True` / `HERMES_SKIP_ASYNC_WRAP = True` as class attributes so the auxiliary client does not re-dispatch it through an HTTP wire adapter.
+Operators may override the launch command and argv without changing the plugin:
+
+```yaml
+providers:
+  your-provider:
+    command: /absolute/path/to/provider-cli
+    args: ["--stdio"]
+```
+
+Launch settings resolve in this order: profile-declared environment override, `config.yaml`, then profile defaults. The client returned by `create_client` receives the resolved `command` and `args` in `client_kwargs`.
+
+A profile may implement a bounded, non-secret `external_process_auth_status(*, command, args, timeout)` hook returning `{"logged_in": bool, "auth_evidence": str}`. The model picker stops before selection when that live probe explicitly reports authentication unavailable. Providers without the hook retain structural executable/endpoint status for compatibility.
+
+If the custom client is already complete and async-safe, declare `HERMES_SKIP_TRANSPORT_WRAP = True` / `HERMES_SKIP_ASYNC_WRAP = True` as class attributes so the auxiliary client does not re-dispatch it through an HTTP wire adapter.
 
 ## Hook reference examples
 
@@ -222,7 +236,7 @@ Set `profile.api_mode` to match the default your provider ships — it acts as a
 | `oauth_external` | User signs in elsewhere, tokens land in `auth.json` | Anthropic OAuth, MiniMax OAuth, Qwen Portal, Nous Portal |
 | `copilot` | GitHub Copilot token refresh cycle | `copilot` plugin only |
 | `aws_sdk` | AWS SDK credential chain (IAM role, profile, env) | `bedrock` plugin only |
-| `external_process` | Auth handled by a subprocess the agent spawns (see [External-process providers](#external-process-acp-providers)) | `copilot-acp` plugin, out-of-tree ACP plugins |
+| `external_process` | Auth handled by a subprocess the agent spawns (see [External-process providers](#external-process-providers)) | `copilot-acp` plugin, out-of-tree ACP plugins |
 
 `auth_type` gates which codepaths treat your provider as a "simple api-key provider" — if it's not `api_key`, the PluginManager still records the manifest but Hermes' CLI-level automation (doctor checks, `--provider` flag, setup wizard delegation) may skip over it.
 


### PR DESCRIPTION
## Summary
- include generic external-process provider plugins in the normal provider/model picker
- resolve launch command and argv from environment, operator config, then profile defaults
- support bounded provider-owned authentication probes and live model catalogs
- preserve the existing specialized Copilot ACP flow while routing other process providers generically
- document the external-process plugin contract

No vendor-specific provider is added to Hermes core.

## Verification
- `28 passed` in the focused external-process suites
- `324 passed` in the broader provider/model/runtime/auxiliary selection
- one unrelated pre-existing Codex auxiliary timing assertion fails consistently on this host
- Ruff passed on all changed Python files
- `compileall` and `git diff --check` passed

## Security
- malformed configured argv is rejected with a structured diagnostic
- provider auth hooks are hard-bounded at the caller even if a plugin ignores its advisory timeout
- negative authentication probes are not marked as verified authentication
