### PR TITLE
fix(delegate): stop subagent worktree isolation from mutating tracked .gitignore

### DIFF
--- a/tests/tools/test_subagent_worktree.py
+++ b/tests/tools/test_subagent_worktree.py
@@ -86,9 +86,12 @@ class SubagentWorktreeTests(unittest.TestCase):
         self.assertTrue(info["base_commit"])
         # Worktree carries the committed file
         self.assertTrue((Path(info["path"]) / "README.md").exists())
-        # .gitignore gained the .worktrees/ entry
+        # .worktrees/ is excluded via .git/info/exclude (untracked, local-only) —
+        # the parent's tracked .gitignore must not be touched.
+        self.assertFalse((repo / ".gitignore").exists())
         self.assertIn(
-            ".worktrees/", (repo / ".gitignore").read_text(encoding="utf-8").splitlines()
+            ".worktrees/",
+            (repo / ".git" / "info" / "exclude").read_text(encoding="utf-8").splitlines(),
         )
         # A write in the worktree does not touch the parent checkout
         (Path(info["path"]) / "child.txt").write_text("x", encoding="utf-8")

--- a/tools/subagent_worktree.py
+++ b/tools/subagent_worktree.py
@@ -60,16 +60,27 @@ def resolve_repo_root(path: Optional[str]) -> Optional[str]:
 
 
 def _ensure_gitignore_entry(repo_root: str) -> None:
-    """Best-effort: keep ``.worktrees/`` out of git status."""
-    gitignore = Path(repo_root) / ".gitignore"
+    """Best-effort: keep ``.worktrees/`` out of git status.
+
+    Uses ``.git/info/exclude`` rather than the tracked ``.gitignore`` so this
+    never writes to a file the parent repo tracks (#103302).
+    """
     try:
-        existing = gitignore.read_text(encoding="utf-8-sig", errors="replace") if gitignore.exists() else ""
+        common_dir = _run_git(["rev-parse", "--git-common-dir"], cwd=repo_root)
+        git_dir_str = common_dir.stdout.strip() if common_dir.returncode == 0 else ".git"
+        git_dir = Path(git_dir_str)
+        if not git_dir.is_absolute():
+            git_dir = (Path(repo_root) / git_dir).resolve()
+        info_dir = git_dir / "info"
+        info_dir.mkdir(parents=True, exist_ok=True)
+        exclude = info_dir / "exclude"
+        existing = exclude.read_text(encoding="utf-8-sig", errors="replace") if exclude.exists() else ""
         if ".worktrees/" not in existing.splitlines():
-            with open(gitignore, "a", encoding="utf-8") as f:
+            with open(exclude, "a", encoding="utf-8") as f:
                 sep = "\n" if existing and not existing.endswith("\n") else ""
                 f.write(f"{sep}.worktrees/\n")
     except Exception as exc:
-        logger.debug("subagent worktree: could not update .gitignore: %s", exc)
+        logger.debug("subagent worktree: could not update git exclude file: %s", exc)
 
 
 def create_subagent_worktree(parent_cwd: Optional[str], subagent_id: Optional[str] = None) -> Optional[Dict[str, str]]:


### PR DESCRIPTION
## What does this PR do?

`tools/subagent_worktree.py::create_subagent_worktree()` unconditionally appends
`.worktrees/` to the parent repository's **tracked** `.gitignore` on every
successful worktree creation. That's a write to a tracked file in the parent
checkout, which contradicts the module's own isolation contract that the
parent's checkout stays untouched while a child works in its own worktree.

This PR fixes the mutation side of #103302 by switching `_ensure_gitignore_entry()`
to write the `.worktrees/` exclusion into `.git/info/exclude` instead —
untracked, local-only, and never touches anything the parent repo tracks or
that `git status`/`git diff` in the parent checkout would ever show.

(Note: #103302 also reports that isolation silently degrades to a shared cwd
when no git anchor can be resolved. That part is already addressed by open PR
#97228, which adds `delegation.worktree_repo_root` and upgrades the relevant
`logger.debug` calls to visible `logger.warning`s at the `delegate_tool.py`
call site. This PR only fixes the still-unaddressed `.gitignore` write, to
avoid duplicating that work.)

## Related Issue

Fixes #103302

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/subagent_worktree.py`: `_ensure_gitignore_entry()` now resolves the
  repo's common `.git` directory (via `git rev-parse --git-common-dir`, so it
  works correctly even when `repo_root` is itself a linked worktree) and
  appends the `.worktrees/` entry to `<git-common-dir>/info/exclude` instead
  of `<repo_root>/.gitignore`.
- `tests/tools/test_subagent_worktree.py`: `test_create_makes_isolated_worktree`
  now asserts `.gitignore` is **not** created in the parent repo, and that
  `.git/info/exclude` gained the `.worktrees/` entry instead.

## How to Test

Reproduction / proof the test catches the bug:

```bash
$ git checkout HEAD~1 -- tools/subagent_worktree.py   # pre-fix source
$ python -m pytest tests/tools/test_subagent_worktree.py::SubagentWorktreeTests::test_create_makes_isolated_worktree -q
F
AssertionError: True is not false
# repo/.gitignore existed — the tracked file was mutated
$ git checkout HEAD -- tools/subagent_worktree.py     # restore the fix
```

Full file suite after the fix:

```bash
$ python -m pytest tests/tools/test_subagent_worktree.py -q
......................
22 passed in 1.01s
```

`ruff check tools/subagent_worktree.py tests/tools/test_subagent_worktree.py`
— all checks passed.

(This sandbox's Python environment was missing several unrelated third-party
packages, e.g. `pytest`, `pyyaml`, `requests`, `python-dotenv` — installed
locally via `pip` to run the suite; no manifest/lockfile in the repo was
touched. `scripts/run_tests.sh` itself requires a project `.venv`/Nix devShell
that doesn't exist in this sandbox, so I ran the equivalent `pytest` directly
against `tests/tools/test_subagent_worktree.py` instead.)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform: Linux (sandbox), not verified on macOS/Windows

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring on `_ensure_gitignore_entry` updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — `git rev-parse --git-common-dir` and `Path` handling are platform-neutral
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool schema changed

## AI assistance disclosure

This PR was prepared with AI assistance (Claude, Anthropic) under human/pipeline
supervision: it located the issue, wrote the fix and test, and verified the
test fails on the pre-fix source and passes after the fix.
