### PR TITLE
test: pin pytest-asyncio fixture loop scope

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -581,6 +581,7 @@ plugins = ["**/plugin.yaml", "**/plugin.yml"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+asyncio_default_fixture_loop_scope = "function"
 markers = [
     "integration: marks tests requiring external services (API keys, Modal, etc.)",
     "real_concurrent_gate: opt out of the autouse stub that disables _detect_concurrent_hermes_instances",


### PR DESCRIPTION
## Summary

Pins `asyncio_default_fixture_loop_scope = "function"` in pytest configuration.

Current pytest-asyncio emits a deprecation warning because this option is unset; future versions change the default fixture loop scope. Making the existing function-scoped behavior explicit removes the warning and prevents a future implicit behavior change.

## Local validation

- focused gateway regression: PASS
- `PytestDeprecationWarning` count after config change: **0**
- `git diff --check`: PASS

This is test configuration only; no runtime behavior changes.