### PR TITLE
fix(slack): clear sticky assistant status when posting interactive clarify/approval prompts (#102704)

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4531,6 +4531,15 @@ class SlackAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
         chat_id = await self._dm_target(chat_id, metadata)
         try:
+            # Clear the sticky assistant status before posting an interactive
+            # prompt (#102704, #92202): pause_typing stops future writes but
+            # leaves the last "still working..." line on screen, and Slack
+            # disables the thread's compose box while a status is set. Ordinary
+            # sends clear via stop_typing after post; interactive prompts post
+            # via chat_postMessage and must clear explicitly here so the
+            # question is answerable. _clear_thread_status_quietly is idempotent
+            # and never masks the SendResult.
+            await self._clear_thread_status_quietly(chat_id, metadata)
             text, blocks = build()
             result = await self._post_interactive_blocks(
                 chat_id, text, blocks, metadata, sanitize=sanitize, team_scoped=team_scoped_key)


### PR DESCRIPTION
Fixes #102704

**Problem:** When the agent calls `clarify` with choices on Slack, the assistant status line (`still working… (Nm)`) stays sticky above the question. `pause_typing_for_chat()` only stops future refreshes — Slack's `assistant.threads.setStatus` remains until explicitly cleared. The Block Kit interactive prompts (`send_clarify` multi-choice, `send_exec_approval`, `send_slash_confirm`) post via `chat_postMessage` through `_send_interactive_prompt` and never reached the `stop_typing` clear that ordinary `send()` does. Slack disables the thread's compose box while a status is set, so the user cannot answer until `clarify_timeout` (default 3600s).

**Fix:** Call `await self._clear_thread_status_quietly(chat_id, metadata)` at the start of `_send_interactive_prompt` before building and posting the Block Kit payload. The helper is idempotent, best-effort, and never masks the `SendResult`. This single site fixes all three interactive prompts transitively — clarify multi-choice (#102704) and exec approval (#92202) plus slash confirm — without duplicating logic. Open-ended clarify (no choices) delegates to `BasePlatformAdapter.send_clarify` → `self.send()` and already clears.

**Verification:**
- `python -m py_compile plugins/platforms/slack/adapter.py` — ok
- `pytest tests/gateway/test_slack_clarify_buttons.py tests/gateway/test_slack_approval_buttons.py tests/gateway/test_slack_block_kit_adapter.py tests/gateway/test_slack_status_update.py` — 38 passed