### PR TITLE
feat(lsp): support custom language servers in config

### DIFF
--- a/agent/lsp/cli.py
+++ b/agent/lsp/cli.py
@@ -5,7 +5,11 @@ Handlers live here (not in ``hermes_cli/main.py``) so the LSP module ships self-
 from __future__ import annotations
 
 import argparse
+import os
 import sys
+
+from agent.lsp.config import configured_servers
+from agent.lsp.servers import ServerDef
 
 _STATUS_MARKERS = {"installed": "✓", "missing": "·", "manual-only": "?"}
 
@@ -56,20 +60,37 @@ def run_lsp_command(args: argparse.Namespace) -> int:
         return 130
 
 
-def _status_for(server_id: str) -> str:
+def _configured_custom(server_id: str, servers: list[ServerDef] | None = None) -> ServerDef | None:
+    from agent.lsp.servers import SERVERS
+    if any(s.server_id == server_id for s in SERVERS):
+        return None
+    return next((s for s in (configured_servers() if servers is None else servers)
+                 if s.server_id == server_id), None)
+
+
+def _custom_binary(server: ServerDef) -> str | None:
+    from agent.lsp.servers import ServerContext
+    root = os.getcwd()
+    spec = server.build_spawn(root, ServerContext(root, install_strategy="manual"))
+    return spec.command[0] if spec is not None else None
+
+
+def _status_for(server_id: str, servers: list[ServerDef] | None = None) -> str:
     from agent.lsp.install import detect_status
+    if server := _configured_custom(server_id, servers):
+        return "installed" if _custom_binary(server) else "manual-only"
     return detect_status(_recipe_pkg_for(server_id))
 
 
 def _cmd_status(emit_json: bool) -> int:
     from agent.lsp import get_service
-    from agent.lsp.servers import SERVERS
+    servers = configured_servers()
     svc = get_service()
     info = svc.get_status() if svc is not None else {"enabled": False}
     if emit_json:
         import json
         registry = [{"server_id": s.server_id, "extensions": list(s.extensions), "description": s.description,
-                     "binary_status": _status_for(s.server_id)} for s in SERVERS]
+                     "binary_status": _status_for(s.server_id, servers)} for s in servers]
         sys.stdout.write(json.dumps({"service": info, "registry": registry}, indent=2) + "\n")
         return 0
 
@@ -91,8 +112,8 @@ def _cmd_status(emit_json: bool) -> int:
     if backend_warnings := _backend_warnings():
         out += ["", "Backend warnings", "================"] + [f"  ! {line}" for line in backend_warnings]
     out += ["", "Registered Servers", "=================="]
-    for s in SERVERS:
-        status = _status_for(s.server_id)
+    for s in servers:
+        status = _status_for(s.server_id, servers)
         ext_summary = ", ".join(list(s.extensions)[:5])
         if len(s.extensions) > 5:
             ext_summary += f", … (+{len(s.extensions) - 5})"
@@ -104,9 +125,9 @@ def _cmd_status(emit_json: bool) -> int:
 
 
 def _cmd_list(installed_only: bool) -> int:
-    from agent.lsp.servers import SERVERS
-    for s in SERVERS:
-        status = _status_for(s.server_id)
+    servers = configured_servers()
+    for s in servers:
+        status = _status_for(s.server_id, servers)
         if not (installed_only and status != "installed"):
             sys.stdout.write(f"{s.server_id:24s} [{status:11s}] {','.join(s.extensions)}\n")
     return 0
@@ -118,6 +139,9 @@ def _cmd_install(server_id: str) -> int:
     if _status_for(server_id) == "installed":
         sys.stdout.write(f"{server_id} already installed\n")
         return 0
+    if _configured_custom(server_id) is not None:
+        sys.stderr.write(f"{server_id}: install the configured command manually; custom servers have no auto-install recipe.\n")
+        return 1
     sys.stdout.write(f"installing {server_id} (pkg={pkg}) ...\n")
     sys.stdout.flush()
     bin_path = try_install(pkg, "auto")
@@ -159,7 +183,9 @@ def _cmd_restart() -> int:
 
 def _cmd_which(server_id: str) -> int:
     from agent.lsp.install import INSTALL_RECIPES, _existing_binary
-    resolved = _existing_binary((INSTALL_RECIPES.get(server_id) or {}).get("bin", server_id))
+    server = _configured_custom(server_id)
+    resolved = (_custom_binary(server) if server is not None else
+                _existing_binary((INSTALL_RECIPES.get(server_id) or {}).get("bin", server_id)))
     if resolved:
         sys.stdout.write(resolved + "\n")
         return 0

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -33,7 +34,7 @@ DIAGNOSTICS_DOCUMENT_WAIT = 5.0
 DIAGNOSTICS_FULL_WAIT = 10.0
 DIAGNOSTICS_REQUEST_TIMEOUT = 3.0
 PUSH_DEBOUNCE = 0.15
-SHUTDOWN_GRACE = 1.0  # seconds between SIGTERM and SIGKILL
+SHUTDOWN_GRACE = 1.0  # seconds for clean exit, then again between SIGTERM and SIGKILL
 # Retry policy for transient ContentModified errors: 0.5, 1.0, 2.0s.
 MAX_CONTENT_MODIFIED_RETRIES = 3
 RETRY_BASE_DELAY = 0.5
@@ -86,14 +87,13 @@ def uri_to_path(uri: str) -> str:
 
 
 def _end_position(text: str) -> Dict[str, int]:
-    """LSP Position at the end of ``text`` (for a whole-document replace range)."""
-    if not text:
-        return {"line": 0, "character": 0}
-    lines = text.splitlines(keepends=False)
-    # splitlines drops a trailing newline: the end is then the start of the next (empty) line.
-    if text.endswith(("\n", "\r")):
-        return {"line": len(lines), "character": 0}
-    return {"line": len(lines) - 1, "character": len(lines[-1])}
+    """UTF-16 LSP position at the end of ``text`` for a whole-document replacement."""
+    lines = re.split(r"\r\n|\r|\n", text)
+    # The client advertises UTF-16 positions. Python's len() counts Unicode code
+    # points, so non-BMP characters would otherwise leave old text behind when an
+    # incremental-sync server applies this replacement range.
+    units = len(lines[-1].encode("utf-16-le")) // 2
+    return {"line": len(lines) - 1, "character": units}
 
 
 @dataclass
@@ -312,6 +312,12 @@ class LSPClient:
                     await self._send_notification("exit", None)
                 except Exception:  # noqa: BLE001
                     pass
+                proc = self._proc
+                if proc is not None and proc.returncode is None:
+                    try:
+                        await asyncio.wait_for(proc.wait(), timeout=SHUTDOWN_GRACE)
+                    except asyncio.TimeoutError:
+                        pass
         finally:
             self._state = "stopped"
             await self._cleanup_process()
@@ -484,16 +490,18 @@ class LSPClient:
         doc = self._docs.get(abs_path)
         if doc is not None and doc.version < 0:
             doc = None  # never opened (relatedDocuments spillover): treat as new
-        # FileChangeType: 1 = CREATED, 2 = CHANGED.
-        await self._send_notification(
-            "workspace/didChangeWatchedFiles", {"changes": [{"uri": uri, "type": 1 if doc is None else 2}]}
-        )
         if doc is None:
             # Fresh state: anything a pre-open push stashed under this path (relatedDocuments spillover) is discarded.
             self._docs[abs_path] = _DocState(version=0, text=text)
             await self._send_notification(
                 "textDocument/didOpen",
                 {"textDocument": {"uri": uri, "languageId": language_id, "version": 0, "text": text}},
+            )
+            # Notify file watchers after synchronizing the buffer. Servers that
+            # reload from disk on this notification must not apply didOpen or
+            # didChange a second time to the newly reloaded content.
+            await self._send_notification(
+                "workspace/didChangeWatchedFiles", {"changes": [{"uri": uri, "type": 1}]}
             )
             return 0
         change: Dict[str, Any] = {"text": text}
@@ -503,6 +511,9 @@ class LSPClient:
         await self._send_notification(
             "textDocument/didChange",
             {"textDocument": {"uri": uri, "version": new_version}, "contentChanges": [change]},
+        )
+        await self._send_notification(
+            "workspace/didChangeWatchedFiles", {"changes": [{"uri": uri, "type": 2}]}
         )
         # Bumping the version is the whole invalidation story (see _DocState).
         doc.version, doc.text = new_version, text

--- a/agent/lsp/config.py
+++ b/agent/lsp/config.py
@@ -1,0 +1,70 @@
+"""Build profile-local LSP definitions without mutating the built-in registry."""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from agent.lsp.servers import SERVERS, ServerContext, ServerDef, SpawnSpec, _make_spec
+from agent.lsp.workspace import nearest_root
+
+logger = logging.getLogger(__name__)
+
+
+def _string_list(value: Any, *, allow_empty: bool = False) -> bool:
+    return (isinstance(value, list) and (allow_empty or bool(value))
+            and all(isinstance(v, str) and bool(v.strip()) for v in value))
+
+
+def _custom_server(server_id: str, config: dict) -> ServerDef:
+    command = tuple(config["command"])
+    markers = tuple(config.get("root_markers", []))
+
+    def build_spawn(root: str, ctx: ServerContext) -> SpawnSpec | None:
+        from agent.lsp.install import _existing_binary
+        binary = _existing_binary(os.path.expanduser(command[0]))
+        if binary is None:
+            return None
+        return _make_spec(root, ctx, server_id, [binary, *command[1:]])
+
+    return ServerDef(
+        server_id=server_id,
+        extensions=tuple(ext.lower() if ext.startswith(".") else ext for ext in config["extensions"]),
+        resolve_root=lambda path, workspace: nearest_root(path, markers, ceiling=workspace) or workspace,
+        build_spawn=build_spawn,
+        description="Custom language server",
+        language_id=config.get("language_id", ""),
+    )
+
+
+def configured_servers(servers_config: Any = None) -> list[ServerDef]:
+    """Custom servers in YAML order take precedence; built-ins remain available.
+
+    Called once when a service starts (or for a CLI inspection). Invalid custom
+    entries cannot take down unrelated language servers or the post-write hook.
+    """
+    if servers_config is None:
+        from hermes_cli.config import load_config_readonly
+        lsp_config = load_config_readonly().get("lsp")
+        servers_config = lsp_config.get("servers", {}) if isinstance(lsp_config, dict) else {}
+    if not isinstance(servers_config, dict):
+        return list(SERVERS)
+    builtin_ids = {server.server_id for server in SERVERS}
+    custom = []
+    for server_id, config in servers_config.items():
+        if server_id in builtin_ids:
+            continue
+        if not isinstance(server_id, str) or not server_id.strip() or not isinstance(config, dict):
+            logger.warning("Ignoring lsp.servers.%s: expected a named server mapping", server_id)
+            continue
+        invalid = next((key for key, valid in {
+            "command": _string_list(config.get("command")),
+            "extensions": _string_list(config.get("extensions")),
+            "root_markers": _string_list(config.get("root_markers", []), allow_empty=True),
+            "language_id": isinstance(config.get("language_id", ""), str),
+        }.items() if not valid), None)
+        if invalid:
+            logger.warning("Ignoring lsp.servers.%s: invalid %s", server_id, invalid)
+            continue
+        custom.append(_custom_server(server_id, config))
+    return custom + list(SERVERS)

--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -20,7 +20,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from agent.lsp import eventlog
 from agent.lsp.client import DIAGNOSTICS_DOCUMENT_WAIT, LSPClient, _diagnostic_key as _diag_key
-from agent.lsp.servers import ServerContext, ServerDef, find_server_for_file, language_id_for
+from agent.lsp.config import configured_servers
+from agent.lsp.servers import SERVERS, ServerContext, ServerDef, find_server_for_file, language_id_for
 from agent.lsp.workspace import clear_cache, resolve_workspace_for_file
 
 logger = logging.getLogger("agent.lsp.manager")
@@ -103,6 +104,7 @@ class LSPService:
         init_overrides: Optional[Dict[str, Dict[str, Any]]] = None,
         disabled_servers: Optional[List[str]] = None,
         idle_timeout: float = DEFAULT_IDLE_TIMEOUT,
+        server_definitions: Optional[List[ServerDef]] = None,
     ) -> None:
         self._enabled = enabled
         self._wait_mode = wait_mode if wait_mode in {"document", "full"} else "document"
@@ -113,6 +115,7 @@ class LSPService:
         self._init_overrides = init_overrides or {}
         self._disabled_servers = set(disabled_servers or [])
         self._idle_timeout = idle_timeout
+        self._servers = list(SERVERS if server_definitions is None else server_definitions)
 
         self._loop = _BackgroundLoop()
         if self._enabled:
@@ -165,6 +168,7 @@ class LSPService:
                             if isinstance(c.get("initialization_options"), dict)},
             disabled_servers=[n for n, c in servers.items() if c.get("disabled")],
             idle_timeout=idle_timeout,
+            server_definitions=configured_servers(servers_cfg),
         )
 
     # ---- public API ----
@@ -190,7 +194,7 @@ class LSPService:
     def enabled_for(self, file_path: str) -> bool:
         """True iff LSP should run for this file: registered non-disabled server, git workspace,
         and pair not broken (a failed server costs nothing until ``hermes lsp restart`` / exit)."""
-        srv = find_server_for_file(file_path) if self._enabled else None
+        srv = find_server_for_file(file_path, self._servers) if self._enabled else None
         if srv is None or srv.server_id in self._disabled_servers:
             return False
         key = self._broken_key(srv, file_path)
@@ -224,7 +228,7 @@ class LSPService:
         """
         if not self.enabled_for(file_path):
             return []
-        server_id = find_server_for_file(file_path).server_id  # enabled_for guarantees a match
+        server_id = find_server_for_file(file_path, self._servers).server_id  # enabled_for guarantees a match
         try:
             t = timeout if timeout is not None else self._wait_timeout + 2.0
             diags = self._loop.run(self._open_and_wait_async(file_path), timeout=t)
@@ -276,7 +280,7 @@ class LSPService:
         The outer ``_loop.run`` timeout cancels the in-flight spawn before ``_get_or_spawn`` could record
         the failure; without this every later write would re-pay the full timeout.  Also kills any
         half-initialized client and logs the failure once."""
-        srv = find_server_for_file(file_path)
+        srv = find_server_for_file(file_path, self._servers)
         key = self._broken_key(srv, file_path) if srv is not None else None
         if key is None:
             return
@@ -338,7 +342,8 @@ class LSPService:
         if client is None:
             return None
         try:
-            version = await client.open_file(file_path, language_id=language_id_for(file_path))
+            srv = find_server_for_file(file_path, self._servers)
+            version = await client.open_file(file_path, language_id=srv.language_id or language_id_for(file_path))
             if not snapshot:
                 await client.save_file(file_path)
             fresh = await client.wait_for_diagnostics(
@@ -355,15 +360,15 @@ class LSPService:
 
     async def _current_diags_async(self, file_path: str) -> _Diags:
         ws, gated = resolve_workspace_for_file(file_path)
-        srv = find_server_for_file(file_path)
+        srv = find_server_for_file(file_path, self._servers)
         if not (ws and gated and srv):
             return []
         with self._state_lock:
-            client = self._clients.get(_client_key(srv, ws))
+            client = self._clients.get(_client_key(srv, srv.resolve_root(file_path, ws) or ws))
         return list(client.diagnostics_for(file_path, fresh_only=True)) if client else []
 
     async def _get_or_spawn(self, file_path: str) -> Optional[LSPClient]:
-        srv = find_server_for_file(file_path)
+        srv = find_server_for_file(file_path, self._servers)
         if srv is None:
             return None
         if srv.server_id in self._disabled_servers:

--- a/agent/lsp/servers.py
+++ b/agent/lsp/servers.py
@@ -75,6 +75,7 @@ class ServerDef:
     # Server handles ``workspace/didChangeWorkspaceFolders``: one process serves every project root
     # (git worktrees included) as extra workspaceFolders instead of one process per root.
     multi_root: bool = False
+    language_id: str = ""
 
     def matches(self, file_path: str) -> bool:
         return _file_ext_or_basename(file_path) in self.extensions
@@ -337,9 +338,9 @@ SERVERS: List[ServerDef] = [
 ]
 
 
-def find_server_for_file(file_path: str) -> Optional[ServerDef]:
+def find_server_for_file(file_path: str, servers: Optional[Sequence[ServerDef]] = None) -> Optional[ServerDef]:
     """Return the registry entry that handles ``file_path``, or None."""
-    return next((srv for srv in SERVERS if srv.matches(file_path)), None)
+    return next((srv for srv in (SERVERS if servers is None else servers) if srv.matches(file_path)), None)
 
 
 def language_id_for(path: str) -> str:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2116,6 +2116,7 @@ DEFAULT_CONFIG = {
         # Per-server overrides keyed by registry server_id (pyright, gopls...): disabled: true;
         # command: ["path/to/server", "--stdio"] (bypasses auto- install); env: {...};
         # initialization_options: {...} (merged into LSP initializationOptions).
+        # Custom ids additionally require command + extensions; optional root_markers and language_id.
         "servers": {},
     },
     # X (Twitter) Search via xAI's x_search Responses tool. Registers when xAI creds exist

--- a/tests/agent/lsp/_mock_lsp_server.py
+++ b/tests/agent/lsp/_mock_lsp_server.py
@@ -74,6 +74,10 @@ def main():
         if msg is None:
             return 0
 
+        if log_path := os.environ.get("MOCK_LSP_MESSAGES_LOG"):
+            with open(f"{log_path}.{os.getpid()}", "a", encoding="utf-8") as fh:
+                fh.write(json.dumps({"message": msg, "argv": sys.argv[1:], "cwd": os.getcwd()}) + "\n")
+
         if "id" in msg and msg.get("method") == "initialize":
             if script == "slow":
                 time.sleep(1.0)

--- a/tests/agent/lsp/test_client_e2e.py
+++ b/tests/agent/lsp/test_client_e2e.py
@@ -36,10 +36,12 @@ def _client(workspace: Path, script: str = "clean") -> LSPClient:
 async def test_client_lifecycle_clean(tmp_path: Path):
     """Full lifecycle: spawn, initialize, open, get clean diagnostics, shutdown."""
     f = tmp_path / "x.py"
-    f.write_text("print('hi')\n")
+    f.write_text("print('hi')\n", encoding="utf-8")
 
     client = _client(tmp_path, "clean")
     await client.start()
+    proc = client._proc
+    assert proc is not None
     try:
         assert client.is_running
         version = await client.open_file(str(f), language_id="python")
@@ -50,12 +52,13 @@ async def test_client_lifecycle_clean(tmp_path: Path):
     finally:
         await client.shutdown()
     assert not client.is_running
+    assert proc.returncode == 0
 
 
 @pytest.mark.asyncio
 async def test_client_receives_published_errors(tmp_path: Path):
     f = tmp_path / "x.py"
-    f.write_text("print('hi')\n")
+    f.write_text("print('hi')\n", encoding="utf-8")
 
     client = _client(tmp_path, "errors")
     await client.start()
@@ -98,7 +101,7 @@ async def test_reader_failure_retires_client_and_rejects_later_work(
     tmp_path: Path, script: str
 ):
     f = tmp_path / "x.py"
-    f.write_text("print('hi')\n")
+    f.write_text("print('hi')\n", encoding="utf-8")
 
     client = _client(tmp_path, script)
     await client.start()

--- a/tests/agent/lsp/test_client_positions.py
+++ b/tests/agent/lsp/test_client_positions.py
@@ -1,0 +1,42 @@
+"""Position encoding contracts used by incremental document synchronization."""
+import pytest
+
+from agent.lsp.client import LSPClient, _end_position
+
+
+@pytest.mark.parametrize(("text", "expected"), [
+    ("", {"line": 0, "character": 0}),
+    ("ascii", {"line": 0, "character": 5}),
+    ("a😀", {"line": 0, "character": 3}),
+    ("a\r\n😀\n", {"line": 2, "character": 0}),
+    ("a\rb", {"line": 1, "character": 1}),
+    ("a\u2028b", {"line": 0, "character": 3}),
+])
+def test_end_position_uses_lsp_lines_and_utf16_units(text, expected):
+    assert _end_position(text) == expected
+
+
+@pytest.mark.asyncio
+async def test_document_sync_precedes_disk_change_notification(tmp_path, monkeypatch):
+    path = tmp_path / "document.qmd"
+    path.write_text("old 😀 content", encoding="utf-8")
+    client = LSPClient(server_id="test", workspace_root=str(tmp_path), command=["unused"])
+    client._sync_kind = 2
+    sent = []
+
+    async def capture(method, params):
+        sent.append((method, params))
+
+    monkeypatch.setattr(LSPClient, "is_running", property(lambda self: True))
+    monkeypatch.setattr(client, "_send_notification", capture)
+    await client.open_file(str(path), language_id="quarto")
+    path.write_text("new content", encoding="utf-8")
+    await client.open_file(str(path), language_id="quarto")
+
+    assert [method for method, _ in sent] == [
+        "textDocument/didOpen", "workspace/didChangeWatchedFiles",
+        "textDocument/didChange", "workspace/didChangeWatchedFiles",
+    ]
+    change = sent[2][1]["contentChanges"][0]
+    assert change["range"]["end"] == {"line": 0, "character": 14}
+    assert change["text"] == "new content"

--- a/tests/agent/lsp/test_custom_servers.py
+++ b/tests/agent/lsp/test_custom_servers.py
@@ -1,0 +1,130 @@
+"""Custom servers reach the real config loader, CLI and stdio diagnostic loop."""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from agent.lsp import get_service, shutdown_service
+from agent.lsp.cli import register_subparser, run_lsp_command
+from agent.lsp.manager import LSPService
+from agent.lsp.servers import find_server_for_file
+from tools.file_operations_lint import LintMixin
+
+
+@pytest.mark.parametrize("extension,language,expected_language", [
+    (".QMD", "quarto", "quarto"),
+    (".py", None, "python"),
+    (".custom", None, "plaintext"),
+    ("Customfile", "customfile", "customfile"),
+])
+def test_custom_server_config_to_diagnostics(tmp_path, monkeypatch, capsys, extension, language, expected_language):
+    home = tmp_path / "profile"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    (tmp_path / "project.marker").touch()  # must not root a server outside its workspace
+    project = repo / "nested project"
+    project.mkdir()
+    (project / "project.marker").touch()
+    filename = "document" + extension if extension.startswith(".") else extension
+    source = project / filename
+    source.write_text("before\n", encoding="utf-8")
+    monkeypatch.chdir(repo)
+    messages = tmp_path / "messages.jsonl"
+    command = [sys.executable, str(Path(__file__).with_name("_mock_lsp_server.py")), "arg with spaces"]
+    config = {"lsp": {"install_strategy": "manual", "idle_timeout": 0, "wait_timeout": 3, "servers": {"custom-test": {
+        "command": command,
+        "extensions": [extension],
+        "root_markers": ["project.marker"],
+        "env": {"MOCK_LSP_SCRIPT": "errors", "MOCK_LSP_MESSAGES_LOG": str(messages)},
+        "initialization_options": {"example": {"enabled": True}},
+    }}}}
+    if language is not None:
+        config["lsp"]["servers"]["custom-test"]["language_id"] = language
+    config["lsp"]["servers"]["aaa-shadowed"] = {
+        "command": ["missing-shadowed-lsp"], "extensions": [extension],
+    }
+    (home / "config.yaml").write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+    original = find_server_for_file(str(source))
+    parser = argparse.ArgumentParser()
+    register_subparser(parser.add_subparsers())
+    shutdown_service()
+    try:
+        svc = get_service()
+        assert svc is not None and svc.enabled_for(str(source))
+        lint_hook = LintMixin()
+        monkeypatch.setattr(lint_hook, "_lsp_service", lambda: svc)
+        assert lint_hook._lsp_will_handle(str(source))
+        assert not svc.enabled_for(str(tmp_path / filename))
+        svc.snapshot_baseline(str(source))
+        source.write_text("after\n", encoding="utf-8")
+        assert svc.get_diagnostics_sync(str(source)) == []
+        assert svc.get_diagnostics_sync(str(source), delta=False)
+        assert svc._loop.run(svc._current_diags_async(str(source)), timeout=3)
+        assert {c["server_id"] for c in svc.get_status()["clients"]} == {"custom-test"}
+        fallback = repo / filename
+        fallback.write_text("fallback\n", encoding="utf-8")
+        assert svc.get_diagnostics_sync(str(fallback), delta=False)
+        assert {Path(c["workspace_root"]) for c in svc.get_status()["clients"]} == {repo, project}
+
+        for args in (["lsp", "list", "--installed-only"], ["lsp", "status", "--json"]):
+            assert run_lsp_command(parser.parse_args(args)) == 0
+            assert "custom-test" in capsys.readouterr().out
+        assert run_lsp_command(parser.parse_args(["lsp", "which", "custom-test"])) == 0
+        assert Path(capsys.readouterr().out.strip()) == Path(sys.executable)
+    finally:
+        shutdown_service()
+
+    traffic = [json.loads(line) for log in tmp_path.glob("messages.jsonl.*")
+               for line in log.read_text(encoding="utf-8").splitlines()]
+    initialize = next(row for row in traffic if row["message"].get("method") == "initialize"
+                      and Path(row["cwd"]) == project)
+    assert initialize["argv"] == command[2:]
+    assert Path(initialize["cwd"]) == project
+    params = initialize["message"]["params"]
+    assert params["rootUri"] == project.as_uri()
+    assert params["initializationOptions"] == config["lsp"]["servers"]["custom-test"]["initialization_options"]
+    opened = next(row["message"] for row in traffic if row["message"].get("method") == "textDocument/didOpen")
+    assert opened["params"]["textDocument"]["languageId"] == expected_language
+    assert find_server_for_file(str(source)) is original
+
+
+@pytest.mark.parametrize("invalid", [
+    None,
+    {"command": "server --stdio", "extensions": [".bad"]},
+    {"command": [], "extensions": [".bad"]},
+    {"command": [42], "extensions": [".bad"]},
+    {"command": ["server"], "extensions": ".bad"},
+    {"command": ["server"], "extensions": []},
+    {"command": ["server"], "extensions": [42]},
+    {"command": ["server"], "extensions": [".bad"], "root_markers": "project.marker"},
+    {"command": ["server"], "extensions": [".bad"], "language_id": []},
+])
+def test_invalid_custom_server_does_not_break_other_servers(tmp_path, monkeypatch, caplog, invalid):
+    home = tmp_path / "profile"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    (tmp_path / ".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    config = {"lsp": {"idle_timeout": 0, "servers": {
+        "invalid-custom": invalid,
+        "valid-custom": {"command": [sys.executable], "extensions": [".custom"]},
+        "disabled-custom": {"command": [sys.executable], "extensions": [".disabled"], "disabled": True},
+    }}}
+    (home / "config.yaml").write_text(yaml.safe_dump(config), encoding="utf-8")
+    svc = LSPService.create_from_config()
+    assert svc is not None
+    try:
+        assert svc.enabled_for(str(tmp_path / "valid.custom"))
+        assert svc.enabled_for(str(tmp_path / "builtin.py"))
+        assert not svc.enabled_for(str(tmp_path / "bad.bad"))
+        assert not svc.enabled_for(str(tmp_path / "off.disabled"))
+        assert "lsp.servers.invalid-custom" in caplog.text
+        assert find_server_for_file(str(tmp_path / "valid.custom")) is None
+    finally:
+        svc.shutdown()

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1215,7 +1215,7 @@ class ShellFileOperations(LintMixin, SearchMixin, FileOperations):
 
         # Pre-content is read only for extensions in the UNION of in-process lint and
         # LSP coverage (keeps the hot path fast for binaries).
-        want_pre = ext in LINTERS_INPROC or self._lsp_handles_extension(ext)
+        want_pre = ext in LINTERS_INPROC or self._lsp_will_handle(path)
         has_bom, pre_content, original_ending = self._probe_write_target(path, pre_content, want_pre)
         # read_file strips the BOM and models send bare-LF text, so a round-trip would
         # otherwise normalize CRLF files and drop the BOM (prepend only when absent).

--- a/tools/file_operations_lint.py
+++ b/tools/file_operations_lint.py
@@ -215,18 +215,6 @@ class LintMixin:
         except Exception:  # noqa: BLE001
             return None
 
-    def _lsp_handles_extension(self, ext: str) -> bool:
-        """True iff some registered LSP server claims ``ext`` (static registry
-        only; safe on remote backends). Decides whether pre-write content is
-        worth capturing for the line-shift map."""
-        if not ext:
-            return False
-        try:
-            from agent.lsp.servers import SERVERS
-        except Exception:  # noqa: BLE001
-            return False
-        return any(ext.lower() in srv.extensions for srv in SERVERS)
-
     def _has_ancestor_tsconfig(self, path: str) -> bool:
         """True iff a tsconfig.json exists in ``path``'s directory or any ancestor.
         Host-side walk, local backend only: on a remote backend this answers False so

--- a/website/docs/user-guide/features/lsp.md
+++ b/website/docs/user-guide/features/lsp.md
@@ -196,6 +196,52 @@ lsp:
   `initializationOptions` payload sent in the `initialize`
   handshake. Server-specific; consult the language server's docs.
 
+### Custom language servers
+
+Register a stdio language server that isn't built in by adding a new ID
+under `lsp.servers` in your profile's `config.yaml`:
+
+```yaml
+lsp:
+  servers:
+    my-markdown-server:
+      command: ["/absolute/path/to/markdown-server", "--stdio"]
+      extensions: [".md", ".markdown"]
+      language_id: markdown
+      root_markers: [".markdown-project", "package.json"]
+      initialization_options: {}
+```
+
+Replace the example command with your server's actual stdio command.
+Install the server yourself; Hermes does not auto-install custom servers.
+The executable can be an absolute path (including `~`), a command on PATH,
+or a binary in `<HERMES_HOME>/lsp/bin/`. Each argument is a separate list
+item, so paths and arguments containing spaces need no shell escaping.
+
+Custom IDs require `command` and a non-empty `extensions` list. Use dotted
+extensions such as `.md`, or exact extensionless filenames such as
+`Dockerfile`. Extensions are case-insensitive; filenames are case-sensitive.
+Optional `language_id` sets the LSP `didOpen` language ID for all matched
+files. If omitted, Hermes uses its existing extension-to-language mapping,
+falling back to `plaintext` for unknown extensions.
+
+Optional `root_markers` lists exact file or directory names (no globs).
+Hermes uses the nearest matching ancestor inside the Git workspace,
+falling back to the workspace root if no marker matches. The existing Git
+workspace gate still applies. `disabled`, `env` and
+`initialization_options` work the same way as for built-in servers.
+
+Custom servers take precedence over built-ins for matching files. If
+multiple custom servers match, the first entry in YAML order wins.
+Disabling that server disables diagnostics for its matching files; it
+does not select a different server. Built-in IDs retain their existing
+override behavior; use a new ID to replace their file matching or root
+detection. Malformed custom entries are skipped with a warning in the logs.
+
+`hermes lsp list`, `hermes lsp status` and `hermes lsp which <id>` include
+custom servers. Restart your Hermes process after changing the configuration
+so the LSP service picks up the new definitions.
+
 ## Installation locations
 
 When `install_strategy: auto`, Hermes installs binaries into


### PR DESCRIPTION
## What does this PR do?
Custom language servers declared in `lsp.servers` now participate in post-write semantic diagnostics. New server IDs provide a command and file extensions, with optional project root markers and a language ID; existing environment, initialization, and disable settings are reused.
The service keeps its own registry, custom definitions take precedence in configuration order, and root discovery stays inside the Git workspace. The LSP CLI lists and resolves custom servers and explains when manual installation is required.
Live Panache testing exposed two protocol issues in the existing client. Incremental synchronization now uses UTF-16 positions and sends document updates before watched-file notifications, preventing servers that reload from disk from retaining or duplicating old text. Custom extensions also participate in pre-write content capture, and graceful shutdown gives servers time to exit before termination.

## Related Issue
Closes #100257

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made
- Added validated custom LSP definitions from `lsp.servers` without mutating the built-in registry.
- Routed matching, language IDs, root discovery, CLI status, binary lookup, and manual installation guidance through the configured definitions.
- Corrected UTF-16 replacement ranges, document/watch notification ordering, custom-extension baseline capture, and graceful server shutdown.
- Documented the custom server schema, matching priority, root markers, and restart behavior.

## How to Test
1. Configure a custom stdio server under `lsp.servers` with `command`, `extensions`, `root_markers`, and `language_id`.
2. Run `hermes lsp list`, `hermes lsp status`, and `hermes lsp which <id>` and verify the custom definition is resolved.
3. Edit a matching file inside a Git workspace and verify only newly introduced diagnostics are reported.
4. Run `scripts/run_tests.sh tests/agent/lsp`.

## Checklist
### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md).
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this feature.
- [x] I've run `pytest tests/ -q` — all tests pass except the 6 known baseline failures documented below.
- [x] I've added tests for my changes.
- [x] I've tested on Windows 11 with Python 3.12.14 and Panache 3.8.0 (Windows x86-64).
### Documentation & Housekeeping
- [x] I've updated relevant documentation.
- [x] I've considered `cli-config.yaml.example` — N/A; this extends the existing `lsp.servers` mapping and the schema is documented in the LSP guide.
- [x] I've considered `CONTRIBUTING.md` and `AGENTS.md` — N/A; no architecture or contribution workflow changed.
- [x] I've considered cross-platform impact; native Windows tests pass and Linux/macOS CI remains pending.
- [x] I've considered tool descriptions and schemas — N/A; no model-facing tool schema changed.

## Screenshots / Logs
Validation:
- Targeted regression suite: 24 passed.
- Full LSP suite:
  - Base (unchanged): 64 passed, 6 known baseline failures.
  - This PR: 84 passed, same 6 known baseline failures — 20 new LSP tests added, all pass.
- Live Panache 3.8.0 Windows x86-64 suite: 6 passed, covering Markdown, Quarto, R Markdown, incremental Unicode edits, write/patch diagnostics, CLI discovery, and clean process shutdown.
- Ruff, Windows footgun, plugin compatibility, and diff checks passed.

Known baseline failures cover two Git Bash environment tests, one Windows npm mock expectation, two clean-EOF timing tests, and one Windows `HOME`/`USERPROFILE` assumption. Linux/macOS have not been run locally. Panache's common lint rules are warnings; Hermes's existing reporter remains error-only.
