### PR TITLE
fix(state): self-heal pre-v3 telegram topic tables on read

### DIFF
--- a/hermes_state_telegram.py
+++ b/hermes_state_telegram.py
@@ -97,8 +97,8 @@ _UNLINKED_SCOPE_CLAUSES = """                      AND COALESCE(NULLIF(TRIM(s.pr
 
 class SessionTelegramTopicsMixin:
     """Telegram DM topic-mode tables, bindings and lookups. Read paths tolerate absent
-    tables (nobody ran ``/topic``) by returning their empty value; only
-    ``enable``/``bind`` run the migration."""
+    tables (nobody ran ``/topic``) by returning their empty value and never create them;
+    pre-v3 tables left by an upgrade are self-healed on read."""
 
     def _topic_read_one(self, sql: str, params):
         """``fetchone`` that treats an unmigrated table as None. A pre-v3 table left by an
@@ -109,16 +109,31 @@ class SessionTelegramTopicsMixin:
         except sqlite3.OperationalError as exc:
             if "no such column: profile_name" not in str(exc):
                 return None
-            self.apply_telegram_topic_migration()
+            self._heal_pre_v3_topic_tables()
             try:
                 return self._read_one(sql, params)
             except sqlite3.OperationalError:
                 return None
 
+    def _heal_pre_v3_topic_tables(self) -> None:
+        """Heal pre-v3 topic tables left by an upgrade. A failed heal (lock timeout,
+        cross-process race) warns once instead of surfacing through the readers as the
+        silent-return shape they exist to avoid; the next read retries the heal."""
+        try:
+            self.apply_telegram_topic_migration()
+        except sqlite3.Error:
+            if not getattr(self, "_topic_heal_warned", False):
+                self._topic_heal_warned = True
+                logger.warning(
+                    "telegram topic self-heal to v3 failed; reads keep hitting the "
+                    "pre-v3 schema and read as empty until the heal succeeds",
+                    exc_info=True,
+                )
+
     def apply_telegram_topic_migration(self) -> None:
-        """Create Telegram DM topic-mode tables on explicit /topic opt-in. Deliberately NOT
-        part of startup reconciliation: operators can upgrade and keep the old bot
-        behavior until a user runs /topic. Schema versions: v1 initial; v2 session_id FK
+        """Create Telegram DM topic-mode tables on explicit /topic opt-in and self-heal
+        pre-v3 tables on read (#103363); absent tables stay read-only, and startup
+        reconciliation never runs this. Schema versions: v1 initial; v2 session_id FK
         ON DELETE CASCADE (pruning clears bindings); v3 ``profile_name`` on both tables so
         multiplexed gateways sharing one state.db isolate topic state per profile.
 
@@ -131,23 +146,29 @@ class SessionTelegramTopicsMixin:
                 if "profile_name" in have:
                     continue
                 # v1/v2 → v3. SQLite can't ALTER a PK or FK, so rebuild (also supplies v2's
-                # ON DELETE CASCADE). Legacy rows land in "default" only.
+                # ON DELETE CASCADE). Legacy rows land in "default" only. Plain execute()
+                # keeps every statement inside _execute_write's BEGIN IMMEDIATE:
+                # executescript would implicitly commit the open transaction and run each
+                # statement in autocommit, so a crash after the DROP strands legacy rows
+                # in {table}_new (#42004 diagnosed the same shape for v1→v2) and breaks
+                # the whole-callback retry contract.
                 legacy_columns = columns.replace("profile_name, ", "", 1)
-                conn.executescript(f"""
-                    CREATE TABLE {table}_new ({ddl});
-                    INSERT INTO {table}_new ({columns})
-                        SELECT 'default', {legacy_columns} FROM {table};
-                    DROP TABLE {table};
-                    ALTER TABLE {table}_new RENAME TO {table};
-                    """)
+                conn.execute(f"CREATE TABLE {table}_new ({ddl})")
+                conn.execute(
+                    f"INSERT INTO {table}_new ({columns}) "
+                    f"SELECT 'default', {legacy_columns} FROM {table}"
+                )
+                conn.execute(f"DROP TABLE {table}")
+                conn.execute(f"ALTER TABLE {table}_new RENAME TO {table}")
             # Indexes after any rebuild: the user index needs profile_name.
-            conn.executescript("""
-                CREATE UNIQUE INDEX IF NOT EXISTS idx_telegram_dm_topic_bindings_session
-                ON telegram_dm_topic_bindings(session_id);
-
-                CREATE INDEX IF NOT EXISTS idx_telegram_dm_topic_bindings_user
-                ON telegram_dm_topic_bindings(profile_name, user_id, chat_id);
-                """)
+            conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_telegram_dm_topic_bindings_session "
+                "ON telegram_dm_topic_bindings(session_id)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_telegram_dm_topic_bindings_user "
+                "ON telegram_dm_topic_bindings(profile_name, user_id, chat_id)"
+            )
             conn.execute(
                 "INSERT INTO state_meta (key, value) VALUES (?, ?) "
                 "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
@@ -245,7 +266,7 @@ class SessionTelegramTopicsMixin:
             if "no such column: profile_name" not in str(exc):
                 return []
             # Same pre-v3 self-heal as _topic_read_one (issue #103363).
-            self.apply_telegram_topic_migration()
+            self._heal_pre_v3_topic_tables()
             try:
                 rows = self._read_all(
                     "SELECT * FROM telegram_dm_topic_bindings WHERE profile_name = ? AND chat_id = ? ORDER BY updated_at DESC",

--- a/hermes_state_telegram.py
+++ b/hermes_state_telegram.py
@@ -101,11 +101,19 @@ class SessionTelegramTopicsMixin:
     ``enable``/``bind`` run the migration."""
 
     def _topic_read_one(self, sql: str, params):
-        """``fetchone`` that treats an unmigrated table as None."""
+        """``fetchone`` that treats an unmigrated table as None. A pre-v3 table left by an
+        upgrade (issue #103363) is healed to v3 once and the read retried, so topic mode
+        keeps working on existing installs instead of silently reading as empty."""
         try:
             return self._read_one(sql, params)
-        except sqlite3.OperationalError:
-            return None
+        except sqlite3.OperationalError as exc:
+            if "no such column: profile_name" not in str(exc):
+                return None
+            self.apply_telegram_topic_migration()
+            try:
+                return self._read_one(sql, params)
+            except sqlite3.OperationalError:
+                return None
 
     def apply_telegram_topic_migration(self) -> None:
         """Create Telegram DM topic-mode tables on explicit /topic opt-in. Deliberately NOT
@@ -233,8 +241,18 @@ class SessionTelegramTopicsMixin:
                 "SELECT * FROM telegram_dm_topic_bindings WHERE profile_name = ? AND chat_id = ? ORDER BY updated_at DESC",
                 (profile_name, str(chat_id)),
             )
-        except sqlite3.OperationalError:
-            return []
+        except sqlite3.OperationalError as exc:
+            if "no such column: profile_name" not in str(exc):
+                return []
+            # Same pre-v3 self-heal as _topic_read_one (issue #103363).
+            self.apply_telegram_topic_migration()
+            try:
+                rows = self._read_all(
+                    "SELECT * FROM telegram_dm_topic_bindings WHERE profile_name = ? AND chat_id = ? ORDER BY updated_at DESC",
+                    (profile_name, str(chat_id)),
+                )
+            except sqlite3.OperationalError:
+                return []
         return [dict(row) for row in rows]
 
     def get_telegram_topic_binding_by_session(self, *, session_id: str) -> Optional[Dict[str, Any]]:

--- a/tests/gateway/test_telegram_topic_read_selfheal_103363.py
+++ b/tests/gateway/test_telegram_topic_read_selfheal_103363.py
@@ -8,8 +8,10 @@ migration was never reached. Reads now heal the table once and retry.
 
 from __future__ import annotations
 
+import logging
 import sqlite3
 from pathlib import Path
+from unittest import mock
 
 from hermes_state import SessionDB
 
@@ -105,4 +107,84 @@ def test_absent_tables_still_read_empty_and_are_not_created(tmp_path: Path):
     }
     assert "telegram_dm_topic_bindings" not in tables
     assert "telegram_dm_topic_mode" not in tables
+    db.close()
+
+
+def test_heal_rebuild_rolls_back_atomically(tmp_path: Path):
+    """The v2→v3 rebuild must stay inside _execute_write's transaction.
+
+    Pre-fix the rebuild ran via executescript, which implicitly commits the
+    open transaction and then autocommits each statement: a failure once the
+    rebuild reaches the DROP strands legacy rows in {table}_new (#42004
+    diagnosed the same shape for the v1→v2 rebuild) and the retry then builds
+    an empty v3 table. The same mid-rebuild failure must now roll back to the
+    intact v2 table so the next read can heal cleanly.
+    """
+    db_path = tmp_path / "v2-upgrade.db"
+    _create_v2_state(db_path)
+    db = SessionDB(db_path=db_path)
+
+    ok = getattr(sqlite3, "SQLITE_OK", 0)
+    deny = getattr(sqlite3, "SQLITE_DENY", 2)
+    drop_table = getattr(sqlite3, "SQLITE_DROP_TABLE", 11)
+
+    def deny_topic_rebuild_drop(action, arg1, arg2, db_name, trigger):
+        if action == drop_table and arg1 and arg1.startswith("telegram_dm_topic"):
+            return deny
+        return ok
+
+    db._conn.set_authorizer(deny_topic_rebuild_drop)
+    try:
+        # The guarded read degrades to "off" instead of raising...
+        assert not db.is_telegram_topic_mode_enabled(
+            chat_id=CHAT, user_id=CHAT, profile_name="default",
+        )
+    finally:
+        db._conn.set_authorizer(None)
+
+    # ...and the interrupted rebuild rolled back completely: the v2 table and
+    # its legacy row are intact, with nothing stranded in *_new.
+    tables = {
+        row[0]
+        for row in db._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table'"
+        ).fetchall()
+    }
+    assert "telegram_dm_topic_mode" in tables
+    assert not any(t.endswith("_new") for t in tables)
+    mode_row = db._conn.execute(
+        "SELECT enabled FROM telegram_dm_topic_mode WHERE chat_id = ?", (CHAT,)
+    ).fetchone()
+    assert mode_row is not None and mode_row[0] == 1
+
+    # Idempotent under retry (the _execute_write contract): the next clean
+    # read heals and keeps the legacy rows.
+    assert db.is_telegram_topic_mode_enabled(
+        chat_id=CHAT, user_id=CHAT, profile_name="default",
+    )
+    db.close()
+
+
+def test_failed_heal_warns_once_and_degrades_to_empty(tmp_path: Path, caplog):
+    """A failing heal (lock timeout, cross-process race) must not surface as the
+    silent-return shape the readers exist to fix: one warning per instance,
+    reads keep returning their empty value."""
+    db_path = tmp_path / "v2-upgrade.db"
+    _create_v2_state(db_path)
+    db = SessionDB(db_path=db_path)
+
+    def locked(*args, **kwargs):
+        raise sqlite3.OperationalError("database is locked")
+
+    with mock.patch.object(SessionDB, "apply_telegram_topic_migration", locked):
+        with caplog.at_level(logging.WARNING, logger="hermes_state"):
+            assert not db.is_telegram_topic_mode_enabled(
+                chat_id=CHAT, user_id=CHAT, profile_name="default",
+            )
+            assert db.get_telegram_topic_binding(
+                chat_id=CHAT, thread_id="99", profile_name="default",
+            ) is None
+            assert db.list_telegram_topic_bindings_for_chat(chat_id=CHAT) == []
+    # One warning across every reader, not one per read.
+    assert len([r for r in caplog.records if "self-heal" in r.getMessage()]) == 1
     db.close()

--- a/tests/gateway/test_telegram_topic_read_selfheal_103363.py
+++ b/tests/gateway/test_telegram_topic_read_selfheal_103363.py
@@ -1,0 +1,108 @@
+"""Issue #103363 — reading pre-v3 telegram topic tables self-heals to v3.
+
+Upgrades that enabled DM topic mode before #76423 keep v2 tables (no
+``profile_name`` column). Reads used to swallow ``no such column`` as an empty
+result, so auto topic-rename silently died on existing installs; the write-only
+migration was never reached. Reads now heal the table once and retry.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from hermes_state import SessionDB
+
+
+CHAT = "208214988"
+
+
+def _create_v2_state(db_path: Path) -> None:
+    """The schema an install predating #76423 has on disk after upgrading."""
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        f"""
+        CREATE TABLE state_meta (key TEXT PRIMARY KEY, value TEXT);
+        INSERT INTO state_meta(key, value) VALUES ('telegram_dm_topic_schema_version', '2');
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY, source TEXT, user_id TEXT, model TEXT,
+            model_config TEXT, system_prompt TEXT, parent_session_id TEXT,
+            started_at REAL, ended_at REAL, end_reason TEXT,
+            message_count INTEGER DEFAULT 0, tool_call_count INTEGER DEFAULT 0,
+            input_tokens INTEGER DEFAULT 0, output_tokens INTEGER DEFAULT 0
+        );
+        INSERT INTO sessions(id, source, user_id, started_at)
+            VALUES ('legacy-sess', 'telegram', '{CHAT}', 1.0);
+        CREATE TABLE telegram_dm_topic_mode (
+            chat_id TEXT PRIMARY KEY, user_id TEXT NOT NULL,
+            enabled INTEGER NOT NULL DEFAULT 1,
+            activated_at REAL NOT NULL, updated_at REAL NOT NULL,
+            has_topics_enabled INTEGER, allows_users_to_create_topics INTEGER,
+            capability_checked_at REAL, intro_message_id TEXT, pinned_message_id TEXT
+        );
+        INSERT INTO telegram_dm_topic_mode(chat_id, user_id, enabled, activated_at, updated_at)
+            VALUES ('{CHAT}', '{CHAT}', 1, 1.0, 1.0);
+        CREATE TABLE telegram_dm_topic_bindings (
+            chat_id TEXT NOT NULL, thread_id TEXT NOT NULL, user_id TEXT NOT NULL,
+            session_key TEXT NOT NULL,
+            session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+            managed_mode TEXT NOT NULL DEFAULT 'auto',
+            linked_at REAL NOT NULL, updated_at REAL NOT NULL,
+            PRIMARY KEY (chat_id, thread_id)
+        );
+        INSERT INTO telegram_dm_topic_bindings
+            VALUES ('{CHAT}', '99', '{CHAT}', 'k', 'legacy-sess', 'auto', 1.0, 1.0);
+        """
+    )
+    conn.close()
+
+
+def test_topic_reads_selfheal_pre_v3_tables(tmp_path: Path):
+    db_path = tmp_path / "v2-upgrade.db"
+    _create_v2_state(db_path)
+    db = SessionDB(db_path=db_path)
+
+    # Reads on the un-migrated v2 tables return the legacy rows instead of
+    # silently reading as empty, and land them in the 'default' namespace.
+    assert db.is_telegram_topic_mode_enabled(
+        chat_id=CHAT, user_id=CHAT, profile_name="default",
+    )
+    binding = db.get_telegram_topic_binding(chat_id=CHAT, thread_id="99", profile_name="default")
+    assert binding is not None
+    assert binding["session_id"] == "legacy-sess"
+    assert db.get_meta("telegram_dm_topic_schema_version") == "3"
+    # Profile isolation still holds after the heal.
+    assert not db.is_telegram_topic_mode_enabled(
+        chat_id=CHAT, user_id=CHAT, profile_name="coder",
+    )
+    assert db.get_telegram_topic_binding(chat_id=CHAT, thread_id="99", profile_name="coder") is None
+    db.close()
+
+
+def test_list_bindings_selfheals_pre_v3_table(tmp_path: Path):
+    db_path = tmp_path / "v2-upgrade.db"
+    _create_v2_state(db_path)
+    db = SessionDB(db_path=db_path)
+
+    rows = db.list_telegram_topic_bindings_for_chat(chat_id=CHAT, profile_name="default")
+    assert [row["session_id"] for row in rows] == ["legacy-sess"]
+    assert db.get_meta("telegram_dm_topic_schema_version") == "3"
+    db.close()
+
+
+def test_absent_tables_still_read_empty_and_are_not_created(tmp_path: Path):
+    db = SessionDB(db_path=tmp_path / "fresh.db")
+
+    assert not db.is_telegram_topic_mode_enabled(chat_id=CHAT, user_id=CHAT)
+    assert db.get_telegram_topic_binding(chat_id=CHAT, thread_id="99") is None
+    assert db.list_telegram_topic_bindings_for_chat(chat_id=CHAT) == []
+    # The deliberate "reads never create the tables" contract is preserved.
+    tables = {
+        row[0]
+        for row in db._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table'"
+        ).fetchall()
+    }
+    assert "telegram_dm_topic_bindings" not in tables
+    assert "telegram_dm_topic_mode" not in tables
+    db.close()


### PR DESCRIPTION
## What does this PR do?

Installs that enabled Telegram DM topic mode **before** the #76423 `profile_name` schema (v3) keep v2 tables after upgrading. The v2→v3 migration is write-triggered only (deliberately not part of startup reconciliation), but every read path on those tables — `is_telegram_topic_mode_enabled`, `get_telegram_topic_binding`, `get_telegram_topic_binding_by_session`, `is_telegram_session_linked_to_topic`, `list_telegram_topic_bindings_for_chat` — selects `profile_name`, raises `sqlite3.OperationalError: no such column: profile_name`, and swallows it as an empty result. Topic mode therefore reads as disabled on existing installs, auto topic-rename silently dies (the auto-rename lane checks topic mode before renaming), and the migration is never reached because `bind_telegram_topic`/`enable_telegram_topic_mode` are never invoked — a self-reinforcing failure loop, exactly as reported in #103363.

This PR makes the two shared read paths self-heal: when a read fails specifically with `no such column: profile_name`, it runs the idempotent `apply_telegram_topic_migration()` once and retries. Absent tables still read as their empty value and are still never created, so the deliberate "migration only on explicit /topic opt-in" contract is preserved.

## Related Issue

Fixes #103363

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state_telegram.py` — `_topic_read_one()`: on `no such column: profile_name`, heal the pre-v3 table via `apply_telegram_topic_migration()` once and retry the read (other `OperationalError`s, e.g. absent tables, still return `None` as before).
- `hermes_state_telegram.py` — `list_telegram_topic_bindings_for_chat()`: same self-heal for its `SELECT`, which had its own identical swallow.
- `tests/gateway/test_telegram_topic_read_selfheal_103363.py` — regression tests: a hand-built v2 state.db (mode + bindings, no `profile_name`) is healed by a plain read with legacy rows landing in the `default` namespace and profile isolation intact; a fresh install still reads empty without creating the tables.

## How to Test

1. `PYTHONPATH=. python -m pytest tests/gateway/test_telegram_topic_read_selfheal_103363.py -q`
   - Observed result: `3 passed` on this branch; with the source change reverted, `test_topic_reads_selfheal_pre_v3_tables` and `test_list_bindings_selfheals_pre_v3_table` fail (reads return empty on the v2 table), reproducing the issue.
2. `PYTHONPATH=. python -m pytest tests/gateway/test_telegram_topic_read_selfheal_103363.py tests/gateway/test_telegram_topic_profile_isolation_76423.py tests/gateway/test_telegram_topic_mode.py tests/gateway/test_telegram_prune_stale_topic_binding_31501.py tests/hermes_cli/test_session_recovery.py -q`
   - Observed result: `40 passed` (existing telegram-topic and session-recovery suites unaffected).
3. `python -m ruff check hermes_state_telegram.py tests/gateway/test_telegram_topic_read_selfheal_103363.py`
   - Observed result: `All checks passed!`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstring on `_topic_read_one` documents the new heal behavior)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (SQLite schema logic, platform-independent)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
