### PR TITLE
fix(matrix): continue proactive replies from the latest thread event

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -62,6 +62,8 @@ from gateway.platforms.base import (
     SendResult, resolve_proxy_url, proxy_kwargs_for_aiohttp, _ssrf_redirect_guard)
 from gateway.platforms.helpers import ThreadParticipationTracker
 
+from plugins.platforms.matrix.thread_replies import resolve_thread_reply_target
+
 logger = logging.getLogger(__name__)
 
 _MATRIX_VOICE_WAVEFORM_BINS = 30
@@ -1313,9 +1315,13 @@ class MatrixAdapter(BasePlatformAdapter):
         if not content:
             return SendResult(success=True)
         last_event_id = None
+        effective_reply_to = reply_to
+        thread_id = str((metadata or {}).get("thread_id") or "")
+        if thread_id and not effective_reply_to:
+            effective_reply_to = await resolve_thread_reply_target(self._client, chat_id, thread_id)
         for chunk in self.truncate_message(self.format_message(content), self.max_message_length):
             msg_content = self._build_text_message_content(chunk)
-            self._apply_relation_metadata(msg_content, reply_to=reply_to, metadata=metadata)
+            self._apply_relation_metadata(msg_content, reply_to=effective_reply_to, metadata=metadata)
             try:
                 last_event_id = await self._send_room_message(chat_id, msg_content)
                 logger.info("Matrix: sent event %s to %s", last_event_id, chat_id)
@@ -1330,6 +1336,8 @@ class MatrixAdapter(BasePlatformAdapter):
                 except Exception as retry_exc:
                     logger.error("Matrix: failed to send to %s after retry: %s", chat_id, retry_exc)
                     return SendResult(success=False, error=str(retry_exc))
+            if thread_id:
+                effective_reply_to = last_event_id
         return SendResult(success=True, message_id=last_event_id)
 
     async def _send_room_message(self, chat_id: str, msg_content: Dict[str, Any]) -> str:
@@ -1685,7 +1693,16 @@ class MatrixAdapter(BasePlatformAdapter):
                 msg_content["info"]["duration"] = audio_metadata["duration"]
             if audio_metadata:
                 msg_content["org.matrix.msc1767.audio"] = audio_metadata
-        self._apply_relation_metadata(msg_content, reply_to=reply_to, metadata=metadata)
+
+        effective_reply_to = reply_to
+        thread_id = str((metadata or {}).get("thread_id") or "")
+        if thread_id and not effective_reply_to:
+            effective_reply_to = await resolve_thread_reply_target(self._client, room_id, thread_id)
+        self._apply_relation_metadata(
+            msg_content,
+            reply_to=effective_reply_to,
+            metadata=metadata,
+        )
         return await self._send_content_event(room_id, msg_content)
 
     async def _room_needs_encrypted_upload(self, room_id: str) -> bool:

--- a/plugins/platforms/matrix/thread_replies.py
+++ b/plugins/platforms/matrix/thread_replies.py
@@ -1,0 +1,59 @@
+"""Resolve reply fallbacks for proactive Matrix thread delivery."""
+import asyncio
+import logging
+from urllib.parse import quote
+
+logger = logging.getLogger(__name__)
+
+async def resolve_thread_reply_target(
+    client,
+    room_id: str,
+    thread_id: str,
+) -> str:
+    """Return the newest event in a thread for reply fallback chaining.
+
+    Matrix thread events always relate to the thread root, while
+    ``m.in_reply_to`` should point at the message being continued. Proactive
+    sends do not have an inbound ``reply_to`` value, so resolve the latest
+    thread event from the homeserver. If the lookup is unavailable, the
+    root remains a valid protocol-level fallback.
+    """
+    if not client or not thread_id:
+        return thread_id
+
+    encoded_room = quote(room_id, safe="")
+    encoded_thread = quote(thread_id, safe="")
+    path = (
+        f"/_matrix/client/v1/rooms/{encoded_room}/relations/"
+        f"{encoded_thread}/m.thread/m.room.message"
+    )
+    get_method: object
+    try:
+        from mautrix.api import Method as MatrixMethod
+
+        get_method = MatrixMethod.GET
+    except ImportError:
+        get_method = "GET"
+    try:
+        response = await asyncio.wait_for(
+            client.api.request(
+                get_method,
+                path,
+                query_params={"dir": "b", "limit": "1"},
+            ),
+            timeout=10,
+        )
+        chunk = response.get("chunk", []) if isinstance(response, dict) else []
+        if chunk and isinstance(chunk[0], dict):
+            event_id = str(chunk[0].get("event_id") or "")
+            if event_id:
+                return event_id
+    except Exception as exc:
+        logger.debug(
+            "Matrix: could not resolve latest event for thread %s in %s: %s",
+            thread_id,
+            room_id,
+            exc,
+        )
+    return thread_id
+

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -631,7 +631,11 @@ class TestMatrixRenderingPayloads:
 
 
     @pytest.mark.asyncio
-    async def test_thread_payload_uses_m_thread_with_reply_fallback(self):
+    async def test_thread_payload_replies_to_latest_thread_event(self):
+        self.mock_client.api.request = AsyncMock(
+            return_value={"chunk": [{"event_id": "$latest"}]}
+        )
+
         result = await self.adapter.send(
             "!room:example.org",
             "threaded",
@@ -644,9 +648,22 @@ class TestMatrixRenderingPayloads:
             "rel_type": "m.thread",
             "event_id": "$root",
             "is_falling_back": True,
-            "m.in_reply_to": {"event_id": "$root"},
+            "m.in_reply_to": {"event_id": "$latest"},
         }
+        self.mock_client.api.request.assert_awaited_once()
 
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("reply_to,lookup_fails,expected", [
+        (None, True, "$root"), ("$explicit", False, "$explicit")
+    ])
+    async def test_thread_fallback_respects_explicit_target_and_lookup_failure(self, reply_to, lookup_fails, expected):
+        self.mock_client.api.request = AsyncMock(side_effect=RuntimeError("offline") if lookup_fails else None)
+        result = await self.adapter.send("!room:example.org", "threaded", reply_to=reply_to, metadata={"thread_id": "$root"})
+        assert result.success is True
+        assert self._sent_contents()[0]["m.relates_to"]["m.in_reply_to"] == {"event_id": expected}
+        if reply_to:
+            self.mock_client.api.request.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_long_response_split_preserves_thread_context(self):
@@ -664,10 +681,13 @@ class TestMatrixRenderingPayloads:
         assert result.success is True
         contents = self._sent_contents()
         assert len(contents) > 1
-        for content in contents:
+        for index, content in enumerate(contents):
             assert content["m.relates_to"]["rel_type"] == "m.thread"
             assert content["m.relates_to"]["event_id"] == "$root"
-            assert content["m.relates_to"]["m.in_reply_to"] == {"event_id": "$root"}
+            expected_reply = "$root" if index == 0 else "$evt"
+            assert content["m.relates_to"]["m.in_reply_to"] == {
+                "event_id": expected_reply
+            }
             assert content["body"].count("```") % 2 == 0
 
 
@@ -1457,6 +1477,9 @@ class TestMatrixUploadAndSend:
     async def test_media_preserves_caption_and_thread(self):
         adapter = _make_adapter()
         mock_client = MagicMock()
+        mock_client.api.request = AsyncMock(
+            return_value={"chunk": [{"event_id": "$latest"}]}
+        )
         mock_client.upload_media = AsyncMock(return_value="mxc://example.org/plain")
         mock_client.send_message_event = AsyncMock(return_value="$event")
         adapter._client = mock_client
@@ -1476,7 +1499,7 @@ class TestMatrixUploadAndSend:
         assert sent["body"] == "Chart caption"
         assert sent["m.relates_to"]["rel_type"] == "m.thread"
         assert sent["m.relates_to"]["event_id"] == "$root"
-        assert sent["m.relates_to"]["m.in_reply_to"] == {"event_id": "$root"}
+        assert sent["m.relates_to"]["m.in_reply_to"] == {"event_id": "$latest"}
 
 
 class TestMatrixDiagnostics:

--- a/tests/gateway/test_matrix_thread_transport.py
+++ b/tests/gateway/test_matrix_thread_transport.py
@@ -1,0 +1,45 @@
+"""Exercise proactive thread delivery through the real mautrix HTTP client."""
+import pytest
+from aiohttp import web
+from mautrix.client import Client
+from mautrix.types import UserID
+from gateway.config import PlatformConfig
+from plugins.platforms.matrix.adapter import MatrixAdapter
+
+
+@pytest.mark.asyncio
+async def test_proactive_thread_lookup_and_chunk_chaining_use_real_http_transport():
+    received = []
+
+    async def handle(request):
+        assert request.headers['Authorization'] == 'Bearer fixture-token'
+        if request.method == 'GET':
+            assert request.path == '/_matrix/client/v1/rooms/!room:example.org/relations/$root/m.thread/m.room.message'
+            assert request.query['dir'] == 'b'
+            return web.json_response({'chunk': [{'event_id': '$latest'}]})
+        content = await request.json()
+        received.append(content)
+        return web.json_response({'event_id': f'$sent{len(received)}'})
+
+    app = web.Application()
+    app.router.add_route('*', '/{tail:.*}', handle)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, '127.0.0.1', 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]
+    client = Client(mxid=UserID('@fixture:example.org'), base_url=f'http://127.0.0.1:{port}', token='fixture-token')
+    try:
+        adapter = MatrixAdapter(PlatformConfig(enabled=True))
+        adapter._client = client
+        adapter.max_message_length = 100
+        result = await adapter.send('!room:example.org', 'word ' * 60, metadata={'thread_id': '$root'})
+        assert result.success
+        assert len(received) > 1
+        for index, content in enumerate(received):
+            relation = content['m.relates_to']
+            assert relation['event_id'] == '$root'
+            assert relation['m.in_reply_to']['event_id'] == ('$latest' if index == 0 else f'$sent{index}')
+    finally:
+        await client.api.session.close()
+        await runner.cleanup()


### PR DESCRIPTION
Proactive sends have a thread root but no incoming reply target. They currently set `m.in_reply_to` to the root for every message, so clients showing reply fallbacks do not see a continuation of the latest thread message. Split replies repeat that fallback too.

Resolve the newest thread message when no explicit reply target exists, then chain subsequent chunks to the preceding chunk. Keep `m.thread.event_id` on the root. An unavailable lookup falls back to the root, and an explicit reply target avoids the lookup. The same resolution applies to media delivery.

Validation: the Matrix adapter tests and a loopback HTTP test using the real mautrix client pass through `scripts/run_tests.sh`. The transport test verifies the relations endpoint and each outgoing chunk's root and reply target. No live account or model calls are used.
