### PR TITLE
fix(tui): skip live compression hot-reload on external context engines (#103410)

### DIFF
--- a/tests/tui_gateway/test_compression_config_hot_reload.py
+++ b/tests/tui_gateway/test_compression_config_hot_reload.py
@@ -282,3 +282,40 @@ def test_removing_codex_native_threshold_restores_default(monkeypatch):
     session["agent"].codex_responses_compact_threshold = 120_000
     _sync_with_cfg(monkeypatch, session, {"compression": {}})
     assert session["agent"].codex_responses_compact_threshold == 200_000
+
+
+def test_external_context_engine_skips_compressor_hot_reload(monkeypatch, caplog):
+    """External engines (e.g. LCM) own compaction policy: live sync must leave
+    them alone. Regression: the god-file extraction assumed ContextCompressor
+    and logged ``'LCMEngine' object has no attribute
+    '_coerce_threshold_tokens_cap'`` on every config change."""
+    import logging
+
+    plugin_calls: list = []
+    engine = SimpleNamespace(
+        name="lcm",
+        threshold_tokens=100_000,
+        threshold_percent=0.65,
+        model_thresholds={},
+        update_model=lambda *a, **k: plugin_calls.append((a, k)),
+    )
+    agent = SimpleNamespace(
+        model="m",
+        provider="p",
+        context_compressor=engine,
+        compression_enabled=True,
+        compression_idle_compact_after_seconds=0,
+        codex_responses_native_compaction=False,
+        codex_responses_compact_threshold=200_000,
+    )
+    session = {"agent": agent, "session_key": "session-external-engine"}
+    with caplog.at_level(logging.WARNING):
+        _sync_with_cfg(
+            monkeypatch,
+            session,
+            {"compression": {"threshold_tokens": 50_000, "tail_mode": "legacy"}},
+        )
+    assert "Could not apply live compression config" not in caplog.text
+    assert engine.threshold_tokens == 100_000
+    assert not hasattr(engine, "tail_mode")
+    assert plugin_calls == []

--- a/tui_gateway/session_compression.py
+++ b/tui_gateway/session_compression.py
@@ -100,6 +100,13 @@ def _apply_live_compression_config(agent: Any, cfg: dict | None) -> None:
     cc = getattr(agent, "context_compressor", None)
     if cc is None:
         return
+    from agent.context_compressor import ContextCompressor
+    if not isinstance(cc, ContextCompressor):
+        # External context engines (e.g. LCM) own compaction policy: live
+        # compression.* hot-reload never drives the plugin API, so there is
+        # nothing to apply here (agent_init #44439 pattern; construction-time
+        # model_thresholds/update_model in agent_init are untouched).
+        return
     # tail_mode: unknown/absent values land on the ctor default ("lean"), matching agent_init.
     default_tail = str(_compressor_ctor_default("tail_mode", "lean"))
     mode = str(compression.get("tail_mode", default_tail) or default_tail).strip().lower()


### PR DESCRIPTION
## Bug Description

Live compression hot-reload (`_sync_agent_compression_with_config`) crashed on sessions
with an external context engine, logging `Could not apply live compression config ...
'LCMEngine' object has no attribute '_coerce_threshold_tokens_cap'` on every config change.

Fixes #103410

## Root Cause

`tui_gateway/session_compression.py` assumed `agent.context_compressor` is always a
`ContextCompressor`. External engines own compaction policy (agent_init #44439 pattern).

## Fix

- Early `isinstance(cc, ContextCompressor)` return in `_apply_live_compression_config`,
  after the agent-level flags — same guard as `conversation_compression.py:336`.

## How to Test

- `scripts/run_tests.sh tests/tui_gateway/test_compression_config_hot_reload.py` → 19/19 green
- New test `test_external_context_engine_skips_compressor_hot_reload` fails on base
  (warning logged, engine mutated) and passes with the fix (untouched, `update_model` uncalled)

## Test Plan

- [x] Added regression test for this bug (red-on-base verified via checkout/apply)
- [x] Existing tests still pass (19/19 in file)
- [ ] CI green on PR (watch after create)

## Risk Assessment

Low — external-engine sessions go from crash-and-warn to clean skip; `ContextCompressor`
sessions (incl. subclasses) take the identical path as before.
