### PR TITLE
fix(gateway): reap aborted streaming TTS task after timeout

### DIFF
--- a/gateway/streaming_tts_consumer.py
+++ b/gateway/streaming_tts_consumer.py
@@ -222,8 +222,23 @@ class StreamingTTSConsumer:
                 self._loop.call_soon_threadsafe(asyncio.create_task, self._safe_abort(reason))
 
     async def wait_complete(self, timeout: float = 10.0) -> bool:
-        """Wait for the drain task to finish. Returns True only on full success."""
-        if self._task is not None:
-            with contextlib.suppress(asyncio.CancelledError, Exception):
-                await asyncio.wait_for(asyncio.shield(self._task), timeout=timeout)
+        """Wait for the drain task to finish. Returns True only on full success.
+
+        After ``abort()``, a provider iterator may still be blocked inside
+        ``asyncio.to_thread(next, ...)``. If the graceful wait expires, cancel
+        and reap the asyncio drain task so it cannot survive turn teardown.
+        """
+        if self._task is None:
+            return self._completed
+        try:
+            await asyncio.wait_for(asyncio.shield(self._task), timeout=timeout)
+        except asyncio.TimeoutError:
+            if self._aborted and not self._task.done():
+                self._task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await self._task
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            pass
         return self._completed

--- a/tests/gateway/test_streaming_tts_consumer.py
+++ b/tests/gateway/test_streaming_tts_consumer.py
@@ -631,11 +631,14 @@ class TestPostAudioTimeoutAbort:
 
             # Simulate the outer loop's abort-on-timeout behaviour.
             consumer.abort("streaming TTS finalisation timeout")
-            await asyncio.sleep(0.05)
+            await consumer.wait_complete(timeout=0.05)
 
-            # The consumer must not complete later in the background.
+            # The consumer must not complete later in the background, and the
+            # asyncio drain task must be reaped even while provider ``next()``
+            # is still blocked in its executor thread.
             assert consumer.completed is False
             assert consumer._aborted is True
+            assert consumer.done is True
 
         _run_test(run)
 


### PR DESCRIPTION
## Summary

Ensure an aborted `StreamingTTSConsumer` cannot survive turn/event-loop teardown when a provider iterator remains blocked inside `asyncio.to_thread(next, ...)`.

The gateway already performs `abort()` followed by a bounded second `wait_complete()`. Previously, when that second wait expired, `wait_complete()` returned while the asyncio drain task was still pending. With asyncio debug enabled this reproduces as:

`Task was destroyed but it is pending!`

pointing at `StreamingTTSConsumer._run()`.

## Fix

- after `abort()`, if the bounded wait expires and the drain task is still alive, cancel and await/reap that asyncio task;
- preserve the existing suppression/fallback contract and audible-delivery semantics;
- strengthen the post-audio timeout regression to require `consumer.done is True` even while the provider's executor thread is still blocked.

## Local validation

Against current `origin/main`:

- deterministic pre-fix reproduction: test passes but emits the pending-task diagnostic under `PYTHONASYNCIODEBUG=1`;
- fixed regression under `PYTHONASYNCIODEBUG=1`: **1 passed**, no pending-task diagnostic;
- `tests/gateway/test_streaming_tts_consumer.py`: **15 passed**, no pending-task diagnostic;
- Ruff focused check: **PASS**;
- `git diff --check`: **PASS**.

This is intentionally a focused lifecycle fix; it does not alter provider selection, audio content, or the gateway's whole-file fallback policy.