### PR TITLE
fix(cli): in-chat /model picker must show pricing like hermes model (#102990)

### DIFF
--- a/hermes_cli/cli_model_switch_mixin.py
+++ b/hermes_cli/cli_model_switch_mixin.py
@@ -628,9 +628,27 @@ class CLIModelSwitchMixin:
                     model_list = provider_model_ids(provider_data["slug"]) or model_list
                 except Exception:
                     pass
+            # $/Mtok pricing rows from the same provider catalog the standalone `hermes model`
+            # picker feeds to _prompt_model_selection(pricing=...) (#102990). Purely decorative:
+            # selection resolves bare model ids via _filtered_pairs, never these labels.
+            model_price_rows = None
+            try:
+                slug = (provider_data.get("slug") or "").strip().lower()
+                if slug and model_list:
+                    from hermes_cli.auth_model_picker import _ModelPickerRows
+                    from hermes_cli.models_pricing import get_pricing_for_provider
+                    pricing = get_pricing_for_provider(slug) or {}
+                    if pricing:
+                        model_price_rows = _ModelPickerRows(
+                            list(model_list), pricing,
+                            current_model=str(state.get("current_model") or ""),
+                            sale_chrome=slug == "nous")
+            except Exception:
+                model_price_rows = None
             state.update(
                 stage="model", provider_data=provider_data, model_list=model_list,
-                selected=0, filter="", _filtered_pairs=None)
+                selected=0, filter="", _filtered_pairs=None,
+                _model_price_rows=model_price_rows)
             self._invalidate(min_interval=0.0)
             return
         if stage == "model":
@@ -645,6 +663,7 @@ class CLIModelSwitchMixin:
             if selected == back_idx:
                 state.update(
                     stage="provider", filter="", _filtered_pairs=None,
+                    _model_price_rows=None,
                     selected=next((i for i, p in enumerate(state.get("providers") or [])
                                    if p.get("slug") == provider_data.get("slug")), 0))
                 self._invalidate(min_interval=0.0)

--- a/hermes_cli/cli_tui_mixin.py
+++ b/hermes_cli/cli_tui_mixin.py
@@ -639,7 +639,19 @@ class CLITuiMixin:
             _query = state.get("filter", "") or ""
             filtered_pairs = self._filter_model_picker_entries(model_list, _query)
             state["_filtered_pairs"] = filtered_pairs
-            model_labels = [e for (_i, e) in filtered_pairs]
+            # Priced catalogs render through the same _ModelPickerRows decorator the standalone
+            # `hermes model` picker uses ($/Mtok + Nous sale chrome). filtered_pairs keep
+            # carrying the bare ids, so the decorated labels never reach model resolution.
+            _model_price_rows = state.get("_model_price_rows")
+            model_labels = []
+            for (_i, e) in filtered_pairs:
+                if _model_price_rows is not None:
+                    try:
+                        model_labels.append(_model_price_rows.label(e))
+                    except Exception:
+                        model_labels.append(e)
+                else:
+                    model_labels.append(e)
             choices = list(model_labels) + ["← Back", "Cancel"]
             if _query:
                 hint = (
@@ -647,6 +659,12 @@ class CLITuiMixin:
                     "— type to narrow, Backspace to clear)")
             elif model_list:
                 hint = f"Select a model ({len(model_list)} available) — type to filter"
+                if _model_price_rows is not None and getattr(_model_price_rows, "has_pricing", False):
+                    hint += " · $/Mtok columns: In/Out"
+                    if getattr(_model_price_rows, "has_cache", False):
+                        hint += "/Cache"
+                    if getattr(_model_price_rows, "any_on_sale", False):
+                        hint += " · ★ = on sale"
             else:
                 hint = "No models listed for this provider. Use Back or Cancel."
         return self._render_scroll_list_panel(

--- a/tests/hermes_cli/test_chat_model_picker_pricing.py
+++ b/tests/hermes_cli/test_chat_model_picker_pricing.py
@@ -1,0 +1,160 @@
+"""In-chat (/model) model picker must show $/Mtok pricing + Nous sale chrome (#102990).
+
+The standalone ``hermes model`` picker passes ``pricing=get_pricing_for_provider(slug)`` into
+``_prompt_model_selection``; the prompt_toolkit in-chat picker previously rendered bare model ids.
+These tests prove the chat path now builds the same ``_ModelPickerRows`` decoration when the
+provider catalog is priced, while selection/resolution keep operating on bare model ids.
+"""
+
+from types import SimpleNamespace
+
+import cli as cli_mod
+import pytest
+
+_MODELS = ["m-a", "m-b"]
+_PRICING = {
+    "m-a": {"prompt": "0.000006", "completion": "0.000018"},
+    "m-b": {
+        "prompt": "0.000012", "completion": "0.000036",
+        "original": {"prompt": "0.000060", "completion": "0.000120"},
+    },
+}
+
+
+def _bound(fn, instance):
+    return fn.__get__(instance, type(instance))
+
+
+def _chat_picker_state(stage="provider", **extra):
+    state = {
+        "stage": stage,
+        "providers": [{"slug": "nous", "name": "Nous", "models": list(_MODELS)}],
+        "selected": 0,
+        "current_model": "m-a",
+        "current_provider": "nous",
+        "user_provs": None,
+        "custom_provs": None,
+        "filter": "",
+    }
+    state.update(extra)
+    return state
+
+
+def _select_provider(monkeypatch, fake_pricing, slug="nous"):
+    """Drive the picker's Enter handler on the provider stage; returns the cli stub."""
+    monkeypatch.setattr(
+        "hermes_cli.models_pricing.get_pricing_for_provider",
+        lambda provider, **kwargs: fake_pricing(provider) if callable(fake_pricing) else fake_pricing,
+    )
+    self_ = SimpleNamespace(
+        _model_picker_state=_chat_picker_state(providers=[
+            {"slug": slug, "name": "P", "models": list(_MODELS)}]),
+        _invalidate=lambda **kwargs: None,
+    )
+    _bound(cli_mod.HermesCLI._handle_model_picker_selection, self_)()
+    return self_
+
+
+@pytest.mark.parametrize("slug,expected_extra", [("nous", True), ("openrouter", False)])
+def test_provider_select_builds_pricing_rows_with_sale_chrome_only_for_nous(
+        monkeypatch, slug, expected_extra):
+    self_ = _select_provider(monkeypatch, dict(_PRICING), slug=slug)
+    state = self_._model_picker_state
+    assert state["stage"] == "model"
+    rows = state["_model_price_rows"]
+    assert rows is not None and rows.has_pricing
+    sale_row = rows.label("m-b")
+    assert "$12.00" in sale_row and "$36.00" in sale_row
+    if expected_extra:
+        assert "★ " in sale_row and "-80%" in sale_row
+        assert "was $60.00/$120.00" in sale_row
+    else:
+        assert "★" not in sale_row and "-80%" not in sale_row
+        assert "was " not in sale_row
+    # Non-sale row keeps the price columns but no chrome.
+    plain_row = rows.label("m-a")
+    assert "$6.00" in plain_row and "$18.00" in plain_row
+    assert "★" not in plain_row and "was " not in plain_row
+
+
+def test_provider_select_without_pricing_catalog_keeps_plain_rows(monkeypatch):
+    self_ = _select_provider(monkeypatch, lambda provider: {})
+    state = self_._model_picker_state
+    assert state["stage"] == "model"
+    assert state["_model_price_rows"] is None
+
+
+def test_pricing_fetch_failure_degrades_to_plain_rows(monkeypatch):
+    def _boom(provider, **kwargs):
+        raise RuntimeError("endpoint down")
+
+    monkeypatch.setattr(
+        "hermes_cli.models_pricing.get_pricing_for_provider", _boom)
+    self_ = SimpleNamespace(
+        _model_picker_state=_chat_picker_state(),
+        _invalidate=lambda **kwargs: None,
+    )
+    _bound(cli_mod.HermesCLI._handle_model_picker_selection, self_)()
+    assert self_._model_picker_state["_model_price_rows"] is None
+
+
+def test_model_stage_fragments_show_pricing_but_resolution_stays_on_bare_ids(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.models_pricing.get_pricing_for_provider",
+        lambda provider, **kwargs: dict(_PRICING))
+    self_ = SimpleNamespace(
+        _model_picker_state=_chat_picker_state(),
+        _invalidate=lambda **kwargs: None,
+    )
+    _bound(cli_mod.HermesCLI._handle_model_picker_selection, self_)()
+
+    captured = {}
+
+    def _fake_render(state, title, hint, labels, **kwargs):
+        captured["hint"] = hint
+        captured["labels"] = list(labels)
+        return []
+
+    self_._render_scroll_list_panel = _fake_render
+    self_._filter_model_picker_entries = cli_mod.HermesCLI._filter_model_picker_entries
+    _bound(cli_mod.HermesCLI._get_model_picker_display_fragments, self_)()
+
+    state = self_._model_picker_state
+    # Decoration reached the panel rows (sale chrome for the Nous provider).
+    assert any("$12.00" in label and "★ " in label and "-80%" in label
+               for label in captured["labels"])
+    assert captured["hint"].endswith("★ = on sale")
+    assert "$/Mtok" in captured["hint"]
+    # Back/Cancel appended after the priced rows.
+    assert captured["labels"][-2:] == ["← Back", "Cancel"]
+    # Resolution data is untouched: pairs carry bare ids and the Enter handler would map
+    # the visible row back to exactly the original model id.
+    assert state["_filtered_pairs"] == [(0, "m-a"), (1, "m-b")]
+    assert [e for _i, e in state["_filtered_pairs"]] == ["m-a", "m-b"]
+
+    # Filtering still matches bare ids and yields decorated labels for the survivors.
+    state["filter"] = "m-b"
+    _bound(cli_mod.HermesCLI._get_model_picker_display_fragments, self_)()
+    assert state["_filtered_pairs"] == [(1, "m-b")]
+    assert len(captured["labels"]) == 3  # 1 model + Back + Cancel
+    assert "$36.00" in captured["labels"][0]
+
+
+def test_model_stage_fragments_unpriced_catalog_shows_bare_ids(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.models_pricing.get_pricing_for_provider",
+        lambda provider, **kwargs: {})
+    self_ = SimpleNamespace(
+        _model_picker_state=_chat_picker_state(),
+        _invalidate=lambda **kwargs: None,
+    )
+    _bound(cli_mod.HermesCLI._handle_model_picker_selection, self_)()
+
+    captured = {}
+    self_._render_scroll_list_panel = (
+        lambda state, title, hint, labels, **kwargs: captured.update(
+            hint=hint, labels=list(labels)) or [])
+    self_._filter_model_picker_entries = cli_mod.HermesCLI._filter_model_picker_entries
+    _bound(cli_mod.HermesCLI._get_model_picker_display_fragments, self_)()
+    assert captured["labels"] == ["m-a", "m-b", "← Back", "Cancel"]
+    assert "$" not in captured["hint"]


### PR DESCRIPTION
Closes #102990

The prompt_toolkit in-chat `/model` picker rendered models as bare ids, so priced providers showed no `$/Mtok` columns and Nous showed no sale chrome — while the standalone `hermes model` picker (which passes `pricing=get_pricing_for_provider(slug)` into `_prompt_model_selection`) shows both for the same catalog.

This wires the same pricing data into the chat picker:

- `cli_model_switch_mixin.py`: when a provider is selected, fetch `get_pricing_for_provider(slug)` (guarded, degrades to `None` on failure/empty) and build the shared `_ModelPickerRows` decorator used by the standalone picker, stored on the picker state as `_model_price_rows`. Nous gets the sale chrome, exactly like the standalone `confirm_provider="nous"` rule.
- `cli_tui_mixin.py`: the model-stage panel renders each row through `_ModelPickerRows.label()` (aligned `In/Out $/Mtok` columns, `Cache` when present, `★ -80% was $x/y` sale badges, `← currently in use` marker) and extends the hint with a legend (`$/Mtok columns: In/Out · ★ = on sale`). Filtering and Enter-resolution keep operating on the bare model ids carried by `_filtered_pairs`, so decorated labels never reach model switching.

Standalone `hermes model` flows are untouched.

## Tests

- New `tests/hermes_cli/test_chat_model_picker_pricing.py` (6 tests): provider selection builds pricing rows with sale chrome for `nous` only; unpriced catalogs and fetch failures degrade to the previous plain rows; model-stage display fragments show priced/sale-decorated labels while `_filtered_pairs` and Back/Cancel rows keep bare ids; filtered views stay decorated; unpriced catalogs render bare ids with no legend.
- Regression suites re-run green:
  - `test_chat_model_picker_pricing.py test_model_picker_expensive_confirm.py test_terminal_menu_fallbacks.py` — 14 passed
  - `test_auth_nous_provider.py test_model_provider_persistence.py tests/cli/test_cli_provider_resolution.py` — 51 passed
  - `test_model_switch_confirm_thread.py test_25106_global_switch_persists_base_url_api_mode.py test_nous_policy_surfaces.py` — 20 passed