### PR TITLE
fix(auth): stop healthy Codex pool accounts from appearing quota-exhausted

### DIFF
--- a/hermes_cli/auth_codex.py
+++ b/hermes_cli/auth_codex.py
@@ -619,11 +619,13 @@ def _pool_codex_access_token() -> str:
 
     Fallback for ``resolve_codex_runtime_credentials`` when the singleton has no creds.
     """
+    from agent.credential_pool import _parse_absolute_timestamp
     from hermes_cli.auth import _nonempty_str
     try:
         for entry in _codex_pool_dicts(_read_codex_pool_entries()):
-            token, reset_at = entry.get("access_token"), entry.get("last_error_reset_at")
-            in_cooldown = isinstance(reset_at, (int, float)) and reset_at > time.time()
+            token = entry.get("access_token")
+            reset_at = _parse_absolute_timestamp(entry.get("last_error_reset_at"))
+            in_cooldown = reset_at is not None and reset_at > time.time()
             if _nonempty_str(token) and not in_cooldown:
                 return token.strip()
     except Exception:

--- a/tests/hermes_cli/test_auth_codex_quota_probe.py
+++ b/tests/hermes_cli/test_auth_codex_quota_probe.py
@@ -244,6 +244,34 @@ def test_resolver_recovers_when_probe_confirms_reset(tmp_path, monkeypatch):
     assert entry["last_error_reset_at"] is None
 
 
+def test_resolver_selects_entry_with_expired_millisecond_reset(tmp_path, monkeypatch):
+    now = time.time()
+    store = _pool_only_rate_limited_store(now)
+    main = store["credential_pool"]["openai-codex"][0]
+    main["access_token"] = "tok-main"
+    main["last_error_reset_at"] = (now - 3600) * 1000
+    reserve = dict(main)
+    reserve.update(
+        {
+            "id": "cred-reserve",
+            "access_token": "tok-reserve",
+            "priority": 1,
+            "last_error_reset_at": now + 886,
+        }
+    )
+    store["credential_pool"]["openai-codex"].append(reserve)
+    hermes_home = tmp_path / "hermes"
+    _write_auth_store(hermes_home, store)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(auth_mod, "_probe_codex_quota_restored", lambda token, **kw: False)
+    monkeypatch.setattr(auth_codex, "_probe_codex_quota_restored", lambda token, **kw: False)
+
+    resolved = resolve_codex_runtime_credentials()
+
+    assert resolved["api_key"] == "tok-main"
+    assert resolved["source"] == "credential_pool"
+
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Codex credential pools now select a usable account when its persisted quota reset timestamp is expressed in milliseconds. Without this fix, a healthy credential can be skipped and users receive a false `Codex provider quota exhausted (429)` error when another credential is genuinely exhausted.

### Symptom

A two-account Codex pool can report `Codex provider quota exhausted (429); retry after Ns` even though one account has already left cooldown and has available quota.

### Impact

Affected users lose the healthy credential from fallback selection, so Codex requests fail when the remaining selectable credential is exhausted.

### Bug Cause

**Trigger:** `hermes_cli/auth_codex.py:617` / `_pool_codex_access_token()` receives a millisecond `last_error_reset_at` for an expired cooldown.

**Causal chain:**
1. The fallback selector compares the raw millisecond epoch directly with `time.time()`.
2. The expired cooldown appears to be far in the future, so the healthy credential is skipped.
3. The rate-limit lookup parses the same field with the canonical seconds/milliseconds/ISO parser, skips the expired entry, and reports the genuinely exhausted reserve credential instead.
4. Runtime credential resolution raises the false quota-exhausted error.

**Why it is wrong:** Two readers of the same persisted field disagree about its unit and therefore disagree about credential availability.

**Working sibling / contrast:** `_codex_pool_rate_limit_status()` and the general credential-pool cooldown path already use `_parse_absolute_timestamp()`, which normalizes epoch seconds, epoch milliseconds, and ISO-8601 strings.

**Ruled out:** The write path is not the source on current main. `CredentialPool._mark_exhausted()` passes provider reset metadata through `_normalize_error_context()`, which normalizes it before persistence. Existing or imported stores can still contain millisecond values, so the read path must remain robust.

### Fix

Use the existing canonical `_parse_absolute_timestamp()` helper in Codex fallback selection before comparing the cooldown against the current time. Add an end-to-end resolver regression with a healthy expired-millisecond primary credential and an exhausted seconds-based reserve credential.

## Related Issue

Fixes #103349

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/auth_codex.py` - normalize persisted reset timestamps before Codex pool fallback selection.
- `tests/hermes_cli/test_auth_codex_quota_probe.py` - cover mixed millisecond/second reset timestamps across two credentials.

## How to Test

1. Create a Codex pool whose primary credential has an expired reset timestamp in milliseconds.
2. Add an exhausted reserve credential with a future reset timestamp in seconds.
3. Resolve runtime credentials and verify the primary token is selected.
4. Run the relevant suites:

```bash
scripts/run_tests.sh tests/hermes_cli/test_auth_codex_quota_probe.py tests/hermes_cli/test_auth_codex_self_heal.py tests/hermes_cli/test_auth_codex_provider.py tests/agent/test_credential_pool.py
```

Result: 76 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant suites and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A - behavior is covered by the regression test
- [x] `cli-config.yaml.example` update: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered - timestamp normalization is platform-independent
- [x] Tool descriptions/schemas update: N/A - no tool schema changed

## Screenshots / Logs

N/A - the automated resolver regression reproduces and verifies the failure path.
