### PR TITLE
fix(toolsets): stop disabled browser from stripping web_search

### DIFF
--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -450,6 +450,28 @@ class TestDisabledToolsetsPlatformBundle:
         assert "discord" not in names
 
 
+    def test_disabling_browser_keeps_web_search_when_web_enabled(self):
+        """Regression for #64503: disabling the `browser` toolset must NOT
+        strip `web_search`, which belongs to `web`/`search`. Disabling browser
+        (natural in headless/Docker deployments with no Chromium) previously
+        removed web_search from every session because `browser` statically
+        listed it as a member and disabled_toolsets is a strict subtraction.
+
+        Asserted at the toolset-resolution layer, not get_tool_definitions:
+        web_search's check_fn (Tavily key) filters it from the final schema in
+        CI, so membership is the correct layer to pin the fix."""
+        from toolsets import resolve_toolset
+
+        browser_tools = set(resolve_toolset("browser"))
+        assert "web_search" not in browser_tools, (
+            "web_search must not be a member of the `browser` toolset — that "
+            "is what lets `disabled_toolsets: [browser]` strip it (#64503)"
+        )
+        # browser still owns its own tools, and web/search still own web_search.
+        assert "browser_navigate" in browser_tools
+        assert "web_search" in set(resolve_toolset("web"))
+        assert "web_search" in set(resolve_toolset("search"))
+
 
 
     def test_bundle_non_core_tools_unknown_falls_back(self):

--- a/tests/test_toolset_distributions.py
+++ b/tests/test_toolset_distributions.py
@@ -66,16 +66,7 @@ class TestDistributionStructure:
 
 
 class TestGroupedCompoundEntries:
-    """"+"-grouped entries roll once and select all members together.
-
-    browser_tasks uses "browser+search" so web_search availability stays
-    coupled to browser at the original 97% co-occurrence after #64503 removed
-    web_search from the browser toolset (independent 97% rolls would co-occur
-    only ~94% of the time).
-    """
-
-    def test_browser_tasks_uses_grouped_entry(self):
-        assert "browser+search" in DISTRIBUTIONS["browser_tasks"]["toolsets"]
+    """"+"-grouped entries roll once and select all members together (#64503)."""
 
     def test_hit_roll_selects_all_members_together(self, monkeypatch):
         import toolset_distributions as td
@@ -86,21 +77,17 @@ class TestGroupedCompoundEntries:
         assert "search" in result
         assert "browser+search" not in result  # members, not the raw key
 
-    def test_members_always_co_occur(self, monkeypatch):
-        import random as _random
-
-        _random.seed(64525)
-        for _ in range(500):
-            result = sample_toolsets_from_distribution("browser_tasks")
-            assert ("browser" in result) == ("search" in result), result
-
     def test_fallback_expands_compound_members(self, monkeypatch):
         import toolset_distributions as td
 
+        monkeypatch.setitem(
+            td.DISTRIBUTIONS,
+            "_test_compound_fallback",
+            {"description": "t", "toolsets": {"browser+search": 60, "web": 10}},
+        )
         monkeypatch.setattr(td.random, "random", lambda: 1.0)  # every roll misses
-        # browser+search is browser_tasks' highest-probability entry (97%).
-        result = sample_toolsets_from_distribution("browser_tasks")
-        assert result == ["browser", "search"]
+        result = sample_toolsets_from_distribution("_test_compound_fallback")
+        assert set(result) == {"browser", "search"}
 
     def test_invalid_member_skips_whole_entry(self, monkeypatch, capsys):
         import toolset_distributions as td

--- a/tests/test_toolset_distributions.py
+++ b/tests/test_toolset_distributions.py
@@ -64,3 +64,54 @@ class TestDistributionStructure:
             for ts_name, prob in dist["toolsets"].items():
                 assert 0 < prob <= 100, f"{name}.{ts_name} has invalid probability {prob}"
 
+
+class TestGroupedCompoundEntries:
+    """"+"-grouped entries roll once and select all members together.
+
+    browser_tasks uses "browser+search" so web_search availability stays
+    coupled to browser at the original 97% co-occurrence after #64503 removed
+    web_search from the browser toolset (independent 97% rolls would co-occur
+    only ~94% of the time).
+    """
+
+    def test_browser_tasks_uses_grouped_entry(self):
+        assert "browser+search" in DISTRIBUTIONS["browser_tasks"]["toolsets"]
+
+    def test_hit_roll_selects_all_members_together(self, monkeypatch):
+        import toolset_distributions as td
+
+        monkeypatch.setattr(td.random, "random", lambda: 0.0)  # every roll hits
+        result = sample_toolsets_from_distribution("browser_tasks")
+        assert "browser" in result
+        assert "search" in result
+        assert "browser+search" not in result  # members, not the raw key
+
+    def test_members_always_co_occur(self, monkeypatch):
+        import random as _random
+
+        _random.seed(64525)
+        for _ in range(500):
+            result = sample_toolsets_from_distribution("browser_tasks")
+            assert ("browser" in result) == ("search" in result), result
+
+    def test_fallback_expands_compound_members(self, monkeypatch):
+        import toolset_distributions as td
+
+        monkeypatch.setattr(td.random, "random", lambda: 1.0)  # every roll misses
+        # browser+search is browser_tasks' highest-probability entry (97%).
+        result = sample_toolsets_from_distribution("browser_tasks")
+        assert result == ["browser", "search"]
+
+    def test_invalid_member_skips_whole_entry(self, monkeypatch, capsys):
+        import toolset_distributions as td
+
+        monkeypatch.setitem(
+            td.DISTRIBUTIONS,
+            "_test_compound_invalid",
+            {"description": "t", "toolsets": {"browser+__not_a_toolset__": 100, "web": 100}},
+        )
+        monkeypatch.setattr(td.random, "random", lambda: 0.0)
+        result = sample_toolsets_from_distribution("_test_compound_invalid")
+        assert "browser" not in result  # invalid member disqualifies the group
+        assert "web" in result
+        assert "not valid" in capsys.readouterr().out

--- a/toolset_distributions.py
+++ b/toolset_distributions.py
@@ -2,7 +2,8 @@
 """Toolset distributions for batch data-generation runs.
 
 A distribution maps toolset names to the % chance each is enabled for a prompt
-(sampled independently, so several toolsets can be active at once).
+(sampled independently, so several toolsets can be active at once). A key may
+be a "+"-grouped compound ("browser+search") that rolls once for all members.
 """
 
 from typing import Dict, List, Optional
@@ -30,10 +31,8 @@ DISTRIBUTIONS = {
     "reasoning": _dist("Heavy research/reasoning distribution with minimal other tools", web=90, file=60, terminal=20),
     "browser_use": _dist("Full browser-based web interaction with search, vision, and page control", browser=100, web=80, vision=70),
     "browser_only": _dist("Only browser automation tools for pure web interaction tasks", browser=100),
-    # browser-use-tasks.jsonl: web_search for finding URLs since Google blocks direct browser searches.
-    # One grouped roll keeps web_search coupled to browser at the original 97%
-    # co-occurrence (browser no longer bundles it since #64503; independent
-    # rolls would drop co-occurrence to ~94%).
+    # browser-use-tasks.jsonl: one grouped roll keeps web_search (for finding URLs) coupled to browser
+    # at the original 97% now that `browser` no longer bundles it (#64503).
     "browser_tasks": _dist(
         "Browser-focused distribution with web_search for finding URLs (Google blocks direct browser searches)",
         **{"browser+search": 97}, vision=12, terminal=15,

--- a/toolset_distributions.py
+++ b/toolset_distributions.py
@@ -30,10 +30,13 @@ DISTRIBUTIONS = {
     "reasoning": _dist("Heavy research/reasoning distribution with minimal other tools", web=90, file=60, terminal=20),
     "browser_use": _dist("Full browser-based web interaction with search, vision, and page control", browser=100, web=80, vision=70),
     "browser_only": _dist("Only browser automation tools for pure web interaction tasks", browser=100),
-    # browser-use-tasks.jsonl: web_search for finding URLs since Google blocks direct browser searches
+    # browser-use-tasks.jsonl: web_search for finding URLs since Google blocks direct browser searches.
+    # One grouped roll keeps web_search coupled to browser at the original 97%
+    # co-occurrence (browser no longer bundles it since #64503; independent
+    # rolls would drop co-occurrence to ~94%).
     "browser_tasks": _dist(
         "Browser-focused distribution with web_search for finding URLs (Google blocks direct browser searches)",
-        browser=97, search=97, vision=12, terminal=15,
+        **{"browser+search": 97}, vision=12, terminal=15,
     ),
     # nous-terminal-tasks.jsonl
     "terminal_tasks": _dist("Terminal-focused distribution with high terminal/file availability, occasional other tools",
@@ -57,25 +60,37 @@ def validate_distribution(distribution_name: str) -> bool:
     return distribution_name in DISTRIBUTIONS
 
 
-def sample_toolsets_from_distribution(distribution_name: str) -> List[str]:
-    """Sample toolset names, each included independently with its % probability.
+def _entry_members(entry: str) -> List[str]:
+    """Toolsets named by a distribution entry: a bare name or a "+"-grouped compound."""
+    return [name.strip() for name in entry.split("+")]
 
-    Falls back to the highest-probability toolset when nothing was rolled.
+
+def sample_toolsets_from_distribution(distribution_name: str) -> List[str]:
+    """Sample toolset names, each entry included independently with its % probability.
+
+    An entry may be a single toolset or a "+"-grouped compound like
+    "browser+search": one roll selects (or skips) every member together, so
+    co-occurrence guarantees survive that independent rolls would break
+    (two independent 97% rolls co-occur only ~94% of the time).
+    Falls back to the highest-probability entry when nothing was rolled.
     Raises ValueError for an unknown distribution.
     """
     dist = get_distribution(distribution_name)
     if not dist:
         raise ValueError(f"Unknown distribution: {distribution_name}")
     selected_toolsets = []
-    for toolset_name, probability in dist["toolsets"].items():
-        if not validate_toolset(toolset_name):
-            print(f"⚠️  Warning: Toolset '{toolset_name}' in distribution '{distribution_name}' is not valid")
+    for entry, probability in dist["toolsets"].items():
+        members = _entry_members(entry)
+        invalid = [name for name in members if not validate_toolset(name)]
+        if invalid:
+            print(f"⚠️  Warning: Toolset '{'+'.join(invalid)}' in distribution '{distribution_name}' is not valid")
         elif random.random() * 100 < probability:
-            selected_toolsets.append(toolset_name)
+            selected_toolsets.extend(members)
     if not selected_toolsets and dist["toolsets"]:
-        highest_prob_toolset = max(dist["toolsets"].items(), key=lambda x: x[1])[0]
-        if validate_toolset(highest_prob_toolset):
-            selected_toolsets.append(highest_prob_toolset)
+        highest_prob_entry = max(dist["toolsets"].items(), key=lambda x: x[1])[0]
+        members = _entry_members(highest_prob_entry)
+        if all(validate_toolset(name) for name in members):
+            selected_toolsets.extend(members)
     return selected_toolsets
 
 

--- a/toolset_distributions.py
+++ b/toolset_distributions.py
@@ -30,10 +30,10 @@ DISTRIBUTIONS = {
     "reasoning": _dist("Heavy research/reasoning distribution with minimal other tools", web=90, file=60, terminal=20),
     "browser_use": _dist("Full browser-based web interaction with search, vision, and page control", browser=100, web=80, vision=70),
     "browser_only": _dist("Only browser automation tools for pure web interaction tasks", browser=100),
-    # browser-use-tasks.jsonl: the browser toolset includes web_search since Google blocks direct browser searches
+    # browser-use-tasks.jsonl: web_search for finding URLs since Google blocks direct browser searches
     "browser_tasks": _dist(
-        "Browser-focused distribution (browser toolset includes web_search for finding URLs since Google blocks direct browser searches)",
-        browser=97, vision=12, terminal=15,
+        "Browser-focused distribution with web_search for finding URLs (Google blocks direct browser searches)",
+        browser=97, search=97, vision=12, terminal=15,
     ),
     # nous-terminal-tasks.jsonl
     "terminal_tasks": _dist("Terminal-focused distribution with high terminal/file availability, occasional other tools",

--- a/toolsets.py
+++ b/toolsets.py
@@ -100,10 +100,14 @@ TOOLSETS = {
         "instructions and knowledge",
         ["skills_list", "skill_view", "skill_manage"],
     ),
+    # web_search belongs to `web`/`search` only. Listing it here too let
+    # `disabled_toolsets: [browser]` (headless/Docker deployments) strip
+    # web_search from every session, because disabled toolsets are a strict
+    # end-of-pipeline subtraction (#17309, #64503).
     "browser": _ts(
         "Browser automation for web interaction (navigate, click, type, scroll, "
-        "iframes, hold-click) with web search for finding URLs",
-        [t for t in _HERMES_CORE_TOOLS if t.startswith("browser_")] + ["web_search"],
+        "iframes, hold-click)",
+        [t for t in _HERMES_CORE_TOOLS if t.startswith("browser_")],
     ),
     "cronjob": _ts(
         "Cronjob management tool - create, list, update, pause, resume, remove, and "


### PR DESCRIPTION
## Summary
`agent.disabled_toolsets: [browser]` no longer strips `web_search` from sessions that have `web`/`search` enabled.

Root cause: `toolsets.py` listed `web_search` as a member of the `browser` toolset, and disabled toolsets are a strict end-of-pipeline tool-level subtraction (#17309), so disabling `browser` removed `web_search` even though `web` still owned it. Headless/Docker deployments that disable `browser` lost web search everywhere (CLI, gateway, cron).

Salvage of #64525 by @falkoro (both commits cherry-picked, authorship preserved), rebased onto current `main` where `toolsets.py` and `toolset_distributions.py` had been condensed. Follow-up commits are mine.

## Changes
- `toolsets.py`: drop `web_search` from `browser`; comment records why it must not be re-added.
- `toolset_distributions.py`: `browser_tasks` uses a `"browser+search": 97` grouped entry; the sampler rolls a `+`-compound once and selects all members together, so the RL distribution keeps the original 97% browser/web_search co-occurrence (independent rolls would drop it to ~94%). Invalid members disqualify the whole group; the low-probability fallback expands compounds too.
- `tests/test_model_tools.py`: `browser` no longer resolves `web_search`; `web`/`search` still do.
- `tests/test_toolset_distributions.py`: two invariant tests for grouped entries (hit rolls select all members; fallback expands a compound), on a throwaway distribution so they don't pin `browser_tasks` weights.

## Validation
| | main | this PR |
|---|---|---|
| `_select_tool_names(["hermes-cli"], ["browser"])` contains `web_search` | no | yes |
| `resolve_toolset("browser")` contains `web_search` | yes | no |
| `browser_tasks` hit roll selects browser AND search together | n/a | yes |

- Targeted: `tests/test_model_tools.py tests/test_toolsets.py tests/test_toolset_distributions.py` — 62 passed.
- Mutation: reverting `toolsets.py` + `toolset_distributions.py` to `main` fails 3/3 new tests.
- ruff clean on changed files.
- Consumers checked: `hermes-*` bundles get `web_search` via `_HERMES_CORE_TOOLS` (unchanged); `browser_only`/`browser_use` distributions no longer leak `web_search`, matching their descriptions; `model_tools` already drops the "prefer web_search" hint from `browser_navigate` when web tools are absent.

Closes #64503. Closes #73692 (first half; the display/runtime split it also describes is #97015 → follow-up PR). Supersedes #73732 (same fix, no sampler coupling).
