### PR TITLE
feat(gateway): add GET /v1/peers, read-only listing of registered bot_peers

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1514,6 +1514,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             ("GET", "/v1/models", self._handle_models),
             ("GET", "/api/model/options", self._handle_model_options),
             ("GET", "/v1/capabilities", self._handle_capabilities),
+            ("GET", "/v1/peers", self._handle_peers),
             # Browser-control (gated on browser.extension_control.enabled + API key): POST
             # mints a short-lived ticket, WS consumes it; artifacts are bounded + scope-bound.
             ("POST", "/v1/browser-control/register", self._handle_browser_control_register),
@@ -2204,6 +2205,23 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             "exit_reason": runtime.get("exit_reason"),
             # Contract: RFC3339 string | null, never a number (legacy epoch floats exist).
             "updated_at": normalize_updated_at(runtime.get("updated_at")), "pid": os.getpid()})
+
+    @_require_auth
+    async def _handle_peers(self, request: "web.Request") -> "web.Response":
+        """GET /v1/peers — read-only listing of this gateway's registered ``hermes peer``
+        targets (name + URL only, never the peer's stored API key), so fleet-topology
+        tooling (e.g. a dashboard drawing the peer mesh) can discover who is peered with
+        whom without SSHing into every box and running `hermes peer list` by hand."""
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        bot_peers = cfg.get("bot_peers")
+        peers = []
+        if isinstance(bot_peers, dict):
+            for name in sorted(bot_peers):
+                entry = bot_peers[name] if isinstance(bot_peers[name], dict) else {}
+                peers.append({"name": name, "url": entry.get("url"), "note": entry.get("note") or None})
+        return web.json_response({"peers": peers})
 
     @_require_auth
     async def _handle_models(self, request: "web.Request") -> "web.Response":

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -310,6 +310,7 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_get("/v1/models", adapter._handle_models)
     app.router.add_get("/api/model/options", adapter._handle_model_options)
     app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
+    app.router.add_get("/v1/peers", adapter._handle_peers)
     app.router.add_get("/v1/skills", adapter._handle_skills)
     app.router.add_get("/v1/toolsets", adapter._handle_toolsets)
     app.router.add_post("/api/sessions/{session_id}/chat", adapter._handle_session_chat)
@@ -848,6 +849,62 @@ class TestModelsEndpoint:
             "include_unconfigured": True,
             "refresh": True,
         }
+
+
+# ---------------------------------------------------------------------------
+# /v1/peers endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestPeersEndpoint:
+    @pytest.mark.asyncio
+    async def test_peers_returns_registered_bot_peers(self, adapter):
+        """GET /v1/peers lists this gateway's registered ``hermes peer``
+        targets (name + url + note), sorted by name, never including the
+        peer's stored API key."""
+        app = _create_app(adapter)
+        with patch("hermes_cli.config.load_config", return_value={
+            "bot_peers": {
+                "sage": {"url": "http://192.168.1.185:8642", "note": "household ops"},
+                "angela": {"url": "http://100.90.113.22:8643"},
+            }
+        }):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/v1/peers")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["peers"] == [
+                    {"name": "angela", "url": "http://100.90.113.22:8643", "note": None},
+                    {"name": "sage", "url": "http://192.168.1.185:8642", "note": "household ops"},
+                ]
+                # No credential field of any kind is ever present on a peer entry.
+                for peer in data["peers"]:
+                    assert "key" not in peer
+                    assert "token" not in peer
+
+    @pytest.mark.asyncio
+    async def test_peers_returns_empty_list_when_none_configured(self, adapter):
+        app = _create_app(adapter)
+        with patch("hermes_cli.config.load_config", return_value={}):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/v1/peers")
+                assert resp.status == 200
+                assert (await resp.json()) == {"peers": []}
+
+    @pytest.mark.asyncio
+    async def test_peers_tolerates_malformed_entries(self, adapter):
+        """A hand-edited config.yaml with a non-dict peer entry must not 500
+        the endpoint -- it degrades that one entry instead of crashing."""
+        app = _create_app(adapter)
+        with patch("hermes_cli.config.load_config", return_value={
+            "bot_peers": {"broken": "not-a-dict", "ok": {"url": "http://x:1"}}
+        }):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/v1/peers")
+                assert resp.status == 200
+                data = await resp.json()
+                names = [p["name"] for p in data["peers"]]
+                assert names == ["broken", "ok"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Fleet-topology tooling (e.g. a dashboard drawing the peer mesh across several Hermes gateways) currently has no way to discover which peers a given gateway is registered against without SSHing into that box and running `hermes peer list` by hand — there's no existing network-facing surface for it.

## What

Adds `GET /v1/peers`, gated by the same Bearer auth (`@_require_auth`) as every other route on this surface. Returns only `{name, url, note}` per registered peer, read straight from `config.yaml`'s `bot_peers` (the same source `hermes_cli/subcommands/peer.py`'s `list` action already reads) — **never** the peer's stored `API_SERVER_KEY`, which is a credential this gateway holds to call OUT to that peer, not something to hand back over its own inbound API.

No new server primitive, no core tool added, no env var: a thin read-only GET mirroring the existing `/health/detailed` pattern exactly, consistent with the project's smallest-footprint-at-the-core / expand-at-the-edges rubric (AGENTS.md).

## Testing

- 3 new unit tests (registered peers list correctly sorted + shaped, empty-peers case, malformed non-dict entry degrades gracefully instead of 500ing) — all pass, plus the full existing `tests/gateway/test_api_server.py` suite (113 passed, no regressions).
- Live-verified against a real, running hermes-agent gateway instance (isolated `HERMES_HOME` on a scratch port, this branch's own code, not just the test suite): `GET /v1/peers` with a valid Bearer token returned the two configured peers correctly sorted and shaped; without a token, correctly 401s.

## Context

Built for an external, standalone dashboard (`hermes-fleet-dashboard`) that polls `/health/detailed` across a small self-hosted fleet and wants to draw the peer mesh (who's peered with whom) alongside health status. No dashboard code lands in this repo — per the contribution guide, that stays a separate plugin repo.