### PR TITLE
fix(state): refuse second-process writers via flock single-writer gate

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2761,8 +2761,19 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
                 stale = db.get_session_by_title(title_filter) if title_filter == BOT_CHAT_TITLE else None
                 if stale and stale.get("archived") and db.unarchive_recoverable_session(stale["id"]):
                     sessions = await _list()
-            except Exception:
-                pass  # resolution degrades to today's no-row behavior
+            except Exception as exc:
+                # A structural writer-gate refusal (see #103339) must not
+                # degrade the listing to an empty 200 — the caller would read
+                # "no canonical chat" and mint a duplicate. Map it to the
+                # store-busy 503 envelope (retry shortly), like every other
+                # unavailable-store path here.
+                from hermes_state_errors import is_gate_refusal
+                if is_gate_refusal(exc):
+                    return _error_response(
+                        "Session database busy: a structural operation owns the store; retry shortly.",
+                        503, code="session_db_unavailable")
+                # resolution degrades to today's no-row behavior
+                pass
         # Back-filled pins arrive PAST the limit, so counting them would report
         # another page that doesn't exist. Only the recency window decides.
         windowed = sum(1 for s in sessions if not s.get("pinned"))

--- a/hermes_cli/doctor_state.py
+++ b/hermes_cli/doctor_state.py
@@ -158,11 +158,11 @@ _STATE_DB_REPAIRS = {
     "fts": ("Repaired state.db FTS write health",
             "state.db FTS write-health repair did not recover automatically",
             "state.db FTS write corruption and auto-repair failed — restore from the backup copy beside state.db",
-            "state.db FTS write corruption — run 'hermes doctor --fix' (or 'hermes sessions repair') to rebuild the FTS index"),
+            "state.db FTS write corruption — stop the profile's gateway first, then run 'hermes doctor --fix' (or 'hermes sessions repair') to rebuild the FTS index"),
     "schema": ("Repaired state.db schema ({count} sessions recovered)",
                "state.db schema repair did not recover automatically",
                "state.db schema malformed and auto-repair failed — restore from the backup copy beside state.db",
-               "state.db schema malformed — run 'hermes doctor --fix' (or 'hermes sessions repair') to recover hidden sessions"),
+               "state.db schema malformed — stop the profile's gateway first, then run 'hermes doctor --fix' (or 'hermes sessions repair') to recover hidden sessions"),
 }
 
 
@@ -235,10 +235,49 @@ def _state_db_wal(f: Finding, should_fix: bool, state_db_path: Path) -> None:
             check_warn(f"WAL file is large ({size // (1024*1024)} MB)", "(may indicate missed checkpoints)")
             if not should_fix:
                 return f.issues.append("Large WAL file — run 'hermes doctor --fix' to checkpoint")
+            # Single-writer gate (#103339): a bare connect runs WAL recovery and
+            # the checkpoint joins the live WAL — under a running gateway that
+            # second-writer handling corrupts state.db. Refuse instead.
+            from hermes_state_writergate import (
+                OwnerToken, acquire_writer_gate, release_writer_gate, writer_gate_holder,
+            )
+            gate_holder = writer_gate_holder(state_db_path)
+            if gate_holder is not None:
+                check_warn("WAL checkpoint skipped: a live writer holds state.db",
+                           f"({gate_holder}). Stop the profile's gateway "
+                           "(`hermes gateway stop`) and re-run 'hermes doctor --fix'.")
+                return f.issues.append(
+                    "Large WAL file — stop the profile's gateway first, then "
+                    "re-run 'hermes doctor --fix' to checkpoint")
+            # Hold the global structural lock through the checkpoint (same
+            # usage contract as repair): writers announcing mid-checkpoint
+            # see it held and refuse, closing the probe-to-checkpoint race.
+            checkpoint_token = OwnerToken("doctor-checkpoint")
+            try:
+                acquire_writer_gate(state_db_path, role="repair",
+                                    owner=checkpoint_token, exclusive=True)
+            except Exception as exc:
+                check_warn("WAL checkpoint skipped: a live writer holds state.db",
+                           f"({exc}). Stop the profile's gateway "
+                           "(`hermes gateway stop`) and re-run 'hermes doctor --fix'.")
+                return f.issues.append(
+                    "Large WAL file — stop the profile's gateway first, then "
+                    "re-run 'hermes doctor --fix' to checkpoint")
             import sqlite3
-            conn = sqlite3.connect(str(state_db_path))
-            conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
-            conn.close()
+            conn = None
+            try:
+                conn = sqlite3.connect(str(state_db_path))
+                conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+            finally:
+                # Close BEFORE releasing the gate: a failed checkpoint must
+                # not leave its connection open under a released gate where a
+                # new writer could be admitted onto it.
+                if conn is not None:
+                    try:
+                        conn.close()
+                    except Exception:
+                        pass
+                release_writer_gate(state_db_path, checkpoint_token)
             check_ok(f"WAL checkpoint performed ({size // 1024}K → {wal_size() // 1024}K)")
             f.fixed += 1
         elif size > 10 * 1024 * 1024:  # 10 MB

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -14,6 +14,7 @@ from functools import partial
 from pathlib import Path
 
 from hermes_cli.sessions_cmd_browse import _relative_time, _session_browse_picker
+from hermes_state_errors import StateDbWriterHeldError
 
 
 def get_hermes_home():
@@ -97,7 +98,7 @@ def _cmd_repair(args):
         return
     print(f"✗ {db_path} does not open cleanly: {reason}")
     if getattr(args, "check_only", False):
-        return
+        return 1  # an unclean check is a failed check for scripting/CI callers
     print("Repairing (a backup copy is made first)…")
     report = repair_state_db_schema(db_path, backup=not getattr(args, "no_backup", False))
     if report.get("repaired"):
@@ -126,6 +127,7 @@ def _cmd_repair(args):
         f"    hermes sessions recover --source {source_hint} \\\n"
         "        --output recovered-state.db"
     )
+    return 1  # a failed repair is never exit 0 for scripting/CI callers
 
 
 def _cmd_recover(args):
@@ -964,5 +966,10 @@ def cmd_sessions(args, sessions_parser=None):
             sessions_parser.print_help()
             return
         return handler(db, args)
+    except StateDbWriterHeldError as e:
+        # Single-writer gate (#103339): another process (usually the running
+        # gateway) owns this state.db — report, don't traceback.
+        print(f"Error: {e}")
+        return 1
     finally:
         db.close()

--- a/hermes_cli/subcommands/sessions.py
+++ b/hermes_cli/subcommands/sessions.py
@@ -102,7 +102,9 @@ def build_sessions_parser(subparsers, *, cmd_sessions: Callable) -> None:
     add_yes_flag(sessions_delete, "Skip confirmation")
 
     sessions_prune = sessions_subparsers.add_parser(
-        "prune", help="Delete old sessions (filterable by time window, source, title, ...)")
+        "prune", help="Delete old sessions (filterable by time window, source, title, ...)",
+        description="Delete old sessions. Stop the profile's gateway first "
+            "(`hermes gateway stop`): pruning a live database can corrupt it (#103339).")
     _add_session_filter_args(
         sessions_prune, "Delete sessions older than AGE — days if bare number, or a duration "
         "like '5h'/'2d'/'1w', or an ISO timestamp (bare prune with no filters "
@@ -161,7 +163,9 @@ def build_sessions_parser(subparsers, *, cmd_sessions: Callable) -> None:
         description="Recover a state.db whose schema is malformed (e.g. 'table "
             "messages_fts already exists'), which makes Desktop/Dashboard show "
             "no sessions. A backup is made first; sessions and messages are "
-            "preserved and the FTS search index is rebuilt if needed.")
+            "preserved and the FTS search index is rebuilt if needed. Stop the "
+            "profile's gateway first (`hermes gateway stop`): repairing a live "
+            "database can corrupt it (#103339).")
     _flag(sessions_repair, "--check-only",
         help="Only report whether the database opens cleanly; do not modify it")
     _flag(sessions_repair, "--no-backup", help="Skip the timestamped backup copy (not recommended)")

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -31,7 +31,7 @@ from hermes_state_common import escape_like as _escape_like, stat_db_file_identi
 from hermes_state_errors import (
     _DELETED_WAL_GENERATION_MSG, _DISK_IO_ERROR_MARKER, _STATE_DB_CORRUPT_MSG, _STATE_DB_GENERATION_KEY,
     _STATE_DB_REPLACED_MSG, DeletedWalGenerationError, SessionCompressionInProgressError, StateDbCorruptError,
-    StateDbReplacedError, _is_no_more_rows, classify_persistence_error, is_malformed_db_error,
+    StateDbReplacedError, StateDbWriterHeldError, _is_no_more_rows, classify_persistence_error, is_malformed_db_error,
     is_malformed_schema_error,
 )
 from hermes_state_guard import (
@@ -53,6 +53,7 @@ from hermes_state_dbfile import (
 from hermes_state_messages import SessionMessagesMixin
 from hermes_state_wal import _WAL_INCOMPAT_MARKERS, apply_database_pragmas, apply_wal_with_fallback
 from hermes_state_repair import _claim_repair_attempt, preflight_db_writability, repair_state_db_schema
+from hermes_state_writergate import acquire_writer_gate
 from hermes_state_titles import SessionTitlesMixin
 from hermes_state_usage import SessionUsageMixin
 from hermes_state_maintenance import SessionMaintenanceMixin
@@ -419,6 +420,9 @@ class SessionDB(
 
     def __init__(self, db_path: Path = None, read_only: bool = False):
         self.db_path = db_path or _default_db_path()
+        # Set first: __del__/close() consult it on every path, including a
+        # failed open whose attribute block below never ran.
+        self._gate_release_pending = False
         _ensure_test_isolation(self.db_path)  # before any connection/pragma/mkdir
         self.read_only = read_only
         self._lock = threading.Lock()
@@ -482,13 +486,32 @@ class SessionDB(
             raise
         finally:
             if not initialization_complete:
+                # Gate presence was announced at _open_writer entry; a failed
+                # open must not leave it pinned (otherwise a later repair sees
+                # a phantom writer and starves). The live-but-doomed
+                # connection closes FIRST: close-time WAL work must settle
+                # while our presence still holds off structural takes.
                 conn, self._conn = self._conn, None
                 self._close_connection_quietly(conn)
+                if not self.read_only:
+                    try:
+                        from hermes_state_writergate import release_writer_gate
+                        if not release_writer_gate(self.db_path, self):
+                            self._gate_release_pending = True
+                    except Exception:
+                        pass
 
     def _open_writer(self) -> None:
         """Writable open: preflight, zero-byte quarantine, connect + schema (one in-place repair of a
         malformed sqlite_master), generation stamp."""
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        # Structural gate (#103339): announce writer presence BEFORE any sqlite
+        # open/DDL so the proof lifetime covers the mutation. Structural takes
+        # (repair/checkpoint) hold the global lock and then scan presences;
+        # our presence being held from before _connect makes either order
+        # (open-first or surgery-first) refuse the second party. Fail-closed
+        # on presence-establishment failure as well.
+        acquire_writer_gate(self.db_path, owner=self)
         # Read-only file/sidecar preflight BEFORE the first connection: an actionable message
         # instead of an opaque "attempt to write a readonly database" from inside _init_schema.
         preflight_db_writability(self.db_path, db_label="state.db")
@@ -517,9 +540,31 @@ class SessionDB(
                 "repair (a backup copy is made first).", exc,
             )
             self._close_connection_quietly(self._conn)
-            if not repair_state_db_schema(self.db_path).get("repaired"):
+            # Structural gate (#103339): self-heal runs in the same process
+            # that already announced presence. The exclusive take counts own
+            # presences as live (unrelated owners must not be invisible), so
+            # drop ours before repairing — our connection is closed anyway —
+            # and re-pin after. A foreign writer announcing in between makes
+            # the repair refuse (correct); a foreign surgery makes our
+            # re-acquire refuse (correct).
+            try:
+                from hermes_state_writergate import release_writer_gate
+                release_writer_gate(self.db_path, self)
+            except Exception:
+                pass
+            try:
+                if not repair_state_db_schema(self.db_path).get("repaired"):
+                    raise
+                # Re-pin BEFORE reopening: a foreign surgery may have taken
+                # the global while we were repairing (we dropped presence).
+                # Propagate its refusal — never open SQLite under a surgery.
+                acquire_writer_gate(self.db_path, owner=self)
+                self._connect_and_init_with_lock_patience()
+            except Exception:
+                # Repair failed/refused, or our re-admission lost to a foreign
+                # surgery: __init__'s finally releases any partial pin and
+                # closes the (never opened) conn. Do NOT reopen here.
                 raise
-            self._connect_and_init_with_lock_patience()
         # FTS optimization is OPT-IN (`hermes db optimize`); no background worker races session lifecycle.
         self._ensure_db_file_generation()
 
@@ -761,14 +806,36 @@ class SessionDB(
             "state.db connection for %s was closed while a %s was still in "
             "flight — reopening (teardown/worker race, #94736)", self.db_path, context,
         )
+        # Structural gate (#103339): re-pin admission BEFORE opening SQLite
+        # for BOTH contexts — _open_writer_conn() opens a read-write handle
+        # with WAL handling either way, so a read reopen must not join a live
+        # surgery's WAL either. Fail-closed; the callback/read has not run.
+        acquire_writer_gate(self.db_path, owner=self)
         try:
             self._conn = self._open_writer_conn()
         except Exception as exc:
+            # Never leave a half-opened connection behind a refusal: the
+            # next writer would inherit a live handle outside the proof.
+            # Close first, release after (same order as the init-fail path):
+            # close-time WAL work settles while presence still holds off
+            # structural takes.
+            conn, self._conn = self._conn, None
+            self._close_connection_quietly(conn)
+            try:
+                from hermes_state_writergate import release_writer_gate
+                if not release_writer_gate(self.db_path, self):
+                    self._gate_release_pending = True
+            except Exception:
+                pass
             raise sqlite3.OperationalError(
                 f"state.db connection was closed while a {context} was still "
                 f"in flight (a session-teardown path called close() before "
                 f"this worker finished — #94736) and the automatic reopen failed: {exc}"
             ) from exc
+        # The racing close() released this instance's share; the pre-open
+        # acquire above already re-pinned it, so nothing more to do. This
+        # second call is a cheap idempotent registry hit.
+        acquire_writer_gate(self.db_path, owner=self)
 
     def _execute_write(
         self, fn: Callable[[sqlite3.Connection], T], patience_s: Optional[float] = None,
@@ -777,7 +844,18 @@ class SessionDB(
         is handled here (callers must not commit). Returns *fn*'s result.
         BEGIN IMMEDIATE takes the WAL write lock up front so contention surfaces
         immediately; on locked/busy the Python lock is released, a jitter slept,
-        and the WHOLE callback retried — *fn* must stay idempotent under retry."""
+        and the WHOLE callback retried — *fn* must stay idempotent under retry.
+
+        Single-writer gate (#103339): the first write of a process announces
+        presence (``<state.db>.writer.<pid>.lock``); structural operations
+        (repair surgery) refuse while any presence is live. Row writes
+        themselves proceed under SQLite's own WAL locking no matter how many
+        processes announce — and are refused only while a surgery holds the
+        global structural lock (fail-closed in both directions).
+        Read-only handles never reach this path. ``close()`` releases this
+        instance's presence share."""
+        if not self.read_only:
+            acquire_writer_gate(self.db_path, owner=self)
         if patience_s is None:
             patience_s = self._WRITE_PATIENCE_S
         deadline = time.monotonic() + patience_s
@@ -832,6 +910,8 @@ class SessionDB(
                     continue
                 raise
             except sqlite3.Error as exc:
+                if isinstance(exc, StateDbWriterHeldError):
+                    raise  # fail-closed (structural gate): never retry as locked/busy
                 # 'no more rows' is a transient engine error on contended WAL appends (some builds
                 # raise it as InterfaceError, a sibling of DatabaseError): retry like locked/busy.
                 if _is_no_more_rows(exc) and self._sleep_before_write_retry(deadline, patience_s):
@@ -933,6 +1013,8 @@ class SessionDB(
                     self._conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
                 except sqlite3.Error:
                     pass
+        except StateDbWriterHeldError:
+            raise
         except sqlite3.Error as exc:
             logger.debug("state.db generation stamp skipped: %s", exc)
 
@@ -946,7 +1028,10 @@ class SessionDB(
         elif self._conn is not None and not self._db_file_application_id:
             try:
                 pragma_row = self._read_one("PRAGMA application_id")
-            except sqlite3.Error:
+            except sqlite3.Error as exc:
+                from hermes_state_errors import is_gate_refusal
+                if is_gate_refusal(exc):
+                    raise  # structural gate refusal (#103339): never mis-observe identity under surgery
                 pragma_row = None
             if pragma_row and pragma_row[0]:
                 self._db_file_application_id = int(pragma_row[0])
@@ -1173,11 +1258,30 @@ class SessionDB(
                 # A clean close lets SQLite unlink the sidecars (a legitimate end of the
                 # generation, not a split): a teardown-race reopen must re-adopt.
                 self._db_sidecar_identity = {}
+        # Single-writer gate (#103339): release this instance's presence
+        # share (best effort, never breaks close). Presence drops when the
+        # last in-process owner closes; a live gateway's registry-owned
+        # handle is never closed mid-life, so it keeps announcing exactly
+        # while it can write. Registry-owned early-return above skips this
+        # (not our share to release).
+        if not self.read_only:
+            try:
+                from hermes_state_writergate import release_writer_gate
+                if not release_writer_gate(self.db_path, self):
+                    # Mutex Ward: the presence hold is still pinned (flock
+                    # held, share restored). Keep retry state so __del__
+                    # drains it independently — close() must never return a
+                    # record that names a live pid with no retry left.
+                    self._gate_release_pending = True
+                else:
+                    self._gate_release_pending = False
+            except Exception:
+                pass
 
     def __del__(self) -> None:
         """Safety net: close() if the caller forgot. Attribute access stays
         guarded: module teardown order is undefined."""
-        if self.__dict__.get("_conn") is not None:
+        if self.__dict__.get("_conn") is not None or self.__dict__.get("_gate_release_pending"):
             try:
                 self.close()
             except Exception:

--- a/hermes_state_compression.py
+++ b/hermes_state_compression.py
@@ -266,6 +266,9 @@ class SessionCompressionMixin:
         try:
             self._write_sql(sql, params)
         except sqlite3.Error as exc:
+            from hermes_state_errors import is_gate_refusal
+            if is_gate_refusal(exc):
+                raise  # structural gate refusal (#103339): a refused write is never "logged and done"
             logger.warning("%s(%s) failed: %s", op, session_id, exc)
 
     def record_compression_failure_cooldown(

--- a/hermes_state_errors.py
+++ b/hermes_state_errors.py
@@ -74,8 +74,8 @@ def is_disk_full_error(exc: BaseException | str | None) -> bool:
 
 # Every classify_persistence_error bucket; consumers enumerate this tuple.
 PERSISTENCE_ERROR_CAUSES = (
-    "locked", "compression", "compression_closed", "turn_lease", "corrupt", "replaced", "disk",
-    "unknown",
+    "locked", "gate_setup", "compression", "compression_closed", "turn_lease", "corrupt", "replaced",
+    "disk", "unknown",
 )
 
 
@@ -178,12 +178,50 @@ _STATE_DB_CORRUPT_MSG = (
 )
 
 
+class StateDbWriterHeldError(sqlite3.OperationalError):
+    """Another process holds ``<state.db>.writer.lock``: this process must not
+    write (a second WAL writer corrupts the live database, #103339).
+
+    Subclasses OperationalError so generic sqlite handlers treat it as an
+    operational refusal; it is raised BEFORE ``_execute_write``'s retry loop,
+    so it never waits out a patience window — the holder keeps the gate for
+    its lifetime, and only stopping that process frees it.
+    """
+
+
+class StateDbGateSetupError(StateDbWriterHeldError):
+    """The gate's own coordination files cannot be established (unwritable
+    dir, unflockable presence file): retrying NEVER helps, unlike a live
+    holder that will eventually leave (#103339).
+
+    Still a StateDbWriterHeldError (structural paths must refuse it via
+    is_gate_refusal), but classify_persistence_error reports it as
+    "gate_setup" so patience loops (turn lease) raise at once instead of
+    polling a permanent failure.
+    """
+
+
+def is_gate_refusal(exc: BaseException) -> bool:
+    """Shared classifier for the structural-gate refusal (#103339).
+
+    Every fallback that degrades a read/write to empty/None/logged-and-done
+    must re-raise when this returns True — a refused admission is never a
+    missing row, an FTS syntax error, or a completed write. Single choke
+    point so new swallow sites cannot drift from the contract.
+    """
+    return isinstance(exc, StateDbWriterHeldError)
+
+
 _PERSISTENCE_CAUSE_BY_TYPE = (
     (SessionTurnLeaseLostError, "turn_lease"),
     (CompressionSessionClosedError, "compression_closed"),
     (CompressionSessionBusyError, "compression"),
     (StateDbReplacedError, "replaced"),
     (StateDbCorruptError, "corrupt"),
+    # Subclass BEFORE its parent: a permanent setup failure is never "locked"
+    # (patience loops must raise at once, not poll it).
+    (StateDbGateSetupError, "gate_setup"),
+    (StateDbWriterHeldError, "locked"),
 )
 _PERSISTENCE_CAUSE_BY_PHRASE = (
     (("turn lease",), "turn_lease"),

--- a/hermes_state_gateway.py
+++ b/hermes_state_gateway.py
@@ -639,7 +639,10 @@ class SessionGatewayMixin:
                 return None
             return {"state": row["handoff_state"], "platform": row["handoff_platform"],
                     "error": row["handoff_error"]}
-        except Exception:
+        except Exception as exc:
+            from hermes_state_errors import is_gate_refusal
+            if is_gate_refusal(exc):
+                raise  # structural gate refusal (#103339): never swallow as no handoff
             return None
 
     def list_pending_handoffs(self) -> List[Dict[str, Any]]:
@@ -651,7 +654,10 @@ class SessionGatewayMixin:
                 "WHERE s.handoff_state = 'pending' "
                 "ORDER BY s.started_at ASC")
             return [self._session_row_dict(r) for r in rows]
-        except Exception:
+        except Exception as exc:
+            from hermes_state_errors import is_gate_refusal
+            if is_gate_refusal(exc):
+                raise  # structural gate refusal (#103339): never swallow as no pendings
             return []
 
     def claim_handoff(self, session_id: str) -> bool:
@@ -697,9 +703,13 @@ class SessionGatewayMixin:
             return ids
         try:
             return self._execute_write(_do) or []
-        except Exception:
+        except Exception as exc:
             # Swallow but never silently: a persistently failing reclaim leaves poisonous
             # 'running' rows in place, so the operator needs a trace.
+            # A gate refusal is never a reclaim failure (see #103339).
+            from hermes_state_errors import is_gate_refusal
+            if is_gate_refusal(exc):
+                raise
             logger.warning(
                 "reclaim_stale_running_handoffs failed; stranded 'running' "
                 "handoff rows (if any) were left in place", exc_info=True)

--- a/hermes_state_maintenance.py
+++ b/hermes_state_maintenance.py
@@ -303,6 +303,9 @@ class SessionMaintenanceMixin:
                     return None
                 return [int(conn.execute(f"PRAGMA {name}").fetchone()[0]) for name in names]
         except Exception as exc:
+            from hermes_state_errors import is_gate_refusal
+            if is_gate_refusal(exc):
+                raise  # structural gate refusal (#103339): never degrade to unknown size
             logger.debug(fail_msg, exc)
             return None
 

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -703,7 +703,10 @@ class SessionMessagesMixin:
             return session_id
         try:
             session_id = self.get_compression_tip(session_id) or session_id
-        except Exception:
+        except Exception as exc:
+            from hermes_state_errors import is_gate_refusal
+            if is_gate_refusal(exc):
+                raise  # structural gate refusal (#103339): never resolve against a refused read
             pass
         with self._read_ctx() as conn:
             current = session_id

--- a/hermes_state_repair.py
+++ b/hermes_state_repair.py
@@ -797,53 +797,101 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
     if not db_path.exists():
         report["error"] = f"{db_path} does not exist"
         return report
-    # Cross-restart cap: the in-memory claim bounds one process, but unhealable b-tree damage used to re-run
-    # surgery + a fresh backup on EVERY restart.
-    # Cross-restart attempt cap (#86747): the in-memory claim bounds one process, but a corruption class the
-    # strategies below cannot heal (b-tree page damage) previously re-ran the whole surgery — and took a
-    # fresh multi-hundred-MB forensic backup — on EVERY restart, forever. After
-    # _MAX_PERSISTENT_REPAIR_ATTEMPTS failures against the same damaged file, stop retrying and surface a
-    # terminal, actionable error.
-    if _persistent_repair_attempts_exhausted(db_path):
-        return _repair_skip(report, "skipped", _persistent_repair_exhausted_error(db_path))
-
-    with _cross_process_repair_lock(db_path) as holding_lock:
-        if not holding_lock:
-            # Another process holds the lock (or the lock file was unopenable); it may have healed the file
-            # already, so re-probe before failing.
-            if _db_opens_cleanly(db_path) is None:
-                report["repaired"], report["strategy"] = True, "repaired_by_other_process"
-            else:
-                report["error"] = ("could not obtain the state.db repair lock (held by another process, or the lock "
-                                   "file was unopenable); skipped schema surgery to avoid racing a concurrent repairer")
-            return report
-
-        result = report
-        # Recheck exhaustion after acquisition: a queued repairer can have recorded the final failure while
-        # this process waited.
+    # Single-writer gate (#103339): surgery under a live gateway mints a second
+    # WAL and corrupts the file — and the EXCLUSIVE-probe below is blind exactly
+    # here (a malformed db answers DatabaseError instead of busy). The flock is
+    # held by ANY open SQLite writer regardless of db health, so refuse first
+    # and touch nothing (no backup, no ledger mutation, no repair lock).
+    from hermes_state_writergate import (
+        acquire_writer_gate, release_writer_gate, writer_gate_holder, writer_gate_holder_role,
+        OwnerToken,
+    )
+    gate_holder = writer_gate_holder(db_path)
+    gate_role = writer_gate_holder_role(db_path)
+    if gate_holder is not None and gate_role not in (None, "repair"):
+        return _repair_skip(
+            report, "refused",
+            f"REFUSED: {gate_holder}; schema surgery under a live writer corrupts "
+            "state.db. Stop the gateway (`hermes gateway stop`) and retry. "
+            "The database was not modified.",
+        )
+    # A fellow repairer's hold is NOT a refusal: repairers serialize on the
+    # cross-process repair lock below (queuing is the pinned contract); only a
+    # live writer — or an unidentifiable holder — refuses. Hold the gate as
+    # repair through surgery so a writer starting mid-surgery is refused, and
+    # release it after: a repair's need is bounded, unlike a writer's.
+    repair_token = OwnerToken("repair")
+    try:
+        acquire_writer_gate(db_path, role="repair", owner=repair_token, exclusive=True)
+    except Exception as exc:
+        # Lost a flock race after a free probe. A fellow repairer (role) means
+        # queue briefly for the gate — repairers serialize, like on the repair
+        # lock below; a live writer means refuse outright.
+        if writer_gate_holder_role(db_path) != "repair":
+            return _repair_skip(report, "refused", f"REFUSED: {exc} The database was not modified.")
+        from hermes_state import _REPAIR_LOCK_TIMEOUT_SECONDS
+        deadline = time.monotonic() + _REPAIR_LOCK_TIMEOUT_SECONDS
+        while True:
+            try:
+                acquire_writer_gate(db_path, role="repair", owner=repair_token, exclusive=True)
+                break
+            except Exception as exc2:
+                if writer_gate_holder_role(db_path) != "repair" or time.monotonic() >= deadline:
+                    return _repair_skip(report, "refused", f"REFUSED: {exc2} The database was not modified.")
+                time.sleep(0.2)
+    # NOTE: no separate post-take presence check here — acquire_writer_gate
+    # with exclusive=True is atomic (take global, then verify quiet) and is
+    # the single authority carrier; re-checking would duplicate it.
+    try:
+        # Cross-restart cap: the in-memory claim bounds one process, but unhealable b-tree damage used to re-run
+        # surgery + a fresh backup on EVERY restart.
+        # Cross-restart attempt cap (#86747): the in-memory claim bounds one process, but a corruption class the
+        # strategies below cannot heal (b-tree page damage) previously re-ran the whole surgery — and took a
+        # fresh multi-hundred-MB forensic backup — on EVERY restart, forever. After
+        # _MAX_PERSISTENT_REPAIR_ATTEMPTS failures against the same damaged file, stop retrying and surface a
+        # terminal, actionable error.
         if _persistent_repair_attempts_exhausted(db_path):
-            _repair_skip(report, "skipped", _persistent_repair_exhausted_error(db_path))
-        # WAL-holder preflight: fail closed for active readers before a backup is taken. Not the race defence — the
-        # exclusive guard in the locked routine excludes writers through promotion and sees DELETE-mode readers too.
-        elif _live_writer_holds_db(db_path):
-            _repair_skip(report, "skipped", "a live writer still holds state.db; skipped schema surgery to avoid tearing "
-                         "b-tree pages under a concurrent writer. Stop the gateway (hermes gateway stop) and retry.")
-        else:
-            # Probe journal mode BEFORE surgery: a rebuilt file comes back in the default (delete) mode and nothing
-            # else records the flip. Unprobeable (damaged file) -> database.journal_mode is the restore target.
-            # The open-time WAL-reset gate never sees this flip because it happens inside the repair path
-            # (distinct from the open-time flip #89393 warns about).
-            before_mode = _probe_journal_mode_for_repair(db_path)
-            result = _repair_state_db_schema_locked(db_path, backup=backup, report=report,
-                                                    journal_mode_before=before_mode)
-            if result.get("repaired"):
-                result["journal_mode_before"] = before_mode
-        # Environmental aborts (before a strategy mutates the snapshot) are retriable, not proof of exhaustion;
-        # the private marker stays out of the public report. The ledger update stays under the cross-process
-        # lock so two repairers cannot lose each other's updates; a queued loser must not record at all.
-        if result.pop("_repair_attempted", False) or result.get("repaired"):
-            _record_repair_outcome(db_path, repaired=bool(result.get("repaired")))
-    return result
+            return _repair_skip(report, "skipped", _persistent_repair_exhausted_error(db_path))
+
+        with _cross_process_repair_lock(db_path) as holding_lock:
+            if not holding_lock:
+                # Another process holds the lock (or the lock file was unopenable); it may have healed the file
+                # already, so re-probe before failing.
+                if _db_opens_cleanly(db_path) is None:
+                    report["repaired"], report["strategy"] = True, "repaired_by_other_process"
+                else:
+                    report["error"] = ("could not obtain the state.db repair lock (held by another process, or the lock "
+                                       "file was unopenable); skipped schema surgery to avoid racing a concurrent repairer")
+                return report
+
+            result = report
+            # Recheck exhaustion after acquisition: a queued repairer can have recorded the final failure while
+            # this process waited.
+            if _persistent_repair_attempts_exhausted(db_path):
+                _repair_skip(report, "skipped", _persistent_repair_exhausted_error(db_path))
+            # WAL-holder preflight: fail closed for active readers before a backup is taken. Not the race defence — the
+            # exclusive guard in the locked routine excludes writers through promotion and sees DELETE-mode readers too.
+            elif _live_writer_holds_db(db_path):
+                _repair_skip(report, "skipped", "a live writer still holds state.db; skipped schema surgery to avoid tearing "
+                             "b-tree pages under a concurrent writer. Stop the gateway (hermes gateway stop) and retry.")
+            else:
+                # Probe journal mode BEFORE surgery: a rebuilt file comes back in the default (delete) mode and nothing
+                # else records the flip. Unprobeable (damaged file) -> database.journal_mode is the restore target.
+                # The open-time WAL-reset gate never sees this flip because it happens inside the repair path
+                # (distinct from the open-time flip #89393 warns about).
+                before_mode = _probe_journal_mode_for_repair(db_path)
+                result = _repair_state_db_schema_locked(db_path, backup=backup, report=report,
+                                                        journal_mode_before=before_mode)
+                if result.get("repaired"):
+                    result["journal_mode_before"] = before_mode
+            # Environmental aborts (before a strategy mutates the snapshot) are retriable, not proof of exhaustion;
+            # the private marker stays out of the public report. The ledger update stays under the cross-process
+            # lock so two repairers cannot lose each other's updates; a queued loser must not record at all.
+            if result.pop("_repair_attempted", False) or result.get("repaired"):
+                _record_repair_outcome(db_path, repaired=bool(result.get("repaired")))
+        return result
+    finally:
+        release_writer_gate(db_path, repair_token)
 
 
 def _probe_journal_mode_for_repair(db_path: Path) -> Optional[str]:

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -314,6 +314,9 @@ class SessionSearchMixin:
         try:
             more = self._execute_write(_do)
         except sqlite3.OperationalError as exc:
+            from hermes_state_errors import is_gate_refusal
+            if is_gate_refusal(exc):
+                raise  # structural gate refusal (#103339): never spin the transient retry loop
             logger.debug(fail_msg, exc)
             return True  # transient (lock contention) — caller retries
         if more is False:
@@ -386,6 +389,9 @@ class SessionSearchMixin:
         try:
             return bool(self._execute_write(_do))
         except sqlite3.OperationalError as exc:
+            from hermes_state_errors import is_gate_refusal
+            if is_gate_refusal(exc):
+                raise  # structural gate refusal (#103339): never spin the transient retry loop
             logger.debug("FTS trash teardown chunk failed (will retry): %s", exc)
             return True
 
@@ -879,7 +885,10 @@ class SessionSearchMixin:
         sql, params = self._fts_match_sql(table, match_query, order_by_sql, **kwargs)
         try:
             return [dict(row) for row in self._read_all(sql, params)]
-        except sqlite3.OperationalError:
+        except sqlite3.OperationalError as exc:
+            from hermes_state_errors import is_gate_refusal
+            if is_gate_refusal(exc):
+                raise  # structural gate refusal (#103339): never swallow as FTS syntax
             if operational_debug:
                 logger.debug(operational_debug, exc_info=True)
             return None
@@ -952,7 +961,10 @@ class SessionSearchMixin:
             return
         try:
             stale = self._read_one("SELECT 1 FROM state_meta WHERE key = ? LIMIT 1", (FTS_STALE_KEY,))
-        except sqlite3.Error:
+        except sqlite3.Error as exc:
+            from hermes_state_errors import is_gate_refusal
+            if is_gate_refusal(exc):
+                raise  # structural gate refusal (#103339): never swallow as fresh
             return
         if stale is not None:
             self._fts_stale = True
@@ -971,7 +983,10 @@ class SessionSearchMixin:
                         rows = conn.execute(sql, list(contexts)).fetchall()
                     for row in rows:
                         contexts[row["match_id"]].append(row)
-                except Exception:
+                except Exception as exc:
+                    from hermes_state_errors import is_gate_refusal
+                    if is_gate_refusal(exc):
+                        raise  # structural gate refusal (#103339): never swallow as no context
                     contexts = {}
                 for match in batch:
                     try:
@@ -1053,7 +1068,10 @@ class SessionSearchMixin:
             sql, params = self._fts_match_sql("messages_fts", query, **route)
             try:
                 matches = [dict(row) for row in self._read_all(sql, params)]
-            except sqlite3.OperationalError:
+            except sqlite3.OperationalError as exc:
+                from hermes_state_errors import is_gate_refusal
+                if is_gate_refusal(exc):
+                    raise  # structural gate refusal (#103339): never swallow as FTS syntax
                 return []  # FTS5 syntax error despite sanitization
             except sqlite3.DatabaseError as exc:
                 # Corruption parent class: detach the derived indexes and answer from
@@ -1075,6 +1093,9 @@ class SessionSearchMixin:
                 seen_ids = {m["id"] for m in matches}
                 matches.extend(m for m in gap_matches if m["id"] not in seen_ids)
             except sqlite3.OperationalError as exc:
+                from hermes_state_errors import is_gate_refusal
+                if is_gate_refusal(exc):
+                    raise  # structural gate refusal (#103339): never return a partial gap as complete
                 logger.debug("Unindexed-gap supplement skipped: %s", exc)
 
         # unicode61 puts no boundary between Latin and adjacent CJK ("修改youer服务端" is

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -480,7 +480,10 @@ class SessionSessionsMixin:
                 f"OR end_reason IN ({_RECOVERABLE_END_REASONS_SQL}))",
                 (now, reason, session_id), session_id, reason,
             )))
-        except Exception:
+        except Exception as exc:
+            from hermes_state_errors import is_gate_refusal
+            if is_gate_refusal(exc):
+                raise  # structural gate refusal (#103339): a refused end is never "not ended"
             return False
 
     def update_session_cwd(
@@ -592,7 +595,10 @@ class SessionSessionsMixin:
                 "SELECT last_activity_description, last_activity_provenance FROM sessions WHERE id = ?",
                 (session_id,),
             )
-        except sqlite3.Error:
+        except sqlite3.Error as exc:
+            from hermes_state_errors import is_gate_refusal
+            if is_gate_refusal(exc):
+                raise  # structural gate refusal (#103339): never swallow as missing row
             row = None
         if row is not None and not row[0] and (not row[1] or row[1] == ActivityProvenance.UNKNOWN.value):
             return
@@ -852,7 +858,10 @@ class SessionSessionsMixin:
             return False
         try:
             row = self.get_session(session_id)
-        except Exception:
+        except Exception as exc:
+            from hermes_state_errors import is_gate_refusal
+            if is_gate_refusal(exc):
+                raise  # structural gate refusal (#103339): never hide a live session as absent
             return False
         if not row or not row.get("archived"):
             return False
@@ -862,7 +871,10 @@ class SessionSessionsMixin:
             tip_id = self.get_compression_tip(session_id) or session_id
             if tip_id != session_id:
                 tip = self.get_session(tip_id) or row
-        except Exception:
+        except Exception as exc:
+            from hermes_state_errors import is_gate_refusal
+            if is_gate_refusal(exc):
+                raise  # structural gate refusal (#103339): never judge recoverability on stale state
             pass
         if (tip.get("end_reason") or "") not in self.RECOVERABLE_END_REASONS:
             return False

--- a/hermes_state_telegram.py
+++ b/hermes_state_telegram.py
@@ -104,7 +104,10 @@ class SessionTelegramTopicsMixin:
         """``fetchone`` that treats an unmigrated table as None."""
         try:
             return self._read_one(sql, params)
-        except sqlite3.OperationalError:
+        except sqlite3.OperationalError as exc:
+            from hermes_state_errors import is_gate_refusal
+            if is_gate_refusal(exc):
+                raise  # structural gate refusal (#103339): never swallow as unmigrated
             return None
 
     def apply_telegram_topic_migration(self) -> None:
@@ -233,7 +236,10 @@ class SessionTelegramTopicsMixin:
                 "SELECT * FROM telegram_dm_topic_bindings WHERE profile_name = ? AND chat_id = ? ORDER BY updated_at DESC",
                 (profile_name, str(chat_id)),
             )
-        except sqlite3.OperationalError:
+        except sqlite3.OperationalError as exc:
+            from hermes_state_errors import is_gate_refusal
+            if is_gate_refusal(exc):
+                raise  # structural gate refusal (#103339): never swallow as absent bindings
             return []
         return [dict(row) for row in rows]
 

--- a/hermes_state_writergate.py
+++ b/hermes_state_writergate.py
@@ -1,0 +1,1352 @@
+"""Cross-process writer coordination for ``state.db`` (see #103339).
+
+Design (v3): SQLite owns *row* concurrency; this gate owns *file-structure*
+concurrency. Ordinary row writes (appends, claims, handoffs, leases) from any
+number of processes proceed under SQLite's own WAL locking — exactly as on
+base, where a pinned conformance cell proves 8 concurrent claimants stay
+exactly-once. What this gate forbids is *structural* work under a live
+writer — schema surgery, checkpoints from a second connection, VACUUM-class
+operations — the evidenced corruption class: the second connection's WAL
+handling unlinks/replaces the WAL inode the owning gateway holds.
+
+Mechanism, two files beside the database:
+
+- Presence: ``<state.db>.writer.<pid>.lock``. Each writing process holds its
+  OWN file exclusive for as long as it may write (first write → close).
+  Per-pid files never contend with each other, so any number of writers
+  coexist; a probe enumerates them to learn that a writer lives. Crashed
+  writers leave litter, which the probe reaps (see below) — no wedged state.
+- Structural exclusion: ``<state.db>.writer.lock`` (global). A structural
+  operation (today: schema repair) holds it exclusive for the whole surgery.
+  Row announces refuse while it is held, and it is only grantable when no
+  writer presence is live — closing the race in both directions.
+
+Fail-closed everywhere: contention, an unopenable file, or an unreadable
+holder record refuses the structural op, never allows it. Row announces
+refuse only while a surgery holds the global lock.
+
+Probe liveness rules for a presence file (all best-effort, never raising):
+
+- Our own pid's file, registered locally → ours, skip.
+- Exclusive flock still acquirable → holder gone. Unlink + ignore, UNLESS the
+  file is brand new with no readable record (a racing announcer mid-create)
+  or the record names a live pid (a mid-close race) — both read as LIVE.
+- Exclusive flock contended → live holder; role comes from its record
+  (``writer``; unreadable → ``unknown``, still a refusal).
+
+Roles (``writer`` / ``repair``) live in the global lock's record so repair
+can tell a fellow repairer (serialize via the repair lock — queuing is
+correct) from a live writer (refuse).
+
+Ownership is per SessionDB instance: ``SessionDB.close()`` releases its
+share, and presence drops when the last in-process owner closes. A live
+gateway (registry-owned handle, never closed mid-life) therefore announces
+exactly while it can write; a CLI that wrote and closed does not pin
+presence against a later repair. (``close()`` on a registry-shared instance
+only decrements the registry refcount; the share releases on final registry
+release, which runs the real ``close()``.)
+
+``fork()`` needs no pid guard by construction: presence files are keyed by
+pid, so the child naturally announces under its own pid, and release only
+ever unlinks a file whose pid matches the releaser — a child can never
+delete its parent's presence. A child that never touches the gate leaves no
+trace; one that writes announces like any other second process.
+
+Read-only paths never touch the gate (``sessions list/export``, backups,
+health probes, ``SessionDB(read_only=True)``).
+
+Windows tier: ``msvcrt.locking`` is exclusive-only. Takes are exclusive on
+both platforms; observation probes are shared on POSIX (concurrent probes
+never contend with each other) but exclusive on Windows, where a contended
+observation retries briefly to separate probe transients from real surgery
+holds. Residual Windows-only case (a probe paused indefinitely while
+holding): fail-closed spurious refusal, retryable by the caller.
+
+Known limitation: open-time writes that bypass ``_execute_write`` (the
+``state_meta`` generation stamp, schema init DDL) announce nothing — gating
+the open would refuse speculative writer handles that never write
+(``sessions list`` while the gateway runs).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import sys
+import threading
+import time
+import weakref
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from hermes_state_common import (
+    _proc_start_ticks,
+    _read_lock_holder_record,
+    _rewrite_lock_file,
+    is_advisory_lock_contention,
+)
+from hermes_state_errors import StateDbGateSetupError, StateDbWriterHeldError
+
+logger = logging.getLogger("hermes_state")
+
+_IS_WINDOWS = sys.platform == "win32"
+
+#: Global structural lock: ``<state.db>.writer.lock`` sits beside the database.
+_WRITER_LOCK_SUFFIX = ".writer.lock"
+#: Presence-file infixes: ``<state.db>.writer.<pid>.lock``.
+_WRITER_PRESENCE_INFIX = ".writer."
+_PRESENCE_SUFFIX = ".lock"
+
+#: Fresh-file window (seconds): a flock-free presence file younger than this
+#: with no readable record is a racing announcer, not litter — read as live.
+_PRESENCE_SETTLE_SECONDS = 60.0
+
+#: Holder roles recorded in lock files.
+_WRITER_ROLE = "writer"
+_REPAIR_ROLE = "repair"
+_UNKNOWN_ROLE = "unknown"
+
+
+class _GateHold:
+    """One held lock file plus its in-process owners and acquirer pid.
+
+    ``structural_owner`` is only set on the global structural hold: the token
+    of the operation that owns the surgery. Same-process re-entry is allowed
+    solely for that identical token — a distinct structural owner (repair vs
+    checkpoint) must serialize outside, never piggyback.
+
+    ``anon_leases`` counts anonymous (owner=None) announces on a presence
+    hold. Anonymous callers share an empty ``owners`` set by design, so the
+    count — incremented under ``_held_lock`` for every anonymous announce —
+    is what lets a refused announce roll back exactly its own lease without
+    disturbing other live anonymous callers.
+    """
+
+    __slots__ = ("handle", "owners", "role", "acquired_pid", "structural_owner", "anon_leases",
+                 "deferred_release", "db_path")
+
+    def __init__(self, handle, role: str, db_path: Optional[Path] = None):
+        self.handle = handle
+        self.role = role
+        self.owners = weakref.WeakSet()
+        self.acquired_pid = os.getpid()
+        self.structural_owner = None
+        self.anon_leases = 0
+        #: Sticky flag: a release exhausted the mutation-mutex budget with the
+        #: hold still pinned, so the pathname cleanup is owed. The module-level
+        #: drain completes it once no owner/lease is live — the cleanup can
+        #: never be stranded by the owner dying without another retry (P1).
+        self.deferred_release = False
+        #: ``db_path`` for the deferred drain (presence-path mutations need it).
+        self.db_path = db_path
+
+
+class OwnerToken:
+    """Weakref-able owner token for :func:`acquire_writer_gate` (a bare
+    ``object()`` cannot be weak-referenced). SessionDB instances pass
+    themselves; one-shot holders (repair surgery) mint one of these."""
+
+    __slots__ = ("label", "__weakref__")
+
+    def __init__(self, label: str = ""):
+        self.label = label
+
+    def __repr__(self) -> str:  # pragma: no cover - diagnostics only
+        return f"OwnerToken({self.label!r})"
+
+
+#: Lock path -> live hold. Guarded by ``_held_lock``.
+_held: Dict[str, _GateHold] = {}
+_held_lock = threading.Lock()
+
+
+def _writer_lock_path(db_path: Path) -> Path:
+    """Global structural lock file for *db_path*."""
+    try:
+        resolved = Path(db_path).expanduser().resolve()
+    except OSError:
+        resolved = Path(db_path).expanduser().absolute()
+    return resolved.with_name(resolved.name + _WRITER_LOCK_SUFFIX)
+
+
+def _presence_path(db_path: Path, pid: int) -> Path:
+    """This process's presence file for *db_path* (never shared across pids,
+    so a symlink and its target resolve to one gate like the registry)."""
+    try:
+        resolved = Path(db_path).expanduser().resolve()
+    except OSError:
+        resolved = Path(db_path).expanduser().absolute()
+    return resolved.with_name(
+        f"{resolved.name}{_WRITER_PRESENCE_INFIX}{pid}{_PRESENCE_SUFFIX}"
+    )
+
+
+#: Presence-path mutation mutex: ``<state.db>.writer.mtx.lock``. Persistent
+#: sentinel beside the database (never unlinked, like the global lock).
+#: Every presence-pathname mutation (stale reclaim unlink+create, litter
+#: reap check+unlink, orphan break, release unlink) holds it exclusive, so a
+#: replacement can never win the pathname between another actor's identity
+#: check and unlink. Fresh creates need no mutex (they delete nothing).
+#: Callers always take ``_held_lock`` first (mutex ward); the mutex is the
+#: inner lock for cross-process serialization. Contention fails closed.
+#: Release-path mutex retries: a closer colliding with a reaper's
+#: microsecond mutex hold rides it out instead of leaving litter. Past the
+#: budget the hold is re-registered (flock still held, owner restored),
+#: flagged ``deferred_release``, and the module-level drain finishes the
+#: unlinking as soon as the mutex frees — cleanup never depends on the
+#: owner surviving to retry (never an unlinked-but-recorded ghost either).
+_RELEASE_MUTEX_ATTEMPTS = 10
+_RELEASE_MUTEX_RETRY_S = 0.02
+_MUTATION_MUTEX_SUFFIX = ".writer.mtx.lock"
+
+#: Deferred-release drain: a release that exhausts the mutation-mutex budget
+#: leaves its hold flagged (share dropped, flock + presence file still held).
+#: This drain completes the pathname cleanup once no owner/lease is live. It
+#: works from the hold record alone, so the cleanup cannot be stranded when
+#: the owner that owed it dies without another ``close()`` (P1) — a caller's
+#: lifecycle retry is a second chance, never the only one.
+_DEFERRED_RELEASE_DRAIN_POLL_S = 0.2
+_DEFERRED_RELEASE_DRAIN_MAX_S = 900.0
+
+_drain_lock = threading.Lock()
+_drain_running = False
+#: Bumped on every deferred-release flag set; the drain compares epochs to
+#: decide whether a NEW hold needs a fresh worker after it exits.
+_deferred_release_epoch = 0
+
+
+def _mutation_mutex_path(db_path: Path) -> Path:
+    """Mutex file serializing presence-pathname mutations for *db_path*."""
+    try:
+        resolved = Path(db_path).expanduser().resolve()
+    except OSError:
+        resolved = Path(db_path).expanduser().absolute()
+    return resolved.with_name(resolved.name + _MUTATION_MUTEX_SUFFIX)
+
+
+@contextlib.contextmanager
+def _presence_mutation_serialized(db_path: Path):
+    """Hold the presence-path mutation mutex across a pathname mutation.
+
+    Yields True when serialized (caller may unlink/create). Yields False on
+    real contention — another cooperating mutator holds the mutex. Yields
+    None when the mutex itself cannot be opened or locked (an unexpected,
+    non-contention failure): retrying never helps there, so the announce
+    path classifies it as ``StateDbGateSetupError`` instead of a
+    live-holder refusal. Failure callers must fail closed (report live /
+    refuse the announce), never mutate. ``_held_lock`` must already be held
+    (it is always the outer lock). Never raises.
+    """
+    try:
+        handle = _open_gate_file(_mutation_mutex_path(db_path))
+    except OSError:
+        yield None
+        return
+    try:
+        held = _try_flock_nb(handle)
+        if held is not True:
+            yield (False if held is False else None)
+            return
+        yield True
+    finally:
+        _unlock_handle(handle)
+        try:
+            handle.close()
+        except OSError:
+            pass
+
+
+def _presence_pid(lock_path: Path, db_name: str) -> Optional[int]:
+    """PID encoded in a presence filename, or None when it is not one."""
+    name = lock_path.name
+    prefix = db_name + _WRITER_PRESENCE_INFIX
+    if not name.startswith(prefix) or not name.endswith(_PRESENCE_SUFFIX):
+        return None
+    try:
+        return int(name[len(prefix):-len(_PRESENCE_SUFFIX)])
+    except ValueError:
+        return None
+
+
+def _cmdline_of(pid: int) -> Optional[str]:
+    """Best-effort ``pid -> cmdline`` for refusal messages; None when unknowable."""
+    try:
+        with open(f"/proc/{pid}/cmdline", "rb") as fh:
+            cmd = fh.read().replace(b"\0", b" ").decode("utf-8", "replace").strip()
+            return cmd[:200] if cmd else None
+    except (OSError, ValueError):
+        return None
+
+
+def _read_gate_record(lock_path: Path) -> Optional[dict]:
+    """Best-effort parse of the holder record; None when unreadable."""
+    try:
+        with lock_path.open("rb") as fh:
+            record = _read_lock_holder_record(fh)
+    except OSError:
+        return None
+    return record if isinstance(record, dict) else None
+
+
+def _holder_role(record: Optional[dict]) -> str:
+    if not record:
+        return _UNKNOWN_ROLE
+    role = record.get("role")
+    return role if role in (_WRITER_ROLE, _REPAIR_ROLE) else _UNKNOWN_ROLE
+
+
+def _describe_holder(lock_path: Path, record: Optional[dict] = None) -> str:
+    """Human-readable holder for refusal messages; never raises."""
+    if record is None:
+        record = _read_gate_record(lock_path)
+    if not record:
+        return f"another process holds {lock_path} (holder record unreadable)"
+    pid = record.get("pid")
+    try:
+        pid = int(pid) if pid is not None else 0
+    except (TypeError, ValueError):
+        pid = 0
+    if pid <= 0:
+        return f"another process holds {lock_path} (holder record has no pid)"
+    cmd = _cmdline_of(pid)
+    who = f"pid {pid}" + (f" ({cmd})" if cmd else "")
+    return f"another process holds {lock_path} ({who})"
+
+
+def _open_gate_file(lock_path: Path):
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    return lock_path.open("a+b")
+
+
+def _try_flock_nb(handle) -> Optional[bool]:
+    """Non-blocking exclusive flock: True (held), False (contended), None
+    (non-contention OSError — fail closed upstream)."""
+    try:
+        if _IS_WINDOWS:
+            import msvcrt
+
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)  # type: ignore[attr-defined]
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except (BlockingIOError, OSError) as exc:
+        if not is_advisory_lock_contention(exc):
+            logger.warning(
+                "state.db writer gate: unexpected lock error (fail closed): %s", exc
+            )
+            return None
+        return False
+
+
+def _try_flock_observe_nb(handle) -> Optional[bool]:
+    """Observation flock for probes: shared on POSIX, exclusive on Windows.
+
+    POSIX ``LOCK_SH`` lets concurrent probes coexist — a probe never mistakes
+    a fellow probe's transient observation for structural ownership; only a
+    real exclusive holder (surgery) contends. ``msvcrt.locking`` has no shared
+    mode, so Windows probes stay exclusive (see ``_probe_global``'s retry,
+    which separates microsecond probe transients from real surgery holds).
+    Same fail-closed contract as :func:`_try_flock_nb`.
+    """
+    try:
+        if _IS_WINDOWS:
+            import msvcrt
+
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)  # type: ignore[attr-defined]
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_SH | fcntl.LOCK_NB)
+        return True
+    except (BlockingIOError, OSError) as exc:
+        if not is_advisory_lock_contention(exc):
+            logger.warning(
+                "state.db writer gate: unexpected lock error (fail closed): %s", exc
+            )
+            return None
+        return False
+
+
+def _unlock_handle(handle) -> None:
+    """Release a disposable handle's flock (never a registered hold)."""
+    try:
+        if _IS_WINDOWS:
+            import msvcrt
+
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)  # type: ignore[attr-defined]
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except OSError:
+        pass
+
+
+def _write_gate_record(handle, role: str) -> None:
+    """Record this process as holder (best effort, under the flock)."""
+    record = {
+        "pid": os.getpid(),
+        "start_ticks": _proc_start_ticks(os.getpid()),
+        "acquired_at": time.time(),
+        "role": role,
+    }
+    _rewrite_lock_file(handle, json.dumps(record, sort_keys=True).encode("utf-8"))
+
+
+def _pid_is_alive(pid: int) -> Optional[bool]:
+    """Windows-safe liveness: True/False, None when unknowable (fail closed).
+
+    Uses ``psutil.pid_exists`` (core dependency); falls back to ``os.kill``
+    only on POSIX. Never calls ``os.kill(pid, 0)`` on Windows (CPython maps
+    signal 0 to CTRL_C_EVENT there).
+    """
+    try:
+        pid = int(pid)
+    except (TypeError, ValueError):
+        return None
+    if pid <= 0:
+        return False
+    try:
+        import psutil as _psutil  # type: ignore[import-not-found]
+    except ImportError:
+        _psutil = None  # type: ignore[assignment]
+    if _psutil is not None:
+        try:
+            return bool(_psutil.pid_exists(pid))
+        except Exception:
+            return None
+    if _IS_WINDOWS:
+        return None  # unknowable without psutil: fail closed
+    try:
+        os.kill(pid, 0)  # windows-footgun: ok — POSIX-only (guarded by _IS_WINDOWS above)
+        return True
+    except ProcessLookupError:
+        return False
+    except OSError:
+        return None
+
+
+def _file_age_seconds(path: Path) -> float:
+    try:
+        return time.time() - path.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+def _path_identity_matches_handle(handle, lock_path: Path) -> Optional[bool]:
+    """True when *lock_path* still names *handle*'s inode (dev+ino, both nonzero).
+
+    False when the pathname names a different inode (a replacement won the
+    path between our open and now). None when identity cannot be established
+    (fstat/stat failure, zero inode on network FS). ENOENT counts as False —
+    callers re-stat to tell gone (reaped) from replaced (live).
+    """
+    try:
+        fd_stat = os.fstat(handle.fileno())
+    except OSError:
+        return None
+    try:
+        path_stat = lock_path.stat()
+    except OSError:
+        return False
+    if not fd_stat.st_ino or not path_stat.st_ino:
+        return None
+    return (fd_stat.st_dev, fd_stat.st_ino) == (path_stat.st_dev, path_stat.st_ino)
+
+
+def _locked_reap_presence(handle, lock_path: Path, db_path: Path) -> bool:
+    """Unlink *lock_path* while the caller holds its flock; identity-safe.
+
+    Returns True when the pathname is gone afterwards (reaped: do NOT report
+    live). Returns False to treat as live (fail closed): the mutation mutex
+    is contended, a replacement was detected, identity is unverifiable on
+    POSIX, or the unlink failed. The mutex makes check+unlink atomic against
+    cooperating mutators (reclaim/reap/release all serialize on it); the
+    identity check additionally catches replacements that slipped in outside
+    the mutex. On Windows a contested unlink fails via OS share semantics
+    (failure → live), the safe equivalent.
+    """
+    with _presence_mutation_serialized(db_path) as serialized:
+        if not serialized:
+            return False
+        same = _path_identity_matches_handle(handle, lock_path)
+        if same is False:
+            try:
+                lock_path.stat()
+            except OSError:
+                return True  # already gone: reaped
+            return False  # replacement holds the path: live
+        if same is None and not _IS_WINDOWS:
+            return False  # POSIX: unverifiable identity never reaps
+        try:
+            lock_path.unlink()
+        except OSError:
+            return False
+        return True
+
+
+def _unlink_orphan_presence(lock_path: Path, db_path: Path, expected_record) -> bool:
+    """Best-effort removal of an orphan-held presence pathname (no flock held).
+
+    For the #100108 shape: recorded holder dead, a fork-inherited descriptor
+    holds the flock. Opens fresh (no flock), reaps only when the CURRENT
+    record still equals ``expected_record`` (the dead classification made
+    pre-mutex) AND the open probe matches the current pathname identity —
+    a replacement that won the path in between differs in record content
+    and is kept live. True means gone (do NOT report live), False means
+    treat as live. Never raises.
+    """
+    with _presence_mutation_serialized(db_path) as serialized:
+        if not serialized:
+            return False
+        try:
+            probe = lock_path.open("r+b")
+        except FileNotFoundError:
+            return True
+        except OSError:
+            return False
+        try:
+            if _path_identity_matches_handle(probe, lock_path) is not True:
+                return False
+            if expected_record is not None and _read_gate_record(lock_path) != expected_record:
+                return False  # replaced after classification: live
+            try:
+                lock_path.unlink()
+            except OSError:
+                return False
+            return True
+        finally:
+            try:
+                probe.close()
+            except OSError:
+                pass
+
+
+def _presence_holder_provably_dead(record) -> bool:
+    """POSIX-only break-glass: True only when the recorded holder is provably
+    dead or PID-recycled (same contract as
+    ``hermes_state_common._lock_holder_provably_dead``). Always False on
+    Windows (fail closed) — it must never run there: CPython maps
+    ``os.kill(pid, 0)`` to CTRL_C_EVENT.
+    """
+    if _IS_WINDOWS:
+        return False
+    try:
+        from hermes_state_common import _lock_holder_provably_dead
+        return bool(_lock_holder_provably_dead(record))
+    except Exception:
+        return False
+
+
+def _live_writer_presences(db_path: Path, *, include_self: bool = False) -> List[str]:
+    """Descriptions of live foreign writer presences; reaps crash litter.
+
+    Never raises. A flock-free file is litter ONLY when it is old or names a
+    provably-absent record; a fresh file with no record is a racing announcer
+    (fail closed), as is a file whose record names a live pid (mid-close).
+
+    With ``include_self`` (structural-take quietness check) the caller's own
+    presence counts as live: same-process reentrancy applies only to the same
+    structural operation (global re-entry), never to unrelated writer owners.
+    """
+    try:
+        resolved = Path(db_path).expanduser().resolve()
+    except OSError:
+        resolved = Path(db_path).expanduser().absolute()
+    parent, db_name = resolved.parent, resolved.name
+    try:
+        candidates = list(parent.glob(db_name + _WRITER_PRESENCE_INFIX + "*" + _PRESENCE_SUFFIX))
+    except OSError:
+        return [f"cannot scan {parent} for writer presence (fail closed)"]
+    live: List[str] = []
+    me = os.getpid()
+    for lock_path in candidates:
+        pid = _presence_pid(lock_path, db_name)
+        if pid is None:
+            continue
+        # One mutex around open + flock + unlock + close: sibling threads'
+        # identical sequences can never overlap, so probes never mistake each
+        # other for a foreign holder (same-process flock descriptions
+        # contend). Record reads and litter reaps stay outside (fail-closed).
+        # Own files skip via registry AND pid (unless include_self): a forked
+        # child inherits the registry copy but has a new pid, so it must still
+        # see (never skip) its parent's presence file.
+        with _held_lock:
+            if not include_self and pid == me and str(lock_path) in _held:
+                continue  # ours
+            try:
+                handle = lock_path.open("a+b")
+            except OSError:
+                live.append(f"unopenable presence file {lock_path} (fail closed)")
+                continue
+            try:
+                held = _try_flock_nb(handle)
+                if held is True:
+                    _unlock_handle(handle)
+            finally:
+                try:
+                    handle.close()
+                except OSError:
+                    pass
+            if held is None:
+                live.append(f"unprovable presence file {lock_path} (fail closed)")
+                continue
+            if held is False:
+                # Contended: usually a live holder. POSIX orphan exception
+                # (#100108 shape): recorded holder provably dead while a
+                # fork-inherited descriptor holds the flock — break it like
+                # _acquire_db_flock does, else one dead parent blocks surgery
+                # until its unrelated child exits. Windows never takes this
+                # branch (no fork; fail closed to live).
+                if not _IS_WINDOWS:
+                    _rec = _read_gate_record(lock_path)
+                    if _rec is not None and _presence_holder_provably_dead(_rec):
+                        # Already under _held_lock (mutex ward above): the
+                        # helper takes only the cross-process mutex, never
+                        # _held_lock (threading.Lock is not reentrant).
+                        # _rec is the pre-mutex classification; the helper
+                        # re-reads under the mutex and only unlinks when the
+                        # current record still equals it (no replacement won
+                        # the path in between).
+                        if _unlink_orphan_presence(lock_path, db_path, _rec):
+                            continue  # reaped: not live
+                live.append(_describe_holder(lock_path, _read_gate_record(lock_path)))
+                continue
+        # Flock-free here: litter only when provably not a racer. A free
+        # flock plus a record naming a dead pid cannot be a racing announcer
+        # (announcers hold the flock while writing their record), so it is
+        # reaped regardless of file age.
+        record = _read_gate_record(lock_path)
+        if record is None and _file_age_seconds(lock_path) < _PRESENCE_SETTLE_SECONDS:
+            live.append(_describe_holder(lock_path, record))  # racing announcer
+            continue
+        if record is not None and _holder_role(record) == _UNKNOWN_ROLE:
+            live.append(_describe_holder(lock_path, record))  # conservative
+            continue
+        if record is not None:
+            rp = record.get("pid")
+            try:
+                rp = int(rp) if rp is not None else 0
+            except (TypeError, ValueError):
+                rp = 0
+            if rp > 0:
+                if not _IS_WINDOWS:
+                    # POSIX: pid existence alone cannot prove liveness (PID
+                    # reuse); compare start_ticks via the provably-dead
+                    # contract. Unknown identity fails closed to live.
+                    if not _presence_holder_provably_dead(record):
+                        live.append(_describe_holder(lock_path, record))  # live or unknowable
+                        continue
+                else:
+                    alive = _pid_is_alive(rp)
+                    if alive is True:
+                        live.append(_describe_holder(lock_path, record))  # mid-close race
+                        continue
+                    if alive is None:
+                        live.append(_describe_holder(lock_path, record))  # unknowable: closed
+                        continue
+                # Dead pid with a record, flock already proven free above:
+                # crash litter (a racing announcer holds the flock while
+                # writing, so this cannot be one). Reap under the mutex with
+                # the flock HELD across the unlink: a replacement winning the
+                # pathname in between is detected by identity and kept live.
+                with _held_lock:
+                    try:
+                        handle = lock_path.open("a+b")
+                    except OSError:
+                        continue
+                    try:
+                        if _try_flock_nb(handle) is not True:
+                            # Lost the re-verify race (someone holds it now):
+                            # no lock held here, so no unlock — just report.
+                            live.append(_describe_holder(
+                                lock_path, _read_gate_record(lock_path)))
+                            continue
+                        if not _locked_reap_presence(handle, lock_path, db_path):
+                            live.append(_describe_holder(
+                                lock_path, _read_gate_record(lock_path)))
+                        _unlock_handle(handle)
+                    finally:
+                        try:
+                            handle.close()
+                        except OSError:
+                            pass
+                continue
+        # Re-verify under the mutex before reaping (covers the residual
+        # no-record old-litter path; dead-pid records were reaped above).
+        # The flock stays HELD across the unlink (same identity-safe reap).
+        with _held_lock:
+            try:
+                handle = lock_path.open("a+b")
+            except OSError:
+                continue
+            try:
+                if _try_flock_nb(handle) is not True:
+                    live.append(_describe_holder(lock_path, _read_gate_record(lock_path)))
+                    continue
+                if _file_age_seconds(lock_path) < _PRESENCE_SETTLE_SECONDS:
+                    live.append(_describe_holder(lock_path, _read_gate_record(lock_path)))
+                    _unlock_handle(handle)
+                    continue
+                if not _locked_reap_presence(handle, lock_path, db_path):
+                    live.append(_describe_holder(lock_path, _read_gate_record(lock_path)))
+                    _unlock_handle(handle)
+                    continue
+                _unlock_handle(handle)
+            finally:
+                try:
+                    handle.close()
+                except OSError:
+                    pass
+    return live
+
+
+def _probe_global(db_path: Path, *, settle_role: bool = False) -> Tuple[bool, str, str]:
+    """Non-holding probe of the global structural lock:
+    ``(foreign_held, role, description)``. Never raises (fail closed).
+
+    Observation uses a SHARED flock on POSIX, so concurrent probes never
+    contend with each other — only a real exclusive holder (surgery) refuses
+    a row writer. On Windows (no shared ``msvcrt.locking`` mode) a contended
+    observation is retried briefly: a fellow probe's microsecond hold clears,
+    a real surgery's hold persists. Residual Windows-only case (a probe
+    paused indefinitely while holding): fail-closed spurious refusal,
+    retryable by the caller.
+    """
+    lock_path = _writer_lock_path(db_path)
+    key = str(lock_path)
+    attempts = 6 if settle_role else 1
+    last: Tuple[bool, str, str] = (True, _UNKNOWN_ROLE, _describe_holder(lock_path))
+    for _ in range(attempts):
+        # Mutex Ward (see _live_writer_presences): open + flock + unlock +
+        # close never overlap a sibling thread, so no false contention.
+        # No self fast-path here: a global hold by this process must still
+        # refuse row callers (unrelated owners are never invisible). Re-entry
+        # for the same structural operation is handled in acquire_writer_gate
+        # itself, not in the probe. Fork-inherited holds are dropped below.
+        with _held_lock:
+            hold = _held.get(key)
+            if hold is not None and hold.acquired_pid != os.getpid():
+                # Fork-inherited: drop locally without touching the fd (the
+                # parent's description keeps the kernel lock; unlocking here
+                # would release the parent).
+                try:
+                    hold.handle.close()
+                except OSError:
+                    pass
+                _held.pop(key, None)
+            try:
+                handle = _open_gate_file(lock_path)
+            except OSError as exc:
+                return True, _UNKNOWN_ROLE, f"cannot open {lock_path} ({exc})"
+            try:
+                held = _try_flock_observe_nb(handle)
+                if held is True:
+                    _unlock_handle(handle)
+                elif held is False and _IS_WINDOWS:
+                    # No shared mode on Windows: a contended observation may
+                    # be a fellow probe's microsecond hold, not a surgery.
+                    # Retry briefly — transients clear, real holds persist.
+                    for _ in range(10):
+                        time.sleep(0.005)
+                        try:
+                            handle.seek(0)
+                        except OSError:
+                            break
+                        held = _try_flock_observe_nb(handle)
+                        if held is not False:
+                            break
+                    if held is True:
+                        _unlock_handle(handle)
+            finally:
+                try:
+                    handle.close()
+                except OSError:
+                    pass
+            if held is not True:
+                pass  # contended: report held below (no self fast-path)
+        if held is True:
+            return False, _UNKNOWN_ROLE, ""
+        record = _read_gate_record(lock_path)
+        role = _holder_role(record)
+        if role != _UNKNOWN_ROLE or not settle_role:
+            return True, role, _describe_holder(lock_path, record)
+        last = (True, role, _describe_holder(lock_path, record))
+        time.sleep(0.2)
+    return last
+
+
+def _refusal(db_path: Path, what: str) -> StateDbWriterHeldError:
+    return StateDbWriterHeldError(
+        f"state.db writer gate: {what}; refusing structural work on {db_path} so it cannot "
+        "corrupt the live WAL (see #103339). Stop that process's gateway "
+        "(`hermes gateway stop`) and retry."
+    )
+
+
+def acquire_writer_gate(db_path: Path, *, role: str = _WRITER_ROLE, owner=None,
+                        exclusive: bool = False) -> None:
+    """Take this process's share of *db_path*'s writer gate.
+
+    - Row announces (``exclusive=False``, the ``_execute_write`` path):
+      idempotent per process; records presence in this process's own
+      presence file and refuses ONLY while a surgery holds the global
+      structural lock (fail-closed in both directions). Any number of
+      processes may announce concurrently — SQLite arbitrates their row
+      writes, as on base.
+    - Structural takes (``exclusive=True``, repair surgery): ATOMIC —
+      takes the global lock, then scans foreign writer presences, and
+      releases + refuses when any are live. Only an actually-quiet database
+      is ever returned held. Same-process re-entry is allowed solely for the
+      identical owner token (same logical operation); a distinct structural
+      owner refuses and serializes outside (repairers queue via the repair
+      lock). Requires a non-None ``owner``. This primitive is the single
+      authority carrier: every structural caller (repair, checkpoints,
+      future VACUUM/optimize/migration gates) takes through here instead of
+      reimplementing probe-then-take.
+    """
+    if role not in (_WRITER_ROLE, _REPAIR_ROLE):
+        role = _WRITER_ROLE
+    if exclusive and owner is None:
+        raise ValueError(
+            "state.db writer gate: exclusive take requires an owner token "
+            "(anonymous structural holds cannot be released or re-entered)."
+        )
+    if not exclusive:
+        _announce_presence(db_path, owner=owner)
+        foreign, _role, description = _probe_global(db_path)
+        if foreign:
+            # Our presence was registered BEFORE the probe (announce-first
+            # closes the check-then-act gap); a refusal must roll it back or
+            # the refused opener's file litters and blocks later surgery.
+            _rollback_announce(db_path, owner)
+            raise StateDbWriterHeldError(
+                f"state.db writer gate: {description}; refusing to write {db_path} while a "
+                "structural operation owns it (see #103339). Retry once it finishes."
+            )
+        return
+    lock_path = _writer_lock_path(db_path)
+    key = str(lock_path)
+    # Mutex Ward: the whole check + open + flock + register sequence runs
+    # under one hold so sibling threads can never interleave two takes of
+    # the same file (same-process flock descriptions contend).
+    # Fork safety: an inherited hold is foreign — drop it locally (never
+    # unlock: the parent's description keeps the kernel lock) and take fresh.
+    with _held_lock:
+        hold = _held.get(key)
+        if hold is not None and hold.acquired_pid != os.getpid():
+            try:
+                hold.handle.close()
+            except OSError:
+                pass
+            _held.pop(key, None)
+            hold = None
+        if hold is not None:
+            # Same-process re-entry is the SAME logical operation only: the
+            # identical owner token. A distinct structural owner (checkpoint
+            # vs repair) must serialize outside — piggybacking would run
+            # surgery under a foreign hold.
+            if hold.structural_owner is not owner:
+                raise _refusal(
+                    db_path,
+                    f"another structural operation of this process holds {lock_path}",
+                )
+            hold.owners.add(owner)
+            return
+        try:
+            handle = _open_gate_file(lock_path)
+        except OSError as exc:
+            raise StateDbWriterHeldError(
+                f"state.db writer gate: cannot open {lock_path} ({exc}); refusing structural work on "
+                f"{db_path} rather than risk a second-writer corruption (see #103339)."
+            ) from exc
+        # The mutex is held from the registry check through registration, so
+        # no sibling thread can interleave a competing take of this file.
+        # The holder record goes down BEFORE registration: a sibling probe
+        # that lands mid-announce then reads a complete role instead of a
+        # transient unknown (both fail closed; the former avoids spurious
+        # refusals).
+        held = _try_flock_nb(handle)
+        if held is not True:
+            try:
+                handle.close()
+            except OSError:
+                pass
+            raise _refusal(db_path, _describe_holder(lock_path))
+        _write_gate_record(handle, role)
+        hold = _GateHold(handle, role)
+        hold.structural_owner = owner
+        hold.owners.add(owner)
+        _held[key] = hold
+    # Atomicity: the global flock is held from here on, so verify foreign
+    # writer presence BEFORE returning. A writer announcing later sees the
+    # held global lock and refuses; a writer already present is seen here.
+    # Either order closes fully — only an actually-quiet database is ever
+    # returned held. Own presences count too (include_self): a live local
+    # SessionDB must refuse a structural take from an unrelated owner in the
+    # same process. (Fellow repairers never announce per-pid presence, so
+    # they cannot trip this; they queue via the repair lock.)
+    writers = _live_writer_presences(db_path, include_self=True)
+    if writers:
+        with _held_lock:
+            _held.pop(key, None)
+        _unlock_handle(handle)
+        try:
+            handle.close()
+        except OSError:
+            pass
+        raise _refusal(db_path, "; ".join(writers))
+    return
+
+
+def structural_lock_held_by_other(db_path: Path) -> Optional[str]:
+    """Global-structural-lock-only probe for open-time mutation sites.
+
+    Unlike :func:`writer_gate_holder` this ignores mere writer presence:
+    ordinary writers coexisting must NOT block opens — only a live surgery
+    (repair/checkpoint/VACUUM-class holder) refuses constructor-time DDL
+    and generation writes. Returns a holder description or None. Never
+    raises (unprovable reads as held).
+    """
+    foreign, _role, description = _probe_global(db_path)
+    return description if foreign else None
+
+
+def refuse_if_structural_op_holds(db_path: Path, what: str) -> None:
+    """Fail-closed entry guard for open-time mutation sites (schema DDL,
+    generation stamp): constructor work must not interleave a live surgery.
+
+    Only a held global structural lock refuses — coexisting writers never
+    do. Raises :class:`StateDbWriterHeldError` with an actionable message
+    (worded to avoid the write path's locked/busy retry match, so opens
+    fail fast instead of waiting out a patience window).
+    """
+    holder = structural_lock_held_by_other(db_path)
+    if holder is not None:
+        raise StateDbWriterHeldError(
+            f"state.db structural gate: {holder}; refusing {what} on {db_path} while a "
+            "structural operation owns it (see #103339). Stop that process's gateway "
+            "(`hermes gateway stop`) and retry once it finishes."
+        )
+
+
+def _announce_presence(db_path: Path, owner=None) -> None:
+    """Record this process as a live writer (fail-closed).
+
+    Warns and raises :class:`StateDbWriterHeldError` when presence itself
+    cannot be recorded (exotic filesystem): proceeding without an authority
+    record would let a later structural acquirer see an apparently quiet
+    database. The caller must not run its mutation in that case.
+    """
+    lock_path = _presence_path(db_path, os.getpid())
+    key = str(lock_path)
+    # Mutex Ward (see _live_writer_presences): the whole check + open + flock
+    # + register sequence runs under one hold. Without it, two sibling
+    # threads announcing at once contend on the same per-pid file and the
+    # loser would unlink the winner's live file as "stale".
+    with _held_lock:
+        if key in _held:
+            hold = _held[key]
+            # A live announce re-pins the presence: a deferred cleanup
+            # flagged while the hold was orphaned is no longer owed.
+            hold.deferred_release = False
+            # Lifetime invariant: every announcing owner registers, so the
+            # presence drops only when the LAST in-process owner closes.
+            # Anonymous announces take a lease (see _GateHold.anon_leases)
+            # so a refused announce can roll back exactly its own share.
+            if owner is not None:
+                hold.owners.add(owner)
+            else:
+                hold.anon_leases += 1
+            return
+        try:
+            handle = _open_gate_file(lock_path)
+        except OSError as exc:
+            logger.warning(
+                "state.db writer gate: cannot record presence in %s (%s); refusing the mutation.",
+                lock_path, exc)
+            raise StateDbGateSetupError(
+                f"state.db writer gate: cannot establish presence in {lock_path} ({exc}); refusing "
+                f"mutation on {db_path} so a later structural operation cannot miss this writer (see #103339)."
+            ) from exc
+        held = _try_flock_nb(handle)
+        if held is not True:
+            # None (unexpected lock error) is a permanent setup failure, not
+            # contention — never classify it as a live holder downstream.
+            flock_error = held is None
+            # Same-pid stale file (crashed previous owner with a recycled pid):
+            # reclaim once under the same hold. The unlink+create runs under
+            # the presence-path mutation mutex, so a concurrent reaper cannot
+            # slip a replacement between our unlink and recreate (or vice
+            # versa); contention fails closed via the refusal below.
+            with _presence_mutation_serialized(db_path) as serialized:
+                if serialized is None:
+                    try:
+                        handle.close()
+                    except OSError:
+                        pass
+                    raise StateDbGateSetupError(
+                        f"state.db writer gate: cannot open or lock the presence-path mutation "
+                        f"mutex for {lock_path}; refusing mutation on {db_path} — a permanent "
+                        f"setup failure, not holder contention (see #103339)."
+                    )
+                if serialized is False:
+                    try:
+                        handle.close()
+                    except OSError:
+                        pass
+                    if flock_error:
+                        raise StateDbGateSetupError(
+                            f"state.db writer gate: cannot lock presence file {lock_path} "
+                            f"(unexpected lock error); refusing mutation on {db_path} (see #103339)."
+                        )
+                    raise StateDbWriterHeldError(
+                        f"state.db writer gate: presence-path mutation for {lock_path} is contended; "
+                        f"refusing mutation on {db_path} rather than risk a pathname race (see #103339)."
+                    )
+                try:
+                    handle.close()
+                except OSError:
+                    pass
+                try:
+                    lock_path.unlink()
+                    handle = _open_gate_file(lock_path)
+                    held = _try_flock_nb(handle)
+                except OSError as exc:
+                    logger.warning(
+                        "state.db writer gate: cannot record presence in %s (%s); refusing the mutation.",
+                        lock_path, exc)
+                    raise StateDbGateSetupError(
+                        f"state.db writer gate: cannot re-establish presence in {lock_path} ({exc}); refusing "
+                        f"mutation on {db_path} (see #103339)."
+                    ) from exc
+            if held is not True:
+                logger.warning(
+                    "state.db writer gate: cannot lock presence file %s; refusing the mutation.", lock_path)
+                try:
+                    handle.close()
+                except OSError:
+                    pass
+                raise StateDbGateSetupError(
+                    f"state.db writer gate: cannot lock presence file {lock_path}; refusing mutation on "
+                    f"{db_path} (see #103339)."
+                )
+        hold = _held.get(key)
+        if hold is not None:
+            if owner is not None:
+                hold.owners.add(owner)
+            try:
+                handle.close()
+            except OSError:
+                pass
+            return
+        # Record before registration (see exclusive take above).
+        _write_gate_record(handle, _WRITER_ROLE)
+        hold = _GateHold(handle, _WRITER_ROLE, db_path)
+        if owner is not None:
+            hold.owners.add(owner)
+        else:
+            hold.anon_leases = 1
+        _held[key] = hold
+
+
+def _rollback_announce(db_path: Path, owner) -> None:
+    """Undo one :func:`_announce_presence` share; never raises.
+
+    A refused row announce (structural probe reported a holder AFTER our
+    presence was registered) must not leave litter: without rollback the
+    refused opener's presence file stays live and blocks later surgery.
+    Named owners roll back via :func:`release_writer_gate` (other live
+    owners keep the hold). Anonymous announces consume exactly one lease;
+    the hold drops only when its last lease and last owner are gone.
+
+    A ``False`` from :func:`release_writer_gate` is never discarded: that
+    hold already flagged ``deferred_release`` and armed the module drain
+    (below), so the owed unlink survives an owner that never closes again
+    instead of blocking structural takes until process exit.
+    """
+    if owner is not None:
+        try:
+            release_writer_gate(db_path, owner)
+        except Exception:
+            pass
+        return
+    try:
+        lock_path = _presence_path(db_path, os.getpid())
+    except Exception:
+        return
+    key = str(lock_path)
+    with _held_lock:
+        hold = _held.get(key)
+        if hold is None:
+            return
+        if hold.anon_leases > 0:
+            hold.anon_leases -= 1
+        if len(list(hold.owners)) > 0 or hold.anon_leases > 0:
+            return  # other live callers keep the presence
+        del _held[key]
+        if hold.acquired_pid != os.getpid():
+            return  # fork-inherited: drop locally, never touch the fd
+        handle = hold.handle
+        try:
+            db_name = Path(db_path).expanduser().resolve().name
+        except OSError:
+            db_name = Path(db_path).name
+        if _presence_pid(lock_path, db_name) == os.getpid():
+            with _presence_mutation_serialized(db_path) as ok:
+                if ok:
+                    with contextlib.suppress(OSError):
+                        lock_path.unlink()
+        _unlock_handle(handle)
+        try:
+            handle.close()
+        except OSError:
+            pass
+
+
+def release_writer_gate(db_path: Path, owner) -> bool:
+    """Drop *owner*'s share; the flock goes when the last owner closes.
+
+    Never raises. ``owner=None`` is a no-op. Presence files are unlinked only
+    when their pid matches the releaser (a forked child can never delete its
+    parent's presence); the global structural file is never unlinked. A hold
+    acquired by another pid (fork-inherited) is dropped locally without
+    unlocking — the owner's description keeps the kernel lock.
+
+    Returns True when nothing of *owner* remains held. Returns False when the
+    presence-path cleanup was retained for an independent retry (the mutation
+    mutex stayed contended for the whole budget): the hold is still accurate
+    (flock held, owner restored, ``deferred_release`` flagged), the module
+    drain completes the unlink with no owner dependence, and the caller's
+    lifecycle retry (``SessionDB._gate_release_pending``) is a second chance
+    rather than the single retry that could be stranded by the owner's death.
+    """
+    if owner is None:
+        return True
+    global_path = _writer_lock_path(db_path)
+    try:
+        db_name = Path(db_path).expanduser().resolve().name
+    except OSError:
+        db_name = Path(db_path).name
+    fully_released = True
+    for lock_path in (_presence_path(db_path, os.getpid()), global_path):
+        key = str(lock_path)
+        # Unlock + close + unlink under the same hold (Mutex Ward): a sibling
+        # thread's open + flock can never land between our unlock and close
+        # and mistake itself for a foreign holder.
+        needs_retry = False
+        for _attempt in range(_RELEASE_MUTEX_ATTEMPTS):
+            needs_retry = False
+            with _held_lock:
+                hold = _held.get(key)
+                if hold is None:
+                    pass  # already gone: done
+                else:
+                    try:
+                        hold.owners.discard(owner)
+                    except (KeyError, TypeError):
+                        pass
+                    if len(list(hold.owners)) > 0 or hold.anon_leases > 0:
+                        pass  # other live callers keep the hold: done
+                    elif hold.acquired_pid != os.getpid():
+                        del _held[key]  # fork-inherited: drop locally, never touch the fd
+                    else:
+                        handle = hold.handle
+                        # Presence files are unlinked only when their pid matches the
+                        # releaser (a forked child can never delete its parent's
+                        # presence); the global structural file is never unlinked.
+                        # The unlink runs under the presence-path mutation mutex
+                        # while the flock is still held, so no replacement can win
+                        # the pathname in between; the unlock follows.
+                        if lock_path != global_path and _presence_pid(lock_path, db_name) == os.getpid():
+                            with _presence_mutation_serialized(db_path) as ok:
+                                if not ok:
+                                    # Mutex contended: re-register this share
+                                    # and retry outside the lock. The hold
+                                    # (flock still held) stays accurate — the
+                                    # caller is told (False return) to keep
+                                    # retry lifecycle state — instead of an
+                                    # unlocked ghost whose record names a
+                                    # live pid forever.
+                                    hold.owners.add(owner)
+                                    needs_retry = True
+                                else:
+                                    with contextlib.suppress(OSError):
+                                        lock_path.unlink()
+                                    del _held[key]
+                                    _unlock_handle(handle)
+                                    try:
+                                        handle.close()
+                                    except OSError:
+                                        pass
+                        else:
+                            del _held[key]
+                            _unlock_handle(handle)
+                            try:
+                                handle.close()
+                            except OSError:
+                                pass
+            if not needs_retry:
+                break
+            time.sleep(_RELEASE_MUTEX_RETRY_S)
+        if needs_retry:
+            # Budget exhausted with the hold still pinned: flag it and arm the
+            # module drain, which finishes the pathname cleanup once no
+            # owner/lease is live. Then report False so the caller keeps its
+            # lifecycle retry state as a second chance (never fail silent).
+            global _deferred_release_epoch
+            with _held_lock:
+                hold = _held.get(key)
+                if hold is not None:
+                    hold.deferred_release = True
+                    _deferred_release_epoch += 1
+            _ensure_deferred_release_drain()
+            fully_released = False
+    return fully_released
+
+
+def _ensure_deferred_release_drain() -> None:
+    """Start the single deferred-release drain worker (idempotent, never raises)."""
+    global _drain_running
+    with _drain_lock:
+        if _drain_running:
+            return
+        try:
+            t = threading.Thread(
+                target=_deferred_release_drain,
+                name="hermes-writergate-drain",
+                daemon=True,
+            )
+            t.start()
+        except RuntimeError:
+            return  # interpreter teardown: process exit reaps the flock anyway
+        _drain_running = True
+
+
+def _deferred_release_drain() -> None:
+    """Finish shadowed presence-pathname cleanups once no owner/lease is live.
+
+    Works from the hold record (flock still held, ``owners`` /
+    ``anon_leases`` as the liveness tally), never the dead owner's lifecycle
+    state, so teardown cannot strand a live-pid presence when the owner died
+    before another ``close()``. Exits when nothing is flagged; re-arms only
+    when a NEW flag was raised after this run started (epoch), never into an
+    endless retry of a permanently failed setup.
+    """
+    global _drain_running
+    with _held_lock:
+        seen_epoch = _deferred_release_epoch
+    deadline = time.monotonic() + _DEFERRED_RELEASE_DRAIN_MAX_S
+    try:
+        while time.monotonic() < deadline:
+            with _held_lock:
+                items = [
+                    (key, hold) for key, hold in _held.items()
+                    if getattr(hold, "deferred_release", False)
+                ]
+            if not items:
+                return  # nothing left to drain: single-shot worker
+            for key, hold in items:
+                _drain_one_deferred_release(key, hold)
+            time.sleep(_DEFERRED_RELEASE_DRAIN_POLL_S)
+    finally:
+        with _drain_lock:
+            _drain_running = False
+        # Re-arm only for flags raised after this run began: the setter arms
+        # the drain itself, so this only closes the scan-tail window.
+        with _held_lock:
+            new_flags = _deferred_release_epoch != seen_epoch
+        if new_flags:
+            _ensure_deferred_release_drain()
+
+
+def _drain_one_deferred_release(key: str, hold: "_GateHold") -> None:
+    """Attempt the deferred pathname cleanup for one hold (best effort, never raises).
+
+    The whole check + unlink runs under ``_held_lock`` with the mutation
+    mutex nested inside (the same ordering ``release_writer_gate`` uses), so
+    a live announce that re-pins the presence between our scan and the unlink
+    is impossible: announce takes the same outer lock.
+    """
+    try:
+        with _held_lock:
+            if hold.deferred_release is not True:
+                return
+            # Stale-capture guard: the scan captured (key, hold) before the
+            # lock; a release that won the race since then popped the hold
+            # (flag still True on the orphaned object) and a fresh announce
+            # may have installed a NEW presence at the same path. Unlinking
+            # then would erase a live writer's file. Only the CURRENT owner
+            # of the key may be drained.
+            if _held.get(key) is not hold:
+                return
+            if len(list(hold.owners)) > 0 or hold.anon_leases > 0:
+                return  # re-pinned live; _announce_presence cleared the flag
+            if hold.acquired_pid != os.getpid():
+                del _held[key]  # fork-inherited: never touch the parent's fd
+                return
+            lock_path = Path(key)
+            db_path = getattr(hold, "db_path", None)
+            if db_path is None:
+                # Cannot happen in-process: every presence hold registers its
+                # db_path at announce time (see _GateHold.db_path). Dropping
+                # the ghost keeps the invariant honest without dead code.
+                del _held[key]
+                return
+            handle = hold.handle
+            with _presence_mutation_serialized(db_path) as ok:
+                if not ok:
+                    return  # contended or setup-failed: retry on the next poll
+                with contextlib.suppress(OSError):
+                    lock_path.unlink()
+            _held.pop(key, None)
+        _unlock_handle(handle)
+        try:
+            handle.close()
+        except OSError:
+            pass
+    except Exception:
+        logger.debug("deferred writer-gate drain failed for %s", key, exc_info=True)
+
+
+def writer_gate_holder(db_path: Path) -> Optional[str]:
+    """Non-acquiring probe: None when no foreign surgery or writer presence
+    is live (or only ours is); otherwise a human-readable description.
+
+    Used by repair/doctor/checkpoint paths that must refuse without taking
+    the gate.
+    """
+    foreign, _role, description = _probe_global(db_path)
+    if foreign:
+        return description
+    writers = _live_writer_presences(db_path)
+    if writers:
+        return "; ".join(writers)
+    return None
+
+
+def writer_gate_holder_role(db_path: Path) -> Optional[str]:
+    """Non-acquiring probe: None when this process may do structural work;
+    otherwise the live holder's role (``writer`` / ``repair`` / ``unknown``).
+
+    Repair uses this to tell a fellow repairer (serialize via the repair
+    lock — queuing is correct) from a live writer (refuse).
+    """
+    foreign, role, _description = _probe_global(db_path, settle_role=True)
+    if foreign:
+        if role == _UNKNOWN_ROLE and not _live_writer_presences(db_path):
+            # Contended global lock with no readable record and no writer
+            # presence: fellow repairer mid-record-write (settle already
+            # retried) — report repair so we queue rather than refuse.
+            return _REPAIR_ROLE
+        return role
+    if _live_writer_presences(db_path):
+        return _WRITER_ROLE
+    return None

--- a/tests/hermes_cli/test_sessions_error_exit_codes.py
+++ b/tests/hermes_cli/test_sessions_error_exit_codes.py
@@ -47,3 +47,51 @@ def test_import_missing_file_returns_1(tmp_path, monkeypatch, capsys):
     rc = sc.cmd_sessions(_args("import", path=str(tmp_path / "nope.jsonl")))
     assert rc == 1
     assert "file not found" in capsys.readouterr().out.lower()
+
+
+def test_repair_failed_returns_1(tmp_path, monkeypatch, capsys):
+    import hermes_state_repair
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import hermes_state
+
+    db_path = home / "state.db"
+    db_path.write_bytes(b"not a database")
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(
+        hermes_state_repair, "_db_opens_cleanly", lambda path: "file is not a database")
+    monkeypatch.setattr(
+        hermes_state_repair, "repair_state_db_schema",
+        lambda *a, **k: {"repaired": False, "error": "boom"})
+    rc = sc.cmd_sessions(_args("repair"))
+    assert rc == 1
+    assert "repair failed" in capsys.readouterr().out.lower()
+
+
+def test_repair_clean_returns_none(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_state import SessionDB
+    SessionDB(tmp_path / "state.db")  # initialize an empty store
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    rc = sc.cmd_sessions(_args("repair"))
+    assert rc is None
+    assert "opens cleanly" in capsys.readouterr().out.lower()
+
+
+def test_repair_check_only_unclean_returns_1(tmp_path, monkeypatch, capsys):
+    import hermes_state
+    import hermes_state_repair
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db_path = tmp_path / "state.db"
+    db_path.write_bytes(b"not a database")
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(
+        hermes_state_repair, "_db_opens_cleanly", lambda path: "file is not a database")
+    rc = sc.cmd_sessions(_args("repair", check_only=True))
+    assert rc == 1
+    assert "does not open cleanly" in capsys.readouterr().out.lower()

--- a/tests/test_state_writer_gate.py
+++ b/tests/test_state_writer_gate.py
@@ -1,0 +1,1882 @@
+"""Cross-process writer coordination for state.db (see #103339).
+
+SQLite owns row concurrency; the gate owns file-structure concurrency:
+ordinary row writes from any number of processes proceed, while structural
+work (repair surgery, second-connection checkpoints) refuses under a live
+writer instead of corrupting the WAL.
+"""
+import multiprocessing as mp
+import os
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+from hermes_state import SessionDB
+from hermes_state_errors import StateDbWriterHeldError
+from hermes_state_repair import repair_state_db_schema
+from hermes_state_writergate import (
+    OwnerToken,
+    acquire_writer_gate,
+    release_writer_gate,
+    writer_gate_holder,
+)
+
+
+def _hold_gate_child(db_path_str, ready, release):
+    """Second process: take the gate and hold it until released."""
+    acquire_writer_gate(Path(db_path_str))
+    ready.set()
+    release.wait(60)
+
+
+def _write_child(db_path_str, queue):
+    """Second process: try one real SessionDB write, report the outcome."""
+    try:
+        db = SessionDB(db_path=Path(db_path_str))
+        sid = db.create_session(session_id=str(uuid.uuid4()), source="cli")
+        db.append_message(sid, role="user", content="second writer hello")
+        db.close()
+        queue.put("wrote")
+    except Exception as exc:  # noqa: BLE001 — the refusal IS the assertion
+        queue.put(f"{type(exc).__name__}: {exc}")
+
+
+def _build_db_child(db_path_str, queue):
+    """Second process: build a healthy db, then exit (gate dies with it)."""
+    try:
+        db = SessionDB(db_path=Path(db_path_str))
+        sid = db.create_session(session_id=str(uuid.uuid4()), source="cli")
+        db.append_message(sid, role="user", content="hello")
+        db.close()
+        queue.put("built")
+    except Exception as exc:  # noqa: BLE001
+        queue.put(f"{type(exc).__name__}: {exc}")
+
+
+def _corrupt_duplicate_fts(db_path: Path) -> None:
+    """Duplicate messages_fts row in sqlite_master (raw sqlite: no gate)."""
+    import sqlite3
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA writable_schema=ON")
+    conn.execute(
+        "INSERT INTO sqlite_master (type, name, tbl_name, rootpage, sql) "
+        "SELECT type, name, tbl_name, rootpage, sql FROM sqlite_master "
+        "WHERE name='messages_fts'"
+    )
+    conn.commit()
+    conn.close()
+
+
+def _hold_surgery_child(db_path_str, ready, release):
+    """Second process: hold the GLOBAL structural lock as repair (surgery)."""
+    from hermes_state_writergate import OwnerToken, acquire_writer_gate
+
+    acquire_writer_gate(
+        Path(db_path_str), role="repair", owner=OwnerToken("surgery"), exclusive=True)
+    ready.set()
+    release.wait(60)
+
+
+def _presence_file(db_path: Path, pid: int) -> Path:
+    return db_path.with_name(f"{db_path.name}.writer.{pid}.lock")
+
+
+def _spawn(fn, *args):
+    # "spawn", not fork: a genuinely separate process shares neither memory
+    # nor fds — exactly the gateway-vs-CLI shape. Fork presence safety is
+    # pinned by test_forked_child_cannot_remove_parent_presence below.
+    ctx = mp.get_context("spawn")
+    proc = ctx.Process(target=fn, args=args)
+    proc.start()
+    return proc
+
+
+def _snapshot(db_path: Path) -> bytes:
+    return db_path.read_bytes()
+
+
+def test_concurrent_row_writes_proceed_under_sqlite(tmp_path):
+    """Row writes are SQLite's job: a second process announces presence and
+    writes; both land (the pinned conformance cell proves exactly-once)."""
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    sid = db.create_session(session_id=str(uuid.uuid4()), source="cli")
+    db.append_message(sid, role="user", content="holder hello")
+
+    queue = mp.get_context("spawn").Queue()
+    proc = _spawn(_write_child, str(db_path), queue)
+    try:
+        outcome = queue.get(timeout=60)
+    finally:
+        proc.join(timeout=60)
+    assert outcome == "wrote", outcome
+    db.append_message(sid, role="assistant", content="holder again")
+    row = db._read_one("SELECT COUNT(*) FROM sessions")
+    assert row is not None and row[0] == 2
+    row = db._read_one("SELECT COUNT(*) FROM messages")
+    assert row is not None and row[0] == 3
+    db.close()
+
+
+def test_same_process_second_handle_writes_freely(tmp_path):
+    """Same-process writers (registry, threads, sub-agents) never self-lock."""
+    db_path = tmp_path / "state.db"
+    db1 = SessionDB(db_path=db_path)
+    db2 = SessionDB(db_path=db_path)
+    sid = db1.create_session(session_id=str(uuid.uuid4()), source="cli")
+    db2.append_message(sid, role="user", content="via second handle")
+    db1.append_message(sid, role="assistant", content="via first handle")
+    row = db1._read_one("SELECT COUNT(*) FROM messages")
+    assert row is not None and row[0] == 2
+    db1.close()
+    db2.close()
+
+
+def test_read_only_unaffected_by_foreign_gate(tmp_path):
+    """Reads never touch the gate: a foreign holder blocks writes, not reads."""
+    db_path = tmp_path / "state.db"
+    queue = mp.get_context("spawn").Queue()
+    builder = _spawn(_build_db_child, str(db_path), queue)
+    try:
+        assert queue.get(timeout=60) == "built"
+    finally:
+        builder.join(timeout=60)
+
+    ctx = mp.get_context("spawn")
+    ready, release = ctx.Event(), ctx.Event()
+    holder = _spawn(_hold_gate_child, str(db_path), ready, release)
+    try:
+        assert ready.wait(timeout=60)
+        assert writer_gate_holder(db_path) is not None  # foreign holder visible
+        ro = SessionDB(db_path=db_path, read_only=True)
+        row = ro._read_one("SELECT COUNT(*) FROM sessions")
+        ro.close()
+        assert row is not None and row[0] == 1
+    finally:
+        release.set()
+        holder.join(timeout=60)
+
+
+def test_repair_refuses_live_gated_db_without_touching_file(tmp_path):
+    """Repair under a live writer returns REFUSED and modifies nothing."""
+    db_path = tmp_path / "state.db"
+    queue = mp.get_context("spawn").Queue()
+    builder = _spawn(_build_db_child, str(db_path), queue)
+    try:
+        assert queue.get(timeout=60) == "built"
+    finally:
+        builder.join(timeout=60)
+
+    ctx = mp.get_context("spawn")
+    ready, release = ctx.Event(), ctx.Event()
+    holder = _spawn(_hold_gate_child, str(db_path), ready, release)
+    try:
+        assert ready.wait(timeout=60)
+        before = _snapshot(db_path)
+        report = repair_state_db_schema(db_path, backup=False)
+        assert report.get("repaired") is False
+        assert "REFUSED" in (report.get("error") or ""), report
+        assert _snapshot(db_path) == before
+        assert report.get("backup_path") is None
+        assert list(tmp_path.glob("*.backup*")) == []
+    finally:
+        release.set()
+        holder.join(timeout=60)
+    # Gate free again: no longer refused (healthy db needs no repair either way).
+    report = repair_state_db_schema(db_path, backup=False)
+    assert "REFUSED" not in (report.get("error") or ""), report
+
+
+def test_doctor_checkpoint_skipped_under_live_writer(tmp_path):
+    """`doctor --fix` never checkpoints a WAL a live writer owns."""
+    from hermes_cli.doctor_report import Finding
+    from hermes_cli.doctor_state import _state_db_wal
+
+    db_path = tmp_path / "state.db"
+    queue = mp.get_context("spawn").Queue()
+    builder = _spawn(_build_db_child, str(db_path), queue)
+    try:
+        assert queue.get(timeout=60) == "built"
+    finally:
+        builder.join(timeout=60)
+
+    wal_path = tmp_path / "state.db-wal"
+    fd = os.open(str(wal_path), os.O_WRONLY | os.O_CREAT)
+    try:
+        os.ftruncate(fd, 60 * 1024 * 1024)  # sparse: big size, no disk cost
+    finally:
+        os.close(fd)
+
+    ctx = mp.get_context("spawn")
+    ready, release = ctx.Event(), ctx.Event()
+    holder = _spawn(_hold_gate_child, str(db_path), ready, release)
+    try:
+        assert ready.wait(timeout=60)
+        f = Finding()
+        _state_db_wal(f, True, db_path)
+        assert f.fixed == 0
+        assert any("gateway" in issue for issue in f.issues), f.issues
+        assert wal_path.stat().st_size == 60 * 1024 * 1024
+    finally:
+        release.set()
+        holder.join(timeout=60)
+
+
+def test_close_releases_gate_for_other_processes(tmp_path):
+    """A writer that closed does not pin the gate: later processes proceed."""
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    sid = db.create_session(session_id=str(uuid.uuid4()), source="cli")
+    db.append_message(sid, role="user", content="hello")
+    db.close()
+    assert writer_gate_holder(db_path) is None
+    queue = mp.get_context("spawn").Queue()
+    proc = _spawn(_write_child, str(db_path), queue)
+    try:
+        outcome = queue.get(timeout=60)
+    finally:
+        proc.join(timeout=60)
+    assert outcome == "wrote", outcome
+
+
+def test_gate_free_when_nobody_holds(tmp_path):
+    """Probe is silent on a free gate; same-process acquire is idempotent."""
+    db_path = tmp_path / "state.db"
+    assert writer_gate_holder(db_path) is None
+    acquire_writer_gate(db_path)
+    acquire_writer_gate(db_path)  # idempotent, no self-lock
+    assert writer_gate_holder(db_path) is None  # ours reads as free
+
+
+@pytest.mark.linux_only
+def test_forked_child_cannot_remove_parent_presence(tmp_path):
+    """After fork(), the child announces under its own pid and its close()
+    must not disturb the parent's presence (unlink is own-pid-only)."""
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    sid = db.create_session(session_id=str(uuid.uuid4()), source="cli")
+    db.append_message(sid, role="user", content="holder hello")
+    parent_file = _presence_file(db_path, os.getpid())
+    assert parent_file.exists()
+
+    pid = os.fork()  # windows-footgun: ok — linux_only test, fork guarded by marker
+    if pid == 0:  # child: own presence ok; close must spare the parent file
+        try:
+            from hermes_state_writergate import OwnerToken, acquire_writer_gate
+
+            acquire_writer_gate(db_path, owner=OwnerToken("fork"))
+            child_file = _presence_file(db_path, os.getpid())
+            announced = child_file.exists()
+            db.close()
+            ok = announced and parent_file.exists() and not child_file.exists()
+            os._exit(20 if ok else 10)
+        except Exception:  # noqa: BLE001
+            os._exit(30)
+    _, status = os.waitpid(pid, 0)
+    assert os.waitstatus_to_exitcode(status) == 20
+    assert parent_file.exists()
+    db.append_message(sid, role="assistant", content="parent still writes")
+    db.close()
+
+
+def test_stale_presence_litter_ignored_and_reaped(tmp_path):
+    """A crashed writer's presence file (dead pid, old, flock-free) neither
+    blocks repair nor survives it."""
+    db_path = tmp_path / "state.db"
+    queue = mp.get_context("spawn").Queue()
+    builder = _spawn(_build_db_child, str(db_path), queue)
+    try:
+        assert queue.get(timeout=60) == "built"
+    finally:
+        builder.join(timeout=60)
+
+    stale = _presence_file(db_path, 1 << 30)
+    stale.write_bytes(b'{"pid": 1073741824, "role": "writer"}')
+    stamp = time.time() - 120.0
+    os.utime(stale, (stamp, stamp))
+    report = repair_state_db_schema(db_path, backup=False)
+    assert "REFUSED" not in (report.get("error") or ""), report
+    assert not stale.exists()
+
+
+def test_row_write_refused_while_surgery_holds_global(tmp_path):
+    """Surgery first, then writer: the writer's open (which now announces
+    presence fail-closed and holds it across DDL) must refuse while the global
+    is held (P1 — proof lifetime covers mutation). After surgery releases,
+    the writer opens and writes cleanly."""
+    db_path = tmp_path / "state.db"
+    queue = mp.get_context("spawn").Queue()
+    builder = _spawn(_build_db_child, str(db_path), queue)
+    try:
+        assert queue.get(timeout=60) == "built"
+    finally:
+        builder.join(timeout=60)
+
+    ctx = mp.get_context("spawn")
+    ready, release = ctx.Event(), ctx.Event()
+    surgery = _spawn(_hold_surgery_child, str(db_path), ready, release)
+    try:
+        assert ready.wait(timeout=60)
+        with pytest.raises(StateDbWriterHeldError, match="structural"):
+            SessionDB(db_path=db_path)
+    finally:
+        release.set()
+        surgery.join(timeout=60)
+    db = SessionDB(db_path=db_path)
+    db.create_session(session_id=str(uuid.uuid4()), source="cli")
+    db.close()
+
+
+def test_open_refuses_init_repair_under_live_gate(tmp_path):
+    """SessionDB() on a corrupt db held by a live writer raises instead of
+    repairing: the INIT self-heal delegates to the gated repair (proven
+    REFUSED by test_repair_refuses_live_gated_db_without_touching_file), so
+    the open fails with the original error and the file is untouched."""
+    import sqlite3
+
+    db_path = tmp_path / "state.db"
+    queue = mp.get_context("spawn").Queue()
+    builder = _spawn(_build_db_child, str(db_path), queue)
+    try:
+        assert queue.get(timeout=60) == "built"
+    finally:
+        builder.join(timeout=60)
+    _corrupt_duplicate_fts(db_path)
+
+    ctx = mp.get_context("spawn")
+    ready, release = ctx.Event(), ctx.Event()
+    holder = _spawn(_hold_gate_child, str(db_path), ready, release)
+    try:
+        assert ready.wait(timeout=60)
+        before = _snapshot(db_path)
+        with pytest.raises(sqlite3.DatabaseError):
+            SessionDB(db_path=db_path)
+        assert _snapshot(db_path) == before
+    finally:
+        release.set()
+        holder.join(timeout=60)
+
+
+def test_doctor_repair_path_refuses_live_gate(tmp_path):
+    """`doctor --fix` schema repair delegates to the gated repair: REFUSED
+    under a live writer, recorded as failed-issue, file untouched."""
+    from hermes_cli.doctor_report import Finding
+    from hermes_cli.doctor_state import _repair_state_db
+
+    db_path = tmp_path / "state.db"
+    queue = mp.get_context("spawn").Queue()
+    builder = _spawn(_build_db_child, str(db_path), queue)
+    try:
+        assert queue.get(timeout=60) == "built"
+    finally:
+        builder.join(timeout=60)
+    _corrupt_duplicate_fts(db_path)
+
+    ctx = mp.get_context("spawn")
+    ready, release = ctx.Event(), ctx.Event()
+    holder = _spawn(_hold_gate_child, str(db_path), ready, release)
+    try:
+        assert ready.wait(timeout=60)
+        before = _snapshot(db_path)
+        f = Finding()
+        _repair_state_db(f, True, db_path, "schema")
+        assert f.fixed == 0
+        assert any("malformed" in issue for issue in f.issues), f.issues
+        assert _snapshot(db_path) == before
+    finally:
+        release.set()
+        holder.join(timeout=60)
+
+
+def test_doctor_checkpoint_runs_when_gate_free(tmp_path):
+    """Free gate: `doctor --fix` checkpoints the WAL and reports fixed."""
+    import os
+
+    from hermes_cli.doctor_report import Finding
+    from hermes_cli.doctor_state import _state_db_wal
+
+    db_path = tmp_path / "state.db"
+    queue = mp.get_context("spawn").Queue()
+    builder = _spawn(_build_db_child, str(db_path), queue)
+    try:
+        assert queue.get(timeout=60) == "built"
+    finally:
+        builder.join(timeout=60)
+
+    wal_path = tmp_path / "state.db-wal"
+    fd = os.open(str(wal_path), os.O_WRONLY | os.O_CREAT)
+    try:
+        os.ftruncate(fd, 60 * 1024 * 1024)  # sparse
+    finally:
+        os.close(fd)
+
+    f = Finding()
+    _state_db_wal(f, True, db_path)
+    assert f.fixed == 1, f.issues
+    assert not any("gateway" in issue for issue in f.issues), f.issues
+
+
+def _probe_child(db_path_str, queue):
+    """Second process: report the foreign structural probe (None or holder)."""
+    from hermes_state_writergate import writer_gate_holder
+
+    try:
+        queue.put(("holder", writer_gate_holder(Path(db_path_str))))
+    except Exception as exc:  # noqa: BLE001
+        queue.put(("error", f"{type(exc).__name__}: {exc}"))
+
+
+def _foreign_holder(db_path):
+    """writer_gate_holder() as seen by a genuinely separate process."""
+    queue = mp.get_context("spawn").Queue()
+    proc = _spawn(_probe_child, str(db_path), queue)
+    try:
+        kind, value = queue.get(timeout=60)
+    finally:
+        proc.join(timeout=60)
+    assert kind == "holder", value
+    return value
+
+
+def test_second_handle_pins_presence_until_it_closes(tmp_path):
+    """Lifetime invariant: with two writable handles, closing the first must
+    not clear presence — only the second close may (blocker 2)."""
+    db_path = tmp_path / "state.db"
+    db1 = SessionDB(db_path=db_path)
+    db1.create_session(session_id=str(uuid.uuid4()), source="cli")
+    db2 = SessionDB(db_path=db_path)
+    db2.create_session(session_id=str(uuid.uuid4()), source="cli")
+    db1.close()
+    assert _foreign_holder(db_path) is not None
+    db2.close()
+    assert _foreign_holder(db_path) is None
+
+
+def test_structural_take_refuses_writer_announced_after_probe(tmp_path):
+    """Deterministic probe->take interleaving: a writer announcing after our
+    free probe still refuses the structural take (blocker 1)."""
+    from hermes_state_writergate import OwnerToken, acquire_writer_gate
+
+    db_path = tmp_path / "state.db"
+    queue = mp.get_context("spawn").Queue()
+    builder = _spawn(_build_db_child, str(db_path), queue)
+    try:
+        assert queue.get(timeout=60) == "built"
+    finally:
+        builder.join(timeout=60)
+
+    assert _foreign_holder(db_path) is None  # probe: free
+    ctx = mp.get_context("spawn")
+    ready, release = ctx.Event(), ctx.Event()
+    holder = _spawn(_hold_gate_child, str(db_path), ready, release)
+    try:
+        assert ready.wait(timeout=60)  # writer announces after the probe
+        token = OwnerToken("late-take")
+        with pytest.raises(StateDbWriterHeldError):
+            acquire_writer_gate(db_path, role="repair", owner=token, exclusive=True)
+    finally:
+        release.set()
+        holder.join(timeout=60)
+    token = OwnerToken("late-take")
+    acquire_writer_gate(db_path, role="repair", owner=token, exclusive=True)
+    release_writer_gate(db_path, token)
+
+
+def test_open_time_mutations_refuse_during_surgery(tmp_path):
+    """Constructor DDL/generation writes refuse while a surgery holds the
+    global lock, and open cleanly once it releases (blocker 3)."""
+    db_path = tmp_path / "state.db"
+    queue = mp.get_context("spawn").Queue()
+    builder = _spawn(_build_db_child, str(db_path), queue)
+    try:
+        assert queue.get(timeout=60) == "built"
+    finally:
+        builder.join(timeout=60)
+
+    ctx = mp.get_context("spawn")
+    ready, release = ctx.Event(), ctx.Event()
+    surgery = _spawn(_hold_surgery_child, str(db_path), ready, release)
+    try:
+        assert ready.wait(timeout=60)
+        with pytest.raises(StateDbWriterHeldError, match="structural"):
+            SessionDB(db_path=db_path)
+    finally:
+        release.set()
+        surgery.join(timeout=60)
+    db = SessionDB(db_path=db_path)
+    db.close()
+
+
+def test_row_write_refuses_when_presence_cannot_be_established(tmp_path, monkeypatch):
+    """Fail-closed: inability to hold the presence authority record must
+    refuse the row mutation and the callback is never reached (P1)."""
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    db.create_session(session_id=str(uuid.uuid4()), source="cli")
+    # Fresh fault path so the next announce actually tries to open/lock.
+    fault_path = tmp_path / "fault.db"
+    fault_path.write_bytes(b"")
+    reached = []
+
+    def fake_open(*a, **k):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr("hermes_state_writergate._open_gate_file", fake_open)
+
+    def cb(conn):
+        reached.append(1)
+        conn.execute("INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+                     (str(uuid.uuid4()), "x", 0))
+
+    # Even SessionDB open itself now announces presence fail-closed.
+    with pytest.raises(StateDbWriterHeldError, match="cannot establish presence|re-establish presence|cannot lock presence|cannot open"):
+        SessionDB(db_path=fault_path)
+    # And a direct _execute_write on the already-open handle also refuses
+    # before the callback (clear this db's presence so the next announce
+    # really hits the fault; otherwise the fast path skips it).
+    from hermes_state_writergate import _held, _held_lock, _presence_path
+
+    with _held_lock:
+        _held.pop(str(_presence_path(db_path, os.getpid())), None)
+    import pathlib as _pl
+
+    _pl.Path(_presence_path(db_path, os.getpid())).unlink(missing_ok=True)
+    with pytest.raises(StateDbWriterHeldError, match="cannot establish presence|re-establish presence|cannot lock presence|cannot open"):
+        db._execute_write(cb)
+    assert reached == []
+    db.close()
+
+
+def test_open_probes_free_then_structural_take_then_mutation_refuses(tmp_path):
+    """Deterministic open-vs-surgery: open probes free, surgery takes global,
+    then open-time mutation must still refuse before mutating (P1)."""
+    from hermes_state_writergate import writer_gate_holder
+
+    db_path = tmp_path / "state.db"
+    queue = mp.get_context("spawn").Queue()
+    builder = _spawn(_build_db_child, str(db_path), queue)
+    try:
+        assert queue.get(timeout=60) == "built"
+    finally:
+        builder.join(timeout=60)
+
+    # Phase 1: open probes free.
+    assert writer_gate_holder(db_path) is None
+    # Phase 2: surgery takes the global lock before open's DDL runs.
+    ctx = mp.get_context("spawn")
+    ready, release = ctx.Event(), ctx.Event()
+    surgery = _spawn(_hold_surgery_child, str(db_path), ready, release)
+    try:
+        assert ready.wait(timeout=60)
+        # Phase 3: open-time mutation must refuse (presence announced before
+        # connect, global held, so fail-closed; file untouched).
+        before = _snapshot(db_path)
+        with pytest.raises(StateDbWriterHeldError, match="structural"):
+            SessionDB(db_path=db_path)
+        assert _snapshot(db_path) == before
+    finally:
+        release.set()
+        surgery.join(timeout=60)
+    db = SessionDB(db_path=db_path)
+    db.close()
+
+
+@pytest.mark.linux_only
+def test_forked_child_refused_while_parent_holds_structural(tmp_path):
+    """Fork safety (P1): a parent holding exclusive=True must refuse a forked
+    child's SessionDB write — the inherited global hold is foreign, not local."""
+    from hermes_state_writergate import OwnerToken, acquire_writer_gate, release_writer_gate
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    db.create_session(session_id=str(uuid.uuid4()), source="cli")
+    db.close()
+    # Parent takes the global structural lock (surgery).
+    token = OwnerToken("parent-surgery")
+    acquire_writer_gate(db_path, role="repair", owner=token, exclusive=True)
+    try:
+        pid = os.fork()  # windows-footgun: ok — linux_only test, fork guarded by marker
+        if pid == 0:  # child: must see the inherited hold as foreign
+            try:
+                child_db = SessionDB(db_path=db_path)
+                try:
+                    child_db.create_session(session_id=str(uuid.uuid4()), source="cli")
+                finally:
+                    with __import__("contextlib").suppress(Exception):
+                        child_db.close()
+                os._exit(10)  # BUG: wrote under parent surgery
+            except StateDbWriterHeldError:
+                os._exit(20)  # OK: refused
+            except Exception:  # noqa: BLE001
+                os._exit(30)
+        _, status = os.waitpid(pid, 0)
+        assert os.waitstatus_to_exitcode(status) == 20
+    finally:
+        release_writer_gate(db_path, token)
+
+
+def test_exclusive_refuses_with_live_same_process_writer(tmp_path):
+    """Quietness includes self (P1): a live local SessionDB must refuse an
+    unrelated structural take in the same process."""
+    from hermes_state_writergate import OwnerToken, acquire_writer_gate, release_writer_gate
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    db.create_session(session_id=str(uuid.uuid4()), source="cli")
+    token = OwnerToken("unrelated-surgery")
+    with pytest.raises(StateDbWriterHeldError):
+        acquire_writer_gate(db_path, role="repair", owner=token, exclusive=True)
+    # And the reverse: after a (foreign-process) surgery holds, a local row
+    # write refuses too. Covered by test_row_write_refused_while_surgery_holds_global
+    # for the cross-process case; here assert the local writer still works
+    # once no surgery holds.
+    db.create_session(session_id=str(uuid.uuid4()), source="cli")
+    db.close()
+
+
+def test_reopen_refuses_without_opening_when_structural_holds(tmp_path):
+    """Reopen admission precedes SQLite open (P1): close, structural take,
+    then in-flight write must refuse with conn left None (no second WAL join)."""
+    from hermes_state_writergate import OwnerToken, acquire_writer_gate, release_writer_gate
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    sid = db.create_session(session_id=str(uuid.uuid4()), source="cli")
+    db.append_message(sid, role="user", content="before close")
+    # Simulate the teardown race: close drops conn + presence...
+    db.close()
+    # ...then a structural op takes the global while we are conn-less...
+    token = OwnerToken("surgery")
+    acquire_writer_gate(db_path, role="repair", owner=token, exclusive=True)
+    try:
+        # ...then the in-flight writer resumes via the reopen path and must
+        # refuse BEFORE opening SQLite (no new connection, no WAL handling).
+        with pytest.raises(StateDbWriterHeldError, match="structural|writer gate"):
+            db._execute_write(lambda conn: conn.execute("SELECT 1").fetchone())
+        assert db._conn is None
+    finally:
+        release_writer_gate(db_path, token)
+
+
+def test_self_heal_repin_failure_does_not_reopen(tmp_path, monkeypatch):
+    """Post-repair re-admission failure must propagate without reopening
+    SQLite (P1 hermes_state.py:558: swallowed re-pin + reopen under surgery)."""
+    import hermes_state as _hs_mod
+    from hermes_state_errors import StateDbWriterHeldError as _Held
+
+    db_path = tmp_path / "state.db"
+    queue = mp.get_context("spawn").Queue()
+    builder = _spawn(_build_db_child, str(db_path), queue)
+    try:
+        assert queue.get(timeout=60) == "built"
+    finally:
+        builder.join(timeout=60)
+    _corrupt_duplicate_fts(db_path)
+
+    real_acquire = _hs_mod.acquire_writer_gate
+    calls = {"n": 0}
+
+    def fake_acquire(path, *a, **k):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return real_acquire(path, *a, **k)  # open admission ok
+        raise _Held("foreign surgery took the global before re-pin")
+
+    monkeypatch.setattr(_hs_mod, "acquire_writer_gate", fake_acquire)
+    monkeypatch.setattr(
+        "hermes_state_repair.repair_state_db_schema",
+        lambda *a, **k: {"repaired": True, "strategy": "mocked", "backup_path": None, "error": None},
+    )
+    connects = {"n": 0}
+    real_connect = _hs_mod.SessionDB._connect_and_init_with_lock_patience
+
+    def counting_connect(self):
+        connects["n"] += 1
+        return real_connect(self)
+
+    monkeypatch.setattr(
+        _hs_mod.SessionDB, "_connect_and_init_with_lock_patience", counting_connect)
+    with pytest.raises(_Held, match="foreign surgery"):
+        SessionDB(db_path=db_path)
+    # Initial connect only; the reopen after failed re-pin must never run.
+    assert connects["n"] == 1, connects
+
+
+def test_stale_reap_keeps_racing_replacement(tmp_path, monkeypatch):
+    """P1-A: a replacement winning the pathname between verify and unlink
+    must be detected by identity and kept live (deterministic forced order:
+    the swap fires inside the reaper's own stat/unlink calls)."""
+    import json
+    from pathlib import Path
+
+    import hermes_state_writergate as _wg
+
+    db_path = tmp_path / "state.db"
+    db_path.write_bytes(b"")
+    dead_pid = 2**30 - 7
+    stale = _wg._presence_path(db_path, dead_pid)
+    stale.parent.mkdir(parents=True, exist_ok=True)
+    stale.write_bytes(json.dumps(
+        {"pid": dead_pid, "start_ticks": 1, "acquired_at": 0.0, "role": "writer"}
+    ).encode())
+    swapped = {"n": 0}
+
+    def _swap_in_replacement():
+        # A live replacement takes the pathname RIGHT NOW (new inode).
+        with __import__("contextlib").suppress(OSError):
+            os.unlink(stale)
+        stale.write_bytes(json.dumps(
+            {"pid": os.getpid(), "start_ticks": _wg._proc_start_ticks(os.getpid()),
+             "acquired_at": time.time(), "role": "writer"}
+        ).encode())
+
+    real_stat = Path.stat
+    real_unlink = Path.unlink
+
+    def swapping_stat(self, *a, **k):
+        if str(self) == str(stale) and swapped["n"] == 0:
+            swapped["n"] += 1
+            _swap_in_replacement()
+        return real_stat(self, *a, **k)
+
+    def swapping_unlink(self, *a, **k):
+        if str(self) == str(stale) and swapped["n"] == 0:
+            swapped["n"] += 1
+            _swap_in_replacement()
+        return real_unlink(self, *a, **k)
+
+    monkeypatch.setattr(Path, "stat", swapping_stat)
+    monkeypatch.setattr(Path, "unlink", swapping_unlink)
+    live = _wg._live_writer_presences(db_path)
+    assert swapped["n"] == 1  # the race actually fired, not vacuous
+    assert any(str(stale) in d for d in live)  # replacement kept live
+    assert stale.exists()  # and NOT deleted
+    assert b"acquired_at" in stale.read_bytes()  # replacement content intact
+
+
+@pytest.mark.linux_only
+def test_recycled_pid_stale_record_reaped(tmp_path):
+    """P1-B: a record naming a live pid with mismatched start_ticks (PID
+    recycled onto an unrelated process) must reap, not block surgery."""
+    import json
+
+    import hermes_state_writergate as _wg
+
+    db_path = tmp_path / "state.db"
+    db_path.write_bytes(b"")
+    me = os.getpid()
+    ticks = _wg._proc_start_ticks(me)
+    assert ticks is not None
+    rec_path = _wg._presence_path(db_path, me)
+    rec_path.parent.mkdir(parents=True, exist_ok=True)
+    rec_path.write_bytes(json.dumps(
+        {"pid": me, "start_ticks": int(ticks) + 1000000,
+         "acquired_at": time.time(), "role": "writer"}
+    ).encode())
+    live = _wg._live_writer_presences(db_path, include_self=True)
+    assert live == []  # reaped, not live
+    assert not rec_path.exists()
+
+
+@pytest.mark.linux_only
+def test_orphaned_fork_descriptor_does_not_block_surgery(tmp_path):
+    """P1-B: dead parent + live child inheriting the presence flock (#100108
+    shape) must not block structural work; the orphan file is reaped."""
+    import signal
+    import time as _time
+
+    import hermes_state_writergate as _wg
+    from hermes_state_writergate import OwnerToken, acquire_writer_gate, release_writer_gate
+
+    db_path = tmp_path / "state.db"
+    db_path.write_bytes(b"")
+    c1 = os.fork()  # windows-footgun: ok — linux_only test, fork guarded by marker
+    if c1 == 0:
+        try:
+            from hermes_state_writergate import _open_gate_file, _try_flock_nb, _write_gate_record
+            mine = _wg._presence_path(db_path, os.getpid())
+            mine.parent.mkdir(parents=True, exist_ok=True)
+            fh = _open_gate_file(mine)
+            assert _try_flock_nb(fh) is True
+            _write_gate_record(fh, "writer")
+            fh.flush()
+            try:
+                os.fsync(fh.fileno())
+            except OSError:
+                pass
+            c2 = os.fork()  # windows-footgun: ok — linux_only test, fork guarded by marker
+            if c2 == 0:
+                _time.sleep(30)
+                os._exit(0)
+            # C1 dies holding nothing released: kernel keeps the flock alive
+            # via C2's inherited description.
+            os._exit(0)
+        except Exception:  # noqa: BLE001
+            os._exit(99)
+    _, status = os.waitpid(c1, 0)
+    assert os.waitstatus_to_exitcode(status) == 0
+    # Find C2 = the live child still holding C1's flock.
+    orphan = _wg._presence_path(db_path, c1)
+    assert orphan.exists()
+    token = OwnerToken("surgery-after-orphan")
+    try:
+        acquire_writer_gate(db_path, role="repair", owner=token, exclusive=True)
+    finally:
+        with __import__("contextlib").suppress(Exception):
+            release_writer_gate(db_path, token)
+    assert not orphan.exists()  # orphan file reaped
+    # Reap C2 (the sleeper, C1's child now orphaned) via /proc ppid scan.
+    c2pid = None
+    for p in os.listdir("/proc"):
+        if not p.isdigit():
+            continue
+        try:
+            with open(f"/proc/{p}/stat", "rb") as fh:
+                parts = fh.read().rsplit(b")", 1)[1].split()
+            if int(parts[1]) == c1:  # ppid == dead C1 → likely C2
+                c2pid = int(p)
+                break
+        except (OSError, ValueError, IndexError):
+            continue
+    if c2pid is not None:
+        with __import__("contextlib").suppress(OSError):
+            os.kill(c2pid, signal.SIGTERM)
+
+
+@pytest.mark.linux_only
+def test_overlapping_probes_coexist(tmp_path):
+    """P1 (probe owns flock): two overlapping observation probes must not
+    refuse each other — only a real exclusive holder is structural."""
+    import threading
+
+    import hermes_state_writergate as _wg
+
+    db_path = tmp_path / "state.db"
+    db_path.write_bytes(b"")
+    lock_path = _wg._writer_lock_path(db_path)
+    holding, release = threading.Event(), threading.Event()
+
+    def _hold_observe():
+        fh = _wg._open_gate_file(lock_path)
+        assert _wg._try_flock_observe_nb(fh) is True
+        holding.set()
+        assert release.wait(timeout=60)
+        _wg._unlock_handle(fh)
+        fh.close()
+
+    t = threading.Thread(target=_hold_observe)
+    t.start()
+    try:
+        assert holding.wait(timeout=60)
+        foreign, _role, _desc = _wg._probe_global(db_path)
+        assert foreign is False  # fellow probe is not a surgery
+    finally:
+        release.set()
+        t.join(timeout=60)
+
+
+def test_probe_sees_real_structural_hold(tmp_path):
+    """Observation still refuses under a real exclusive holder."""
+    import hermes_state_writergate as _wg
+    from hermes_state_writergate import OwnerToken, acquire_writer_gate, release_writer_gate
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    db.close()
+    token = OwnerToken("surgery")
+    acquire_writer_gate(db_path, role="repair", owner=token, exclusive=True)
+    try:
+        foreign, _role, _desc = _wg._probe_global(db_path)
+        assert foreign is True
+    finally:
+        release_writer_gate(db_path, token)
+
+
+def test_exclusive_refuses_fellow_exclusive_owner_same_process(tmp_path):
+    """P1 (shared hold): a distinct same-process structural owner must not
+    piggyback — only the identical token re-enters; anonymous takes raise."""
+    from hermes_state_writergate import OwnerToken, acquire_writer_gate, release_writer_gate
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    db.close()
+    with pytest.raises(ValueError, match="owner token"):
+        acquire_writer_gate(db_path, role="repair", owner=None, exclusive=True)
+    a = OwnerToken("repair-a")
+    b = OwnerToken("checkpoint-b")
+    acquire_writer_gate(db_path, role="repair", owner=a, exclusive=True)
+    try:
+        with pytest.raises(StateDbWriterHeldError, match="another structural operation"):
+            acquire_writer_gate(db_path, role="repair", owner=b, exclusive=True)
+        acquire_writer_gate(db_path, role="repair", owner=a, exclusive=True)  # same token: ok
+    finally:
+        release_writer_gate(db_path, a)
+    acquire_writer_gate(db_path, role="repair", owner=b, exclusive=True)  # free after release
+    release_writer_gate(db_path, b)
+
+
+@pytest.mark.linux_only
+def test_mutation_mutex_held_across_reap_unlink(tmp_path, monkeypatch):
+    """P1 (final interval): the reaper must hold the presence-path mutation
+    mutex while unlinking — proven by failing a fresh mutex take inside the
+    unlink call itself."""
+    import fcntl
+    import json
+    from pathlib import Path
+
+    import hermes_state_writergate as _wg
+
+    db_path = tmp_path / "state.db"
+    db_path.write_bytes(b"")
+    dead_pid = 2**30 - 7
+    stale = _wg._presence_path(db_path, dead_pid)
+    stale.parent.mkdir(parents=True, exist_ok=True)
+    stale.write_bytes(json.dumps(
+        {"pid": dead_pid, "start_ticks": 1, "acquired_at": 0.0, "role": "writer"}
+    ).encode())
+    mtx = _wg._mutation_mutex_path(db_path)
+    observed = {"held": None}
+    real_unlink = Path.unlink
+
+    def _checked_unlink(self, *a, **k):
+        if str(self) == str(stale):
+            probe = mtx.open("a+b")
+            try:
+                try:
+                    fcntl.flock(probe.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError:
+                    observed["held"] = True  # mutex held by the reaper: serialized
+                else:
+                    observed["held"] = False
+                    fcntl.flock(probe.fileno(), fcntl.LOCK_UN)
+            finally:
+                probe.close()
+        return real_unlink(self, *a, **k)
+
+    monkeypatch.setattr(Path, "unlink", _checked_unlink)
+    assert _wg._live_writer_presences(db_path) == []
+    assert observed["held"] is True
+    assert not stale.exists()
+
+
+def test_mutation_mutex_contention_reports_live(tmp_path):
+    """A reaper blocked on the mutation mutex fails closed (live, no unlink);
+    the litter reaps once the mutex is free. Deterministic via join."""
+    import json
+    import threading
+
+    import hermes_state_writergate as _wg
+
+    db_path = tmp_path / "state.db"
+    db_path.write_bytes(b"")
+    dead_pid = 2**30 - 7
+    stale = _wg._presence_path(db_path, dead_pid)
+    stale.parent.mkdir(parents=True, exist_ok=True)
+    stale.write_bytes(json.dumps(
+        {"pid": dead_pid, "start_ticks": 1, "acquired_at": 0.0, "role": "writer"}
+    ).encode())
+    out = {}
+    with _wg._presence_mutation_serialized(db_path) as serialized:
+        assert serialized
+        t = threading.Thread(target=lambda: out.update(live=_wg._live_writer_presences(db_path)))
+        t.start()
+        t.join(timeout=60)
+        assert not t.is_alive()
+    assert any(str(stale) in d for d in out["live"])
+    assert stale.exists()
+    assert _wg._live_writer_presences(db_path) == []
+    assert not stale.exists()
+
+
+def test_read_reopen_refuses_without_opening_when_structural_holds(tmp_path):
+    """P1 (read fallback): close, structural take, then an in-flight read
+    must refuse BEFORE opening SQLite — same invariant as the write reopen."""
+    from hermes_state_writergate import OwnerToken, acquire_writer_gate, release_writer_gate
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    sid = db.create_session(session_id=str(uuid.uuid4()), source="cli")
+    db.append_message(sid, role="user", content="before close")
+    db.close()
+    token = OwnerToken("surgery")
+    acquire_writer_gate(db_path, role="repair", owner=token, exclusive=True)
+    try:
+        with pytest.raises(StateDbWriterHeldError, match="structural|writer gate"):
+            db._read_one("SELECT COUNT(*) FROM sessions")
+        assert db._conn is None
+    finally:
+        release_writer_gate(db_path, token)
+
+
+def test_doctor_checkpoint_closes_conn_before_releasing_gate_on_error(tmp_path, monkeypatch):
+    """P1 (doctor lifecycle): a failed checkpoint closes its connection
+    BEFORE releasing the structural gate — close, then release, in order."""
+    import sqlite3
+
+    from hermes_cli.doctor_report import Finding
+    from hermes_cli.doctor_state import _state_db_wal
+    import hermes_state_writergate as _wg
+
+    db_path = tmp_path / "state.db"
+    queue = mp.get_context("spawn").Queue()
+    builder = _spawn(_build_db_child, str(db_path), queue)
+    try:
+        assert queue.get(timeout=60) == "built"
+    finally:
+        builder.join(timeout=60)
+
+    wal_path = tmp_path / "state.db-wal"
+    fd = os.open(str(wal_path), os.O_WRONLY | os.O_CREAT)
+    try:
+        os.ftruncate(fd, 60 * 1024 * 1024)  # sparse
+    finally:
+        os.close(fd)
+
+    events = []
+    real_release = _wg.release_writer_gate
+
+    def _spy_release(path, owner):
+        events.append("release")
+        return real_release(path, owner)
+
+    monkeypatch.setattr(_wg, "release_writer_gate", _spy_release)
+
+    class _FailConn:
+        def execute(self, *a, **k):
+            raise sqlite3.OperationalError("injected checkpoint failure")
+
+        def close(self):
+            events.append("close")
+
+    def _fail_connect(*a, **k):
+        events.append("connect")
+        return _FailConn()
+
+    monkeypatch.setattr(sqlite3, "connect", _fail_connect)
+    f = Finding()
+    _state_db_wal(f, True, db_path)  # error swallowed by warn_on_error; order is the assert
+    assert events == ["connect", "close", "release"], events
+    assert f.fixed == 0
+    assert _wg.writer_gate_holder(db_path) is None
+
+
+def _surgery_backdrop(tmp_path):
+    """Build a db, open+close it in this process, then hold surgery from a
+    spawned process. Yields the closed db; caller drives reads/writes that
+    must refuse. Setup helper, not a test."""
+    import contextlib
+
+    db_path = tmp_path / "state.db"
+    queue = mp.get_context("spawn").Queue()
+    builder = _spawn(_build_db_child, str(db_path), queue)
+    try:
+        assert queue.get(timeout=60) == "built"
+    finally:
+        builder.join(timeout=60)
+    db = SessionDB(db_path=db_path)
+    db.close()  # teardown race shape: conn-less handle, presence released
+    ctx = mp.get_context("spawn")
+    ready, release = ctx.Event(), ctx.Event()
+    surgery = _spawn(_hold_surgery_child, str(db_path), ready, release)
+    assert ready.wait(timeout=60)
+
+    class _Backdrop:
+        def __init__(self):
+            self.db = db
+            self._surgery = surgery
+            self._release = release
+
+        def __enter__(self):
+            return db
+
+        def __exit__(self, *exc):
+            self._release.set()
+            self._surgery.join(timeout=60)
+            with contextlib.suppress(Exception):
+                db.close()
+            return False
+
+    return _Backdrop()
+
+
+def test_gate_refusal_propagates_from_fts_match_rows(tmp_path, monkeypatch):
+    """Swallow-site guard: a gate refusal from _match_rows propagates instead
+    of degrading to an FTS-syntax fallback (None). Fault at the seam: the
+    guard, not SQL building, is under test."""
+    from hermes_state_errors import StateDbWriterHeldError as _Held
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    try:
+        monkeypatch.setattr(db, "_fts_match_sql", lambda *a, **k: ("SELECT 1", ()))
+
+        def _raise(sql, params):
+            raise _Held("injected gate refusal")
+
+        monkeypatch.setattr(db, "_read_all", _raise)
+        with pytest.raises(_Held, match="injected gate refusal"):
+            db._match_rows("messages_fts", "hello", "rank", limit=10, offset=0)
+    finally:
+        db.close()
+
+
+def test_gate_refusal_propagates_from_clear_session_activity_labels(tmp_path, monkeypatch):
+    """Swallow-site guard: a gate refusal from clear_session_activity_labels
+    propagates before any write is attempted (not swallowed as missing row).
+    Fault at the seam: the read guard, not the gate, is under test."""
+    from hermes_state_errors import StateDbWriterHeldError as _Held
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    try:
+        def _raise(sql, params):
+            raise _Held("injected gate refusal")
+
+        monkeypatch.setattr(db, "_read_one", _raise)
+        writes = []
+        monkeypatch.setattr(db, "_write_sql", lambda *a, **k: writes.append(1))
+        with pytest.raises(_Held, match="injected gate refusal"):
+            db.clear_session_activity_labels("sid")
+        assert writes == []  # refused before any write attempt
+    finally:
+        db.close()
+
+
+def test_gate_refusal_propagates_from_topic_read_one(tmp_path):
+    """Swallow-site guard: a gate refusal from _topic_read_one propagates
+    instead of degrading to unmigrated-table None."""
+    with _surgery_backdrop(tmp_path) as db:
+        with pytest.raises(StateDbWriterHeldError, match="structural|writer gate"):
+            db._topic_read_one("SELECT 1", ())
+
+
+def test_gate_refusal_propagates_from_write_sql_logged(tmp_path):
+    """Swallow-site guard: a refused write via _write_sql_logged raises
+    instead of being logged-and-done (a lost write must never be silent)."""
+    with _surgery_backdrop(tmp_path) as db:
+        with pytest.raises(StateDbWriterHeldError, match="structural|writer gate"):
+            db._write_sql_logged("test-op", "sid", "UPDATE sessions SET source=? WHERE id=?", ("x", "y"))
+
+
+def test_mutation_mutex_file_is_a_persistent_sentinel(tmp_path):
+    """The .writer.mtx.lock file is never unlinked (like the global lock):
+    pins the intentional-persistence contract against future cleanups."""
+    import hermes_state_writergate as _wg
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    db.create_session(session_id=str(uuid.uuid4()), source="cli")
+    db.close()
+    mtx = _wg._mutation_mutex_path(db_path)
+    # Run a reap cycle (dead-pid litter); the sentinel is created and stays.
+    import json
+
+    dead_pid = 2**30 - 7
+    stale = _wg._presence_path(db_path, dead_pid)
+    stale.write_bytes(json.dumps(
+        {"pid": dead_pid, "start_ticks": 1, "acquired_at": 0.0, "role": "writer"}
+    ).encode())
+    assert _wg._live_writer_presences(db_path) == []
+    assert mtx.exists()
+
+
+def test_refused_announce_leaves_no_presence(tmp_path):
+    """P1 (announce rollback): a refused row announce must roll back its own
+    presence — post-refusal state, not just the raise. After surgery exits,
+    the gate is quiet and a fresh writer proceeds."""
+    import hermes_state_writergate as _wg
+
+    db_path = tmp_path / "state.db"
+    queue = mp.get_context("spawn").Queue()
+    builder = _spawn(_build_db_child, str(db_path), queue)
+    try:
+        assert queue.get(timeout=60) == "built"
+    finally:
+        builder.join(timeout=60)
+    db = SessionDB(db_path=db_path)
+    db.close()  # conn-less handle, presence released
+    presence = _wg._presence_path(db_path, os.getpid())
+    assert not presence.exists()
+    ctx = mp.get_context("spawn")
+    ready, release = ctx.Event(), ctx.Event()
+    surgery = _spawn(_hold_surgery_child, str(db_path), ready, release)
+    try:
+        assert ready.wait(timeout=60)
+        with pytest.raises(StateDbWriterHeldError, match="structural|writer gate"):
+            db._execute_write(lambda conn: conn.execute("SELECT 1").fetchone())
+        assert db._conn is None
+        assert not presence.exists(), "refused announce littered presence"
+    finally:
+        release.set()
+        surgery.join(timeout=60)
+    assert _wg.writer_gate_holder(db_path) is None
+    db2 = SessionDB(db_path=db_path)
+    db2.create_session(session_id=str(uuid.uuid4()), source="cli")
+    db2.close()
+
+
+def test_refused_anonymous_announce_keeps_other_leases(tmp_path):
+    """Rollback consumes exactly one anonymous lease: with two live leases,
+    one rollback keeps the presence; the second drops it. (A live local
+    presence blocks foreign surgery by design, so the refused-second-lease
+    shape is exercised at the rollback unit level.)"""
+    import hermes_state_writergate as _wg
+    from hermes_state_writergate import _held, _held_lock, _rollback_announce
+
+    db_path = tmp_path / "state.db"
+    db_path.write_bytes(b"")
+    _wg.acquire_writer_gate(db_path)  # lease 1
+    _wg.acquire_writer_gate(db_path)  # lease 2
+    presence = _wg._presence_path(db_path, os.getpid())
+    assert presence.exists()
+    with _held_lock:
+        assert _held[str(presence)].anon_leases == 2
+    _rollback_announce(db_path, None)  # refused lease 2 rolls back
+    assert presence.exists(), "rollback ate another caller's live lease"
+    with _held_lock:
+        assert _held[str(presence)].anon_leases == 1
+    _rollback_announce(db_path, None)  # last lease drops the hold
+    assert not presence.exists()
+    assert _wg.writer_gate_holder(db_path) is None
+
+
+def test_release_close_marks_pending_when_mutex_contended(tmp_path):
+    """P1 (release wedge): a closer colliding with the mutation mutex keeps
+    its hold (flock held, owner restored) instead of an unlocked ghost, marks
+    retry state, and __del__ drains it independently — close() never returns
+    a live-pid record with no retry left. Deterministic via join, no timing."""
+    import threading
+
+    import hermes_state_writergate as _wg
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    db.create_session(session_id=str(uuid.uuid4()), source="cli")
+    presence = _wg._presence_path(db_path, os.getpid())
+    assert presence.exists()
+    entered, free = threading.Event(), threading.Event()
+
+    def _hold_mutex():
+        with _wg._presence_mutation_serialized(db_path) as serialized:
+            assert serialized
+            entered.set()
+            assert free.wait(timeout=60)
+
+    t = threading.Thread(target=_hold_mutex)
+    t.start()
+    try:
+        assert entered.wait(timeout=60)
+        db.close()  # mutex contended: hold re-registered, retry state marked
+        # Retained, never a ghost: file present and an independent retry armed.
+        assert presence.exists()
+        assert db._gate_release_pending is True
+    finally:
+        free.set()
+        t.join(timeout=60)
+    db.__del__()  # independent retry without an explicit close
+    assert db._gate_release_pending is False
+    assert not presence.exists()
+    assert _wg.writer_gate_holder(db_path) is None
+
+
+@pytest.mark.linux_only
+def test_orphan_reap_keeps_replacement_record(tmp_path, monkeypatch):
+    """P1 (orphan record race): a replacement that wins the pathname between
+    dead-classification and mutex cleanup differs in record content and must
+    be kept live — identity alone is insufficient."""
+    import fcntl
+    import json
+
+    import hermes_state_writergate as _wg
+
+    db_path = tmp_path / "state.db"
+    db_path.write_bytes(b"")
+    dead_pid = 2**30 - 7
+    orphan = _wg._presence_path(db_path, dead_pid)
+    orphan.parent.mkdir(parents=True, exist_ok=True)
+    dead_record = {"pid": dead_pid, "start_ticks": 1, "acquired_at": 0.0, "role": "writer"}
+    orphan.write_bytes(json.dumps(dead_record).encode())
+    # Orphan descriptor: an unrelated live fd holding the flock.
+    keeper = orphan.open("r+b")
+    fcntl.flock(keeper.fileno(), fcntl.LOCK_EX)
+    real_serialized = _wg._presence_mutation_serialized
+    swapped = {"n": 0}
+
+    @__import__("contextlib").contextmanager
+    def _swapping_serialized(path):
+        with real_serialized(path) as ok:
+            if ok and swapped["n"] == 0:
+                swapped["n"] += 1
+                # Replacement wins NOW: new inode, live record, flock held.
+                with __import__("contextlib").suppress(OSError):
+                    os.unlink(orphan)
+                orphan.write_bytes(json.dumps(
+                    {"pid": os.getpid(), "start_ticks": _wg._proc_start_ticks(os.getpid()),
+                     "acquired_at": time.time(), "role": "writer"}
+                ).encode())
+            yield ok
+
+    monkeypatch.setattr(_wg, "_presence_mutation_serialized", _swapping_serialized)
+    try:
+        live = _wg._live_writer_presences(db_path)
+    finally:
+        try:
+            fcntl.flock(keeper.fileno(), fcntl.LOCK_UN)
+        except OSError:
+            pass
+        keeper.close()
+    assert swapped["n"] == 1
+    assert any(str(orphan) in d for d in live), "replacement record was reaped as orphan"
+    assert orphan.exists()
+
+
+def test_gate_refusal_propagates_from_telegram_bindings(tmp_path):
+    with _surgery_backdrop(tmp_path) as db:
+        with pytest.raises(StateDbWriterHeldError, match="structural|writer gate"):
+            db.list_telegram_topic_bindings_for_chat(chat_id="c")
+
+
+def test_gate_refusal_propagates_from_handoff_reads(tmp_path):
+    with _surgery_backdrop(tmp_path) as db:
+        with pytest.raises(StateDbWriterHeldError, match="structural|writer gate"):
+            db.get_handoff_state("sid")
+    with _surgery_backdrop(tmp_path) as db:
+        with pytest.raises(StateDbWriterHeldError, match="structural|writer gate"):
+            db.list_pending_handoffs()
+
+
+def test_gate_refusal_propagates_from_fts_stale_refresh(tmp_path):
+    with _surgery_backdrop(tmp_path) as db:
+        with pytest.raises(StateDbWriterHeldError, match="structural|writer gate"):
+            db._refresh_fts_stale_state()
+
+
+def test_gate_refusal_propagates_from_unindexed_gap(tmp_path, monkeypatch):
+    """P1 (deferred-gap swallow): a gate refusal inside the FTS-rebuild gap
+    supplement must propagate, not return the indexed subset as complete.
+    Precise fault injection: a real interleaving cannot be scheduled
+    in-process (the main FTS query would refuse first)."""
+    import sqlite3
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    db._fts_enabled = True
+    db._fts_stale = False
+    monkeypatch.setattr(db, "_read_all", lambda sql, params: [{"id": 1}])
+    monkeypatch.setattr(
+        db, "fts_rebuild_status",
+        lambda: {"pending": True, "total": 2, "indexed": 1, "percent": 50},
+    )
+
+    def _refuse(*args, **kwargs):
+        raise StateDbWriterHeldError("writer gate held: structural surgery in progress")
+
+    monkeypatch.setattr(db, "_search_unindexed_gap", _refuse)
+    with pytest.raises(StateDbWriterHeldError):
+        db.search_messages("hello", limit=10)
+
+    def _ordinary_failure(*args, **kwargs):
+        raise sqlite3.OperationalError("no such table: messages_fts")
+
+    monkeypatch.setattr(db, "_search_unindexed_gap", _ordinary_failure)
+    assert [m["id"] for m in db.search_messages("hello", limit=10)] == [1]
+
+
+def test_gate_refusal_propagates_from_page_pragmas(tmp_path):
+    with _surgery_backdrop(tmp_path) as db:
+        with pytest.raises(StateDbWriterHeldError, match="structural|writer gate"):
+            db._page_pragmas(("page_count",), "probe")
+
+
+def test_gate_refusal_propagates_from_fts_backfill_retry(tmp_path, monkeypatch):
+    """Retry-loop sites must not spin on a refusal: it propagates instead of
+    degrading to will-retry True."""
+    from hermes_state_errors import StateDbWriterHeldError as _Held
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    try:
+        monkeypatch.setattr(db, "get_meta", lambda *a, **k: "1000")
+
+        def _raise(_cb):
+            raise _Held("injected gate refusal")
+
+        monkeypatch.setattr(db, "_execute_write", _raise)
+        with pytest.raises(_Held, match="injected gate refusal"):
+            db._rebuild_step("t", [], fail_msg="x", finish=lambda: None)
+        monkeypatch.setattr(db, "_read_ctx", lambda: (_ for _ in ()).throw(_Held("injected gate refusal")))
+        with pytest.raises(_Held, match="injected gate refusal"):
+            db._fts_teardown_trash_step()
+    finally:
+        db.close()
+
+
+def test_gate_refusal_propagates_from_write_seams(tmp_path, monkeypatch):
+    """Write-fallback sites (reclaim, end_session, compression lock, tip
+    resolve, identity probe) propagate via the shared classifier."""
+    from hermes_state_errors import StateDbWriterHeldError as _Held
+    from hermes_state_errors import is_gate_refusal
+
+    assert is_gate_refusal(_Held("x"))
+    assert not is_gate_refusal(ValueError("x"))
+    assert not is_gate_refusal(__import__("sqlite3").OperationalError("busy"))
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    try:
+        def _raise(*a, **k):
+            raise _Held("injected gate refusal")
+
+        monkeypatch.setattr(db, "_execute_write", _raise)
+        with pytest.raises(_Held, match="injected gate refusal"):
+            db.reclaim_stale_running_handoffs("boom")
+    finally:
+        db.close()
+    db2 = SessionDB(db_path=db_path)
+    try:
+        monkeypatch.setattr(db2, "_execute_write", _raise)
+        with pytest.raises(_Held, match="injected gate refusal"):
+            db2.promote_to_session_reset("sid")
+    finally:
+        db2.close()
+
+
+def test_failed_init_closes_conn_before_releasing_presence(tmp_path, monkeypatch):
+    """P3 (init-finally order): a failed construction must settle close-time
+    WAL work BEFORE releasing writer presence, so no structural take can
+    slip into the window. Deterministic fault injection at the seam."""
+    import hermes_state_writergate as _wg
+
+    events = []
+    real_open = SessionDB._open_writer
+    real_close_conn = SessionDB._close_connection_quietly
+    real_release = _wg.release_writer_gate
+
+    def _fail_after_open(self):
+        real_open(self)
+        raise RuntimeError("boom-after-open")
+
+    def _rec_close(self, conn):
+        events.append("close")
+        return real_close_conn(conn)
+
+    def _rec_release(db_path, owner):
+        events.append("release")
+        return real_release(db_path, owner)
+
+    monkeypatch.setattr(SessionDB, "_open_writer", _fail_after_open)
+    monkeypatch.setattr(SessionDB, "_close_connection_quietly", _rec_close)
+    monkeypatch.setattr(_wg, "release_writer_gate", _rec_release)
+    with pytest.raises(RuntimeError, match="boom-after-open"):
+        SessionDB(db_path=tmp_path / "state.db")
+    assert events == ["close", "release"]
+
+
+def test_reopen_failure_closes_conn_before_releasing_presence(tmp_path, monkeypatch):
+    """P3 (reopen-fail order): same close-before-release contract on the
+    teardown/worker-races reopen path. Deterministic fault injection."""
+    import hermes_state_writergate as _wg
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    db.close()
+    events = []
+    real_close_conn = SessionDB._close_connection_quietly
+    real_release = _wg.release_writer_gate
+
+    def _rec_close(self, conn):
+        events.append("close")
+        return real_close_conn(conn)
+
+    def _rec_release(path, owner):
+        events.append("release")
+        return real_release(path, owner)
+
+    monkeypatch.setattr(db, "_open_writer_conn", lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+    monkeypatch.setattr(SessionDB, "_close_connection_quietly", _rec_close)
+    monkeypatch.setattr(_wg, "release_writer_gate", _rec_release)
+    with pytest.raises(__import__("sqlite3").OperationalError):
+        db._reopen_after_close_locked("test")
+    assert events == ["close", "release"]
+    db.close()
+
+
+def test_gate_setup_failure_classifies_distinct_from_locked(tmp_path):
+    """P4 (lease poll): permanent gate-setup failures must not classify as
+    retryable "locked" — only live-holder contention polls."""
+    from hermes_state import classify_persistence_error
+    from hermes_state_errors import StateDbGateSetupError
+
+    assert classify_persistence_error(
+        StateDbWriterHeldError("writer gate held: structural surgery in progress")) == "locked"
+    assert classify_persistence_error(
+        StateDbGateSetupError("state.db writer gate: cannot establish presence")) == "gate_setup"
+
+
+def test_turn_lease_raises_at_once_on_gate_setup_failure(tmp_path, monkeypatch):
+    """P4 (lease poll): the turn lease must raise a permanent setup failure
+    immediately instead of polling it for wait_seconds."""
+    from hermes_state_errors import StateDbGateSetupError
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        def _setup_failed(*a, **k):
+            raise StateDbGateSetupError("state.db writer gate: cannot establish presence")
+
+        monkeypatch.setattr(db, "try_acquire_session_turn_lease", _setup_failed)
+        started = __import__("time").monotonic()
+        with pytest.raises(StateDbGateSetupError):
+            db.acquire_session_turn_lease("sid", "holder", wait_seconds=2.0)
+        # Immediate: the raise precedes any poll sleep, so it must land well
+        # before the budget a polling regression would exhaust.
+        assert __import__("time").monotonic() - started < 2.0
+    finally:
+        db.close()
+
+
+def test_gate_refusal_propagates_from_unarchive_lookup(tmp_path):
+    """P5 (unarchive swallow): gate refusal during unarchive lookup must
+    propagate, not hide the canonical session as absent. Real second-process
+    surgery against a closed handle (teardown-race shape)."""
+    import contextlib
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    try:
+        sid_live = str(uuid.uuid4())
+        db.create_session(session_id=sid_live, source="cli")
+        db.end_session(sid_live, "ws_orphan_reap")
+        db.set_session_archived(sid_live, True)
+        assert db.unarchive_recoverable_session(sid_live) is True
+
+        sid_test = str(uuid.uuid4())
+        db.create_session(session_id=sid_test, source="cli")
+        db.end_session(sid_test, "ws_orphan_reap")
+        db.set_session_archived(sid_test, True)
+    finally:
+        db.close()
+    ctx = mp.get_context("spawn")
+    ready, release = ctx.Event(), ctx.Event()
+    surgery = _spawn(_hold_surgery_child, str(db_path), ready, release)
+    assert ready.wait(timeout=60)
+    try:
+        with pytest.raises(StateDbWriterHeldError):
+            db.unarchive_recoverable_session(sid_test)
+    finally:
+        release.set()
+        surgery.join(timeout=60)
+        with contextlib.suppress(Exception):
+            db.close()
+
+
+def test_pending_release_drains_without_owner_retry(tmp_path, monkeypatch):
+    """P1 (release wedge): a close() that exhausts the mutation-mutex budget
+    must not strand the presence when the owner dies with no retry left.
+    Real contention via a holder thread, then a REAL gc collection of the
+    owner — the module drain (not __del__, not another close) cleans up.
+    Event-driven: the drain's poll loop is patched to a barrier the test
+    controls, so no timing is assumed."""
+    import threading
+
+    import hermes_state_writergate as _wg
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    db.create_session(session_id=str(uuid.uuid4()), source="cli")
+    presence = _wg._presence_path(db_path, os.getpid())
+    assert presence.exists()
+    entered, free, drained = threading.Event(), threading.Event(), threading.Event()
+
+    def _hold_mutex():
+        with _wg._presence_mutation_serialized(db_path) as serialized:
+            assert serialized is True
+            entered.set()
+            assert free.wait(timeout=60)
+
+    # Gate the drain's poll on events the test controls (no timing races).
+    real_sleep = _wg.time.sleep
+
+    def _sleep_and_signal(seconds):
+        real_sleep(seconds)
+        if seconds == _wg._DEFERRED_RELEASE_DRAIN_POLL_S:
+            drained.set()
+
+    monkeypatch.setattr(_wg.time, "sleep", _sleep_and_signal)
+
+    t = threading.Thread(target=_hold_mutex)
+    t.start()
+    try:
+        assert entered.wait(timeout=60)
+        db.close()  # mutex contended: hold flagged deferred, drain armed
+        assert db._gate_release_pending is True
+        assert presence.exists()
+        with _wg._held_lock:
+            hold = _wg._held[str(presence)]
+            assert hold.deferred_release is True
+        # Kill EVERY retry the owner could ever provide: __del__ has already
+        # run (close() left _conn=None), so the object's collection below is
+        # the "no future close()" world the reviewer reproduced.
+        del db
+        import gc
+        gc.collect()
+        with _wg._held_lock:
+            assert str(presence) in _wg._held  # flagged hold survives GC
+    finally:
+        free.set()
+        t.join(timeout=60)
+    # The module drain — no owner, no close(), no __del__ — finishes it.
+    assert drained.wait(timeout=60)
+    real_sleep(0.5)
+    with _wg._held_lock:
+        assert str(presence) not in _wg._held
+    assert not presence.exists()
+    assert _wg.writer_gate_holder(db_path) is None
+
+
+def _wait_until(predicate, timeout_s: float = 30.0) -> bool:
+    """Event-friendly poll (no timing assumption beyond the wall bound)."""
+    import time as _time
+
+    deadline = _time.monotonic() + timeout_s
+    while _time.monotonic() < deadline:
+        if predicate():
+            return True
+        _time.sleep(0.05)
+    return predicate()
+
+
+def test_rollback_announce_preserves_live_retry_path(tmp_path):
+    """P1 (rollback wedge): a refused announce whose rollback release also
+    collides with a contended mutation mutex must leave a flagged hold and
+    an armed drain — never a live-pid presence with zero owners and no
+    retry. Real mutex contention, deterministic via join/events."""
+    import gc
+    import threading
+
+    import hermes_state_writergate as _wg
+    from hermes_state_writergate import _held, _held_lock
+
+    db_path = tmp_path / "state.db"
+    db_path.write_bytes(b"")
+    # Build the announce to roll back: one named-owner share we can refuse.
+    token = _wg.OwnerToken("victim")
+    _wg.acquire_writer_gate(db_path, owner=token)
+    presence = _wg._presence_path(db_path, os.getpid())
+    assert presence.exists()
+    entered, free = threading.Event(), threading.Event()
+
+    def _hold_mutex():
+        with _wg._presence_mutation_serialized(db_path) as serialized:
+            assert serialized is True
+            entered.set()
+            assert free.wait(timeout=60)
+
+    t = threading.Thread(target=_hold_mutex)
+    t.start()
+    try:
+        assert entered.wait(timeout=60)
+        # Rollback under contention: this is the exact _rollback_announce ->
+        # release_writer_gate path the reviewer's P1 names.
+        _wg._rollback_announce(db_path, token)
+        with _held_lock:
+            hold = _held.get(str(presence))
+            assert hold is not None, "rollback dropped the pinned hold entirely"
+            assert hold.deferred_release is True, "False release result was discarded"
+            assert list(hold.owners), "hold must stay accurate (owner restored)"
+        del token  # the owner dies: only the module drain can finish this
+        gc.collect()
+        with _held_lock:
+            assert not list(hold.owners)  # weak owner died with the object
+    finally:
+        free.set()
+        t.join(timeout=60)
+    # The drain — no owner, no close() — completes the owed unlink.
+    assert _wait_until(lambda: not presence.exists())
+    with _held_lock:
+        assert str(presence) not in _held
+    assert _wg.writer_gate_holder(db_path) is None
+
+
+@pytest.mark.linux_only
+def test_gate_setup_failure_on_mutex_open_not_classified_locked(tmp_path, monkeypatch):
+    """P1 (lease poll): a mutation-mutex SETUP failure (PermissionError on
+    opening the MUTEX file, not flock contention, not the presence file)
+    during a stale-presence reclaim must raise StateDbGateSetupError —
+    classify_persistence_error then reports gate_setup, so the turn lease
+    raises at once instead of polling the 1800s default. The probe paths
+    keep their never-raises contract."""
+    from hermes_state_errors import StateDbGateSetupError, classify_persistence_error
+
+    import hermes_state_writergate as _wg
+
+    db_path = tmp_path / "state.db"
+    db_path.write_bytes(b"")
+    # Stale same-pid presence file, flock-held by a leftover descriptor (the
+    # pid-recycled shape), so the reclaim branch runs inside _announce_presence.
+    presence = _wg._presence_path(db_path, os.getpid())
+    presence.parent.mkdir(parents=True, exist_ok=True)
+    presence.write_bytes(b'{"pid": 1, "start_ticks": 1, "acquired_at": 0.0, "role": "writer"}')
+    import fcntl
+
+    stale_fd = presence.open("a+b")
+    fcntl.flock(stale_fd.fileno(), fcntl.LOCK_EX)  # contended: reclaim branch
+    mutex_path = _wg._mutation_mutex_path(db_path)
+
+    real_open = _wg._open_gate_file
+
+    def _denied_only_mutex(lock_path, *a, **k):
+        if Path(str(lock_path)) == mutex_path:
+            raise PermissionError(13, "Permission denied")
+        return real_open(lock_path, *a, **k)
+
+    monkeypatch.setattr(_wg, "_open_gate_file", _denied_only_mutex)
+    monkeypatch.delitem(_wg._held, str(presence), raising=False)
+
+    try:
+        with pytest.raises(StateDbGateSetupError, match="mutation mutex"):
+            _wg.acquire_writer_gate(db_path)
+    finally:
+        fcntl.flock(stale_fd.fileno(), fcntl.LOCK_UN)
+        stale_fd.close()
+    assert classify_persistence_error(
+        StateDbGateSetupError("cannot open or lock the presence-path mutation mutex")
+    ) == "gate_setup"
+    # The never-raises probe contract is untouched: the same fault on the
+    # probe path (unopenable presence file) still fails closed to "live",
+    # never raises.
+    monkeypatch.undo()
+    monkeypatch.setattr(_wg, "_open_gate_file", _denied_only_mutex)
+    assert _wg._live_writer_presences(db_path)  # fail-closed: reports live
+
+
+def test_api_and_profiles_re_raise_gate_refusals(tmp_path, monkeypatch):
+    """P1 (caller boundaries): a gate refusal from unarchive_recoverable_session
+    must surface at BOTH production caller boundaries — the api_server
+    heal path returns the store-busy 503 envelope (not an empty 200 list)
+    and the tui_gateway canonical resolver propagates (not a silent
+    canonical_session=None)."""
+    import asyncio
+
+    from aiohttp.test_utils import TestClient, TestServer
+    from unittest.mock import MagicMock
+
+    from hermes_state_errors import StateDbWriterHeldError
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    try:
+        sid = str(uuid.uuid4())
+        db.create_session(session_id=sid, source="cli")
+        db.end_session(sid, "ws_orphan_reap")
+        db.set_session_archived(sid, True)
+    finally:
+        db.close()
+
+    def _refuse(*a, **k):
+        raise StateDbWriterHeldError("writer gate held: structural surgery in progress")
+
+    from gateway.config import PlatformConfig
+    from gateway.platforms.api_server import APIServerAdapter
+
+    adapter = APIServerAdapter(PlatformConfig(enabled=True))
+    adapter._session_db = MagicMock()
+    adapter._session_db.get_session_by_title = lambda title: {
+        "id": sid, "title": title, "archived": True}
+    adapter._session_db.unarchive_recoverable_session = _refuse
+    adapter._session_db.list_sessions_rich = lambda **k: []
+
+    from aiohttp import web
+
+    app = web.Application()
+    app.router.add_get("/api/sessions", adapter._handle_list_sessions)
+    app["api_server_adapter"] = adapter
+
+    async def _drive():
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/sessions", params={"title": "Bot Chat"})
+            return resp.status, await resp.json()
+
+    status, payload = asyncio.run(_drive())
+    assert status == 503
+    assert payload["error"]["code"] == "session_db_unavailable"
+
+    # TUI gateway boundary, through the REAL server binding (the module's
+    # bodies resolve Path & friends from server.py globals, so a direct
+    # module call is not the production path): the refusal surfaces as a
+    # profiles.list error envelope, never a silent canonical_session=None.
+    import tui_gateway.server as srv
+
+    home = tmp_path / ".hermes"
+    profile_dir = home / "profiles" / "ops"
+    profile_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    prof_db = SessionDB(db_path=profile_dir / "state.db")
+    bot = str(uuid.uuid4())
+    prof_db.create_session(bot, "cli")
+    prof_db.end_session(bot, "ws_orphan_reap")
+    prof_db.set_session_archived(bot, True)
+    with prof_db._lock:
+        prof_db._conn.execute(
+            "UPDATE sessions SET title = ? WHERE id = ?", ("Bot Chat", bot))
+    prof_db.close()
+
+    fake_wdb = MagicMock()
+    fake_wdb.unarchive_recoverable_session = _refuse
+    # The resurrect path late-imports acquire/release_or_close from
+    # hermes_state_registry inside the function: a module-attribute patch is
+    # the seam production reads.
+    import hermes_state_registry as _reg
+    from unittest.mock import patch as _patch
+
+    with _patch.object(_reg, "acquire", lambda path: fake_wdb), \
+         _patch.object(_reg, "release_or_close", lambda wdb: None):
+        envelope = srv._methods["profiles.list"](1, {"include_sessions": True})
+    assert envelope.get("error", {}).get("code") == 5061, envelope
+
+
+def test_deferred_drain_never_unlinks_a_replacement(tmp_path):
+    """P1 (stale capture): the drain's scan snapshots (key, hold) before
+    taking _held_lock; a release+re-announce may install a NEW hold at the
+    same path in that window. The drain must drain only the CURRENT owner
+    of the key — never unlink the replacement's live presence, never pop a
+    hold it does not own."""
+    import hermes_state_writergate as _wg
+    from hermes_state_writergate import _held, _held_lock
+
+    db_path = tmp_path / "state.db"
+    db_path.write_bytes(b"")
+    presence = _wg._presence_path(db_path, os.getpid())
+
+    # Old hold: flagged (as a budget-exhausted release leaves it), then
+    # orphaned exactly as a winning release does (popped, never re-registered).
+    old_token = _wg.OwnerToken("old")
+    _wg.acquire_writer_gate(db_path, owner=old_token)
+    with _held_lock:
+        old_hold = _held[str(presence)]
+        old_hold.deferred_release = True
+
+    # The winning release: drops old share, unlinks, pops — the live path.
+    assert _wg.release_writer_gate(db_path, old_token) is True
+    with _held_lock:
+        assert str(presence) not in _held
+    assert not presence.exists()
+
+    # A fresh announce installs a NEW hold at the same key.
+    new_token = _wg.OwnerToken("new")
+    _wg.acquire_writer_gate(db_path, owner=new_token)
+    with _held_lock:
+        new_hold = _held[str(presence)]
+        assert new_hold is not old_hold
+
+    # The drain, still holding the stale (key, old_hold) capture, must no-op.
+    _wg._drain_one_deferred_release(str(presence), old_hold)
+    assert presence.exists(), "drain unlinked the replacement's live presence"
+    with _held_lock:
+        assert _held.get(str(presence)) is new_hold, "drain popped a hold it does not own"
+
+    # And the new hold still works: releases cleanly.
+    assert _wg.release_writer_gate(db_path, new_token) is True
+    assert not presence.exists()

--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -131,7 +131,13 @@ def _resurrect_recoverable_canonical(db, profile_path, session_id):
             return bool(wdb.unarchive_recoverable_session(session_id))
         finally:
             _best_effort(lambda: _lazy("hermes_state_registry", "release_or_close")(wdb))
-    except Exception:
+    except Exception as exc:
+        from hermes_state_errors import is_gate_refusal
+        # A writer-gate refusal must not degrade an existing canonical chat to
+        # absent: propagating lets the _profile_handler emit a 5061 error row
+        # instead of a silent canonical_session=None (P1, #103339).
+        if is_gate_refusal(exc):
+            raise
         return False
 
 
@@ -168,7 +174,12 @@ def _canonical_session_row(db, profile_path):
             "started_at": tip_row.get("started_at") or started,
             "last_active": tip_row.get("last_activity_at") or tip_row.get("started_at") or started,
             "message_count": tip_row.get("message_count") or 0}
-    except Exception:
+    except Exception as exc:
+        from hermes_state_errors import is_gate_refusal
+        # Same fail-closed rule as _resurrect_recoverable_canonical: a gate
+        # refusal is store-busy, never "no canonical chat" (P1, #103339).
+        if is_gate_refusal(exc):
+            raise
         return None
 
 


### PR DESCRIPTION
## Problem

Second process doing structural work on the live WAL state.db corrupts it (fleet report: 7 events in 4 days). The existing guards are fail-open exactly when repair runs: a malformed db answers DatabaseError instead of busy, so the EXCLUSIVE probe goes blind; and doctor's raw wal_checkpoint opens the db with no guard at all.

Refs #103339 (partial: repair/doctor-checkpoint/docs here; hosted_rooms shared-root routing stays with #102176; VACUUM/optimize/migration gates as follow-up).

## Approach — SQLite owns rows, the gate owns file structure

Ordinary row writes proceed under SQLite's own WAL locking — as on base, where a pinned conformance cell proves 8 concurrent claimants stay exactly-once. A first blanket-refusal design broke that cell plus cron-tick/handoff/lease flows, so the gate narrowed to the evidenced class:

- New hermes_state_writergate.py: per-pid presence files (coexistent, fail-closed via psutil-safe liveness plus start_ticks identity) + one global structural lock. The exclusive take is ATOMIC (take global, verify no live presence including own-process writers, release+refuse otherwise). Row probes observe with shared flock (POSIX) so concurrent probes never refuse each other, and never take a self fast-path. Same-process structural re-entry requires the identical owner token. Presence establishment failure refuses the mutation. Fork-inherited holds are foreign by PID (never unlocked).
- Stale reaps hold the presence-path mutation mutex (<db>.writer.mtx.lock, persistent sentinel) across an identity-checked (dev+ino) unlink: check+unlink atomic among cooperating mutators (reclaim, reap, orphan-break, release); POSIX unverifiable never reaps; on Windows contested unlinks fail via OS share semantics. Orphaned fork descriptors (#100108 shape) break like _acquire_db_flock (POSIX only).
- Release/close paths retry a contended mutation mutex, then flag the hold for a module-level deferred drain that completes the presence unlink+unlock once no owner/lease is live — cleanup never depends on the owner surviving to retry (the `__del__` path has a single bounded attempt). The drain re-checks its capture under the same lock before unlinking, so a replacement's live presence is never erased. A mutation-mutex setup failure classifies apart from contention (StateDbGateSetupError; patience loops raise at once instead of polling). Refused lookups propagate at the production boundaries: api_server returns the store-busy 503 envelope and the tui_gateway canonical resolver surfaces an error instead of reporting a missing canonical session.
- Open-time mutations hold the same admission from before any sqlite open through DDL/generation; reopen re-pins before opening SQLite for reads and writes alike (five swallow sites re-raise WriterHeld explicitly); self-heal drops presence before repairing, re-pins before reopening, and propagates re-admission failure without reopening.
- repair_state_db_schema: REFUSED contract on live presence; fellow repairers serialize via roles + repair lock; global held through surgery.
- doctor --fix WAL checkpoint skipped under live presence, held under the global lock when it runs, connection closed before the gate releases.
- sessions CLI reports StateDbWriterHeldError cleanly (exit 1).

Single-commit series (rebased onto current main, every surviving commit green).

## How to Test

scripts/run_tests.sh tests/test_state_writer_gate.py tests/test_state_db_malformed_repair.py tests/conformance/persistence/test_cell2_consume_once.py
scripts/run_tests.sh tests/tui_gateway/test_profiles_list_canonical_session.py tests/gateway/test_session_api.py tests/tui_gateway/test_stranded_session_adoption.py tests/hermes_cli/test_sessions_error_exit_codes.py tests/test_state_db_repair_live_writer_guard.py

## Tests

- 58 tests in tests/test_state_writer_gate.py (all sabotage-verified, incl. overlapping probes, owner identity, mutex-held proof, read reopen, doctor close-order, replacement-race, recycled-pid, orphan-descriptor, release-pending retry, owner-independent deferred drain, drain capture identity, rollback retry state, setup-vs-locked classify, lease fast-raise, unarchive propagation, api+profiles refusal boundaries).
- CLI exit-code contract: repair-fail / check-only-unclean -> 1, clean -> None (tests/hermes_cli/test_sessions_error_exit_codes.py).
- Neighbor suites green (malformed-repair, cell2, lease, classify/explainer, hermes_state/*, profiles canonical resolver, session API, stranded-adoption, sessions exit codes); search/fts subset green except pre-existing `test_search_projection_skips_context_enrichment_queries`, which fails identically on the base head.
- check-windows-footguns clean on all touched files; ruff clean; fork tests use linux_only markers. Hosted CI pending Actions approval (fork PR).

## Risk

Fail-closed throughout (Windows paused-probe residual documented: fail-closed spurious refusal, retryable). Row-write behavior unchanged from base. Windows parity via psutil liveness + share-semantics unlink.

## Exclusions

- hosted_rooms shared-root routing (stays with #102176).
- prune DELETEs / in-process periodic checkpoints: unchanged SQLite behavior.
- VACUUM / optimize / migration gates: follow-up through the same atomic contract.


