### PR TITLE
fix(update): discharge fleet-restart obligation on the receipt after catch-up

### DIFF
--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -109,6 +109,14 @@ def _receipt_reports_stale_runtime(expected_sha: str | None = None) -> bool:
     if not expected_sha:
         return False
 
+    # An out-of-band catch-up restart records the SHA it discharged the
+    # obligation against. Honour it: without this the empty-``fleet`` +
+    # failed-``outcome`` receipt below falls back to a pre-pull plan SHA
+    # that can never match HEAD, so the warning re-fires forever even after
+    # the fleet was verifiably restarted.
+    if str(receipt.get("fleet_restart_resolved_sha") or "") == str(expected_sha):
+        return False
+
     def _sha_mismatch(code_sha) -> bool:
         return bool(code_sha) and str(code_sha) != str(expected_sha)
 
@@ -282,6 +290,36 @@ def _run_pending_fleet_restart() -> bool:
         return False
 
 
+def _record_catchup_fleet_resolution() -> None:
+    """Tell the owing receipt that the catch-up restart happened.
+
+    ``_clear_fleet_restart_pending_marker()`` only removes the breadcrumb
+    file. ``_pending_fleet_restart_needed()`` ALSO consults the receipt, and
+    a receipt with an empty ``fleet`` and a failed/partial ``outcome`` falls
+    back to ``plan.runtimes[].code_sha`` — captured before the pull, so it
+    can never match the post-pull checkout. Recording the restart against
+    the current HEAD is what actually discharges the obligation. Never
+    raises: a failure here costs one redundant restart, not a broken update.
+    """
+    try:
+        from hermes_cli.update_receipt import (
+            collect_fleet_versions,
+            record_fleet_resolution,
+        )
+
+        expected_sha = _current_checkout_sha()
+        if not expected_sha:
+            return
+        try:
+            fleet = collect_fleet_versions()
+        except Exception as exc:
+            logger.debug("Catch-up fleet probe failed: %s", exc)
+            fleet = None
+        record_fleet_resolution(fleet, expected_sha)
+    except Exception as exc:
+        logger.debug("Could not record catch-up fleet resolution: %s", exc)
+
+
 def _apply_pending_fleet_restart_catchup() -> None:
     """On an already-up-to-date ``hermes update``, finish a skipped restart.
 
@@ -296,6 +334,7 @@ def _apply_pending_fleet_restart_catchup() -> None:
     print("→ Running the pending fleet restart...")
     if _run_pending_fleet_restart():
         _clear_fleet_restart_pending_marker()
+        _record_catchup_fleet_resolution()
         return
     print("  ⚠ Fleet restart incomplete. Recover with: hermes gateway restart")
     sys.exit(1)

--- a/hermes_cli/update_receipt.py
+++ b/hermes_cli/update_receipt.py
@@ -206,6 +206,56 @@ def finalize_pending_update_receipt(exit_code: Optional[int] = None, stop_reason
     return finalize_update_receipt(outcome, stop_reason=stop_reason)
 
 
+def record_fleet_resolution(
+    fleet: "list[dict[str, Any]] | None", resolved_sha: str
+) -> bool:
+    """Stamp a completed out-of-band fleet restart onto the latest receipt.
+
+    The pending-fleet-restart catch-up restarts gateways OUTSIDE any open
+    receipt (the already-up-to-date path never begins one), so the receipt
+    that owed the restart is never told the debt was paid. Recording the
+    discharge against ``resolved_sha`` is what actually clears
+    ``_receipt_reports_stale_runtime()``; a later pull moves HEAD and
+    correctly re-arms the obligation. Never raises.
+    """
+    if not resolved_sha:
+        return False
+    try:
+        directory = _receipt_dir()
+        latest = directory / "latest.json"
+        if not latest.is_file():
+            return False
+        data = json.loads(latest.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return False
+        if fleet:
+            data["fleet"] = fleet
+        data["fleet_restart_resolved_sha"] = str(resolved_sha)
+        data["fleet_restart_resolved_at"] = _utc_now_iso()
+        payload = json.dumps(data, indent=2, default=str)
+        latest.write_text(payload, encoding="utf-8")
+        # Keep the timestamped twin in sync when it mirrors this receipt, so
+        # the archived copy does not contradict the pointer.
+        try:
+            stamped = sorted(
+                (p for p in directory.glob("update_*.json") if p.is_file()),
+                key=lambda p: p.stat().st_mtime,
+                reverse=True,
+            )
+            if stamped:
+                twin = json.loads(stamped[0].read_text(encoding="utf-8"))
+                if isinstance(twin, dict) and twin.get("started_at") == data.get(
+                    "started_at"
+                ):
+                    stamped[0].write_text(payload, encoding="utf-8")
+        except (OSError, ValueError) as exc:
+            logger.debug("Could not sync timestamped receipt twin: %s", exc)
+        return True
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Could not record fleet resolution: %s", exc)
+        return False
+
+
 def _prune_old_receipts(directory: Path) -> None:
     with suppress(Exception):
         receipts = (p for p in directory.glob("update_*.json") if p.is_file())

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -543,3 +543,83 @@ def test_startup_warn_silent_when_nothing_pending(capsys):
     captured = capsys.readouterr()
     assert captured.err == ""
     assert captured.out == ""
+
+
+def _write_owing_receipt(disk_sha: str, old_sha: str):
+    """A failed receipt with an empty fleet — the shape that owes a restart."""
+    receipt_dir = get_hermes_home() / "logs" / "update_receipts"
+    receipt_dir.mkdir(parents=True, exist_ok=True)
+    (receipt_dir / "latest.json").write_text(
+        json.dumps(
+            {
+                "started_at": "T0",
+                "exit_code": 1,
+                "stop_reason": "sys.exit(1)",
+                "outcome": "failed",
+                "fleet": [],
+                "plan": {
+                    "expected_sha": disk_sha,
+                    "runtimes": [
+                        {"kind": "gateway", "profile": "default",
+                         "pid": 4242, "code_sha": old_sha}
+                    ],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_catchup_restart_discharges_the_receipt_obligation(monkeypatch):
+    """The catch-up must clear the condition, not just the marker.
+
+    Regression: ``_apply_pending_fleet_restart_catchup`` cleared only the
+    breadcrumb file, so a failed receipt with an empty ``fleet`` kept
+    falling back to its pre-pull ``plan.runtimes[].code_sha`` — which can
+    never match HEAD — and the "did not restart running gateways" warning
+    re-fired on every CLI startup even after the fleet was verifiably
+    restarted. Proven red on base: without the receipt discharge, the
+    post-catch-up assertion below fails.
+    """
+    disk_sha = "1" * 40
+    old_sha = "2" * 40
+    # Patch where production reads: the catch-up late-imports from update_cmd;
+    # the recorder uses update_cmd_fleet's own module-level binding.
+    monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: disk_sha)
+    monkeypatch.setattr(update_cmd_fleet, "_current_checkout_sha", lambda: disk_sha)
+    monkeypatch.setattr(update_cmd, "_run_pending_fleet_restart", lambda: True)
+
+    update_cmd._write_fleet_restart_pending_marker()
+    _write_owing_receipt(disk_sha, old_sha)
+    assert update_cmd_fleet._pending_fleet_restart_needed() is True
+
+    # Clearing the marker alone must NOT be enough (the original bug).
+    update_cmd_fleet._clear_fleet_restart_pending_marker()
+    assert update_cmd_fleet._pending_fleet_restart_needed() is True
+
+    # The real catch-up entry point discharges the receipt obligation too.
+    update_cmd._write_fleet_restart_pending_marker()
+    update_cmd_fleet._apply_pending_fleet_restart_catchup()
+    assert update_cmd_fleet._pending_fleet_restart_needed() is False
+
+
+def test_catchup_resolution_is_rearmed_by_a_later_pull(monkeypatch):
+    """A resolution is scoped to the SHA it discharged, not forever: a later
+    pull moves HEAD and the obligation must come back."""
+    from hermes_cli.update_receipt import record_fleet_resolution
+
+    disk_sha = "3" * 40
+    old_sha = "4" * 40
+    newer_sha = "5" * 40
+    monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: disk_sha)
+    monkeypatch.setattr(update_cmd_fleet, "_current_checkout_sha", lambda: disk_sha)
+
+    _write_owing_receipt(disk_sha, old_sha)
+    assert record_fleet_resolution(
+        [{"state": "current", "code_sha": disk_sha}], disk_sha
+    ) is True
+    assert update_cmd_fleet._pending_fleet_restart_needed() is False
+
+    monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: newer_sha)
+    monkeypatch.setattr(update_cmd_fleet, "_current_checkout_sha", lambda: newer_sha)
+    assert update_cmd_fleet._pending_fleet_restart_needed() is True


### PR DESCRIPTION
## Problem

Refs #98022. When a `hermes update` is interrupted after `git pull` advanced HEAD but before the fleet restart (receipt: `outcome=failed`, `fleet=[]`), the next already-up-to-date `hermes update` runs the catch-up restart — but only clears the `fleet_restart_pending` marker file. `_pending_fleet_restart_needed()` **also** consults `update_receipts/latest.json`, and an unfinished receipt with an empty `fleet` matrix falls back to `plan.runtimes[].code_sha`, which was captured *before* the pull and can never match the post-pull checkout. The result: `⚠ A previous hermes update pulled new code but did not restart running gateways` re-fires on **every CLI startup forever**, even after the fleet was verifiably restarted onto current code (observed live: gateway PID changed twice — once via manual `hermes gateway restart`, once via the catch-up — while the warning persisted).

## Fix

After a successful catch-up restart, stamp the owing receipt with `fleet_restart_resolved_sha` (+ `fleet_restart_resolved_at`, and a fresh `collect_fleet_versions()` matrix when the probe succeeds), via a new never-raising `record_fleet_resolution()` in `update_receipt.py`. `_receipt_reports_stale_runtime()` honours the stamp. The discharge is scoped to the SHA it was recorded against: a later pull moves HEAD and correctly re-arms the obligation. The timestamped receipt twin is kept in sync so the archived copy doesn't contradict the `latest.json` pointer.

Mechanism follows the design first proposed by @RootZ3n in #100249 — same SHA-scoped discharge semantics, rebased onto current `main` (the fleet code moved `update_cmd.py` → `update_cmd_fleet.py`, which is why #100249 now conflicts) — full credit for the approach. This PR additionally wires the recording into the real catch-up entry point on the post-split layout and verifies against a real interrupted receipt.

## Tests (discriminator-verified)

Two invariant tests in `tests/hermes_cli/test_update_fleet_restart_pending.py`, both proven red on base (reverting only the two source files on the committed tree fails both in 0.2s; restoring passes both):

- `test_catchup_restart_discharges_the_receipt_obligation` — end-to-end through the real `_apply_pending_fleet_restart_catchup()`: marker-only clearing leaves the obligation pending (the original bug); the catch-up discharges it.
- `test_catchup_resolution_is_rearmed_by_a_later_pull` — the resolution is SHA-scoped, not forever.

Local run: `scripts/run_tests.sh tests/hermes_cli/test_update_fleet_restart_pending.py` → 15 passed, 2 failed — the 2 failures (`test_marker_written_after_pull_cleared_after_successful_restart`, `test_clean_update_warns_about_surviving_pre_update_serve_runtime`) reproduce identically on unmodified `main` on this macOS host (live-service interaction class, cf. #95830), i.e. pre-existing, not from this change.

E2E against a real interrupted receipt (the actual `latest.json` from a genuinely failed update, replayed in a sandbox `HERMES_HOME`): `_pending_fleet_restart_needed()` flips `True → False` after `record_fleet_resolution(None, HEAD)`, with the stamp persisted.

## Out of scope (noted, not silently dropped)

- A manual `hermes gateway restart` (no update involved) still doesn't discharge the receipt — the warning's remediation text mentions it, but only the catch-up path records the resolution here. Happy to extend if you want that covered in this PR.
