### PR TITLE
feat(plugins): pre_tool_call serve directive — supply a tool result without executing

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2175,7 +2175,7 @@ def _pre_tool_block_message(agent, function_name, function_args, effective_task_
     """Plugin pre-tool-call hook verdict: ``(block_message, function_args)``; failures never block."""
     try:
         from hermes_cli.plugins import _dispatch_pre_tool_call_hooks
-        block_message, modified_args = _dispatch_pre_tool_call_hooks(
+        block_message, modified_args, _ = _dispatch_pre_tool_call_hooks(
             function_name, function_args, task_id=effective_task_id or "",
             session_id=getattr(agent, "session_id", "") or "", tool_call_id=tool_call_id or "",
             turn_id=getattr(agent, "_current_turn_id", "") or "",

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2172,19 +2172,20 @@ def switch_model(
 
 
 def _pre_tool_block_message(agent, function_name, function_args, effective_task_id, tool_call_id, middleware_trace):
-    """Plugin pre-tool-call hook verdict: ``(block_message, function_args)``; failures never block."""
+    """Plugin pre-tool-call hook verdict: ``(block_message, function_args, serve)``;
+    ``serve: Optional[_ServeDirective]``; failures never block."""
     try:
         from hermes_cli.plugins import _dispatch_pre_tool_call_hooks
-        block_message, modified_args, _ = _dispatch_pre_tool_call_hooks(
+        block_message, modified_args, serve = _dispatch_pre_tool_call_hooks(
             function_name, function_args, task_id=effective_task_id or "",
             session_id=getattr(agent, "session_id", "") or "", tool_call_id=tool_call_id or "",
             turn_id=getattr(agent, "_current_turn_id", "") or "",
             api_request_id=getattr(agent, "_current_api_request_id", "") or "",
             middleware_trace=list(middleware_trace),
         )
-        return block_message, (modified_args if modified_args is not None else function_args)
+        return block_message, (modified_args if modified_args is not None else function_args), serve
     except Exception:
-        return None, function_args
+        return None, function_args, None
 
 
 def invoke_tool(agent, function_name: str, function_args: dict, effective_task_id: str,
@@ -2212,8 +2213,9 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     except Exception as _mw_err:
         logger.debug("tool_request middleware error: %s", _mw_err)
     block_message: Optional[str] = None
+    serve = None
     if not pre_tool_block_checked:
-        block_message, function_args = _pre_tool_block_message(
+        block_message, function_args, serve = _pre_tool_block_message(
             agent, function_name, function_args, effective_task_id, tool_call_id, _tool_middleware_trace
         )
     if block_message is not None:
@@ -2225,6 +2227,21 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             middleware_trace=_tool_middleware_trace,
         )
         return result
+    if serve is not None:
+        # serve: emit the RAW served value to post_tool_call (cache plugins observe it
+        # pre-transform), then re-apply transform_tool_result so sanitization runs before
+        # the model sees replayed cache data; normalize None -> "" for the ``-> str``
+        # contract (callers that ``json.loads`` the result never see a null value).
+        emit_terminal_post_tool_call(
+            agent, function_name=function_name, function_args=function_args, result=serve.result,
+            effective_task_id=effective_task_id, tool_call_id=tool_call_id, status="cached",
+            error_type=None, error_message=None, middleware_trace=_tool_middleware_trace,
+        )
+        from model_tools import _apply_transform_tool_result_hook, _CallIds
+        result = _apply_transform_tool_result_hook(
+            function_name, function_args, serve.result, 0, _CallIds(**hook_ids),
+        )
+        return "" if result is None else result
     tool_start_time = time.monotonic()
     inline_executor = resolve_invoke_tool_executor(agent, function_name)
     if inline_executor is not None:

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -439,6 +439,7 @@ class _ManagedToolResult:
     middleware_trace: list[dict[str, Any]]
     blocked: bool
     dispatched: bool
+    served: bool = False
 
 
 class _ToolTimeoutResult(str):
@@ -614,20 +615,21 @@ def _blocked_tool_result(agent, ref: _ToolCallRef, *, block_message: Optional[st
 
 
 def _pre_tool_block(agent, ref: _ToolCallRef):
-    """Run ``pre_tool_call`` plugin hooks; returns ``(block_message, final_args)`` with any
-    hook-modified args applied. Hook failures never block."""
+    """Run ``pre_tool_call`` plugin hooks; returns ``(block_message, final_args, serve)``
+    with ``serve: Optional[_ServeDirective]`` and any hook-modified args applied. Hook
+    failures never block."""
     try:
         from hermes_cli.plugins import _dispatch_pre_tool_call_hooks
 
-        block_msg, modified_args, _ = _dispatch_pre_tool_call_hooks(
+        block_msg, modified_args, serve = _dispatch_pre_tool_call_hooks(
             ref.name,
             ref.args,
             **tool_hook_ids(agent, ref.task_id, ref.call_id),
             middleware_trace=list(ref.trace),
         )
-        return block_msg, (ref.args if modified_args is None else modified_args)
+        return block_msg, (ref.args if modified_args is None else modified_args), serve
     except Exception:
-        return None, ref.args
+        return None, ref.args, None
 
 
 def _dispatch_authorized_once(
@@ -654,10 +656,11 @@ def _dispatch_authorized_once(
             callback()
 
     block_message, block_error_type = scope_block, "tool_scope_block"
+    serve = None
     if block_message is None:
         block_error_type = "plugin_block"
         resolve = lambda: _pre_tool_block(agent, ref)  # noqa: E731
-        block_message, ref.args = resolve() if authorization_gate is None else authorization_gate.run(resolve)
+        block_message, ref.args, serve = resolve() if authorization_gate is None else authorization_gate.run(resolve)
         state.args = ref.args
 
     guardrail_decision = None
@@ -673,6 +676,24 @@ def _dispatch_authorized_once(
             agent, ref,
             block_message=block_message, block_error_type=block_error_type, guardrail_decision=guardrail_decision,
         )
+
+    if serve is not None:
+        # serve is weakest: it settles here only when no scope/plugin block and no
+        # guardrail fired. The tool does NOT run; emit the terminal post_tool_call with
+        # status="cached" for the RAW served value, re-apply transform_tool_result (the
+        # value is what a cache plugin observed pre-transform), and return the re-
+        # sanitized result. ``None`` normalizes to "" so the downstream pipeline never
+        # sees a null result.
+        _advance_start_order()
+        state.served = True
+        ref.emit_post(agent, serve.result, status="cached", error_type=None,
+                      error_message=None, duration_ms=0)
+        from model_tools import _apply_transform_tool_result_hook, _CallIds
+        result = _apply_transform_tool_result_hook(
+            ref.name, ref.args, serve.result, 0,
+            _CallIds(**tool_hook_ids(agent, ref.task_id, ref.call_id)),
+        )
+        return "" if result is None else result
 
     if ref.name == "memory":
         agent._turns_since_memory = 0
@@ -1631,8 +1652,9 @@ def _publish_sequential_result(agent, messages: list, ref: _ToolCallRef, managed
     _is_error_result, _ = _detect_tool_failure(ref.name, function_result)
     # Inline-dispatched runtime tools never reach handle_function_call, so the
     # executor owns the one terminal post_tool_call per tool_call_id (the inner
-    # observer is suppressed); also stops an abandoned timeout worker reporting late.
-    if not managed.blocked and not _execution_timed_out:
+    # observer is suppressed); also stops an abandoned timeout worker reporting late,
+    # and a served call (which already emitted status="cached") reporting twice.
+    if not managed.blocked and not managed.served and not _execution_timed_out:
         ref.emit_post(agent, function_result, duration_ms=int(tool_duration * 1000))
     committed = _commit_tool_result(
         agent, messages, ref, function_result,

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -619,7 +619,7 @@ def _pre_tool_block(agent, ref: _ToolCallRef):
     try:
         from hermes_cli.plugins import _dispatch_pre_tool_call_hooks
 
-        block_msg, modified_args = _dispatch_pre_tool_call_hooks(
+        block_msg, modified_args, _ = _dispatch_pre_tool_call_hooks(
             ref.name,
             ref.args,
             **tool_hook_ids(agent, ref.task_id, ref.call_id),

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1754,6 +1754,7 @@ class _PreToolCallDirective:
     message: Optional[str] = None
     rule_key: Optional[str] = None
     modified_args: Optional[Dict[str, Any]] = None
+    result: Any = None  # ``serve`` directive: the pre-supplied tool result (skip execution)
 
 
 def set_thread_tool_whitelist(
@@ -1801,6 +1802,14 @@ def _get_pre_tool_call_directive_details(
                 modified_args = {**(modified_args if modified_args is not None else
                                     (args if isinstance(args, dict) else {})), **partial}
             continue
+        if action == "serve":
+            # "serve" — supply the tool result without executing the tool (e.g. a
+            # cache hit). ``result`` is the pre-supplied result, returned as-is to
+            # the caller; the tool never runs. A serve without a result key is
+            # ignored (same fail-open posture as a block without a message).
+            if "result" not in result:
+                continue
+            return _PreToolCallDirective(action="serve", result=result["result"], modified_args=modified_args)
         if action not in ("block", "approve"):
             continue
         message = result.get("message")
@@ -1873,13 +1882,15 @@ def _resolve_block_from_details(
 
 def _dispatch_pre_tool_call_hooks(
     tool_name: str, args: Optional[Dict[str, Any]], **hook_kwargs: Any
-) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
-    """Invoke ``pre_tool_call`` hooks once; return ``(block_message, modified_args)`` — the resolved
-    block/approve message (``None`` to proceed) and merged ``modify`` args (``None`` if none)."""
+) -> Tuple[Optional[str], Optional[Dict[str, Any]], Any]:
+    """Invoke ``pre_tool_call`` hooks once; return ``(block_message, modified_args, served_result)`` —
+    the resolved block/approve message (``None`` to proceed), merged ``modify`` args (``None`` if
+    none), and a ``serve`` directive's pre-supplied result (``None`` if none)."""
     details = _get_pre_tool_call_directive_details(tool_name, args, **hook_kwargs)
     block_msg = _resolve_block_from_details(
         details, tool_name, **{k: hook_kwargs.get(k, "") for k in ("turn_id", "tool_call_id", "session_id")})
-    return (block_msg, details.modified_args)
+    served = details.result if details.action == "serve" else None
+    return (block_msg, details.modified_args, served)
 
 
 def get_pre_verify_continue_message(

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1749,12 +1749,26 @@ _thread_tool_whitelist = threading.local()
 
 
 @dataclass(frozen=True)
+class _ServeDirective:
+    """A ``pre_tool_call`` ``serve`` directive: supply ``result`` without executing the tool.
+
+    The OBJECT is the discriminator — its presence means "a serve directive was issued",
+    never ``result`` (which may legitimately be ``None``).
+
+    ``result`` is the RAW pre-``transform_tool_result`` value (what a cache plugin
+    observed via ``post_tool_call``); the serve path re-applies ``transform_tool_result``
+    before the value reaches the model so sanitization (e.g. ``security-guidance``) still
+    runs on replayed cache data."""
+    result: Any  # may be None
+
+
+@dataclass(frozen=True)
 class _PreToolCallDirective:
-    action: Optional[str] = None
+    action: Optional[str] = None                 # "block" | "approve" | None (serve sets this None)
     message: Optional[str] = None
     rule_key: Optional[str] = None
     modified_args: Optional[Dict[str, Any]] = None
-    result: Any = None  # ``serve`` directive: the pre-supplied tool result (skip execution)
+    serve: Optional[_ServeDirective] = None      # non-None only when a serve directive won
 
 
 def set_thread_tool_whitelist(
@@ -1774,10 +1788,14 @@ def _get_pre_tool_call_directive_details(
     tool_call_id: str = "", turn_id: str = "", api_request_id: str = "",
     middleware_trace: Optional[List[Dict[str, Any]]] = None,
 ) -> _PreToolCallDirective:
-    """Check ``pre_tool_call`` hooks for ``{"action": "block", "message"}`` (veto; message becomes
-    the tool result) or ``{"action": "approve", "message", "rule_key"?}`` (escalate ANY tool to the
-    human-approval gate; ``rule_key`` picks the ``[a]lways`` allowlist grain). First valid directive
-    wins; irrelevant returns are ignored."""
+    """Resolve ``pre_tool_call`` hooks to one directive under a restriction lattice where
+    ``block`` (veto; message becomes the tool result) > ``approve`` (escalate ANY tool to the
+    human-approval gate; ``rule_key`` picks the ``[a]lways`` allowlist grain) > ``serve``
+    (supply a pre-computed result without executing the tool). The most-restrictive directive
+    wins independent of registration order; ``modify`` is orthogonal and always accumulates.
+    Ties among equal rank break by registration order (first wins). A ``serve`` is valid only
+    when its ``"result"`` KEY is present (``result: null`` is a serve of ``None``); a block
+    without a message is ignored (fail-open)."""
     allowed = getattr(_thread_tool_whitelist, "allowed", None)
     if allowed is not None and tool_name not in allowed:
         fmt = getattr(_thread_tool_whitelist, "fmt", "Tool '{tool_name}' denied")
@@ -1789,13 +1807,18 @@ def _get_pre_tool_call_directive_details(
         api_request_id=api_request_id, middleware_trace=list(middleware_trace or []),
     )
     modified_args: Optional[Dict[str, Any]] = None
+    best_rank = 0                        # 0=none, 1=serve, 2=approve, 3=block
+    block_message: Optional[str] = None
+    approve_message: Optional[str] = None
+    approve_rule_key: Optional[str] = None
+    serve_directive: Optional[_ServeDirective] = None
+
     for result in hook_results:
         if not isinstance(result, dict):
             continue
         action = result.get("action")
-        # "modify" — transform tool_input before dispatch. Processed before the block/approve gate
-        # so modify directives are visible even when a later hook blocks. Each modify directive
-        # shallow-merges its keys into one accumulated dict built from the original args.
+        # "modify" — transform tool_input before dispatch; orthogonal to the restriction
+        # lattice, so it always accumulates regardless of any block/approve/serve.
         if action == "modify":
             partial = result.get("args")
             if isinstance(partial, dict) and partial:
@@ -1803,13 +1826,14 @@ def _get_pre_tool_call_directive_details(
                                     (args if isinstance(args, dict) else {})), **partial}
             continue
         if action == "serve":
-            # "serve" — supply the tool result without executing the tool (e.g. a
-            # cache hit). ``result`` is the pre-supplied result, returned as-is to
-            # the caller; the tool never runs. A serve without a result key is
-            # ignored (same fail-open posture as a block without a message).
+            # Presence of the "result" KEY (not its value) validates the directive:
+            # {"action":"serve","result":null} is a valid serve of None. Weakest
+            # restriction; keep scanning so a later block/approve still wins.
             if "result" not in result:
                 continue
-            return _PreToolCallDirective(action="serve", result=result["result"], modified_args=modified_args)
+            if best_rank < 1:
+                best_rank, serve_directive = 1, _ServeDirective(result=result["result"])
+            continue
         if action not in ("block", "approve"):
             continue
         message = result.get("message")
@@ -1819,7 +1843,21 @@ def _get_pre_tool_call_directive_details(
             continue
         rule_key = result.get("rule_key") if action == "approve" else None
         rule_key = (rule_key.strip() or None) if isinstance(rule_key, str) else None
-        return _PreToolCallDirective(action=action, message=message, rule_key=rule_key, modified_args=modified_args)
+        rank = 3 if action == "block" else 2
+        if rank > best_rank:               # strict > keeps the first-registered winner on ties
+            best_rank = rank
+            if action == "block":
+                block_message = message
+            else:
+                approve_message, approve_rule_key = message, rule_key
+
+    if best_rank >= 3:
+        return _PreToolCallDirective(action="block", message=block_message, modified_args=modified_args)
+    if best_rank == 2:
+        return _PreToolCallDirective(action="approve", message=approve_message,
+                                     rule_key=approve_rule_key, modified_args=modified_args)
+    if best_rank == 1:
+        return _PreToolCallDirective(serve=serve_directive, modified_args=modified_args)
     return _PreToolCallDirective(modified_args=modified_args)
 
 
@@ -1882,15 +1920,14 @@ def _resolve_block_from_details(
 
 def _dispatch_pre_tool_call_hooks(
     tool_name: str, args: Optional[Dict[str, Any]], **hook_kwargs: Any
-) -> Tuple[Optional[str], Optional[Dict[str, Any]], Any]:
-    """Invoke ``pre_tool_call`` hooks once; return ``(block_message, modified_args, served_result)`` —
+) -> Tuple[Optional[str], Optional[Dict[str, Any]], Optional[_ServeDirective]]:
+    """Invoke ``pre_tool_call`` hooks once; return ``(block_message, modified_args, serve)`` —
     the resolved block/approve message (``None`` to proceed), merged ``modify`` args (``None`` if
-    none), and a ``serve`` directive's pre-supplied result (``None`` if none)."""
+    none), and the winning ``_ServeDirective`` (``None`` if none)."""
     details = _get_pre_tool_call_directive_details(tool_name, args, **hook_kwargs)
     block_msg = _resolve_block_from_details(
         details, tool_name, **{k: hook_kwargs.get(k, "") for k in ("turn_id", "tool_call_id", "session_id")})
-    served = details.result if details.action == "serve" else None
-    return (block_msg, details.modified_args, served)
+    return (block_msg, details.modified_args, details.serve)
 
 
 def get_pre_verify_continue_message(

--- a/model_tools.py
+++ b/model_tools.py
@@ -707,22 +707,25 @@ def _pre_dispatch_guards(function_name: str, function_args: Dict[str, Any], skip
     # both the block message and modified args. skip=True: caller already fired it.
     if not skip_pre_tool_call_hook:
         block_message: Optional[str] = None
-        served_result: Any = None
+        serve = None                                     # Optional[_ServeDirective]
         try:
             from hermes_cli.plugins import _dispatch_pre_tool_call_hooks
-            block_message, modified_args, served_result = _dispatch_pre_tool_call_hooks(
+            block_message, modified_args, serve = _dispatch_pre_tool_call_hooks(
                 function_name, function_args, middleware_trace=list(middleware_trace), **ids.hook_kwargs(),
             )
             if modified_args is not None:
                 function_args = modified_args
         except Exception as _hook_err:
             logger.debug("pre_tool_call hook error: %s", _hook_err)
-        if served_result is not None:
-            # serve directive: the plugin supplied the tool result (e.g. a cache
-            # hit) — skip execution and emit with status="cached".
-            return function_args, (served_result, "cached", None, None)
+        # block wins over serve (defense-in-depth: the lattice lives in the dispatcher,
+        # but the caller must not re-introduce serve shadowing a block).
         if block_message is not None:
             return function_args, (tool_error(block_message), "blocked", "plugin_block", block_message)
+        if serve is not None:
+            # serve directive: the plugin supplied the RAW tool result (e.g. a cache
+            # hit) — skip execution and emit with status="cached". handle_function_call
+            # re-applies transform_tool_result before returning.
+            return function_args, (serve.result, "cached", None, None)
 
     # ACP/Zed edit approval before any file mutation. The requester is bound
     # via ContextVar only for ACP sessions, so CLI/gateway paths are unaffected.
@@ -860,6 +863,14 @@ def handle_function_call(
         function_args, blocked = _pre_dispatch_guards(function_name, function_args, skip_pre_tool_call_hook, ids, trace)
         if blocked is not None:
             result, status, error_type, error_message = blocked
+            if status == "cached":
+                # serve: the served value is RAW (what a cache plugin observed via
+                # post_tool_call, before transform_tool_result). Re-apply the transform
+                # so sanitization (e.g. security-guidance) still runs before the model
+                # sees replayed cache data.
+                _emit(result, status=status, error_type=error_type, error_message=error_message)
+                transformed = _apply_transform_tool_result_hook(function_name, function_args, result, 0, ids)
+                return "" if transformed is None else transformed
             return _emit(result, status=status, error_type=error_type, error_message=error_message)
 
         # Any non-read/search tool resets the consecutive-read-loop counter.

--- a/model_tools.py
+++ b/model_tools.py
@@ -696,27 +696,33 @@ def _apply_request_middleware(
 
 def _pre_dispatch_guards(function_name: str, function_args: Dict[str, Any], skip_pre_tool_call_hook: bool,
                          ids: _CallIds, middleware_trace: List[Dict[str, Any]],
-                         ) -> Tuple[Dict[str, Any], Optional[Tuple[Any, str, Optional[str]]]]:
+                         ) -> Tuple[Dict[str, Any], Optional[Tuple[Any, str, Optional[str], Optional[str]]]]:
     """Plugin pre_tool_call hook, then ACP edit approval.
 
     ``(args, None)`` to proceed (args possibly plugin-modified), or
-    ``(args, (result, error_type, error_message))`` when blocked.
+    ``(args, (result, status, error_type, error_message))`` when blocked or
+    served (a plugin-supplied result that skips execution, e.g. a cache hit).
     """
     # pre_tool_call fires exactly once per execution: one invoke_hook pass yields
     # both the block message and modified args. skip=True: caller already fired it.
     if not skip_pre_tool_call_hook:
         block_message: Optional[str] = None
+        served_result: Any = None
         try:
             from hermes_cli.plugins import _dispatch_pre_tool_call_hooks
-            block_message, modified_args = _dispatch_pre_tool_call_hooks(
+            block_message, modified_args, served_result = _dispatch_pre_tool_call_hooks(
                 function_name, function_args, middleware_trace=list(middleware_trace), **ids.hook_kwargs(),
             )
             if modified_args is not None:
                 function_args = modified_args
         except Exception as _hook_err:
             logger.debug("pre_tool_call hook error: %s", _hook_err)
+        if served_result is not None:
+            # serve directive: the plugin supplied the tool result (e.g. a cache
+            # hit) — skip execution and emit with status="cached".
+            return function_args, (served_result, "cached", None, None)
         if block_message is not None:
-            return function_args, (tool_error(block_message), "plugin_block", block_message)
+            return function_args, (tool_error(block_message), "blocked", "plugin_block", block_message)
 
     # ACP/Zed edit approval before any file mutation. The requester is bound
     # via ContextVar only for ACP sessions, so CLI/gateway paths are unaffected.
@@ -724,11 +730,11 @@ def _pre_dispatch_guards(function_name: str, function_args: Dict[str, Any], skip
         from acp_adapter.edit_approval import maybe_require_edit_approval
         edit_block_message = maybe_require_edit_approval(function_name, function_args)
         if edit_block_message is not None:
-            return function_args, (edit_block_message, "edit_approval_denied", None)
+            return function_args, (edit_block_message, "blocked", "edit_approval_denied", None)
     except Exception as _edit_approval_err:
         logger.debug("ACP edit approval guard error: %s", _edit_approval_err)
         if function_name in {"write_file", "patch"}:
-            return function_args, (tool_error("Edit approval denied: approval guard failed"), "edit_approval_error", None)
+            return function_args, (tool_error("Edit approval denied: approval guard failed"), "blocked", "edit_approval_error", None)
     return function_args, None
 
 
@@ -853,8 +859,8 @@ def handle_function_call(
 
         function_args, blocked = _pre_dispatch_guards(function_name, function_args, skip_pre_tool_call_hook, ids, trace)
         if blocked is not None:
-            result, error_type, error_message = blocked
-            return _emit(result, status="blocked", error_type=error_type, error_message=error_message)
+            result, status, error_type, error_message = blocked
+            return _emit(result, status=status, error_type=error_type, error_message=error_message)
 
         # Any non-read/search tool resets the consecutive-read-loop counter.
         if function_name not in _READ_SEARCH_TOOLS:

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1472,7 +1472,7 @@ class TestPreToolCallModify:
                 {"action": "modify", "args": {"path": "/safe/dir"}}
             ],
         )
-        block_msg, modified = _dispatch_pre_tool_call_hooks(
+        block_msg, modified, _ = _dispatch_pre_tool_call_hooks(
             "write_file", {"path": "/unsafe/dir", "content": "x"}
         )
         assert block_msg is None
@@ -1487,7 +1487,7 @@ class TestPreToolCallModify:
                 {"action": "modify", "args": {"content": "fixed"}},
             ],
         )
-        block_msg, modified = _dispatch_pre_tool_call_hooks(
+        block_msg, modified, _ = _dispatch_pre_tool_call_hooks(
             "write_file", {"path": "/unsafe", "content": "original"}
         )
         assert block_msg is None
@@ -1502,7 +1502,7 @@ class TestPreToolCallModify:
                 {"action": "modify", "args": {"path": "/second"}},
             ],
         )
-        block_msg, modified = _dispatch_pre_tool_call_hooks(
+        block_msg, modified, _ = _dispatch_pre_tool_call_hooks(
             "write_file", {"path": "/original"}
         )
         assert modified == {"path": "/second"}
@@ -1516,7 +1516,7 @@ class TestPreToolCallModify:
                 {"action": "block", "message": "still blocked"},
             ],
         )
-        block_msg, modified = _dispatch_pre_tool_call_hooks(
+        block_msg, modified, _ = _dispatch_pre_tool_call_hooks(
             "write_file", {"path": "/unsafe"}
         )
         assert block_msg == "still blocked"
@@ -1531,7 +1531,7 @@ class TestPreToolCallModify:
                 {"action": "modify", "args": {"path": "/invisible"}},
             ],
         )
-        block_msg, modified = _dispatch_pre_tool_call_hooks(
+        block_msg, modified, _ = _dispatch_pre_tool_call_hooks(
             "write_file", {"path": "/original"}
         )
         assert block_msg == "stopped"
@@ -1545,7 +1545,7 @@ class TestPreToolCallModify:
                 {"action": "modify", "args": {"path": "/safe"}}
             ],
         )
-        block_msg, modified = _dispatch_pre_tool_call_hooks("write_file", None)
+        block_msg, modified, _ = _dispatch_pre_tool_call_hooks("write_file", None)
         assert block_msg is None
         assert modified == {"path": "/safe"}
 
@@ -1555,7 +1555,7 @@ class TestPreToolCallModify:
             "hermes_cli.plugins.invoke_hook",
             lambda hook_name, **kwargs: [],
         )
-        block_msg, modified = _dispatch_pre_tool_call_hooks(
+        block_msg, modified, _ = _dispatch_pre_tool_call_hooks(
             "terminal", {"cmd": "ls"}
         )
         assert block_msg is None
@@ -1571,10 +1571,57 @@ class TestPreToolCallModify:
                 {"action": "modify", "args": {"path": "/real"}},
             ],
         )
-        block_msg, modified = _dispatch_pre_tool_call_hooks(
+        block_msg, modified, _ = _dispatch_pre_tool_call_hooks(
             "write_file", {"path": "/original"}
         )
         assert modified == {"path": "/real"}
+
+
+class TestPreToolCallServe:
+    """`pre_tool_call` serve directive — supply a tool result without executing the tool."""
+
+    def test_serve_returns_result(self, monkeypatch):
+        """A serve directive returns its result as the third tuple element."""
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [{"action": "serve", "result": "cached"}],
+        )
+        block_msg, modified, served = _dispatch_pre_tool_call_hooks("read_file", {"path": "/x"})
+        assert block_msg is None
+        assert modified is None
+        assert served == "cached"
+
+    def test_serve_without_result_key_is_ignored(self, monkeypatch):
+        """A serve without a result key is ignored (fail-open to normal execution)."""
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [{"action": "serve"}],
+        )
+        block_msg, _, served = _dispatch_pre_tool_call_hooks("read_file", {"path": "/x"})
+        assert block_msg is None
+        assert served is None
+
+    def test_serve_result_is_json_string(self, monkeypatch):
+        """Tool results are JSON strings; serve passes them through verbatim."""
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [{"action": "serve", "result": '{"content": "hi"}'}],
+        )
+        _, _, served = _dispatch_pre_tool_call_hooks("read_file", {"path": "/x"})
+        assert served == '{"content": "hi"}'
+
+    def test_serve_beats_block_on_first_wins(self, monkeypatch):
+        """First valid directive wins — a serve before a block short-circuits."""
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {"action": "serve", "result": "cached"},
+                {"action": "block", "message": "should not reach"},
+            ],
+        )
+        block_msg, _, served = _dispatch_pre_tool_call_hooks("read_file", {"path": "/x"})
+        assert served == "cached"
+        assert block_msg is None
 
 
 class TestGetPreVerifyContinueMessage:

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -17,6 +17,7 @@ from hermes_cli.plugins import (
     PluginContext,
     PluginManager,
     PluginManifest,
+    _ServeDirective,
     _dispatch_pre_tool_call_hooks,
     get_plugin_command_handler,
     get_plugin_commands,
@@ -1522,8 +1523,8 @@ class TestPreToolCallModify:
         assert block_msg == "still blocked"
         assert modified == {"path": "/safe"}
 
-    def test_modify_after_block_is_invisible(self, monkeypatch):
-        """A modify after a block is never reached — first block wins."""
+    def test_modify_after_block_still_accumulates(self, monkeypatch):
+        """A modify after a block still accumulates — modify is orthogonal to the lattice."""
         monkeypatch.setattr(
             "hermes_cli.plugins.invoke_hook",
             lambda hook_name, **kwargs: [
@@ -1535,7 +1536,7 @@ class TestPreToolCallModify:
             "write_file", {"path": "/original"}
         )
         assert block_msg == "stopped"
-        assert modified is None
+        assert modified == {"path": "/invisible"}
 
     def test_modify_with_none_args(self, monkeypatch):
         """Modify should handle None args gracefully."""
@@ -1581,7 +1582,7 @@ class TestPreToolCallServe:
     """`pre_tool_call` serve directive — supply a tool result without executing the tool."""
 
     def test_serve_returns_result(self, monkeypatch):
-        """A serve directive returns its result as the third tuple element."""
+        """A serve directive returns its result inside a ``_ServeDirective``."""
         monkeypatch.setattr(
             "hermes_cli.plugins.invoke_hook",
             lambda hook_name, **kwargs: [{"action": "serve", "result": "cached"}],
@@ -1589,7 +1590,8 @@ class TestPreToolCallServe:
         block_msg, modified, served = _dispatch_pre_tool_call_hooks("read_file", {"path": "/x"})
         assert block_msg is None
         assert modified is None
-        assert served == "cached"
+        assert isinstance(served, _ServeDirective)
+        assert served.result == "cached"
 
     def test_serve_without_result_key_is_ignored(self, monkeypatch):
         """A serve without a result key is ignored (fail-open to normal execution)."""
@@ -1602,26 +1604,158 @@ class TestPreToolCallServe:
         assert served is None
 
     def test_serve_result_is_json_string(self, monkeypatch):
-        """Tool results are JSON strings; serve passes them through verbatim."""
+        """Tool results are JSON strings; serve carries them inside ``_ServeDirective``."""
         monkeypatch.setattr(
             "hermes_cli.plugins.invoke_hook",
             lambda hook_name, **kwargs: [{"action": "serve", "result": '{"content": "hi"}'}],
         )
         _, _, served = _dispatch_pre_tool_call_hooks("read_file", {"path": "/x"})
-        assert served == '{"content": "hi"}'
+        assert isinstance(served, _ServeDirective)
+        assert served.result == '{"content": "hi"}'
 
-    def test_serve_beats_block_on_first_wins(self, monkeypatch):
-        """First valid directive wins — a serve before a block short-circuits."""
+    def test_serve_null_result_is_a_serve_not_absent(self, monkeypatch):
+        """``result: null`` is a serve of ``None``, distinguishable from no directive."""
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [{"action": "serve", "result": None}],
+        )
+        block_msg, _, served = _dispatch_pre_tool_call_hooks("read_file", {"path": "/x"})
+        assert block_msg is None
+        assert served is not None
+        assert served.result is None
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda hook_name, **kwargs: [])
+        _, _, absent = _dispatch_pre_tool_call_hooks("read_file", {"path": "/x"})
+        assert absent is None
+
+    def test_serve_does_not_beat_block(self, monkeypatch):
+        """block dominates serve regardless of registration order (serve first)."""
         monkeypatch.setattr(
             "hermes_cli.plugins.invoke_hook",
             lambda hook_name, **kwargs: [
                 {"action": "serve", "result": "cached"},
-                {"action": "block", "message": "should not reach"},
+                {"action": "block", "message": "veto"},
             ],
         )
         block_msg, _, served = _dispatch_pre_tool_call_hooks("read_file", {"path": "/x"})
-        assert served == "cached"
+        assert block_msg == "veto"
+        assert served is None
+
+    def test_block_beats_serve(self, monkeypatch):
+        """block dominates serve regardless of registration order (block first)."""
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {"action": "block", "message": "veto"},
+                {"action": "serve", "result": "cached"},
+            ],
+        )
+        block_msg, _, served = _dispatch_pre_tool_call_hooks("read_file", {"path": "/x"})
+        assert block_msg == "veto"
+        assert served is None
+
+    def test_serve_then_approve_still_gates(self, monkeypatch):
+        """approve outranks serve in both orders — serve never bypasses the human gate."""
+        from hermes_cli.plugins import get_pre_tool_call_directive, _get_pre_tool_call_directive_details
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {"action": "serve", "result": "cached"},
+                {"action": "approve", "message": "ask human"},
+            ],
+        )
+        assert get_pre_tool_call_directive("read_file", {"path": "/x"}) == ("approve", "ask human")
+        details = _get_pre_tool_call_directive_details("read_file", {"path": "/x"})
+        assert details.action == "approve"
+        assert details.serve is None
+
+    def test_approve_then_serve_still_gates(self, monkeypatch):
+        """approve outranks serve in both orders — serve never bypasses the human gate."""
+        from hermes_cli.plugins import get_pre_tool_call_directive, _get_pre_tool_call_directive_details
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {"action": "approve", "message": "ask human"},
+                {"action": "serve", "result": "cached"},
+            ],
+        )
+        assert get_pre_tool_call_directive("read_file", {"path": "/x"}) == ("approve", "ask human")
+        details = _get_pre_tool_call_directive_details("read_file", {"path": "/x"})
+        assert details.action == "approve"
+        assert details.serve is None
+
+    def test_multiple_serve_first_wins(self, monkeypatch):
+        """Two serve directives: the first registered wins the tie."""
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {"action": "serve", "result": "a"},
+                {"action": "serve", "result": "b"},
+            ],
+        )
+        block_msg, _, served = _dispatch_pre_tool_call_hooks("read_file", {"path": "/x"})
         assert block_msg is None
+        assert isinstance(served, _ServeDirective)
+        assert served.result == "a"
+
+    def test_serve_with_modify_combined(self, monkeypatch):
+        """modify accumulates while serve still carries its result."""
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {"action": "modify", "args": {"path": "/safe"}},
+                {"action": "serve", "result": "R"},
+            ],
+        )
+        block_msg, modified, served = _dispatch_pre_tool_call_hooks("read_file", {"path": "/orig"})
+        assert block_msg is None
+        assert isinstance(served, _ServeDirective)
+        assert served.result == "R"
+        assert modified == {"path": "/safe"}
+
+    def test_modify_after_serve_still_accumulates(self, monkeypatch):
+        """modify accumulates regardless of order relative to serve."""
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {"action": "serve", "result": "R"},
+                {"action": "modify", "args": {"path": "/safe"}},
+            ],
+        )
+        block_msg, modified, served = _dispatch_pre_tool_call_hooks("read_file", {"path": "/orig"})
+        assert block_msg is None
+        assert isinstance(served, _ServeDirective)
+        assert served.result == "R"
+        assert modified == {"path": "/safe"}
+
+    def test_thread_whitelist_rejection_dominates_serve(self, monkeypatch):
+        """Thread-whitelist rejection blocks before any hook, so serve cannot win."""
+        from hermes_cli.plugins import set_thread_tool_whitelist, clear_thread_tool_whitelist
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [{"action": "serve", "result": "cached"}],
+        )
+        set_thread_tool_whitelist({"read_file"})
+        try:
+            block_msg, _, served = _dispatch_pre_tool_call_hooks("write_file", {"path": "/x"})
+        finally:
+            clear_thread_tool_whitelist()
+        assert block_msg is not None
+        assert served is None
+
+    def test_modify_block_serve_triple_merges_args_block_beats_serve(self, monkeypatch):
+        """modify merges args while block beats serve in a three-way directive."""
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {"action": "modify", "args": {"path": "/safe"}},
+                {"action": "serve", "result": "cached"},
+                {"action": "block", "message": "veto"},
+            ],
+        )
+        block_msg, modified, served = _dispatch_pre_tool_call_hooks("write_file", {"path": "/orig"})
+        assert block_msg == "veto"
+        assert served is None
+        assert modified == {"path": "/safe"}
 
 
 class TestGetPreVerifyContinueMessage:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2211,7 +2211,7 @@ class TestConcurrentToolExecution:
         )
         monkeypatch.setattr(
             "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
-            lambda *_args, **_kwargs: (None, None),
+            lambda *_args, **_kwargs: (None, None, None),
         )
         monkeypatch.setattr(
             "agent.tool_executor._begin_tool_execution",
@@ -2273,7 +2273,7 @@ class TestConcurrentToolExecution:
 
         monkeypatch.setattr(
             "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
-            lambda *args, **kwargs: ("Blocked by policy", None),
+            lambda *args, **kwargs: ("Blocked by policy", None, None),
         )
         agent._checkpoint_mgr.enabled = True
         agent._checkpoint_mgr.ensure_checkpoint = MagicMock(
@@ -2349,7 +2349,7 @@ class TestConcurrentToolExecution:
         agent._turns_since_memory = 5
         monkeypatch.setattr(
             "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
-            lambda *args, **kwargs: ("Blocked", None),
+            lambda *args, **kwargs: ("Blocked", None, None),
         )
         with patch("tools.memory_tool.memory_tool", side_effect=AssertionError("should not run")):
             result = agent._invoke_tool(
@@ -2383,7 +2383,7 @@ class TestConcurrentToolExecution:
         )
         monkeypatch.setattr(
             "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
-            lambda *_args, **_kwargs: (None, None),
+            lambda *_args, **_kwargs: (None, None, None),
         )
         monkeypatch.setattr(tool_executor, "_begin_tool_execution", lambda *_a, **_k: None)
 
@@ -2438,7 +2438,7 @@ class TestConcurrentToolExecution:
         )
         monkeypatch.setattr(
             "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
-            lambda *_args, **_kwargs: (None, None),
+            lambda *_args, **_kwargs: (None, None, None),
         )
         monkeypatch.setattr(tool_executor, "_begin_tool_execution", lambda *_a, **_k: None)
 
@@ -2507,7 +2507,7 @@ class TestAgentRuntimePostHookOwnershipSync:
         hook_calls = []
         monkeypatch.setattr(
             "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
-            lambda *args, **kwargs: (None, None),
+            lambda *args, **kwargs: (None, None, None),
         )
         monkeypatch.setattr(
             "hermes_cli.lifecycle.invoke_hook",

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -364,7 +364,7 @@ def test_plugin_pre_tool_block_wins_without_counting_as_toolguard_block():
     with (
         patch(
             "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
-            return_value=("plugin policy", None),
+            return_value=("plugin policy", None, None),
         ),
         patch("model_tools.handle_function_call", return_value="SHOULD_NOT_RUN") as mock_hfc,
     ):
@@ -373,6 +373,30 @@ def test_plugin_pre_tool_block_wins_without_counting_as_toolguard_block():
     mock_hfc.assert_not_called()
     assert "plugin policy" in messages[0]["content"]
     assert agent._tool_guardrails.before_call("web_search", args).action == "allow"
+
+
+def test_serve_directive_skips_dispatch_and_emits_cached():
+    """A pre_tool_call serve directive returns the cached result without executing
+    the tool, and the post_tool_call observation carries status='cached'."""
+    from model_tools import handle_function_call
+    emitted = []
+    with (
+        patch(
+            "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
+            return_value=(None, None, '{"cached": true}'),
+        ),
+        patch("model_tools.registry.dispatch") as dispatch,
+        patch(
+            "model_tools._emit_post_tool_call_hook",
+            side_effect=lambda **kwargs: emitted.append(kwargs),
+        ),
+    ):
+        result = handle_function_call("read_file", {"path": "/x"})
+
+    assert result == '{"cached": true}'
+    dispatch.assert_not_called()
+    assert emitted[0]["status"] == "cached"
+    assert emitted[0]["error_type"] is None
 
 
 def test_default_run_conversation_warns_without_guardrail_halt():

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from run_agent import AIAgent
+from hermes_cli.plugins import _ServeDirective
 
 
 def _make_tool_defs(*names: str) -> list[dict]:
@@ -280,7 +281,7 @@ def test_relay_rewrite_precedes_sequential_policy_approval_checkpoint_and_dispat
     def observe_plugin(name, args, **kwargs):
         del kwargs
         observed["plugin"].append((name, dict(args)))
-        return (None, None)
+        return (None, None, None)
 
     def observe_approval(name, args):
         observed["approval"].append((name, dict(args)))
@@ -383,12 +384,16 @@ def test_serve_directive_skips_dispatch_and_emits_cached():
     with (
         patch(
             "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
-            return_value=(None, None, '{"cached": true}'),
+            return_value=(None, None, _ServeDirective(result='{"cached": true}')),
         ),
         patch("model_tools.registry.dispatch") as dispatch,
         patch(
             "model_tools._emit_post_tool_call_hook",
             side_effect=lambda **kwargs: emitted.append(kwargs),
+        ),
+        patch(
+            "model_tools._apply_transform_tool_result_hook",
+            side_effect=lambda _name, _args, result, _dur, _ids: result,
         ),
     ):
         result = handle_function_call("read_file", {"path": "/x"})
@@ -397,6 +402,302 @@ def test_serve_directive_skips_dispatch_and_emits_cached():
     dispatch.assert_not_called()
     assert emitted[0]["status"] == "cached"
     assert emitted[0]["error_type"] is None
+
+
+def test_serve_null_result_does_not_dispatch():
+    """A serve of ``None`` settles as an empty string without dispatching (the object
+    presence, not the value, is the discriminator)."""
+    from model_tools import handle_function_call
+    emitted = []
+    with (
+        patch(
+            "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
+            return_value=(None, None, _ServeDirective(result=None)),
+        ),
+        patch("model_tools.registry.dispatch") as dispatch,
+        patch(
+            "model_tools._emit_post_tool_call_hook",
+            side_effect=lambda **kwargs: emitted.append(kwargs),
+        ),
+        patch(
+            "model_tools._apply_transform_tool_result_hook",
+            side_effect=lambda _name, _args, result, _dur, _ids: result,
+        ),
+    ):
+        result = handle_function_call("read_file", {"path": "/x"})
+
+    dispatch.assert_not_called()
+    assert emitted[0]["status"] == "cached"
+    assert emitted[0]["result"] is None
+    assert result == ""
+
+
+def test_serve_result_is_re_transformed():
+    """A served result is RAW (what a cache plugin observed pre-transform), so
+    ``transform_tool_result`` re-runs before the model sees the replayed value."""
+    from model_tools import handle_function_call
+    emitted = []
+    with (
+        patch(
+            "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
+            return_value=(None, None, _ServeDirective(result='{"cached": true}')),
+        ),
+        patch("model_tools.registry.dispatch") as dispatch,
+        patch(
+            "model_tools._emit_post_tool_call_hook",
+            side_effect=lambda **kwargs: emitted.append(kwargs),
+        ),
+        patch(
+            "model_tools._apply_transform_tool_result_hook",
+            return_value='{"cached": true, "sanitized": true}',
+        ) as transform,
+    ):
+        result = handle_function_call("read_file", {"path": "/x"})
+
+    dispatch.assert_not_called()
+    transform.assert_called_once()
+    assert result == '{"cached": true, "sanitized": true}'
+    assert emitted[0]["status"] == "cached"
+    assert emitted[0]["result"] == '{"cached": true}'
+
+
+def test_serve_directive_honored_by_concurrent_executor():
+    """The real concurrent executor settles a serve directive without dispatch and
+    re-applies ``transform_tool_result`` on the raw served value."""
+    agent = _make_agent("read_file")
+    tc = _mock_tool_call("read_file", '{"path": "/x"}', "c1")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+    post_calls = []
+    with (
+        patch(
+            "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
+            return_value=(None, None, _ServeDirective(result='{"cached": true}')),
+        ),
+        patch("model_tools.handle_function_call", side_effect=AssertionError("must not run")) as handle,
+        patch(
+            "model_tools._apply_transform_tool_result_hook",
+            return_value='{"cached": true, "sanitized": true}',
+        ) as transform,
+        patch(
+            "model_tools._emit_post_tool_call_hook",
+            side_effect=lambda **kwargs: post_calls.append(kwargs),
+        ),
+    ):
+        agent._execute_tool_calls_concurrent(msg, messages, "task-1")
+
+    handle.assert_not_called()
+    transform.assert_called_once()
+    assert len(messages) == 1
+    assert json.loads(messages[0]["content"]) == {"cached": True, "sanitized": True}
+    cached = [c for c in post_calls if c.get("tool_call_id") == "c1"]
+    assert len(cached) == 1
+    assert cached[0]["status"] == "cached"
+
+
+def test_serve_directive_honored_by_sequential_executor():
+    """The real sequential executor settles a serve directive without dispatch,
+    re-applies ``transform_tool_result``, and emits exactly one terminal post_tool_call."""
+    agent = _make_agent("read_file")
+    tc = _mock_tool_call("read_file", '{"path": "/x"}', "c2")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+    post_calls = []
+    with (
+        patch(
+            "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
+            return_value=(None, None, _ServeDirective(result='{"cached": true}')),
+        ),
+        patch("model_tools.handle_function_call", side_effect=AssertionError("must not run")) as handle,
+        patch(
+            "model_tools._apply_transform_tool_result_hook",
+            return_value='{"cached": true, "sanitized": true}',
+        ) as transform,
+        patch(
+            "model_tools._emit_post_tool_call_hook",
+            side_effect=lambda **kwargs: post_calls.append(kwargs),
+        ),
+    ):
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+
+    handle.assert_not_called()
+    transform.assert_called_once()
+    assert len(messages) == 1
+    assert json.loads(messages[0]["content"]) == {"cached": True, "sanitized": True}
+    cached = [c for c in post_calls if c.get("tool_call_id") == "c2"]
+    assert len(cached) == 1
+    assert cached[0]["status"] == "cached"
+
+
+def test_serve_directive_honored_by_invoke_tool():
+    """The runtime helper ``invoke_tool`` settles a serve directive without dispatch,
+    emits the RAW served value to post_tool_call, and re-applies transform_tool_result."""
+    from agent.agent_runtime_helpers import invoke_tool
+    agent = _make_agent("read_file")
+    post_calls = []
+    with (
+        patch(
+            "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
+            return_value=(None, None, _ServeDirective(result='{"cached": true}')),
+        ),
+        patch(
+            "model_tools._apply_transform_tool_result_hook",
+            return_value='{"cached": true, "sanitized": true}',
+        ) as transform,
+        patch(
+            "agent.inline_tool_executors.emit_terminal_post_tool_call",
+            side_effect=lambda *args, **kwargs: post_calls.append(kwargs),
+        ),
+        patch(
+            "agent.inline_tool_executors.resolve_invoke_tool_executor",
+            side_effect=AssertionError("must not run"),
+        ) as resolve,
+    ):
+        result = invoke_tool(
+            agent, "read_file", {"path": "/x"}, "task-1", "c-invoke",
+            skip_tool_request_middleware=True,
+        )
+
+    resolve.assert_not_called()
+    transform.assert_called_once()
+    assert result == '{"cached": true, "sanitized": true}'
+    assert len(post_calls) == 1
+    assert post_calls[0]["status"] == "cached"
+    assert post_calls[0]["result"] == '{"cached": true}'  # RAW value emitted to observers
+
+
+def test_serve_null_result_through_invoke_tool():
+    """A serve of ``None`` through ``invoke_tool`` emits the raw None to observers and
+    returns a normalized ``""`` (no null leaks into the ``-> str`` contract)."""
+    from agent.agent_runtime_helpers import invoke_tool
+    agent = _make_agent("read_file")
+    post_calls = []
+    with (
+        patch(
+            "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
+            return_value=(None, None, _ServeDirective(result=None)),
+        ),
+        patch(
+            "model_tools._apply_transform_tool_result_hook",
+            return_value="",
+        ) as transform,
+        patch(
+            "agent.inline_tool_executors.emit_terminal_post_tool_call",
+            side_effect=lambda *args, **kwargs: post_calls.append(kwargs),
+        ),
+        patch(
+            "agent.inline_tool_executors.resolve_invoke_tool_executor",
+            side_effect=AssertionError("must not run"),
+        ) as resolve,
+    ):
+        result = invoke_tool(
+            agent, "read_file", {"path": "/x"}, "task-1", "c-invoke-null",
+            skip_tool_request_middleware=True,
+        )
+
+    resolve.assert_not_called()
+    transform.assert_called_once()
+    assert result == ""
+    assert len(post_calls) == 1
+    assert post_calls[0]["status"] == "cached"
+    assert post_calls[0]["result"] is None  # RAW None emitted, not ""
+
+
+def test_serve_null_result_through_concurrent_executor():
+    """A serve of ``None`` flows through the real concurrent executor without crashing
+    the downstream result pipeline."""
+    agent = _make_agent("read_file")
+    tc = _mock_tool_call("read_file", '{"path": "/x"}', "c-null-conc")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+    with (
+        patch(
+            "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
+            return_value=(None, None, _ServeDirective(result=None)),
+        ),
+        patch("model_tools.handle_function_call", side_effect=AssertionError("must not run")),
+        patch(
+            "model_tools._apply_transform_tool_result_hook",
+            side_effect=lambda _name, _args, result, _dur, _ids: result,
+        ),
+    ):
+        agent._execute_tool_calls_concurrent(msg, messages, "task-1")
+
+    assert len(messages) == 1
+    assert messages[0]["tool_call_id"] == "c-null-conc"
+    assert messages[0]["content"] == ""
+
+
+def test_serve_null_result_through_sequential_executor():
+    """A serve of ``None`` flows through the real sequential executor without crashing
+    the downstream result pipeline."""
+    agent = _make_agent("read_file")
+    tc = _mock_tool_call("read_file", '{"path": "/x"}', "c-null-seq")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+    with (
+        patch(
+            "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
+            return_value=(None, None, _ServeDirective(result=None)),
+        ),
+        patch("model_tools.handle_function_call", side_effect=AssertionError("must not run")),
+        patch(
+            "model_tools._apply_transform_tool_result_hook",
+            side_effect=lambda _name, _args, result, _dur, _ids: result,
+        ),
+    ):
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+
+    assert len(messages) == 1
+    assert messages[0]["tool_call_id"] == "c-null-seq"
+    assert messages[0]["content"] == ""
+
+
+def test_guardrail_before_call_rejection_blocks_serve():
+    """A guardrail ``before_call`` rejection blocks execution even when serve is present."""
+    agent = _make_agent("read_file", config=_hard_stop_config())
+    args = {"path": "/x"}
+    _seed_exact_failures(agent, "read_file", args, count=5)
+    tc = _mock_tool_call("read_file", json.dumps(args), "c-guardrail")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+    with (
+        patch(
+            "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
+            return_value=(None, None, _ServeDirective(result='{"cached": true}')),
+        ),
+        patch("model_tools.handle_function_call", side_effect=AssertionError("must not run")) as handle,
+    ):
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+
+    handle.assert_not_called()
+    assert len(messages) == 1
+    assert "repeated_exact_failure_block" in messages[0]["content"]
+
+
+def test_scope_block_suppresses_pre_tool_block_and_prevents_serve():
+    """A scope block short-circuits the plugin pre-tool hooks, so a serve can never win."""
+    agent = _make_agent("read_file")
+    from agent.tool_executor import _run_agent_tool_execution_middleware
+    dispatched = []
+    with (
+        patch("hermes_cli.plugins._dispatch_pre_tool_call_hooks") as hooks,
+        patch("model_tools.handle_function_call", side_effect=AssertionError("must not run")),
+    ):
+        outcome = _run_agent_tool_execution_middleware(
+            agent,
+            function_name="read_file",
+            function_args={"path": "/x"},
+            effective_task_id="task-1",
+            tool_call_id="c-scope",
+            execute=lambda args: dispatched.append(args) or "SHOULD_NOT_RUN",
+            scope_block="'read_file' is out of scope",
+        )
+
+    hooks.assert_not_called()
+    assert outcome.blocked is True
+    assert dispatched == []
+    assert json.loads(outcome.result) == {"error": "'read_file' is out of scope"}
 
 
 def test_default_run_conversation_warns_without_guardrail_halt():


### PR DESCRIPTION
## Summary

Add a `serve` directive to `pre_tool_call` so a plugin can **supply a tool result without executing the tool**. When a plugin returns `{"action": "serve", "result": <JSON>}`, the core skips the registry dispatch and emits the supplied result with `status="cached"` — so observers (and cost accounting) can distinguish a cache hit from a real execution.

## Motivation

Hermes exposes `tool_execution` middleware that can short-circuit (not call `next_call`), which lets a standalone plugin implement a transparent tool-result cache today — **zero core changes**. But the core can't tell the result came from a short-circuit: `_tool_result_observer_fields` derives `status="ok"` from the result bytes, so a cache hit is recorded as a real execution.

`pre_tool_call` is already a **directive/control** hook (documented in `hooks.md`): it consumes documented return shapes (`block` / `approve` / `modify`). Adding `serve` is an additive, back-compatible widen of that same directive surface — exactly the "widen the generic plugin surface" path from `CONTRIBUTING.md`, with a concrete consumer.

Concrete consumer: the **tool-cache** standalone plugin (pure-function tool result cache over `read_file` / `search_files`). It uses `serve` to replay a cached result within TTL without re-executing, and `status="cached"` keeps cost/usage accounting honest.

## Design

- **`serve` requires a `result` key**; a `serve` without one is ignored (same fail-open posture as a `block` without a message).
- **Monotonic precedence `block > approve > serve`**: all hook results are aggregated by `best_rank` (serve=1, approve=2, block=3), so a restrictive directive always dominates a permissive one regardless of hook registration order. This extends the lattice established in #87449 (`block` > `approve`) with the new `serve` rank and closes the veto-shadowing defect tracked in #87420 — a cache hit can never erase a later security veto. Ties among equal rank break by registration order (first wins).
- **Typed sentinel (`_ServeDirective`)**: a serve's `result` may be `null` and still count as a serve — presence is encoded by the typed wrapper, not by the result value, so `{"action":"serve","result":null}` is never confused with "no directive".
- **Topology-independent settlement**: the served result is honored on both the direct path (`model_tools._pre_dispatch_guards`) and the concurrent/runtime paths (`agent_runtime_helpers._pre_tool_block_message`, `agent.tool_executor._pre_tool_block`), so a `serve` settles identically (without dispatching the tool) regardless of scheduler topology — never silently executing a tool whose directive said "do not run".
- **`_pre_dispatch_guards` now returns `(result, status, error_type, error_message)`** instead of a hard-coded `status="blocked"` at the call site — the generic widen. A `serve` maps to `status="cached"`; `block`/edit-approval-denial still map to `status="blocked"`.

## Changes

- `hermes_cli/plugins.py` — `_ServeDirective` typed sentinel; `best_rank` aggregation of `block`/`approve`/`serve`; third element from `_dispatch_pre_tool_call_hooks`.
- `model_tools.py` — `_pre_dispatch_guards` returns `(result, status, error_type, error_message)`; `handle_function_call` emits the dynamic status.
- `agent/agent_runtime_helpers.py`, `agent/tool_executor.py` — honor the served result so direct and concurrent paths settle identically.

## Tests

New coverage (all green locally):
- `tests/hermes_cli/test_plugins.py::TestPreToolCallServe` — serve returns its result; serve-without-result ignored; JSON-string passthrough; null result is a serve (not absent); **block beats serve** and **serve does not beat block** in both orders; **approve outranks serve** in both orders; multiple-serve first-wins; serve+modify accumulation.
- `tests/run_agent/test_tool_call_guardrail_runtime.py` — production-path `handle_function_call` witness (`registry.dispatch` not called, `status="cached"`), null-result through invoke_tool/concurrent/sequential executors, and security gates (`guardrail` rejection, scope block) dominating `serve`.

## Related

- #87449 (`block` > `approve` lattice) — this PR extends that lattice with the `serve` rank (`block` > `approve` > `serve`).
- #87420 (pre_tool_call directive aggregation first-valid-wins) — the veto-shadowing defect this PR closes.
- #98281 (opt-in cross-tool result cache via decorator) — complementary; the decorator is a per-tool eligibility declaration, while `serve` is the execution-layer short-circuit. This PR is the "executor integration" seam that #98281 leaves as a follow-up.
- #90432 (pre_api_request Transform) — a different layer (per-request), out of scope here.
