### PR TITLE
feat(gateway): live reasoning relay to streaming platforms

### DIFF
--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1430,6 +1430,11 @@ class GatewayTurnMixin:
         last_reasoning = agent_result.get("last_reasoning")
         if not (_show_reasoning_effective and response and not _intentional_silence and last_reasoning):
             return response
+        # Live reasoning relay already delivered 💭 bubbles mid-turn (stream
+        # consumer reasoning_delivered) — skip the final prepend so the user
+        # doesn't see the same reasoning twice.
+        if agent_result.get("reasoning_delivered"):
+            return response
         from gateway.stream_consumer_fences import escape_code_fences_for_display
         # Collapse long reasoning to keep messages readable
         lines = last_reasoning.strip().splitlines()

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -17,7 +17,7 @@ import threading
 import time
 from contextlib import suppress
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
 from agent.interrupt_compat import _accepts_keyword
 from agent.replay_cleanup import strip_stale_dangerous_confirmations
@@ -826,6 +826,22 @@ class TurnRunner:
                     for sink in delta_sinks:
                         sink.on_delta(text)
 
+        # Live reasoning relay: same gate pair as the CLI's reasoning box —
+        # token streaming active (relay rides the consumer queue) AND the
+        # user opted into show_reasoning on this platform.  Buffers thinking-
+        # channel deltas for flush as 💭 bubbles on the cadence above.
+        reasoning_stream_cb: "Callable[[str], None] | None" = None
+        if stream_consumer is not None and want_stream_deltas:
+            from gateway.run import _resolve_gateway_display_bool
+            _want_reasoning_stream = _resolve_gateway_display_bool(
+                ctx.user_config, platform_key, "show_reasoning",
+                default=False, platform=ctx.source.platform,
+            )
+            if _want_reasoning_stream:
+                def reasoning_stream_cb(text: str) -> None:
+                    if ctx._run_still_current() and hasattr(stream_consumer, "on_reasoning"):
+                        stream_consumer.on_reasoning(text)
+
         def interim_assistant_cb(text: str, *, already_streamed: bool = False) -> None:
             if not ctx._run_still_current():
                 return
@@ -834,7 +850,7 @@ class TurnRunner:
             elif not already_streamed and ctx._status_adapter and str(text or "").strip():
                 self._send_status_text(text, ctx._status_thread_metadata, "interim_assistant_callback scheduling error")
 
-        return stream_consumer, stream_delta_cb, interim_assistant_cb, want_interim_messages
+        return stream_consumer, stream_delta_cb, interim_assistant_cb, want_interim_messages, reasoning_stream_cb
 
     # ── agent resolution (cache reuse vs fresh build) ───────────────────────────────────────
 
@@ -1084,7 +1100,8 @@ class TurnRunner:
         agent._gateway_turn_request_overrides = turn_overrides
 
     def _wire_turn_agent_callbacks(self, agent, turn_route, reasoning_config,
-                                   stream_delta_cb, interim_assistant_cb, want_interim_messages):
+                                   stream_delta_cb, interim_assistant_cb, want_interim_messages,
+                                   reasoning_stream_cb=None):
         """Per-message state — callbacks and reasoning config change every turn, so they aren't
         baked into the cached agent."""
         ctx = self._ctx
@@ -1101,6 +1118,12 @@ class TurnRunner:
         agent.tool_complete_callback = ctx.native_tool_complete_callback if ctx._native_slack_task_cards else None
         agent.step_callback = ctx._step_callback_sync if ctx._hooks_ref.loaded_hooks else None
         agent.stream_delta_callback = stream_delta_cb
+        # Live reasoning relay (gateway parity with the CLI's reasoning box):
+        # the agent fires reasoning_callback with structured reasoning deltas
+        # (reasoning_content — GLM / DeepSeek / Qwen thinking channels).  Only
+        # wired when token streaming is active (the relay rides the stream
+        # consumer's queue) AND the user opted into show_reasoning.
+        agent.reasoning_callback = reasoning_stream_cb
         agent.interim_assistant_callback = interim_assistant_cb if want_interim_messages else None
         agent.status_callback, agent.notice_callback = ctx._status_callback_sync, self._notice_callback_sync
         agent.notice_clear_callback = None  # sends can't be retracted
@@ -1450,6 +1473,14 @@ class TurnRunner:
 
     def _finish_stream_consumer(self, result, agent_history, stream_consumer):
         ctx = self._ctx
+        # Live reasoning relay: surface mid-turn 💭 delivery on the result so
+        # the final prepend can skip re-sending the same reasoning block.
+        if (
+            stream_consumer is not None
+            and isinstance(result, dict)
+            and getattr(stream_consumer, "reasoning_delivered", False)
+        ):
+            result["reasoning_delivered"] = True
         # Canonicalize a model-emitted computer-use screenshot path at the common result boundary so
         # the streaming finalizer and the non-streaming delivery path see the same response.
         if isinstance(result, dict) and isinstance(result.get("final_response"), str):
@@ -1636,12 +1667,12 @@ class TurnRunner:
         reasoning_config = runner._resolve_session_reasoning_config(source=ctx.source, session_key=ctx.session_key, model=model)
         runner._reasoning_config = reasoning_config
         runner._service_tier = runner._resolve_session_service_tier(source=ctx.source, session_key=ctx.session_key)
-        stream_consumer, stream_delta_cb, interim_cb, want_interim = self._setup_stream_consumer(platform_key)
+        stream_consumer, stream_delta_cb, interim_cb, want_interim, reasoning_stream_cb = self._setup_stream_consumer(platform_key)
         turn_route = runner._resolve_turn_agent_config(ctx.message, model, runtime_kwargs)
         agent, reused_cached_agent = self._resolve_turn_agent(
             turn_route, platform_key, combined_ephemeral, max_iterations, reasoning_config, pr,
         )
-        self._wire_turn_agent_callbacks(agent, turn_route, reasoning_config, stream_delta_cb, interim_cb, want_interim)
+        self._wire_turn_agent_callbacks(agent, turn_route, reasoning_config, stream_delta_cb, interim_cb, want_interim, reasoning_stream_cb)
         agent_history, observed_group_context, history_media_paths = self._load_turn_history(agent, reused_cached_agent)
         persist_msg, persist_ts = self._prepare_turn_message(agent_history)
         result = self._run_conversation_with_approval(agent, agent_history, observed_group_context, persist_msg, persist_ts)

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -51,6 +51,7 @@ _FINAL_TEXT = object()
 _FLUSH = object()
 _APPROVAL_BOUNDARY = object()
 _REOPEN_SEED = object()
+_REASONING = object()
 _FUTURE_TYPES = (asyncio.Future, concurrent.futures.Future)
 
 # Boundary finalize text when nothing has accumulated yet (overridable per boundary).
@@ -155,6 +156,30 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
         self._delivered_segment_texts: list[str] = []  # finalized text per past segment
         self._in_think_block = False  # think-tag filter state (mirrors CLI _stream_delta)
         self._think_buffer = ""
+        # ── Live reasoning relay state ─────────────────────────────────────
+        # The agent's reasoning_callback buffers thinking-channel deltas
+        # (GLM / DeepSeek / Qwen reasoning_content) here; run() flushes them
+        # as 💭 commentary bubbles on a time/length cadence (see
+        # _reasoning_flush_due).  Gated by the gateway on show_reasoning.
+        self._reasoning_buf: str = ""
+        self._reasoning_last_delta_ts: float = 0.0
+        # When the buffer transitioned empty→non-empty (oldest buffered
+        # char).  Age-based cadence: during a continuously streaming
+        # reasoning phase a silence-only timer never fires (every delta
+        # resets it), so the first bubble would wait for the full char
+        # threshold (~30s at typical token rates).  Basing the flush on
+        # buffer AGE guarantees a bubble at least every
+        # _REASONING_FLUSH_SECONDS once reasoning starts streaming.
+        self._reasoning_first_delta_ts: float = 0.0
+        # Bubbles emitted for the CURRENT reasoning phase.  Reset when a
+        # phase ends (flush on done/boundary/content) so the next phase's
+        # first bubble gets the fast path again — "first bubble is fast,
+        # later bubbles keep cadence" without extra state machines.
+        self._reasoning_bubble_count: int = 0
+        # True when at least one reasoning bubble was delivered this turn —
+        # suppresses the gateway's final 💭 prepend when streaming already
+        # showed the reasoning live (mirrors the CLI's reasoning box).
+        self.reasoning_delivered: bool = False
         self._before_finalize_notified = False
         self._reset_message_state()
 
@@ -388,6 +413,60 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
         if text:
             self._queue.put((_COMMENTARY, text))
 
+    def on_reasoning(self, text: str) -> None:
+        """Thread-safe: buffer a reasoning delta from the agent's thinking channel.
+
+        Called from the agent's worker thread via ``agent.reasoning_callback``;
+        the async ``run()`` task drains it from the queue and flushes buffered
+        reasoning as 💭 commentary bubbles on the _reasoning_flush_due cadence.
+        """
+        if text:
+            self._queue.put((_REASONING, text))
+
+    # ── live reasoning flush cadence ──────────────────────────────────────
+
+    _REASONING_FLUSH_CHARS = 1500     # flush partial text at this length
+    _REASONING_FLUSH_SECONDS = 6.0    # ... or when buffer is this old
+    # First bubble of a reasoning phase: show something fast (confirms the
+    # model is alive after TTFT) instead of making the user wait the full
+    # cadence window.  Only applies to the FIRST flush of each phase —
+    # subsequent bubbles keep the regular cadence to avoid spam.
+    _REASONING_FIRST_BUBBLE_SECONDS = 2.5
+
+    def _reasoning_flush_due(self) -> bool:
+        """True when the buffered reasoning should be flushed as a bubble."""
+        if not self._reasoning_buf:
+            return False
+        now = time.monotonic()
+        # Buffer-age cadence (primary): guarantees a bubble at least every
+        # _REASONING_FLUSH_SECONDS while reasoning streams continuously.
+        # A silence-only timer never fires mid-stream (every delta resets
+        # it), which delayed the first bubble to the full char threshold.
+        if self._reasoning_first_bubble_due():
+            return True
+        if self._reasoning_first_delta_ts and (
+            now - self._reasoning_first_delta_ts >= self._REASONING_FLUSH_SECONDS
+        ):
+            return True
+        if len(self._reasoning_buf) >= self._REASONING_FLUSH_CHARS:
+            return True
+        return False
+
+    def _reasoning_first_bubble_due(self) -> bool:
+        """First bubble of a reasoning phase flushes early so the user sees
+        something right after TTFT instead of staring at nothing for the
+        full cadence window.  Only the FIRST bubble gets this fast path —
+        subsequent bubbles keep the regular cadence to avoid spam."""
+        return bool(
+            self._reasoning_buf
+            and not self._reasoning_bubble_count
+            and self._reasoning_first_delta_ts
+            and (
+                time.monotonic() - self._reasoning_first_delta_ts
+                >= self._REASONING_FIRST_BUBBLE_SECONDS
+            )
+        )
+
     def flush_pending_sync(self, timeout: float = 5.0) -> bool:
         """Block the agent worker thread until everything queued so far is delivered:
         ``(_FLUSH, Event)`` barrier — run() drains earlier items (FIFO), finalizes the
@@ -550,7 +629,49 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
                         await self._suppress_silence_marker()
                         return
 
-                if self._should_edit(tick) and (
+                # ── Live reasoning flush ─────────────────────────────────
+                # Emit buffered reasoning as an interim 💭 bubble when: the
+                # stream is ending (got_done), a tool boundary arrived, or
+                # the time/length threshold tripped.  Sent BEFORE the
+                # content update below so the bubble lands above the answer.
+                should_edit = self._should_edit(tick)
+                if self._reasoning_buf and (
+                    tick.got_done
+                    or tick.got_segment_break
+                    or self._reasoning_flush_due()
+                    or (should_edit and self._accumulated)
+                ):
+                    _rtext = self._reasoning_buf
+                    self._reasoning_buf = ""
+                    # Whether this flush ENDS the reasoning phase (stream
+                    # done / tool boundary / real content arriving). Only
+                    # then does the next reasoning delta start a NEW phase
+                    # whose first bubble earns the fast path again; a
+                    # mid-phase time/length flush must keep the cadence,
+                    # or every bubble would re-trigger the fast path.
+                    _phase_ended = (
+                        tick.got_done
+                        or tick.got_segment_break
+                        or (should_edit and self._accumulated)
+                    )
+                    # Age clock restarts for the next bubble's cadence.
+                    self._reasoning_first_delta_ts = time.monotonic()
+                    self._reasoning_last_delta_ts = time.monotonic()
+                    _rtext = ensure_closed_code_fences(
+                        self._clean_for_display(_rtext)
+                    ).strip()
+                    if _rtext:
+                        _rok = await self._send_commentary(f"💭 {_rtext}")
+                        if _rok:
+                            self._reasoning_bubble_count += 1
+                            self.reasoning_delivered = True
+                        self._last_edit_time = time.monotonic()
+                    if _phase_ended:
+                        # New phase starts with the next delta (if any):
+                        # re-arm the first-bubble fast path for it.
+                        self._reasoning_bubble_count = 0
+
+                if should_edit and (
                     self._accumulated or (self._use_native_streaming and self._tool_progress_active)
                 ):
                     # Overflow split.  Native streaming bypasses this: the adapter
@@ -649,6 +770,20 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
             elif kind is _COMMENTARY:
                 tick.commentary_text = item[1]
                 return tick
+            elif kind is _REASONING:
+                # Reasoning delta: accumulate into the reasoning buffer;
+                # flushed in run() on time/length/boundary cadence.  Keep
+                # draining — a reasoning delta is not a stop item.
+                if not self._reasoning_buf:
+                    # Empty→non-empty: restart the age clock for the flush
+                    # cadence.  NOTE: do NOT reset _reasoning_bubble_count
+                    # here — a mid-phase time/length flush also empties the
+                    # buffer, so this transition does NOT imply a new phase.
+                    # Phase-end (done/boundary/content) re-arms the fast
+                    # path in the flush block in run().
+                    self._reasoning_first_delta_ts = time.monotonic()
+                self._reasoning_buf += item[1]
+                self._reasoning_last_delta_ts = time.monotonic()
             elif kind is _FLUSH:
                 # Barrier: finalize like a tool boundary, signal at the end of the tick.
                 tick.got_flush = tick.got_segment_break = True

--- a/tests/gateway/test_stream_consumer_reasoning_relay.py
+++ b/tests/gateway/test_stream_consumer_reasoning_relay.py
@@ -1,0 +1,155 @@
+"""Live reasoning relay: 💭 bubbles flushed from the stream consumer queue.
+
+Covers the relay added for gateway parity with the CLI's reasoning box:
+``agent.reasoning_callback`` → ``GatewayStreamConsumer.on_reasoning`` →
+buffered deltas flushed as interim 💭 commentary on an age/length cadence.
+"""
+
+import asyncio
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+
+def _consumer(adapter):
+    return GatewayStreamConsumer(
+        adapter=adapter,
+        chat_id="1",
+        config=StreamConsumerConfig(edit_interval=0.05, buffer_threshold=10**6, cursor=""),
+        metadata={},
+        run_still_current=lambda: True,
+    )
+
+
+class _RecordingAdapter:
+    """Minimal async adapter that records every send/edit with timestamps."""
+
+    platform = SimpleNamespace(value="telegram")
+    name = "telegram-test"
+
+    def __init__(self):
+        self.calls = []  # (kind, monotonic_ts, content)
+
+    async def send(self, chat_id=None, content=None, reply_to=None, metadata=None, **kw):
+        self.calls.append(("send", time.monotonic(), content))
+        return SimpleNamespace(success=True, message_id=f"msg{len(self.calls)}")
+
+    async def edit_message(self, chat_id=None, message_id=None, content=None, finalize=False, metadata=None, **kw):
+        self.calls.append(("edit", time.monotonic(), content))
+        return SimpleNamespace(success=True, message_id=message_id)
+
+    async def send_stream_frame(self, *a, **kw):
+        return False
+
+    def message_len_fn_for_chat(self, chat_id):
+        return len
+
+
+def _bubbles(adapter):
+    return [(ts, c) for kind, ts, c in adapter.calls if kind == "send" and c.startswith("💭")]
+
+
+def _run(coro):
+    return asyncio.get_event_loop_policy().new_event_loop().run_until_complete(coro)
+
+
+# ── intake ────────────────────────────────────────────────────────────────
+
+
+class TestOnReasoningIntake:
+    def test_empty_delta_is_dropped(self):
+        consumer = _consumer(MagicMock())
+        consumer.on_reasoning("")
+        assert consumer._queue.qsize() == 0
+
+    def test_delta_is_queued(self):
+        consumer = _consumer(MagicMock())
+        consumer.on_reasoning("thinking ")
+        assert consumer._queue.qsize() == 1
+
+    def test_drain_accumulates_into_buffer(self):
+        consumer = _consumer(MagicMock())
+        consumer.on_reasoning("alpha ")
+        consumer.on_reasoning("beta")
+        consumer._drain_queue()
+        assert consumer._reasoning_buf == "alpha beta"
+
+
+# ── flush cadence ─────────────────────────────────────────────────────────
+
+
+class TestReasoningFlushCadence:
+    def test_first_bubble_fast_path(self):
+        """First bubble of a phase arrives at the first-bubble deadline (not
+        the full cadence) when reasoning streams continuously."""
+        GatewayStreamConsumer._REASONING_FLUSH_SECONDS = 6.0
+        GatewayStreamConsumer._REASONING_FIRST_BUBBLE_SECONDS = 1.0
+        adapter = _RecordingAdapter()
+        consumer = _consumer(adapter)
+        t0 = time.monotonic()
+
+        async def scenario():
+            task = asyncio.create_task(consumer.run())
+            for _ in range(30):  # 3s of continuous deltas, no silence gap
+                consumer.on_reasoning("chunk ")
+                await asyncio.sleep(0.1)
+            consumer.finish()
+            await task
+
+        _run(scenario())
+        bubbles = _bubbles(adapter)
+        assert bubbles, "expected at least one 💭 bubble"
+        first_ts = bubbles[0][0]
+        # Fast path: bubble landed at ~1s, well before the 6s cadence.
+        assert first_ts - t0 < 3.0
+
+    def test_char_threshold_flush(self):
+        """Buffer at/over the char threshold flushes regardless of age."""
+        consumer = _consumer(MagicMock())
+        consumer._reasoning_buf = "x" * consumer._REASONING_FLUSH_CHARS
+        consumer._reasoning_first_delta_ts = time.monotonic()
+        consumer._reasoning_bubble_count = 1  # fast path already spent
+        assert consumer._reasoning_flush_due() is True
+
+    def test_young_buffer_under_threshold_not_due(self):
+        consumer = _consumer(MagicMock())
+        consumer._reasoning_buf = "young"
+        consumer._reasoning_first_delta_ts = time.monotonic()
+        consumer._reasoning_bubble_count = 1  # fast path spent, cadence rules
+        assert consumer._reasoning_flush_due() is False
+
+    def test_empty_buffer_never_due(self):
+        consumer = _consumer(MagicMock())
+        assert consumer._reasoning_flush_due() is False
+
+
+# ── turn-level flags ──────────────────────────────────────────────────────
+
+
+class TestReasoningDeliveredFlag:
+    def test_flag_set_after_successful_bubble(self):
+        adapter = _RecordingAdapter()
+        consumer = _consumer(adapter)
+        assert consumer.reasoning_delivered is False
+
+        async def scenario():
+            task = asyncio.create_task(consumer.run())
+            consumer.on_reasoning("visible reasoning ")
+            await asyncio.sleep(0.3)
+            consumer.finish()
+            await task
+
+        _run(scenario())
+        assert consumer.reasoning_delivered is True
+        assert _bubbles(adapter)
+
+
+# ── wiring gates (unit) ──────────────────────────────────────────────────
+
+
+class TestRelayWiringGates:
+    def test_on_reasoning_exists(self):
+        consumer = _consumer(MagicMock())
+        assert hasattr(consumer, "on_reasoning")


### PR DESCRIPTION
## Summary

Wire the agent's existing `reasoning_callback` (thinking-channel deltas: GLM / DeepSeek / Qwen `reasoning_content`) into the gateway stream consumer, giving streaming platforms the same live reasoning visibility the CLI reasoning box has while a reply generates.

- **`GatewayStreamConsumer.on_reasoning`** buffers reasoning deltas on the consumer queue (thread-safe, same pattern as `on_commentary`); `run()` flushes them as interim 💭 commentary bubbles sent **before** the content edit so the bubble lands above the streamed answer.
- **Flush cadence** — three tiers, all unit-tested:
  - *first-bubble fast path*: the first bubble of each reasoning phase fires early after TTFT so the user sees the model is alive instead of staring at nothing for the full cadence window;
  - *age cadence*: buffer age guarantees a bubble at least every `_REASONING_FLUSH_SECONDS` — a silence-only timer never fires mid-stream because every delta resets it;
  - *length cap*: `_REASONING_FLUSH_CHARS` bounds buffer growth on fast streams.
  - Phase boundaries (done / segment break / real content arriving) re-arm the fast path; mid-phase flushes keep the cadence so later bubbles don't spam.
- **Gate pair mirrors the CLI** (`agent.reasoning_callback` is only set when): token streaming is active on the platform (the relay rides the stream consumer's queue) **and** `display.show_reasoning` (per-platform override honored) is on. Otherwise the callback stays `None` and behavior is byte-identical to current main.
- **`reasoning_delivered`** rides the turn result so `_hmwa_prepend_reasoning` skips the final 💭 prepend when bubbles already showed the reasoning live — the user never sees the same reasoning block twice.

## Relationship to existing PRs

Deliberately distinct from the two open reasoning-streaming efforts — this is a third UX:

- #41549 — `/reasoning stream` mode with a **transient auto-deleting bubble** (OpenClaw parity, clean final conversation)
- #7369 / #7148 — reasoning collapsed into the **final message** (blockquote / code block)
- **this PR** — **permanent 💭 commentary bubbles mid-turn**, above the streamed answer; no new command, rides the existing `show_reasoning` opt-in

## Test plan

- [x] New `tests/gateway/test_stream_consumer_reasoning_relay.py` — 9 tests: intake (empty-drop / queue / drain-accumulate), flush cadence (first-bubble fast path end-to-end, char threshold, young-buffer not due, empty never due), `reasoning_delivered` flag end-to-end
- [x] Existing stream-consumer suites pass unchanged: `test_stream_consumer{,_fresh_final,_silence,_tool_progress,_thread_routing}` + `test_reasoning_command` — 105 passed, 1 skipped
- [x] Turn-runner suites: 62 passed, 2 skipped (`-k "turn_runner or run_turn or wire"`)
- [x] Manual: Telegram with `display.platforms.telegram.show_reasoning: true` streams GLM thinking as live 💭 bubbles; final reply arrives without the duplicated prepend

Note: tests marked to run under the repo's dev extras; `aiohttp` was additionally installed for full gateway collection (missing from dev extras, unrelated to this change).
