### PR TITLE
fix(memory): refuse batch that would empty a non-empty store (#103419)

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -733,6 +733,7 @@ class TestBatchRefusesToEmptyNonEmptyStore:
 
         assert result["success"] is False
         assert "current_entries" in result  # actionable, counts toward degrade budget
+        assert "single remove()" in result["error"]  # points at the deliberate-wipe path
         assert seed in path.read_text(encoding="utf-8")  # nothing written
         assert path.read_text(encoding="utf-8") == before
         assert seed in store._entries_for(target)

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -704,3 +704,55 @@ class TestBomToleranceInMemoryFiles:
         raw, read_ok = MemoryStore._read_raw_checked(path)
         assert read_ok is False
         assert raw == ""
+
+
+# =========================================================================
+# Batch must not silently empty a non-empty store (#103419)
+#
+# A background consolidation batch that removes the last remaining entry
+# commits an empty USER.md/MEMORY.md as a normal successful write — silent
+# profile data loss. The batch path must refuse to reduce a previously
+# non-empty target to zero entries (all-or-nothing: nothing is written).
+# Single remove-last stays allowed (explicit delete, pinned elsewhere).
+# =========================================================================
+
+
+class TestBatchRefusesToEmptyNonEmptyStore:
+    @pytest.mark.parametrize(
+        ("target", "seed"),
+        [("user", "Name: Alice"), ("memory", "fact A")],
+    )
+    def test_batch_removing_last_entry_is_refused_and_preserves_disk(
+        self, store, target, seed
+    ):
+        assert store.add(target, seed)["success"] is True
+        path = store._path_for(target)
+        before = path.read_text(encoding="utf-8")
+
+        result = store.apply_batch(target, [{"action": "remove", "old_text": seed}])
+
+        assert result["success"] is False
+        assert "current_entries" in result  # actionable, counts toward degrade budget
+        assert seed in path.read_text(encoding="utf-8")  # nothing written
+        assert path.read_text(encoding="utf-8") == before
+        assert seed in store._entries_for(target)
+
+    @pytest.mark.parametrize(
+        ("target", "seed"),
+        [("user", "Name: Alice"), ("memory", "fact A")],
+    )
+    def test_batch_ending_nonempty_still_succeeds(self, store, target, seed):
+        assert store.add(target, seed)["success"] is True
+        assert store.add(target, "second entry here")["success"] is True
+
+        result = store.apply_batch(
+            target,
+            [
+                {"action": "remove", "old_text": seed},
+                {"action": "add", "content": "replacement entry here"},
+            ],
+        )
+
+        assert result["success"] is True
+        assert seed not in store._entries_for(target)
+        assert "replacement entry here" in store._entries_for(target)

--- a/tools/memory_tool_store.py
+++ b/tools/memory_tool_store.py
@@ -322,14 +322,16 @@ class MemoryStore:
                 # store (#103419): a background consolidation that removes the
                 # last entry would otherwise commit an empty USER.md/MEMORY.md
                 # as a normal successful write. Refuse all-or-nothing so the
-                # model keeps at least one entry; a deliberate wipe is a manual
-                # file edit, not a consolidation side effect.
+                # model keeps at least one entry; deleting the final entry on
+                # purpose is what single remove() calls are for, not a
+                # consolidation side effect.
                 label = "USER.md" if target == "user" else "MEMORY.md"
                 return self._failure_with_entries(target, (
                     f"Refusing to empty {label}: this batch would remove every entry from a "
                     f"previously non-empty profile. Nothing was applied (batch is all-or-nothing). "
                     f"Keep at least one entry — merge overlapping entries into a shorter one instead "
-                    f"of removing the last one (see current_entries below)."))
+                    f"of removing the last one (see current_entries below). To delete the final entry "
+                    f"deliberately, use single remove() calls."))
             new_total = len(ENTRY_DELIMITER.join(working))  # budget check against the FINAL state only
             if new_total > limit:
                 return self._failure_with_entries(target, (

--- a/tools/memory_tool_store.py
+++ b/tools/memory_tool_store.py
@@ -317,6 +317,19 @@ class MemoryStore:
                                            (op.get("old_text") or "").strip(), f"Operation {i + 1} ({act or 'unknown'})")
                 if msg:
                     return self._failure_with_entries(target, msg + " No operations were applied (batch is all-or-nothing).")
+            if entries and not working:
+                # A batch must never silently empty a previously non-empty
+                # store (#103419): a background consolidation that removes the
+                # last entry would otherwise commit an empty USER.md/MEMORY.md
+                # as a normal successful write. Refuse all-or-nothing so the
+                # model keeps at least one entry; a deliberate wipe is a manual
+                # file edit, not a consolidation side effect.
+                label = "USER.md" if target == "user" else "MEMORY.md"
+                return self._failure_with_entries(target, (
+                    f"Refusing to empty {label}: this batch would remove every entry from a "
+                    f"previously non-empty profile. Nothing was applied (batch is all-or-nothing). "
+                    f"Keep at least one entry — merge overlapping entries into a shorter one instead "
+                    f"of removing the last one (see current_entries below)."))
             new_total = len(ENTRY_DELIMITER.join(working))  # budget check against the FINAL state only
             if new_total > limit:
                 return self._failure_with_entries(target, (


### PR DESCRIPTION
## Summary

Background memory consolidation could silently wipe the user profile: a valid `memory(action=batch, target=user)` batch that removed the last remaining entry committed an empty USER.md as a normal successful write (`apply_batch()` computed a final usage of 0 chars, under the limit, and persisted it). Next session behaved as though the profile was brand new.

This PR makes `MemoryStore.apply_batch()` refuse — all-or-nothing, nothing written — any batch that would reduce a previously non-empty store to zero entries, for both `user` (USER.md) and `memory` (MEMORY.md) targets. The refusal returns live `current_entries` through the existing consolidation-failure path, so it counts toward the per-turn degrade budget (#42405) instead of looping the turn.

Fixes #103419.

## Approach

- Single guard inside `apply_batch()`'s `_apply` closure, evaluated on the final `working` list after all ops validate: `if entries and not working` → `_failure_with_entries(...)`. `entries` is the disk-reloaded state inside the lock, so the check cannot go stale.
- Single-entry `remove()` (explicit delete) is intentionally untouched — `test_remove_entry` pins emptying to zero as allowed design there. Only the batch (background-consolidation) path is gated, per the issue's proposed fix.
- A deliberate wipe remains possible via manual file edit, not as a consolidation side effect; no backup machinery needed since refused batches write nothing.

## Tests

- New `TestBatchRefusesToEmptyNonEmptyStore` in `tests/tools/test_memory_tool.py` (parametrized over `user`/`memory`):
  - batch removing the last entry is refused, disk bytes and live entries preserved;
  - batch ending non-empty (remove + add swap) still succeeds.
- Sabotage run: with the fix reverted (`git checkout origin/main -- tools/memory_tool_store.py`), the 2 refusal tests FAIL; with the fix restored, the full file passes 45/45.
- `ruff check` clean on both touched files. (`ruff format --check` flags pre-existing drift across the whole files, unrelated to this change — left untouched per repo guidance.)

## How to Test

`scripts/run_tests.sh tests/tools/test_memory_tool.py` — expect 45 passed.

Manual repro: seed one USER.md entry, call `store.apply_batch('user', [{'action': 'remove', 'old_text': <entry>}])` → `success: False`, file unchanged. Before the fix this returned success with an emptied file.

## Risk

Low. One conditional refusal on one path; success responses and all other ops byte-identical. No migration, no config, rollback = revert one hunk.