### PR TITLE
fix(tui): severed stdin pipe exits cleanly instead of crash-looping the gateway

### DIFF
--- a/tests/tui_gateway/test_stdin_oserror_graceful_exit.py
+++ b/tests/tui_gateway/test_stdin_oserror_graceful_exit.py
@@ -1,0 +1,69 @@
+"""Regression test: severed stdin pipe must exit cleanly, not crash.
+
+On Windows the TUI gateway child's stdio pipe can be invalidated under a live
+read loop (parent restarted/reloaded and orphaned it, console torn down) and
+``sys.stdin.readline()`` raises ``OSError: [Errno 22] Invalid argument``.
+Unhandled that is a traceback + exit 1, which the client surfaces as
+"gateway exited — recovering your session" and instantly respawns into the
+same broken pipe (reconnect storm). ``entry.main()`` must log forensics and
+return normally instead; same for the slash worker loop (covered here via the
+shared shape: both loops must survive ``OSError`` from ``readline``).
+
+Harness: same style as test_entry_picker_prewarm.py — import the modules and
+monkeypatch I/O collaborators (no subprocess, no real gateway).
+"""
+
+from __future__ import annotations
+
+import io
+
+from tui_gateway import entry
+from hermes_cli import model_switch_providers
+
+
+class _SeveredStdin(io.StringIO):
+    """stdin whose pipe was invalidated: every read raises like Windows."""
+
+    def readline(self, *args):
+        raise OSError(22, "Invalid argument")
+
+
+def _stub_entry_main(monkeypatch, stdin):
+    monkeypatch.setattr(entry, "_install_sidecar_publisher", lambda: None)
+    monkeypatch.setattr(entry, "ensure_mcp_discovery_started", lambda: None)
+    monkeypatch.setattr(entry, "resolve_skin", lambda: "default")
+    monkeypatch.setattr(entry.server, "_ensure_skin_watcher", lambda: None)
+    monkeypatch.setattr(entry, "handle_spurious_eof", lambda *a: False)
+    monkeypatch.setattr(entry, "write_json", lambda payload: True)
+    monkeypatch.setattr(
+        model_switch_providers, "prewarm_picker_cache_async", lambda: None
+    )
+    monkeypatch.setattr(entry.sys, "stdin", stdin)
+
+
+def test_main_returns_normally_on_stdin_oserror(monkeypatch):
+    """main() must survive OSError from readline: log + return, never raise."""
+    _stub_entry_main(monkeypatch, _SeveredStdin())
+
+    reasons: list[str] = []
+    monkeypatch.setattr(entry, "_log_exit", lambda reason: reasons.append(reason))
+    appended: list[str] = []
+    monkeypatch.setattr(
+        entry, "_append_crash_log", lambda header, dump=None: appended.append(header)
+    )
+
+    entry.main()  # returning at all proves the OSError was handled
+
+    assert reasons, "expected a [gateway-exit] reason for the severed stdin"
+    assert any("stdin" in r for r in reasons), f"reason should name stdin: {reasons!r}"
+    assert appended, "expected a crash-log forensics entry"
+    assert any("stdin" in h for h in appended), f"forensics should name stdin: {appended!r}"
+
+
+def test_main_still_returns_on_genuine_eof(monkeypatch):
+    """The OSError guard must not change the genuine-EOF path (empty read)."""
+    _stub_entry_main(monkeypatch, io.StringIO(""))
+    monkeypatch.setattr(entry, "_log_exit", lambda reason: None)
+    monkeypatch.setattr(entry, "_append_crash_log", lambda header, dump=None: None)
+
+    entry.main()  # empty stdin -> EOF -> returns

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -16,7 +16,7 @@ import traceback
 from contextlib import suppress
 
 from tui_gateway._env import env_float
-from tui_gateway._stdin_recovery import handle_spurious_eof
+from tui_gateway._stdin_recovery import diagnose_stdin_state, handle_spurious_eof
 
 from tui_gateway import server
 from tui_gateway.event_replay import replay_epoch
@@ -272,7 +272,22 @@ def main():
         logger.debug("picker cache prewarm (tui) failed to start", exc_info=True)
 
     while True:
-        raw = sys.stdin.readline()
+        try:
+            raw = sys.stdin.readline()
+        except OSError as exc:
+            # Windows: the stdio pipe can be invalidated under a live loop
+            # (parent restarted/reloaded and orphaned us, console torn down).
+            # Unhandled this exits 1, which the client surfaces as "gateway
+            # exited — recovering your session" and instantly respawns into
+            # the same broken pipe (reconnect storm). Log forensics and exit
+            # cleanly instead: one quiet reconnect when owned, silent death
+            # when already orphaned.
+            _append_crash_log(
+                f"stdin read failed · {time.strftime('%Y-%m-%d %H:%M:%S')} "
+                f"({type(exc).__name__}: {exc}; {diagnose_stdin_state()})",
+                lambda f: traceback.print_exc(file=f))
+            _log_exit(f"stdin unreadable ({exc}); exiting for parent reconnect")
+            break
         if not raw:
             # Spurious (child flipped O_NONBLOCK on the shared description) or genuine EOF?
             if not handle_spurious_eof(_recovery_times, _log_exit):

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -27,7 +27,7 @@ import time
 import cli as cli_mod
 from cli import HermesCLI
 from tui_gateway._env import env_float
-from tui_gateway._stdin_recovery import handle_spurious_eof
+from tui_gateway._stdin_recovery import diagnose_stdin_state, handle_spurious_eof
 from rich.console import Console
 
 # Env-overridable so the integration test can drive sub-second timing.
@@ -113,7 +113,15 @@ def main():
     # point — any child inheriting fd 0 can flip the flag).
     _sw_recovery_times: list[float] = []
     while True:
-        raw = sys.stdin.readline()
+        try:
+            raw = sys.stdin.readline()
+        except OSError as exc:
+            # Same severed-pipe class as the gateway entry point (Windows
+            # Errno 22 when the parent goes away): exit quietly instead of a
+            # traceback, so the next slash command respawns us cleanly.
+            _sw_log(f"stdin read failed ({type(exc).__name__}: {exc}; "
+                    f"{diagnose_stdin_state()}); exiting")
+            break
         if not raw:
             if not handle_spurious_eof(_sw_recovery_times, _sw_log):
                 break

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -32,6 +32,13 @@ export const WS_HEARTBEAT_DEAD_MS = 45_000
 // Exponential backoff for reconnect attempts after a transport drop.
 export const RECONNECT_BASE_MS = 1_000
 export const RECONNECT_MAX_MS = 30_000
+// A child that dies within seconds of spawn is crash-looping, not a transient
+// drop: keep the backoff counter so reconnects slow toward RECONNECT_MAX_MS
+// instead of hammering at 1s. Duplicate start() calls inside the window below
+// are the same race (reconnect timer + UI subscriber + in-flight request all
+// firing at once) — the second one just orphans a booting child on Windows.
+export const QUICK_EXIT_MS = 10_000
+const SPAWN_DEBOUNCE_MS = 1_500
 
 const getWebSocketCtor = (): typeof WebSocket =>
   typeof WebSocket === 'undefined' ? (UndiciWebSocket as unknown as typeof WebSocket) : WebSocket
@@ -164,6 +171,7 @@ export class GatewayClient extends EventEmitter {
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
   private reconnectAttempts = 0
+  private lastSpawnAt = 0
   private lastActivityAt = 0
   private heartbeatSeq = 0
   private heartbeatPendingId: string | null = null
@@ -485,6 +493,7 @@ export class GatewayClient extends EventEmitter {
     env.HERMES_PYTHON_SRC_ROOT = root
     this.startReadyTimer(python, cwd)
     this.proc = spawn(python, ['-m', 'tui_gateway.entry'], { cwd, env, stdio: ['pipe', 'pipe', 'pipe'] })
+    this.lastSpawnAt = Date.now()
     this.lifecycle(`[lifecycle] spawned gateway child ${describeChild(this.proc)} python=${python} cwd=${cwd}`)
 
     this.stdoutRl = createInterface({ input: this.proc.stdout! })
@@ -655,8 +664,26 @@ export class GatewayClient extends EventEmitter {
   }
 
   start() {
+    // Debounce racing restarts: a transport exit fans out to the reconnect
+    // timer, the UI recovery subscriber, and in-flight request() calls, which
+    // can each invoke start() within milliseconds (three spawned children in
+    // 8ms observed). Killing a child that is still booting orphans it on
+    // Windows, and each orphan later dies on its severed stdin pipe.
+    if (!resolveGatewayAttachUrl() && this.proc && !this.proc.killed && this.proc.exitCode === null
+        && Date.now() - this.lastSpawnAt < SPAWN_DEBOUNCE_MS) {
+      this.lifecycle(`[lifecycle] debounced duplicate start (${describeChild(this.proc)})`)
+      return
+    }
     this.disposed = false
-    this.clearReconnect()
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
+    // Preserve backoff across fast-crash loops: only a child that lived a
+    // healthy life resets the counter, otherwise reconnects back off 1s→30s.
+    if (this.lastSpawnAt === 0 || Date.now() - this.lastSpawnAt > QUICK_EXIT_MS) {
+      this.reconnectAttempts = 0
+    }
 
     const root = process.env.HERMES_PYTHON_SRC_ROOT ?? resolve(import.meta.dirname, '../../')
     const attachUrl = resolveGatewayAttachUrl()
@@ -665,12 +692,12 @@ export class GatewayClient extends EventEmitter {
     this.attachUrl = attachUrl
     this.sidecarUrl = sidecarUrl
     this.resetStartupState()
-    this.clearReconnect()
     this.stopHeartbeat()
 
     if (this.proc && !this.proc.killed && this.proc.exitCode === null) {
-      this.lifecycle(`[lifecycle] replacing live gateway child ${describeChild(this.proc)}`)
-      this.proc.kill()
+      const target = describeChild(this.proc)
+      const killed = this.proc.kill()
+      this.lifecycle(`[lifecycle] replacing live gateway child ${target} killResult=${killed ?? 'none'}`)
     }
 
     this.proc = null


### PR DESCRIPTION
## Symptom

Repeated `gateway exited — recovering your session (any in-flight reply was lost)` in CLI (`hermes --tui`) on Windows. Crash log (`logs/tui_gateway_crash.log`) fills with:

```
File "tui_gateway/entry.py", line 275, in main
    raw = sys.stdin.readline()
OSError: [Errno 22] Invalid argument
```

followed by `transport exit code=1` → reconnect in 1000ms → respawn → same crash. Also observed three gateway children spawned within 8ms after one transport exit.

## Root cause

1. **Unguarded stdin read.** The stdio pipe can be invalidated under a live read loop on Windows (parent restarted/reloaded and orphaned the child, console torn down). Neither `entry.py` nor `slash_worker.py` (same loop shape, same bug class) handled `OSError` from `readline()` — only POSIX spurious-EOF was covered. Unhandled = traceback + exit 1 = loud crash + instant respawn into the same broken pipe.
2. **Racing restarts orphan children.** A transport exit fans out to the reconnect timer, the UI recovery subscriber, and in-flight `request()` calls, each invoking `start()`. Killing a child that is still booting orphans it on Windows, and each orphan later dies on its severed stdin pipe. Additionally `start()` unconditionally reset the backoff counter, so fast-crash loops hammered at a constant 1s instead of backing off.

## Changes

- `tui_gateway/entry.py` / `tui_gateway/slash_worker.py`: catch `OSError` around `sys.stdin.readline()`, append traceback + `diagnose_stdin_state()` to the crash log, exit quietly (one reconnect when owned, silent death when orphaned).
- `ui-tui/src/gatewayClient.ts`: debounce duplicate `start()` within 1.5s of a live spawn; preserve reconnect backoff across fast-crash loops (reset only after a child lived >10s); log kill results for forensics.
- `tests/tui_gateway/test_stdin_oserror_graceful_exit.py`: new — `OSError` → clean return + forensics logged; genuine-EOF path unchanged.

## Verification

- `scripts/run_tests.sh tests/tui_gateway/test_stdin_oserror_graceful_exit.py tests/tui_gateway/test_entry_picker_prewarm.py` → 4 passed
- `ui-tui: npm run typecheck` → clean; `vitest run src/__tests__/gatewayClient.test.ts` → 18 passed