### PR TITLE
fix(codex): allow Responses text field through Codex preflight

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -733,6 +733,8 @@ _PREFLIGHT_OPTIONAL_FIELDS: tuple[tuple[str, Callable[[Any], bool], Optional[Cal
     ("reasoning", lambda v: isinstance(v, dict), None),
     ("include", lambda v: isinstance(v, list), None),
     ("service_tier", _nonblank, str.strip),
+    # Responses text controls (verbosity, structured-output format).
+    ("text", lambda v: isinstance(v, dict) and bool(v), None),
     ("max_output_tokens", lambda v: isinstance(v, (int, float)) and v > 0, int),
     ("timeout", lambda v: isinstance(v, (int, float)) and not isinstance(v, bool) and 0 < v < float("inf"), float),
     ("temperature", lambda v: isinstance(v, (int, float)), float),

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -625,3 +625,37 @@ def _xai_reasoning_only_response(reasoning_text):
             )
         ],
     )
+
+
+def test_preflight_passes_text_verbosity_through():
+    """``text`` survives preflight instead of failing the whole request.
+
+    ``_PREFLIGHT_ALLOWED_KEYS`` is derived from ``_PREFLIGHT_OPTIONAL_FIELDS``,
+    so before this entry existed a caller setting ``text.verbosity`` got
+    ``Codex Responses request has unsupported field(s): text.`` locally --
+    the request never reached the provider, which accepts the field.
+    """
+    normalized = _preflight_codex_api_kwargs({
+        "model": "gpt-5.6-sol",
+        "instructions": "hi",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "ping"}]}],
+        "store": False,
+        "text": {"verbosity": "high"},
+    })
+
+    assert normalized["text"] == {"verbosity": "high"}
+
+
+def test_preflight_drops_empty_or_malformed_text():
+    """Only a non-empty object is forwarded; anything else is dropped rather
+    than rejected, matching how the other optional fields behave."""
+    base = {
+        "model": "gpt-5.6-sol",
+        "instructions": "hi",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "ping"}]}],
+        "store": False,
+    }
+
+    for value in ({}, None, "high", 3):
+        normalized = _preflight_codex_api_kwargs(dict(base, text=value))
+        assert "text" not in normalized, value


### PR DESCRIPTION
## What does this PR do?

Hermes refuses its own request before it reaches the provider when that request
carries the Responses API `text` field:

```
Codex Responses request has unsupported field(s): text.
```

`_PREFLIGHT_ALLOWED_KEYS` is derived from `_PREFLIGHT_OPTIONAL_FIELDS`, and
`text` is not on that table, so `_preflight_codex_api_kwargs` raises and the
call never happens. `text` is a documented part of the Responses API — it
carries `verbosity` and the structured-output `format` block — and the
providers accept it.

I verified acceptance directly rather than assuming it, over the ChatGPT Codex
route (`chatgpt.com/backend-api/codex/responses`):

| request | model | `text.verbosity` | result |
|---|---|---|---|
| raw HTTP, minimal body | `gpt-6-astra` | yes | 200 |
| raw HTTP, minimal body | `gpt-5.6-sol` | yes | 200 |
| raw HTTP, minimal body | `gpt-5.5` | yes | 200 |
| raw HTTP + `reasoning` / `include` / `prompt_cache_key` / `service_tier`, each and combined | `gpt-5.6-sol` | yes | 200 |
| openai SDK 2.24.0, same field set Hermes builds | `gpt-5.6-sol` | yes | 200 |

So the rejection is entirely local. Adding one entry to the optional-field
table both allows the key and passes it through normalization, the same way
`service_tier` and `context_management` are handled. Values that are not
non-empty objects are dropped rather than rejected, matching the behaviour of
the other optional fields.

## Related Issue

Related to #20203 — this is the transport-level prerequisite for a user-facing
`agent.text_verbosity` option. It deliberately does **not** add the config
surface, so #20203 stays open. Happy to follow up with the config layer if the
approach here looks right.

Same shape as #930, which added `parallel_tool_calls`, `prompt_cache_key` and
`tool_choice` to this allowlist for the same reason.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/codex_responses_adapter.py` — add `("text", ...)` to
  `_PREFLIGHT_OPTIONAL_FIELDS`, which extends `_PREFLIGHT_ALLOWED_KEYS` and
  forwards the field into the normalized request.
- `tests/agent/test_codex_responses_adapter.py` — two regression tests: `text`
  survives preflight, and empty/malformed values are dropped rather than
  raising.

## How to Test

1. Before the change, a request carrying `text` fails locally:

   ```python
   from agent.codex_responses_adapter import _preflight_codex_api_kwargs
   _preflight_codex_api_kwargs({
       "model": "gpt-5.6-sol", "instructions": "hi",
       "input": [{"role": "user", "content": [{"type": "input_text", "text": "ping"}]}],
       "store": False, "text": {"verbosity": "high"},
   })
   # ValueError: Codex Responses request has unsupported field(s): text.
   ```

2. After the change the same call returns a normalized request containing
   `{"text": {"verbosity": "high"}}`.

3. `pytest tests/agent/test_codex_responses_adapter.py` — 28 passed.
   Reverting only the adapter hunk turns the two new tests red, so they bite.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Searched open and merged issues/PRs first (#20203 open feature request,
      #930 closed precedent; no competing PR)
- [x] Tests added and passing
- [x] No behaviour change for requests that do not set `text`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
