### PR TITLE
feat(desktop): show purple status for subagents and background work

### DIFF
--- a/apps/desktop/DESIGN.md
+++ b/apps/desktop/DESIGN.md
@@ -102,6 +102,14 @@ for call-site shadow or border inventions.
 Never hardcode `border-gray-*`, `bg-white`, `text-black`, etc. The white tile in
 `BrandMark` is the one sanctioned literal (the mark needs a fixed backdrop).
 
+Session status dots share one resolver and primitive across the sidebar, pane
+tabs, and switcher. Active subagents use filled `--ui-purple` with a localized
+active count in the tooltip and accessible label; queued children count as
+active. This takes priority over the parent turn's dot, but never over amber
+needs-input. The parent's running arc remains independent. Background terminal
+processes use the same filled purple dot when no subagents or parent turn own it;
+their tooltip and accessible label still identify background work.
+
 ## Buttons — one component
 
 `src/components/ui/button.tsx` is the single source. Pick a `variant` + `size`;

--- a/apps/desktop/e2e/sidebar-states.spec.ts
+++ b/apps/desktop/e2e/sidebar-states.spec.ts
@@ -25,6 +25,8 @@ import {
 
 /** Background-running dot aria-label (from i18n en.ts). */
 const BG_DOT_LABEL = 'Background task running'
+/** Active-child dot aria-label (one child in this scenario). */
+const SUBAGENT_DOT_LABEL = '1 subagent active'
 /** Foreground turn-running dot aria-label. */
 const SESSION_RUNNING_DOT_LABEL = 'Session running'
 /** Finished-unread dot aria-label. */
@@ -143,13 +145,17 @@ test.describe('sidebar states — subagent and background dot coexist', () => {
     restartMockServer()
     fixture = await setupMockBackend({
       extraConfig: DISABLE_AUTO_TITLE,
-      mockServer: { backgroundReleasePath: bgRelease.path },
+      mockServer: {
+        backgroundReleasePath: bgRelease.path,
+        holdFirstCompletionContaining: 'Testing that the background dot updates across sessions.',
+      },
     })
     await waitForAppReady(fixture, 120_000)
   })
 
   test.afterAll(async () => {
     bgRelease.release()
+    fixture?.mock.releaseHeldStream()
     await fixture?.cleanup()
     bgRelease.cleanup()
   })
@@ -171,11 +177,20 @@ test.describe('sidebar states — subagent and background dot coexist', () => {
       { timeout: 15_000 },
     )
 
-    // While the turn is busy the dot-state priority paints the session as
-    // "working" ('Session running') — that claim OUTRANKS 'background', so
-    // polling for the bg dot mid-turn races the turn length against the poll
-    // budget. Wait for the turn to END (final text + running dot cleared),
-    // then assert the background dot as a stable, sentinel-held state.
+    // Hold the child's mock-model response so queued/running state is stable.
+    // The violet dot owns the status mark while the parent's live turn keeps
+    // its arc independently.
+    await fixture.mock.waitForHeldCompletion()
+    const subagentDot = page.locator(`[aria-label="${SUBAGENT_DOT_LABEL}"]`)
+    await expect(subagentDot).toBeVisible()
+    await expect(subagentDot).toHaveAttribute('title', SUBAGENT_DOT_LABEL)
+    await expect(subagentDot).toHaveClass(/bg-\(--ui-purple\)/)
+    await expect(page.locator('.arc-row')).toBeVisible()
+    await page.screenshot({ path: 'test-results/violet-subagent-dot-with-running-arc.png' })
+    fixture.mock.releaseHeldStream()
+
+    // Wait for the turn to END (final text + running arc cleared), then assert
+    // the background dot as a stable, sentinel-held state.
     await page.waitForFunction(
       (text) => (document.body.textContent ?? '').includes(text),
       SIDEBAR_CROSS_TEXTS.finalText,
@@ -199,6 +214,8 @@ test.describe('sidebar states — subagent and background dot coexist', () => {
       .toBeGreaterThan(0)
 
     // Evidence: the background dot is visible while the process runs.
+    await expect(page.locator(`[aria-label="${BG_DOT_LABEL}"]`)).toHaveClass(/bg-\(--ui-purple\)/)
+    await expect(page.locator('.arc-row')).toHaveCount(0)
     await page.screenshot({ path: 'test-results/bg-dot-while-subagent-runs.png' })
 
     // Release the process; the dot should clear on the completion event —

--- a/apps/desktop/src/app/chat/session-status-dot.test.tsx
+++ b/apps/desktop/src/app/chat/session-status-dot.test.tsx
@@ -1,0 +1,67 @@
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { I18nProvider, TRANSLATIONS } from '@/i18n'
+import { LOCALE_OPTIONS } from '@/i18n/languages'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { setSessions } from '@/store/session'
+import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
+import { $subagentsBySession, upsertSubagent } from '@/store/subagents'
+import type { SessionInfo } from '@/types/hermes'
+
+import { sessionDotClassName, SessionStatusDot } from './session-status-dot'
+
+const session = {
+  id: 'stored-1',
+  message_count: 1,
+  source: 'cli',
+  started_at: 0,
+  title: 'Parent session'
+} as SessionInfo
+
+afterEach(() => {
+  cleanup()
+  clearAllSessionStates()
+  $subagentsBySession.set({})
+  setSessions([])
+})
+
+describe('SessionStatusDot subagent state', () => {
+  it('uses the same filled activity mark for background processes and subagents', () => {
+    expect(sessionDotClassName('background')).toBe(sessionDotClassName('subagents'))
+  })
+
+  it('renders the violet dot with a localized plural count, then the singular count', () => {
+    setSessions([session])
+    publishSessionState('runtime-1', { ...createClientSessionState('stored-1'), busy: false })
+    upsertSubagent('runtime-1', { goal: 'first', status: 'running', subagent_id: 'a', task_index: 0 })
+    upsertSubagent('runtime-1', { goal: 'second', status: 'queued', subagent_id: 'b', task_index: 1 })
+
+    render(
+      <I18nProvider configClient={null} initialLocale="en">
+        <SessionStatusDot session={session} storedSessionId="stored-1" />
+      </I18nProvider>
+    )
+
+    const plural = screen.getByRole('status', { name: '2 subagents active' })
+    expect(plural.getAttribute('title')).toBe('2 subagents active')
+    expect(plural.classList.contains('bg-(--ui-purple)')).toBe(true)
+
+    act(() => {
+      upsertSubagent('runtime-1', { status: 'completed', subagent_id: 'a', task_index: 0 }, false, 'subagent.complete')
+    })
+
+    const singular = screen.getByRole('status', { name: '1 subagent active' })
+    expect(singular.getAttribute('title')).toBe('1 subagent active')
+  })
+
+  it('provides count-aware copy in every supported locale', () => {
+    for (const { id } of LOCALE_OPTIONS) {
+      const activeSubagents = TRANSLATIONS[id].sidebar.row.activeSubagents
+
+      expect(activeSubagents(1), id).not.toBe('')
+      expect(activeSubagents(2), id).not.toBe('')
+      expect(activeSubagents(1), id).not.toBe(activeSubagents(2))
+    }
+  })
+})

--- a/apps/desktop/src/app/chat/session-status-dot.tsx
+++ b/apps/desktop/src/app/chat/session-status-dot.tsx
@@ -4,23 +4,23 @@ import { type Translations, useI18n } from '@/i18n'
 import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
 import { $sessionColorById, sessionColorFor } from '@/store/session-color'
-import { $sessionDotStateById, type SessionDotState } from '@/store/session-dot-state'
+import { $activeSubagentCountBySessionId, $sessionDotStateById, type SessionDotState } from '@/store/session-dot-state'
 import type { SessionInfo } from '@/types/hermes'
 
 // A pure lookup table: each state maps to its className, aria-label, and title.
 // No priority resolution here — $sessionDotStateById already picked one.
 // Label/title resolve from sidebar.row translations, keyed by name.
 type DotVariant = {
-  ariaLabel?: (r: Translations['sidebar']['row']) => string
+  ariaLabel?: (r: Translations['sidebar']['row'], activeSubagents: number) => string
   className: string
   role?: 'status'
-  title?: (r: Translations['sidebar']['row']) => string
+  title?: (r: Translations['sidebar']['row'], activeSubagents: number) => string
 }
 
 // Shared base for every active dot; idle is smaller and uses its own class.
 const DOT_BASE = 'size-1.5 rounded-full'
 
-// Three colors and one fill/hollow axis, none of it moving. Motion on a 6px
+// Semantic colors and one fill/hollow axis, none of it moving. Motion on a 6px
 // circle can only say "something is happening" — which the row's arc already
 // says, better — while costing a repaint per frame on every row at once. What
 // the dot is for is telling states APART, and that is a job for color and fill:
@@ -50,12 +50,19 @@ const DOT_VARIANTS: Record<SessionDotState, DotVariant> = {
     role: 'status',
     title: r => r.sessionRunning
   },
-  // Hollow muted — a terminal(background=true) process outlived the turn. An
-  // outline reads as "still open" without claiming the model is working; a
-  // filled grey dot read as finished, the opposite of what this means.
+  // Violet — queued/running children. It owns the dot even while the parent
+  // turn is live; the row arc continues to describe that parent independently.
+  subagents: {
+    ariaLabel: (r, count) => r.activeSubagents(count),
+    className: `${DOT_BASE} bg-(--ui-purple)`,
+    role: 'status',
+    title: (r, count) => r.activeSubagents(count)
+  },
+  // Violet — background processes and subagents both mean work is ongoing.
+  // Their labels retain the distinction without using different visual marks.
   background: {
     ariaLabel: r => r.backgroundRunning,
-    className: `${DOT_BASE} border border-(--ui-text-tertiary)`,
+    className: `${DOT_BASE} bg-(--ui-purple)`,
     role: 'status',
     title: r => r.backgroundRunning
   },
@@ -69,10 +76,7 @@ const DOT_VARIANTS: Record<SessionDotState, DotVariant> = {
     role: 'status',
     title: r => r.finishedUnread
   },
-  // Hollow grey, the faintest ink the app has — nothing has ever run here. It
-  // shares the outline with `background` because both mean "open, not
-  // producing", and sits a shade dimmer because a draft is the one state that
-  // has yet to do anything at all.
+  // Hollow grey, the faintest ink the app has — nothing has ever run here.
   draft: {
     ariaLabel: r => r.draftSession,
     className: `${DOT_BASE} border border-(--ui-text-quaternary)`,
@@ -137,6 +141,10 @@ export function SessionStatusDot({ storedSessionId, session, branchStem, classNa
     storedSessionId ? (states[storedSessionId] ?? 'idle') : 'draft'
   )
 
+  const activeSubagents = useStoreSelector($activeSubagentCountBySessionId, counts =>
+    storedSessionId ? (counts[storedSessionId] ?? 0) : 0
+  )
+
   const variant = DOT_VARIANTS[dotState]
 
   return (
@@ -153,10 +161,10 @@ export function SessionStatusDot({ storedSessionId, session, branchStem, classNa
         <span aria-hidden="true" className={variant.className} style={color ? { backgroundColor: color } : undefined} />
       ) : (
         <span
-          aria-label={variant.ariaLabel?.(r)}
+          aria-label={variant.ariaLabel?.(r, activeSubagents)}
           className={variant.className}
           role={variant.role}
-          title={variant.title?.(r)}
+          title={variant.title?.(r, activeSubagents)}
         />
       )}
     </span>

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -28,7 +28,7 @@ import { $sidebarRowMeta } from '@/store/layout'
 import { normalizeProfileKey } from '@/store/profile'
 import { $projects } from '@/store/projects'
 import { $pullRequestsByBranch, sessionPrKey } from '@/store/pull-requests'
-import { $sessionDotStateById, hasLiveTurn, showsRunningArc } from '@/store/session-dot-state'
+import { $sessionLiveTurnStateById, hasLiveTurn, showsRunningArc } from '@/store/session-dot-state'
 import { $sessionListDensity } from '@/store/session-list-density'
 import { $openStoredSessionIds } from '@/store/session-states'
 import { sessionCostUsd } from '@/store/sidebar-archive'
@@ -252,11 +252,11 @@ function SidebarSessionRowImpl({
   // Telegram thread continued here still reads as Telegram.
   const handoffSource = handoffOriginSource(session.handoff_state, session.handoff_platform)
   const handoffLabel = handoffSource ? (sessionSourceLabel(handoffSource) ?? handoffSource) : null
-  // The same resolved state the row's dot paints, so the arc and the dot cannot
-  // contradict each other. A selector, not a plain useStore: the map is rebuilt
-  // whenever any session's status changes, but a row only repaints on its own.
-  const dotState = useStoreSelector($sessionDotStateById, states => states[session.id] ?? 'idle')
-  const liveTurn = hasLiveTurn(dotState)
+  // Child activity may own the dot while the parent remains live, so the arc
+  // reads the independent parent-turn projection. Selectors keep unrelated
+  // session changes from repainting this row.
+  const liveTurnState = useStoreSelector($sessionLiveTurnStateById, states => states[session.id])
+  const liveTurn = hasLiveTurn(liveTurnState)
 
   // Card header line: the workspace this belongs to — the project when it
   // resolves (same function the session color reads, so name and tint agree;
@@ -402,7 +402,7 @@ function SidebarSessionRowImpl({
         style={style}
         {...rest}
       >
-        {showsRunningArc(dotState) && <span aria-hidden="true" className="arc-border arc-row" />}
+        {showsRunningArc(liveTurnState) && <span aria-hidden="true" className="arc-border arc-row" />}
         <SidebarRowBody
           // Every trailing figure lives in the actions slot, which the row
           // measures — so the title needs a gap from it and nothing else. Hover

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -27,7 +27,7 @@ import {
   toggleWorkspaceNodeCollapsed
 } from '@/store/layout'
 import { sessionPinId } from '@/store/session'
-import { $sessionDotStateById, hasLiveTurn } from '@/store/session-dot-state'
+import { $sessionLiveTurnStateById, hasLiveTurn } from '@/store/session-dot-state'
 
 import { SidebarDateDivider, SidebarSectionMeta } from './chrome'
 import { mergeVisibleReorder, orderRowsWithinGroups, reorderableRowIds } from './order'
@@ -228,7 +228,7 @@ export function SidebarSessionsSection({
   const { t } = useI18n()
   const dividerLabels = t.sidebar.dateDivider
   const statusDividerLabels = t.sidebar.statusDivider
-  const dotStates = useStore($sessionDotStateById)
+  const liveTurnStates = useStore($sessionLiveTurnStateById)
   const nodeOpen = useStore($sidebarWorkspaceNodeOpen)
   const isListGroupOpen = useCallback((key: string) => nodeOpen[listGroupNodeId(key)] ?? true, [nodeOpen])
   const sectionOpen = collapsible ? open : true
@@ -396,13 +396,13 @@ export function SidebarSessionsSection({
         : grouping === 'status'
           ? groupEntriesByStatus(
               displayEntries,
-              entry => hasLiveTurn(dotStates[entry.session.id] ?? 'idle'),
+              entry => hasLiveTurn(liveTurnStates[entry.session.id]),
               statusDividerLabels
             )
           : toSessionRows(displayEntries)
 
     return manualOrderIds?.length ? orderRowsWithinGroups(rows, manualOrderIds) : rows
-  }, [grouping, displayEntries, dotStates, manualOrderIds, statusDividerLabels])
+  }, [grouping, displayEntries, liveTurnStates, manualOrderIds, statusDividerLabels])
 
   // Closed date/status buckets keep their divider and drop the sessions under
   // it. Same array when nothing is collapsed so the virtualizer's rows ref

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1810,6 +1810,7 @@ export const ar = defineLocale({
       needsInput: 'تحتاج إدخالا',
       waitingForAnswer: 'بانتظار إجابة',
       backgroundRunning: 'تعمل في الخلفية',
+      activeSubagents: count => (count === 1 ? 'وكيل فرعي واحد نشط' : `${count} وكلاء فرعيون نشطون`),
       draftSession: 'مسودة — لم تُرسل بعد',
       finishedUnread: 'اكتملت وفيها جديد',
       hideTabBar: 'إخفاء شريط التبويبات',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2450,6 +2450,7 @@ export const en: Translations = {
       waitingForAnswer: 'Waiting for your answer',
       finishedUnread: 'Finished — unread',
       backgroundRunning: 'Background task running',
+      activeSubagents: count => `${count} subagent${count === 1 ? '' : 's'} active`,
       draftSession: 'Draft — nothing sent yet',
       handoffOrigin: platform => `Handed off from ${platform}`,
       ownedByProfile: profile => `Profile: ${profile}`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2116,6 +2116,7 @@ export const ja = defineLocale({
       waitingForAnswer: '回答を待っています',
       finishedUnread: '完了 — 未読',
       backgroundRunning: 'バックグラウンドタスク実行中',
+      activeSubagents: count => `サブエージェント ${count} 件が実行中`,
       draftSession: '下書き — 未送信',
       handoffOrigin: platform => `${platform} から引き継ぎ`,
       ownedByProfile: profile => `プロファイル: ${profile}`,

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -2487,6 +2487,8 @@ export const ru = defineLocale({
       waitingForAnswer: 'Ждёт вашего ответа',
       finishedUnread: 'Завершён — не прочитан',
       backgroundRunning: 'Фоновая задача выполняется',
+      activeSubagents: count =>
+        `${count} ${RU_PLURAL(count, 'активный субагент', 'активных субагента', 'активных субагентов')}`,
       draftSession: 'Черновик — ещё ничего не отправлено',
       handoffOrigin: platform => `Передано из ${platform}`,
       ownedByProfile: profile => `Профиль: ${profile}`,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2094,6 +2094,7 @@ export interface Translations {
       waitingForAnswer: string
       finishedUnread: string
       backgroundRunning: string
+      activeSubagents: (count: number) => string
       draftSession: string
       handoffOrigin: (platform: string) => string
       ownedByProfile: (profile: string) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2037,6 +2037,7 @@ export const zhHant = defineLocale({
       waitingForAnswer: '等待您的回答',
       finishedUnread: '已完成 — 未讀',
       backgroundRunning: '背景任務執行中',
+      activeSubagents: count => `${count} 個子代理正在執行`,
       draftSession: '草稿 — 尚未傳送',
       handoffOrigin: platform => `從 ${platform} 轉接`,
       ownedByProfile: profile => `設定檔：${profile}`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2615,6 +2615,7 @@ export const zh: Translations = {
       waitingForAnswer: '正在等待你的回答',
       finishedUnread: '已完成 — 未读',
       backgroundRunning: '后台任务运行中',
+      activeSubagents: count => `${count} 个子代理正在运行`,
       draftSession: '草稿 — 尚未发送',
       handoffOrigin: platform => `从 ${platform} 转接`,
       ownedByProfile: profile => `配置档：${profile}`,

--- a/apps/desktop/src/store/session-dot-state.test.ts
+++ b/apps/desktop/src/store/session-dot-state.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import type { SessionInfo } from '@/types/hermes'
 
+import { $backgroundStatusBySession } from './composer-status'
 import {
   $cronSessions,
   $messagingSessions,
@@ -14,8 +15,10 @@ import {
   setSessions
 } from './session'
 import {
+  $activeSubagentCountBySessionId,
   $delegatingSessionIds,
   $sessionDotStateById,
+  $sessionLiveTurnStateById,
   $unreadSessionCount,
   hasLiveTurn,
   showsRunningArc,
@@ -23,7 +26,7 @@ import {
 } from './session-dot-state'
 import { clearAllSessionStates, publishSessionState } from './session-states'
 import { $unreadWriteGuard } from './session-unread-remote'
-import { $subagentsBySession, type SubagentProgress } from './subagents'
+import { $subagentsBySession, type SubagentProgress, upsertSubagent } from './subagents'
 
 describe('showsRunningArc', () => {
   it('keeps the arc when an authoritative turn goes quiet', () => {
@@ -60,8 +63,8 @@ describe('hasLiveTurn', () => {
 })
 
 describe('$delegatingSessionIds', () => {
-  const subagent = (status: SubagentProgress['status']): SubagentProgress => ({
-    id: 'sub-1',
+  const subagent = (status: SubagentProgress['status'], id = 'sub-1'): SubagentProgress => ({
+    id,
     parentId: null,
     goal: 'do a thing',
     status,
@@ -76,6 +79,7 @@ describe('$delegatingSessionIds', () => {
 
   afterEach(() => {
     clearAllSessionStates()
+    $backgroundStatusBySession.set({})
     $subagentsBySession.set({})
     $sessions.set([])
   })
@@ -99,6 +103,67 @@ describe('$delegatingSessionIds', () => {
     $subagentsBySession.set({ 'runtime-fresh': [subagent('queued')] })
 
     expect($delegatingSessionIds.get()).toContain('runtime-fresh')
+  })
+
+  it('keeps a violet subagent claim while any queued or running child remains', () => {
+    publishSessionState('runtime-1', { ...createClientSessionState('stored-1'), busy: false })
+    upsertSubagent('runtime-1', { goal: 'first', status: 'running', subagent_id: 'a', task_index: 0 })
+    upsertSubagent('runtime-1', { goal: 'second', status: 'queued', subagent_id: 'b', task_index: 1 })
+
+    expect($activeSubagentCountBySessionId.get()['stored-1']).toBe(2)
+    expect($sessionDotStateById.get()['stored-1']).toBe('subagents')
+
+    upsertSubagent('runtime-1', { status: 'completed', subagent_id: 'a', task_index: 0 }, false, 'subagent.complete')
+    expect($activeSubagentCountBySessionId.get()['stored-1']).toBe(1)
+    expect($sessionDotStateById.get()['stored-1']).toBe('subagents')
+
+    upsertSubagent('runtime-1', { status: 'error', subagent_id: 'b', task_index: 1 }, false, 'subagent.complete')
+    expect($activeSubagentCountBySessionId.get()['stored-1']).toBeUndefined()
+    expect($sessionDotStateById.get()['stored-1']).not.toBe('subagents')
+  })
+
+  it('publishes the active count under every stored lineage alias', () => {
+    setSessions([
+      storedRow('tip', {
+        _lineage_ids: ['root', 'middle', 'tip'],
+        _lineage_root_id: 'root'
+      })
+    ])
+    publishSessionState('runtime-1', { ...createClientSessionState('tip'), busy: false })
+    $subagentsBySession.set({ 'runtime-1': [subagent('running', 'child')] })
+
+    expect($activeSubagentCountBySessionId.get()).toMatchObject({ root: 1, middle: 1, tip: 1 })
+    expect($sessionDotStateById.get()).toMatchObject({ root: 'subagents', middle: 'subagents', tip: 'subagents' })
+  })
+
+  it('lets needs-input outrank subagents without hiding a concurrent parent turn', () => {
+    publishSessionState('runtime-1', { ...createClientSessionState('stored-1'), busy: true })
+    $subagentsBySession.set({ 'runtime-1': [subagent('running')] })
+
+    expect($sessionDotStateById.get()['stored-1']).toBe('subagents')
+    expect($sessionLiveTurnStateById.get()['stored-1']).toBe('working')
+    expect(showsRunningArc($sessionLiveTurnStateById.get()['stored-1'])).toBe(true)
+
+    publishSessionState('runtime-1', { ...createClientSessionState('stored-1'), busy: true, needsInput: true })
+
+    expect($sessionDotStateById.get()['stored-1']).toBe('needs-input')
+    expect($sessionLiveTurnStateById.get()['stored-1']).toBe('needs-input')
+    expect(showsRunningArc($sessionLiveTurnStateById.get()['stored-1'])).toBe(false)
+  })
+
+  it('restores the background terminal state after the last child finishes', () => {
+    publishSessionState('runtime-1', { ...createClientSessionState('stored-1'), busy: false })
+    $backgroundStatusBySession.set({
+      'runtime-1': [{ id: 'job-1', state: 'running', title: 'sleep', type: 'background' }]
+    })
+
+    expect($sessionDotStateById.get()['stored-1']).toBe('background')
+
+    upsertSubagent('runtime-1', { goal: 'child', status: 'running', subagent_id: 'a', task_index: 0 })
+    expect($sessionDotStateById.get()['stored-1']).toBe('subagents')
+
+    upsertSubagent('runtime-1', { status: 'completed', subagent_id: 'a', task_index: 0 }, false, 'subagent.complete')
+    expect($sessionDotStateById.get()['stored-1']).toBe('background')
   })
 })
 

--- a/apps/desktop/src/store/session-dot-state.ts
+++ b/apps/desktop/src/store/session-dot-state.ts
@@ -37,54 +37,72 @@ import {
   $workingSessionIds
 } from './session-states'
 import { $unreadWriteGuard, UNREAD_WRITE_GUARD_MS } from './session-unread-remote'
-import { $subagentsBySession, activeSubagentCount } from './subagents'
+import { $subagentsBySession } from './subagents'
 
-// Sessions parked in async delegation: the parent turn has ended (busy=false —
-// delegate_task(background=true) returns its handle the moment the children
-// are spawned) while those subagents keep working for minutes. Without this
-// input the sidebar row dropped to a plain idle dot mid-delegation, reading as
-// "done" while work was still running in child sessions. Same runtime→stored
-// bridge and fresh-chat fallback as $backgroundRunningSessionIds:
-// $subagentsBySession is keyed by runtime id, surfaces key on stored ids, and
-// lineageAliases covers whichever tip of the conversation a surface holds.
-let delegatingIds: readonly string[] = []
-export const $delegatingSessionIds = computed(
+// Active subagent count under every id a conversation answers to. The store is
+// keyed by runtime id while surfaces use stored ids; compression can rotate the
+// stored tip again. Deduplicating by child id also prevents a runtime/stored
+// overlap during re-keying from briefly double-counting the same child.
+let activeSubagentCounts: Readonly<Record<string, number>> = {}
+export const $activeSubagentCountBySessionId = computed(
   [$subagentsBySession, $sessionStates, $sessions],
   (bySession, states, sessions) => {
-    const ids = new Set<string>()
+    const idsByAlias = new Map<string, Set<string>>()
 
     for (const [runtimeId, items] of Object.entries(bySession)) {
-      if (activeSubagentCount(items) === 0) {
+      const active = items.filter(item => item.status === 'queued' || item.status === 'running')
+
+      if (!active.length) {
         continue
       }
 
       for (const alias of lineageAliases(states[runtimeId]?.storedSessionId ?? runtimeId, sessions)) {
-        ids.add(alias)
+        const ids = idsByAlias.get(alias) ?? new Set<string>()
+
+        for (const item of active) {
+          ids.add(item.id)
+        }
+
+        idsByAlias.set(alias, ids)
       }
     }
 
-    return (delegatingIds = stableArray(delegatingIds, [...ids]))
+    const next = Object.fromEntries([...idsByAlias].map(([id, childIds]) => [id, childIds.size]))
+
+    return (activeSubagentCounts = stableRecord(activeSubagentCounts, next))
   }
 )
 
-export type SessionDotState = 'background' | 'draft' | 'idle' | 'needs-input' | 'stalled' | 'unread' | 'working'
+// Sessions parked in async delegation: the parent turn has ended while its
+// children keep working. Kept as the membership view for existing consumers;
+// the count map above is the authoritative projection.
+let delegatingIds: readonly string[] = []
+export const $delegatingSessionIds = computed(
+  $activeSubagentCountBySessionId,
+  counts => (delegatingIds = stableArray(delegatingIds, Object.keys(counts)))
+)
+
+export type SessionDotState =
+  'background' | 'draft' | 'idle' | 'needs-input' | 'stalled' | 'subagents' | 'unread' | 'working'
+
+export type SessionLiveTurnState = Extract<SessionDotState, 'needs-input' | 'stalled' | 'working'>
 
 /** The sidebar row's arc. A quiet turn is still authoritatively running, so
  *  `stalled` keeps it; a blocking prompt drops it, because the amber dot is the
  *  louder cue and two treatments at once fight each other. */
-export const showsRunningArc = (state: SessionDotState): boolean => state === 'stalled' || state === 'working'
+export const showsRunningArc = (state?: SessionDotState): boolean => state === 'stalled' || state === 'working'
 
 /** Whether this turn is the session's own, live: brighter title, and the row's
  *  age yields to the actions menu. Wider than the arc — a turn waiting on an
  *  answer has not ended. */
-export const hasLiveTurn = (state: SessionDotState): boolean => showsRunningArc(state) || state === 'needs-input'
+export const hasLiveTurn = (state?: SessionDotState): boolean => showsRunningArc(state) || state === 'needs-input'
 
 /** The buckets the sidebar's status filter and ordering work in. `stalled` and
  *  `background` fold into the state a user would name them. */
 export type SessionStatusBucket = 'draft' | 'idle' | 'needs-input' | 'unread' | 'working'
 
 export const sessionStatusBucket = (state: SessionDotState = 'idle'): SessionStatusBucket =>
-  state === 'stalled' || state === 'background' ? 'working' : state
+  state === 'stalled' || state === 'background' || state === 'subagents' ? 'working' : state
 
 const STATUS_RANK: Record<SessionStatusBucket, number> = {
   'needs-input': 0,
@@ -99,19 +117,46 @@ export const sessionStatusRank = (state?: SessionDotState): number => STATUS_RAN
 
 let dotStates: Readonly<Record<string, SessionDotState>> = {}
 
+// The dot may deliberately describe child activity while the parent's own turn
+// is still live. Keep that turn signal independently so the row arc, brighter
+// title, and status grouping do not disappear behind the violet child dot.
+let liveTurnStates: Readonly<Record<string, SessionLiveTurnState>> = {}
+export const $sessionLiveTurnStateById = computed(
+  [$attentionSessionIds, $workingSessionIds, $stalledSessionIds],
+  (attention, working, stalled) => {
+    const next: Record<string, SessionLiveTurnState> = {}
+
+    for (const id of working) {
+      next[id] = 'working'
+    }
+
+    for (const id of stalled) {
+      if (next[id] === 'working') {
+        next[id] = 'stalled'
+      }
+    }
+
+    for (const id of attention) {
+      next[id] = 'needs-input'
+    }
+
+    return (liveTurnStates = stableRecord(liveTurnStates, next))
+  }
+)
+
 export const $sessionDotStateById = computed(
   [
     $attentionSessionIds,
     $workingSessionIds,
     $stalledSessionIds,
     $backgroundRunningSessionIds,
-    $delegatingSessionIds,
+    $activeSubagentCountBySessionId,
     $unreadFinishedSessionIds,
     $draftSessionIds,
     $sessions,
     $unreadWriteGuard
   ],
-  (attention, working, stalled, background, delegating, unread, draft, sessions, unreadWriteGuard) => {
+  (attention, working, stalled, background, activeSubagents, unread, draft, sessions, unreadWriteGuard) => {
     const next: Record<string, SessionDotState> = {}
 
     const claim = (ids: readonly string[], state: SessionDotState) => {
@@ -158,11 +203,6 @@ export const $sessionDotStateById = computed(
     claim(persistedUnread, 'unread')
 
     claim(background, 'background')
-    // Async delegation: the parent turn has ended but its subagents are still
-    // running, so the session's work continues in child sessions. Same visual
-    // claim as background processes — and it yields to `working` below the
-    // moment the parent turn itself is live (synchronous orchestrator children).
-    claim(delegating, 'background')
     claim(working, 'working')
 
     // Stalled REFINES working rather than rivalling it — the turn is still
@@ -177,6 +217,9 @@ export const $sessionDotStateById = computed(
       }
     }
 
+    // Child work owns the dot even while the parent is working; the separate
+    // live-turn map above preserves the parent's arc and row semantics.
+    claim(Object.keys(activeSubagents), 'subagents')
     claim(attention, 'needs-input')
 
     return (dotStates = stableRecord(dotStates, next))


### PR DESCRIPTION
## What does this PR do?

Make ongoing subagent and terminal background work visible with a filled purple session-status dot across the sidebar, pane tabs, and session switcher.

Motivated by our Astra usage, which involves frequent background work and subagent delegation: a quiet parent chat should not look finished while its children are still working. This is model-independent and uses existing Desktop state and the existing `--ui-purple` design token.

Queued/running children get a localized active count in the tooltip and accessible label. Terminal background work uses the same filled purple mark with its existing background-task label. Amber needs-input remains highest priority. The parent's running arc and live-turn behavior remain independent, so child-only activity does not pretend the parent model is running.

## Related Issue / prior-art check

No issue claimed as fixed. Searched open, closed, and merged PRs and issues before submission.

Related: #87915 addresses delegation lifecycle/rehydration and proposes treating the parent as working; this PR is a narrower visual treatment and deliberately preserves the distinction between child activity and a live parent turn. #50735 covers broader unread/badge visibility. This does not implement reconnect hydration or claim to fix stale subagent lifecycle state.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `apps/desktop/src/store/session-dot-state.ts`: count active children across stored/runtime lineage aliases; resolve a distinct `subagents` state; retain a stable independent parent-turn projection.
- `apps/desktop/src/app/chat/session-status-dot.tsx`: render filled purple for subagents and background processes; provide count-aware labels through the shared primitive.
- Sidebar row/grouping consumers preserve existing parent live-turn semantics.
- Add count copy to all six supported locales and document the visual contract in `apps/desktop/DESIGN.md`.
- Add lifecycle, priority, lineage, locale, and shared-style regression coverage; extend the existing Electron sidebar test with a held child response, purple-dot assertions, and independent parent-arc checks.
- No backend, core tool/schema, dependency, configuration, or prompt-cache changes.

## How to Test

1. Run the Desktop dev app and ask for multiple parallel subagents. While any child is queued/running, the parent session shows purple; hover to inspect the active count.
2. Let children finish one by one: the count decreases and the child claim clears after the last one. If the parent is still running, its own arc remains visible; an input request overrides the dot with amber.
3. Run a long-lived background terminal command. After the parent and children finish, the remaining background task still shows filled purple with the background-task label. When it finishes, normal unread/idle behavior resumes.

Tested on Linux with the real Electron app. Automated E2E uses the real backend/delegation path with a mock inference server and isolated test state, not paid provider calls.

## Verification

After updating the branch onto upstream `79445a496c`:

- `npm test` in `apps/desktop`: **872 test files passed, 2 skipped; 9,343 tests passed, 6 skipped**.
- `npm run typecheck`: passed (renderer, Electron, E2E).
- `npm run lint`: passed, 0 errors; 124 existing warnings.
- `npm run build`: passed.
- `npx playwright test e2e/sidebar-states.spec.ts --reporter=list`: **3 passed**.
- `git diff --check`: passed.
- Independent read-only code review: no actionable security or logic findings.

The previous unrelated listing-tooltip guard failure is resolved by the latest upstream; no workaround or unrelated fix is included here. Python-only tests were not run for this Desktop-only change.

## Checklist

- [x] Read `CONTRIBUTING.md`, root and Desktop `AGENTS.md`, and Desktop design guidance.
- [x] Conventional commit and focused feature diff.
- [x] Searched existing PRs; overlap and scope noted above.
- [x] Added regression coverage and exercised the live Desktop UI.
- [x] Updated documentation and every supported locale.
- [x] Considered cross-platform impact: renderer-only behavior, existing tokens and APIs; Linux tested, macOS/Windows not exercised locally.
- [x] Config examples, tool schemas, and new-skill documentation: N/A.
