### PR TITLE
fix(bot-mode): deliver local DMs into a live Bot Chat owner instead of refusing

### DIFF
--- a/tests/test_tui_gateway_bot_dm_live_owner.py
+++ b/tests/test_tui_gateway_bot_dm_live_owner.py
@@ -1,0 +1,76 @@
+"""Live-owner Bot Mode DM handoff (#103030) — the gateway's registered deliverer.
+
+The LOCAL ``message_agent`` path (``tools/bot_mode_dm``) used to spawn a second CLI for
+the target's canonical Bot Chat; when THIS gateway hosts that chat live, the single-owner
+lease fences the subprocess out and the DM is refused (``target_busy``) with no turn ever
+run. The gateway registers ``_deliver_dm_to_live_session`` so the tool submits through
+``prompt.submit(queued=True)`` instead — the same mechanism ``bot_relay.deliver`` uses for
+relayed DMs (#101293). No live session for the profile → ``None`` → subprocess fallback.
+"""
+
+import pytest
+
+from tools import bot_mode_dm
+from tui_gateway import server
+
+
+def test_gateway_registers_live_dm_deliverer():
+    """Server import must wire the handoff into bot_mode_dm — without it the local path
+    stays on the subprocess transport and live-owned targets keep getting refused."""
+    assert server._deliver_dm_to_live_session in bot_mode_dm._LIVE_DM_DELIVERERS
+
+
+def test_deliverer_submits_queued_into_live_bot_chat(monkeypatch):
+    profile_home = "/srv/hermes/profiles/nezuko"
+    record = {"profile_home": profile_home, "pending_title": "Bot Chat"}
+    monkeypatch.setattr(server, "_sessions", {"live-sid": record})
+    monkeypatch.setattr(server, "_profile_home", lambda profile: profile_home)
+    submitted: list[tuple[int, dict]] = []
+
+    def _fake_prompt_submit(rid, params):
+        submitted.append((rid, params))
+        return {"jsonrpc": "2.0", "id": rid, "result": {"ok": True}}
+
+    monkeypatch.setattr(server, "_methods", {"prompt.submit": _fake_prompt_submit})
+
+    receipt = server._deliver_dm_to_live_session("nezuko", "Message from 🤖 tanjiro (@tanjiro): ping")
+
+    assert receipt is not None
+    assert receipt["status"] == "sent"
+    assert receipt["to"] == "@nezuko"
+    assert "open Bot Chat" in receipt["detail"]
+    assert [(rid, params) for rid, params in submitted] == [
+        (0, {"session_id": "live-sid", "text": "Message from 🤖 tanjiro (@tanjiro): ping", "queued": True})
+    ]
+
+
+def test_deliverer_returns_none_without_live_session(monkeypatch):
+    """No live Bot Chat for the profile → None → the subprocess transport runs as before."""
+    monkeypatch.setattr(server, "_sessions", {})
+    monkeypatch.setattr(server, "_profile_home", lambda profile: None)
+    submitted: list[tuple[int, dict]] = []
+
+    def _fake_prompt_submit(rid, params):
+        submitted.append((rid, params))
+        return {"jsonrpc": "2.0", "id": rid, "result": {"ok": True}}
+
+    monkeypatch.setattr(server, "_methods", {"prompt.submit": _fake_prompt_submit})
+
+    assert server._deliver_dm_to_live_session("nezuko", "ping") is None
+    assert submitted == []
+
+
+def test_deliverer_defers_to_subprocess_transport_on_submit_error(monkeypatch):
+    """A prompt.submit error surfaces through the subprocess transport's error shaping
+    (target_busy refusal + retry policy) instead of a half-acknowledged delivery."""
+    profile_home = "/srv/hermes/profiles/nezuko"
+    record = {"profile_home": profile_home, "pending_title": "Bot Chat"}
+    monkeypatch.setattr(server, "_sessions", {"live-sid": record})
+    monkeypatch.setattr(server, "_profile_home", lambda profile: profile_home)
+
+    def _failing_prompt_submit(rid, params):
+        return {"jsonrpc": "2.0", "id": rid, "error": {"code": 4009, "message": "session busy"}}
+
+    monkeypatch.setattr(server, "_methods", {"prompt.submit": _failing_prompt_submit})
+
+    assert server._deliver_dm_to_live_session("nezuko", "ping") is None

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -338,6 +338,58 @@ def test_named_profile_sender_prefix(tmp_path, monkeypatch):
     )
 
 
+# ── live-owner handoff (#103030) ─────────────────────────────────────────────
+
+
+def test_live_owner_delivery_skips_subprocess(tmp_path, monkeypatch):
+    """When a surface hosts the target's canonical Bot Chat live, message_agent hands the
+    DM to that owner instead of spawning a subprocess the single-owner lease fences out
+    into a target_busy refusal."""
+    home = _managed_home(tmp_path, teammates=("researcher",))
+    agent = _FakeAgent(home, title="Bot Chat")
+    calls: list[tuple[str, str]] = []
+
+    def _live_deliverer(profile: str, content: str):
+        calls.append((profile, content))
+        return {"status": "sent", "to": f"@{profile}",
+                "detail": "Delivered into the recipient's open Bot Chat; the reply will appear there."}
+
+    monkeypatch.setattr(bot_mode_dm, "_LIVE_DM_DELIVERERS", [_live_deliverer])
+    spawn = _capture_spawn(monkeypatch)
+
+    result = json.loads(
+        bot_mode_dm.message_agent_tool(target="researcher", message="ping", agent=agent)
+    )
+
+    assert calls == [("researcher", "Message from 🤖 hermes (@hermes): ping")]
+    assert result["status"] == "sent"
+    assert "open Bot Chat" in result["detail"]
+    assert spawn == []  # the fenced-out subprocess transport never runs
+
+
+def test_live_owner_delivery_falls_back_when_no_live_session(tmp_path, monkeypatch):
+    """A deliverer that reports no live session leaves the subprocess transport untouched."""
+    home = _managed_home(tmp_path, teammates=("researcher",))
+    agent = _FakeAgent(home, title="Bot Chat")
+    calls: list[tuple[str, str]] = []
+
+    def _no_live_session(profile: str, content: str):
+        calls.append((profile, content))
+        return None
+
+    monkeypatch.setattr(bot_mode_dm, "_LIVE_DM_DELIVERERS", [_no_live_session])
+    spawn = _capture_spawn(monkeypatch)
+
+    result = json.loads(
+        bot_mode_dm.message_agent_tool(target="researcher", message="ping", agent=agent)
+    )
+
+    assert calls == [("researcher", "Message from 🤖 hermes (@hermes): ping")]
+    assert result["status"] == "sent"
+    assert result["process_id"]
+    assert len(spawn) == 1
+
+
 def test_spawn_failure_reports_error(tmp_path, monkeypatch):
     home = _managed_home(tmp_path)
     agent = _FakeAgent(home, title="Bot Chat")

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -27,7 +27,7 @@ import sys
 import tempfile
 import time
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 # Top-level imports stay stdlib-only: this module also runs directly as the background
 # delivery runner (``python bot_mode_dm.py --run-delivery …``); Hermes helpers import lazily.
@@ -38,6 +38,36 @@ MESSAGE_AGENT_TOOL_NAME = "message_agent"
 
 # Message body cap — generous for real work, small enough that a runaway paste can't
 # turn one DM into a context bomb on the recipient.
+MESSAGE_MAX_CHARS = 16000
+
+# Live-owner delivery hooks: surfaces that host live Bot Chat sessions (the TUI/desktop
+# gateway) register a deliverer so message_agent can hand the turn to the target session's
+# existing owner instead of spawning a second CLI that the single-owner lease fences out
+# into a target_busy refusal (#103030, completing #101293's relay-path fix). Each hook is
+# ``fn(profile_name, content) -> ack dict | None``: an ack dict is returned to the sender
+# as the tool result; None means no live session for that profile here and the caller falls
+# back to the subprocess transport. Registration inversion mirrors tools/approval's
+# ``_gateway_notify_cbs`` — tools never import the server that hosts the sessions.
+_LIVE_DM_DELIVERERS: list[Callable[[str, str], Optional[dict[str, Any]]]] = []
+
+
+def register_live_dm_deliverer(fn: Callable[[str, str], Optional[dict[str, Any]]]) -> None:
+    """Register a live-owner deliverer; idempotent per function."""
+    if fn not in _LIVE_DM_DELIVERERS:
+        _LIVE_DM_DELIVERERS.append(fn)
+
+
+def _deliver_via_live_owner(profile: str, content: str) -> Optional[str]:
+    """Try each registered live-owner deliverer; the first ack wins, None = not handled."""
+    for fn in list(_LIVE_DM_DELIVERERS):
+        try:
+            receipt = fn(profile, content)
+        except Exception:
+            logger.warning("live DM deliverer failed for profile %s", profile, exc_info=True)
+            continue
+        if receipt is not None:
+            return json.dumps(receipt)
+    return None
 MESSAGE_MAX_CHARS = 16000
 # A runner owns and removes each DM file; this bounds residual plaintext lifetime if
 # the machine dies between spawn ack and the runner's finally.
@@ -229,6 +259,13 @@ def message_agent_tool(target: str = "", message: str = "", task_id: Optional[st
         return _roster_err(f"No teammate named '{raw_target}' on this install, on a connected "
                            "machine, or on a registered peer. Pick a name from the roster "
                            "(roles are listed in your system prompt).")
+    # Live-owner handoff: when this process hosts the target's canonical Bot Chat session,
+    # submit through it (queued — never interrupts a turn in flight) instead of spawning a
+    # second CLI that the single-owner lease would fence into a target_busy refusal,
+    # dropping the message. See #103030.
+    live_receipt = _deliver_via_live_owner(resolved, content)
+    if live_receipt is not None:
+        return live_receipt
     return _start_delivery(["hermes", "-p", resolved, *BOT_CHAT_TURN_ARGS], content, f"@{_handle(resolved)}",
                            stdin_file=False, **delivery)
 

--- a/tui_gateway/methods_bot_relay.py
+++ b/tui_gateway/methods_bot_relay.py
@@ -86,14 +86,7 @@ def _(rid, params: dict, _root=_relay_root, _run=_run_delivery) -> dict:
         # session via prompt.submit — the composer's choke point, so role alternation, persistence
         # and streaming behave as a typed message would.
         # (Nested per method_ctx rebinding.) See #100523.
-        from tools.bot_mode_probe import BOT_CHAT_TITLE
-        live_home = _profile_home(resolved)
-        want_home = str(live_home) if live_home is not None else None
-        live_sid = next((
-            live_sid for live_sid, record in list(_sessions.items())
-            if isinstance(record, dict) and (record.get("profile_home") or None) == want_home
-            and _session_live_title(
-                record, _session_lookup_key(record, fallback=live_sid)) == BOT_CHAT_TITLE), "")
+        live_sid = _live_bot_chat_session_for_profile(resolved)
         if live_sid:
             # queued=True: a teammate's DM runs as the NEXT turn and never interrupts or steers a
             # turn in flight (the default busy mode does); arrivals queue in order.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2619,6 +2619,21 @@ def _session_lookup_key(session: dict, *, fallback: str = "") -> str:
     return str(getattr(session.get("agent"), "session_id", None) or session.get("session_key") or fallback or "")
 
 
+def _live_bot_chat_session_for_profile(profile: str | None) -> str:
+    """The live session id of ``profile``'s canonical Bot Chat in THIS gateway, or "".
+
+    Shared by ``bot_relay.deliver`` and the local Bot Mode DM live-owner handoff (both must
+    agree on what "the target's Bot Chat is live here" means)."""
+    from tools.bot_mode_probe import BOT_CHAT_TITLE
+
+    home = _profile_home(profile)
+    want_home = str(home) if home is not None else None
+    return next((
+        sid for sid, record in list(_sessions.items())
+        if isinstance(record, dict) and (record.get("profile_home") or None) == want_home
+        and _session_live_title(record, _session_lookup_key(record, fallback=sid)) == BOT_CHAT_TITLE), "")
+
+
 def _find_live_session_by_key(session_key: str, profile_home=_ANY_PROFILE) -> tuple[str, dict] | None:
     # Timestamp-based stored ids can exist in several profiles' stores; a bare-id match would hand
     # profile B's resume profile A's runtime, so profile-aware callers match on (profile_home, key).
@@ -3224,3 +3239,32 @@ for _m in (
     _methods_bot_relay, _prompt_turn, _billing_view, _methods_projects):
     _m.register(sys.modules[__name__])
 del _m
+
+
+# ── Live-owner Bot Mode DM handoff (#103030; completes #101293's relay-path fix) ─────
+# The LOCAL delivery path (tools/bot_mode_dm.message_agent) spawns a second CLI for the
+# target's canonical Bot Chat; when THIS gateway hosts that chat live the single-owner
+# lease fences the subprocess out and the DM is refused (target_busy) with no turn ever
+# run. Registering this deliverer lets message_agent submit through prompt.submit
+# (queued=True: runs as the NEXT turn, never interrupts a turn in flight) instead —
+# the same mechanism bot_relay.deliver uses for relayed DMs. No live session here →
+# None → the subprocess transport runs exactly as before.
+def _deliver_dm_to_live_session(profile: str, content: str) -> dict | None:
+    live_sid = _live_bot_chat_session_for_profile(profile)
+    if not live_sid:
+        return None
+    submitted = _methods["prompt.submit"](0, {"session_id": live_sid, "text": content, "queued": True})
+    if "error" in submitted:
+        # Let the subprocess transport surface the failure — it owns the error shaping
+        # (target_busy refusal) and the retry policy. See #100523.
+        return None
+    from tools.bot_mode_probe import _handle
+
+    return {"status": "sent", "to": f"@{_handle(profile)}",
+            "detail": "Delivered into the recipient's open Bot Chat; the reply will appear there.",
+            "sent_at": int(time.time())}
+
+
+from tools.bot_mode_dm import register_live_dm_deliverer  # noqa: E402
+
+register_live_dm_deliverer(_deliver_dm_to_live_session)


### PR DESCRIPTION
## What does this PR do?

Bot Mode local DM delivery (`message_agent` → `hermes -p <profile> chat -c "Bot Chat"`) is refused with `target_busy` whenever the target's canonical Bot Chat session is live in this gateway — even when nobody is viewing that chat and no turn is running. One background Desktop tab silently black-holes all DM/cron delivery to that teammate.

Surfaces that host live Bot Chat sessions now register a live-owner deliverer: `message_agent` hands the DM to the existing owner via `prompt.submit(queued=True)` — the composer choke point, so role alternation, persistence, and streaming behave as a typed message, and the DM runs as the NEXT turn (never interrupts a turn in flight) — instead of spawning a competing CLI that the single-owner lease fences out. With no live session for the target profile, the subprocess transport runs exactly as before.

This completes for the **local** delivery path the live-owner handoff that #101293 landed for the **relay** path (`bot_relay.deliver`); the single-owner fence itself is untouched.

## Mechanism

- `tools/bot_mode_dm.py` gains a `register_live_dm_deliverer(fn)` hook registry (same inversion pattern as `tools/approval`'s `_gateway_notify_cbs` — tools never import the server hosting the sessions). `message_agent_tool` consults the hooks before spawning the subprocess; the first accepted ack returns synchronously to the sender; `None` falls through to the subprocess transport unchanged.
- `tui_gateway/server.py` implements the deliverer: `_live_bot_chat_session_for_profile(profile)` (factored out of `bot_relay.deliver`'s inline lookup so both paths agree on what "the target's Bot Chat is live here" means) + `_deliver_dm_to_live_session`, which submits via `prompt.submit(queued=True)` and returns a truthful ack. A `prompt.submit` error defers to the subprocess transport's error shaping (target_busy refusal + retry policy) rather than half-acknowledging.
- Registration happens at server import (after the split-module install loop), so headless/CLI-only usage is unaffected.

## Related Issue

Closes #103030 (follow-up to #100523; completes #101293 for the local path — the maintainer-endorsed "deliver through the live owner" direction)

## How was this tested?

- `scripts/run_tests.sh tests/tools/ tests/test_tui_gateway_server.py tests/tui_gateway/` — 10,168 passed; the 7 failures are pre-existing/flaky on this machine and reproduce identically on a pristine `main` worktree (voice_mode/pulse-audio sockets, STT/compute-host timing, delegate/zombie cleanup retries, `test_tui_gateway_server::test_model_options_preserves_canonical_custom_row_after_agent_init`).
- New invariant tests, **proven red on `main` @ 79445a496c** (all 6 fail there with `AttributeError` on the missing mechanism, then pass with the fix):
  - `tests/test_tui_gateway_bot_dm_live_owner.py` — registration wiring; live Bot Chat → `prompt.submit(queued=True)` + truthful ack; no live session → `None` (subprocess fallback); `prompt.submit` error → `None` (subprocess transport owns the error shaping).
  - `tests/tools/test_bot_mode_dm.py::test_live_owner_delivery_skips_subprocess` / `::test_live_owner_delivery_falls_back_when_no_live_session` — hook preferred over subprocess (zero spawns), fallback intact when the deliverer reports no live session.
- `ruff check` on touched files; `scripts/check-windows-footguns.py` clean.

## Platforms

Linux (tested). The change is transport-layer Python with no platform-specific I/O; the refusal path is unchanged for remote/peer deliveries and for profiles with no live session.
