### PR TITLE
fix(state): re-widen the SessionDB lock gates to all 12 mixin files

### DIFF
--- a/tests/state/test_no_locked_readers_gate.py
+++ b/tests/state/test_no_locked_readers_gate.py
@@ -18,11 +18,15 @@ lock's legitimate users and pass. New violations fail with the method
 name and the fix (route through ``_read_ctx()``).
 
 ``SessionDB`` itself is declared in ``hermes_state.py`` as
-``class SessionDB(SessionSearchMixin, SessionSchemaMixin,
-SessionPortabilityMixin)`` — its actual methods live across four files.
-A gate that only opens ``hermes_state.py`` never sees a locked reader
-declared in one of the three mixin files, so ``_ALL_STATE_SOURCES`` scans
-each of them under their own class name.
+``class SessionDB(<12 mixins>)`` — its actual methods live across
+``hermes_state.py`` plus every one of those mixin files. A gate that only
+opens ``hermes_state.py`` never sees a locked reader declared in a mixin
+file, so ``_ALL_STATE_SOURCES`` scans each of them under their own class
+name. ``test_all_state_sources_matches_sessiondb_bases`` re-derives the
+current mixin list from ``hermes_state.py`` itself and fails loudly if a
+future split adds/removes a mixin without a matching update here — this
+list previously only covered 3 of 11 mixins after a further split grew
+``SessionDB`` from 4 bases to 12 with no update to this file.
 
 Deliberately NOT flagged:
 - methods that INSERT/UPDATE/DELETE/REPLACE under the lock (writers);
@@ -44,12 +48,24 @@ _STATE_PY = _REPO_ROOT / "hermes_state.py"
 
 # SessionDB's own class body lives in hermes_state.py; the rest of its
 # methods come from these mixins (see module docstring). Each entry is
-# (source file, class name to scan in that file).
+# (source file, class name to scan in that file). Keep in sync with
+# hermes_state.py's `class SessionDB(...)` bases — see
+# test_all_state_sources_matches_sessiondb_bases below, which fails
+# loudly the moment this list drifts from the real composition.
 _ALL_STATE_SOURCES: list[tuple[Path, str]] = [
     (_STATE_PY, "SessionDB"),
+    (_REPO_ROOT / "hermes_state_sessions.py", "SessionSessionsMixin"),
+    (_REPO_ROOT / "hermes_state_fts.py", "SessionFtsSetupMixin"),
     (_REPO_ROOT / "hermes_state_search.py", "SessionSearchMixin"),
     (_REPO_ROOT / "hermes_state_schema.py", "SessionSchemaMixin"),
     (_REPO_ROOT / "hermes_state_portability.py", "SessionPortabilityMixin"),
+    (_REPO_ROOT / "hermes_state_telegram.py", "SessionTelegramTopicsMixin"),
+    (_REPO_ROOT / "hermes_state_compression.py", "SessionCompressionMixin"),
+    (_REPO_ROOT / "hermes_state_gateway.py", "SessionGatewayMixin"),
+    (_REPO_ROOT / "hermes_state_maintenance.py", "SessionMaintenanceMixin"),
+    (_REPO_ROOT / "hermes_state_usage.py", "SessionUsageMixin"),
+    (_REPO_ROOT / "hermes_state_titles.py", "SessionTitlesMixin"),
+    (_REPO_ROOT / "hermes_state_messages.py", "SessionMessagesMixin"),
 ]
 
 _WRITE_RE = re.compile(
@@ -289,3 +305,45 @@ class TestNoPureReadersUnderWriterLock:
             f"{p.name}: {v}" for v in _scan_locked_readers(p, "FakeMixin")
         ]
         assert any("guilty_mixin_reader" in v for v in violations), violations
+
+    def test_all_state_sources_matches_sessiondb_bases(self):
+        """Re-derive SessionDB's actual mixin composition from
+        hermes_state.py itself (its `class SessionDB(...)` bases, resolved
+        to their defining files via this module's own `from
+        hermes_state_X import Y` imports) and assert it matches
+        _ALL_STATE_SOURCES exactly.
+
+        Independent ground truth, not a copy of the hardcoded list above:
+        if a future mixin split adds/removes/renames a base without a
+        matching update here, this fails loudly instead of the gate
+        silently going blind on the new/renamed file — exactly how
+        _ALL_STATE_SOURCES previously fell behind (covered 3 of 11 mixins
+        once SessionDB grew from 4 bases to 12).
+        """
+        tree = ast.parse(_STATE_PY.read_text(encoding="utf-8"))
+        base_to_file: dict[str, str] = {}
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.ImportFrom)
+                and node.module
+                and node.module.startswith("hermes_state_")
+            ):
+                for alias in node.names:
+                    base_to_file[alias.asname or alias.name] = f"{node.module}.py"
+
+        session_db = next(
+            n for n in tree.body
+            if isinstance(n, ast.ClassDef) and n.name == "SessionDB"
+        )
+        expected = {"SessionDB": _STATE_PY.name}
+        for base in session_db.bases:
+            if isinstance(base, ast.Name) and base.id in base_to_file:
+                expected[base.id] = base_to_file[base.id]
+
+        actual = {class_name: path.name for path, class_name in _ALL_STATE_SOURCES}
+        assert actual == expected, (
+            "hermes_state.py's SessionDB bases no longer match "
+            "_ALL_STATE_SOURCES in this file — update the list above.\n"
+            f"expected (derived from hermes_state.py): {expected}\n"
+            f"actual (_ALL_STATE_SOURCES):              {actual}"
+        )

--- a/tests/test_hermes_state_conn_lock_audit.py
+++ b/tests/test_hermes_state_conn_lock_audit.py
@@ -19,22 +19,71 @@ writer connection *under* ``self._lock``.
 This is an AST audit in the spirit of
 ``tests/gateway/test_async_session_db.py``: it fails on the next
 ``self._conn.<method>(...)`` call site added outside ``with self._lock:``.
+
+``SessionDB`` is declared in ``hermes_state.py`` as ``class
+SessionDB(<12 mixins>)`` — its methods live across ``hermes_state.py``
+plus every one of those mixin files, so this audit scans all 13.
+``test_state_files_match_sessiondb_bases`` re-derives that file list from
+``hermes_state.py`` itself and fails loudly if a future split
+adds/removes a mixin without a matching update here — this audit
+previously scanned only ``hermes_state.py``, invisible to ~31 of the
+~42 ``self._conn`` call sites once ``SessionDB``'s body was split into
+12 mixins.
 """
 
 import ast
 from pathlib import Path
 
-# Functions allowed to touch self._conn without the lock: construction-time
-# code that runs before the instance is ever shared with another thread.
+# Functions allowed to touch self._conn without holding self._lock, for one of two
+# proven-safe reasons — keep this list SHRINKING, never add a name without tracing
+# every one of its callers the way the ones below were traced:
+#  (a) construction-time: runs before the instance is ever shared with another thread;
+#  (b) callee-locked: the function has no caller that isn't itself inside self._lock.
 _ALLOWED_UNLOCKED_FNS = frozenset({
+    # (a) construction-time
     "__init__",
     "_connect_and_init",
     "_connect_and_init_with_lock_patience",
+    "_init_schema",  # sole caller: _connect_and_init, above
+    # (b) callee-locked (every caller traced and confirmed to hold self._lock)
+    "_fts_table_exists",  # sole caller _present_fts_tables's 3 call sites all `with self._lock:`
+    "_recover_stale_fts_locked",  # reached only via _init_schema (construction-time) or
+                                   # retry_deferred_fts_recovery, which holds self._lock
+    "_try_checkpoint",  # sole caller vacuum(), both call sites inside `with self._lock:`
 })
 
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[1]
+
+
+def _sessiondb_state_files() -> list[str]:
+    """hermes_state.py plus every file SessionDB's actual class bases are
+    imported from — independent ground truth (see
+    test_state_files_match_sessiondb_bases), not a hand-maintained list."""
+    root = _repo_root()
+    tree = ast.parse((root / "hermes_state.py").read_text(encoding="utf-8"))
+    base_to_file: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ImportFrom)
+            and node.module
+            and node.module.startswith("hermes_state_")
+        ):
+            for alias in node.names:
+                base_to_file[alias.asname or alias.name] = f"{node.module}.py"
+
+    session_db = next(
+        n for n in tree.body
+        if isinstance(n, ast.ClassDef) and n.name == "SessionDB"
+    )
+    files = ["hermes_state.py"]
+    for base in session_db.bases:
+        if isinstance(base, ast.Name) and base.id in base_to_file:
+            fname = base_to_file[base.id]
+            if fname not in files:
+                files.append(fname)
+    return files
 
 
 def _nearest_enclosing_fn(tree: ast.AST) -> dict:
@@ -94,16 +143,56 @@ def _unlocked_conn_calls(tree: ast.AST):
 
 
 def test_every_conn_call_outside_construction_holds_the_lock():
-    src = (_repo_root() / "hermes_state.py").read_text(encoding="utf-8")
-    tree = ast.parse(src)
-    offending = _unlocked_conn_calls(tree)
+    root = _repo_root()
+    offending: list[str] = []
+    for filename in _sessiondb_state_files():
+        src = (root / filename).read_text(encoding="utf-8")
+        tree = ast.parse(src)
+        for lineno, fn, meth in _unlocked_conn_calls(tree):
+            offending.append(f"{filename}:{lineno} in {fn}(): self._conn.{meth}(...)")
     assert not offending, (
         "self._conn.<method>() called without `with self._lock:` — this "
         "races SessionDB.close() inside pysqlite's statement cache and "
         "segfaults the process (#99349). Use `with self._read_ctx() as "
-        "conn:` for reads, or take self._lock. Sites: "
-        + ", ".join(
-            f"line {lineno} in {fn}(): self._conn.{meth}(...)"
-            for lineno, fn, meth in offending
-        )
+        "conn:` for reads, or take self._lock. Sites: " + ", ".join(offending)
     )
+
+
+def test_gate_detects_an_unlocked_call_in_a_mixin_file(tmp_path):
+    """Sabotage self-check for the multi-file scope itself: a lock-free
+    self._conn call planted in a MIXIN file (not hermes_state.py) must
+    still be caught. Guards against the scan narrowing back to
+    hermes_state.py alone — exactly how this audit's real blind spot
+    happened (it scanned only hermes_state.py while ~31 of SessionDB's
+    ~42 self._conn call sites lived in mixin files)."""
+    sabotage = (
+        "class FakeMixin:\n"
+        "    def guilty_reader(self):\n"
+        "        return self._conn.execute(\"SELECT 1\").fetchone()\n"
+    )
+    p = tmp_path / "fake_mixin.py"
+    p.write_text(sabotage, encoding="utf-8")
+    tree = ast.parse(p.read_text(encoding="utf-8"))
+    offending = _unlocked_conn_calls(tree)
+    assert any(
+        fn == "guilty_reader" and meth == "execute" for _, fn, meth in offending
+    ), offending
+
+
+def test_state_files_include_every_mixin():
+    """_sessiondb_state_files() must resolve to hermes_state.py PLUS every
+    one of SessionDB's mixin bases, not silently collapse back to just
+    hermes_state.py if the AST-based base-class/import discovery ever
+    breaks (e.g. a mixin imported under an alias, or SessionDB's bases
+    written in a shape the walk doesn't expect). A silent collapse here
+    is exactly how this audit's real blind spot happened, just one layer
+    up: it hardcoded a single file instead of deriving the list at all."""
+    files = _sessiondb_state_files()
+    assert files[0] == "hermes_state.py"
+    assert len(files) >= 12, (
+        "expected hermes_state.py plus at least 11 mixin files, got only "
+        f"{files} -- base-class/import discovery in _sessiondb_state_files() "
+        "may be broken, silently narrowing this audit back toward "
+        "hermes_state.py alone"
+    )
+    assert len(files) == len(set(files)), f"duplicate entries: {files}"


### PR DESCRIPTION
## Summary

`hermes_state.py`'s whole-codebase simplification pass (#102117) grew `SessionDB` from 4 mixin bases to 12, but neither safety gate that scans its class body was updated to match:

- `tests/state/test_no_locked_readers_gate.py`'s `_ALL_STATE_SOURCES` still only covered 4 of the 13 sources that contribute methods to `SessionDB` (the class itself + 3 mixins), leaving 9 mixin files' methods completely invisible to the Pattern-C locked-reader scanner.
- `tests/test_hermes_state_conn_lock_audit.py` scanned only `hermes_state.py` itself, leaving roughly 31 of `SessionDB`'s ~42 `self._conn` call sites entirely outside the #99349 segfault-prevention audit.

Both gates had already been widened once before (#97845, salvaged and merged as #101699) for a smaller mixin count — this is the same drift class recurring after a further mixin split grew the class again without a matching gate update.

## What changed

- Widened both files' hardcoded source lists to the current 12-mixin composition of `SessionDB`.
- Added one test per gate that independently re-derives the current mixin list from `hermes_state.py`'s own `class SessionDB(...)` bases and its `from hermes_state_X import Y` imports, rather than trusting a hand-maintained list to stay in sync with itself — so a future further split fails loudly here instead of silently reopening the same blind spot a third time.
- Added a sabotage self-check to `test_hermes_state_conn_lock_audit.py` (mirroring the one the other gate already had) proving a lock-free `self._conn` call planted in a mixin file is actually caught.
- The wider scan surfaced 4 previously out-of-scope call sites needing an allowlist decision (`_init_schema`, `_fts_table_exists`, `_recover_stale_fts_locked`, `_try_checkpoint`). I traced every caller of each by hand: `_init_schema`'s sole caller is `_connect_and_init` (already construction-time-exempt); `_fts_table_exists`'s sole caller's 3 call sites all hold `self._lock`; `_recover_stale_fts_locked` is reached only via construction-time `_init_schema` or `retry_deferred_fts_recovery`, which holds `self._lock`; `_try_checkpoint`'s sole caller `vacuum()` holds `self._lock` at both of its call sites. All 4 are genuinely safe and now documented in the allowlist with the traced reason.

## Scope note

No live violation exists in the newly-covered files today — both gates report clean once widened. This restores dormant coverage rather than fixing an active bug, but it directly protects the exact segfault class #99349 was filed for, on the ~75% of `SessionDB`'s surface where nothing was checking before this PR.

## Test plan

- [x] `pytest tests/test_hermes_state_conn_lock_audit.py tests/state/test_no_locked_readers_gate.py -v` — 7/7 pass
- [x] Mutation-verify: swapped in the pre-fix versions of both files against current `hermes_state.py` — both passed silently (proving the blind spot is real), confirming the new tests actually exercise the gap
- [x] `pytest tests/state/` — 177 passed, 5 skipped
- [x] `pytest tests/ -k "hermes_state or session_db or sessiondb"` (excluding an unrelated pre-existing `tests/acp*` collection error from a missing `acp` package in this environment) — 768 passed, 44 skipped, 0 failures