### PR TITLE
feat(doctor): add quick diagnostic mode

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -163,6 +163,7 @@ def _print_summary(should_fix: bool, total: Finding) -> None:
 def run_doctor(args):
     """Run diagnostic checks."""
     should_fix = getattr(args, 'fix', False)
+    quick = getattr(args, 'quick', False)
     # Doctor runs from the interactive CLI, so CLI-gated tool checks (e.g. cronjob) see the same context.
     os.environ.setdefault("HERMES_INTERACTIVE", "1")
     if getattr(args, 'ack', None):
@@ -174,6 +175,8 @@ def run_doctor(args):
         print(color(line, Colors.CYAN))
     total = Finding()
     for title, check in DOCTOR_CHECKS:
+        if quick and check in (_check_npm_audit, _check_api_connectivity):
+            continue
         if title:
             _section(title)
         total.merge(check(should_fix))

--- a/hermes_cli/subcommands/doctor.py
+++ b/hermes_cli/subcommands/doctor.py
@@ -12,7 +12,11 @@ def build_doctor_parser(subparsers, *, cmd_doctor: Callable) -> None:
         description="Diagnose issues with Hermes Agent setup")
     doctor_parser.add_argument(
         "--fix", action="store_true", help="Attempt to fix issues automatically")
-    doctor_parser.add_argument(
+    mode_group = doctor_parser.add_mutually_exclusive_group()
+    mode_group.add_argument(
+        "--quick", action="store_true",
+        help="Skip npm audits and API connectivity checks for a faster local run.")
+    mode_group.add_argument(
         "--live", action="store_true",
         help="Opt-in: run one bounded, read-only real-call health probe per "
             "configured tool backend (Firecrawl/FAL/browser/MCP/TTS/STT) "

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -26,6 +26,34 @@ from hermes_cli import doctor_config
 from tools import browser_tool_install as bt_install
 
 
+def test_doctor_quick_skips_network_checks(monkeypatch):
+    import argparse
+    from unittest.mock import Mock
+
+    from hermes_cli.doctor_report import Finding
+    from hermes_cli.subcommands.doctor import build_doctor_parser
+
+    local_check = Mock(return_value=Finding())
+    npm_check = Mock(side_effect=AssertionError("npm audit ran in quick mode"))
+    api_check = Mock(side_effect=AssertionError("API connectivity ran in quick mode"))
+
+    monkeypatch.setattr(doctor_mod, "_check_npm_audit", npm_check)
+    monkeypatch.setattr(doctor_mod, "_check_api_connectivity", api_check)
+    monkeypatch.setattr(doctor_mod, "DOCTOR_CHECKS", (
+        (None, local_check),
+        (None, npm_check),
+        (None, api_check),
+    ))
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    build_doctor_parser(subparsers, cmd_doctor=doctor_mod.run_doctor)
+    args = parser.parse_args(["doctor", "--quick"])
+    args.func(args)
+
+    local_check.assert_called_once_with(False)
+
+
 class TestDoctorPlatformHints:
     def test_termux_package_hint(self, monkeypatch):
         monkeypatch.setenv("TERMUX_VERSION", "0.118.3")


### PR DESCRIPTION
## Related Issue

Fixes #103266

## What does this PR do?

`hermes doctor --quick` now skips the two checks that can block on routine network access: npm audits and provider API connectivity.

This gives boot hooks and CI a faster diagnostic path when registry or provider access is slow. The normal `hermes doctor` behavior is unchanged. `--quick` and `--live` are mutually exclusive because `--live` explicitly requests real network calls.

Related PR #68460 reduces and bounds npm audit waits, but still performs registry calls. This flag gives automation an explicit way to skip those calls.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add the `--quick` flag to the existing doctor parser.
- Skip `_check_npm_audit` and `_check_api_connectivity` in quick mode while keeping every other check unchanged.
- Add a regression test that exercises the real parser and proves both network-heavy checks are skipped.

## How to Test

```bash
scripts/run_tests.sh \
  tests/hermes_cli/test_doctor.py \
  tests/hermes_cli/test_doctor_live.py \
  tests/hermes_cli/test_doctor_journal_modes.py \
  tests/hermes_cli/test_doctor_command_install.py \
  tests/hermes_cli/test_doctor_dedicated_provider_skip.py \
  tests/hermes_cli/test_subcommands_batch.py -q

uvx --from ruff==0.15.10 ruff check \
  hermes_cli/doctor.py \
  hermes_cli/subcommands/doctor.py \
  tests/hermes_cli/test_doctor.py

python scripts/check-windows-footguns.py \
  hermes_cli/doctor.py \
  hermes_cli/subcommands/doctor.py

git diff --check origin/main...HEAD
```

Results: 139 focused tests passed; Ruff, the production-file Windows scan, and `git diff --check` passed.

I also ran `hermes doctor --quick` with an empty temporary `HERMES_HOME`. It completed in 1.74 seconds on macOS, with the npm audit and API connectivity sections absent.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A; the flag is documented by `hermes doctor --help`
- [x] I've updated `cli-config.yaml.example` — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact — the change only uses argparse and the existing platform-neutral check loop
- [x] I've updated tool descriptions/schemas — N/A; no model tool changed

## Screenshots / Logs

N/A — covered by the parser/dispatcher regression test and the manual CLI run above.
