### PR TITLE
feat(slack): add durable thread leave and rejoin

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3835,6 +3835,16 @@ class SlackAdapter(BasePlatformAdapter):
             return False
         return True
 
+    @staticmethod
+    def _slack_participation_mention_text(text: str, bot_uid: Optional[str]) -> Optional[str]:
+        """Return text sans this bot's exact Slack mention, or None when absent."""
+        if not bot_uid:
+            return None
+        token = f"<@{bot_uid}>"
+        if token not in text:
+            return None
+        return text.replace(token, "").strip()
+
     async def _channel_gate_allows(
         self, *, channel_id: str, routing_text: str, bot_uid: str, is_mentioned: bool,
         is_thread_reply: bool, event_thread_ts, user_id: str, team_id: str, is_dm: bool,
@@ -4258,6 +4268,7 @@ class SlackAdapter(BasePlatformAdapter):
         is_mentioned = bool(
             (bot_uid and f"<@{bot_uid}>" in routing_text)
             or self._slack_message_matches_mention_patterns(routing_text))
+        participation_text = self._slack_participation_mention_text(original_text, bot_uid)
         event_thread_ts = event.get("thread_ts")
         is_thread_reply = bool(event_thread_ts and event_thread_ts != ts)
         # Internal triggers (reactions) skip the mention requirement but NOT
@@ -4267,9 +4278,8 @@ class SlackAdapter(BasePlatformAdapter):
             return
         if not is_one_to_one_dm and bot_uid and not self._allowed_channel_gate_allows(channel_id):
             return
-        if is_mentioned and thread_ts:
-            mention_stripped = original_text.replace(f"<@{bot_uid}>", "").strip()
-            if is_thread_reply and mention_stripped.lower() == "!leave":
+        if participation_text is not None and thread_ts:
+            if is_thread_reply and participation_text.lower() == "!leave":
                 result = self._thread_participation_store().mute(
                     team_id, channel_id, thread_ts)
                 marker = self._workspace_message_marker(team_id, thread_ts)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -43,8 +43,10 @@ from gateway.platforms.base import (
 
 try:  # sibling module; support both package and flat plugin-dir import
     from .block_kit import render_blocks, sanitize_blocks
+    from .thread_participation import SlackThreadParticipationStore
 except ImportError:  # pragma: no cover - plugin loaded outside package context
     from block_kit import render_blocks, sanitize_blocks  # type: ignore
+    from thread_participation import SlackThreadParticipationStore  # type: ignore
 
 
 logger = logging.getLogger(__name__)
@@ -902,6 +904,7 @@ class SlackAdapter(BasePlatformAdapter):
         # Bot-sent message ts / @mentioned threads: replies there get answered without a mention.
         self._bot_message_ts: set[str] = set()
         self._mentioned_threads: set[str] = set()
+        self._thread_participation = SlackThreadParticipationStore()
         # (team_id, channel_id, thread_ts) → Assistant thread metadata; lifecycle
         # events may precede message events and carry session-scoping identity.
         self._assistant_threads: Dict[Tuple[str, str, str], Dict[str, str]] = {}
@@ -1032,6 +1035,9 @@ class SlackAdapter(BasePlatformAdapter):
             value = factory()
             setattr(self, name, value)
         return value
+
+    def _thread_participation_store(self) -> SlackThreadParticipationStore:
+        return self._lazy_attr("_thread_participation", SlackThreadParticipationStore)
 
     def _remember_channel_team(self, channel_id: str, team_id: str) -> None:
         """Record which workspace owns *channel_id* (bounded oldest-first). Channel ids are
@@ -3833,6 +3839,13 @@ class SlackAdapter(BasePlatformAdapter):
         if allowed_channels and channel_id not in allowed_channels:
             logger.debug("[Slack] Ignoring message in non-allowed channel: %s", channel_id)
             return False
+        if event_thread_ts and self._thread_participation_store().is_muted(
+            team_id, channel_id, event_thread_ts
+        ):
+            logger.debug(
+                "[Slack] Ignoring message in a thread this bot left: channel=%s thread_ts=%s",
+                channel_id, event_thread_ts)
+            return False
         self_uids = {u for u in (bot_uid, self._bot_user_id) if u}
         if (
             self._slack_ignore_other_user_mentions() and not is_mentioned
@@ -4246,6 +4259,21 @@ class SlackAdapter(BasePlatformAdapter):
         force_process = bool(event.get("_hermes_force_process"))
         if await self._peer_bot_drop(event, user_id, bot_uid, channel_id, team_id, is_mentioned):
             return
+        if is_mentioned and thread_ts:
+            mention_stripped = original_text.replace(f"<@{bot_uid}>", "").strip()
+            if is_thread_reply and mention_stripped.lower() == "!leave":
+                self._thread_participation_store().mute(team_id, channel_id, thread_ts)
+                marker = self._workspace_message_marker(team_id, thread_ts)
+                self._mentioned_threads.discard(marker)
+                self._mentioned_threads.discard(thread_ts)
+                await self.send(
+                    channel_id,
+                    "Left this thread. Mention me to rejoin.",
+                    reply_to=thread_ts,
+                    metadata={"team_id": team_id},
+                )
+                return
+            self._thread_participation_store().unmute(team_id, channel_id, thread_ts)
         if (
             not is_one_to_one_dm and bot_uid and not await self._channel_gate_allows(
             channel_id=channel_id, routing_text=routing_text, bot_uid=bot_uid,

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4262,16 +4262,24 @@ class SlackAdapter(BasePlatformAdapter):
         if is_mentioned and thread_ts:
             mention_stripped = original_text.replace(f"<@{bot_uid}>", "").strip()
             if is_thread_reply and mention_stripped.lower() == "!leave":
-                self._thread_participation_store().mute(team_id, channel_id, thread_ts)
+                persisted = self._thread_participation_store().mute(
+                    team_id, channel_id, thread_ts)
                 marker = self._workspace_message_marker(team_id, thread_ts)
-                self._mentioned_threads.discard(marker)
-                self._mentioned_threads.discard(thread_ts)
                 await self.send(
                     channel_id,
-                    "Left this thread. Mention me to rejoin.",
+                    (
+                        "Left this thread. Mention me to rejoin."
+                        if persisted
+                        else "Couldn't leave this thread because the leave state could not be saved. Please try again."
+                    ),
                     reply_to=thread_ts,
                     metadata={"team_id": team_id},
                 )
+                # send() records its reply root as bot participation, so clear direct wake
+                # markers only after the acknowledgement has completed.
+                for wake_markers in (self._mentioned_threads, self._bot_message_ts):
+                    wake_markers.discard(marker)
+                    wake_markers.discard(thread_ts)
                 return
             self._thread_participation_store().unmute(team_id, channel_id, thread_ts)
         if (

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3827,6 +3827,14 @@ class SlackAdapter(BasePlatformAdapter):
                 "[Slack] Early reject of unauthorized user %s in channel %s", user_id, channel_id)
         return decision is False
 
+    def _allowed_channel_gate_allows(self, channel_id: str) -> bool:
+        """Apply the configured channel allowlist before any channel-scoped side effect."""
+        allowed_channels = self._slack_allowed_channels()
+        if allowed_channels and channel_id not in allowed_channels:
+            logger.debug("[Slack] Ignoring message in non-allowed channel: %s", channel_id)
+            return False
+        return True
+
     async def _channel_gate_allows(
         self, *, channel_id: str, routing_text: str, bot_uid: str, is_mentioned: bool,
         is_thread_reply: bool, event_thread_ts, user_id: str, team_id: str, is_dm: bool,
@@ -3835,9 +3843,7 @@ class SlackAdapter(BasePlatformAdapter):
         ``thread_require_mention``), when @mentioned, or when a wake check passes. Always silent
         outside ``allowed_channels`` or when addressed to another user; ``force_process`` skips only
         the mention rule."""
-        allowed_channels = self._slack_allowed_channels()
-        if allowed_channels and channel_id not in allowed_channels:
-            logger.debug("[Slack] Ignoring message in non-allowed channel: %s", channel_id)
+        if not self._allowed_channel_gate_allows(channel_id):
             return False
         if event_thread_ts and self._thread_participation_store().is_muted(
             team_id, channel_id, event_thread_ts
@@ -4259,17 +4265,19 @@ class SlackAdapter(BasePlatformAdapter):
         force_process = bool(event.get("_hermes_force_process"))
         if await self._peer_bot_drop(event, user_id, bot_uid, channel_id, team_id, is_mentioned):
             return
+        if not is_one_to_one_dm and bot_uid and not self._allowed_channel_gate_allows(channel_id):
+            return
         if is_mentioned and thread_ts:
             mention_stripped = original_text.replace(f"<@{bot_uid}>", "").strip()
             if is_thread_reply and mention_stripped.lower() == "!leave":
-                persisted = self._thread_participation_store().mute(
+                result = self._thread_participation_store().mute(
                     team_id, channel_id, thread_ts)
                 marker = self._workspace_message_marker(team_id, thread_ts)
                 await self.send(
                     channel_id,
                     (
                         "Left this thread. Mention me to rejoin."
-                        if persisted
+                        if result.persisted
                         else "Couldn't leave this thread because the leave state could not be saved. Please try again."
                     ),
                     reply_to=thread_ts,
@@ -4277,11 +4285,21 @@ class SlackAdapter(BasePlatformAdapter):
                 )
                 # send() records its reply root as bot participation, so clear direct wake
                 # markers only after the acknowledgement has completed.
-                for wake_markers in (self._mentioned_threads, self._bot_message_ts):
-                    wake_markers.discard(marker)
-                    wake_markers.discard(thread_ts)
+                if result.persisted:
+                    for wake_markers in (self._mentioned_threads, self._bot_message_ts):
+                        wake_markers.discard(marker)
+                        wake_markers.discard(thread_ts)
                 return
-            self._thread_participation_store().unmute(team_id, channel_id, thread_ts)
+            result = self._thread_participation_store().unmute(
+                team_id, channel_id, thread_ts)
+            if not result.persisted:
+                await self.send(
+                    channel_id,
+                    "Couldn't rejoin this thread because the leave state could not be saved. Please try again.",
+                    reply_to=thread_ts,
+                    metadata={"team_id": team_id},
+                )
+                return
         if (
             not is_one_to_one_dm and bot_uid and not await self._channel_gate_allows(
             channel_id=channel_id, routing_text=routing_text, bot_uid=bot_uid,

--- a/plugins/platforms/slack/thread_participation.py
+++ b/plugins/platforms/slack/thread_participation.py
@@ -1,0 +1,74 @@
+"""Durable, profile-scoped Slack thread participation state."""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+from hermes_constants import get_hermes_home
+from utils import atomic_json_write
+
+logger = logging.getLogger(__name__)
+
+
+class SlackThreadParticipationStore:
+    """Persistent bounded set of threads this bot explicitly left."""
+
+    MAX_ENTRIES = 5000
+
+    def __init__(self, path: Optional[Path] = None, *, max_entries: int = MAX_ENTRIES) -> None:
+        self._path = path or get_hermes_home() / "gateway" / "slack_left_threads.json"
+        self._max_entries = max(2, max_entries)
+        self._lock = threading.RLock()
+        self._entries: dict[str, float] = {}
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8")) if self._path.exists() else {}
+            if isinstance(raw, dict):
+                self._entries = {
+                    str(key): float(marked_at)
+                    for key, marked_at in raw.items()
+                    if isinstance(marked_at, (int, float))
+                }
+        except (OSError, ValueError, TypeError) as exc:
+            logger.debug("Slack thread participation state could not be loaded: %s", exc)
+        if self._prune_locked():
+            self._flush_locked()
+
+    @staticmethod
+    def _key(team_id: str, channel_id: str, thread_ts: str) -> str:
+        return json.dumps([str(team_id), str(channel_id), str(thread_ts)], separators=(",", ":"))
+
+    def _prune_locked(self) -> bool:
+        if len(self._entries) <= self._max_entries:
+            return False
+        keep = self._max_entries // 2
+        newest = sorted(self._entries.items(), key=lambda item: item[1], reverse=True)[:keep]
+        self._entries = dict(newest)
+        return True
+
+    def _flush_locked(self) -> None:
+        try:
+            atomic_json_write(self._path, self._entries, indent=None, separators=(",", ":"))
+        except OSError as exc:
+            logger.debug("Slack thread participation state could not be persisted: %s", exc)
+
+    def is_muted(self, team_id: str, channel_id: str, thread_ts: str) -> bool:
+        with self._lock:
+            return self._key(team_id, channel_id, thread_ts) in self._entries
+
+    def mute(self, team_id: str, channel_id: str, thread_ts: str) -> None:
+        with self._lock:
+            self._entries[self._key(team_id, channel_id, thread_ts)] = time.time()
+            self._prune_locked()
+            self._flush_locked()
+
+    def unmute(self, team_id: str, channel_id: str, thread_ts: str) -> bool:
+        with self._lock:
+            removed = self._entries.pop(self._key(team_id, channel_id, thread_ts), None) is not None
+            if removed:
+                self._flush_locked()
+            return removed

--- a/plugins/platforms/slack/thread_participation.py
+++ b/plugins/platforms/slack/thread_participation.py
@@ -6,6 +6,7 @@ import json
 import logging
 import threading
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
@@ -13,6 +14,14 @@ from hermes_constants import get_hermes_home
 from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ParticipationMutationResult:
+    """Outcome of an in-memory mutation and its required durable write."""
+
+    changed: bool
+    persisted: bool
 
 
 class SlackThreadParticipationStore:
@@ -62,15 +71,28 @@ class SlackThreadParticipationStore:
         with self._lock:
             return self._key(team_id, channel_id, thread_ts) in self._entries
 
-    def mute(self, team_id: str, channel_id: str, thread_ts: str) -> bool:
+    def mute(
+        self, team_id: str, channel_id: str, thread_ts: str
+    ) -> ParticipationMutationResult:
         with self._lock:
+            before = self._entries.copy()
             self._entries[self._key(team_id, channel_id, thread_ts)] = time.time()
             self._prune_locked()
-            return self._flush_locked()
+            changed = self._entries != before
+            persisted = self._flush_locked()
+            if not persisted:
+                self._entries = before
+            return ParticipationMutationResult(changed=changed, persisted=persisted)
 
-    def unmute(self, team_id: str, channel_id: str, thread_ts: str) -> bool:
+    def unmute(
+        self, team_id: str, channel_id: str, thread_ts: str
+    ) -> ParticipationMutationResult:
         with self._lock:
+            before = self._entries.copy()
             removed = self._entries.pop(self._key(team_id, channel_id, thread_ts), None) is not None
-            if removed:
-                self._flush_locked()
-            return removed
+            if not removed:
+                return ParticipationMutationResult(changed=False, persisted=True)
+            persisted = self._flush_locked()
+            if not persisted:
+                self._entries = before
+            return ParticipationMutationResult(changed=True, persisted=persisted)

--- a/plugins/platforms/slack/thread_participation.py
+++ b/plugins/platforms/slack/thread_participation.py
@@ -50,21 +50,23 @@ class SlackThreadParticipationStore:
         self._entries = dict(newest)
         return True
 
-    def _flush_locked(self) -> None:
+    def _flush_locked(self) -> bool:
         try:
             atomic_json_write(self._path, self._entries, indent=None, separators=(",", ":"))
         except OSError as exc:
             logger.debug("Slack thread participation state could not be persisted: %s", exc)
+            return False
+        return True
 
     def is_muted(self, team_id: str, channel_id: str, thread_ts: str) -> bool:
         with self._lock:
             return self._key(team_id, channel_id, thread_ts) in self._entries
 
-    def mute(self, team_id: str, channel_id: str, thread_ts: str) -> None:
+    def mute(self, team_id: str, channel_id: str, thread_ts: str) -> bool:
         with self._lock:
             self._entries[self._key(team_id, channel_id, thread_ts)] = time.time()
             self._prune_locked()
-            self._flush_locked()
+            return self._flush_locked()
 
     def unmute(self, team_id: str, channel_id: str, thread_ts: str) -> bool:
         with self._lock:

--- a/tests/gateway/test_slack_thread_leave.py
+++ b/tests/gateway/test_slack_thread_leave.py
@@ -1,0 +1,106 @@
+import asyncio
+import json
+
+from unittest.mock import AsyncMock
+
+from gateway.config import PlatformConfig
+from plugins.platforms.slack.adapter import SlackAdapter
+from plugins.platforms.slack.thread_participation import SlackThreadParticipationStore
+
+
+def _event(text: str, *, ts: str, thread_ts: str, team: str = "T1") -> dict:
+    return {
+        "type": "message",
+        "channel": "C123",
+        "channel_type": "channel",
+        "team": team,
+        "user": "U123",
+        "client_msg_id": f"msg-{team}-{ts}",
+        "text": text,
+        "ts": ts,
+        "thread_ts": thread_ts,
+    }
+
+
+def _adapter() -> SlackAdapter:
+    adapter = SlackAdapter(
+        PlatformConfig(
+            extra={
+                "allowed_channels": ["C123"],
+                "require_mention": True,
+                "reply_in_thread": True,
+            }
+        )
+    )
+    adapter._bot_user_id = "UBOT"
+    adapter._team_bot_user_ids.update({"T1": "UBOT", "T2": "UBOT"})
+    adapter._has_active_session_for_thread = lambda **_: True
+    adapter.send = AsyncMock()
+    adapter.handle_message = AsyncMock()
+    return adapter
+
+
+def test_direct_leave_mutes_active_thread_until_direct_mention_rejoins():
+    adapter = _adapter()
+
+    asyncio.run(
+        adapter._handle_slack_message(
+            _event("<@UBOT> !leave", ts="99.000", thread_ts="99.000")
+        )
+    )
+    adapter.handle_message.assert_awaited_once()
+    adapter.handle_message.reset_mock()
+
+    asyncio.run(
+        adapter._handle_slack_message(
+            _event("!leave", ts="100.500", thread_ts="100.000")
+        )
+    )
+    adapter.handle_message.assert_awaited_once()
+    adapter.handle_message.reset_mock()
+
+    asyncio.run(
+        adapter._handle_slack_message(
+            _event("<@UBOT> !leave", ts="101.000", thread_ts="100.000")
+        )
+    )
+    adapter.handle_message.assert_not_awaited()
+    adapter.send.assert_awaited_once_with(
+        "C123", "Left this thread. Mention me to rejoin.", reply_to="100.000",
+        metadata={"team_id": "T1"},
+    )
+
+    adapter = _adapter()  # Restart: profile-scoped state must survive adapter reconstruction.
+    asyncio.run(
+        adapter._handle_slack_message(
+            _event(
+                "same ids, other workspace", ts="101.500", thread_ts="100.000", team="T2"
+            )
+        )
+    )
+    adapter.handle_message.assert_awaited_once()
+    adapter.handle_message.reset_mock()
+
+    asyncio.run(
+        adapter._handle_slack_message(
+            _event("ordinary follow-up", ts="102.000", thread_ts="100.000")
+        )
+    )
+    adapter.handle_message.assert_not_awaited()
+
+    asyncio.run(
+        adapter._handle_slack_message(
+            _event("<@UBOT> come back", ts="103.000", thread_ts="100.000")
+        )
+    )
+    adapter.handle_message.assert_awaited_once()
+    assert adapter.handle_message.await_args.args[0].text == "come back"
+
+
+def test_participation_store_prunes_oversized_state_on_load(tmp_path):
+    path = tmp_path / "left.json"
+    path.write_text(json.dumps({f"thread-{i}": i for i in range(6)}), encoding="utf-8")
+
+    SlackThreadParticipationStore(path, max_entries=4)
+
+    assert len(json.loads(path.read_text(encoding="utf-8"))) <= 4

--- a/tests/gateway/test_slack_thread_leave.py
+++ b/tests/gateway/test_slack_thread_leave.py
@@ -8,10 +8,12 @@ from plugins.platforms.slack.adapter import SlackAdapter
 from plugins.platforms.slack.thread_participation import SlackThreadParticipationStore
 
 
-def _event(text: str, *, ts: str, thread_ts: str, team: str = "T1") -> dict:
+def _event(
+    text: str, *, ts: str, thread_ts: str, team: str = "T1", channel: str = "C123"
+) -> dict:
     return {
         "type": "message",
-        "channel": "C123",
+        "channel": channel,
         "channel_type": "channel",
         "team": team,
         "user": "U123",
@@ -144,7 +146,78 @@ def test_leave_reports_failure_when_mute_cannot_be_persisted(tmp_path, monkeypat
         reply_to="100.000",
         metadata={"team_id": "T1"},
     )
+    assert not adapter._thread_participation.is_muted("T1", "C123", "100.000")
+
+
+def test_failed_mute_restores_exact_state_before_insert_and_prune(tmp_path, monkeypatch):
+    store = SlackThreadParticipationStore(tmp_path / "left.json", max_entries=2)
+    store._entries = {"older": 1.0, "newer": 2.0}
+    before = store._entries.copy()
+
+    def fail_write(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(
+        "plugins.platforms.slack.thread_participation.atomic_json_write", fail_write)
+
+    result = store.mute("T1", "C123", "100.000")
+
+    assert result.persisted is False
+    assert store._entries == before
+
+
+def test_failed_unmute_restores_state_and_reports_persistence_failure(tmp_path, monkeypatch):
+    store = SlackThreadParticipationStore(tmp_path / "left.json")
+    assert store.mute("T1", "C123", "100.000").persisted is True
+    before = store._entries.copy()
+
+    def fail_write(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(
+        "plugins.platforms.slack.thread_participation.atomic_json_write", fail_write)
+
+    result = store.unmute("T1", "C123", "100.000")
+
+    assert result.changed is True
+    assert result.persisted is False
+    assert store._entries == before
+
+
+def test_failed_durable_rejoin_acknowledges_failure_without_model_turn(tmp_path, monkeypatch):
+    adapter = _adapter(tmp_path)
+    assert adapter._thread_participation.mute("T1", "C123", "100.000").persisted is True
+
+    def fail_write(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(
+        "plugins.platforms.slack.thread_participation.atomic_json_write", fail_write)
+
+    asyncio.run(adapter._handle_slack_message(
+        _event("<@UBOT> come back", ts="101.000", thread_ts="100.000")))
+
+    adapter.send.assert_awaited_once_with(
+        "C123",
+        "Couldn't rejoin this thread because the leave state could not be saved. Please try again.",
+        reply_to="100.000",
+        metadata={"team_id": "T1"},
+    )
+    adapter.handle_message.assert_not_awaited()
     assert adapter._thread_participation.is_muted("T1", "C123", "100.000")
+
+
+def test_leave_in_excluded_channel_is_silently_ignored(tmp_path):
+    adapter = _adapter(tmp_path)
+
+    asyncio.run(adapter._handle_slack_message(
+        _event(
+            "<@UBOT> !leave", ts="101.000", thread_ts="100.000", channel="C999"
+        )))
+
+    adapter.send.assert_not_awaited()
+    adapter.handle_message.assert_not_awaited()
+    assert not adapter._thread_participation.is_muted("T1", "C999", "100.000")
 
 
 def test_participation_store_prunes_oversized_state_on_load(tmp_path):

--- a/tests/gateway/test_slack_thread_leave.py
+++ b/tests/gateway/test_slack_thread_leave.py
@@ -43,6 +43,28 @@ def _adapter(tmp_path) -> SlackAdapter:
     return adapter
 
 
+def test_pattern_matching_bare_leave_never_mutes_thread(tmp_path):
+    adapter = _adapter(tmp_path)
+    adapter.config.extra["mention_patterns"] = [r"^!leave$"]
+
+    asyncio.run(adapter._handle_slack_message(
+        _event("!leave", ts="101.000", thread_ts="100.000")))
+
+    assert not adapter._thread_participation.is_muted("T1", "C123", "100.000")
+
+
+def test_pattern_only_match_never_rejoins_muted_thread(tmp_path):
+    adapter = _adapter(tmp_path)
+    adapter.config.extra["mention_patterns"] = [r"^wake up$"]
+    assert adapter._thread_participation.mute("T1", "C123", "100.000").persisted
+
+    asyncio.run(adapter._handle_slack_message(
+        _event("wake up", ts="101.000", thread_ts="100.000")))
+
+    assert adapter._thread_participation.is_muted("T1", "C123", "100.000")
+    adapter.handle_message.assert_not_awaited()
+
+
 def test_direct_leave_mutes_active_thread_until_direct_mention_rejoins(tmp_path):
     adapter = _adapter(tmp_path)
 
@@ -90,6 +112,14 @@ def test_direct_leave_mutes_active_thread_until_direct_mention_rejoins(tmp_path)
         )
     )
     adapter.handle_message.assert_not_awaited()
+
+    asyncio.run(
+        adapter._handle_slack_message(
+            _event("<@UOTHER> !leave", ts="102.500", thread_ts="100.000")
+        )
+    )
+    adapter.handle_message.assert_not_awaited()
+    assert adapter._thread_participation.is_muted("T1", "C123", "100.000")
 
     asyncio.run(
         adapter._handle_slack_message(

--- a/tests/gateway/test_slack_thread_leave.py
+++ b/tests/gateway/test_slack_thread_leave.py
@@ -22,7 +22,7 @@ def _event(text: str, *, ts: str, thread_ts: str, team: str = "T1") -> dict:
     }
 
 
-def _adapter() -> SlackAdapter:
+def _adapter(tmp_path) -> SlackAdapter:
     adapter = SlackAdapter(
         PlatformConfig(
             extra={
@@ -34,14 +34,15 @@ def _adapter() -> SlackAdapter:
     )
     adapter._bot_user_id = "UBOT"
     adapter._team_bot_user_ids.update({"T1": "UBOT", "T2": "UBOT"})
+    adapter._thread_participation = SlackThreadParticipationStore(tmp_path / "left.json")
     adapter._has_active_session_for_thread = lambda **_: True
     adapter.send = AsyncMock()
     adapter.handle_message = AsyncMock()
     return adapter
 
 
-def test_direct_leave_mutes_active_thread_until_direct_mention_rejoins():
-    adapter = _adapter()
+def test_direct_leave_mutes_active_thread_until_direct_mention_rejoins(tmp_path):
+    adapter = _adapter(tmp_path)
 
     asyncio.run(
         adapter._handle_slack_message(
@@ -70,7 +71,7 @@ def test_direct_leave_mutes_active_thread_until_direct_mention_rejoins():
         metadata={"team_id": "T1"},
     )
 
-    adapter = _adapter()  # Restart: profile-scoped state must survive adapter reconstruction.
+    adapter = _adapter(tmp_path)  # Restart: profile-scoped state must survive reconstruction.
     asyncio.run(
         adapter._handle_slack_message(
             _event(
@@ -95,6 +96,55 @@ def test_direct_leave_mutes_active_thread_until_direct_mention_rejoins():
     )
     adapter.handle_message.assert_awaited_once()
     assert adapter.handle_message.await_args.args[0].text == "come back"
+
+
+def test_leave_ack_clears_every_direct_wake_marker_and_mute_overrides_them(tmp_path):
+    adapter = _adapter(tmp_path)
+    root = "100.000"
+    marker = adapter._workspace_message_marker("T1", root)
+    adapter._mentioned_threads.update({marker, root})
+    adapter._bot_message_ts.update({marker, root})
+
+    async def send_ack(*args, **kwargs):
+        # The real send path records the reply's root as bot participation.
+        adapter._bot_message_ts.add(marker)
+
+    adapter.send.side_effect = send_ack
+
+    asyncio.run(adapter._handle_slack_message(
+        _event("<@UBOT> !leave", ts="101.000", thread_ts=root)))
+
+    assert marker not in adapter._mentioned_threads
+    assert root not in adapter._mentioned_threads
+    assert marker not in adapter._bot_message_ts
+    assert root not in adapter._bot_message_ts
+    assert adapter._thread_participation.is_muted("T1", "C123", root)
+
+    adapter.handle_message.reset_mock()
+    asyncio.run(adapter._handle_slack_message(
+        _event("ordinary follow-up", ts="102.000", thread_ts=root)))
+    adapter.handle_message.assert_not_awaited()
+
+
+def test_leave_reports_failure_when_mute_cannot_be_persisted(tmp_path, monkeypatch):
+    adapter = _adapter(tmp_path)
+
+    def fail_write(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(
+        "plugins.platforms.slack.thread_participation.atomic_json_write", fail_write)
+
+    asyncio.run(adapter._handle_slack_message(
+        _event("<@UBOT> !leave", ts="101.000", thread_ts="100.000")))
+
+    adapter.send.assert_awaited_once_with(
+        "C123",
+        "Couldn't leave this thread because the leave state could not be saved. Please try again.",
+        reply_to="100.000",
+        metadata={"team_id": "T1"},
+    )
+    assert adapter._thread_participation.is_muted("T1", "C123", "100.000")
 
 
 def test_participation_store_prunes_oversized_state_on_load(tmp_path):


### PR DESCRIPTION
## Summary
- add bot-specific `@bot !leave` handling in Slack threads
- persist muted thread participation by workspace, channel, and root thread
- suppress every automatic wake path until an exact direct mention rejoins
- fail safely on persistence errors and honor channel allowlists

## Test plan
- `scripts/run_tests.sh tests/gateway/test_slack_thread_leave.py tests/gateway/test_slack.py tests/gateway/test_slack_mention.py tests/gateway/test_slack_ignore_other_user_mentions.py`
- 281 passed, 0 failed
- `git diff origin/main...HEAD --check`
- Python compile checks for modified Slack modules