### PR TITLE
fix(local-models): resume ranged model downloads per-worker instead of restarting from zero (#103416)

### DIFF
--- a/hermes_cli/web_routers/local_models.py
+++ b/hermes_cli/web_routers/local_models.py
@@ -49,6 +49,13 @@ _LLAMACPP_PROVIDERS = ("llamacpp", "llama.cpp", "llama-cpp")
 _SPLIT_PART_RE = r"-\d{5}-of-\d{5}"
 # One TCP stream to a CDN rarely fills a fast line; 8 ranged connections into a preallocated file saturate gigabit.
 _DOWNLOAD_CONNECTIONS = 8
+# A dropped connection on any one of the 8 range workers must not discard the gigabytes the
+# other workers already wrote: each worker retries its own remaining sub-range from the last
+# byte it wrote (Range: bytes=<high-water>-<end>), with exponential backoff, before the whole
+# download is failed. On a 16 GB GGUF over flaky Wi-Fi/VPN this turns a total restart-from-zero
+# into a few seconds of re-fetching one worker's tail. (#103416)
+_DOWNLOAD_RANGE_RETRIES = 4
+_DOWNLOAD_RANGE_BACKOFF = 1.0
 _CHUNK = 4 << 20
 _SERVER_START_FAILED = "The local server could not start — check the runtime is installed"
 
@@ -333,13 +340,32 @@ def download_file(url: str, dest: Path, job: Dict[str, Any], *, base_done: int =
                 job["done_bytes"] = base_done + file_done[0]
 
     def fetch_range(start: int, end: int) -> None:
-        try:
-            req = urllib.request.Request(url, headers={"Range": f"bytes={start}-{end}"})
-            with urllib.request.urlopen(req, timeout=120) as r, open(tmp, "r+b") as f:
-                f.seek(start)
-                pump(r, f)
-        except Exception as exc:  # noqa: BLE001
-            errors.append(exc)
+        # ``pos`` is the next byte this worker still needs. It advances per chunk as bytes land on
+        # disk — so if a read drops mid-stream, ``pos`` already reflects what was written and the
+        # retry re-requests only bytes=<pos>-<end>, never re-downloading (or re-counting) the head.
+        pos = start
+        for attempt in range(_DOWNLOAD_RANGE_RETRIES + 1):
+            try:
+                req = urllib.request.Request(url, headers={"Range": f"bytes={pos}-{end}"})
+                with urllib.request.urlopen(req, timeout=120) as r, open(tmp, "r+b") as f:
+                    f.seek(pos)
+                    for chunk in iter(lambda: r.read(_CHUNK), b""):
+                        f.write(chunk)
+                        pos += len(chunk)
+                        with progress_lock:
+                            file_done[0] += len(chunk)
+                            job["done_bytes"] = base_done + file_done[0]
+                if pos > end:
+                    return  # full sub-range delivered (ranges are inclusive: last byte is ``end``)
+                # Server closed the stream early without raising — treat the short read as retryable.
+                raise RuntimeError(f"range {start}-{end} ended early at byte {pos}")
+            except Exception as exc:  # noqa: BLE001
+                if pos > end:
+                    return  # the failure arrived after the last needed byte; the range is complete
+                if attempt >= _DOWNLOAD_RANGE_RETRIES:
+                    errors.append(exc)
+                    return
+                time.sleep(_DOWNLOAD_RANGE_BACKOFF * (2 ** attempt))
 
     try:
         # Probe and preallocation take real seconds on a 20+ GB file — narrate them, or the pane shows a dead '— of X GB'.

--- a/tests/hermes_cli/test_local_model_download_resume.py
+++ b/tests/hermes_cli/test_local_model_download_resume.py
@@ -1,0 +1,119 @@
+"""Regression tests for resumable ranged model downloads (issue #103416).
+
+Large local-model downloads (16 GB GGUF) run over 8 parallel Range connections
+into a preallocated ``.part`` file. Before #103416 a drop on any one connection
+raised out of the whole download and the ``.part`` was deleted, discarding every
+worker's completed bytes — a 7 GB head start lost to one Wi-Fi/VPN blip, retry
+restarting from zero.
+
+These tests pin the fix: each range worker retries its own *remaining* sub-range
+from the last byte it wrote, so a transient mid-stream drop costs only a re-fetch
+of that worker's tail, never the other workers' gigabytes. A drop that outlasts
+the retry budget still fails the download and removes the ``.part`` (a preallocated
+zero-filled file is useless without range metadata).
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+import hermes_cli.web_routers.local_models as lm
+
+
+class _FakeResp:
+    """Serves a byte slice, optionally raising mid-stream after ``fail_after`` bytes."""
+
+    def __init__(self, data: bytes, fail_after: int | None = None):
+        self._data = data
+        self._pos = 0
+        self._fail_after = fail_after
+        self.status = 206
+
+    def read(self, n: int = -1) -> bytes:
+        if self._fail_after is not None and self._pos >= self._fail_after:
+            raise ConnectionResetError("simulated connection drop")
+        end = len(self._data) if n is None or n < 0 else min(self._pos + n, len(self._data))
+        if self._fail_after is not None:
+            end = min(end, self._fail_after)
+        chunk = self._data[self._pos:end]
+        self._pos = end
+        return chunk
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _install_fake_transport(monkeypatch, master: bytes, *, drop_plan: dict[int, int] | None = None):
+    """Patch urlopen so range requests are served from ``master`` in memory.
+
+    ``drop_plan`` maps a range-start offset -> number of bytes to deliver before the
+    FIRST request for that start raises (the retry for the advanced start succeeds).
+    """
+    monkeypatch.setattr(lm, "_probe_range_support", lambda url: len(master))
+    monkeypatch.setattr(lm, "_CHUNK", 4)  # small reads so a drop lands mid-range
+    monkeypatch.setattr(lm.time, "sleep", lambda *_a, **_k: None)
+    seen_starts: set[int] = set()
+    seen_lock = threading.Lock()
+    drop_plan = dict(drop_plan or {})
+
+    def fake_urlopen(req, timeout=None):
+        rng = req.headers["Range"].split("=", 1)[1]
+        start_s, end_s = rng.split("-")
+        start, end = int(start_s), int(end_s)
+        fail_after = None
+        with seen_lock:
+            if start in drop_plan and start not in seen_starts:
+                fail_after = drop_plan[start]
+            seen_starts.add(start)
+        return _FakeResp(master[start:end + 1], fail_after=fail_after)
+
+    monkeypatch.setattr(lm.urllib.request, "urlopen", fake_urlopen)
+
+
+def test_range_worker_resumes_after_mid_stream_drop(monkeypatch, tmp_path):
+    """A drop on one of the 8 workers costs only that worker's tail — no lost bytes,
+    no double counting, the assembled file is byte-exact."""
+    total = lm._DOWNLOAD_CONNECTIONS * 8  # 64 bytes, 8 bytes per worker
+    master = bytes((i * 7 + 3) & 0xFF for i in range(total))
+    # Worker 3 owns bytes [24, 31]; deliver 3 bytes, then drop. Retry resumes at 27.
+    _install_fake_transport(monkeypatch, master, drop_plan={24: 3})
+
+    dest = tmp_path / "model.gguf"
+    job: dict = {}
+    lm.download_file("https://example/model.gguf", dest, job)
+
+    assert dest.read_bytes() == master
+    assert not dest.with_suffix(".part").exists()
+    # Every byte counted exactly once — the resumed request must not re-pump bytes 24-26.
+    assert job["done_bytes"] == total
+    assert job["total_bytes"] == total
+
+
+def test_download_fails_and_clears_part_when_drops_outlast_retries(monkeypatch, tmp_path):
+    """A worker that never gets past its first byte exhausts the retry budget; the whole
+    download fails and the ``.part`` is removed (no truncated file staged)."""
+    monkeypatch.setattr(lm, "_DOWNLOAD_RANGE_RETRIES", 2)
+    total = lm._DOWNLOAD_CONNECTIONS * 8
+    master = bytes(range(total % 256)) if total <= 256 else bytes(total)
+    monkeypatch.setattr(lm, "_probe_range_support", lambda url: total)
+    monkeypatch.setattr(lm, "_CHUNK", 4)
+    monkeypatch.setattr(lm.time, "sleep", lambda *_a, **_k: None)
+
+    def always_drop(req, timeout=None):
+        rng = req.headers["Range"].split("=", 1)[1]
+        start = int(rng.split("-", 1)[0])
+        # Worker 0 (start 0) always drops immediately; others would succeed.
+        return _FakeResp(master[start:], fail_after=0 if start == 0 else None)
+
+    monkeypatch.setattr(lm.urllib.request, "urlopen", always_drop)
+
+    dest = tmp_path / "model.gguf"
+    with pytest.raises(Exception):
+        lm.download_file("https://example/model.gguf", dest, {})
+    assert not dest.with_suffix(".part").exists()
+    assert not dest.exists()


### PR DESCRIPTION
Fixes #103416.

## Problem
Large local-model downloads (e.g. a 16 GB GGUF) run over 8 parallel Range connections into a preallocated `.part` file. When any one of the eight workers hit a dropped connection, `fetch_range` recorded the error and `download_file` re-raised it — and the `except` block ran `tmp.unlink(missing_ok=True)`, deleting the `.part` and **every worker's completed bytes**. The retry then restarted from byte 0. On a connection that drops every few GB (VPN/TUN, ordinary Wi-Fi blips — amplified by 8 concurrent range connections), a big model could effectively never finish. The issue reports 5 consecutive failures in one day, the best reaching 7.4 of 16.4 GB before dying.

## Fix
Each range worker now retries its **own remaining sub-range** instead of aborting the whole download:

- A per-worker `pos` high-water mark advances per chunk as bytes land on disk. If a read drops mid-stream, `pos` already reflects what was written, so the retry re-requests only `bytes=<pos>-<end>` — never re-downloading, and never double-counting toward progress, the head it already has.
- Retries use bounded exponential backoff (`_DOWNLOAD_RANGE_RETRIES = 4`). A short read that ends without raising is treated as a retryable early close.
- A drop that outlasts the retry budget still fails the download and removes the `.part`, exactly as before — a preallocated zero-filled file is useless without range metadata.

This is the in-attempt resilience the issue names as the minimum fix ("per-range retry within one attempt would avoid losing a 7 GB head start over one dropped connection"). One transient drop now costs a re-fetch of a single worker's tail rather than a restart from zero.

## Scope / follow-up
Cross-invocation resume (retrying a *new* `download_file` call against an existing on-disk `.part`) is deliberately **out of scope**: the `.part` is preallocated and zero-filled, so completed bytes can't be told from padding without a persisted per-range manifest. That's a larger, separate change; this PR fixes the dominant failure mode (a single flaky connection nuking gigabytes mid-attempt) with a localized change and no new on-disk format.

## Tests
`tests/hermes_cli/test_local_model_download_resume.py`:
- `test_range_worker_resumes_after_mid_stream_drop` — a worker drops mid-range; asserts the assembled file is byte-exact, `.part` is gone, and progress counts each byte exactly once (proving the resume didn't re-pump the head).
- `test_download_fails_and_clears_part_when_drops_outlast_retries` — a worker that never advances exhausts the retry budget; the download fails and the `.part` is removed.

Note: the arm64-fork-Docker CI job is expected to fail on fork PRs and is unrelated to this change.
