### PR TITLE
fix(dashboard): serve live SSH session token on Isolated handshake page

### DIFF
--- a/hermes_cli/web_server_dashboard.py
+++ b/hermes_cli/web_server_dashboard.py
@@ -102,7 +102,15 @@ def mount_spa(application: FastAPI):
     with a missing dist per-request (404 JSON / ``check_dir=False``), so a long-lived
     ``--skip-build`` process recovers the moment a build appears on disk — no restart.
     """
-    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, _SESSION_TOKEN, app
+    # Read ``web_server._SESSION_TOKEN`` per request. ``from web_server import
+    # _SESSION_TOKEN`` snapshots the string at mount time, which is BEFORE
+    # ``start_server`` applies the Desktop SSH spawn token. Desktop then
+    # scrapes ``/`` and adopts the stale .env / import-time token; ``/api/profiles``
+    # 401s against the live token and the app surfaces "SSH connection failed".
+    # Late-bind via the module (not ``web_deps._server``) so this stays off the
+    # PLUGIN-COMPAT pointer list.
+    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, app
+    import hermes_cli.web_server as _web_server
 
     # `hermes serve` is the headless backend: it must NEVER serve the browser SPA, even if a
     # dist is lying around, so only the JSON-RPC/WS/API surface is reachable.
@@ -120,7 +128,7 @@ def mount_spa(application: FastAPI):
             if full_path == "" and not gated:
                 return HTMLResponse(
                     "<!doctype html><html><head><script>"
-                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(_SESSION_TOKEN)};"
+                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(_web_server._SESSION_TOKEN)};"
                     "window.__HERMES_AUTH_REQUIRED__=false;"
                     f"</script></head><body>{_HEADLESS_MSG}</body></html>",
                     headers=_NO_STORE,
@@ -151,7 +159,7 @@ def mount_spa(application: FastAPI):
             return JSONResponse({"error": "Frontend not built. Run: cd web && npm run build"}, status_code=404)
         chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
         gated = bool(getattr(app.state, "auth_required", False))
-        token_js = "" if gated else f'window.__HERMES_SESSION_TOKEN__="{_SESSION_TOKEN}";'
+        token_js = "" if gated else f"window.__HERMES_SESSION_TOKEN__={json.dumps(_web_server._SESSION_TOKEN)};"
         bootstrap_script = (
             f"<script>{token_js}"
             f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5110,6 +5110,32 @@ class TestHeadlessServeTokenPage:
         assert _json.loads(match.group(1)) == ws._SESSION_TOKEN
         assert "window.__HERMES_AUTH_REQUIRED__=false" in resp.text
 
+    def test_root_reflects_ssh_token_applied_after_mount(self, monkeypatch):
+        """Desktop SSH applies the spawn token after mount_spa imported.
+
+        ``from web_server import _SESSION_TOKEN`` used to freeze the import-time
+        / .env token into the ``/`` handler. Desktop then scraped that stale
+        value, ``/api/profiles`` 401'd against the live token, and the UI said
+        SSH connection failed.
+        """
+        import json as _json
+        import re
+
+        client, ws = self._headless_client(monkeypatch, gated=False)
+        original = ws._SESSION_TOKEN
+        applied = "ab" * 32
+        try:
+            ws._apply_ssh_session_token(applied)
+            resp = client.get("/")
+            match = re.search(
+                r'window\.__HERMES_SESSION_TOKEN__\s*=\s*("(?:\\.|[^"\\])*")',
+                resp.text,
+            )
+            assert match, resp.text
+            assert _json.loads(match.group(1)) == applied
+        finally:
+            ws._SESSION_TOKEN = original
+
     def test_root_stays_404_json_when_auth_gated(self, monkeypatch):
         client, ws = self._headless_client(monkeypatch, gated=True)
         resp = client.get("/")


### PR DESCRIPTION
## Bug Description

Desktop SSH Isolated reports "SSH connection failed" after OpenSSH and `HERMES_BACKEND_READY` already succeeded. The renderer then 401s `GET /api/profiles` (`refreshProfiles`) because it adopted a stale token from `/`.

Fixes #103366
Related: #102930

## Root Cause

`mount_spa()` did `from hermes_cli.web_server import _SESSION_TOKEN`, freezing the import-time / `.env` `HERMES_DASHBOARD_SESSION_TOKEN` into the headless `/` handler and `_serve_index`. `start_server()` later applies `--ssh-session-token-file` onto the module global that `_has_valid_session_token` reads. Desktop `adoptServedDashboardToken` scrapes `/` and sends the HTML token; API auth wants the spawn token.

## Fix

- Read `hermes_cli.web_server._SESSION_TOKEN` per request (module late-bind).
- Do not use `web_deps._server()` / `get_session_token()` from in-tree code (PLUGIN-COMPAT, `check_compat_pointers.py`).
- SPA bootstrap uses `json.dumps` so the token is a valid JS string.

## How to Verify

1. `hermes serve --isolated --ssh-session-token-file <64-hex>` then `GET /` must inject that 64-hex token, not the `.env` token.
2. `GET /api/profiles` with `X-Hermes-Session-Token: <spawn token>` returns 200.
3. Desktop SSH reconnect no longer 401s `refreshProfiles`.

## Test Plan

- [x] Added `TestHeadlessServeTokenPage.test_root_reflects_ssh_token_applied_after_mount` (mount, `_apply_ssh_session_token`, `GET /` equals the new token)
- [ ] Existing tests still pass
- [x] Manual Isolated check: HTML token == token that authenticates `/api/profiles`

## Risk Assessment

Low. Token injection is the existing handshake. Gated mode still omits the token. Isolated `auth_required` is unchanged.
