### PR TITLE
fix(agent): stop idle /steer from silently stranding user input

### DIFF
--- a/agent/interrupt_control.py
+++ b/agent/interrupt_control.py
@@ -89,6 +89,22 @@ def _ic_signal_tool_workers(agent, active: bool, **kw) -> None:
 class InterruptControlMixin:
     """interrupt()/hard_interrupt()/clear_interrupt()/steer()/redirect() (see module docstring)."""
 
+    def _set_model_request_active(self, active: bool) -> None:
+        """Toggle model steer admission atomically with redirect and pending-steer state."""
+        with _ic_lock(self, "_pending_redirect_lock"):
+            with _ic_lock(self, "_pending_steer_lock"):
+                marker = getattr(self, "_model_request_active", None)
+                if marker is not None:
+                    if active:
+                        marker.set()
+                    else:
+                        marker.clear()
+
+    def _set_tool_execution_active(self, active: bool) -> None:
+        """Toggle tool steer admission atomically with pending-steer state."""
+        with _ic_lock(self, "_pending_steer_lock"):
+            self._executing_tools = active
+
     def interrupt(
         self, message: Optional[str] = None, *, hard_cancel: bool = False,
         tool_reason: Optional[str] = None, require_generation: Optional[int] = None,
@@ -218,16 +234,16 @@ class InterruptControlMixin:
         concatenate with newlines. Returns False without a live model/tool delivery window."""
         if not text or not text.strip():
             return False
-        _model_active = getattr(self, "_model_request_active", None)
-        _executing_tools = getattr(self, "_executing_tools", None)
-        if (
-            (_executing_tools is not None or _model_active is not None)
-            and not _executing_tools
-            and (_model_active is None or not _model_active.is_set())
-        ):
-            return False
         cleaned = text.strip()
         with _ic_lock(self, "_pending_steer_lock"):
+            _model_active = getattr(self, "_model_request_active", None)
+            _executing_tools = getattr(self, "_executing_tools", None)
+            if (
+                (_executing_tools is not None or _model_active is not None)
+                and not _executing_tools
+                and (_model_active is None or not _model_active.is_set())
+            ):
+                return False
             existing = _ic_slot(self, "_pending_steer_lock", "_pending_steer")
             self._pending_steer = (existing + "\n" + cleaned) if existing else cleaned
         return True

--- a/agent/interrupt_control.py
+++ b/agent/interrupt_control.py
@@ -215,8 +215,16 @@ class InterruptControlMixin:
 
     def steer(self, text: str) -> bool:
         """Append user text to the LAST tool result once the batch finishes (no interrupt); multiple calls
-        concatenate with newlines. Returns False for empty text."""
+        concatenate with newlines. Returns False without a live model/tool delivery window."""
         if not text or not text.strip():
+            return False
+        _model_active = getattr(self, "_model_request_active", None)
+        _executing_tools = getattr(self, "_executing_tools", None)
+        if (
+            (_executing_tools is not None or _model_active is not None)
+            and not _executing_tools
+            and (_model_active is None or not _model_active.is_set())
+        ):
             return False
         cleaned = text.strip()
         with _ic_lock(self, "_pending_steer_lock"):

--- a/agent/turn_api_call.py
+++ b/agent/turn_api_call.py
@@ -8,7 +8,6 @@ redirect ``_model_request_active`` bracket and the response-vs-redirect crossing
 
 from __future__ import annotations
 
-from contextlib import nullcontext
 from dataclasses import dataclass
 import logging
 import time
@@ -114,14 +113,10 @@ def perform_api_call(
 
     from hermes_cli.middleware import run_llm_execution_middleware
 
-    # The ``_model_request_active`` bracket is taken under the redirect lock when one exists,
-    # so redirect() can't observe a half-toggled flag.
-    _model_request_active = getattr(agent, "_model_request_active", None)
+    # The lifecycle helper shares redirect and steer admission locks, so neither surface can
+    # commit a correction after request closure has won the race.
     _redirect_lock = getattr(agent, "_pending_redirect_lock", None)
-    _bracket = nullcontext() if _redirect_lock is None else _redirect_lock
-    with _bracket:
-        if _model_request_active is not None:
-            _model_request_active.set()
+    agent._set_model_request_active(True)
     try:
         response = run_llm_execution_middleware(
             api_kwargs, _perform_api_call, original_request=_original_api_kwargs,
@@ -131,13 +126,12 @@ def perform_api_call(
             api_call_count=api_call_count, middleware_trace=list(_llm_middleware_trace),
         )
     finally:
-        with _bracket:
-            if _model_request_active is not None:
-                _model_request_active.clear()
-            _redirect_crossed_response = (
-                bool(agent._pending_redirect) if _redirect_lock is not None
-                else agent._has_pending_redirect()
-            )
+        agent._set_model_request_active(False)
+        if _redirect_lock is not None:
+            with _redirect_lock:
+                _redirect_crossed_response = bool(agent._pending_redirect)
+        else:
+            _redirect_crossed_response = agent._has_pending_redirect()
     if _redirect_crossed_response:
         # Response and redirect can cross threads: discard the now-stale
         # response and rebuild from the correction rather than lose it.

--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -880,7 +880,7 @@ class GatewayBusySessionMixin:
             logger.warning("Steer failed for session %s: %s", quick_key, exc)
             return f"⚠️ Steer failed: {exc}"
         if not accepted:
-            return "Steer rejected (empty payload)."
+            return _queue_fallback("No live delivery window; /steer queued for the next turn.")
         preview = steer_text[:60] + ("..." if len(steer_text) > 60 else "")
         return f"⏩ Steer queued — arrives after the next tool call: '{preview}'"
 

--- a/hermes_cli/cli_loops_mixin.py
+++ b/hermes_cli/cli_loops_mixin.py
@@ -291,7 +291,10 @@ class CLILoopsMixin:
                 if accepted:
                     _cprint(f"  ⏩ Steer queued — arrives after the next tool call: {_preview(payload)}")
                 else:
-                    _cprint("  Steer rejected (empty payload).")
+                    self._pending_input.put(payload)
+                    _cprint(
+                        f"  No live delivery window; queued as next turn: {_preview(payload)}"
+                    )
         else:
             self._pending_input.put(payload)
             _cprint(f"  No agent running; queued as next turn: {_preview(payload)}")

--- a/run_agent.py
+++ b/run_agent.py
@@ -1277,7 +1277,7 @@ class AIAgent(
         """
         tool_calls = assistant_message.tool_calls
         args = (assistant_message, messages, effective_task_id, api_call_count)
-        self._executing_tools = True  # allow _vprint during tool execution even with stream consumers
+        self._set_tool_execution_active(True)  # allow _vprint during tool execution even with stream consumers
         try:
             if len(tool_calls) <= 1:
                 return self._execute_tool_calls_sequential(*args)
@@ -1292,7 +1292,7 @@ class AIAgent(
             from agent.tool_executor import execute_tool_calls_segmented
             return execute_tool_calls_segmented(self, *args, segments=segments)
         finally:
-            self._executing_tools = False
+            self._set_tool_execution_active(False)
 
     def _dispatch_delegate_task(self, function_args: dict) -> str:
         """Single call site for delegate_task dispatch; new DELEGATE_TASK_SCHEMA fields are added only here."""

--- a/run_agent.py
+++ b/run_agent.py
@@ -1293,6 +1293,7 @@ class AIAgent(
             return execute_tool_calls_segmented(self, *args, segments=segments)
         finally:
             self._set_tool_execution_active(False)
+            self._apply_pending_steer_to_tool_results(messages, len(tool_calls))
 
     def _dispatch_delegate_task(self, function_args: dict) -> str:
         """Single call site for delegate_task dispatch; new DELEGATE_TASK_SCHEMA fields are added only here."""

--- a/tests/cli/test_cli_steer_busy_path.py
+++ b/tests/cli/test_cli_steer_busy_path.py
@@ -122,6 +122,19 @@ class TestSteerBusyPathDispatch:
         cli.agent.steer.assert_called_once_with("focus on errors")
         cli._pending_input.put.assert_not_called()
 
+    def test_rejected_live_steer_queues_as_next_turn(self):
+        """A busy-path race with no live delivery window must not lose text."""
+        cli = _make_cli()
+        cli._agent_running = True
+        cli.agent = MagicMock()
+        cli.agent.steer = MagicMock(return_value=False)
+        cli._pending_input = MagicMock()
+
+        cli.process_command("/steer preserve this correction")
+
+        cli.agent.steer.assert_called_once_with("preserve this correction")
+        cli._pending_input.put.assert_called_once_with("preserve this correction")
+
     def test_idle_path_queues_as_next_turn(self):
         """Control — when the agent is NOT running, /steer correctly falls
         back to next-turn queue semantics.  Demonstrates why the fix was

--- a/tests/gateway/test_steer_command.py
+++ b/tests/gateway/test_steer_command.py
@@ -5,9 +5,10 @@ interrupting. The gateway runner must:
 
   1. When an agent IS running → call ``agent.steer(text)``, do NOT set
      ``_interrupt_requested``, do NOT touch ``_pending_messages``.
-  2. When the agent is the PENDING sentinel → fall back to /queue
+  2. When the agent rejects live delivery → fall back to /queue semantics.
+  3. When the agent is the PENDING sentinel → fall back to /queue
      semantics (store in ``adapter._pending_messages``).
-  3. When no agent is active → strip the slash prefix and let the normal
+  4. When no agent is active → strip the slash prefix and let the normal
      prompt pipeline handle it as a regular user message.
 """
 from __future__ import annotations
@@ -115,6 +116,24 @@ async def test_steer_calls_agent_steer_and_does_not_interrupt():
     # _pending_messages (that would be turn-boundary /queue semantics).
     assert runner._pending_messages == {}
     assert adapter._pending_messages == {}
+
+
+@pytest.mark.asyncio
+async def test_rejected_live_steer_queues_payload_for_next_turn():
+    """A retained agent without a live delivery window must not lose the payload."""
+    runner, adapter = _make_runner(_session_entry())
+    sk = build_session_key(_make_source())
+    running_agent = MagicMock()
+    running_agent.steer.return_value = False
+    runner._running_agents[sk] = running_agent
+
+    result = await runner._handle_message(_make_event("/steer preserve this correction"))
+
+    running_agent.steer.assert_called_once_with("preserve this correction")
+    running_agent.interrupt.assert_not_called()
+    assert adapter._pending_messages[sk].text == "preserve this correction"
+    assert runner._session_state(sk).conversation.queued_events == []
+    assert "queued for the next turn" in result.lower()
 
 
 @pytest.mark.asyncio

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -136,6 +136,64 @@ class TestSteerAcceptance:
         assert outcome["accepted"] is False
         assert agent._pending_steer is None
 
+    def test_pending_commit_before_tool_window_closure_is_delivered(self):
+        agent = _bare_agent()
+        closure_attempted = threading.Event()
+        release_closure = threading.Event()
+        inner_drained = threading.Event()
+        real_lock = threading.Lock()
+        closure_gated = False
+
+        class GateLock:
+            def __enter__(self):
+                nonlocal closure_gated
+                if (
+                    threading.current_thread().name == "tool-worker"
+                    and inner_drained.is_set()
+                    and not closure_gated
+                ):
+                    closure_gated = True
+                    closure_attempted.set()
+                    assert release_closure.wait(timeout=1)
+                real_lock.acquire()
+                return self
+
+            def __exit__(self, *exc_info):
+                real_lock.release()
+
+        agent._pending_steer_lock = GateLock()
+        messages = []
+        outcome = {}
+
+        def execute_tools(*_args):
+            messages.append(
+                {"role": "tool", "content": "tool output", "tool_call_id": "call-1"}
+            )
+            outcome["inner_drained"] = agent._drain_pending_steer()
+            inner_drained.set()
+
+        agent._execute_tool_calls_sequential = execute_tools
+        assistant_message = type("AssistantMessage", (), {"tool_calls": [object()]})()
+        tool_worker = threading.Thread(
+            name="tool-worker",
+            target=lambda: agent._execute_tool_calls(
+                assistant_message, messages, "task-id"
+            ),
+        )
+        tool_worker.start()
+        assert closure_attempted.wait(timeout=1)
+
+        outcome["accepted"] = agent.steer("late correction")
+        release_closure.set()
+        tool_worker.join(timeout=1)
+
+        assert tool_worker.is_alive() is False
+        assert outcome == {"inner_drained": None, "accepted": True}
+        assert messages[-1]["content"] == (
+            "tool output" + format_steer_marker("late correction")
+        )
+        assert agent._pending_steer is None
+
 
 
 

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -44,10 +44,44 @@ def _bare_agent() -> AIAgent:
 
 
 class TestSteerAcceptance:
-    def test_accepts_non_empty_text(self):
+    def test_rejects_text_without_a_live_delivery_window(self):
+        from tui_gateway import server
+
         agent = _bare_agent()
-        assert agent.steer("go ahead and check the logs") is True
-        assert agent._pending_steer == "go ahead and check the logs"
+
+        assert agent.steer("go ahead and check the logs") is False
+        assert agent._pending_steer is None
+        server._sessions["idle-steer"] = {"agent": agent}
+        try:
+            response = server.handle_request(
+                {
+                    "id": "request-1",
+                    "method": "command.dispatch",
+                    "params": {
+                        "name": "steer",
+                        "arg": "go ahead and check the logs",
+                        "session_id": "idle-steer",
+                    },
+                }
+            )
+        finally:
+            server._sessions.pop("idle-steer", None)
+        assert response["result"] == {
+            "type": "send",
+            "message": "go ahead and check the logs",
+        }
+        assert agent._pending_steer is None
+
+    def test_accepts_text_during_live_model_and_tool_windows(self):
+        for phase in ("model", "tools"):
+            agent = _bare_agent()
+            if phase == "model":
+                agent._model_request_active.set()
+            else:
+                agent._executing_tools = True
+
+            assert agent.steer("go ahead and check the logs") is True
+            assert agent._pending_steer == "go ahead and check the logs"
 
 
 
@@ -58,6 +92,7 @@ class TestSteerAcceptance:
 class TestSteerDrain:
     def test_drain_returns_and_clears(self):
         agent = _bare_agent()
+        agent._executing_tools = True
         agent.steer("hello")
         assert agent._drain_pending_steer() == "hello"
         assert agent._pending_steer is None
@@ -488,6 +523,7 @@ class TestEmptyHiddenAssistantRehealRegression:
 class TestSteerInjection:
     def test_appends_to_last_tool_result(self):
         agent = _bare_agent()
+        agent._executing_tools = True
         agent.steer("please also check auth.log")
         messages = [
             {"role": "user", "content": "what's in /var/log?"},
@@ -522,6 +558,7 @@ class TestSteerInjection:
         rewrites existing tool content, never the message-role sequence.
         """
         agent = _bare_agent()
+        agent._executing_tools = True
         agent.steer("stop after next step")
         messages = [{"role": "tool", "content": "x", "tool_call_id": "1"}]
         agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
@@ -533,6 +570,7 @@ class TestSteerInjection:
         """Anthropic-style list content should be preserved, with the steer
         appended as a text block."""
         agent = _bare_agent()
+        agent._executing_tools = True
         agent.steer("extra note")
         original_blocks = [{"type": "text", "text": "existing output"}]
         messages = [
@@ -551,6 +589,7 @@ class TestSteerInjection:
 class TestSteerThreadSafety:
     def test_concurrent_steer_calls_preserve_all_text(self):
         agent = _bare_agent()
+        agent._executing_tools = True
         N = 200
 
         def worker(idx: int) -> None:
@@ -584,6 +623,7 @@ class TestSteerClearedOnInterrupt:
         agent._tool_worker_threads = None
         agent._tool_worker_threads_lock = None
 
+        agent._executing_tools = True
         agent.steer("will be dropped")
         agent._pending_redirect = "also drop this"
         assert agent._pending_steer == "will be dropped"
@@ -613,6 +653,7 @@ class TestPreApiCallSteerDrain:
             {"role": "tool", "content": "output here", "tool_call_id": "tc1"},
         ]
         # Steer arrives during API call (set after tool execution)
+        agent._model_request_active.set()
         agent.steer("focus on error handling")
         # Simulate what the pre-API-call drain does:
         _pre_api_steer = agent._drain_pending_steer()
@@ -633,6 +674,7 @@ class TestPreApiCallSteerDrain:
         messages = [
             {"role": "user", "content": "hello"},
         ]
+        agent._model_request_active.set()
         agent.steer("early steer")
         _pre_api_steer = agent._drain_pending_steer()
         assert _pre_api_steer == "early steer"

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -83,6 +83,59 @@ class TestSteerAcceptance:
             assert agent.steer("go ahead and check the logs") is True
             assert agent._pending_steer == "go ahead and check the logs"
 
+    def test_tool_window_closure_wins_before_pending_commit(self):
+        agent = _bare_agent()
+        attempted = threading.Event()
+        release = threading.Event()
+        tool_started = threading.Event()
+        finish_tools = threading.Event()
+        real_lock = threading.Lock()
+
+        class GateLock:
+            def __enter__(self):
+                if threading.current_thread().name == "late-steer":
+                    attempted.set()
+                    assert release.wait(timeout=1)
+                real_lock.acquire()
+                return self
+
+            def __exit__(self, *exc_info):
+                real_lock.release()
+
+        agent._pending_steer_lock = GateLock()
+        outcome = {}
+
+        def execute_tools(*_args):
+            tool_started.set()
+            assert finish_tools.wait(timeout=1)
+            outcome["drained"] = agent._drain_pending_steer()
+
+        agent._execute_tool_calls_sequential = execute_tools
+        assistant_message = type("AssistantMessage", (), {"tool_calls": [object()]})()
+        tool_worker = threading.Thread(
+            target=lambda: agent._execute_tool_calls(assistant_message, [], "task-id")
+        )
+        tool_worker.start()
+        assert tool_started.wait(timeout=1)
+
+        steer_worker = threading.Thread(
+            name="late-steer",
+            target=lambda: outcome.setdefault("accepted", agent.steer("preserve this correction")),
+        )
+        steer_worker.start()
+        assert attempted.wait(timeout=1)
+
+        finish_tools.set()
+        tool_worker.join(timeout=1)
+        assert tool_worker.is_alive() is False
+        assert outcome["drained"] is None
+        release.set()
+        steer_worker.join(timeout=1)
+
+        assert steer_worker.is_alive() is False
+        assert outcome["accepted"] is False
+        assert agent._pending_steer is None
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Idle `/steer` requests no longer report that guidance was queued for a tool call that cannot occur. `AIAgent.steer()` now accepts text only while a model request or tool execution provides a live delivery window, allowing surfaces with a next-turn fallback to route idle text honestly instead of leaving it in `_pending_steer`.

### Symptom

When a gateway session retained an agent object but had no active turn, `/steer <text>` returned `Steer queued - arrives after the next tool call`. The text remained in `_pending_steer` even though no tool batch was active.

### Impact

The UI confirmed delivery of a user correction that was not submitted as a new turn. The correction could be delayed until unrelated future tool work or cleared by a later interrupt.

### Bug Cause

**Trigger:** `agent/interrupt_control.py:216` / `InterruptControlMixin.steer()` accepting text while both `_model_request_active` and `_executing_tools` were inactive.

**Causal chain:**
1. An idle gateway session calls `AIAgent.steer()` with non-empty text.
2. `steer()` stores the text and returns `True` without checking for a live model or tool phase.
3. The gateway reports successful steering and skips its existing next-turn fallback, while no active tool boundary can drain the text.

**Why it is wrong:** A successful return means the caller may suppress its fallback, so acceptance must imply that the current turn has a delivery window.

**Working sibling / contrast:** The classic CLI checks `_agent_running` before calling `steer()` and queues idle text as the next turn.

**Ruled out:** The final-turn `pending_steer` handoff protects text that races with completion of a live turn, but it cannot make an idle call part of a turn that has already finished.

### Fix

Reject steering when an initialized agent has neither an active model request nor active tool execution. Preserve the lock-less minimal-stub compatibility path, and cover idle gateway fallback plus both valid live phases with behavior tests.

## Related Issue

Fixes #103287

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/interrupt_control.py` - require a live model or tool phase before accepting steer text.
- `tests/run_agent/test_steer.py` - verify idle rejection and gateway next-turn fallback while preserving model/tool steering coverage.

## How to Test

1. Run the steer regression suite and related surface tests:

```bash
scripts/run_tests.sh tests/run_agent/test_steer.py tests/cli/test_cli_steer_busy_path.py tests/gateway/test_steer_command.py tests/gateway/test_api_server_runs.py tests/test_tui_gateway_server.py -k steer
scripts/run_tests.sh tests/run_agent/test_steer.py tests/agent/test_lock_fallback_base_semantics.py
```

2. Confirm idle `command.dispatch` returns a `send` result and live model/tool phases still return accepted steering.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repo's test entry on relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation and docstrings are updated, or N/A
- [x] `cli-config.yaml.example` update is N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no architecture or workflow changed
- [x] Cross-platform impact was considered; the change uses existing platform-independent runtime state
- [x] Tool description/schema updates are N/A because no tool schema changed
