### PR TITLE
fix(acp): honour explicit provider: prefix in model selection

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -307,13 +307,29 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
 
     @staticmethod
     def _resolve_model_selection(raw_model: str, current_provider: str) -> tuple[str, str]:
-        """Resolve ``provider:model`` input into the provider and normalized model id."""
+        """Resolve ``provider:model`` input into the provider and normalized model id.
+
+        An explicit ``provider:`` prefix is authoritative: name-based provider
+        detection is skipped entirely for it.  Detection only runs for bare
+        model ids, where there is no caller-stated provider to honour.
+
+        Without that guard, ``anthropic:<model>`` sent while the session is
+        already on ``anthropic`` was indistinguishable from a bare model id,
+        so detection could reroute it to another provider while the agent kept
+        the Anthropic ``base_url`` -- yielding HTTP 404 on every request.
+        """
         target_provider, new_model = current_provider, raw_model.strip()
         try:
             from hermes_cli.models import detect_provider_for_model, parse_model_input
 
+            # Probe with a sentinel provider so an explicit prefix is
+            # detectable even when it names the session's current provider.
+            _sentinel = "\x00-no-provider-\x00"
+            probe_provider, _ = parse_model_input(new_model, _sentinel)
+            explicit_provider = probe_provider != _sentinel
+
             target_provider, new_model = parse_model_input(new_model, current_provider)
-            if target_provider == current_provider:
+            if not explicit_provider and target_provider == current_provider:
                 detected = detect_provider_for_model(new_model, current_provider)
                 if detected:
                     target_provider, new_model = detected

--- a/tests/acp_adapter/test_acp_model_selection.py
+++ b/tests/acp_adapter/test_acp_model_selection.py
@@ -1,0 +1,81 @@
+"""Regression tests for ACP ``provider:model`` resolution.
+
+``_resolve_model_selection`` ran name-based provider detection whenever the
+parsed provider equalled the session's current provider.  An explicit
+``anthropic:<model>`` request sent while the session was already on
+``anthropic`` was therefore indistinguishable from a bare model id, so
+detection could reroute it to a different provider while the agent kept the
+Anthropic ``base_url`` -- every request then failed with HTTP 404.
+
+Observed via Buzz Desktop, which launches Hermes over ACP with a fully
+qualified ``anthropic:<model>`` and got a provider the caller never asked
+for.  These tests pin the contract: an explicit prefix wins, bare ids still
+get detection.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from acp_adapter.server import HermesACPAgent
+
+
+def _resolve(raw: str, current: str) -> tuple[str, str]:
+    return HermesACPAgent._resolve_model_selection(raw, current)
+
+
+class TestExplicitProviderPrefixWins:
+    def test_explicit_prefix_matching_current_provider_skips_detection(self):
+        """The bug: ``anthropic:x`` on an anthropic session must stay anthropic
+        even when detection would claim ``x`` for someone else."""
+
+        def _detect(_model, _current):
+            return ("opencode-zen", _model)
+
+        with patch("hermes_cli.models.detect_provider_for_model", side_effect=_detect):
+            assert _resolve("anthropic:some-model", "anthropic") == (
+                "anthropic",
+                "some-model",
+            )
+
+    def test_explicit_prefix_switching_provider_is_honoured(self):
+        assert _resolve("nous:hermes-3", "anthropic") == ("nous", "hermes-3")
+
+    def test_explicit_prefix_with_slash_in_model_id(self):
+        assert _resolve("openrouter:anthropic/claude-sonnet-4.5", "anthropic") == (
+            "openrouter",
+            "anthropic/claude-sonnet-4.5",
+        )
+
+    def test_detection_never_consulted_for_explicit_prefix(self):
+        with patch("hermes_cli.models.detect_provider_for_model") as detect:
+            _resolve("anthropic:some-model", "anthropic")
+            detect.assert_not_called()
+
+
+class TestBareModelIdStillDetected:
+    def test_bare_model_id_uses_detection(self):
+        """No caller-stated provider -> detection still gets to reroute."""
+
+        def _detect(_model, _current):
+            return ("opencode-zen", _model)
+
+        with patch("hermes_cli.models.detect_provider_for_model", side_effect=_detect):
+            assert _resolve("some-model", "anthropic") == ("opencode-zen", "some-model")
+
+    def test_bare_model_id_falls_back_to_current_provider(self):
+        with patch("hermes_cli.models.detect_provider_for_model", return_value=None):
+            assert _resolve("some-model", "anthropic") == ("anthropic", "some-model")
+
+
+class TestResolutionIsTotal:
+    def test_whitespace_is_stripped(self):
+        assert _resolve("  nous:hermes-3  ", "anthropic") == ("nous", "hermes-3")
+
+    def test_import_failure_falls_back_to_raw_model(self):
+        """A broken detection import must not take the session down."""
+        with patch(
+            "hermes_cli.models.parse_model_input",
+            side_effect=RuntimeError("boom"),
+        ):
+            assert _resolve("some-model", "anthropic") == ("anthropic", "some-model")


### PR DESCRIPTION
## What does this PR do?

`_resolve_model_selection` (`acp_adapter/server.py`) ran name-based provider
detection whenever the parsed provider equalled the session's current
provider. An explicit `anthropic:<model>` request sent while the session was
already on `anthropic` was therefore indistinguishable from a bare model id,
so `detect_provider_for_model` could reroute it to a different provider —
while the agent kept the Anthropic `base_url`. Every subsequent request then
failed with HTTP 404 and the agent never answered.

An explicit `provider:` prefix is a caller-stated fact, so detection is now
skipped for it entirely. Detection still runs for bare model ids, where there
is no stated provider to honour.

Detecting *"was a prefix present?"* needs a sentinel probe: `parse_model_input`
folds the no-prefix case into the caller-supplied default, so a prefix that
names the current provider is otherwise invisible to the caller.

**Why this approach:** the alternative — teaching `detect_provider_for_model`
about the Anthropic model in question — only fixes one model name and leaves
the same trap for the next one. The bug is that a caller's explicit statement
was being overridden by a guess; that is what this fixes, at the one call site
that owns the decision.

## Related Issue

No existing issue — found in the field. Happy to open one if maintainers
prefer that ordering.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `acp_adapter/server.py` — `_resolve_model_selection` now probes with a
  sentinel provider to tell an explicit `provider:` prefix apart from a bare
  model id, and skips `detect_provider_for_model` when the prefix is explicit.
  Docstring records the failure mode.
- `tests/acp_adapter/test_acp_model_selection.py` — new; 8 tests pinning the
  contract (explicit prefix wins, detection never consulted for it, bare ids
  still detected, whitespace/import-failure totality).

## How to Test

Reproduction (any ACP client that sends a fully qualified model id — Buzz
Desktop does this by default):

1. Configure an ACP agent with model `anthropic:<a model name that
   `detect_provider_for_model` claims for another provider>`.
2. Send it a message. Before this patch the session logs:

   ```
   Session <id>: model switched to <model> via provider opencode-zen
   base_url=https://api.anthropic.com model=<model>
   openai.NotFoundError: Error code: 404
   ```

   …retries 3× and gives up. The agent never replies.
3. With this patch the provider stays `anthropic` and the turn completes
   normally.

Automated:

```bash
pytest tests/acp_adapter/test_acp_model_selection.py -q   # 8 passed
```

The tests are non-vacuous — reverting only `acp_adapter/server.py` and
re-running fails exactly the two that encode the fix
(`test_explicit_prefix_matching_current_provider_skips_detection`,
`test_detection_never_consulted_for_explicit_prefix`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/acp_adapter/ -q` — my new tests pass; 3 pre-existing failures in `test_acp_commands.py` / `test_acp_images.py` are unrelated (missing `pytest-asyncio`) and fail identically on unpatched `main`
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.5 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring on the fixed function records the failure mode
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact — pure string handling, no platform-specific behaviour
- [x] N/A — no tool descriptions/schemas changed

## Screenshots / Logs

Live failure before the fix (Buzz Desktop → `hermes-acp`, model
`anthropic:<model>`):

```
2026-09-02 20:04:55 [INFO] acp_adapter.server: Session f7e40fd4-…: model switched to <model> via provider opencode-zen
2026-09-02 20:04:56 [WARNING] agent.conversation_loop: API call failed (attempt 1/3) error_type=NotFoundError base_url=https://api.anthropic.com model=<model> summary=HTTP 404
2026-09-02 20:05:04 [ERROR] agent.conversation_loop: API call failed after 3 retries. HTTP 404: Error code: 404 | provider= model=<model> msgs=2 tokens=~9,996
```

After the patch the same agent answers normally with no config change.
