### PR TITLE
docs(skills): align baoyu image inputs and result handling

### DIFF
--- a/optional-skills/creative/baoyu-article-illustrator/PORT_NOTES.md
+++ b/optional-skills/creative/baoyu-article-illustrator/PORT_NOTES.md
@@ -14,9 +14,9 @@ Ported from [JimLiu/baoyu-skills](https://github.com/JimLiu/baoyu-skills) v1.57.
 | Trigger | `/baoyu-article-illustrator` slash command + CLI flags | Natural language skill matching |
 | User config | EXTEND.md (project/user/XDG paths) + first-time-setup | Removed — not part of Hermes infra |
 | User prompts | `AskUserQuestion` (batched, multi-question) | `clarify` tool (one question at a time) |
-| Image generation | `baoyu-imagine` (Bun/TypeScript, multi-provider, accepts `--ref`, writes to local path) | `image_generate` (returns URL only; agent downloads via `terminal`/`curl`) |
+| Image generation | `baoyu-imagine` (Bun/TypeScript, multi-provider, accepts `--ref`, writes to local path) | `image_generate` (`image` result is a URL or absolute file path; download URLs or copy/reuse local files via `terminal`) |
 | Backend selection | User picks provider via CLI flags | Not agent-selectable — `image_generate` uses the user-configured FAL model. Removed hardcoded "nano banana pro" line from `prompts/system.md`. |
-| Reference images | Passed to backend via `--ref`, copied via shell | `vision_analyze` extracts a textual description (binary never touched by `write_file`/`read_file`); description is embedded in prompts. Optional `terminal cp` for a local record. |
+| Reference images | Passed to backend via `--ref`, copied via shell | `vision_analyze` descriptions remain embedded in prompts. Edits can also use `image_url` plus up to 16 `reference_image_urls` (URLs or absolute local paths); preserve exact source provenance and selected arguments. Optional `terminal cp` for a local record; never use text file tools for binaries. |
 | Platform support | Linux/macOS/Windows/WSL/PowerShell | Linux/macOS only |
 | File operations | Bash commands | Hermes file tools: `write_file`/`read_file` for text, `terminal` for binaries and URL downloads, `vision_analyze` for reading images |
 | Watermark | Driven by EXTEND.md `watermark.enabled` | Optional — user asks for it per-article |

--- a/optional-skills/creative/baoyu-article-illustrator/SKILL.md
+++ b/optional-skills/creative/baoyu-article-illustrator/SKILL.md
@@ -96,7 +96,7 @@ If the user supplies reference images (paths pasted inline, attachments, or a UR
 
 1. For each reference, call `vision_analyze` with the path/URL and a question asking for style, palette, composition, and subject. Record the returned description in `{output-dir}/references/NN-ref-{slug}.md` via `write_file`.
 2. **Do not** try to copy the binary via `write_file` / `read_file` — those are text-only. If you want a local copy for the record, use `terminal` (`cp "$src" "{output-dir}/references/NN-ref-{slug}.{ext}"`). The skill itself never needs to read the binary; it works off the vision description.
-3. Since `image_generate` doesn't take image inputs, the vision description is what gets embedded in prompts during Step 5.
+3. Embed the vision description in prompts during Step 5. For edits/transforms, `image_generate` also accepts `image_url` (a public URL or absolute local path) and up to 16 additional `reference_image_urls` (URLs or absolute local paths) guiding the edit. Record the exact original source and selected image arguments alongside the saved prompt; never substitute an invented path or URL.
 
 Full procedures: [references/workflow.md](references/workflow.md#step-1-detect-reference-images).
 
@@ -153,15 +153,17 @@ For each illustration:
 2. Save to `{output-dir}/prompts/NN-{type}-{slug}.md` using `write_file` with YAML frontmatter.
 3. Prompts MUST use type-specific templates with structured sections (ZONES / LABELS / COLORS / STYLE / ASPECT).
 4. LABELS MUST include article-specific data: actual numbers, terms, metrics, quotes.
-5. Process references (`direct`/`style`/`palette`) per prompt frontmatter — for `direct` usage, embed a textual description of the reference in the prompt (since `image_generate` doesn't take reference-image inputs).
+5. Process references (`direct`/`style`/`palette`) per prompt frontmatter — retain textual descriptions and record any image inputs. Use `image_url` when editing/transforming a source, with `reference_image_urls` for additional visual guidance; keep text-only style/palette extraction when that is the intended usage.
 
 ### Step 6: Generate Images
 
+Inspect the exposed `image_generate` schema first: input support can vary with the configured provider. Use only advertised arguments; if image inputs are unavailable, retain the vision-derived text guidance and disclose the limitation rather than silently ignoring references.
+
 For each prompt file:
 
-1. Call `image_generate(prompt=..., aspect_ratio=...)`. `image_generate` returns a JSON result containing an image URL; it does NOT write to disk and does NOT accept an output path.
+1. Call `image_generate(prompt=..., aspect_ratio=...)` for text-to-image, or include the recorded `image_url` and optional `reference_image_urls` for an edit. The result's `image` field is a URL or an absolute file path; the tool does NOT accept an output-path argument.
 2. Map the prompt's `ASPECT` to `image_generate`'s enum: `16:9` → `landscape`, `9:16` → `portrait`, `1:1` → `square`. Custom ratios → nearest named aspect.
-3. Download the returned URL to `{output-dir}/NN-{type}-{slug}.png` via `terminal` (e.g. `curl -sSL -o "{output-dir}/NN-{type}-{slug}.png" "{url}"`).
+3. Save the result to an absolute path for `{output-dir}/NN-{type}-{slug}.png` via `terminal`: download a URL with `curl -fsSL`, or copy a returned local file with `cp` (reuse it if already at the target). Verify the exact target exists and is non-empty before inserting its relative path into the article. If the image is not PNG, convert it rather than merely renaming its extension.
 4. On generation failure, auto-retry once.
 
 Note: the underlying image-generation backend is user-configured (default: FAL FLUX 2 Klein 9B) and is NOT agent-selectable via `image_generate`. Do not write model names into prompts expecting them to route.
@@ -203,5 +205,5 @@ Images: X/N generated
 3. **Don't illustrate metaphors literally** — visualize the underlying concept.
 4. **Prompt files are mandatory** — no image generation without a saved prompt file. The file is what lets you regenerate or switch backends later.
 5. **`image_generate` aspect ratios** — the tool supports `landscape`, `portrait`, and `square`. Custom ratios map to the nearest option.
-6. **`image_generate` returns a URL, not a local file** — always download via `terminal` (`curl`) before inserting local image paths into the article.
+6. **Inspect the `image` result** — download URLs or copy/reuse absolute local files, then verify the exact output path before inserting it into the article.
 7. **No backend selection from the agent** — `image_generate` uses whatever model the user configured (default: FAL FLUX 2 Klein 9B). Don't write `"use <model> to generate this"` into prompts expecting it to route.

--- a/optional-skills/creative/baoyu-article-illustrator/references/prompt-construction.md
+++ b/optional-skills/creative/baoyu-article-illustrator/references/prompt-construction.md
@@ -30,9 +30,11 @@ references:                    # ⚠️ ONLY if files EXIST in references/ direc
 
 | Usage | Description | Generation Action |
 |-------|-------------|-------------------|
-| `direct` | Primary visual reference | Describe the reference (composition, subject, style, palette) in prompt text — `image_generate` does not accept reference-image inputs |
+| `direct` | Primary visual reference | Describe composition, subject, style, and palette in prompt text; when editing/transforming the source, also pass its URL or absolute local path as `image_url` |
 | `style` | Style characteristics only | Describe style in prompt text |
 | `palette` | Color palette extraction | Include colors in prompt |
+
+For edits, up to 16 additional `reference_image_urls` (URLs or absolute local paths) can guide style, character, or composition. Save the exact source provenance and selected image arguments alongside the prompt before generation; keep trait descriptions even when image inputs are used.
 
 **If no reference file but style/palette extracted verbally**, append directly to prompt body:
 ```

--- a/optional-skills/creative/baoyu-article-illustrator/references/workflow.md
+++ b/optional-skills/creative/baoyu-article-illustrator/references/workflow.md
@@ -2,7 +2,7 @@
 
 ## Step 1: Detect Reference Images
 
-If the user provides reference images (local path or URL), the goal is to produce **textual descriptions** that can be embedded in prompts — `image_generate` doesn't accept reference-image inputs, and Hermes' text file tools can't read or write binaries.
+If the user provides reference images (local path or URL), produce **textual descriptions** for prompts and preserve the exact source for optional image inputs. `image_generate` accepts a public URL or absolute local path in `image_url` for edits/transforms, plus up to 16 additional `reference_image_urls` (URLs or absolute local paths) guiding the edit. Hermes' text file tools can't read or write binaries.
 
 **Tool rules**:
 
@@ -103,7 +103,7 @@ For each reference image (use the `vision_analyze` description from Step 1):
 | `style` | Extract visual style characteristics only | Append style traits to prompt body |
 | `palette` | Extract color scheme only | Append extracted hex colors to prompt body |
 
-Note: `image_generate` does not accept reference-image inputs under any usage type. Everything is mediated through the `vision_analyze` description.
+Retain the `vision_analyze` description under every usage type. When editing/transforming a source, also pass it as `image_url`, with optional `reference_image_urls` for additional guidance. Text-only style/palette extraction remains appropriate when no image edit is intended.
 
 ---
 
@@ -266,7 +266,7 @@ For each illustration in the outline:
 
 ### 5.1 Process References (if analyzed in Step 1)
 
-Read the `vision_analyze` description from the sidecar `references/NN-ref-{slug}.md` (via `read_file`) and embed it in the prompt body. `image_generate` never receives the binary.
+Read the `vision_analyze` description from the sidecar `references/NN-ref-{slug}.md` (via `read_file`) and embed it in the prompt body. Record any selected `image_url` / `reference_image_urls` alongside the saved prompt, retaining the sidecar's exact original source. Resolve local inputs to existing absolute paths; never invent references.
 
 | Usage | Action |
 |-------|--------|
@@ -278,19 +278,25 @@ Read the `vision_analyze` description from the sidecar `references/NN-ref-{slug}
 
 ## Step 6: Generate Images
 
-`image_generate` returns a JSON blob with a URL (`{"success": true, "image": "<url>"}`). It does NOT save a local file, does NOT accept an output path, and does NOT let the agent pick a backend/model. Treat the URL as a temporary artifact and download it explicitly.
+`image_generate` returns an `image` field containing a URL or an absolute local file path. It does NOT accept an output path or let the agent pick a backend/model. Save the result at the intended output path, downloading only when it is a URL.
+
+Edit example (replace paths with verified sources and save the full prompt/arguments first; use only arguments advertised by the exposed schema):
+
+```python
+image_generate(prompt="Simplify this diagram, retaining its exact labels and the recorded palette.", aspect_ratio="landscape", image_url="/absolute/references/diagram.png", reference_image_urls=["/absolute/references/style.png"])
+```
 
 For each prompt file:
 
 1. Read the prompt file (via `read_file`) and extract the assembled prompt
 2. Map the prompt's `ASPECT` to `image_generate`'s enum: `16:9` → `landscape`, `9:16` → `portrait`, `1:1` → `square`. Custom ratios → nearest named aspect.
-3. Call `image_generate(prompt=<assembled>, aspect_ratio=<enum>)` and extract the `image` URL from the returned JSON.
+3. Call `image_generate(prompt=<assembled>, aspect_ratio=<enum>)` for text-to-image, or add the recorded `image_url` and optional `reference_image_urls` for an edit. Extract the `image` field from the result.
 4. **Backup rule**: If `{output-dir}/NN-{type}-{slug}.png` already exists, rename it via `terminal` (`mv "{output-dir}/NN-{type}-{slug}.png" "{output-dir}/NN-{type}-{slug}-backup-YYYYMMDD-HHMMSS.png"`) before writing.
-5. Download the URL via `terminal`:
+5. Resolve the output directory to an absolute path. For a URL result, download via `terminal`:
    ```bash
-   curl -sSL -o "{output-dir}/NN-{type}-{slug}.png" "{image_url}"
+   curl -fsSL -o "/absolute/output-dir/NN-type-slug.png" "<returned-image-url>"
    ```
-   If `curl` is unavailable, fall back to `wget -qO "{output-dir}/NN-{type}-{slug}.png" "{image_url}"`.
+   If `curl` is unavailable, use `wget` with the same absolute target. For a local-path result, copy it via `terminal` (`cp "<returned-absolute-path>" "/absolute/output-dir/NN-type-slug.png"`), or reuse it if already at the target. Convert non-PNG data before saving with a `.png` extension.
 6. Verify the file exists and has non-zero size (`terminal`: `test -s "{path}" && echo ok`).
 7. On generation failure, retry `image_generate` once. On download failure, retry `curl` once with a longer timeout. Then log and continue.
 8. After each generation, report "Generated X/N".

--- a/optional-skills/creative/baoyu-article-illustrator/references/workflow.md
+++ b/optional-skills/creative/baoyu-article-illustrator/references/workflow.md
@@ -282,7 +282,7 @@ Read the `vision_analyze` description from the sidecar `references/NN-ref-{slug}
 
 Edit example (replace paths with verified sources and save the full prompt/arguments first; use only arguments advertised by the exposed schema):
 
-```python
+```text
 image_generate(prompt="Simplify this diagram, retaining its exact labels and the recorded palette.", aspect_ratio="landscape", image_url="/absolute/references/diagram.png", reference_image_urls=["/absolute/references/style.png"])
 ```
 

--- a/optional-skills/creative/baoyu-comic/PORT_NOTES.md
+++ b/optional-skills/creative/baoyu-comic/PORT_NOTES.md
@@ -12,7 +12,7 @@ Ported from [JimLiu/baoyu-skills](https://github.com/JimLiu/baoyu-skills) v1.56.
 | Trigger | Slash commands / CLI flags | Natural language skill matching |
 | User config | EXTEND.md file (project/user/XDG paths) | Removed — not part of Hermes infra |
 | User prompts | `AskUserQuestion` (batched) | `clarify` tool (one question at a time) |
-| Image generation | baoyu-imagine (Bun/TypeScript, supports `--ref`) | `image_generate` — **prompt-only**, returns a URL; no reference image input; agent must download the URL to the output directory |
+| Image generation | baoyu-imagine (Bun/TypeScript, supports `--ref`) | `image_generate` — text-to-image or edits with image inputs; `image` result is a URL or absolute file path, saved to the output directory |
 | PDF assembly | `scripts/merge-to-pdf.ts` (Bun + `pdf-lib`) | Removed — the PDF merge step is out of scope for this port; pages are delivered as PNGs only |
 | Platform support | Linux/macOS/Windows/WSL/PowerShell | Linux/macOS only |
 | File operations | Generic instructions | Hermes file tools (`write_file`, `read_file`) |
@@ -30,12 +30,12 @@ Ported from [JimLiu/baoyu-skills](https://github.com/JimLiu/baoyu-skills) v1.56.
 
 ### Image generation strategy changes
 
-`image_generate`'s schema accepts only `prompt` and `aspect_ratio` (`landscape` | `portrait` | `square`). Upstream's reference-image flow (`--ref characters.png` for character consistency, plus user-supplied refs for style/palette/scene) does not map to this tool, so the workflow was restructured:
+`image_generate` accepts `prompt`, optional `aspect_ratio` (`landscape` | `portrait` | `square`), `image_url` for edits/transforms (public URL or absolute local path), and up to 16 additional `reference_image_urls` (URLs or absolute local paths) guiding an edit. The Hermes adaptation retains text traits and saved prompts alongside optional image inputs:
 
-- **Character sheet PNG** is still generated for multi-page comics, but it is repositioned as a **human-facing review artifact** (for visual verification) and a reference for later regenerations / manual prompt edits. Page prompts themselves are built from the **text descriptions** in `characters/characters.md` (embedded inline during Step 5). `image_generate` never sees the PNG as a visual input.
-- **User-supplied reference images** are reduced to `style` / `palette` / `scene` trait extraction — traits are embedded in the prompt body; the image files themselves are kept only for provenance under `refs/`.
-- **Page prompts** now mandate that character descriptions are embedded inline (copied from `characters/characters.md`) — this is the only mechanism left to enforce cross-page character consistency.
-- **Download step** — after every `image_generate` call, the returned URL is fetched to disk (e.g., `curl -fsSL "<url>" -o <target>.png`) and verified before the workflow advances.
+- **Character sheet PNG** remains a **human-facing review artifact**. After visual verification it can also be an edit source or additional visual reference. Page prompts retain **text descriptions** from `characters/characters.md`, embedded inline during Step 5.
+- **User-supplied reference images** retain `style` / `palette` / `scene` trait extraction via `vision_analyze`, plus optional image inputs. Preserve exact original sources, local-copy paths, and selected tool arguments alongside saved prompts.
+- **Page prompts** mandate embedded character descriptions, whether or not image inputs are used. Keep the same reviewed traits/style and verify cross-page consistency.
+- **Save step** — inspect the returned `image`: download a URL or copy/reuse an absolute local file, then verify the exact absolute target before advancing. No output-path argument is exposed.
 
 ### SKILL.md reductions
 

--- a/optional-skills/creative/baoyu-comic/SKILL.md
+++ b/optional-skills/creative/baoyu-comic/SKILL.md
@@ -23,10 +23,11 @@ Trigger this skill when the user asks to create a knowledge/educational comic, b
 
 ## Reference Images
 
-Hermes' `image_generate` tool is **prompt-only** — it accepts a text prompt and an aspect ratio, and returns an image URL. It does **NOT** accept reference images. When the user supplies a reference image, use it to **extract traits in text** that get embedded in every page prompt:
+Hermes' `image_generate` accepts `prompt`, optional `aspect_ratio`, and `image_url` (a public URL or absolute local path) for edits/transforms, plus up to 16 additional `reference_image_urls` (URLs or absolute local paths) guiding an edit. Its `image` result is a URL or absolute file path. When the user supplies a reference, use `vision_analyze` to **extract traits in text** for page prompts as well as retaining the source for optional image inputs:
 
-**Intake**: Accept file paths when the user provides them (or pastes images in conversation).
+**Intake**: Accept file paths or URLs when the user provides them (or pastes images in conversation). Preserve the exact original source, local-copy path if any, and selected image arguments alongside the saved prompt; never invent a path or URL.
 - File path(s) → copy to `refs/NN-ref-{slug}.{ext}` alongside the comic output for provenance
+- URL(s) → analyze the URL and record it exactly; optionally download a local provenance copy
 - Pasted image with no path → ask the user for the path via `clarify`, or extract style traits verbally as a text fallback
 - No reference → skip this section
 
@@ -44,11 +45,12 @@ Hermes' `image_generate` tool is **prompt-only** — it accepts a text prompt an
 references:
   - ref_id: 01
     filename: 01-ref-scene.png
+    source: "<original path or URL>"
     usage: style
     traits: "muted earth tones, soft-edged ink wash, low-contrast backgrounds"
 ```
 
-Character consistency is driven by **text descriptions** in `characters/characters.md` (written in Step 3) that get embedded inline in every page prompt (Step 5). The optional PNG character sheet generated in Step 7.1 is a human-facing review artifact, not an input to `image_generate`.
+Character consistency uses **text descriptions** in `characters/characters.md` (written in Step 3) embedded inline in every page prompt (Step 5). The optional PNG character sheet generated in Step 7.1 remains a human-facing review artifact and can also be an `image_url` source for a transformation into a page, or an additional `reference_image_urls` entry when editing another source. Keep the same approved traits and style across pages; visual inputs do not guarantee consistency.
 
 ## Options
 
@@ -61,7 +63,7 @@ Character consistency is driven by **text descriptions** in `characters/characte
 | Layout | standard (default), cinematic, dense, splash, mixed, webtoon, four-panel | Panel arrangement |
 | Aspect | 3:4 (default, portrait), 4:3 (landscape), 16:9 (widescreen) | Page aspect ratio |
 | Language | auto (default), zh, en, ja, etc. | Output language |
-| Refs | File paths | Reference images used for style / palette trait extraction (not passed to the image model). See [Reference Images](#reference-images) above. |
+| Refs | File paths or URLs | Reference images used for trait extraction and optional edit inputs. See [Reference Images](#reference-images) above. |
 
 ### Partial Workflow Options
 
@@ -105,9 +107,9 @@ Output directory: `comic/{topic-slug}/`
 | `analysis.md` | Content analysis |
 | `storyboard.md` | Storyboard with panel breakdown |
 | `characters/characters.md` | Character definitions |
-| `characters/characters.png` | Character reference sheet (downloaded from `image_generate`) |
+| `characters/characters.png` | Character reference sheet (saved from `image_generate`) |
 | `prompts/NN-{cover\|page}-[slug].md` | Generation prompts |
-| `NN-{cover\|page}-[slug].png` | Generated images (downloaded from `image_generate`) |
+| `NN-{cover\|page}-[slug].png` | Generated images (saved from `image_generate`) |
 | `refs/NN-ref-{slug}.{ext}` | User-supplied reference images (optional, for provenance) |
 
 ## Language Handling
@@ -178,7 +180,9 @@ Use the `clarify` tool to confirm options. Since `clarify` handles one question 
 
 ### Step 7: Image Generation
 
-Use Hermes' built-in `image_generate` tool for all image rendering. Its schema accepts only `prompt` and `aspect_ratio` (`landscape` | `portrait` | `square`); it **returns a URL**, not a local file. Every generated page or character sheet must therefore be downloaded to the output directory.
+Inspect the exposed `image_generate` schema first: input support can vary with the configured provider. Use only advertised arguments; if image inputs are unavailable, retain the text traits and disclose the limitation rather than silently ignoring references.
+
+Use Hermes' `image_generate` tool for all image rendering. Use `prompt` and optional `aspect_ratio` (`landscape` | `portrait` | `square`) for text-to-image; add `image_url` and optional `reference_image_urls` for edits as described above. Save the returned `image` (URL or absolute local file path) to the output directory. There is no output-path argument.
 
 **Prompt file requirement (hard)**: write each image's full, final prompt to a standalone file under `prompts/` (naming: `NN-{type}-[slug].md`) BEFORE calling `image_generate`. The prompt file is the reproducibility record.
 
@@ -190,17 +194,18 @@ Use Hermes' built-in `image_generate` tool for all image rendering. Its schema a
 | `4:3`, `16:9`, `3:2` | `landscape` |
 | `1:1` | `square` |
 
-**Download step** — after every `image_generate` call:
-1. Read the URL from the tool result
-2. Fetch the image bytes using an **absolute** output path, e.g.
+**Save step** — after every successful `image_generate` call:
+1. Read the `image` field from the tool result
+2. If it is a URL, fetch the image bytes using an **absolute** output path, e.g.
    `curl -fsSL "<url>" -o /abs/path/to/comic/<slug>/NN-page-<slug>.png`
+   If it is a local path, copy it with `terminal` (`cp "<returned-absolute-path>" "/abs/path/to/comic/slug/NN-page-slug.png"`), or reuse it if already at the target. Convert non-PNG data rather than merely renaming its extension.
 3. Verify the file exists and is non-empty at that exact path before proceeding to the next page
 
 **Never rely on shell CWD persistence for `-o` paths.** The terminal tool's persistent-shell CWD can change between batches (session expiry, `TERMINAL_LIFETIME_SECONDS`, a failed `cd` that leaves you in the wrong directory). `curl -o relative/path.png` is a silent footgun: if CWD has drifted, the file lands somewhere else with no error. **Always pass a fully-qualified absolute path to `-o`**, or pass `workdir=<abs path>` to the terminal tool. Incident Apr 2026: pages 06-09 of a 10-page comic landed at the repo root instead of `comic/<slug>/` because batch 3 inherited a stale CWD from batch 2 and `curl -o 06-page-skills.png` wrote to the wrong directory. The agent then spent several turns claiming the files existed where they didn't.
 
-**7.1 Character sheet** — generate it (to `characters/characters.png`, aspect `landscape`) when the comic is multi-page with recurring characters. Skip for simple presets (e.g., four-panel minimalist) or single-page comics. The prompt file at `characters/characters.md` must exist before invoking `image_generate`. The rendered PNG is a **human-facing review artifact** (so the user can visually verify character design) and a reference for later regenerations or manual prompt edits — it does **not** drive Step 7.2. Page prompts are already written in Step 5 from the **text descriptions** in `characters/characters.md`; `image_generate` cannot accept images as visual input.
+**7.1 Character sheet** — generate it (to `characters/characters.png`, aspect `landscape`) when the comic is multi-page with recurring characters. Skip for simple presets (e.g., four-panel minimalist) or single-page comics. The prompt file at `characters/characters.md` must exist before invoking `image_generate`. Inspect the rendered PNG with `vision_analyze` against the character definitions before using it as a visual input in Step 7.2. It remains a **human-facing review artifact** and a reference for later regenerations or manual prompt edits.
 
-**7.2 Pages** — each page's prompt MUST already be at `prompts/NN-{cover|page}-[slug].md` before invoking `image_generate`. Because `image_generate` is prompt-only, character consistency is enforced by **embedding character descriptions (sourced from `characters/characters.md`) inline in every page prompt during Step 5**. The embedding is done uniformly whether or not a PNG sheet is produced in 7.1; the PNG is only a review/regeneration aid.
+**7.2 Pages** — each page's prompt MUST already be at `prompts/NN-{cover|page}-[slug].md` before invoking `image_generate`. **Embed character descriptions (sourced from `characters/characters.md`) inline in every page prompt during Step 5**, whether or not a PNG sheet is produced. Before an edit, also record the actual `image_url` and any `reference_image_urls` alongside that prompt. Use the reviewed sheet consistently where appropriate and verify each page against the same character/style definitions.
 
 **Backup rule**: existing `prompts/…md` and `…png` files → rename with `-backup-YYYYMMDD-HHMMSS` suffix before regenerating.
 
@@ -229,7 +234,7 @@ Full step-by-step workflow (analysis, storyboard, review gates, regeneration var
 
 | Action | Steps |
 |--------|-------|
-| **Edit** | **Update prompt file FIRST** → regenerate image → download new PNG |
+| **Edit** | **Update prompt file FIRST** → regenerate image → save new PNG |
 | **Add** | Create prompt at position → generate with character descriptions embedded → renumber subsequent → update storyboard |
 | **Delete** | Remove files → renumber subsequent → update storyboard |
 
@@ -238,10 +243,10 @@ Full step-by-step workflow (analysis, storyboard, review gates, regeneration var
 ## Pitfalls
 
 - Image generation: 10-30 seconds per page; auto-retry once on failure
-- **Always download** the URL returned by `image_generate` to a local PNG — downstream tooling (and the user's review) expects files in the output directory, not ephemeral URLs
-- **Use absolute paths for `curl -o`** — never rely on persistent-shell CWD across batches. Silent footgun: files land in the wrong directory and subsequent `ls` on the intended path shows nothing. See Step 7 "Download step".
+- **Always save and verify** the `image` result in the output directory — download URLs, or copy/reuse absolute local files; downstream tooling and review expect local images
+- **Use absolute paths for `curl -o` and copy targets** — never rely on persistent-shell CWD across batches. Files can silently land in the wrong directory. See Step 7 "Save step".
 - Use stylized alternatives for sensitive public figures
 - **Step 2 confirmation required** - do not skip
 - **Steps 4/6 conditional** - only if user requested in Step 2
-- **Step 7.1 character sheet** - recommended for multi-page comics, optional for simple presets. The PNG is a review/regeneration aid; page prompts (written in Step 5) use the text descriptions in `characters/characters.md`, not the PNG. `image_generate` does not accept images as visual input
+- **Step 7.1 character sheet** - recommended for multi-page comics, optional for simple presets. Retain text descriptions in page prompts even when the reviewed PNG is also used as an image input
 - **Strip secrets** — scan source content for API keys, tokens, or credentials before writing any output file

--- a/optional-skills/creative/baoyu-comic/references/partial-workflows.md
+++ b/optional-skills/creative/baoyu-comic/references/partial-workflows.md
@@ -87,7 +87,7 @@ Regenerate specific pages only.
 **Workflow**:
 1. Read existing prompts for specified pages
 2. Regenerate images only for those pages via `image_generate`
-3. Download each returned URL and overwrite the existing PNG
+3. Follow [Step 7's save procedure](workflow.md#step-7-generate-images): back up the existing PNG, then download a returned URL or copy/reuse a returned local file, and verify the exact absolute target
 
 **Prerequisites** (must exist):
 - `prompts/NN-{cover|page}-[slug].md` for specified pages

--- a/optional-skills/creative/baoyu-comic/references/workflow.md
+++ b/optional-skills/creative/baoyu-comic/references/workflow.md
@@ -247,7 +247,7 @@ Create image generation prompts for all pages.
 
 **For each page (cover + pages)**:
 1. Create prompt following art style + tone guidelines
-2. **Embed character descriptions** inline (copy relevant traits from `characters/characters.md`) — `image_generate` is prompt-only, so the prompt text is the sole vehicle for character consistency
+2. **Embed character descriptions** inline (copy relevant traits from `characters/characters.md`) — retain these even when visual inputs also guide generation
 3. Save to `prompts/NN-{cover|page}-[slug].md` using `write_file`
    - **Backup rule**: If prompt file exists, rename to `prompts/NN-{cover|page}-[slug]-backup-YYYYMMDD-HHMMSS.md`
 
@@ -308,7 +308,13 @@ options:
 
 ## Step 7: Generate Images
 
-With confirmed prompts from Step 5/6, use the `image_generate` tool. The tool accepts only `prompt` and `aspect_ratio` (`landscape` | `portrait` | `square`) and **returns a URL** — it does not accept reference images and does not write local files. Every invocation must be followed by a download step.
+With confirmed prompts from Step 5/6, use `image_generate` with `prompt` and optional `aspect_ratio` (`landscape` | `portrait` | `square`). For edits/transforms, `image_url` accepts a public URL or absolute local path, and `reference_image_urls` accepts up to 16 additional URLs or absolute local paths guiding the edit. Record those arguments and exact source provenance alongside the saved prompt before generation. The result's `image` field is a URL or absolute local file path; no output-path argument is accepted.
+
+Edit example (replace paths with verified sources and use the saved full page prompt; use only arguments advertised by the exposed schema):
+
+```python
+image_generate(prompt="Revise this page using the saved character traits and panel dialogue; match the reviewed sheet.", aspect_ratio="portrait", image_url="/absolute/comic/01-page.png", reference_image_urls=["/absolute/comic/characters/characters.png"])
+```
 
 **Aspect ratio mapping** — map the storyboard's `aspect_ratio` to the tool's enum:
 
@@ -318,11 +324,11 @@ With confirmed prompts from Step 5/6, use the `image_generate` tool. The tool ac
 | `4:3`, `16:9`, `3:2` | `landscape` |
 | `1:1` | `square` |
 
-**Download procedure** (run after every successful `image_generate` call):
+**Save procedure** (run after every successful `image_generate` call):
 
-1. Extract the `url` field from the tool result
-2. Fetch it to disk, e.g. `curl -fsSL "<url>" -o comic/{slug}/<target>.png`
-3. Verify the file is non-empty (`test -s <target>.png`); on failure, retry the generation once
+1. Extract the `image` field from the tool result
+2. For a URL, fetch to an absolute target: `curl -fsSL "<url>" -o "/abs/path/to/comic/slug/NN-page-slug.png"`. For a local file, copy it with `terminal`: `cp "<returned-absolute-path>" "/abs/path/to/comic/slug/NN-page-slug.png"`, or reuse it if already at the target. Convert non-PNG data rather than merely renaming its extension.
+3. Verify that exact absolute target is non-empty before proceeding. On a download failure, retry the download once rather than regenerating a successful image; report unresolved failures honestly.
 
 ### 7.1 Generate Character Reference Sheet (conditional)
 
@@ -340,17 +346,17 @@ Character sheet is recommended for multi-page comics with recurring characters, 
 1. Use Reference Sheet Prompt from `characters/characters.md`
 2. **Backup rule**: If `characters/characters.png` exists, rename to `characters/characters-backup-YYYYMMDD-HHMMSS.png`
 3. Call `image_generate` with `landscape` format
-4. Download the returned URL → save to `characters/characters.png`
+4. Apply the save procedure above → `characters/characters.png`
 
-**Important**: the downloaded sheet is a **human-facing review artifact** (so the user can visually verify character design) and a reference for later regenerations or manual prompt edits. It does **not** drive Step 7.2 — page prompts were already written in Step 5 from the text descriptions in `characters/characters.md`. `image_generate` cannot accept images as visual input, so the text is the sole cross-page consistency mechanism.
+**Important**: the saved sheet is a **human-facing review artifact** and a reference for later regenerations or manual prompt edits. Inspect it with `vision_analyze` against `characters/characters.md` before using it in Step 7.2. It can be an `image_url` source for transformation into a page, or an additional `reference_image_urls` entry when editing another source. Retain Step 5's embedded character descriptions; visual inputs do not guarantee consistency.
 
 ### 7.2 Generate Comic Pages
 
 **Before generating any page**:
 1. Confirm each prompt file exists at `prompts/NN-{cover|page}-[slug].md`
-2. Confirm that each prompt has character descriptions embedded inline (see Step 5). `image_generate` is prompt-only, so the prompt text is the sole consistency mechanism.
+2. Confirm that each prompt has character descriptions embedded inline (see Step 5). Record any selected image inputs alongside it, preserving exact original sources and resolving local inputs to existing absolute paths.
 
-**Page Generation Strategy**: every page prompt must embed character descriptions (sourced from `characters/characters.md`) inline. This is done during Step 5, uniformly whether or not the PNG sheet was produced in 7.1 — the PNG is only a review/regeneration aid, never a generation input.
+**Page Generation Strategy**: every page prompt must embed character descriptions (sourced from `characters/characters.md`) inline. This is done during Step 5, whether or not the PNG sheet was produced in 7.1. When using visual inputs, use the reviewed sheet consistently and verify every page against the same character/style definitions.
 
 **Example embedded prompt** (`prompts/01-page-xxx.md`):
 
@@ -368,8 +374,8 @@ Character sheet is recommended for multi-page comics with recurring characters, 
 **For each page (cover + pages)**:
 1. Read prompt from `prompts/NN-{cover|page}-[slug].md`
 2. **Backup rule**: If image file exists, rename to `NN-{cover|page}-[slug]-backup-YYYYMMDD-HHMMSS.png`
-3. Call `image_generate` with the prompt text and mapped aspect ratio
-4. Download the returned URL → save to `NN-{cover|page}-[slug].png`
+3. Call `image_generate` with the prompt text and mapped aspect ratio, plus the recorded image inputs if editing
+4. Apply the save procedure above → `NN-{cover|page}-[slug].png`
 5. Report progress after each generation: "Generated X/N: [page title]"
 
 ---
@@ -392,8 +398,8 @@ Location: [path]
 
 | Action | Steps |
 |--------|-------|
-| **Edit** | Update prompt → Regenerate image → Download new PNG |
-| **Add** | Create prompt at position → Generate image → Download PNG → Renumber subsequent (NN+1) → Update storyboard |
+| **Edit** | Update prompt → Regenerate image → Save new PNG |
+| **Add** | Create prompt at position → Generate image → Save PNG → Renumber subsequent (NN+1) → Update storyboard |
 | **Delete** | Remove files → Renumber subsequent (NN-1) → Update storyboard |
 
 **File naming**: `NN-{cover|page}-[slug].png` (e.g., `03-page-enigma-machine.png`)


### PR DESCRIPTION
## Summary
- Align the two Hermes-adapted baoyu skills and affected workflow/port notes with `image_generate`: `image_url` accepts a public URL or absolute local path, optional `reference_image_urls` supplies additional edit guidance, and the `image` result may be a URL or absolute file path.
- Inspect the exposed provider-specific schema before supplying image arguments. Preserve vision-derived traits, saved prompts, exact source provenance, character/style consistency, and attribution.
- Download only URL results; copy/reuse local results, verify the absolute output target, and convert non-PNG data instead of changing only its extension. Correct the comic reference's stale `url` result-field name.

## Evidence
Confirmed stale instructions on current `main` (`79445a496c86a19332ad786494b8384d2167e2d0`) and inspected the live `tool_describe(image_generate)` schema (prompt required; landscape/square/portrait; image_url; reference_image_urls with maxItems 16; URL-or-file `image` result). No image generation was invoked.

The provider-sensitive schema and result contract are also implemented in [tools/image_generation_tool.py](https://github.com/NousResearch/hermes-agent/blob/79445a496c86a19332ad786494b8384d2167e2d0/tools/image_generation_tool.py#L796-L851).

## Verification
- `git diff --check`: passed.
- Offline documentation validation: both concrete edit examples parsed with Python AST and validated against the exposed argument names, required prompt, types, aspect enum, and reference-array limit. Examples were not sent to a provider.
- Scanned all 70 Markdown files in the two packages: no remaining targeted prompt-only/URL-only contract claims; 28 relative Markdown support links resolve, no missing links. Attribution frontmatter unchanged; style/palette/character template files untouched.
- Canonical authoring suite (`scripts/run_tests.sh tests/skills/test_authoring_standards.py -q -j 1`): **1172 passed, 0 failed** on this exact head. The initial missing-test-environment blocker was resolved using a separate test virtualenv; no packages were installed into the live checkout. These are authoring checks, not runtime or provider-generation tests. Hosted CI still awaits maintainer approval.
