### PR TITLE
fix(cli): honor the moa rm alias

### DIFF
--- a/hermes_cli/moa_cmd.py
+++ b/hermes_cli/moa_cmd.py
@@ -144,7 +144,8 @@ _SUBCOMMANDS = {
     "ls": _cmd_list,
     "config": _cmd_configure,
     "configure": _cmd_configure,
-    "delete": _cmd_delete}
+    "delete": _cmd_delete,
+    "rm": _cmd_delete}
 
 
 def cmd_moa(args) -> None:

--- a/tests/hermes_cli/test_moa_cli_delete_alias.py
+++ b/tests/hermes_cli/test_moa_cli_delete_alias.py
@@ -1,0 +1,31 @@
+"""The public parser's removal aliases must reach the real command handler."""
+
+import argparse
+from copy import deepcopy
+
+import pytest
+
+
+@pytest.mark.parametrize("verb", ["delete", "rm"])
+def test_moa_delete_alias_removes_named_preset(monkeypatch, verb):
+    from hermes_cli import moa_cmd
+    from hermes_cli.subcommands.moa import build_moa_parser
+
+    config = {
+        "moa": {
+            "default_preset": "keep",
+            "presets": {"keep": {}, "remove-me": {}},
+        }
+    }
+    saved = []
+    monkeypatch.setattr(moa_cmd, "load_config", lambda: deepcopy(config))
+    monkeypatch.setattr(moa_cmd, "save_config", lambda value: saved.append(deepcopy(value)))
+    parser = argparse.ArgumentParser()
+    build_moa_parser(parser.add_subparsers(dest="command"))
+
+    args = parser.parse_args(["moa", verb, "remove-me"])
+    args.func(args)
+
+    assert len(saved) == 1
+    assert set(saved[0]["moa"]["presets"]) == {"keep"}
+    assert saved[0]["moa"]["default_preset"] == "keep"


### PR DESCRIPTION
## What does this PR do?

Honor the already-registered `hermes moa rm <preset>` alias by routing it to the existing delete handler.

`build_moa_parser()` registers `rm` as an alias of `delete`, but argparse preserves the spelling the user typed. `_SUBCOMMANDS` only contains `delete`, so `moa rm` currently reaches `Unknown moa subcommand: rm` instead of deleting the requested preset.

## Related Issue / Duplicate Check

Reproduced on `79445a496c86a19332ad786494b8384d2167e2d0`. No issue is claimed as fixed. Searched existing issues and open/closed/merged PRs using `moa rm`, MoA deletion aliases, and dispatch-related terms; no matching fix was found.

## Type of Change

- [x] Bug fix (non-breaking)

## Changes Made

- `hermes_cli/moa_cmd.py`: map `rm` to `_cmd_delete`, without duplicating deletion logic.
- `tests/hermes_cli/test_moa_cli_delete_alias.py`: one parameterized behavior contract for `delete` and `rm` (two cases). Exercise the real parser and dispatch; assert the named preset is removed and the unrelated active preset remains selected. Configuration I/O is replaced with an in-memory fixture in this regression test.

No configuration keys, dependencies, command schema, or unrelated command handlers change.

## How to Test

```sh
scripts/run_tests.sh \
  tests/hermes_cli/test_moa_cli_delete_alias.py \
  tests/hermes_cli/test_moa_config.py \
  tests/hermes_cli/test_moa_set_models_preserves_extra_keys.py \
  tests/cli/test_moa_command.py -q --tb=short
```

Verified locally on macOS using the canonical hermetic runner:

- Baseline plus regression test: **1 passed, 1 failed**; the failing case is `rm`, with `SystemExit: Unknown moa subcommand: rm`.
- This branch, related tests above: **16 passed, 0 failed**.
- Also exercised the actual CLI subprocess (`python -m hermes_cli.main moa rm remove-me`) against separate temporary `HOME`/`HERMES_HOME` directories containing generic presets `keep` and `remove-me`: baseline exits 1 and retains the named preset; the patched CLI exits 0, removes it, and preserves `keep` as the default. No real user configuration was used.
- `git diff --check` passes. Independent code-only review completed after the final test changes.

## Checklist

- [x] Read the contributing guide; conventional commit; focused change.
- [x] Searched existing PRs and issues for duplicates.
- [x] Added behavioral regression coverage and ran the targeted canonical tests above.
- [ ] Full repository test suite (not run locally; results above are targeted, not a full-suite claim).
- [x] Considered cross-platform impact: no new platform-specific production behavior; tested on macOS only.
- [x] Documentation/configuration/tool-schema updates: N/A; restores an alias already advertised by the parser.

AI-assisted implementation and independent review; reproduction and test results are from actual local execution.
