### PR TITLE
fix(dashboard): stop mount_spa from freezing a pre-SSH-token snapshot

### DIFF
--- a/hermes_cli/web_server_dashboard.py
+++ b/hermes_cli/web_server_dashboard.py
@@ -102,7 +102,16 @@ def mount_spa(application: FastAPI):
     with a missing dist per-request (404 JSON / ``check_dir=False``), so a long-lived
     ``--skip-build`` process recovers the moment a build appears on disk — no restart.
     """
-    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, _SESSION_TOKEN, app
+    from hermes_cli import web_server as _web_server
+    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, app
+
+    # `_SESSION_TOKEN` is read off `_web_server` (not imported by name) because
+    # Desktop SSH's `--ssh-session-token-file` applies the real token via
+    # `_apply_ssh_session_token()` in `start_server()`, which runs AFTER this
+    # module-level `mount_spa(app)` call. A `from ... import _SESSION_TOKEN`
+    # binding would freeze on the pre-token default and keep serving it to the
+    # renderer forever, while `_has_valid_session_token` checks the live global
+    # and 401s every request against it (#103454).
 
     # `hermes serve` is the headless backend: it must NEVER serve the browser SPA, even if a
     # dist is lying around, so only the JSON-RPC/WS/API surface is reachable.
@@ -120,7 +129,7 @@ def mount_spa(application: FastAPI):
             if full_path == "" and not gated:
                 return HTMLResponse(
                     "<!doctype html><html><head><script>"
-                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(_SESSION_TOKEN)};"
+                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(_web_server._SESSION_TOKEN)};"
                     "window.__HERMES_AUTH_REQUIRED__=false;"
                     f"</script></head><body>{_HEADLESS_MSG}</body></html>",
                     headers=_NO_STORE,
@@ -151,7 +160,7 @@ def mount_spa(application: FastAPI):
             return JSONResponse({"error": "Frontend not built. Run: cd web && npm run build"}, status_code=404)
         chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
         gated = bool(getattr(app.state, "auth_required", False))
-        token_js = "" if gated else f'window.__HERMES_SESSION_TOKEN__="{_SESSION_TOKEN}";'
+        token_js = "" if gated else f'window.__HERMES_SESSION_TOKEN__="{_web_server._SESSION_TOKEN}";'
         bootstrap_script = (
             f"<script>{token_js}"
             f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5125,6 +5125,29 @@ class TestHeadlessServeTokenPage:
             assert "web UI disabled" in resp.json()["error"]
             assert ws._SESSION_TOKEN not in resp.text
 
+    def test_root_serves_ssh_session_token_applied_after_mount(self, monkeypatch):
+        """Desktop SSH's `--ssh-session-token-file` applies the real token via
+        `_apply_ssh_session_token()` inside `start_server()`, which runs AFTER
+        `mount_spa(app)` already executed at module import (#103454). The page
+        must reflect that later token, not whatever `_SESSION_TOKEN` held at
+        mount time — otherwise Desktop adopts a token `_has_valid_session_token`
+        (checking the live global) will never accept, and every REST call 401s.
+        """
+        import re
+        import json as _json
+
+        client, ws = self._headless_client(monkeypatch, gated=False)
+        ws._apply_ssh_session_token("ssh-file-token")
+
+        resp = client.get("/")
+        assert resp.status_code == 200
+        match = re.search(
+            r'window\.__HERMES_SESSION_TOKEN__\s*=\s*("(?:\\.|[^"\\])*")',
+            resp.text,
+        )
+        assert match, resp.text
+        assert _json.loads(match.group(1)) == "ssh-file-token"
+
 
 class TestHashedAssetCacheHeaders:
     """Hashed /assets/* responses must be immutable-cacheable; index.html


### PR DESCRIPTION
Fixes #103454.

## Root cause

`mount_spa()` in `hermes_cli/web_server_dashboard.py` runs exactly once, at
module import time (`hermes_cli/web_server.py:975` calls `mount_spa(app)` at
module scope). Until this change it did:

```python
from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, _SESSION_TOKEN, app
```

`from module import name` binds a **snapshot** of the attribute's value at
that moment into `mount_spa`'s closure — it is not a live reference to the
mutable global in `hermes_cli.web_server`. The two request handlers defined
inside `mount_spa` (the headless `no_frontend` root page and `_serve_index`)
capture that same stale snapshot in their closures and keep serving it for
the lifetime of the process.

Desktop's SSH connection path spawns the remote dashboard as `hermes serve
--isolated --ssh-session-token-file <path>` (see
`apps/desktop/electron/remote-lifecycle.ts`). The real, file-backed token is
only applied *after* module import/mount, inside `start_server()`:

```python
# hermes_cli/web_server.py
_apply_ssh_session_token(ssh_session_token or "")   # runs long after mount_spa(app) already executed
```

`_apply_ssh_session_token` reassigns the module global `_SESSION_TOKEN`. The
auth check `_has_valid_session_token` reads that global fresh on every
request and correctly sees the new file-backed token — but the HTML served
at `/` (which Desktop reads via `window.__HERMES_SESSION_TOKEN__` to
authenticate `/api/*`) still reflects whatever `_SESSION_TOKEN` was *before*
the SSH token was ever applied (the ephemeral default from
`_resolve_session_token()`).

So on every SSH connection: Desktop faithfully adopts the token the served
page hands it, that token doesn't match what `_has_valid_session_token`
checks, and the first authenticated request (`/api/profiles`) 401s — exactly
matching the issue's repro (`waitForHermes`'s own readiness probe happens to
pass because it's probing before the mismatch was even measurable in this
report's timeline, and the reporter's own manual curl with the *real*
file-token got `200`, confirming the server-side auth was fine all along).
This only affects the SSH path — the local-Desktop path sets
`HERMES_DASHBOARD_SESSION_TOKEN` *before* the module ever imports, so
`_resolve_session_token()` already picks it up at `_SESSION_TOKEN =
_resolve_session_token()` and the later mount-time snapshot is already
correct.

(I also checked the two other `from hermes_cli.web_server import
_SESSION_TOKEN, ...` sites in `hermes_cli/web_server_chat.py` — those imports
run inside per-request functions, re-executing the import on every call, so
they already see the live value and don't share this bug.)

## Fix

Read `_SESSION_TOKEN` off the `web_server` module object at request time
instead of importing it by name, so both handlers always see whatever token
is current when they're actually invoked:

```python
from hermes_cli import web_server as _web_server
...
json.dumps(_web_server._SESSION_TOKEN)
```

## Test

Added `test_root_serves_ssh_session_token_applied_after_mount` to the
existing `TestHeadlessServeTokenPage` class in
`tests/hermes_cli/test_web_server.py`. It mounts the SPA (as `mount_spa`
does at real startup), then applies an SSH session token via
`_apply_ssh_session_token()` — mirroring the real order of operations — and
asserts the served `/` page reflects that new token.

Confirmed the test fails without the fix:

```
$ git checkout HEAD -- hermes_cli/web_server_dashboard.py   # revert source only, test stays
$ python -m pytest tests/hermes_cli/test_web_server.py -k TestHeadlessServeTokenPage -q
...F                                                                     [100%]
    assert _json.loads(match.group(1)) == "ssh-file-token"
E   AssertionError: assert 'Z2aGEi8nNpI0...y20Qi-rd6IkGY' == 'ssh-file-token'
1 failed, 3 passed, 183 deselected, 2 warnings in 1.28s

$ git checkout HEAD -- hermes_cli/web_server_dashboard.py   # (no-op, HEAD already has revert)
# reapplied the fix, reran:
$ python -m pytest tests/hermes_cli/test_web_server.py -k TestHeadlessServeTokenPage -q
....                                                                     [100%]
4 passed, 183 deselected, 2 warnings in 3.06s
```

Full file suite after the fix:

```
$ python -m pytest tests/hermes_cli/test_web_server.py -q
........................................................................ [ 38%]
........................................................................ [ 77%]
...........................................                              [100%]
186 passed, 1 skipped, 2 warnings in 15.99s
```

## AI assistance disclosure

This change was written by an autonomous coding agent (Claude, via an
internal OSS-contribution pipeline) that traced the issue's log lines
through `apps/desktop/electron/remote-lifecycle.ts` /
`apps/desktop/electron/dashboard-token.ts` on the Desktop side, then into
`hermes_cli/web_server.py` / `hermes_cli/web_server_dashboard.py` on the
Python side, before writing and verifying the fix and test above. A human
has not manually reproduced this against real SSH hardware.
