### PR TITLE
fix(skills): honor session cwd during project discovery

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -414,20 +414,24 @@ _PROJECT_ROOT_MAX_DEPTH = 64  # walk-up bound for pathological cwds
 
 def find_project_root(start: Optional[Path] = None) -> Optional[Path]:
     """Nearest ancestor containing ``.git`` (dir or worktree file), or None.
-    Without *start*, the surface's ``TERMINAL_CWD`` wins over process cwd so
-    cron/API surfaces inherit an interactive trust decision by project identity.
+    Without *start*, the surface's effective cwd wins over process cwd. This
+    includes a per-session cwd override before the scoped ``TERMINAL_CWD``, so
+    Desktop sessions and non-interactive surfaces inherit trust by project
+    identity.
 
-    When *start* is not given, the surface's working directory wins over the process cwd: ``TERMINAL_CWD``
-    is the same per-surface workdir the terminal tool and cron jobs use (a cron job sets it from its per-job
-    ``workdir`` without chdir'ing the scheduler process). This is what lets non-interactive surfaces inherit
-    a prior interactive trust decision by project identity — and a surface with no workdir in a trusted repo
-    simply resolves no project and loads nothing (#48975).
+    When *start* is not given, the surface's working directory wins over the
+    process cwd: the session override or ``TERMINAL_CWD`` is the same
+    per-surface workdir the terminal tool and cron jobs use (a cron job sets it
+    from its per-job ``workdir`` without chdir'ing the scheduler process). This
+    is what lets interactive and non-interactive surfaces inherit a prior trust
+    decision by project identity — and a surface with no workdir in a trusted
+    repo simply resolves no project and loads nothing (#48975).
     """
     try:
         if start is None:
-            from agent.runtime_cwd import scope_terminal_cwd
-            env_cwd = scope_terminal_cwd()
-            start = Path(env_cwd) if env_cwd else Path.cwd()
+            from agent.runtime_cwd import resolve_context_cwd
+            context_cwd = resolve_context_cwd()
+            start = context_cwd if context_cwd is not None else Path.cwd()
         cur = Path(start).resolve()
     except OSError:
         return None

--- a/tests/agent/test_project_skills.py
+++ b/tests/agent/test_project_skills.py
@@ -139,6 +139,24 @@ class TestNonInteractiveInheritance:
         assert su.find_project_root() == project_env["repo"].resolve()
         assert su.get_project_skills_dirs() != []
 
+    def test_session_cwd_overrides_stale_terminal_cwd(self, project_env, monkeypatch, tmp_path):
+        # Desktop binds the selected workspace per session while the gateway's
+        # process-level fallback may still point at another relative directory.
+        outside = tmp_path / "elsewhere"
+        outside.mkdir()
+        monkeypatch.chdir(outside)
+        monkeypatch.setenv("TERMINAL_CWD", "./workspace")
+        _trust(project_env["config"], project_env["repo"])
+
+        from agent.runtime_cwd import clear_session_cwd, set_session_cwd
+
+        set_session_cwd(str(project_env["repo"]))
+        try:
+            assert su.find_project_root() == project_env["repo"].resolve()
+            assert su.get_project_skills_dirs() != []
+        finally:
+            clear_session_cwd()
+
     def test_no_workdir_no_trust_inheritance(self, project_env, monkeypatch, tmp_path):
         # A surface running outside any repo (API server from home-like dir)
         # resolves no project even when OTHER repos are trusted.


### PR DESCRIPTION
## What does this PR do?

Fixes project-local skill discovery for sessions that have an explicit `session.cwd` while the gateway also has a global `TERMINAL_CWD`.

The session-aware runtime cwd resolver already exists and is used by terminal/runtime paths. This change makes project-root discovery use that same resolver.

## Related Issue

Fixes #103423

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Updated `agent.skill_utils.find_project_root()` to use `resolve_context_cwd()`.
- Preserved the fallback to scoped `TERMINAL_CWD` and then process cwd.
- Added a regression test for `session.cwd` taking precedence over a stale/global `TERMINAL_CWD`.
- Kept the existing `skills.trusted_project_dirs` security gate unchanged.

## How to Test

```bash
/opt/homebrew/bin/pytest \
  tests/agent/test_project_skills.py \
  tests/agent/test_runtime_cwd.py \
  -o 'addopts=' -q
```

Result:

```text
28 passed
```

Relevant Gateway tests:

```bash
/opt/homebrew/bin/pytest tests/test_tui_gateway_server.py \
  -o 'addopts=' -q \
  -k 'cwd or session_context or workspace'
```

Result:

```text
24 passed, 613 deselected
```

Additional checks:

- `python3 -m py_compile agent/skill_utils.py tests/agent/test_project_skills.py`
- `git diff --check`

## Compatibility and Security

- Sessions with `session.cwd` use that directory for project discovery.
- Non-interactive surfaces without `session.cwd` continue to use scoped `TERMINAL_CWD`.
- Project-local skills remain gated by `skills.trusted_project_dirs`.
- No Desktop-specific code changes are required.
- The change introduces no new configuration keys or environment variables.
