### PR TITLE
fix(desktop): bound unspoken turn speech to current turn when anchor is missing (#102372)

### DIFF
--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -1337,6 +1337,22 @@ describe('collectUnspokenTurnSpeech', () => {
     expect(speech?.pending).toBe(true)
   })
 
+  it('bounds speech to the latest visible user turn when lastSpokenId is null in multi-turn history', () => {
+    const messages = [
+      user('u0', 'First ancient question'),
+      assistant('a0', 'First ancient answer from question 1.'),
+      user('u1', 'Latest current question'),
+      assistant('a1', 'Narration.', { interim: true }),
+      assistant('a2', 'Current real answer.')
+    ]
+
+    const speech = collectUnspokenTurnSpeech(messages, null)
+
+    expect(speech?.id).toBe('a1')
+    expect(speech?.text).toBe('Narration.\n\nCurrent real answer.')
+    expect(speech?.text).not.toContain('First ancient answer')
+  })
+
   it('returns null when everything is spoken or there is no assistant text', () => {
     expect(collectUnspokenTurnSpeech([], null)).toBeNull()
     expect(collectUnspokenTurnSpeech([assistant('a1', 'Done.')], 'a1')).toBeNull()

--- a/apps/desktop/src/lib/chat-messages/parts.ts
+++ b/apps/desktop/src/lib/chat-messages/parts.ts
@@ -74,12 +74,13 @@ export function collectUnspokenTurnSpeech(
   lastSpokenId: string | null
 ): UnspokenTurnSpeech | null {
   const spokenIndex = lastSpokenId ? messages.findLastIndex(m => m.id === lastSpokenId) : -1
+  const startIndex = spokenIndex >= 0 ? spokenIndex : messages.findLastIndex(m => m.role === 'user' && !m.hidden)
 
   let id: string | null = null
   let pending = false
   const parts: string[] = []
 
-  for (const message of messages.slice(spokenIndex + 1)) {
+  for (const message of messages.slice(startIndex + 1)) {
     if (message.role !== 'assistant' || message.hidden) {
       continue
     }


### PR DESCRIPTION
## Bug Description

When Desktop voice conversation starts in an existing or hydrated chat and no valid `lastSpokenId` anchor is available, `collectUnspokenTurnSpeech()` treats the entire hydrated transcript as unspoken. It selects an old assistant reply from earlier in the chat (often the very first assistant message in history) instead of the current reply.

Fixes #102372

## Root Cause

In `apps/desktop/src/lib/chat-messages/parts.ts`, `collectUnspokenTurnSpeech` computes:
```ts
const spokenIndex = lastSpokenId ? messages.findLastIndex(m => m.id === lastSpokenId) : -1
for (const message of messages.slice(spokenIndex + 1)) {
```
When `lastSpokenId` is `null` (such as on newly opened or hydrated chats, or when voice conversation starts without prior spoken state), `spokenIndex` evaluates to `-1`. Consequently, `messages.slice(0)` slices the transcript from the very beginning, turning ancient assistant replies into unspoken backlog.

## Fix

When `spokenIndex < 0`, bound speech collection to the current turn by finding the latest visible user message (`messages.findLastIndex(m => m.role === 'user' && !m.hidden)`):
```ts
const startIndex = spokenIndex >= 0 ? spokenIndex : messages.findLastIndex(m => m.role === 'user' && !m.hidden)
for (const message of messages.slice(startIndex + 1)) {
```
This ensures:
1. When a valid `lastSpokenId` exists, existing anchor tracking behavior is preserved intact.
2. When `lastSpokenId` is absent in a conversation with prior history, speech collection is strictly bounded to assistant responses after the latest user turn.
3. In a fresh chat without user messages (e.g. an initial bot greeting), `findLastIndex` returns `-1`, so `startIndex + 1` remains `0` and allows the greeting to be voiced.

## How to Verify

1. Open a chat with existing historical messages.
2. Ensure voice conversation / auto speak replies is triggered.
3. Submit a new turn.
4. Verify that only the current assistant reply is synthesized and spoken, rather than replaying responses from earlier turns.

## Test Plan

- [x] Added regression test in `apps/desktop/src/lib/chat-messages.test.ts` verifying that `collectUnspokenTurnSpeech` does not pick historical replies when `lastSpokenId` is null in multi-turn history.
- [x] Ran vitest test suite (`74/74 passed`).
- [x] Live manual verification on Desktop.

## Risk Assessment

Low — Narrow scoped boundary check that only takes effect when `lastSpokenId` is missing/unmatched, cleanly falling back to the current turn's user boundary.
