### PR TITLE
fix(agent): record pre-override rough estimate as defer baseline to prevent spurious compaction on edit-resend

### DIFF
--- a/agent/turn_request_assembly.py
+++ b/agent/turn_request_assembly.py
@@ -242,6 +242,12 @@ def assemble_api_request(
     request_pressure_tokens = _midturn_request_pressure_tokens(
         agent, api_messages, effective_system or "", approx_tokens
     )
+    # Stash the pre-override rough estimate so update_from_response() can pair it with the real
+    # count on the same measurement scale (should_defer_preflight_to_real_usage). getattr: test doubles lack it.
+    _note_rough = getattr(agent.context_compressor, "note_request_rough_estimate", None)
+    if callable(_note_rough):
+        _note_rough(request_pressure_tokens)
+
     # Usage-anchored override: real prompt_tokens (incl. system + tool schemas) +
     # delta estimate replaces the whole-history heuristic when the anchor is fresh.
     _anchored_pressure = anchored_context_tokens(messages, getattr(agent, "_usage_anchor", None))
@@ -254,11 +260,6 @@ def assemble_api_request(
         request_pressure_tokens = _pressure_with_real_floor(
             agent.context_compressor, request_pressure_tokens
         )
-    # Stash the rough estimate so update_from_response() can pair it with the real
-    # count (should_defer_preflight_to_real_usage). getattr: test doubles lack it.
-    _note_rough = getattr(agent.context_compressor, "note_request_rough_estimate", None)
-    if callable(_note_rough):
-        _note_rough(request_pressure_tokens)
     return AssembledRequest(
         "fallthrough", api_messages, tools_for_api, _moa_prepared_request,
         pending_moa_prepared_request, approx_tokens, request_pressure_tokens, approx_tokens * 4,

--- a/tests/agent/test_usage_anchor.py
+++ b/tests/agent/test_usage_anchor.py
@@ -208,5 +208,91 @@ class TestCompressionTriggerUsesAnchor:
         assert anchored is not None and anchored < threshold
 
 
+class TestDeferBaselineAnchoredInteraction:
+    def test_assemble_api_request_records_rough_scale_defer_baseline(self):
+        """Regression test for #103391:
+        When an anchor is present, assemble_api_request overrides request_pressure_tokens
+        with the anchored real token count. However, note_request_rough_estimate must
+        record the PRE-OVERRIDE rough estimate, so the defer baseline matches the scale
+        of subsequent rough preflight estimates if the anchor is invalidated (e.g. edit-resend).
+        """
+        from agent.context_compressor import ContextCompressor
+        from agent.turn_request_assembly import assemble_api_request
+
+        messages = _history_with_images(10)
+        # Real prompt usage is 12,000; rough whole-history estimate is ~15,000+
+        anchor = capture_usage_anchor(12_000, 100, messages)
+        messages.append(_msg("assistant", "reply"))
+        messages.append(_msg("user", "edit follow up"))
+
+        compressor = ContextCompressor(
+            model="test/model",
+            threshold_percent=0.8,
+            protect_first_n=2,
+            protect_last_n=2,
+            quiet_mode=True,
+        )
+        compressor.context_length = 20_000
+        compressor.threshold_tokens = 16_000
+        agent = SimpleNamespace(
+            _usage_anchor=anchor,
+            context_compressor=compressor,
+            tools=[],
+            prefill_messages=[],
+            _use_prompt_caching=False,
+            provider="openai",
+            model="test-model",
+            api_mode="chat",
+            ephemeral_system_prompt="",
+            _copy_reasoning_content_for_api=lambda msg, api_msg: None,
+            _should_sanitize_tool_calls=lambda: False,
+            _sanitize_api_messages=lambda msgs: msgs,
+            _drop_thinking_only_and_merge_users=lambda msgs, **kw: msgs,
+        )
+
+        assembled = assemble_api_request(
+            agent,
+            messages=messages,
+            current_turn_user_idx=len(messages) - 1,
+            _ext_prefetch_cache=None,
+            _plugin_user_context=None,
+            moa_config=None,
+            active_system_prompt="sys",
+            original_user_message="edit follow up",
+            pending_moa_prepared_request=None,
+            request_logger=None,
+        )
+
+        # Assembled request pressure tokens use the anchored figure (~12k + delta)
+        assert assembled.request_pressure_tokens < 13_000
+
+        # But compressor._pending_request_rough_tokens must be on the rough scale (>= 15,000)
+        assert compressor._pending_request_rough_tokens >= 15_000
+        rough_baseline = compressor._pending_request_rough_tokens
+
+        # Now simulate API response updating usage with real prompt tokens
+        compressor.update_from_response({"prompt_tokens": 12_100})
+        assert compressor.last_real_prompt_tokens == 12_100
+        assert compressor.last_rough_tokens_when_real_prompt_fit == rough_baseline
+
+        # Simulate user edit-resend: history rewinds/truncates, invalidating the anchor
+        rewound_messages = messages[:5]
+        # Anchor is invalidated because length < anchor base_count
+        assert anchored_context_tokens(rewound_messages, anchor) is None
+
+        # Rough estimate for rewound messages is ~7,500+
+        rough_now = estimate_messages_tokens_rough(rewound_messages)
+
+        # With threshold = 16,000 (80% of 20,000), a subsequent rough estimate of 18,000
+        # (over threshold due to rough estimator overcharging images/CJK) should defer:
+        # projected_real = 12_100 + max(0, 18_000 - 15_493) = 14_607 < 16_000 -> True
+        # (Under the old bug where baseline was stored on the real scale ~12,000,
+        # projected_real would be 12_100 + (18_000 - 12_000) = 18_100 >= 16_000 -> False,
+        # causing spurious compaction!)
+        assert compressor.should_defer_preflight_to_real_usage(18_000) is True
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))
+
+


### PR DESCRIPTION
## What does this PR do?

When an API request is assembled with an active usage anchor, `_anchored_pressure` overrides `request_pressure_tokens` with the provider-reported real token scale (e.g. ~200k) plus estimated appended delta. Previously, `note_request_rough_estimate(request_pressure_tokens)` was called *after* this override, which inadvertently stored the real-scale count as the "rough" baseline in `compressor.last_rough_tokens_when_real_prompt_fit`.

When history is subsequently truncated (such as when a user rewinds or edits and resends an earlier message in a long session), the anchor invalidates because `len(messages) < anchor["base_count"]`. Preflight context compression then falls back to `_preflight_request_tokens` rough estimation (e.g. ~564k due to character-heuristic overcharging of CJK/reasoning-echo tokens).

When `should_defer_preflight_to_real_usage()` evaluated:
```python
projected_real = self.last_real_prompt_tokens + max(0, rough_tokens - baseline)
```
The baseline was on the real scale (~200k) instead of the rough scale (~564k), resulting in `564k - 200k = 364k` phantom growth! `projected_real` computed as `201k + 364k = 565k >= 524k`, causing `should_defer_preflight_to_real_usage` to return `False` and fire spurious compaction on a context that easily fit within the limit.

This fix calls `_note_rough(request_pressure_tokens)` with the pre-override rough estimate immediately after `_midturn_request_pressure_tokens()`, ensuring the defer baseline remains on the rough measurement scale so `rough_tokens - baseline` accurately measures growth since the last fitting response.

## Related Issue

Fixes #103391

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/turn_request_assembly.py`: Call `note_request_rough_estimate(request_pressure_tokens)` immediately after computing `request_pressure_tokens` from `_midturn_request_pressure_tokens()`, prior to `_anchored_pressure` overriding `request_pressure_tokens`.
- `tests/agent/test_usage_anchor.py`: Add `TestDeferBaselineAnchoredInteraction.test_assemble_api_request_records_rough_scale_defer_baseline` asserting that request assembly records the pre-override rough scale, syncs `last_rough_tokens_when_real_prompt_fit` on response usage, and successfully defers preflight when the anchor is invalidated after edit-resend.

## How to Test

1. Run unit tests covering usage anchors, context compressor, and request assembly:
   `pytest tests/agent/test_usage_anchor.py tests/agent/test_context_compressor.py tests/agent/test_turn_context.py -v`
2. Verify that `test_assemble_api_request_records_rough_scale_defer_baseline` passes, confirming preflight deferral behaves correctly when usage anchor is invalidated.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
