### PR TITLE
fix: omit temperature for bare k3 Kimi slugs in auxiliary calls

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -580,10 +580,16 @@ def _bare_model(model: Optional[str]) -> str:
     return (model or "").strip().lower().rsplit("/", 1)[-1]
 
 
+# K3 slug family: bare k3, plan variants like k3-256k, kimi-k3* aliases.
+# Same boundary-token regex as agent/reasoning_effort._KIMI_K3_SLUG_RE (from #76427,
+# credit @ruizanthony) so temperature handling and effort vocabulary never disagree.
+_KIMI_K3_SLUG_RE = re.compile(r"(?:^|[^a-z0-9])k3(?:[^a-z0-9]|$)")
+
+
 def _is_kimi_model(model: Optional[str]) -> bool:
     """True for any Kimi / Moonshot model that manages temperature server-side."""
     bare = _bare_model(model)
-    return bare.startswith("kimi-") or bare == "kimi"
+    return bare.startswith("kimi-") or bare == "kimi" or bool(_KIMI_K3_SLUG_RE.search(bare))
 
 
 def _is_arcee_trinity_thinking(model: Optional[str]) -> bool:


### PR DESCRIPTION
## Summary

`_is_kimi_model()` in `agent/auxiliary_client.py` only matched `kimi-*` slugs, so the bare `k3` model name (and plan variants like `k3-256k`) fell through. Auxiliary calls such as session title generation then went out with `temperature=0.3`, which the Moonshot endpoint rejects:

```
HTTP 400: invalid temperature: only 1 is allowed for this model
```

This applies the same boundary-token slug regex already used for K3 reasoning-effort detection in `agent/reasoning_effort.py` (`_KIMI_K3_SLUG_RE`, from #76427, credit @ruizanthony) so temperature omission and effort vocabulary never disagree on what counts as a K3 model.

## Repro

1. Set `auxiliary.title_generation.provider: custom:kimi-oauth` and `model: k3`.
2. Start any chat session.
3. Title generation fails with `HTTP 400: invalid temperature: only 1 is allowed for this model`; sessions stay untitled or fall back to a snippet.

## Fix

`_is_kimi_model()` now also matches the `_KIMI_K3_SLUG_RE` boundary-token regex (`k3`, `k3-256k`, `kimi-k3-cot`, never `mk3000` or `kimi-k2.6`). `_fixed_temperature_for_model()` returns `OMIT_TEMPERATURE` for these slugs, so the temperature key is stripped and the server manages it.

## Test plan

- [x] 15 targeted assertions: k3 family detected, K2 and unrelated slugs unchanged, no false positives (`mk3000`, `gpt-4o`, `None`)
- [x] `tests/agent/test_auxiliary_client.py`: 192 passed
- [x] Live end-to-end: fresh session with `custom:kimi-oauth` + `k3` generates a title with no 400 and no temperature warning
