### PR TITLE
fix(gateway): dedupe BlueBubbles duplicate deliveries; canonicalize 1:1 chat ids

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -61,6 +61,15 @@ _PAGINATION_SUFFIX_RE = re.compile(r"\s*\(\d+/\d+\)$")
 _ADDRESS_RE = re.compile(r"^\+\d+")
 
 _GUID_CACHE_SIZE = 500  # LRU cap for resolved chat-GUID lookups
+_SEEN_EVENT_CACHE_SIZE = 1000  # LRU cap for webhook message-guid dedupe
+_RECENT_EVENT_CACHE_SIZE = 200  # LRU cap for guid-less duplicate-delivery window
+_DUPLICATE_DELIVERY_WINDOW_S = 5.0  # BB re-sends the same message in variant payloads within ~1s
+
+# Chat-GUID service prefixes. BlueBubbles guids look like ``iMessage;-;+1555...`` / ``any;-;+1555...`` /
+# ``SMS;-;+1555...``; the prefix is the delivery-service hint, not a distinct conversation. A bare
+# address (``+1555...``) is the canonical 1:1 key: ``send()`` resolves it via ``_resolve_chat_guid``
+# (exact chatIdentifier match), which BB accepts for the same DM regardless of the inbound prefix.
+_GUID_SERVICE_PREFIXES = ("iMessage", "any", "SMS", "sms")
 _LOCAL_HOSTS = {"0.0.0.0", "127.0.0.1", "localhost", "::"}
 
 
@@ -132,6 +141,12 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
         self._guid_cache: OrderedDict[str, str] = OrderedDict()
+        # Inbound duplicate-delivery guards: BB fires the same message multiple times in variant
+        # payload shapes (guid present → ``iMessage;-;addr``, guid absent → bare address), which
+        # used to fragment into separate sessions. Keyed on message guid when available; guid-less
+        # events fall back to a short (sender, text) window. See #bluebubbles-duplicate-delivery.
+        self._seen_event_ids: OrderedDict[str, datetime] = OrderedDict()
+        self._recent_events: OrderedDict[tuple, tuple] = OrderedDict()
 
     # --- API helpers ---
 
@@ -538,6 +553,51 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         return (request.query.get("password") or request.query.get("guid") or request.headers.get("x-password")
                 or request.headers.get("x-guid") or request.headers.get("x-bluebubbles-guid"))
 
+    @staticmethod
+    def _canonical_chat_id(chat_guid: Optional[str], chat_identifier: Optional[str], sender: Optional[str]) -> str:
+        """One DM, one session key: BlueBubbles delivers the same 1:1 chat as ``iMessage;-;+1...``,
+        ``any;-;+1...`` or a bare ``+1...`` depending on payload shape; the service prefix is a
+        delivery hint, not a distinct conversation. Canonical form is the bare address for 1:1
+        chats (``send()`` re-resolves it via ``_resolve_chat_guid``); group/unknown-prefix guids
+        pass through untouched. Never returns an empty string (caller guarantees an id exists)."""
+        for raw in (chat_guid, chat_identifier, sender):
+            if raw:
+                parts = raw.split(";-;", 1)
+                if len(parts) == 2 and parts[0] in _GUID_SERVICE_PREFIXES:
+                    return parts[1]
+                return raw
+        return ""
+
+    def _is_duplicate_delivery(self, message_id: Optional[str], sender: Optional[str], text: str) -> bool:
+        """True when this webhook event is a re-delivery of a message we already dispatched.
+
+        BB double-fires the same message in variant payload shapes (~1s apart): one carries the
+        message guid + ``iMessage;-;addr`` chat, the other omits the guid and uses a bare address.
+        Guards: (1) exact guid replay is always suppressed; (2) a (sender, text) match inside a
+        short window suppresses the guid-less variant AND the guid-bearing variant when the prior
+        event was guid-less (either delivery order). Two distinct guid-bearing messages with the
+        same text inside the window still both deliver. Cost of the guard: repeated guid-less
+        identical texts inside the window are indistinguishable from duplicates and suppressed.
+        """
+        now = datetime.now()
+        if message_id and message_id in self._seen_event_ids:
+            return True
+        key = (sender or "", text)
+        last = self._recent_events.get(key)
+        if last is not None and (now - last[0]).total_seconds() <= _DUPLICATE_DELIVERY_WINDOW_S:
+            if not message_id or last[1] is None:
+                if message_id:  # attach the guid the earlier guid-less event was missing
+                    self._recent_events[key] = (now, message_id)
+                return True
+        if message_id:
+            self._seen_event_ids[message_id] = now
+            while len(self._seen_event_ids) > _SEEN_EVENT_CACHE_SIZE:
+                self._seen_event_ids.popitem(last=False)
+        self._recent_events[key] = (now, message_id)
+        while len(self._recent_events) > _RECENT_EVENT_CACHE_SIZE:
+            self._recent_events.popitem(last=False)
+        return False
+
     def _resolve_chat_and_sender(self, payload: Dict[str, Any], record: Dict[str, Any]):
         """Returns ``(chat_guid, chat_identifier, sender)`` from the many BlueBubbles payload shapes."""
         chat_guid = self._value(record.get("chatGuid"), payload.get("chatGuid"), record.get("chat_guid"),
@@ -581,7 +641,13 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         chat_guid, chat_identifier, sender = self._resolve_chat_and_sender(payload, record)
         if not sender or not (chat_guid or chat_identifier) or not text:
             return web.json_response({"error": "missing message fields"}, status=400)
-        session_chat_id = chat_guid or chat_identifier
+        if self._is_duplicate_delivery(
+                self._value(record.get("guid"), record.get("messageGuid"), record.get("id")), sender, text):
+            return _ok()
+        # One DM, one session: BB delivers the same chat as `iMessage;-;addr` / `any;-;addr` / bare
+        # `addr` depending on payload shape; without this the gateway fragments one conversation
+        # into parallel sessions with separate context histories. Groups keep their raw guid.
+        session_chat_id = self._canonical_chat_id(chat_guid, chat_identifier, sender) or chat_guid or chat_identifier or ""
         is_group = bool(record.get("isGroup")) or (";+;" in (chat_guid or ""))
         if is_group and self.require_mention:
             if not self._message_matches_mention_patterns(text):

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -1,12 +1,14 @@
 """Tests for the BlueBubbles iMessage gateway adapter."""
 import asyncio
 import json
+from datetime import datetime
 
 import httpx
 import pytest
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter
+from gateway.platforms.bluebubbles import _DUPLICATE_DELIVERY_WINDOW_S
 
 
 def _make_adapter(monkeypatch, **extra):
@@ -114,6 +116,91 @@ class TestBlueBubblesMentionGating:
 
         assert response.status == 200
         assert handled == []
+
+
+class TestBlueBubblesCanonicalChatId:
+
+    def test_service_prefixes_collapse_to_bare_address(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        for prefixed in ("iMessage;-;+15551234567", "any;-;+15551234567", "SMS;-;+15551234567"):
+            assert adapter._canonical_chat_id(prefixed, None, None) == "+15551234567"
+
+    def test_bare_address_and_fallbacks_pass_through(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        assert adapter._canonical_chat_id(None, "+15551234567", None) == "+15551234567"
+        assert adapter._canonical_chat_id("iMessage;+;group-chat", None, None) == "iMessage;+;group-chat"
+        assert adapter._canonical_chat_id(None, None, "user@example.com") == "user@example.com"
+        assert adapter._canonical_chat_id(None, None, None) == ""
+
+
+class TestBlueBubblesDuplicateDelivery:
+
+    def test_same_guid_replay_is_suppressed(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        assert adapter._is_duplicate_delivery("m-1", "+15551234567", "Good to go?") is False
+        assert adapter._is_duplicate_delivery("m-1", "+15551234567", "Good to go?") is True
+
+    def test_variant_payload_shapes_dedupe_either_order(self, monkeypatch):
+        # Real-world case: BB fires guid+prefixed-chat and guid-less+bare-address variants ~1s apart.
+        adapter = _make_adapter(monkeypatch)
+        assert adapter._is_duplicate_delivery(None, "+15551234567", "Good to go?") is False
+        assert adapter._is_duplicate_delivery("m-1", "+15551234567", "Good to go?") is True
+
+        adapter2 = _make_adapter(monkeypatch)
+        assert adapter2._is_duplicate_delivery("m-2", "+15551234567", "Good to go?") is False
+        assert adapter2._is_duplicate_delivery(None, "+15551234567", "Good to go?") is True
+
+    def test_distinct_guids_same_text_both_deliver(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        assert adapter._is_duplicate_delivery("m-1", "+15551234567", "ok") is False
+        assert adapter._is_duplicate_delivery("m-2", "+15551234567", "ok") is False
+
+    def test_repeat_outside_window_delivers(self, monkeypatch):
+        from datetime import timedelta
+        adapter = _make_adapter(monkeypatch)
+        assert adapter._is_duplicate_delivery(None, "+15551234567", "ok") is False
+        stale = (datetime.now() - timedelta(seconds=_DUPLICATE_DELIVERY_WINDOW_S * 2), None)
+        adapter._recent_events[("+15551234567", "ok")] = stale
+        assert adapter._is_duplicate_delivery(None, "+15551234567", "ok") is False
+
+
+class TestBlueBubblesWebhookDuplicateSuppression:
+
+    @pytest.mark.asyncio
+    async def test_variant_deliveries_dispatch_one_event(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        guid_payload = {
+            "type": "new-message",
+            "data": {
+                "guid": "E288AD24-82F6-46F5-815C-B65C7BBE9D5A",
+                "text": "Good to go?",
+                "handle": {"address": "+15551234567"},
+                "isFromMe": False,
+                "chats": [{"guid": "any;-;+15551234567"}],
+            },
+        }
+        bare_payload = {
+            "type": "new-message",
+            "data": {
+                "text": "Good to go?",
+                "handle": {"address": "+15551234567"},
+                "isFromMe": False,
+            },
+        }
+        assert (await adapter._handle_webhook(_FakeBlueBubblesRequest(guid_payload))).status == 200
+        assert (await adapter._handle_webhook(_FakeBlueBubblesRequest(bare_payload))).status == 200
+        await asyncio.sleep(0)
+
+        assert len(handled) == 1
+        source = handled[0].source
+        assert source.chat_id == "+15551234567"  # canonical bare address, not any;-;+15551234567
+        assert source.user_id == "+15551234567"
 
 
 class TestBlueBubblesWebhookParsing:


### PR DESCRIPTION
## Bug Description

BlueBubbles double-fires every inbound iMessage to the webhook in variant payload shapes ~1s apart:

- **Event A**: carries the message `guid` and chat `iMessage;-;+1…` (Private API / live-tap shape)
- **Event B**: no `guid`, bare `+1…` address (database-watcher shape)

On stock `main` the adapter treats these as two distinct events and dispatches the same user message **twice** — and because the session key is the raw chat id as delivered, the two shapes produce *different* session keys. The gateway not only replies twice, it fragments **one DM into two parallel sessions with separate context histories**, so each reply is generated from half the conversation.

Fixes #30708
Fixes #34372

## Root Cause

1. No deduplication in `_handle_webhook` — every delivery is dispatched as a turn.
2. Session key = raw chat id as delivered: `iMessage;-;+1…` vs bare `+1…` become distinct conversations.

## Fix

Two guards plus canonicalization in `gateway/platforms/bluebubbles.py`:

- **Guid-level dedupe**: an exact guid replay is always suppressed (bounded LRU, 1000 entries).
- **(sender, text) window dedupe (5s)**: suppresses the guid-less variant *and* the guid-bearing variant when the prior event was guid-less — either delivery order. Two distinct guid-bearing messages with the same text inside the window still both deliver (tapping the same word twice to a friend keeps working). Bounded LRU (200).
- **Canonical 1:1 chat id**: `iMessage;-;+1…`, `any;-;+1…` and bare `+1…` all resolve to the bare address as the session key — one DM, one session, regardless of payload shape. Group and unknown-prefix guids pass through untouched. Outbound `send()` already resolves bare addresses via `_resolve_chat_guid`, so replies re-resolve to the live chat guid.

## How to Verify

1. Configure BlueBubbles with the Private API helper enabled.
2. POST the repro pair to the webhook: a `new-message` with `guid` + `chats[0].guid = iMessage;-;<addr>`, then the guid-less variant ~1s later, same text/handle.
3. Observe exactly **one** `inbound message: platform=bluebubbles … chat=<bare addr>` line and one agent reply; both shapes map to the same session key.
4. On stock `main`, the same pair produces two inbound lines with different chat keys and two replies.

This was verified E2E against a live gateway + BlueBubbles server (v1.9.x, macOS): one inbound per pair, canonical key, one reply.

## Test Plan

- [x] Added regression tests for this bug — 9 invariant tests in `tests/gateway/test_bluebubbles.py`, proven RED on the stock adapter (7 fail without the fix; 2 assert the existing-correct no-suppress behavior)
- [x] Existing tests still pass — 30/30 in `tests/gateway/test_bluebubbles.py` on current `main`
- [x] Manual verification against a live BlueBubbles server

## Risk Assessment

Low — the dedupe guards only suppress within a 5s window keyed on (sender, text), and two distinct guid-bearing messages are never conflated. Canonicalization only rewrites 1:1 chat ids whose service prefix is a known iMessage/any/SMS hint; groups (`;+;`) and unknown prefixes pass through unchanged, and outbound sends already resolve bare addresses through `_resolve_chat_guid`.

## Relation to other open PRs

This addresses the full failure class also targeted (partially) by #68726 (guid replay only — the guid-less variant still double-replies), #45378 (60s fingerprint window, no session canonicalization), #82548 (stable DM session keys, no dedupe) and #45717 (subscription narrowing + guid dedupe). Happy to coordinate or absorb any of those.
