### PR TITLE
fix(kanban): scratch decompose children must not inherit a claimed root's workspace_path

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3598,16 +3598,18 @@ def _insert_decomposed_child(
 
     Workspace: per-child override wins, else inherit the root's kind. Path
     inherits only when kinds match (a 'dir' child must not point at the
-    root's worktree) and NEVER for worktrees — siblings dispatch concurrently
-    and one shared checkout would put them all on the first sibling's branch
-    with no lock; leaving it unset makes dispatch materialize a fresh
-    ``<repo>/.worktrees/<child-id>`` per child from the board anchor.
+    root's worktree) and NEVER for worktree or scratch — siblings dispatch
+    concurrently and one shared checkout/dir would put them all on the first
+    sibling's branch, or writing into one directory, with no lock; leaving
+    it unset makes dispatch materialize a fresh per-child path (worktree:
+    ``<repo>/.worktrees/<child-id>``; scratch: ``workspaces/<child-id>``)
+    from the board anchor.
     """
     root_ws_kind = root_row["workspace_kind"] or "scratch"
     child_ws_kind = child.get("workspace_kind") or root_ws_kind
     if child.get("workspace_path"):
         child_ws_path = child.get("workspace_path")
-    elif child_ws_kind == "worktree":
+    elif child_ws_kind in ("worktree", "scratch"):
         child_ws_path = None
     elif child_ws_kind == root_ws_kind:
         child_ws_path = root_row["workspace_path"]

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -69,6 +69,39 @@ def test_decompose_creates_children_and_promotes_root(kanban_home):
     assert c1.assignee == "engineer"
 
 
+def test_decompose_scratch_children_get_own_workspace(kanban_home):
+    """A scratch root already claimed (workspace_path set) must not pin its
+    decomposed children to that same directory — each should resolve its own
+    ``workspaces/<child-id>`` at dispatch, exactly like worktree children do.
+    """
+    with kbc.connect() as conn:
+        tid = _create_triage(conn, title="rough idea")
+        conn.execute(
+            "UPDATE tasks SET workspace_kind='scratch', "
+            "workspace_path='/home/x/.hermes/workspaces/root' WHERE id = ?",
+            (tid,),
+        )
+        conn.commit()
+
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orchestrator",
+            children=[{"title": "A"}, {"title": "B"}],
+            author="decomposer",
+        )
+    assert child_ids is not None and len(child_ids) == 2
+
+    with kbc.connect() as conn:
+        for cid in child_ids:
+            row = conn.execute(
+                "SELECT workspace_kind, workspace_path FROM tasks WHERE id = ?",
+                (cid,),
+            ).fetchone()
+            assert row["workspace_kind"] == "scratch"
+            assert row["workspace_path"] is None
+
+
 def test_decompose_records_audit_comment_and_event(kanban_home):
     with kbc.connect() as conn:
         tid = _create_triage(conn)


### PR DESCRIPTION
## Problem

`decompose_triage_task()` (`hermes_cli/kanban_db.py`, `_insert_decomposed_child`) deliberately leaves a `worktree`-kind child's `workspace_path` unset so dispatch materializes a distinct `<repo>/.worktrees/<child-id>` per sibling. `scratch` children got no such treatment: they fell into the `child_ws_kind == root_ws_kind` branch and inherited the root's literal `workspace_path` verbatim.

That's harmless while the root has never been claimed (`workspace_path` is `NULL`, so children get `NULL` too and resolve their own `workspaces/<child-id>` at dispatch). But once the root has been claimed at least once, the dispatcher has already stamped a concrete path onto it via `set_workspace_path()`. Decomposing *that* root pins every scratch sibling to the same directory, so concurrently dispatched workers all write into one shared dir instead of isolated per-task scratch dirs — silent cross-contamination with no error anywhere in the board state, diagnostics, or run logs.

Fixes #103303.

## Fix

Route `scratch` through the same "leave `workspace_path` unset" branch already used for `worktree`:

```python
elif child_ws_kind in ("worktree", "scratch"):
    child_ws_path = None
elif child_ws_kind == root_ws_kind:
    child_ws_path = root_row["workspace_path"]
```

`dir`-kind inheritance (the intentional shared-checkout case) is untouched. Per-child explicit `workspace_path` overrides still win, exactly as before.

## Test

Added `test_decompose_scratch_children_get_own_workspace` in `tests/hermes_cli/test_kanban_decompose_db.py`, modeled on the existing worktree-isolation regression test: creates a scratch-kind triage root, stamps a concrete `workspace_path` onto it (simulating a prior claim), decomposes it, and asserts both children come back with `workspace_path IS NULL`.

Confirmed the test fails without the fix (`git checkout HEAD~1 -- hermes_cli/kanban_db.py` equivalent — actually verified by stashing the fix hunk before it was committed):

```
FAILED tests/hermes_cli/test_kanban_decompose_db.py::test_decompose_scratch_children_get_own_workspace
AssertionError: assert '/home/x/.hermes/workspaces/root' is None
```

And passes with the fix applied:

```
$ python -m pytest tests/hermes_cli/test_kanban_decompose_db.py tests/hermes_cli/test_kanban_worktree_isolation.py tests/hermes_cli/test_kanban_decompose.py -v
...
8 passed in 1.32s
```

`ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_decompose_db.py` — all checks passed.

A broader `-k kanban` run shows 15 pre-existing failures (write-guard/hook-isolation/module-import issues unrelated to this change) — verified identical on unmodified `upstream/main` before this fix was applied, so they are not caused or affected by this patch.

## AI assistance disclosure

This PR was prepared with AI assistance (Claude), with the diff reviewed and verified against the issue's repro before submission.
