### PR TITLE
fix(update): stop Windows shim updates reporting stale restarts

### DIFF
--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -285,15 +285,20 @@ def _run_pending_fleet_restart() -> bool:
 def _apply_pending_fleet_restart_catchup() -> None:
     """On an already-up-to-date ``hermes update``, finish a skipped restart.
 
-    No-op when nothing is pending; exits 1 on incomplete catch-up so automation
-    does not treat the fleet as healthy.
+    A Windows shim hand-off also arrives here with an already-current checkout,
+    but it is the continuation of this update rather than recovery from a prior
+    one. In both cases, no-op when nothing is pending; exit 1 on incomplete
+    catch-up so automation does not treat the fleet as healthy.
     """
-    from hermes_cli.update_cmd import _run_pending_fleet_restart
+    from hermes_cli.update_cmd import _m, _run_pending_fleet_restart
     if not _pending_fleet_restart_needed():
         return
     print()
-    _warn_pending_fleet_restart()
-    print("→ Running the pending fleet restart...")
+    if os.environ.get(_m()._UPDATE_REEXEC_ENV) == "1":
+        print("→ Completing the fleet restart handed off by hermes.exe...")
+    else:
+        _warn_pending_fleet_restart()
+        print("→ Running the pending fleet restart...")
     if _run_pending_fleet_restart():
         _clear_fleet_restart_pending_marker()
         return

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -454,6 +454,31 @@ def test_already_up_to_date_runs_pending_restart_when_marker_present(
     assert "did not restart running gateways" in out
 
 
+def test_windows_handoff_finishes_current_restart_without_stale_warning(
+    monkeypatch, capsys
+):
+    """The re-exec child continues this update; it is not repairing a prior one."""
+    update_cmd._write_fleet_restart_pending_marker(expected_sha="def456")
+    monkeypatch.setenv(hermes_main._UPDATE_REEXEC_ENV, "1")
+
+    seen = {"ran": False}
+
+    def _restart():
+        seen["ran"] = True
+        return True
+
+    monkeypatch.setattr(update_cmd, "_run_pending_fleet_restart", _restart)
+    monkeypatch.setattr(update_cmd_fleet, "_run_pending_fleet_restart", _restart)
+
+    update_cmd._apply_pending_fleet_restart_catchup()
+
+    assert seen["ran"] is True
+    assert not update_cmd._fleet_restart_pending_marker_path().exists()
+    out = capsys.readouterr().out
+    assert "fleet restart handed off by hermes.exe" in out
+    assert "A previous `hermes update`" not in out
+
+
 def test_already_up_to_date_runs_pending_restart_when_receipt_skewed(
     monkeypatch, tmp_path, capsys
 ):


### PR DESCRIPTION
## What does this PR do?

Windows updates launched through a venv console shim no longer report their own continuation as a failed previous update. The hand-off child still performs the required fleet restart and clears the pending marker, preserving interrupted-update recovery while removing the recurring false warning.

### Symptom

After every code-advancing `hermes update` launched through `venv\Scripts\hermes.exe`, the hand-off child printed:

`A previous hermes update pulled new code but did not restart running gateways.`

This appeared even when the current update was proceeding normally and no gateway was running.

### Impact

Windows shim users received an alarming stale-fleet warning on every successful code update. On gateway-less installs it was immediately followed by `No running gateways - nothing to restart`, making a healthy update look interrupted.

### Bug Cause

**Trigger:** `hermes_cli/update_cmd_fleet.py:_apply_pending_fleet_restart_catchup` when `HERMES_UPDATE_REEXEC=1` and `fleet_restart_pending` exists.

**Causal chain:**
1. A code-advancing update writes the pending fleet-restart marker before dependency synchronization.
2. The Windows console shim cannot replace itself, so the parent starts a venv-Python child with `HERMES_UPDATE_REEXEC=1` and exits at the synchronization boundary.
3. The child intentionally sees an already-current checkout, completes dependency repair, and enters fleet-restart catch-up, which previously treated every marker as evidence of an interrupted prior update and emitted the false warning.

**Why it is wrong:** `HERMES_UPDATE_REEXEC=1` identifies the current update's continuation, not an abandoned earlier run. The restart obligation remains valid, but the stale-update diagnosis does not.

**Working sibling / contrast:** An ordinary already-current update with a leftover marker has no hand-off environment marker and must continue to warn about a genuinely unfinished earlier update.

**Ruled out:** Skipping marker creation when no gateways are detected would narrow interrupted-update safety and would not address shim updates that do have gateways. This change keeps restart execution and marker cleanup unchanged.

### Fix

Detect the existing hand-off environment marker in fleet catch-up. Hand-off children print a continuation message, run the same restart bookkeeping, and clear the marker only after success. Ordinary catch-up retains the previous-update warning.

## Related Issue

Closes #103031

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd_fleet.py` - distinguish same-update Windows hand-off continuation from prior-update recovery without skipping restart work.
- `tests/hermes_cli/test_update_fleet_restart_pending.py` - verify the hand-off path runs restart bookkeeping, clears the marker, and suppresses only the false stale-update warning.

## How to Test

1. Run a code-advancing `hermes update` through `venv\Scripts\hermes.exe` on Windows.
2. Confirm the child reports that it is completing the handed-off fleet restart and does not claim a previous update failed.
3. Run the automated regression suite:

```bash
scripts/run_tests.sh tests/hermes_cli/test_update_fleet_restart_pending.py tests/hermes_cli/test_update_shim_self_lock.py tests/hermes_cli/test_update_handoff_exit.py -q
```

Result: 47 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant updater tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested the regression on Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation is N/A; the behavior and ownership distinction are documented in the code and regression test
- [x] `cli-config.yaml.example` is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact; the new branch is active only for the existing Windows hand-off environment marker
- [x] Tool descriptions and schemas are N/A; no tool contract changed
