### PR TITLE
fix(desktop): stage native deps via per-file copies to survive non-ASCII Windows paths

### DIFF
--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -33,6 +33,29 @@ function makeExecutable(filePath) {
   chmodSync(filePath, 0o755)
 }
 
+/**
+ * Recursive directory copy using per-file cpSync.
+ *
+ * Workaround for a Node.js bug on Windows: fs.cpSync({ recursive: true })
+ * crashes the process (STATUS_STACK_BUFFER_OVERRUN, 0xC0000409, no output)
+ * when the source path contains non-ASCII characters — e.g. a user folder
+ * like C:\Users\涂\ or C:\Users\JorgeFigulsGarcía\. Per-file copies sidestep
+ * the buggy path entirely. Semantics are equivalent to cpSync(recursive: true)
+ * for our use case (whole-directory copy, no filtering).
+ */
+function copyDirSyncSafe(srcDir, destDir) {
+  mkdirSync(destDir, { recursive: true })
+  for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
+    const srcPath = join(srcDir, entry.name)
+    const destPath = join(destDir, entry.name)
+    if (entry.isDirectory()) {
+      copyDirSyncSafe(srcPath, destPath)
+    } else if (entry.isFile()) {
+      cpSync(srcPath, destPath)
+    }
+  }
+}
+
 function patchUnixTerminalAsarPaths(destRoot) {
   const filePath = join(destRoot, 'lib', 'unixTerminal.js')
   if (!existsSync(filePath)) return
@@ -96,7 +119,7 @@ function copyBuildRelease(srcDir, destDir) {
   mkdirSync(destDir, { recursive: true })
   for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
     if (entry.isDirectory()) {
-      cpSync(join(srcDir, entry.name), join(destDir, entry.name), { recursive: true })
+      copyDirSyncSafe(join(srcDir, entry.name), join(destDir, entry.name))
       continue
     }
     if (entry.name === 'spawn-helper' || /\.(node|dll|exe)$/.test(entry.name)) {
@@ -261,7 +284,7 @@ export function stageNodePtyInto(srcRoot, destRoot, { platform = process.platfor
     mkdirSync(destPrebuild, { recursive: true })
     for (const entry of readdirSync(prebuildDir, { withFileTypes: true })) {
       if (entry.name === 'conpty' && entry.isDirectory()) {
-        cpSync(join(prebuildDir, 'conpty'), join(destPrebuild, 'conpty'), { recursive: true })
+        copyDirSyncSafe(join(prebuildDir, 'conpty'), join(destPrebuild, 'conpty'))
         continue
       }
       if (entry.isFile() && /\.(node|dll|exe)$/.test(entry.name)) {

--- a/apps/desktop/scripts/stage-native-deps.test.mjs
+++ b/apps/desktop/scripts/stage-native-deps.test.mjs
@@ -361,6 +361,60 @@ test('validation rejects a staged binary with the wrong platform magic', () => {
   }
 })
 
+test('staging survives non-ASCII source paths (recursive-copy crash workaround)', () => {
+  // Regression for nodejs/node#60447: on Windows, fs.cpSync({ recursive: true })
+  // crashes the process (STATUS_STACK_BUFFER_OVERRUN, 0xC0000409, no output)
+  // when a path contains non-ASCII characters — e.g. a user profile like
+  // C:\Users\涂\. copyDirSyncSafe stages whole directories by per-file copies
+  // instead. The fixture path is deliberately non-ASCII so the pre-fix
+  // recursive cpSync hard-crashes this test on Windows; the deep-copy
+  // assertions pin the recursive-copy contract everywhere.
+  const tmp = fs.mkdtempSync(join(os.tmpdir(), 'hermes-stage-'))
+  try {
+    const srcRoot = join(tmp, 'node-pty-测试')
+    const destRoot = join(tmp, 'dest-测试')
+
+    makeFakeNodePty(srcRoot)
+    makeFakeNode(join(srcRoot, 'build', 'Release', 'pty.node'), process.platform)
+
+    // Nested payloads that recursive directory copies must carry over:
+    // a conpty/ subdir inside the host prebuild, and a nested dir under
+    // build/Release (validator only scans *.node, so a nested .node must
+    // carry real platform magic while a plain file proves whole-dir copy).
+    const prebuildDir = join(srcRoot, 'prebuilds', `${process.platform}-${process.arch}`)
+    fs.mkdirSync(join(prebuildDir, 'conpty', 'x64'), { recursive: true })
+    fs.writeFileSync(join(prebuildDir, 'conpty', 'x64', 'conpty.dll'), 'conpty payload')
+    fs.mkdirSync(join(srcRoot, 'build', 'Release', 'sub'), { recursive: true })
+    makeFakeNode(join(srcRoot, 'build', 'Release', 'sub', 'nested.node'), process.platform)
+    fs.writeFileSync(join(srcRoot, 'build', 'Release', 'sub', 'payload.dat'), 'nested payload')
+
+    stageNodePtyInto(srcRoot, destRoot, { platform: process.platform, arch: process.arch })
+
+    assert.equal(
+      existsSync(join(destRoot, 'build', 'Release', 'pty.node')),
+      true,
+      'host build/Release .node must be staged'
+    )
+    assert.equal(
+      existsSync(join(destRoot, 'build', 'Release', 'sub', 'nested.node')),
+      true,
+      'nested build/Release .node must be copied recursively'
+    )
+    assert.equal(
+      existsSync(join(destRoot, 'build', 'Release', 'sub', 'payload.dat')),
+      true,
+      'non-binary files inside a nested build/Release subdirectory must be copied'
+    )
+    assert.equal(
+      existsSync(join(destRoot, 'prebuilds', `${process.platform}-${process.arch}`, 'conpty', 'x64', 'conpty.dll')),
+      true,
+      'conpty prebuild subdirectory must be copied recursively'
+    )
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
 // ─── stageGetWindowsInto tests ──────────────────────────────────────
 
 /** Create a minimal fake get-windows source tree in a temp dir. */


### PR DESCRIPTION
# PR: fix(desktop): stage native deps via per-file copies to survive non-ASCII Windows paths

## Summary

`fs.cpSync({ recursive: true })` **crashes the Node process** on Windows
(`STATUS_STACK_BUFFER_OVERRUN`, 0xC0000409, no output) when a path contains
non-ASCII characters. The desktop pack stages node-pty / get-windows native
payloads under `apps/desktop/dist`, which inherits the user-profile path
component — so **Windows users whose username is non-ASCII (e.g. `C:\Users\涂`)
can never complete a local desktop build**; the pack dies silently mid-stage
(`npm run pack` fails with no error, `Hermes.exe` never gets produced).

This replaces the two recursive `fs.cpSync` call sites in
`apps/desktop/scripts/stage-native-deps.mjs` — whole `build/Release` dirs and a
`conpty/` prebuild subdir — with a `copyDirSyncSafe` helper that walks the tree
using per-file copies, sidestepping the buggy path. Semantics are equivalent for
these whole-directory copies; file modes are unchanged (files are still copied
with `cpSync`).

Reference: [nodejs/node#60447](https://github.com/nodejs/node/issues/60447) (the
underlying Node crash).

## Changes

- `apps/desktop/scripts/stage-native-deps.mjs`
  - add `copyDirSyncSafe(srcDir, destDir)` (recursive copy via per-file `cpSync`)
  - `copyBuildRelease()`: nested dirs → `copyDirSyncSafe`
  - `stageNodePtyInto()`: `conpty/` prebuild subdir → `copyDirSyncSafe`
- `apps/desktop/scripts/stage-native-deps.test.mjs`
  - new regression test `staging survives non-ASCII source paths
    (recursive-copy crash workaround)`: fixture paths deliberately contain CJK
    characters; asserts host `build/Release`, a nested `build/Release/sub`
    directory (`.node` + plain file), and a nested `conpty/x64/` prebuild dir are
    all staged. Pre-fix on Windows the recursive `cpSync` hard-crashes the test
    process; post-fix it passes everywhere.

## Test plan

- `cd apps/desktop && npx vitest run scripts/stage-native-deps.test.mjs`
  - New test passes; no regressions in the suite.
  - Note: `darwin staging ships the Swift helper executable…` asserts POSIX
    `0o755` on a helper and fails on a Windows host regardless of this change
    (Windows does not map exec bits) — pre-existing, unrelated.
- **Real-world proof**: the packaged desktop app was built end-to-end on a
  Windows 11 host whose user profile contains CJK characters. Before this fix
  the pack crashed silently at `stage-native-deps`; after, it stages
  `node-pty (win32-x64)` and `get-windows (win32)` and packs cleanly.
- CI expectation: green on linux/macos; on `windows-latest` the new test passes
  with the fix (and would have hard-crashed pre-fix thanks to its non-ASCII
  fixture paths).

## Notes

- The helper is deliberately a private function (no export/ABI change); it only
  swaps the copy mechanism at existing call sites.
- A proper upstream resolution lives in Node itself; until the Node fix reaches
  the Node versions Hermes supports, this workaround keeps local desktop builds
  working for affected users. Happy to drop it once the engine floor includes a
  fixed Node.
