### PR TITLE
feat(a2a): support detached tasks with bounded wait and durable replies

### DIFF
--- a/plugins/platforms/a2a/DESIGN.md
+++ b/plugins/platforms/a2a/DESIGN.md
@@ -19,10 +19,13 @@ must not touch core files.** A2A now lives entirely under
 ### Outbound — client tools (`a2a` toolset)
 - `a2a_discover(url)` — fetch + summarize a peer's Agent Card (v1.0
   `supportedInterfaces` aware, tolerates 0.3 cards).
-- `a2a_call(agent, message, context_id?)` — send a JSON-RPC `message/send`
-  task to a peer, return the reply. Multi-turn via `context_id` (carried
-  inside the Message per v1.0). Surfaces `TASK_STATE_INPUT_REQUIRED` so the
-  model knows to answer and continue the context.
+- `a2a_call(agent, message, context_id?, wait?)` — send a JSON-RPC
+  `SendMessage` task. The default preserves blocking behavior; `wait=false`
+  sends `configuration.returnImmediately=true` and returns the Task id/state.
+  Multi-turn uses `context_id`; input-required remains caller-visible.
+- `a2a_get_task(agent, task_id)` — issue `GetTask` for a detached task.
+- `a2a_wait(agent, task_id, timeout?, poll_interval?)` — poll `GetTask` until
+  terminal/input-required. Its local timeout never cancels remote execution.
 - `a2a_list()` — configured peers + persisted conversations + metrics.
 - `a2a_history(context_id, limit?)` — recall a persisted conversation
   (this is the production consumer of the persistence layer).
@@ -51,14 +54,15 @@ Peers resolved from `config.yaml` → `a2a_agents`, or a direct URL.
   the normal `MessageEvent` → `handle_message` path keyed by the A2A
   `contextId`, so the agent that answers is the same one serving the user —
   full memory/context, not a clone. The reply returns through `adapter.send()`,
-  which fulfils the pending per-**task** `Future` the HTTP request is blocked
-  on (per-context FIFO, so concurrent same-context requests can't cross-talk);
-  `on_processing_complete` resolves failures/cancellations promptly.
+  which fulfils a pending per-**task** `Future` (per-context FIFO prevents
+  cross-talk). Blocking sends wait on that Future; `returnImmediately` sends
+  start a daemon finalizer and return the `WORKING` Task while the same Future
+  continues through persistence, terminal state, and push delivery.
 - **Task store:** every task (including terminal ones, bounded to the last
-  500) stays queryable via `tasks/get` / `tasks/list`, and `tasks/subscribe`
-  reattaches to a running task's stream via store watchers. A watchdog fails
-  orphaned tasks after 5 minutes (idempotent transitions — no double
-  counting in metrics).
+  500) stays queryable via `GetTask` / `ListTasks`, and subscriptions reattach
+  through store watchers. The watchdog only fails an old task when no live
+  pending executor owns its id; elapsed wall time alone cannot kill a running
+  task. `on_processing_complete` still resolves failures/cancellations.
 - **input-required:** the platform hint tells the agent to start a reply with
   `[INPUT_REQUIRED]` when it needs clarification; the adapter maps that to
   `TASK_STATE_INPUT_REQUIRED` with the question in `status.message`.

--- a/plugins/platforms/a2a/README.md
+++ b/plugins/platforms/a2a/README.md
@@ -31,14 +31,23 @@ a2a_agents:
 
 ## Outbound — call other agents
 
-The agent gets five tools:
+The agent gets seven tools:
 
 - `a2a_discover(url)` — what can this agent do?
-- `a2a_call(agent, message, context_id?)` — send it a task, get the reply.
+- `a2a_call(agent, message, context_id?, wait?)` — send a task. The default
+  waits for its reply; `wait=false` returns a task id immediately.
+- `a2a_get_task(agent, task_id)` — fetch a detached task's latest state/output.
+- `a2a_wait(agent, task_id, timeout?, poll_interval?)` — wait locally for a
+  detached task. A local timeout never cancels the remote execution.
 - `a2a_list()` — configured peers, saved conversations, metrics.
 - `a2a_history(context_id)` — recall a saved A2A conversation.
 - `a2a_orchestrate(capability, message, mode?)` — fan-out a task to every
   peer advertising a capability (`all` / `first` / `best`).
+
+Use `a2a_call(..., wait=false)` for long-running work. The peer returns a
+`WORKING` Task, closes the original HTTP request, continues execution in its
+own gateway/profile, and stores the terminal result for `a2a_get_task`,
+`a2a_wait`, subscriptions, or configured push notifications.
 
 ## Inbound — be callable
 
@@ -83,7 +92,7 @@ via `tasks/get`.
 | `A2A_ALLOW_ALL_USERS` | `false` | Allow any authed peer (dev only). |
 | `A2A_RATE_LIMIT` | `60` | Requests/minute per identity. |
 | `A2A_MAX_PINGPONG_TURNS` | `5` | Anti-loop turn cap per context (max 20). |
-| `A2A_REPLY_TIMEOUT` | `300` | Seconds to wait for the agent's reply. |
+| `A2A_REPLY_TIMEOUT` | `300` | Seconds a blocking call waits for a reply; detached tasks are not failed by this timeout. |
 | `A2A_PUSH_SECRET` | bearer token | HMAC secret for push signing. |
 | `A2A_ADVERTISED_TOOLSETS` | all registered | Restrict skills on the Agent Card. |
 

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -329,11 +329,68 @@ class A2AAdapter(BasePlatformAdapter):
             self._pending.clear()
             self._pending_order.clear()
 
+    def _fail_orphaned_tasks(self, timeout_seconds: int = _ORPHAN_TIMEOUT) -> list[str]:
+        """Fail stale tasks only when no in-process executor still owns them."""
+        with self._pending_lock:
+            active_task_ids = set(self._pending)
+        return self.tasks.fail_orphans(
+            timeout_seconds=timeout_seconds,
+            active_task_ids=active_task_ids,
+        )
+
+
+    @staticmethod
+    def _return_immediately(params: dict) -> bool:
+        """Read the v1 field while accepting the protobuf-style spelling."""
+        configuration = params.get("configuration") or {}
+        if not isinstance(configuration, dict):
+            return False
+        return (
+            configuration.get("returnImmediately") is True
+            or configuration.get("return_immediately") is True
+        )
+
+
+    def _finalize_task_in_background(self, pending: dict) -> Optional[dict]:
+        """Start a detached finalizer, or return its terminal failure Task.
+
+        Registration happens before the thread is started so the normal
+        outcome path must close the pending owner when ``start()`` fails.
+        """
+        task_id = str(pending["task_id"])
+
+        def wait_and_finalize() -> None:
+            try:
+                state, reply = pending["future"].result()
+                self._finalize_task(pending, state, reply)
+            except Exception as exc:
+                logger.exception("A2A: async task %s finalizer failed", task_id)
+                self.tasks.complete(
+                    task_id,
+                    protocol.STATE_FAILED,
+                    security.redact_outbound(f"Task finalization failed: {exc}"),
+                )
+                self._pop_pending(task_id)
+
+        try:
+            threading.Thread(
+                target=wait_and_finalize,
+                name=f"a2a-finalize-{task_id[:8]}",
+                daemon=True,
+            ).start()
+        except Exception as exc:
+            logger.exception("A2A: async task %s finalizer could not start", task_id)
+            return self._failed_pending_task(
+                pending, f"Task finalization failed: {exc}"
+            )
+        return None
+
+
     def _watchdog_loop(self) -> None:
         """Background thread that fails orphaned tasks (keeps them queryable)."""
         while not self._watchdog_stop.wait(_WATCHDOG_INTERVAL):
             try:
-                for tid in self.tasks.fail_orphans(_ORPHAN_TIMEOUT):
+                for tid in self._fail_orphaned_tasks():
                     logger.warning("A2A: orphaned task %s marked failed (timeout %ds)", tid, _ORPHAN_TIMEOUT)
                     protocol.metrics.tasks_failed += 1
             except Exception:
@@ -491,44 +548,163 @@ class A2AAdapter(BasePlatformAdapter):
         return protocol.build_task(rec["task_id"], rec["context_id"], state, text, created_at=rec["created_iso"]), None
 
     def _prepare_task(self, params: dict, peer: str, agent: Optional[dict] = None) -> tuple[Optional[dict], Optional[dict]]:
-        """Validate, register, and dispatch an inbound message (HTTP worker thread). Returns
-        (terminal_task, None) when it ends immediately, else (None, pending) with the future to wait on."""
+        """Validate, register, and dispatch an inbound message.
+
+        Returns (terminal_task, None) when the task ends immediately
+        (rejected / not ready), else (None, pending) where pending carries
+        the future the caller must wait on. Runs on an HTTP worker thread.
+        """
         agent = agent or self._agents[""]
         text = protocol.extract_text(params)
         context_id = protocol.extract_context_id(params) or protocol.new_context_id()
         task_id = protocol.new_task_id()
+
+        # Anti-loop ping-pong protection
         turn = self._turns.track(context_id)
-        max_turns = protocol.max_pingpong_turns()
-        rec = self.tasks.create(task_id, context_id, peer, *self._scope_for_agent(agent))
-        if turn > max_turns:
+        if turn > protocol.max_pingpong_turns():
             protocol.metrics.anti_loop_triggers += 1
-            logger.warning("A2A: anti-loop triggered for context %s (turn %d > %d)", context_id, turn, max_turns)
-            return self._end_task(rec, protocol.STATE_REJECTED, f"Anti-loop protection: context {context_id} exceeded "
-                                  f"{max_turns} turns. Start a new context or increase A2A_MAX_PINGPONG_TURNS.")
+            logger.warning("A2A: anti-loop triggered for context %s (turn %d > %d)",
+                           context_id, turn, protocol.max_pingpong_turns())
+            rec = self.tasks.create(task_id, context_id, peer, *self._scope_for_agent(agent))
+            explanation = (
+                f"Anti-loop protection: context {context_id} exceeded "
+                f"{protocol.max_pingpong_turns()} turns. Start a new context or "
+                "increase A2A_MAX_PINGPONG_TURNS."
+            )
+            return self._end_task(
+                rec, protocol.STATE_REJECTED, explanation, stored_reply=explanation
+            )
+
         if not text:
-            return self._end_task(rec, protocol.STATE_REJECTED, "Empty task — nothing to do.")
+            rec = self.tasks.create(task_id, context_id, peer, *self._scope_for_agent(agent))
+            explanation = "Empty task — nothing to do."
+            return self._end_task(
+                rec, protocol.STATE_REJECTED, explanation, stored_reply=explanation
+            )
+
         framed = security.wrap_inbound(peer, text)
         security.audit("inbound", peer, task_id, text)
         protocol.persist_message(context_id, "user", text, task_id)
         protocol.metrics.inbound_total += 1
+
+        rec = self.tasks.create(task_id, context_id, peer, *self._scope_for_agent(agent))
         self._register_inline_push(task_id, params, agent=agent)
-        if not agent.get("local", True):
-            reply, state = self._forward_to_profile(agent, peer, context_id, framed)
-            self._record_outcome(task_id, context_id, peer, state, reply)
-            return protocol.build_task(task_id, context_id, state, reply, created_at=rec["created_iso"]), None
-        if self._loop is None or self._message_handler is None:
-            return self._end_task(rec, protocol.STATE_FAILED, "Agent gateway not ready to accept A2A tasks.")
+
+        local_agent = bool(agent.get("local", True))
+        event_loop = self._loop
+        if local_agent and (event_loop is None or self._message_handler is None):
+            explanation = "Agent gateway not ready to accept A2A tasks."
+            return self._end_task(
+                rec, protocol.STATE_FAILED, explanation, stored_reply=explanation
+            )
+
         fut = self._add_pending(task_id, context_id)
-        event = MessageEvent(text=framed, message_type=MessageType.TEXT, message_id=task_id,
-                             source=self.build_source(chat_id=context_id, chat_name=f"a2a:{peer}", chat_type="dm", user_id=peer, user_name=peer))
+        pending = {
+            "task_id": task_id,
+            "context_id": context_id,
+            "peer": peer,
+            "future": fut,
+            "created_iso": rec["created_iso"],
+            "started": time.time(),
+        }
+        self.tasks.set_state(task_id, protocol.STATE_WORKING)
+
+        if not local_agent:
+            if not self._return_immediately(params):
+                try:
+                    reply, state = self._forward_to_profile(
+                        agent, peer, context_id, framed,
+                    )
+                except Exception as exc:
+                    reply = security.redact_outbound(
+                        f"Profile dispatch failed: {exc}"
+                    )
+                    state = protocol.STATE_FAILED
+                state, reply = self._finalize_task(pending, state, reply)
+                return protocol.build_task(
+                    task_id,
+                    context_id,
+                    state,
+                    reply,
+                    created_at=rec["created_iso"],
+                ), None
+
+            def forward_task() -> None:
+                try:
+                    reply, state = self._forward_to_profile(
+                        agent, peer, context_id, framed,
+                    )
+                except Exception as exc:
+                    reply = security.redact_outbound(
+                        f"Profile dispatch failed: {exc}"
+                    )
+                    state = protocol.STATE_FAILED
+                self._resolve_task(task_id, state, reply)
+
+            try:
+                threading.Thread(
+                    target=forward_task,
+                    name=f"a2a-forward-{task_id[:8]}",
+                    daemon=True,
+                ).start()
+            except Exception as exc:
+                return (
+                    self._failed_pending_task(
+                        pending, f"Profile dispatch failed: {exc}"
+                    ),
+                    None,
+                )
+            return None, pending
+
+        assert event_loop is not None
+        event = MessageEvent(
+            text=framed,
+            message_type=MessageType.TEXT,
+            source=self.build_source(
+                chat_id=context_id,
+                chat_name=f"a2a:{peer}",
+                chat_type="dm",
+                user_id=peer,
+                user_name=peer,
+            ),
+            message_id=task_id,
+        )
+
         try:
-            asyncio.run_coroutine_threadsafe(self.handle_message(event), self._loop)
+            dispatch_future = asyncio.run_coroutine_threadsafe(
+                self.handle_message(event), event_loop,
+            )
+            pending["dispatch_future"] = dispatch_future
+
+            def resolve_failed_dispatch(done: Future) -> None:
+                # BasePlatformAdapter.handle_message returns after scheduling the
+                # agent turn. A successful dispatch is not task completion;
+                # send() / on_processing_complete() own terminal resolution.
+                if fut.done():
+                    return
+                try:
+                    error = done.exception()
+                except Exception as exc:
+                    error = exc
+                if error is not None:
+                    self._resolve_task(
+                        task_id,
+                        protocol.STATE_FAILED,
+                        security.redact_outbound(f"Dispatch failed: {error}"),
+                    )
+
+            dispatch_future.add_done_callback(resolve_failed_dispatch)
         except Exception as e:
             self._pop_pending(task_id)
             msg = security.redact_outbound(f"Dispatch failed: {e}")
-            return self._end_task(rec, protocol.STATE_FAILED, msg, stored_reply=msg)
-        self.tasks.set_state(task_id, protocol.STATE_WORKING)
-        return None, {"task_id": task_id, "context_id": context_id, "peer": peer, "future": fut, "created_iso": rec["created_iso"], "started": time.time()}
+            self.tasks.complete(task_id, protocol.STATE_FAILED, msg)
+            protocol.metrics.tasks_failed += 1
+            return protocol.build_task(
+                task_id, context_id, protocol.STATE_FAILED, msg,
+                created_at=rec["created_iso"],
+            ), None
+
+        return None, pending
 
     def _forward_to_profile(self, agent: dict, peer: str, context_id: str, framed_text: str) -> tuple[str, str]:
         """Forward a routed task to another local profile via ``hermes chat``. First contact creates a
@@ -585,13 +761,24 @@ class A2AAdapter(BasePlatformAdapter):
         """Record a dispatched task's outcome; returns (state, reply) after redaction and
         input-required detection (a leading marker flags a clarification request)."""
         task_id, context_id, peer = pending["task_id"], pending["context_id"], pending["peer"]
-        self._pop_pending(task_id)
         reply = security.redact_outbound(reply or "")
         stripped = reply.lstrip()
         if state == protocol.STATE_COMPLETED and stripped.upper().startswith(protocol.INPUT_REQUIRED_MARKER):
             state, reply = protocol.STATE_INPUT_REQUIRED, stripped[len(protocol.INPUT_REQUIRED_MARKER):].strip()
         self._record_outcome(task_id, context_id, peer, state, reply, started=pending["started"])
+        self._pop_pending(task_id)
         return state, reply
+
+    def _failed_pending_task(self, pending: dict, message: str) -> dict:
+        """Close a registered pending task through the normal failed-outcome path."""
+        state, reply = self._finalize_task(pending, protocol.STATE_FAILED, message)
+        return protocol.build_task(
+            pending["task_id"],
+            pending["context_id"],
+            state,
+            reply,
+            created_at=pending["created_iso"],
+        )
 
     @staticmethod
     def _await_future(fut: Future, deadline: float, keepalive, on_timeout: tuple[str, str]) -> tuple[str, str]:
@@ -616,11 +803,33 @@ class A2AAdapter(BasePlatformAdapter):
                                   (protocol.STATE_FAILED, "[agent did not reply in time]"))
 
     def _rpc_message_send(self, req_id: Any, params: dict, peer: str, agent: Optional[dict] = None, v1_response: bool = False) -> dict:
-        task, pending = self._prepare_task(params, peer, agent=agent)
-        if task is None:
-            state, reply = self._finalize_task(pending, *self._await_reply(pending))
-            task = protocol.build_task(pending["task_id"], pending["context_id"], state, reply, created_at=pending["created_iso"])
-        return _ok(req_id, protocol.send_message_response(task) if v1_response else task)
+        terminal, pending = self._prepare_task(params, peer, agent=agent)
+        if terminal is not None:
+            result = protocol.send_message_response(terminal) if v1_response else terminal
+            return protocol.jsonrpc_result(req_id, result)
+        assert pending is not None
+        if self._return_immediately(params):
+            failure = self._finalize_task_in_background(pending)
+            if failure is not None:
+                result = protocol.send_message_response(failure) if v1_response else failure
+                return protocol.jsonrpc_result(req_id, result)
+            record = self.tasks.get(pending["task_id"])
+            task = protocol.TaskStore.to_task(record) if record else protocol.build_task(
+                pending["task_id"],
+                pending["context_id"],
+                protocol.STATE_WORKING,
+                created_at=pending["created_iso"],
+            )
+            result = protocol.send_message_response(task) if v1_response else task
+            return protocol.jsonrpc_result(req_id, result)
+        state, reply = self._await_reply(pending)
+        state, reply = self._finalize_task(pending, state, reply)
+        task = protocol.build_task(
+            pending["task_id"], pending["context_id"], state, reply,
+            created_at=pending["created_iso"],
+        )
+        result = protocol.send_message_response(task) if v1_response else task
+        return protocol.jsonrpc_result(req_id, result)
 
     @staticmethod
     def _sse_headers(handler) -> None:

--- a/plugins/platforms/a2a/plugin.yaml
+++ b/plugins/platforms/a2a/plugin.yaml
@@ -6,10 +6,11 @@ description: >
   A2A (Agent-to-Agent) protocol v1.0 support for Hermes Agent — both directions
   of the open Linux Foundation standard for inter-agent communication.
 
-  OUTBOUND (client tools): a2a_discover, a2a_call, a2a_list, a2a_history, and
-  a2a_orchestrate let the agent fetch another agent's Agent Card and send it
-  tasks over JSON-RPC — works with any A2A-compliant peer (Hermes, LangChain,
-  CrewAI, Google ADK, OpenClaw, ...).
+  OUTBOUND (client tools): a2a_discover, a2a_call, a2a_get_task, a2a_wait,
+  a2a_list, a2a_history, and a2a_orchestrate let the agent fetch another
+  agent's Agent Card and send blocking or detached tasks over JSON-RPC — works
+  with any A2A-compliant peer (Hermes, LangChain, CrewAI, Google ADK, OpenClaw,
+  ...).
 
   INBOUND (platform adapter): exposes Hermes as an A2A-discoverable agent. An
   Agent Card is served at /.well-known/agent-card.json (v1.0 canonical path;
@@ -33,6 +34,8 @@ author: Nous Research
 provides_tools:
   - a2a_discover
   - a2a_call
+  - a2a_get_task
+  - a2a_wait
   - a2a_list
   - a2a_history
   - a2a_orchestrate

--- a/plugins/platforms/a2a/protocol.py
+++ b/plugins/platforms/a2a/protocol.py
@@ -414,11 +414,26 @@ class TaskStore:
         next_offset = offset + page_size if offset + page_size < total else 0
         return (page, next_offset, total) if with_total else (page, next_offset)
 
-    def fail_orphans(self, timeout_seconds: int = 300) -> list[str]:
+    def fail_orphans(
+        self,
+        timeout_seconds: int = 300,
+        active_task_ids: Optional[set[str]] = None,
+    ) -> list[str]:
+        """Fail stale non-terminal tasks that no live executor still owns."""
+        active = active_task_ids or set()
         with self._lock:
-            stale = [tid for tid, rec in self._tasks.items()
-                     if rec["state"] not in TERMINAL_STATES and time.time() - rec["created_at"] > timeout_seconds]
-        return [tid for tid in stale if self.complete(tid, STATE_FAILED, "[task orphaned — no reply produced]")]
+            now = time.time()
+            stale = [
+                tid for tid, rec in self._tasks.items()
+                if rec["state"] not in TERMINAL_STATES
+                and tid not in active
+                and now - rec["created_at"] > timeout_seconds
+            ]
+        failed = []
+        for tid in stale:
+            if self.complete(tid, STATE_FAILED, "[task orphaned — no reply produced]"):
+                failed.append(tid)
+        return failed
 
     def _trim_locked(self) -> None:
         terminal = [tid for tid, rec in self._tasks.items() if rec["state"] in TERMINAL_STATES]
@@ -440,21 +455,69 @@ def _conv_path(context_id: str) -> Path:
     return _hermes_home() / "a2a_conversations" / f"{safe}.jsonl"
 
 
+# Detached polls can arrive on multiple worker threads. Keep the identity check
+# and append together so two polls cannot both persist the same task reply.
+_CONVERSATION_LOCK = threading.RLock()
+
+
+def _message_line(role: str, text: str, task_id: str) -> str:
+    return json.dumps(
+        {"ts": time.time(), "role": role, "text": text, "task_id": task_id},
+        ensure_ascii=False,
+    ) + "\n"
+
+
 def persist_message(context_id: str, role: str, text: str, task_id: str = "") -> None:
     """Append one message to the context's on-disk conversation log. Never raises."""
     try:
         path = _conv_path(context_id)
         path.parent.mkdir(parents=True, exist_ok=True)
-        with path.open("a", encoding="utf-8") as fh:
-            fh.write(json.dumps({"ts": time.time(), "role": role, "text": text, "task_id": task_id}, ensure_ascii=False) + "\n")
+        with _CONVERSATION_LOCK:
+            with path.open("a", encoding="utf-8") as fh:
+                fh.write(_message_line(role, text, task_id))
     except Exception:
         pass
+
+
+def persist_message_once(
+    context_id: str, role: str, text: str, task_id: str = ""
+) -> bool:
+    """Append only when ``(context_id, task_id, role)`` is absent from JSONL.
+
+    The context id is represented by the selected JSONL path; the lock covers
+    the streamed read-before-append transaction without loading history into
+    memory or changing the persisted schema.
+    """
+    try:
+        path = _conv_path(context_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with _CONVERSATION_LOCK:
+            with path.open("a+", encoding="utf-8") as fh:
+                fh.seek(0)
+                for line in fh:
+                    if not line.strip():
+                        continue
+                    try:
+                        message = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if (
+                        message.get("role") == role
+                        and message.get("task_id") == task_id
+                    ):
+                        return False
+                fh.seek(0, 2)
+                fh.write(_message_line(role, text, task_id))
+        return True
+    except Exception:
+        return False
 
 
 def load_conversation(context_id: str, limit: int = 50) -> list[dict]:
     """Last *limit* messages for a context (empty list if none / unreadable)."""
     try:
-        lines = _conv_path(context_id).read_text(encoding="utf-8").splitlines()
+        with _CONVERSATION_LOCK:
+            lines = _conv_path(context_id).read_text(encoding="utf-8").splitlines()
     except Exception:
         return []
     out: list[dict] = []

--- a/plugins/platforms/a2a/tools.py
+++ b/plugins/platforms/a2a/tools.py
@@ -8,10 +8,12 @@ import contextlib
 import json
 import logging
 import os
+import time
 import urllib.error
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Any, Optional
+from contextvars import ContextVar
+from typing import Any, Optional, TypedDict
 
 from gateway.platforms._shared import coerce_port as _coerce_int
 
@@ -21,6 +23,27 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_TIMEOUT = 120
 _ORCHESTRATE_MAX_WORKERS = 6  # max parallel peers for fan-out
+
+
+class _LocalWaitTimeout(TimeoutError):
+    """A caller-owned wait budget expired before the detached task finished."""
+
+
+_WAIT_DEADLINE: ContextVar[float | None] = ContextVar(
+    "a2a_wait_deadline", default=None
+)
+
+
+def _request_timeout(default: float, deadline: float | None = None) -> float:
+    """Return one request's remaining budget, or raise before an over-budget call."""
+    if deadline is None:
+        return max(0.1, float(default))
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise _LocalWaitTimeout
+    # Do not pad a short remaining budget: urllib must not receive the full
+    # poll budget again after an Agent Card lookup or 404 fallback.
+    return min(max(0.001, float(default)), remaining)
 
 
 def _load_config() -> dict:
@@ -67,15 +90,25 @@ def _http_post_json(url: str, body: dict, headers: dict, timeout: int) -> dict:
     return _http_json(url, hdrs, timeout, "POST", json.dumps(body).encode("utf-8"))
 
 
-def _fetch_card(base_url: str, headers: dict, timeout: int) -> dict:
-    """GET the v1.0 agent-card.json; on 404 fall back to the v0.2 agent.json alias."""
+def _fetch_card(
+    base_url: str,
+    headers: dict,
+    timeout: float,
+    *,
+    deadline: float | None = None,
+) -> dict:
+    """GET the v1.0 card, falling back to v0.2 without resetting *deadline*."""
     base = base_url.rstrip("/")
+
+    def get(url: str) -> dict:
+        return _http_get_json(url, headers, _request_timeout(timeout, deadline))
+
     try:
-        return _http_get_json(base + "/.well-known/agent-card.json", headers, timeout)
+        return get(base + "/.well-known/agent-card.json")
     except urllib.error.HTTPError as e:
         if e.code != 404:
             raise
-    return _http_get_json(base + "/.well-known/agent.json", headers, timeout)
+    return get(base + "/.well-known/agent.json")
 
 
 def _select_jsonrpc_interface(card: Optional[dict]) -> Optional[dict]:
@@ -95,40 +128,285 @@ def _rpc_url(base_url: str, card: Optional[dict]) -> str:
     return base_url.rstrip("/")
 
 
-def _send_task(agent_label: str, peer: dict, message: str, context_id: str) -> tuple[str, str, str]:
-    """One SendMessage to a peer -> (reply_text, context_id, state). Raises urllib errors /
-    ValueError for the caller to format; handles redaction, audit, persistence, metrics."""
+def _interface_tenant(card: Optional[dict], peer: dict) -> str:
+    iface = _select_jsonrpc_interface(card)
+    if iface and iface.get("tenant"):
+        return str(iface["tenant"])
+    return str(peer.get("tenant") or "")
+
+
+def _short_state(state: str) -> str:
+    """TASK_STATE_COMPLETED -> completed (also passes through v0.3 states)."""
+    return state.replace("TASK_STATE_", "").replace("_", "-").lower() if state else ""
+
+
+class _TaskResult(TypedDict):
+    reply: str
+    context_id: str
+    state: str
+    task_id: str
+
+
+def _send_task_result(
+    agent_label: str,
+    peer: dict,
+    message: str,
+    context_id: str,
+    *,
+    return_immediately: bool = False,
+) -> _TaskResult:
+    """Send one task and retain the protocol task id for later retrieval."""
     base_url = peer.get("url", "")
     headers = _auth_header(peer.get("auth", {}) or {})
     timeout = int(peer.get("timeout", _DEFAULT_TIMEOUT))
+
+    # Best-effort card fetch (to learn the rpc URL); non-fatal on failure.
+    card = None
     try:
-        card = _fetch_card(base_url, headers, min(timeout, 30))  # best-effort, to learn the rpc URL
+        card = _fetch_card(base_url, headers, min(timeout, 30))
     except Exception:
-        card = None
+        pass
+
     ctx = context_id or protocol.new_context_id()
     safe_message = security.redact_outbound(message)
     # v1.0: contextId lives inside the Message, not at the params top level.
-    rpc_body = {"jsonrpc": "2.0", "id": protocol.new_task_id(), "method": "SendMessage",
-                "params": {"message": protocol.text_message(protocol.ROLE_USER, safe_message, context_id=ctx)}}
-    iface = _select_jsonrpc_interface(card)
-    tenant = str(iface["tenant"]) if iface and iface.get("tenant") else str(peer.get("tenant") or "")
+    rpc_body = {
+        "jsonrpc": "2.0",
+        "id": protocol.new_task_id(),
+        "method": "SendMessage",
+        "params": {
+            "message": protocol.text_message(protocol.ROLE_USER, safe_message, context_id=ctx),
+        },
+    }
+    if return_immediately:
+        rpc_body["params"]["configuration"] = {"returnImmediately": True}
+
+    tenant = _interface_tenant(card, peer)
     if tenant:
         rpc_body["params"]["tenant"] = tenant
+
     security.audit("outbound", agent_label, rpc_body["id"], safe_message)
     protocol.persist_message(ctx, "user", safe_message, rpc_body["id"])
     protocol.metrics.outbound_total += 1
+
     resp = _http_post_json(_rpc_url(base_url, card), rpc_body, headers, timeout)
     if "error" in resp:
-        raise ValueError(f"Peer '{agent_label}' returned an error: {resp['error'].get('message', resp['error'])}")
-    payload = protocol.unwrap_send_message_response(resp.get("result", {}))
+        err = resp["error"]
+        raise ValueError(f"Peer '{agent_label}' returned an error: {err.get('message', err)}")
+
+    result = resp.get("result", {})
+    payload = protocol.unwrap_send_message_response(result)
     reply = _reply_text_from_result(payload)
-    reply_ctx, state = ctx, ""
+    reply_ctx, state, task_id = ctx, "", ""
     if isinstance(payload, dict):
-        reply_ctx = payload.get("contextId", ctx)
-        state = (payload.get("status") or {}).get("state", "")
-    protocol.persist_message(reply_ctx, "agent", reply, rpc_body["id"])
+        reply_ctx = str(payload.get("contextId") or ctx)
+        state = str((payload.get("status") or {}).get("state") or "")
+        task_id = str(payload.get("id") or payload.get("taskId") or "")
+    if reply:
+        protocol.persist_message(reply_ctx, "agent", reply, task_id or rpc_body["id"])
     protocol.metrics.inbound_total += 1
-    return reply, reply_ctx, state
+    return {
+        "reply": reply,
+        "context_id": reply_ctx,
+        "state": state,
+        "task_id": task_id,
+    }
+
+
+def _get_task_result(
+    agent: str,
+    peer: dict,
+    task_id: str,
+    request_timeout: float | None = None,
+) -> _TaskResult:
+    """Issue one GetTask request and return a structured task snapshot."""
+    base_url = peer.get("url", "")
+    headers = _auth_header(peer.get("auth", {}) or {})
+    timeout = float(peer.get("timeout", _DEFAULT_TIMEOUT))
+    deadline = _WAIT_DEADLINE.get()
+    if deadline is None and request_timeout is not None:
+        deadline = time.monotonic() + max(0.0, request_timeout)
+    card = None
+    try:
+        card = _fetch_card(
+            base_url,
+            headers,
+            min(timeout, 30),
+            deadline=deadline,
+        )
+    except _LocalWaitTimeout:
+        raise
+    except Exception:
+        pass
+
+    rpc_body = {
+        "jsonrpc": "2.0",
+        "id": protocol.new_task_id(),
+        "method": "GetTask",
+        "params": {"id": task_id},
+    }
+    tenant = _interface_tenant(card, peer)
+    if tenant:
+        rpc_body["params"]["tenant"] = tenant
+    response = _http_post_json(
+        _rpc_url(base_url, card),
+        rpc_body,
+        headers,
+        _request_timeout(timeout, deadline),
+    )
+    if "error" in response:
+        error = response["error"]
+        raise ValueError(
+            f"Peer '{agent}' returned an error: {error.get('message', error)}"
+        )
+    payload = protocol.unwrap_send_message_response(response.get("result", {}))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Peer '{agent}' returned an invalid task response.")
+
+    protocol.metrics.inbound_total += 1
+    return {
+        "reply": _reply_text_from_result(payload),
+        "context_id": str(payload.get("contextId") or ""),
+        "state": str((payload.get("status") or {}).get("state") or ""),
+        "task_id": str(payload.get("id") or payload.get("taskId") or task_id),
+    }
+
+
+def _task_lookup_error(agent: str, error: Exception) -> str:
+    """Format task lookup failures without exposing remote credentials."""
+    if isinstance(error, urllib.error.HTTPError):
+        if error.code in (401, 403):
+            return f"Error: peer '{agent}' rejected auth (HTTP {error.code}). Check the configured token."
+        if error.code == 429:
+            return f"Error: peer '{agent}' rate limited us (HTTP 429). Retry later."
+        return f"Error: task lookup on '{agent}' failed — HTTP {error.code}."
+    if isinstance(error, ValueError):
+        return str(error)
+    return f"Error: task lookup on '{agent}' failed — {error}."
+
+
+def _format_task_result(agent: str, task: _TaskResult) -> str:
+    """Render one task snapshot consistently for get and wait tools."""
+    header = f"[{agent} · task {task['task_id']}"
+    if task["context_id"]:
+        header += f" · context {task['context_id']}"
+    if task["state"]:
+        header += f" · {_short_state(task['state'])}"
+    header += "]"
+    return f"{header}\n{task['reply'] or '(task has no final text yet)'}"
+
+
+def _format_local_wait_timeout(agent: str, task: _TaskResult) -> str:
+    """Render a local timeout without implying cancellation of the remote task."""
+    return (
+        f"{_format_task_result(agent, task)}\n\n"
+        "Local wait timed out; the remote task was not canceled. "
+        "Call a2a_get_task or a2a_wait again with the same task id."
+    )
+
+
+def _persist_task_reply(task: _TaskResult) -> None:
+    """Persist a reply once by its JSONL identity, not a bounded history tail."""
+    if task["reply"]:
+        protocol.persist_message_once(
+            task["context_id"],
+            "agent",
+            task["reply"],
+            task["task_id"],
+        )
+
+
+def _task_lookup_args(args: dict) -> tuple[str, str, dict | None, str | None]:
+    """Resolve common task lookup arguments and return any validation error."""
+    agent = str(args.get("agent") or args.get("agent_name") or args.get("name") or "").strip()
+    task_id = str(args.get("task_id") or args.get("taskId") or args.get("id") or "").strip()
+    if not agent or not task_id:
+        return agent, task_id, None, "Error: both 'agent' and 'task_id' are required."
+    peer = _resolve_peer(agent)
+    if not peer or not peer.get("url"):
+        error = (
+            f"Error: unknown agent '{agent}'. Configure it under 'a2a_agents' in "
+            f"config.yaml or pass a full http(s):// URL."
+        )
+        return agent, task_id, None, error
+    return agent, task_id, peer, None
+
+
+def a2a_get_task(args: dict, **_: Any) -> str:
+    """Fetch the latest state and output of a previously submitted task."""
+    agent, task_id, peer, error = _task_lookup_args(args)
+    if error:
+        return error
+    assert peer is not None
+    try:
+        task = _get_task_result(agent, peer, task_id)
+    except Exception as exc:
+        return _task_lookup_error(agent, exc)
+    _persist_task_reply(task)
+    return _format_task_result(agent, task)
+
+
+def a2a_wait(args: dict, **_: Any) -> str:
+    """Poll a detached task until it reaches a caller-visible stopping state."""
+    agent, task_id, peer, error = _task_lookup_args(args)
+    if error:
+        return error
+    assert peer is not None
+    try:
+        timeout = max(0.0, min(float(args.get("timeout", 300)), 86400.0))
+    except (TypeError, ValueError):
+        timeout = 300.0
+    try:
+        poll_interval = max(
+            0.1,
+            min(float(args.get("poll_interval", 2)), 30.0),
+        )
+    except (TypeError, ValueError):
+        poll_interval = 2.0
+
+    deadline = time.monotonic() + timeout
+    last_task: _TaskResult = {
+        "reply": "",
+        "context_id": "",
+        "state": "",
+        "task_id": task_id,
+    }
+    while True:
+        remaining = max(0.0, deadline - time.monotonic())
+        token = _WAIT_DEADLINE.set(deadline)
+        try:
+            task = _get_task_result(
+                agent,
+                peer,
+                task_id,
+                request_timeout=remaining,
+            )
+        except _LocalWaitTimeout:
+            return _format_local_wait_timeout(agent, last_task)
+        except Exception as exc:
+            if time.monotonic() >= deadline:
+                return _format_local_wait_timeout(agent, last_task)
+            return _task_lookup_error(agent, exc)
+        finally:
+            _WAIT_DEADLINE.reset(token)
+
+        last_task = task
+        if (
+            task["state"] in protocol.TERMINAL_STATES
+            or task["state"] == protocol.STATE_INPUT_REQUIRED
+        ):
+            _persist_task_reply(task)
+            return _format_task_result(agent, task)
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return _format_local_wait_timeout(agent, task)
+        time.sleep(min(poll_interval, remaining))
+
+
+def _send_task(agent_label: str, peer: dict, message: str, context_id: str) -> tuple[str, str, str]:
+    """Compatibility wrapper returning (reply_text, context_id, state)."""
+    result = _send_task_result(agent_label, peer, message, context_id)
+    return result["reply"], result["context_id"], result["state"]
 
 
 def _reply_text_from_result(result: Any) -> str:
@@ -173,29 +451,66 @@ def a2a_discover(args: dict, **_: Any) -> str:
 
 
 def a2a_call(args: dict, **_: Any) -> str:
-    """Send a task to a peer (configured name or direct URL); ``context_id`` continues a prior exchange."""
+    """Send a task to a peer, optionally returning before it completes."""
     # Accept common aliases models reach for (observed live: 'agent_name').
     agent = str(args.get("agent") or args.get("agent_name") or args.get("name") or "").strip()
     message = str(args.get("message") or args.get("text") or args.get("task") or "").strip()
     context_id = str(args.get("context_id") or args.get("contextId") or "").strip()
+    wait = args.get("wait") is not False
     if not agent or not message:
         return "Error: both 'agent' and 'message' are required."
+
     peer = _resolve_peer(agent)
     if not peer or not peer.get("url"):
-        return f"Error: unknown agent '{agent}'. Configure it under 'a2a_agents' in config.yaml or pass a full http(s):// URL."
+        return (
+            f"Error: unknown agent '{agent}'. Configure it under 'a2a_agents' in "
+            f"config.yaml or pass a full http(s):// URL."
+        )
+
     try:
-        reply, reply_ctx, state = _send_task(agent, peer, message, context_id)
+        task = _send_task_result(
+            agent,
+            peer,
+            message,
+            context_id,
+            return_immediately=not wait,
+        )
     except urllib.error.HTTPError as e:
-        return _HTTP_CALL_ERRORS.get(e.code, "Error: call to '{agent}' failed — HTTP {code}.").format(agent=agent, code=e.code)
+        if e.code in (401, 403):
+            return f"Error: peer '{agent}' rejected auth (HTTP {e.code}). Check the configured token."
+        if e.code == 429:
+            return f"Error: peer '{agent}' rate limited us (HTTP 429). Retry later."
+        return f"Error: call to '{agent}' failed — HTTP {e.code}."
     except ValueError as e:
         return str(e)
     except Exception as e:
         return f"Error: call to '{agent}' failed — {e}."
-    short_state = state.replace("TASK_STATE_", "").replace("_", "-").lower()  # v0.3 states pass through
-    header = f"[{agent} · context {reply_ctx}" + (f" · {short_state}" if state else "") + "]"
+
+    reply = task["reply"]
+    reply_ctx = task["context_id"]
+    state = task["state"]
+    task_id = task["task_id"]
+    if not wait and not task_id:
+        return f"Error: peer '{agent}' did not return a task id for the non-blocking call."
+
+    header = f"[{agent}"
+    if task_id:
+        header += f" · task {task_id}"
+    header += f" · context {reply_ctx}"
+    if state:
+        header += f" · {_short_state(state)}"
+    header += "]"
     body = reply or "(no text reply)"
+    if not wait and task_id and not reply:
+        body = (
+            "Task accepted. Retrieve it with a2a_get_task using "
+            f"agent '{agent}' and task_id '{task_id}'."
+        )
     if state == protocol.STATE_INPUT_REQUIRED:
-        body += f"\n\n(The peer needs more input — answer by calling a2a_call again with context_id '{reply_ctx}'.)"
+        body += (
+            "\n\n(The peer needs more input — answer by calling a2a_call again "
+            f"with context_id '{reply_ctx}'.)"
+        )
     return f"{header}\n{body}"
 
 
@@ -328,6 +643,11 @@ _TOOLS: dict[str, tuple[Any, str, dict, list[str]]] = {
                         ["capability", "message"]),
 }
 
+
+# Local detached-task extensions, on the upstream registration table.
+_TOOLS["a2a_call"][2]["wait"] = {'type': 'boolean', 'description': 'Wait for completion (default true). Set false to return a task id immediately.'}
+_TOOLS['a2a_get_task'] = (a2a_get_task, 'Fetch the current state and final output of a task returned by a non-blocking a2a_call.', {'agent': {'type': 'string', 'description': 'Configured peer name or a full http(s):// URL.'}, 'task_id': {'type': 'string', 'description': 'Task id returned by a2a_call(wait=false).'}}, ['agent', 'task_id'])
+_TOOLS['a2a_wait'] = (a2a_wait, 'Wait for a detached A2A task to finish by polling GetTask. A local timeout never cancels the remote task.', {'agent': {'type': 'string', 'description': 'Configured peer name or a full http(s):// URL.'}, 'task_id': {'type': 'string', 'description': 'Task id returned by a2a_call(wait=false).'}, 'timeout': {'type': 'number', 'description': 'Maximum local wait in seconds (default 300, max 86400).'}, 'poll_interval': {'type': 'number', 'description': 'Seconds between GetTask polls (default 2).'}}, ['agent', 'task_id'])
 
 def _a2a_tools_available() -> bool:
     """check_fn: serve the client tools ONLY when the operator opted into A2A (peers under

--- a/tests/hermes_cli/test_deferred_platform_client_tools.py
+++ b/tests/hermes_cli/test_deferred_platform_client_tools.py
@@ -3,8 +3,8 @@
 Issue #78050: a bundled ``kind: platform`` plugin is registered as a deferred
 loader so ``hermes chat`` doesn't import ~20 gateway SDKs. The a2a plugin ships
 two independent things behind that one deferral — an inbound adapter (heavy)
-and five outbound client tools (``a2a_call``, ``a2a_discover``, ``a2a_list``,
-``a2a_history``, ``a2a_orchestrate``). Deferring the plugin deferred both, so
+and seven outbound client tools (``a2a_call``, ``a2a_discover``, ``a2a_get_task``,
+``a2a_wait``, ``a2a_list``, ``a2a_history``, ``a2a_orchestrate``). Deferring the plugin deferred both, so
 in a CLI/TUI process the client tools never registered at all:
 ``resolve_toolset("a2a")`` returned ``[]`` and the toolset was absent from the
 ``hermes tools`` checklist. The same tools worked in gateway/web processes only
@@ -27,9 +27,11 @@ import yaml
 A2A_CLIENT_TOOLS = {
     "a2a_call",
     "a2a_discover",
+    "a2a_get_task",
     "a2a_history",
     "a2a_list",
     "a2a_orchestrate",
+    "a2a_wait",
 }
 
 

--- a/tests/plugins/test_a2a_async_tasks.py
+++ b/tests/plugins/test_a2a_async_tasks.py
@@ -1,0 +1,685 @@
+"""Behavioral tests for non-blocking A2A task submission and retrieval."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import urllib.error
+from concurrent.futures import Future
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.a2a import adapter as adapter_module
+from plugins.platforms.a2a import protocol, security, tools
+from plugins.platforms.a2a.adapter import A2AAdapter
+
+
+def _bare_adapter() -> A2AAdapter:
+    """Create an adapter without opening a socket or starting the gateway."""
+    return A2AAdapter(PlatformConfig(enabled=True))
+
+
+def _configured_peer(monkeypatch) -> None:
+    monkeypatch.setattr(
+        tools,
+        "_load_config",
+        lambda: {"a2a_agents": {"peer": {"url": "http://localhost:9999"}}},
+    )
+    monkeypatch.setattr(tools, "_http_get_json", lambda url, headers, timeout: None)
+    monkeypatch.setattr(protocol, "persist_message", lambda *args, **kwargs: None)
+    monkeypatch.setattr(security, "audit", lambda *args, **kwargs: None)
+
+
+def _isolate_server_side_effects(monkeypatch, tmp_path) -> None:
+    """Keep task persistence and audit writes inside pytest-owned state."""
+    monkeypatch.setattr(protocol, "_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(security, "audit", lambda *args, **kwargs: None)
+
+
+def _status_text(task: dict) -> str:
+    return protocol.extract_text((task.get("status") or {}).get("message") or {})
+
+
+def _send_then_get(adapter: A2AAdapter, params: dict) -> tuple[dict, dict]:
+    sent = adapter._rpc_message_send("send", params, "peer", v1_response=True)
+    sent_task = protocol.unwrap_send_message_response(sent["result"])
+    fetched = adapter._rpc_tasks_get("get", {"id": sent_task["id"]})
+    return sent_task, fetched["result"]
+
+
+def test_anti_loop_explanation_survives_send_then_get(monkeypatch):
+    """Anti-loop rejection keeps the same explanation in the stored Task."""
+    monkeypatch.setenv("A2A_MAX_PINGPONG_TURNS", "1")
+    adapter = _bare_adapter()
+    adapter._turns.track("ctx-loop")
+
+    sent, fetched = _send_then_get(
+        adapter,
+        {"message": protocol.text_message(protocol.ROLE_USER, "loop", "ctx-loop")},
+    )
+
+    assert sent["status"]["state"] == protocol.STATE_REJECTED
+    assert _status_text(sent) == _status_text(fetched)
+    assert "Anti-loop protection" in _status_text(fetched)
+
+
+def test_empty_message_explanation_survives_send_then_get():
+    """Empty-message rejection keeps its explanation in the stored Task."""
+    adapter = _bare_adapter()
+
+    sent, fetched = _send_then_get(
+        adapter,
+        {"message": protocol.text_message(protocol.ROLE_USER, "", "ctx-empty")},
+    )
+
+    assert sent["status"]["state"] == protocol.STATE_REJECTED
+    assert _status_text(sent) == _status_text(fetched) == "Empty task — nothing to do."
+
+
+def test_not_ready_explanation_survives_send_then_get():
+    """A not-ready gateway failure keeps its explanation in the stored Task."""
+    adapter = _bare_adapter()
+
+    sent, fetched = _send_then_get(
+        adapter,
+        {"message": protocol.text_message(protocol.ROLE_USER, "work", "ctx-not-ready")},
+    )
+
+    assert sent["status"]["state"] == protocol.STATE_FAILED
+    assert _status_text(sent) == _status_text(fetched)
+    assert "gateway not ready" in _status_text(fetched)
+
+
+def test_finalizer_thread_start_failure_returns_failed_task_and_cleans_pending(
+    monkeypatch, tmp_path
+):
+    """A detached finalizer that cannot start must not leave WORKING ownership."""
+    _isolate_server_side_effects(monkeypatch, tmp_path)
+
+    class StartFails:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            raise RuntimeError("finalizer thread start failed")
+
+    monkeypatch.setattr(adapter_module.threading, "Thread", StartFails)
+    adapter = _bare_adapter()
+    record = adapter.tasks.create("task-finalizer", "ctx-finalizer", "peer")
+    adapter.tasks.set_state("task-finalizer", protocol.STATE_WORKING)
+    future: Future = adapter._add_pending("task-finalizer", "ctx-finalizer")
+    pending = {
+        "task_id": "task-finalizer",
+        "context_id": "ctx-finalizer",
+        "peer": "peer",
+        "future": future,
+        "created_iso": record["created_iso"],
+        "started": 0.0,
+    }
+    monkeypatch.setattr(adapter, "_prepare_task", lambda *args, **kwargs: (None, pending))
+
+    response = adapter._rpc_message_send(
+        "rpc-finalizer",
+        {"configuration": {"returnImmediately": True}},
+        "peer",
+        v1_response=True,
+    )
+    task = protocol.unwrap_send_message_response(response["result"])
+    stored = adapter.tasks.get("task-finalizer")
+
+    assert task["status"]["state"] == protocol.STATE_FAILED
+    assert stored["state"] == protocol.STATE_FAILED
+    assert "finalizer thread start failed" in stored["reply"]
+    assert "task-finalizer" not in adapter._pending
+
+
+def test_forward_thread_start_failure_returns_failed_task_and_cleans_pending(
+    monkeypatch, tmp_path
+):
+    """A detached profile forwarder that cannot start follows the failed outcome path."""
+    _isolate_server_side_effects(monkeypatch, tmp_path)
+
+    class StartFails:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            raise RuntimeError("forward thread start failed")
+
+    monkeypatch.setattr(adapter_module.threading, "Thread", StartFails)
+    adapter = A2AAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"agents": {"dev": {"profile": "dev", "tenant": "dev"}}},
+        )
+    )
+    agent = adapter._agents["dev"]
+
+    response = adapter._rpc_message_send(
+        "rpc-forward",
+        {
+            "tenant": "dev",
+            "message": protocol.text_message(
+                protocol.ROLE_USER, "slow profile work", "ctx-forward"
+            ),
+            "configuration": {"returnImmediately": True},
+        },
+        "peer",
+        agent=agent,
+        v1_response=True,
+    )
+    task = protocol.unwrap_send_message_response(response["result"])
+    stored = adapter.tasks.get(task["id"], "dev", "dev")
+
+    assert task["status"]["state"] == protocol.STATE_FAILED
+    assert stored["state"] == protocol.STATE_FAILED
+    assert "forward thread start failed" in stored["reply"]
+    assert task["id"] not in adapter._pending
+
+
+def test_call_can_submit_nonblocking_task(monkeypatch):
+    """Non-blocking calls request immediate return and expose the task id."""
+    _configured_peer(monkeypatch)
+    captured = {}
+
+    def fake_post(url, body, headers, timeout):
+        captured["body"] = body
+        return protocol.jsonrpc_result(
+            body["id"],
+            protocol.build_task(
+                "task-async",
+                "ctx-async",
+                protocol.STATE_WORKING,
+                "",
+            ),
+        )
+
+    monkeypatch.setattr(tools, "_http_post_json", fake_post)
+    output = tools.a2a_call(
+        {"agent": "peer", "message": "slow work", "wait": False}
+    )
+
+    configuration = captured["body"]["params"]["configuration"]
+    assert configuration["returnImmediately"] is True
+    assert "task-async" in output
+    assert "working" in output
+
+
+def test_get_task_fetches_terminal_reply(monkeypatch):
+    """A submitted task remains retrievable after the send request returns."""
+    _configured_peer(monkeypatch)
+    captured = {}
+
+    def fake_post(url, body, headers, timeout):
+        captured["body"] = body
+        return protocol.jsonrpc_result(
+            body["id"],
+            protocol.build_task(
+                "task-async",
+                "ctx-async",
+                protocol.STATE_COMPLETED,
+                "finished result",
+            ),
+        )
+
+    monkeypatch.setattr(tools, "_http_post_json", fake_post)
+    output = tools.a2a_get_task({"agent": "peer", "task_id": "task-async"})
+
+    assert captured["body"]["method"] == "GetTask"
+    assert captured["body"]["params"]["id"] == "task-async"
+    assert "completed" in output
+    assert "finished result" in output
+
+
+def test_wait_task_polls_until_terminal(monkeypatch):
+    """Waiting polls the detached task without controlling its execution."""
+    _configured_peer(monkeypatch)
+    states = iter(
+        [
+            {
+                "reply": "",
+                "context_id": "ctx-async",
+                "state": protocol.STATE_WORKING,
+                "task_id": "task-async",
+            },
+            {
+                "reply": "finished result",
+                "context_id": "ctx-async",
+                "state": protocol.STATE_COMPLETED,
+                "task_id": "task-async",
+            },
+        ]
+    )
+    calls = []
+
+    def fake_get(agent, peer, task_id, request_timeout=None):
+        calls.append((agent, task_id))
+        return next(states)
+
+    monkeypatch.setattr(tools, "_get_task_result", fake_get)
+    monkeypatch.setattr(tools.time, "sleep", lambda _seconds: None)
+
+    output = tools.a2a_wait(
+        {
+            "agent": "peer",
+            "task_id": "task-async",
+            "timeout": 1,
+            "poll_interval": 0.01,
+        }
+    )
+
+    assert calls == [("peer", "task-async"), ("peer", "task-async")]
+    assert "completed" in output
+    assert "finished result" in output
+
+
+def test_wait_timeout_does_not_cancel_remote_task(monkeypatch):
+    """A local wait deadline leaves the detached remote task untouched."""
+    _configured_peer(monkeypatch)
+    calls = []
+
+    def fake_get(agent, peer, task_id, request_timeout=None):
+        calls.append((agent, task_id))
+        return {
+            "reply": "",
+            "context_id": "ctx-async",
+            "state": protocol.STATE_WORKING,
+            "task_id": task_id,
+        }
+
+    monkeypatch.setattr(tools, "_get_task_result", fake_get)
+    output = tools.a2a_wait(
+        {"agent": "peer", "task_id": "task-async", "timeout": 0}
+    )
+
+    assert calls == [("peer", "task-async")]
+    assert "not canceled" in output
+    assert "a2a_get_task" in output
+
+
+def test_wait_bounds_get_request_by_remaining_deadline(monkeypatch):
+    """One slow HTTP lookup cannot overrun the caller's local wait budget."""
+    _configured_peer(monkeypatch)
+    request_timeouts = []
+
+    def fake_get(agent, peer, task_id, request_timeout=None):
+        request_timeouts.append(request_timeout)
+        return {
+            "reply": "finished result",
+            "context_id": "ctx-async",
+            "state": protocol.STATE_COMPLETED,
+            "task_id": task_id,
+        }
+
+    monkeypatch.setattr(tools, "_get_task_result", fake_get)
+    monkeypatch.setattr(tools.time, "monotonic", lambda: 100.0)
+
+    output = tools.a2a_wait(
+        {"agent": "peer", "task_id": "task-async", "timeout": 0.25}
+    )
+
+    assert 0 < request_timeouts[0] <= 0.25
+    assert "completed" in output
+
+
+def test_wait_budget_covers_card_fallback_and_get_task(monkeypatch):
+    """Agent-card fallback and GetTask share one fake monotonic budget."""
+    _configured_peer(monkeypatch)
+    clock = [0.0]
+    card_timeouts = []
+    task_timeouts = []
+
+    def fake_monotonic():
+        return clock[0]
+
+    def fake_get(url, headers, timeout):
+        card_timeouts.append(timeout)
+        if url.endswith("/.well-known/agent-card.json"):
+            clock[0] += 0.6
+            raise urllib.error.HTTPError(url, 404, "missing", {}, None)
+        clock[0] += 0.2
+        return {
+            "supportedInterfaces": [
+                {"protocolBinding": "JSONRPC", "url": "http://peer/rpc"}
+            ]
+        }
+
+    def fake_post(url, body, headers, timeout):
+        task_timeouts.append(timeout)
+        clock[0] += timeout
+        raise TimeoutError("GetTask timed out")
+
+    monkeypatch.setattr(tools.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(tools, "_http_get_json", fake_get)
+    monkeypatch.setattr(tools, "_http_post_json", fake_post)
+
+    output = tools.a2a_wait(
+        {
+            "agent": "peer",
+            "task_id": "task-async",
+            "timeout": 1,
+            "poll_interval": 0.1,
+        }
+    )
+
+    assert card_timeouts == [pytest.approx(1.0), pytest.approx(0.4)]
+    assert task_timeouts == [pytest.approx(0.2)]
+    assert clock[0] == pytest.approx(1.0)
+    assert "Local wait timed out; the remote task was not canceled." in output
+    assert "task lookup" not in output
+
+
+def test_repeated_get_does_not_duplicate_persisted_reply(monkeypatch, tmp_path):
+    """A terminal reply stays idempotent after more than 50 newer messages."""
+    monkeypatch.setattr(protocol, "_hermes_home", lambda: tmp_path)
+    task = {
+        "reply": "finished result",
+        "context_id": "ctx-async",
+        "state": protocol.STATE_COMPLETED,
+        "task_id": "task-async",
+    }
+    protocol.persist_message(
+        task["context_id"], "agent", task["reply"], task["task_id"]
+    )
+    for index in range(60):
+        protocol.persist_message(
+            task["context_id"], "user", f"newer-{index}", f"newer-{index}"
+        )
+
+    tools._persist_task_reply(task)
+    tools._persist_task_reply(task)
+
+    messages = protocol.load_conversation(task["context_id"], limit=200)
+    matches = [
+        message
+        for message in messages
+        if message.get("role") == "agent"
+        and message.get("task_id") == task["task_id"]
+    ]
+    assert len(matches) == 1
+
+
+def test_concurrent_task_reply_persistence_is_single_write(monkeypatch, tmp_path):
+    """Concurrent polls append one record for the same task identity."""
+    monkeypatch.setattr(protocol, "_hermes_home", lambda: tmp_path)
+    task = {
+        "reply": "finished result",
+        "context_id": "ctx-concurrent",
+        "state": protocol.STATE_COMPLETED,
+        "task_id": "task-concurrent",
+    }
+    ready = threading.Barrier(2)
+    errors = []
+
+    def poll_task():
+        try:
+            ready.wait()
+            tools._persist_task_reply(task)
+        except BaseException as exc:  # pragma: no cover - diagnostic only
+            errors.append(exc)
+
+    workers = [threading.Thread(target=poll_task) for _ in range(2)]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(2.0)
+
+    messages = protocol.load_conversation(task["context_id"], limit=20)
+    matches = [
+        message
+        for message in messages
+        if message.get("role") == "agent"
+        and message.get("task_id") == task["task_id"]
+    ]
+    assert not errors
+    assert all(not worker.is_alive() for worker in workers)
+    assert len(matches) == 1
+
+
+def test_async_tools_are_registered_with_wait_schema():
+    """The runtime exposes submit/get/wait through the A2A toolset."""
+    from types import SimpleNamespace
+    registered = {}
+    tools.register_tools(SimpleNamespace(register_tool=lambda **item: registered.update({item["name"]: item})))
+    call_properties = registered["a2a_call"]["schema"]["parameters"]["properties"]
+    assert call_properties["wait"]["type"] == "boolean"
+    assert registered["a2a_get_task"]["handler"] is tools.a2a_get_task
+    assert registered["a2a_wait"]["handler"] is tools.a2a_wait
+    assert registered["a2a_get_task"]["schema"]["parameters"][
+        "required"
+    ] == ["agent", "task_id"]
+    assert registered["a2a_wait"]["schema"]["parameters"][
+        "required"
+    ] == ["agent", "task_id"]
+
+
+def test_http_detached_task_round_trip(monkeypatch, tmp_path):
+    """Real HTTP submit returns before gateway completion and remains queryable."""
+    monkeypatch.delenv("A2A_PORT", raising=False)
+    monkeypatch.delenv("A2A_TOKEN", raising=False)
+    monkeypatch.setenv("A2A_BIND_HOST", "127.0.0.1")
+    _isolate_server_side_effects(monkeypatch, tmp_path)
+
+    async def scenario():
+        adapter = _bare_adapter()
+        adapter.port = 0
+        release = asyncio.Event()
+        finalized = threading.Event()
+
+        async def delayed_handle(event):
+            await release.wait()
+            await adapter.send(
+                event.source.chat_id,
+                "finished over HTTP",
+                metadata={"notify": True},
+            )
+
+        adapter.set_message_handler(delayed_handle)
+        original_finalize = adapter._finalize_task
+
+        def finalize_task(*args, **kwargs):
+            try:
+                return original_finalize(*args, **kwargs)
+            finally:
+                finalized.set()
+
+        adapter._finalize_task = finalize_task  # type: ignore[method-assign]
+        assert await adapter.connect()
+        try:
+            assert adapter._httpd is not None
+            port = adapter._httpd.server_address[1]
+            peer = {"url": f"http://127.0.0.1:{port}", "auth": {}, "timeout": 2}
+
+            submitted = await asyncio.wait_for(
+                asyncio.to_thread(
+                    tools._send_task_result,
+                    "peer",
+                    peer,
+                    "slow task",
+                    "ctx-http",
+                    return_immediately=True,
+                ),
+                timeout=2.0,
+            )
+            assert submitted["task_id"]
+            assert submitted["state"] == protocol.STATE_WORKING
+
+            working = await asyncio.to_thread(
+                tools._get_task_result,
+                "peer",
+                peer,
+                submitted["task_id"],
+            )
+            assert working["state"] == protocol.STATE_WORKING
+
+            release.set()
+            assert await asyncio.to_thread(finalized.wait, 2.0)
+            final = await asyncio.to_thread(
+                tools._get_task_result,
+                "peer",
+                peer,
+                submitted["task_id"],
+            )
+            assert final["state"] == protocol.STATE_COMPLETED
+            assert final["reply"] == "finished over HTTP"
+        finally:
+            release.set()
+            await adapter.disconnect()
+
+    asyncio.run(scenario())
+
+
+def test_send_return_immediately_finalizes_in_background(monkeypatch, tmp_path):
+    """The HTTP response returns WORKING while task completion stays live."""
+    _isolate_server_side_effects(monkeypatch, tmp_path)
+    adapter = _bare_adapter()
+    record = adapter.tasks.create("task-async", "ctx-async", "peer")
+    adapter.tasks.set_state("task-async", protocol.STATE_WORKING)
+    future: Future = adapter._add_pending("task-async", "ctx-async")
+    pending = {
+        "task_id": "task-async",
+        "context_id": "ctx-async",
+        "peer": "peer",
+        "future": future,
+        "created_iso": record["created_iso"],
+        "started": 0.0,
+    }
+    monkeypatch.setattr(adapter, "_prepare_task", lambda *args, **kwargs: (None, pending))
+    monkeypatch.setattr(
+        adapter,
+        "_await_reply",
+        lambda _pending: pytest.fail("non-blocking send must not await the reply"),
+    )
+
+    finalized = threading.Event()
+    original_finalize = adapter._finalize_task
+
+    def finalize_task(*args, **kwargs):
+        try:
+            return original_finalize(*args, **kwargs)
+        finally:
+            finalized.set()
+
+    monkeypatch.setattr(adapter, "_finalize_task", finalize_task)
+    response = adapter._rpc_message_send(
+        "rpc-1",
+        {
+            "message": protocol.text_message(
+                protocol.ROLE_USER,
+                "slow work",
+                context_id="ctx-async",
+            ),
+            "configuration": {"returnImmediately": True},
+        },
+        "peer",
+        v1_response=True,
+    )
+    task = protocol.unwrap_send_message_response(response["result"])
+
+    assert task["id"] == "task-async"
+    assert task["status"]["state"] == protocol.STATE_WORKING
+    assert not future.done()
+
+    adapter.tasks._tasks["task-async"]["created_at"] = 0.0
+    assert adapter._fail_orphaned_tasks(timeout_seconds=1) == []
+
+    future.set_result((protocol.STATE_COMPLETED, "finished result"))
+    assert finalized.wait(2.0)
+    stored = adapter.tasks.get("task-async")
+    assert stored["state"] == protocol.STATE_COMPLETED
+    assert stored["reply"] == "finished result"
+    assert "task-async" not in adapter._pending
+
+
+def test_forwarded_profile_return_immediately_runs_in_background(monkeypatch, tmp_path):
+    """Profile-backed agents also detach only for non-blocking requests."""
+    _isolate_server_side_effects(monkeypatch, tmp_path)
+    adapter = A2AAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"agents": {"dev": {"profile": "dev", "tenant": "dev"}}},
+        )
+    )
+    agent = adapter._agents["dev"]
+    release = threading.Event()
+    finalized = threading.Event()
+
+    def fake_forward(agent_arg, peer, context_id, framed_text):
+        assert agent_arg["slug"] == "dev"
+        assert release.wait(2.0)
+        return "profile result", protocol.STATE_COMPLETED
+
+    adapter._forward_to_profile = fake_forward  # type: ignore[method-assign]
+    original_finalize = adapter._finalize_task
+
+    def finalize_task(*args, **kwargs):
+        try:
+            return original_finalize(*args, **kwargs)
+        finally:
+            finalized.set()
+
+    monkeypatch.setattr(adapter, "_finalize_task", finalize_task)
+    response = adapter._rpc_message_send(
+        "rpc-profile",
+        {
+            "tenant": "dev",
+            "message": protocol.text_message(
+                protocol.ROLE_USER,
+                "slow profile work",
+                context_id="ctx-profile",
+            ),
+            "configuration": {"returnImmediately": True},
+        },
+        "peer",
+        agent=agent,
+        v1_response=True,
+    )
+    task = protocol.unwrap_send_message_response(response["result"])
+
+    assert task["status"]["state"] == protocol.STATE_WORKING
+    assert not finalized.is_set()
+    release.set()
+    assert finalized.wait(2.0)
+    stored = adapter.tasks.get(task["id"], "dev", "dev")
+    assert stored["state"] == protocol.STATE_COMPLETED
+    assert stored["reply"] == "profile result"
+
+
+def test_orphan_sweep_preserves_active_pending_task():
+    """Elapsed wall time alone must not kill an actively executing task."""
+    adapter = _bare_adapter()
+    adapter.tasks.create("task-active", "ctx-active", "peer")
+    adapter.tasks.create("task-orphan", "ctx-orphan", "peer")
+    adapter.tasks.set_state("task-active", protocol.STATE_WORKING)
+    adapter.tasks.set_state("task-orphan", protocol.STATE_WORKING)
+    adapter.tasks._tasks["task-active"]["created_at"] = 0.0
+    adapter.tasks._tasks["task-orphan"]["created_at"] = 0.0
+    adapter._add_pending("task-active", "ctx-active")
+
+    try:
+        failed = adapter._fail_orphaned_tasks(timeout_seconds=1)
+    finally:
+        adapter._pop_pending("task-active")
+
+    assert failed == ["task-orphan"]
+    assert adapter.tasks.get("task-active")["state"] == protocol.STATE_WORKING
+    assert adapter.tasks.get("task-orphan")["state"] == protocol.STATE_FAILED
+
+
+def test_task_store_orphan_sweep_can_exclude_active_task():
+    """TaskStore keeps an active old task while failing an equally old orphan."""
+    store = protocol.TaskStore()
+    store.create("task-active", "ctx-active", "peer")
+    store.create("task-orphan", "ctx-orphan", "peer")
+    store._tasks["task-active"]["created_at"] = 0.0
+    store._tasks["task-orphan"]["created_at"] = 0.0
+
+    failed = store.fail_orphans(
+        timeout_seconds=1,
+        active_task_ids={"task-active"},
+    )
+
+    assert failed == ["task-orphan"]
+    assert store.get("task-active")["state"] == protocol.STATE_SUBMITTED
+    assert store.get("task-orphan")["state"] == protocol.STATE_FAILED

--- a/tests/plugins/test_a2a_schema_registration.py
+++ b/tests/plugins/test_a2a_schema_registration.py
@@ -52,4 +52,5 @@ def test_a2a_call_schema_round_trips_through_tool_describe(monkeypatch):
         "agent",
         "message",
         "context_id",
+        "wait",
     }


### PR DESCRIPTION
## Summary
Support `a2a_call(wait=false)` using the A2A `configuration.returnImmediately` path, plus `a2a_get_task` and `a2a_wait`. Blocking calls retain their default behavior. Detached local and profile-backed work remains owned until completion rather than failing solely because a watchdog age threshold passes.

Keep terminal rejection/failure explanations queryable; clean up failed finalizer/thread starts; share a monotonic local wait budget across card discovery and task lookup; persist retrieved replies once by context/task/role rather than a short history tail. Include lazy tool metadata and documentation.

## Related work
Related to #91688, #63946 and #55805. The existing open implementations were compared rather than treated as merged replacements. This candidate also covers bounded local waiting, profile-backed detached execution, terminal-error persistence and durable reply deduplication.

## Verification
- 19 detached-task tests passed, including a real loopback HTTP submit → working → completed round trip and concurrency/error cases.
- 115 existing A2A tests, 1 schema-registration test and 4 focused lazy-discovery tests passed in separate native-Windows subprocesses.
- One unchanged POSIX fake-hermes profile fixture cannot execute on native Windows and fails identically on the base; excluded by its exact node name (`test_forward_to_profile_first_contact_creates_then_resumes_fake_hermes`).
- Focused lint and diff checks passed. Independent final static review found no remaining blocker within this scope.
- No claim of a whole-repository green suite or completed upstream CI.

Behavior remains in the existing adapter lifecycle, protocol persistence and outbound client-tool modules, with matching tests and plugin metadata; no core tool or separate infrastructure is introduced.
