### PR TITLE
fix(terminal): stop session snapshot from executing orphaned function bodies

### DIFF
--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -369,9 +369,33 @@ class BaseEnvironment(ABC):
         # backends) into every terminal-tool response.
         _quoted_snap = shlex.quote(self._snapshot_path)
         _quoted_cwd_file = shlex.quote(self._cwd_file)
+        # Select functions to keep by NAME, then dump only those.
+        #
+        # The previous form -- ``declare -f | grep -vE '^_[^_]'`` -- filtered
+        # the dump LINE BY LINE.  That drops the ``_foo () `` header line of
+        # every single-underscore-prefixed function while KEEPING its body,
+        # leaving an orphaned top-level ``{ ... }`` group command in the
+        # snapshot.  Group commands EXECUTE on ``source``, so any such body
+        # containing a loop or a blocking call hangs every terminal command
+        # until the tool timeout (exit 124) -- with the failure invisible
+        # because the source is ``>/dev/null 2>&1``.  Real-world trigger:
+        # shells that define ``_``-prefixed helpers (completion handlers,
+        # chpwd/PROMPT_COMMAND hooks) in the user's rc files.
+        #
+        # ``declare -F`` lists names only, so filtering there keeps each
+        # function definition intact (header + body) or omits it entirely.
+        # The snapshot is a verbatim ``export -p`` dump, so it contains every
+        # exported secret in the user's shell (API tokens, PATs, and anything
+        # else sourced from their rc files).  Default umask would create it
+        # 0644.  Force 0600 so the dump is readable only by the owning user --
+        # the redirect in ``_wrap_command`` then preserves that mode, since
+        # ``>`` truncates in place rather than recreating.
         bootstrap = (
+            "umask 077\n"
             f"export -p > {_quoted_snap}\n"
-            f"declare -f | grep -vE '^_[^_]' >> {_quoted_snap}\n"
+            f"__hermes_fns=$(declare -F | awk '{{print $3}}' | grep -vE '^_[^_]' | tr '\\n' ' ')\n"
+            f"[ -n \"$__hermes_fns\" ] && declare -f $__hermes_fns >> {_quoted_snap} 2>/dev/null\n"
+            f"unset __hermes_fns\n"
             f"alias -p >> {_quoted_snap}\n"
             f"echo 'shopt -s expand_aliases' >> {_quoted_snap}\n"
             f"echo 'set +e' >> {_quoted_snap}\n"


### PR DESCRIPTION
## Problem

`BaseEnvironment.init_session()` builds the shell snapshot with:

```
declare -f | grep -vE '^_[^_]'
```

The intent is to skip private, single-underscore-prefixed functions. But `grep` filters the dump **line by line**, and `declare -f` emits each function as a header line followed by a brace-delimited body. The filter therefore deletes the `_foo () ` header while **keeping the body**, leaving an orphaned top-level group command in the snapshot:

```
{
    ...body of what used to be _foo...
}
```

A bare `{ ... }` at top level is a group command, and group commands **execute** when the snapshot is sourced. If any such body contains a loop or a blocking call, every terminal command hangs until the tool timeout and returns exit 124.

The failure is silent. `_wrap_command` sources the snapshot as `source "$snap" >/dev/null 2>&1 || true`, so nothing surfaces — the only symptom is that a trivial command like `pwd` times out.

## Impact

Any user whose rc files define `_`-prefixed shell functions. Completion handlers, `chpwd`/`PROMPT_COMMAND` hooks, and several popular shell frameworks all do this by convention.

On the affected host, 8 such functions were present. Every `terminal` call — including a bare `pwd` — returned exit 124 after the full timeout, for roughly a week, while `execute_code` on the same host worked normally. That asymmetry makes it easy to misdiagnose as a sandbox, cwd, or network problem rather than a snapshot problem.

Minimal reproduction:

```bash
_hang() { while :; do :; done; }
declare -f | grep -vE '^_[^_]' > /tmp/snap.sh
bash -c 'source /tmp/snap.sh >/dev/null 2>&1; echo never reached'
```

## Fix

Select functions to keep by **name** via `declare -F`, then dump only those. Each definition is preserved whole or omitted whole, so no orphaned bodies can be produced:

```
__hermes_fns=$(declare -F | awk '{print $3}' | grep -vE '^_[^_]' | tr '\n' ' ')
[ -n "$__hermes_fns" ] && declare -f $__hermes_fns >> "$snap" 2>/dev/null
unset __hermes_fns
```

Filtering semantics are unchanged: the same set of functions is excluded.

## Also included

`umask 077` for the bootstrap. The snapshot is a verbatim `export -p` dump, so it contains every exported secret in the user's shell (API keys, tokens). It was being created `0644`. The redirect in `_wrap_command` preserves the tightened mode, since `>` truncates in place rather than recreating.

Happy to split this into a separate PR if preferred.

## Verification

- `pwd` returns in ~0.1s (previously 60s / exit 124)
- `PATH` lookups resolve correctly again
- snapshot and cwd files are created `0600`
- `tests/tools/test_base_environment.py`, `test_init_session_cwd_respect.py`, `test_terminal_task_cwd.py`, `test_terminal_exit_semantics.py` — **55 passed, 0 failed**

Tested on macOS (Apple Silicon), bash 3.2 login shell.