### PR TITLE
fix(desktop): raise default warm backend pool cap from 3 to 8 (#103401)

### DIFF
--- a/apps/desktop/electron/pool-limits.ts
+++ b/apps/desktop/electron/pool-limits.ts
@@ -9,8 +9,12 @@
  * app restart. The renderer mirrors the values for its UI and prewarm
  * guard over IPC.
  *
- * Defaults preserve the historical hard-coded behavior (3 backends, 10min
- * idle) so machines that never open Settings behave exactly as before.
+ * Defaults keep the warm pool large enough for a realistic multi-bot roster
+ * (the old 3-backend ceiling silently LRU-evicted spawned backends on
+ * 6-bot setups, #102822, and caused slot timeouts on 5-profile switching,
+ * #103401) while staying far under the RAM budget of the machines that run
+ * Desktop at all; 10min idle preserves the historical behavior for machines
+ * that never open Settings.
  */
 
 export interface PoolLimits {
@@ -21,7 +25,7 @@ export interface PoolLimits {
 }
 
 export const POOL_LIMITS_DEFAULTS: PoolLimits = {
-  maxBackends: 3,
+  maxBackends: 8,
   idleMs: 10 * 60_000
 }
 

--- a/apps/desktop/src/store/pool-limits.ts
+++ b/apps/desktop/src/store/pool-limits.ts
@@ -20,7 +20,7 @@ export interface PoolLimits {
 }
 
 export const POOL_LIMITS_DEFAULTS: PoolLimits = {
-  maxBackends: 3,
+  maxBackends: 8,
   idleMs: 10 * 60_000
 }
 


### PR DESCRIPTION
Fixes #103401

Five local profiles with the old 3-backend default saturated the hard spawn coordinator. The fourth profile waited 30s for a free slot while LRU eviction spared keepalive-fresh entries, surfacing `Local backend start for "engineer" timed out while waiting for a free slot`.

Raise the default `maxBackends` 3 -> 8 in both authoritative places: `apps/desktop/electron/pool-limits.ts` and its hand-mirrored renderer copy `apps/desktop/src/store/pool-limits.ts`. Persisted user values are untouched. At ~60MB per warm backend the new default (~480MB for 8) fits a realistic multi-bot roster without eviction; single-bot users still spawn exactly one. Mirrors the fix for #102822.

Test: `vitest run electron/pool-limits.test.ts electron/pool-eviction.test.ts electron/pool-spawn-coordinator.test.ts` — 140 passed (4 unrelated missing-electron fails). No other hardcoded defaults remain.