### PR TITLE
fix(tools): paginate multi-root content search once

### DIFF
--- a/tests/tools/test_search_multi_root_pagination.py
+++ b/tests/tools/test_search_multi_root_pagination.py
@@ -1,0 +1,47 @@
+"""The registered search tool must paginate the combined root results."""
+
+import json
+
+import pytest
+
+from tools import file_tools
+from tools.environments.local import LocalEnvironment
+from tools.file_operations import ShellFileOperations
+from tools.registry import registry
+
+
+@pytest.mark.parametrize("output_mode", ["content", "files_only"])
+def test_multi_root_search_paginates_combined_results(tmp_path, monkeypatch, output_mode):
+    roots = [tmp_path / "first", tmp_path / "second"]
+    files = []
+    for root in roots:
+        root.mkdir()
+        file = root / "example.txt"
+        file.write_text("needle\nneedle\n" if root == roots[0] else "needle\n", encoding="utf-8")
+        files.append(str(file))
+    ops = ShellFileOperations(LocalEnvironment(str(tmp_path)))
+    monkeypatch.setattr(file_tools, "_get_file_ops", lambda task_id: ops)
+
+    expected = files if output_mode == "files_only" else [
+        (files[0], 1), (files[0], 2), (files[1], 1),
+    ]
+    for offset, limit in ((0, 1), (1, 1), (1, 2), (2, 1), (3, 1)):
+        response = registry.dispatch("search_files", {
+            "pattern": "needle",
+            "path": ", ".join(map(str, roots)),
+            "target": "content",
+            "output_mode": output_mode,
+            "limit": limit,
+            "offset": offset,
+        })
+        assert isinstance(response, str)
+        # A truncated response appends a human-facing pagination hint after JSON.
+        result, _ = json.JSONDecoder().raw_decode(response)
+
+        assert "error" not in result
+        if output_mode == "files_only":
+            page = result.get("files", [])
+        else:
+            page = [(match["path"], match["line"]) for match in result.get("matches", [])]
+        assert page == expected[offset:offset + limit]
+        assert result.get("truncated", False) == (offset + limit < len(expected))

--- a/tools/file_operations_search.py
+++ b/tools/file_operations_search.py
@@ -445,8 +445,12 @@ class SearchMixin:
             merged = self._search_files(pattern, existing, limit, offset, order)
         else:
             merged = SearchResult()
+            page_end = offset + limit
             for root in existing:
-                sub = self._search_content(pattern, root, file_glob, limit, offset, output_mode, context)
+                # Apply pagination once, after combining the root prefixes. An
+                # extra row lets the combined result report a truncated page.
+                root_limit, root_offset = (limit, offset) if output_mode == "count" else (page_end + 1, 0)
+                sub = self._search_content(pattern, root, file_glob, root_limit, root_offset, output_mode, context)
                 if sub.error:
                     return sub
                 merged.matches.extend(sub.matches)
@@ -454,8 +458,10 @@ class SearchMixin:
                 merged.counts.update(sub.counts)
                 merged.total_count += sub.total_count
                 merged.truncated = merged.truncated or sub.truncated
-            merged.matches = merged.matches[:limit]
-            merged.files = merged.files[:limit]
+            if output_mode != "count":
+                merged.truncated = merged.truncated or merged.total_count > page_end
+            merged.matches = merged.matches[offset:page_end]
+            merged.files = merged.files[offset:page_end]
         note = f"path contained {len(parts)} entries; searched {len(existing)} that exist"
         if missing:
             note += "; skipped missing: " + ", ".join(missing[:3])


### PR DESCRIPTION
## What does this PR do?

Apply content-search pagination once to the combined results when a supplied path is recovered as multiple existing search roots. Preserve the merged truncation signal so callers know when to request another page.

Currently `_try_multi_path_search()` passes the same `offset` into every root's `_search_content()` call, then concatenates and clips the results. This skips entries in each root rather than in the combined sequence. The aggregate also fails to mark results truncated when its own final slice omits entries.

For example, let `first/example.txt` have two matching lines and `second/example.txt` one. The combined content sequence is `[first:1, first:2, second:1]`. With `limit=1, offset=2`, main returns no matches instead of `second:1`. With `offset=0`, a one-item page may be returned without `truncated=true`. The corresponding `files_only` pagination also skips later roots.

## Related Issue / Duplicate Check

Reproduced on `79445a496c86a19332ad786494b8384d2167e2d0`. No issue is claimed as fixed. Searched symptoms, multi-root pagination, and `_try_multi_path_search` across existing issues and PRs.

Related work was inspected rather than treated as a duplicate based only on titles:

- #103201 concerns root expansion for **filename/glob search**.
- #41439 and #58210 concern **underlying single-root search truncation**.

This PR fixes the separate **multi-root content aggregation** layer: applying offset globally and detecting when the merged result exceeds the requested page. It does not modify the filename-search branch or change count aggregation semantics.

## Type of Change

- [x] Bug fix (non-breaking)

## Changes Made

- `tools/file_operations_search.py`: request a sufficient prefix plus one look-ahead item from each root, with zero per-root offset; merge first, slice once, and preserve/set the aggregate truncation flag. Keep the existing count-mode arguments and aggregation.
- `tests/tools/test_search_multi_root_pagination.py`: one parameterized invariant (two cases: `content` and `files_only`) through the **registered `search_files` handler**, backed by real temporary files and `LocalEnvironment`/`ShellFileOperations`. Only backend construction is substituted. The fixture covers multiple content matches in the first root, cross-root windows, page ends, and empty pages. The test decodes the JSON prefix because truncated tool responses intentionally append a human-facing pagination hint.

## How to Test

```sh
scripts/run_tests.sh \
  tests/tools/test_search_multi_root_pagination.py \
  tests/tools/test_file_operations.py \
  tests/tools/test_file_operations_edge_cases.py \
  tests/tools/test_search_files_engine_selection.py \
  tests/tools/test_search_budget_truncation.py \
  tests/tools/test_macos_protected_search.py \
  tests/tools/test_search_zero_match_and_multipath.py -q --tb=short
```

Verified locally on macOS with the canonical hermetic runner:

- Baseline plus the new invariant: **2 failed** (assertion failures, not setup/import failures).
- This branch, related tests above: **184 passed, 5 skipped, 0 failed**. The skips are Windows-only tests.
- The new test's **2 cases pass** on the patched implementation.
- Additional temporary local checks covered an empty middle root and unchanged count aggregation; they are not added to this focused PR.
- `git diff --check` passes. Independent code-only review completed with the relevant result parsing/serialization source supplied as context.

## Checklist

- [x] Read the contributing guide; conventional commit; focused change.
- [x] Searched existing PRs/issues and inspected related diffs.
- [x] Added real-import behavioral regression coverage and ran the targeted canonical tests above.
- [ ] Full repository test suite (not run locally; results above are targeted).
- [x] Considered cross-platform impact: no new OS-specific production branch; Windows execution was not verified locally.
- [x] Configuration/dependency/schema updates: N/A; restores the existing pagination contract.

AI-assisted implementation and independent review; reproduction and test results are from actual local execution. No real user files or profile data were used as fixtures.
