### PR TITLE
fix(desktop): improve tooltip line wrapping

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/preview-row.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/preview-row.test.tsx
@@ -34,6 +34,7 @@ describe('PreviewStatusRow', () => {
     const decoration = content?.firstElementChild
 
     expect(content).not.toBeNull()
+    expect(content?.classList.contains('text-pretty')).toBe(true)
     expect(view.container.contains(content)).toBe(false)
     // The decoration's per-line background only wraps inline FLOW. A flex box
     // (block or inline-flex) under it lights the first line and leaves the

--- a/apps/desktop/src/app/right-sidebar/terminal/rail.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/rail.test.tsx
@@ -29,6 +29,7 @@ describe('TerminalRail', () => {
     const decoration = content?.firstElementChild
 
     expect(content).not.toBeNull()
+    expect(content?.classList.contains('text-pretty')).toBe(true)
     expect(view.container.contains(content)).toBe(false)
     // No flex box under the decoration: its per-line background only wraps
     // inline flow, so a flex label would hang its overflow dark-on-dark.

--- a/apps/desktop/src/components/ui/tooltip.tsx
+++ b/apps/desktop/src/components/ui/tooltip.tsx
@@ -109,7 +109,7 @@ function TooltipContent({
         // elapses the chip appears at once.
         // pointer-events-none: the tip must never steal hover/clicks from the
         // chrome underneath (titlebar tools, adjacent tabs, etc.).
-        className={cn('pointer-events-none z-(--z-over-modal) w-fit max-w-64 select-none', className)}
+        className={cn('pointer-events-none z-(--z-over-modal) w-fit max-w-64 select-none text-pretty', className)}
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         {...props}


### PR DESCRIPTION
## What does this PR do?

Improves line wrapping in the shared Hermes Desktop tooltip component so long labels avoid awkward orphaned words or single-character final lines.

This is a focused follow-up to the existing tooltip work in `a22b295` (multi-line background painting). It does not overlap with #67043, which only removes the forced Arial font from tooltips to address CJK glyph corruption.

## Related Issue

Related: #67042

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/ui/tooltip.tsx` — apply Tailwind's `text-pretty` utility to the portaled tooltip content wrapper, preserving the existing inline-flow decoration and width constraints.
- `apps/desktop/src/app/chat/composer/status-stack/preview-row.test.tsx` — assert the preview tooltip keeps the line-wrapping utility.
- `apps/desktop/src/app/right-sidebar/terminal/rail.test.tsx` — assert the terminal tooltip keeps the line-wrapping utility.

## How to Test

1. Hover long status-bar labels in the Desktop app with Chinese or mixed Chinese/English text.
2. Confirm the tooltip avoids an isolated final character or very short trailing word when the label wraps.
3. Confirm multi-line tooltip backgrounds remain painted across every line.

Automated verification:

- `npm run test:ui -- --run src/app/chat/composer/status-stack/preview-row.test.tsx src/app/right-sidebar/terminal/rail.test.tsx` — 2 files, 6 tests passed.
- `npm run typecheck` — passed.
- `npx prettier --check src/components/ui/tooltip.tsx src/app/chat/composer/status-stack/preview-row.test.tsx src/app/right-sidebar/terminal/rail.test.tsx` — passed.
- `npm run build` — passed; `assert-dist-built` passed and the production bundle was generated.
- `npm run lint` — 0 errors; existing warnings remain.
- Full `npm run test:ui` was attempted but exceeded the 300-second timeout; it is not reported as passing.

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A for this Desktop-only change
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

The original reproduction shows long Desktop status-bar tooltips splitting into awkward one-character or short-word final lines. This PR keeps the existing compact tooltip appearance while enabling the browser's balanced wrapping behavior for the shared tooltip content wrapper.
