### PR TITLE
fix(desktop): prevent background tile reconcile from starving pool slots (#103375)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -16411,6 +16411,32 @@ async function dispatchRegistryApiRequest(
   routeProfile = request?.profile,
   requestProfile = request?.profile
 ) {
+  // Passive tile reconcile must never cold-start a pooled backend (#103375):
+  // fail fast when no warm entry exists instead of spawning a child and
+  // starving the pool. Interactive opens (passive:false) keep the normal spawn.
+  if (request?.passive) {
+    const poolKey = backendScopeKey(registryConnectionId, routeProfile)
+    const entry = backendPool.get(poolKey)
+
+    if (!entry) {
+      throw new Error(`Passive read: no warm backend for "${poolKey}"`)
+    }
+
+    const connection = await entry.connectionPromise
+    const requestPath = pathForRegistryBackendRequest(request.path, requestProfile, connection)
+
+    const response = await fetchJsonForBackend(connection, requestPath, {
+      method: request?.method,
+      body: request?.body,
+      upload: request?.upload,
+      timeoutMs: resolveTimeoutMs(request?.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
+    })
+
+    return (request?.method || 'GET').toUpperCase() === 'GET'
+      ? tagRegistrySessionResponse(requestPath, response, registryConnectionId)
+      : response
+  }
+
   // Claim-guarded (#90812): every registry-scoped REST call funnels through
   // here, so it can race a renderer's own WS reconnect dial for the same
   // (connectionId, profile) scope; coalescing avoids bootstrapping a second
@@ -16502,7 +16528,26 @@ async function handleHermesApiRequest(request) {
   let response
 
   try {
-    const connection = await ensureBackend(routeProfile)
+    // Passive reads (tile reconciles) must not spawn pool backends (#103375).
+    // If the target is pooled and has no warm entry, fail fast without
+    // consuming a slot; interactive reads keep the normal ensureBackend path.
+    // Primary route (backendProfile === null) always has a backend (startHermes).
+    const isPassivePooled = Boolean(request?.passive && routeProfile && apiRoute.backendProfile)
+
+    let connection
+
+    if (isPassivePooled) {
+      const key = String(routeProfile).trim()
+      const entry = backendPool.get(key) || backendPool.get(backendScopeKey(null, key))
+
+      if (!entry) {
+        throw new Error(`Passive read: no warm backend for profile "${key}"`)
+      }
+
+      connection = await entry.connectionPromise
+    } else {
+      connection = await ensureBackend(routeProfile)
+    }
     const timeoutMs = resolveTimeoutMs(request?.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
 
     const url = `${connection.baseUrl}${apiRoute.requestPath}`

--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -396,7 +396,8 @@ export function getSession(id: string, profile?: ProfileScope): Promise<SessionI
 export function getSessionMessages(
   id: string,
   profile?: ProfileScope,
-  page: { limit?: number; offset?: number; order?: 'latest' | 'oldest'; includeCompacted?: boolean } = {}
+  page: { limit?: number; offset?: number; order?: 'latest' | 'oldest'; includeCompacted?: boolean } = {},
+  options: { passive?: boolean } = {}
 ): Promise<SessionMessagesResponse> {
   const query = new URLSearchParams()
 
@@ -426,7 +427,8 @@ export function getSessionMessages(
 
   return hermesApi<SessionMessagesResponse>({
     ...sessionScope,
-    path: `/api/sessions/${encodeURIComponent(id)}/messages${suffix}`
+    path: `/api/sessions/${encodeURIComponent(id)}/messages${suffix}`,
+    ...(options.passive ? { passive: true } : {})
   })
 }
 
@@ -439,15 +441,20 @@ export function getSessionMessages(
  */
 export const LATEST_SESSION_MESSAGES_LIMIT = 120
 
-export function getLatestSessionMessages(id: string, profile?: ProfileScope): Promise<SessionMessagesResponse> {
+export function getLatestSessionMessages(id: string, profile?: ProfileScope, passive = false): Promise<SessionMessagesResponse> {
   // includeCompacted: durable display history must include rows preserved by
   // in-place compaction (active=0, compacted=1); without them the transcript
   // silently ends at the compaction boundary and earlier turns are unreachable.
-  return getSessionMessages(id, profile, {
-    limit: LATEST_SESSION_MESSAGES_LIMIT,
-    order: 'latest',
-    includeCompacted: true
-  }).then(page => {
+  return getSessionMessages(
+    id,
+    profile,
+    {
+      limit: LATEST_SESSION_MESSAGES_LIMIT,
+      order: 'latest',
+      includeCompacted: true
+    },
+    passive ? { passive: true } : {}
+  ).then(page => {
     // Record whether the tail was truncated (page came back full) and where
     // the next older page starts, so "Show earlier" can backfill over REST
     // (app/chat/transcript-backfill). Keyed under both the requested id and

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -160,7 +160,7 @@ export async function reconcileTileTranscripts({
     const signatureKey = tileTranscriptSignatureKey(tile)
 
     try {
-      const latest = await getLatestSessionMessages(storedSessionId, profileScope)
+      const latest = await getLatestSessionMessages(storedSessionId, profileScope, true)
 
       if (
         requestId !== requestSequenceRef.current ||

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -1230,6 +1230,11 @@ export interface HermesApiRequest {
   // through the owning connection, not the local profile pool. Omit / '' to
   // keep the legacy profile-routed path; explicit 'local' forces this device.
   connectionId?: string | null
+  // Passive background read that must never cold-start a pooled backend (#103375).
+  // When true and the target profile has no warm pool entry, the main process
+  // fails fast without spawning a child or consuming a pool slot, so background
+  // tile reconciles cannot starve interactive opens.
+  passive?: boolean
 }
 
 export interface HermesNotification {


### PR DESCRIPTION
Fixes #103375.

**Problem:** With 20 profiles, every `sessions.changed` tick runs `reconcileTileTranscripts` over every open bot tile. Each tile read goes through `hermes:api → ensureBackend → spawnPoolBackend`, cold-starting a pooled backend even for hidden tiles. The 10s touch loop then holds each spawned slot for its lifetime (idle reap never fires), so the Warm Bot Backends pool (3-10 slots) is permanently saturated and interactive opens time out with "waiting for a free local slot".

**Root cause:** Passive cache-refresh reads share the same spawn path as interactive opens. See issue comment with detailed trace (shared `__bots_workspace__` bucket → `SESSIONS_LIST_TICK_GAP_MS` tick → `ensureBackend` spawn → lease held until exit + `lastActiveAt` bump every 10s).

**Fix:** Add a passive read intent that never spawns:

- `HermesApiRequest.passive` + `getSessionMessages(..., {passive})` / `getLatestSessionMessages(..., passive)`.
- `apps/desktop/src/app/contrib/hooks/use-background-sync.ts`: tile reconciles use `passive:true`.
- `apps/desktop/electron/main.ts`: `handleHermesApiRequest` and `dispatchRegistryApiRequest` honor `passive` — if no warm pool entry exists they fail fast with "no warm backend" (caught and retried next tick, no slot consumed), otherwise serve from the existing entry without bumping `lastActiveAt`. Primary route (always warm) is unaffected.

Interactive tile opens keep the normal spawn path, and hidden tiles remain presentation-only (no eviction per `hidden-bots.ts` contract).

**Testing:** TypeScript project check (electron) shows no new errors in changed files; existing desktop vitest config requires `@rolldown/plugin-babel` not present in this environment (unrelated to change). Manual code review against the log trace confirms slots no longer leak.