### PR TITLE
fix(telegram): heal v2->v3 schema gap on read paths before SELECT

### DIFF
--- a/hermes_state_telegram.py
+++ b/hermes_state_telegram.py
@@ -101,10 +101,16 @@ class SessionTelegramTopicsMixin:
     ``enable``/``bind`` run the migration."""
 
     def _topic_read_one(self, sql: str, params):
-        """``fetchone`` that treats an unmigrated table as None."""
+        """``fetchone`` that treats an unmigrated table as None.
+
+        Logs OperationalError at warning so schema-regression failures are visible
+        in production (previously logged at debug, hiding the v2→v3 migration gap
+        that causes silent topic-rename breakage — issue #103363).
+        """
         try:
             return self._read_one(sql, params)
-        except sqlite3.OperationalError:
+        except sqlite3.OperationalError as exc:
+            logger.warning("Telegram topic read failed (table may need migration): %s", exc)
             return None
 
     def apply_telegram_topic_migration(self) -> None:
@@ -215,7 +221,17 @@ class SessionTelegramTopicsMixin:
     def get_telegram_topic_binding(
         self, *, chat_id: str, thread_id: str, profile_name: str = "default"
     ) -> Optional[Dict[str, Any]]:
-        """Return the session binding for a Telegram DM topic, if present."""
+        """Return the session binding for a Telegram DM topic, if present.
+
+        Runs the v2→v3 schema migration before the read so that installs upgraded
+        from < 0.21.0 (schema v2, no ``profile_name`` column) are healed on first
+        access rather than silently returning None and breaking auto-rename.  The
+        migration is write-based so this is safe to call on every read — it is a
+        no-op once the schema is current.
+
+        Fixes #103363.
+        """
+        self.apply_telegram_topic_migration()
         profile_name = _normalize_telegram_topic_profile_name(profile_name)
         row = self._topic_read_one("""
                     SELECT * FROM telegram_dm_topic_bindings
@@ -226,19 +242,30 @@ class SessionTelegramTopicsMixin:
     def list_telegram_topic_bindings_for_chat(
         self, *, chat_id: str, profile_name: str = "default"
     ) -> List[Dict[str, Any]]:
-        """All bindings for one chat, newest first ([] when the table is absent)."""
+        """All bindings for one chat, newest first ([] when the table is absent).
+
+        Runs the migration first so v2→v3 schema gaps are healed on read
+        (same pattern as ``get_telegram_topic_binding`` — issue #103363).
+        """
+        self.apply_telegram_topic_migration()
         profile_name = _normalize_telegram_topic_profile_name(profile_name)
         try:
             rows = self._read_all(
                 "SELECT * FROM telegram_dm_topic_bindings WHERE profile_name = ? AND chat_id = ? ORDER BY updated_at DESC",
                 (profile_name, str(chat_id)),
             )
-        except sqlite3.OperationalError:
+        except sqlite3.OperationalError as exc:
+            logger.warning("Telegram topic read failed (table may need migration): %s", exc)
             return []
         return [dict(row) for row in rows]
 
     def get_telegram_topic_binding_by_session(self, *, session_id: str) -> Optional[Dict[str, Any]]:
-        """Reverse lookup via the UNIQUE INDEX on session_id; None when unbound."""
+        """Reverse lookup via the UNIQUE INDEX on session_id; None when unbound.
+
+        Runs the migration first so v2→v3 schema gaps are healed on read
+        (same pattern as ``get_telegram_topic_binding`` — issue #103363).
+        """
+        self.apply_telegram_topic_migration()
         row = self._topic_read_one("""
                     SELECT * FROM telegram_dm_topic_bindings
                     WHERE session_id = ?


### PR DESCRIPTION
## Summary

After updating to 0.21.0, on installs where Telegram DM topic mode was enabled **before** the update (bindings table still at schema v2), the automatic Telegram topic rename **silently stops working**, while LLM title generation and persistence keep working. No warning is emitted -- the failure is swallowed at logger.debug.

## Root Cause

The 0.21.0 change for #76423 added `profile_name` as a leading PK column on `telegram_dm_topic_bindings` (schema **v3**) with a v2 to v3 rebuild migration in `apply_telegram_topic_migration()`.

**That migration was write-triggered only.** Callers `enable_telegram_topic_mode()` and `bind_telegram_topic()` called it, but `get_telegram_topic_binding()` did NOT.

On a v2 table (no `profile_name` column), `get_telegram_topic_binding()` runs:

```
SELECT * FROM telegram_dm_topic_bindings
WHERE profile_name = ? AND chat_id = ? AND thread_id = ?
```

This raises `sqlite3.OperationalError: no such column: profile_name`, which `_topic_read_one()` swallowed at **debug level** -- completely invisible in production. The method returned `None`, so the auto-rename path was silently broken.

## Fix

1. **`get_telegram_topic_binding()`**: call `apply_telegram_topic_migration()` before the SELECT. The migration is idempotent (CREATE TABLE IF NOT EXISTS + conditional rebuild) and safe to call on every read -- it is a no-op once schema is v3.
2. **`get_telegram_topic_binding_by_session()`**: same pattern.
3. **`list_telegram_topic_bindings_for_chat()`**: same pattern.
4. **`_topic_read_one()`**: upgrade OperationalError logging from silent debug to **warning** so any future schema mismatch is immediately visible in production logs.

This is the same pattern used elsewhere in the codebase for schema healing on read (e.g., #80037 `s.last_read_at`, #20842 `spawn_failures`).

## Testing

- All three read methods now trigger the v2 to v3 migration on first access
- Existing tests pass unchanged (the migration is a no-op when schema is already v3)
- New OperationalError warning will appear in logs if schema mismatches recur

Closes #103363
