### PR TITLE
fix(kanban): snapshot worktree completion artifacts into durable board-correct attachments

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2530,7 +2530,7 @@ class HallucinatedCardsError(ValueError):
 
 
 class ArtifactPreservationError(RuntimeError):
-    """Raised when a declared scratch deliverable cannot be preserved."""
+    """Raised when a declared completion deliverable cannot be preserved."""
 
 
 def complete_task(
@@ -2644,7 +2644,7 @@ def _gate_created_cards(
 
 
 def _stage_completion_artifacts(conn: sqlite3.Connection, task_id: str, metadata: dict, now: int) -> None:
-    """Copy scratch artifacts to the attachments dir and record each as an attachment row."""
+    """Copy scratch/worktree artifacts to the attachments dir and record each as an attachment row."""
     _persist_scratch_completion_artifacts(conn, task_id, metadata)
     for stored_path in metadata.pop("_staged_artifacts", []):
         path = Path(stored_path)
@@ -2736,20 +2736,82 @@ def _merge_completion_prose_artifacts(
     return updated
 
 
+def _board_slug_for_connection(conn: sqlite3.Connection) -> Optional[str]:
+    """Board slug whose DB file this connection is open on, if the layout is known.
+
+    Scratch artifact copies infer board from the managed workspace path.
+    Worktree paths live outside that root, so the live connection file is the
+    authority that keeps snapshot bytes on the same board as the attachment rows.
+    """
+    try:
+        row = conn.execute("PRAGMA database_list").fetchone()
+    except sqlite3.Error:
+        return None
+    raw = ""
+    if row is not None:
+        keys = row.keys() if hasattr(row, "keys") else ()
+        if "file" in keys:
+            raw = row["file"] or ""
+        elif len(row) > 2:
+            raw = row[2] or ""
+    if not raw:
+        return None
+    db_path = Path(raw).expanduser()
+    try:
+        db_path = db_path.resolve()
+    except OSError:
+        return None
+    try:
+        parent = db_path.parent
+        if db_path.name == "kanban.db" and parent.parent.resolve() == boards_root().resolve():
+            return _normalize_board_slug(parent.name)
+    except (OSError, ValueError):
+        pass
+    try:
+        # Env-independent default-board path: kanban_db_path() honors the
+        # HERMES_KANBAN_DB pin the dispatcher injects into workers and ignores
+        # board=, so comparing against it would misreport a pinned named-board
+        # connection as 'default'. Build the legacy default location directly.
+        if db_path == (kanban_home() / "kanban.db").expanduser().resolve():
+            return DEFAULT_BOARD
+    except OSError:
+        pass
+    return None
+
+
+def _worktree_completion_workspace(
+    conn: sqlite3.Connection, task_id: str,
+) -> tuple[Optional[Path], Optional[str]]:
+    """Worktree path + board for declared completion artifacts, else ``(None, None)``."""
+    row = conn.execute(
+        "SELECT workspace_kind, workspace_path FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if not row or row["workspace_kind"] != "worktree" or not row["workspace_path"]:
+        return None, None
+    board = _board_slug_for_connection(conn) or get_current_board()
+    return Path(row["workspace_path"]).expanduser(), board
+
+
 def _persist_scratch_completion_artifacts(
     conn: sqlite3.Connection, task_id: str, metadata: dict,
 ) -> None:
-    """Copy scratch-workspace completion artifacts before cleanup removes them."""
+    """Copy scratch/worktree completion artifacts before cleanup can drop them."""
     raw_artifacts = metadata.get("artifacts")
     if not isinstance(raw_artifacts, (list, tuple)):
         return
 
     workspace = _scratch_workspace(conn, task_id)
-    if workspace is None:
-        return
-    is_managed, board = _managed_scratch_path_info(workspace)
-    if not is_managed:
-        return
+    kind = "scratch"
+    if workspace is not None:
+        is_managed, board = _managed_scratch_path_info(workspace)
+        if not is_managed:
+            return
+    else:
+        workspace, board = _worktree_completion_workspace(conn, task_id)
+        kind = "worktree"
+        if workspace is None:
+            return
 
     try:
         workspace_root = workspace.resolve()
@@ -2785,10 +2847,10 @@ def _persist_scratch_completion_artifacts(
 
         problem = None
         if not src.is_file():
-            problem = f"declared scratch artifact is unavailable or not a regular file: {artifact}"
+            problem = f"declared {kind} artifact is unavailable or not a regular file: {artifact}"
         elif resolved_src.stat().st_size > KANBAN_ATTACHMENT_MAX_BYTES:
             problem = (
-                f"declared scratch artifact exceeds the "
+                f"declared {kind} artifact exceeds the "
                 f"{KANBAN_ATTACHMENT_MAX_BYTES}-byte limit: {artifact}"
             )
         if problem:
@@ -2808,7 +2870,7 @@ def _persist_scratch_completion_artifacts(
             if isinstance(exc, ArtifactPreservationError):
                 raise
             raise ArtifactPreservationError(
-                f"could not preserve declared scratch artifact {artifact}: {exc}"
+                f"could not preserve declared {kind} artifact {artifact}: {exc}"
             ) from exc
         used_destinations.add(dest)
         persisted.append(str(dest.resolve()))
@@ -2829,7 +2891,7 @@ def _copy_capped(src: Path, dest: Path, artifact: str) -> None:
             copied += len(chunk)
             if copied > KANBAN_ATTACHMENT_MAX_BYTES:
                 raise ArtifactPreservationError(
-                    f"declared scratch artifact grew beyond the size limit: {artifact}"
+                    f"declared artifact grew beyond the size limit: {artifact}"
                 )
             destination_file.write(chunk)
 

--- a/tests/hermes_cli/test_kanban_worktree_teardown.py
+++ b/tests/hermes_cli/test_kanban_worktree_teardown.py
@@ -182,6 +182,136 @@ def test_complete_task_reaps_clean_worktree(kanban_home: Path, repo: Path) -> No
     assert not _branch_exists(repo, f"wt/{tid}")
 
 
+def test_complete_task_worktree_artifact_survives_source_mutation(
+    kanban_home: Path, repo: Path
+) -> None:
+    """Declared worktree artifacts keep the bytes submitted at completion.
+
+    Scratch workspaces already copy declared deliverables into durable
+    attachment storage. Worktree tasks must use that same staging path so a
+    post-completion mutation or removal of the original file cannot alias
+    the completed evidence. Worktree deletion is not required: unlinking
+    the original file is enough to prove the snapshot is independent.
+    """
+    bytes_a = b"completion-boundary-A"
+    bytes_b = b"post-completion-B----"
+    with kbc.connect_closing() as conn:
+        tid, wt = _worktree_task(conn, repo)
+        artifact = wt / "deliverable.bin"
+        artifact.write_bytes(bytes_a)
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+        assert kb.claim_task(conn, tid, claimer="worker") is not None
+        assert kb.complete_task(
+            conn,
+            tid,
+            result="ok",
+            metadata={"artifacts": [str(artifact)]},
+        )
+        completed = [e for e in kb.list_events(conn, tid) if e.kind == "completed"][-1]
+        run = kb.latest_run(conn, tid)
+        attachments = kb.list_attachments(conn, tid)
+        event_refs = list((completed.payload or {}).get("artifacts") or [])
+        run_refs = list((run.metadata or {}).get("artifacts") or []) if run else []
+        attachment_paths = [a.stored_path for a in attachments]
+
+    assert event_refs and run_refs and attachment_paths
+    assert event_refs == run_refs == attachment_paths
+    persisted = Path(event_refs[0])
+    assert persisted.parent == kb.task_attachments_dir(tid)
+    assert persisted.name == "deliverable.bin"
+    assert str(persisted) != str(artifact)
+    assert persisted.read_bytes() == bytes_a
+
+    assert artifact.exists(), "dirty worktree is preserved; mutation does not need deletion"
+    artifact.write_bytes(bytes_b)
+    artifact.unlink()
+    assert persisted.read_bytes() == bytes_a
+    assert [(a.filename, a.stored_path) for a in attachments] == [
+        ("deliverable.bin", str(persisted.resolve()))
+    ]
+
+
+def test_complete_task_worktree_artifact_uses_connection_board(
+    kanban_home: Path, repo: Path
+) -> None:
+    """Worktree snapshots land on the connection's board, not the ambient board."""
+    kb.create_board("other")
+    assert kb.get_current_board() == "default"
+    bytes_a = b"explicit-board-A"
+    bytes_b = b"explicit-board-B"
+    with kbc.connect_closing(board="other") as conn:
+        tid, wt = _worktree_task(conn, repo)
+        artifact = wt / "board.bin"
+        artifact.write_bytes(bytes_a)
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+        assert kb.claim_task(conn, tid, claimer="worker") is not None
+        assert kb.complete_task(
+            conn,
+            tid,
+            result="ok",
+            metadata={"artifacts": [str(artifact)]},
+        )
+        completed = [e for e in kb.list_events(conn, tid) if e.kind == "completed"][-1]
+        run = kb.latest_run(conn, tid)
+        attachments = kb.list_attachments(conn, tid)
+        event_refs = list((completed.payload or {}).get("artifacts") or [])
+        run_refs = list((run.metadata or {}).get("artifacts") or []) if run else []
+        attachment_paths = [a.stored_path for a in attachments]
+
+    assert event_refs == run_refs == attachment_paths
+    persisted = Path(event_refs[0])
+    other_dir = kb.task_attachments_dir(tid, board="other")
+    default_dir = kb.task_attachments_dir(tid, board="default")
+    assert persisted.parent == other_dir
+    assert persisted.parent != default_dir
+    artifact.write_bytes(bytes_b)
+    artifact.unlink()
+    assert persisted.read_bytes() == bytes_a
+    assert not (default_dir / "board.bin").exists()
+
+
+def test_complete_task_worktree_artifact_worker_env_pins_named_board(
+    kanban_home: Path, repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Dispatcher-spawned workers keep named-board snapshots on the named board.
+
+    ``kanban_db_dispatch._default_spawn`` pins ``HERMES_KANBAN_DB`` (and
+    ``HERMES_KANBAN_BOARD``) into every worker's env. Because
+    ``kanban_db_path()`` honors that pin regardless of its ``board=``
+    argument, board resolution from the live connection must not compare
+    against env-contaminated paths — otherwise a named board's snapshot
+    lands under the default board's attachments tree.
+    """
+    kb.create_board("other")
+    other_db = kb.kanban_db_path(board="other")
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(other_db))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "other")
+    payload = b"worker-env-A"
+    with kbc.connect_closing() as conn:
+        tid, wt = _worktree_task(conn, repo)
+        artifact = wt / "worker.bin"
+        artifact.write_bytes(payload)
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+        assert kb.claim_task(conn, tid, claimer="worker") is not None
+        assert kb.complete_task(
+            conn,
+            tid,
+            result="ok",
+            metadata={"artifacts": [str(artifact)]},
+        )
+        attachments = kb.list_attachments(conn, tid)
+
+    assert [a.filename for a in attachments] == ["worker.bin"]
+    persisted = Path(attachments[0].stored_path)
+    assert persisted.parent == kb.task_attachments_dir(tid, board="other")
+    assert persisted.parent != kb.task_attachments_dir(tid, board="default")
+    artifact.unlink()
+    assert persisted.read_bytes() == payload
+
+
 def test_complete_task_preserves_dirty_worktree(kanban_home: Path, repo: Path) -> None:
     with kbc.connect_closing() as conn:
         tid, wt = _worktree_task(conn, repo)

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -574,7 +574,7 @@ def _handle_complete(args: dict, **kw) -> str:
             # blocks or crashes the run instead of retrying. See #22923.
             return tool_error(
                 f"kanban_complete could not preserve the declared artifacts: {artifact_err}. "
-                f"Your task is still in-flight and its scratch workspace was kept. Fix the "
+                f"Your task is still in-flight and its workspace was kept. Fix the "
                 f"artifact path or storage error, then retry kanban_complete with the same "
                 f"handoff.")
         except kb.HallucinatedCardsError as hall_err:

--- a/tools/kanban_tools_schemas.py
+++ b/tools/kanban_tools_schemas.py
@@ -156,8 +156,10 @@ KANBAN_COMPLETE_SCHEMA = _schema(
                 "are not the deliverable. The path must exist "
                 "on disk at completion. Files inside a managed scratch "
                 "workspace are copied to durable task attachments before "
-                "cleanup; a missing declared scratch artifact keeps the "
-                "task in-flight so you can fix the path and retry."
+                "cleanup; declared files inside a worktree workspace are "
+                "snapshotted the same way. A missing declared scratch or "
+                "worktree artifact keeps the task in-flight so you can fix "
+                "the path and retry."
             ),
         },
     },


### PR DESCRIPTION
## Problem

Worktree-backed Kanban tasks that declare completion artifacts keep **live worktree paths** as their completion evidence. The completed-event payload, run metadata, and attachment state all reference files inside the task's worktree, so anything that later mutates or unlinks the original file silently aliases or destroys the recorded deliverable:

```
A written inside task worktree
→ kanban_complete(..., artifacts=[path])   # succeeds
→ original file overwritten with B (or unlinked)
→ completed-event artifact reference now resolves to B (or nothing)
```

Scratch workspaces already handle this correctly: declared deliverables are copied into durable task-attachment storage before completion becomes authoritative (`_persist_scratch_completion_artifacts`). Worktree workspaces bail out of that path entirely — `_scratch_workspace()` returns `None` and the artifacts pass through untouched.

## Fix

Generalize the existing scratch preservation mechanism to worktree-contained regular files, inside the completion transaction and **before** `_end_run`, the `completed` event emission, and workspace cleanup:

- snapshot declared in-worktree files into `task_attachments_dir(task_id)` (same containment check, regular-file requirement, 25 MiB cap, collision handling, and atomic discard-on-failure the scratch path uses);
- rewrite the event/run artifact references to the durable snapshot and insert the matching attachment row;
- resolve the destination **board from the live DB connection** via an env-independent layout check (`PRAGMA database_list` → `boards/<slug>/kanban.db` structural match first, then an env-clean default-board path). This matters because the dispatcher pins `HERMES_KANBAN_DB` into every spawned worker; comparing against `kanban_db_path()` (which honors that pin and ignores its `board=` argument) would misplace a named board's snapshots under the default board's attachment tree. Unknown layouts fall back to ambient board resolution (`HERMES_KANBAN_BOARD` / ContextVar).

Scratch and `dir` workspace semantics are unchanged; no gateway changes. A missing/oversized declared worktree artifact now keeps the task in-flight with a retryable tool error — the same contract scratch already documents (tool error text + `kanban_complete` schema description updated accordingly).

## Tests (all proven RED on unmodified `main` before the fix)

Three invariant tests in `tests/hermes_cli/test_kanban_worktree_teardown.py`, exercising the real path (real git worktree, real sqlite, temp `HERMES_HOME`):

- `test_complete_task_worktree_artifact_survives_source_mutation` — completion-time bytes survive post-completion mutation and unlink of the original; event == run == attachment references; snapshot lives outside the worktree.
- `test_complete_task_worktree_artifact_uses_connection_board` — explicit cross-board completion places the snapshot under the connection's board, not the ambient board.
- `test_complete_task_worktree_artifact_worker_env_pins_named_board` — reproduces the dispatcher worker env shape (`HERMES_KANBAN_DB` + `HERMES_KANBAN_BOARD` pinned) and asserts named-board snapshots land under the named board's attachment tree. This one specifically caught (and now guards) the env-contaminated board-resolution bug described above.

Regression: `scripts/run_tests.sh tests/hermes_cli/test_kanban_worktree_teardown.py tests/hermes_cli/test_kanban_db.py tests/tools/test_kanban_tools.py` → 76 passed; the only failure in my environment is the pre-existing `test_tree_dirtied_between_check_and_removal_preserved` (`ModuleNotFoundError: rich`), reproduced identically on unmodified `main` (environment issue, not introduced here).

## Notes

- 4 files, +209/−15. Production surface is `hermes_cli/kanban_db.py` plus message/schema wording in `tools/kanban_tools.py` / `tools/kanban_tools_schemas.py`.
- Escaping symlinks are deliberately passed through unchanged (not copied) — same semantics as the scratch path; no new copy-out-of-workspace surface.
- Copy is `"xb"`-open, chunked, size-capped mid-copy; per-artifact failure discards partial copies and keeps the task in-flight (no half-staged completion).
