### PR TITLE
fix(fallback): honor deployment context windows

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2085,11 +2085,11 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
         old_model, old_provider, old_base_url = agent.model, agent.provider, agent.base_url
 
-        # The primary's config override must never follow a fallback. A fallback
-        # can instead carry its own deployment-specific context window (for
-        # example, a locally hosted model started below its native maximum).
+        # The primary's config override must never follow a fallback. Keep the
+        # fallback-only deployment window local to the compressor update below:
+        # this attribute is also read by UI preflight paths between turns.
         fallback_context_length = _fallback_context_length(fb)
-        agent._config_context_length = fallback_context_length
+        agent._config_context_length = None
         agent.model, agent.provider, agent.requested_provider = fb_model, fb_provider, fb_provider
         agent.base_url, agent.api_mode = fb_base_url, fb_api_mode
         # reasoning_content echo opt-in travels with the active provider; restore_primary_runtime reverts it.

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1946,9 +1946,13 @@ def _swap_fallback_clients(agent, fb_client, fb_provider: str, fb_model: str, fb
         agent._replace_primary_openai_client(reason="fallback_timeout_apply")
 
 
-def _update_fallback_context_compressor(agent) -> None:
-    """Point compression limits at the fallback model's context window (not the primary's),
-    respecting the explicit model.context_length config override."""
+def _update_fallback_context_compressor(agent, *, context_length: int | None = None) -> None:
+    """Point compression limits at the fallback's actual context window.
+
+    A fallback entry may declare ``context_length`` for a deployment whose
+    configured server window is smaller than the model family's native window.
+    When absent, preserve the existing resolver-based behavior.
+    """
     compressor = getattr(agent, "context_compressor", None)
     if not compressor:
         return
@@ -1957,13 +1961,29 @@ def _update_fallback_context_compressor(agent) -> None:
         agent.model, base_url=agent.base_url,
         api_key=agent.api_key if isinstance(agent.api_key, str) else "",  # callable (Entra ID) → probes need str
         provider=agent.provider,
-        config_context_length=getattr(agent, "_config_context_length", None),
+        config_context_length=context_length,
         custom_providers=getattr(agent, "_custom_providers", None),
     )
     compressor.update_model(  # callable api_key preserved → call_llm
         model=agent.model, context_length=fb_context_length, base_url=agent.base_url,
         api_key=getattr(agent, "api_key", ""), provider=agent.provider, api_mode=agent.api_mode,
     )
+
+
+def _fallback_context_length(entry: dict) -> int | None:
+    """Return a valid deployment-specific fallback context override, if given."""
+    value = entry.get("context_length")
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        context_length = int(value)
+    except (TypeError, ValueError):
+        logger.warning("Fallback context_length=%r is not an integer; using model resolution", value)
+        return None
+    if context_length <= 0:
+        logger.warning("Fallback context_length=%r must be positive; using model resolution", value)
+        return None
+    return context_length
 
 
 def _reresolve_fallback_reasoning_config(agent) -> None:
@@ -2065,10 +2085,11 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
         old_model, old_provider, old_base_url = agent.model, agent.provider, agent.base_url
 
-        # Clear the per-config context_length override so the fallback model's own context
-        # window is resolved instead of the previous model's stale value.
-        # See #22387.
-        agent._config_context_length = None
+        # The primary's config override must never follow a fallback. A fallback
+        # can instead carry its own deployment-specific context window (for
+        # example, a locally hosted model started below its native maximum).
+        fallback_context_length = _fallback_context_length(fb)
+        agent._config_context_length = fallback_context_length
         agent.model, agent.provider, agent.requested_provider = fb_model, fb_provider, fb_provider
         agent.base_url, agent.api_mode = fb_base_url, fb_api_mode
         # reasoning_content echo opt-in travels with the active provider; restore_primary_runtime reverts it.
@@ -2086,7 +2107,9 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         agent._use_prompt_caching, agent._use_native_cache_layout = agent._anthropic_prompt_cache_policy(
             provider=fb_provider, base_url=fb_base_url, api_mode=fb_api_mode, model=fb_model)
         agent._ensure_lmstudio_runtime_loaded()  # LM Studio: preload before probing context length
-        _update_fallback_context_compressor(agent)
+        _update_fallback_context_compressor(
+            agent, context_length=fallback_context_length
+        )
         _reresolve_fallback_reasoning_config(agent)
         _rescope_fallback_extra_body(agent, old_model, old_provider, old_base_url)
         rewrite_prompt_model_identity(agent, fb_model, fb_provider)

--- a/tests/hermes_cli/test_fallback_config.py
+++ b/tests/hermes_cli/test_fallback_config.py
@@ -1,7 +1,7 @@
 """Tests for hermes_cli/fallback_config.py — fallback entry API-key resolution."""
 
 from agent.secret_scope import reset_secret_scope, set_secret_scope
-from hermes_cli.fallback_config import resolve_entry_api_key
+from hermes_cli.fallback_config import get_fallback_chain, resolve_entry_api_key
 
 
 class TestResolveEntryApiKey:
@@ -37,3 +37,21 @@ class TestResolveEntryApiKey:
         # secret scope installed, resolution still reads os.environ.
         monkeypatch.setenv("FB_KEY", "env-key")
         assert resolve_entry_api_key({"key_env": "FB_KEY"}) == "env-key"
+
+
+class TestFallbackEntryMetadata:
+    def test_context_length_is_preserved_when_declared(self):
+        chain = get_fallback_chain({
+            "fallback_providers": [{
+                "provider": "custom",
+                "model": "qwen3-coder-next",
+                "context_length": 131_072,
+            }]
+        })
+        assert chain[0]["context_length"] == 131_072
+
+    def test_entries_without_context_length_remain_compatible(self):
+        chain = get_fallback_chain({
+            "fallback_providers": [{"provider": "custom", "model": "qwen3-coder-next"}]
+        })
+        assert chain == [{"provider": "custom", "model": "qwen3-coder-next"}]

--- a/tests/run_agent/test_compressor_fallback_update.py
+++ b/tests/run_agent/test_compressor_fallback_update.py
@@ -1,12 +1,13 @@
 """Tests that _try_activate_fallback updates the context compressor."""
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from run_agent import AIAgent
 from agent.context_compressor import ContextCompressor
 
 
-def _make_agent_with_compressor() -> AIAgent:
+def _make_agent_with_compressor() -> Any:
     """Build a minimal AIAgent with a context_compressor, skipping __init__."""
     agent = AIAgent.__new__(AIAgent)
 
@@ -70,5 +71,33 @@ def test_compressor_updated_on_fallback(mock_ctx_len, mock_resolve):
     assert c.provider == "openai"
     assert c.context_length == 128_000
     assert c.threshold_tokens == int(128_000 * c.threshold_percent)
+    assert getattr(agent, "_config_context_length") is None
+    assert mock_ctx_len.call_args.kwargs["config_context_length"] is None
 
 
+@patch("agent.auxiliary_client.resolve_provider_client")
+@patch("agent.model_metadata.get_model_context_length", return_value=131_072)
+def test_fallback_entry_context_length_overrides_model_metadata(mock_ctx_len, mock_resolve):
+    """A fallback deployment window wins over the model family's native window."""
+    agent: Any = _make_agent_with_compressor()
+    agent._fallback_model = {
+        "provider": "custom",
+        "model": "qwen3-coder-next",
+        "base_url": "http://127.0.0.1:8092/v1",
+        "context_length": 131_072,
+    }
+    agent._fallback_chain = [agent._fallback_model]
+
+    fb_client = MagicMock()
+    fb_client.base_url = "http://127.0.0.1:8092/v1"
+    fb_client.api_key = ""
+    mock_resolve.return_value = (fb_client, None)
+
+    agent._is_direct_openai_url = lambda url: False
+    agent._emit_status = lambda msg: None
+
+    assert agent._try_activate_fallback() is True
+
+    assert agent._config_context_length == 131_072
+    assert agent.context_compressor.context_length == 131_072
+    assert mock_ctx_len.call_args.kwargs["config_context_length"] == 131_072

--- a/tests/run_agent/test_compressor_fallback_update.py
+++ b/tests/run_agent/test_compressor_fallback_update.py
@@ -87,6 +87,7 @@ def test_fallback_entry_context_length_overrides_model_metadata(mock_ctx_len, mo
         "context_length": 131_072,
     }
     agent._fallback_chain = [agent._fallback_model]
+    agent._config_context_length = 240_000  # primary-only override; must not leak to fallback/UI state
 
     fb_client = MagicMock()
     fb_client.base_url = "http://127.0.0.1:8092/v1"
@@ -98,6 +99,8 @@ def test_fallback_entry_context_length_overrides_model_metadata(mock_ctx_len, mo
 
     assert agent._try_activate_fallback() is True
 
-    assert agent._config_context_length == 131_072
+    # The deployment override is compressor-local; it must not leak into
+    # cross-turn UI preflight state.
+    assert agent._config_context_length is None
     assert agent.context_compressor.context_length == 131_072
     assert mock_ctx_len.call_args.kwargs["config_context_length"] == 131_072

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -37,7 +37,17 @@ fallback_providers:
     model: anthropic/claude-sonnet-4
 ```
 
-Each entry requires both `provider` and `model`. Entries missing either field are ignored.
+Each entry requires both `provider` and `model`. Entries missing either field are ignored. A deployment-specific `context_length` is optional but recommended for local or custom endpoints whose serving window is smaller than the model family's native maximum:
+
+```yaml
+fallback_providers:
+  - provider: custom
+    model: qwen3-coder-next
+    base_url: http://localhost:8092/v1
+    context_length: 131072  # must match the backend's actual serving window
+```
+
+Hermes uses this value to re-budget compression immediately after fallback, before it sends an oversized history to the smaller deployment.
 
 :::note `fallback_model` vs `fallback_providers`
 `fallback_providers` (plural, list) is the current config shape and supports multiple fallbacks tried in order. `fallback_model` (singular) is the legacy single-fallback key — Hermes still honors it for back-compat, but `hermes fallback` writes the current `fallback_providers` key and migrates legacy config on write. When both are set, `fallback_providers` takes priority.


### PR DESCRIPTION
## Summary
- allow a `fallback_providers` entry to declare its deployed `context_length`
- use that value only when re-budgeting the active fallback compressor
- do not leak the fallback-only window into post-turn UI preflight state
- preserve resolver behavior when the entry omits the field
- document local/custom endpoint configuration

This complements #99501: that PR fixes custom-provider metadata lookup; this fixes the fallback handoff when the actual serving window is intentionally lower than the model family's native maximum.

## Validation
- `scripts/run_tests.sh tests/hermes_cli/test_fallback_config.py tests/run_agent/test_compressor_fallback_update.py tests/run_agent/test_provider_fallback.py tests/run_agent/test_conversation_fallback_state.py tests/run_agent/test_switch_model_fallback_prune.py tests/agent/test_context_compressor.py -q` (196 passed)
- `ruff check` on changed Python files
- `git diff --check`

## Compatibility
Fallback entries without `context_length` retain existing resolver-based behavior.