### PR TITLE
fix(cli): keep radio choices visible below long descriptions

### DIFF
--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -657,7 +657,15 @@ def curses_radiolist(
 
     def _draw_header(stdscr, max_y, max_x, search=None, back_enabled=False):
         row = 1
-        for dline in desc_lines[: max(0, max_y - 2)]:  # ★ painted yellow to match rows
+        # Reserve title, hint, spacer, bottom margin, and up to five choices.
+        # A long description must not push the selected row off-screen.
+        choice_rows = min(max(1, len(items)), 5)
+        description_rows = max(0, max_y - 4 - choice_rows)
+        visible_description = desc_lines[:description_rows]
+        if len(desc_lines) > description_rows and visible_description:
+            hidden = len(desc_lines) - description_rows + 1
+            visible_description[-1] = f"  ... {hidden} more description lines (enlarge terminal)"
+        for dline in visible_description:  # ★ painted yellow to match rows
             _draw_description_line(stdscr, row, dline, max_x)
             row += 1
         hint = _search_hint(search, searchable, "ENTER/SPACE select", "ESC cancel", back_enabled)

--- a/tests/hermes_cli/test_curses_radiolist_viewport.py
+++ b/tests/hermes_cli/test_curses_radiolist_viewport.py
@@ -1,0 +1,97 @@
+"""Exercise radiolist rendering and navigation with a bounded terminal surface."""
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import curses_ui
+
+
+class Screen:
+    def __init__(self, keys, heights):
+        self.keys = iter(keys)
+        self.heights = iter(heights)
+        self.height = 24
+        self.frames = []
+
+    def clear(self):
+        self.rows = {}
+
+    def getmaxyx(self):
+        self.height = next(self.heights, self.height)
+        return self.height, 100
+
+    def addnstr(self, y, x, text, n, attr):
+        assert 0 <= y < self.height, f"off-screen write at row {y}"
+        self.rows[y] = self.rows.get(y, "") + text[:n]
+
+    def refresh(self):
+        self.frames.append(dict(self.rows))
+
+    def getch(self):
+        return next(self.keys)
+
+
+@pytest.fixture
+def run_menu(monkeypatch):
+    def run(keys, heights, *, description=None, selected=0):
+        screen = Screen(keys, heights)
+        curses = SimpleNamespace(
+            error=type("CursesError", (Exception,), {}),
+            A_BOLD=1, A_DIM=2, A_NORMAL=0,
+            KEY_UP=259, KEY_DOWN=258, KEY_LEFT=260, KEY_ENTER=343,
+            KEY_BACKSPACE=263,
+            has_colors=lambda: False, curs_set=lambda value: None,
+            wrapper=lambda draw: draw(screen),
+        )
+        monkeypatch.setitem(sys.modules, "curses", curses)
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr(curses_ui, "flush_stdin", lambda: None)
+        result = curses_ui.curses_radiolist(
+            "Select default model:", [f"model-{i:02}" for i in range(20)],
+            selected=selected, description=description, searchable=True,
+        )
+        return result, screen.frames
+    return run
+
+
+LONG_DESCRIPTION = "\n".join(f"Unavailable model {i}" for i in range(40))
+
+
+@pytest.mark.parametrize("height", [5, 8, 12, 24, 50])
+def test_long_description_keeps_selected_choice_and_hint_visible(run_menu, height):
+    result, frames = run_menu([10], [height], description=LONG_DESCRIPTION, selected=19)
+    assert result == 19
+    rows = list(frames[0].values())
+    assert any("model-19" in row and "\u2192" in row for row in rows)
+    assert any("/ search" in row for row in rows)
+    choices = [row for row in rows if "model-" in row]
+    assert len(choices) >= min(5, height - 4)
+    if 12 <= height < 50:
+        assert any("more description lines" in row for row in rows)
+    if height == 50:
+        assert all(f"Unavailable model {i}" in rows for i in range(40))
+
+
+def test_choice_scrolls_after_terminal_shrinks(run_menu):
+    result, frames = run_menu([258] * 19 + [10], [50, 12], description=LONG_DESCRIPTION)
+    assert result == 19
+    for index, frame in enumerate(frames):
+        assert any(f"model-{index:02}" in row and "\u2192" in row for row in frame.values())
+
+
+def test_search_result_stays_visible_with_long_description(run_menu):
+    result, frames = run_menu(
+        [ord("/"), ord("1"), ord("9"), 10], [12], description=LONG_DESCRIPTION)
+    assert result == 19
+    assert any("Search: 19" in row for row in frames[-1].values())
+    assert any("model-19" in row and "\u2192" in row for row in frames[-1].values())
+
+
+@pytest.mark.parametrize("description", [None, "First line\nSecond line"])
+def test_short_description_layout_is_unchanged(run_menu, description):
+    result, frames = run_menu([10], [24], description=description)
+    assert result == 0
+    start = 3 + (2 if description else 0)
+    assert "model-00" in frames[0][start]
+    assert not any("more description lines" in row for row in frames[0].values())


### PR DESCRIPTION
## What does this PR do?

Keeps selectable rows visible when a curses radio menu has a long description. The Nous model picker places unavailable models and pricing information in that description. On a short terminal, the description currently consumes the viewport and pushes every selectable model below the screen, even though keyboard navigation and search still run.

The renderer now reserves space for the title, key hint, spacing, bottom margin, and up to five choices before drawing description lines. When the description does not fit, its last visible line reports the omitted count. The budget is recalculated on every redraw, including terminal resize. Short descriptions and terminals large enough for the full description retain their existing layout.

This changes no model availability, ordering, default selection, or search behavior.

## Related Issue

Reported through Discord support; no GitHub issue.

Overlap checked before and after tracing `auth_model_picker.py` into `curses_radiolist`. #35039 addresses plugin-menu scrolling/navigation, and #102968 changes the Nous picker's default selection; neither bounds the description that hides the radio rows.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/curses_ui.py`: bound radio-menu descriptions after reserving choice rows, with an omission indicator.
- `tests/hermes_cli/test_curses_radiolist_viewport.py`: run the real renderer and key loop against a bounded screen double; cover short/tall terminals, resize, scrolling, search, and unchanged short-description layout.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_curses_radiolist_viewport.py tests/hermes_cli/test_curses_ui_search.py tests/hermes_cli/test_curses_ui_fuzzy_rank.py -q -j 4`.
2. The new tests render 40 synthetic description lines and 20 choices at heights of 5, 8, 12, 24, and 50 rows. They check that the selected choice and key hint are visible, navigate to the last choice after shrinking, and search for a choice while the description overflows.
3. For a real-terminal check, open a Nous model picker with many unavailable models in a 24-row terminal. Confirm choices remain visible and navigable, then resize while the menu is open.

Verified on Windows with a curses screen/module double, not a native terminal emulator: **13 tests passed across the three focused files**. Reverting only the renderer fix makes **6 of the 9 new tests fail** because the selected choice is not drawn; the large-terminal and short-description controls still pass.

The first test attempt stopped in shared fixture setup because the isolated environment lacked runtime dependencies. After making existing runtime dependencies available read-only to that environment, the focused run passed. The runner's bytecode precompile step was temporarily restricted to the two changed Python files and four workers for local safety; that runner modification is not included in this PR. Full-suite coverage is left to CI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows, focused renderer/key-loop tests with a bounded curses double; no native-terminal manual run

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, existing behavior repair
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide - platform-independent row budgeting; native curses behavior is unchanged
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

```text
With fix:     3 files, 13 passed, 0 failed
Without fix: viewport tests: 6 failed, 3 passed
```
