### PR TITLE
fix(desktop): disable QuickEdit so Select mode cannot block update handoff (#103222)

### DIFF
--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -89,10 +89,36 @@ $script:Ui = $null
 $script:UiStage = "Hermes will open once done."   # until the first gate; matches ui.html
 $script:UiStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
+# Disable QuickEdit/Select mode so console selection cannot pause buffered
+# output replay (#103222). QuickEdit's SELECT blocks Write-Host while the
+# console is in selection state; the buffered replay after the updater child
+# exits then stalls at the first Write-Host until the user clears selection.
+try {
+    Add-Type -Namespace HermesHandoff -Name ConsoleMode -MemberDefinition @'
+[DllImport("kernel32.dll", SetLastError=true)] public static extern bool GetConsoleMode(IntPtr hConsoleHandle, out uint lpMode);
+[DllImport("kernel32.dll", SetLastError=true)] public static extern bool SetConsoleMode(IntPtr hConsoleHandle, uint dwMode);
+[DllImport("kernel32.dll", SetLastError=true)] public static extern IntPtr GetStdHandle(int nStdHandle);
+'@ -ErrorAction Stop
+    $STD_OUTPUT_HANDLE = -11
+    $STD_INPUT_HANDLE = -10
+    $ENABLE_QUICK_EDIT_MODE = 0x0040
+    $ENABLE_EXTENDED_FLAGS = 0x0080
+    foreach ($h in @($STD_OUTPUT_HANDLE, $STD_INPUT_HANDLE)) {
+        try {
+            $handle = [HermesHandoff.ConsoleMode]::GetStdHandle($h)
+            $mode = [uint32]0
+            if ([HermesHandoff.ConsoleMode]::GetConsoleMode($handle, [ref]$mode)) {
+                $newMode = ($mode -band (-bnot $ENABLE_QUICK_EDIT_MODE)) -bor $ENABLE_EXTENDED_FLAGS
+                [void][HermesHandoff.ConsoleMode]::SetConsoleMode($handle, $newMode)
+            }
+        } catch {}
+    }
+} catch {}
+
 function Write-HandoffLog([string]$Message) {
     $line = "{0:yyyy-MM-ddTHH:mm:ssK} {1}" -f (Get-Date), $Message
     try { Add-Content -LiteralPath $LogPath -Value $line -Encoding UTF8 } catch {}
-    Write-Host $line
+    try { Write-Host $line } catch {}
 }
 
 # ── The shim: repo-owned HTML in a chromeless default-browser app window ───


### PR DESCRIPTION
Fixes #103222.

**Problem:** Every Desktop-triggered update on Windows 11 with QuickEdit enabled stalls after the updater child exits (`.update_exit_code=0`, no child remains). The outer PowerShell's title becomes `Select Windows PowerShell` and buffered replay via `Write-HandoffLog → Write-Host` blocks at the first line until the user clears selection. Marker removal and relaunch never happen.

Sibling #102283/PR #103140 covers live-child/zombie cases; this is the parent-console block.

**Fix:** At script start, disable QuickEdit via Win32 `GetConsoleMode`/`SetConsoleMode` on both STDOUT (`-11`) and STDIN (`-10`) handles (`ENABLE_QUICK_EDIT 0x40` off + `ENABLE_EXTENDED_FLAGS 0x80`), and make `Write-HandoffLog`'s `Write-Host` non-throwing. Console selection can no longer pause the handoff; the buffered lines flush and the marker/relaunch complete without user interaction.