### PR TITLE
feat(tools): read_file markdown outline mode (#103374)

### DIFF
--- a/tests/tools/test_read_file_outline.py
+++ b/tests/tools/test_read_file_outline.py
@@ -1,0 +1,185 @@
+"""read_file optional Markdown outline mode (#103374).
+
+Covers the opt-in ``mode="outline"`` behavior: Markdown heading extraction
+(ATX and Setext levels, source line numbers), empty outlines for Markdown
+without headings, the clear note for non-Markdown paths, bounded output with
+an explicit continuation offset, and the unchanged default read mode.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.file_tools import READ_FILE_SCHEMA, read_file_tool
+from tools.markdown_outline import markdown_outline
+
+
+def _mock_raw_read(content: str, file_size: int = 1234, error: str = None):
+    """Patch _get_file_ops so read_file_raw serves *content* (or *error*)."""
+    ops = MagicMock()
+    result = MagicMock()
+    result.content = content if error is None else ""
+    to_dict = {"file_size": file_size}
+    if error is not None:
+        to_dict = {"error": error, "file_size": file_size}
+    else:
+        to_dict["content"] = content
+    result.to_dict.return_value = to_dict
+    ops.read_file_raw.return_value = result
+    patcher = patch("tools.file_tools._get_file_ops", return_value=ops)
+    patcher.start()
+    return ops, patcher
+
+
+class TestMarkdownOutlineScanner:
+    def test_atx_levels_and_closing_hash_sequence(self):
+        entries = markdown_outline("# Title ###\n## Sub\n### Deep\nbody\n###### H6\n")
+        assert entries == [
+            {"line": 1, "level": 1, "heading": "Title"},
+            {"line": 2, "level": 2, "heading": "Sub"},
+            {"line": 3, "level": 3, "heading": "Deep"},
+            {"line": 5, "level": 6, "heading": "H6"},
+        ]
+
+    def test_setext_headings(self):
+        entries = markdown_outline("Setext H1\n=======\nSetext H2\n-------\n")
+        assert entries == [
+            {"line": 1, "level": 1, "heading": "Setext H1"},
+            {"line": 3, "level": 2, "heading": "Setext H2"},
+        ]
+
+    def test_ignores_heading_like_lines_inside_fences(self):
+        content = (
+            "# Real\n"
+            "```\n"
+            "# Not a heading\n"
+            "```\n"
+            "~~~python\n"
+            "## Also not\n"
+            "~~~\n"
+            "# Real 2\n"
+        )
+        entries = markdown_outline(content)
+        assert [e["heading"] for e in entries] == ["Real", "Real 2"]
+        assert [e["line"] for e in entries] == [1, 8]
+
+    def test_duplicate_headings_kept_as_separate_entries(self):
+        entries = markdown_outline("# Same\nbody\n# Same\n# Same\n")
+        assert [e["line"] for e in entries] == [1, 3, 4]
+        assert all(e["heading"] == "Same" for e in entries)
+
+    def test_crlf_line_numbers(self):
+        entries = markdown_outline("# A\r\nbody\r\n## B\r\n")
+        assert [e["line"] for e in entries] == [1, 3]
+
+    def test_no_headings(self):
+        assert markdown_outline("just text\nno structure\n") == []
+        assert markdown_outline("") == []
+
+
+class TestReadFileOutlineTool:
+    def test_markdown_with_multiple_levels(self, tmp_path):
+        md = (
+            "# Title\n"
+            "intro\n"
+            "## Background\n"
+            "### Details\n"
+            "## Scope\n"
+        )
+        ops, patcher = _mock_raw_read(md)
+        try:
+            result = json.loads(read_file_tool("/tmp/outline_multi.md", mode="outline"))
+        finally:
+            patcher.stop()
+        assert result["mode"] == "outline"
+        assert result["total_headings"] == 4
+        assert result["truncated"] is False
+        assert result["outline"] == [
+            {"line": 1, "level": 1, "heading": "Title"},
+            {"line": 3, "level": 2, "heading": "Background"},
+            {"line": 4, "level": 3, "heading": "Details"},
+            {"line": 5, "level": 2, "heading": "Scope"},
+        ]
+        ops.read_file_raw.assert_called_once_with("/tmp/outline_multi.md")
+        ops.read_file.assert_not_called()
+
+    def test_markdown_without_headings(self, tmp_path):
+        ops, patcher = _mock_raw_read("plain paragraph\nno headings here\n")
+        try:
+            result = json.loads(read_file_tool("/tmp/outline_nohead.md", mode="outline"))
+        finally:
+            patcher.stop()
+        assert result["outline"] == []
+        assert result["total_headings"] == 0
+        assert result["truncated"] is False
+
+    def test_non_markdown_file_returns_clear_note(self, tmp_path):
+        ops, patcher = _mock_raw_read("print('hello')\n")
+        try:
+            result = json.loads(read_file_tool("/tmp/outline_prog.py", mode="outline"))
+        finally:
+            patcher.stop()
+        assert result["outline"] == []
+        assert "Markdown" in result["note"]
+        assert ".py" in result["note"]
+        ops.read_file_raw.assert_not_called()
+        ops.read_file.assert_not_called()
+
+    def test_default_mode_is_unchanged(self, tmp_path):
+        ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.content = "line1\nline2"
+        result_obj.to_dict.return_value = {"content": "line1\nline2", "total_lines": 2}
+        ops.read_file.return_value = result_obj
+        with patch("tools.file_tools._get_file_ops", return_value=ops):
+            result = json.loads(read_file_tool("/tmp/outline_default.txt"))
+        assert result["content"] == "line1\nline2"
+        assert "mode" not in result
+        ops.read_file.assert_called_once_with("/tmp/outline_default.txt", 1, 2000)
+        ops.read_file_raw.assert_not_called()
+
+    def test_explicit_mode_read_is_unchanged(self, tmp_path):
+        ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.content = "line1\nline2"
+        result_obj.to_dict.return_value = {"content": "line1\nline2", "total_lines": 2}
+        ops.read_file.return_value = result_obj
+        with patch("tools.file_tools._get_file_ops", return_value=ops):
+            result = json.loads(read_file_tool("/tmp/outline_read.txt", mode="read"))
+        assert result["content"] == "line1\nline2"
+        ops.read_file.assert_called_once_with("/tmp/outline_read.txt", 1, 2000)
+
+    def test_outline_truncated_with_continuation_offset(self):
+        md = "\n".join(f"# Heading {i}" for i in range(505))
+        ops, patcher = _mock_raw_read(md)
+        try:
+            first = json.loads(read_file_tool("/tmp/outline_big.md", mode="outline"))
+            second = json.loads(read_file_tool("/tmp/outline_big.md", mode="outline", offset=501))
+        finally:
+            patcher.stop()
+        assert first["total_headings"] == 505
+        assert len(first["outline"]) == 500
+        assert first["truncated"] is True
+        assert "offset=501" in first["_hint"]
+        assert len(second["outline"]) == 5
+        assert second["truncated"] is False
+
+    def test_unknown_mode_returns_error(self):
+        result = json.loads(read_file_tool("/tmp/outline_unknown.md", mode="table"))
+        assert "unknown mode" in result["error"]
+
+    def test_binary_markdown_returns_backend_error(self):
+        ops, patcher = _mock_raw_read("", error="Binary file (PNG image data, 1.2 KB)")
+        try:
+            result = json.loads(read_file_tool("/tmp/outline_binary.md", mode="outline"))
+        finally:
+            patcher.stop()
+        assert "error" in result
+
+    def test_schema_exposes_opt_in_mode_default_read(self):
+        mode = READ_FILE_SCHEMA["parameters"]["properties"]["mode"]
+        assert mode["type"] == "string"
+        assert mode["enum"] == ["read", "outline"]
+        assert mode["default"] == "read"
+        assert "path" in READ_FILE_SCHEMA["parameters"]["required"]

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -22,6 +22,8 @@ from agent.file_safety import get_read_block_error
 from tools.binary_extensions import has_binary_extension
 from tools.file_operations import (
     ShellFileOperations, normalize_read_pagination, normalize_search_pagination)
+from tools.markdown_outline import (
+    MARKDOWN_EXTENSIONS, OUTLINE_HEADING_MAX_CHARS, OUTLINE_MAX_ENTRIES, markdown_outline)
 from tools import file_state
 from agent.redact import redact_sensitive_text
 from tools.file_tools_paths import (
@@ -536,15 +538,140 @@ def _record_successful_read(task_data: dict, task_id: str, path: str, resolved_s
     return count
 
 
-def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str = "default") -> str:
+def _read_file_outline(path: str, resolved: Path, offset: int, limit: int,
+                   task_id: str) -> str:
+    """read_file(mode="outline") implementation: Markdown heading structure.
+
+    Runs AFTER the device-path blocklist, special-file guard, Hermes-internal
+    denylist and negative-result cache shared with the content path.
+    Non-Markdown paths return an empty outline with a clear note (no body
+    read happens). Markdown files are scanned whole via ``file_ops.read_file_raw``
+    (same backend + per-heading sensitive-text redaction), but the OUTPUT is
+    bounded: at most ``min(limit, OUTLINE_MAX_ENTRIES)`` headings per call,
+    starting at the 1-based heading ordinal ``offset``; when more headings
+    exist the result is marked ``truncated`` and the hint names the next
+    ``offset`` to continue from. Outline reads are recorded as PARTIAL reads:
+    the body was never served, so read-before-write checks must not treat it
+    as a full read.
+    """
+    resolved_str = str(resolved)
+    suffix = resolved.suffix.lower()
+    if suffix not in MARKDOWN_EXTENSIONS:
+        # Clear, read-free answer for non-Markdown paths: no body read happens.
+        return json.dumps({
+            "mode": "outline",
+            "path": path,
+            "outline": [],
+            "note": (
+                f"Outline mode only supports Markdown files — '{path}' is not "
+                f"Markdown (extension '{suffix or '(none)'}'). Read the file "
+                "with the default mode (no mode argument) to see its content."),
+        }, ensure_ascii=False)
+
+    dedup_key = (resolved_str, "outline", offset, limit)
+    with _read_tracker_lock:
+        task_data = _task_data(task_id)
+        cached_mtime = task_data["dedup"].get(dedup_key)
+        content_served_in_generation = dedup_key in task_data["dedup_generation_reads"]
+    if cached_mtime is not None:
+        try:
+            if os.path.getmtime(resolved_str) == cached_mtime and content_served_in_generation:
+                return _dedup_stub_or_block(task_data, dedup_key, path)
+        except OSError:
+            pass  # stat failed — fall through to a fresh outline read
+
+    result = _get_file_ops(task_id).read_file_raw(path)
+    result_dict = result.to_dict()
+
+    # Cache a not-found result for retries (mirrors the content path).
+    _err = result_dict.get("error") or ""
+    if isinstance(_err, str) and _err.startswith("File not found:"):
+        _record_not_found("read", resolved_str, task_id, json.dumps(result_dict, ensure_ascii=False))
+
+    if result_dict.get("error"):
+        # e.g. a binary blob with a .md name, or an unreadable path: surface the
+        # backend's error unchanged instead of an outline.
+        payload = result_dict
+    else:
+        content = result.content or ""
+        total_lines = len(content.splitlines())
+        entries = markdown_outline(content)
+        total_headings = len(entries)
+        start = max(offset - 1, 0)
+        headings_per_call = max(1, min(limit, OUTLINE_MAX_ENTRIES))
+        page = [
+            {
+                "line": e["line"],
+                "level": e["level"],
+                # Redact then cap: a single pathological "heading" line must not
+                # dominate the budget.
+                "heading": redact_sensitive_text(e["heading"], file_read=True)[:OUTLINE_HEADING_MAX_CHARS],
+            }
+            for e in entries[start:start + headings_per_call]
+        ]
+        truncated = start + len(page) < total_headings
+        payload = {
+            "mode": "outline",
+            "path": path,
+            "file_size": result_dict.get("file_size", 0),
+            "total_lines": total_lines,
+            "total_headings": total_headings,
+            "outline": page,
+            "truncated": truncated,
+        }
+        if truncated:
+            payload["_hint"] = (
+                f"Outline truncated: showing {len(page)} of {total_headings} headings. "
+                f"Continue the outline with read_file(mode='outline', "
+                f"offset={start + len(page) + 1}, limit={limit}).")
+        if total_lines > 2000:
+            payload["_hint"] = (payload.get("_hint") + " " if payload.get("_hint") else "") + (
+                "The file is long; after choosing a section, read just that "
+                "range with the default mode (offset/limit) to save context.")
+
+    count = _record_successful_read(task_data, task_id, path, resolved_str, offset, limit,
+                                    dedup_key, partial=True)
+    if count >= 4:
+        return tool_error(
+            f"BLOCKED: You have read this exact file region {count} times in a row. "
+            "The content has NOT changed. You already have this information. "
+            "STOP re-reading and proceed with your task.",
+            path=path,
+            already_read=count)
+    if count >= 3:
+        payload["_warning"] = (
+            f"You have read this exact file region {count} times consecutively. "
+            "The content has not changed since your last read. Use the information you already have. "
+            "If you are stuck in a loop, stop reading and proceed with writing or responding.")
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str = "default",
+                   mode: str = "read") -> str:
     """Read a file with pagination and line numbers.
 
     Guard order: device-path blocklist (no I/O) → stat-based special-file
     guard (host only) → document extraction → binary-extension guard → Hermes
     internal denylist → negative-result cache → dedup stub → real read.
+
+    Optional ``mode="outline"`` (opt-in; the default ``"read"`` is unchanged):
+    returns the document's Markdown heading structure — each heading's text,
+    level (1-6), and 1-based source line — instead of the body content, for
+    quick orientation in long documents. ``offset``/``limit`` then bound the
+    returned HEADINGS (1-based ordinal of the first heading, maximum headings
+    per call capped at 500) rather than lines. Non-Markdown paths return an
+    empty outline with a note. Backend access, dedup/loop tracking and
+    sensitive-text redaction are reused; outline reads never count as having
+    read the file's body.
     """
     try:
         offset, limit = normalize_read_pagination(offset, limit)
+        mode = (mode or "read").strip().lower()
+        if mode not in ("read", "outline"):
+            return tool_error(
+                f"read_file: unknown mode {mode!r} — supported modes: "
+                "'read' (default, current behavior) and 'outline' "
+                "(Markdown heading structure only).")
 
         device_base = None if Path(path).expanduser().is_absolute() else _resolve_base_dir(task_id)
         if _is_blocked_device(path, base_dir=device_base):
@@ -565,6 +692,18 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
                         "it would block indefinitely, so no read was "
                         "attempted. Use terminal utilities if you need to "
                         "interact with it.")})
+
+        if mode == "outline":
+            # Hermes-internal denylist + negative-result cache BEFORE any scan
+            # (the shared content path re-checks these below after extraction;
+            # outline must not probe internal or previously-not-found files).
+            block_error = get_read_block_error(str(_resolved))
+            if block_error:
+                return tool_error(block_error)
+            cached_not_found = _check_not_found_cache("read", str(_resolved), task_id)
+            if cached_not_found is not None:
+                return cached_not_found
+            return _read_file_outline(path, _resolved, offset, limit, task_id)
 
         extracted = _read_extracted_document(path, _resolved, offset, limit, task_id)
         if extracted is not None:
@@ -973,13 +1112,14 @@ READ_FILE_SCHEMA = {
     # route we trust (_read_file_schema_overrides). Scanned-page coverage
     # teaching lives in the response-time NEEDS-OCR warning
     # (read_extract.py); the schema doesn't pre-teach it.
-    "description": "Read a text file with line numbers and pagination. Use this instead of cat/head/tail in terminal. Output format: 'LINE_NUM|CONTENT'. Suggests similar filenames if not found. Use offset and limit for large files. Reads exceeding ~100K characters are truncated on a line boundary and return a next_offset; continue with offset to read the rest. Documents auto-extract to readable text: .ipynb, Office (.docx/.xlsx/.pptx and legacy .doc/.ppt/.xls), PDF (text layer), OpenDocument, RTF, EPUB. Cannot read images/binary — use vision_analyze for images.",
+    "description": "Read a text file with line numbers and pagination. Use this instead of cat/head/tail in terminal. Output format: 'LINE_NUM|CONTENT'. Suggests similar filenames if not found. Use offset and limit for large files. Reads exceeding ~100K characters are truncated on a line boundary and return a next_offset; continue with offset to read the rest. Documents auto-extract to readable text: .ipynb, Office (.docx/.xlsx/.pptx and legacy .doc/.ppt/.xls), PDF (text layer), OpenDocument, RTF, EPUB. Cannot read images/binary — use vision_analyze for images. Optional mode='outline' (Markdown only) returns the document's heading structure — level, heading text, and 1-based source line, in source order — instead of the body content: a compact structural view for quick orientation in long documents.",
     "parameters": {
         "type": "object",
         "properties": {
             "path": {"type": "string", "description": "Path to the file to read (absolute, relative, or ~/path)"},
-            "offset": {"type": "integer", "description": "Line number to start reading from (1-indexed, default: 1)", "default": 1, "minimum": 1},
-            "limit": {"type": "integer", "description": "Maximum number of lines to read (default: 2000, max: 2000). Reads are additionally capped at a ~100K-character budget with a next_offset continuation.", "default": 2000, "maximum": 2000}
+            "offset": {"type": "integer", "description": "Line number to start reading from (1-indexed, default: 1). In outline mode: 1-based ordinal of the first heading to return.", "default": 1, "minimum": 1},
+            "limit": {"type": "integer", "description": "Maximum number of lines to read (default: 2000, max: 2000). Reads are additionally capped at a ~100K-character budget with a next_offset continuation. In outline mode: maximum headings to return per call (capped at 500; continue with a new offset when the outline is truncated).", "default": 2000, "maximum": 2000},
+            "mode": {"type": "string", "enum": ["read", "outline"], "default": "read", "description": "Read mode: 'read' (default) paginates file content exactly as before. 'outline' (opt-in, Markdown only) returns the file's heading structure — each heading's text, level, and 1-based source line — instead of its body, for quick orientation in long documents. Non-Markdown files return an empty outline with a note."}
         },
         "required": ["path"]
     }
@@ -1123,7 +1263,7 @@ SEARCH_FILES_SCHEMA = {
 
 def _handle_read_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid)
+    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid, mode=args.get("mode", "read"))
 
 
 def _handle_write_file(args, **kw):

--- a/tools/markdown_outline.py
+++ b/tools/markdown_outline.py
@@ -1,0 +1,76 @@
+"""Markdown heading-outline scanning for read_file's optional outline mode (#103374).
+
+Pure stdlib text parsing — no model calls, network, or new dependency:
+
+* Recognizes ATX (``#``..``######``) and Setext (``===`` / ``---`` underline)
+  headings, in source order.
+* Ignores heading-like lines inside fenced code blocks (backtick and tilde).
+* Preserves duplicate headings as separate entries with their own line.
+* Reports 1-based source line numbers (CRLF-safe via ``str.splitlines``).
+
+The scanner is deliberately line-oriented and lenient (CommonMark-ish rather
+than full CommonMark): it exists to orient the agent, not to render HTML.
+"""
+
+import re
+
+# Lowercased file suffixes that outline mode treats as Markdown.
+MARKDOWN_EXTENSIONS = frozenset({".md", ".markdown", ".mdown", ".mkd"})
+
+# Per-call output bounds. A bounded page keeps the JSON well under the tool
+# registry's max_result_size_chars even for pathological documents; the caller
+# marks truncation and continues with a new offset instead of dumping it all.
+OUTLINE_MAX_ENTRIES = 500
+OUTLINE_HEADING_MAX_CHARS = 150
+
+# Up to 3 leading spaces are part of the syntax, not the content.
+_ATX_RE = re.compile(r" {0,3}(#{1,6})(?:[ \t]+(.*))?$")
+# A trailing run of hashes preceded by whitespace is a closing sequence
+# (CommonMark), not heading text: "# Title ###" -> "Title".
+_CLOSING_HASHES_RE = re.compile(r"[ \t]+#+[ \t]*$")
+_FENCE_OPEN_RE = re.compile(r" {0,3}(`{3,}|~{3,})")
+_FENCE_CLOSE_RE = re.compile(r" {0,3}(`{3,}|~{3,})[ \t]*$")
+_SETEXT_UNDERLINE_RE = re.compile(r" {0,3}(=+|-+)[ \t]*$")
+
+
+def markdown_outline(content: str) -> list:
+    """Return every Markdown heading in *content*, in source order.
+
+    Each entry is ``{"line": int, "level": int, "heading": str}`` where
+    ``line`` is the 1-based source line of the heading text (the ATX marker
+    line, or the Setext text line above its underline).
+    """
+    entries = []
+    fence_char = None  # None = outside a fenced code block
+    lines = content.splitlines()
+    for i, line in enumerate(lines):
+        if fence_char is not None:
+            close = _FENCE_CLOSE_RE.match(line)
+            if close is not None and close.group(1)[0] == fence_char:
+                fence_char = None
+            continue
+        open_fence = _FENCE_OPEN_RE.match(line)
+        if open_fence is not None:
+            fence_char = open_fence.group(1)[0]
+            continue
+        stripped = line.strip()
+        if not stripped:
+            continue
+        atx = _ATX_RE.match(line)
+        if atx is not None:
+            text = _CLOSING_HASHES_RE.sub("", atx.group(2) or "").strip()
+            entries.append({"line": i + 1, "level": len(atx.group(1)), "heading": text})
+            continue
+        # Setext: the previous line is paragraph text and this line is an
+        # underline of "=" (H1) or "-" (H2). CommonMark requires the text line
+        # to be a paragraph, so heading/fence/blank/underline lines are excluded.
+        if i > 0:
+            underline = _SETEXT_UNDERLINE_RE.match(line)
+            if underline is not None:
+                prev = lines[i - 1]
+                if (prev.strip() and _ATX_RE.match(prev) is None
+                        and _FENCE_OPEN_RE.match(prev) is None
+                        and _SETEXT_UNDERLINE_RE.match(prev) is None):
+                    level = 1 if underline.group(1).startswith("=") else 2
+                    entries.append({"line": i, "level": level, "heading": prev.strip()})
+    return entries


### PR DESCRIPTION
Closes #103374

Adds an optional, opt-in `mode="outline"` parameter to the `read_file` tool: instead of paginated file content, it returns the Markdown heading structure of the document — each heading's text, nesting level (1-6), and 1-based source line, in source order — for quick orientation in long documents before choosing a targeted read with the existing `offset`/`limit` parameters.

## Parameter

- `mode`: `"read"` (default, current behavior unchanged) or `"outline"` (Markdown only).
- In outline mode, `offset` becomes the 1-based ordinal of the first heading to return and `limit` caps the headings returned per call (hard cap 500, with `truncated: true` + a hint naming the next `offset` when more headings exist — bounded output, explicit continuation).
- Non-Markdown paths return an empty outline with a clear note; no body read happens.
- Backend access (`read_file_raw`), sensitive-text redaction (per heading), the negative-result cache, dedup/loop tracking and read-before-write bookkeeping are reused — outline reads are recorded as partial reads and never count as having read the file body.

## Implementation

- ATX (`#`..`######`, incl. closing-hash sequences) and Setext (`===` / `---` underline) headings are recognized by a new pure-stdlib scanner (`tools/markdown_outline.py`); heading-like lines inside backtick/tilde fenced code blocks are ignored; duplicate headings are preserved as separate entries; line numbers are CRLF-safe.
- `tools/file_tools.py`: new `mode` schema parameter + handler wiring, `_read_file_outline` helper, schema/docstring documentation.

## Tests

`tests/tools/test_read_file_outline.py` (26 tests, all passing with the rest of the read_file/file_tools suite: 364 passed, 2 skipped):

- Markdown with headings at several levels → correct level/line/heading entries.
- Markdown with no headings → empty outline.
- Non-Markdown file → clear note, no read performed.
- Default mode (and explicit `mode="read"`) unchanged — content read path untouched.
- Scanner: ATX levels, closing hashes, Setext, fences (backtick + tilde), duplicate headings, CRLF line numbers.
- Output bound: 505-heading document returns 500 + `truncated`/continuation hint, and `offset=501` returns the remaining 5.
- Unknown mode → explicit error; binary `.md` content surfaces the backend error; schema exposes the opt-in param with `default: "read"`.
