### PR TITLE
fix(gateway): stabilize Node directory aliases in service PATH

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2728,8 +2728,9 @@ def _append_node_dir_for_service(path_entries: list[str], hermes_root: Path | No
     if not resolved_node:
         return
 
-    # Use the dir where node is FOUND, not the symlink target (~/.local/bin/node often links into one profile).
-    resolved_node_dir = str(Path(resolved_node).parent)
+    # Resolve directory aliases (for example fnm's per-shell directory), not
+    # the node symlink itself, which may point into another Hermes profile.
+    resolved_node_dir = str(Path(resolved_node).parent.resolve())
     if resolved_node_dir not in path_entries:
         path_entries.append(resolved_node_dir)
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -296,6 +296,28 @@ class TestGeneratedSystemdUnits:
         assert str(local_bin) in unit
         assert str(profile_node_bin) not in unit
 
+    def test_user_unit_is_current_across_node_directory_aliases(self, tmp_path, monkeypatch):
+        node_bin = tmp_path / "node-version" / "bin"
+        node_bin.mkdir(parents=True)
+        (node_bin / "node").write_text("#!/bin/sh\n")
+        first_shell = tmp_path / "first-shell"
+        second_shell = tmp_path / "second-shell"
+        first_shell.symlink_to(node_bin, target_is_directory=True)
+        second_shell.symlink_to(node_bin, target_is_directory=True)
+        monkeypatch.setattr("hermes_constants.hermes_managed_node_tree_present", lambda root=None: False)
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: str(first_shell / "node") if cmd == "node" else None)
+        unit_path = tmp_path / "hermes-gateway.service"
+        unit_path.write_text(gateway_cli.generate_systemd_unit())
+        monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
+
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: str(second_shell / "node") if cmd == "node" else None)
+
+        assert gateway_cli.systemd_unit_is_current()
+        assert str(node_bin) in unit_path.read_text()
+        assert str(first_shell) not in unit_path.read_text()
+        unit_path.write_text(unit_path.read_text().replace("RestartSec=5", "RestartSec=19"))
+        assert not gateway_cli.systemd_unit_is_current()
+
     def test_launchd_plist_does_not_leak_profile_node_symlink_target(self, tmp_path, monkeypatch):
         # Same #48700 regression for the macOS twin generate_launchd_plist().
         local_bin = tmp_path / ".local" / "bin"


### PR DESCRIPTION
## Problem

With Node on an fnm per-shell directory symlink, generating a systemd unit in one shell and checking it in another produces a different PATH. `hermes gateway status` consequently reports an outdated service immediately after a successful refresh.

## Change

Resolve the directory containing the discovered Node executable before adding it to the service PATH. Resolve the directory, not the executable: a node symlink under a real local bin directory can point into a different Hermes profile, and that existing isolation behavior must remain intact. Real changes to the service definition still cause the stale check to fail.

Related: #46276 (the per-shell directory alias case).

## Validation

- Added a regression using two directory symlinks to the same Node installation. It failed on the original code and passes with the fix.
- `bash scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py -j 1`: 104 passed, one macOS-only test skipped on Linux. Existing cross-profile executable-symlink tests pass.
- Ruff checks and `git diff --check` passed.
