### PR TITLE
fix(desktop): honor Reasoning Blocks off as answer-only

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-hermes-config.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { $terminalFontFamily, setTerminalFontFamilyFromConfig } from '@/app/right-sidebar/terminal/terminal-font'
 import { getHermesConfig } from '@/hermes'
 import { persistString } from '@/lib/storage'
+import { $showReasoning, setShowReasoningFromConfig } from '@/store/reasoning-disclosure'
 import {
   $currentCwd,
   $currentFastMode,
@@ -41,7 +42,26 @@ describe('useHermesConfig refreshHermesConfig', () => {
     setCurrentReasoningEffort('')
     setDefaultReasoningEffort('')
     setTerminalFontFamilyFromConfig('')
+    setShowReasoningFromConfig(false)
     persistString(WORKSPACE_CWD_KEY, null)
+  })
+
+  it('publishes display.show_reasoning so the renderer can hide thinking and tools', async () => {
+    mockConfig({ display: { show_reasoning: true } })
+    const { result } = renderHook(() => useHermesConfig({ activeSessionIdRef: { current: null } }))
+
+    await act(async () => {
+      await result.current.refreshHermesConfig()
+    })
+
+    expect($showReasoning.get()).toBe(true)
+
+    mockConfig({ display: { show_reasoning: 'false' } })
+    await act(async () => {
+      await result.current.refreshHermesConfig()
+    })
+
+    expect($showReasoning.get()).toBe(false)
   })
 
   // Regression: the composer keeps a manual model pick sticky, which skips the

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.ts
@@ -5,6 +5,7 @@ import { getHermesConfig, getHermesConfigDefaults } from '@/hermes'
 import { BUILTIN_PERSONALITIES, normalizePersonalityValue, personalityNamesFromConfig } from '@/lib/chat-runtime'
 import { normalize } from '@/lib/text'
 import { setDisplayTimestampsFromConfig } from '@/store/display-timestamps'
+import { setShowReasoningFromConfig } from '@/store/reasoning-disclosure'
 import {
   getComposerSelectionGeneration,
   getCurrentModelSource,
@@ -138,6 +139,7 @@ export function useHermesConfig({ activeSessionIdRef }: HermesConfigOptions) {
         }
 
         setDisplayTimestampsFromConfig(config.display?.timestamps)
+        setShowReasoningFromConfig(config.display?.show_reasoning)
         setTerminalFontFamilyFromConfig(config.terminal?.font_family)
 
         if (!canPublish()) {

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
@@ -9,6 +9,7 @@ import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { $displayTimestamps } from '@/store/display-timestamps'
+import { $showReasoning } from '@/store/reasoning-disclosure'
 
 import { stubThreadEnvironment } from '../test-utils'
 
@@ -18,6 +19,7 @@ import { Thread } from '.'
 
 // Timeline timestamps render only when `display.timestamps` is enabled.
 $displayTimestamps.set(true)
+$showReasoning.set(true)
 
 const createdAt = new Date('2026-05-01T00:00:00.000Z')
 const completedAt = createdAt.getTime() / 1000 + 1.25
@@ -142,5 +144,15 @@ describe('message timeline timestamps', () => {
     )
 
     expect(stamps.filter(stamp => stamp === formatTimelineRange(startedAt, completedAt))).toHaveLength(1)
+  })
+})
+
+describe('answer-only transcript (#93817 / #85110 / #49664)', () => {
+  it('hides thinking chrome when display.show_reasoning is off', async () => {
+    $showReasoning.set(false)
+    render(<Harness />)
+    await screen.findByText('done')
+    expect(screen.queryByText('checked carefully')).toBeNull()
+    $showReasoning.set(true)
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
@@ -24,7 +24,7 @@ import { generatedImageFromResult } from '@/lib/generated-images'
 import { separateGluedReasoningBlocks } from '@/lib/reasoning-blocks'
 import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
-import { $reasoningCollapsedByDefault } from '@/store/reasoning-disclosure'
+import { $reasoningCollapsedByDefault, $showReasoning } from '@/store/reasoning-disclosure'
 
 type TimelineToolCallProps = ToolCallMessagePartProps & { completedAt?: number; timestamp?: number }
 
@@ -63,8 +63,37 @@ const DelegateToolPart: FC<TimelineToolCallProps> = props => {
 }
 
 const ChainToolFallback: FC<TimelineToolCallProps> = props => {
+  const showReasoning = useStore($showReasoning)
+
   // todo parts are hoisted to a dedicated panel above the message content.
   if (props.toolName === 'todo') {
+    return null
+  }
+
+  // Answer-only: hide agent-work chrome. Keep clarify / MCP setup / generated
+  // images / failed calls the user still has to act on (#93817 / #85110).
+  if (!showReasoning) {
+    if (props.toolName === 'clarify') {
+      return (
+        <>
+          <TimelineTimestamp className="mb-0.5 block" completedAt={props.completedAt} timestamp={props.timestamp} />
+          <ClarifyTool {...props} />
+        </>
+      )
+    }
+
+    if (props.toolName === 'setup_mcp') {
+      return <McpSetupTool {...props} />
+    }
+
+    if (props.toolName === 'image_generate') {
+      return <ImageGenerateTool {...props} />
+    }
+
+    if (props.isError) {
+      return <ToolFallback {...props} />
+    }
+
     return null
   }
 
@@ -301,7 +330,9 @@ const ReasoningAccordionGroup: FC<{ children?: ReactNode; endIndex: number; star
     }, undefined)
   )
 
-  if (!hasContent) {
+  const showReasoning = useStore($showReasoning)
+
+  if (!hasContent || !showReasoning) {
     return null
   }
 

--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -17,6 +17,7 @@ import {
 } from 'react'
 
 import { useSessionView } from '@/app/chat/session-view'
+import { $showReasoning } from '@/store/reasoning-disclosure'
 import { AnsiText } from '@/components/assistant-ui/ansi-text'
 import { TimelineTimestamp } from '@/components/assistant-ui/thread/timeline-timestamp'
 import { useElapsedSeconds } from '@/components/chat/activity-timer'
@@ -993,6 +994,14 @@ export const ToolGroupSlot: FC<PropsWithChildren<{ endIndex: number; startIndex:
   endIndex,
   startIndex
 }) => {
+  const showReasoning = useStore($showReasoning)
+
+  // Answer-only: skip the run-group scaffold. Children still mount so
+  // Fallback can keep clarify / errors (#93817 / #85110).
+  if (!showReasoning) {
+    return children
+  }
+
   // Joined rather than returned as an array: assistant-ui compares selector
   // results with `Object.is` and re-runs them on every store update, so a
   // fresh array would re-render the whole group on every text delta.

--- a/apps/desktop/src/store/reasoning-disclosure.ts
+++ b/apps/desktop/src/store/reasoning-disclosure.ts
@@ -12,3 +12,16 @@ $reasoningCollapsedByDefault.subscribe(value => persistBoolean(REASONING_COLLAPS
 export function setReasoningCollapsedByDefault(value: boolean) {
   $reasoningCollapsedByDefault.set(value)
 }
+
+/**
+ * `display.show_reasoning` — Settings → Chat → Reasoning Blocks.
+ *
+ * Off by default, matching gateway/CLI (`display.show_reasoning: false`).
+ * When false the transcript is answer-only: no Thinking disclosure and no
+ * tool-run chrome (#93817, #85110, #49664). Quoted YAML `'false'` is off.
+ */
+export const $showReasoning = atom(false)
+
+export function setShowReasoningFromConfig(value: unknown): void {
+  $showReasoning.set(value === true || value === 'true' || value === 1 || value === '1')
+}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -347,6 +347,7 @@ export interface HermesConfig {
     skin?: string
     interim_assistant_messages?: boolean
     timestamps?: boolean
+    show_reasoning?: boolean | string
   }
   desktop?: {
     repo_scan_enabled?: boolean


### PR DESCRIPTION
## What does this PR do?

Settings → Chat → **Reasoning Blocks** off (`display.show_reasoning: false`) still dumped Grok (and every other provider) thinking plus every tool-call row into the Desktop transcript. The toggle already wrote config. The renderer never read it.

When the setting is off, the transcript is **answer-only**: no Thinking disclosure, no tool-run scaffold. Clarify, MCP setup, generated images, and failed calls the user still has to act on remain.

## Related Issue

Fixes #93817
Fixes #85110
Fixes #49664

Related open PR #101376 (same hide-thinking intent plus Grok answer stacking). This PR is the hide-thinking/tool-chrome slice on current main.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `$showReasoning` atom from `display.show_reasoning` (quoted YAML `false` is off)
- `ReasoningAccordionGroup` does not mount when the flag is off
- `ToolGroupSlot` skips run-group chrome; `ChainToolFallback` returns null for agent-work tools
- Tests: config publish + assistant-message hides reasoning text

## How to Test

1. Desktop. Settings → Chat → Reasoning Blocks off.
2. Send a Grok (or any) turn that thinks and uses tools.
3. Transcript should show the answer only — no Thinking row, no tool-run dump.
4. Turn the setting on: thinking and tools return.

```
npm run test:ui -- src/app/session/hooks/use-hermes-config.test.ts src/components/assistant-ui/thread/assistant-message.test.tsx
```

14 passed. Sabotage: forcing `$showReasoning` always true fails the quoted-`false` config test; restoring the fix passes.

## Checklist

### Code

- [x] Contributing Guide
- [x] Conventional Commits
- [x] Searched existing PRs (#101376 noted)
- [x] Only this fix
- [x] Desktop UI tests for touched files. Full pytest not run (UI-only).
- [x] Tests added
- [x] Linux unit tests. Bug is Desktop × Grok/all providers.

### Documentation & Housekeeping

- [x] Docs — N/A
- [x] cli-config — N/A
- [x] AGENTS.md — N/A
- [x] Cross-platform: display flag only
- [x] Tool schemas — N/A
