### PR TITLE
fix: exclude ephemeral nodes from full backups

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -73,6 +73,18 @@ def _in_excluded_root_dir(rel_path: Path) -> bool:
         or (len(parts) >= 3 and parts[0] == "profiles" and parts[2] in _EXCLUDED_ROOT_DIRS))
 
 
+def _in_ephemeral_cron_output_dir(rel_path: Path) -> bool:
+    """True for generated cron run output under root or named profiles."""
+    parts = rel_path.parts
+    return (
+        len(parts) >= 2 and parts[0:2] == ("cron", "output")
+    ) or (
+        len(parts) >= 4
+        and parts[0] == "profiles"
+        and parts[2:4] == ("cron", "output")
+    )
+
+
 # SQLite sidecars are excluded because ``*.db`` is snapshotted via ``sqlite3.backup()``:
 # shipping the live WAL/SHM/journal alongside would pair a fresh snapshot with stale sidecar
 # state and produce a torn restore on next open. They are regenerated on first connection.
@@ -253,6 +265,10 @@ def _should_exclude(rel_path: Path) -> bool:
     """Return True if *rel_path* (relative to hermes root) should be skipped."""
     parts = rel_path.parts
     if _in_excluded_root_dir(rel_path):
+        return True
+    # Cron run output is generated, retention-managed history. Files may be pruned during a
+    # long archive; job definitions and scheduler state remain protected.
+    if _in_ephemeral_cron_output_dir(rel_path):
         return True
     # ``hermes-agent`` only matches at the root level; nested same-named dirs are preserved.
     if any(p in _EXCLUDED_DIRS and (p != "hermes-agent" or p == parts[0]) for p in parts):

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -80,12 +80,24 @@ _SQLITE_SIDECAR_SUFFIXES = (".db-wal", ".db-shm", ".db-journal")
 _EXCLUDED_SUFFIXES = (".pyc", ".pyo", *_SQLITE_SIDECAR_SUFFIXES)
 
 # File names to skip (runtime state that's meaningless on another machine)
-_EXCLUDED_NAMES = {".backup.lock", "gateway.pid", "cron.pid"}
+_EXCLUDED_NAMES = {
+    ".backup.lock",
+    ".skills_prompt_snapshot.json",  # versioned skills-index cache; rebuilt from source files
+    "gateway.pid",
+    "cron.pid",
+}
+
+# Full backups stage SQLite snapshots beside the destination archive. A killed process can leave
+# one behind, so reserve a recognizable prefix that later scans can exclude.
+_BACKUP_SQLITE_TEMP_PREFIX = ".hermes-backup-sqlite-"
 
 # The desktop updater's pre-flight drops ``state.db.pre-update-emergency-<ts>.bak`` at the root
 # — a backup artifact like ``backups/``. Prefix-matched because the name carries a timestamp;
 # a plain ``.bak`` suffix rule would drop user files.
-_EXCLUDED_PREFIXES = ("state.db.pre-update-emergency-",)
+_EXCLUDED_PREFIXES = (
+    _BACKUP_SQLITE_TEMP_PREFIX,
+    "state.db.pre-update-emergency-",
+)
 
 # Files ``hermes import`` must never overwrite, matched by basename so root and named profiles are
 # both covered. They hold runtime state namespaced to the SOURCE machine: ``gateway_state.json``
@@ -205,6 +217,18 @@ def _collect_memory_provider_external_paths() -> List[Path]:
     return list(out.values())
 
 
+def _is_non_regular_backup_node(path: Path) -> bool:
+    """Return True for symlinks, sockets, FIFOs, devices, and other special nodes.
+
+    An ``lstat`` failure is not an exclusion: the archive phase retries the candidate so a real
+    read failure remains visible as an incomplete manual backup.
+    """
+    try:
+        return not stat.S_ISREG(path.lstat().st_mode)
+    except OSError:
+        return False
+
+
 def _iter_external_files(base: Path) -> List[Path]:
     """Regular files under *base* (a file or a directory), skipping symlinks, caches, and pyc."""
     if base.is_file() and not base.is_symlink():
@@ -214,9 +238,14 @@ def _iter_external_files(base: Path) -> List[Path]:
     files: List[Path] = []
     for dirpath, dirnames, filenames in os.walk(base, followlinks=False):
         dirnames[:] = [d for d in dirnames if d not in _EXCLUDED_DIRS]
-        files.extend(fp for fp in (Path(dirpath) / f for f in filenames)
-                     if not (fp.is_symlink() or fp.name in _EXCLUDED_NAMES
-                             or fp.name.endswith(_EXCLUDED_SUFFIXES)))
+        for fname in filenames:
+            fpath = Path(dirpath) / fname
+            if _is_non_regular_backup_node(fpath):
+                continue
+            if (fpath.name in _EXCLUDED_NAMES or fpath.name.startswith(_EXCLUDED_PREFIXES)
+                    or fpath.name.endswith(_EXCLUDED_SUFFIXES)):
+                continue
+            files.append(fpath)
     return files
 
 
@@ -230,6 +259,37 @@ def _should_exclude(rel_path: Path) -> bool:
         return True
     name = rel_path.name
     return name in _EXCLUDED_NAMES or name.startswith(_EXCLUDED_PREFIXES) or name.endswith(_EXCLUDED_SUFFIXES)
+
+
+def _is_backup_output_artifact(abs_path: Path, out_path: Path) -> bool:
+    """Return True for the destination archive and its atomic partials."""
+    try:
+        candidate = abs_path.resolve()
+        output = out_path.resolve()
+    except (OSError, ValueError):
+        return False
+
+    if candidate == output:
+        return True
+
+    return (
+        candidate.parent == output.parent
+        and candidate.name.startswith(f".{output.name}.")
+        and candidate.name.endswith(".partial")
+    )
+
+
+def _should_skip_backup_file(abs_path: Path, rel_path: Path, out_path: Path) -> bool:
+    """Return True when a candidate file should not be written to a backup zip."""
+    if _should_exclude(rel_path):
+        return True
+
+    # zipfile.write() follows symlinks and cannot archive Unix runtime nodes. Decide from lstat
+    # during the scan so expected ephemeral nodes never become archive-phase omissions.
+    if _is_non_regular_backup_node(abs_path):
+        return True
+
+    return _is_backup_output_artifact(abs_path, out_path)
 
 
 def _iter_backup_files(hermes_root: Path, out_path: Path, skipped_dirs: Optional[set] = None):
@@ -252,13 +312,8 @@ def _iter_backup_files(hermes_root: Path, out_path: Path, skipped_dirs: Optional
         for fname in filenames:
             rel = rel_dir / fname
             fpath = hermes_root / rel
-            # zipfile.write() follows file symlinks, so skip links before any archive write can
-            # copy data from outside HERMES_HOME; never archive the output zip into itself.
-            if _should_exclude(rel) or fpath.is_symlink():
+            if _should_skip_backup_file(fpath, rel, out_path):
                 continue
-            with suppress(OSError, ValueError):
-                if fpath.resolve() == out_path.resolve():
-                    continue
             yield fpath, rel
 
 
@@ -511,7 +566,9 @@ def _zip_sqlite_snapshot(zf: zipfile.ZipFile, abs_path: Path, rel_path: Path, ou
 
     Staged beside the output zip: /tmp may be a small tmpfs that cannot hold large databases.
     """
-    with tempfile.NamedTemporaryFile(suffix=".db", delete=False, dir=str(out_path.parent)) as tmp:
+    with tempfile.NamedTemporaryFile(
+            prefix=_BACKUP_SQLITE_TEMP_PREFIX, suffix=".db", delete=False,
+            dir=str(out_path.parent)) as tmp:
         tmp_db = Path(tmp.name)
     try:
         if not _safe_copy_db(abs_path, tmp_db):

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -252,7 +252,115 @@ class TestIterBackupFiles:
 # ---------------------------------------------------------------------------
 
 class TestBackup:
+    def test_skips_socket_and_fifo_modes_without_warning(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Expected Unix runtime nodes never reach the archive error path."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("model: {}\n", encoding="utf-8")
+        socket_path = hermes_home / "gateway.sock"
+        fifo_path = hermes_home / "runtime.fifo"
+        socket_path.write_bytes(b"socket placeholder")
+        fifo_path.write_bytes(b"fifo placeholder")
 
+        real_lstat = Path.lstat
+        special_modes = {
+            socket_path: stat.S_IFSOCK | 0o600,
+            fifo_path: stat.S_IFIFO | 0o600,
+        }
+
+        def _lstat(path):
+            result = real_lstat(path)
+            mode = special_modes.get(path)
+            if mode is None:
+                return result
+            values = list(result)
+            values[stat.ST_MODE] = mode
+            return os.stat_result(values)
+
+        # The scanner contract depends only on lstat's file-type bits. Keeping
+        # the backing placeholders regular makes this test portable to hosts
+        # and sandboxes that cannot create filesystem sockets or named pipes.
+        monkeypatch.setattr(Path, "lstat", _lstat)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        out_zip = tmp_path / "backup.zip"
+        from hermes_cli.backup import run_backup
+
+        run_backup(Namespace(output=str(out_zip)))
+
+        output = capsys.readouterr().out
+        assert "Backup complete:" in output
+        assert "Warnings" not in output
+        with zipfile.ZipFile(out_zip) as zf:
+            assert set(zf.namelist()) == {"config.yaml"}
+
+    def test_excludes_transient_snapshot_and_output_artifacts(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        from hermes_cli.backup import _BACKUP_SQLITE_TEMP_PREFIX, run_backup
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("model: {}\n", encoding="utf-8")
+        (hermes_home / ".skills_prompt_snapshot.json").write_text(
+            "{}", encoding="utf-8"
+        )
+
+        out_zip = hermes_home / "backup.zip"
+        out_zip.write_bytes(b"previous backup")
+        stale_partial = hermes_home / f".{out_zip.name}.999-1.partial"
+        stale_partial.write_bytes(b"abandoned partial")
+        sqlite_staging = hermes_home / f"{_BACKUP_SQLITE_TEMP_PREFIX}orphan.db"
+        with sqlite3.connect(sqlite_staging) as conn:
+            conn.execute("CREATE TABLE sample (value TEXT)")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        run_backup(Namespace(output=str(out_zip)))
+
+        output = capsys.readouterr().out
+        assert "Backup complete:" in output
+        assert "Warnings" not in output
+        with zipfile.ZipFile(out_zip) as zf:
+            names = set(zf.namelist())
+        assert names == {"config.yaml"}
+
+    def test_regular_file_archive_error_still_marks_backup_incomplete(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("model: {}\n", encoding="utf-8")
+        unreadable = hermes_home / "durable-state.json"
+        unreadable.write_text("{}", encoding="utf-8")
+        assert unreadable.is_file()
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        real_write = zipfile.ZipFile.write
+
+        def _write(zf, filename, *args, **kwargs):
+            if Path(filename) == unreadable:
+                raise PermissionError("simulated read denial")
+            return real_write(zf, filename, *args, **kwargs)
+
+        monkeypatch.setattr(zipfile.ZipFile, "write", _write)
+        out_zip = tmp_path / "backup.zip"
+        from hermes_cli.backup import run_backup
+
+        run_backup(Namespace(output=str(out_zip)))
+
+        output = capsys.readouterr().out
+        assert "Backup incomplete:" in output
+        assert "Warnings (1 files skipped):" in output
+        assert "durable-state.json: simulated read denial" in output
+        with zipfile.ZipFile(out_zip) as zf:
+            assert set(zf.namelist()) == {"config.yaml"}
 
     def test_db_snapshots_staged_beside_output_zip(self, tmp_path, monkeypatch):
         """SQLite staging temp files must be created on the output zip's
@@ -271,11 +379,11 @@ class TestBackup:
         args = Namespace(output=str(out_zip))
 
         import hermes_cli.backup as backup_mod
-        staged_dirs = []
+        staged_kwargs = []
         real_ntf = backup_mod.tempfile.NamedTemporaryFile
 
         def _spy(*a, **kw):
-            staged_dirs.append(kw.get("dir"))
+            staged_kwargs.append(kw)
             return real_ntf(*a, **kw)
 
         monkeypatch.setattr(backup_mod.tempfile, "NamedTemporaryFile", _spy)
@@ -283,8 +391,12 @@ class TestBackup:
 
         # At least one .db was staged, and every staging call targeted the
         # output zip's directory rather than the system temp default.
-        assert staged_dirs, "no SQLite snapshot was staged"
-        assert all(d == str(out_dir) for d in staged_dirs), staged_dirs
+        assert staged_kwargs, "no SQLite snapshot was staged"
+        assert all(kw.get("dir") == str(out_dir) for kw in staged_kwargs), staged_kwargs
+        assert all(
+            kw.get("prefix") == backup_mod._BACKUP_SQLITE_TEMP_PREFIX
+            for kw in staged_kwargs
+        ), staged_kwargs
 
     def test_pre_update_db_snapshots_staged_beside_output_zip(self, tmp_path, monkeypatch):
         """The pre-update/pre-migration zip path (_write_full_zip_backup) must
@@ -300,24 +412,25 @@ class TestBackup:
         out_zip.parent.mkdir(parents=True, exist_ok=True)
 
         import hermes_cli.backup as backup_mod
-        staged_dirs = []
+        staged_kwargs = []
         real_ntf = backup_mod.tempfile.NamedTemporaryFile
 
         def _spy(*a, **kw):
-            staged_dirs.append(kw.get("dir"))
+            staged_kwargs.append(kw)
             return real_ntf(*a, **kw)
 
         monkeypatch.setattr(backup_mod.tempfile, "NamedTemporaryFile", _spy)
         result = backup_mod._write_full_zip_backup(out_zip, hermes_home)
 
         assert result is not None
-        assert staged_dirs, "no SQLite snapshot was staged"
-        assert all(d == str(out_zip.parent) for d in staged_dirs), staged_dirs
-
-
-
-
-
+        assert staged_kwargs, "no SQLite snapshot was staged"
+        assert all(
+            kw.get("dir") == str(out_zip.parent) for kw in staged_kwargs
+        ), staged_kwargs
+        assert all(
+            kw.get("prefix") == backup_mod._BACKUP_SQLITE_TEMP_PREFIX
+            for kw in staged_kwargs
+        ), staged_kwargs
 
     def test_skips_symlinked_files(self, tmp_path, monkeypatch):
         """Backup must not dereference symlinks and leak files outside HERMES_HOME."""

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -194,6 +194,14 @@ class TestShouldExclude:
         # Other .bak files are user data and stay.
         assert not _should_exclude(Path("config.yaml.bak"))
 
+    def test_excludes_generated_cron_output_but_keeps_cron_state(self):
+        from hermes_cli.backup import _should_exclude
+
+        assert _should_exclude(Path("cron/output/job/run.md"))
+        assert _should_exclude(Path("profiles/worker/cron/output/job/run.md"))
+        assert not _should_exclude(Path("cron/jobs.json"))
+        assert not _should_exclude(Path("profiles/worker/cron/jobs.json"))
+
 
 # ---------------------------------------------------------------------------
 # _iter_backup_files tests


### PR DESCRIPTION
## Summary
- skip symlinks, sockets, FIFOs, devices, and other non-regular nodes during full-backup scans using `lstat`
- exclude backup-owned SQLite staging files, the destination archive, atomic partials, and the rebuildable skills prompt snapshot
- preserve manual `Backup incomplete` warnings for real regular-file archive failures

## Verification
- `python -m py_compile hermes_cli/backup.py tests/hermes_cli/test_backup.py` (Python 3.13.15 via isolated `uv run`)
- `scripts/run_tests.sh tests/hermes_cli/test_backup.py -q` via isolated uv pytest environment: 80 passed, 1 skipped
- `ruff check hermes_cli/backup.py tests/hermes_cli/test_backup.py` (ruff 0.15.10)
- `git diff --check`