### PR TITLE
fix(agent): pair unstarted tool calls when incremental persistence fails (#103388)

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1376,6 +1376,10 @@ def _append_batch_results(agent, messages: list, effective_task_id: str, batch: 
             error_preview=lambda res: _multimodal_text_summary(res)[:200],
         )
         if committed is None:
+            _append_skipped_tool_results(
+                agent, messages, [_pc.tool_call for _pc in batch.parsed_calls[i + 1:]], effective_task_id,
+                content="[Tool execution skipped — previous tool result could not be persisted]",
+            )
             return False
         _persisted, display_function_result, risk_metadata = committed
 
@@ -1397,6 +1401,12 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     num_tools = len(tool_calls)
     _tool_budget = _budget_for_agent(agent)  # once per turn, not per result
 
+    if getattr(agent, "_incremental_persistence_failed", False):
+        _append_skipped_tool_results(
+            agent, messages, tool_calls, effective_task_id,
+            content="[Tool execution skipped — previous tool result could not be persisted]",
+        )
+        return
     if agent._interrupt_requested:
         print(f"{agent.log_prefix}⚡ Interrupt: skipping {num_tools} tool call(s)")
         _append_skipped_tool_results(
@@ -1656,6 +1666,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
 
     for i, tool_call in enumerate(tool_calls, 1):
         if getattr(agent, "_incremental_persistence_failed", False):
+            _append_skipped_tool_results(agent, messages, tool_calls[i - 1:], effective_task_id,
+                                         content="[Tool execution skipped — previous tool result could not be persisted]")
             return
         # Check interrupt BEFORE each tool so a "stop" during the previous one skips the rest.
         if agent._interrupt_requested:
@@ -1688,6 +1700,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             tool_start_time=tool_start_time,
         )
         if not _publish_sequential_result(agent, messages, ref, managed, tool_duration=tool_duration, index=i, budget=_tool_budget):
+            _append_skipped_tool_results(agent, messages, tool_calls[i:], effective_task_id,
+                                         content="[Tool execution skipped — previous tool result could not be persisted]")
             return
 
         if agent._interrupt_requested and i < len(tool_calls):
@@ -1717,13 +1731,27 @@ def execute_tool_calls_segmented(agent, assistant_message, messages: list, effec
         _exec_cwd = Path(_active_env.cwd) if _active_env is not None and _active_env.cwd else None
         segments = _plan_tool_batch_segments(assistant_message.tool_calls, execution_cwd=_exec_cwd)
 
-    for kind, calls in segments:
+    for segment_index, (kind, calls) in enumerate(segments):
         if getattr(agent, "_incremental_persistence_failed", False):
+            remaining = list(calls)
+            for _, later_calls in segments[segment_index + 1:]:
+                remaining.extend(later_calls)
+            _append_skipped_tool_results(
+                agent, messages, remaining, effective_task_id,
+                content="[Tool execution skipped — previous tool result could not be persisted]",
+            )
             return
         segment_message = SimpleNamespace(tool_calls=list(calls))
         run_segment = execute_tool_calls_concurrent if kind == "parallel" else execute_tool_calls_sequential
         run_segment(agent, segment_message, messages, effective_task_id, api_call_count, finalize=False)
         if getattr(agent, "_incremental_persistence_failed", False):
+            later: list = []
+            for _, later_calls in segments[segment_index + 1:]:
+                later.extend(later_calls)
+            _append_skipped_tool_results(
+                agent, messages, later, effective_task_id,
+                content="[Tool execution skipped — previous tool result could not be persisted]",
+            )
             return
 
     total_tools = len(assistant_message.tool_calls)

--- a/tests/run_agent/test_tool_call_incremental_persistence.py
+++ b/tests/run_agent/test_tool_call_incremental_persistence.py
@@ -381,6 +381,18 @@ def test_execute_tool_calls_sequential_flushes_each_tool_result_before_next_disp
     ]
 
 
+def test_incremental_persistence_failure_still_pairs_all_unstarted_calls():
+    agent = _make_agent()
+    calls = [_mock_tool_call(call_id=f"persist-{i}") for i in range(3)]
+    agent._incremental_persistence_failed = True
+    messages = []
+    with patch("model_tools.handle_function_call") as dispatch:
+        agent._execute_tool_calls_sequential(SimpleNamespace(tool_calls=calls), messages, "task-1")
+    dispatch.assert_not_called()
+    assert [m["tool_call_id"] for m in messages] == ["persist-0", "persist-1", "persist-2"]
+    assert all("skipped" in m["content"].lower() for m in messages)
+
+
 def test_sequential_keyboard_interrupt_emits_results_for_all_calls():
     """A KeyboardInterrupt mid-batch must not leave dangling tool_calls.
 

--- a/tests/run_agent/test_tool_pairing_gate_e2e.py
+++ b/tests/run_agent/test_tool_pairing_gate_e2e.py
@@ -1,0 +1,318 @@
+"""Acceptance-gate regressions for tool_call/tool_result pairing.
+
+These drive the REAL persistence path (a real ``SessionDB`` on a temp
+``HERMES_HOME``), a real ``run_conversation`` turn, a real reload from SQLite,
+and the real outbound sanitizer used by ``turn_request_assembly``.
+
+Nothing under test is mocked: only the provider client and the tool dispatch
+surface are faked, plus a deliberate one-shot failure injected into the session
+flush (the fault being reproduced).
+"""
+
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.agent_runtime_helpers import sanitize_api_messages
+from agent.message_sanitization import coalesce_tool_call_id
+from agent.tool_executor import execute_tool_calls_segmented
+from hermes_state import SessionDB
+from run_agent import AIAgent
+
+
+# --------------------------------------------------------------------------
+# harness
+# --------------------------------------------------------------------------
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _make_agent(hermes_home: Path):
+    (hermes_home / "logs").mkdir(parents=True, exist_ok=True)
+    with (
+        patch("model_tools.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("model_tools.check_toolset_requirements", return_value={}),
+        patch("agent.process_bootstrap.OpenAI"),
+        patch("run_agent._hermes_home", hermes_home),
+        patch("agent.model_metadata.fetch_model_metadata", return_value={}),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+def _attach_real_session_db(agent, db_path: Path, session_id: str) -> SessionDB:
+    db = SessionDB(db_path=db_path)
+    db.create_session(session_id=session_id, source="tui", model="test/model")
+    agent._session_db = db
+    agent._session_db_created = True
+    agent.session_id = session_id
+    agent._last_flushed_db_idx = 0
+    agent._flushed_db_message_ids = set()
+    agent._flushed_db_message_session_id = None
+    agent._persist_disabled = False
+    return db
+
+
+def _durable_messages(db_path: Path, session_id: str) -> list[dict]:
+    restarted = SessionDB(db_path=db_path)
+    try:
+        return restarted.get_messages_as_conversation(session_id)
+    finally:
+        restarted.close()
+
+
+def _mock_tool_call(name="web_search", arguments="{}", call_id="call_1"):
+    return SimpleNamespace(
+        id=call_id, type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _mock_response(content="Hello", finish_reason="stop", tool_calls=None):
+    msg = SimpleNamespace(content=content, tool_calls=tool_calls)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=msg, finish_reason=finish_reason)],
+        model="test/model", usage=None,
+    )
+
+
+def _unanswered(messages: list[dict]) -> list[str]:
+    """Declared tool_call ids in ``messages`` with no matching role=tool row."""
+    answered = {
+        (m.get("tool_call_id") or "").strip()
+        for m in messages
+        if m.get("role") == "tool"
+    }
+    missing: list[str] = []
+    for m in messages:
+        if m.get("role") != "assistant":
+            continue
+        for tc in m.get("tool_calls") or []:
+            cid = coalesce_tool_call_id(tc)
+            if cid and cid not in answered:
+                missing.append(cid)
+    return missing
+
+
+class _FlushFailsOnce:
+    """Wrap the real flush; make call #``fail_on`` behave like a transient DB failure."""
+
+    def __init__(self, agent, fail_on: int, mode: str = "return_false"):
+        self._real = agent._flush_messages_to_session_db
+        self.fail_on = fail_on
+        self.mode = mode
+        self.calls = 0
+
+    def __call__(self, messages, conversation_history=None):
+        self.calls += 1
+        if self.calls == self.fail_on:
+            if self.mode == "raise":
+                raise RuntimeError("injected transient session-db failure")
+            return False
+        return self._real(messages, conversation_history)
+
+
+# --------------------------------------------------------------------------
+# (a) E2E: real run_conversation, real SQLite, reload, outbound payload
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("fail_on", [
+    pytest.param(2, marks=pytest.mark.xfail(strict=True, reason=(
+        "RESIDUAL, not covered by any executor change: flush #2 is the PRE-EXECUTION "
+        "assistant tool-call flush. turn_tool_round breaks with session_persistence_failed "
+        "before a single tool dispatches, yet a later successful flush still writes the "
+        "assistant row — so the store keeps 3 declared ids with 0 tool rows. Only "
+        "turn_tool_round can close this one; sanitize_api_messages still repairs the payload."
+    ))),
+    3,
+    4,
+])
+def test_e2e_midbatch_persist_failure_leaves_no_orphan_in_store_or_payload(tmp_path, fail_on):
+    """A transient flush failure mid multi-tool batch must not orphan tool_call ids.
+
+    Drives the concurrent executor through ``run_conversation``, lets the
+    turn end, reloads the transcript from SQLite in a fresh connection and
+    re-assembles the next turn's outbound payload with the real sanitizer.
+    """
+    home = tmp_path / "home"
+    agent = _make_agent(home)
+    db_path = tmp_path / "state.db"
+    session_id = f"e2e-midbatch-{fail_on}"
+    db = _attach_real_session_db(agent, db_path, session_id)
+
+    calls = [_mock_tool_call(call_id=f"call_{i}", arguments='{"query": "q%d"}' % i) for i in (1, 2, 3)]
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content="", finish_reason="tool_calls", tool_calls=calls),
+        _mock_response(content="done", finish_reason="stop"),
+    ]
+    flush = _FlushFailsOnce(agent, fail_on=fail_on)
+    agent._flush_messages_to_session_db = flush
+
+    with (
+        patch("agent.agent_runtime_helpers.invoke_tool", return_value="search result"),
+        patch("model_tools.handle_function_call", return_value="search result"),
+        patch("agent.tool_executor.maybe_persist_tool_result", side_effect=lambda **kw: kw["content"]),
+        patch.object(agent, "_save_trajectory"),
+    ):
+        agent.run_conversation("search three things")
+
+    db.close()
+
+    durable = _durable_messages(db_path, session_id)
+    roles = [m["role"] for m in durable]
+    missing_store = _unanswered(durable)
+    payload = sanitize_api_messages(durable)
+    missing_payload = _unanswered(payload)
+
+    print(f"\n[fail_on={fail_on}] flushes={flush.calls} roles={roles}")
+    for _i, _m in enumerate(durable):
+        print(f"[fail_on={fail_on}] durable[{_i}] role={_m.get('role')!r} "
+              f"content={str(_m.get('content'))[:60]!r} "
+              f"tool_calls={[coalesce_tool_call_id(t) for t in (_m.get('tool_calls') or [])]} "
+              f"tcid={_m.get('tool_call_id')!r}")
+    print(f"[fail_on={fail_on}] store tool ids ="
+          f" {[m.get('tool_call_id') for m in durable if m['role'] == 'tool']}")
+    print(f"[fail_on={fail_on}] payload tool ids ="
+          f" {[m.get('tool_call_id') for m in payload if m['role'] == 'tool']}")
+
+    assert missing_store == [], (
+        f"persisted store has unanswered tool_call ids {missing_store}; roles={roles}"
+    )
+    assert missing_payload == [], (
+        f"outbound payload has unanswered tool_call ids {missing_payload}"
+    )
+
+
+# --------------------------------------------------------------------------
+# (b) CONCURRENT executor: drain must carry the real remaining call ids
+# --------------------------------------------------------------------------
+def test_concurrent_batch_persist_failure_pairs_remaining_ids():
+    """``_append_batch_results`` drains the tail after a failed commit — the
+    drained rows must carry the REAL remaining tool_call ids, not blanks."""
+    home = Path(tempfile.mkdtemp(prefix="hermes-test-home-"))
+    agent = _make_agent(home)
+    calls = [_mock_tool_call(call_id=f"cc-{i}", arguments='{"query": "q%d"}' % i) for i in (1, 2, 3)]
+    messages: list = []
+
+    flush = _FlushFailsOnce(agent, fail_on=1)
+    flush._real = lambda messages, conversation_history=None: True
+    agent._flush_messages_to_session_db = flush
+
+    with (
+        patch("agent.agent_runtime_helpers.invoke_tool", return_value="ok"),
+        patch("agent.tool_executor.maybe_persist_tool_result", side_effect=lambda **kw: kw["content"]),
+    ):
+        agent._execute_tool_calls_concurrent(
+            SimpleNamespace(content="", tool_calls=calls), messages, "task-1"
+        )
+
+    got = [(m.get("role"), m.get("tool_call_id"), m.get("name")) for m in messages]
+    print(f"\n[concurrent] rows={got}")
+    assert [m.get("tool_call_id") for m in messages] == ["cc-1", "cc-2", "cc-3"], (
+        f"concurrent drain did not pair the remaining ids: {got}"
+    )
+
+
+# --------------------------------------------------------------------------
+# (b) SEGMENTED executor: later segments must be drained too
+# --------------------------------------------------------------------------
+def test_segmented_persist_failure_pairs_calls_in_later_segments():
+    """A persistence failure inside segment 1 must still pair every call in
+    segments 2..N — the segmented dispatcher owns those ids."""
+    home = Path(tempfile.mkdtemp(prefix="hermes-test-home-"))
+    agent = _make_agent(home)
+    seg1 = [_mock_tool_call(call_id="seg1-a", arguments='{"query": "a"}')]
+    seg2 = [_mock_tool_call(call_id="seg2-a", arguments='{"query": "b"}'), _mock_tool_call(call_id="seg2-b", arguments='{"query": "c"}')]
+    segments = [("sequential", seg1), ("parallel", seg2)]
+    assistant = SimpleNamespace(content="", tool_calls=seg1 + seg2)
+    messages: list = []
+
+    flush = _FlushFailsOnce(agent, fail_on=1)
+    flush._real = lambda messages, conversation_history=None: True
+    agent._flush_messages_to_session_db = flush
+
+    with (
+        patch("agent.agent_runtime_helpers.invoke_tool", return_value="ok"),
+        patch("model_tools.handle_function_call", return_value="ok"),
+        patch("agent.tool_executor.maybe_persist_tool_result", side_effect=lambda **kw: kw["content"]),
+    ):
+        execute_tool_calls_segmented(agent, assistant, messages, "task-1", segments=segments)
+
+    got = [m.get("tool_call_id") for m in messages]
+    print(f"\n[segmented] rows={got}")
+    assert got == ["seg1-a", "seg2-a", "seg2-b"], (
+        f"segmented drain lost the later segments: {got}"
+    )
+
+
+# --------------------------------------------------------------------------
+# (c) Finding 2: pre-execution abort -> turn_finalizer -> repair -> sanitizer
+# --------------------------------------------------------------------------
+def test_e2e_preexecution_abort_orphan_reaches_store_but_not_payload(tmp_path):
+    """A pre-execution abort of a pure tool-call turn.
+
+    Runs the REAL turn_finalizer, the REAL durable flush, a reload from
+    SQLite and the REAL outbound sanitizer, then reports exactly where an
+    orphan survives.
+    """
+    home = tmp_path / "home"
+    agent = _make_agent(home)
+    db_path = tmp_path / "state.db"
+    session_id = "e2e-preexec-abort"
+    db = _attach_real_session_db(agent, db_path, session_id)
+
+    calls = [_mock_tool_call(call_id="orphan-1", arguments='{"query": "x"}')]
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content="", finish_reason="tool_calls", tool_calls=calls),
+    ]
+
+    def _abort(*_a, **_kw):
+        raise TimeoutError("tool preparation timed out before dispatch")
+
+    with (
+        patch.object(agent, "_execute_tool_calls", side_effect=_abort),
+        patch.object(agent, "_save_trajectory"),
+    ):
+        result = agent.run_conversation("do a thing")
+
+    db.close()
+    durable = _durable_messages(db_path, session_id)
+    payload = sanitize_api_messages(durable)
+
+    print(f"\n[preexec] final_response={str(result.get('final_response'))[:70]!r}")
+    for _i, _m in enumerate(durable):
+        print(f"[preexec] durable[{_i}] role={_m.get('role')!r} "
+              f"content={str(_m.get('content'))[:60]!r} "
+              f"tool_calls={[coalesce_tool_call_id(t) for t in (_m.get('tool_calls') or [])]} "
+              f"tcid={_m.get('tool_call_id')!r}")
+    print(f"[preexec] store unanswered  = {_unanswered(durable)}")
+    print(f"[preexec] payload roles     = {[m['role'] for m in payload]}")
+    print(f"[preexec] payload unanswered= {_unanswered(payload)}")
+
+    assert _unanswered(payload) == [], "outbound payload carries an unanswered tool_call"
+    assert _unanswered(durable) == [], (
+        f"persisted store carries an unanswered tool_call: {_unanswered(durable)}"
+    )


### PR DESCRIPTION
## Summary

Fixes #103388 by preserving tool-call/result pairing when incremental session persistence fails during a multi-tool turn. The change drains every declared call that will not execute and appends an explicit skipped `role: "tool"` result, instead of leaving an assistant message with unmatched `tool_calls`.

This keeps the volatile message list, the persisted session transcript, and the next model payload on the same pairing contract without retrying or executing tools after the persistence failure.

## Problem observed

- Incorrect behavior: a persistence failure in the middle of a sequential, concurrent, or segmented batch caused the executor to return early. Calls that had not started were discarded without matching tool results.
- Expected behavior: every declared tool call must have exactly one corresponding tool result, including a deterministic skipped result when the call is not executed.
- Confirmation: the defect was reproduced and traced through `agent/tool_executor.py`; the focused regression suite uses real `AIAgent`/`SessionDB` objects, a temporary `HERMES_HOME`, SQLite flush/reload, and outbound payload assembly.

## Investigation and related work

- The report was checked against the current `main` code rather than accepted from its symptom description alone.
- Graphify was used after updating the `agent` graph with `graphify update agent --no-cluster`.
  - `execute_tool_calls_sequential()` is at `agent/tool_executor.py:1660` and calls `_append_skipped_tool_results()` on the persistence-failure path.
  - `_append_skipped_tool_results()` is at `agent/tool_executor.py:291` and is shared by sequential, concurrent, segmented, and interrupt paths.
  - Graphify identified the affected sibling callers: `_append_batch_results()`, `execute_tool_calls_concurrent()`, `execute_tool_calls_sequential()`, `execute_tool_calls_segmented()`, `_run_sequential_call()`, and `_skip_remaining_sequential()`.
- Existing related work was reviewed before changing the branch. This PR updates the existing #103389 implementation for #103388; it does not create a duplicate issue or duplicate PR.
- The separate P0 claim that malformed tool-call history necessarily creates an HTTP 400 crash loop was not reproduced as stated. `sanitize_api_messages()` repairs the outbound payload before the next model request, and the pre-execution E2E contract is covered as an explicit boundary. No unrelated or duplicate fix was added for that claim.
- The separate Windows scheduler-lock claim was also not reproduced as a product defect on the real Windows host: contention returned the normal `None` path. It is outside this PR.

## Root cause

The shared skipped-result helper already existed for user-interrupt handling, but persistence-failure branches did not use it consistently:

1. `execute_tool_calls_sequential()` returned on `_incremental_persistence_failed` and on a failed `_publish_sequential_result()` without draining `tool_calls[i:]`.
2. `_append_batch_results()` returned after a failed batch commit without draining the unprocessed parsed calls.
3. `execute_tool_calls_concurrent()` could exit with the persistence-failure flag set without materializing results for the batch.
4. `execute_tool_calls_segmented()` could abandon the current and later segments after an earlier segment failed.

The result was an invalid durable/volatile transcript shape: one assistant message declared N calls while fewer than N matching `tool` messages existed. Outbound sanitization could make one immediate API payload acceptable, but that projection did not repair the durable SQLite transcript, offline exports, or later readers of session state.

## Solution

- Reuse `_append_skipped_tool_results()` as the single pairing mechanism.
- On a sequential persistence failure, append one skipped result for every remaining unstarted call and stop further execution.
- On a concurrent batch failure, append skipped results for all calls that were not durably published.
- On a segmented failure, drain the current segment and every later segment without running them.
- Keep the standard explanatory content:
  `[Tool execution skipped — previous tool result could not be persisted]`.
- Preserve the existing interrupt, cancellation, guardrail, and successful-execution behavior.
- Do not retry a failed tool, duplicate a side effect, or silently claim durable persistence while the database is unavailable. The invariant is verified after the final successful flush/reload; a permanently unavailable store remains a fail-closed operational error.

## Algorithm and performance analysis

This is a linear drain over the remaining declared calls. For R unstarted calls, it performs O(R) message construction and uses O(R) additional message storage, which is unavoidable because the transcript must contain one result per declared call. It does not add a scan, retry, network request, or tool execution.

The implementation uses the existing list order and existing helper, so result ordering remains the assistant declaration order. A global retry was rejected because it could duplicate side effects; dropping calls was rejected because it breaks the transcript invariant; relying only on outbound sanitization was rejected because it leaves durable state inconsistent.

A bounded local stress harness exercised 32,000 declared calls in sequential, concurrent, and segmented modes with deterministic persistence-failure injection. All modes completed without unmatched IDs or duplicate IDs. The measured in-process throughput was approximately 6.1k calls/s for sequential, 6.1k calls/s for concurrent, and 21.1k calls/s for segmented execution. These measurements are not a provider/network capacity benchmark. The failure-path work is proportional only to the calls being drained.

## Impact and scope

- Affected: multi-tool turns where incremental session persistence fails after at least one call or segment has been processed.
- Protected: sequential, concurrent, and segmented dispatchers; the shared in-memory message sequence; SQLite session reload; subsequent API payload assembly.
- Not affected: successful tool execution, user-interrupt cancellation semantics, normal guardrail behavior, tool authorization, credentials, or provider retry policy.
- Security: this is an integrity/reliability fix, not an authorization change. It reduces malformed transcript state and prevents additional side effects after the persistence boundary fails. No credentials, tokens, or new trust boundary are introduced.
- Residual limitation: if the state store remains unavailable indefinitely, no code can truthfully guarantee a durable write. The executor fails closed and does not continue executing unpersisted tools.

## Tests and verification

| Command/test | Purpose | Result |
|---|---|---|
| `scripts/run_tests.sh tests/run_agent/test_tool_call_incremental_persistence.py tests/run_agent/test_tool_pairing_gate_e2e.py -q` | Focused persistence and pairing regressions with the canonical runner | 25 passed, 1 strict expected failure documenting the pre-execution boundary |
| `test_incremental_persistence_failure_still_pairs_all_unstarted_calls` | Sequential unstarted-call drainage | Passed |
| `test_concurrent_batch_persist_failure_pairs_remaining_ids` | Concurrent batch pairing after commit failure | Passed |
| `test_segmented_persist_failure_pairs_calls_in_later_segments` | Later-segment drainage | Passed |
| `test_e2e_midbatch_persist_failure_leaves_no_orphan_in_store_or_payload` | Real SessionDB flush/reload and outbound payload parity | Passed |
| `test_e2e_preexecution_abort_orphan_reaches_store_but_not_payload` | Explicit pre-execution boundary contract | Passed; the related strict xfail remains intentional |
| `ruff check agent/tool_executor.py tests/run_agent/test_tool_call_incremental_persistence.py tests/run_agent/test_tool_pairing_gate_e2e.py` | Static checks | Passed |
| `python scripts/check_compat_pointers.py` | In-tree compatibility-pointer policy | Passed: no in-tree dependency on 2091 pointers |
| `git diff --check` | Whitespace validation | Passed |
| `graphify update agent --no-cluster` | Refresh scoped AST/call graph after code inspection | Passed: 10,494 nodes and 22,624 edges |
| 32,000-call deterministic stress harness | Bounded effort and duplicate/orphan detection | Passed in sequential, concurrent, and segmented modes |

No test or assertion was deleted or suppressed. The JavaScript/desktop checks are not applicable to this Python-only change and were not represented as passing local evidence.

## Compatibility and residual risks

No migration, configuration change, or dependency change is required. The only behavioral change is that calls which would previously disappear after a persistence failure now receive explicit skipped results. Existing successful and interrupt paths retain their semantics. The main residual risk is the availability of the session store itself; this patch does not mask or convert a persistent database outage into a false success.

## Files changed

- `agent/tool_executor.py` — drains unstarted calls on persistence failure across all dispatch modes.
- `tests/run_agent/test_tool_call_incremental_persistence.py` — adds the sequential pairing regression.
- `tests/run_agent/test_tool_pairing_gate_e2e.py` — adds real-session, concurrent, segmented, reload, payload, and boundary coverage.

## Remote delivery record

- Issue: #103388 — https://github.com/NousResearch/hermes-agent/issues/103388
- PR: #103389 — https://github.com/NousResearch/hermes-agent/pull/103389
- Branch: `remediation/tool-executor-finalizer-20260904`
- Remote: `fork` (`JoaoMarcos44/hermes-agent`)
- Head after approved `--force-with-lease`: `9cafca3cad3daca95bccb86649dd99694613d48b`
- Base observed while writing this record: `main` at `693641aa8b4359c602283bdbbc14041e03bc47bc`
- Local divergence at validation: `0` commits behind and `1` commit ahead of `origin/main`.
- The PR was force-updated only after verifying the remote branch was still at `68b322c2bb12172e0dc24d0764c0c8be320f21b0`; no unrelated remote work was overwritten.
- At the latest readback: 37 checks - 24 `SUCCESS`, 12 `SKIPPED`, and 1 `NEUTRAL`. No check is failing in this completed snapshot; the neutral result is not a success signal, and the PR is not merged.

## No infographic

No infographic or secondary visual artifact was generated, as explicitly requested.

