### PR TITLE
fix(agent): improve unknown persistence failure guidance

### DIFF
--- a/agent/turn_explainers.py
+++ b/agent/turn_explainers.py
@@ -137,7 +137,9 @@ _PERSISTENCE_CAUSE_EXPLANATIONS: Dict[str, str] = {
 _PERSISTENCE_DEFAULT_EXPLANATION = (
     "the turn was stopped because session storage could not be "
     "written (the transcript would have been lost on restart). "
-    "Check the state database health (`hermes doctor`), then "
+    "A concurrent session compression or another state database "
+    "write may be responsible. Check the state database health "
+    "(`hermes doctor`) and gateway log, then "
     "send your message again."
 )
 

--- a/tests/run_agent/test_turn_completion_explainer.py
+++ b/tests/run_agent/test_turn_completion_explainer.py
@@ -444,3 +444,9 @@ def test_classify_persistence_error_quarantined_handle_is_corrupt() -> None:
     from hermes_state import StateDbCorruptError, classify_persistence_error
 
     assert classify_persistence_error(StateDbCorruptError("quarantined")) == "corrupt"
+
+def test_session_persistence_explanation_includes_concurrent_compression():
+    """Unknown storage failures retain local concurrent-write troubleshooting."""
+    out = AIAgent._format_turn_completion_explanation("session_persistence_failed")
+    assert "concurrent session compression" in out.lower()
+    assert "gateway log" in out.lower()


### PR DESCRIPTION
## What does this PR do?
Improve the fallback explanation for an unclassified session-persistence failure. It points users to possible concurrent compression or another database writer, and to the gateway log alongside `hermes doctor`.

This is a diagnostic-text change only: it does **not** alter storage writes, recovery, locking, or the failure classifier, and does not assert that concurrency is always the cause.

## Related issue / scope
No exact existing diagnostic-text PR was found in the persistence/concurrent-session search. Kept separate from storage and gateway fixes so it can be reviewed independently.

## Changes
- `agent/turn_explainers.py`: extend the unknown-cause troubleshooting hint.
- `tests/run_agent/test_turn_completion_explainer.py`: pin the concurrency and gateway-log guidance.

## Verification
- Windows 11 / Python 3.11: `python -m pytest tests/run_agent/test_turn_completion_explainer.py -q -o addopts=` — **25 passed**.
- `python -m ruff check --select E9,F63,F7,F82 agent/turn_explainers.py tests/run_agent/test_turn_completion_explainer.py` — passed.
- `git diff --check` — passed.
- The two-file candidate was statically reviewed and then tested in an isolated checkout of the upstream base.
- Full repository suite not run; CI results remain to be checked by the normal upstream workflow.

## Checklist
- [x] Read the contributing guide and searched related PRs.
- [x] Conventional commit; only this diagnostic and its regression test.
- [x] Focused regression executed on Windows.
- [ ] Full repository test suite / upstream CI.
- [x] No configuration, dependency, or storage-schema change.
