### PR TITLE
feat(dashboard-auth): authorize scoped bearer WebSockets

### DIFF
--- a/hermes_cli/dashboard_auth/token_auth.py
+++ b/hermes_cli/dashboard_auth/token_auth.py
@@ -30,6 +30,7 @@ from hermes_cli.dashboard_auth.request_utils import (
 _log = logging.getLogger(__name__)
 _token_routes: dict[str, tuple[str, ...]] = {}
 _lock = threading.Lock()
+NOT_HANDLED = "not_handled"
 
 
 def _normalise_scopes(required_scopes: tuple[str, ...] | tuple[()] | tuple[str, ...]) -> tuple[str, ...]:
@@ -62,10 +63,14 @@ def register_token_route(path: str, *, required_scopes: tuple[str, ...] = ()) ->
 
     ``required_scopes`` is backwards-compatible metadata: unscoped routes keep working, while a
     route that lists scopes requires the presented principal to satisfy all of them.
+    Re-registering the same path is monotonic: scopes are unioned so later empty
+    registrations cannot downgrade an earlier protected route.
     """
     scopes = _normalise_scopes(required_scopes)
     with _lock:
-        _token_routes[path] = scopes
+        existing = _token_routes.get(path, ())
+        merged = tuple(dict.fromkeys((*existing, *scopes)))
+        _token_routes[path] = merged
 
 
 def is_token_route(path: str) -> bool:
@@ -186,29 +191,15 @@ async def token_auth_middleware(
 def _ws_auth_reason(ws) -> tuple[Optional[str], str]:
     """Validate WebSocket bearer auth for registered token routes.
 
-    Returns ``(None, "bearer")`` when a registered route accepts the bearer; otherwise a reason
-    token plus the safe credential kind ``bearer``. If the route has no bearer header, the legacy
-    browser/query auth path remains the caller's responsibility.
+    Returns ``(None, "bearer")`` when a registered route accepts the bearer;
+    returns ``(NOT_HANDLED, "bearer")`` when the request has no Authorization
+    header so the caller can delegate to the canonical browser/query gate;
+    otherwise returns a failure reason token plus ``bearer``.
     """
     path = ws.url.path
     auth_header = ws.headers.get("authorization", "") or ""
     if not auth_header:
-        try:
-            from importlib import import_module
-
-            legacy_ws = import_module("hermes_cli.web_server_chat")
-        except Exception:
-            return None, "bearer"
-
-        legacy_reason = getattr(legacy_ws, "_ws_auth_reason", None)
-        if callable(legacy_reason):
-            return legacy_reason(ws)
-
-        legacy_ok = getattr(legacy_ws, "_ws_auth_ok", None)
-        if callable(legacy_ok):
-            return (None, "bearer") if legacy_ok(ws) else ("token_unrecognised", "bearer")
-
-        return None, "bearer"
+        return NOT_HANDLED, "bearer"
 
     ip = ws.client.host if getattr(ws, "client", None) else ""
     if not is_token_route(path):

--- a/hermes_cli/dashboard_auth/token_auth.py
+++ b/hermes_cli/dashboard_auth/token_auth.py
@@ -1,4 +1,4 @@
-"""Route-agnostic non-interactive (bearer-token) auth seam for the dashboard.
+"""Route-agnostic bearer-token auth seam for the dashboard.
 
 Any machine-credential provider plugs in here. A route opts in by registering its exact path via
 :func:`register_token_route`; only registered paths are token-authable, so the auth surface of
@@ -6,6 +6,11 @@ existing routes never widens. :func:`token_auth_middleware` runs OUTERMOST (inst
 owns the decision for a token route: a recognised token attaches ``request.state.token_principal``
 + ``token_authenticated`` (the cookie gates honour that flag and never bounce to /login);
 otherwise 401, or 503 when a provider's backing store was unreachable. Fails closed.
+
+WebSocket services reuse the same registry, but only the exact registered path may accept a
+Bearer upgrade credential. Browser/query credentials stay unchanged for the
+legacy WebSocket paths; a present bearer header never falls back to query auth when it is malformed,
+unrecognised, or lacks required scope.
 """
 from __future__ import annotations
 
@@ -23,15 +28,44 @@ from hermes_cli.dashboard_auth.request_utils import (
     client_ip as _client_ip, extract_bearer as extract_bearer_token, unreachable_response)
 
 _log = logging.getLogger(__name__)
-
-_token_routes: set[str] = set()  # exact paths that accept bearer-token auth
+_token_routes: dict[str, tuple[str, ...]] = {}
 _lock = threading.Lock()
 
 
-def register_token_route(path: str) -> None:
-    """Mark ``path`` (exact match) as token-authable. Idempotent; does NOT make the route public."""
+def _normalise_scopes(required_scopes: tuple[str, ...] | tuple[()] | tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(scope.strip() for scope in required_scopes if str(scope).strip())
+
+
+def _has_required_scopes(principal: TokenPrincipal, required_scopes: tuple[str, ...]) -> bool:
+    if not required_scopes:
+        return True
+    granted = set(principal.scopes)
+    return all(scope in granted for scope in required_scopes)
+
+
+def _audit_token_failure(
+    reason: str,
+    *,
+    path: str,
+    ip: str,
+    provider: Optional[str] = None,
+) -> None:
+    audit_log(AuditEvent.TOKEN_AUTH_FAILURE, reason=reason, provider=provider, path=path, ip=ip)
+
+
+def _audit_token_success(*, path: str, ip: str, provider: str) -> None:
+    audit_log(AuditEvent.TOKEN_AUTH_SUCCESS, reason="accepted", provider=provider, path=path, ip=ip)
+
+
+def register_token_route(path: str, *, required_scopes: tuple[str, ...] = ()) -> None:
+    """Mark ``path`` (exact match) as token-authable.
+
+    ``required_scopes`` is backwards-compatible metadata: unscoped routes keep working, while a
+    route that lists scopes requires the presented principal to satisfy all of them.
+    """
+    scopes = _normalise_scopes(required_scopes)
     with _lock:
-        _token_routes.add(path)
+        _token_routes[path] = scopes
 
 
 def is_token_route(path: str) -> bool:
@@ -40,17 +74,31 @@ def is_token_route(path: str) -> bool:
         return path in _token_routes
 
 
+def token_route_required_scopes(path: str) -> tuple[str, ...]:
+    """Required scopes for a registered token route, or ``()`` when unregistered/unscoped."""
+    with _lock:
+        return _token_routes.get(path, ())
+
+
 def clear_token_routes() -> None:
     """Test-only: drop all registered token routes."""
     with _lock:
         _token_routes.clear()
 
 
-def authenticate_token(request: Request) -> Tuple[Optional[TokenPrincipal], Optional[str]]:
-    """Try every token provider against the request's bearer token. Returns ``(principal, None)``
-    on success; ``(None, None)`` for no token or no recogniser (401); ``(None, name)`` when no
-    provider accepted it AND at least one was unreachable (caller surfaces 503). Never raises."""
-    token = extract_bearer_token(request)
+def _extract_bearer_value(header_value: str) -> str:
+    parts = header_value.split(" ", 1)
+    if len(parts) == 2 and parts[0].strip().lower() == "bearer":
+        return parts[1].strip()
+    return ""
+
+
+def authenticate_token_value(token: str) -> Tuple[Optional[TokenPrincipal], Optional[str]]:
+    """Try every token provider against ``token``.
+
+    Returns ``(principal, None)`` on success; ``(None, None)`` for no recogniser; ``(None, name)``
+    when no provider accepted it AND at least one was unreachable. Never raises.
+    """
     if not token:
         return None, None
     unreachable: Optional[str] = None
@@ -72,25 +120,118 @@ def authenticate_token(request: Request) -> Tuple[Optional[TokenPrincipal], Opti
     return None, unreachable
 
 
+def authenticate_token(request: Request) -> Tuple[Optional[TokenPrincipal], Optional[str]]:
+    """Request wrapper around :func:`authenticate_token_value` for HTTP callers."""
+    token = extract_bearer_token(request)
+    if not token:
+        return None, None
+    return authenticate_token_value(token)
+
+
+def _request_scope_reason(
+    principal: Optional[TokenPrincipal],
+    *,
+    path: str,
+    required_scopes: tuple[str, ...],
+) -> Optional[str]:
+    if principal is None:
+        return None
+    if _has_required_scopes(principal, required_scopes):
+        return None
+    return "insufficient_scope"
+
+
 async def token_auth_middleware(
     request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
     """Pass-through for unregistered paths; for a token route, valid token -> attach principal +
-    flag, unreachable -> 503, else 401."""
+    flag, unreachable -> 503, else 401. A malformed bearer on a registered route fails closed and
+    does not consult any non-bearer credential path."""
     path = request.url.path
     if not is_token_route(path):
         return await call_next(request)
-    principal, unreachable = authenticate_token(request)
+
+    auth_header = request.headers.get("authorization", "")
+    if not auth_header:
+        _audit_token_failure("missing_authorization", path=path, ip=_client_ip(request))
+        return JSONResponse({"error": "unauthenticated", "detail": "Unauthorized"}, status_code=401)
+
+    token = _extract_bearer_value(auth_header)
+    ip = _client_ip(request)
+    if not token:
+        _audit_token_failure("malformed_authorization", path=path, ip=ip)
+        return JSONResponse({"error": "unauthenticated", "detail": "Unauthorized"}, status_code=401)
+
+    principal, unreachable = authenticate_token_value(token)
     if principal is not None:
-        request.state.token_principal = principal
-        request.state.token_authenticated = True
-        return await call_next(request)
+        required_scopes = token_route_required_scopes(path)
+        scope_reason = _request_scope_reason(principal, path=path, required_scopes=required_scopes)
+        if scope_reason is None:
+            request.state.token_principal = principal
+            request.state.token_authenticated = True
+            _audit_token_success(path=path, ip=ip, provider=principal.provider)
+            return await call_next(request)
+        _audit_token_failure(
+            scope_reason, path=path, ip=ip, provider=principal.provider,
+        )
+        return JSONResponse({"error": "unauthenticated", "detail": "Unauthorized"}, status_code=401)
+
     if unreachable:
-        audit_log(
-            AuditEvent.TOKEN_AUTH_FAILURE, provider=unreachable, reason="provider_unreachable",
-            path=path, ip=_client_ip(request))
+        _audit_token_failure("provider_unreachable", path=path, ip=ip, provider=unreachable)
         return unreachable_response(unreachable)
 
-    audit_log(
-        AuditEvent.TOKEN_AUTH_FAILURE, reason="no_provider_recognises_token", path=path,
-        ip=_client_ip(request))
+    _audit_token_failure("token_unrecognised", path=path, ip=ip)
     return JSONResponse({"error": "unauthenticated", "detail": "Unauthorized"}, status_code=401)
+
+
+def _ws_auth_reason(ws) -> tuple[Optional[str], str]:
+    """Validate WebSocket bearer auth for registered token routes.
+
+    Returns ``(None, "bearer")`` when a registered route accepts the bearer; otherwise a reason
+    token plus the safe credential kind ``bearer``. If the route has no bearer header, the legacy
+    browser/query auth path remains the caller's responsibility.
+    """
+    path = ws.url.path
+    auth_header = ws.headers.get("authorization", "") or ""
+    if not auth_header:
+        try:
+            from importlib import import_module
+
+            legacy_ws = import_module("hermes_cli.web_server_chat")
+        except Exception:
+            return None, "bearer"
+
+        legacy_reason = getattr(legacy_ws, "_ws_auth_reason", None)
+        if callable(legacy_reason):
+            return legacy_reason(ws)
+
+        legacy_ok = getattr(legacy_ws, "_ws_auth_ok", None)
+        if callable(legacy_ok):
+            return (None, "bearer") if legacy_ok(ws) else ("token_unrecognised", "bearer")
+
+        return None, "bearer"
+
+    ip = ws.client.host if getattr(ws, "client", None) else ""
+    if not is_token_route(path):
+        _audit_token_failure("route_not_registered", path=path, ip=ip)
+        return "route_not_registered", "bearer"
+
+    token = _extract_bearer_value(auth_header)
+    if not token:
+        _audit_token_failure("malformed_authorization", path=path, ip=ip)
+        return "malformed_authorization", "bearer"
+
+    principal, unreachable = authenticate_token_value(token)
+    if principal is not None:
+        required_scopes = token_route_required_scopes(path)
+        if _has_required_scopes(principal, required_scopes):
+            _audit_token_success(path=path, ip=ip, provider=principal.provider)
+            return None, "bearer"
+        _audit_token_failure("insufficient_scope", path=path, ip=ip, provider=principal.provider)
+        return "insufficient_scope", "bearer"
+
+    if unreachable:
+        _audit_token_failure("provider_unreachable", path=path, ip=ip, provider=unreachable)
+        return "provider_unreachable", "bearer"
+
+    _audit_token_failure("token_unrecognised", path=path, ip=ip)
+    return "token_unrecognised", "bearer"

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -3,8 +3,9 @@
 Every handler is a thin wrapper around ``hermes_cli.kanban_db`` (the same code paths the CLI
 and gateway ``/kanban`` command use, so the surfaces cannot drift). The ``/events`` WebSocket
 tails the append-only ``task_events`` table on a short poll (WAL reads run alongside the
-dispatcher's write txns); it carries its credential in the query string (browsers can't set
-``Authorization`` on an upgrade) and is gated by the dashboard's canonical WS auth check.
+dispatcher's write txns); browsers still authenticate with the legacy query credential, while
+non-browser service clients may use Bearer tokens only on the exact registered token
+route and only after the bearer principal satisfies the route's required scopes.
 """
 
 from __future__ import annotations
@@ -43,17 +44,30 @@ router = APIRouter()
 _BOARD_Q = Query(None, description="Kanban board slug (omit for current)")
 
 
+# Register the service-visible read routes with the shared bearer-token seam.
+try:
+    from hermes_cli.dashboard_auth.token_auth import register_token_route
+
+    register_token_route("/api/plugins/kanban/board", required_scopes=("kanban:read",))
+    register_token_route("/api/plugins/kanban/events", required_scopes=("kanban:read",))
+except Exception as exc:  # noqa: BLE001 — auth seam absence must not break plugin import
+    log = logging.getLogger(__name__)
+    log.warning("kanban dashboard token-route registration failed: %s", exc)
+
+
 # --- Connection / board helpers ---------------------------------------------
 
 def _ws_upgrade_authorized(ws: "WebSocket") -> bool:
-    """Authorize a WS upgrade via the dashboard's canonical gate (``web_server_chat._ws_auth_ok``:
-    ``?token=`` / ``?ticket=`` / ``?internal=``) so this endpoint can never drift from core
-    auth; accepts when the dashboard isn't importable (bare-FastAPI test harness)."""
+    """Authorize a WS upgrade using the shared token-auth seam when possible.
+
+    Bearer auth is only accepted on an exact registered token route. If the request has no bearer
+    header, the legacy browser/query path remains intact.
+    """
     try:
-        from hermes_cli import web_server_chat as _ws
+        from hermes_cli.dashboard_auth import token_auth
     except Exception:
         return True
-    return bool(_ws._ws_auth_ok(ws))
+    return token_auth._ws_auth_reason(ws)[0] is None
 
 
 def _normalize_slug_or_400(slug: str) -> Optional[str]:

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -44,17 +44,6 @@ router = APIRouter()
 _BOARD_Q = Query(None, description="Kanban board slug (omit for current)")
 
 
-# Register the service-visible read routes with the shared bearer-token seam.
-try:
-    from hermes_cli.dashboard_auth.token_auth import register_token_route
-
-    register_token_route("/api/plugins/kanban/board", required_scopes=("kanban:read",))
-    register_token_route("/api/plugins/kanban/events", required_scopes=("kanban:read",))
-except Exception as exc:  # noqa: BLE001 — auth seam absence must not break plugin import
-    log = logging.getLogger(__name__)
-    log.warning("kanban dashboard token-route registration failed: %s", exc)
-
-
 # --- Connection / board helpers ---------------------------------------------
 
 def _ws_upgrade_authorized(ws: "WebSocket") -> bool:
@@ -66,8 +55,21 @@ def _ws_upgrade_authorized(ws: "WebSocket") -> bool:
     try:
         from hermes_cli.dashboard_auth import token_auth
     except Exception:
-        return True
-    return token_auth._ws_auth_reason(ws)[0] is None
+        return False
+    reason, _credential = token_auth._ws_auth_reason(ws)
+    if reason == token_auth.NOT_HANDLED:
+        try:
+            legacy_ws = importlib.import_module("hermes_cli.web_server_chat")
+        except Exception:
+            return False
+        legacy_ok = getattr(legacy_ws, "_ws_auth_ok", None)
+        if not callable(legacy_ok):
+            return False
+        try:
+            return bool(legacy_ok(ws))
+        except Exception:
+            return False
+    return reason is None
 
 
 def _normalize_slug_or_400(slug: str) -> Optional[str]:

--- a/tests/hermes_cli/test_dashboard_token_auth.py
+++ b/tests/hermes_cli/test_dashboard_token_auth.py
@@ -242,6 +242,32 @@ def test_registered_route_tracks_required_scopes():
     assert token_auth.token_route_required_scopes("/api/plugins/kanban/board") == ()
 
 
+def test_register_token_route_is_monotonic_and_never_clears_existing_scopes():
+    token_auth.register_token_route("/api/plugins/kanban/events", required_scopes=("kanban:read",))
+    token_auth.register_token_route("/api/plugins/kanban/events", required_scopes=("kanban:write",))
+    assert token_auth.token_route_required_scopes("/api/plugins/kanban/events") == (
+        "kanban:read",
+        "kanban:write",
+    )
+
+    token_auth.register_token_route("/api/plugins/kanban/events", required_scopes=())
+    assert token_auth.token_route_required_scopes("/api/plugins/kanban/events") == (
+        "kanban:read",
+        "kanban:write",
+    )
+
+
+def test_ws_bearer_without_authorization_is_explicitly_not_handled():
+    provider = _CountingTokenProvider(secret="good-secret", scopes=("kanban:read",))
+    register_provider(provider)
+    token_auth.register_token_route("/api/plugins/kanban/events", required_scopes=("kanban:read",))
+
+    reason = token_auth._ws_auth_reason(_FakeWS(headers={}))
+
+    assert reason == (token_auth.NOT_HANDLED, "bearer")
+    assert provider.calls == 0
+
+
 class _CountingTokenProvider(_TokenProvider):
     def __init__(self, *, secret: str = "good-secret", scopes=("kanban:read",)):
         super().__init__(secret=secret, scopes=scopes)

--- a/tests/hermes_cli/test_dashboard_token_auth.py
+++ b/tests/hermes_cli/test_dashboard_token_auth.py
@@ -9,7 +9,7 @@ behaviour.
 from __future__ import annotations
 
 import asyncio
-from typing import Optional
+from typing import Any, Optional, cast
 
 import pytest
 
@@ -167,7 +167,7 @@ class _NonInteractiveProvider(_TokenProvider):
 def test_authenticate_token_accepts_valid():
     register_provider(_TokenProvider(secret="good-secret"))
     req = _FakeRequest(headers={"authorization": "Bearer good-secret"})
-    principal, unreachable = token_auth.authenticate_token(req)
+    principal, unreachable = token_auth.authenticate_token(cast(Any, req))
     assert unreachable is None
     assert principal is not None
     assert principal.provider == "tok"
@@ -177,7 +177,7 @@ def test_authenticate_token_accepts_valid():
 def test_authenticate_token_rejects_wrong_secret():
     register_provider(_TokenProvider(secret="good-secret"))
     req = _FakeRequest(headers={"authorization": "Bearer wrong"})
-    principal, unreachable = token_auth.authenticate_token(req)
+    principal, unreachable = token_auth.authenticate_token(cast(Any, req))
     assert principal is None
     assert unreachable is None
 
@@ -188,7 +188,7 @@ def test_authenticate_token_stacks_first_match_wins():
     second.name = "tok2"
     register_provider(second)
     req = _FakeRequest(headers={"authorization": "Bearer bbb"})
-    principal, _ = token_auth.authenticate_token(req)
+    principal, _ = token_auth.authenticate_token(cast(Any, req))
     assert principal is not None and principal.provider == "tok2"
 
 
@@ -196,7 +196,7 @@ def test_authenticate_token_unreachable_then_valid_provider_wins():
     register_provider(_UnreachableTokenProvider())
     register_provider(_TokenProvider(secret="good"))
     req = _FakeRequest(headers={"authorization": "Bearer good"})
-    principal, unreachable = token_auth.authenticate_token(req)
+    principal, unreachable = token_auth.authenticate_token(cast(Any, req))
     # A later provider accepting the token beats the earlier outage.
     assert principal is not None and principal.provider == "tok"
     assert unreachable is None
@@ -206,7 +206,7 @@ def test_authenticate_token_buggy_provider_does_not_crash():
     register_provider(_BuggyTokenProvider())
     register_provider(_TokenProvider(secret="good"))
     req = _FakeRequest(headers={"authorization": "Bearer good"})
-    principal, unreachable = token_auth.authenticate_token(req)
+    principal, unreachable = token_auth.authenticate_token(cast(Any, req))
     assert principal is not None and principal.provider == "tok"
 
 
@@ -231,7 +231,84 @@ def test_seam_rejects_wrong_token_401():
     req = _FakeRequest(
         path="/api/gateway/drain", headers={"authorization": "Bearer bad"}
     )
-    resp = _run(token_auth.token_auth_middleware(req, _call_next_ok))
+    resp = _run(token_auth.token_auth_middleware(cast(Any, req), _call_next_ok))
     assert resp.status_code == 401
+
+
+def test_registered_route_tracks_required_scopes():
+    token_auth.register_token_route("/api/plugins/kanban/events", required_scopes=("kanban:read",))
+    assert token_auth.is_token_route("/api/plugins/kanban/events") is True
+    assert token_auth.token_route_required_scopes("/api/plugins/kanban/events") == ("kanban:read",)
+    assert token_auth.token_route_required_scopes("/api/plugins/kanban/board") == ()
+
+
+class _CountingTokenProvider(_TokenProvider):
+    def __init__(self, *, secret: str = "good-secret", scopes=("kanban:read",)):
+        super().__init__(secret=secret, scopes=scopes)
+        self.calls = 0
+
+    def verify_token(self, *, token: str):
+        self.calls += 1
+        return super().verify_token(token=token)
+
+
+class _FakeWS:
+    def __init__(self, path="/api/plugins/kanban/events", headers=None):
+        self.url = _FakeURL(path)
+        self.headers = headers or {}
+        self.client = _FakeClient()
+        self.query_params = {}
+
+
+def test_ws_bearer_accepts_only_exact_registered_route():
+    provider = _CountingTokenProvider(secret="good-secret", scopes=("kanban:read",))
+    register_provider(provider)
+    token_auth.register_token_route("/api/plugins/kanban/events", required_scopes=("kanban:read",))
+
+    accepted = token_auth._ws_auth_reason(
+        _FakeWS(headers={"authorization": "Bearer good-secret"})
+    )
+    assert accepted == (None, "bearer")
+    assert provider.calls == 1
+
+    unregistered = token_auth._ws_auth_reason(
+        _FakeWS(path="/api/plugins/kanban/other", headers={"authorization": "Bearer good-secret"})
+    )
+    assert unregistered[0] == "route_not_registered"
+    assert provider.calls == 1
+
+
+def test_ws_bearer_rejects_malformed_authorization_header():
+    provider = _CountingTokenProvider(secret="good-secret", scopes=("kanban:read",))
+    register_provider(provider)
+    token_auth.register_token_route("/api/plugins/kanban/events", required_scopes=("kanban:read",))
+
+    malformed = token_auth._ws_auth_reason(
+        _FakeWS(headers={"authorization": "Bearer"})
+    )
+    assert malformed[0] == "malformed_authorization"
+    assert provider.calls == 0
+
+
+def test_ws_bearer_rejects_scope_mismatch_and_outage_without_fallback():
+    scope_limited = _CountingTokenProvider(secret="good-secret", scopes=("drain",))
+    register_provider(scope_limited)
+    token_auth.register_token_route("/api/plugins/kanban/events", required_scopes=("kanban:read",))
+
+    insufficient = token_auth._ws_auth_reason(
+        _FakeWS(headers={"authorization": "Bearer good-secret"})
+    )
+    assert insufficient[0] == "insufficient_scope"
+    assert scope_limited.calls == 1
+
+    clear_providers()
+    token_auth.clear_token_routes()
+    token_auth.register_token_route("/api/plugins/kanban/events", required_scopes=("kanban:read",))
+    unreachable = _UnreachableTokenProvider()
+    register_provider(unreachable)
+    failure = token_auth._ws_auth_reason(
+        _FakeWS(headers={"authorization": "Bearer good-secret"})
+    )
+    assert failure[0] == "provider_unreachable"
 
 

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -7,6 +7,7 @@ REST surface without spinning up the whole dashboard.
 
 from __future__ import annotations
 
+import asyncio
 import importlib.util
 import json
 import os
@@ -14,9 +15,12 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
 from hermes_cli import kanban_db as kb
@@ -37,8 +41,8 @@ from hermes_cli.dashboard_auth import token_auth
 # ---------------------------------------------------------------------------
 
 
-def _load_plugin_router():
-    """Dynamically load plugins/kanban/dashboard/plugin_api.py and return its router."""
+def _load_plugin_module():
+    """Dynamically load plugins/kanban/dashboard/plugin_api.py and return the module."""
     repo_root = Path(__file__).resolve().parents[2]
     plugin_file = repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
     assert plugin_file.exists(), f"plugin file missing: {plugin_file}"
@@ -50,7 +54,12 @@ def _load_plugin_router():
     mod = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = mod
     spec.loader.exec_module(mod)
-    return mod.router
+    return mod
+
+
+def _load_plugin_router():
+    """Dynamically load plugins/kanban/dashboard/plugin_api.py and return its router."""
+    return _load_plugin_module().router
 
 
 @pytest.fixture(autouse=True)
@@ -130,6 +139,33 @@ def test_board_empty(client):
     assert data["tenants"] == []
     assert data["assignees"] == []
     assert data["latest_event_id"] == 0
+
+
+def test_board_stays_on_browser_cookie_path_when_no_kanban_read_provider_is_configured():
+    _load_plugin_module()
+
+    assert token_auth.is_token_route("/api/plugins/kanban/board") is False
+    assert token_auth.is_token_route("/api/plugins/kanban/events") is False
+
+    async def _call_next(request):
+        return JSONResponse({"ok": True}, status_code=200)
+
+    request = cast(
+        Any,
+        type(
+            "Req",
+            (),
+            {
+                "url": type("URL", (), {"path": "/api/plugins/kanban/board"})(),
+                "headers": {},
+                "client": type("Client", (), {"host": "1.2.3.4"})(),
+                "state": type("State", (), {})(),
+            },
+        )(),
+    )
+    response = asyncio.run(token_auth.token_auth_middleware(request, _call_next))
+
+    assert response.status_code == 200
 
 
 # ---------------------------------------------------------------------------
@@ -586,6 +622,23 @@ def test_dispatch_dry_run(client):
 # ---------------------------------------------------------------------------
 
 
+class _FakeURL:
+    def __init__(self, path):
+        self.path = path
+
+
+class _FakeClient:
+    host = "1.2.3.4"
+
+
+class _FakeWS:
+    def __init__(self, path="/api/plugins/kanban/events", headers=None):
+        self.url = _FakeURL(path)
+        self.headers = headers or {}
+        self.client = _FakeClient()
+        self.query_params = {}
+
+
 def test_ws_events_rejects_when_token_required(tmp_path, monkeypatch):
     """Loopback mode: a missing or wrong ?token= must be rejected with
     policy-violation; the correct token is accepted. The kanban WS now
@@ -645,6 +698,7 @@ def test_ws_events_rejects_when_token_required(tmp_path, monkeypatch):
 def test_ws_events_accepts_bearer_on_exact_registered_route(client):
     provider = _BearerProvider(secret="bearer-good", scopes=("kanban:read",))
     register_provider(provider)
+    token_auth.register_token_route("/api/plugins/kanban/events", required_scopes=("kanban:read",))
 
     with client.websocket_connect(
         "/api/plugins/kanban/events",
@@ -657,6 +711,7 @@ def test_ws_events_accepts_bearer_on_exact_registered_route(client):
 def test_ws_events_rejects_bearer_scope_mismatch(client):
     provider = _BearerProvider(secret="bearer-good", scopes=("drain",))
     register_provider(provider)
+    token_auth.register_token_route("/api/plugins/kanban/events", required_scopes=("kanban:read",))
 
     from starlette.websockets import WebSocketDisconnect
     with pytest.raises(WebSocketDisconnect) as exc:
@@ -667,6 +722,53 @@ def test_ws_events_rejects_bearer_scope_mismatch(client):
             pass
     assert exc.value.code == 1008
     assert provider.calls == 1
+
+
+def test_ws_upgrade_without_bearer_uses_canonical_browser_gate(monkeypatch):
+    mod = _load_plugin_module()
+    seen = []
+
+    def fake_ws_auth_ok(ws):
+        seen.append(ws.url.path)
+        return True
+
+    monkeypatch.setattr(
+        mod.importlib,
+        "import_module",
+        lambda name: SimpleNamespace(_ws_auth_ok=fake_ws_auth_ok),
+    )
+
+    assert mod._ws_upgrade_authorized(_FakeWS(headers={})) is True
+    assert seen == ["/api/plugins/kanban/events"]
+
+
+def test_ws_upgrade_fails_closed_when_canonical_browser_gate_cannot_load(monkeypatch):
+    mod = _load_plugin_module()
+
+    def _boom(name):
+        raise ImportError(name)
+
+    monkeypatch.setattr(mod.importlib, "import_module", _boom)
+
+    assert mod._ws_upgrade_authorized(_FakeWS(headers={})) is False
+
+
+def test_ws_upgrade_malformed_bearer_does_not_fallback_to_canonical_browser_gate(monkeypatch):
+    mod = _load_plugin_module()
+    seen = []
+
+    def fake_ws_auth_ok(ws):
+        seen.append(ws.url.path)
+        return True
+
+    monkeypatch.setattr(
+        mod.importlib,
+        "import_module",
+        lambda name: SimpleNamespace(_ws_auth_ok=fake_ws_auth_ok),
+    )
+
+    assert mod._ws_upgrade_authorized(_FakeWS(headers={"authorization": "Bearer"})) is False
+    assert seen == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -21,6 +21,15 @@ from fastapi.testclient import TestClient
 
 from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_db_connect as kbc
+from hermes_cli.dashboard_auth import (
+    DashboardAuthProvider,
+    LoginStart,
+    Session,
+    TokenPrincipal,
+    clear_providers,
+    register_provider,
+)
+from hermes_cli.dashboard_auth import token_auth
 
 
 # ---------------------------------------------------------------------------
@@ -44,6 +53,15 @@ def _load_plugin_router():
     return mod.router
 
 
+@pytest.fixture(autouse=True)
+def _reset_token_auth():
+    clear_providers()
+    token_auth.clear_token_routes()
+    yield
+    clear_providers()
+    token_auth.clear_token_routes()
+
+
 @pytest.fixture
 def kanban_home(tmp_path, monkeypatch):
     """Isolated HERMES_HOME with an empty kanban DB."""
@@ -60,6 +78,38 @@ def client(kanban_home):
     app = FastAPI()
     app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")
     return TestClient(app)
+
+
+class _BearerProvider(DashboardAuthProvider):
+    name = "bearer"
+    display_name = "Bearer"
+    supports_token = True
+
+    def __init__(self, *, secret: str, scopes=("kanban:read",)):
+        self.secret = secret
+        self.scopes = tuple(scopes)
+        self.calls = 0
+
+    def start_login(self, *, redirect_uri):
+        return LoginStart(redirect_url="x", cookie_payload={})
+
+    def complete_login(self, *, code, state, code_verifier, redirect_uri):
+        return Session("u", "e", "n", "o", self.name, 0, "a", "r")
+
+    def verify_session(self, *, access_token):
+        return None
+
+    def refresh_session(self, *, refresh_token):
+        return Session("u", "e", "n", "o", self.name, 0, "a", "r")
+
+    def revoke_session(self, *, refresh_token):
+        return None
+
+    def verify_token(self, *, token: str):
+        self.calls += 1
+        if token == self.secret:
+            return TokenPrincipal(principal=self.name, provider=self.name, scopes=self.scopes)
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -590,6 +640,33 @@ def test_ws_events_rejects_when_token_required(tmp_path, monkeypatch):
     # The bug symptom was a traceback; we don't assert on stderr because
     # capturing asyncio's internal "exception was never retrieved" logging
     # is flaky. The assertion that matters is: no CancelledError escaped.
+
+
+def test_ws_events_accepts_bearer_on_exact_registered_route(client):
+    provider = _BearerProvider(secret="bearer-good", scopes=("kanban:read",))
+    register_provider(provider)
+
+    with client.websocket_connect(
+        "/api/plugins/kanban/events",
+        headers={"Authorization": "Bearer bearer-good"},
+    ) as ws:
+        assert ws is not None
+    assert provider.calls == 1
+
+
+def test_ws_events_rejects_bearer_scope_mismatch(client):
+    provider = _BearerProvider(secret="bearer-good", scopes=("drain",))
+    register_provider(provider)
+
+    from starlette.websockets import WebSocketDisconnect
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with client.websocket_connect(
+            "/api/plugins/kanban/events",
+            headers={"Authorization": "Bearer bearer-good"},
+        ):
+            pass
+    assert exc.value.code == 1008
+    assert provider.calls == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- extend the existing dashboard token-auth seam to authenticate non-browser WebSocket upgrades with an `Authorization: Bearer` header on exact registered routes only
- enforce monotonic per-route required scopes so a later registration cannot downgrade `kanban:read`
- preserve the official browser WebSocket paths: single-use ticket in gated mode, loopback token, and server-internal credential
- keep malformed, unrecognized, insufficient-scope, and provider-unavailable bearer attempts fail-closed without falling back to query credentials
- allow the Kanban events WebSocket to delegate bearer-less upgrades to the canonical browser/query gate

## Motivation

Hermes officially exposes Kanban live updates as `WS /api/plugins/kanban/events`. A separate backend service needs machine-to-machine access without placing a long-lived credential in the WebSocket URL, query string, proxy logs, or error reports. This change reuses the generic token-provider framework rather than adding a Kanban-specific bypass.

## Security properties

- bearer auth is evaluated only on exact `register_token_route()` paths
- route scopes are monotonic and cannot be cleared by an empty re-registration
- malformed or rejected bearer headers never fall back to ticket/token/internal auth
- a missing bearer remains `NOT_HANDLED` and delegates to the existing canonical WS gate
- canonical-gate import/error paths fail closed
- normal browser `/api/plugins/kanban/board` cookie behavior remains unchanged when no machine provider is configured
- token values are never logged or included in audit metadata

## Verification

- `76 passed` across dashboard WebSocket auth, token auth, and Kanban dashboard plugin tests
- profile-local Kanban read-provider integration: `8 passed`
- Ruff: passed on changed files
- targeted ty: passed on the new/changed auth surface; unrelated pre-existing diagnostics remain elsewhere
- independent exact-SHA review passed on `12cad2423f52c3e652e19fff4ebb58ea0c450ef4`

No deployment or runtime configuration changes are included.
