### PR TITLE
fix(config): key load_env()'s cache on content digest, not mtime/size

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3,6 +3,7 @@ validation, migration, and the ``hermes config`` command."""
 
 import copy
 import difflib
+import hashlib
 import json
 import logging
 import os
@@ -2385,9 +2386,15 @@ def _parse_env_value(raw_value: str) -> str:
     return value
 
 
-# load_env() memo keyed on (path, mtime, size). Editing .env bumps mtime -> rebuild;
-# invalidate_env_cache() is the explicit knob for writers on coarse-mtime filesystems.
-_env_cache: Optional[Tuple[Tuple[str, Optional[float], Optional[int]], Dict[str, str]]] = None
+# load_env() memo keyed on the file's content digest, not mtime/size: .env holds API
+# keys, and a stat-only key is right for a config cache but wrong for a credential
+# cache -- a dotfile-sync, backup/restore, or `cp -p`-style tool can rewrite the bytes
+# while preserving the mtime, which a stat idiom would never detect (mirrors
+# agent/vertex_adapter.py's _read_sa_file() and hermes_cli/auth.py's
+# _load_global_auth_store(), both fixed for the same reason). The file is a few KB, so
+# hashing it on every miss is negligible. invalidate_env_cache() remains the explicit
+# knob for writers that want to skip the read+hash on their own next load_env() call.
+_env_cache: Optional[Tuple[Tuple[str, Optional[str]], Dict[str, str]]] = None
 
 
 def load_env() -> Dict[str, str]:
@@ -2397,10 +2404,9 @@ def load_env() -> Dict[str, str]:
     env_path = get_env_path()
 
     try:
-        st = env_path.stat()
-        cache_key = (str(env_path), st.st_mtime, st.st_size)
+        cache_key = (str(env_path), hashlib.sha256(env_path.read_bytes()).hexdigest())
     except FileNotFoundError:
-        cache_key = (str(env_path), None, None)
+        cache_key = (str(env_path), None)
     except Exception:
         cache_key = None
     if cache_key is not None and _env_cache is not None and _env_cache[0] == cache_key:

--- a/tests/hermes_cli/test_env_load_cache.py
+++ b/tests/hermes_cli/test_env_load_cache.py
@@ -2,8 +2,10 @@
 
 The cache exists to keep `hermes tools` → "All Platforms" fast: every
 `get_env_value()` lookup used to re-read and re-sanitise the entire
-.env file, racking up hundreds of ms across one menu render. The
-cache is keyed on (path, mtime, size); writers (save_env_value /
+.env file, racking up hundreds of ms across one menu render. .env
+holds API keys, so the cache is keyed on a content digest (not
+mtime/size, which a dotfile-sync or backup/restore tool can leave
+unchanged while rewriting the bytes); writers (save_env_value /
 remove_env_value / sanitise_env_file) call invalidate_env_cache().
 """
 
@@ -47,6 +49,42 @@ def test_load_env_caches_on_repeat_calls():
         invalidate_env_cache()
 
 
+
+
+def test_load_env_detects_content_change_with_preserved_mtime(tmp_path):
+    """A tool that rewrites .env's bytes but restores the original mtime (e.g. `cp -p`,
+    a dotfile-sync, or a backup/restore) must still be seen on the next load_env() call.
+
+    This is the discriminating case for content-digest vs. mtime/size keying: bumping
+    mtime while changing content (the OTHER natural test) passes under either scheme,
+    since mtime usually changes too. Only holding mtime fixed while changing content
+    tells them apart -- this fails under a (path, mtime, size) key and passes under a
+    (path, content-digest) key.
+    """
+    from hermes_cli.config import invalidate_env_cache, load_env
+
+    invalidate_env_cache()
+
+    env_path = tmp_path / ".env"
+    env_path.write_text("OPENAI_API_KEY=sk-old\n", encoding="utf-8")
+    original_stat = env_path.stat()
+
+    try:
+        with patch("hermes_cli.config.get_env_path", return_value=env_path):
+            first = load_env()
+            assert first.get("OPENAI_API_KEY") == "sk-old"
+
+            # Same length new content (size unchanged too), mtime explicitly restored.
+            env_path.write_text("OPENAI_API_KEY=sk-new\n", encoding="utf-8")
+            os.utime(env_path, ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns))
+            assert env_path.stat().st_mtime_ns == original_stat.st_mtime_ns
+            assert env_path.stat().st_size == original_stat.st_size
+
+            second = load_env()
+
+        assert second.get("OPENAI_API_KEY") == "sk-new"
+    finally:
+        invalidate_env_cache()
 
 
 def test_remove_env_value_invalidates_cache(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

`load_env()`'s process-level memo of `~/.hermes/.env` is keyed on `(path, mtime, size)`. `.env` holds API keys, and this cache feeds credential-resolution paths — `agent/credential_pool.py`, `ELEVENLABS_API_KEY` lookup in `hermes_cli/web_routers/audio.py`, `hermes_cli/credential_lifecycle.py`, `hermes_cli/web_server_memory.py`, among others.

A stat idiom is the right freshness check for a *config* cache, but wrong for a *credential* cache: a dotfile-sync, backup/restore, or `cp -p`-style tool can rewrite `.env`'s bytes while preserving its mtime and size, and the cache would keep serving the old (possibly rotated/revoked) credentials for the rest of the process's lifetime — there's no TTL to fall back on.

This is the same anti-pattern already fixed twice in this codebase for the identical reason:
- `agent/vertex_adapter.py`'s `_read_sa_file()`
- `hermes_cli/auth.py`'s `_load_global_auth_store()`

## What changed

Rekeyed `_env_cache` on `(path, sha256-content-digest)`, mirroring both prior fixes exactly. The file is a few KB, so hashing it on every cache miss is negligible.

Added a discriminating regression test (`test_load_env_detects_content_change_with_preserved_mtime`): it changes `.env`'s content and then explicitly restores the original mtime via `os.utime()`. This is the only scenario that actually tells a content-digest key apart from a `(path, mtime, size)` key — bumping mtime while changing content passes under either scheme, since mtime normally changes too when you edit a file.

## Scope note

Open PR #81458 ("don't cache a failed .env read as empty; log resolution failures") touches this same function but for an orthogonal concern (falling back to the last successful load on a transient read failure, vs. this PR's freshness-on-success concern) — and it's based on a much older, pre-refactor shape of `load_env()` (inline parsing rather than the current `_read_env_lines()` helper), so it will need a rebase regardless of this PR.

## Test plan

- [x] `pytest tests/hermes_cli/test_env_load_cache.py -v` — 3/3 pass
- [x] Mutation-verify: reverted only the source fix (kept the new test) — the new test fails exactly as predicted (`sk-old` served instead of `sk-new`); the other 2 pre-existing tests are unaffected either way
- [x] `pytest tests/hermes_cli/test_config.py tests/hermes_cli/test_env_export_line_lifecycle.py tests/hermes_cli/test_env_export_prefix.py tests/hermes_cli/test_credential_lifecycle.py` — 138 passed, 4 skipped
- [x] `pytest tests/tools/test_xai_http_credentials.py tests/hermes_cli/test_managed_scope_regression.py tests/hermes_cli/test_xiaomi_provider.py tests/hermes_cli/test_mcp_catalog_env_boundary.py` (other files referencing `_env_cache`/`invalidate_env_cache`, none accessing the cache tuple's internal shape directly) — 48 passed