### PR TITLE
fix(gateway): fire on_processing_start/complete for in-band queued follow-ups

### DIFF
--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -3494,13 +3494,30 @@ class GatewayTurnMixin:
         if pending_event is not None and adapter is not None:
             await adapter._run_processing_hook("on_processing_start", pending_event)
 
-        followup_result = await self._run_agent(
-            message=next_message, context_prompt=turn_ctx.context_prompt, history=updated_history,
-            source=next_source, session_id=session_id, session_key=next_session_key,
-            run_generation=run_generation, _interrupt_depth=_interrupt_depth + 1,
-            event_message_id=next_message_id, channel_prompt=next_channel_prompt,
-            message_type=next_message_type,
-        )
+        # Once on_processing_start has fired above, on_processing_complete MUST fire no matter how
+        # the recursive call below ends — including an unhandled exception from the follow-up turn
+        # or a CancelledError from the surrounding task (gateway shutdown/restart) — or the platform
+        # reaction it drives (e.g. Telegram's 👀) is left stuck forever. Mirrors the outcome
+        # classification BasePlatformAdapter._process_message_background uses for the analogous case.
+        try:
+            followup_result = await self._run_agent(
+                message=next_message, context_prompt=turn_ctx.context_prompt, history=updated_history,
+                source=next_source, session_id=session_id, session_key=next_session_key,
+                run_generation=run_generation, _interrupt_depth=_interrupt_depth + 1,
+                event_message_id=next_message_id, channel_prompt=next_channel_prompt,
+                message_type=next_message_type,
+            )
+        except asyncio.CancelledError:
+            if pending_event is not None and adapter is not None:
+                _expected = asyncio.current_task() in getattr(adapter, "_expected_cancelled_tasks", ())
+                await adapter._run_processing_hook(
+                    "on_processing_complete", pending_event,
+                    ProcessingOutcome.CANCELLED if _expected else ProcessingOutcome.FAILURE)
+            raise
+        except BaseException:
+            if pending_event is not None and adapter is not None:
+                await adapter._run_processing_hook("on_processing_complete", pending_event, ProcessingOutcome.FAILURE)
+            raise
         if pending_event is not None and adapter is not None:
             _outcome = (
                 ProcessingOutcome.FAILURE if isinstance(followup_result, dict) and followup_result.get("failed")

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -3394,7 +3394,7 @@ class GatewayTurnMixin:
         response: Any, result: Any, stream_task: Any,
     ) -> Any:
         """Run the queued / interrupting follow-up as the next turn (recursive ``_run_agent``)."""
-        from gateway.platforms.base import merge_pending_message_event
+        from gateway.platforms.base import ProcessingOutcome, merge_pending_message_event
         from gateway.run import _preserve_queued_followup_history_offset
         source, session_id, session_key, run_generation = (
             turn_ctx.source, turn_ctx.session_id, turn_ctx.session_key, turn_ctx.run_generation,
@@ -3486,6 +3486,14 @@ class GatewayTurnMixin:
         # guard will consult. Fail-safe in helper.
         await self._refresh_agent_cache_message_count(session_key, session_id)
 
+        # The in-band drain below consumes pending_event directly from adapter._pending_messages
+        # (via _run_agent_drain_pending), so BasePlatformAdapter._process_message_background's own
+        # end-of-turn drain never sees it and never fires on_processing_start/complete for it — no
+        # reaction ack, no outcome reaction. Fire them here so a queued follow-up gets the same
+        # per-message lifecycle as one processed out-of-band. See #103429.
+        if pending_event is not None and adapter is not None:
+            await adapter._run_processing_hook("on_processing_start", pending_event)
+
         followup_result = await self._run_agent(
             message=next_message, context_prompt=turn_ctx.context_prompt, history=updated_history,
             source=next_source, session_id=session_id, session_key=next_session_key,
@@ -3493,6 +3501,12 @@ class GatewayTurnMixin:
             event_message_id=next_message_id, channel_prompt=next_channel_prompt,
             message_type=next_message_type,
         )
+        if pending_event is not None and adapter is not None:
+            _outcome = (
+                ProcessingOutcome.FAILURE if isinstance(followup_result, dict) and followup_result.get("failed")
+                else ProcessingOutcome.SUCCESS
+            )
+            await adapter._run_processing_hook("on_processing_complete", pending_event, _outcome)
         return _preserve_queued_followup_history_offset(result, followup_result)
 
     async def _run_agent_cleanup_turn_tasks(

--- a/tests/gateway/test_queued_followup_processing_hooks.py
+++ b/tests/gateway/test_queued_followup_processing_hooks.py
@@ -1,0 +1,111 @@
+"""Regression coverage for issue #103429 (part 1).
+
+``busy_input_mode: queue`` follow-ups are drained IN-BAND by
+``GatewayRunner._run_agent_queued_followup`` (via ``_run_agent_drain_pending``),
+which pops the pending event straight out of ``adapter._pending_messages``
+before ``BasePlatformAdapter._process_message_background``'s own end-of-turn
+drain ever sees it. That out-of-band drain is what normally fires
+``on_processing_start`` / ``on_processing_complete`` (the hooks that drive a
+Telegram reaction ack) — so a queued follow-up consumed in-band got neither
+hook call, and so no reaction, ever.
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.platforms.base import MessageEvent, MessageType, Platform, ProcessingOutcome
+from gateway.run import GatewayRunner
+from gateway.turn_context import TurnContext
+
+
+class _StubAdapter:
+    def __init__(self):
+        self.hook_calls = []
+        self._active_sessions = {}
+
+    async def _run_processing_hook(self, hook_name, *args, **kwargs):
+        self.hook_calls.append((hook_name, args, kwargs))
+
+
+class _FakeGatewayRunner(GatewayRunner):
+    """Overrides every collaborator of ``_run_agent_queued_followup`` except the
+    method under test, so the real recursion/hook-firing logic runs unmodified."""
+
+    def __init__(self, adapter, followup_result):
+        self._adapter = adapter
+        self._followup_result = followup_result
+        self.run_agent_calls = []
+
+    def _adapter_for_source(self, source):
+        return self._adapter
+
+    def _session_key_for_source(self, source):
+        return "telegram:dm:1"
+
+    async def _prepare_profile_scoped_inbound_message_text(self, *, event, source, history, session_key=None):
+        return event.text
+
+    async def _run_agent_deliver_first_response(self, *args, **kwargs):
+        return None
+
+    async def _refresh_agent_cache_message_count(self, *args, **kwargs):
+        return None
+
+    async def _run_agent(self, **kwargs):
+        self.run_agent_calls.append(kwargs)
+        return self._followup_result
+
+
+def _plain_dm_pending_event() -> MessageEvent:
+    # A plain Telegram private chat: no forum/DM topic, so thread_id is None.
+    source = MagicMock(platform=Platform.TELEGRAM, thread_id=None, chat_type="dm", profile=None)
+    return MessageEvent(
+        text="second message", message_type=MessageType.TEXT, source=source, message_id="msg2",
+    )
+
+
+def _make_turn_ctx(pending_event: MessageEvent) -> TurnContext:
+    return TurnContext(
+        source=MagicMock(platform=Platform.TELEGRAM, thread_id=None, chat_type="dm", profile=None),
+        session_id="sess-1", session_key="telegram:dm:1", history=[],
+        _interrupt_depth=0, _status_thread_metadata=None,
+    )
+
+
+class TestQueuedFollowupFiresProcessingHooks:
+    def test_on_processing_start_and_complete_fire_for_pending_event(self):
+        pending_event = _plain_dm_pending_event()
+        adapter = _StubAdapter()
+        turn_ctx = _make_turn_ctx(pending_event)
+        runner = _FakeGatewayRunner(adapter, followup_result={"final_response": "the answer"})
+
+        result = asyncio.run(runner._run_agent_queued_followup(
+            turn_ctx, adapter, pending="second message", pending_event=pending_event,
+            response={}, result={"messages": []}, stream_task=None,
+        ))
+
+        assert result == {"final_response": "the answer"}
+        # The queued message must get its OWN on_processing_start/complete calls —
+        # not zero, and not the original message's.
+        hook_names = [name for name, _args, _kwargs in adapter.hook_calls]
+        assert hook_names == ["on_processing_start", "on_processing_complete"]
+        start_call = adapter.hook_calls[0]
+        assert start_call[1] == (pending_event,)
+        complete_call = adapter.hook_calls[1]
+        assert complete_call[1] == (pending_event, ProcessingOutcome.SUCCESS)
+
+    def test_failed_followup_reports_failure_outcome(self):
+        pending_event = _plain_dm_pending_event()
+        adapter = _StubAdapter()
+        turn_ctx = _make_turn_ctx(pending_event)
+        runner = _FakeGatewayRunner(adapter, followup_result={"final_response": "", "failed": True})
+
+        asyncio.run(runner._run_agent_queued_followup(
+            turn_ctx, adapter, pending="second message", pending_event=pending_event,
+            response={}, result={"messages": []}, stream_task=None,
+        ))
+
+        complete_call = adapter.hook_calls[1]
+        assert complete_call[1] == (pending_event, ProcessingOutcome.FAILURE)

--- a/tests/gateway/test_queued_followup_processing_hooks.py
+++ b/tests/gateway/test_queued_followup_processing_hooks.py
@@ -24,6 +24,7 @@ class _StubAdapter:
     def __init__(self):
         self.hook_calls = []
         self._active_sessions = {}
+        self._expected_cancelled_tasks = set()
 
     async def _run_processing_hook(self, hook_name, *args, **kwargs):
         self.hook_calls.append((hook_name, args, kwargs))
@@ -33,9 +34,10 @@ class _FakeGatewayRunner(GatewayRunner):
     """Overrides every collaborator of ``_run_agent_queued_followup`` except the
     method under test, so the real recursion/hook-firing logic runs unmodified."""
 
-    def __init__(self, adapter, followup_result):
+    def __init__(self, adapter, followup_result=None, followup_exception=None):
         self._adapter = adapter
         self._followup_result = followup_result
+        self._followup_exception = followup_exception
         self.run_agent_calls = []
 
     def _adapter_for_source(self, source):
@@ -55,6 +57,8 @@ class _FakeGatewayRunner(GatewayRunner):
 
     async def _run_agent(self, **kwargs):
         self.run_agent_calls.append(kwargs)
+        if self._followup_exception is not None:
+            raise self._followup_exception
         return self._followup_result
 
 
@@ -109,3 +113,46 @@ class TestQueuedFollowupFiresProcessingHooks:
 
         complete_call = adapter.hook_calls[1]
         assert complete_call[1] == (pending_event, ProcessingOutcome.FAILURE)
+
+    def test_unhandled_exception_still_fires_processing_complete(self):
+        """A raised exception from the recursive turn must not leave on_processing_start unpaired
+        (else the platform reaction it drives, e.g. Telegram's 👀, is stuck forever)."""
+        pending_event = _plain_dm_pending_event()
+        adapter = _StubAdapter()
+        turn_ctx = _make_turn_ctx(pending_event)
+        runner = _FakeGatewayRunner(adapter, followup_exception=RuntimeError("boom"))
+
+        with pytest.raises(RuntimeError, match="boom"):
+            asyncio.run(runner._run_agent_queued_followup(
+                turn_ctx, adapter, pending="second message", pending_event=pending_event,
+                response={}, result={"messages": []}, stream_task=None,
+            ))
+
+        hook_names = [name for name, _args, _kwargs in adapter.hook_calls]
+        assert hook_names == ["on_processing_start", "on_processing_complete"]
+        complete_call = adapter.hook_calls[1]
+        assert complete_call[1] == (pending_event, ProcessingOutcome.FAILURE)
+
+    def test_cancelled_error_still_fires_processing_complete(self):
+        """A CancelledError (e.g. gateway shutdown/restart) from the recursive turn must still pair
+        with on_processing_complete, classified as CANCELLED when the cancellation was expected."""
+        pending_event = _plain_dm_pending_event()
+        adapter = _StubAdapter()
+        turn_ctx = _make_turn_ctx(pending_event)
+        runner = _FakeGatewayRunner(adapter, followup_exception=asyncio.CancelledError())
+
+        async def _run():
+            task = asyncio.current_task()
+            adapter._expected_cancelled_tasks.add(task)
+            with pytest.raises(asyncio.CancelledError):
+                await runner._run_agent_queued_followup(
+                    turn_ctx, adapter, pending="second message", pending_event=pending_event,
+                    response={}, result={"messages": []}, stream_task=None,
+                )
+
+        asyncio.run(_run())
+
+        hook_names = [name for name, _args, _kwargs in adapter.hook_calls]
+        assert hook_names == ["on_processing_start", "on_processing_complete"]
+        complete_call = adapter.hook_calls[1]
+        assert complete_call[1] == (pending_event, ProcessingOutcome.CANCELLED)


### PR DESCRIPTION
## Summary

Addresses part of #103429: with `display.busy_input_mode: queue`, a text
message that arrives while a turn is running is drained **in-band** by
`GatewayRunner._run_agent_queued_followup()` (via `_run_agent_drain_pending()`
→ `_dequeue_pending_event()`), which pops the event straight out of
`adapter._pending_messages`.

`BasePlatformAdapter._process_message_background()` is what normally fires
`on_processing_start` / `on_processing_complete` for a message — those hooks
are what drive a platform's processing reaction (Telegram's busy/outcome
emoji is the default implementation). But its own end-of-turn drain
(`if session_key in self._pending_messages: ...`) only runs for a message
that's *still* in the slot when the outer turn returns. The in-band drain
already popped it, so that check is always false for a queued follow-up
processed this way — the hooks never fire, and the queued message never
gets a reaction.

## Fix

`_run_agent_queued_followup()` now fires the same `on_processing_start` /
`on_processing_complete` hooks on the adapter around the recursive
follow-up turn, so an in-band-drained queued message gets the same
per-message lifecycle as one drained out-of-band. `on_processing_complete`
reports `FAILURE` when the follow-up's result carries `failed`, `SUCCESS`
otherwise (matching the outcome classification already used at the
top-level call site in `gateway/platforms/base.py`).

The recursive `self._run_agent(...)` call is now wrapped in `try`/`except`
so `on_processing_complete` always fires once `on_processing_start` has
fired — including when the follow-up turn raises, or is cancelled (e.g.
gateway shutdown/restart, since this recursive call runs in-line in the
same task as the outer `_process_message_background`, not a separate
task). Without this, an unhandled exception or `CancelledError` from the
recursive call left the queued message's `on_processing_start` unpaired,
which for Telegram means the 👀 "in progress" reaction gets stuck forever
— a regression an earlier version of this PR introduced. The
`except CancelledError` branch classifies the outcome as `CANCELLED` vs
`FAILURE` using `adapter._expected_cancelled_tasks`, mirroring
`BasePlatformAdapter._process_message_background`'s own
`except CancelledError` handling for the analogous top-level case.

## Scope note

Issue #103429 also reports that the follow-up's reply quotes the *previous*
message (the one that opened the turn) rather than the queued message
itself. I traced that separately: it's a different, unrelated mechanism
(which `event` object the outermost `_process_message_background()` uses
to anchor `_send_final_text()` once the recursive result bubbles back up),
not the `_thread_metadata_for_target()` path the issue names — and the
general "carry the deepest queued turn's event back to the delivery layer"
fix for that is already the explicit scope of open PR #64752
("preserve reply anchors across queued turns"). This PR does not touch
that part; it only fixes the missing-reaction/hook half.

## Test plan

`tests/gateway/test_queued_followup_processing_hooks.py`:
- `test_on_processing_start_and_complete_fire_for_pending_event` — drives
  `GatewayRunner._run_agent_queued_followup()` with a plain Telegram-DM
  pending event and asserts the adapter receives
  `on_processing_start(pending_event)` then
  `on_processing_complete(pending_event, ProcessingOutcome.SUCCESS)`.
- `test_failed_followup_reports_failure_outcome` — same, with a failed
  follow-up result, asserts `ProcessingOutcome.FAILURE`.
- `test_unhandled_exception_still_fires_processing_complete` (new) — the
  recursive follow-up turn raises `RuntimeError`; asserts the exception
  still propagates AND `on_processing_complete(pending_event,
  ProcessingOutcome.FAILURE)` still fires (guards the try/except added
  around the recursive call, described above).
- `test_cancelled_error_still_fires_processing_complete` (new) — the
  recursive follow-up turn raises `asyncio.CancelledError` from a task in
  `adapter._expected_cancelled_tasks`; asserts the error still propagates
  AND `on_processing_complete(pending_event, ProcessingOutcome.CANCELLED)`
  still fires.

Verified all four fail without the fix (`git stash` the
`gateway/run_turn.py` hunk, keeping the tests):

```
$ scripts/run_tests.sh tests/gateway/test_queued_followup_processing_hooks.py -v
...
FAILED ...test_unhandled_exception_still_fires_processing_complete
AssertionError: assert ['on_processing_start'] == ['on_processing_start', 'on_processing_complete']
FAILED ...test_cancelled_error_still_fires_processing_complete
AssertionError: assert ['on_processing_start'] == ['on_processing_start', 'on_processing_complete']
========================= 2 failed, 2 passed in 0.79s ==========================
```

(The first two tests, predating this round, still pass without the
try/except — they only cover the happy/failed-result paths, which is why
the reviewer flagged the gap. The two new tests target the exception/
cancellation gap directly and fail without the fix, pass with it.)

And pass with it:

```
$ scripts/run_tests.sh tests/gateway/test_queued_followup_processing_hooks.py -v
[100.0% |     4/~4 | ✓4 | ✗0] ✓ tests/gateway/test_queued_followup_processing_hooks.py (4✓, 1.1s)
=== Summary: 1 files, 4 tests passed, 0 failed (100% complete) in 1.1s (8 workers) ===
```

Ran the broader queue/interrupt/telegram regression set plus the full
`tests/gateway/` suite:

```
$ scripts/run_tests.sh tests/gateway/test_compression_interrupt_demotion_56391.py \
    tests/gateway/test_cron_interrupt_notification.py \
    tests/gateway/test_internal_event_never_interrupts_busy_session.py \
    tests/gateway/test_interrupt_key_match.py tests/gateway/test_queue_command.py \
    tests/gateway/test_queue_consumption.py tests/gateway/test_queued_native_image_session_key.py \
    tests/gateway/test_run_progress_interrupt.py tests/gateway/test_telegram_photo_interrupts.py
=== Summary: 9 files, 29 tests passed, 0 failed (100% complete) in 34.1s (8 workers) ===

$ scripts/run_tests.sh tests/gateway/
=== Summary: 772 files, 7725 tests passed, 2 failed, 40 skipped (100% complete) in 453.4s (8 workers) ===
```

The 2 failures (`tests/gateway/test_wecom_callback.py`) are pre-existing
and environmental — this sandbox never installed the `wecom` extra
(`defusedxml`), so `xml.etree.ElementTree` resolves to `None` in
`plugins/platforms/wecom/callback_adapter.py`. Unrelated to this change
(confirmed `pip show defusedxml` reports not installed; the failure is in
XML parsing setup, nothing touched by this diff).

`ruff check gateway/run_turn.py tests/gateway/test_queued_followup_processing_hooks.py`: all checks passed.

## AI assistance disclosure

This change (investigation, fix, and test) was written with AI assistance
(Claude / Claude Code), reviewed and verified by running the test suite
before and after the fix as described above.
