### PR TITLE
fix(memory/mem0): harden OSS backend against qdrant lock races, router retries, and multi-vendor keys

### DIFF
--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -2,9 +2,21 @@
 
 from __future__ import annotations
 
+import logging
+import time
 from abc import ABC, abstractmethod
 from contextlib import closing, suppress
 from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Qdrant local mode (vector_store.path) serializes access with an exclusive
+# flock on ``<path>/.lock``, held by the first opener for its whole lifetime.
+# A second opener fails instantly with "already accessed by another instance";
+# OSSBackend.__init__ retries briefly so transient contention (e.g. the
+# gateway-restart overlap window) self-heals instead of permanently failing.
+_LOCK_RETRY_ATTEMPTS = 10
+_LOCK_RETRY_WAIT_SECS = 3
 
 
 def _add_kwargs(user_id: str, agent_id: str, infer: bool, metadata: dict | None) -> dict[str, Any]:
@@ -127,6 +139,31 @@ class OSSBackend(Mem0Backend):
             canonical_key = registry.get(str(block.get("provider") or "").strip().lower(), {}).get("base_url_key")
             if legacy_base and canonical_key:
                 provider_config.setdefault(canonical_key, legacy_base)
+            if name == "embedder":
+                # Embedding dims move to the vector-store config (embedding_model_dims);
+                # keep them out of the API call — SiliconFlow rejects ``dimensions=``.
+                provider_config.pop("embedding_dims", None)
+            # Inject API key from environment if not already in config.
+            provider = str(block.get("provider") or "").strip().lower()
+            if "api_key" not in provider_config:
+                env_var = registry.get(provider, {}).get("env_var", "")
+                env_key = os.environ.get(env_var, "") if env_var else ""
+                # Also check the Hermes-specific MEM0_<section>_API_KEY fallback
+                fallback_key = os.environ.get(f"MEM0_{name.upper()}_API_KEY", "")
+                base = str(provider_config.get("openai_base_url", ""))
+                if provider == "openai" and "siliconflow" in base:
+                    # Same-vendor reuse: on this deployment SiliconFlow hosts
+                    # both the embedder and the extraction LLM under one key;
+                    # never fall through to a mismatched vendor's key.
+                    api_key = os.environ.get("SILICONFLOW_API_KEY") or os.environ.get("MEM0_EMBEDDER_API_KEY", "")
+                else:
+                    api_key = env_key or fallback_key
+                if api_key:
+                    provider_config["api_key"] = api_key
+            # Ensure max_tokens is set for LLM (OpenAI SDK default of 16384+
+            # can exceed provider credit budgets).
+            if name == "llm" and "max_tokens" not in provider_config:
+                provider_config["max_tokens"] = 2000
             block["config"] = provider_config
             return block
 
@@ -141,18 +178,35 @@ class OSSBackend(Mem0Backend):
             self._recreate_collection_if_dims_changed(vector_store.get("provider", "qdrant"), vs_config, dims)
         vector_store["config"] = vs_config
         config = {"vector_store": vector_store, "llm": _provider_block("llm", LLM_PROVIDERS), "embedder": _provider_block("embedder", EMBEDDER_PROVIDERS), "version": "v1.1"}
-        if str(config["llm"].get("provider") or "").strip().lower() == "openai":
-            # mem0 validates LlmConfig.provider before its factory lookup: build the supported OpenAI config, then swap the provider.
-            _register_direct_openai_provider()
-            from mem0.configs.base import MemoryConfig
-            memory_config = MemoryConfig(**config)
+        # See _LOCK_RETRY_* above: local qdrant storage is single-opener.
+        # Retry only the lock-conflict error — everything else raises
+        # immediately, preserving prior behavior.
+        for attempt in range(1, _LOCK_RETRY_ATTEMPTS + 1):
             try:
-                memory_config.llm.provider = _DIRECT_OPENAI_PROVIDER
-            except (AttributeError, TypeError) as exc:
-                raise RuntimeError("mem0 MemoryConfig does not expose a mutable llm.provider for the Hermes OpenAI OSS backend") from exc
-            self._memory = Memory(memory_config)
-        else:
-            self._memory = Memory.from_config(config)
+                if str(config["llm"].get("provider") or "").strip().lower() == "openai":
+                    # mem0 validates LlmConfig.provider before its factory lookup: build the supported OpenAI config, then swap the provider.
+                    _register_direct_openai_provider()
+                    from mem0.configs.base import MemoryConfig
+                    memory_config = MemoryConfig(**config)
+                    try:
+                        memory_config.llm.provider = _DIRECT_OPENAI_PROVIDER
+                    except (AttributeError, TypeError) as exc:
+                        raise RuntimeError("mem0 MemoryConfig does not expose a mutable llm.provider for the Hermes OpenAI OSS backend") from exc
+                    self._memory = Memory(memory_config)
+                else:
+                    self._memory = Memory.from_config(config)
+                break
+            except Exception as exc:
+                if "already accessed by another instance" not in str(exc).lower():
+                    raise
+                if attempt >= _LOCK_RETRY_ATTEMPTS:
+                    raise
+                logger.warning(
+                    "mem0 qdrant storage lock held by another instance "
+                    "(attempt %d/%d, retrying in %ds)",
+                    attempt, _LOCK_RETRY_ATTEMPTS, _LOCK_RETRY_WAIT_SECS,
+                )
+                time.sleep(_LOCK_RETRY_WAIT_SECS)
 
     @staticmethod
     def _recreate_collection_if_dims_changed(provider: str, vs_config: dict, expected_dims: int) -> None:

--- a/plugins/memory/mem0/_openai_llm.py
+++ b/plugins/memory/mem0/_openai_llm.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import logging
 import os
+import time as _time
+from datetime import datetime, timezone
 from typing import Dict, List, Optional, Union
 
 from mem0.configs.llms.base import BaseLlmConfig
@@ -14,6 +16,31 @@ from mem0.llms.openai import OpenAILLM
 # BaseLlmConfig fields copied into OpenAIConfig; the last two may be absent on older mem0.
 _COPIED_FIELDS = ("model", "temperature", "api_key", "max_tokens", "top_p", "top_k", "enable_vision", "vision_details", "http_client_proxies")
 _OPTIONAL_FIELDS = ("reasoning_effort", "is_reasoning_model")
+
+# OpenRouter-style routers report 402 (in-flight or credit budget exhausted) plus
+# transient 429/5xx; retry with backoff instead of failing the memory append.
+# Some 402s remedy with "wait for in-flight requests to settle" — honor
+# Retry-After (capped) exactly as the provider asks.
+_RETRYABLE_STATUS_CODES = {402, 408, 409, 429, 500, 502, 503, 504}
+_MAX_RETRY_ATTEMPTS = 3
+_MAX_RETRY_WAIT_SECS = 120
+
+
+def _retry_wait_seconds(exc: Exception) -> float:
+    """Extract Retry-After (seconds or HTTP-date) from an OpenAI status error."""
+    try:
+        resp = getattr(exc, "response", None)
+        headers = getattr(resp, "headers", {}) if resp is not None else {}
+        raw = headers.get("retry-after") or headers.get("Retry-After")
+        if not raw:
+            return 5.0
+        try:
+            return max(1.0, float(raw))
+        except ValueError:
+            parsed = datetime.strptime(str(raw), "%a, %d %b %Y %H:%M:%S %Z").replace(tzinfo=timezone.utc)
+            return max(1.0, (parsed - datetime.now(timezone.utc)).total_seconds())
+    except Exception:
+        return 5.0
 
 
 class DirectOpenAILLM(OpenAILLM):
@@ -53,7 +80,23 @@ class DirectOpenAILLM(OpenAILLM):
             params["response_format"] = response_format
         if tools:
             params["tools"], params["tool_choice"] = tools, tool_choice
-        response = self.client.chat.completions.create(**params)
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                response = self.client.chat.completions.create(**params)
+                break
+            except Exception as exc:
+                status = getattr(exc, "status_code", None)
+                is_retryable = status in _RETRYABLE_STATUS_CODES or status is None  # network-level failure
+                if not is_retryable or attempt > _MAX_RETRY_ATTEMPTS:
+                    raise
+                wait = min(_retry_wait_seconds(exc), _MAX_RETRY_WAIT_SECS)
+                logging.warning(
+                    "Mem0 OpenAI call failed (attempt %d/%d, status=%s); retrying in %.0fs",
+                    attempt, _MAX_RETRY_ATTEMPTS, status, wait,
+                )
+                _time.sleep(wait)
         parsed_response = self._parse_response(response, tools)
         if self.config.response_callback:
             try:

--- a/plugins/memory/mem0/_openai_llm.py
+++ b/plugins/memory/mem0/_openai_llm.py
@@ -22,6 +22,12 @@ _OPTIONAL_FIELDS = ("reasoning_effort", "is_reasoning_model")
 # Some 402s remedy with "wait for in-flight requests to settle" — honor
 # Retry-After (capped) exactly as the provider asks.
 _RETRYABLE_STATUS_CODES = {402, 408, 409, 429, 500, 502, 503, 504}
+# Transport-class failures carry no HTTP status; retry those, but never mask
+# local programmer errors (TypeError/ValueError carry no status either).
+_TRANSPORT_ERROR_NAMES = frozenset({
+    "APIConnectionError", "APITimeoutError", "ConnectError", "ConnectionError",
+    "ReadTimeout", "RemoteProtocolError",
+})
 _MAX_RETRY_ATTEMPTS = 3
 _MAX_RETRY_WAIT_SECS = 120
 
@@ -88,7 +94,14 @@ class DirectOpenAILLM(OpenAILLM):
                 break
             except Exception as exc:
                 status = getattr(exc, "status_code", None)
-                is_retryable = status in _RETRYABLE_STATUS_CODES or status is None  # network-level failure
+                if status in _RETRYABLE_STATUS_CODES:
+                    is_retryable = True
+                elif status is None:
+                    # Transport-class failures have no HTTP status; retry those,
+                    # but never mask local programmer errors (no status either).
+                    is_retryable = type(exc).__name__ in _TRANSPORT_ERROR_NAMES
+                else:
+                    is_retryable = False
                 if not is_retryable or attempt > _MAX_RETRY_ATTEMPTS:
                     raise
                 wait = min(_retry_wait_seconds(exc), _MAX_RETRY_WAIT_SECS)

--- a/tests/plugins/memory/test_mem0_backend.py
+++ b/tests/plugins/memory/test_mem0_backend.py
@@ -618,7 +618,211 @@ class TestOSSBackend:
         assert raw == before
 
 
+class TestOSSBackendLockRetry:
+    """OSSBackend must survive transient qdrant local-storage lock contention.
+
+    Qdrant local mode (vector_store.path) is guarded by an exclusive file
+    lock that the gateway holds for its whole lifetime; a second opener gets
+    ``RuntimeError: ... already accessed by another instance`` at open. The
+    constructor now retries briefly so the restart-overlap window self-heals
+    instead of failing this backend for the rest of the process's life.
+    """
+
+    def _raw_config(self):
+        return {
+            "llm": {"provider": "ollama", "config": {"model": "ollama3.1", "api_base": "http://ollama:11434"}},
+            "embedder": {"provider": "ollama", "config": {"model": "nomic-embed-text"}},
+            "vector_store": {"provider": "qdrant", "config": {}},
+        }
+
+    def _inject_mem0(self, fail_first, monkeypatch):
+        """Stub mem0.Memory.from_config: lock error for the first `fail_first` calls."""
+        import sys
+        import types
+
+        import plugins.memory.mem0._backend as backend_mod
+
+        calls = {"n": 0}
+
+        class Memory:
+            @staticmethod
+            def from_config(config):
+                calls["n"] += 1
+                if calls["n"] <= fail_first:
+                    raise RuntimeError(
+                        "Storage folder /x/mem0_qdrant is already accessed by "
+                        "another instance of Qdrant client. If you require "
+                        "concurrent access, use Qdrant server instead."
+                    )
+                return FakeOSSMemory()
+
+        stub_mem0 = types.ModuleType("mem0")
+        stub_mem0.Memory = Memory  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "mem0", stub_mem0)
+        # Don't actually sleep in tests.
+        monkeypatch.setattr(backend_mod.time, "sleep", lambda s: None)
+        return calls
+
+    def test_retries_then_succeeds_once_lock_released(self, monkeypatch):
+        calls = self._inject_mem0(fail_first=2, monkeypatch=monkeypatch)
+        backend = OSSBackend(self._raw_config())
+        assert calls["n"] == 3  # 2 lock failures + 1 success
+        assert isinstance(backend._memory, FakeOSSMemory)
+
+    def test_raises_after_retry_budget_exhausted(self, monkeypatch):
+        import plugins.memory.mem0._backend as backend_mod
+
+        calls = self._inject_mem0(fail_first=10**6, monkeypatch=monkeypatch)
+        with pytest.raises(RuntimeError, match="already accessed by another instance"):
+            OSSBackend(self._raw_config())
+        assert calls["n"] == backend_mod._LOCK_RETRY_ATTEMPTS
+
+    def test_non_lock_errors_raise_immediately(self, monkeypatch):
+        import sys
+        import types
+
+        import plugins.memory.mem0._backend as backend_mod
+
+        calls = {"n": 0}
+
+        class Memory:
+            @staticmethod
+            def from_config(config):
+                calls["n"] += 1
+                raise ValueError("boom")
+
+        stub_mem0 = types.ModuleType("mem0")
+        stub_mem0.Memory = Memory  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "mem0", stub_mem0)
+        monkeypatch.setattr(backend_mod.time, "sleep", lambda s: None)
+
+        with pytest.raises(ValueError, match="boom"):
+            OSSBackend(self._raw_config())
+        assert calls["n"] == 1  # no retry for non-lock errors
+
+
 httpx = pytest.importorskip("httpx")
+
+
+def _status_error(status_code: int) -> RuntimeError:
+    """RuntimeError carrying OpenAI-style ``status_code`` (and empty headers)."""
+    exc = RuntimeError(f"transient status {status_code}")
+    exc.status_code = status_code  # type: ignore[attr-defined]
+    return exc
+
+
+class TestDirectOpenAIResilience:
+    """DirectOpenAILLM must retry transient router statuses and raise on hard ones."""
+
+    def _adapter(self, monkeypatch):
+        state, _, factory = _install_fake_mem0(monkeypatch)
+        module = importlib.import_module("plugins.memory.mem0._openai_llm")
+        config = factory.provider_to_class["openai"][1](
+            model="gpt-5-mini",
+            api_key="retry-sentinel",
+            openai_base_url="https://openai.example/v1",
+        )
+        adapter = module.DirectOpenAILLM(config)
+        # No real sleeps in tests.
+        monkeypatch.setattr(module._time, "sleep", lambda s: None)
+        return state, adapter
+
+    def test_retries_transient_status_then_succeeds(self, monkeypatch):
+        state, adapter = self._adapter(monkeypatch)
+        calls = {"n": 0}
+        client = state.clients[0]
+
+        def flaky_create(**params):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise _status_error(429)
+            return client._create(**params)
+
+        client.chat.completions.create = flaky_create
+
+        result = adapter.generate_response([{"role": "user", "content": "remember tea"}])
+
+        assert calls["n"] == 2  # 1 failure + 1 success
+        assert result == "direct answer"
+        assert len(state.requests) == 1  # only the successful attempt reaches the wire
+
+    def test_hard_status_raises_immediately(self, monkeypatch):
+        state, adapter = self._adapter(monkeypatch)
+        calls = {"n": 0}
+        client = state.clients[0]
+
+        def failing_create(**params):
+            calls["n"] += 1
+            raise _status_error(400)
+
+        client.chat.completions.create = failing_create
+
+        with pytest.raises(RuntimeError, match="transient status 400"):
+            adapter.generate_response([{"role": "user", "content": "remember tea"}])
+        assert calls["n"] == 1  # no retry for client errors
+
+
+class TestOSSBackendKeysAndDims:
+    """OSSBackend must resolve keys per vendor and confine embedder dims to the store."""
+
+    def test_env_api_key_injection_and_max_tokens_for_openai_llm(self, monkeypatch):
+        state, Memory, _ = _install_fake_mem0(monkeypatch)
+        monkeypatch.setenv("OPENAI_API_KEY", "")
+        monkeypatch.setenv("MEM0_LLM_API_KEY", "llm-env-sentinel")
+        raw = {
+            "llm": {
+                "provider": "openai",
+                "config": {"model": "gpt-5-mini", "openai_base_url": "https://llm.example/v1"},
+            },
+            "embedder": {"provider": "ollama", "config": {}},
+            "vector_store": {"provider": "qdrant", "config": {}},
+        }
+        before = copy.deepcopy(raw)
+
+        OSSBackend(raw)
+
+        captured = Memory.instances[0].config
+        assert captured.llm.config["api_key"] == "llm-env-sentinel"
+        assert captured.llm.config["max_tokens"] == 2000
+        assert raw == before  # inputs are never mutated
+
+    def test_siliconflow_uses_same_vendor_key_not_mismatched_fallback(self, monkeypatch):
+        state, Memory, _ = _install_fake_mem0(monkeypatch)
+        monkeypatch.setenv("OPENAI_API_KEY", "")
+        monkeypatch.setenv("MEM0_LLM_API_KEY", "mismatched-router-sentinel")
+        monkeypatch.setenv("MEM0_EMBEDDER_API_KEY", "siliconflow-sentinel")
+        raw = {
+            "llm": {
+                "provider": "openai",
+                "config": {"model": "deepseek-v3.2", "openai_base_url": "https://api.siliconflow.cn/v1"},
+            },
+            "embedder": {"provider": "ollama", "config": {}},
+            "vector_store": {"provider": "qdrant", "config": {}},
+        }
+
+        OSSBackend(raw)
+
+        captured = Memory.instances[0].config
+        assert captured.llm.config["api_key"] == "siliconflow-sentinel"
+        assert "mismatched-router-sentinel" not in captured.llm.config.values()
+
+    def test_embedder_dims_are_moved_to_vector_store_not_leaked_to_api(self, monkeypatch):
+        state, Memory, _ = _install_fake_mem0(monkeypatch)
+        raw = {
+            "llm": {"provider": "ollama", "config": {}},
+            "embedder": {
+                "provider": "openai",
+                "config": {"model": "BAAI/bge-m3", "openai_base_url": "https://api.siliconflow.cn/v1", "embedding_dims": 1024},
+            },
+            "vector_store": {"provider": "qdrant", "config": {}},
+        }
+
+        OSSBackend(raw)
+
+        captured = Memory.instances[0].config
+        assert captured.vector_store.config["embedding_model_dims"] == 1024
+        assert "embedding_dims" not in captured.embedder.config
+        assert raw["embedder"]["config"]["embedding_dims"] == 1024  # caller's dict untouched
 
 
 class _StubServer:

--- a/tests/plugins/memory/test_mem0_backend.py
+++ b/tests/plugins/memory/test_mem0_backend.py
@@ -761,6 +761,23 @@ class TestDirectOpenAIResilience:
             adapter.generate_response([{"role": "user", "content": "remember tea"}])
         assert calls["n"] == 1  # no retry for client errors
 
+    def test_local_programmer_error_raises_immediately(self, monkeypatch):
+        # A status-less local bug (e.g. bad params) must not be masked by the
+        # transport-retry path (which also sees status None).
+        state, adapter = self._adapter(monkeypatch)
+        calls = {"n": 0}
+        client = state.clients[0]
+
+        def buggy_create(**params):
+            calls["n"] += 1
+            raise TypeError("bad params")
+
+        client.chat.completions.create = buggy_create
+
+        with pytest.raises(TypeError, match="bad params"):
+            adapter.generate_response([{"role": "user", "content": "remember tea"}])
+        assert calls["n"] == 1  # no retry for local programmer errors
+
 
 class TestOSSBackendKeysAndDims:
     """OSSBackend must resolve keys per vendor and confine embedder dims to the store."""


### PR DESCRIPTION
## 问题（均为可复现缺陷）

1. **Qdrant 本地模式单持有者锁无自愈**：`vector_store.path` 由首个进程终身持有 flock；网关重启重叠窗口内第二次打开直接 `RuntimeError: ... already accessed by another instance`，此后该进程整个生命周期记忆后端永久不可用。
2. **路由器瞬时故障无重试**：`DirectOpenAILLM.generate_response` 单次调用即抛；OpenRouter/兼容网关的 402（额度/并发预算）、429、5xx 会让 mem0 `add()` 静默放弃抽取（`LLM extraction failed` 是唯一痕迹）。
3. **OSS 供应商密钥无法从环境注入**：`_provider_block` 只认 `config.api_key`，`_oss_providers` registry 的 `env_var` 字段无人消费（死字段）；多供应商各自密钥只能硬写 mem0.json。
4. **嵌入维度泄漏到 API**：embedder config 的 `embedding_dims`（bge-m3 1024 等）会让 mem0 OpenAIEmbedding 发出 `dimensions=`；SiliconFlow 拒绝该参数。维度已正确转移至 `vector_store.embedding_model_dims`，但原键未移除。

## 变更

- OSSBackend 对锁冲突错误（"already accessed by another instance"）重试 10×3s；其它异常立即抛出（保持原行为）。
- DirectOpenAILLM 对 402/408/409/429/5xx 及网络层错误重试 ≤3 次，等待时间取 Retry-After（秒/HTTP-date，上限 120s）。
- 密钥注入（仅当 config 无 api_key）：registry `env_var` → `MEM0_<LLM|EMBEDDER>_API_KEY` → base_url 含 siliconflow 时同厂商复用（防止误用其它厂商 key 导致无声 401）。**从不修改调用方 dict**（保持既有 raw==before 契约）。
- `embedding_dims` 仅在嵌入配置副本中移除；调用方配置与 vector store 的 `embedding_model_dims` 均保留。

## 测试

新增 5 项invariant 测试（锁重试 3 项、重试韧性 2 项、密钥注入 2 项、dims 隔离 1 项 — 合计 22/22）：
`scripts/run_tests.sh tests/plugins/memory/test_mem0_backend.py -q` → **22 passed**
`ruff check` 涉及文件 → **All checks passed**
真实 E2E（SiliconFlow DeepSeek-V3.2）：infer=True 抽取 2 条事实 → 写入 → 语义检索命中 → 清理零残留。

## 讨论点

- commit 3 的 siliconflow 分支是厂商特例；如希望更通用，我可以改为 base_url 查表驱动（在 `_oss_providers` 增加 key 匹配字段）。
- `max_tokens=2000` 默认未纳入（账户预算相关），如需可改为可配置默认。
