### PR TITLE
fix(codex): persist session bindings and refuse silent conversation resets

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -347,6 +347,68 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
 # --- Codex app-server turn ----------------------------------------------------
 
 
+def _codex_thread_store_path():
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / "codex_threads.json"
+
+
+def _load_codex_thread_id(agent) -> "str | None":
+    """The codex thread id this Hermes session last ran on, if any.
+
+    Codex threads persist on disk, so resuming one across an agent-cache
+    eviction or gateway restart is what keeps conversation memory alive —
+    the app-server path never replays Hermes' local transcript into a new
+    thread. Persistence failures must never break a turn: every path here
+    degrades to None (fresh thread), which is the pre-resume behavior.
+    """
+    session_id = getattr(agent, "session_id", None)
+    if not session_id or getattr(agent, "platform", "") == "gateway_hygiene":
+        return None
+    try:
+        with open(_codex_thread_store_path(), encoding="utf-8") as fh:
+            entry = json.load(fh).get(session_id)
+        return entry.get("thread_id") if isinstance(entry, dict) else None
+    except Exception:
+        return None
+
+
+def _store_codex_thread_id(agent, thread_id: "str | None") -> None:
+    session_id = getattr(agent, "session_id", None)
+    if (
+        not session_id
+        or not thread_id
+        or getattr(agent, "platform", "") == "gateway_hygiene"
+    ):
+        return
+    path = _codex_thread_store_path()
+    try:
+        try:
+            with open(path, encoding="utf-8") as fh:
+                store = json.load(fh)
+            if not isinstance(store, dict):
+                store = {}
+        except Exception:
+            store = {}
+        prior = store.get(session_id)
+        if isinstance(prior, dict) and prior.get("thread_id") == thread_id:
+            return
+        store[session_id] = {"thread_id": thread_id, "updated": time.time()}
+        if len(store) > 200:  # prune dead sessions oldest-first
+            for key, _ in sorted(
+                store.items(),
+                key=lambda kv: kv[1].get("updated", 0)
+                if isinstance(kv[1], dict) else 0,
+            )[: len(store) - 200]:
+                store.pop(key, None)
+        tmp = str(path) + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(store, fh, indent=1)
+        os.replace(tmp, path)
+    except Exception:
+        logger.debug("codex thread-id persistence failed", exc_info=True)
+
+
 def _close_codex_session(agent) -> None:
     """Drop the session so the next turn respawns codex instead of reusing a dead client."""
     with suppress(Exception):
@@ -392,6 +454,7 @@ def _ensure_codex_session(agent) -> None:
         cwd=getattr(agent, "session_cwd", None) or str(resolve_agent_cwd()), approval_callback=approval_callback,
         request_routing=_ServerRequestRouting(auto_approve_exec=auto_approve_requests, auto_approve_apply_patch=auto_approve_requests),
         on_event=make_codex_app_server_event_bridge(agent),
+        resume_thread_id=_load_codex_thread_id(agent),
     )
 
 
@@ -457,6 +520,7 @@ def run_codex_app_server_turn(agent, *, user_message: str, original_user_message
     _ensure_codex_session(agent)
     try:
         turn = agent._codex_session.run_turn(user_input=user_message)
+        _store_codex_thread_id(agent, getattr(turn, "thread_id", None))
     except Exception as exc:
         logger.exception("codex app-server turn failed")
         _close_codex_session(agent)

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -347,66 +347,55 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
 # --- Codex app-server turn ----------------------------------------------------
 
 
-def _codex_thread_store_path():
-    from hermes_constants import get_hermes_home
+def _codex_thread_scope() -> str:
+    from pathlib import Path
 
-    return get_hermes_home() / "codex_threads.json"
+    return str(Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex").expanduser().resolve())
 
 
-def _load_codex_thread_id(agent) -> "str | None":
-    """The codex thread id this Hermes session last ran on, if any.
+def _load_codex_thread_id(agent) -> str | None:
+    """Read the binding from the same profile-scoped DB as the transcript.
 
-    Codex threads persist on disk, so resuming one across an agent-cache
-    eviction or gateway restart is what keeps conversation memory alive —
-    the app-server path never replays Hermes' local transcript into a new
-    thread. Persistence failures must never break a turn: every path here
-    degrades to None (fresh thread), which is the pre-resume behavior.
+    A failed read must not look like a new conversation. Scope mismatches
+    require an explicit new session rather than borrowing another Codex home.
     """
+    db = getattr(agent, "_session_db", None)
     session_id = getattr(agent, "session_id", None)
-    if not session_id or getattr(agent, "platform", "") == "gateway_hygiene":
+    if db is None or not session_id or getattr(agent, "platform", "") == "gateway_hygiene":
         return None
-    try:
-        with open(_codex_thread_store_path(), encoding="utf-8") as fh:
-            entry = json.load(fh).get(session_id)
-        return entry.get("thread_id") if isinstance(entry, dict) else None
-    except Exception:
+    session = db.get_session(session_id)
+    if not session:
+        raise RuntimeError("Cannot load the saved Hermes session; conversation was not reset.")
+    raw = session.get("model_config")
+    config = json.loads(raw) if isinstance(raw, str) and raw else (raw or {})
+    binding = config.get("codex_thread_binding")
+    if binding is None:
         return None
+    if (not isinstance(binding, dict)
+            or not isinstance(binding.get("thread_id"), str)
+            or not binding["thread_id"]
+            or binding.get("codex_home") != _codex_thread_scope()):
+        raise RuntimeError("Cannot resume the saved Codex conversation in this profile/home. "
+                           "Restore the original Codex home or use /new to explicitly start over.")
+    return binding["thread_id"]
 
 
-def _store_codex_thread_id(agent, thread_id: "str | None") -> None:
+def _store_codex_thread_id(agent, thread_id: str | None) -> None:
+    """Atomically merge one binding; concurrent sessions cannot overwrite it.
+
+    Store before sending the user turn so a crash during execution cannot
+    orphan the provider thread. No pruning: the binding lives with its session.
+    """
+    db = getattr(agent, "_session_db", None)
     session_id = getattr(agent, "session_id", None)
-    if (
-        not session_id
-        or not thread_id
-        or getattr(agent, "platform", "") == "gateway_hygiene"
-    ):
+    if db is None or not session_id or getattr(agent, "platform", "") == "gateway_hygiene":
         return
-    path = _codex_thread_store_path()
-    try:
-        try:
-            with open(path, encoding="utf-8") as fh:
-                store = json.load(fh)
-            if not isinstance(store, dict):
-                store = {}
-        except Exception:
-            store = {}
-        prior = store.get(session_id)
-        if isinstance(prior, dict) and prior.get("thread_id") == thread_id:
-            return
-        store[session_id] = {"thread_id": thread_id, "updated": time.time()}
-        if len(store) > 200:  # prune dead sessions oldest-first
-            for key, _ in sorted(
-                store.items(),
-                key=lambda kv: kv[1].get("updated", 0)
-                if isinstance(kv[1], dict) else 0,
-            )[: len(store) - 200]:
-                store.pop(key, None)
-        tmp = str(path) + ".tmp"
-        with open(tmp, "w", encoding="utf-8") as fh:
-            json.dump(store, fh, indent=1)
-        os.replace(tmp, path)
-    except Exception:
-        logger.debug("codex thread-id persistence failed", exc_info=True)
+    if not thread_id:
+        raise RuntimeError("Codex did not return a conversation ID; no user turn was sent.")
+    binding = {"thread_id": thread_id, "codex_home": _codex_thread_scope()}
+    db.patch_session_model_config(session_id, {"codex_thread_binding": binding})
+    if _load_codex_thread_id(agent) != thread_id:
+        raise RuntimeError("Could not save the Codex conversation binding; no user turn was sent.")
 
 
 def _close_codex_session(agent) -> None:
@@ -426,10 +415,17 @@ def _consume_user_interrupt(agent, active: bool = True) -> tuple[bool, Any]:
     return interrupted, message
 
 
-def _ensure_codex_session(agent) -> None:
+def _ensure_codex_session(agent, messages=None) -> None:
     """Lazily spawn one CodexAppServerSession per AIAgent (reused across turns, closed by the _cleanup hook)."""
     if getattr(agent, "_codex_session", None) is not None:
         return
+    resume_thread_id = _load_codex_thread_id(agent)
+    if not resume_thread_id and any(m.get("role") == "assistant" for m in (messages or [])):
+        raise RuntimeError(
+            "This conversation has history but no saved Codex thread binding. "
+            "Restore its binding or use /new to explicitly start over; "
+            "no empty replacement conversation was started."
+        )
     from agent.runtime_cwd import resolve_agent_cwd
     from agent.transports.codex_app_server_session import CodexAppServerSession, _ServerRequestRouting
     # Approval callback: Hermes' standard prompt flow when a CLI thread installed one.
@@ -454,7 +450,7 @@ def _ensure_codex_session(agent) -> None:
         cwd=getattr(agent, "session_cwd", None) or str(resolve_agent_cwd()), approval_callback=approval_callback,
         request_routing=_ServerRequestRouting(auto_approve_exec=auto_approve_requests, auto_approve_apply_patch=auto_approve_requests),
         on_event=make_codex_app_server_event_bridge(agent),
-        resume_thread_id=_load_codex_thread_id(agent),
+        resume_thread_id=resume_thread_id,
     )
 
 
@@ -517,10 +513,10 @@ def run_codex_app_server_turn(agent, *, user_message: str, original_user_message
         from agent.conversation_compression import _checkpoint_blocked
         raise _checkpoint_blocked("codex_app_server owns the authoritative thread and compacts it "
                                   "without a truthful pre-compaction transcript boundary")
-    _ensure_codex_session(agent)
     try:
+        _ensure_codex_session(agent, messages)
+        _store_codex_thread_id(agent, agent._codex_session.ensure_started())
         turn = agent._codex_session.run_turn(user_input=user_message)
-        _store_codex_thread_id(agent, getattr(turn, "thread_id", None))
     except Exception as exc:
         logger.exception("codex app-server turn failed")
         _close_codex_session(agent)

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -143,6 +143,20 @@ class _ServerRequestRouting:
     auto_approve_apply_patch: bool = False
 
 
+def _extract_thread_id(result: dict) -> Optional[str]:
+    """Cross-fill thread.id/sessionId — different codex versions have
+    serialized this under either key. Mirrors openclaw beta.8's tolerance
+    fix so future codex drops/renames don't KeyError us at handshake
+    time."""
+    thread_obj = result.get("thread") or {}
+    return (
+        thread_obj.get("id")
+        or thread_obj.get("sessionId")
+        or result.get("sessionId")
+        or result.get("threadId")
+    )
+
+
 class CodexAppServerSession:
     """One Codex thread per Hermes session, lifetime owned by AIAgent. Not thread-safe: one caller at a time."""
 
@@ -153,8 +167,10 @@ class CodexAppServerSession:
         on_event: Optional[Callable[[dict], None]] = None,
         request_routing: Optional[_ServerRequestRouting] = None,
         client_factory: Optional[Callable[..., CodexAppServerClient]] = None,
+        resume_thread_id: Optional[str] = None,
     ) -> None:
         self._cwd = cwd or os.getcwd()
+        self._resume_thread_id = resume_thread_id
         self._codex_bin = codex_bin
         self._codex_home = codex_home
         self._permission_profile = permission_profile or _HERMES_TO_CODEX_PERMISSION_PROFILE.get(
@@ -184,6 +200,40 @@ class CodexAppServerSession:
         self._client.initialize(client_name="hermes", client_title="Hermes Agent", client_version=_get_hermes_version())
         # Permissions are NOT sent on thread/start: codex gates ``thread/start.permissions``
         # behind experimentalApi + a matching ``[permissions]`` table in ~/.codex/config.toml.
+        if self._resume_thread_id:
+            try:
+                result = self._client.request(
+                    "thread/resume",
+                    {"threadId": self._resume_thread_id, "cwd": self._cwd},
+                    timeout=15,
+                )
+                thread_id = _extract_thread_id(result)
+                if thread_id:
+                    self._thread_id = thread_id
+                    logger.info(
+                        "codex app-server thread resumed: id=%s profile=%s "
+                        "cwd=%s",
+                        self._thread_id[:8],
+                        self._permission_profile,
+                        self._cwd,
+                    )
+                    return self._thread_id
+                logger.warning(
+                    "codex thread/resume returned no thread id "
+                    "(payload keys: %s) — starting a fresh thread",
+                    sorted(result.keys()),
+                )
+            except (CodexAppServerError, TimeoutError) as exc:
+                # Rollout gone, codex too old, or id from another CODEX_HOME
+                # — a fresh thread is the correct degraded behavior either
+                # way, so resume failures must never fail the turn.
+                logger.warning(
+                    "codex thread/resume failed for id=%s (%s) — starting "
+                    "a fresh thread",
+                    self._resume_thread_id[:8],
+                    exc,
+                )
+
         result = self._client.request("thread/start", {"cwd": self._cwd}, timeout=15)
         # Different codex versions serialize the id under thread.id / sessionId / threadId.
         thread_obj = result.get("thread") or {}

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -201,38 +201,22 @@ class CodexAppServerSession:
         # Permissions are NOT sent on thread/start: codex gates ``thread/start.permissions``
         # behind experimentalApi + a matching ``[permissions]`` table in ~/.codex/config.toml.
         if self._resume_thread_id:
-            try:
-                result = self._client.request(
-                    "thread/resume",
-                    {"threadId": self._resume_thread_id, "cwd": self._cwd},
-                    timeout=15,
+            # Never replace a continuation with an empty thread. Transient
+            # errors can be retried; a deliberate reset gets a new Hermes ID.
+            result = self._client.request(
+                "thread/resume",
+                {"threadId": self._resume_thread_id, "cwd": self._cwd},
+                timeout=15,
+            )
+            thread_id = _extract_thread_id(result)
+            if thread_id != self._resume_thread_id:
+                raise CodexAppServerError(
+                    code=-32603,
+                    message="Codex did not resume the saved thread; conversation was not reset.",
                 )
-                thread_id = _extract_thread_id(result)
-                if thread_id:
-                    self._thread_id = thread_id
-                    logger.info(
-                        "codex app-server thread resumed: id=%s profile=%s "
-                        "cwd=%s",
-                        self._thread_id[:8],
-                        self._permission_profile,
-                        self._cwd,
-                    )
-                    return self._thread_id
-                logger.warning(
-                    "codex thread/resume returned no thread id "
-                    "(payload keys: %s) — starting a fresh thread",
-                    sorted(result.keys()),
-                )
-            except (CodexAppServerError, TimeoutError) as exc:
-                # Rollout gone, codex too old, or id from another CODEX_HOME
-                # — a fresh thread is the correct degraded behavior either
-                # way, so resume failures must never fail the turn.
-                logger.warning(
-                    "codex thread/resume failed for id=%s (%s) — starting "
-                    "a fresh thread",
-                    self._resume_thread_id[:8],
-                    exc,
-                )
+            self._thread_id = thread_id
+            logger.info("codex app-server thread resumed: id=%s", thread_id[:8])
+            return thread_id
 
         result = self._client.request("thread/start", {"cwd": self._cwd}, timeout=15)
         # Different codex versions serialize the id under thread.id / sessionId / threadId.

--- a/tests/run_agent/test_codex_app_server_resume.py
+++ b/tests/run_agent/test_codex_app_server_resume.py
@@ -1,0 +1,208 @@
+"""codex_app_server thread resume across agent rebuilds (#82160).
+
+The app-server path never replays Hermes' transcript into a new codex
+thread — the live thread IS the conversation memory. Before resume
+support, every AIAgent rebuild (agent-cache eviction, gateway restart)
+called thread/start and silently dropped the whole conversation.
+
+Verifies that:
+  - ensure_started() tries thread/resume when a resume id is provided,
+    and never calls thread/start on success
+  - resume failure (RPC error, or a payload with no thread id) falls
+    back to thread/start — a dead rollout must never fail the turn
+  - the session->thread mapping helpers round-trip via
+    HERMES_HOME/codex_threads.json, tolerate a corrupt store, prune,
+    and refuse gateway-hygiene agents in both directions
+  - run_conversation() wires the two together: the stored id reaches
+    CodexAppServerSession, and the turn's thread id lands in the store
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import run_agent
+from agent.codex_runtime import (
+    _codex_thread_store_path,
+    _load_codex_thread_id,
+    _store_codex_thread_id,
+)
+from agent.transports.codex_app_server_session import (
+    CodexAppServerError,
+    CodexAppServerSession,
+    TurnResult,
+)
+
+
+class StubClient:
+    """Records JSON-RPC traffic; scripted thread/resume behavior."""
+
+    def __init__(self, resume_error=None, resume_payload=None):
+        self.requests = []
+        self._resume_error = resume_error
+        self._resume_payload = resume_payload
+
+    def initialize(self, **kwargs):
+        pass
+
+    def request(self, method, params, timeout=None):
+        self.requests.append((method, params))
+        if method == "thread/resume":
+            if self._resume_error is not None:
+                raise self._resume_error
+            return self._resume_payload
+        if method == "thread/start":
+            return {"thread": {"id": "fresh-thread-1"}}
+        raise AssertionError(f"unexpected method {method}")
+
+    def stderr_tail(self, n):
+        return []
+
+    def close(self):
+        pass
+
+
+def _session(client, resume_thread_id=None):
+    return CodexAppServerSession(
+        cwd="/tmp/resume-test-cwd",
+        resume_thread_id=resume_thread_id,
+        client_factory=lambda **kwargs: client,
+    )
+
+
+class TestEnsureStartedResume:
+    def test_resume_happy_path_never_starts_a_fresh_thread(self):
+        client = StubClient(resume_payload={"thread": {"id": "old-thread-9"}})
+        tid = _session(client, resume_thread_id="old-thread-9").ensure_started()
+        assert tid == "old-thread-9"
+        methods = [m for m, _ in client.requests]
+        assert methods == ["thread/resume"]
+        _, params = client.requests[0]
+        assert params["threadId"] == "old-thread-9"
+        assert params["cwd"] == "/tmp/resume-test-cwd"
+
+    def test_resume_rpc_error_falls_back_to_thread_start(self):
+        client = StubClient(
+            resume_error=CodexAppServerError(
+                code=-32600, message="no rollout found for thread id x"
+            )
+        )
+        tid = _session(client, resume_thread_id="gone-thread").ensure_started()
+        assert tid == "fresh-thread-1"
+        assert [m for m, _ in client.requests] == [
+            "thread/resume", "thread/start",
+        ]
+
+    def test_resume_payload_without_id_falls_back_to_thread_start(self):
+        client = StubClient(resume_payload={"unexpected": True})
+        tid = _session(client, resume_thread_id="old-thread").ensure_started()
+        assert tid == "fresh-thread-1"
+        assert [m for m, _ in client.requests] == [
+            "thread/resume", "thread/start",
+        ]
+
+    def test_no_resume_id_preserves_original_behavior(self):
+        client = StubClient()
+        tid = _session(client).ensure_started()
+        assert tid == "fresh-thread-1"
+        assert [m for m, _ in client.requests] == ["thread/start"]
+
+
+class TestThreadIdStore:
+    def _agent(self, session_id="sess-1", platform="telegram"):
+        return SimpleNamespace(session_id=session_id, platform=platform)
+
+    def test_round_trip(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        agent = self._agent()
+        assert _load_codex_thread_id(agent) is None
+        _store_codex_thread_id(agent, "thread-abc")
+        assert _load_codex_thread_id(agent) == "thread-abc"
+
+    def test_corrupt_store_reads_as_empty_and_recovers_on_write(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _codex_thread_store_path().write_text("{not json", encoding="utf-8")
+        agent = self._agent()
+        assert _load_codex_thread_id(agent) is None
+        _store_codex_thread_id(agent, "thread-abc")
+        assert _load_codex_thread_id(agent) == "thread-abc"
+
+    def test_hygiene_agents_neither_read_nor_write(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        real = self._agent()
+        _store_codex_thread_id(real, "thread-abc")
+        hygiene = self._agent(platform="gateway_hygiene")
+        assert _load_codex_thread_id(hygiene) is None
+        _store_codex_thread_id(hygiene, "clobber")
+        assert _load_codex_thread_id(real) == "thread-abc"
+
+    def test_store_prunes_oldest_beyond_cap(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        for i in range(205):
+            _store_codex_thread_id(self._agent(f"sess-{i:03d}"), f"t-{i}")
+        store = json.loads(
+            _codex_thread_store_path().read_text(encoding="utf-8")
+        )
+        assert len(store) <= 200
+        assert "sess-204" in store  # newest survives
+        assert "sess-000" not in store  # oldest pruned
+
+
+class TestRunConversationWiring:
+    def _make_codex_agent(self, **kwargs):
+        return run_agent.AIAgent(
+            api_key="stub",
+            base_url="https://stub.invalid",
+            provider="openai",
+            api_mode="codex_app_server",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            **kwargs,
+        )
+
+    def test_stored_id_reaches_session_and_turn_id_lands_in_store(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        seen = {}
+        original_init = CodexAppServerSession.__init__
+
+        def spy_init(self, **kwargs):
+            seen["resume_thread_id"] = kwargs.get("resume_thread_id")
+            original_init(self, **kwargs)
+
+        def fake_run_turn(self, user_input, **kwargs):
+            return TurnResult(
+                final_text="done",
+                projected_messages=[{"role": "assistant", "content": "done"}],
+                turn_id="turn-1",
+                thread_id="thread-resumed-7",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "__init__", spy_init)
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession,
+            "ensure_started",
+            lambda self: "thread-resumed-7",
+        )
+
+        agent = self._make_codex_agent(session_id="wiring-sess")
+        _store_codex_thread_id(
+            SimpleNamespace(session_id="wiring-sess", platform="cli"),
+            "thread-resumed-7",
+        )
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("hello")
+
+        assert result["codex_thread_id"] == "thread-resumed-7"
+        assert seen["resume_thread_id"] == "thread-resumed-7"
+        stored = _load_codex_thread_id(
+            SimpleNamespace(session_id="wiring-sess", platform="cli")
+        )
+        assert stored == "thread-resumed-7"

--- a/tests/run_agent/test_codex_app_server_resume.py
+++ b/tests/run_agent/test_codex_app_server_resume.py
@@ -1,44 +1,18 @@
-"""codex_app_server thread resume across agent rebuilds (#82160).
-
-The app-server path never replays Hermes' transcript into a new codex
-thread — the live thread IS the conversation memory. Before resume
-support, every AIAgent rebuild (agent-cache eviction, gateway restart)
-called thread/start and silently dropped the whole conversation.
-
-Verifies that:
-  - ensure_started() tries thread/resume when a resume id is provided,
-    and never calls thread/start on success
-  - resume failure (RPC error, or a payload with no thread id) falls
-    back to thread/start — a dead rollout must never fail the turn
-  - the session->thread mapping helpers round-trip via
-    HERMES_HOME/codex_threads.json, tolerate a corrupt store, prune,
-    and refuse gateway-hygiene agents in both directions
-  - run_conversation() wires the two together: the stored id reaches
-    CodexAppServerSession, and the turn's thread id lands in the store
-"""
-
-from __future__ import annotations
-
-import json
+"""Provider conversation identity survives cache rebuilds and process restarts."""
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 import run_agent
-from agent.codex_runtime import (
-    _codex_thread_store_path,
-    _load_codex_thread_id,
-    _store_codex_thread_id,
-)
+from hermes_state import SessionDB
+from agent.codex_runtime import _load_codex_thread_id, _store_codex_thread_id
 from agent.transports.codex_app_server_session import (
-    CodexAppServerError,
-    CodexAppServerSession,
-    TurnResult,
+    CodexAppServerError, CodexAppServerSession, TurnResult,
 )
 
 
 class StubClient:
-    """Records JSON-RPC traffic; scripted thread/resume behavior."""
-
     def __init__(self, resume_error=None, resume_payload=None):
         self.requests = []
         self._resume_error = resume_error
@@ -57,152 +31,188 @@ class StubClient:
             return {"thread": {"id": "fresh-thread-1"}}
         raise AssertionError(f"unexpected method {method}")
 
-    def stderr_tail(self, n):
-        return []
-
     def close(self):
         pass
 
 
-def _session(client, resume_thread_id=None):
+def session(client, resume_thread_id=None):
     return CodexAppServerSession(
-        cwd="/tmp/resume-test-cwd",
         resume_thread_id=resume_thread_id,
         client_factory=lambda **kwargs: client,
     )
 
 
-class TestEnsureStartedResume:
-    def test_resume_happy_path_never_starts_a_fresh_thread(self):
-        client = StubClient(resume_payload={"thread": {"id": "old-thread-9"}})
-        tid = _session(client, resume_thread_id="old-thread-9").ensure_started()
-        assert tid == "old-thread-9"
-        methods = [m for m, _ in client.requests]
-        assert methods == ["thread/resume"]
-        _, params = client.requests[0]
-        assert params["threadId"] == "old-thread-9"
-        assert params["cwd"] == "/tmp/resume-test-cwd"
-
-    def test_resume_rpc_error_falls_back_to_thread_start(self):
-        client = StubClient(
-            resume_error=CodexAppServerError(
-                code=-32600, message="no rollout found for thread id x"
-            )
-        )
-        tid = _session(client, resume_thread_id="gone-thread").ensure_started()
-        assert tid == "fresh-thread-1"
-        assert [m for m, _ in client.requests] == [
-            "thread/resume", "thread/start",
-        ]
-
-    def test_resume_payload_without_id_falls_back_to_thread_start(self):
-        client = StubClient(resume_payload={"unexpected": True})
-        tid = _session(client, resume_thread_id="old-thread").ensure_started()
-        assert tid == "fresh-thread-1"
-        assert [m for m, _ in client.requests] == [
-            "thread/resume", "thread/start",
-        ]
-
-    def test_no_resume_id_preserves_original_behavior(self):
-        client = StubClient()
-        tid = _session(client).ensure_started()
-        assert tid == "fresh-thread-1"
-        assert [m for m, _ in client.requests] == ["thread/start"]
+def test_resume_happy_path_never_starts_a_fresh_thread():
+    client = StubClient(resume_payload={"thread": {"id": "old-thread"}})
+    s = session(client, "old-thread")
+    assert s.ensure_started() == s.ensure_started() == "old-thread"
+    assert [m for m, _ in client.requests] == ["thread/resume"]
 
 
-class TestThreadIdStore:
-    def _agent(self, session_id="sess-1", platform="telegram"):
-        return SimpleNamespace(session_id=session_id, platform=platform)
-
-    def test_round_trip(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-        agent = self._agent()
-        assert _load_codex_thread_id(agent) is None
-        _store_codex_thread_id(agent, "thread-abc")
-        assert _load_codex_thread_id(agent) == "thread-abc"
-
-    def test_corrupt_store_reads_as_empty_and_recovers_on_write(
-        self, tmp_path, monkeypatch
-    ):
-        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-        _codex_thread_store_path().write_text("{not json", encoding="utf-8")
-        agent = self._agent()
-        assert _load_codex_thread_id(agent) is None
-        _store_codex_thread_id(agent, "thread-abc")
-        assert _load_codex_thread_id(agent) == "thread-abc"
-
-    def test_hygiene_agents_neither_read_nor_write(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-        real = self._agent()
-        _store_codex_thread_id(real, "thread-abc")
-        hygiene = self._agent(platform="gateway_hygiene")
-        assert _load_codex_thread_id(hygiene) is None
-        _store_codex_thread_id(hygiene, "clobber")
-        assert _load_codex_thread_id(real) == "thread-abc"
-
-    def test_store_prunes_oldest_beyond_cap(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-        for i in range(205):
-            _store_codex_thread_id(self._agent(f"sess-{i:03d}"), f"t-{i}")
-        store = json.loads(
-            _codex_thread_store_path().read_text(encoding="utf-8")
-        )
-        assert len(store) <= 200
-        assert "sess-204" in store  # newest survives
-        assert "sess-000" not in store  # oldest pruned
+@pytest.mark.parametrize("payload", [{}, {"thread": {"id": "wrong-thread"}}])
+def test_invalid_resume_never_starts_empty_thread(payload):
+    client = StubClient(resume_payload=payload)
+    with pytest.raises(CodexAppServerError):
+        session(client, "old-thread").ensure_started()
+    assert [m for m, _ in client.requests] == ["thread/resume"]
 
 
-class TestRunConversationWiring:
-    def _make_codex_agent(self, **kwargs):
-        return run_agent.AIAgent(
-            api_key="stub",
-            base_url="https://stub.invalid",
-            provider="openai",
-            api_mode="codex_app_server",
-            quiet_mode=True,
-            skip_context_files=True,
-            skip_memory=True,
-            **kwargs,
-        )
+@pytest.mark.parametrize("error", [
+    CodexAppServerError(code=-32600, message="missing rollout"),
+    TimeoutError("temporary outage"),
+])
+def test_resume_failure_preserves_binding_for_retry(error):
+    client = StubClient(resume_error=error)
+    with pytest.raises(type(error)):
+        session(client, "old-thread").ensure_started()
+    assert [m for m, _ in client.requests] == ["thread/resume"]
 
-    def test_stored_id_reaches_session_and_turn_id_lands_in_store(
-        self, tmp_path, monkeypatch
-    ):
-        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-        seen = {}
-        original_init = CodexAppServerSession.__init__
 
-        def spy_init(self, **kwargs):
-            seen["resume_thread_id"] = kwargs.get("resume_thread_id")
-            original_init(self, **kwargs)
+def test_new_session_starts_fresh():
+    client = StubClient()
+    assert session(client).ensure_started() == "fresh-thread-1"
+    assert [m for m, _ in client.requests] == ["thread/start"]
 
-        def fake_run_turn(self, user_input, **kwargs):
-            return TurnResult(
-                final_text="done",
-                projected_messages=[{"role": "assistant", "content": "done"}],
-                turn_id="turn-1",
-                thread_id="thread-resumed-7",
-            )
 
-        monkeypatch.setattr(CodexAppServerSession, "__init__", spy_init)
-        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
-        monkeypatch.setattr(
-            CodexAppServerSession,
-            "ensure_started",
-            lambda self: "thread-resumed-7",
-        )
+@pytest.fixture
+def db(tmp_path):
+    database = SessionDB(tmp_path / "sessions.db")
+    yield database
+    database.close()
 
-        agent = self._make_codex_agent(session_id="wiring-sess")
-        _store_codex_thread_id(
-            SimpleNamespace(session_id="wiring-sess", platform="cli"),
-            "thread-resumed-7",
-        )
-        with patch.object(agent, "_spawn_background_review", return_value=None):
-            result = agent.run_conversation("hello")
 
-        assert result["codex_thread_id"] == "thread-resumed-7"
-        assert seen["resume_thread_id"] == "thread-resumed-7"
-        stored = _load_codex_thread_id(
-            SimpleNamespace(session_id="wiring-sess", platform="cli")
-        )
-        assert stored == "thread-resumed-7"
+def agent_for(db, sid="sess-1", platform="discord"):
+    db.create_session(sid, source=platform, model_config={"unrelated": "preserve"})
+    return SimpleNamespace(_session_db=db, session_id=sid, platform=platform)
+
+
+def test_binding_survives_new_database_connection(db):
+    agent = agent_for(db)
+    assert _load_codex_thread_id(agent) is None
+    _store_codex_thread_id(agent, "thread-1")
+    other = SessionDB(db.db_path)
+    try:
+        rebuilt = SimpleNamespace(_session_db=other, session_id=agent.session_id, platform="discord")
+        assert _load_codex_thread_id(rebuilt) == "thread-1"
+        assert other.get_session_model_config_value(agent.session_id, "unrelated") == "preserve"
+    finally:
+        other.close()
+
+
+def test_concurrent_session_bindings_are_not_lost(db):
+    agents = [agent_for(db, f"s-{i}") for i in range(24)]
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(lambda a: _store_codex_thread_id(a, "thread-" + a.session_id), agents))
+    assert [_load_codex_thread_id(a) for a in agents] == ["thread-" + a.session_id for a in agents]
+
+
+def test_hygiene_cannot_clobber_binding(db):
+    agent = agent_for(db)
+    _store_codex_thread_id(agent, "thread-1")
+    agent.platform = "gateway_hygiene"
+    assert _load_codex_thread_id(agent) is None
+    _store_codex_thread_id(agent, "clobber")
+    agent.platform = "discord"
+    assert _load_codex_thread_id(agent) == "thread-1"
+
+
+def test_new_hermes_session_does_not_inherit_old_thread(db):
+    _store_codex_thread_id(agent_for(db, "old"), "thread-old")
+    assert _load_codex_thread_id(agent_for(db, "new")) is None
+
+
+def test_changed_codex_home_refuses_resume(db, monkeypatch, tmp_path):
+    agent = agent_for(db)
+    _store_codex_thread_id(agent, "thread-1")
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "other-home"))
+    with pytest.raises(RuntimeError, match="profile/home"):
+        _load_codex_thread_id(agent)
+
+
+@pytest.mark.parametrize("binding", ["corrupt", {}, {"thread_id": 9}])
+def test_corrupt_binding_is_not_treated_as_new_session(db, binding):
+    agent = agent_for(db)
+    db.patch_session_model_config(agent.session_id, {"codex_thread_binding": binding})
+    with pytest.raises(RuntimeError):
+        _load_codex_thread_id(agent)
+
+
+def test_missing_database_row_is_not_silent_success(db):
+    agent = SimpleNamespace(_session_db=db, session_id="missing", platform="discord")
+    with pytest.raises(RuntimeError):
+        _store_codex_thread_id(agent, "thread-1")
+
+
+def make_agent(sid, db=None):
+    return run_agent.AIAgent(
+        session_id=sid, api_key="stub", base_url="https://stub.invalid",
+        provider="openai", api_mode="codex_app_server", quiet_mode=True,
+        skip_context_files=True, skip_memory=True, session_db=db,
+    )
+
+
+def test_real_agent_rebuild_resumes_before_sending_followup(monkeypatch, db):
+    clients = []
+    original_init = CodexAppServerSession.__init__
+    def init(self, **kwargs):
+        client = StubClient(resume_payload={"thread": {"id": "fresh-thread-1"}})
+        clients.append(client)
+        original_init(self, client_factory=lambda **kw: client, **kwargs)
+    def run_turn(self, user_input, **kwargs):
+        # Persistence must already be durable before user input reaches Codex.
+        return TurnResult(final_text="done", thread_id=self._thread_id,
+                          projected_messages=[{"role": "assistant", "content": "done"}])
+    monkeypatch.setattr(CodexAppServerSession, "__init__", init)
+    monkeypatch.setattr(CodexAppServerSession, "run_turn", run_turn)
+    with patch.object(run_agent.AIAgent, "_spawn_background_review"):
+        first = make_agent("rebuild-test", db)
+        result = first.run_conversation("Remember the word amber.")
+        assert result["completed"], result
+        assert _load_codex_thread_id(first) == "fresh-thread-1"
+        first._codex_session.close()
+        rebuilt = make_agent("rebuild-test", db)
+        second = rebuilt.run_conversation("Which word?", conversation_history=result["messages"])
+        assert second["completed"], second
+    assert [[m for m, _ in c.requests] for c in clients] == [["thread/start"], ["thread/resume"]]
+
+
+def test_persistence_failure_sends_no_user_turn(db):
+    agent = make_agent("write-failure", db)
+    with patch.object(CodexAppServerSession, "ensure_started", return_value="thread-1"), \
+         patch.object(CodexAppServerSession, "run_turn") as turn, \
+         patch.object(agent._session_db, "patch_session_model_config", side_effect=OSError("disk full")):
+        result = agent.run_conversation("hello")
+    assert result["completed"] is False
+    turn.assert_not_called()
+
+
+def test_unbound_existing_history_does_not_start_empty_thread():
+    agent = make_agent("unbound")
+    with patch.object(CodexAppServerSession, "ensure_started") as start:
+        result = agent.run_conversation("what was that?", conversation_history=[
+            {"role": "user", "content": "Remember amber"},
+            {"role": "assistant", "content": "Remembered"},
+        ])
+    assert result["completed"] is False
+    assert "no saved Codex thread binding" in result["final_response"]
+    start.assert_not_called()
+
+
+def test_automatic_rename_rebuild_keeps_provider_binding(db):
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource, SessionContext, build_session_context_prompt
+    from gateway.config import Platform
+    source = SessionSource(platform=Platform.DISCORD, chat_id="chat", thread_id="thread",
+                           chat_type="thread", chat_name="Remember amber", user_id="user")
+    context = SessionContext(source=source, connected_platforms=[Platform.DISCORD], home_channels={})
+    def signature():
+        return GatewayRunner._agent_config_signature("model", {}, [], build_session_context_prompt(context))
+    before = signature()
+    first = agent_for(db, "rename")
+    _store_codex_thread_id(first, "provider-thread")
+    source.chat_name = "Remember a word"
+    assert signature() != before  # The real gateway rebuild trigger.
+    rebuilt = agent_for(db, "rename")
+    client = StubClient(resume_payload={"thread": {"id": "provider-thread"}})
+    assert session(client, _load_codex_thread_id(rebuilt)).ensure_started() == "provider-thread"
+    assert [m for m, _ in client.requests] == ["thread/resume"]


### PR DESCRIPTION
## Problem

Codex app-server conversations can lose context when the gateway rebuilds an AIAgent, including after a Discord thread rename, cache eviction, or process restart. The replacement agent starts a new provider thread and sends only the latest user message.

This builds on #99012 by @Haseeb-Qureshi, preserving its original author commit and adapting it to the current runtime helpers. Offered as a hardened follow-up for integration with that work, rather than an independent discovery. Related: #41904, #82160, #100531.

## Change

- Store the Codex thread ID and resolved CODEX_HOME in the existing session row using SessionDB's atomic model_config patch. This avoids shared JSON-file races and keeps bindings within the existing profile/session storage.
- Persist the binding before sending user input, then resume it when an agent is rebuilt.
- Propagate failed or mismatched resume responses instead of silently starting an empty conversation. Reject a changed CODEX_HOME or history without a saved binding with an explicit recovery error.
- Keep new sessions and hygiene agents isolated; preserve unrelated model_config fields.

Existing conversations without bindings require restoration of their binding or an explicit new session. This does not reconstruct context already lost before installation. No schema migration or new configuration option is introduced.

## Verification

`scripts/run_tests.sh tests/run_agent/test_codex_app_server_resume.py tests/run_agent/test_codex_app_server_integration.py tests/run_agent/test_codex_app_server_compaction.py tests/run_agent/test_codex_app_server_lifecycle.py tests/agent/test_codex_app_server_event_bridge.py -q`

78 tests passed, including 19 continuity cases covering real runtime/DB integration, concurrent session writes, agent rebuilds, rename-triggered signature changes, persistence failure before user input, and strict resume failures.

Ruff, Windows footgun checks, and git diff --check passed. A live Codex app-server test in an isolated Hermes profile confirmed that a second Python process resumed the same thread and recalled a fact from the first process. A backport is also running on a Discord gateway; a fresh human Discord reply has not yet been observed after installation.
