### PR TITLE
fix(cua): make path fixtures and WSL path construction portable

### DIFF
--- a/tests/computer_use/test_cua_wsl_manifest_path.py
+++ b/tests/computer_use/test_cua_wsl_manifest_path.py
@@ -15,6 +15,12 @@ def test_wsl_windows_manifest_path_translates_to_drvfs():
         ) == "/mnt/c/Users/Fernando/AppData/Local/cua-driver/cua-driver.exe"
 
 
+def test_non_wsl_windows_manifest_path_is_unchanged():
+    path = r"C:\Users\Fernando\AppData\Local\cua-driver\cua-driver.exe"
+    with patch("hermes_constants.is_wsl", return_value=False):
+        assert cua_backend_driver._wsl_windows_path_to_posix(path) == path
+
+
 
 
 

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1424,8 +1424,11 @@ class TestCuaDriverSessionReconnect:
             returncode = 0
             stderr = ""
             # Daemon returns a path, not inline base64.
-            stdout = ('{"element_count": 7, "tree_markdown": "- [0] AXButton",'
-                      ' "screenshot_file_path": "%s"}' % str(shot))
+            stdout = json.dumps({
+                "element_count": 7,
+                "tree_markdown": "- [0] AXButton",
+                "screenshot_file_path": str(shot),
+            })
 
         import subprocess as _sp
         orig_run = _sp.run

--- a/tools/computer_use/cua_backend_driver.py
+++ b/tools/computer_use/cua_backend_driver.py
@@ -11,7 +11,7 @@ import re
 import shutil
 import subprocess
 import sys
-from pathlib import PureWindowsPath
+from pathlib import PurePosixPath, PureWindowsPath
 from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger("tools.computer_use.cua_backend")
@@ -71,7 +71,7 @@ def _wsl_windows_path_to_posix(path: str) -> str:
         wsl = False
     win = PureWindowsPath(path)
     drive = (win.drive or "").rstrip(":").lower()
-    return os.path.join("/mnt", drive, *(str(part) for part in win.parts[1:])) if wsl and drive else path
+    return str(PurePosixPath("/mnt", drive, *(str(part) for part in win.parts[1:]))) if wsl and drive else path
 
 def _candidate_cua_driver_commands(override: Optional[str] = None) -> List[str]:
     """Candidate commands in resolution order. ``override`` / a non-empty ``HERMES_CUA_DRIVER_CMD`` is authoritative


### PR DESCRIPTION
## Summary
Serialize screenshot-path test fixtures with `json.dumps` so Windows backslashes remain valid JSON. Use `PurePosixPath` for the explicit WSL target path and preserve native Windows paths when the WSL branch is not selected.

## Verification
- `tests/tools/test_computer_use.py`: 100 passed on native Windows.
- `tests/computer_use/test_cua_wsl_manifest_path.py`: 3 passed.
- Diff checks passed; no new focused lint diagnostics.
- One existing F821 (`Optional`) in an untouched test helper also occurs on the unchanged base and is not fixed by this PR.
- This verifies fixture portability and deterministic path construction; it does not claim a live WSL desktop session was exercised.

The implementation remains in the existing driver path resolver; no new backend or OS-detection behavior is added.
