### PR TITLE
fix(dashboard): serve live SSH session token in mount_spa

### DIFF
--- a/hermes_cli/web_server_dashboard.py
+++ b/hermes_cli/web_server_dashboard.py
@@ -102,7 +102,15 @@ def mount_spa(application: FastAPI):
     with a missing dist per-request (404 JSON / ``check_dir=False``), so a long-lived
     ``--skip-build`` process recovers the moment a build appears on disk — no restart.
     """
-    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, _SESSION_TOKEN, app
+    # ``_SESSION_TOKEN`` is deliberately NOT imported by value: mount_spa() runs at
+    # import time, while start_server() rebinds ``web_server._SESSION_TOKEN`` afterwards
+    # via _apply_ssh_session_token() (--ssh-session-token-file, Desktop SSH). A frozen
+    # copy would serve a token the API middleware rejects (401 on every /api call).
+    # The handlers below must read it live off the module. (WEB_DIST and
+    # _DASHBOARD_EMBEDDED_CHAT_ENABLED are static config, never rebound, so
+    # by-value capture is correct for them.)
+    from hermes_cli import web_server as _ws
+    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED
 
     # `hermes serve` is the headless backend: it must NEVER serve the browser SPA, even if a
     # dist is lying around, so only the JSON-RPC/WS/API surface is reachable.
@@ -120,7 +128,7 @@ def mount_spa(application: FastAPI):
             if full_path == "" and not gated:
                 return HTMLResponse(
                     "<!doctype html><html><head><script>"
-                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(_SESSION_TOKEN)};"
+                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(_ws._SESSION_TOKEN)};"
                     "window.__HERMES_AUTH_REQUIRED__=false;"
                     f"</script></head><body>{_HEADLESS_MSG}</body></html>",
                     headers=_NO_STORE,
@@ -139,7 +147,7 @@ def mount_spa(application: FastAPI):
     def _serve_index(prefix: str = ""):
         """index.html with the session token + base-path injected.
 
-        When the OAuth auth gate is active (``app.state.auth_required``), the legacy
+        When the OAuth auth gate is active (``application.state.auth_required``), the legacy
         ``_SESSION_TOKEN`` is NOT injected — the SPA reads identity from ``/api/auth/me`` over
         cookie auth; ``__HERMES_AUTH_REQUIRED__`` tells it which scheme to use for /api/pty
         and /api/ws (ticket vs token).
@@ -150,8 +158,11 @@ def mount_spa(application: FastAPI):
             # Partial build / wiped dist / permissions: same JSON 404 as a fully-missing dist.
             return JSONResponse({"error": "Frontend not built. Run: cd web && npm run build"}, status_code=404)
         chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
-        gated = bool(getattr(app.state, "auth_required", False))
-        token_js = "" if gated else f'window.__HERMES_SESSION_TOKEN__="{_SESSION_TOKEN}";'
+        gated = bool(getattr(application.state, "auth_required", False))
+        # Live read (see note above): the token is rebound after import on the
+        # Desktop SSH path. json.dumps like the headless page — the token comes
+        # from --ssh-session-token-file (external input), never interpolate raw.
+        token_js = "" if gated else f"window.__HERMES_SESSION_TOKEN__={json.dumps(_ws._SESSION_TOKEN)};"
         bootstrap_script = (
             f"<script>{token_js}"
             f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5126,6 +5126,79 @@ class TestHeadlessServeTokenPage:
             assert ws._SESSION_TOKEN not in resp.text
 
 
+class TestSpaSessionTokenLiveRead:
+    """Both served pages must inject the LIVE ``web_server._SESSION_TOKEN``.
+
+    ``mount_spa()`` runs at import time but ``start_server()`` rebinds the token
+    afterwards via ``_apply_ssh_session_token()`` (``--ssh-session-token-file``,
+    Desktop SSH). A mount-time copy serves a token the API rejects, so Desktop
+    (which adopts the served token) 401s every /api call (#102930).
+    """
+
+    _TOKEN_RE = r'window\.__HERMES_SESSION_TOKEN__\s*=\s*("(?:\\.|[^"\\])*")'
+
+    def test_headless_root_serves_token_applied_after_mount(self, monkeypatch):
+        import json as _json
+        import re
+
+        client, ws = TestHeadlessServeTokenPage._headless_client(
+            monkeypatch, gated=False
+        )
+        original_token = ws._SESSION_TOKEN
+        try:
+            ws._apply_ssh_session_token("ssh-token-applied-after-mount")
+            resp = client.get("/")
+            assert resp.status_code == 200
+            match = re.search(self._TOKEN_RE, resp.text)
+            assert match, resp.text
+            assert _json.loads(match.group(1)) == "ssh-token-applied-after-mount"
+        finally:
+            ws._apply_ssh_session_token(original_token)
+
+    def test_spa_index_serves_token_applied_after_mount(
+        self, tmp_path, monkeypatch
+    ):
+        import json as _json
+        import re
+
+        client, _dist = TestServeIndexMissingIndex._client_with_dist(
+            tmp_path, monkeypatch, write_index=True
+        )
+        import hermes_cli.web_server as ws
+
+        original_token = ws._SESSION_TOKEN
+        try:
+            ws._apply_ssh_session_token("ssh-token-applied-after-mount")
+            resp = client.get("/chat")
+            assert resp.status_code == 200
+            match = re.search(self._TOKEN_RE, resp.text)
+            assert match, resp.text
+            assert _json.loads(match.group(1)) == "ssh-token-applied-after-mount"
+        finally:
+            ws._apply_ssh_session_token(original_token)
+
+    def test_spa_index_omits_token_when_mounted_app_gated(
+        self, tmp_path, monkeypatch
+    ):
+        from fastapi import FastAPI
+        from starlette.testclient import TestClient
+        import hermes_cli.web_server as ws
+
+        dist = tmp_path / "web_dist"
+        (dist / "assets").mkdir(parents=True)
+        (dist / "index.html").write_text(
+            "<html><head></head><body>SPA</body></html>", encoding="utf-8"
+        )
+        monkeypatch.setattr(ws, "WEB_DIST", dist)
+        monkeypatch.delenv("HERMES_SERVE_HEADLESS", raising=False)
+        spa_app = FastAPI()
+        spa_app.state.auth_required = True
+        _web_server_dashboard.mount_spa(spa_app)
+        resp = TestClient(spa_app).get("/chat")
+        assert resp.status_code == 200
+        assert "__HERMES_SESSION_TOKEN__" not in resp.text
+
+
 class TestHashedAssetCacheHeaders:
     """Hashed /assets/* responses must be immutable-cacheable; index.html
     must stay no-store so it always references the current hashes


### PR DESCRIPTION
Fixes #102930

## Problem
Desktop SSH mode 401s every /api call: the served
`window.__HERMES_SESSION_TOKEN__` doesn't match the token the API validates.

## Root cause
`mount_spa()` runs at `web_server` import time and captured `_SESSION_TOKEN`
by value (`from`-import). `start_server()` rebinds it afterwards via
`_apply_ssh_session_token()` (`--ssh-session-token-file`). Both injection
sites (headless handshake page + SPA index) served the stale mount-time token.

## Approach
- Read `web_server._SESSION_TOKEN` live off the module at request time in both
  handlers (never `from`-import the token; it is rebound after import).
- Inject via `json.dumps` on both sites (the token is external input from
  `--ssh-session-token-file`; the index previously interpolated it raw).
- Read `auth_required` from the mounted `application`, not the global `app`,
  so a gated mount actually omits the token.
- `WEB_DIST` / `_DASHBOARD_EMBEDDED_CHAT_ENABLED` stay by-value (static
  config, never rebound) — noted in a comment so the next reader doesn't
  "fix" them or re-hoist the token import.
- Deliberately NOT via `web_deps.get_session_token()`: it lives in the
  PLUGIN-COMPAT block, forbidden for in-tree code.

## How to Test
- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py -q` (189 passed, 0 failed)
- Sabotage: with only `hermes_cli/web_server_dashboard.py` restored to base,
  the 3 new `TestSpaSessionTokenLiveRead` tests fail; with the fix, green.
- `python3 scripts/check_compat_pointers.py` clean.

## Risk
Low. Output identical for the existing token alphabet (`token_urlsafe`); only
changes post-rebind reads and the gated-mount lookup. No new surface.

Related duplicates (same root cause, partial): #102948, #102954, #103004,
#103013, #103040, #103126, #103155, #103305, #102985, #103314.
Orthogonal, not covered here: #101678 (orphaned `serve --isolated` backends).
