### PR TITLE
feat(tools): biometric sudo via PAM PTY (HERMES_SUDO_BIOMETRIC)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -285,6 +285,11 @@ DEFAULT_CONFIG = {
         # Env vars passed into sandboxed terminal/execute_code (skill-declared
         # required_environment_variables pass through automatically).
         "env_passthrough": [],
+        # Biometric sudo (Linux): set HERMES_SUDO_BIOMETRIC=1 to route interactive-local
+        # sudo through a PTY (script -qec) so the platform PAM stack (pam_fprintd) drives
+        # fingerprint auth instead of the text password box. Opt-in; see
+        # tools/terminal_tool_sudo.py::_sudo_biometric_path_available for gating.
+        #
         # HOME for host tool subprocesses: "auto" = host keeps the real OS-user HOME, containers use
         # HERMES_HOME/home; "real" = force real HOME; "profile" = force HERMES_HOME/home when it
         # exists (strict per-profile isolation).

--- a/tests/tools/test_terminal_sudo_biometric.py
+++ b/tests/tools/test_terminal_sudo_biometric.py
@@ -1,0 +1,187 @@
+"""HERMES_SUDO_BIOMETRIC: interactive-local sudo runs through a PTY so the platform
+PAM stack (pam_fprintd on Linux) can drive fingerprint auth instead of a text
+password box.
+
+Opt-in via HERMES_SUDO_BIOMETRIC=1. Only applies on a local, interactive,
+non-delegated, non-gateway session with util-linux ``script`` present. Headless
+contexts (delegate_task children, cron, gateway/messaging) keep failing gracefully
+exactly as before — no hang, no prompt.
+"""
+
+import contextvars
+import os
+import threading
+
+import pytest
+
+from agent.delegation_context import delegated_child_context
+from tools import terminal_tool as tt
+from tools import terminal_tool_sudo as tts
+
+
+@pytest.fixture(autouse=True)
+def _clean_sudo_state(monkeypatch):
+    """Isolate sudo-related process/thread state per test."""
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_SUDO_BIOMETRIC", raising=False)
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    # Host sudoers NOPASSWD must not short-circuit the path under test.
+    monkeypatch.setattr(tts, "_sudo_nopasswd_works", lambda: False)
+    # Deterministic script availability regardless of the test host.
+    monkeypatch.setattr(tts, "_script_available", lambda: True)
+    tts._reset_cached_sudo_passwords()
+    tt.set_sudo_password_callback(None)
+    yield
+    tt.set_sudo_password_callback(None)
+    tts._reset_cached_sudo_passwords()
+
+
+def _transform_in_child(command: str):
+    """Run _transform_sudo_command the way delegate_tool runs children:
+    inside delegated_child_context(), through contextvars.copy_context(),
+    on a separate worker thread."""
+    result = {}
+
+    def _parent_side():
+        with delegated_child_context("child-session"):
+            ctx = contextvars.copy_context()
+
+            def _worker():
+                result["value"] = ctx.run(tts._transform_sudo_command, command)
+
+            t = threading.Thread(target=_worker)
+            t.start()
+            t.join(timeout=10)
+            assert not t.is_alive(), "child transform blocked (prompt fired?)"
+
+    _parent_side()
+    return result["value"]
+
+
+class TestBiometricSudoPath:
+    def test_enabled_local_interactive_wraps_in_pty(self, monkeypatch):
+        monkeypatch.setenv("HERMES_SUDO_BIOMETRIC", "1")
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+
+        transformed, sudo_stdin = tts._transform_sudo_command("sudo apt-get update")
+
+        assert sudo_stdin is None
+        assert transformed is not None
+        assert transformed.startswith("script -qec ")
+        assert "sudo apt-get update" in transformed
+        assert "sudo -S" not in transformed
+
+    def test_banner_present_so_user_knows_to_touch(self, monkeypatch):
+        monkeypatch.setenv("HERMES_SUDO_BIOMETRIC", "1")
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+
+        transformed, sudo_stdin = tts._transform_sudo_command("sudo whoami")
+
+        assert sudo_stdin is None
+        assert transformed is not None
+        assert "TOUCH YOUR FINGER NOW" in transformed
+        # Banner must run before the sudo command inside the PTY.
+        assert transformed.index("TOUCH YOUR FINGER NOW") < transformed.index("sudo whoami")
+
+    def test_disabled_keeps_password_prompt(self, monkeypatch):
+        # HERMES_SUDO_BIOMETRIC unset -> existing password-box path unchanged.
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.setattr(
+            tts, "_prompt_for_sudo_password", lambda timeout_seconds=45: "hunter2"
+        )
+
+        transformed, sudo_stdin = tts._transform_sudo_command("sudo whoami")
+
+        assert sudo_stdin == "hunter2\n"
+        assert transformed is not None
+        assert "sudo -S -p ''" in transformed
+
+    def test_configured_password_wins_over_biometric(self, monkeypatch):
+        monkeypatch.setenv("SUDO_PASSWORD", "s3cret")
+        monkeypatch.setenv("HERMES_SUDO_BIOMETRIC", "1")
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+
+        transformed, sudo_stdin = tts._transform_sudo_command("sudo whoami")
+
+        assert sudo_stdin == "s3cret\n"
+        assert transformed is not None
+        assert "sudo -S -p ''" in transformed
+
+    def test_cached_password_wins_over_biometric(self, monkeypatch):
+        monkeypatch.setenv("HERMES_SUDO_BIOMETRIC", "1")
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        tts._set_cached_sudo_password("cachedpw")
+        try:
+            transformed, sudo_stdin = tts._transform_sudo_command("sudo whoami")
+        finally:
+            tts._reset_cached_sudo_passwords()
+
+        assert sudo_stdin == "cachedpw\n"
+        assert transformed is not None
+        assert "sudo -S -p ''" in transformed
+
+    def test_never_in_delegated_child(self, monkeypatch):
+        monkeypatch.setenv("HERMES_SUDO_BIOMETRIC", "1")
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+
+        transformed, sudo_stdin = _transform_in_child("sudo apt-get update")
+
+        assert sudo_stdin is None
+        # Unchanged: child has no user on the other side, fails gracefully.
+        assert transformed == "sudo apt-get update"
+        assert "script -qec" not in (transformed or "")
+
+    def test_never_in_gateway_session(self, monkeypatch):
+        monkeypatch.setenv("HERMES_SUDO_BIOMETRIC", "1")
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+
+        transformed, sudo_stdin = tts._transform_sudo_command("sudo whoami")
+
+        # Gateway: no interactive prompt either -> unchanged, no password.
+        assert sudo_stdin is None
+        assert transformed == "sudo whoami"
+        assert "script -qec" not in (transformed or "")
+
+    def test_script_missing_falls_back_to_password(self, monkeypatch):
+        monkeypatch.setenv("HERMES_SUDO_BIOMETRIC", "1")
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.setattr(tts, "_script_available", lambda: False)
+        monkeypatch.setattr(
+            tts, "_prompt_for_sudo_password", lambda timeout_seconds=45: "hunter2"
+        )
+
+        transformed, sudo_stdin = tts._transform_sudo_command("sudo whoami")
+
+        assert sudo_stdin == "hunter2\n"
+        assert transformed is not None
+        assert "sudo -S -p ''" in transformed
+
+    def test_windows_never_biometric(self, monkeypatch):
+        monkeypatch.setenv("HERMES_SUDO_BIOMETRIC", "1")
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        # Force Windows detection; the biometric path must not fire on Windows
+        # (no PAM/fprintd; MSYS 'script' would be a false positive).
+        monkeypatch.setattr(tts.platform, "system", lambda: "Windows")
+
+        assert tts._sudo_biometric_path_available() is False
+
+        transformed, sudo_stdin = tts._transform_sudo_command("sudo whoami")
+
+        assert "script -qec" not in (transformed or "")
+        assert sudo_stdin is None
+
+    def test_non_local_backend_never_biometric(self, monkeypatch):
+        monkeypatch.setenv("HERMES_SUDO_BIOMETRIC", "1")
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+
+        # _sudo_biometric_path_available re-imports _tenv from tools.terminal_tool at
+        # call time, so patching the module attribute controls the branch.
+        import tools.terminal_tool as tt_mod
+
+        monkeypatch.setattr(tt_mod, "_tenv", lambda name, default=None: "ssh")
+        assert tts._sudo_biometric_path_available() is False
+
+        monkeypatch.setattr(tt_mod, "_tenv", lambda name, default=None: "local")
+        assert tts._sudo_biometric_path_available() is True

--- a/tools/terminal_tool_sudo.py
+++ b/tools/terminal_tool_sudo.py
@@ -8,6 +8,8 @@ import logging
 import os
 import platform
 import re
+import shlex
+import shutil
 import subprocess
 import sys
 import threading
@@ -336,6 +338,57 @@ def _sudo_nopasswd_works() -> bool:
         return False
 
 
+def _script_available() -> bool:
+    """True when util-linux ``script`` (the PTY wrapper) is on PATH. Required for the
+    biometric sudo path — without a PTY the platform PAM stack cannot drive interactive
+    auth, so we degrade back to the password prompt when it is missing."""
+    try:
+        return shutil.which("script") is not None
+    except Exception:
+        return False
+
+
+def _sudo_biometric_path_available() -> bool:
+    """True when in-session sudo should run through the real platform PAM stack on a PTY
+    instead of a password box: ``HERMES_SUDO_BIOMETRIC=1`` on a local, interactive,
+    non-delegated, non-gateway session with util-linux ``script`` present.
+
+    Headless contexts (delegate_task children, cron, gateway/messaging sessions) never
+    take this path — there is no local console to touch a fingerprint reader, so they
+    keep failing gracefully exactly as they do today."""
+    if not env_var_enabled("HERMES_SUDO_BIOMETRIC"):
+        return False
+    if platform.system() == "Windows":
+        return False
+    if _in_delegated_child_context() or env_var_enabled("HERMES_GATEWAY_SESSION"):
+        return False
+    if not _script_available():
+        return False
+    from tools.terminal_tool import _tenv
+    if (_tenv("TERMINAL_ENV", "local").strip().lower() or "local") != "local":
+        return False
+    from tools.terminal_tool import _get_sudo_password_callback
+    return env_var_enabled("HERMES_INTERACTIVE") or _get_sudo_password_callback() is not None
+
+
+_SUDO_BIOMETRIC_BANNER = (
+    "printf '\\n\\a================================================\\n"
+    "  TOUCH YOUR FINGER NOW - fingerprint required for sudo\\n"
+    "================================================\\n\\n'; "
+)
+
+
+def _wrap_sudo_pty(command: str) -> str:
+    """Wrap *command* in ``script -qec ... /dev/null`` so the child gets a controlling PTY
+    and PAM can drive interactive auth (fingerprint first via pam_fprintd, password
+    fallback). A visible banner (plus terminal bell) is printed before the sudo command
+    so the user knows to touch the sensor inside PAM's prompt window — the fprintd prompt
+    itself is plain text inside the captured PTY and gives no on-screen cue. The
+    typescript is discarded to /dev/null; the child's stdout/stderr still streams to the
+    terminal tool's capture."""
+    return f"script -qec {shlex.quote(_SUDO_BIOMETRIC_BANNER + command)} /dev/null"
+
+
 def _rewrite_compound_background(command: str) -> str:
     """Wrap `A && B &` (or `A || B &`) to `A && { B & }` at depth 0. Bash binds `&&` tighter
     than `&`, so `A && B &` backgrounds a subshell that runs B in the foreground and waits for
@@ -421,6 +474,12 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
     # sudoers NOPASSWD hosts must not be forced through the prompt or the -S pipe (local only).
     if not has_configured_password and not sudo_password and _sudo_nopasswd_works():
         return command, None
+
+    # Biometric PAM path (opt-in): hand sudo a real PTY so the platform PAM stack
+    # (pam_fprintd on Linux) drives fingerprint auth instead of a text password box.
+    # Password stays authoritative — a configured or session-cached password wins.
+    if not has_configured_password and not sudo_password and _sudo_biometric_path_available():
+        return _wrap_sudo_pty(command), None
 
     # delegate_task children inherit HERMES_INTERACTIVE=1 (and possibly a stale thread-local
     # callback on a recycled worker) but have no user on the other side — always headless;


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in biometric path for interactive-local sudo on Linux: when
`HERMES_SUDO_BIOMETRIC=1` is set, sudo commands run through a PTY
(`script -qec '<cmd>' /dev/null`) so the platform PAM stack (`pam_fprintd`)
drives fingerprint auth instead of the text password box. A visible banner +
terminal bell prints before the command so the user knows to touch the sensor
inside PAM's prompt window.

**Why this approach:** on Linux with pam_fprintd configured in `common-auth`,
sudo already supports fingerprint auth on a real TTY — the terminal tool just
never gave it a TTY (`_run_bash` spawns with pipes and `start_new_session`).
Wrapping the command in `script(1)` allocates a controlling PTY so PAM's
conversation works unchanged. No credentials are stored or piped; the platform
PAM stack validates the biometric directly.

**Gating (fail-safe):**
- Opt-in via env var; without it, behavior is unchanged (password prompt).
- Password stays authoritative: configured `SUDO_PASSWORD` or a session-cached
  password wins over the biometric path.
- Headless contexts (delegate_task children, cron, gateway/messaging sessions)
  never take this path and keep failing gracefully as before.
- Non-local backends (SSH, Modal, Docker) are excluded.
- Windows is excluded (no PAM/fprintd; MSYS `script` would be a false positive).
- If util-linux `script(1)` is missing, the password prompt remains the fallback.

## Related Issue

No issue filed — feature request surfaced from local use. Happy to file one if
maintainers prefer.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tools/terminal_tool_sudo.py` — `_script_available()`,
  `_sudo_biometric_path_available()`, `_SUDO_BIOMETRIC_BANNER`,
  `_wrap_sudo_pty()`; biometric branch in `_transform_sudo_command()`.
- `tests/tools/test_terminal_sudo_biometric.py` — 10 tests: PTY wrap, banner
  ordering, password precedence (configured + cached), delegated-child
  exclusion, gateway exclusion, script-missing fallback, non-local backend
  exclusion, Windows exclusion.
- `hermes_cli/config_defaults.py` — documentation comment for the env var next
  to the `terminal:` config section.

## How to Test

1. Set `HERMES_SUDO_BIOMETRIC=1` and `HERMES_INTERACTIVE=1` in a local
   interactive CLI session.
2. Run a sudo command (e.g. `sudo whoami`) through the terminal tool.
3. Confirm the banner "TOUCH YOUR FINGER NOW" prints, then the PAM prompt
   "Place your finger on the fingerprint reader".
4. Touch an enrolled finger; the command completes with elevated rights.
5. Without the env var, confirm the existing password-box path is unchanged.

Automated: `scripts/run_tests.sh tests/tools/test_terminal_sudo_biometric.py
tests/tools/test_subagent_sudo_prompt.py` (17 tests, all pass).

## Screenshots / Logs

End-to-end run through the real production path (LocalEnvironment.execute ->
transform -> script PTY -> PAM -> fprintd):

```
================================================
  TOUCH YOUR FINGER NOW - fingerprint required for sudo
================================================

Place your finger on the fingerprint reader
root
ROOT_OK
```

`rc=0`, `sudo whoami` returned `root` after a live fingerprint match.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(tools): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` (full suite): ~42,274 pass; 68 pre-existing failures (acp/video-gen/update-guard/daytona-modal), zero overlap with this diff; 10/10 new tests pass
- [x] I've added tests for my changes (10 new)
- [x] I've tested on my platform: Linux Mint 22 Cinnamon (x11), Framework 16

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstring + config_defaults.py comment)
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (env var only)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Windows explicitly excluded
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A (internal transform, no tool schema change)

## For New Skills

N/A
