### PR TITLE
Dockerfile: install full Chromium (drop --only-shell)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -198,7 +198,7 @@ ENV npm_config_install_links=false
 
 RUN npm install --prefer-offline --no-audit --fetch-retries=5 && \
     for i in 1 2 3; do \
-        npx playwright install --with-deps chromium --only-shell && break || \
+        npx playwright install --with-deps chromium && break || \
         { [ "$i" = 3 ] && exit 1; echo "playwright install failed (attempt $i); retrying in 10s"; sleep 10; }; \
     done && \
     npm cache clean --force

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -488,7 +488,7 @@ The official image is based on `debian:13.4` and includes:
 
 - Python 3.13 with dependencies synced from the lockfile via `uv sync --frozen --no-install-project` for the baked extras (`all`, `messaging`, Anthropic/Bedrock/Azure identity, Hindsight, Matrix), followed by a no-dependency editable install of Hermes itself.
 - Node.js 26 + npm (for browser automation, WhatsApp bridge, TUI/Desktop bundles, and workspace build tooling)
-- Playwright with Chromium (`npx playwright install --with-deps chromium --only-shell`)
+- Playwright with Chromium (`npx playwright install --with-deps chromium`)
 - ripgrep, ffmpeg, git, and `xz-utils` as system utilities
 - **`docker-cli`** — so agents running inside the container can drive the host's Docker daemon (bind-mount `/var/run/docker.sock` to opt in) for `docker build`, `docker run`, container inspection, etc.
 - **`openssh-client`** — enables the [SSH terminal backend](/user-guide/configuration#ssh-backend) from inside the container. The SSH backend shells out to the system `ssh` binary; without this, it failed silently in containerized installs.


### PR DESCRIPTION
## What does this PR do?

Stop baking Chromium with `--only-shell` so full Chromium lands under `PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright`.

Local Browser / agent-browser needs full `chromium-*`. `headless_shell` alone breaks seats with `HERMES_DISABLE_LAZY_INSTALLS=1`. Image size increases. AgentOS will bump digest after a published image.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 📝 Documentation update

## Changes Made

- `Dockerfile`: `npx playwright install --with-deps chromium --only-shell` → `npx playwright install --with-deps chromium` in the Playwright install retry loop
- `website/docs/user-guide/docker.md`: match the documented install command

## How to Test

1. Build the image and confirm `PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright` contains a full `chromium-*` browser, not only `chromium_headless_shell-*`.
2. With `HERMES_DISABLE_LAZY_INSTALLS=1`, start a Local Browser / agent-browser seat and verify it can launch Chromium without a runtime Playwright install.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (docs/Dockerfile-only; no Python behavior change)
- [x] I've added tests for my changes — N/A (image build install command)
- [x] I've tested on my platform: Linux (Dockerfile + docs edit verified against current `main`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/docker.md`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (official Linux image)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A