### PR TITLE
fix(tools): align inspection surfaces with disabled composite toolsets

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2531,6 +2531,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin, CLITuiMix
     # Seeded -q first message (see _should_seed_interactive); run() re-creates
     # _pending_input, so it is enqueued only after the fresh queue exists.
     _seeded_first_message: Optional["_SeededQueryMessage"] = None
+    # Inspection surfaces (banner, /tools, status line) read this on partially built instances too.
+    disabled_toolsets: Optional[List[str]] = None
 
     def __init__(
         self,

--- a/hermes_cli/cli_info_mixin.py
+++ b/hermes_cli/cli_info_mixin.py
@@ -133,7 +133,8 @@ class CLIInfoMixin:
                     try:
                         from model_tools import get_toolset_for_tool
                         tools = get_tool_definitions(
-                            enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
+                            enabled_toolsets=self.enabled_toolsets,
+                            disabled_toolsets=self.disabled_toolsets, quiet_mode=True)
                         availability = compute_toolset_availability(self.enabled_toolsets)
                         tmap = _toolset_map(tools, availability, get_toolset_for_tool)
                         save_banner_snapshot(tools, self.enabled_toolsets, availability, tmap)
@@ -146,7 +147,8 @@ class CLIInfoMixin:
             else:
                 # Cold path: compute live, then persist the snapshot for the next launch.
                 from model_tools import get_toolset_for_tool
-                tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
+                tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets,
+                                             disabled_toolsets=self.disabled_toolsets, quiet_mode=True)
                 availability = compute_toolset_availability(self.enabled_toolsets)
                 build_welcome_banner(tools=tools, availability=availability, **banner_kw)
                 try:
@@ -354,7 +356,8 @@ class CLIInfoMixin:
         from model_tools import get_toolset_for_tool
         # Pre-assembly list: /tools is a discovery surface, so it must show the full catalog
         # including tools deferred behind the tool_search bridge (users verify MCP installs here).
-        tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True,
+        tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets,
+                                     disabled_toolsets=self.disabled_toolsets, quiet_mode=True,
                                      skip_tool_search_assembly=True)
         if not tools:
             print("(;_;) No tools available")

--- a/hermes_cli/cli_info_mixin.py
+++ b/hermes_cli/cli_info_mixin.py
@@ -134,7 +134,7 @@ class CLIInfoMixin:
                         from model_tools import get_toolset_for_tool
                         tools = get_tool_definitions(
                             enabled_toolsets=self.enabled_toolsets,
-                            disabled_toolsets=self.disabled_toolsets, quiet_mode=True)
+                            disabled_toolsets=getattr(self, "disabled_toolsets", None), quiet_mode=True)
                         availability = compute_toolset_availability(self.enabled_toolsets)
                         tmap = _toolset_map(tools, availability, get_toolset_for_tool)
                         save_banner_snapshot(tools, self.enabled_toolsets, availability, tmap)
@@ -148,7 +148,7 @@ class CLIInfoMixin:
                 # Cold path: compute live, then persist the snapshot for the next launch.
                 from model_tools import get_toolset_for_tool
                 tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets,
-                                             disabled_toolsets=self.disabled_toolsets, quiet_mode=True)
+                                             disabled_toolsets=getattr(self, "disabled_toolsets", None), quiet_mode=True)
                 availability = compute_toolset_availability(self.enabled_toolsets)
                 build_welcome_banner(tools=tools, availability=availability, **banner_kw)
                 try:
@@ -357,7 +357,7 @@ class CLIInfoMixin:
         # Pre-assembly list: /tools is a discovery surface, so it must show the full catalog
         # including tools deferred behind the tool_search bridge (users verify MCP installs here).
         tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets,
-                                     disabled_toolsets=self.disabled_toolsets, quiet_mode=True,
+                                     disabled_toolsets=getattr(self, "disabled_toolsets", None), quiet_mode=True,
                                      skip_tool_search_assembly=True)
         if not tools:
             print("(;_;) No tools available")

--- a/hermes_cli/cli_info_mixin.py
+++ b/hermes_cli/cli_info_mixin.py
@@ -134,7 +134,7 @@ class CLIInfoMixin:
                         from model_tools import get_toolset_for_tool
                         tools = get_tool_definitions(
                             enabled_toolsets=self.enabled_toolsets,
-                            disabled_toolsets=getattr(self, "disabled_toolsets", None), quiet_mode=True)
+                            disabled_toolsets=self.disabled_toolsets, quiet_mode=True)
                         availability = compute_toolset_availability(self.enabled_toolsets)
                         tmap = _toolset_map(tools, availability, get_toolset_for_tool)
                         save_banner_snapshot(tools, self.enabled_toolsets, availability, tmap)
@@ -148,7 +148,7 @@ class CLIInfoMixin:
                 # Cold path: compute live, then persist the snapshot for the next launch.
                 from model_tools import get_toolset_for_tool
                 tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets,
-                                             disabled_toolsets=getattr(self, "disabled_toolsets", None), quiet_mode=True)
+                                             disabled_toolsets=self.disabled_toolsets, quiet_mode=True)
                 availability = compute_toolset_availability(self.enabled_toolsets)
                 build_welcome_banner(tools=tools, availability=availability, **banner_kw)
                 try:
@@ -357,7 +357,7 @@ class CLIInfoMixin:
         # Pre-assembly list: /tools is a discovery surface, so it must show the full catalog
         # including tools deferred behind the tool_search bridge (users verify MCP installs here).
         tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets,
-                                     disabled_toolsets=getattr(self, "disabled_toolsets", None), quiet_mode=True,
+                                     disabled_toolsets=self.disabled_toolsets, quiet_mode=True,
                                      skip_tool_search_assembly=True)
         if not tools:
             print("(;_;) No tools available")

--- a/hermes_cli/cli_loops_mixin.py
+++ b/hermes_cli/cli_loops_mixin.py
@@ -82,7 +82,8 @@ class CLILoopsMixin:
         if self.compact or shutil.get_terminal_size().columns < 80:
             cc.print(_build_compact_banner())
         else:
-            tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
+            tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets,
+                                         disabled_toolsets=self.disabled_toolsets, quiet_mode=True)
             agent = getattr(self, "agent", None)
             ctx_len = None
             if agent and hasattr(agent, "context_compressor"):

--- a/hermes_cli/cli_loops_mixin.py
+++ b/hermes_cli/cli_loops_mixin.py
@@ -83,7 +83,7 @@ class CLILoopsMixin:
             cc.print(_build_compact_banner())
         else:
             tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets,
-                                         disabled_toolsets=self.disabled_toolsets, quiet_mode=True)
+                                         disabled_toolsets=getattr(self, "disabled_toolsets", None), quiet_mode=True)
             agent = getattr(self, "agent", None)
             ctx_len = None
             if agent and hasattr(agent, "context_compressor"):

--- a/hermes_cli/cli_loops_mixin.py
+++ b/hermes_cli/cli_loops_mixin.py
@@ -83,7 +83,7 @@ class CLILoopsMixin:
             cc.print(_build_compact_banner())
         else:
             tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets,
-                                         disabled_toolsets=getattr(self, "disabled_toolsets", None), quiet_mode=True)
+                                         disabled_toolsets=self.disabled_toolsets, quiet_mode=True)
             agent = getattr(self, "agent", None)
             ctx_len = None
             if agent and hasattr(agent, "context_compressor"):

--- a/hermes_cli/cli_session_mixin.py
+++ b/hermes_cli/cli_session_mixin.py
@@ -216,7 +216,8 @@ class CLISessionMixin:
         if os.environ.get("HERMES_DEFER_AGENT_STARTUP") == "1":
             tool_status = "tools deferred"
         else:
-            tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
+            tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets,
+                                         disabled_toolsets=self.disabled_toolsets, quiet_mode=True)
             tool_status = f"{len(tools) if tools else 0} tools"
 
         model_short = self.model.split("/")[-1] if "/" in self.model else self.model

--- a/hermes_cli/cli_session_mixin.py
+++ b/hermes_cli/cli_session_mixin.py
@@ -217,7 +217,7 @@ class CLISessionMixin:
             tool_status = "tools deferred"
         else:
             tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets,
-                                         disabled_toolsets=getattr(self, "disabled_toolsets", None), quiet_mode=True)
+                                         disabled_toolsets=self.disabled_toolsets, quiet_mode=True)
             tool_status = f"{len(tools) if tools else 0} tools"
 
         model_short = self.model.split("/")[-1] if "/" in self.model else self.model

--- a/hermes_cli/cli_session_mixin.py
+++ b/hermes_cli/cli_session_mixin.py
@@ -217,7 +217,7 @@ class CLISessionMixin:
             tool_status = "tools deferred"
         else:
             tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets,
-                                         disabled_toolsets=self.disabled_toolsets, quiet_mode=True)
+                                         disabled_toolsets=getattr(self, "disabled_toolsets", None), quiet_mode=True)
             tool_status = f"{len(tools) if tools else 0} tools"
 
         model_short = self.model.split("/")[-1] if "/" in self.model else self.model

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -588,11 +588,9 @@ def _get_platform_tools(config: dict, platform: str, *, include_default_mcp_serv
     explicit_passthrough = {ts for ts in toolset_names if ts not in explicit_known_keys and ts not in platform_default_keys}
     enabled_toolsets |= _merge_mcp_servers(config, toolset_names, explicit_passthrough, include_default_mcp_servers)
 
-    # agent.disabled_toolsets is a global suppression list and runs LAST so it overrides everything above. It
-    # may arrive as a JSON-array string ("['memory']") from `hermes config set` or a JSON-mode editor save.
+    # agent.disabled_toolsets is a global suppression list (#86661) and runs LAST so it overrides everything
+    # above. It may arrive as a JSON-array string ("['memory']") from `hermes config set` or a JSON-mode editor.
     disabled_toolsets = (config.get("agent") or {}).get("disabled_toolsets")
-    # Honor agent.disabled_toolsets from config.yaml — allows users to globally suppress specific toolsets
-    # (e.g. "memory") across all platforms without per-platform toolset configuration. See #86661.
     if disabled_toolsets:
         from agent.skill_utils import parse_config_string_list
         disabled_names = [name.strip() for name in parse_config_string_list(disabled_toolsets) if name.strip()]
@@ -615,18 +613,11 @@ def _prune_toolsets_stripped_by_disabled(enabled_toolsets: Set[str], disabled_na
     from model_tools import _apply_toolset_selection
     from toolsets import resolve_toolset, validate_toolset
 
-    remaining = set(enabled_toolsets) - set(disabled_names)
-    surviving: Set[str] = set()
-    for name in remaining:
-        if validate_toolset(name):
-            surviving.update(resolve_toolset(name))
+    remaining = enabled_toolsets - set(disabled_names)
+    resolved = {name: set(resolve_toolset(name)) if validate_toolset(name) else set() for name in remaining}
+    surviving: Set[str] = set().union(*resolved.values())
     _apply_toolset_selection(surviving, disabled_names, quiet_mode=True, disable=True)
-    pruned = set()
-    for name in remaining:
-        tools = set(resolve_toolset(name)) if validate_toolset(name) else set()
-        if tools and not tools & surviving:
-            pruned.add(name)
-    return remaining - pruned
+    return {name for name, tools in resolved.items() if not tools or tools & surviving}
 
 
 def _recover_platform_native_toolsets(enabled_toolsets: Set[str], platform: str, *, skip: Set[str]) -> None:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -595,11 +595,38 @@ def _get_platform_tools(config: dict, platform: str, *, include_default_mcp_serv
     # (e.g. "memory") across all platforms without per-platform toolset configuration. See #86661.
     if disabled_toolsets:
         from agent.skill_utils import parse_config_string_list
-        enabled_toolsets -= {name.strip() for name in parse_config_string_list(disabled_toolsets) if name.strip()}
+        disabled_names = [name.strip() for name in parse_config_string_list(disabled_toolsets) if name.strip()]
+        enabled_toolsets = _prune_toolsets_stripped_by_disabled(enabled_toolsets, disabled_names)
 
     if explicitly_configured and toolset_names:
         _warn_all_invalid_platform_toolsets(platform, platform_toolsets[platform])
     return enabled_toolsets
+
+
+def _prune_toolsets_stripped_by_disabled(enabled_toolsets: Set[str], disabled_names: List[str]) -> Set[str]:
+    """Drop disabled names AND every toolset whose tools the runtime would strip anyway.
+
+    The agent subtracts ``agent.disabled_toolsets`` at TOOL granularity (``model_tools._select_tool_names``),
+    so disabling a composite like ``debugging`` removes the terminal/web/file tools even though those names
+    never appear in the list. A name-only subtraction here left inspection surfaces (``hermes tools
+    --summary``, banner, ``/tools``) showing toolsets as enabled that no session could call (#97015).
+    Passthrough entries (MCP server names) and toolsets with no static tools (``context_engine``) are kept.
+    """
+    from model_tools import _apply_toolset_selection
+    from toolsets import resolve_toolset, validate_toolset
+
+    remaining = set(enabled_toolsets) - set(disabled_names)
+    surviving: Set[str] = set()
+    for name in remaining:
+        if validate_toolset(name):
+            surviving.update(resolve_toolset(name))
+    _apply_toolset_selection(surviving, disabled_names, quiet_mode=True, disable=True)
+    pruned = set()
+    for name in remaining:
+        tools = set(resolve_toolset(name)) if validate_toolset(name) else set()
+        if tools and not tools & surviving:
+            pruned.add(name)
+    return remaining - pruned
 
 
 def _recover_platform_native_toolsets(enabled_toolsets: Set[str], platform: str, *, skip: Set[str]) -> None:

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1143,26 +1143,21 @@ def test_disabled_composite_debugging_prunes_constituent_platform_toolsets():
     assert "web" not in enabled
 
 
-def test_disabled_composite_debugging_matches_runtime_tool_definitions():
-    """CLI inspection surfaces should list the same tools the agent receives."""
-    from model_tools import get_tool_definitions
+def test_disabled_composite_display_matches_runtime_tool_selection():
+    """Display/runtime parity: a toolset is listed as enabled iff the agent keeps
+    at least one of its tools after the runtime's tool-level subtraction."""
+    from model_tools import _select_tool_names
+    from toolsets import resolve_toolset
 
     config = {
         "platform_toolsets": {"cli": ["hermes-cli"]},
         "agent": {"disabled_toolsets": ["debugging"]},
     }
-    enabled = sorted(_get_platform_tools(config, "cli", include_default_mcp_servers=False))
-    summary_tools = {
-        t["function"]["name"]
-        for t in get_tool_definitions(
-            enabled_toolsets=enabled,
-            disabled_toolsets=["debugging"],
-            quiet_mode=True,
-        )
-    }
-    assert "terminal" not in summary_tools
-    assert "read_file" not in summary_tools
-    assert "web_search" not in summary_tools
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+    runtime = _select_tool_names(sorted(enabled), ["debugging"], quiet_mode=True)
+
+    for name in ("terminal", "file", "web", "vision", "skills"):
+        assert (name in enabled) == bool(set(resolve_toolset(name)) & runtime), name
 
 
 @_requires_recently_shipped

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1129,6 +1129,42 @@ def test_agent_disabled_toolsets_python_literal_string_form_still_wins():
     assert not (_RECENTLY_SHIPPED_TOOLSETS & enabled)
 
 
+def test_disabled_composite_debugging_prunes_constituent_platform_toolsets():
+    """#97015: ``agent.disabled_toolsets: [debugging]`` must hide member
+    toolsets on ``hermes tools --summary``, not only strip them at runtime."""
+    config = {
+        "platform_toolsets": {"cli": ["hermes-cli"]},
+        "agent": {"disabled_toolsets": ["debugging"]},
+    }
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+
+    assert "terminal" not in enabled
+    assert "file" not in enabled
+    assert "web" not in enabled
+
+
+def test_disabled_composite_debugging_matches_runtime_tool_definitions():
+    """CLI inspection surfaces should list the same tools the agent receives."""
+    from model_tools import get_tool_definitions
+
+    config = {
+        "platform_toolsets": {"cli": ["hermes-cli"]},
+        "agent": {"disabled_toolsets": ["debugging"]},
+    }
+    enabled = sorted(_get_platform_tools(config, "cli", include_default_mcp_servers=False))
+    summary_tools = {
+        t["function"]["name"]
+        for t in get_tool_definitions(
+            enabled_toolsets=enabled,
+            disabled_toolsets=["debugging"],
+            quiet_mode=True,
+        )
+    }
+    assert "terminal" not in summary_tools
+    assert "read_file" not in summary_tools
+    assert "web_search" not in summary_tools
+
+
 @_requires_recently_shipped
 def test_platforms_whose_composite_excludes_it_are_left_narrow():
     """Parity is the justification, so don't widen a deliberately small


### PR DESCRIPTION
## Summary
`hermes tools --summary`, the welcome banner, `/tools`, and the status-line tool count now show the same tool surface the agent actually gets when `agent.disabled_toolsets` contains a composite toolset (e.g. `debugging`).

Root cause: display surfaces subtracted `disabled_toolsets` by toolset **name** (`_get_platform_tools`), while the runtime subtracts at **tool** level (`model_tools._select_tool_names`). `debugging` never appears in the enabled-name set (only its constituents `terminal`/`web`/`file` do), so name-level subtraction removed nothing and the summary reported ✓ Terminal ✓ Web ✓ File for sessions that could not call any of them. Separately, five CLI inspection sites called `get_tool_definitions()` without `disabled_toolsets` at all.

Salvage of #97082 by @aydnOktay (two commits cherry-picked, authorship preserved) onto current `main`. On `main` the runtime subtraction had already been extracted into `model_tools._apply_toolset_selection`, so the contributor's parallel helper was not needed — the display path reuses the runtime one directly. Follow-up commits are mine.

## Changes
- `hermes_cli/tools_config.py`: `_prune_toolsets_stripped_by_disabled` — after removing disabled names, resolve each remaining toolset, apply the runtime subtraction, and keep a toolset only if it has no static tools (MCP passthrough, `context_engine`) or at least one tool survived.
- `hermes_cli/cli_info_mixin.py`, `cli_loops_mixin.py`, `cli_session_mixin.py`: banner (warm + cold path), `/tools`, status line, and re-banner pass `disabled_toolsets`.
- `cli.py`: class-level `disabled_toolsets = None` default (inspection surfaces run on partially built instances; tests use `HermesCLI.__new__`).
- `tests/hermes_cli/test_tools_config.py`: composite `debugging` hides `terminal`/`file`/`web`; display↔runtime parity — a toolset is listed iff at least one of its tools survives `_select_tool_names`.

## Validation
| `disabled_toolsets: [debugging]`, `hermes tools --summary` CLI row | main | this PR |
|---|---|---|
| count | 17/27 with ✓ File ✓ Terminal ✓ Web | 14/27, none of the three |

- E2E (real imports, temp `HERMES_HOME`): composite hides constituents; bundle name in disabled (`hermes-telegram`) still displays core toolsets (#33924 semantics preserved); MCP passthrough names survive; no `disabled_toolsets` → unchanged.
- Targeted: `tests/hermes_cli/test_tools_config.py tests/cli/test_cli_context_warning.py tests/cli/test_cli_tools_command.py tests/cli/test_cli_new_session.py tests/hermes_cli/test_status.py tests/test_model_tools.py` — 109 passed.
- Mutation: reverting `tools_config.py` to `main` fails both new tests.
- Banner snapshot cache: keyed on config.yaml mtime + `enabled_toolsets` (now the pruned set), so a `disabled_toolsets` edit invalidates it. `get_tool_definitions` memo key already includes `disabled_toolsets`.
- ruff clean on changed files.

Not in scope (found during review, filing separately): the TUI/desktop runtime (`tui_gateway/server.py` `AIAgent(...)`) and ACP runtime (`acp_adapter/session.py`) never pass `agent.disabled_toolsets` to the agent at all — a runtime gap, not a display one.

Closes #97015.
