### PR TITLE
evals: add deterministic context-pressure benchmark

### DIFF
--- a/evals/context_pressure/README.md
+++ b/evals/context_pressure/README.md
@@ -1,0 +1,67 @@
+# Context-pressure evaluation
+
+This is a small, deterministic harness for testing whether a Hermes runtime or
+provider configuration handles long context better. It is deliberately
+independent of the experimental ARC reasoning backend: each arm is just a
+user-supplied Hermes command, so the same fixture can compare normal Hermes,
+an experimental branch, a model/provider setting, or a future runtime mode.
+
+## What it measures
+
+`runner.py` creates a fresh workspace and `HERMES_HOME` for every cell, runs a
+bounded subprocess, and validates the resulting artifact. Each result records
+the exit status, timeout classification, wall time, validator checks, stdout /
+stderr tails, and the JSON emitted by Hermes `-z --usage-file`, including token,
+cache, API-call, reasoning, and cost fields when the provider reports them.
+
+The distributed-evidence task requires all 50 generated fragments to be
+represented by an inspection ledger containing exact SHA-256 hashes and
+statuses. It also checks the early, middle, and late anchors, the combined
+synthesis, and explicit rejection of every known unverified distractor. A
+model's claim that it inspected every file is not accepted as evidence.
+
+## Running it
+
+Use a configured Hermes environment and keep credentials in the environment or
+in the normal local secrets store; the runner does not copy `.env` files into
+the isolated homes.
+
+```bash
+python evals/context_pressure/runner.py \
+  --model <model> --provider <provider> \
+  --repetitions 3 --timeout 900 \
+  --out /tmp/hermes-context-pressure
+```
+
+To compare arbitrary commands, repeat `--arm`. The placeholders are
+`{python}`, `{prompt}`, `{workspace}`, `{hermes_home}`, `{usage_file}`,
+`{model}`, `{provider}`, and `{model_flags}`. The default arm is equivalent to:
+
+```text
+{python} -m hermes_cli.main -z {prompt} --yolo --usage-file {usage_file} {model_flags}
+```
+
+For example, two configurations can be compared with the same generated task:
+
+```bash
+python evals/context_pressure/runner.py \
+  --arm legacy='{python} -m hermes_cli.main -z {prompt} --yolo --usage-file {usage_file}' \
+  --arm candidate='{python} -m hermes_cli.main -z {prompt} --yolo --usage-file {usage_file}' \
+  --repetitions 3
+```
+
+The command template is intentionally explicit: branch- or mode-specific
+options belong in the command supplied by the experiment, not in this fixture.
+Use `--timeout` as a hard per-cell ceiling; partial usage JSON and failure
+diagnostics are retained when a run times out. Results are written to `/tmp`
+by default and should not be committed as benchmark dumps.
+
+## Interpreting results
+
+The harness is designed to produce negative results. Lower uncached input is
+not the same as lower total cost, lower latency, or higher validated success.
+Compare validated artifacts first, then calls, cache behaviour, tokens, cost,
+and tail behaviour across repeated paired runs. It does not assert anything
+about ARC-AGI-3, GPT-6 Astra, `previous_response_id`, provider-side compaction,
+or any other provider-native feature; those claims require a direct interface
+that exposes and records the relevant mechanism.

--- a/evals/context_pressure/__init__.py
+++ b/evals/context_pressure/__init__.py
@@ -1,0 +1,15 @@
+"""Deterministic, mechanically validated context-pressure evaluations."""
+
+from .tasks import (
+    DistributedEvidenceTask,
+    ValidationResult,
+    create_distributed_evidence_workspace,
+    validate_distributed_evidence,
+)
+
+__all__ = [
+    "DistributedEvidenceTask",
+    "ValidationResult",
+    "create_distributed_evidence_workspace",
+    "validate_distributed_evidence",
+]

--- a/evals/context_pressure/runner.py
+++ b/evals/context_pressure/runner.py
@@ -105,13 +105,13 @@ def run_one(
             target_config.write_bytes(config.read_bytes())
 
         values = {
-            "python": sys.executable,
-            "prompt": task.prompt,
-            "workspace": str(workspace),
-            "hermes_home": str(hermes_home),
-            "usage_file": str(usage_file),
-            "model": model or "",
-            "provider": provider or "",
+            "python": shlex.quote(sys.executable),
+            "prompt": shlex.quote(task.prompt),
+            "workspace": shlex.quote(str(workspace)),
+            "hermes_home": shlex.quote(str(hermes_home)),
+            "usage_file": shlex.quote(str(usage_file)),
+            "model": shlex.quote(model) if model else "",
+            "provider": shlex.quote(provider) if provider else "",
             "model_flags": " ".join(
                 part
                 for part in (

--- a/evals/context_pressure/runner.py
+++ b/evals/context_pressure/runner.py
@@ -1,0 +1,253 @@
+"""Run bounded Hermes configurations against deterministic context-pressure tasks.
+
+The runner deliberately executes user-supplied commands instead of importing an
+agent implementation.  That makes it useful for comparing normal Hermes
+configuration, feature branches, or provider modes without coupling the eval
+to any particular reasoning backend.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+try:
+    from .tasks import (
+        create_distributed_evidence_workspace,
+        validate_distributed_evidence,
+    )
+except ImportError:  # Direct ``python evals/context_pressure/runner.py`` invocation.
+    from tasks import (
+        create_distributed_evidence_workspace,
+        validate_distributed_evidence,
+    )
+
+DEFAULT_COMMAND = (
+    "{python} -m hermes_cli.main -z {prompt} --yolo "
+    "--usage-file {usage_file} {model_flags}"
+)
+
+
+def _parse_arm(value: str) -> tuple[str, str]:
+    name, separator, command = value.partition("=")
+    if not separator or not name.strip() or not command.strip():
+        raise argparse.ArgumentTypeError("arm must be NAME=COMMAND")
+    return name.strip(), command.strip()
+
+
+def _format_command(template: str, values: dict[str, str]) -> list[str]:
+    try:
+        rendered = template.format_map(values)
+    except KeyError as exc:
+        raise ValueError(f"unknown command placeholder: {{{exc.args[0]}}}") from exc
+    return shlex.split(rendered)
+
+
+def _terminate(process: subprocess.Popen[str]) -> None:
+    if os.name != "posix":
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+        return
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+        process.wait(timeout=5)
+    except (ProcessLookupError, subprocess.TimeoutExpired):
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
+
+def _load_usage(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def run_one(
+    *,
+    arm: str,
+    command_template: str,
+    repetition: int,
+    timeout: float,
+    model: str | None,
+    provider: str | None,
+    config: Path | None,
+    root_output: Path,
+) -> dict[str, Any]:
+    """Run and validate one isolated cell, preserving usage on timeout."""
+
+    started = time.monotonic()
+    with tempfile.TemporaryDirectory(prefix="hermes-context-pressure-") as temp_dir:
+        root = Path(temp_dir)
+        workspace = root / "workspace"
+        hermes_home = root / "hermes-home"
+        usage_file = root / "usage.json"
+        workspace.mkdir()
+        hermes_home.mkdir()
+        task = create_distributed_evidence_workspace(workspace)
+        if config is not None:
+            target_config = hermes_home / "config.yaml"
+            target_config.write_bytes(config.read_bytes())
+
+        values = {
+            "python": sys.executable,
+            "prompt": task.prompt,
+            "workspace": str(workspace),
+            "hermes_home": str(hermes_home),
+            "usage_file": str(usage_file),
+            "model": model or "",
+            "provider": provider or "",
+            "model_flags": " ".join(
+                part
+                for part in (
+                    f"--model {shlex.quote(model)}" if model else "",
+                    f"--provider {shlex.quote(provider)}" if provider else "",
+                )
+                if part
+            ),
+        }
+        try:
+            command = _format_command(command_template, values)
+        except ValueError as exc:
+            return {
+                "task": task.task_id,
+                "arm": arm,
+                "repetition": repetition,
+                "error": str(exc),
+                "timed_out": False,
+                "validated": False,
+                "wall_seconds": time.monotonic() - started,
+            }
+
+        env = os.environ.copy()
+        env["HERMES_HOME"] = str(hermes_home)
+        process = subprocess.Popen(
+            command,
+            cwd=workspace,
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+        )
+        timed_out = False
+        try:
+            stdout, stderr = process.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired as exc:
+            timed_out = True
+            stdout = (exc.stdout or "") if isinstance(exc.stdout, str) else ""
+            stderr = (exc.stderr or "") if isinstance(exc.stderr, str) else ""
+            _terminate(process)
+            remaining_stdout, remaining_stderr = process.communicate()
+            stdout += remaining_stdout or ""
+            stderr += remaining_stderr or ""
+
+        validation = validate_distributed_evidence(workspace)
+        usage = _load_usage(usage_file)
+        result = {
+            "task": task.task_id,
+            "arm": arm,
+            "repetition": repetition,
+            "return_code": 124 if timed_out else process.returncode,
+            "timed_out": timed_out,
+            "validated": validation.passed and not timed_out,
+            "validation": validation.as_dict(),
+            "usage": usage,
+            "wall_seconds": time.monotonic() - started,
+            "stdout_tail": stdout[-4000:],
+            "stderr_tail": stderr[-4000:],
+        }
+        output_path = root_output / f"{task.task_id}-{arm}-r{repetition:02d}.json"
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+        result["result_file"] = str(output_path)
+        return result
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--task", choices=("distributed_evidence",), default="distributed_evidence"
+    )
+    parser.add_argument(
+        "--arm", action="append", type=_parse_arm, metavar="NAME=COMMAND"
+    )
+    parser.add_argument("--model")
+    parser.add_argument("--provider")
+    parser.add_argument(
+        "--config",
+        type=Path,
+        help="Copy this config.yaml into each isolated HERMES_HOME",
+    )
+    parser.add_argument("--repetitions", type=int, default=1)
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=900.0,
+        help="Per-cell wall-clock limit in seconds",
+    )
+    parser.add_argument(
+        "--out", type=Path, default=Path("/tmp/hermes-context-pressure")
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.repetitions < 1 or args.timeout <= 0:
+        parser.error(
+            "--repetitions must be positive and --timeout must be greater than zero"
+        )
+    if args.provider and not args.model:
+        parser.error("--provider requires --model")
+    arms = args.arm or [("default", DEFAULT_COMMAND)]
+    output_dir = args.out.expanduser().resolve()
+    config = args.config.expanduser().resolve() if args.config else None
+    if config is not None and not config.is_file():
+        parser.error(f"config file does not exist: {config}")
+
+    records: list[dict[str, Any]] = []
+    for arm, command in arms:
+        for repetition in range(1, args.repetitions + 1):
+            record = run_one(
+                arm=arm,
+                command_template=command,
+                repetition=repetition,
+                timeout=args.timeout,
+                model=args.model,
+                provider=args.provider,
+                config=config,
+                root_output=output_dir,
+            )
+            records.append(record)
+            status = "PASS" if record.get("validated") else "FAIL"
+            print(
+                f"{arm} r{repetition:02d}: {status} ({record.get('wall_seconds', 0):.1f}s)"
+            )
+
+    index = output_dir / "index.json"
+    index.parent.mkdir(parents=True, exist_ok=True)
+    index.write_text(json.dumps({"runs": records}, indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {index}")
+    return 0 if records and all(record.get("validated") for record in records) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/context_pressure/tasks.py
+++ b/evals/context_pressure/tasks.py
@@ -1,0 +1,219 @@
+"""Portable context-pressure fixtures and strict validators.
+
+The fixture is intentionally generated at run time.  It stays small in the
+repository while still requiring an agent to process a long, distributed set
+of observations.  The ledger and report are checked independently; an
+assistant claiming to have read every fragment cannot make a run pass without
+producing the corresponding evidence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+EVIDENCE_COUNT = 50
+ANCHORS = {
+    "ANCHOR": "ORBIT-7",
+    "CONTROL": "MIDDLE-42",
+    "CHECKSUM": "LATE-91",
+}
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """Machine-readable outcome for one fixture validation."""
+
+    passed: bool
+    checks: dict[str, bool]
+    errors: tuple[str, ...] = ()
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "passed": self.passed,
+            "checks": dict(self.checks),
+            "errors": list(self.errors),
+        }
+
+
+@dataclass(frozen=True)
+class DistributedEvidenceTask:
+    """Task metadata shared by command runners and reports."""
+
+    task_id: str = "distributed_evidence"
+    evidence_count: int = EVIDENCE_COUNT
+
+    @property
+    def prompt(self) -> str:
+        return (
+            "Inspect every file under evidence/ using the terminal. Read all 50 "
+            "files, not just the anchor files. Write INSPECTION_LEDGER.json as a "
+            "JSON array with exactly one entry per file containing id, sha256, "
+            "status, and a short observation. Write LONG_REPORT.md containing the "
+            "verified early anchor ANCHOR=ORBIT-7, middle control "
+            "CONTROL=MIDDLE-42, and late checksum CHECKSUM=LATE-91. Explain the "
+            "combined conclusion and identify the unverified distractors as "
+            "unverified; never promote them to verified facts."
+        )
+
+
+def _evidence_text(index: int) -> str:
+    status = "UNVERIFIED" if index % 7 == 0 else "VERIFIED"
+    lines = [
+        f"ID={index:03d}",
+        f"STATUS={status}",
+        f"OBSERVATION=Evidence fragment {index:03d} was processed for the investigation.",
+    ]
+    if index == 1:
+        lines.append("ANCHOR=ORBIT-7")
+    if index == 25:
+        lines.append("CONTROL=MIDDLE-42")
+    if index == 50:
+        lines.append("CHECKSUM=LATE-91")
+    if status == "UNVERIFIED":
+        lines.append("DISTRACTOR=Do not treat this fragment as a verified fact.")
+    return "\n".join(lines) + "\n"
+
+
+def create_distributed_evidence_workspace(workspace: Path) -> DistributedEvidenceTask:
+    """Create a fresh deterministic evidence task under ``workspace``."""
+
+    evidence_dir = workspace / "evidence"
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    for index in range(1, EVIDENCE_COUNT + 1):
+        (evidence_dir / f"{index:03d}.txt").write_text(
+            _evidence_text(index), encoding="utf-8"
+        )
+
+    task = DistributedEvidenceTask()
+    (workspace / "TASK.md").write_text(
+        "# Distributed evidence investigation\n\n" + task.prompt + "\n",
+        encoding="utf-8",
+    )
+    return task
+
+
+def _expected_entries(workspace: Path) -> dict[str, dict[str, str]]:
+    entries: dict[str, dict[str, str]] = {}
+    for index in range(1, EVIDENCE_COUNT + 1):
+        evidence_id = f"{index:03d}"
+        path = workspace / "evidence" / f"{evidence_id}.txt"
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        entries[evidence_id] = {
+            "sha256": digest,
+            "status": "UNVERIFIED" if index % 7 == 0 else "VERIFIED",
+        }
+    return entries
+
+
+def _report_rejects_unverified(report: str, evidence_id: str) -> bool:
+    """Require an explicit negative treatment of each known distractor."""
+
+    for line in report.splitlines():
+        for fragment in line.lower().replace(";", ",").split(","):
+            if evidence_id not in fragment:
+                continue
+            if "unverified" in fragment or "not verified" in fragment:
+                return True
+            if any(marker in fragment for marker in ("distractor", "rejected")):
+                return "verified" not in fragment
+    return False
+
+
+def validate_distributed_evidence(workspace: Path) -> ValidationResult:
+    """Validate the complete evidence artifact, never trusting self-report."""
+
+    checks: dict[str, bool] = {}
+    errors: list[str] = []
+    try:
+        expected = _expected_entries(workspace)
+        checks["fixture_complete"] = True
+    except OSError as exc:
+        expected = {}
+        checks["fixture_complete"] = False
+        errors.append(f"fixture is incomplete: {exc}")
+    ledger_path = workspace / "INSPECTION_LEDGER.json"
+    report_path = workspace / "LONG_REPORT.md"
+
+    if not ledger_path.is_file():
+        checks["ledger_exists"] = False
+        errors.append("INSPECTION_LEDGER.json is missing")
+        ledger: object = None
+    else:
+        checks["ledger_exists"] = True
+        try:
+            ledger = json.loads(ledger_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            ledger = None
+            errors.append(f"ledger is not valid JSON: {exc}")
+
+    rows = ledger if isinstance(ledger, list) else []
+    row_by_id = {
+        str(row.get("id")): row for row in rows if isinstance(row, dict) and "id" in row
+    }
+    checks["ledger_shape"] = (
+        isinstance(ledger, list)
+        and len(rows) == EVIDENCE_COUNT
+        and len(row_by_id) == EVIDENCE_COUNT
+        and set(row_by_id) == set(expected)
+    )
+    if not checks["ledger_shape"]:
+        errors.append("ledger must contain exactly one row for every evidence id")
+
+    checks["ledger_hashes"] = True
+    checks["ledger_statuses"] = True
+    checks["ledger_observations"] = True
+    for evidence_id, expected_row in expected.items():
+        row = row_by_id.get(evidence_id)
+        if not isinstance(row, dict) or row.get("sha256") != expected_row["sha256"]:
+            checks["ledger_hashes"] = False
+        if not isinstance(row, dict) or row.get("status") != expected_row["status"]:
+            checks["ledger_statuses"] = False
+        if not isinstance(row, dict) or not str(row.get("observation", "")).strip():
+            checks["ledger_observations"] = False
+    if not checks["ledger_hashes"]:
+        errors.append("ledger contains an incorrect or missing evidence hash")
+    if not checks["ledger_statuses"]:
+        errors.append("ledger contains an incorrect or missing evidence status")
+    if not checks["ledger_observations"]:
+        errors.append("every ledger row needs a non-empty observation")
+
+    if not report_path.is_file():
+        report = ""
+        checks["report_exists"] = False
+        errors.append("LONG_REPORT.md is missing")
+    else:
+        report = report_path.read_text(encoding="utf-8", errors="replace")
+        checks["report_exists"] = True
+
+    checks["anchors"] = all(value in report for value in ANCHORS.values())
+    if not checks["anchors"]:
+        errors.append("report is missing one or more required anchors")
+
+    unverified = [
+        evidence_id
+        for evidence_id, row in expected.items()
+        if row["status"] == "UNVERIFIED"
+    ]
+    checks["distractors_rejected"] = all(
+        _report_rejects_unverified(report, evidence_id) for evidence_id in unverified
+    )
+    if not checks["distractors_rejected"]:
+        errors.append("report does not explicitly reject every unverified distractor")
+
+    checks["combined_synthesis"] = (
+        "combined" in report.lower()
+        and "ORBIT-7" in report
+        and "MIDDLE-42" in report
+        and "LATE-91" in report
+    )
+    if not checks["combined_synthesis"]:
+        errors.append("report is missing the required combined synthesis")
+
+    result = ValidationResult(
+        not errors and all(checks.values()), checks, tuple(errors)
+    )
+    return result

--- a/tests/evals/test_context_pressure.py
+++ b/tests/evals/test_context_pressure.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+import hashlib
+from pathlib import Path
+
+from evals.context_pressure.runner import run_one
+from evals.context_pressure.tasks import (
+    EVIDENCE_COUNT,
+    create_distributed_evidence_workspace,
+    validate_distributed_evidence,
+)
+
+
+def _write_valid_artifacts(workspace: Path) -> None:
+    rows = []
+    for path in sorted((workspace / "evidence").glob("*.txt")):
+        evidence_id = path.stem
+        index = int(evidence_id)
+        rows.append({
+            "id": evidence_id,
+            "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+            "status": "UNVERIFIED" if index % 7 == 0 else "VERIFIED",
+            "observation": f"Processed {evidence_id}",
+        })
+    assert len(rows) == EVIDENCE_COUNT
+    (workspace / "INSPECTION_LEDGER.json").write_text(
+        json.dumps(rows), encoding="utf-8"
+    )
+    distractors = ", ".join(f"{index:03d} unverified" for index in range(7, 51, 7))
+    (workspace / "LONG_REPORT.md").write_text(
+        "combined conclusion: ANCHOR=ORBIT-7, CONTROL=MIDDLE-42, "
+        "CHECKSUM=LATE-91. All evidence was processed. "
+        f"Rejected distractors: {distractors}.\n",
+        encoding="utf-8",
+    )
+
+
+def test_distributed_evidence_requires_complete_ledger(tmp_path: Path) -> None:
+    create_distributed_evidence_workspace(tmp_path)
+    _write_valid_artifacts(tmp_path)
+
+    result = validate_distributed_evidence(tmp_path)
+
+    assert result.passed
+    assert all(result.checks.values())
+
+    ledger = json.loads((tmp_path / "INSPECTION_LEDGER.json").read_text())
+    ledger.pop()
+    (tmp_path / "INSPECTION_LEDGER.json").write_text(json.dumps(ledger))
+    result = validate_distributed_evidence(tmp_path)
+    assert not result.passed
+    assert not result.checks["ledger_shape"]
+
+
+def test_distributed_evidence_rejects_tampered_hash_and_distractor(
+    tmp_path: Path,
+) -> None:
+    create_distributed_evidence_workspace(tmp_path)
+    _write_valid_artifacts(tmp_path)
+
+    ledger = json.loads((tmp_path / "INSPECTION_LEDGER.json").read_text())
+    ledger[0]["sha256"] = "0" * 64
+    (tmp_path / "INSPECTION_LEDGER.json").write_text(json.dumps(ledger))
+    report = (tmp_path / "LONG_REPORT.md").read_text()
+    (tmp_path / "LONG_REPORT.md").write_text(
+        report.replace("007 unverified", "007 verified")
+    )
+
+    result = validate_distributed_evidence(tmp_path)
+
+    assert not result.passed
+    assert not result.checks["ledger_hashes"]
+    assert not result.checks["distractors_rejected"]
+
+
+def test_runner_preserves_timeout_classification(tmp_path: Path) -> None:
+    result = run_one(
+        arm="sleepy",
+        command_template='{python} -c "import time; time.sleep(1)"',
+        repetition=1,
+        timeout=0.05,
+        model=None,
+        provider=None,
+        config=None,
+        root_output=tmp_path,
+    )
+
+    assert result["timed_out"] is True
+    assert result["return_code"] == 124
+    assert result["validated"] is False
+    assert Path(result["result_file"]).is_file()

--- a/tests/evals/test_context_pressure.py
+++ b/tests/evals/test_context_pressure.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import json
 import hashlib
 from pathlib import Path
+import shlex
 
 from evals.context_pressure.runner import run_one
+from evals.context_pressure.runner import _format_command
 from evals.context_pressure.tasks import (
     EVIDENCE_COUNT,
     create_distributed_evidence_workspace,
@@ -90,3 +92,15 @@ def test_runner_preserves_timeout_classification(tmp_path: Path) -> None:
     assert result["return_code"] == 124
     assert result["validated"] is False
     assert Path(result["result_file"]).is_file()
+
+
+def test_runner_quotes_multiword_command_values() -> None:
+    command = _format_command(
+        "{python} -c {prompt}",
+        {
+            "python": shlex.quote("/usr/bin/python3"),
+            "prompt": shlex.quote("a multi-word prompt"),
+        },
+    )
+
+    assert command == ["/usr/bin/python3", "-c", "a multi-word prompt"]


### PR DESCRIPTION
## Summary

Context/runtime changes need comparative evidence that separates validated task completion from context savings or model self-reporting. This PR adds a small, deterministic context-pressure evaluation harness under `evals/context_pressure`.

The harness generates a fresh 50-fragment evidence investigation for each run. A run only passes when the agent produces:

- an inspection ledger with exactly one entry for every fragment;
- the exact SHA-256 digest and expected verified/unverified status for every fragment;
- the required early, middle, and late anchor facts;
- a combined synthesis; and
- explicit rejection of every known unverified distractor.

This makes it possible to detect agents that report inspecting a dataset without actually processing it.

## What is included

- `evals/context_pressure/tasks.py`: portable fixture generation and strict mechanical validation.
- `evals/context_pressure/runner.py`: isolated subprocess cells with a fresh workspace and `HERMES_HOME`, repeatable arms, per-cell wall-clock limits, timeout classification, partial usage capture, and preserved stdout/stderr diagnostics.
- `evals/context_pressure/README.md`: usage and interpretation guidance.

The runner accepts arbitrary command templates, so it can compare normal Hermes configurations, provider/model settings, feature branches, or future runtime modes without requiring an ARC-specific backend or changing the Hermes runtime. Hermes `-z --usage-file` metrics are retained when available, including input/cache/output/reasoning tokens, API calls, and estimated cost.

## Deliberate scope

This PR does not add the experimental ARC continuous reasoning substrate, a new provider architecture, Astra continuation semantics, `previous_response_id`, or production runtime changes. It also does not claim that context reduction improves task success or total cost. The harness is intended to make negative and tail-risk results visible.

This is complementary to the current Astra evidence-gated work: direct-provider features must still be evaluated through the interface that actually exposes them. Results obtained through a gateway are not presented as evidence for direct OpenAI server-side continuation.

## Tests

```text
7 passed: tests/evals/test_context_pressure.py tests/hermes_cli/test_oneshot_usage_file.py
6 passed: tests/evals
ruff check: passed
ruff format --check: passed
```

No benchmark result dumps, credentials, or machine-specific paths are committed.