### PR TITLE
feat(models): add GPT-6 Astra to Copilot fallback

### DIFF
--- a/hermes_cli/models_catalog_static.py
+++ b/hermes_cli/models_catalog_static.py
@@ -165,7 +165,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "openai-codex": _codex_curated_models(),
     "xai-oauth": list(_XAI_MODELS),
     "copilot-acp": ["copilot-acp"],
-    "copilot": _OPENAI_CHAT_MODELS + [
+    "copilot": ["gpt-6-astra"] + _OPENAI_CHAT_MODELS + [
         "claude-sonnet-4.6", "claude-sonnet-5", "claude-sonnet-4", "claude-sonnet-4.5", "claude-haiku-4.5",
         "gemini-3.1-pro-preview", "gemini-3-pro-preview", "gemini-3-flash-preview", "gemini-2.5-pro",
     ],

--- a/tests/hermes_cli/test_copilot_astra.py
+++ b/tests/hermes_cli/test_copilot_astra.py
@@ -1,0 +1,18 @@
+"""GPT-6 Astra support contracts for the GitHub Copilot provider."""
+
+from unittest.mock import patch
+
+from hermes_cli.models import copilot_model_api_mode, provider_model_ids
+
+
+def test_copilot_offline_fallback_keeps_gpt6_astra() -> None:
+    """A transient catalog outage must not remove the GA model from the picker."""
+    with patch("hermes_cli.models._PROVIDER_CATALOG_FETCHERS", {}):
+        models = provider_model_ids("copilot")
+
+    assert "gpt-6-astra" in models
+
+
+def test_copilot_gpt6_astra_uses_responses_api() -> None:
+    """Copilot exposes Astra only on /responses, never chat/completions."""
+    assert copilot_model_api_mode("gpt-6-astra", catalog=[]) == "codex_responses"


### PR DESCRIPTION
## Summary

- add GitHub Copilot's GA `gpt-6-astra` model to the static/offline fallback catalog
- preserve the live `/models` catalog as the account-specific source of truth
- add contracts for offline picker visibility and Responses API routing

## Evidence

GitHub announced GPT-6 Astra for Copilot on 2026-09-04:
https://github.blog/changelog/2026-09-04-gpt-6-astra-is-generally-available-in-github-copilot

The authenticated Copilot catalog returns:

- id: `gpt-6-astra`
- picker enabled: `true`
- endpoints: `/responses`, `ws:/responses`
- max prompt tokens: `872000`
- max output tokens: `128000`

A live Hermes request through provider `github-copilot` and model `gpt-6-astra` completed successfully.

## Verification

```text
scripts/run_tests.sh \
  tests/hermes_cli/test_copilot_astra.py \
  tests/hermes_cli/test_copilot_in_model_list.py \
  tests/hermes_cli/test_model_switch_copilot_api_mode.py

6 passed, 0 failed
```

Also passed:

- `ruff check` on both changed files
- `ruff format --check` on the new test
- `git diff --check`
