### PR TITLE
feat(slack): interactive Block Kit model picker for /model

### DIFF
--- a/gateway/platforms/ADDING_A_PLATFORM.md
+++ b/gateway/platforms/ADDING_A_PLATFORM.md
@@ -119,7 +119,7 @@ If your platform supports interactive button/menu messages, implement these for 
 | `send_clarify(chat_id, question, choices, clarify_id, session_key, ...)` | Render the `clarify` tool's multi-choice question as tappable buttons. Pair with inbound dispatch that routes button taps to `tools.clarify_gateway.resolve_gateway_clarify`. |
 | `send_exec_approval(chat_id, command, session_key, description, ...)` | Render dangerous-command approval as Approve/Deny buttons. Inbound dispatch routes to `tools.approval.resolve_gateway_approval`. |
 | `send_slash_confirm(chat_id, title, message, session_key, confirm_id, ...)` | Render slash-command confirmations (e.g. `/reload-mcp`) as Once/Always/Cancel buttons. Inbound dispatch routes to `tools.slash_confirm.resolve`. |
-| `send_model_picker(...)` | Interactive `/model` picker. Used by Telegram and Discord. |
+| `send_model_picker(...)` | Interactive `/model` picker. Used by Telegram, Discord, and Slack (Socket Mode). |
 | `send_choice_picker(...)` | Flat single-level picker for finite-choice commands (`/reasoning`, `/fast`). Implemented by Telegram (inline keyboard), Discord (select menu), and Matrix (reactions). Platforms without it fall back to the text status card automatically. |
 
 See `gateway/platforms/telegram.py`, `discord.py`, and `whatsapp_cloud.py` for reference implementations. The button-callback id convention (`cl:<id>:<idx>`, `appr:<id>:<choice>`, `sc:<choice>:<id>`) is shared across adapters — match it so the gateway-side resolvers work without modification.

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -59,6 +59,23 @@ _HERMES_SLACK_USER_AGENT_PREFIX = f"HermesAgent/{_HERMES_VERSION}"
 _SLACK_ERROR_BODY_LIMIT_BYTES = 8 * 1024
 _BOOL_WORDS = frozenset({"1", "0", "true", "false", "yes", "no", "on", "off"})
 
+# Model picker Block Kit action IDs. The picker is a two-step drill-down:
+# provider static_select → model static_select, plus Back/Cancel buttons.
+_MODEL_PICKER_PROVIDER_ACTION = "hermes_model_provider"
+_MODEL_PICKER_MODEL_ACTION = "hermes_model_model"
+_MODEL_PICKER_BACK_ACTION = "hermes_model_back"
+_MODEL_PICKER_CANCEL_ACTION = "hermes_model_cancel"
+# Rendered when a live-looking picker message can no longer resolve (gateway
+# restart, aged-out state entry, or a value the stored state no longer
+# covers): the message is rewritten to this so the control visibly dies.
+_MODEL_PICKER_EXPIRED_NOTICE = "⏳ This model picker expired — please run /model again."
+_MODEL_PICKER_ACTION_IDS = (
+    _MODEL_PICKER_PROVIDER_ACTION,
+    _MODEL_PICKER_MODEL_ACTION,
+    _MODEL_PICKER_BACK_ACTION,
+    _MODEL_PICKER_CANCEL_ACTION,
+)
+
 
 def _slack_unfurl_kwargs(extra: Optional[Dict[str, Any]]) -> Dict[str, bool]:
     """Explicitly configured link-preview controls (omitted key = Slack default). String bools are
@@ -854,6 +871,9 @@ class SlackAdapter(BasePlatformAdapter):
     _REACTING_MESSAGE_IDS_MAX = _TITLED_ASSISTANT_THREADS_MAX = 5000
     _CHANNEL_TEAM_MAX = 10000
     _APPROVAL_RESOLVED_MAX = _CLARIFY_RESOLVED_MAX = _ACTIVE_STATUS_THREADS_MAX = 1000
+    # Tighter cap than the approval/clarify dicts: each entry holds the
+    # full provider list, and a picker is only live for minutes.
+    _MODEL_PICKER_STATE_MAX = 100
     _STATUS_MESSAGE_IDS_MAX = 2000
     _THREAD_CACHE_MAX = 2500
     _THREAD_CACHE_TTL = 60.0
@@ -899,6 +919,12 @@ class SlackAdapter(BasePlatformAdapter):
         # Bounded: never-clicked prompts would otherwise leak forever.
         self._approval_resolved: Dict[Any, bool] = {}
         self._clarify_resolved: Dict[Any, bool] = {}
+        # Model picker state keyed by workspace message marker (team_id, ts) →
+        # picker context (providers, session_key, on_model_selected, stage).
+        # Mirrors _approval_resolved / _clarify_resolved: bounded, and the
+        # marker scopes entries per workspace so multi-workspace installs
+        # never resolve a picker against another tenant's session.
+        self._model_picker_state: Dict[Any, dict] = {}
         # Bot-sent message ts / @mentioned threads: replies there get answered without a mention.
         self._bot_message_ts: set[str] = set()
         self._mentioned_threads: set[str] = set()
@@ -1503,6 +1529,10 @@ class SlackAdapter(BasePlatformAdapter):
         # Block Kit requires unique IDs within an actions block.
         self._app.action(re.compile(r"^hermes_clarify_choice_\d+$"))(self._handle_clarify_action)
         self._app.action("hermes_clarify_other")(self._handle_clarify_action)
+        # Register Block Kit action handlers for the model picker
+        # (provider/model static_select + Back/Cancel buttons).
+        for _action_id in _MODEL_PICKER_ACTION_IDS:
+            self._app.action(_action_id)(self._handle_model_picker_action)
         self._register_plugin_action_handlers()
         # ctx.register_platform_handler("slack", ...) factories get the full
         # AsyncApp surface (event/action/command), wired before Socket Mode starts.
@@ -4607,6 +4637,399 @@ class SlackAdapter(BasePlatformAdapter):
             return f"{title or 'Confirm'}: {body[:100]}", blocks
 
         return await self._send_interactive_prompt(chat_id, metadata, _build, "send_slash_confirm")
+
+    def _build_model_picker_provider_blocks(
+        self, providers: list, current_model: str, provider_label: str
+    ) -> List[dict]:
+        """Build the provider-select stage of the model picker.
+
+        A section header (current model/provider) plus an actions block with a
+        ``static_select`` of providers and a Cancel button. Provider option
+        ``value`` carries the list index (same scheme as the model stage) so
+        an over-long custom provider slug never trips Slack's 75-char option
+        value cap — the handler resolves the real slug from picker state.
+        """
+        options = []
+        for idx, p in enumerate(providers[:100]):
+            count = p.get("total_models", len(p.get("models", [])))
+            options.append({
+                "text": {"type": "plain_text", "text": f"{p['name']} ({count} models)"[:75], "emoji": True},
+                "value": str(idx),
+            })
+        extra = (
+            f"\n*{len(providers) - 100} more available — type `/model <name>` directly*"
+            if len(providers) > 100
+            else ""
+        )
+        section_text = (
+            f"*⚙ Model Configuration*\n"
+            f"Current model: `{current_model or 'unknown'}`\n"
+            f"Provider: {provider_label}\n\n"
+            f"Select a provider:{extra}"
+        )
+        return [
+            {"type": "section", "text": {"type": "mrkdwn", "text": section_text[:3000]}},
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "static_select",
+                        "placeholder": {"type": "plain_text", "text": "Choose a provider…", "emoji": True},
+                        "action_id": _MODEL_PICKER_PROVIDER_ACTION,
+                        "options": options,
+                    },
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "Cancel", "emoji": True},
+                        "style": "danger",
+                        "action_id": _MODEL_PICKER_CANCEL_ACTION,
+                        "value": "cancel",
+                    },
+                ],
+            },
+        ]
+
+    def _build_model_picker_model_blocks(self, providers: list, provider_slug: str) -> List[dict]:
+        """Build the model-select stage for a chosen provider.
+
+        A section header (provider name) plus an actions block with a
+        ``static_select`` of models and Back/Cancel buttons. Model option
+        ``value`` carries the list index so over-long model IDs never trip
+        Slack's 75-char value cap; the handler resolves the real model ID
+        from the provider's model list in picker state.
+        """
+        provider = next((p for p in providers if p["slug"] == provider_slug), None)
+        pname = provider.get("name", provider_slug) if provider else provider_slug
+        models = (provider or {}).get("models", [])[:100]
+        options = []
+        for idx, model_id in enumerate(models):
+            short = model_id.split("/")[-1] if "/" in model_id else model_id
+            options.append({
+                "text": {"type": "plain_text", "text": short[:75], "emoji": True},
+                "value": str(idx),
+            })
+        total = (provider or {}).get("total_models", len(models))
+        extra = (
+            f"\n*{total - len(models)} more available — type `/model <name>` directly*"
+            if total > len(models)
+            else ""
+        )
+        section_text = f"*⚙ Model Configuration*\n\nProvider: *{pname}*\nSelect a model:{extra}"
+        elements = [
+            {
+                "type": "static_select",
+                "placeholder": {"type": "plain_text", "text": f"Choose a model from {pname}…"[:150], "emoji": True},
+                "action_id": _MODEL_PICKER_MODEL_ACTION,
+                "options": options,
+            },
+        ]
+        if provider_slug:
+            elements.append({
+                "type": "button",
+                "text": {"type": "plain_text", "text": "◀ Back", "emoji": True},
+                "action_id": _MODEL_PICKER_BACK_ACTION,
+                "value": provider_slug,
+            })
+        elements.append({
+            "type": "button",
+            "text": {"type": "plain_text", "text": "Cancel", "emoji": True},
+            "style": "danger",
+            "action_id": _MODEL_PICKER_CANCEL_ACTION,
+            "value": "cancel",
+        })
+        return [
+            {"type": "section", "text": {"type": "mrkdwn", "text": section_text[:3000]}},
+            {"type": "actions", "elements": elements},
+        ]
+
+    async def send_model_picker(
+        self,
+        chat_id: str,
+        providers: list,
+        current_model: str,
+        current_provider: str,
+        session_key: str,
+        on_model_selected,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an interactive Block Kit model picker.
+
+        Two-step drill-down: provider ``static_select`` → model
+        ``static_select``, with Back/Cancel buttons. Resolves via
+        ``_handle_model_picker_action``, which calls ``on_model_selected`` on
+        a model choice.
+        """
+        if not self._app:
+            return SendResult(success=False, error="Not connected")
+
+        chat_id = await self._ensure_dm_conversation(
+            chat_id, team_id=self._metadata_team_id(metadata)
+        )
+        try:
+            thread_ts = self._resolve_thread_ts(None, metadata)
+
+            try:
+                from hermes_cli.providers import get_label
+                provider_label = get_label(current_provider)
+            except Exception:
+                provider_label = current_provider
+
+            if not providers:
+                return SendResult(success=False, error="No providers available")
+
+            blocks = self._build_model_picker_provider_blocks(
+                providers, current_model, provider_label
+            )
+
+            kwargs: Dict[str, Any] = {
+                "channel": chat_id,
+                "text": "⚙ Model Configuration — select a provider",
+                "blocks": sanitize_blocks(blocks),
+            }
+            if thread_ts:
+                kwargs["thread_ts"] = thread_ts
+
+            result = await self._get_client(
+                chat_id, team_id=self._metadata_team_id(metadata)
+            ).chat_postMessage(**kwargs)
+            msg_ts = result.get("ts", "")
+            if not msg_ts:
+                return SendResult(success=False, error="No message timestamp returned")
+
+            team_id = self._metadata_team_id(metadata)
+            self._model_picker_state[
+                self._workspace_message_marker(team_id, msg_ts)
+            ] = {
+                "providers": providers,
+                "session_key": session_key,
+                "chat_id": chat_id,
+                "team_id": team_id,
+                "current_model": current_model,
+                "current_provider": current_provider,
+                "on_model_selected": on_model_selected,
+                "stage": "provider",
+                "selected_provider_slug": "",
+            }
+            self._trim_oldest_dict_entries(
+                self._model_picker_state, self._MODEL_PICKER_STATE_MAX
+            )
+
+            return SendResult(success=True, message_id=msg_ts, raw_response=result)
+        except Exception as e:
+            logger.error("[Slack] send_model_picker failed: %s", e, exc_info=True)
+            return SendResult(success=False, error=str(e))
+
+    async def _update_picker_message(
+        self,
+        channel_id: str,
+        team_id: str,
+        msg_ts: str,
+        section_text: str,
+    ) -> None:
+        """Replace the picker message body with a plain section (no controls)."""
+        try:
+            await self._get_client(channel_id, team_id=team_id or None).chat_update(
+                channel=channel_id,
+                ts=msg_ts,
+                text=section_text[:3000],
+                blocks=sanitize_blocks([
+                    {"type": "section", "text": {"type": "mrkdwn", "text": section_text[:3000]}},
+                ]),
+            )
+        except Exception as e:
+            logger.warning("[Slack] Failed to update model picker message: %s", e)
+
+    async def _handle_model_picker_action(self, ack, body, action) -> None:
+        """Handle a model picker Block Kit interaction.
+
+        Dispatches on the action_id: provider static_select advances to the
+        model stage, model static_select runs ``on_model_selected``, Back
+        returns to the provider stage, Cancel dismisses the picker.
+        """
+        await ack()
+
+        team_id = self._event_team_id({}, body)
+        action_id = action.get("action_id", "")
+        message = body.get("message", {})
+        msg_ts = message.get("ts", "")
+        channel_id = body.get("channel", {}).get("id", "")
+        user_name = body.get("user", {}).get("name", "unknown")
+        user_id = body.get("user", {}).get("id", "")
+
+        if not self._is_interactive_user_authorized(
+            user_id,
+            channel_id=channel_id,
+            user_name=user_name,
+            team_id=team_id,
+        ):
+            logger.warning(
+                "[Slack] Unauthorized model picker click by %s (%s) - ignoring",
+                user_name, user_id,
+            )
+            return
+
+        # Look up the picker state. The send path may have stored it under a
+        # bare ts (metadata-poor send, no team id) while this click event
+        # carries a team id — that mismatch must not swallow a legitimate
+        # interaction (mirrors _handle_approval_action's dual-key lookup).
+        marker = self._workspace_message_marker(team_id, msg_ts)
+        if msg_ts in self._model_picker_state:
+            marker = msg_ts
+        state = self._model_picker_state.get(marker)
+        if not state:
+            logger.debug("[Slack] Model picker state not found for marker=%s", marker)
+            # Gateway restarted or the entry aged out of the bounded dict —
+            # there is no gateway-side registry to fall back on, so this
+            # dict is the picker's only state. Kill the live-looking
+            # control visibly instead of silently swallowing clicks
+            # (mirrors the clarify handler's expiry notice).
+            await self._update_picker_message(
+                channel_id, team_id, msg_ts, _MODEL_PICKER_EXPIRED_NOTICE
+            )
+            return
+
+        providers = state.get("providers", [])
+        on_model_selected = state.get("on_model_selected")
+
+        # Cancel → dismiss.
+        if action_id == _MODEL_PICKER_CANCEL_ACTION:
+            self._model_picker_state.pop(marker, None)
+            await self._update_picker_message(
+                channel_id, team_id, msg_ts, "❌ Model selection cancelled."
+            )
+            return
+
+        # Provider selected → advance to model stage. The option value is a
+        # list index into the stored providers slice (never the raw slug —
+        # custom slugs can exceed Slack's 75-char option value cap).
+        if action_id == _MODEL_PICKER_PROVIDER_ACTION:
+            selected = action.get("selected_option", {})
+            idx_token = selected.get("value", "")
+            try:
+                idx = int(idx_token)
+                provider = providers[idx] if idx >= 0 else None
+            except (ValueError, IndexError, TypeError):
+                provider = None
+            if provider is None:
+                # Message and stored state are out of sync (stale payload,
+                # re-seeded entry) — the picker can no longer resolve, so
+                # kill it visibly like the expiry path.
+                logger.warning("[Slack] Invalid provider picker index token: %r", idx_token)
+                self._model_picker_state.pop(marker, None)
+                await self._update_picker_message(
+                    channel_id, team_id, msg_ts, _MODEL_PICKER_EXPIRED_NOTICE
+                )
+                return
+            provider_slug = provider.get("slug", "")
+            if not provider.get("models"):
+                await self._update_picker_message(
+                    channel_id, team_id, msg_ts,
+                    f"No models available for `{provider_slug}`.",
+                )
+                self._model_picker_state.pop(marker, None)
+                return
+
+            state["stage"] = "model"
+            state["selected_provider_slug"] = provider_slug
+            blocks = self._build_model_picker_model_blocks(providers, provider_slug)
+            try:
+                await self._get_client(channel_id, team_id=team_id or None).chat_update(
+                    channel=channel_id,
+                    ts=msg_ts,
+                    text=f"⚙ Model Configuration — {provider.get('name', provider_slug)}",
+                    blocks=sanitize_blocks(blocks),
+                )
+            except Exception as e:
+                logger.warning("[Slack] Failed to update model picker (provider→model): %s", e)
+            return
+
+        # Back → return to provider stage.
+        if action_id == _MODEL_PICKER_BACK_ACTION:
+            state["stage"] = "provider"
+            state["selected_provider_slug"] = ""
+            try:
+                from hermes_cli.providers import get_label
+                provider_label = get_label(
+                    state.get("current_provider", "")
+                )
+            except Exception:
+                provider_label = state.get("current_provider", "")
+            blocks = self._build_model_picker_provider_blocks(
+                providers, state.get("current_model", ""), provider_label
+            )
+            try:
+                await self._get_client(channel_id, team_id=team_id or None).chat_update(
+                    channel=channel_id,
+                    ts=msg_ts,
+                    text="⚙ Model Configuration — select a provider",
+                    blocks=sanitize_blocks(blocks),
+                )
+            except Exception as e:
+                logger.warning("[Slack] Failed to update model picker (back): %s", e)
+            return
+
+        # Model selected → run the switch.
+        if action_id == _MODEL_PICKER_MODEL_ACTION and state.get("stage") == "model":
+            selected = action.get("selected_option", {})
+            idx_token = selected.get("value", "")
+            provider_slug = state.get("selected_provider_slug", "")
+            provider = next((p for p in providers if p["slug"] == provider_slug), None)
+            models = (provider or {}).get("models", [])
+            try:
+                idx = int(idx_token)
+                model_id = models[idx] if idx >= 0 else None
+            except (ValueError, IndexError, TypeError):
+                model_id = None
+            if model_id is None:
+                # Message and stored state are out of sync — kill the picker
+                # visibly instead of leaving a dead control.
+                logger.warning("[Slack] Invalid model picker index token: %r", idx_token)
+                self._model_picker_state.pop(marker, None)
+                await self._update_picker_message(
+                    channel_id, team_id, msg_ts, _MODEL_PICKER_EXPIRED_NOTICE
+                )
+                return
+
+            if not on_model_selected:
+                self._model_picker_state.pop(marker, None)
+                await self._update_picker_message(
+                    channel_id, team_id, msg_ts, _MODEL_PICKER_EXPIRED_NOTICE
+                )
+                return
+
+            # Pop the state up-front (double-click guard, mirrors approval).
+            self._model_picker_state.pop(marker, None)
+            await self._update_picker_message(
+                channel_id, team_id, msg_ts, f"⚙ Switching to `{model_id}`…"
+            )
+
+            switch_failed = False
+            try:
+                confirmation = await on_model_selected(
+                    state["chat_id"], model_id, provider_slug
+                )
+                # The gateway reports a failed in-place swap as a localized
+                # error-prefixed return string, not an exception (#50163).
+                # Compare against the same i18n prefix so both failure
+                # shapes get the failed header.
+                try:
+                    from agent.i18n import t as _t
+
+                    _error_prefix = _t("gateway.model.error_prefix", error="").strip()
+                except Exception:
+                    _error_prefix = "Error:"
+                if _error_prefix and str(confirmation).startswith(_error_prefix):
+                    switch_failed = True
+            except Exception as exc:
+                logger.error("[Slack] Model picker callback failed: %s", exc, exc_info=True)
+                confirmation = f"❌ Model switch failed: {exc}"
+                switch_failed = True
+
+            header = "⚙ Model Switch Failed" if switch_failed else "⚙ Model Switched"
+            await self._update_picker_message(
+                channel_id, team_id, msg_ts, f"{header}\n\n{confirmation}"
+            )
+            return
 
     async def send_clarify(
         self, chat_id: str, question: str, choices: Optional[list], clarify_id: str,

--- a/tests/gateway/test_slack_model_picker.py
+++ b/tests/gateway/test_slack_model_picker.py
@@ -1,0 +1,732 @@
+"""Tests for the Slack Block Kit interactive model picker.
+
+Mirrors test_slack_approval_buttons.py (harness) and
+test_discord_model_picker.py (semantics) for the ``send_model_picker``
+override and the ``hermes_model_provider`` / ``hermes_model_model`` /
+``hermes_model_back`` / ``hermes_model_cancel`` action dispatch.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure the repo root is importable
+# ---------------------------------------------------------------------------
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+# ---------------------------------------------------------------------------
+# Minimal Slack SDK mock so SlackAdapter can be imported (mirrors
+# test_slack_approval_buttons.py)
+# ---------------------------------------------------------------------------
+def _ensure_slack_mock():
+    if "slack_bolt" in sys.modules:
+        return
+    slack_bolt = MagicMock()
+    slack_bolt.async_app.AsyncApp = MagicMock
+    sys.modules["slack_bolt"] = slack_bolt
+    sys.modules["slack_bolt.async_app"] = slack_bolt.async_app
+    handler_mod = MagicMock()
+    handler_mod.AsyncSocketModeHandler = MagicMock
+    sys.modules["slack_bolt.adapter"] = MagicMock()
+    sys.modules["slack_bolt.adapter.socket_mode"] = MagicMock()
+    sys.modules["slack_bolt.adapter.socket_mode.async_handler"] = handler_mod
+    sdk_mod = MagicMock()
+    sdk_mod.web = MagicMock()
+    sdk_mod.web.async_client = MagicMock()
+    sdk_mod.web.async_client.AsyncWebClient = MagicMock
+    sys.modules["slack_sdk"] = sdk_mod
+    sys.modules["slack_sdk.web"] = sdk_mod.web
+    sys.modules["slack_sdk.web.async_client"] = sdk_mod.web.async_client
+
+
+_ensure_slack_mock()
+
+from plugins.platforms.slack.adapter import SlackAdapter
+from gateway.config import PlatformConfig, Platform
+
+
+def _make_adapter():
+    """Create a SlackAdapter instance with mocked internals."""
+    config = PlatformConfig(enabled=True, token="«redacted:xox…»")
+    adapter = SlackAdapter(config)
+    adapter._app = MagicMock()
+    adapter._bot_user_id = "U_BOT"
+    adapter._team_clients = {"T1": AsyncMock()}
+    adapter._team_bot_user_ids = {"T1": "U_BOT"}
+    adapter._channel_team = {"C1": "T1"}
+    return adapter
+
+
+class _AuthRunner:
+    def __init__(self, auth_fn=None):
+        self._auth_fn = auth_fn or (lambda _source: True)
+        self.seen_sources = []
+
+    async def handle(self, event):
+        return None
+
+    def _is_user_authorized(self, source):
+        self.seen_sources.append(source)
+        return self._auth_fn(source)
+
+
+def _attach_auth_runner(adapter, auth_fn=None):
+    runner = _AuthRunner(auth_fn=auth_fn)
+    adapter.set_message_handler(runner.handle)
+    return runner
+
+
+_PROVIDERS = [
+    {
+        "slug": "openrouter",
+        "name": "OpenRouter",
+        "models": ["anthropic/claude-sonnet-4", "openai/gpt-5"],
+        "total_models": 2,
+        "is_current": True,
+    },
+    {
+        "slug": "anthropic",
+        "name": "Anthropic",
+        "models": ["claude-sonnet-4-20250514"],
+        "total_models": 1,
+        "is_current": False,
+    },
+]
+
+
+def _interaction_body(msg_ts="1234.5678", channel_id="C1", user="alice", uid="U_ALICE"):
+    return {
+        "message": {"ts": msg_ts, "blocks": []},
+        "channel": {"id": channel_id},
+        "user": {"name": user, "id": uid},
+        "team_id": "T1",
+    }
+
+
+# ===========================================================================
+# send_model_picker — Block Kit structure
+# ===========================================================================
+
+class TestSlackModelPickerSend:
+    """Test send_model_picker sends the provider-stage Block Kit."""
+
+    @pytest.mark.asyncio
+    async def test_sends_provider_dropdown(self):
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "1234.5678"})
+
+        async def on_selected(chat_id, model_id, provider_slug):
+            return "Switched!"
+
+        result = await adapter.send_model_picker(
+            chat_id="C1",
+            providers=_PROVIDERS,
+            current_model="anthropic/claude-sonnet-4",
+            current_provider="openrouter",
+            session_key="test-session",
+            on_model_selected=on_selected,
+        )
+
+        assert result.success is True
+        assert result.message_id == "1234.5678"
+
+        kwargs = mock_client.chat_postMessage.call_args[1]
+        assert "blocks" in kwargs
+        blocks = kwargs["blocks"]
+        assert len(blocks) == 2
+        assert blocks[0]["type"] == "section"
+        assert "anthropic/claude-sonnet-4" in blocks[0]["text"]["text"]
+        assert blocks[1]["type"] == "actions"
+
+        elements = blocks[1]["elements"]
+        assert len(elements) == 2
+        assert elements[0]["type"] == "static_select"
+        assert elements[0]["action_id"] == "hermes_model_provider"
+        assert len(elements[0]["options"]) == 2
+        # Option values are list indices, never raw slugs (75-char value cap)
+        assert elements[0]["options"][0]["value"] == "0"
+        assert elements[0]["options"][1]["value"] == "1"
+        assert "OpenRouter" in elements[0]["options"][0]["text"]["text"]
+        assert elements[1]["type"] == "button"
+        assert elements[1]["action_id"] == "hermes_model_cancel"
+
+        # State should be stashed for the callback (no metadata → bare ts key)
+        assert "1234.5678" in adapter._model_picker_state
+        state = adapter._model_picker_state["1234.5678"]
+        assert state["stage"] == "provider"
+        assert state["session_key"] == "test-session"
+
+    @pytest.mark.asyncio
+    async def test_sends_in_thread(self):
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "1.2"})
+
+        async def on_selected(chat_id, model_id, provider_slug):
+            return "ok"
+
+        await adapter.send_model_picker(
+            chat_id="C1",
+            providers=_PROVIDERS,
+            current_model="m",
+            current_provider="openrouter",
+            session_key="s",
+            on_model_selected=on_selected,
+            metadata={"thread_id": "9999.0000"},
+        )
+
+        kwargs = mock_client.chat_postMessage.call_args[1]
+        assert kwargs.get("thread_ts") == "9999.0000"
+
+    @pytest.mark.asyncio
+    async def test_not_connected(self):
+        adapter = _make_adapter()
+        adapter._app = None
+        result = await adapter.send_model_picker(
+            chat_id="C1", providers=[], current_model="", current_provider="",
+            session_key="s", on_model_selected=AsyncMock(),
+        )
+        assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_no_providers(self):
+        adapter = _make_adapter()
+        result = await adapter.send_model_picker(
+            chat_id="C1", providers=[], current_model="", current_provider="",
+            session_key="s", on_model_selected=AsyncMock(),
+        )
+        assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_long_custom_slug_never_reaches_option_value(self):
+        """A custom provider slug >75 chars would fail the whole picker post
+        with invalid_blocks if it were used as an option value; index values
+        keep every value well under the cap."""
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "1234.5678"})
+
+        long_slug = "custom-" + "x" * 100
+        providers = _PROVIDERS + [
+            {"slug": long_slug, "name": "CustomCo", "models": ["m1"], "total_models": 1},
+        ]
+
+        result = await adapter.send_model_picker(
+            chat_id="C1", providers=providers, current_model="m",
+            current_provider="openrouter", session_key="s",
+            on_model_selected=AsyncMock(),
+        )
+
+        assert result.success is True
+        options = (
+            mock_client.chat_postMessage.call_args[1]["blocks"][1]["elements"][0]["options"]
+        )
+        assert len(options) == 3
+        assert all(len(o["value"]) <= 75 for o in options)
+        assert [o["value"] for o in options] == ["0", "1", "2"]
+        assert "CustomCo" in options[2]["text"]["text"]
+
+    @pytest.mark.asyncio
+    async def test_provider_stage_hint_when_over_option_cap(self):
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "1234.5678"})
+
+        providers = [
+            {"slug": f"p{i}", "name": f"P{i}", "models": [f"m{i}"], "total_models": 1}
+            for i in range(120)
+        ]
+
+        result = await adapter.send_model_picker(
+            chat_id="C1", providers=providers, current_model="m",
+            current_provider="p0", session_key="s", on_model_selected=AsyncMock(),
+        )
+
+        assert result.success is True
+        blocks = mock_client.chat_postMessage.call_args[1]["blocks"]
+        options = blocks[1]["elements"][0]["options"]
+        assert len(options) == 100  # static_select caps at 100 options
+        assert "20 more available" in blocks[0]["text"]["text"]
+
+
+# ===========================================================================
+# _handle_model_picker_action — drill-down dispatch
+# ===========================================================================
+
+class TestSlackModelPickerAction:
+    """Test the model picker action handler."""
+
+    def _seed_state(self, adapter, msg_ts="1234.5678", on_selected=None, stage="provider",
+                    selected_provider="", bare_ts=False, providers=None):
+        # bare_ts=True mirrors the metadata-poor send path: no team id, so the
+        # state is keyed by the raw ts instead of the (team_id, ts) marker.
+        key = msg_ts if bare_ts else ("T1", msg_ts)
+        adapter._model_picker_state[key] = {
+            "providers": _PROVIDERS if providers is None else providers,
+            "session_key": "s1",
+            "chat_id": "C1",
+            "team_id": "" if bare_ts else "T1",
+            "current_model": "old",
+            "current_provider": "openrouter",
+            "on_model_selected": on_selected or AsyncMock(return_value="ok"),
+            "stage": stage,
+            "selected_provider_slug": selected_provider,
+        }
+
+    @pytest.mark.asyncio
+    async def test_provider_select_shows_models(self):
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+        self._seed_state(adapter)
+
+        ack = AsyncMock()
+        action = {
+            "action_id": "hermes_model_provider",
+            "selected_option": {"value": "0"},  # index 0 = openrouter
+        }
+
+        await adapter._handle_model_picker_action(ack, _interaction_body(), action)
+
+        ack.assert_called_once()
+        mock_client.chat_update.assert_called_once()
+        update_kwargs = mock_client.chat_update.call_args[1]
+        elements = update_kwargs["blocks"][1]["elements"]
+        assert elements[0]["action_id"] == "hermes_model_model"
+        # Two models for openrouter, values are indices
+        assert [o["value"] for o in elements[0]["options"]] == ["0", "1"]
+        # Back + Cancel buttons present
+        assert elements[1]["action_id"] == "hermes_model_back"
+        assert elements[2]["action_id"] == "hermes_model_cancel"
+
+        state = adapter._model_picker_state[("T1", "1234.5678")]
+        assert state["stage"] == "model"
+        assert state["selected_provider_slug"] == "openrouter"
+
+    @pytest.mark.asyncio
+    async def test_bare_ts_state_resolves_on_team_scoped_click(self):
+        """A team-scoped click must find state stored under the bare ts.
+
+        The metadata-poor send path keys state by raw ts (no team id); the
+        click event still carries one. The handler's dual-key lookup must not
+        swallow that legitimate interaction.
+        """
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+        self._seed_state(adapter, bare_ts=True)
+
+        ack = AsyncMock()
+        action = {
+            "action_id": "hermes_model_provider",
+            "selected_option": {"value": "0"},  # index 0 = openrouter
+        }
+
+        await adapter._handle_model_picker_action(ack, _interaction_body(), action)
+
+        ack.assert_called_once()
+        mock_client.chat_update.assert_called_once()
+        state = adapter._model_picker_state["1234.5678"]
+        assert state["stage"] == "model"
+        assert state["selected_provider_slug"] == "openrouter"
+
+    @pytest.mark.asyncio
+    async def test_provider_select_with_no_models_dismisses_picker(self):
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+        self._seed_state(
+            adapter,
+            providers=[{
+                "slug": "empty", "name": "EmptyCo", "models": [],
+                "total_models": 0, "is_current": False,
+            }],
+        )
+
+        ack = AsyncMock()
+        action = {
+            "action_id": "hermes_model_provider",
+            "selected_option": {"value": "0"},  # the single seeded provider
+        }
+
+        await adapter._handle_model_picker_action(ack, _interaction_body(), action)
+
+        ack.assert_called_once()
+        mock_client.chat_update.assert_called_once()
+        assert "No models available" in mock_client.chat_update.call_args[1]["text"]
+        assert ("T1", "1234.5678") not in adapter._model_picker_state
+
+    @pytest.mark.asyncio
+    async def test_model_select_calls_callback(self):
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        events = []
+
+        async def on_selected(chat_id, model_id, provider_slug):
+            events.append((chat_id, model_id, provider_slug))
+            return "✅ Switched to claude-sonnet-4"
+
+        self._seed_state(
+            adapter, stage="model", selected_provider="openrouter", on_selected=on_selected
+        )
+
+        ack = AsyncMock()
+        action = {
+            "action_id": "hermes_model_model",
+            "selected_option": {"value": "0"},  # index 0 = anthropic/claude-sonnet-4
+        }
+
+        await adapter._handle_model_picker_action(ack, _interaction_body(), action)
+
+        ack.assert_called_once()
+        assert events == [("C1", "anthropic/claude-sonnet-4", "openrouter")]
+
+        # State cleaned up
+        assert ("T1", "1234.5678") not in adapter._model_picker_state
+
+        # chat_update called twice: "Switching..." then the confirmation
+        assert mock_client.chat_update.call_count == 2
+        last_update = mock_client.chat_update.call_args_list[-1][1]
+        assert "⚙ Model Switched" in last_update["text"]
+        assert "Switched to claude-sonnet-4" in last_update["text"]
+
+    @pytest.mark.asyncio
+    async def test_model_select_callback_error_is_reported(self):
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        async def on_selected(chat_id, model_id, provider_slug):
+            raise RuntimeError("boom")
+
+        self._seed_state(
+            adapter, stage="model", selected_provider="openrouter", on_selected=on_selected
+        )
+
+        ack = AsyncMock()
+        action = {"action_id": "hermes_model_model", "selected_option": {"value": "1"}}
+
+        await adapter._handle_model_picker_action(ack, _interaction_body(), action)
+
+        last_update = mock_client.chat_update.call_args_list[-1][1]
+        assert "⚙ Model Switch Failed" in last_update["text"]
+        assert "Model switch failed" in last_update["text"]
+
+    @pytest.mark.asyncio
+    async def test_model_select_gateway_error_return_uses_failure_header(self):
+        """The gateway's error-prefixed return (in-place swap rollback,
+        #50163) must get the failed header too — both failure shapes.
+        """
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        async def on_selected(chat_id, model_id, provider_slug):
+            return f"Error: Model switch to {model_id} failed (boom); staying on old."
+
+        self._seed_state(
+            adapter, stage="model", selected_provider="openrouter", on_selected=on_selected
+        )
+
+        ack = AsyncMock()
+        action = {"action_id": "hermes_model_model", "selected_option": {"value": "0"}}
+
+        await adapter._handle_model_picker_action(ack, _interaction_body(), action)
+
+        last_update = mock_client.chat_update.call_args_list[-1][1]
+        assert last_update["text"].startswith("⚙ Model Switch Failed")
+        assert "staying on old" in last_update["text"]
+
+    @pytest.mark.asyncio
+    async def test_model_select_invalid_index_expires_picker(self):
+        """An unresolvable option value means message↔state desync.
+
+        The picker can no longer resolve, so it dies visibly (expired
+        notice) instead of leaving a dead control.
+        """
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+        on_selected = AsyncMock()
+        self._seed_state(
+            adapter, stage="model", selected_provider="openrouter", on_selected=on_selected
+        )
+
+        ack = AsyncMock()
+        action = {
+            "action_id": "hermes_model_model",
+            "selected_option": {"value": "bogus"},
+        }
+
+        await adapter._handle_model_picker_action(ack, _interaction_body(), action)
+
+        ack.assert_called_once()
+        on_selected.assert_not_called()
+        mock_client.chat_update.assert_called_once()
+        assert "expired" in mock_client.chat_update.call_args[1]["text"].lower()
+        assert ("T1", "1234.5678") not in adapter._model_picker_state
+
+    @pytest.mark.asyncio
+    async def test_model_select_out_of_range_index_expires_picker(self):
+        """Out-of-range and negative indices must not resolve (or wrap)."""
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+        on_selected = AsyncMock()
+        self._seed_state(
+            adapter, stage="model", selected_provider="openrouter", on_selected=on_selected
+        )
+
+        for token in ("2", "-1"):
+            ack = AsyncMock()
+            action = {
+                "action_id": "hermes_model_model",
+                "selected_option": {"value": token},
+            }
+            # Re-seed: the first miss pops the entry.
+            if ("T1", "1234.5678") not in adapter._model_picker_state:
+                self._seed_state(
+                    adapter, stage="model", selected_provider="openrouter",
+                    on_selected=on_selected,
+                )
+
+            await adapter._handle_model_picker_action(ack, _interaction_body(), action)
+
+            on_selected.assert_not_called()
+        assert "expired" in mock_client.chat_update.call_args[1]["text"].lower()
+
+    @pytest.mark.asyncio
+    async def test_provider_select_invalid_index_expires_picker(self):
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+        self._seed_state(adapter)
+
+        ack = AsyncMock()
+        action = {
+            "action_id": "hermes_model_provider",
+            "selected_option": {"value": "7"},  # only 2 providers seeded
+        }
+
+        await adapter._handle_model_picker_action(ack, _interaction_body(), action)
+
+        ack.assert_called_once()
+        mock_client.chat_update.assert_called_once()
+        assert "expired" in mock_client.chat_update.call_args[1]["text"].lower()
+        assert ("T1", "1234.5678") not in adapter._model_picker_state
+
+    @pytest.mark.asyncio
+    async def test_cancel_clears_state(self):
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+        self._seed_state(adapter)
+
+        ack = AsyncMock()
+        action = {"action_id": "hermes_model_cancel", "value": "cancel"}
+
+        await adapter._handle_model_picker_action(ack, _interaction_body(), action)
+
+        ack.assert_called_once()
+        assert ("T1", "1234.5678") not in adapter._model_picker_state
+        mock_client.chat_update.assert_called_once()
+        assert "cancelled" in mock_client.chat_update.call_args[1]["text"].lower()
+
+    @pytest.mark.asyncio
+    async def test_back_returns_to_provider(self):
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+        self._seed_state(adapter, stage="model", selected_provider="openrouter")
+
+        ack = AsyncMock()
+        action = {"action_id": "hermes_model_back", "value": "openrouter"}
+
+        await adapter._handle_model_picker_action(ack, _interaction_body(), action)
+
+        mock_client.chat_update.assert_called_once()
+        update_kwargs = mock_client.chat_update.call_args[1]
+        elements = update_kwargs["blocks"][1]["elements"]
+        assert elements[0]["action_id"] == "hermes_model_provider"
+        state = adapter._model_picker_state[("T1", "1234.5678")]
+        assert state["stage"] == "provider"
+        assert state["selected_provider_slug"] == ""
+
+    @pytest.mark.asyncio
+    async def test_state_not_found_shows_expiry(self):
+        """A click with missing picker state must visibly kill the control.
+
+        The dict is the picker's only state (no gateway-side registry), so a
+        gateway restart or aged-out entry would otherwise leave a
+        live-looking dropdown that silently swallows clicks.
+        """
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+        ack = AsyncMock()
+        action = {"action_id": "hermes_model_provider", "selected_option": {"value": "0"}}
+
+        await adapter._handle_model_picker_action(
+            ack, _interaction_body(msg_ts="nonexistent"), action
+        )
+        ack.assert_called_once()
+        mock_client.chat_update.assert_called_once()
+        assert "expired" in mock_client.chat_update.call_args[1]["text"].lower()
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_user_blocked(self, monkeypatch):
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter, auth_fn=lambda s: s.user_id == "U_OWNER")
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+        self._seed_state(adapter)
+
+        ack = AsyncMock()
+        action = {"action_id": "hermes_model_provider", "selected_option": {"value": "openrouter"}}
+
+        await adapter._handle_model_picker_action(
+            ack, _interaction_body(user="intruder", uid="U_BAD"), action
+        )
+
+        ack.assert_called_once()
+        mock_client.chat_update.assert_not_called()
+        # State unchanged
+        assert adapter._model_picker_state[("T1", "1234.5678")]["stage"] == "provider"
+
+
+# ===========================================================================
+# Gateway integration — routes /model to the picker
+# ===========================================================================
+
+class TestSlackModelPickerGatewayIntegration:
+    """Verify _handle_model_command detects the Slack picker capability."""
+
+    @pytest.mark.asyncio
+    async def test_bare_model_triggers_picker(self, tmp_path, monkeypatch):
+        import types
+
+        import yaml
+
+        from gateway.platforms.base import MessageEvent, MessageType
+        from gateway.session import SessionSource
+
+        captured = {}
+
+        class SlackPickerAdapter:
+            async def send_model_picker(self, *, on_model_selected, **kwargs):
+                captured["called"] = True
+                captured["callback"] = on_model_selected
+                return types.SimpleNamespace(success=True)
+
+        adapter = SlackPickerAdapter()
+
+        from gateway.run import GatewayRunner
+        runner = object.__new__(GatewayRunner)
+        runner.adapters = {Platform.SLACK: adapter}
+        runner._voice_mode = {}
+        runner._session_model_overrides = {}
+        runner._running_agents = {}
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        cfg_path = hermes_home / "config.yaml"
+        cfg_path.write_text(
+            yaml.safe_dump({
+                "model": {"default": "old-model", "provider": "openrouter"},
+                "providers": {},
+            }),
+            encoding="utf-8",
+        )
+
+        import gateway.run as gateway_run
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+        monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+        monkeypatch.setattr(
+            "hermes_cli.model_switch_providers.list_picker_providers",
+            lambda **kw: [{"slug": "openrouter", "name": "OR", "models": ["m1"], "total_models": 1}],
+        )
+
+        event = MessageEvent(
+            text="/model",
+            message_type=MessageType.TEXT,
+            source=SessionSource(
+                platform=Platform.SLACK, chat_id="C1", chat_type="group", user_id="U1"
+            ),
+        )
+
+        result = await runner._handle_model_command(event)
+
+        assert result is None
+        assert captured.get("called") is True
+
+    @pytest.mark.asyncio
+    async def test_text_fallback_when_no_picker(self, tmp_path, monkeypatch):
+        import yaml
+
+        from gateway.platforms.base import MessageEvent, MessageType
+        from gateway.session import SessionSource
+
+        class SlackNoPickerAdapter:
+            pass  # no send_model_picker
+
+        adapter = SlackNoPickerAdapter()
+
+        from gateway.run import GatewayRunner
+        runner = object.__new__(GatewayRunner)
+        runner.adapters = {Platform.SLACK: adapter}
+        runner._voice_mode = {}
+        runner._session_model_overrides = {}
+        runner._running_agents = {}
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        cfg_path = hermes_home / "config.yaml"
+        cfg_path.write_text(
+            yaml.safe_dump({
+                "model": {"default": "old-model", "provider": "openrouter"},
+                "providers": {},
+            }),
+            encoding="utf-8",
+        )
+
+        import gateway.run as gateway_run
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+        monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+        monkeypatch.setattr(
+            "hermes_cli.model_switch_providers.list_authenticated_providers",
+            lambda **kw: [],
+        )
+
+        event = MessageEvent(
+            text="/model",
+            message_type=MessageType.TEXT,
+            source=SessionSource(
+                platform=Platform.SLACK, chat_id="C1", chat_type="group", user_id="U1"
+            ),
+        )
+
+        result = await runner._handle_model_command(event)
+
+        assert isinstance(result, str)
+        assert "old-model" in result


### PR DESCRIPTION
## Summary

Salvage of PR #101542 — interactive Block Kit model picker for Slack `/model` command.

Adds a two-step drill-down picker (provider → model) with Back/Cancel buttons, matching the Discord `ModelPickerView` UX. Resolves through the same gateway callback as Discord/Telegram, so persistence and failed-switch rollback semantics come for free.

## Changes

- `plugins/platforms/slack/adapter.py`:
  - `send_model_picker()` posts Block Kit provider/model picker via `chat_postMessage`
  - `_handle_model_picker_action()` dispatches provider/model/back/cancel actions
  - `_model_picker_state` bounded dict (cap=100, workspace-scoped keys)
  - Expired-state UX: missing state rewrites message to expiry notice
  - Failure header: both exception and gateway error-prefix get 'Failed' header
  - Index-based option values avoid Slack's 75-char value cap
- `gateway/platforms/ADDING_A_PLATFORM.md`: picker hook table now lists Slack
- `tests/gateway/test_slack_model_picker.py`: 21 tests covering send, action dispatch, gateway integration

## Validation

| Check | Result |
|-------|--------|
| Unit tests | 21/21 passed |
| Phase 2a (test suite) | ✓ |
| Phase 2b (smoke tests with real imports) | ✓ |
| Phase 2c (10 Hermes invariant checks) | ✓ |
| Ruff lint | Clean |
| /simplify-code (3 parallel reviewers) | Refactor opportunities identified, not blockers |

## Review Status

Original PR #101542 reviewed and approved by @victor-kyriazakos after all 4 requested changes + 2 non-blocking notes were addressed.

## Credit

Original implementation by @sohomsahaun. Cherry-picked onto fresh `origin/main` to resolve merge conflicts.

Closes #101542
