### PR TITLE
fix(tools): prevent terminal probe hang and kill orphaned processes on Windows

### DIFF
--- a/tests/tools/test_find_shell.py
+++ b/tests/tools/test_find_shell.py
@@ -15,6 +15,7 @@ import pytest
 from tools.environments.local import _find_bash, _find_shell
 
 
+@pytest.mark.skipif(platform.system() == "Windows", reason="POSIX user shell preference")
 class TestFindShellPrefersUserShell:
     """_find_shell should prefer $SHELL over bash on POSIX."""
 
@@ -138,23 +139,43 @@ class TestGitBashExternalProgramProbe:
 
     def test_probe_runs_external_msys_programs(self, monkeypatch):
         """``_bash_starts`` builds the same external-program probe argv on
-        every host, so this stays on the Linux runner with ``subprocess.run``
+        every host, so this stays on the Linux runner with ``_run_probe_command``
         mocked — no platform faking needed."""
-        import tools.environments.local as local_mod
         from tools.environments import local_gitbash_probe as gitbash_probe
 
         gitbash_probe._bash_starts_cache.clear()
         gitbash_probe._bash_probe_details_cache.clear()
         calls = []
 
-        def fake_run(argv, **kwargs):
-            calls.append((argv, kwargs))
-            return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+        def fake_run(argv, timeout=5.0):
+            calls.append((argv, timeout))
+            return 0, ""
 
-        monkeypatch.setattr(local_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(gitbash_probe, "_run_probe_command", fake_run)
 
         assert gitbash_probe._bash_starts(r"C:\Git\bin\bash.exe") is True
         assert calls[0][0][-1] == "/usr/bin/true; /usr/bin/cat --version >/dev/null"
+
+    def test_probe_timeout_records_deadlock_diagnostic(self, monkeypatch):
+        """Regression for #103398: When a probe times out (e.g. MSYS2 deadlock),
+        _bash_starts must fail cleanly and record a deadlock/timeout diagnostic
+        recognized as an MSYS spawn failure."""
+        from tools.environments import local_gitbash_probe as gitbash_probe
+
+        gitbash_probe._bash_starts_cache.clear()
+        gitbash_probe._bash_probe_details_cache.clear()
+
+        def timeout_run(argv, timeout=5.0):
+            return -1, f"Git Bash probe timed out after {timeout}s (process hang/deadlock)"
+
+        monkeypatch.setattr(gitbash_probe, "_run_probe_command", timeout_run)
+
+        path = r"C:\Git\bin\bash.exe"
+        assert gitbash_probe._bash_starts(path) is False
+        assert "timed out" in gitbash_probe._bash_probe_details_cache[path]
+        assert gitbash_probe._looks_like_msys_spawn_failure(
+            gitbash_probe._bash_probe_details_cache[path]
+        ) is True
 
     @pytest.mark.windows_only
     def test_aslr_failure_surfaces_targeted_windows_command(

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -343,20 +343,29 @@ def build_subprocess_env(
 
 # --- Shell discovery ---
 def _windows_bash_candidates(custom: "str | None") -> list[str]:
-    """Ordered bash.exe candidates on Windows: HERMES_GIT_BASH_PATH, our portable Git
-    under %LOCALAPPDATA%\\hermes\\git (PortableGit ``bin`` and MinGit ``usr\\bin``),
-    known Git-for-Windows dirs, then PATH last — ``shutil.which`` may return WSL's
-    bash, which fails silently on Windows paths."""
+    """Ordered bash.exe candidates on Windows: HERMES_GIT_BASH_PATH (and its direct usr/bin counterpart),
+    our portable Git under %LOCALAPPDATA%\\hermes\\git (PortableGit ``bin`` and MinGit ``usr\\bin``),
+    known Git-for-Windows dirs (both ``bin`` and ``usr\\bin``), then PATH last — ``shutil.which``
+    may return WSL's bash, which fails silently on Windows paths."""
     getenv = os.environ.get
     lad = getenv("LOCALAPPDATA", "")
     roots = [
         lad and os.path.join(lad, "hermes", "git", "bin"),
         lad and os.path.join(lad, "hermes", "git", "usr", "bin"),
         os.path.join(getenv("ProgramFiles", r"C:\Program Files"), "Git", "bin"),
+        os.path.join(getenv("ProgramFiles", r"C:\Program Files"), "Git", "usr", "bin"),
         os.path.join(getenv("ProgramFiles(x86)", r"C:\Program Files (x86)"), "Git", "bin"),
+        os.path.join(getenv("ProgramFiles(x86)", r"C:\Program Files (x86)"), "Git", "usr", "bin"),
         lad and os.path.join(lad, "Programs", "Git", "bin"),
+        lad and os.path.join(lad, "Programs", "Git", "usr", "bin"),
     ]
-    raw = [custom or "", *(os.path.join(r, "bash.exe") for r in roots if r)]
+    raw = [custom or ""]
+    if custom and os.path.normpath(custom).lower().endswith(os.path.join("bin", "bash.exe").lower()):
+        # Check if the direct MSYS2 bash under usr\bin exists for the custom installation
+        usr_candidate = os.path.join(os.path.dirname(os.path.dirname(os.path.normpath(custom))), "usr", "bin", "bash.exe")
+        if os.path.isfile(usr_candidate):
+            raw.append(usr_candidate)
+    raw.extend(os.path.join(r, "bash.exe") for r in roots if r)
     candidates = list(dict.fromkeys(c for c in raw if c and os.path.isfile(c)))
     found = shutil.which("bash")
     if found and found not in candidates:

--- a/tools/environments/local_gitbash_probe.py
+++ b/tools/environments/local_gitbash_probe.py
@@ -23,7 +23,7 @@ _mandatory_aslr_enabled_cache: "bool | None" = None
 # misses Git-for-Windows fork/spawn failures under system-wide Mandatory ASLR.
 _BASH_EXTERNAL_PROGRAM_PROBE = "/usr/bin/true; /usr/bin/cat --version >/dev/null"
 
-_MSYS_SPAWN_FAILURE_MARKERS = ("dofork:", "child_copy:", "0xc0000142", "0xc0000005")
+_MSYS_SPAWN_FAILURE_MARKERS = ("dofork:", "child_copy:", "0xc0000142", "0xc0000005", "timed out", "hang", "deadlock")
 
 
 def _looks_like_msys_spawn_failure(details: str) -> bool:
@@ -80,6 +80,44 @@ def _git_bash_aslr_help(bash: str, details: str = "") -> str:
     )
 
 
+def _run_probe_command(cmd: list[str], timeout: float = 5.0) -> tuple[int, str]:
+    """Execute a probe command bounded by a timeout, terminating the entire process tree on Windows."""
+    creationflags = windows_hide_flags() if _IS_WINDOWS else 0
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        creationflags=creationflags,
+    )
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+        return proc.returncode, f"{stdout or ''}{stderr or ''}".strip()
+    except subprocess.TimeoutExpired:
+        if _IS_WINDOWS:
+            try:
+                subprocess.run(
+                    ["taskkill", "/F", "/T", "/PID", str(proc.pid)],
+                    capture_output=True,
+                    timeout=5,
+                    creationflags=windows_hide_flags(),
+                )
+            except Exception:
+                pass
+        try:
+            proc.kill()
+        except Exception:
+            pass
+        try:
+            proc.communicate(timeout=2)
+        except Exception:
+            pass
+        return -1, f"Git Bash probe timed out after {timeout}s (process hang/deadlock)"
+
+
 def _bash_starts(bash: str) -> bool:
     """True if *bash* can launch external MSYS programs (cached per path).
     ``--noprofile --norc`` so a broken login post-install (``Directory
@@ -87,18 +125,18 @@ def _bash_starts(bash: str) -> bool:
     if bash in _bash_starts_cache:
         return _bash_starts_cache[bash]
     try:
-        result = subprocess.run(
+        returncode, output = _run_probe_command(
             [bash, "--noprofile", "--norc", "-c", _BASH_EXTERNAL_PROGRAM_PROBE],
-            capture_output=True, text=True, encoding="utf-8", errors="replace",
-            timeout=15, creationflags=windows_hide_flags() if _IS_WINDOWS else 0)
-        ok = result.returncode == 0
+            timeout=5.0,
+        )
+        ok = returncode == 0
         if not ok:
-            combined = f"{result.stdout or ''}{result.stderr or ''}".strip()
-            _bash_probe_details_cache[bash] = combined[:2000]
-            logger.debug("bash probe failed for %s: %s", bash, combined[:200])
+            _bash_probe_details_cache[bash] = output[:2000]
+            logger.debug("bash probe failed for %s (exit %d): %s", bash, returncode, output[:200])
     except Exception as exc:
         _bash_probe_details_cache[bash] = str(exc)[:2000]
         logger.debug("bash probe error for %s: %s", bash, exc)
         ok = False
     _bash_starts_cache[bash] = ok
     return ok
+


### PR DESCRIPTION
## What does this PR do?

When testing whether candidate Git Bash executables on Windows can successfully launch MSYS child processes, `_bash_starts` runs an external program probe (`/usr/bin/true; /usr/bin/cat --version >/dev/null`).

On Windows, Git for Windows' `<root>\bin\bash.exe` is a wrapper shim that spawns `<root>\usr\bin\bash.exe`. When the probe child deadlocks (e.g. MSYS2 fork deadlock), `subprocess.run(..., timeout=15)` times out and calls `proc.kill()`. However, on Windows `proc.kill()` (via `TerminateProcess`) only terminates the direct wrapper process, leaving the re-exec'd `usr\bin\bash.exe` process alive and holding open the stdout/stderr pipe handles.

Because Python's standard library `subprocess.run` implementation calls `proc.communicate()` without a timeout inside its `except TimeoutExpired` block to drain pipes, it blocks indefinitely waiting for EOF on the still-open pipes. This causes the entire `terminal` environment creation to hang for minutes past the timeout.

### Fix
1. Implement `_run_probe_command` with explicit process tree termination on Windows (`taskkill /F /T /PID <pid>`) upon timeout before killing the process, ensuring all child/grandchild processes are stopped and pipes are closed.
2. Tighten probe timeout from 15s to 5s (a healthy probe finishes in <0.2s).
3. Update `_windows_bash_candidates` to probe `<root>\usr\bin\bash.exe` directly alongside `<root>\bin\bash.exe`, avoiding the extra wrapper process layer.
4. Expand `_MSYS_SPAWN_FAILURE_MARKERS` to recognize timeout/deadlock probe diagnostics as MSYS spawn failures, ensuring actionable remediation guidance is presented if all candidates fail.

## Related Issue

Fixes #103398

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/environments/local_gitbash_probe.py`: Replace unbounded `subprocess.run` with `_run_probe_command` which executes `taskkill /F /T /PID <pid>` on Windows timeout. Tighten timeout to 5s. Add timeout/deadlock markers to `_MSYS_SPAWN_FAILURE_MARKERS`.
- `tools/environments/local.py`: In `_windows_bash_candidates`, include `usr/bin` bash candidate paths and resolve direct `usrinash.exe` for custom paths.
- `tests/tools/test_find_shell.py`: Update unit tests to mock `_run_probe_command` and add `test_probe_timeout_records_deadlock_diagnostic` asserting that probe timeouts fail cleanly and record MSYS failure diagnostics.

## How to Test

1. Run unit tests covering shell resolution and probe execution:
   `pytest tests/tools/test_find_shell.py -v`
2. Verify all tests pass and `test_probe_timeout_records_deadlock_diagnostic` validates that a hung probe times out and registers as an MSYS failure.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
