### PR TITLE
fix(context): load hints from dotted-named directories (src.v2) instead of climbing to the parent

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -97,7 +97,11 @@ class SubdirectoryHintTracker:
             if not p.is_absolute():
                 p = self.working_dir / p
             p = p.resolve()
-            if p.suffix or (p.exists() and p.is_file()):
+            # A path pointing AT an existing directory must not be climbed past just
+            # because its final component contains a dot ("src.v2", "app.old", "tools.1"):
+            # such directories carry their own hint files. Only file paths (existing or
+            # to-be-created) climb to their parent directory.
+            if not (p.exists() and p.is_dir()) and (p.suffix or (p.exists() and p.is_file())):
                 p = p.parent
             for _ in range(_MAX_ANCESTOR_WALK):
                 if p in self._loaded_dirs:

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -96,6 +96,25 @@ class TestSubdirectoryHintTracker:
 
 
 
+    def test_dotted_directory_name_is_a_directory(self, project):
+        """A path pointing AT an existing directory whose final component contains a dot
+        (src.v2, app.old) is a directory, not a file path: its own hint must load, not be
+        silently climbed past to the parent (which may hold no hint or the wrong one)."""
+        dotted = project / "backend.v2"
+        dotted.mkdir()
+        (dotted / "AGENTS.md").write_text("V2-specific instructions")
+        (dotted / "main.py").write_text("print('v2')")
+
+        # workdir pointing at the dotted directory (terminal) must load ITS hint.
+        tracker = SubdirectoryHintTracker(working_dir=str(project))
+        result = tracker.check_tool_call("terminal", {"command": "ls", "workdir": str(dotted)})
+        assert result is not None and "V2-specific instructions" in result
+
+        # Reading a file inside the dotted directory loads its hint too.
+        tracker2 = SubdirectoryHintTracker(working_dir=str(project))
+        result2 = tracker2.check_tool_call("read_file", {"path": str(dotted / "main.py")})
+        assert result2 is not None and "V2-specific instructions" in result2
+
     def test_truncation_of_large_hints(self, tmp_path, caplog):
         """Over the ceiling: head AND tail survive, the marker names the file to read_file, and it is logged
         (the old silent tail-chop hid a truncated apps/desktop/AGENTS.md for months)."""


### PR DESCRIPTION
## Problem

`SubdirectoryHintTracker._add_path_candidate` treats any path whose final component contains a dot as a **file path** and climbs to its parent. When a tool argument points **at an existing directory** whose name has a dotted final component (very common in real trees: `src.v2`, `app.old`, `tools.1`, `build.2026`), the directory is never hinted — its own `AGENTS.md`/`CLAUDE.md` is silently skipped, and the parent's hint is delivered instead when the parent is not already loaded.

## Repro

```python
tracker = SubdirectoryHintTracker(working_dir="/repo")
# /repo/backend.v2/AGENTS.md exists with its own instructions
result = tracker.check_tool_call("terminal", {"command": "ls", "workdir": "/repo/backend.v2"})
assert result is None  # BUG: backend.v2/AGENTS.md never delivered
```

Files *inside* such directories were already handled (their own `.py` suffix climbs to the directory); only paths pointing at the dotted directory itself (terminal `workdir=`, search `path=`, `cd` targets) hit the defect.

## Fix

Only climb to the parent for file paths (existing or to-be-created). An existing directory is hinted directly regardless of a dot in its final component — one extra `not (p.exists() and p.is_dir())` guard, no behavior change for file paths or suffix-less directories.

## Test

Regression test `test_dotted_directory_name_is_a_directory`: `workdir` pointing at a dotted directory loads its hint; reading a file inside it still loads its hint. Verified: the test fails on current main (None returned) and passes with the fix; full `tests/agent/test_subdirectory_hints.py` is green (59 passed).

Found while reviewing the on-demand subdirectory hint feature (recently raised 8k→32k ceiling) against real-world directory layouts.