### PR TITLE
fix(cli): decode percent-encoded fs paths that arrive double-encoded

### DIFF
--- a/hermes_cli/web_routers/files.py
+++ b/hermes_cli/web_routers/files.py
@@ -654,7 +654,7 @@ async def fs_write_text(payload: FsWriteText):
     temp file and ``os.replace``-d so a crash can't truncate the original.
     Stale-on-disk detection is the client's job (re-read before save).
     """
-    target = _fs_path(payload.path)
+    target = _fs_path(payload.path, decode_fallback=False)
     text = payload.content or ""
     if len(text.encode("utf-8")) > _FS_TEXT_WRITE_MAX_BYTES:
         raise HTTPException(status_code=413, detail="Content too large")

--- a/hermes_cli/web_server_files.py
+++ b/hermes_cli/web_server_files.py
@@ -21,7 +21,14 @@ class ManagedFilesPolicy:
     can_change_path: bool
 
 
-def _fs_path(raw_path: str) -> Path:
+def _resolve_fs_candidate(raw: str) -> Path:
+    candidate = Path(raw).expanduser()
+    if not candidate.is_absolute():
+        candidate = Path.cwd() / candidate
+    return candidate.resolve(strict=False)
+
+
+def _fs_path(raw_path: str, *, decode_fallback: bool = True) -> Path:
     raw = str(raw_path or "").strip()
     if not raw:
         raise HTTPException(status_code=400, detail="Path is required")
@@ -33,10 +40,17 @@ def _fs_path(raw_path: str) -> Path:
             if parsed.netloc and parsed.netloc not in {"", "localhost"}:
                 raise ValueError
             raw = urllib.request.url2pathname(parsed.path)
-        candidate = Path(raw).expanduser()
-        if not candidate.is_absolute():
-            candidate = Path.cwd() / candidate
-        return candidate.resolve(strict=False)
+        candidate = _resolve_fs_candidate(raw)
+        # A remote client hop may percent-encode a path on top of HTTP's own
+        # decoding, so a non-ASCII name can arrive as a literal "%E5%8D%8A..."
+        # string that stats as missing (issue #103425). The verbatim path wins
+        # whenever it exists, so filenames that genuinely contain "%XX" keep
+        # resolving as-is; the unquoted form only rescues the lookup.
+        if decode_fallback and "%" in raw and not candidate.exists():
+            decoded = _resolve_fs_candidate(urllib.parse.unquote(raw))
+            if decoded.exists():
+                candidate = decoded
+        return candidate
     except (OSError, RuntimeError, ValueError):
         raise HTTPException(status_code=400, detail="Invalid path")
 

--- a/tests/hermes_cli/test_web_server_fs.py
+++ b/tests/hermes_cli/test_web_server_fs.py
@@ -1,4 +1,5 @@
 import base64
+import urllib.parse
 from pathlib import Path
 
 import pytest
@@ -89,3 +90,43 @@ def test_fs_endpoints_require_auth(tmp_path):
     assert list_response.status_code == 401
     assert read_response.status_code == 401
     assert default_response.status_code == 401
+
+
+def test_fs_read_text_decodes_double_encoded_non_ascii_path(client, tmp_path):
+    target = tmp_path / "半导体行业运营分享会纪要.md"
+    target.write_text("hello")
+
+    # One percent-encoding on top of HTTP's own query decoding: the server
+    # receives the literal "%E5%8D%8A..." string (issue #103425).
+    double_encoded = urllib.parse.quote(str(target))
+
+    response = client.get("/api/fs/read-text", params={"path": double_encoded})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["path"] == str(target)
+    assert body["text"] == "hello"
+
+
+def test_fs_read_text_keeps_literal_percent_filename_verbatim(client, tmp_path):
+    target = tmp_path / "50%25off.md"
+    target.write_text("literal percent name")
+
+    response = client.get("/api/fs/read-text", params={"path": str(target)})
+
+    assert response.status_code == 200
+    assert response.json()["text"] == "literal percent name"
+
+
+def test_fs_write_text_never_decodes_percent_path(client, tmp_path):
+    sibling = tmp_path / "report v2.md"
+    sibling.write_text("existing")
+
+    response = client.post(
+        "/api/fs/write-text",
+        json={"path": str(tmp_path / "report%20v2.md"), "content": "new"},
+    )
+
+    assert response.status_code == 200
+    assert sibling.read_text() == "existing"
+    assert (tmp_path / "report%20v2.md").read_text() == "new"


### PR DESCRIPTION
## What does this PR do?

A remote-client hop can percent-encode an `/api/fs` path on top of HTTP's own query decoding, so a non-ASCII (CJK) filename reaches the gateway as a literal `%E5%8D%8A...` string. `_fs_path` never percent-decodes a plain path, the stat fails, and the dashboard file preview returns `404 {"detail":"File not found"}` even though the file exists (#103425).

`_fs_path` now resolves the verbatim path first and only falls back to one `unquote` retry when that path does not exist on disk:

- filenames that genuinely contain `%XX` sequences keep resolving verbatim (the fallback only fires when the literal path is missing and the decoded form exists);
- write-text opts out of the fallback so creating a literal-percent filename can never silently overwrite its decoded sibling.

## Related Issue

Fixes #103425

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server_files.py`: extracted path candidate resolution into `_resolve_fs_candidate`; `_fs_path` gained a decode-retry fallback (verbatim path wins whenever it exists) behind a `decode_fallback` switch.
- `hermes_cli/web_routers/files.py`: `fs_write_text` passes `decode_fallback=False` to keep literal-percent write semantics.
- `tests/hermes_cli/test_web_server_fs.py`: three regression tests — double-encoded CJK preview now 200s, literal `%XX` filenames stay verbatim, write-text never decodes paths.

## How to Test

1. `pytest tests/hermes_cli/test_web_server_fs.py -q` — Observed result: 8 passed (the double-encoded CJK test fails with 404 on unpatched `_fs_path`, confirming the red→green transition).
2. `pytest tests/hermes_cli/test_web_server.py tests/hermes_cli/test_web_server_fs.py -q` — Observed result: 193 passed, 1 skipped.
3. Manual equivalent of the issue repro: request `GET /api/fs/read-text?path=<percent-encoded absolute path of a CJK-named file>` — should return 200 with the decoded file path/text instead of 404.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Red→green proof on the regression test (unpatched `_fs_path`):

```
GET http://testserver/api/fs/read-text?path=...%25E5%258D%258A... → 404 Not Found
FAILED tests/hermes_cli/test_web_server_fs.py::test_fs_read_text_decodes_double_encoded_non_ascii_path
```