### PR TITLE
fix(desktop): wrap transcript output instead of horizontal scroll

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-table.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-table.tsx
@@ -32,9 +32,9 @@ import { cn } from '@/lib/utils'
  * per-column component, no index threading — a column knows its position
  * because it *is* in that position.
  *
- * Until a table is resized it stays in auto layout, which is the better
- * default: the browser fits columns to their content. The colgroup only appears
- * once there is a width to state.
+ * Tables use `table-layout: fixed` so long cells wrap inside the card instead
+ * of growing a horizontal scrollbar (#101311). The colgroup only appears once
+ * there is a stored width to state.
  *
  * A drag sets state on this component alone, and `children` is an already-built
  * element tree whose reference does not change, so React reconciles the
@@ -154,11 +154,10 @@ export function ResizableMarkdownTable({ children, className, ...props }: Compon
   }, [])
 
   return (
-    <div className="aui-md-table my-2 max-w-full overflow-x-auto rounded-[0.375rem] border border-(--ui-stroke-tertiary)">
+    <div className="aui-md-table my-2 max-w-full overflow-x-hidden rounded-[0.375rem] border border-(--ui-stroke-tertiary)">
       <table
         className={cn(
-          'm-0 w-full min-w-[18rem] border-collapse text-[0.8125rem] [&_tr]:border-b [&_tr]:border-(--ui-stroke-tertiary) last:[&_tr]:border-0',
-          widths && 'table-fixed [&_td]:wrap-anywhere',
+          'm-0 w-full table-fixed border-collapse text-[0.8125rem] [&_tr]:border-b [&_tr]:border-(--ui-stroke-tertiary) last:[&_tr]:border-0 [&_td]:wrap-anywhere',
           className
         )}
         onDoubleClick={onDoubleClick}
@@ -193,7 +192,7 @@ export function ResizableMarkdownTh({ children, className, ...props }: Component
     >
       {/* Truncation lives on an inner box, not the cell: the grab band straddles
           the cell's edge, so a clipping `<th>` would cut half of it off. */}
-      <span className="block overflow-hidden text-ellipsis whitespace-nowrap">{children}</span>
+      <span className="block wrap-anywhere">{children}</span>
       {/* Invisible grab band straddling the seam, with the hairline revealed on
           hover — the pane sash treatment (`tree-split.tsx`) scaled to a header
           row. The table carries no vertical rules otherwise, so the line only

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -491,7 +491,7 @@ function HugeTextFallback({ containerClassName, text }: { containerClassName?: s
       <ExpandableBlock className="p-2">
         {chunks.map((chunk, index) => (
           <div
-            className="[content-visibility:auto]"
+            className="whitespace-pre-wrap wrap-anywhere [content-visibility:auto]"
             key={index}
             style={{ containIntrinsicSize: `auto ${chunk.lines * 16}px` }}
           >
@@ -622,7 +622,7 @@ function MarkdownTextSurface({
         ),
         th: ResizableMarkdownTh,
         td: ({ className, ...props }: ComponentProps<'td'>) => (
-          <td className={cn('px-2.5 py-1.5 align-top text-[0.8125rem] leading-snug', className)} {...props} />
+          <td className={cn('px-2.5 py-1.5 align-top text-[0.8125rem] leading-snug wrap-anywhere', className)} {...props} />
         ),
         img: MarkdownImage,
         // ```mermaid / ```svg fences route to their lazy renderers; substantial

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-text.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-text.test.tsx
@@ -58,4 +58,17 @@ describe('a sent reference renders as the chip the composer showed', () => {
 
     expect(document.querySelector('[data-slot="aui_user-fence"]')?.textContent).toBe('const x = 1\n')
   })
+
+  it('wraps fenced code instead of growing a horizontal scrollbar', () => {
+    render(<UserMessageText text={'```\n' + 'a'.repeat(400) + '\n```'} />)
+
+    const fence = document.querySelector('[data-slot="aui_user-fence"]')
+    const code = fence?.querySelector('code')
+
+    expect(fence?.className).toContain('overflow-x-hidden')
+    expect(fence?.className).not.toContain('overflow-x-auto')
+    expect(fence?.className).toContain('whitespace-pre-wrap')
+    expect(code?.className).toContain('whitespace-pre-wrap')
+    expect(code?.className).toContain('wrap-anywhere')
+  })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-text.tsx
@@ -127,11 +127,11 @@ export const UserMessageText: FC<UserMessageTextProps> = ({ className, text }) =
         if (segment.kind === 'fence') {
           return (
             <pre
-              className="my-1.5 max-w-full overflow-x-auto rounded-md border border-(--ui-stroke-tertiary) bg-[color-mix(in_srgb,currentColor_5%,transparent)] px-2.5 py-2 font-mono text-[0.86em] leading-snug"
+              className="my-1.5 max-w-full overflow-x-hidden whitespace-pre-wrap wrap-anywhere rounded-md border border-(--ui-stroke-tertiary) bg-[color-mix(in_srgb,currentColor_5%,transparent)] px-2.5 py-2 font-mono text-[0.86em] leading-snug"
               data-slot="aui_user-fence"
               key={`fence-${segmentIndex}`}
             >
-              <code className="block whitespace-pre">{segment.code}</code>
+              <code className="block whitespace-pre-wrap wrap-anywhere">{segment.code}</code>
             </pre>
           )
         }

--- a/apps/desktop/src/components/chat/code-card.test.tsx
+++ b/apps/desktop/src/components/chat/code-card.test.tsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { CodeCardBody } from './code-card'
+
+describe('CodeCardBody', () => {
+  it('wraps fenced pre instead of enabling horizontal scroll', () => {
+    const { container } = render(
+      <CodeCardBody>
+        <pre>{'a'.repeat(400)}</pre>
+      </CodeCardBody>
+    )
+
+    expect(container.firstElementChild?.className).toContain('overflow-x-hidden')
+    expect(container.firstElementChild?.className).toContain('whitespace-pre-wrap')
+    expect(container.firstElementChild?.className).toContain('[overflow-wrap:anywhere]')
+    expect(container.firstElementChild?.className).not.toContain('overflow-x-auto')
+  })
+})

--- a/apps/desktop/src/components/chat/code-card.tsx
+++ b/apps/desktop/src/components/chat/code-card.tsx
@@ -36,7 +36,7 @@ function CodeCardBody({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       className={cn(
-        'font-mono text-[0.7rem] leading-relaxed text-foreground/90 [&_pre]:m-0 [&_pre]:overflow-x-auto [&_pre]:scrollbar-overlay [&_pre]:bg-transparent! [&_pre]:px-2 [&_pre]:py-1.5 [&_pre]:font-mono [&_pre]:leading-relaxed',
+        'font-mono text-[0.7rem] leading-relaxed text-foreground/90 [&_pre]:m-0 [&_pre]:overflow-x-hidden [&_pre]:whitespace-pre-wrap [&_pre]:[overflow-wrap:anywhere] [&_pre]:scrollbar-overlay [&_pre]:bg-transparent! [&_pre]:px-2 [&_pre]:py-1.5 [&_pre]:font-mono [&_pre]:leading-relaxed',
         className
       )}
       data-slot="code-card-body"

--- a/apps/desktop/src/components/chat/compact-markdown.tsx
+++ b/apps/desktop/src/components/chat/compact-markdown.tsx
@@ -20,9 +20,9 @@ const TAG_CLASSES = {
   li: 'marker:text-muted-foreground/60',
   ol: 'mb-2 list-decimal pl-5 last:mb-0',
   p: 'mb-1.5 leading-relaxed last:mb-0',
-  pre: 'mb-2 overflow-x-auto rounded-md border border-(--ui-stroke-tertiary) bg-background/70 p-2 font-mono text-[0.7rem] leading-[1.55] last:mb-0',
-  td: 'px-2 py-1 align-top leading-snug',
-  th: 'px-2 py-1 text-left text-[0.62rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground/80',
+  pre: 'mb-2 overflow-x-hidden whitespace-pre-wrap wrap-anywhere rounded-md border border-(--ui-stroke-tertiary) bg-background/70 p-2 font-mono text-[0.7rem] leading-[1.55] last:mb-0',
+  td: 'px-2 py-1 align-top leading-snug wrap-anywhere',
+  th: 'px-2 py-1 text-left text-[0.62rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground/80 wrap-anywhere',
   thead: 'bg-muted/40',
   ul: 'mb-2 list-disc pl-5 last:mb-0'
 } as const
@@ -66,10 +66,10 @@ function MarkdownCode({ className, ...rest }: ComponentProps<'code'>) {
 
 function MarkdownTable({ className, ...rest }: ComponentProps<'table'>) {
   return (
-    <div className="mb-2 max-w-full overflow-x-auto rounded-md border border-(--ui-stroke-tertiary) last:mb-0">
+    <div className="mb-2 max-w-full overflow-x-hidden rounded-md border border-(--ui-stroke-tertiary) last:mb-0">
       <table
         className={cn(
-          'w-full border-collapse text-[0.72rem] [&_tr]:border-b [&_tr]:border-(--ui-stroke-tertiary) last:[&_tr]:border-0',
+          'w-full table-fixed border-collapse text-[0.72rem] [&_tr]:border-b [&_tr]:border-(--ui-stroke-tertiary) last:[&_tr]:border-0',
           className
         )}
         {...rest}

--- a/apps/desktop/src/components/chat/expandable-block.test.tsx
+++ b/apps/desktop/src/components/chat/expandable-block.test.tsx
@@ -24,7 +24,7 @@ afterEach(() => {
 })
 
 describe('ExpandableBlock', () => {
-  it('lets horizontal scroll through and keeps the last line selectable', () => {
+  it('scrolls vertically only and keeps the last line selectable', () => {
     vi.stubGlobal('ResizeObserver', TestResizeObserver)
 
     const { container } = render(
@@ -37,14 +37,16 @@ describe('ExpandableBlock', () => {
     const toggle = screen.getByRole('button', { name: /expand|collapse/i })
     const fade = toggle.parentElement!
 
-    // Inner container allows horizontal scroll so wide code gets a scrollbar:
-    // platform overlay (`scrollbar-overlay`), not the always-on classic gutter.
-    expect(inner.className).toContain('overflow-x-auto')
+    // Output wraps inside the card. Horizontal pan is the unreadable bar
+    // (#101311); keep overlay gutters for the vertical scroller only.
+    expect(inner.className).toContain('overflow-x-hidden')
+    expect(inner.className).toContain('overflow-y-auto')
+    expect(inner.className).not.toContain('overflow-x-auto')
     expect(inner.className).toContain('scrollbar-overlay')
 
     // The full-width fade is a pure cue: it spans the bottom edge but must not
-    // intercept pointer events, so the scrollbar drag and text selection on the
-    // last line pass through to the content underneath.
+    // intercept pointer events, so text selection on the last line passes
+    // through to the content underneath.
     expect(fade.className).toContain('pointer-events-none')
     expect(fade.className).toContain('inset-x-0')
 

--- a/apps/desktop/src/components/chat/expandable-block.tsx
+++ b/apps/desktop/src/components/chat/expandable-block.tsx
@@ -33,9 +33,11 @@ export function ExpandableBlock({ children, className }: ExpandableBlockProps) {
     <div className="relative">
       <div
         className={cn(
+          // Vertical scroll only. Horizontal pan on output is unreadable
+          // (#101311); long tokens wrap inside the card instead.
           // `scrollbar-overlay` opts out of the app-wide classic thin gutters so
           // this scroller keeps platform overlay bars (no always-on track).
-          'scrollbar-overlay overflow-y-auto overflow-x-auto',
+          'scrollbar-overlay overflow-y-auto overflow-x-hidden',
           expanded ? 'max-h-[40dvh]' : 'max-h-[7.5rem]',
           className
         )}
@@ -45,11 +47,10 @@ export function ExpandableBlock({ children, className }: ExpandableBlockProps) {
       </div>
       {overflowing && (
         // The fade is a pure overflow cue and must not intercept pointer events:
-        // it spans the full bottom edge (over the horizontal scrollbar of a wide
-        // code block AND the block's last line), so making it clickable killed
-        // both sideways scrolling and text selection. Keep the fade
-        // `pointer-events-none` and pin the only clickable target — a compact
-        // toggle — to the right edge, clear of the draggable scrollbar track.
+        // it spans the full bottom edge over the block's last line, so making it
+        // clickable killed text selection. Keep the fade `pointer-events-none`
+        // and pin the only clickable target — a compact toggle — to the right
+        // edge, clear of the vertical overlay scrollbar track.
         <div className="pointer-events-none absolute inset-x-0 bottom-0 flex h-7 justify-end bg-linear-to-t from-[var(--expandable-fade-from,var(--ui-chat-surface-background))] to-transparent">
           <button
             aria-expanded={expanded}

--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -105,14 +105,14 @@ const PlainCode: FC<{ code: string }> = ({ code }) => {
   const chunks = useMemo(() => chunkByLines(code, CHUNK_LINES), [code])
 
   if (chunks.length === 1) {
-    return <code className="block whitespace-pre">{code}</code>
+    return <code className="block whitespace-pre-wrap wrap-anywhere">{code}</code>
   }
 
   return (
     <>
       {chunks.map((chunk, index) => (
         <code
-          className="block whitespace-pre [content-visibility:auto]"
+          className="block whitespace-pre-wrap wrap-anywhere [content-visibility:auto]"
           key={index}
           style={{ containIntrinsicSize: `auto ${chunk.lines * EST_LINE_PX}px` }}
         >

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1893,6 +1893,20 @@ body.guest-pointer-lock :is(webview, iframe) {
   padding: 0 !important;
 }
 
+/* Transcript output wraps. Nested overflow-x:auto on fences/tables made the
+   reply unreadable (#101311 / #70451). Shiki's default `white-space: pre`
+   would still grow a horizontal bar; force wrap on the highlighted path. */
+[data-slot='aui_assistant-message-content'] .aui-md .aui-shiki,
+[data-slot='aui_assistant-message-content'] .aui-md .aui-shiki pre,
+[data-slot='aui_assistant-message-content'] .aui-md .aui-shiki code,
+[data-slot='aui_assistant-message-content'] .aui-md .aui-shiki .line {
+  max-width: 100%;
+  overflow-x: hidden;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 [data-slot='aui_assistant-message-content'] .aui-md .aui-md-table {
   border-spacing: 0;
 }


### PR DESCRIPTION
## What does this PR do?

Desktop transcript output grew nested horizontal scrollbars on fenced code, tables, tool markdown, and user-bubble fences. Reading required sideways pan. This wraps long lines inside each card and keeps the thread as a **vertical scroller only**.

Matches the RCA in #101311: inner surfaces had opted back into `overflow-x-auto` / `whitespace-pre` / `whitespace-nowrap` even though the thread viewport is already `overflow-x-hidden`.

Related open work (not closed by this PR):
- #101560 (same symptom, other contributor)
- #70520 (prose/table containment; still keeps fenced-code X scroll)
- #70451 (original wrap request; duplicate of this bug class)

## Related Issue

Fixes #101311

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/components/chat/expandable-block.tsx` — `overflow-x-hidden` (was `overflow-x-auto`)
- `apps/desktop/src/components/chat/code-card.tsx` — wrap `<pre>` (`whitespace-pre-wrap` + `overflow-wrap: anywhere`)
- `apps/desktop/src/components/chat/shiki-highlighter.tsx` — plain/fallback code wraps
- `apps/desktop/src/styles.css` — Shiki highlighted path wraps in the transcript
- `apps/desktop/src/components/chat/compact-markdown.tsx` — tool markdown pre/table wrap
- `apps/desktop/src/components/assistant-ui/markdown-table.tsx` — `table-fixed`, no `min-w-[18rem]`, no X scroll
- `apps/desktop/src/components/assistant-ui/markdown-text.tsx` — table cells + huge-text fallback wrap
- `apps/desktop/src/components/assistant-ui/thread/user-message-text.tsx` — user fences wrap
- Tests: `expandable-block.test.tsx`, `user-message-text.test.tsx`, new `code-card.test.tsx`

Out of scope: bot group-chat plugin fences, terminal/diff `whitespace-pre` surfaces, preview pane.

## How to Test

1. Open Desktop chat. Send a prompt that produces a long unbroken line, a fenced block, and a wide markdown table.
2. Confirm the conversation column has no horizontal scrollbar.
3. Confirm long tokens wrap inside the card; tall blocks still expand/collapse and scroll vertically.

Unit tests (from `apps/desktop`):

```
npm run test:ui -- src/components/chat/expandable-block.test.tsx src/components/assistant-ui/thread/user-message-text.test.tsx src/components/chat/code-card.test.tsx src/components/chat/shiki-highlighter.test.ts
```

16 passed. The expandable-block wrap assertion was sabotage-run: restoring `overflow-x-auto` fails the new test; restoring the fix passes.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (noted #101560 / #70520)
- [x] My PR contains **only** changes related to this fix
- [x] Desktop UI tests for the touched files pass (`npm run test:ui --` those files). Full `pytest tests/ -q` not run (UI-only change).
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (unit tests). Bug is macOS Desktop; CSS wrap is cross-platform.

### Documentation & Housekeeping

- [x] Documentation — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform: CSS wrap; no OS-specific APIs
- [x] Tool schemas — N/A
