### PR TITLE
fix(desktop): restore per-session transcript scroll on return

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -32,6 +32,12 @@ import { isSecondaryWindow } from '@/store/windows'
 
 import { MessageRenderBoundary } from '../message-render-boundary'
 
+import {
+  classifySessionScroll,
+  sessionScrollMemory,
+  sessionScrollOffsetPlaceable,
+  sessionScrollTargetTop
+} from './session-scroll-memory'
 import { resolveShowEarlierAction, useTranscriptWindow } from './transcript-window'
 
 type ThreadMessageComponents = ComponentProps<typeof ThreadPrimitive.MessageByIndex>['components']
@@ -501,7 +507,18 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   const anchorBeforePrepend = useCallback(() => {
     const el = scrollRef.current
 
-    restoreFromBottomRef.current = el && loadSettledRef.current ? el.scrollHeight - el.scrollTop : 0
+    if (!el) {
+      return
+    }
+
+    // Mid-load, a session-switch restore may already own the target. Do not
+    // replace it with 0 — that is what used to pin a mid-read return to the
+    // bottom while older turns backfilled (#45562).
+    if (!loadSettledRef.current) {
+      return
+    }
+
+    restoreFromBottomRef.current = el.scrollHeight - el.scrollTop
   }, [scrollRef])
 
   // Backfill from FIRST_PAINT_BUDGET to the full budget after the small
@@ -653,12 +670,13 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     }
   })
 
-  // Reset the cap and pin to bottom on mount + every session switch (messages
-  // swap in place on a long-lived runtime, so sessionKey is the only signal).
-  // The swap is multi-step and lays out over many frames; letting the library
-  // follow re-pins every frame to a moving target — visible as ~10 scroll jumps.
-  // Instead: quiet it, glue to the true bottom until the height holds steady,
-  // then hand back locked. Live streaming afterward uses the normal resize follow.
+  // Reset the cap on mount + every session switch (messages swap in place on a
+  // long-lived runtime, so sessionKey is the only signal). The swap is multi-step
+  // and lays out over many frames; letting the library follow re-pins every
+  // frame to a moving target — visible as ~10 scroll jumps. Instead: quiet it,
+  // glue to the remembered target (bottom, or the mid-read offset saved when
+  // we left) until the height holds steady, then hand back. Live streaming
+  // afterward uses the normal resize follow.
   //
   // `hasGroups` joins sessionKey as a dep because a COLD load changes the key
   // while the transcript is still empty and publishes messages hundreds of ms
@@ -671,6 +689,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   // streaming append.
   useLayoutEffect(() => {
     const el = scrollRef.current
+    const armedKey = sessionKey
 
     if (!el) {
       return
@@ -682,15 +701,25 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
       settledNonEmptyRef.current = false
     }
 
+    const rememberArmed = () => {
+      const node = scrollRef.current
+
+      if (node && armedKey && loadSettledRef.current) {
+        sessionScrollMemory.remember(armedKey, classifySessionScroll(node))
+      }
+    }
+
     // Same-session refresh (transcript briefly cleared and repopulated) must
     // keep the reader's position. Run before stopScroll / scrollTop reset so
     // a refresh neither yanks the view nor clears the settled flag.
     if (!shouldRePinOnTranscriptReload({ sessionSwitched, settledNonEmpty: settledNonEmptyRef.current })) {
-      return
+      return rememberArmed
     }
 
+    const remembered = sessionSwitched ? sessionScrollMemory.recall(sessionKey) : null
+    const restoreOffset = remembered?.kind === 'offset' ? remembered : null
+
     stopScroll()
-    el.scrollTop = el.scrollHeight
     loadSettledRef.current = false
 
     // An anchor captured for the OUTGOING transcript must not be applied to
@@ -698,8 +727,18 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     // re-arm is the SAME load, whose in-flight anchor is still correct.
     if (sessionSwitched) {
       settleKeyRef.current = sessionKey
-      restoreFromBottomRef.current = null
+      restoreFromBottomRef.current = restoreOffset ? restoreOffset.fromBottom : null
     }
+
+    const applyTarget = (node: HTMLElement) => {
+      if (restoreOffset) {
+        node.scrollTop = sessionScrollTargetTop(restoreOffset, node)
+      } else {
+        node.scrollTop = node.scrollHeight
+      }
+    }
+
+    applyTarget(el)
 
     let frame = 0
     let stableFrames = 0
@@ -713,18 +752,31 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
       }
 
       const height = node.scrollHeight
+      const placed = !restoreOffset || sessionScrollOffsetPlaceable(restoreOffset, height)
 
-      stableFrames = height === lastHeight ? stableFrames + 1 : 0
+      stableFrames = height === lastHeight && placed ? stableFrames + 1 : 0
       lastHeight = height
-      node.scrollTop = height
+      applyTarget(node)
 
       // Most session switches are synchronous and stabilize within 2 frames;
       // the old 90-frame ceiling was for slow async image loads. Cap at 15
       // frames to minimize the settle-loop racing markdown paint on every switch.
+      // An offset deeper than the painted height waits for backfill instead of
+      // declaring a clamped frame stable — unless we hit the cap.
       if (stableFrames >= 2 || ++frame > 15) {
-        void scrollToBottom('instant')
+        if (restoreOffset) {
+          applyTarget(node)
+          stopScroll()
+        } else {
+          void scrollToBottom('instant')
+        }
+
         settledNonEmptyRef.current = hasGroups
         loadSettledRef.current = true
+
+        if (restoreOffset) {
+          restoreFromBottomRef.current = null
+        }
 
         return
       }
@@ -734,7 +786,10 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
 
     let rafId = requestAnimationFrame(settle)
 
-    return () => cancelAnimationFrame(rafId)
+    return () => {
+      cancelAnimationFrame(rafId)
+      rememberArmed()
+    }
   }, [hasGroups, scrollRef, scrollToBottom, sessionKey, stopScroll])
 
   // Prepend an older page while preserving the on-screen position. The user is
@@ -764,7 +819,14 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
 
     if (el && restoreFromBottomRef.current != null) {
       el.scrollTop = el.scrollHeight - restoreFromBottomRef.current
-      restoreFromBottomRef.current = null
+
+      // Keep a session-switch mid-read target across backfill prepends until
+      // the settle loop parks the load. Clearing it here used to drop the
+      // offset after the first prepend and pin the rest of the restore to
+      // whatever was on screen (usually the tail).
+      if (loadSettledRef.current) {
+        restoreFromBottomRef.current = null
+      }
     }
     // renderBudget covers DOM pages; groups.length covers store-window expands.
   }, [scrollRef, renderBudget, groups.length])

--- a/apps/desktop/src/components/assistant-ui/thread/session-scroll-memory.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/session-scroll-memory.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  classifySessionScroll,
+  createSessionScrollMemory,
+  SESSION_SCROLL_MEMORY_CAP,
+  sessionScrollOffsetPlaceable,
+  sessionScrollTargetTop
+} from './session-scroll-memory'
+
+const metrics = (scrollTop: number, scrollHeight = 1000, clientHeight = 200) => ({
+  clientHeight,
+  scrollHeight,
+  scrollTop
+})
+
+describe('classifySessionScroll', () => {
+  it('treats the tail as bottom, including a few pixels of slack', () => {
+    expect(classifySessionScroll(metrics(800))).toEqual({ kind: 'bottom' })
+    expect(classifySessionScroll(metrics(792))).toEqual({ kind: 'bottom' })
+  })
+
+  it('records distance-from-bottom when the reader is in history', () => {
+    expect(classifySessionScroll(metrics(200))).toEqual({ fromBottom: 800, kind: 'offset' })
+  })
+
+  it('does not record a position for a zero-size scroller as history', () => {
+    expect(classifySessionScroll(metrics(0, 0, 0))).toEqual({ kind: 'bottom' })
+  })
+})
+
+describe('sessionScrollTargetTop', () => {
+  it('pins bottom sessions to the current tail as content grows', () => {
+    const state = classifySessionScroll(metrics(800, 1000, 200))
+
+    expect(sessionScrollTargetTop(state, { clientHeight: 200, scrollHeight: 1000 })).toBe(800)
+    expect(sessionScrollTargetTop(state, { clientHeight: 200, scrollHeight: 1600 })).toBe(1400)
+  })
+
+  it('keeps a mid-read offset as the transcript grows above the viewport', () => {
+    const state = classifySessionScroll(metrics(200, 1000, 200))
+
+    expect(state).toEqual({ fromBottom: 800, kind: 'offset' })
+    expect(sessionScrollTargetTop(state, { clientHeight: 200, scrollHeight: 1000 })).toBe(200)
+    expect(sessionScrollTargetTop(state, { clientHeight: 200, scrollHeight: 1800 })).toBe(1000)
+  })
+
+  it('clamps an offset that is still deeper than the painted height', () => {
+    const state = { fromBottom: 8000, kind: 'offset' as const }
+
+    expect(sessionScrollTargetTop(state, { clientHeight: 200, scrollHeight: 300 })).toBe(0)
+    expect(sessionScrollOffsetPlaceable(state, 300)).toBe(false)
+    expect(sessionScrollOffsetPlaceable(state, 8000)).toBe(true)
+  })
+})
+
+describe('createSessionScrollMemory', () => {
+  it('recalls the last position for a session and ignores empty keys', () => {
+    const memory = createSessionScrollMemory()
+    const offset = { fromBottom: 400, kind: 'offset' as const }
+
+    memory.remember('session-a', offset)
+    memory.remember(null, { kind: 'bottom' })
+    memory.remember('', { kind: 'bottom' })
+
+    expect(memory.recall('session-a')).toEqual(offset)
+    expect(memory.recall(null)).toBeNull()
+    expect(memory.recall('')).toBeNull()
+    expect(memory.recall('missing')).toBeNull()
+  })
+
+  it('evicts the oldest session once the cap is reached', () => {
+    const memory = createSessionScrollMemory(2)
+
+    memory.remember('a', { kind: 'bottom' })
+    memory.remember('b', { fromBottom: 10, kind: 'offset' })
+    memory.remember('c', { fromBottom: 20, kind: 'offset' })
+
+    expect(memory.recall('a')).toBeNull()
+    expect(memory.recall('b')).toEqual({ fromBottom: 10, kind: 'offset' })
+    expect(memory.recall('c')).toEqual({ fromBottom: 20, kind: 'offset' })
+  })
+
+  it('treats a re-remember as recency so it is not evicted next', () => {
+    const memory = createSessionScrollMemory(2)
+
+    memory.remember('a', { kind: 'bottom' })
+    memory.remember('b', { kind: 'bottom' })
+    memory.remember('a', { fromBottom: 50, kind: 'offset' })
+    memory.remember('c', { kind: 'bottom' })
+
+    expect(memory.recall('b')).toBeNull()
+    expect(memory.recall('a')).toEqual({ fromBottom: 50, kind: 'offset' })
+  })
+
+  it('caps at SESSION_SCROLL_MEMORY_CAP by default', () => {
+    const memory = createSessionScrollMemory()
+
+    for (let i = 0; i < SESSION_SCROLL_MEMORY_CAP + 5; i += 1) {
+      memory.remember(`s${i}`, { kind: 'bottom' })
+    }
+
+    expect(memory.size()).toBe(SESSION_SCROLL_MEMORY_CAP)
+    expect(memory.recall('s0')).toBeNull()
+    expect(memory.recall(`s${SESSION_SCROLL_MEMORY_CAP + 4}`)).toEqual({ kind: 'bottom' })
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/session-scroll-memory.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/session-scroll-memory.ts
@@ -1,0 +1,112 @@
+/**
+ * Per-session transcript reading position.
+ *
+ * The thread scroller pins to the bottom on every sessionKey change. That is
+ * correct for sessions the user left following the tail, and wrong for sessions
+ * they left mid-read: coming back jumps to newest and the place is lost
+ * (#45562).
+ *
+ * Store distance-from-bottom (`scrollHeight - scrollTop`), the same anchor
+ * "Show earlier" already uses, so prepends and late markdown layout do not
+ * invalidate it. Sessions within a few pixels of the edge are remembered as
+ * `bottom` so a return still follows new turns.
+ *
+ * In-memory only (session switches in this window). Bounded LRU so a long
+ * profile does not grow without cap.
+ */
+export const SESSION_SCROLL_BOTTOM_PX = 8
+export const SESSION_SCROLL_MEMORY_CAP = 64
+
+export type SessionScrollState = { kind: 'bottom' } | { kind: 'offset'; fromBottom: number }
+
+export type ScrollMetrics = {
+  clientHeight: number
+  scrollHeight: number
+  scrollTop: number
+}
+
+export function classifySessionScroll(metrics: ScrollMetrics, thresholdPx = SESSION_SCROLL_BOTTOM_PX): SessionScrollState {
+  const remaining = metrics.scrollHeight - metrics.scrollTop - metrics.clientHeight
+
+  if (remaining <= thresholdPx) {
+    return { kind: 'bottom' }
+  }
+
+  return { kind: 'offset', fromBottom: metrics.scrollHeight - metrics.scrollTop }
+}
+
+export function sessionScrollTargetTop(state: SessionScrollState, metrics: Pick<ScrollMetrics, 'clientHeight' | 'scrollHeight'>): number {
+  if (state.kind === 'bottom') {
+    return Math.max(0, metrics.scrollHeight - metrics.clientHeight)
+  }
+
+  return Math.max(0, metrics.scrollHeight - state.fromBottom)
+}
+
+/** True when the current content is tall enough to place an offset without clamping to 0. */
+export function sessionScrollOffsetPlaceable(state: SessionScrollState, scrollHeight: number): boolean {
+  if (state.kind === 'bottom') {
+    return true
+  }
+
+  return scrollHeight >= state.fromBottom
+}
+
+export function createSessionScrollMemory(cap = SESSION_SCROLL_MEMORY_CAP) {
+  const map = new Map<string, SessionScrollState>()
+
+  const remember = (key: string | null | undefined, state: SessionScrollState): void => {
+    if (!key) {
+      return
+    }
+
+    if (map.has(key)) {
+      map.delete(key)
+    }
+
+    map.set(key, state)
+
+    while (map.size > cap) {
+      const oldest = map.keys().next().value
+
+      if (oldest === undefined) {
+        break
+      }
+
+      map.delete(oldest)
+    }
+  }
+
+  const recall = (key: string | null | undefined): SessionScrollState | null => {
+    if (!key) {
+      return null
+    }
+
+    const state = map.get(key)
+
+    if (!state) {
+      return null
+    }
+
+    map.delete(key)
+    map.set(key, state)
+
+    return state
+  }
+
+  const forget = (key: string | null | undefined): void => {
+    if (!key) {
+      return
+    }
+
+    map.delete(key)
+  }
+
+  const reset = (): void => {
+    map.clear()
+  }
+
+  return { forget, recall, remember, reset, size: () => map.size }
+}
+
+export const sessionScrollMemory = createSessionScrollMemory()


### PR DESCRIPTION
## What does this PR do?

Leaving a Desktop chat mid-read (scrolled up in a long transcript), switching to another session, and coming back pinned the viewport to the newest turn. The place you were reading is gone.

The session-switch settle loop in `ThreadMessageList` always glued `scrollTop` to `scrollHeight`, then handed control back locked to the tail. Sessions the user left **following** the bottom should still do that. Sessions they left **mid-read** should restore that reading position.

## Related Issue

Fixes #45562

Related open PRs (same gap, different authors): #69554, #70478.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/components/assistant-ui/thread/session-scroll-memory.ts` — bounded LRU of per-session state: `bottom` vs `fromBottom` offset (same anchor as "Show earlier")
- `apps/desktop/src/components/assistant-ui/thread/list.tsx` — save on settle-effect cleanup; restore through the settle loop; do not let backfill prepends replace an in-flight mid-read target with 0
- `apps/desktop/src/components/assistant-ui/thread/session-scroll-memory.test.ts` — classification, height-stable restore, LRU

Not changed: run-start snap, keep-alive hidden→visible re-anchor, localStorage durability across app restarts.

## How to Test

1. Open a long chat. Scroll up and stop in the middle.
2. Switch to another session, then come back.
3. The transcript should still be at the same reading place, not jumped to the bottom.
4. A session you left at the bottom should still land on the newest turn.

Unit tests (from `apps/desktop`):

```
npm run test:ui -- src/components/assistant-ui/thread/session-scroll-memory.test.ts src/components/assistant-ui/thread/list.test.ts
```

45 passed. Sabotage: forcing `sessionScrollTargetTop` to always pin the tail fails the mid-read offset tests; restoring the fix passes.

## Checklist

### Code

- [x] Contributing Guide
- [x] Conventional Commits (`fix(desktop):`)
- [x] Searched existing PRs (#69554, #70478 noted)
- [x] Only this fix
- [x] Desktop UI tests for the touched files pass. Full pytest not run (UI-only).
- [x] Tests added
- [x] Platform: Linux unit tests. Bug is Desktop session-switch scroll.

### Documentation & Housekeeping

- [x] Docs — N/A
- [x] cli-config — N/A
- [x] AGENTS.md — N/A
- [x] Cross-platform: in-memory scroll metrics only
- [x] Tool schemas — N/A
