### PR TITLE
fix(agent): stage unmounted binary reference files into attachments for container backends

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -438,7 +438,18 @@ def _binary_reference_block(ref: ContextReference, path: Path) -> str:
     try:
         from tools.terminal_tool import _ensure_terminal_env_bridged
         _ensure_terminal_env_bridged()
-        from tools.credential_files import to_agent_visible_cache_path
+        from tools.credential_files import to_agent_visible_cache_path, map_cache_path_to_container
+        backend = (os.environ.get("TERMINAL_ENV") or "local").strip().lower()
+        if backend in ("docker", "modal", "ssh", "daytona", "vercel_sandbox", "singularity"):
+            if map_cache_path_to_container(str(path)) is None and path.is_file():
+                import shutil
+                from hermes_constants import get_hermes_dir
+                attachments_dir = get_hermes_dir("attachments", "attachments")
+                attachments_dir.mkdir(parents=True, exist_ok=True)
+                staged_path = attachments_dir / path.name
+                if not staged_path.exists() or staged_path.stat().st_mtime < path.stat().st_mtime:
+                    shutil.copy2(str(path), str(staged_path))
+                path = staged_path
         visible = to_agent_visible_cache_path(str(path))
     except Exception:
         visible = str(path)

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -175,6 +175,35 @@ def test_binary_reference_block_keeps_host_path_on_local_backend(tmp_path: Path,
     assert "/root/.hermes/attachments/" not in result.message
 
 
+def test_binary_reference_block_stages_unmounted_file_under_container_backend(tmp_path: Path, monkeypatch):
+    """Container backend: a binary reference pointing outside cache mounts is auto-staged
+    into attachments so the container sandbox can access it."""
+    from agent.context_references import preprocess_context_references
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir(parents=True)
+    external_dir = tmp_path / "Downloads"
+    external_dir.mkdir(parents=True)
+    payload = external_dir / "report.pdf"
+    payload.write_bytes(b"%PDF-1.4 test bytes")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+    result = preprocess_context_references(
+        f"Read @file:{payload}",
+        cwd=tmp_path,
+        context_length=100_000,
+    )
+
+    assert result.expanded
+    assert "/root/.hermes/attachments/report.pdf" in result.message
+    staged = hermes_home / "attachments" / "report.pdf"
+    assert staged.exists()
+    assert staged.read_bytes() == b"%PDF-1.4 test bytes"
+
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Under container terminal backends (`docker`, `modal`, `ssh`, `daytona`, `vercel_sandbox`, `singularity`), host paths outside mounted cache directories dangle inside the sandbox. When expanding `@file:` binary references (such as dropped PDF/ZIP files or gateway-attached documents outside `HERMES_HOME`), `_binary_reference_block` previously rendered the host path directly if it was not already located under a cache directory mount. This caused agent tools in sandbox containers to fail finding the attached file.

This PR ensures that when a binary reference targets a file outside mounted cache roots under a container backend, the file is automatically staged into the bind-mounted `attachments/` directory so it maps to a container-visible path (e.g. `/root/.hermes/attachments/<name>`) that sandbox tools can immediately read.

## Related Issue

Fixes #103147

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/context_references.py`: Auto-stage unmounted binary reference files into `attachments/` when running under a container backend (`docker`, `modal`, `ssh`, `daytona`, `vercel_sandbox`, `singularity`) before computing `to_agent_visible_cache_path`.
- `tests/agent/test_context_references.py`: Add regression test `test_binary_reference_block_stages_unmounted_file_under_container_backend` asserting file staging into `attachments/` and path translation to `/root/.hermes/attachments/<file>`.

## How to Test

1. Run `pytest tests/agent/test_context_references.py -v`
2. Verify all 14 tests pass, including `test_binary_reference_block_stages_unmounted_file_under_container_backend`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
