### PR TITLE
fix(compression): re-arm attempt budget after plugin context-engine compaction

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3651,10 +3651,21 @@ def compress_context(
     try:
         # Capture the verdict before rotation callbacks: lifecycle hooks may reset
         # compressor fields on rebind; record only after the full boundary commits.
-        _compression_made_progress, _compression_used_fallback, _compression_feasibility_skip = (
-            bool(getattr(agent.context_compressor, name, False))
-            for name in ("_last_compression_made_progress", "_last_summary_fallback_used", "_last_feasibility_skip")
+        # Plugin context engines (``context.engine``, e.g. hermes-lcm) never set the
+        # built-in compressor's private progress latch, so the host falls back to the
+        # same structural no-op comparison _candidate_rejected() applies below: a
+        # committed rewrite that actually differs from the input proves progress.
+        # Without this the boundary latch below never arms and the per-turn budget
+        # reads as "compactions this turn" instead of the documented consecutive
+        # ineffective-attempt backstop (#103355).
+        _cc = agent.context_compressor
+        _compression_made_progress = bool(getattr(_cc, "_last_compression_made_progress", False)) or (
+            compressed != messages_before_compression
+            and _strip_marker_for_comparison(compressed)
+            != _strip_marker_for_comparison(messages_before_compression)
         )
+        _compression_used_fallback = bool(getattr(_cc, "_last_summary_fallback_used", False))
+        _compression_feasibility_skip = bool(getattr(_cc, "_last_feasibility_skip", False))
         if _candidate_rejected(
             agent, compressed, messages, messages_before_compression, attempt_generation=attempt.generation,
             attempt_started_at=attempt.started_at,

--- a/agent/turn_usage.py
+++ b/agent/turn_usage.py
@@ -112,6 +112,16 @@ def record_response_usage(
         getattr(compressor, "_verify_compaction_cleared_threshold", False)
     )
     compressor.update_from_response(usage_dict)
+    # Host-side consume of the boundary latch. The built-in engine clears it inside
+    # update_from_response() (one-shot); a plugin context engine's contract method knows
+    # nothing of the private latch, so without this a successful plugin compaction leaves
+    # the latch armed forever and ANY later below-threshold response refunds an
+    # ineffective attempt that should stay burnt (anti-thrash backstop #11529). Setting
+    # False here is idempotent for the built-in and restores one-shot for plugins.
+    if _completed_compaction_pending and hasattr(
+        compressor, "_verify_compaction_cleared_threshold"
+    ):
+        compressor._verify_compaction_cleared_threshold = False
     # Usage-anchored accounting: snapshot exact provider usage against the durable
     # transcript (main-loop ONLY; MoA uses pre-fold aggregator usage). The display meter
     # anchors on the turn's FIRST response: later same-turn responses inflate

--- a/tests/run_agent/test_compression_rearm_plugin_engine.py
+++ b/tests/run_agent/test_compression_rearm_plugin_engine.py
@@ -1,0 +1,120 @@
+"""Regression test for #103355: a successful compaction performed by a PLUGIN
+context engine must arm the completed-compaction boundary latch so the next
+provider-confirmed prompt count can re-arm the per-turn compression budget.
+
+Plugin engines selected via ``context.engine`` become ``agent.context_compressor``
+(agent/agent_init.py) but implement only the ContextEngine contract
+(agent/context_engine.py). They never set the built-in compressor's private
+progress latch (``_last_compression_made_progress``) and do not define
+``record_completed_compaction``. The host therefore falls back to structural
+proof of progress: a committed rewrite that differs from the input arms the
+boundary latch (``_verify_compaction_cleared_threshold``) that the next real
+prompt count consumes to reset ``compression_attempts``.
+
+See https://github.com/NousResearch/hermes-agent/issues/103355
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from agent.context_compressor import ContextCompressor
+
+
+def _seed(db, sid, title, n=8):
+    db.create_session(sid, "cli", model="test/model")
+    db.set_session_title(sid, title)
+    for i in range(n):
+        db.append_message(
+            session_id=sid,
+            role="user" if i % 2 == 0 else "assistant",
+            content=f"msg {i}",
+        )
+
+
+def _make_agent(session_db, session_id):
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=session_db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.compression_in_place = True
+    return agent
+
+
+class TestPluginEngineCompressionRearm:
+    def test_plugin_shaped_rewrite_arms_boundary_latch(self):
+        """A committed rewrite by an engine that never sets the built-in private
+        progress latch must still arm ``_verify_compaction_cleared_threshold`` —
+        the latch the next provider prompt count consumes to re-arm the budget.
+
+        Regression for #103355: plugin context engines (context.engine, e.g.
+        hermes-lcm) cannot know about ``_last_compression_made_progress`` (it is
+        not part of the ContextEngine contract), so every successful compaction
+        used to burn an attempt and long turns died at ``max_attempts``.
+        """
+        from agent.conversation_compression import compress_context
+        from hermes_state import SessionDB
+
+        def _rewrite_compress(messages, current_tokens=None, focus_topic=None, force=False, memory_context=""):
+            # A plugin engine rewrites the transcript WITHOUT touching the built-in
+            # private latches.
+            return [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary of prior turns"},
+                {"role": "assistant", "content": "recent reply"},
+            ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "20260904_120000_plugin01"
+            _seed(db, sid, "plugin-engine")
+            agent = _make_agent(db, sid)
+            agent.context_compressor.compress = _rewrite_compress
+            # The plugin contract has no record_completed_compaction: the boundary
+            # must fall back to arming the latch directly (getattr on the class).
+            with patch.object(ContextCompressor, "record_completed_compaction", None):
+                messages = [{"role": "user", "content": f"m{i}"} for i in range(8)]
+                compressed, _sp = compress_context(
+                    agent, messages, approx_tokens=100_000, system_message="sys"
+                )
+
+        assert len(compressed) == 2
+        assert agent.context_compressor._verify_compaction_cleared_threshold is True, (
+            "a committed compaction must arm the completed-compaction latch even when "
+            "the engine never set the built-in _last_compression_made_progress flag"
+        )
+
+    def test_noop_rewrite_does_not_arm(self):
+        """A no-op (transcript unchanged) must NOT arm the latch: the structural
+        fallback mirrors _candidate_rejected's no-op comparison, so it cannot
+        turn ineffective compactions into budget re-arms."""
+        from agent.conversation_compression import compress_context
+        from hermes_state import SessionDB
+
+        def _noop_compress(messages, current_tokens=None, focus_topic=None, force=False, memory_context=""):
+            return list(messages)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "20260904_120100_noop0001"
+            _seed(db, sid, "noop")
+            agent = _make_agent(db, sid)
+            agent.context_compressor.compress = _noop_compress
+            with patch.object(ContextCompressor, "record_completed_compaction", None):
+                messages = [{"role": "user", "content": f"m{i}"} for i in range(8)]
+                compressed, _sp = compress_context(
+                    agent, messages, approx_tokens=100_000, system_message="sys"
+                )
+
+        # Unchanged input -> rejected before the boundary; nothing armed.
+        assert len(compressed) == 8
+        assert agent.context_compressor._verify_compaction_cleared_threshold is False

--- a/tests/run_agent/test_compression_rearm_plugin_engine.py
+++ b/tests/run_agent/test_compression_rearm_plugin_engine.py
@@ -17,9 +17,32 @@ See https://github.com/NousResearch/hermes-agent/issues/103355
 import os
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 from agent.context_compressor import ContextCompressor
+
+
+class _PluginEngineShim:
+    """ContextEngine-contract compressor: update_from_response() never touches the
+    built-in's private boundary latch (a real plugin engine cannot know about
+    ``_verify_compaction_cleared_threshold`` — it is not part of the contract)."""
+
+    threshold_tokens = 2000
+
+    def __init__(self, armed: bool = False):
+        # A successful plugin compaction arms the latch via the host else-leg
+        # (conversation_compression boundary); nothing else here.
+        self._verify_compaction_cleared_threshold = armed
+        self.awaiting_real_usage_after_compression = False
+        self._context_probed = False
+        self._context_probe_persistable = False
+
+    def update_from_response(self, usage):
+        """Contract method only — deliberately does NOT clear the private latch."""
+
+    def record_completed_compaction(self, **kwargs):
+        """Plugins do not define this; presence here is only to mirror getattr shape."""
 
 
 def _seed(db, sid, title, n=8):
@@ -118,3 +141,107 @@ class TestPluginEngineCompressionRearm:
         # Unchanged input -> rejected before the boundary; nothing armed.
         assert len(compressed) == 8
         assert agent.context_compressor._verify_compaction_cleared_threshold is False
+
+
+class TestPluginEngineLatchIsOneShot:
+    """Review follow-up (strzhao on PR #103373): a PLUGIN engine's successful
+    compaction arms the host's boundary latch, but nothing on the plugin side ever
+    consumes it — the built-in clears it inside ``update_from_response`` while a
+    plugin's contract method does not. Without a host-side consume the latch is
+    STICKY: one successful compaction would re-arm the budget on every later
+    below-threshold response, including after an ineffective attempt that should
+    stay burnt (the anti-thrash backstop #11529 semantics)."""
+
+    def _agent(self, compressor):
+        agent = SimpleNamespace()
+        agent.context_compressor = compressor
+        agent.model = "test/model"
+        agent.provider = "custom"
+        agent.base_url = "http://local/v1"
+        agent.api_mode = "chat_completions"
+        agent.api_key = "test-key"
+        agent.client = None
+        agent.session_api_calls = 0
+        agent.session_prompt_tokens = 0
+        agent.session_completion_tokens = 0
+        agent.session_total_tokens = 0
+        agent.session_input_tokens = 0
+        agent.session_output_tokens = 0
+        agent.session_cache_read_tokens = 0
+        agent.session_cache_write_tokens = 0
+        agent.session_reasoning_tokens = 0
+        agent.session_estimated_cost_usd = 0.0
+        agent.session_cost_status = None
+        agent.session_cost_source = None
+        agent._session_db = None
+        agent.session_id = None
+        agent.verbose_logging = False
+        agent._usage_anchor = None
+        agent._turn_base_usage_anchor = None
+        agent._last_turn_usage = {}
+        return agent
+
+    def _response(self, prompt_tokens=500):
+        return SimpleNamespace(
+            usage=SimpleNamespace(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=50,
+                total_tokens=prompt_tokens + 50,
+                input_tokens=prompt_tokens,
+                output_tokens=50,
+                cache_read_tokens=0,
+                cache_write_tokens=0,
+                reasoning_tokens=0,
+            )
+        )
+
+    def test_plugin_latch_is_consumed_after_first_real_usage(self):
+        """The armed latch must be one-shot for plugin engines: after the first
+        provider-confirmed real usage consumes it, a LATER below-threshold
+        response must NOT re-arm the budget from the stale latch (only a fresh
+        successful compaction may arm it again)."""
+        from agent.turn_usage import record_response_usage
+
+        comp = _PluginEngineShim(armed=True)  # a compaction just succeeded
+        agent = self._agent(comp)
+        outcome = record_response_usage(
+            agent, self._response(prompt_tokens=500), messages=[{"role": "user", "content": "x"}],
+            api_call_count=1, api_duration=0.1, compression_attempts=1,
+            max_compression_attempts=3,
+        )
+        # First response after the successful compaction: budget re-arms (below threshold).
+        assert outcome.rearmed is True
+        assert outcome.compression_attempts == 0
+        # And the latch is now CONSUMED — one-shot, not sticky.
+        assert comp._verify_compaction_cleared_threshold is False, (
+            "host must consume the boundary latch after update_from_response for "
+            "plugin engines (their contract method never clears it)"
+        )
+
+    def test_stale_latch_does_not_rearm_after_ineffective_attempt(self):
+        """Sticky-latch regression: after the consuming response, an ineffective
+        compaction (no progress -> latch NOT re-armed) must leave the budget burnt.
+        With a sticky latch the next below-threshold response would wrongly re-arm."""
+        from agent.turn_usage import record_response_usage
+
+        comp = _PluginEngineShim(armed=True)
+        agent = self._agent(comp)
+        # First response consumes the armed latch and re-arms (attempts -> 0).
+        record_response_usage(
+            agent, self._response(prompt_tokens=500), messages=[{"role": "user", "content": "x"}],
+            api_call_count=1, api_duration=0.1, compression_attempts=1,
+            max_compression_attempts=3,
+        )
+        assert comp._verify_compaction_cleared_threshold is False
+        # Ineffective compaction burns an attempt and arms nothing (latch stays False).
+        outcome = record_response_usage(
+            agent, self._response(prompt_tokens=500), messages=[{"role": "user", "content": "y"}],
+            api_call_count=2, api_duration=0.1, compression_attempts=1,
+            max_compression_attempts=3,
+        )
+        assert outcome.rearmed is False, (
+            "stale latch must not re-arm the budget after an ineffective attempt "
+            "(one-shot semantics, #11529)"
+        )
+        assert outcome.compression_attempts == 1  # attempt stays burnt
+


### PR DESCRIPTION
Fixes #103355.

## Problem
With a plugin context engine active (`context.engine: lcm`), every successful compaction permanently consumed one `compression.max_attempts` slot — long tool-heavy turns died with `Context length exceeded: max compression attempts (10) reached.` after ten compactions that each brought the prompt back under the threshold.

Root cause: the re-arm path only treats a compaction as having made progress when the engine set the built-in `ContextCompressor`'s private `_last_compression_made_progress` latch. Plugin engines become `agent.context_compressor` (`agent/agent_init.py`) but implement only the `ContextEngine` contract (`agent/context_engine.py`), which never names that latch — so the boundary verdict in `compress_context` was always `False`, `_verify_compaction_cleared_threshold` was never armed, and `turn_usage.record_response_usage` could never re-arm the budget. The counter read as "compactions this turn" instead of the documented consecutive-ineffective-attempt backstop.

## Fix
`agent/conversation_compression.py`: when the engine did not report progress, fall back to the same structural no-op comparison `_candidate_rejected()` already applies before anything is allowed to commit — a rewrite that differs from the input (raw and marker-insensitive) proves progress. This is engine-agnostic: plugin engines need no new contract surface, and the anti-thrash backstop is preserved because re-arming still requires a provider-confirmed `prompt_tokens < threshold` on the next response.

## Test
`tests/run_agent/test_compression_rearm_plugin_engine.py`:
- plugin-shaped rewrite (compress shrinks the transcript without touching the built-in private latches; `record_completed_compaction` absent) → boundary latch armed. Fails on main, passes here.
- no-op rewrite (transcript unchanged) → latch stays unarmed.

Verified: `tests/run_agent/test_compression_budget_rearm.py`, `test_compression_budget_refund.py`, `test_in_place_compaction.py` all pass (26 tests total).
