### PR TITLE
feat(providers): add OpenGateway profile

### DIFF
--- a/plugins/model-providers/opengateway/__init__.py
+++ b/plugins/model-providers/opengateway/__init__.py
@@ -1,0 +1,27 @@
+"""OpenGateway provider profile.
+
+OpenGateway is an OpenAI-compatible gateway, so the shared chat-completions
+transport is the correct integration point. Apitopia adds gateway-local
+fallbacks, repetition protection, and Kimi ultrafast output clamping; those
+are deliberately not injected here because direct Hermes requests have a
+different ownership boundary and must preserve the provider contract.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+opengateway = ProviderProfile(
+    name="opengateway",
+    display_name="OpenGateway",
+    description="OpenGateway — OpenAI-compatible gateway for production LLM routing",
+    signup_url="https://opengateway.ai/api-keys",
+    env_vars=("OPENGATEWAY_API_KEY",),
+    base_url="https://apis.opengateway.ai/v1",
+    fallback_models=(
+        "moonshotai/kimi-k3-ultrafast",
+        "z-ai/glm-5.2-ultrafast",
+    ),
+)
+
+register_provider(opengateway)

--- a/plugins/model-providers/opengateway/plugin.yaml
+++ b/plugins/model-providers/opengateway/plugin.yaml
@@ -1,0 +1,6 @@
+name: opengateway-provider
+kind: model-provider
+version: 1.0.0
+description: OpenGateway OpenAI-compatible LLM gateway
+author: Yeongyu Kim
+homepage: https://opengateway.ai/docs/coding-agents/hermes

--- a/tests/plugins/model_providers/test_opengateway_profile.py
+++ b/tests/plugins/model_providers/test_opengateway_profile.py
@@ -1,0 +1,30 @@
+"""Contract tests for the OpenGateway provider profile."""
+
+from __future__ import annotations
+
+
+def _profile():
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("opengateway")
+    assert profile is not None
+    return profile
+
+
+def test_identity_endpoint_and_auth():
+    profile = _profile()
+
+    assert profile.name == "opengateway"
+    assert profile.api_mode == "chat_completions"
+    assert profile.auth_type == "api_key"
+    assert profile.base_url == "https://apis.opengateway.ai/v1"
+    assert profile.env_vars == ("OPENGATEWAY_API_KEY",)
+
+
+def test_models_are_live_discovered_with_known_agentic_fallbacks():
+    profile = _profile()
+
+    assert profile.fallback_models
+    assert "moonshotai/kimi-k3-ultrafast" in profile.fallback_models
+    assert "z-ai/glm-5.2-ultrafast" in profile.fallback_models

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -20,6 +20,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **GitHub Copilot ACP** | `hermes model` (spawns local `copilot --acp --stdio`) |
 | **Anthropic** | `hermes model` (Claude Max + extra usage credits via OAuth; also supports Anthropic API key or manual setup-token — see note below) |
 | **OpenRouter** | `OPENROUTER_API_KEY` in `~/.hermes/.env` |
+| **OpenGateway** | `OPENGATEWAY_API_KEY` in `~/.hermes/.env` (provider: `opengateway`; OpenAI-compatible endpoint: `https://apis.opengateway.ai/v1`) |
 | **Ramp Router** | `RAMP_ROUTER_API_KEY` in `~/.hermes/.env` (provider: `router`; aliases: `ramp-router`, `ramp`, `router.com`; Responses-native gateway, live account-scoped catalog) |
 | **Fireworks AI** | `FIREWORKS_API_KEY` in `~/.hermes/.env` (provider: `fireworks`; aliases: `fireworks-ai`, `fw`) |
 | **NovitaAI** | `NOVITA_API_KEY` in `~/.hermes/.env` (provider: `novita`, 200+ models, Model API, Agent Sandbox, GPU Cloud) |


### PR DESCRIPTION
## Summary

Add OpenGateway as a first-class Hermes Agent model-provider profile.

- Register the `opengateway` provider through the existing model-provider plugin registry.
- Use the documented OpenAI-compatible endpoint `https://apis.opengateway.ai/v1` and `OPENGATEWAY_API_KEY`.
- Keep model selection explicit through live `/v1/models` discovery and known agentic fallback models; do not change the user's default model.
- Document setup and the provider contract in the provider integration guide.

## Integration report

OpenGateway's official Hermes guide uses a named custom provider with the same endpoint and environment variable. This change promotes that documented setup into the native provider registry so auth resolution, model discovery, doctor checks, runtime provider selection, and the shared chat-completions transport all recognize it consistently.

Our Apitopia integration confirms the wire contract: Bearer authentication, OpenAI chat-completions requests, and model IDs such as `moonshotai/kimi-k3-ultrafast` and `z-ai/glm-5.2-ultrafast`. Apitopia also contains gateway-owned mitigations for its own proxy path: Kimi ultrafast output-token clamping at 20480, a 1.05 repetition penalty default, and a 150-second stream-start budget with one reconnect. Those are intentionally not copied into Hermes: they belong to Apitopia's fallback/proxy ownership and would change direct-provider semantics. Hermes keeps the provider profile declarative and uses the shared transport.

## Verification

- `pytest -q tests/plugins/model_providers/test_opengateway_profile.py` — 2 passed.
- Tests cover registry discovery, provider identity, chat-completions mode, endpoint, API-key environment variable, and fallback model contract.
- Live OpenGateway traffic was not run because no test credential was used.

## References

- Official Hermes integration guide: https://opengateway.ai/docs/coding-agents/hermes
- OpenGateway API docs: https://opengateway.ai/docs
- Existing Apitopia provider implementation: `src/providers/opengateway.ts`
