### PR TITLE
fix(cli): propagate non-zero exit codes on cron and webhook subcommand failures

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1752,12 +1752,12 @@ def cmd_proxy(args):
         raise SystemExit(rc)
 
 
-def _forward_command(name: str, module: str, attr: str, *, forward_return: bool = False, doc: str = ""):
+def _forward_command(name: str, module: str, attr: str, *, forward_return: bool = True, doc: str = ""):
     """A ``hermes <cmd>`` handler that hands ``args`` to ``<module>.<attr>``.
 
     Imports at CALL time so fast paths never pay for it and
     ``patch("<module>.<attr>")`` keeps intercepting. ``forward_return``
-    surfaces the return code to ``main()`` (only kanban/project propagate).
+    surfaces the return code to ``main()``.
     """
 
     def _cmd(args):
@@ -1778,8 +1778,8 @@ cmd_auth = _forward_command("cmd_auth", "hermes_cli.auth_commands", "auth_comman
 cmd_status = _forward_command("cmd_status", "hermes_cli.status", "show_status", doc='Show status of all components.')
 cmd_cron = _forward_command("cmd_cron", "hermes_cli.cron", "cron_command", doc='Cron job management.')
 cmd_webhook = _forward_command("cmd_webhook", "hermes_cli.webhook", "webhook_command", doc='Webhook subscription management.')
-cmd_kanban = _forward_command("cmd_kanban", "hermes_cli.kanban", "kanban_command", forward_return=True, doc='Multi-profile collaboration board.')
-cmd_project = _forward_command("cmd_project", "hermes_cli.projects_cmd", "projects_command", forward_return=True, doc='Manage projects (named, multi-folder workspaces).')
+cmd_kanban = _forward_command("cmd_kanban", "hermes_cli.kanban", "kanban_command", doc='Multi-profile collaboration board.')
+cmd_project = _forward_command("cmd_project", "hermes_cli.projects_cmd", "projects_command", doc='Manage projects (named, multi-folder workspaces).')
 cmd_hooks = _forward_command("cmd_hooks", "hermes_cli.hooks", "hooks_command", doc='Shell-hook inspection and management.')
 cmd_doctor = _forward_command("cmd_doctor", "hermes_cli.doctor", "run_doctor", doc='Check configuration and dependencies.')
 cmd_dump = _forward_command("cmd_dump", "hermes_cli.dump", "run_dump", doc='Dump setup summary for support/debugging.')

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -95,20 +95,22 @@ def webhook_command(args):
     if not sub:
         print("Usage: hermes webhook {subscribe|list|remove|test}")
         print("Run 'hermes webhook --help' for details.")
-        return
+        return 1
     if not _is_webhook_enabled():
         print(_setup_hint())
-        return
+        return 1
     handler = _ACTIONS.get(sub)
     if handler is not None:
-        handler(args)
+        rc = handler(args)
+        return rc if isinstance(rc, int) else 0
+    return 1
 
 
 def _cmd_subscribe(args):
     name = args.name.strip().lower().replace(" ", "-")
     if not re.match(r'^[a-z0-9][a-z0-9_-]*$', name):
         print(f"Error: Invalid name '{name}'. Use lowercase alphanumeric with hyphens/underscores.")
-        return
+        return 1
 
     subs = _load_subscriptions()
     is_update = name in subs
@@ -128,7 +130,7 @@ def _cmd_subscribe(args):
             print(
                 "Error: --deliver-only requires --deliver to be a real target "
                 "(telegram, discord, slack, github_comment, etc.) — not 'log'.")
-            return
+            return 1
         route["deliver_only"] = True
     script = (getattr(args, "script", "") or "").strip()
     if script:
@@ -153,6 +155,7 @@ def _cmd_subscribe(args):
     print("\n  Configure your service to POST to the URL above.")
     print("  Use the secret for HMAC-SHA256 signature validation.")
     print("  The gateway must be running to receive events (hermes gateway run).\n")
+    return 0
 
 
 def _cmd_list(args):
@@ -160,7 +163,7 @@ def _cmd_list(args):
     if not subs:
         print("  No dynamic webhook subscriptions.")
         print("  Create one with: hermes webhook subscribe <name>")
-        return
+        return 0
 
     base_url = _get_webhook_base_url()
     print(f"\n  {len(subs)} webhook subscription(s):\n")
@@ -179,6 +182,7 @@ def _cmd_list(args):
         if route.get("script"):
             print(f"    Script:  {route['script']}")
         print()
+    return 0
 
 
 def _cmd_remove(args):
@@ -187,10 +191,11 @@ def _cmd_remove(args):
     if name not in subs:
         print(f"  No subscription named '{name}'.")
         print("  Note: Static routes from config.yaml cannot be removed here.")
-        return
+        return 1
     del subs[name]
     _save_subscriptions(subs)
     print(f"  Removed webhook subscription: {name}")
+    return 0
 
 
 def _cmd_test(args):
@@ -199,7 +204,7 @@ def _cmd_test(args):
     subs = _load_subscriptions()
     if name not in subs:
         print(f"  No subscription named '{name}'.")
-        return
+        return 1
     secret = subs[name].get("secret", "")
     url = f"{_get_webhook_base_url()}/webhooks/{name}"
     payload = args.payload or '{"test": true, "event_type": "test", "message": "Hello from hermes webhook test"}'
@@ -214,9 +219,13 @@ def _cmd_test(args):
         with urllib.request.urlopen(req, timeout=10) as resp:
             body = resp.read().decode()
             print(f"  Response ({resp.status}): {body}")
+            if resp.status >= 400:
+                return 1
+            return 0
     except Exception as e:
         print(f"  Error: {e}")
         print("  Is the gateway running? (hermes gateway run)")
+        return 1
 
 
 _ACTIONS = {

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -586,3 +586,28 @@ class TestSlashCronListLastStatus:
 
         out = self._run_list(tmp_cron_dir, capsys)
         assert "(ok)" in out
+
+
+class TestCronCommandExitCodes:
+
+    def test_cron_edit_nonexistent_returns_nonzero(self, tmp_cron_dir):
+        rc = cron_command(Namespace(cron_command="edit", job_id="nope000000", name="x"))
+        assert rc != 0
+
+    def test_cron_pause_nonexistent_returns_nonzero(self, tmp_cron_dir):
+        rc = cron_command(Namespace(cron_command="pause", job_id="nope000000"))
+        assert rc != 0
+
+    def test_cron_remove_nonexistent_returns_nonzero(self, tmp_cron_dir):
+        rc = cron_command(Namespace(cron_command="remove", job_id="nope000000"))
+        assert rc != 0
+
+    def test_cron_run_nonexistent_returns_nonzero(self, tmp_cron_dir):
+        rc = cron_command(Namespace(cron_command="run", job_id="nope000000"))
+        assert rc != 0
+
+    def test_cmd_cron_forward_return_code(self, tmp_cron_dir):
+        from hermes_cli.main import cmd_cron
+        rc = cmd_cron(Namespace(cron_command="remove", job_id="nope000000"))
+        assert rc != 0
+

--- a/tests/hermes_cli/test_webhook_cli.py
+++ b/tests/hermes_cli/test_webhook_cli.py
@@ -130,14 +130,16 @@ class TestWebhookEnabledGate:
 
     def test_blocks_list_when_disabled(self, capsys, monkeypatch):
         monkeypatch.setattr("hermes_cli.webhook._is_webhook_enabled", lambda: False)
-        webhook_command(_make_args(webhook_action="list"))
+        rc = webhook_command(_make_args(webhook_action="list"))
         out = capsys.readouterr().out
+        assert rc != 0
         assert "not enabled" in out.lower()
 
     def test_allows_when_enabled(self, capsys):
         # _is_webhook_enabled already patched to True by autouse fixture
-        webhook_command(_make_args(webhook_action="subscribe", name="allowed"))
+        rc = webhook_command(_make_args(webhook_action="subscribe", name="allowed"))
         out = capsys.readouterr().out
+        assert rc == 0
         assert "Created" in out
         assert "allowed" in _load_subscriptions()
 
@@ -152,4 +154,28 @@ class TestWebhookEnabledGate:
         )
         import hermes_cli.webhook as wh_mod
         assert wh_mod._is_webhook_enabled() is False
+
+
+class TestWebhookCommandExitCodes:
+
+    def test_missing_subcommand_returns_nonzero(self):
+        rc = webhook_command(_make_args(webhook_action=None))
+        assert rc != 0
+
+    def test_invalid_name_returns_nonzero(self):
+        rc = webhook_command(_make_args(webhook_action="subscribe", name="INVALID NAME!"))
+        assert rc != 0
+
+    def test_invalid_deliver_only_returns_nonzero(self):
+        rc = webhook_command(_make_args(webhook_action="subscribe", name="valid-route", deliver_only=True, deliver="log"))
+        assert rc != 0
+
+    def test_remove_nonexistent_returns_nonzero(self):
+        rc = webhook_command(_make_args(webhook_action="remove", name="nonexistent"))
+        assert rc != 0
+
+    def test_test_nonexistent_returns_nonzero(self):
+        rc = webhook_command(_make_args(webhook_action="test", name="nonexistent"))
+        assert rc != 0
+
 


### PR DESCRIPTION
## What does this PR do?

Ensures that CLI commands executed via `_forward_command` in `hermes_cli/main.py` propagate integer return codes to the shell exit status, and adds explicit non-zero exit codes on error conditions for `hermes webhook` and `hermes cron` subcommands.

Previously, `_forward_command` defaulted `forward_return=False`, causing return codes returned by subcommand handlers (such as `cron_command` returning `1` on error) to be silently dropped as `None` (resulting in exit code 0). Additionally, `hermes webhook` handlers lacked return code propagation on errors (such as disabled webhook platform, invalid subscription name, missing route, or HTTP request failures).

## Related Issue

Fixes #103257

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`hermes_cli/main.py`**:
  - Set `forward_return: bool = True` as default in `_forward_command` so any forwarded CLI subcommand returning an integer status code propagates cleanly to `main()` where `sys.exit(rc)` is invoked for non-zero statuses.
- **`hermes_cli/webhook.py`**:
  - `webhook_command(args)` returns `1` when no action is specified or when the webhook platform is not enabled; propagates return codes from sub-handlers.
  - `_cmd_subscribe(args)` returns `1` on invalid name regex or invalid delivery config; returns `0` on success.
  - `_cmd_remove(args)` returns `1` if the subscription is not found; returns `0` on successful removal.
  - `_cmd_test(args)` returns `1` if subscription is missing, if an HTTP exception is raised, or if `resp.status >= 400`; returns `0` on success.
  - `_cmd_list(args)` returns `0`.
- **`tests/hermes_cli/test_cron.py` & `tests/hermes_cli/test_webhook_cli.py`**:
  - Added unit test cases asserting non-zero exit statuses for failed operations (`edit`, `pause`, `remove`, `run`, `subscribe`, `test`) and end-to-end `cmd_cron` propagation.

## How to Test

Run the targeted test suite:
```bash
pytest tests/hermes_cli/test_cron.py tests/hermes_cli/test_webhook_cli.py tests/hermes_cli/test_projects_cli.py -v
```

Manual verification of exit status:
```bash
hermes cron remove nope000000; echo "exit=$?" # exit=1
hermes webhook remove nope-route; echo "exit=$?" # exit=1
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Linux (Docker)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
======================= 50 passed, 2 skipped in 16.63s ========================
```
