### PR TITLE
feat(delegation): operator-defined worker profiles with gated per-task routing

### DIFF
--- a/agent/delegation_model_routing.py
+++ b/agent/delegation_model_routing.py
@@ -59,6 +59,8 @@ class ProfileRoute:
     max_iterations: Optional[int] = None
     fallback: Tuple[FallbackTarget, ...] = ()
     supports_tools: bool = True
+    request_overrides: Optional[dict] = None     # provider request personality (runtime provider)
+    max_output_tokens: Optional[int] = None
 
 
 def _profiles_section(cfg: Optional[dict]) -> Any:
@@ -93,6 +95,10 @@ def _parse_fallback(name: str, raw: Any) -> Tuple[FallbackTarget, ...]:
 
 
 def _parse_profile(name: str, raw: Any) -> ProfileSpec:
+    if not str(name).strip():
+        raise ValueError(
+            "delegation.profiles contains an empty or whitespace-only profile name; "
+            "every profile needs a non-empty name")
     if not isinstance(raw, dict):
         raise ValueError(
             f"delegation.profiles.{name} must be a mapping (provider/model/...), "
@@ -236,4 +242,6 @@ def resolve_profile_route(name: str, cfg: Optional[dict], parent_agent: Any = No
         max_iterations=spec.max_iterations,
         fallback=spec.fallback,
         supports_tools=supports_tools,
+        request_overrides=dict(runtime.get("request_overrides") or {}) or None,
+        max_output_tokens=runtime.get("max_output_tokens"),
     )

--- a/agent/delegation_model_routing.py
+++ b/agent/delegation_model_routing.py
@@ -201,8 +201,20 @@ def resolve_profile_route(name: str, cfg: Optional[dict], parent_agent: Any = No
 
     # Lazy imports (house style — delegate_tool_config.py does the same) to avoid import cycles.
     from hermes_cli.runtime_provider import resolve_runtime_provider
-    runtime = resolve_runtime_provider(
-        requested=spec.provider or None, target_model=spec.model) or {}
+    # Same wrap as the legacy provider branch (tools/delegate_tool_config.py::
+    # _runtime_provider_credentials): AuthError subclasses RuntimeError, and the delegate_task /
+    # lifecycle seams only catch ValueError — anything else would escape as a raw traceback
+    # instead of a clean tool_error.
+    try:
+        runtime = resolve_runtime_provider(
+            requested=spec.provider or None, target_model=spec.model) or {}
+    except Exception as exc:
+        raise ValueError(
+            f"Cannot resolve delegation profile '{key}' "
+            f"(provider '{spec.provider or 'auto'}'): {exc}. "
+            f"Check that the provider is configured (API key set, valid provider name), "
+            f"or fix the entry under delegation.profiles in config.yaml."
+        ) from exc
 
     supports_tools = True
     try:

--- a/agent/delegation_model_routing.py
+++ b/agent/delegation_model_routing.py
@@ -1,0 +1,227 @@
+"""Delegation model-profile resolver — operator-defined worker tiers for delegate_task.
+
+``delegation.profiles`` maps a profile name to a provider/model pin (plus optional
+reasoning_effort, max_iterations, fallback chain). This module is the single place profiles
+are parsed, validated, and resolved into an immutable :class:`ProfileRoute` that both
+``delegate_task`` and ``SubagentLifecycleService`` consume.
+
+Selection precedence (see docs/plans/2026-09-04-delegation-model-profiles.md):
+  per-task profile > top-level profile > ``delegation.default_profile`` > legacy
+  ``delegation.provider/model`` (this module returns no profile) > parent inherit.
+
+Design rules honored here:
+- Credentials resolve via ``hermes_cli.runtime_provider.resolve_runtime_provider`` — the exact
+  path the legacy ``delegation.provider`` branch uses. No duplicated credential logic.
+- Invalid ``reasoning_effort`` warns and is ignored (NS-696 clamp-at-transport doctrine), it
+  never rejects a profile.
+- Profiles never touch toolsets (#25752) — ``_PROFILE_KEYS`` is a closed set.
+- Imports of heavyweight collaborators are lazy (house style, avoids import cycles).
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_PROFILE_KEYS = frozenset({"provider", "model", "reasoning_effort", "max_iterations", "fallback"})
+_FALLBACK_ENTRY_KEYS = frozenset({"provider", "model"})
+
+
+@dataclass(frozen=True)
+class FallbackTarget:
+    """One provider/model pair in a profile's fallback chain."""
+    provider: str
+    model: str
+
+
+@dataclass(frozen=True)
+class ProfileSpec:
+    """A parsed-and-validated ``delegation.profiles`` entry (no credentials yet)."""
+    name: str
+    provider: str
+    model: str
+    reasoning_config: Optional[dict] = None      # parse_reasoning_effort output, None = inherit
+    max_iterations: Optional[int] = None
+    fallback: Tuple[FallbackTarget, ...] = ()
+
+
+@dataclass(frozen=True)
+class ProfileRoute:
+    """An immutable resolved route: profile spec + runtime-provider credentials."""
+    requested_profile: str
+    provider: Optional[str]
+    model: str
+    base_url: Optional[str]
+    api_key: Optional[str]
+    api_mode: Optional[str]
+    reasoning_config: Optional[dict] = None
+    max_iterations: Optional[int] = None
+    fallback: Tuple[FallbackTarget, ...] = ()
+    supports_tools: bool = True
+
+
+def _profiles_section(cfg: Optional[dict]) -> Any:
+    return ((cfg or {}).get("profiles"))
+
+
+def _parse_fallback(name: str, raw: Any) -> Tuple[FallbackTarget, ...]:
+    if raw in (None, ""):
+        return ()
+    if not isinstance(raw, list):
+        raise ValueError(
+            f"delegation.profiles.{name}.fallback must be a list of {{provider, model}} entries, "
+            f"got {type(raw).__name__}")
+    targets: List[FallbackTarget] = []
+    for i, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"delegation.profiles.{name}.fallback[{i}] must be a dict with provider + model, "
+                f"got {type(entry).__name__}")
+        unknown = set(entry) - _FALLBACK_ENTRY_KEYS
+        if unknown:
+            raise ValueError(
+                f"delegation.profiles.{name}.fallback[{i}] has unknown keys: {sorted(unknown)} "
+                f"(allowed: provider, model)")
+        provider = str(entry.get("provider") or "").strip()
+        model = str(entry.get("model") or "").strip()
+        if not provider or not model:
+            raise ValueError(
+                f"delegation.profiles.{name}.fallback[{i}] needs both 'provider' and 'model'")
+        targets.append(FallbackTarget(provider=provider, model=model))
+    return tuple(targets)
+
+
+def _parse_profile(name: str, raw: Any) -> ProfileSpec:
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"delegation.profiles.{name} must be a mapping (provider/model/...), "
+            f"got {type(raw).__name__}")
+    unknown = set(raw) - _PROFILE_KEYS
+    if unknown:
+        raise ValueError(
+            f"delegation.profiles.{name} has unknown keys: {sorted(unknown)} "
+            f"(allowed: {sorted(_PROFILE_KEYS)})")
+    model = str(raw.get("model") or "").strip()
+    if not model:
+        raise ValueError(f"delegation.profiles.{name} is missing required 'model'")
+    provider = str(raw.get("provider") or "").strip()
+
+    # Reasoning effort: NS-696 clamp doctrine — invalid values warn and are ignored, never reject.
+    reasoning_config = None
+    effort = raw.get("reasoning_effort")
+    if effort or effort is False:
+        from hermes_constants import parse_reasoning_effort
+        reasoning_config = parse_reasoning_effort(effort)
+        if reasoning_config is None:
+            logger.warning(
+                "delegation.profiles.%s.reasoning_effort '%s' is not a recognized level; "
+                "ignoring it (child inherits the parent's reasoning level)", name, effort)
+
+    max_iterations = raw.get("max_iterations")
+    if max_iterations is not None:
+        if isinstance(max_iterations, bool) or not isinstance(max_iterations, int):
+            raise ValueError(
+                f"delegation.profiles.{name}.max_iterations must be an integer, "
+                f"got {type(max_iterations).__name__}")
+
+    return ProfileSpec(
+        name=name, provider=provider, model=model, reasoning_config=reasoning_config,
+        max_iterations=max_iterations, fallback=_parse_fallback(name, raw.get("fallback")),
+    )
+
+
+def parse_profiles(cfg: Optional[dict]) -> Dict[str, ProfileSpec]:
+    """Parse+validate ``delegation.profiles`` from the delegation config section.
+
+    Returns ``{}`` when no profiles are configured. Raises ``ValueError`` with an actionable
+    message on the first malformed profile (use :func:`profile_config_errors` to collect all).
+    """
+    raw = _profiles_section(cfg)
+    if not raw:
+        return {}
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"delegation.profiles must be a mapping of name -> profile, got {type(raw).__name__}")
+    return {str(name): _parse_profile(str(name), spec) for name, spec in raw.items()}
+
+
+def profile_config_errors(cfg: Optional[dict]) -> List[str]:
+    """All profile config problems as messages (for ``hermes config check``); never raises."""
+    errors: List[str] = []
+    raw = _profiles_section(cfg)
+    specs: Dict[str, ProfileSpec] = {}
+    if raw and not isinstance(raw, dict):
+        errors.append(
+            f"delegation.profiles must be a mapping of name -> profile, got {type(raw).__name__}")
+    elif isinstance(raw, dict):
+        for name, spec in raw.items():
+            try:
+                specs[str(name)] = _parse_profile(str(name), spec)
+            except ValueError as exc:
+                errors.append(str(exc))
+    default_profile = str((cfg or {}).get("default_profile") or "").strip()
+    if default_profile and default_profile not in specs:
+        configured = ", ".join(sorted(specs)) or "(none)"
+        errors.append(
+            f"delegation.default_profile '{default_profile}' is not a configured profile "
+            f"(configured: {configured})")
+    return errors
+
+
+def select_profile_name(task_profile: Any, top_profile: Any, cfg: Optional[dict]) -> Optional[str]:
+    """The profile name that applies, by precedence: per-task > top-level > default_profile.
+
+    ``None`` = no profile applies (legacy ``delegation.provider/model`` or parent inherit take
+    over downstream). Falsy values (None/False/''/0) at any level fall through to the next.
+    """
+    for candidate in (task_profile, top_profile, (cfg or {}).get("default_profile")):
+        if candidate:
+            name = str(candidate).strip()
+            if name:
+                return name
+    return None
+
+
+def resolve_profile_route(name: str, cfg: Optional[dict], parent_agent: Any = None) -> ProfileRoute:
+    """Resolve profile *name* into an immutable :class:`ProfileRoute`.
+
+    Raises ``ValueError`` (before any child construction) for an unknown name, listing the
+    configured profile names. Credentials come from ``resolve_runtime_provider`` — the same
+    ladder the legacy ``delegation.provider`` branch uses.
+    """
+    specs = parse_profiles(cfg)
+    key = str(name or "").strip()
+    if key not in specs:
+        configured = ", ".join(sorted(specs)) or "(none configured)"
+        raise ValueError(
+            f"Unknown delegation profile '{key}'. Configured profiles: {configured}. "
+            f"Add it under delegation.profiles in config.yaml or pick a configured name.")
+    spec = specs[key]
+
+    # Lazy imports (house style — delegate_tool_config.py does the same) to avoid import cycles.
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+    runtime = resolve_runtime_provider(
+        requested=spec.provider or None, target_model=spec.model) or {}
+
+    supports_tools = True
+    try:
+        from agent.models_dev import get_model_capabilities
+        caps = get_model_capabilities(spec.provider or "", spec.model)
+        if caps is not None:
+            supports_tools = bool(getattr(caps, "supports_tools", True))
+    except Exception as exc:  # capability metadata is advisory; never block resolution on it
+        logger.debug("Could not load model capabilities for profile '%s': %s", key, exc)
+
+    return ProfileRoute(
+        requested_profile=key,
+        provider=runtime.get("provider") or spec.provider or None,
+        model=spec.model,
+        base_url=runtime.get("base_url"),
+        api_key=runtime.get("api_key"),
+        api_mode=runtime.get("api_mode"),
+        reasoning_config=spec.reasoning_config,
+        max_iterations=spec.max_iterations,
+        fallback=spec.fallback,
+        supports_tools=supports_tools,
+    )

--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -84,6 +84,14 @@ class SubagentHandle:
     role: str
     depth: int
     capability: str
+    # Route provenance (appended last, defaults None, so positional construction and old serialized
+    # handles stay valid). All four are None for legacy profile-less launches. ``resolved_model`` is the
+    # SPAWN-TIME route model while ``model`` tracks the child's live model — divergence between the two
+    # is the requested-vs-effective signal when a fallback fires mid-run.
+    requested_profile: Optional[str] = None
+    resolved_provider: Optional[str] = None
+    resolved_model: Optional[str] = None
+    fallback_policy: Optional[str] = None
 
     def to_dict(self) -> dict[str, Any]:
         return dataclasses.asdict(self)
@@ -224,6 +232,10 @@ _HANDLE_FIELD_CHECKS: tuple[tuple[str, Callable[[Any], bool]], ...] = (
     ("role", lambda v: isinstance(v, str)),
     ("depth", lambda v: type(v) is int),
     ("capability", lambda v: isinstance(v, str)),
+    ("requested_profile", _opt_str),
+    ("resolved_provider", _opt_str),
+    ("resolved_model", _opt_str),
+    ("fallback_policy", _opt_str),
 )
 
 # Launch-request rejections in check order: (predicate, error). The type check leads so later predicates may
@@ -301,6 +313,11 @@ class SubagentLifecycleService:
             PUBLIC_CONTRACT_VERSION, subagent_id, parent_session_id, request.correlation_id, created,
             getattr(child, "provider", None), getattr(child, "model", None), getattr(child, "_delegate_role", request.role),
             int(getattr(child, "_delegate_depth", 1) or 1), self._capability(subagent_id, parent_session_id, created),
+            # Spawn-time route provenance stamped by _build_child_preserving_parent_tools; all None on legacy launches.
+            requested_profile=getattr(child, "_route_requested_profile", None),
+            resolved_provider=getattr(child, "_route_resolved_provider", None),
+            resolved_model=getattr(child, "_route_resolved_model", None),
+            fallback_policy=getattr(child, "_route_fallback_policy", None),
         )
         record = _Record(handle, SubagentState.PENDING, created, agent=child)
         with _REGISTRY.lock:

--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -291,13 +291,19 @@ class SubagentLifecycleService:
             # delegation config, then map the bundle to override_* child-construction kwargs.
             from tools.delegate_tool import _profile_task_overrides
             from tools.delegate_tool_config import _load_config, _resolve_profile_credentials
+            cfg = _load_config()
             try:
-                creds = _resolve_profile_credentials(request.model_profile, _load_config())
+                creds = _resolve_profile_credentials(request.model_profile, cfg)
             except ValueError as exc:
                 raise SubagentLifecycleError(str(exc)) from exc
             model, overrides = creds["model"], _profile_task_overrides(creds)
+            # A profile may only TIGHTEN the budget (#25752) — clamp against the CONFIGURED
+            # delegation budget (delegation.max_iterations), same as delegate_task, not the constant.
+            configured_budget = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
+            if isinstance(configured_budget, int) and not isinstance(configured_budget, bool):
+                max_iterations = configured_budget
             profile_max_iter = creds.get("max_iterations")
-            if isinstance(profile_max_iter, int):  # a profile may only TIGHTEN the budget (#25752)
+            if isinstance(profile_max_iter, int):
                 max_iterations = min(profile_max_iter, max_iterations)
         child = _build_child_preserving_parent_tools(
             task_index=0, goal=request.goal, context=request.context,

--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -47,6 +47,16 @@ class SubagentState(str, enum.Enum):
 
 @dataclasses.dataclass(frozen=True)
 class SubagentLaunchRequest:
+    """Immutable launch contract with two mutually exclusive model surfaces:
+
+    - ``model`` is the raw internal plugin trust surface: an unvalidated model string the
+      plugin takes full responsibility for (passed through to child construction as-is).
+    - ``model_profile`` is the policy path: a name resolved through the operator-configured
+      ``delegation.profiles`` via ``agent.delegation_model_routing.resolve_profile_route`` —
+      the exact seam ``delegate_task`` uses — so a profile means the same provider/model on
+      both APIs. Setting both is rejected at validation.
+    """
+
     goal: str
     context: Optional[str] = None
     role: str = "leaf"
@@ -58,6 +68,8 @@ class SubagentLaunchRequest:
     correlation_id: Optional[str] = None
     metadata: Mapping[str, Any] = dataclasses.field(default_factory=dict)
     timeout_seconds: Optional[float] = None
+    # Appended last so positional construction by existing callers is unaffected.
+    model_profile: Optional[str] = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -227,6 +239,9 @@ _REQUEST_REJECTIONS: tuple[tuple[Callable[[Any], bool], str], ...] = (
      "working_directory is not supported because Hermes delegates use isolated task environments."),
     (lambda r: bool(r.blocked_tools),
      "Per-tool blocking is not supported; use allowed_toolsets. Hermes always blocks unsafe child tools."),
+    (lambda r: not _opt_str(r.model_profile), "model_profile must be a string profile name or None."),
+    (lambda r: r.model is not None and r.model_profile is not None,
+     "model and model_profile are mutually exclusive; pass a raw model OR a configured delegation profile."),
 )
 
 
@@ -257,10 +272,26 @@ class SubagentLifecycleService:
                 raise SubagentLifecycleError("Duplicate correlation_id for this parent session.")
         # Lazy: delegate construction stays internal, plugins never import private delegation helpers.
         from tools.delegate_tool import _build_child_preserving_parent_tools, DEFAULT_MAX_ITERATIONS
+        model, max_iterations, overrides = request.model, DEFAULT_MAX_ITERATIONS, {}
+        if request.model_profile is not None:
+            # The SAME resolution path delegate_task uses (tools/delegate_tool_config.py →
+            # agent.delegation_model_routing.resolve_profile_route): resolve credentials from the
+            # delegation config, then map the bundle to override_* child-construction kwargs.
+            from tools.delegate_tool import _profile_task_overrides
+            from tools.delegate_tool_config import _load_config, _resolve_profile_credentials
+            try:
+                creds = _resolve_profile_credentials(request.model_profile, _load_config())
+            except ValueError as exc:
+                raise SubagentLifecycleError(str(exc)) from exc
+            model, overrides = creds["model"], _profile_task_overrides(creds)
+            profile_max_iter = creds.get("max_iterations")
+            if isinstance(profile_max_iter, int):  # a profile may only TIGHTEN the budget (#25752)
+                max_iterations = min(profile_max_iter, max_iterations)
         child = _build_child_preserving_parent_tools(
             task_index=0, goal=request.goal, context=request.context,
             toolsets=list(request.allowed_toolsets) if request.allowed_toolsets else None,
-            model=request.model, max_iterations=DEFAULT_MAX_ITERATIONS, task_count=1, parent_agent=parent, role=request.role,
+            model=model, max_iterations=max_iterations, task_count=1, parent_agent=parent, role=request.role,
+            **overrides,
         )
         subagent_id = str(getattr(child, "_subagent_id", "") or "")
         if not subagent_id:

--- a/docs/plans/2026-09-04-delegation-model-profiles.md
+++ b/docs/plans/2026-09-04-delegation-model-profiles.md
@@ -1,0 +1,100 @@
+# Delegation Model Profiles — Implementation Plan
+
+> **For Hermes:** implement task-by-task, TDD-first, one conventional commit per task.
+
+**Goal:** Operator-defined worker profiles (`delegation.profiles`) that pin provider/model/effort/fallback per named tier, selectable per task — by config today (Phase 1), by the parent model through `delegate_task.model_profile` behind a default-off gate (Phase 2, `delegation.agent_routing`).
+
+**Architecture:** One resolver module (`agent/delegation_model_routing.py`) parses/validates profiles and returns an immutable route; `delegate_task` and `SubagentLifecycleService` both call it. Precedence: per-task profile > top-level profile > `delegation.default_profile` > legacy `delegation.provider/model` > parent inherit. Route provenance (`requested_profile`, `effective_model`, ...) rides progress events and result entries.
+
+**Repo facts (verified on main 13e72fb205, 2026-09-04):**
+- DEFAULT_CONFIG `delegation` section: `hermes_cli/config_defaults.py:1205`
+- Credential resolution: `tools/delegate_tool_config.py` — `_resolve_delegation_credentials` (:360, three branches: base_url / provider / inherit), `_resolve_child_runtime` (:411, fallback-chain inheritance at :490, pinned-provider fallback clearing already exists)
+- Tool schema: `tools/delegate_tool.py:503-526` (`_build_tasks_param_description`, tasks properties); handler entry :603
+- Batch spawn loop: `tools/delegate_tool_dispatch.py::_run_batch`; single-task normalization `tools/delegate_tool_tasks.py:89`
+- Lifecycle bypass: `agent/subagent_lifecycle.py:53` (`model: Optional[str]`, unvalidated, :211 coercion table, :263 construction)
+- Result entries: `tools/delegate_tool_child_run.py:296,495` (`"model"` only today)
+- Capability metadata: `agent/models_dev.py::get_model_capabilities` (supports_tools :642)
+- Model validation: `hermes_cli/models.py::validate_requested_model` (:4963)
+- Provider resolution: `hermes_cli/runtime_provider.py::resolve_runtime_provider` (:1665)
+- Reasoning parse: `hermes_constants.parse_reasoning_effort` (clamp-at-transport doctrine, NS-696)
+- House rules: no model-facing raw model IDs (NS-696 maintainer policy); config-gated default-off; #25752 layering (per-call can never widen past config); no new HERMES_* env vars; docs in website/docs/user-guide/features/delegation... (check actual page), reference/cli if config check verb touched.
+
+## Config shape
+
+```yaml
+delegation:
+  # existing keys unchanged (provider, model, base_url, ...)
+  default_profile: ""            # name from profiles; "" = legacy behavior
+  agent_routing: false           # Phase 2 gate: expose model_profile enum on delegate_task
+  profiles:
+    small:
+      provider: anthropic
+      model: claude-haiku-current
+      reasoning_effort: none     # optional; parse_reasoning_effort grammar
+      max_iterations: 20         # optional; clamped by delegation.max_iterations semantics
+      fallback: []               # [] = no model promotion (default); list of {provider, model}
+```
+
+## Resolution contract (route = immutable dataclass)
+
+1. per-task `model_profile` (Phase 2 arg or lifecycle field)
+2. top-level `model_profile` (batch-wide)
+3. `delegation.default_profile`
+4. legacy `delegation.provider`/`model` (existing `_resolve_delegation_credentials` path, byte-identical)
+5. parent inherit (existing)
+
+Rules:
+- Unknown profile name → ValueError before child construction (actionable message: configured names listed).
+- Profile resolves via `resolve_runtime_provider(requested=<provider>, target_model=<model>)` — same path as legacy. No duplicated credential logic.
+- supports_tools=False + nonempty child toolset → ValueError (text_only future work, rejected scope).
+- Profile selected → parent fallback chain NOT inherited (reuse the existing pinned-provider mechanism at delegate_tool_config.py:490: profile sets override_provider semantics). Profile `fallback` list becomes the child's chain.
+- #25752: profiles can't widen toolsets — they don't touch toolsets at all (explicitly out of scope).
+- Telemetry: requested_profile / resolved_provider / resolved_model / fallback_policy on result entries + progress events + lifecycle handle.
+
+## Tasks
+
+### T1: resolver module + contract tests
+Create `agent/delegation_model_routing.py`: `ProfileRoute` frozen dataclass, `parse_profiles(cfg) -> Dict[str, ProfileSpec]`, `resolve_profile_route(name, cfg, parent_agent) -> ProfileRoute`, `select_profile_name(task_profile, top_profile, cfg) -> Optional[str]`.
+Tests `tests/agent/test_delegation_model_routing.py`: parse (unknown keys rejected, malformed fallback rejected, empty profiles {}), precedence (all 5 levels), unknown-name ValueError message contains configured names, reasoning_effort parse (invalid warns+ignores per NS-696 clamp doctrine), frozen route immutability. RED first.
+
+### T2: config defaults + validation
+`hermes_cli/config_defaults.py`: add `default_profile`, `agent_routing`, `profiles` keys with house-style comments under delegation (:1205 area).
+`hermes config check` lane: find existing delegation validation (grep `config check` handlers) and add profile validation (names, shapes, default_profile exists in profiles). Tests.
+
+### T3: delegate_task wiring (Phase 1: config-driven)
+`tools/delegate_tool_config.py`: `_resolve_delegation_credentials` grows a profile branch ABOVE the legacy branches — when a profile route is selected, build the credential bundle from the route (base creds via resolve_runtime_provider), set override_provider semantics so `_resolve_child_runtime` clears fallback chain; profile.fallback list feeds `fallback_model` chain when nonempty.
+Per-task selection: `_run_batch`/`_run_single_child` resolve route per task (task dict carries `model_profile` internal field), NOT once per batch. `_strip_model_hidden_task_fields` (delegate_tool.py:603) must NOT strip it when gate on; must strip when gate off (schema honesty).
+Tests: batch with two tasks/two profiles resolves two different models; default_profile applies when task silent; legacy config byte-identical when no profiles configured (existing tests must stay green unmodified — they are the contract).
+
+### T4: Phase 2 gate — model_profile on the public schema
+`tools/delegate_tool.py` schema build: when `delegation.agent_routing` is truthy AND profiles configured+runnable, add `model_profile` enum (configured names) to task properties + top-level; description per the doc ("small for bounded work; do not select a more expensive profile without a task-specific reason"). Gate off → schema byte-identical to today (test asserts absence).
+Handler: reject model_profile args when gate off (defense in depth, tool_error), resolve when on.
+Tests: schema presence/absence by gate; enum content matches configured profiles; unknown profile arg → clean tool error before AIAgent construction (mock spawn, assert not called).
+
+### T5: lifecycle unification
+`agent/subagent_lifecycle.py`: add `model_profile: Optional[str]` to SubagentLaunchRequest; when set, resolve through the SAME resolver (route wins over raw `model`); raw `model` field retained for plugin trust but routed through validate-requested-model when profiles configured... — decision: keep raw model as-is (documented internal trust surface), add model_profile as the policy path; docstring states the trust split. Validator rejects both-set.
+Tests: request with model_profile resolves identically to delegate_task with same profile (parity test); both-set rejected.
+
+### T6: telemetry
+`tools/delegate_tool_child_run.py` result entries (:296,:495): add requested_profile, resolved_provider, resolved_model, fallback_policy. Progress events (`delegate_tool_progress.py::DelegateEvent`) grow the same. Lifecycle handle exposes them. When fallback fires mid-run, preserve requested vs effective (effective = child.model at completion — already captured).
+Tests: result entry contains fields for profile runs; absent (or None) for legacy runs — assert exact shape.
+
+### T7: docs
+Delegation feature page under website/docs (locate: grep "max_concurrent_children" website/docs) — profiles section, YAML example, precedence list, agent_routing gate + policy rationale (operator menu, model picks names not models), fallback isolation semantics. Tool description update = T4. `hermes config check` docs if verb touched.
+
+### T8: E2E + full gates
+Real-import E2E against temp HERMES_HOME (house rule for resolution chains): config file with profiles → delegate_task spawn path resolves route (mock only the network/AIAgent run, real config+resolver+credential imports). Full `tests/tools/ tests/agent/ tests/hermes_cli/` relevant dirs + scripts/run_tests.sh if feasible.
+
+## Rejected scope (PR body material)
+- No free-form model field on the public tool (NS-696 policy; profiles ARE the boundary).
+- No NLP mapping of "use haiku" prompt text (parent converts intent to args).
+- No automatic routing optimizer; telemetry first.
+- No catalog-driven profile mutation (catalog is discovery, not policy).
+- No text_only tool-less profile mode (future; supports_tools=False rejected loudly).
+- Profiles never touch toolsets (#25752 stays untouched).
+
+## Verify
+- Existing delegation tests green UNMODIFIED (legacy contract).
+- New suites RED→GREEN per task; mutation checks on: precedence order, gate-off schema absence, fallback isolation.
+- `python3 -c "from hermes_cli.config_defaults import DEFAULT_CONFIG; print(DEFAULT_CONFIG['delegation']['agent_routing'])"` → False.
+- Salt adversarial review before PR; PR body: phases, rejected scope, policy reconciliation (NS-696), Coatue pilot framing.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1224,11 +1224,30 @@ def _validate_delegation_profiles(config: Dict[str, Any], issues: List[ConfigIss
     if not isinstance(delegation_cfg, dict):
         return
     if not (delegation_cfg.get("profiles") or delegation_cfg.get("default_profile")):
-        return  # legacy config — nothing profile-shaped to validate
+        # legacy config — nothing profile-shaped to validate, but a routing gate with no menu
+        # behind it silently exposes nothing: warn instead of staying quiet.
+        if delegation_cfg.get("agent_routing"):
+            _issue(issues, "warning",
+                   "delegation.agent_routing is enabled but no delegation.profiles are configured; "
+                   "model_profile will not be exposed.",
+                   "Add at least one profile under delegation.profiles in config.yaml, or set "
+                   "delegation.agent_routing: false")
+        return
     try:
-        from agent.delegation_model_routing import profile_config_errors
+        from agent.delegation_model_routing import profile_config_errors, parse_profiles
     except Exception:
         return
+    if delegation_cfg.get("agent_routing"):
+        try:
+            routable = parse_profiles(delegation_cfg)
+        except ValueError:
+            routable = None  # malformed — the error issues below already tell the story
+        if routable == {}:
+            _issue(issues, "warning",
+                   "delegation.agent_routing is enabled but no delegation.profiles are configured; "
+                   "model_profile will not be exposed.",
+                   "Add at least one profile under delegation.profiles in config.yaml, or set "
+                   "delegation.agent_routing: false")
     for message in profile_config_errors(delegation_cfg):
         _issue(issues, "error", message,
                "Fix the entry under delegation.profiles in config.yaml — each profile needs at "

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1216,6 +1216,25 @@ def _validate_web_backends(config: Dict[str, Any], issues: List[ConfigIssue]) ->
                    "Run 'hermes tools' and pick a different Web Search & Extract provider")
 
 
+def _validate_delegation_profiles(config: Dict[str, Any], issues: List[ConfigIssue]) -> None:
+    """delegation.profiles / default_profile: a malformed profile otherwise fails only at the
+    first delegate_task spawn; surface it at startup / `hermes config check` instead. The parse
+    rules live in the resolver (agent/delegation_model_routing.py) — one source of truth."""
+    delegation_cfg = config.get("delegation")
+    if not isinstance(delegation_cfg, dict):
+        return
+    if not (delegation_cfg.get("profiles") or delegation_cfg.get("default_profile")):
+        return  # legacy config — nothing profile-shaped to validate
+    try:
+        from agent.delegation_model_routing import profile_config_errors
+    except Exception:
+        return
+    for message in profile_config_errors(delegation_cfg):
+        _issue(issues, "error", message,
+               "Fix the entry under delegation.profiles in config.yaml — each profile needs at "
+               "minimum a 'model', and default_profile must name a configured profile")
+
+
 def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["ConfigIssue"]:
     """Validate config.yaml structure and return detected issues (accepts a pre-loaded dict).
     Catches common YAML mistakes that otherwise surface as confusing runtime errors."""
@@ -1253,6 +1272,7 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
                    f"Move '{key}' under the appropriate section")
 
     _validate_web_backends(config, issues)
+    _validate_delegation_profiles(config, issues)
     return issues
 
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1246,6 +1246,19 @@ DEFAULT_CONFIG = {
         # notifications to the PARENT; false suppresses them (the child's result is the
         # deliverable). Async-delegation results are NEVER suppressed.
         "surface_child_process_notifications": False,
+        # Named worker profiles pinning provider/model (and optionally reasoning_effort,
+        # max_iterations, fallback) per tier, e.g.
+        # profiles: {small: {provider: anthropic, model: claude-haiku-current, fallback: []}}.
+        # A profile's fallback list ([] = no model promotion) replaces the parent's chain.
+        # Selection precedence: per-task profile > top-level profile > default_profile > legacy
+        # delegation.provider/model > parent inherit. Profiles never touch toolsets.
+        "profiles": {},
+        # Profile applied when a task doesn't pick one; must name a key in profiles. Empty =
+        # legacy behavior (delegation.provider/model or parent inherit).
+        "default_profile": "",
+        # Phase 2 gate: expose a model_profile enum (configured profile names) on delegate_task so
+        # the parent model can pick a tier per task. Off = profiles are config-driven only.
+        "agent_routing": False,
     },
     # Ephemeral prefill messages file — JSON list of {role, content} dicts injected at the start of
     # every API call for few-shot priming. Never saved to sessions/logs/trajectories.

--- a/run_agent.py
+++ b/run_agent.py
@@ -1296,16 +1296,13 @@ class AIAgent(
 
     def _dispatch_delegate_task(self, function_args: dict) -> str:
         """Single call site for delegate_task dispatch; new DELEGATE_TASK_SCHEMA fields are added only here."""
-        from tools.delegate_tool import _strip_model_hidden_task_fields, delegate_task as _delegate_task
+        from tools.delegate_tool import _handle_model_call
         # Top-level MODEL delegations always run in the background (handle returned, results re-enter as
         # messages). An ORCHESTRATOR SUBAGENT (depth > 0) stays synchronous — it needs results in-turn and
         # owns no gateway session. The schema-level `background` param is intentionally ignored.
-        return _delegate_task(
-            goal=function_args.get("goal"), context=function_args.get("context"),
-            tasks=_strip_model_hidden_task_fields(function_args.get("tasks")),
-            max_iterations=function_args.get("max_iterations"), role=function_args.get("role"),
-            background=not (getattr(self, "_delegate_depth", 0) > 0), action=function_args.get("action"),
-            subagent_id=function_args.get("subagent_id"), message=function_args.get("message"), parent_agent=self,
+        # _handle_model_call strips hidden task fields and enforces the delegation.agent_routing gate.
+        return _handle_model_call(
+            function_args, parent_agent=self, background=not (getattr(self, "_delegate_depth", 0) > 0),
         )
 
     _invoke_tool = _forward("agent.agent_runtime_helpers", "invoke_tool")

--- a/tests/agent/test_delegation_model_routing.py
+++ b/tests/agent/test_delegation_model_routing.py
@@ -298,3 +298,10 @@ class TestCredentialErrorSurfacing:
         msg = str(exc.value)
         assert "small" in msg
         assert "ANTHROPIC_API_KEY is not set" in msg
+
+
+class TestEmptyProfileNames:
+    @pytest.mark.parametrize("bad_name", ["", "   ", "\t"])
+    def test_empty_or_whitespace_profile_name_rejected(self, bad_name):
+        with pytest.raises(ValueError, match="empty or whitespace"):
+            parse_profiles(_cfg({bad_name: dict(SMALL)}))

--- a/tests/agent/test_delegation_model_routing.py
+++ b/tests/agent/test_delegation_model_routing.py
@@ -1,0 +1,276 @@
+"""Contract tests for the delegation model-profile resolver (agent/delegation_model_routing.py).
+
+Behavior contracts (not snapshots): parsing rejects malformed shapes loudly, selection follows the
+documented precedence ladder, unknown profile names fail before child construction with an
+actionable message, invalid reasoning_effort warns and is ignored (NS-696 clamp-at-transport
+doctrine — never reject), and the resolved route is immutable.
+"""
+
+import dataclasses
+import logging
+
+import pytest
+
+from agent.delegation_model_routing import (
+    ProfileRoute,
+    parse_profiles,
+    profile_config_errors,
+    resolve_profile_route,
+    select_profile_name,
+)
+
+
+def _cfg(profiles=None, default_profile="", **extra):
+    cfg = {"default_profile": default_profile, "profiles": profiles if profiles is not None else {}}
+    cfg.update(extra)
+    return cfg
+
+
+SMALL = {"provider": "anthropic", "model": "claude-haiku-current"}
+LARGE = {"provider": "openrouter", "model": "big/model"}
+
+
+# ---------------------------------------------------------------------------
+# parse_profiles
+# ---------------------------------------------------------------------------
+
+class TestParseProfiles:
+    def test_empty_profiles_parse_to_empty_dict(self):
+        assert parse_profiles(_cfg()) == {}
+
+    @pytest.mark.parametrize("cfg", [None, {}, {"profiles": None}, {"profiles": {}}])
+    def test_tolerates_missing_or_none_sections(self, cfg):
+        assert parse_profiles(cfg) == {}
+
+    def test_parses_minimal_profile(self):
+        specs = parse_profiles(_cfg({"small": dict(SMALL)}))
+        assert set(specs) == {"small"}
+        spec = specs["small"]
+        assert spec.provider == "anthropic"
+        assert spec.model == "claude-haiku-current"
+        assert spec.fallback == ()
+        assert spec.max_iterations is None
+        assert spec.reasoning_config is None
+
+    def test_unknown_keys_rejected(self):
+        cfg = _cfg({"small": {**SMALL, "toolsets": ["web"]}})
+        with pytest.raises(ValueError) as exc:
+            parse_profiles(cfg)
+        assert "toolsets" in str(exc.value)
+        assert "small" in str(exc.value)
+
+    def test_missing_model_rejected(self):
+        with pytest.raises(ValueError) as exc:
+            parse_profiles(_cfg({"small": {"provider": "anthropic"}}))
+        assert "model" in str(exc.value)
+
+    def test_non_dict_profile_rejected(self):
+        with pytest.raises(ValueError):
+            parse_profiles(_cfg({"small": "claude-haiku-current"}))
+
+    @pytest.mark.parametrize("bad_fallback", [
+        "openrouter/big",                       # not a list
+        [{"provider": "openrouter"}],            # entry missing model
+        [{"model": "x"}],                        # entry missing provider
+        ["openrouter/big"],                      # entry not a dict
+        [{"provider": "p", "model": "m", "extra": 1}],  # unknown entry key
+    ])
+    def test_malformed_fallback_rejected(self, bad_fallback):
+        with pytest.raises(ValueError) as exc:
+            parse_profiles(_cfg({"small": {**SMALL, "fallback": bad_fallback}}))
+        assert "fallback" in str(exc.value)
+
+    def test_valid_fallback_parsed_as_tuple(self):
+        specs = parse_profiles(_cfg({
+            "small": {**SMALL, "fallback": [{"provider": "openrouter", "model": "b/c"}]},
+        }))
+        fb = specs["small"].fallback
+        assert isinstance(fb, tuple) and len(fb) == 1
+        assert fb[0].provider == "openrouter"
+        assert fb[0].model == "b/c"
+
+    def test_valid_reasoning_effort_parsed(self):
+        specs = parse_profiles(_cfg({"small": {**SMALL, "reasoning_effort": "high"}}))
+        assert specs["small"].reasoning_config == {"enabled": True, "effort": "high"}
+
+    def test_reasoning_effort_none_means_disabled(self):
+        specs = parse_profiles(_cfg({"small": {**SMALL, "reasoning_effort": "none"}}))
+        assert specs["small"].reasoning_config == {"enabled": False}
+
+    def test_invalid_reasoning_effort_warns_and_is_ignored(self, caplog):
+        """NS-696 clamp doctrine: an invalid effort must never reject the profile."""
+        with caplog.at_level(logging.WARNING):
+            specs = parse_profiles(_cfg({"small": {**SMALL, "reasoning_effort": "turbo"}}))
+        assert specs["small"].reasoning_config is None
+        assert any("turbo" in rec.getMessage() for rec in caplog.records)
+
+    def test_max_iterations_parsed(self):
+        specs = parse_profiles(_cfg({"small": {**SMALL, "max_iterations": 20}}))
+        assert specs["small"].max_iterations == 20
+
+    def test_non_int_max_iterations_rejected(self):
+        with pytest.raises(ValueError) as exc:
+            parse_profiles(_cfg({"small": {**SMALL, "max_iterations": "lots"}}))
+        assert "max_iterations" in str(exc.value)
+
+
+class TestProfileConfigErrors:
+    """Multi-issue collector used by `hermes config check` — never raises."""
+
+    def test_clean_config_has_no_errors(self):
+        assert profile_config_errors(_cfg({"small": dict(SMALL)})) == []
+
+    def test_collects_multiple_errors(self):
+        errors = profile_config_errors(_cfg({
+            "a": {"provider": "p"},                 # missing model
+            "b": {**SMALL, "bogus": 1},             # unknown key
+        }))
+        joined = "\n".join(errors)
+        assert "a" in joined and "model" in joined
+        assert "b" in joined and "bogus" in joined
+        assert len(errors) >= 2
+
+    def test_default_profile_must_exist(self):
+        errors = profile_config_errors(_cfg({"small": dict(SMALL)}, default_profile="huge"))
+        assert any("huge" in e and "small" in e for e in errors)
+
+    def test_empty_default_profile_is_fine(self):
+        assert profile_config_errors(_cfg({"small": dict(SMALL)}, default_profile="")) == []
+
+    def test_profiles_must_be_a_mapping(self):
+        errors = profile_config_errors({"profiles": ["small"]})
+        assert errors and any("profiles" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# select_profile_name — precedence ladder
+# ---------------------------------------------------------------------------
+
+FALSY = [False, None, "", 0]
+
+
+class TestSelectProfileName:
+    def test_per_task_wins_over_everything(self):
+        cfg = _cfg({"small": dict(SMALL)}, default_profile="large")
+        assert select_profile_name("small", "mid", cfg) == "small"
+
+    def test_top_level_wins_over_default(self):
+        cfg = _cfg({"small": dict(SMALL)}, default_profile="large")
+        assert select_profile_name(None, "small", cfg) == "small"
+
+    def test_default_profile_applies_when_others_silent(self):
+        cfg = _cfg({"small": dict(SMALL)}, default_profile="small")
+        assert select_profile_name(None, None, cfg) == "small"
+
+    def test_legacy_config_selects_no_profile(self):
+        """Level 4: legacy delegation.provider/model config — resolver stays out of the way."""
+        cfg = {"provider": "openrouter", "model": "x/y"}
+        assert select_profile_name(None, None, cfg) is None
+
+    def test_pure_inherit_selects_no_profile(self):
+        """Level 5: nothing configured at all — parent inherit."""
+        assert select_profile_name(None, None, {}) is None
+        assert select_profile_name(None, None, None) is None
+
+    @pytest.mark.parametrize("falsy", FALSY)
+    def test_falsy_task_profile_falls_through(self, falsy):
+        cfg = _cfg({"small": dict(SMALL)}, default_profile="small")
+        assert select_profile_name(falsy, None, cfg) == "small"
+
+    @pytest.mark.parametrize("falsy", FALSY)
+    def test_falsy_top_profile_falls_through(self, falsy):
+        cfg = _cfg({"small": dict(SMALL)}, default_profile="small")
+        assert select_profile_name(None, falsy, cfg) == "small"
+
+    @pytest.mark.parametrize("falsy", FALSY)
+    def test_falsy_default_profile_means_legacy(self, falsy):
+        cfg = _cfg({"small": dict(SMALL)}, default_profile=falsy)
+        assert select_profile_name(None, None, cfg) is None
+
+    def test_whitespace_names_are_stripped(self):
+        cfg = _cfg({"small": dict(SMALL)})
+        assert select_profile_name("  small  ", None, cfg) == "small"
+
+
+# ---------------------------------------------------------------------------
+# resolve_profile_route
+# ---------------------------------------------------------------------------
+
+class _FakeCaps:
+    def __init__(self, supports_tools=True):
+        self.supports_tools = supports_tools
+
+
+@pytest.fixture
+def fake_runtime(monkeypatch):
+    """Stub the two lazy-imported collaborators at their source modules."""
+    calls = {}
+
+    def _resolve(*, requested=None, explicit_api_key=None, explicit_base_url=None, target_model=None):
+        calls["requested"] = requested
+        calls["target_model"] = target_model
+        return {
+            "provider": requested or "resolved-default",
+            "model": target_model,
+            "base_url": "https://api.example.test/v1",
+            "api_key": "sk-test",
+            "api_mode": "chat_completions",
+        }
+
+    import hermes_cli.runtime_provider as rp
+    import agent.models_dev as md
+    monkeypatch.setattr(rp, "resolve_runtime_provider", _resolve)
+    monkeypatch.setattr(md, "get_model_capabilities", lambda *a, **k: _FakeCaps(True))
+    return calls
+
+
+class TestResolveProfileRoute:
+    def test_unknown_name_lists_configured_profiles(self):
+        cfg = _cfg({"small": dict(SMALL), "large": dict(LARGE)})
+        with pytest.raises(ValueError) as exc:
+            resolve_profile_route("huge", cfg, parent_agent=None)
+        msg = str(exc.value)
+        assert "huge" in msg
+        assert "small" in msg and "large" in msg
+
+    def test_unknown_name_with_no_profiles_configured(self):
+        with pytest.raises(ValueError) as exc:
+            resolve_profile_route("small", {}, parent_agent=None)
+        assert "small" in str(exc.value)
+
+    def test_route_resolves_through_runtime_provider(self, fake_runtime):
+        cfg = _cfg({"small": dict(SMALL)})
+        route = resolve_profile_route("small", cfg, parent_agent=None)
+        # credential resolution went through resolve_runtime_provider — same path as legacy
+        assert fake_runtime["requested"] == "anthropic"
+        assert fake_runtime["target_model"] == "claude-haiku-current"
+        assert route.requested_profile == "small"
+        assert route.provider == "anthropic"
+        assert route.model == "claude-haiku-current"
+        assert route.base_url == "https://api.example.test/v1"
+        assert route.api_key == "sk-test"
+        assert route.api_mode == "chat_completions"
+
+    def test_route_carries_profile_extras(self, fake_runtime):
+        cfg = _cfg({"small": {**SMALL, "reasoning_effort": "low", "max_iterations": 20,
+                              "fallback": [{"provider": "openrouter", "model": "b/c"}]}})
+        route = resolve_profile_route("small", cfg, parent_agent=None)
+        assert route.reasoning_config == {"enabled": True, "effort": "low"}
+        assert route.max_iterations == 20
+        assert len(route.fallback) == 1
+        assert route.fallback[0].provider == "openrouter"
+
+    def test_route_exposes_supports_tools(self, monkeypatch, fake_runtime):
+        import agent.models_dev as md
+        monkeypatch.setattr(md, "get_model_capabilities", lambda *a, **k: _FakeCaps(False))
+        route = resolve_profile_route("small", _cfg({"small": dict(SMALL)}), parent_agent=None)
+        assert route.supports_tools is False
+
+    def test_route_is_frozen(self, fake_runtime):
+        route = resolve_profile_route("small", _cfg({"small": dict(SMALL)}), parent_agent=None)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            route.model = "other"
+
+    def test_route_fallback_is_immutable_sequence(self, fake_runtime):
+        route = resolve_profile_route("small", _cfg({"small": dict(SMALL)}), parent_agent=None)
+        assert isinstance(route.fallback, tuple)

--- a/tests/agent/test_delegation_model_routing.py
+++ b/tests/agent/test_delegation_model_routing.py
@@ -274,3 +274,27 @@ class TestResolveProfileRoute:
     def test_route_fallback_is_immutable_sequence(self, fake_runtime):
         route = resolve_profile_route("small", _cfg({"small": dict(SMALL)}), parent_agent=None)
         assert isinstance(route.fallback, tuple)
+
+
+# ---------------------------------------------------------------------------
+# credential-resolution errors surface as ValueError (clean tool_error seam)
+# ---------------------------------------------------------------------------
+
+class TestCredentialErrorSurfacing:
+    def test_runtime_provider_auth_error_surfaces_as_value_error(self, monkeypatch):
+        """AuthError subclasses RuntimeError, which the delegate_task/lifecycle seams do NOT
+        catch — the resolver must re-raise it as ValueError naming the profile, mirroring the
+        legacy provider branch (tools/delegate_tool_config._runtime_provider_credentials)."""
+        import hermes_cli.runtime_provider as rp
+        from hermes_cli.auth_constants import AuthError
+
+        def _boom(**_kw):
+            raise AuthError("ANTHROPIC_API_KEY is not set", provider="anthropic")
+
+        monkeypatch.setattr(rp, "resolve_runtime_provider", _boom)
+        with pytest.raises(ValueError) as exc:
+            resolve_profile_route("small", _cfg({"small": dict(SMALL)}), parent_agent=None)
+        assert not isinstance(exc.value, RuntimeError)
+        msg = str(exc.value)
+        assert "small" in msg
+        assert "ANTHROPIC_API_KEY is not set" in msg

--- a/tests/agent/test_review_engine.py
+++ b/tests/agent/test_review_engine.py
@@ -167,7 +167,7 @@ def test_delegate_task_credentials_cfg_overrides_delegation_config(monkeypatch):
 
     seen = {}
 
-    def fake_resolve(cfg, parent_agent):
+    def fake_resolve(cfg, parent_agent, **kwargs):
         seen["cfg"] = cfg
         return {
             "model": cfg.get("model"), "provider": None, "base_url": None,

--- a/tests/agent/test_subagent_lifecycle_profiles.py
+++ b/tests/agent/test_subagent_lifecycle_profiles.py
@@ -108,3 +108,35 @@ def test_no_profile_keeps_construction_kwargs_unchanged(captured, fake_routing):
     assert kwargs["model"] == "raw-model"
     assert not any(k.startswith("override_") for k in kwargs)
     assert "requested_profile" not in kwargs
+
+
+@pytest.mark.parametrize("profile_iter,budget,expected", [
+    (100, 50, 50),  # profile can never WIDEN the configured budget
+    (7, 50, 7),     # profile may tighten it
+])
+def test_profile_max_iterations_clamps_against_configured_budget(
+        captured, monkeypatch, profile_iter, budget, expected):
+    """The lifecycle path clamps min(profile, delegation.max_iterations) — the CONFIGURED
+    budget, same as delegate_task, not the DEFAULT_MAX_ITERATIONS constant. Both directions
+    are asserted so a min→max mutation cannot survive."""
+    from types import SimpleNamespace as _NS
+    cfg = {
+        "max_iterations": budget,
+        "profiles": {"small": {
+            "provider": "openrouter", "model": "prof/small-model", "max_iterations": profile_iter,
+        }},
+    }
+    import hermes_cli.runtime_provider as rp
+    import agent.models_dev as md
+    monkeypatch.setattr(rp, "resolve_runtime_provider", lambda **kw: {
+        "provider": kw.get("requested"), "model": kw.get("target_model"),
+        "base_url": "https://api.example.test/v1", "api_key": "sk-test",
+        "api_mode": "chat_completions",
+    })
+    monkeypatch.setattr(md, "get_model_capabilities", lambda *a, **k: _NS(supports_tools=True))
+    monkeypatch.setattr("tools.delegate_tool_config._load_config", lambda: cfg)
+
+    service, calls = captured
+    service.launch(SubagentLaunchRequest(goal="budget", model_profile="small"))
+    assert len(calls) == 1
+    assert calls[0]["max_iterations"] == expected

--- a/tests/agent/test_subagent_lifecycle_profiles.py
+++ b/tests/agent/test_subagent_lifecycle_profiles.py
@@ -1,0 +1,110 @@
+"""Lifecycle ``model_profile`` routing: SubagentLaunchRequest resolves delegation profiles
+through the SAME seam delegate_task uses (agent.delegation_model_routing.resolve_profile_route),
+so a profile name means the same provider/model on both APIs."""
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from agent.subagent_lifecycle import (
+    SubagentLaunchRequest,
+    SubagentLifecycleError,
+    SubagentLifecycleService,
+)
+
+PROFILES_CFG = {"profiles": {"small": {"provider": "openrouter", "model": "prof/small-model"}}}
+
+
+class FakeChild:
+    def __init__(self, ident="sa-prof"):
+        self._subagent_id = ident
+        self._delegate_role = "leaf"
+        self._delegate_depth = 1
+        self.provider = "test"
+        self.model = "test-model"
+        self.interrupted = False
+
+
+def _run(_index, _goal, _child, _parent):
+    return {"status": "completed", "summary": "ok", "api_calls": 1, "duration_seconds": 0.01}
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    """Lifecycle service wired to a fake parent; captures _build_child_agent kwargs."""
+    calls = []
+
+    def build(**kwargs):
+        calls.append(kwargs)
+        return FakeChild(f"sa-{len(calls)}")
+
+    monkeypatch.setattr("tools.delegate_tool._build_child_agent", build)
+    monkeypatch.setattr("tools.delegate_tool._run_single_child", _run)
+    parent = SimpleNamespace(session_id="parent-prof", enabled_toolsets=["file"])
+    return SubagentLifecycleService(lambda: parent), calls
+
+
+@pytest.fixture
+def fake_routing(monkeypatch):
+    """Stub the resolver's lazy collaborators at their source modules and pin the delegation cfg."""
+
+    def _resolve(*, requested=None, explicit_api_key=None, explicit_base_url=None, target_model=None):
+        return {
+            "provider": requested or "resolved-default",
+            "model": target_model,
+            "base_url": "https://api.example.test/v1",
+            "api_key": "sk-test",
+            "api_mode": "chat_completions",
+        }
+
+    import hermes_cli.runtime_provider as rp
+    import agent.models_dev as md
+    monkeypatch.setattr(rp, "resolve_runtime_provider", _resolve)
+    monkeypatch.setattr(
+        md, "get_model_capabilities", lambda *a, **k: SimpleNamespace(supports_tools=True)
+    )
+    monkeypatch.setattr("tools.delegate_tool_config._load_config", lambda: dict(PROFILES_CFG))
+
+
+def test_parity_lifecycle_and_delegate_task_resolve_same_route(captured, fake_routing):
+    """The lifecycle path and the delegate_task oracle (resolve_profile_route, the shared seam
+    delegate_tool_config.py calls at :365-366) must land on the same (model, provider)."""
+    from agent.delegation_model_routing import resolve_profile_route
+
+    oracle = resolve_profile_route("small", PROFILES_CFG)
+
+    service, calls = captured
+    service.launch(SubagentLaunchRequest(goal="parity", model_profile="small"))
+    assert len(calls) == 1
+    kwargs = calls[0]
+    assert kwargs["model"] == oracle.model == "prof/small-model"
+    assert kwargs["override_provider"] == oracle.provider == "openrouter"
+
+
+def test_both_model_and_model_profile_rejected(captured, fake_routing):
+    service, calls = captured
+    with pytest.raises(SubagentLifecycleError, match="model_profile"):
+        service.launch(SubagentLaunchRequest(goal="x", model="gpt-x", model_profile="small"))
+    assert calls == []
+
+
+def test_unknown_profile_errors_naming_configured_profiles(captured, fake_routing):
+    service, calls = captured
+    with pytest.raises(SubagentLifecycleError) as exc:
+        service.launch(SubagentLaunchRequest(goal="x", model_profile="huge"))
+    msg = str(exc.value)
+    assert "huge" in msg and "small" in msg
+    assert calls == []
+
+
+def test_no_profile_keeps_construction_kwargs_unchanged(captured, fake_routing):
+    """model_profile=None must be byte-identical to today's behavior: no override_* kwargs
+    appear, and model passes through verbatim."""
+    service, calls = captured
+    service.launch(SubagentLaunchRequest(goal="plain", model="raw-model"))
+    assert len(calls) == 1
+    kwargs = calls[0]
+    assert kwargs["model"] == "raw-model"
+    assert not any(k.startswith("override_") for k in kwargs)
+    assert "requested_profile" not in kwargs

--- a/tests/hermes_cli/test_delegation_profiles_config.py
+++ b/tests/hermes_cli/test_delegation_profiles_config.py
@@ -1,0 +1,74 @@
+"""T2: delegation model-profile config defaults + `hermes config check` validation.
+
+Contracts: DEFAULT_CONFIG ships the new keys with safe (off/legacy) defaults, and
+validate_config_structure surfaces malformed delegation.profiles / default_profile as issues
+while staying silent for healthy and legacy configs.
+"""
+
+import pytest
+
+from hermes_cli.config_defaults import DEFAULT_CONFIG
+from hermes_cli.config import validate_config_structure
+
+
+class TestDelegationProfileDefaults:
+    def test_default_profile_defaults_to_legacy_behavior(self):
+        assert DEFAULT_CONFIG["delegation"]["default_profile"] == ""
+
+    def test_agent_routing_gate_defaults_off(self):
+        assert DEFAULT_CONFIG["delegation"]["agent_routing"] is False
+
+    def test_profiles_default_empty_mapping(self):
+        assert DEFAULT_CONFIG["delegation"]["profiles"] == {}
+
+
+def _issues(delegation):
+    return validate_config_structure({"delegation": delegation})
+
+
+class TestDelegationProfileValidation:
+    def test_healthy_profiles_produce_no_issues(self):
+        assert _issues({
+            "default_profile": "small",
+            "profiles": {"small": {"provider": "anthropic", "model": "claude-haiku-current"}},
+        }) == []
+
+    def test_legacy_delegation_config_produces_no_issues(self):
+        assert _issues({"provider": "openrouter", "model": "x/y"}) == []
+
+    def test_missing_delegation_section_produces_no_issues(self):
+        assert validate_config_structure({}) == []
+
+    def test_profiles_as_list_is_an_error(self):
+        issues = _issues({"profiles": ["small"]})
+        assert any(i.severity == "error" and "profiles" in i.message for i in issues)
+
+    def test_profile_missing_model_is_an_error(self):
+        issues = _issues({"profiles": {"small": {"provider": "anthropic"}}})
+        assert any(i.severity == "error" and "small" in i.message and "model" in i.message
+                   for i in issues)
+
+    def test_profile_unknown_key_is_an_error(self):
+        issues = _issues({"profiles": {"small": {"model": "m", "toolsets": ["web"]}}})
+        assert any(i.severity == "error" and "toolsets" in i.message for i in issues)
+
+    def test_default_profile_must_reference_configured_profile(self):
+        issues = _issues({
+            "default_profile": "huge",
+            "profiles": {"small": {"provider": "anthropic", "model": "m"}},
+        })
+        matching = [i for i in issues if i.severity == "error" and "huge" in i.message]
+        assert matching, "default_profile pointing at a missing profile must be an error"
+        assert any("small" in i.message for i in matching), (
+            "the error must list the configured profile names")
+
+    @pytest.mark.parametrize("falsy", [None, "", False, 0])
+    def test_falsy_default_profile_is_fine(self, falsy):
+        assert _issues({
+            "default_profile": falsy,
+            "profiles": {"small": {"provider": "anthropic", "model": "m"}},
+        }) == []
+
+    def test_malformed_fallback_is_an_error(self):
+        issues = _issues({"profiles": {"small": {"model": "m", "fallback": "openrouter/big"}}})
+        assert any(i.severity == "error" and "fallback" in i.message for i in issues)

--- a/tests/hermes_cli/test_delegation_profiles_config.py
+++ b/tests/hermes_cli/test_delegation_profiles_config.py
@@ -72,3 +72,25 @@ class TestDelegationProfileValidation:
     def test_malformed_fallback_is_an_error(self):
         issues = _issues({"profiles": {"small": {"model": "m", "fallback": "openrouter/big"}}})
         assert any(i.severity == "error" and "fallback" in i.message for i in issues)
+
+
+class TestAgentRoutingWithoutProfiles:
+    WARNING_TEXT = "agent_routing is enabled but no delegation.profiles are configured"
+
+    def test_agent_routing_on_with_no_profiles_warns(self):
+        issues = _issues({"agent_routing": True})
+        assert any(i.severity == "warning" and self.WARNING_TEXT in i.message for i in issues)
+
+    def test_agent_routing_on_with_empty_profiles_mapping_warns(self):
+        issues = _issues({"agent_routing": True, "profiles": {}, "default_profile": "x"})
+        assert any(i.severity == "warning" and self.WARNING_TEXT in i.message for i in issues)
+
+    def test_agent_routing_off_with_no_profiles_stays_silent(self):
+        assert _issues({"agent_routing": False}) == []
+
+    def test_agent_routing_on_with_profiles_stays_silent(self):
+        issues = _issues({
+            "agent_routing": True,
+            "profiles": {"small": {"provider": "anthropic", "model": "m"}},
+        })
+        assert not any(self.WARNING_TEXT in i.message for i in issues)

--- a/tests/tools/test_delegation_model_profiles.py
+++ b/tests/tools/test_delegation_model_profiles.py
@@ -1,0 +1,196 @@
+"""delegate_task wiring for delegation.profiles (T3, Phase 1: config-driven).
+
+Per-task profile routing inside the spawn loop — a batch can mix profiles, default_profile
+applies when a task is silent, profile fallback lists replace the parent's chain,
+supports_tools=False profiles are rejected before AIAgent construction, and legacy behavior
+is byte-identical when no profiles are configured.
+"""
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from tools.delegate_tool import delegate_task
+
+
+# ── helpers (mirrors tests/tools/test_delegate.py fixtures) ──────────────────
+
+def _make_parent(depth=0):
+    parent = MagicMock()
+    parent.base_url = "https://openrouter.ai/api/v1"
+    parent.api_key = "***"
+    parent.provider = "openrouter"
+    parent.api_mode = "chat_completions"
+    parent.model = "anthropic/claude-sonnet-4"
+    parent.platform = "cli"
+    parent.providers_allowed = None
+    parent.providers_ignored = None
+    parent.providers_order = None
+    parent.provider_sort = None
+    parent._session_db = None
+    parent._delegate_depth = depth
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    parent._print_fn = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    parent._fallback_chain = [{"provider": "openrouter", "model": "parent-fallback"}]
+    return parent
+
+
+def _make_child():
+    child = MagicMock()
+    child.run_conversation.return_value = {
+        "final_response": "done", "completed": True, "api_calls": 1, "messages": [],
+    }
+    child._delegate_saved_tool_names = []
+    child._credential_pool = None
+    child.session_prompt_tokens = 0
+    child.session_completion_tokens = 0
+    child.model = "test"
+    return child
+
+
+PROFILES = {
+    "small": {"provider": "openrouter", "model": "prof/small-model", "max_iterations": 7, "fallback": []},
+    "big": {
+        "provider": "openrouter", "model": "prof/big-model",
+        "fallback": [{"provider": "nous", "model": "prof/backup"}],
+    },
+    "tiny": {"provider": "openrouter", "model": "prof/tiny-model", "reasoning_effort": "low"},
+}
+
+
+def _fake_runtime(requested=None, target_model=None, **_kw):
+    return {
+        "provider": requested or "openrouter", "base_url": "https://rt.example/v1",
+        "api_key": "rt-key", "api_mode": "chat_completions",
+        "request_overrides": {}, "max_output_tokens": None,
+    }
+
+
+class _Harness:
+    """Patches the delegation config + provider resolution + AIAgent construction."""
+
+    def __init__(self, cfg, capabilities=None):
+        self.built = []
+        self.cfg = cfg
+        self._patches = [
+            patch("tools.delegate_tool._load_config", return_value=cfg),
+            patch("hermes_cli.runtime_provider.resolve_runtime_provider", side_effect=_fake_runtime),
+            patch("agent.models_dev.get_model_capabilities", return_value=capabilities),
+            patch("run_agent.AIAgent", side_effect=self._factory),
+        ]
+
+    def _factory(self, *args, **kwargs):
+        self.built.append(kwargs)
+        return _make_child()
+
+    def __enter__(self):
+        for p in self._patches:
+            p.start()
+        return self
+
+    def __exit__(self, *exc):
+        for p in reversed(self._patches):
+            p.stop()
+        return False
+
+
+# ── T3: per-task profile routing (config-driven) ─────────────────────────────
+
+def test_batch_mixes_profiles_per_task():
+    """Two tasks with two different profiles resolve two different models in ONE batch."""
+    cfg = {"profiles": PROFILES}
+    with _Harness(cfg) as h:
+        delegate_task(
+            tasks=[
+                {"goal": "Summarize the release notes for QA", "model_profile": "small"},
+                {"goal": "Design the storage migration plan", "model_profile": "big"},
+            ],
+            parent_agent=_make_parent(),
+        )
+    assert [b["model"] for b in h.built] == ["prof/small-model", "prof/big-model"]
+    assert all(b["api_key"] == "rt-key" for b in h.built)
+    assert all(b["provider"] == "openrouter" for b in h.built)
+
+
+def test_default_profile_applies_when_task_silent():
+    cfg = {"profiles": PROFILES, "default_profile": "small"}
+    with _Harness(cfg) as h:
+        delegate_task(goal="Do the maintenance work carefully", parent_agent=_make_parent())
+    assert h.built[0]["model"] == "prof/small-model"
+
+
+def test_profile_max_iterations_clamps_child_budget():
+    cfg = {"profiles": PROFILES, "default_profile": "small"}
+    with _Harness(cfg) as h:
+        delegate_task(goal="Do the maintenance work carefully", parent_agent=_make_parent())
+    assert h.built[0]["max_iterations"] == 7
+
+
+def test_profile_reasoning_effort_overrides_parent():
+    from hermes_constants import parse_reasoning_effort
+    cfg = {"profiles": PROFILES, "default_profile": "tiny"}
+    with _Harness(cfg) as h:
+        delegate_task(goal="Do the maintenance work carefully", parent_agent=_make_parent())
+    assert h.built[0]["reasoning_config"] == parse_reasoning_effort("low")
+
+
+def test_profile_fallback_list_replaces_parent_chain():
+    cfg = {"profiles": PROFILES}
+    with _Harness(cfg) as h:
+        delegate_task(
+            tasks=[{"goal": "Design the storage migration plan", "model_profile": "big"}],
+            parent_agent=_make_parent(),
+        )
+    assert h.built[0]["fallback_model"] == [{"provider": "nous", "model": "prof/backup"}]
+
+
+def test_profile_empty_fallback_isolates_from_parent_chain():
+    """fallback: [] = no model promotion — the parent's chain must NOT leak in."""
+    cfg = {"profiles": PROFILES}
+    with _Harness(cfg) as h:
+        delegate_task(
+            tasks=[{"goal": "Summarize the release notes for QA", "model_profile": "small"}],
+            parent_agent=_make_parent(),
+        )
+    assert not h.built[0]["fallback_model"]
+
+
+def test_no_profiles_legacy_byte_identical():
+    """No profiles configured → parent inherit exactly as before (model + fallback chain)."""
+    parent = _make_parent()
+    with _Harness({}) as h:
+        delegate_task(goal="Do the maintenance work carefully", parent_agent=parent)
+    assert h.built[0]["model"] == parent.model
+    assert h.built[0]["fallback_model"] == parent._fallback_chain
+
+
+def test_unknown_profile_fails_before_any_spawn():
+    cfg = {"profiles": PROFILES}
+    with _Harness(cfg) as h:
+        result = delegate_task(
+            tasks=[
+                {"goal": "Summarize the release notes for QA", "model_profile": "small"},
+                {"goal": "Design the storage migration plan", "model_profile": "nope"},
+            ],
+            parent_agent=_make_parent(),
+        )
+    assert "nope" in result
+    assert "small" in result  # actionable: configured names listed
+    assert h.built == []  # no AIAgent construction at all
+
+
+def test_supports_tools_false_profile_rejected_with_toolsets():
+    cfg = {"profiles": PROFILES}
+    caps = SimpleNamespace(supports_tools=False)
+    with _Harness(cfg, capabilities=caps) as h:
+        parent = _make_parent()
+        parent.enabled_toolsets = ["terminal", "file"]
+        result = delegate_task(
+            tasks=[{"goal": "Summarize the release notes for QA", "model_profile": "small"}],
+            parent_agent=parent,
+        )
+    assert "small" in result and "tool" in result.lower()
+    assert h.built == []

--- a/tests/tools/test_delegation_model_profiles.py
+++ b/tests/tools/test_delegation_model_profiles.py
@@ -194,3 +194,112 @@ def test_supports_tools_false_profile_rejected_with_toolsets():
         )
     assert "small" in result and "tool" in result.lower()
     assert h.built == []
+
+
+# ── T4: agent_routing gate — model_profile on the public schema ──────────────
+
+import json
+
+import pytest
+
+import tools.delegate_tool as dt
+from tools.delegate_tool import DELEGATE_TASK_SCHEMA
+
+FALSY_GATES = [False, None, "", 0]
+
+
+@pytest.mark.parametrize("gate", FALSY_GATES)
+def test_gate_off_schema_has_no_model_profile(gate):
+    cfg = {"profiles": PROFILES, "agent_routing": gate}
+    with patch("tools.delegate_tool._load_config", return_value=cfg):
+        overrides = dt._build_dynamic_schema_overrides()
+    assert "model_profile" not in json.dumps(overrides)
+    assert "model_profile" not in json.dumps(DELEGATE_TASK_SCHEMA)
+
+
+def test_gate_on_schema_exposes_profile_enum():
+    cfg = {"profiles": PROFILES, "agent_routing": True}
+    with patch("tools.delegate_tool._load_config", return_value=cfg):
+        overrides = dt._build_dynamic_schema_overrides()
+    props = overrides["parameters"]["properties"]
+    expected = sorted(PROFILES)
+    assert props["model_profile"]["enum"] == expected
+    assert props["tasks"]["items"]["properties"]["model_profile"]["enum"] == expected
+    desc = props["tasks"]["items"]["properties"]["model_profile"]["description"].lower()
+    for keyword in ("small", "expensive", "omit"):
+        assert keyword in desc, f"model_profile description lost: {keyword!r}"
+    # The static schema dict must never be mutated by the dynamic overrides.
+    assert "model_profile" not in json.dumps(DELEGATE_TASK_SCHEMA)
+
+
+def test_gate_on_without_profiles_stays_absent():
+    cfg = {"profiles": {}, "agent_routing": True}
+    with patch("tools.delegate_tool._load_config", return_value=cfg):
+        overrides = dt._build_dynamic_schema_overrides()
+    assert "model_profile" not in json.dumps(overrides)
+
+
+@pytest.mark.parametrize("gate", FALSY_GATES)
+def test_gate_off_handler_rejects_task_model_profile(gate):
+    cfg = {"profiles": PROFILES, "agent_routing": gate, "max_spawn_depth": 2}
+    with _Harness(cfg) as h:
+        result = dt._handle_model_call(
+            {"tasks": [{"goal": "Summarize the release notes", "model_profile": "small"}]},
+            parent_agent=_make_parent(depth=1),
+        )
+    assert "model_profile" in result
+    assert h.built == []
+
+
+@pytest.mark.parametrize("gate", FALSY_GATES)
+def test_gate_off_handler_rejects_top_level_model_profile(gate):
+    cfg = {"profiles": PROFILES, "agent_routing": gate, "max_spawn_depth": 2}
+    with _Harness(cfg) as h:
+        result = dt._handle_model_call(
+            {"tasks": [{"goal": "Summarize the release notes"}], "model_profile": "small"},
+            parent_agent=_make_parent(depth=1),
+        )
+    assert "model_profile" in result
+    assert h.built == []
+
+
+def test_gate_off_handler_without_model_profile_still_works():
+    cfg = {"profiles": PROFILES, "agent_routing": False, "max_spawn_depth": 2}
+    with _Harness(cfg) as h:
+        result = dt._handle_model_call(
+            {"tasks": [{"goal": "Summarize the release notes"}]},
+            parent_agent=_make_parent(depth=1),
+        )
+    assert "model_profile" not in result
+    assert len(h.built) == 1
+
+
+def test_gate_on_handler_routes_top_level_profile():
+    cfg = {"profiles": PROFILES, "agent_routing": True, "max_spawn_depth": 2}
+    with _Harness(cfg) as h:
+        dt._handle_model_call(
+            {"tasks": [{"goal": "Summarize the release notes"}], "model_profile": "big"},
+            parent_agent=_make_parent(depth=1),
+        )
+    assert h.built[0]["model"] == "prof/big-model"
+
+
+def test_gate_on_handler_routes_per_task_profile():
+    cfg = {"profiles": PROFILES, "agent_routing": True, "max_spawn_depth": 2}
+    with _Harness(cfg) as h:
+        dt._handle_model_call(
+            {"tasks": [{"goal": "Summarize the release notes", "model_profile": "small"}]},
+            parent_agent=_make_parent(depth=1),
+        )
+    assert h.built[0]["model"] == "prof/small-model"
+
+
+def test_gate_on_handler_unknown_profile_clean_error_no_spawn():
+    cfg = {"profiles": PROFILES, "agent_routing": True, "max_spawn_depth": 2}
+    with _Harness(cfg) as h:
+        result = dt._handle_model_call(
+            {"tasks": [{"goal": "Summarize the release notes", "model_profile": "bogus"}]},
+            parent_agent=_make_parent(depth=1),
+        )
+    assert "bogus" in result
+    assert h.built == []

--- a/tests/tools/test_delegation_model_profiles.py
+++ b/tests/tools/test_delegation_model_profiles.py
@@ -303,3 +303,30 @@ def test_gate_on_handler_unknown_profile_clean_error_no_spawn():
         )
     assert "bogus" in result
     assert h.built == []
+
+
+# ── request_overrides / max_output_tokens passthrough on the profile branch ──
+
+def test_profile_bundle_carries_runtime_overrides_and_explicit_config_overrides():
+    """FIX: _resolve_profile_credentials hardcoded request_overrides/max_output_tokens to None.
+    The profile branch must carry the runtime provider's request personality AND merge explicit
+    delegation.request_overrides, identically to the legacy provider branch."""
+    from tools.delegate_tool_config import _resolve_profile_credentials
+
+    def _runtime(requested=None, target_model=None, **_kw):
+        return {
+            "provider": requested, "base_url": "https://rt.example/v1", "api_key": "rt-key",
+            "api_mode": "chat_completions",
+            "request_overrides": {"extra_body": {"provider_flag": 1}},
+            "max_output_tokens": 4096,
+        }
+
+    cfg = {
+        "profiles": {"small": {"provider": "openrouter", "model": "prof/small-model"}},
+        "request_overrides": {"temperature": 0.1},
+    }
+    with patch("hermes_cli.runtime_provider.resolve_runtime_provider", side_effect=_runtime):
+        bundle = _resolve_profile_credentials("small", cfg)
+    assert bundle["max_output_tokens"] == 4096
+    assert bundle["request_overrides"]["temperature"] == 0.1          # explicit config override
+    assert bundle["request_overrides"]["extra_body"] == {"provider_flag": 1}  # runtime personality

--- a/tests/tools/test_delegation_profiles_e2e.py
+++ b/tests/tools/test_delegation_profiles_e2e.py
@@ -1,0 +1,269 @@
+"""Real-import E2E for delegation model profiles (T8).
+
+AGENTS.md: anything touching resolution chains or config propagation must exercise the
+real path with real imports against a temp HERMES_HOME — unit mocks hide integration bugs.
+
+These tests write an ACTUAL config.yaml into the sandboxed HERMES_HOME and drive the real
+runtime chain: config.yaml on disk → hermes_cli.config.load_config_readonly (via
+tools.delegate_tool_config._load_config) → the profile branch in
+_resolve_delegation_credentials → agent.delegation_model_routing.resolve_profile_route →
+hermes_cli.runtime_provider.resolve_runtime_provider → per-task routes in
+_resolve_task_credentials → _build_child_agent construction kwargs.
+
+The ONLY mocked seam is the AIAgent construction boundary (run_agent.AIAgent), captured to
+inspect the kwargs a child would be built with. Config loading, profile parsing, credential
+resolution and the schema gate all run for real against the on-disk file.
+
+Cache note: hermes_cli.config memoises merged config in _LOAD_CONFIG_CACHE keyed on the
+config file's (mtime_ns, size). Tests that rewrite config.yaml clear that cache explicitly
+(the public-enough module-level dict; same pattern as tests/tools/test_approval_config_readonly.py)
+so a rewrite is always observed regardless of filesystem mtime granularity.
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import hermes_cli.config as hc
+
+
+SMALL_MODEL = "prof/small-e2e"
+BIG_MODEL = "prof/big-e2e"
+BIG_FALLBACK = {"provider": "openrouter", "model": "prof/backup-e2e"}
+
+CONFIG_GATE_ON = f"""
+model:
+  default: test-model
+delegation:
+  agent_routing: true
+  default_profile: small
+  profiles:
+    small:
+      provider: openrouter
+      model: {SMALL_MODEL}
+      fallback: []
+    big:
+      provider: openrouter
+      model: {BIG_MODEL}
+      fallback:
+        - provider: {BIG_FALLBACK["provider"]}
+          model: {BIG_FALLBACK["model"]}
+"""
+
+CONFIG_GATE_OFF = CONFIG_GATE_ON.replace("agent_routing: true", "agent_routing: false")
+
+# 'temperature' is not a profile key (_PROFILE_KEYS is a closed set) — the config-check
+# lane must report it and the spawn path must refuse it cleanly.
+CONFIG_MALFORMED = """
+model:
+  default: test-model
+delegation:
+  agent_routing: true
+  profiles:
+    small:
+      provider: openrouter
+      model: prof/small-e2e
+      temperature: 0.2
+"""
+
+
+def _write_config(home, text):
+    """Write the REAL config.yaml and drop the merged-config memo so the next
+    load_config_readonly() re-reads the file even on coarse-mtime filesystems."""
+    (home / "config.yaml").write_text(text)
+    hc._LOAD_CONFIG_CACHE.clear()
+
+
+@pytest.fixture
+def real_home(tmp_path, monkeypatch):
+    """A temp HERMES_HOME holding a real config.yaml the production loaders read."""
+    home = tmp_path / "hermes-e2e-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    # _load_config()'s readonly branch is skipped entirely under this flag — the whole
+    # point of the suite is exercising it, so make sure it is off.
+    monkeypatch.delenv("HERMES_IGNORE_USER_CONFIG", raising=False)
+    # Real credential rung: the openrouter provider resolves from this env var through
+    # the genuine resolve_runtime_provider ladder (no network involved for api_key rungs).
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-e2e-test-key")
+    _write_config(home, CONFIG_GATE_ON)
+    yield home
+    hc._LOAD_CONFIG_CACHE.clear()
+
+
+def _make_parent(depth=0):
+    parent = MagicMock()
+    parent.base_url = "https://openrouter.ai/api/v1"
+    parent.api_key = "parent-key"
+    parent.provider = "openrouter"
+    parent.api_mode = "chat_completions"
+    parent.model = "anthropic/claude-sonnet-4"
+    parent.platform = "cli"
+    parent.session_id = "parent-e2e"
+    parent.providers_allowed = None
+    parent.providers_ignored = None
+    parent.providers_order = None
+    parent.provider_sort = None
+    parent._session_db = None
+    parent._delegate_depth = depth
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    parent._print_fn = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    parent._fallback_chain = [{"provider": "openrouter", "model": "parent-fallback"}]
+    return parent
+
+
+def _make_child():
+    child = MagicMock()
+    child.run_conversation.return_value = {
+        "final_response": "done", "completed": True, "api_calls": 1, "messages": [],
+    }
+    child._delegate_saved_tool_names = []
+    child._credential_pool = None
+    child.session_prompt_tokens = 0
+    child.session_completion_tokens = 0
+    child.model = "test"
+    return child
+
+
+class _CaptureAIAgent:
+    """Patch ONLY run_agent.AIAgent — the construction boundary. Everything upstream
+    (config load, profile parse, credential resolution, per-task routing) runs for real."""
+
+    def __init__(self):
+        self.built = []
+        self._patch = patch("run_agent.AIAgent", side_effect=self._factory)
+
+    def _factory(self, *args, **kwargs):
+        self.built.append(kwargs)
+        return _make_child()
+
+    def __enter__(self):
+        self._patch.start()
+        return self
+
+    def __exit__(self, *exc):
+        self._patch.stop()
+        return False
+
+
+# ── E2E-1: per-task mixed profiles + fallback isolation ─────────────────────
+
+def test_e2e_batch_mixes_profiles_from_real_config(real_home):
+    """Two tasks, two profiles, ONE real config.yaml: the captured construction kwargs
+    carry the two different profile models, real openrouter credentials from the env,
+    and per-profile fallback isolation (small's [] blocks the parent chain; big's chain
+    comes from the file, not the parent)."""
+    from tools.delegate_tool import _handle_model_call
+
+    parent = _make_parent()
+    with _CaptureAIAgent() as cap:
+        result = _handle_model_call(
+            {"tasks": [
+                {"goal": "Summarize the release notes for QA", "model_profile": "small"},
+                {"goal": "Design the storage migration plan", "model_profile": "big"},
+            ]},
+            parent_agent=parent, background=False,
+        )
+    assert "error" not in result.lower() or '"success": true' in result.lower(), result
+    assert [b["model"] for b in cap.built] == [SMALL_MODEL, BIG_MODEL]
+    assert all(b["api_key"] == "sk-or-e2e-test-key" for b in cap.built)
+    # Fallback isolation: small pins fallback [] → parent's chain must NOT leak in;
+    # big's chain is exactly the on-disk profile's, not the parent's.
+    assert not cap.built[0]["fallback_model"]
+    assert cap.built[1]["fallback_model"] == [BIG_FALLBACK]
+    assert parent._fallback_chain not in ([b["fallback_model"] for b in cap.built],)
+
+
+# ── E2E-2: default_profile from the real file ────────────────────────────────
+
+def test_e2e_default_profile_applies_from_real_config(real_home):
+    from tools.delegate_tool import _handle_model_call
+
+    with _CaptureAIAgent() as cap:
+        _handle_model_call(
+            {"tasks": [{"goal": "Do the maintenance work carefully"}]},
+            parent_agent=_make_parent(), background=False,
+        )
+    assert len(cap.built) == 1
+    assert cap.built[0]["model"] == SMALL_MODEL  # default_profile: small, from disk
+
+
+# ── E2E-3: gate on/off schema honesty against the on-disk file ───────────────
+
+def test_e2e_gate_flip_rewrites_schema_and_rejects_fabricated_arg(real_home):
+    """Gate ON (file as written): the dynamic schema advertises model_profile with the
+    real profile names. Flip the FILE to agent_routing: false and re-read through the
+    real loader: the schema must not mention model_profile at all, and a fabricated
+    model_profile arg is rejected with a clean tool_error before any construction."""
+    from tools.delegate_tool import _build_dynamic_schema_overrides, _handle_model_call
+
+    on = _build_dynamic_schema_overrides()["parameters"]["properties"]
+    assert on["model_profile"]["enum"] == ["big", "small"]
+    assert on["tasks"]["items"]["properties"]["model_profile"]["enum"] == ["big", "small"]
+
+    _write_config(real_home, CONFIG_GATE_OFF)
+
+    off = _build_dynamic_schema_overrides()["parameters"]["properties"]
+    assert "model_profile" not in off
+    assert "model_profile" not in off["tasks"]["items"]["properties"]
+
+    with _CaptureAIAgent() as cap:
+        result = _handle_model_call(
+            {"tasks": [{"goal": "Summarize the release notes", "model_profile": "small"}]},
+            parent_agent=_make_parent(), background=False,
+        )
+    assert "model_profile is not enabled" in result
+    assert cap.built == []  # rejected BEFORE any child construction
+
+
+# ── E2E-4: malformed profile — config-check lane + clean spawn refusal ────────
+
+def test_e2e_malformed_profile_reported_by_config_check_and_spawn(real_home):
+    _write_config(real_home, CONFIG_MALFORMED)
+
+    # hermes config check lane: the real validator over the real on-disk config.
+    from hermes_cli.config import load_config_readonly, validate_config_structure
+    issues = validate_config_structure(load_config_readonly())
+    messages = [str(getattr(i, "message", i)) for i in issues]
+    assert any("temperature" in m and "small" in m for m in messages), messages
+
+    # Spawn path: an unparseable profiles section hides the gate entirely
+    # (_routable_profile_names → None on parse failure), so a model-supplied profile is
+    # refused with the clean gate tool_error BEFORE any resolution or construction —
+    # the malformed file never reaches a child spawn.
+    from tools.delegate_tool import _handle_model_call
+    with _CaptureAIAgent() as cap:
+        result = _handle_model_call(
+            {"tasks": [{"goal": "Summarize the notes", "model_profile": "small"}]},
+            parent_agent=_make_parent(), background=False,
+        )
+    assert "model_profile is not enabled" in result
+    assert '"success": true' not in result.lower()
+    assert cap.built == []
+
+
+# ── E2E-5: lifecycle parity through the same on-disk config ──────────────────
+
+def test_e2e_lifecycle_launch_resolves_same_route_as_delegate_task(real_home, monkeypatch):
+    """SubagentLaunchRequest(model_profile='small') resolves through the SAME real
+    config.yaml + loader + resolver to the same model as E2E-1's small task."""
+    from agent.subagent_lifecycle import SubagentLaunchRequest, SubagentLifecycleService
+
+    # Keep the executor-side run inert; construction (the seam under test) is synchronous.
+    monkeypatch.setattr(
+        "tools.delegate_tool._run_child_lifecycle",
+        lambda *a, **k: {"status": "completed", "summary": "ok", "api_calls": 1, "duration_seconds": 0.0},
+    )
+    parent = _make_parent()
+    service = SubagentLifecycleService(lambda: parent)
+    with _CaptureAIAgent() as cap:
+        handle = service.launch(SubagentLaunchRequest(goal="parity check", model_profile="small"))
+    assert len(cap.built) == 1
+    assert cap.built[0]["model"] == SMALL_MODEL  # same route as E2E-1's small task
+    assert cap.built[0]["api_key"] == "sk-or-e2e-test-key"
+    assert not cap.built[0]["fallback_model"]  # small's fallback: [] honored here too
+    assert handle.requested_profile in ("small", None)  # provenance when stamped

--- a/tests/tools/test_delegation_profiles_e2e.py
+++ b/tests/tools/test_delegation_profiles_e2e.py
@@ -267,3 +267,37 @@ def test_e2e_lifecycle_launch_resolves_same_route_as_delegate_task(real_home, mo
     assert cap.built[0]["api_key"] == "sk-or-e2e-test-key"
     assert not cap.built[0]["fallback_model"]  # small's fallback: [] honored here too
     assert handle.requested_profile in ("small", None)  # provenance when stamped
+
+
+# ── E2E-6: unresolvable profile provider → clean tool_error, no child spawned ─
+
+CONFIG_ANTHROPIC_PROFILE = """
+model:
+  default: test-model
+delegation:
+  agent_routing: true
+  profiles:
+    small:
+      provider: anthropic
+      model: claude-haiku-e2e
+"""
+
+
+def test_e2e_unresolvable_provider_credentials_yield_clean_tool_error(real_home, monkeypatch):
+    """A profile pointing at a provider with no credentials must surface as a clean
+    tool_error string from _handle_model_call — never an escaped AuthError/RuntimeError —
+    exactly like the legacy delegation.provider branch."""
+    _write_config(real_home, CONFIG_ANTHROPIC_PROFILE)
+    for var in ("ANTHROPIC_API_KEY", "CLAUDE_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+    from tools.delegate_tool import _handle_model_call
+    with _CaptureAIAgent() as cap:
+        result = _handle_model_call(
+            {"tasks": [{"goal": "x", "model_profile": "small"}]},
+            parent_agent=_make_parent(), background=False,
+        )
+    assert isinstance(result, str)
+    assert "small" in result
+    assert '"success": true' not in result.lower()
+    assert cap.built == []  # refused before any child construction

--- a/tests/tools/test_delegation_profiles_e2e.py
+++ b/tests/tools/test_delegation_profiles_e2e.py
@@ -266,7 +266,7 @@ def test_e2e_lifecycle_launch_resolves_same_route_as_delegate_task(real_home, mo
     assert cap.built[0]["model"] == SMALL_MODEL  # same route as E2E-1's small task
     assert cap.built[0]["api_key"] == "sk-or-e2e-test-key"
     assert not cap.built[0]["fallback_model"]  # small's fallback: [] honored here too
-    assert handle.requested_profile in ("small", None)  # provenance when stamped
+    assert handle.requested_profile == "small"  # spawn-time provenance must be stamped
 
 
 # ── E2E-6: unresolvable profile provider → clean tool_error, no child spawned ─

--- a/tests/tools/test_delegation_route_telemetry.py
+++ b/tests/tools/test_delegation_route_telemetry.py
@@ -1,8 +1,9 @@
 """T6 — route provenance telemetry on result entries, progress payloads, and lifecycle handles.
 
-Contract: every result entry (and SubagentHandle) carries requested_profile / resolved_provider /
-resolved_model / fallback_policy. Legacy (profile-less) runs carry all four as None; profile runs
-carry the SPAWN-TIME route. The pre-existing "model" key stays the child's LIVE model, so
+Contract: profile-run result entries (and SubagentHandle) carry requested_profile /
+resolved_provider / resolved_model / fallback_policy. Legacy (profile-less) runs OMIT all four so
+their entries stay byte-identical to main; profile runs carry the SPAWN-TIME route. The
+pre-existing "model" key stays the child's LIVE model, so
 resolved_model != model is the requested-vs-effective divergence signal when a fallback fires.
 """
 
@@ -34,21 +35,19 @@ def _entry(child):
 
 ROUTE_KEYS = ("requested_profile", "resolved_provider", "resolved_model", "fallback_policy")
 
-# Today's legacy result-entry key set + the four provenance keys. Snapshot of the KEY SET only
-# (values are contract-tested elsewhere) so legacy payload shape stays byte-identical otherwise.
+# Today's legacy result-entry key set on main — EXACTLY this, no provenance keys. Snapshot of the
+# KEY SET only (values are contract-tested elsewhere) so legacy payload shape stays byte-identical.
 LEGACY_ENTRY_KEYS = {
     "task_index", "status", "summary", "api_calls", "duration_seconds", "model", "exit_reason",
     "truncated", "tokens", "tool_trace", "_child_role", "_child_cost_usd", "cost_usd", "cost_status",
-    *ROUTE_KEYS,
 }
 
 
 class TestResultEntryRouteTelemetry(unittest.TestCase):
-    def test_legacy_run_all_none_and_key_set_unchanged(self):
+    def test_legacy_run_omits_route_keys_and_key_set_matches_main(self):
         entry = _entry(_FakeChild())
         for key in ROUTE_KEYS:
-            self.assertIn(key, entry)
-            self.assertIsNone(entry[key])
+            self.assertNotIn(key, entry)
         self.assertEqual(set(entry.keys()), LEGACY_ENTRY_KEYS)
         self.assertEqual(entry["model"], "live-model")
 
@@ -82,9 +81,9 @@ class TestResultEntryRouteTelemetry(unittest.TestCase):
 
 
 class TestChildRouteStamp(unittest.TestCase):
-    def test_stamp_helper_none_for_unstamped_child(self):
+    def test_stamp_helper_empty_for_unstamped_child(self):
         from tools.delegate_tool_child_run import _route_telemetry
-        self.assertEqual(_route_telemetry(object()), {k: None for k in ROUTE_KEYS})
+        self.assertEqual(_route_telemetry(object()), {})
 
 
 class TestHandleRouteTelemetry(unittest.TestCase):

--- a/tests/tools/test_delegation_route_telemetry.py
+++ b/tests/tools/test_delegation_route_telemetry.py
@@ -1,0 +1,117 @@
+"""T6 — route provenance telemetry on result entries, progress payloads, and lifecycle handles.
+
+Contract: every result entry (and SubagentHandle) carries requested_profile / resolved_provider /
+resolved_model / fallback_policy. Legacy (profile-less) runs carry all four as None; profile runs
+carry the SPAWN-TIME route. The pre-existing "model" key stays the child's LIVE model, so
+resolved_model != model is the requested-vs-effective divergence signal when a fallback fires.
+"""
+
+import unittest
+
+from agent.subagent_lifecycle import PUBLIC_CONTRACT_VERSION, SubagentHandle
+from tools.delegate_tool_child_run import _SchemaOutcome, _build_result_entry
+
+
+class _FakeChild:
+    """Minimal child double; route attrs stamped per-test (None == unstamped/legacy)."""
+
+    _route_requested_profile: "str | None" = None
+    _route_resolved_provider: "str | None" = None
+    _route_resolved_model: "str | None" = None
+    _route_fallback_policy: "str | None" = None
+    model = "live-model"
+    _delegate_role = "leaf"
+    session_prompt_tokens = 10
+    session_completion_tokens = 5
+    session_estimated_cost_usd = 0.0
+    session_cost_status = "estimated"
+
+
+def _entry(child):
+    result = {"final_response": "done", "completed": True, "messages": []}
+    return _build_result_entry(child, result, 0, 1.5, _SchemaOutcome(None, None, [], 0))
+
+
+ROUTE_KEYS = ("requested_profile", "resolved_provider", "resolved_model", "fallback_policy")
+
+# Today's legacy result-entry key set + the four provenance keys. Snapshot of the KEY SET only
+# (values are contract-tested elsewhere) so legacy payload shape stays byte-identical otherwise.
+LEGACY_ENTRY_KEYS = {
+    "task_index", "status", "summary", "api_calls", "duration_seconds", "model", "exit_reason",
+    "truncated", "tokens", "tool_trace", "_child_role", "_child_cost_usd", "cost_usd", "cost_status",
+    *ROUTE_KEYS,
+}
+
+
+class TestResultEntryRouteTelemetry(unittest.TestCase):
+    def test_legacy_run_all_none_and_key_set_unchanged(self):
+        entry = _entry(_FakeChild())
+        for key in ROUTE_KEYS:
+            self.assertIn(key, entry)
+            self.assertIsNone(entry[key])
+        self.assertEqual(set(entry.keys()), LEGACY_ENTRY_KEYS)
+        self.assertEqual(entry["model"], "live-model")
+
+    def test_profile_run_carries_all_four_and_model(self):
+        child = _FakeChild()
+        child._route_requested_profile = "fast"
+        child._route_resolved_provider = "openrouter"
+        child._route_resolved_model = "live-model"
+        child._route_fallback_policy = "none"
+        entry = _entry(child)
+        self.assertEqual(entry["requested_profile"], "fast")
+        self.assertEqual(entry["resolved_provider"], "openrouter")
+        self.assertEqual(entry["resolved_model"], "live-model")
+        self.assertEqual(entry["fallback_policy"], "none")
+        self.assertEqual(entry["model"], "live-model")
+
+    def test_fallback_divergence_survives_verbatim(self):
+        """resolved_model is the spawn-time route; "model" is the child's live model. When a
+        fallback fires mid-run they diverge — both must survive verbatim as the signal."""
+        child = _FakeChild()
+        child.model = "fallback/effective-model"
+        child._route_requested_profile = "fast"
+        child._route_resolved_provider = "openrouter"
+        child._route_resolved_model = "primary/spawn-model"
+        child._route_fallback_policy = "profile:fast"
+        entry = _entry(child)
+        self.assertEqual(entry["resolved_model"], "primary/spawn-model")
+        self.assertEqual(entry["model"], "fallback/effective-model")
+        self.assertNotEqual(entry["model"], entry["resolved_model"])
+        self.assertEqual(entry["fallback_policy"], "profile:fast")
+
+
+class TestChildRouteStamp(unittest.TestCase):
+    def test_stamp_helper_none_for_unstamped_child(self):
+        from tools.delegate_tool_child_run import _route_telemetry
+        self.assertEqual(_route_telemetry(object()), {k: None for k in ROUTE_KEYS})
+
+
+class TestHandleRouteTelemetry(unittest.TestCase):
+    def _base(self):
+        return {
+            "contract_version": PUBLIC_CONTRACT_VERSION, "subagent_id": "sa-1", "parent_session_id": "p",
+            "correlation_id": None, "created_at": 1.0, "provider": "openai", "model": "gpt-x",
+            "role": "leaf", "depth": 1, "capability": "cap",
+        }
+
+    def test_from_dict_without_new_keys_defaults_none(self):
+        handle = SubagentHandle.from_dict(self._base())
+        for key in ROUTE_KEYS:
+            self.assertIsNone(getattr(handle, key))
+
+    def test_from_dict_round_trip_with_new_keys(self):
+        payload = {
+            **self._base(), "requested_profile": "fast", "resolved_provider": "openrouter",
+            "resolved_model": "m1", "fallback_policy": "profile:fast",
+        }
+        handle = SubagentHandle.from_dict(payload)
+        self.assertEqual(handle.requested_profile, "fast")
+        self.assertEqual(handle.resolved_provider, "openrouter")
+        self.assertEqual(handle.resolved_model, "m1")
+        self.assertEqual(handle.fallback_policy, "profile:fast")
+        self.assertEqual(SubagentHandle.from_dict(handle.to_dict()), handle)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -25,7 +25,8 @@ logger = logging.getLogger(__name__)
 # ``tools.delegate_tool.<name>`` is re-imported here. Mutable flag globals live only in their owning module.
 from tools.delegate_tool_child_run import (  # noqa: F401
     _ChildRun, _attach_child, _build_result_entry, _dump_subagent_timeout_diagnostic, _fabricated_entry,
-    _lease_child_credential, _merge_late_steer, _register_child, _start_heartbeat, _validate_child_output_schema,
+    _lease_child_credential, _merge_late_steer, _register_child, _route_telemetry, _start_heartbeat,
+    _validate_child_output_schema,
 )
 from tools.delegate_tool_config import (  # noqa: F401
     _DEFAULT_MAX_CONCURRENT_CHILDREN, _get_child_timeout, _get_max_async_children, _get_max_concurrent_children,
@@ -219,6 +220,17 @@ def _build_child_agent(
     child._progress_identity_ref = child_session_ref
     child._delegate_depth, child._delegate_role = child_depth, effective_role  # post-degrade role
     child._subagent_id, child._parent_subagent_id = subagent_id, parent_subagent_id
+    # Spawn-time route provenance (telemetry only; never consulted for routing). Legacy profile-less
+    # children get no stamp so every reader reports all four as None. resolved_model is frozen HERE —
+    # the child's live ``model`` may later diverge when a fallback fires, and that divergence between
+    # the entry's "resolved_model" and "model" keys IS the requested-vs-effective signal.
+    if requested_profile:
+        setattr(child, "_route_requested_profile", requested_profile)
+        setattr(child, "_route_resolved_provider", override_provider)
+        setattr(child, "_route_resolved_model", model)
+        # 'none' = profile route with an empty fallback chain (no model promotion);
+        # 'profile:<name>' = profile route whose own fallback chain replaces the parent's.
+        setattr(child, "_route_fallback_policy", f"profile:{requested_profile}" if override_fallback_model else "none")
     # Ownership chain for action=list/steer/stop; weakref so a finished parent
     # can be collected while a detached child record lingers in the registry.
     try:
@@ -237,7 +249,7 @@ def _build_child_agent(
     _attach_child(parent_agent, child)  # interrupt propagation
     # spawn_requested now — the child may queue for seconds when the pool is
     # saturated — then the subagent_start lifecycle hook.
-    _safe_progress(child_progress_cb, "subagent.spawn_requested", preview=goal)
+    _safe_progress(child_progress_cb, "subagent.spawn_requested", preview=goal, **_route_telemetry(child))
     with _quiet("subagent_start hook invocation failed", exc_info=True):
         from hermes_cli.lifecycle import invoke_hook as _invoke_hook
         _invoke_hook(
@@ -282,7 +294,7 @@ def _run_single_child(
     _child_close_deferred = False
     try:
         heartbeat.start()
-        _safe_progress(child_progress_cb, "subagent.start", preview=goal)
+        _safe_progress(child_progress_cb, "subagent.start", preview=goal, **_route_telemetry(child))
         run.seed_workspace()
         result, failure_entry, _child_close_deferred = run.await_child()
         if failure_entry is not None:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -566,13 +566,49 @@ def _build_tasks_param_description() -> str:
 
 def _build_dynamic_schema_overrides() -> dict:
     """Per-call schema overrides (ToolEntry.dynamic_schema_overrides): every
-    get_definitions() pass rewrites the descriptions to the user's actual limits."""
+    get_definitions() pass rewrites the descriptions to the user's actual limits, and
+    the delegation.agent_routing gate adds/removes the model_profile enum."""
     overrides_params = {**DELEGATE_TASK_SCHEMA["parameters"]}
     # Copy properties so the static schema dict is never mutated.
     overrides_params["properties"] = {k: dict(v) for k, v in DELEGATE_TASK_SCHEMA["parameters"]["properties"].items()}
     overrides_params["properties"]["tasks"]["description"] = _build_tasks_param_description()
 
+    # Phase 2 gate (delegation.agent_routing, default off): expose model_profile — the operator's
+    # named tiers — per task and batch-wide. Gate off (or no profiles) → schema byte-identical.
+    profile_names = _routable_profile_names()
+    if profile_names is not None:
+        tasks_prop = overrides_params["properties"]["tasks"]
+        items = {**tasks_prop["items"]}
+        items["properties"] = {**items["properties"], "model_profile": _model_profile_property(profile_names)}
+        overrides_params["properties"]["tasks"] = {**tasks_prop, "items": items}
+        overrides_params["properties"]["model_profile"] = _model_profile_property(profile_names, batch_wide=True)
+
     return {"description": _build_top_level_description(), "parameters": overrides_params}
+
+def _routable_profile_names() -> Optional[List[str]]:
+    """Sorted profile names when delegation.agent_routing is truthy AND profiles are configured and
+    parseable, else None (gate off → the public schema must not mention model_profile at all)."""
+    try:
+        cfg = _load_config()
+        if not is_truthy_value(cfg.get("agent_routing")):
+            return None
+        from agent.delegation_model_routing import parse_profiles
+        names = sorted(parse_profiles(cfg))
+        return names or None
+    except Exception as exc:
+        logger.debug("agent_routing: profiles unavailable, hiding model_profile: %s", exc)
+        return None
+
+def _model_profile_property(profile_names: List[str], batch_wide: bool = False) -> dict:
+    scope = "every task in this call (per-task model_profile wins)" if batch_wide else "this task"
+    return _p(
+        "string",
+        f"Model tier for {scope}, from the operator-configured delegation profiles. Use the profile the "
+        "caller requested when one is stated. Otherwise select a small/cheap profile for bounded, "
+        "well-specified work; never pick a more expensive profile without a task-specific reason. "
+        "Omit to use the default profile.",
+        enum=list(profile_names),
+    )
 
 def _p(type_: str, description: str, **extra) -> dict:
     return {"type": type_, **extra, "description": description}
@@ -664,18 +700,42 @@ def _strip_model_hidden_task_fields(tasks: Any) -> Any:
         return tasks
     return [{k: v for k, v in t.items() if k not in _MODEL_HIDDEN_TASK_FIELDS} if isinstance(t, dict) else t for t in tasks]
 
+def _handle_model_call(args: dict, parent_agent=None, background: Optional[bool] = None) -> str:
+    """Single MODEL-facing entry (registry handler and run_agent._dispatch_delegate_task): strips hidden
+    task fields and enforces the delegation.agent_routing gate — when the gate is off, a model-supplied
+    model_profile (task-level or top-level) is rejected with a clean tool_error BEFORE any resolution or
+    child construction (defense in depth: the gated schema never advertises it, but schema honesty must
+    hold even against a fabricated arg)."""
+    tasks = _strip_model_hidden_task_fields(args.get("tasks"))
+    model_profile = args.get("model_profile")
+    if _routable_profile_names() is None:
+        requested = [model_profile] if model_profile else []
+        requested += [
+            t.get("model_profile") for t in (tasks if isinstance(tasks, list) else []) if isinstance(t, dict)
+        ]
+        if any(requested):
+            return tool_error(
+                "model_profile is not enabled: delegation.agent_routing is off (or no delegation.profiles "
+                "are configured). Remove model_profile from the call, or have the operator enable "
+                "delegation.agent_routing in config.yaml."
+            )
+        model_profile = None
+    if background is None:
+        background = _model_background_value(args, parent_agent)
+    return delegate_task(
+        goal=args.get("goal"), context=args.get("context"), tasks=tasks,
+        max_iterations=args.get("max_iterations"), role=args.get("role"),
+        background=background, output_schema=args.get("output_schema"),
+        action=args.get("action"), subagent_id=args.get("subagent_id"), message=args.get("message"),
+        parent_agent=parent_agent, model_profile=model_profile,
+    )
+
 
 registry.register(
     name="delegate_task",
     toolset="delegation",
     schema=DELEGATE_TASK_SCHEMA,
-    handler=lambda args, **kw: delegate_task(
-        goal=args.get("goal"), context=args.get("context"), tasks=_strip_model_hidden_task_fields(args.get("tasks")),
-        max_iterations=args.get("max_iterations"), role=args.get("role"),
-        background=_model_background_value(args, kw.get("parent_agent")), output_schema=args.get("output_schema"),
-        action=args.get("action"), subagent_id=args.get("subagent_id"), message=args.get("message"),
-        parent_agent=kw.get("parent_agent"),
-    ),
+    handler=lambda args, **kw: _handle_model_call(args, parent_agent=kw.get("parent_agent")),
     check_fn=check_delegate_requirements,
     emoji="🔀",
     dynamic_schema_overrides=_build_dynamic_schema_overrides,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -121,6 +121,13 @@ def _build_child_agent(
     # ACP transport overrides from trusted delegation config.
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
+    # Profile-route overrides (delegation.profiles): a resolved profile's fallback chain
+    # (list, possibly empty = no model promotion) and reasoning level. None = legacy behavior.
+    override_fallback_model: Optional[List[Dict[str, Any]]] = None,
+    override_reasoning_config: Optional[Dict[str, Any]] = None,
+    # supports_tools from the profile route (None = legacy, no check) + the profile name for the error.
+    override_supports_tools: Optional[bool] = None,
+    requested_profile: Optional[str] = None,
     # Legacy; accepted for wire compat but ignored (capability is depth-derived).
     role: str = "leaf",
 ):
@@ -142,6 +149,14 @@ def _build_child_agent(
 
     delegation_cfg = _load_config()
     child_toolsets, child_disabled_toolsets = _resolve_child_toolsets(parent_agent, toolsets, effective_role)
+    # A profile pinned to a model without tool calling cannot run a tool-bearing child — refuse before
+    # AIAgent construction (text_only tool-less mode is rejected scope; see the plan doc).
+    if override_supports_tools is False and child_toolsets:
+        raise ValueError(
+            f"Delegation profile '{requested_profile}' pins a model that does not support tool calling, "
+            f"but the child would run with toolsets {sorted(child_toolsets)}. Pick a tool-capable profile "
+            f"or remove the profile from this task."
+        )
     child_prompt = _build_child_system_prompt(
         goal, context, workspace_path=_resolve_workspace_hint(parent_agent), role=effective_role,
         max_spawn_depth=max_spawn, child_depth=child_depth,
@@ -162,7 +177,8 @@ def _build_child_agent(
         parent_agent, delegation_cfg, parent_api_key, model=model, override_provider=override_provider,
         override_base_url=override_base_url, override_api_key=override_api_key, override_api_mode=override_api_mode,
         override_max_tokens=override_max_tokens, override_acp_command=override_acp_command,
-        override_acp_args=override_acp_args,
+        override_acp_args=override_acp_args, override_fallback_model=override_fallback_model,
+        override_reasoning_config=override_reasoning_config,
     )
     if override_request_overrides is not None:
         # honored whenever set, incl. the inherit branch where
@@ -297,23 +313,67 @@ def _run_single_child(
         run.cleanup(heartbeat=heartbeat, child_pool=child_pool, leased_cred_id=leased_cred_id, close_deferred=_child_close_deferred)
 
 
+def _profile_task_overrides(c: Dict[str, Any]) -> Dict[str, Any]:
+    """override_* kwargs for one task's credential bundle. Profile-only keys are added ONLY when the bundle
+    came from a profile route, so legacy calls into _build_child_agent stay byte-identical (kwargs included)."""
+    overrides = {
+        "override_provider": c["provider"], "override_base_url": c["base_url"],
+        "override_api_key": c["api_key"], "override_api_mode": c["api_mode"],
+        "override_request_overrides": c.get("request_overrides"),
+        "override_max_tokens": c.get("max_output_tokens"), "override_acp_command": c.get("command"),
+        "override_acp_args": c.get("args"),
+    }
+    if c.get("requested_profile"):
+        overrides.update({
+            "override_fallback_model": c.get("fallback_model"),
+            "override_reasoning_config": c.get("reasoning_config"),
+            "override_supports_tools": c.get("supports_tools"),
+            "requested_profile": c.get("requested_profile"),
+        })
+    return overrides
+
+
+def _resolve_task_credentials(
+    task_list: List[Dict[str, Any]], creds: Dict[str, Any], routing_cfg: dict, parent_agent,
+    top_model_profile: Optional[str] = None,
+) -> tuple[List[Dict[str, Any]], Optional[str]]:
+    """Per-task credential bundles (profile precedence: per-task > top-level > default_profile, resolved via
+    agent.delegation_model_routing), or ``([], error)``. Every route resolves BEFORE any child is built so an
+    unknown profile anywhere in the batch fails with zero spawns. Tasks without a profile reuse the batch
+    bundle unchanged (legacy path)."""
+    from agent.delegation_model_routing import select_profile_name
+    from tools.delegate_tool_config import _resolve_profile_credentials
+    per_task: List[Dict[str, Any]] = []
+    for t in task_list:
+        name = select_profile_name(t.get("model_profile"), top_model_profile, routing_cfg)
+        if not name or name == creds.get("requested_profile"):
+            per_task.append(creds)
+            continue
+        try:
+            per_task.append(_resolve_profile_credentials(name, routing_cfg))
+        except ValueError as exc:
+            return [], str(exc)
+    return per_task, None
+
+
 def _build_children(
     task_list: List[Dict[str, Any]], task_schemas: List[Optional[Dict[str, Any]]], creds: Dict[str, Any], *,
     top_role: str, max_iterations: int, parent_agent, live_deleg_id: Optional[str], live_writers: list,
+    task_creds: Optional[List[Dict[str, Any]]] = None,
 ) -> tuple[List[tuple], Optional[str]]:
     """Build every child on the main thread (construction is not thread-safe);
     ``(children, None)`` or ``([], error)`` on an explicit-pin preflight failure."""
     from tools.delegation_live_log import wrap_progress_callback
     from tools.delegation_output_schema import append_output_contract
-    overrides = {
-        "override_provider": creds["provider"], "override_base_url": creds["base_url"],
-        "override_api_key": creds["api_key"], "override_api_mode": creds["api_mode"],
-        "override_request_overrides": creds.get("request_overrides"),
-        "override_max_tokens": creds.get("max_output_tokens"), "override_acp_command": creds.get("command"),
-        "override_acp_args": creds.get("args"),
-    }
     children = []
     for i, t in enumerate(task_list):
+        _creds = task_creds[i] if task_creds and i < len(task_creds) else creds
+        overrides = _profile_task_overrides(_creds)
+        # A profile's max_iterations can only TIGHTEN the config budget, never widen it (#25752 layering).
+        _profile_max_iter = _creds.get("max_iterations") if _creds.get("requested_profile") else None
+        _task_max_iterations = (
+            min(int(_profile_max_iter), max_iterations) if isinstance(_profile_max_iter, int) else max_iterations
+        )
         _task_schema = task_schemas[i] if i < len(task_schemas) else None
         _child_context = t.get("context")
         if _task_schema is not None:
@@ -322,7 +382,7 @@ def _build_children(
             child = _build_child_preserving_parent_tools(
                 task_index=i, goal=t["goal"], context=_child_context,
                 toolsets=None,  # always inherit the parent's toolsets
-                model=creds["model"], max_iterations=max_iterations, task_count=len(task_list),
+                model=_creds["model"], max_iterations=_task_max_iterations, task_count=len(task_list),
                 parent_agent=parent_agent, role=_normalize_role(t.get("role") or top_role), **overrides,
             )
         except ValueError as exc:
@@ -350,6 +410,7 @@ def delegate_task(
     max_iterations: Optional[int] = None, role: Optional[str] = None, background: Optional[bool] = None,
     output_schema: Optional[Dict[str, Any]] = None, action: Optional[str] = None, subagent_id: Optional[str] = None,
     message: Optional[str] = None, parent_agent=None, credentials_cfg: Optional[Dict[str, Any]] = None,
+    model_profile: Optional[str] = None,
 ) -> str:
     """Spawn child agents (single ``goal`` or ``tasks=[...]`` batch) or control running ones. ``action``
     list/steer/stop run synchronously and bypass the pause gate, depth limit and async dispatch. ``role`` is legacy
@@ -396,8 +457,9 @@ def delegate_task(
         )
     # credentials_cfg (internal callers only, e.g. /review → auxiliary.review) is
     # a per-call override shaped like the delegation config section.
+    routing_cfg = credentials_cfg if credentials_cfg else cfg
     try:
-        creds = _resolve_delegation_credentials(credentials_cfg if credentials_cfg else cfg, parent_agent)
+        creds = _resolve_delegation_credentials(routing_cfg, parent_agent, model_profile=model_profile)
     except ValueError as exc:
         # Explicit-pin preflight failures (e.g. pinned delegation.command missing from PATH) refuse the
         # spawn loudly (#80450).
@@ -406,6 +468,14 @@ def delegate_task(
     task_list, err = _normalize_task_list(goal, context, tasks, output_schema, top_role, max_children)
     if not err:
         task_schemas, err = _coerce_task_schemas(task_list, output_schema)
+    if err:
+        return tool_error(err)
+    # Per-task profile routing (delegation.profiles): every task's route resolves BEFORE any child is
+    # built so a batch can mix profiles and an unknown name anywhere fails with zero spawns. Tasks
+    # without a profile keep the batch bundle (legacy, byte-identical when no profiles configured).
+    task_creds, err = _resolve_task_credentials(
+        task_list, creds, routing_cfg, parent_agent, top_model_profile=model_profile,
+    )
     if err:
         return tool_error(err)
 
@@ -421,7 +491,7 @@ def delegate_task(
 
     children, err = _build_children(
         task_list, task_schemas, creds, top_role=top_role, max_iterations=default_max_iter, parent_agent=parent_agent,
-        live_deleg_id=live_deleg_id, live_writers=live_writers,
+        live_deleg_id=live_deleg_id, live_writers=live_writers, task_creds=task_creds,
     )
     if err:
         return tool_error(err)

--- a/tools/delegate_tool_child_run.py
+++ b/tools/delegate_tool_child_run.py
@@ -31,10 +31,14 @@ def _str_or_none(value: Any) -> Optional[str]:
     return value if isinstance(value, str) else None
 
 def _route_telemetry(child: Any) -> Dict[str, Any]:
-    """Route provenance stamped at spawn time (see _build_child_preserving_parent_tools). All four are None for
-    legacy (profile-less) children. NOTE: ``resolved_model`` is the SPAWN-TIME route model, while the sibling
-    ``model`` key stays the child's LIVE model — divergence between the two IS the requested-vs-effective signal
-    when a fallback fires mid-run, so both must survive verbatim."""
+    """Route provenance stamped at spawn time (see _build_child_preserving_parent_tools). Legacy
+    (profile-less) children carry no stamp and get an EMPTY dict, so their result entries stay
+    byte-identical to main (no null provenance keys). NOTE: ``resolved_model`` is the SPAWN-TIME
+    route model, while the sibling ``model`` key stays the child's LIVE model — divergence between
+    the two IS the requested-vs-effective signal when a fallback fires, so both must survive
+    verbatim."""
+    if _str_or_none(getattr(child, "_route_requested_profile", None)) is None:
+        return {}
     return {
         "requested_profile": _str_or_none(getattr(child, "_route_requested_profile", None)),
         "resolved_provider": _str_or_none(getattr(child, "_route_resolved_provider", None)),

--- a/tools/delegate_tool_child_run.py
+++ b/tools/delegate_tool_child_run.py
@@ -30,11 +30,24 @@ def _num(value: Any, default: int = 0) -> int:
 def _str_or_none(value: Any) -> Optional[str]:
     return value if isinstance(value, str) else None
 
+def _route_telemetry(child: Any) -> Dict[str, Any]:
+    """Route provenance stamped at spawn time (see _build_child_preserving_parent_tools). All four are None for
+    legacy (profile-less) children. NOTE: ``resolved_model`` is the SPAWN-TIME route model, while the sibling
+    ``model`` key stays the child's LIVE model — divergence between the two IS the requested-vs-effective signal
+    when a fallback fires mid-run, so both must survive verbatim."""
+    return {
+        "requested_profile": _str_or_none(getattr(child, "_route_requested_profile", None)),
+        "resolved_provider": _str_or_none(getattr(child, "_route_resolved_provider", None)),
+        "resolved_model": _str_or_none(getattr(child, "_route_resolved_model", None)),
+        "fallback_policy": _str_or_none(getattr(child, "_route_fallback_policy", None)),
+    }
+
 def _fabricated_entry(idx: int, status: str, error: str, child: Any, duration: float = 0) -> Dict[str, Any]:
     """Result entry for a child that raised, never finished, or was abandoned."""
     return {
         "task_index": idx, "status": status, "summary": None, "error": error, "api_calls": 0,
         "duration_seconds": duration, "_child_role": getattr(child, "_delegate_role", None),
+        **_route_telemetry(child),
     }
 
 def _append_missed_steer(entry: Dict[str, Any], late_steer: Optional[str]) -> None:
@@ -494,6 +507,8 @@ def _build_result_entry(
         "duration_seconds": duration,
         "model": _str_or_none(getattr(child, "model", None)),
         "exit_reason": exit_reason,
+        # Spawn-time route provenance; "model" above is the LIVE model so the pair signals fallback divergence.
+        **_route_telemetry(child),
         # A budget-exhausted child still returns a summary (status stays
         # "completed"), so the parent needs this explicit flag.
         "truncated": exit_reason == "max_iterations",
@@ -620,7 +635,7 @@ class _ChildRun:
         the steer text that won the race with the failure, report the worktree."""
         _safe_progress(
             self.child_progress_cb, "subagent.complete", preview=preview, status=status or entry["status"],
-            duration_seconds=entry["duration_seconds"], summary=summary,
+            duration_seconds=entry["duration_seconds"], summary=summary, **_route_telemetry(self.child),
         )
         _append_missed_steer(entry, late_steer)
         return self.attach_worktree(entry)
@@ -713,6 +728,7 @@ class _ChildRun:
             "timeout_phase": "before_first_llm_call" if before_first_call else "after_llm_calls" if is_timeout else None,
             "_child_role": getattr(child, "_delegate_role", None),
             "diagnostic_path": diagnostic_path,
+            **_route_telemetry(child),
         }
         self.finish_failed(_error_entry, _late_pending_steer, preview=f"Timed out after {duration}s" if is_timeout else str(exc))
         close_deferred = is_timeout and not future.done()
@@ -766,6 +782,8 @@ class _ChildRun:
             "files_read": _files_read,
             "files_written": sorted({p for tid, paths in _files_written_map.items() if tid == self.child_task_id for p in paths})[:40],
             "output_tail": _extract_output_tail(result, max_entries=8, max_chars=600),
+            # Spawn-time route provenance (all None for legacy profile-less runs).
+            **_route_telemetry(child),
         }
         _cost_usd = getattr(child, "session_estimated_cost_usd", None)
         if _cost_usd is not None:

--- a/tools/delegate_tool_config.py
+++ b/tools/delegate_tool_config.py
@@ -364,8 +364,14 @@ def _resolve_profile_credentials(profile_name: str, cfg: dict) -> dict:
     (actionable, configured names listed) for an unknown profile — before any child construction."""
     from agent.delegation_model_routing import resolve_profile_route
     route = resolve_profile_route(profile_name, cfg)
+    # request_overrides / max_output_tokens carry through identically to the legacy provider branch:
+    # provider request personality from the runtime resolution, merged with explicit
+    # delegation.request_overrides from config.
+    explicit_request_overrides = cfg.get("request_overrides") if isinstance(cfg.get("request_overrides"), dict) else None
     bundle = _credential_bundle(
-        route.model, route.provider, route.base_url, route.api_key, route.api_mode, None, None,
+        route.model, route.provider, route.base_url, route.api_key, route.api_mode,
+        _merge_request_overrides(route.request_overrides, explicit_request_overrides),
+        route.max_output_tokens,
     )
     bundle.update({
         "requested_profile": route.requested_profile,
@@ -385,7 +391,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent, model_profile: Opti
     existed: ``base_url`` set → direct endpoint (``api_key`` None means inherit the parent's key, so providers
     keyed outside OPENAI_API_KEY work); ``provider`` set → full bundle via the runtime provider system (same
     path as CLI/gateway startup); neither → None values, child inherits everything. ``request_overrides`` is
-    honored on every legacy branch. Raises ValueError with a user-facing message."""
+    honored on every branch. Raises ValueError with a user-facing message."""
     from agent.delegation_model_routing import select_profile_name
     profile_name = select_profile_name(model_profile, None, cfg)
     if profile_name:

--- a/tools/delegate_tool_config.py
+++ b/tools/delegate_tool_config.py
@@ -357,12 +357,39 @@ def _runtime_provider_credentials(v: dict, explicit_request_overrides) -> dict:
         runtime.get("max_output_tokens"), command=pinned_command, args=list(runtime.get("args") or []),
     )
 
-def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
-    """Child credential bundle from the ``delegation`` config section. Three branches: ``base_url`` set → direct
-    endpoint (``api_key`` None means inherit the parent's key, so providers keyed outside OPENAI_API_KEY work);
-    ``provider`` set → full bundle via the runtime provider system (same path as CLI/gateway startup); neither →
-    None values, child inherits everything. ``request_overrides`` is honored on every branch. Raises ValueError
-    with a user-facing message."""
+def _resolve_profile_credentials(profile_name: str, cfg: dict) -> dict:
+    """Credential bundle for a ``delegation.profiles`` route: the standard ``_credential_bundle`` shape plus the
+    profile-only keys (``requested_profile``, ``fallback_model`` as a list of {provider, model} dicts in the
+    ``_fallback_entries`` format, ``reasoning_config``, ``max_iterations``, ``supports_tools``). Raises ValueError
+    (actionable, configured names listed) for an unknown profile — before any child construction."""
+    from agent.delegation_model_routing import resolve_profile_route
+    route = resolve_profile_route(profile_name, cfg)
+    bundle = _credential_bundle(
+        route.model, route.provider, route.base_url, route.api_key, route.api_mode, None, None,
+    )
+    bundle.update({
+        "requested_profile": route.requested_profile,
+        # Profile fallback REPLACES the parent's chain ([] = no model promotion); dict shape matches
+        # agent.agent_init._fallback_entries so it feeds AIAgent(fallback_model=...) directly.
+        "fallback_model": [{"provider": f.provider, "model": f.model} for f in route.fallback],
+        "reasoning_config": route.reasoning_config,
+        "max_iterations": route.max_iterations,
+        "supports_tools": route.supports_tools,
+    })
+    return bundle
+
+def _resolve_delegation_credentials(cfg: dict, parent_agent, model_profile: Optional[str] = None) -> dict:
+    """Child credential bundle from the ``delegation`` config section. A selected profile (explicit
+    ``model_profile`` > ``delegation.default_profile``) resolves ABOVE the legacy branches via
+    ``agent.delegation_model_routing``; otherwise three legacy branches, byte-identical to before profiles
+    existed: ``base_url`` set → direct endpoint (``api_key`` None means inherit the parent's key, so providers
+    keyed outside OPENAI_API_KEY work); ``provider`` set → full bundle via the runtime provider system (same
+    path as CLI/gateway startup); neither → None values, child inherits everything. ``request_overrides`` is
+    honored on every legacy branch. Raises ValueError with a user-facing message."""
+    from agent.delegation_model_routing import select_profile_name
+    profile_name = select_profile_name(model_profile, None, cfg)
+    if profile_name:
+        return _resolve_profile_credentials(profile_name, cfg)
     values = {k: str(cfg.get(k) or "").strip() or None for k in ("model", "provider", "base_url", "api_key")}
     values["api_mode"] = str(cfg.get("api_mode") or "").strip().lower() or None
     explicit_request_overrides = cfg.get("request_overrides") if isinstance(cfg.get("request_overrides"), dict) else None
@@ -412,6 +439,7 @@ def _resolve_child_runtime(
     parent_agent, delegation_cfg: dict, parent_api_key: Any, *, model: Optional[str], override_provider: Optional[str],
     override_base_url: Optional[str], override_api_key: Optional[str], override_api_mode: Optional[str],
     override_max_tokens: Optional[int], override_acp_command: Optional[str], override_acp_args: Optional[List[str]],
+    override_fallback_model: Optional[List[Dict[str, Any]]] = None, override_reasoning_config: Optional[dict] = None,
 ) -> Dict[str, Any]:
     """Child credentials, transport and routing (config override > parent inherit) as ``AIAgent`` kwargs. Rules that
     are easy to break: api_mode is re-derived (not inherited) when the child's provider differs from the parent's
@@ -464,7 +492,7 @@ def _resolve_child_runtime(
         # Forced ACP transport requires provider copilot-acp for run_agent to init the client.
         effective_provider, effective_api_mode = "copilot-acp", "chat_completions"
 
-    # Reasoning: delegation.reasoning_effort > parent. Keep the raw value — a
+    # Reasoning: profile route > delegation.reasoning_effort > parent. Keep the raw value — a
     # YAML ``false`` must disable thinking, not coerce to "" and inherit.
     child_reasoning = getattr(parent_agent, "reasoning_config", None)
     try:
@@ -478,6 +506,8 @@ def _resolve_child_runtime(
                 child_reasoning = parsed
     except Exception as exc:
         logger.debug("Could not load delegation reasoning_effort: %s", exc)
+    if override_reasoning_config is not None:
+        child_reasoning = override_reasoning_config
 
     kwargs: Dict[str, Any] = {
         "base_url": effective_base_url, "api_key": override_api_key or parent_api_key, "model": effective_model,
@@ -487,7 +517,11 @@ def _resolve_child_runtime(
         "reasoning_config": child_reasoning,
         # Inherit the parent's fallback chain EXCEPT under a pinned provider: a mid-run 429/auth failure must not
         # silently reroute the quiet child onto the parent's fallbacks. Predictability > liveness for explicit pins.
-        "fallback_model": None if override_provider else (getattr(parent_agent, "_fallback_chain", None) or None),
+        # A profile route supplies its own chain (possibly []), reusing the same isolation seam.
+        "fallback_model": (
+            (override_fallback_model or None) if override_fallback_model is not None
+            else (None if override_provider else (getattr(parent_agent, "_fallback_chain", None) or None))
+        ),
         "openrouter_min_coding_score": getattr(parent_agent, "openrouter_min_coding_score", None),
         # Routing filters reset to their defaults under a pinned provider (see _ROUTING_FILTER_DEFAULTS).
         **{a: d if override_provider else getattr(parent_agent, a, d) for a, d in _ROUTING_FILTER_DEFAULTS},

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -238,7 +238,7 @@ A profile's `max_iterations` can only tighten the configured delegation budget, 
 | `resolved_model` | The model pinned at spawn time (frozen; never updated afterward) |
 | `fallback_policy` | `"none"` (empty profile fallback chain) or `"profile:<name>"` (the profile's own chain) |
 
-All four are `None` on legacy profile-less children. The existing `model` key stays live: when it diverges from `resolved_model`, a fallback fired, which is the requested-versus-effective audit signal.
+All four are omitted on legacy profile-less children, so profile-free result entries keep their original shape. The existing `model` key stays live: when it diverges from `resolved_model`, a fallback fired, which is the requested-versus-effective audit signal.
 
 ## The `/review` Command
 

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -173,7 +173,7 @@ delegation:
   provider: "openrouter"              # Optional: route subagents to a different provider
 ```
 
-If omitted, subagents use the same model as the parent.
+If omitted, subagents use the same model as the parent. This single pin applies to every child; for named per-task tiers, see [Worker profiles](#worker-profiles-delegationprofiles) below.
 
 ### Cost strategy: frontier planner, inexpensive workers
 
@@ -190,7 +190,55 @@ delegation:
 
 Resolution order: `delegation.base_url` (direct endpoint) takes precedence, then `delegation.provider` (full credential bundle resolved via the runtime provider system), and when neither is set children inherit the parent's provider and credentials; `delegation.model` applies in all cases, and when it is empty children inherit the parent's model. Setting `delegation.provider` alongside `delegation.base_url` keeps the explicit endpoint but carries that provider's request overrides and max output tokens into the child. An explicit `delegation.request_overrides` dict is honored on every branch and merges over those runtime-derived values (see [Configuration](#configuration) below).
 
-Note that the pin is global: `delegate_task` has no per-task model parameter, so every child in a batch runs on the configured delegation model. For quality-sensitive subtasks that need a stronger model, either leave `delegation.model` unset for that session or hand the task to the [kanban board](kanban.md#per-task-model-override), which does support a per-task model override.
+Note that the pin is global: without profiles, every child in a batch runs on the configured delegation model. For per-task routing, define [worker profiles](#worker-profiles-delegationprofiles), or hand the task to the [kanban board](kanban.md#per-task-model-override), which supports its own per-task model override.
+
+### Worker profiles (`delegation.profiles`)
+
+`delegation.profiles` replaces the single global pin with named worker tiers. Each profile pins a provider/model pair and can optionally set `reasoning_effort`, `max_iterations`, and a `fallback` chain; those five keys are the complete set (profiles never touch toolsets):
+
+```yaml
+# ~/.hermes/config.yaml
+delegation:
+  profiles:
+    small:
+      provider: "openrouter"
+      model: "google/gemini-flash-2.0"
+      reasoning_effort: "low"
+      max_iterations: 60
+      fallback: []                       # empty list = no model promotion, ever
+    review:
+      provider: "anthropic"
+      model: "claude-sonnet-4-5"
+      fallback:
+        - provider: "openrouter"
+          model: "google/gemini-2.5-pro"
+  default_profile: "small"               # applied when a task doesn't pick one
+```
+
+Which route a child gets is decided by a five-level precedence, first match wins:
+
+1. Per-task `model_profile` (a `tasks[]` entry field)
+2. Top-level `model_profile` (batch-wide, applies to every task that doesn't set its own)
+3. `delegation.default_profile`
+4. Legacy `delegation.provider` / `delegation.model` (the single pin above)
+5. Parent inherit (child runs on the parent's provider and model)
+
+A profile's `max_iterations` can only tighten the configured delegation budget, never widen it. An unknown profile name is a configuration error: `hermes config check` reports it, and at spawn time every task's route is resolved before any child is built, so an unknown name anywhere in a batch fails the whole call with zero children spawned.
+
+**Fallback isolation.** A profile pin does not inherit the parent's fallback chain. The profile's own `fallback` list is the child's entire chain: `fallback: []` means the child stays on the pinned model or fails, and a non-empty list promotes only through the pairs you wrote down. The rationale is cost accounting: a worker you pinned to a cheap model must not silently complete on a frontier model because the parent's chain ends there. Profile-less children (levels 4 and 5) keep the legacy behavior and inherit the parent's chain unchanged.
+
+**Letting the model pick a tier (`delegation.agent_routing`).** By default profiles are config-driven only: the parent model never sees them. Setting `delegation.agent_routing: true` (with at least one profile configured) adds a `model_profile` enum of your configured profile names to the `delegate_task` schema, per task and batch-wide, so the parent can route each subtask to a tier. The model picks names, never providers or models: operators define the menu, models choose from it. With the gate off, a model-supplied `model_profile` is rejected with a clean tool error before any child is built.
+
+**Route telemetry.** Profile-routed children carry four provenance fields on delegation result entries, progress events, and lifecycle subagent handles:
+
+| Field | Meaning |
+|-------|---------|
+| `requested_profile` | The profile name the route came from |
+| `resolved_provider` | The provider the profile resolved to at spawn time |
+| `resolved_model` | The model pinned at spawn time (frozen; never updated afterward) |
+| `fallback_policy` | `"none"` (empty profile fallback chain) or `"profile:<name>"` (the profile's own chain) |
+
+All four are `None` on legacy profile-less children. The existing `model` key stays live: when it diverges from `resolved_model`, a fallback fired, which is the requested-versus-effective audit signal.
 
 ## The `/review` Command
 

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -385,7 +385,7 @@ If no provider is available for compression, Hermes drops middle conversation tu
 
 ## Delegation Provider Override
 
-Subagents spawned by `delegate_task` inherit the parent agent's primary fallback chain. You can still route subagents to a different primary provider:model pair for cost optimization:
+Subagents spawned by `delegate_task` inherit the parent agent's primary fallback chain. Children routed through a [delegation worker profile](/user-guide/features/delegation#worker-profiles-delegationprofiles) are the exception: a profile pin replaces the inherited chain with the profile's own `fallback` list (empty = no promotion). You can still route subagents to a different primary provider:model pair for cost optimization:
 
 ```yaml
 delegation:


### PR DESCRIPTION
## What

Operator-defined worker profiles for subagent delegation, in two phases:

**Phase 1 (config-driven, active once configured):** `delegation.profiles` defines named tiers (provider, model, reasoning_effort, max_iterations, fallback). `delegation.default_profile` routes every subagent through a tier. Per-task selection is plumbed internally.

**Phase 2 (gated, default off):** `delegation.agent_routing: true` exposes a `model_profile` enum on `delegate_task` whose values are exactly the configured profile names. The model picks a *name* per task; the operator defines what every name means.

```yaml
delegation:
  default_profile: small
  agent_routing: false        # Phase 2 gate, off by default
  profiles:
    small:
      provider: openrouter
      model: google/gemini-3-flash-preview
    review:
      provider: anthropic
      model: claude-sonnet-current
      fallback:
        - provider: openrouter
          model: anthropic/claude-sonnet-current
```

## Why

The single fleet-wide `delegation.provider/model` pin cannot express "cheap worker for bounded retrieval, strong worker for review" — the planner-vs-worker trade every orchestration harness makes. Enterprise deployments have asked for per-task routing; the blocker has been the standing policy that models never decide model configurations, because tested selection behavior is misaligned.

This design keeps that policy intact rather than weakening it:
- The model can only ever emit a profile **name** from an operator-populated enum. Provider and model strings resolve exclusively from config, through the same `resolve_runtime_provider` ladder as the legacy pin.
- The enum does not exist until a human sets `agent_routing: true` (default off; falsy values byte-preserve today's schema — tested).
- A `model_profile` argument supplied while the gate is off is rejected with a clean tool error before any resolution, on both the registry handler and the `run_agent` dispatch seam (single `_handle_model_call` entry).

Same governance shape as the cron reasoning-effort knob (#91038): humans define the menu, the agent chooses from it or not at all.

## Design decisions

- **One resolver, both spawn paths.** `agent/delegation_model_routing.py` is the only place profile config is parsed and resolved. `delegate_task` and `SubagentLaunchRequest.model_profile` (lifecycle API) consume the same wrappers, so semantics cannot drift. Raw `SubagentLaunchRequest.model` stays what it was — a documented internal plugin trust surface; both-set is rejected.
- **Precedence:** per-task `model_profile` > top-level `model_profile` > `delegation.default_profile` > legacy `delegation.provider/model` > parent inherit. Falsy values fall through.
- **Fallback isolation.** A profile-pinned child never inherits the parent's fallback chain — a cheap worker silently completing on a frontier model is a cost bug, not resilience. A profile's own `fallback` list becomes the child's chain; empty list means fail rather than promote.
- **Requested vs effective telemetry.** Result entries, progress payloads, and `SubagentHandle` carry `requested_profile` / `resolved_provider` / `resolved_model` / `fallback_policy` on profile runs (omitted entirely on legacy runs). Spawn-time `resolved_model` diverging from the live `model` is the fallback-fired signal — the audit data for revisiting routing policy with evidence instead of anecdotes.
- **Fail closed.** Unknown profile name → error listing configured names, zero spawns. Unparseable profiles section → the enum is hidden and any supplied arg cleanly rejected; `hermes config check` surfaces the parse errors, and `agent_routing` on with no profiles warns.

## Behavioral notes

- Unconfigured deployments are byte-identical: no profiles → every code path and result-entry shape matches main (contract-tested; existing delegation suites pass unmodified).
- Profile `max_iterations` only tightens the configured delegation budget, on both spawn paths.
- Profiles never touch toolsets; #25752 toolset narrowing is untouched.

## Rejected scope

- Free-form model/provider strings on the public tool — the policy boundary is the point.
- NLP mapping of "use haiku" prose to models; the parent converts intent to a profile argument or nothing.
- Automatic routing optimization; telemetry lands first so policy can be revisited with data.
- Catalog-driven profile mutation (the curated picker catalog is discovery input, not routing policy).
- Tool-less text-only profile mode; `supports_tools=false` models are rejected loudly at resolution instead.

## Tests

- `tests/agent/test_delegation_model_routing.py` — resolver contracts (parse, precedence, errors, immutability)
- `tests/hermes_cli/test_delegation_profiles_config.py` — defaults and `config check` validation
- `tests/tools/test_delegation_model_profiles.py` — per-task routing, gate honesty (schema byte-absence when off, parametrized falsy values), clean rejection paths
- `tests/agent/test_subagent_lifecycle_profiles.py` — lifecycle parity with delegate_task, both-set rejection, budget clamp
- `tests/tools/test_delegation_route_telemetry.py` — entry/progress/handle provenance, legacy shape, requested-vs-effective divergence
- `tests/tools/test_delegation_profiles_e2e.py` — real `config.yaml` in a temp `HERMES_HOME` through the real loader/resolver/credential path, only the AIAgent construction boundary captured

Mutation checks: precedence-order swap and gate-bypass both kill multiple tests; the lifecycle clamp mutation found by adversarial review now has a killing test.
