### PR TITLE
fix(worktree): exclude .worktrees/ locally, never in the tracked .gitignore

### DIFF
--- a/hermes_cli/worktree_ops.py
+++ b/hermes_cli/worktree_ops.py
@@ -212,19 +212,46 @@ def _resolve_worktree_base(repo_root: str, fetch_timeout: float = 5,
     return "HEAD", "HEAD (local — could not reach remote)"
 
 
-def _ensure_worktrees_gitignored(repo_root: str) -> None:
-    """Append ``.worktrees/`` to the repo's .gitignore when missing (fail-soft)."""
-    gitignore = Path(repo_root) / ".gitignore"
+def ensure_worktrees_excluded(repo_root: str, git_out=None) -> None:
+    """Keep ``.worktrees/`` out of ``git status`` without touching a TRACKED file (#103302).
+
+    Writes to ``$GIT_COMMON_DIR/info/exclude`` — untracked, local-only, and shared by the repo
+    and every linked worktree — instead of the repo's tracked ``.gitignore``. Appending to
+    ``.gitignore`` dirtied the very checkout worktree isolation exists to leave untouched: the
+    line lands in the user's ``git status``/``git diff``, rides along in an unrelated ``git
+    commit -a``, and conflicts on rebase. ``info/exclude`` is honored identically by git.
+
+    No-op when git already ignores the directory (many repos, this one included, track the
+    entry in ``.gitignore`` themselves) — the exclude is only for repos that don't. Never
+    removes a pre-existing ``.gitignore`` entry: that would be the same tracked-file write in
+    the other direction.
+
+    *git_out* is the caller's own git runner (``args, cwd -> stripped stdout | None``) so a
+    hardened invocation stays hardened; defaults to this module's :func:`_git_out`.
+    Fail-soft — an exclude we could not write is never worth failing worktree creation over.
+    """
+    runner = git_out or _git_out
     try:
+        # Authoritative: covers .gitignore, an existing info/exclude, and core.excludesFile.
+        # A non-zero exit (not ignored, or git failed) falls through to writing our own
+        # exclude, which is harmless if redundant.
+        if runner(["check-ignore", "-q", ".worktrees/"], repo_root) is not None:
+            return
+        common_dir = runner(["rev-parse", "--path-format=absolute", "--git-common-dir"], repo_root)
+        if not common_dir:
+            return
+        exclude = Path(common_dir) / "info" / "exclude"
         # utf-8-sig: a Notepad BOM would glue to the first line and defeat the membership check.
-        existing = gitignore.read_text(encoding="utf-8-sig", errors="replace") if gitignore.exists() else ""
-        if ".worktrees/" not in existing.splitlines():
-            with open(gitignore, "a", encoding="utf-8") as f:
-                if existing and not existing.endswith("\n"):
-                    f.write("\n")
-                f.write(".worktrees/\n")
+        existing = exclude.read_text(encoding="utf-8-sig", errors="replace") if exclude.exists() else ""
+        if ".worktrees/" in existing.splitlines():
+            return
+        exclude.parent.mkdir(parents=True, exist_ok=True)
+        with open(exclude, "a", encoding="utf-8") as f:
+            if existing and not existing.endswith("\n"):
+                f.write("\n")
+            f.write(".worktrees/\n")
     except Exception as e:
-        logger.debug("Could not update .gitignore: %s", e)
+        logger.debug("Could not update info/exclude: %s", e)
 
 
 def _copy_worktree_includes(repo_root: str, wt_path: Path) -> None:
@@ -339,7 +366,7 @@ def _setup_worktree(repo_root: str = None, sync_base: bool = True,
         print(f"  Pick a different name, or remove it with: git worktree remove {wt_path}")
         return None
 
-    _ensure_worktrees_gitignored(repo_root)
+    ensure_worktrees_excluded(repo_root)
 
     # Resolve the base ref. By default branch from the freshly-fetched remote tip so the worktree starts
     # current with the project, not from the (possibly stale) local HEAD of the standalone clone (#10760

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -342,30 +342,74 @@ class TestWorktreeInclude:
         # Should not crash — just skip all lines
 
 
-class TestGitignoreManagement:
-    """Test that .worktrees/ is added to .gitignore."""
+class TestWorktreeIgnoreRule:
+    """``.worktrees/`` is excluded LOCALLY, never by writing the tracked .gitignore (#103302)."""
 
-    def test_adds_to_gitignore(self, git_repo):
-        """Creating a worktree should add .worktrees/ to .gitignore."""
-        # Remove any existing .gitignore
+    def test_ignore_rule_lands_in_info_exclude(self, git_repo):
+        """The real helper ignores ``.worktrees/`` without touching a tracked file.
+
+        Previously it appended to the repo's ``.gitignore``, so every ``hermes -w``
+        session (and every delegated subagent worktree) left the user's checkout
+        dirty. ``$GIT_COMMON_DIR/info/exclude`` is untracked and local-only.
+        """
         gitignore = git_repo / ".gitignore"
         if gitignore.exists():
             gitignore.unlink()
 
-        info = _setup_worktree(str(git_repo))
-        assert info is not None
+        worktree_ops.ensure_worktrees_excluded(str(git_repo))
 
-        # Now manually add .worktrees/ to .gitignore (mirrors cli.py logic)
-        _ignore_entry = ".worktrees/"
-        existing = gitignore.read_text() if gitignore.exists() else ""
-        if _ignore_entry not in existing.splitlines():
-            with open(gitignore, "a") as f:
-                if existing and not existing.endswith("\n"):
-                    f.write("\n")
-                f.write(f"{_ignore_entry}\n")
+        assert not gitignore.exists()
+        assert subprocess.run(
+            ["git", "check-ignore", "-q", ".worktrees/"],
+            cwd=str(git_repo), capture_output=True,
+        ).returncode == 0
+        assert subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=str(git_repo), capture_output=True, text=True,
+        ).stdout.strip() == ""
 
-        content = gitignore.read_text()
-        assert ".worktrees/" in content
+    def test_second_call_does_not_duplicate_the_rule(self, git_repo):
+        """Idempotent: repeated sessions must not stack identical exclude lines."""
+        worktree_ops.ensure_worktrees_excluded(str(git_repo))
+        worktree_ops.ensure_worktrees_excluded(str(git_repo))
+
+        common = subprocess.run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            cwd=str(git_repo), capture_output=True, text=True,
+        ).stdout.strip()
+        exclude_lines = (Path(common) / "info" / "exclude").read_text(
+            encoding="utf-8"
+        ).splitlines()
+        assert exclude_lines.count(".worktrees/") == 1
+
+    def test_existing_gitignore_entry_is_left_alone(self, git_repo):
+        """A repo that already ignores the dir keeps its own rule, byte for byte."""
+        gitignore = git_repo / ".gitignore"
+        gitignore.write_text(".worktrees/\n", encoding="utf-8")
+        subprocess.run(["git", "add", ".gitignore"], cwd=str(git_repo), capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "ignore worktrees"], cwd=str(git_repo), capture_output=True
+        )
+
+        worktree_ops.ensure_worktrees_excluded(str(git_repo))
+
+        assert gitignore.read_text(encoding="utf-8") == ".worktrees/\n"
+        common = subprocess.run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            cwd=str(git_repo), capture_output=True, text=True,
+        ).stdout.strip()
+        exclude = Path(common) / "info" / "exclude"
+        lines = exclude.read_text(encoding="utf-8").splitlines() if exclude.exists() else []
+        assert ".worktrees/" not in lines
+
+    def test_non_repo_is_a_silent_no_op(self, tmp_path):
+        """Outside a repo there is nothing to exclude — fail-soft, no raise."""
+        plain = tmp_path / "plain"
+        plain.mkdir()
+
+        worktree_ops.ensure_worktrees_excluded(str(plain))
+
+        assert not (plain / ".gitignore").exists()
 
 
 

--- a/tests/tools/test_subagent_worktree.py
+++ b/tests/tools/test_subagent_worktree.py
@@ -86,13 +86,58 @@ class SubagentWorktreeTests(unittest.TestCase):
         self.assertTrue(info["base_commit"])
         # Worktree carries the committed file
         self.assertTrue((Path(info["path"]) / "README.md").exists())
-        # .gitignore gained the .worktrees/ entry
-        self.assertIn(
-            ".worktrees/", (repo / ".gitignore").read_text(encoding="utf-8").splitlines()
+        # #103302: the parent's TRACKED .gitignore is never written — the ignore
+        # rule goes into the untracked, local-only info/exclude instead.
+        self.assertFalse((repo / ".gitignore").exists())
+        self.assertEqual(
+            _git(["check-ignore", "-q", ".worktrees/"], repo, check=False).returncode, 0
         )
         # A write in the worktree does not touch the parent checkout
         (Path(info["path"]) / "child.txt").write_text("x", encoding="utf-8")
         self.assertFalse((repo / "child.txt").exists())
+
+    def test_create_leaves_parent_checkout_clean(self):
+        """#103302: isolation must not dirty the checkout it exists to protect.
+
+        The old code appended ``.worktrees/`` to the repo's TRACKED ``.gitignore``,
+        so the parent's ``git status`` came back dirty after every delegation —
+        the line rides along in an unrelated ``git commit -a`` and conflicts on
+        rebase. Assert the contract the module docstring already claims.
+        """
+        repo = _make_repo(self.tmp)
+        tracked_before = _git(["ls-files"], repo).stdout
+        info = sw.create_subagent_worktree(str(repo), "clean-parent")
+        self.assertIsNotNone(info)
+
+        status = _git(["status", "--porcelain"], repo).stdout.strip()
+        self.assertEqual(status, "", f"parent checkout dirtied by isolation: {status!r}")
+        self.assertEqual(_git(["ls-files"], repo).stdout, tracked_before)
+
+    def test_create_respects_an_existing_gitignore_entry(self):
+        """A repo that already ignores ``.worktrees/`` gets no second rule.
+
+        The exclude write is gated on ``git check-ignore``, so a repo tracking the
+        entry itself (this one included) is left entirely alone — and the parent's
+        ``.gitignore`` keeps exactly the bytes it had.
+        """
+        repo = _make_repo(self.tmp)
+        (repo / ".gitignore").write_text(".worktrees/\n", encoding="utf-8")
+        _git(["add", ".gitignore"], repo)
+        _git(["commit", "-q", "-m", "ignore worktrees"], repo)
+
+        info = sw.create_subagent_worktree(str(repo), "already-ignored")
+        self.assertIsNotNone(info)
+
+        self.assertEqual((repo / ".gitignore").read_text(encoding="utf-8"), ".worktrees/\n")
+        self.assertEqual(_git(["status", "--porcelain"], repo).stdout.strip(), "")
+        common = Path(
+            _git(["rev-parse", "--path-format=absolute", "--git-common-dir"], repo).stdout.strip()
+        )
+        exclude = common / "info" / "exclude"
+        exclude_lines = (
+            exclude.read_text(encoding="utf-8").splitlines() if exclude.exists() else []
+        )
+        self.assertNotIn(".worktrees/", exclude_lines)
 
     def test_create_unborn_head_returns_none(self):
         repo = self.tmp / "empty"

--- a/tools/subagent_worktree.py
+++ b/tools/subagent_worktree.py
@@ -59,17 +59,29 @@ def resolve_repo_root(path: Optional[str]) -> Optional[str]:
     return (result.stdout.strip() or None) if result.returncode == 0 else None
 
 
-def _ensure_gitignore_entry(repo_root: str) -> None:
-    """Best-effort: keep ``.worktrees/`` out of git status."""
-    gitignore = Path(repo_root) / ".gitignore"
+def _ensure_worktrees_excluded(repo_root: str) -> None:
+    """Keep ``.worktrees/`` out of ``git status`` without writing a TRACKED file (#103302).
+
+    Shares :func:`hermes_cli.worktree_ops.ensure_worktrees_excluded` with the ``hermes -w`` path
+    (same bug class, one implementation), passing THIS module's hardened runner so the
+    GHSA-7x36-8jrh-v4pw env/argv hardening still applies: it writes
+    ``$GIT_COMMON_DIR/info/exclude`` instead of appending to the parent's ``.gitignore``.
+    Appending there contradicted this module's own contract — isolation exists so "the parent's
+    checkout stays untouched", and the appended line showed up in the user's ``git status``.
+    """
+    def _out(args, cwd) -> Optional[str]:
+        try:
+            result = _run_git(args, cwd=cwd)
+        except Exception:
+            return None
+        return (result.stdout.strip() or "") if result.returncode == 0 else None
+
     try:
-        existing = gitignore.read_text(encoding="utf-8-sig", errors="replace") if gitignore.exists() else ""
-        if ".worktrees/" not in existing.splitlines():
-            with open(gitignore, "a", encoding="utf-8") as f:
-                sep = "\n" if existing and not existing.endswith("\n") else ""
-                f.write(f"{sep}.worktrees/\n")
-    except Exception as exc:
-        logger.debug("subagent worktree: could not update .gitignore: %s", exc)
+        from hermes_cli.worktree_ops import ensure_worktrees_excluded
+    except Exception as exc:  # pragma: no cover - import-time only
+        logger.debug("subagent worktree: exclude helper unavailable: %s", exc)
+        return
+    ensure_worktrees_excluded(repo_root, git_out=_out)
 
 
 def create_subagent_worktree(parent_cwd: Optional[str], subagent_id: Optional[str] = None) -> Optional[Dict[str, str]]:
@@ -82,7 +94,7 @@ def create_subagent_worktree(parent_cwd: Optional[str], subagent_id: Optional[st
     wt_path = Path(repo_root) / ".worktrees" / wt_name
     try:
         wt_path.parent.mkdir(parents=True, exist_ok=True)
-        _ensure_gitignore_entry(repo_root)
+        _ensure_worktrees_excluded(repo_root)
         base = _run_git(["rev-parse", "HEAD"], cwd=repo_root)
         base_commit = base.stdout.strip() if base.returncode == 0 else ""
         result = _run_git(["worktree", "add", str(wt_path), "-b", branch, "HEAD"], cwd=repo_root)


### PR DESCRIPTION
## Summary

Worktree isolation dirtied the very checkout it exists to leave untouched. Both worktree creation paths appended `.worktrees/` to the repo's **tracked** `.gitignore`; they now write `$GIT_COMMON_DIR/info/exclude` instead — untracked, local-only, and honored identically by git.

## Related Issue

Fixes the `.gitignore` half of #103302.

That issue reports two independent defects; this PR deliberately fixes only the second. The first (isolation silently degrading to shared cwd when `worktree_isolation: true` cannot be established) is already being handled in **#97228**, which adds `delegation.worktree_repo_root` plus visible degradation warnings — I did not want to collide with it.

## Root Cause

Two call sites, same bug shape:

- `hermes_cli/worktree_ops.py::_ensure_worktrees_gitignored` — runs on every `hermes -w` session (`_setup_worktree`).
- `tools/subagent_worktree.py::_ensure_gitignore_entry` — runs for every delegated child when `delegation.worktree_isolation: true` (`create_subagent_worktree`).

Both appended `.worktrees/` to `<repo>/.gitignore`, a tracked file. Consequences in a repo that does not already ignore that directory:

- the parent's `git status` / `git diff` comes back dirty after a delegation the user never asked to modify anything;
- the line rides along in an unrelated `git commit -a`;
- it conflicts on rebase.

`tools/subagent_worktree.py`'s own module contract is that isolation exists so "the parent's checkout stays untouched" — the `.gitignore` write contradicted it directly (the issue quotes this).

## Fix

One shared helper, `worktree_ops.ensure_worktrees_excluded(repo_root, git_out=None)`, called by both paths:

1. `git check-ignore -q .worktrees/` first. If git already ignores the directory — by tracked `.gitignore` (this repo does), an existing `info/exclude`, or `core.excludesFile` — **return without writing anything**.
2. Otherwise append `.worktrees/` to `$GIT_COMMON_DIR/info/exclude`. `--git-common-dir` resolves to the main repo's `.git` from a linked worktree too, so the rule is shared by the repo and every worktree, exactly like the old `.gitignore` entry was.
3. A pre-existing `.gitignore` entry is never *removed* — that would be the same tracked-file write in the other direction.

`tools/subagent_worktree.py` passes its own `_run_git`-backed runner via `git_out`, so the GHSA-7x36-8jrh-v4pw argv/env hardening on that path still applies (`harden_git_argv` + `noninteractive_git_env`) rather than falling back to `worktree_ops`' unhardened `_git_out`.

Fail-soft throughout: an exclude we could not write is never worth failing worktree creation over, matching the previous behavior.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/worktree_ops.py`: `_ensure_worktrees_gitignored` → `ensure_worktrees_excluded` (public — the subagent path imports it), writing `info/exclude` behind a `check-ignore` gate; accepts the caller's git runner.
- `tools/subagent_worktree.py`: `_ensure_gitignore_entry` → `_ensure_worktrees_excluded`, delegating to the shared helper with this module's hardened runner. No behavior of its own to drift.
- `tests/cli/test_worktree.py`: `TestGitignoreManagement` → `TestWorktreeIgnoreRule`, 4 tests.
- `tests/tools/test_subagent_worktree.py`: 2 new tests, 1 updated assertion.

## How to Test

```bash
scripts/run_tests.sh tests/cli/test_worktree.py tests/tools/test_subagent_worktree.py -q
```

Manual, in a repo whose `.gitignore` does **not** mention `.worktrees/`:

```bash
git status --porcelain      # clean
hermes -w                   # (or delegate with worktree_isolation: true)
git status --porcelain      # still clean — was ' M .gitignore' before
git check-ignore -q .worktrees/ && echo ignored   # ignored
```

## Before / After

| | before | after |
|---|---|---|
| repo without the entry | `.gitignore` modified (tracked, dirty status) | `.git/info/exclude` appended (untracked) |
| repo that already ignores it | second identical line risked | nothing written at all |
| repeat sessions | membership-checked | membership-checked + `check-ignore` short-circuit |
| `git status` after isolation | dirty | clean |

## Design Notes

**Why `info/exclude` and not "just stop ignoring it".** Dropping the ignore rule entirely would leave `.worktrees/` as untracked noise in `git status` for every worktree user, which is the thing the original commit (#652) added it to prevent. `info/exclude` keeps that benefit with none of the tracked-file cost.

**Why the `check-ignore` gate.** It is the authoritative answer across all ignore sources, so repos that already handle this (including hermes-agent itself, `.gitignore:79`) get a strict no-op instead of a redundant exclude line.

**Test-quality note.** The replaced `TestGitignoreManagement::test_adds_to_gitignore` re-implemented the CLI's `.gitignore` append *inside the test body* and then asserted on its own write, so it never exercised shipped code and would have passed no matter what `worktree_ops` did. The new tests call the real helper.

## Verification

- `scripts/run_tests.sh tests/cli/test_worktree.py tests/tools/test_subagent_worktree.py -q` → **76 passed, 0 failed, 1 skipped** (`-k 'not TestPrMergedEscapeHatch'`, see below).
- **Sabotage run** — helper reverted in place to the pre-fix `.gitignore` append: **5 of the new/updated tests fail** (`test_ignore_rule_lands_in_info_exclude`, `test_second_call_does_not_duplicate_the_rule`, `test_non_repo_is_a_silent_no_op`, `test_create_leaves_parent_checkout_clean`, `test_create_makes_isolated_worktree`), then pass again once restored. The tests bite.
- **Pre-existing failures on pristine `f159e581c7`, unrelated to this diff** (verified by stashing the whole diff and re-running): `TestPrMergedEscapeHatch::test_merged_pr_tree_is_reaped`, `TestPrMergedEscapeHatch::test_merged_verdict_memoized_by_branch_and_head`, `tests/security/test_gitspawn_config_injection.py::test_baseline_unhardened_git_fires_sinks`, `tests/cli/test_worktree_pushed_tier.py::TestCronWorktreeMaintenance::test_repo_discovery_requires_worktrees_dir`. All four fail identically with and without the change (Windows host).
- Sibling worktree suites run clean otherwise: `test_worktree_selfheal.py`, `test_worktree_sync_base.py`, `test_kanban_worktree_teardown.py` (56 passed / 2 pre-existing failures listed above).
- Branch is based on `origin/main` @ `f159e581c7`; `git diff --check` clean.

## Checklist

- [x] Fixes the whole bug class — both call sites, one shared implementation
- [x] Regression tests proven to fail without the fix (sabotage run)
- [x] Real helper under test, not a re-implementation in the test body
- [x] No new config keys, env vars, dependencies, or core tools
- [x] Pre-existing failures separated from this diff by a stashed baseline run
- [x] Every changed line traces to #103302
