### PR TITLE
fix(usage): account for timestamped windows and recovery coverage

### DIFF
--- a/agent/insights.py
+++ b/agent/insights.py
@@ -11,6 +11,8 @@ from typing import Any, Dict, List, Optional
 
 from agent.usage_pricing import CanonicalUsage, estimate_usage_cost, format_cost_label, format_duration_compact, has_known_pricing
 
+from agent.usage_window import get_usage_window_coverage, get_window_usage_rows
+
 _TOKEN_KEYS = ("input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens")
 _SKILL_TOOLS = {"skill_view", "skill_manage"}
 
@@ -178,18 +180,20 @@ class InsightsEngine:
         if callable(flush):
             flush()
         sessions = self._get_sessions(cutoff, source)
+        usage_rows = self._get_model_usage(cutoff, source)
+        usage_coverage = get_usage_window_coverage(self._conn, cutoff, usage_rows=usage_rows)
         tool_usage = self._get_tool_usage(cutoff, source)
         skill_usage = self._get_skill_usage(cutoff, source)
         message_stats = self._get_message_stats(cutoff, source)
-        if not sessions:
-            return {"days": days, "source_filter": source, "empty": True, "overview": {}, "models": [], "platforms": [], "tools": [],
+        if not sessions and not usage_rows:
+            return {"usage_coverage": usage_coverage, "days": days, "source_filter": source, "empty": True, "overview": {}, "models": [], "platforms": [], "tools": [],
                     "skills": self._compute_skill_breakdown([]), "activity": {}, "top_sessions": []}
-        models = self._compute_model_breakdown(sessions, cutoff, source)
+        models = self._compute_model_breakdown(sessions, cutoff, source, usage_rows=usage_rows)
         return {
-            "days": days, "source_filter": source, "empty": False, "generated_at": time.time(),
-            "overview": self._compute_overview(sessions, message_stats, models),
+            "days": days, "source_filter": source, "empty": False, "generated_at": time.time(), "usage_coverage": usage_coverage,
+            "overview": self._compute_overview(sessions, message_stats, models, usage_rows=usage_rows),
             "models": models,
-            "platforms": self._compute_platform_breakdown(sessions),
+            "platforms": self._compute_platform_breakdown(sessions, usage_rows=usage_rows),
             "tools": self._compute_tool_breakdown(tool_usage),
             "skills": self._compute_skill_breakdown(skill_usage),
             "activity": self._compute_activity_patterns(sessions),
@@ -251,41 +255,59 @@ class InsightsEngine:
         return dict(rows[0]) if rows else {"total_messages": 0, "user_messages": 0, "assistant_messages": 0, "tool_messages": 0}
 
     def _get_model_usage(self, cutoff: float, source: str = None) -> List[Dict]:
-        """Per-model usage rows; [] when the table is missing (older DB) so the caller falls back to the per-session aggregate."""
-        try:
-            return [dict(row) for row in self._query("_GET_MODEL_USAGE", cutoff, source)]
-        except sqlite3.OperationalError:
-            return []
+        """Fetch exact event deltas plus non-overlapping legacy fallback."""
+        return get_window_usage_rows(self._conn, cutoff, source)
 
     # -------------------------------------------------------------- Compute
 
-    def _compute_overview(self, sessions: List[Dict], message_stats: Dict, models: Optional[List[Dict]] = None) -> Dict:
+    def _compute_overview(
+        self,
+        sessions: List[Dict],
+        message_stats: Dict,
+        models: Optional[List[Dict]] = None,
+        *,
+        usage_rows: Optional[List[Dict]] = None,
+    ) -> Dict:
         # Per-model breakdown includes auxiliary usage rows (vision/compression/
         # titles) plus reconciled residuals, while session counters carry
-        # main-loop usage only — sum the breakdown when available so overview
-        # totals match the per-model table and aux spend isn't undercounted.
-        rows = models or sessions
+        # main-loop usage only. Use the exact usage rows for token/cost/session
+        # accounting so a long-lived session's recent event is not discarded.
+        accounting_rows = usage_rows if usage_rows is not None else sessions
+        rows = models or accounting_rows
         total_input, total_output, total_cache_read, total_cache_write = (sum(int(r.get(k) or 0) for r in rows) for k in _TOKEN_KEYS)
         total_tokens = total_input + total_output + total_cache_read + total_cache_write
+        # Message/tool/activity metrics intentionally retain their started-at
+        # session semantics; usage-session denominators below do not.
         total_tool_calls = sum(s.get("tool_call_count") or 0 for s in sessions)
         total_messages = sum(s.get("message_count") or 0 for s in sessions)
         total_cost = actual_cost = 0.0
         models_with_pricing, models_without_pricing, status_counts = set(), set(), Counter()
-        for s in sessions:
-            model = s.get("model") or ""
-            estimated, status = _estimate_cost(s)
+        session_statuses: Dict[Any, str] = {}
+        status_priority = {"unknown": 0, "included": 1, "estimated": 2}
+        for row in accounting_rows:
+            model = row.get("model") or ""
+            estimated, status = _estimate_cost(row)
             total_cost += estimated
-            actual_cost += s.get("actual_cost_usd") or 0.0
-            status_counts[status] += 1
-            known = has_known_pricing(model, s.get("billing_provider"), s.get("billing_base_url"))
+            actual_cost += float(row.get("actual_cost_usd") or 0.0)
+            session_id = row.get("session_id") or row.get("id")
+            if session_id:
+                previous = session_statuses.get(session_id)
+                if previous is None or status_priority.get(status, 0) > status_priority.get(previous, 0):
+                    session_statuses[session_id] = status
+            known = has_known_pricing(model, row.get("billing_provider"), row.get("billing_base_url"))
             (models_with_pricing if known else models_without_pricing).add(_short_model(model))
+        status_counts.update(session_statuses.values())
         if models:
             total_cost = sum(float(m.get("cost") or 0.0) for m in models)
         # Guard against negative durations from clock drift.
         durations = [s["ended_at"] - s["started_at"] for s in sessions
                      if s.get("started_at") and s.get("ended_at") and s["ended_at"] > s["started_at"]]
         started = [s["started_at"] for s in sessions if s.get("started_at")]
-        n = len(sessions)
+        usage_session_ids = {row.get("session_id") or row.get("id") for row in accounting_rows}
+        usage_session_ids.discard(None)
+        usage_session_ids.discard("")
+        n = len(usage_session_ids)
+        started_n = len(sessions)
         return {
             "total_sessions": n, "total_messages": total_messages, "total_tool_calls": total_tool_calls,
             "total_input_tokens": total_input, "total_output_tokens": total_output,
@@ -293,8 +315,8 @@ class InsightsEngine:
             "total_tokens": total_tokens, "estimated_cost": total_cost, "actual_cost": actual_cost,
             "total_hours": sum(durations) / 3600 if durations else 0,
             "avg_session_duration": sum(durations) / len(durations) if durations else 0,
-            "avg_messages_per_session": total_messages / n if sessions else 0,
-            "avg_tokens_per_session": total_tokens / n if sessions else 0,
+            "avg_messages_per_session": total_messages / started_n if started_n else 0,
+            "avg_tokens_per_session": total_tokens / n if n else 0,
             "user_messages": message_stats.get("user_messages") or 0,
             "assistant_messages": message_stats.get("assistant_messages") or 0,
             "tool_messages": message_stats.get("tool_messages") or 0,
@@ -306,7 +328,7 @@ class InsightsEngine:
             "included_cost_sessions": status_counts["included"],
         }
 
-    def _compute_model_breakdown(self, sessions: List[Dict], cutoff: float, source: str = None) -> List[Dict]:
+    def _compute_model_breakdown(self, sessions: List[Dict], cutoff: float, source: str = None, *, usage_rows: Optional[List[Dict]] = None) -> List[Dict]:
         """Tokens/cost per model from session_model_usage, so a session that
         switched models via ``/model`` splits across every model it used.
         Sessions without per-model rows (pre-table data) fall back to their
@@ -334,8 +356,11 @@ class InsightsEngine:
             d["actual_cost"] += float(actual_cost or 0.0)
             d["cost_status"] = status
             d["has_pricing"] = has_known_pricing(model, provider or None, base_url) or d.get("has_pricing", False)
+        if usage_rows is None:
+            usage_rows = self._get_model_usage(cutoff, source)
+        event_session_ids = {r["session_id"] for r in usage_rows if r.get("usage_origin") == "event"}
         usage_totals = defaultdict(lambda: dict.fromkeys(count_keys, 0) | {"estimated_cost_usd": 0.0, "actual_cost_usd": 0.0})
-        for r in self._get_model_usage(cutoff, source):
+        for r in usage_rows:
             totals: Dict[str, Any] = usage_totals[r["session_id"]]
             counts = {key: r[key] or 0 for key in count_keys}
             for key in count_keys:
@@ -349,6 +374,8 @@ class InsightsEngine:
         # interrupted migrations, and absolute cumulative updates without
         # double-counting already-attributed route deltas.
         for s in sessions:
+            if s["id"] in event_session_ids:
+                continue
             totals = usage_totals[s["id"]]
             residual = {k: max(0, (s.get(k) or 0) - totals[k]) for k in _TOKEN_KEYS + ("api_call_count",)}
             residual["reasoning_tokens"] = 0
@@ -367,17 +394,33 @@ class InsightsEngine:
                   for model, data in model_data.items()]
         return sorted(result, key=lambda x: (x["total_tokens"], x["sessions"]), reverse=True)
 
-    def _compute_platform_breakdown(self, sessions: List[Dict]) -> List[Dict]:
-        platform_data = defaultdict(lambda: {"sessions": 0, "messages": 0, **dict.fromkeys(_TOKEN_KEYS, 0), "total_tokens": 0, "tool_calls": 0})
-        for s in sessions:
-            d = platform_data[s.get("source") or "unknown"]
-            d["sessions"] += 1
-            d["messages"] += s.get("message_count") or 0
-            for k in _TOKEN_KEYS:
-                d[k] += s.get(k) or 0
-                d["total_tokens"] += s.get(k) or 0
-            d["tool_calls"] += s.get("tool_call_count") or 0
-        return sorted(({"platform": platform, **data} for platform, data in platform_data.items()), key=lambda x: x["sessions"], reverse=True)
+    def _compute_platform_breakdown(
+        self,
+        sessions: List[Dict],
+        *,
+        usage_rows: Optional[List[Dict]] = None,
+    ) -> List[Dict]:
+        # Platform token/session totals follow the same event window as the
+        # overview. Message and tool counts remain started-at session metrics.
+        accounting_rows = sessions if usage_rows is None else usage_rows
+        platform_data = defaultdict(lambda: {"_sessions": set(), "messages": 0, **dict.fromkeys(_TOKEN_KEYS, 0), "total_tokens": 0, "tool_calls": 0})
+        for row in accounting_rows:
+            d = platform_data[row.get("source") or "unknown"]
+            session_id = row.get("session_id") or row.get("id")
+            if session_id:
+                d["_sessions"].add(session_id)
+            for key in _TOKEN_KEYS:
+                d[key] += row.get(key) or 0
+                d["total_tokens"] += row.get(key) or 0
+        for session in sessions:
+            d = platform_data[session.get("source") or "unknown"]
+            d["messages"] += session.get("message_count") or 0
+            d["tool_calls"] += session.get("tool_call_count") or 0
+        result = []
+        for platform, data in platform_data.items():
+            data["sessions"] = len(data.pop("_sessions"))
+            result.append({"platform": platform, **data})
+        return sorted(result, key=lambda x: x["sessions"], reverse=True)
 
     def _compute_tool_breakdown(self, tool_usage: List[Dict]) -> List[Dict]:
         """Ranked tool list with percentages."""
@@ -421,8 +464,10 @@ class InsightsEngine:
             for prev, cur in zip(dates, dates[1:]):
                 current_streak = current_streak + 1 if (cur - prev).days == 1 else 1
                 max_streak = max(max_streak, current_streak)
-        return {"by_day": day_breakdown, "by_hour": hour_breakdown, "busiest_day": max(day_breakdown, key=lambda x: x["count"]),
-                "busiest_hour": max(hour_breakdown, key=lambda x: x["count"]), "active_days": len(daily_counts), "max_streak": max_streak}
+        return {"by_day": day_breakdown, "by_hour": hour_breakdown,
+                "busiest_day": max(day_breakdown, key=lambda x: x["count"]) if daily_counts else None,
+                "busiest_hour": max(hour_breakdown, key=lambda x: x["count"]) if daily_counts else None,
+                "active_days": len(daily_counts), "max_streak": max_streak}
 
     _TOP_METRICS = (
         ("Most messages", lambda s: s.get("message_count") or 0, "{} msgs"),
@@ -432,6 +477,8 @@ class InsightsEngine:
 
     def _compute_top_sessions(self, sessions: List[Dict]) -> List[Dict]:
         """Notable sessions (longest, most messages, most tokens, most tool calls)."""
+        if not sessions:
+            return []
         top = []
         timed = [s for s in sessions if s.get("started_at") and s.get("ended_at")]
         if timed:

--- a/agent/usage_window.py
+++ b/agent/usage_window.py
@@ -1,0 +1,142 @@
+"""Read exact usage-event windows with an explicit legacy-coverage boundary.
+
+The event ledger owns sessions that have any recorded event. Their lifetime
+aggregates must never be charged again to a shorter reporting window. Older
+sessions without events retain the historical session-start-window fallback.
+All helpers are read-only; no analytics request creates or migrates a database.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timezone
+import sqlite3
+from typing import Any
+
+from hermes_state_common import USAGE_EVENTS_COVERAGE_START_KEY
+
+_COUNTERS = ("input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens", "reasoning_tokens", "api_call_count")
+_COSTS = ("estimated_cost_usd", "actual_cost_usd")
+_ROUTES = ("model", "billing_provider", "billing_base_url", "billing_mode", "task")
+
+
+def _has_table(conn: sqlite3.Connection, table: str) -> bool:
+    return conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)).fetchone() is not None
+
+
+def _dict_rows(cursor: sqlite3.Cursor) -> list[dict[str, Any]]:
+    keys = [column[0] for column in cursor.description or ()]
+    return [dict(zip(keys, row)) for row in cursor.fetchall()]
+
+
+def get_window_usage_rows(conn: sqlite3.Connection, cutoff: float, source: str | None = None) -> list[dict[str, Any]]:
+    """Return exact in-window events plus nonoverlapping legacy route totals."""
+    has_events = _has_table(conn, "session_model_usage_events")
+    source_sql = " AND s.source=?" if source else ""
+    params = [cutoff, source] if source else [cutoff]
+    result: list[dict[str, Any]] = []
+    if has_events:
+        result = _dict_rows(conn.execute(
+            "SELECT e.*, s.source AS source, 'event' AS usage_origin, e.recorded_at AS last_seen "
+            "FROM session_model_usage_events e JOIN sessions s ON s.id=e.session_id "
+            "WHERE e.recorded_at>=?" + source_sql, params))
+    no_events = " AND NOT EXISTS (SELECT 1 FROM session_model_usage_events e WHERE e.session_id=s.id)" if has_events else ""
+    sessions = _dict_rows(conn.execute("SELECT s.* FROM sessions s WHERE s.started_at>=?" + no_events + source_sql, params))
+    usage_by_session: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    if _has_table(conn, "session_model_usage"):
+        for row in _dict_rows(conn.execute(
+            "SELECT u.*, s.source AS source, s.started_at AS recorded_at FROM session_model_usage u JOIN sessions s ON s.id=u.session_id "
+            "WHERE s.started_at>=?" + no_events + source_sql, params)):
+            row.setdefault("task", "")
+            row["usage_origin"] = "legacy"
+            usage_by_session[row["session_id"]].append(row)
+    for session in sessions:
+        rows = usage_by_session[session["id"]]
+        result.extend(rows)
+        # Auxiliary rows never contribute to the session's main-loop counters.
+        main = [row for row in rows if not row.get("task")]
+        residual = {key: max(0, (session.get(key) or 0) - sum(row.get(key) or 0 for row in main)) for key in (*_COUNTERS, *_COSTS)}
+        if any(residual.values()) or not rows:
+            result.append({**{key: session.get(key) or "" for key in _ROUTES}, **residual,
+                           "session_id": session["id"], "source": session.get("source"), "task": "", "recorded_at": session["started_at"],
+                           "last_seen": session["started_at"], "usage_origin": "legacy",
+                           "cost_status": session.get("cost_status"), "cost_source": session.get("cost_source")})
+    return result
+
+
+def get_usage_window_coverage(conn: sqlite3.Connection, cutoff: float, *, usage_rows: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    """Describe exact-ledger availability without fabricating historical events."""
+    available = _has_table(conn, "session_model_usage_events")
+    start = None
+    if _has_table(conn, "state_meta"):
+        row = conn.execute("SELECT value FROM state_meta WHERE key=?", (USAGE_EVENTS_COVERAGE_START_KEY,)).fetchone()
+        if row is not None:
+            try:
+                start = float(row[0])
+            except (TypeError, ValueError):
+                pass
+    rows = usage_rows if usage_rows is not None else get_window_usage_rows(conn, cutoff)
+    legacy = any(row.get("usage_origin") == "legacy" for row in rows)
+    return {"coverage_start": start, "exact_events_available": available,
+            "legacy_fallback_used": legacy, "window_complete": bool(available and start is not None and cutoff >= start and not legacy)}
+
+
+def _aggregate(rows: list[dict[str, Any]], keys: tuple[str, ...]) -> list[dict[str, Any]]:
+    grouped: dict[tuple[Any, ...], dict[str, Any]] = {}
+    for row in rows:
+        key = tuple(row.get(field) or ("unknown" if field == "model" else "") for field in keys)
+        target = grouped.setdefault(key, {**dict(zip(keys, key)), **dict.fromkeys((*_COUNTERS, *_COSTS), 0), "_sessions": set(), "last_used_at": 0})
+        target["_sessions"].add(row["session_id"])
+        for field in (*_COUNTERS, *_COSTS):
+            target[field] += row.get(field) or 0
+        target["last_used_at"] = max(target["last_used_at"], row.get("recorded_at") or row.get("last_seen") or 0)
+    result = []
+    for target in grouped.values():
+        target["sessions"] = len(target.pop("_sessions"))
+        target["estimated_cost"] = target.pop("estimated_cost_usd")
+        target["actual_cost"] = target.pop("actual_cost_usd")
+        target["api_calls"] = target.pop("api_call_count")
+        result.append(target)
+    return sorted(result, key=lambda row: row["input_tokens"] + row["output_tokens"], reverse=True)
+
+
+def aggregate_window_usage(rows: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, Any]]:
+    """Aggregate dashboard day/model/totals with unique session counts."""
+    dated = [{**row, "day": datetime.fromtimestamp(float(row.get("recorded_at") or row.get("last_seen") or 0), timezone.utc).date().isoformat()} for row in rows]
+    daily = sorted(_aggregate(dated, ("day",)), key=lambda row: row["day"])
+    by_model = _aggregate(rows, ("model",))
+    totals = {"total_input": sum(row.get("input_tokens") or 0 for row in rows),
+              "total_output": sum(row.get("output_tokens") or 0 for row in rows),
+              "total_cache_read": sum(row.get("cache_read_tokens") or 0 for row in rows),
+              "total_cache_write": sum(row.get("cache_write_tokens") or 0 for row in rows),
+              "total_reasoning": sum(row.get("reasoning_tokens") or 0 for row in rows),
+              "total_estimated_cost": sum(row.get("estimated_cost_usd") or 0 for row in rows),
+              "total_actual_cost": sum(row.get("actual_cost_usd") or 0 for row in rows),
+              "total_api_calls": sum(row.get("api_call_count") or 0 for row in rows),
+              "total_sessions": len({row["session_id"] for row in rows})}
+    return daily, by_model, totals
+
+
+def aggregate_aux_usage(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Auxiliary calls only, grouped by model, task, and provider."""
+    return _aggregate([row for row in rows if row.get("task")], ("model", "task", "billing_provider"))
+
+
+def aggregate_model_usage(rows: list[dict[str, Any]], tool_rows: list[dict[str, Any]] = ()) -> list[dict[str, Any]]:
+    """Aggregate model cards without collapsing auxiliary task routes."""
+    # ``task`` is part of the historical Models API grouping contract: an
+    # auxiliary call on the same model/provider remains a distinct row.
+    result = _aggregate(rows, ("model", "billing_provider", "task"))
+    by_key = {(row["model"], row["billing_provider"], row["task"]): row for row in result}
+    for row in result:
+        row["tool_calls"] = 0
+        row["avg_tokens_per_session"] = (
+            (row["input_tokens"] + row["output_tokens"]) / max(row["sessions"], 1)
+            if not row["task"] else 0
+        )
+    # Tool counts are session-start metrics and have no auxiliary task route;
+    # attach them only to the main (empty-task) model row.
+    for tool_row in tool_rows:
+        row = by_key.get((tool_row.get("model") or "unknown", tool_row.get("billing_provider") or "", ""))
+        if row is not None:
+            row["tool_calls"] += tool_row.get("tool_calls") or 0
+    return result

--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -12,18 +12,19 @@ import os
 import shutil
 import sqlite3
 import tempfile
+import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Callable, Iterator, Optional
 
 from hermes_state import SessionDB
-from hermes_state_common import FTS_STORAGE_VERSION, SCHEMA_VERSION
+from hermes_state_common import FTS_STORAGE_VERSION, SCHEMA_VERSION, USAGE_EVENTS_COVERAGE_START_KEY
 from hermes_state_repair import _db_opens_cleanly
 
 
 ProgressCallback = Callable[[dict[str, Any]], None]
 _CANONICAL_TABLES = (
-    "system_prompts", "sessions", "messages", "session_model_usage", "compression_locks", "gateway_routing",
+    "system_prompts", "sessions", "messages", "session_model_usage", "session_model_usage_events", "compression_locks", "gateway_routing",
     "async_delegations",
 )
 _TOPIC_TABLES = ("telegram_dm_topic_mode", "telegram_dm_topic_bindings")
@@ -716,7 +717,7 @@ def _reconcile(destination: sqlite3.Connection, table: str, where: str, mutation
     return count
 
 
-_DEPENDENT_TABLES = ("messages", "session_model_usage", "compression_locks", "telegram_dm_topic_bindings")
+_DEPENDENT_TABLES = ("messages", "session_model_usage", "session_model_usage_events", "compression_locks", "telegram_dm_topic_bindings")
 _RELINK_COUNTERS = ("session_prompt_refs_cleared", "sessions_parent_cleared")
 
 
@@ -907,6 +908,48 @@ def _finalize_derived_metadata(destination: sqlite3.Connection) -> dict[str, Any
     return result
 
 
+def _invalidate_incomplete_usage_coverage(
+    destination: sqlite3.Connection,
+    copy_report: dict[str, dict[str, Any]],
+    orphan_cleanup: Optional[dict[str, Any]] = None,
+) -> None:
+    """Bound the usage-ledger coverage marker when exact event history is not intact.
+
+    A fresh destination always has a ``state_meta`` marker from schema setup.
+    Event-table copy status alone is not enough: ``get_window_usage_rows()``
+    inner-joins sessions, so a complete event copy can still lose usable rows
+    after incomplete parent-session recovery or orphan cleanup.
+
+    Incomplete recovery must persist a conservative coverage-start at recovery
+    time. Deleting the key lets the next SessionDB init recreate it from
+    MIN(recorded_at) and treat remaining history as complete.
+    """
+    event_report = copy_report.get("session_model_usage_events") or {}
+    session_report = copy_report.get("sessions") or {}
+    cleanup = orphan_cleanup or {}
+    copied_rows = event_report.get("copied_rows")
+    usable_events = 0
+    if _table_columns(destination, "session_model_usage_events"):
+        usable_events = int(destination.execute(
+            "SELECT COUNT(*) FROM session_model_usage_events AS events "
+            "INNER JOIN sessions ON sessions.id = events.session_id"
+        ).fetchone()[0])
+    if (
+        event_report.get("status") == "complete"
+        and session_report.get("status") == "complete"
+        and not int(cleanup.get("sessions_reconstructed") or 0)
+        and copied_rows is not None
+        and usable_events == int(copied_rows)
+    ):
+        return
+    with _immediate_transaction(destination):
+        destination.execute(
+            "INSERT INTO state_meta(key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (USAGE_EVENTS_COVERAGE_START_KEY, str(time.time())),
+        )
+
+
 def _lost_and_found_plausibility_errors(
     conn: sqlite3.Connection,
 ) -> list[str]:
@@ -1002,8 +1045,13 @@ def _recover_via_lost_and_found(
             "error": "recovered via page-level lost_and_found salvage; "
             "row completeness cannot be verified against the source",
         }
-        for table in ("sessions", "messages", "session_model_usage")
+        for table in ("sessions", "messages", "session_model_usage", "session_model_usage_events")
     }
+    usage_conn = _connect(output)
+    try:
+        _invalidate_incomplete_usage_coverage(usage_conn, copy_report)
+    finally:
+        usage_conn.close()
     orphan_cleanup = {
         "sessions_reconstructed": stubbing["sessions_stubbed"], "messages_retained": stubbing["messages_retained"],
         "messages_removed": 0, "total_removed_or_relinked": 0,
@@ -1110,6 +1158,7 @@ def recover_session_database(
                 )
             orphan_cleanup = _cleanup_partial_orphans(destination_conn) if allow_partial else None
             derived_metadata = _finalize_derived_metadata(destination_conn)
+            _invalidate_incomplete_usage_coverage(destination_conn, copy_report, orphan_cleanup)
         finally:
             source_conn.close()
             if destination_conn is not None:

--- a/hermes_cli/web_routers/analytics.py
+++ b/hermes_cli/web_routers/analytics.py
@@ -14,7 +14,7 @@ from fastapi import APIRouter, HTTPException, Query
 from hermes_cli.config import get_config_path, read_raw_config
 from hermes_cli.web_deps import late
 from hermes_cli.web_server_profiles import (
-    _approval_mode_of, _aux_task_summary, _aux_usage_rows, _broadcast_gateway_session_info, _is_other_profile, _merge_aux_into_by_model,
+    _approval_mode_of, _aux_task_summary, _aux_usage_rows, _broadcast_gateway_session_info, _is_other_profile,
 )
 from hermes_cli.web_models import RawConfigUpdate
 
@@ -76,63 +76,36 @@ def _rows(db, sql: str, cutoff: float) -> List[Dict[str, Any]]:
 
 def _get_usage_analytics(days: int = 30, profile: Optional[str] = None):
     from agent.insights import InsightsEngine
+    from agent.usage_window import (
+        aggregate_window_usage,
+        get_usage_window_coverage,
+        get_window_usage_rows,
+    )
 
     db = _open_session_db_for_profile(profile, read_only=True)
     try:
         cutoff = time.time() - (days * 86400)
-        daily = _rows(db, """
-            SELECT date(started_at, 'unixepoch') as day,
-                   SUM(input_tokens) as input_tokens,
-                   SUM(output_tokens) as output_tokens,
-                   SUM(cache_read_tokens) as cache_read_tokens,
-                   SUM(reasoning_tokens) as reasoning_tokens,
-                   COALESCE(SUM(estimated_cost_usd), 0) as estimated_cost,
-                   COALESCE(SUM(actual_cost_usd), 0) as actual_cost,
-                   COUNT(*) as sessions,
-                   SUM(COALESCE(api_call_count, 0)) as api_calls
-            FROM sessions WHERE started_at > ?
-            GROUP BY day ORDER BY day
-        """, cutoff)
-
-        by_model = _rows(db, """
-            SELECT model,
-                   SUM(input_tokens) as input_tokens,
-                   SUM(output_tokens) as output_tokens,
-                   COALESCE(SUM(estimated_cost_usd), 0) as estimated_cost,
-                   COUNT(*) as sessions,
-                   SUM(COALESCE(api_call_count, 0)) as api_calls
-            FROM sessions WHERE started_at > ? AND model IS NOT NULL
-            GROUP BY model ORDER BY SUM(input_tokens) + SUM(output_tokens) DESC
-        """, cutoff)
-
-        # Fold in auxiliary usage (vision, compression, ...) from session_model_usage.
-        # Aux calls never touch the sessions counters, so this is add-only — no double count.
-        # Without it the models list shows only the main agent model even when aux models are actively
-        # burning tokens (issue #23270).
-        aux_rows = _aux_usage_rows(db, cutoff)
-        by_model = _merge_aux_into_by_model(by_model, aux_rows)
-
-        totals = _rows(db, """
-            SELECT SUM(input_tokens) as total_input,
-                   SUM(output_tokens) as total_output,
-                   SUM(cache_read_tokens) as total_cache_read,
-                   SUM(reasoning_tokens) as total_reasoning,
-                   COALESCE(SUM(estimated_cost_usd), 0) as total_estimated_cost,
-                   COALESCE(SUM(actual_cost_usd), 0) as total_actual_cost,
-                   COUNT(*) as total_sessions,
-                   SUM(COALESCE(api_call_count, 0)) as total_api_calls
-            FROM sessions WHERE started_at > ?
-        """, cutoff)[0]
+        usage_rows = get_window_usage_rows(db._conn, cutoff)
+        usage_coverage = get_usage_window_coverage(
+            db._conn, cutoff, usage_rows=usage_rows
+        )
+        daily, by_model, totals = aggregate_window_usage(usage_rows)
+        aux_rows = _aux_usage_rows(db, cutoff, usage_rows)
         usage = InsightsEngine(db).get_usage_breakdown(days=days)
 
         return {
             "daily": daily,
             "by_model": by_model,
-            "by_task": _aux_task_summary(aux_rows),  # "what is compression costing me"
+            # Aux-task summary across models (vision, compression, ...). Lets
+            # the dashboard answer "what is compression costing me" directly.
+            "by_task": _aux_task_summary(aux_rows),
             "totals": totals,
             "period_days": days,
+            "usage_coverage": usage_coverage,
             "skills": usage["skills"],
-            "tools": usage["tools"],  # per-tool-name counts; desktop aggregates per toolset
+            # Per-tool-name call counts (already computed by InsightsEngine);
+            # the desktop Capabilities page aggregates these per toolset.
+            "tools": usage["tools"],
         }
     finally:
         db.close()
@@ -161,20 +134,21 @@ def _has_usage(row: Dict[str, Any]) -> bool:
 
 
 def _fold_session_only_rows(raw_rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """Fold model rows that carry no billing_provider and no usage into the single
-    accounted provider row for that model.
+    """Fold model/task rows that carry no billing_provider and no usage into the single
+    accounted provider row for that model/task.
 
     Session rows can be created before the first billable call finishes; if that early row
-    records only the model name while a later row has real accounting, the Models page used
-    to show a duplicate "0 tokens / — API calls" card. Only folds when ownership is
+    records only the model and task while a later row has real accounting, the Models page
+    used to show a duplicate "0 tokens / — API calls" card. Only folds when ownership is
     unambiguous (exactly one provider row).
     """
-    rows_by_model: Dict[str, List[Dict[str, Any]]] = {}
+    rows_by_model_task: Dict[tuple, List[Dict[str, Any]]] = {}
     for row in raw_rows:
-        rows_by_model.setdefault(row.get("model") or "", []).append(row)
+        key = (row.get("model") or "", row.get("task") or "")
+        rows_by_model_task.setdefault(key, []).append(row)
 
     rows: List[Dict[str, Any]] = []
-    for model_rows in rows_by_model.values():
+    for model_rows in rows_by_model_task.values():
         provider_rows = [r for r in model_rows if r.get("billing_provider")]
         if len(provider_rows) != 1:
             rows.extend(model_rows)
@@ -231,39 +205,14 @@ def _get_models_analytics(days: int = 30, profile: Optional[str] = None):
     try:
         cutoff = time.time() - (days * 86400)
 
-        raw_rows = _rows(db, """
-            SELECT model,
-                   billing_provider,
-                   SUM(input_tokens) as input_tokens,
-                   SUM(output_tokens) as output_tokens,
-                   SUM(cache_read_tokens) as cache_read_tokens,
-                   SUM(reasoning_tokens) as reasoning_tokens,
-                   COALESCE(SUM(estimated_cost_usd), 0) as estimated_cost,
-                   COALESCE(SUM(actual_cost_usd), 0) as actual_cost,
-                   COUNT(*) as sessions,
-                   SUM(COALESCE(api_call_count, 0)) as api_calls,
-                   SUM(tool_call_count) as tool_calls,
-                   MAX(started_at) as last_used_at,
-                   AVG(input_tokens + output_tokens) as avg_tokens_per_session
-            FROM sessions WHERE started_at > ? AND model IS NOT NULL AND model != ''
-            GROUP BY model, billing_provider
-            ORDER BY SUM(input_tokens) + SUM(output_tokens) DESC
-        """, cutoff)
-
-        # Aux-only models (dedicated vision/compression) as (model, provider) rows,
-        # keyed like the GROUP BY above, so they appear on the Models page.
-        # See #23270.
-        for aux in _aux_usage_rows(db, cutoff):
-            raw_rows.append({
-                "model": aux.get("model") or "unknown",
-                "billing_provider": aux.get("billing_provider") or "",
-                **{key: aux.get(key) or 0 for key in _AUX_SUMMED_KEYS},
-                "actual_cost": 0,
-                "tool_calls": 0,
-                "last_used_at": aux.get("last_used_at"),
-                "avg_tokens_per_session": 0,
-                "aux_task": aux.get("task") or "",
-            })
+        from agent.usage_window import aggregate_model_usage, aggregate_window_usage, get_usage_window_coverage, get_window_usage_rows
+        usage_rows = get_window_usage_rows(db._conn, cutoff)
+        usage_coverage = get_usage_window_coverage(db._conn, cutoff, usage_rows=usage_rows)
+        tool_rows = _rows(db, """SELECT COALESCE(model, 'unknown') AS model,
+            COALESCE(billing_provider, '') AS billing_provider, SUM(COALESCE(tool_call_count, 0)) AS tool_calls
+            FROM sessions WHERE started_at > ? GROUP BY model, billing_provider""", cutoff)
+        raw_rows = aggregate_model_usage(usage_rows, tool_rows)
+        _, _, totals = aggregate_window_usage(usage_rows)
 
         rows = _fold_session_only_rows(raw_rows)
         rows.sort(
@@ -271,30 +220,23 @@ def _get_models_analytics(days: int = 30, profile: Optional[str] = None):
             reverse=True,
         )
 
-        models = [
-            {
+        models = []
+        for row in rows:
+            model = {
                 "model": row["model"],
                 "provider": row.get("billing_provider") or "",
                 **{key: row[key] for key in _MODEL_CARD_KEYS},
                 "capabilities": _model_capabilities(row.get("billing_provider") or "", row["model"]),
             }
-            for row in rows
-        ]
+            # Keep the auxiliary task dimension visible when a task shares the
+            # same model/provider as the main conversation route.
+            if row.get("task"):
+                model["aux_task"] = row["task"]
+            models.append(model)
 
-        totals = _rows(db, """
-            SELECT COUNT(DISTINCT model) as distinct_models,
-                   SUM(input_tokens) as total_input,
-                   SUM(output_tokens) as total_output,
-                   SUM(cache_read_tokens) as total_cache_read,
-                   SUM(reasoning_tokens) as total_reasoning,
-                   COALESCE(SUM(estimated_cost_usd), 0) as total_estimated_cost,
-                   COALESCE(SUM(actual_cost_usd), 0) as total_actual_cost,
-                   COUNT(*) as total_sessions,
-                   SUM(COALESCE(api_call_count, 0)) as total_api_calls
-            FROM sessions WHERE started_at > ? AND model IS NOT NULL AND model != ''
-        """, cutoff)[0]
+        totals["distinct_models"] = len({m["model"] for m in models})
 
-        return {"models": models, "totals": totals, "period_days": days}
+        return {"models": models, "totals": totals, "period_days": days, "usage_coverage": usage_coverage}
     finally:
         db.close()
 

--- a/hermes_cli/web_server_profiles.py
+++ b/hermes_cli/web_server_profiles.py
@@ -292,35 +292,18 @@ def _token_volume(row: Dict[str, Any]) -> Any:
     return (row.get("input_tokens") or 0) + (row.get("output_tokens") or 0)
 
 
-def _aux_usage_rows(db, cutoff: float) -> List[Dict[str, Any]]:
-    """Per-(model, task) auxiliary usage within the window: the task-dimension rows
-    (task != '') record_auxiliary_usage writes into session_model_usage. [] when the
-    table predates the task column (older DB opened read-only by newer code).
+def _aux_usage_rows(
+    db,
+    cutoff: float,
+    usage_rows: Optional[List[Dict[str, Any]]] = None,
+) -> List[Dict[str, Any]]:
+    """Read and aggregate exact-window auxiliary usage."""
+    from agent.usage_window import aggregate_aux_usage, get_window_usage_rows
 
-    See #23270.
-    """
-    try:
-        cur = db._conn.execute("""
-            SELECT u.model,
-                   u.task,
-                   u.billing_provider,
-                   SUM(u.input_tokens) as input_tokens,
-                   SUM(u.output_tokens) as output_tokens,
-                   SUM(u.cache_read_tokens) as cache_read_tokens,
-                   SUM(u.reasoning_tokens) as reasoning_tokens,
-                   COALESCE(SUM(u.estimated_cost_usd), 0) as estimated_cost,
-                   COUNT(DISTINCT u.session_id) as sessions,
-                   SUM(COALESCE(u.api_call_count, 0)) as api_calls,
-                   MAX(u.last_seen) as last_used_at
-            FROM session_model_usage u
-            JOIN sessions s ON s.id = u.session_id
-            WHERE s.started_at > ? AND u.task != ''
-            GROUP BY u.model, u.task, u.billing_provider
-            ORDER BY SUM(u.input_tokens) + SUM(u.output_tokens) DESC
-        """, (cutoff,))
-        return [dict(r) for r in cur.fetchall()]
-    except Exception:
-        return []
+    rows = usage_rows
+    if rows is None:
+        rows = get_window_usage_rows(db._conn, cutoff)
+    return aggregate_aux_usage(rows)
 
 
 def _merge_aux_into_by_model(

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -196,6 +196,9 @@ def _sql_session_last_active_by_id(session_id_expr: str) -> str:
 
 SCHEMA_VERSION = 30
 
+# Private additive ledger: keep the official migration version authoritative.
+USAGE_EVENTS_COVERAGE_START_KEY = "session_model_usage_events_coverage_start"
+
 # Auto-maintenance VACUUMs only above this freelist fraction; below it a rewrite costs more I/O than it returns.
 # Auto-maintenance only VACUUMs when at least this fraction of the database file is reclaimable (``PRAGMA
 # freelist_count / PRAGMA page_count``). Below it a full rewrite costs more I/O than it returns — pruning a
@@ -388,6 +391,30 @@ CREATE TABLE IF NOT EXISTS session_model_usage (
     PRIMARY KEY (session_id, model, billing_provider, billing_base_url, billing_mode, task)
 );
 
+-- Timestamped accounting deltas back exact rolling-window analytics.  The
+-- aggregate table above remains the fast lifetime summary and compatibility
+-- source for databases that predate schema v27.
+CREATE TABLE IF NOT EXISTS session_model_usage_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    recorded_at REAL NOT NULL,
+    model TEXT NOT NULL,
+    billing_provider TEXT NOT NULL DEFAULT '',
+    billing_base_url TEXT NOT NULL DEFAULT '',
+    billing_mode TEXT NOT NULL DEFAULT '',
+    task TEXT NOT NULL DEFAULT '',
+    api_call_count INTEGER NOT NULL DEFAULT 0,
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+    reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+    estimated_cost_usd REAL NOT NULL DEFAULT 0,
+    actual_cost_usd REAL NOT NULL DEFAULT 0,
+    cost_status TEXT,
+    cost_source TEXT
+);
+
 CREATE TABLE IF NOT EXISTS state_meta (
     key TEXT PRIMARY KEY,
     value TEXT
@@ -505,6 +532,10 @@ CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(ex
 CREATE INDEX IF NOT EXISTS idx_session_turn_leases_expires ON session_turn_leases(expires_at);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_session ON session_model_usage(session_id);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_model ON session_model_usage(model);
+CREATE INDEX IF NOT EXISTS idx_session_model_usage_events_recorded
+    ON session_model_usage_events(recorded_at);
+CREATE INDEX IF NOT EXISTS idx_session_model_usage_events_session_recorded
+    ON session_model_usage_events(session_id, recorded_at);
 CREATE INDEX IF NOT EXISTS idx_async_delegations_delivery
     ON async_delegations(delivery_state, completed_at);
 """

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -24,7 +24,7 @@ from hermes_state_common import (
     DEFERRED_INDEX_SQL, FTS_CJK_STALE_KEY, FTS_REBUILD_DEFERRAL_KEY, FTS_STALE_KEY, FTS_SQL,
     FTS_STORAGE_VERSION, FTS_TOOL_FULL_CONTENT_HIGH_WATER_KEY, FTS_TRIGRAM_SQL, LEGACY_FTS_SQL,
     LEGACY_FTS_TRIGRAM_SQL, SCHEMA_SQL,
-    SCHEMA_VERSION, _FTS_CJK_TRIGGERS, _FTS_TRIGGERS, _ephemeral_child_sql, fts_rebuild_admission,
+    SCHEMA_VERSION, USAGE_EVENTS_COVERAGE_START_KEY, _FTS_CJK_TRIGGERS, _FTS_TRIGGERS, _ephemeral_child_sql, fts_rebuild_admission,
 )
 
 # Pre-split logger identity so log filtering/capture is unchanged.
@@ -855,6 +855,25 @@ class SessionSchemaMixin:
             )
         else:
             self._run_data_migrations(cursor, row[0], fts5_available)
+
+        # The event ledger starts at schema-v27 cutover; historical lifetime
+        # aggregates cannot be reconstructed into per-call events honestly.
+        # Persist the earliest exact timestamp once, preserving a copied marker
+        # during recovery and healing interim v27 databases from MIN(event).
+        coverage_row = cursor.execute(
+            "SELECT value FROM state_meta WHERE key = ? LIMIT 1",
+            (USAGE_EVENTS_COVERAGE_START_KEY,),
+        ).fetchone()
+        if coverage_row is None:
+            earliest_row = cursor.execute(
+                "SELECT MIN(recorded_at) FROM session_model_usage_events"
+            ).fetchone()
+            earliest = earliest_row[0] if earliest_row is not None else None
+            coverage_start = float(earliest) if earliest is not None else time.time()
+            cursor.execute(
+                "INSERT INTO state_meta (key, value) VALUES (?, ?)",
+                (USAGE_EVENTS_COVERAGE_START_KEY, str(coverage_start)),
+            )
 
         self._ensure_unique_title_index(cursor)
         if fts5_available:

--- a/hermes_state_usage.py
+++ b/hermes_state_usage.py
@@ -109,6 +109,7 @@ class SessionUsageMixin:
         """Enqueue a token/cost delta for the background writer (same kwargs as
         :meth:`update_token_counts`). After close() stopped the writer, falls back to the
         synchronous path and may raise."""
+        kwargs.setdefault("_usage_recorded_at", time.time())
         with self._token_queue_cond:
             thread = self._token_writer_thread
             writer_alive = thread is not None and thread.is_alive()
@@ -211,23 +212,50 @@ class SessionUsageMixin:
                 # Accounting loss is logged, never raised into a turn.
                 logger.warning("async token accounting: apply failed (session=%s): %s", session_id, exc)
 
-    def _coalesce_token_deltas(self, batch: List[Tuple[str, Dict[str, Any]]]) -> List[Tuple[str, Dict[str, Any]]]:
-        """Merge adjacent incremental deltas with an identical route, so ordering across
-        sessions and /model switches is preserved exactly. absolute=True never merges."""
+    def _coalesce_token_deltas(
+        self, batch: List[Tuple[str, Dict[str, Any]]]
+    ) -> List[Tuple[str, Dict[str, Any]]]:
+        """Merge consecutive incremental deltas with an identical route.
+
+        Only adjacent deltas merge, so ordering across sessions and across
+        a mid-session /model switch is preserved exactly.  absolute=True
+        deltas (cumulative overwrites) never merge. Exact event components are
+        retained so the optimization cannot collapse per-call timestamps.
+        """
+
+        def _event_parts(delta: Dict[str, Any]) -> List[Dict[str, Any]]:
+            parts = delta.get("_usage_event_deltas")
+            if parts is not None:
+                return [dict(part) for part in parts]
+            return [dict(delta)]
+
         groups: List[Tuple[Optional[tuple], str, Dict[str, Any]]] = []
         for session_id, kwargs in batch:
             key = None
             if not kwargs.get("absolute"):
-                key = (session_id, *(kwargs.get(f) for f in self._TOKEN_DELTA_ROUTE_FIELDS))
+                key = (session_id,) + tuple(
+                    kwargs.get(f) for f in self._TOKEN_DELTA_ROUTE_FIELDS
+                )
             if groups and key is not None and groups[-1][0] == key:
                 merged = groups[-1][2]
+                if "_usage_event_deltas" not in merged:
+                    merged["_usage_event_deltas"] = _event_parts(merged)
+                merged["_usage_event_deltas"].extend(_event_parts(kwargs))
                 for f in self._TOKEN_DELTA_SUM_FIELDS:
                     merged[f] = merged.get(f, 0) + kwargs.get(f, 0)
                 for f in self._TOKEN_DELTA_COST_FIELDS:
                     value = kwargs.get(f)
                     if value is not None:
-                        # All-None runs stay None so COALESCE keeps the stored value.
+                        # None-preserving sum: an all-None run must stay
+                        # None so COALESCE keeps the stored value untouched.
                         merged[f] = (merged.get(f) or 0.0) + value
+                event_times = [
+                    part.get("_usage_recorded_at")
+                    for part in merged["_usage_event_deltas"]
+                    if part.get("_usage_recorded_at") is not None
+                ]
+                if event_times:
+                    merged["_usage_recorded_at"] = max(event_times)
             else:
                 groups.append((key, session_id, dict(kwargs)))
         return [(sid, kw) for _, sid, kw in groups]
@@ -278,6 +306,7 @@ class SessionUsageMixin:
         actual_cost_usd: Optional[float]=None, cost_status: Optional[str]=None, cost_source: Optional[str]=None,
         pricing_version: Optional[str]=None, billing_provider: Optional[str]=None, billing_base_url: Optional[str]=None,
         billing_mode: Optional[str]=None, api_call_count: int=0, absolute: bool=False,
+        _usage_recorded_at: Optional[float]=None, _usage_event_deltas: Optional[List[Dict[str, Any]]]=None,
     ) -> None:
         """Update token counters and backfill model if unset. *absolute*=False increments
         (per-API-call deltas, CLI path); *absolute*=True sets directly (gateway path,
@@ -297,20 +326,12 @@ class SessionUsageMixin:
             billing_base_url if has_accounted_usage else None,
             billing_mode if has_accounted_usage else None, model if has_accounted_usage else None,
             api_call_count, session_id)
-        # Per-model attribution: the sessions row keeps one (model, provider) pair, so a
-        # mid-session /model switch would attribute every token to the initial model. Only
-        # the incremental path records here — absolute cumulative updates cannot be split
-        # back into routes; Insights reconciles the residual instead.
-        # ``update_token_counts`` is the single chokepoint every per-API-call delta flows through (CLI,
-        # gateway, cron, delegated runs — see conversation_loop / codex_runtime), and each call carries the
-        # model/provider *active at the time of that call*. Recording the per-call delta into
-        # session_model_usage keyed by the live model preserves an accurate per-model breakdown regardless
-        # of how many times the user switches. See #51607.
-        record_model_usage = (not absolute) and has_usage
+        # Preserve per-call event time while keeping upstream counter/route SQL.
 
         def _do(conn):
             row = conn.execute(
-                "SELECT model, billing_provider, api_call_count FROM sessions WHERE id = ?", (session_id,),
+                "SELECT model, billing_provider, api_call_count, input_tokens, output_tokens, cache_read_tokens, "
+                "cache_write_tokens, reasoning_tokens, estimated_cost_usd, actual_cost_usd FROM sessions WHERE id = ?", (session_id,),
             ).fetchone()
             existing = dict(row) if row is not None else {}
             # create_session records the requested route before any API call. If that fails
@@ -326,40 +347,166 @@ class SessionUsageMixin:
                        SET model = ?, billing_provider = ?,
                        billing_base_url = ?, billing_mode = ?
                        WHERE id = ?""", (model, billing_provider, billing_base_url, billing_mode, session_id))
+            event_usage = dict(usage)
+            if absolute:
+                for key in (*_TOKEN_COUNTERS, "api_call_count", "estimated_cost_usd", "actual_cost_usd"):
+                    value = event_usage.get(key)
+                    event_usage[key] = None if value is None else max(0, value - (existing.get(key) or 0))
             conn.execute(sql, params)
-            if record_model_usage:
-                self._record_model_usage(conn, session_id, **usage)
+            if any(event_usage.get(k) for k in (*_TOKEN_COUNTERS, "api_call_count", "estimated_cost_usd", "actual_cost_usd")):
+                self._record_model_usage(conn, session_id, **event_usage,
+                                         recorded_at=_usage_recorded_at, event_deltas=_usage_event_deltas)
         self._execute_write(_do)
 
     def _record_model_usage(
-        self, conn, session_id: str, *, model: Optional[str]=None, billing_provider: Optional[str]=None,
-        billing_base_url: Optional[str]=None, billing_mode: Optional[str]=None, input_tokens: int=0,
-        output_tokens: int=0, cache_read_tokens: int=0, cache_write_tokens: int=0, reasoning_tokens: int=0,
-        estimated_cost_usd: Optional[float]=None, actual_cost_usd: Optional[float]=None,
-        cost_status: Optional[str]=None, cost_source: Optional[str]=None, api_call_count: int=0, task: str="",
+        self,
+        conn,
+        session_id: str,
+        *,
+        model: Optional[str],
+        billing_provider: Optional[str],
+        billing_base_url: Optional[str],
+        billing_mode: Optional[str] = None,
+        input_tokens: int,
+        output_tokens: int,
+        cache_read_tokens: int,
+        cache_write_tokens: int,
+        reasoning_tokens: int,
+        estimated_cost_usd: Optional[float],
+        actual_cost_usd: Optional[float] = None,
+        cost_status: Optional[str] = None,
+        cost_source: Optional[str] = None,
+        api_call_count: int,
+        task: str = "",
+        recorded_at: Optional[float] = None,
+        event_deltas: Optional[List[Dict[str, Any]]] = None,
     ) -> None:
-        """Accumulate a per-API-call usage delta into session_model_usage, inside the caller's
-        write txn after the ``sessions`` UPDATE. A missing model/provider falls back to
-        the session row — except for aux rows (``task`` set), which must NOT inherit the
-        main-loop route (vision on gemini while the main loop runs anthropic): missing
-        info stays 'unknown'/empty.
+        """Persist a usage delta into the exact ledger and lifetime aggregate.
 
-        ``task`` distinguishes what kind of work consumed the tokens: ``''`` (empty) is the main agent loop;
-        auxiliary calls record their task name (``vision``, ``compression``, ``title_generation``, ...) via
-        :meth:`record_auxiliary_usage` (issue #23270).
+        Runs inside the caller's write transaction (after the ``sessions``
+        UPDATE) so the per-model rows stay consistent with the summary row.
+        When the caller omits the model/provider (some paths only pass token
+        deltas), fall back to the values already recorded on the session row —
+        the same COALESCE-from-session behaviour the summary update uses.
+
+        ``task`` distinguishes what kind of work consumed the tokens:
+        ``''`` (empty) is the main agent loop; auxiliary calls record their
+        task name (``vision``, ``compression``, ``title_generation``, ...)
+        via :meth:`record_auxiliary_usage` (issue #23270).
         """
         row = conn.execute(
-            "SELECT model, billing_provider, billing_base_url, billing_mode FROM sessions WHERE id = ?", (session_id,),
+            "SELECT model, billing_provider, billing_base_url, billing_mode "
+            "FROM sessions WHERE id = ?",
+            (session_id,),
         ).fetchone()
-        sess = dict(row) if (row is not None and not task) else {}
-        counts = [v or 0 for v in (input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens)]
-        now = time.time()
-        conn.execute(_MODEL_USAGE_UPSERT_SQL, (
-            session_id, model or sess.get("model") or "unknown",
-            billing_provider or sess.get("billing_provider") or "",
-            billing_base_url or sess.get("billing_base_url") or "",
-            billing_mode or sess.get("billing_mode") or "", task or "", api_call_count or 0, *counts,
-            float(estimated_cost_usd or 0.0), float(actual_cost_usd or 0.0), cost_status, cost_source, now, now))
+        sess_model = row["model"] if row is not None else None
+        sess_provider = row["billing_provider"] if row is not None else None
+        sess_base_url = row["billing_base_url"] if row is not None else None
+        sess_billing_mode = row["billing_mode"] if row is not None else None
+
+        # Aux-task rows (task != '') must NOT inherit the session's main-loop
+        # route: an aux call may use a completely different provider/model
+        # (vision on gemini while the main loop runs anthropic). Missing info
+        # stays 'unknown'/empty rather than borrowing a misleading route.
+        if task:
+            eff_model = model or "unknown"
+            eff_provider = billing_provider or ""
+            eff_base_url = billing_base_url or ""
+            eff_billing_mode = billing_mode or ""
+        else:
+            eff_model = model or sess_model or "unknown"
+            eff_provider = billing_provider or sess_provider or ""
+            eff_base_url = billing_base_url or sess_base_url or ""
+            eff_billing_mode = billing_mode or sess_billing_mode or ""
+        now = time.time() if recorded_at is None else float(recorded_at)
+        if event_deltas is None:
+            event_deltas = [{
+                "_usage_recorded_at": now,
+                "api_call_count": api_call_count,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "cache_read_tokens": cache_read_tokens,
+                "cache_write_tokens": cache_write_tokens,
+                "reasoning_tokens": reasoning_tokens,
+                "estimated_cost_usd": estimated_cost_usd,
+                "actual_cost_usd": actual_cost_usd,
+                "cost_status": cost_status,
+                "cost_source": cost_source,
+            }]
+
+        event_values = []
+        event_times = []
+        for delta in event_deltas:
+            if not any(
+                delta.get(field)
+                for field in (
+                    "api_call_count",
+                    "input_tokens",
+                    "output_tokens",
+                    "cache_read_tokens",
+                    "cache_write_tokens",
+                    "reasoning_tokens",
+                    "estimated_cost_usd",
+                    "actual_cost_usd",
+                )
+            ):
+                continue
+            event_time = float(delta.get("_usage_recorded_at", now))
+            event_times.append(event_time)
+            event_values.append((
+                session_id,
+                event_time,
+                eff_model,
+                eff_provider,
+                eff_base_url,
+                eff_billing_mode,
+                task or "",
+                delta.get("api_call_count") or 0,
+                delta.get("input_tokens") or 0,
+                delta.get("output_tokens") or 0,
+                delta.get("cache_read_tokens") or 0,
+                delta.get("cache_write_tokens") or 0,
+                delta.get("reasoning_tokens") or 0,
+                float(delta.get("estimated_cost_usd") or 0.0),
+                float(delta.get("actual_cost_usd") or 0.0),
+                delta.get("cost_status", cost_status),
+                delta.get("cost_source", cost_source),
+            ))
+        conn.executemany(
+            """INSERT INTO session_model_usage_events (
+                   session_id, recorded_at, model, billing_provider,
+                   billing_base_url, billing_mode, task, api_call_count,
+                   input_tokens, output_tokens, cache_read_tokens,
+                   cache_write_tokens, reasoning_tokens, estimated_cost_usd,
+                   actual_cost_usd, cost_status, cost_source
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            event_values,
+        )
+        first_seen = min(event_times) if event_times else now
+        last_seen = max(event_times) if event_times else now
+        conn.execute(
+            _MODEL_USAGE_UPSERT_SQL,
+            (
+                session_id,
+                eff_model,
+                eff_provider,
+                eff_base_url,
+                eff_billing_mode,
+                task or "",
+                api_call_count or 0,
+                input_tokens or 0,
+                output_tokens or 0,
+                cache_read_tokens or 0,
+                cache_write_tokens or 0,
+                reasoning_tokens or 0,
+                float(estimated_cost_usd or 0.0),
+                float(actual_cost_usd or 0.0),
+                cost_status,
+                cost_source,
+                first_seen,
+                last_seen,
+            ),
+        )
 
     def record_auxiliary_usage(
         self, session_id: str, task: str, *, model: Optional[str]=None, billing_provider: Optional[str]=None,

--- a/tests/agent/test_async_token_accounting.py
+++ b/tests/agent/test_async_token_accounting.py
@@ -53,6 +53,16 @@ def _model_usage(db, session_id):
     return [dict(r) for r in rows]
 
 
+def _usage_events(db, session_id):
+    with db._lock:
+        rows = db._conn.execute(
+            "SELECT recorded_at, model, input_tokens, output_tokens, api_call_count "
+            "FROM session_model_usage_events WHERE session_id = ? ORDER BY id",
+            (session_id,),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
 # =========================================================================
 # Ordering
 # =========================================================================
@@ -106,6 +116,13 @@ class TestOrdering:
         assert totals["input_tokens"] == 507
         assert totals["output_tokens"] == 50
         assert totals["api_call_count"] == 4
+
+        # The exact-window ledger records only real positive deltas. The
+        # absolute overwrite contributes the residual after the first event,
+        # and the final incremental update contributes one more row.
+        events = _usage_events(db, "s-abs")
+        assert [row["input_tokens"] for row in events] == [100, 400, 7]
+        assert [row["api_call_count"] for row in events] == [1, 2, 1]
 
 
 # =========================================================================
@@ -165,6 +182,44 @@ class TestCoalescing:
         assert len(usage) == 1
         assert usage[0]["input_tokens"] == n
         assert usage[0]["api_call_count"] == n
+        event_rows = _usage_events(db, "s-c")
+        assert len(event_rows) == n
+        assert sum(row["input_tokens"] for row in event_rows) == n
+        assert sum(row["api_call_count"] for row in event_rows) == n
+
+    def test_coalescing_preserves_each_enqueue_timestamp(self, db):
+        """The optimization must not collapse exact event time semantics."""
+        db.create_session("s-time", "test")
+        db._apply_token_batch([
+            (
+                "s-time",
+                dict(
+                    input_tokens=3,
+                    api_call_count=1,
+                    model="m1",
+                    billing_provider="p1",
+                    _usage_recorded_at=1_700_000_001.0,
+                ),
+            ),
+            (
+                "s-time",
+                dict(
+                    input_tokens=4,
+                    api_call_count=1,
+                    model="m1",
+                    billing_provider="p1",
+                    _usage_recorded_at=1_700_000_009.0,
+                ),
+            ),
+        ])
+
+        events = _usage_events(db, "s-time")
+        assert [row["recorded_at"] for row in events] == [
+            1_700_000_001.0,
+            1_700_000_009.0,
+        ]
+        assert [row["input_tokens"] for row in events] == [3, 4]
+        assert _totals(db, "s-time")["input_tokens"] == 7
 
     def test_coalesced_apply_equals_sequential_apply(self, db, tmp_path):
         """Applying a coalesced batch produces byte-identical session and
@@ -536,7 +591,11 @@ class TestCoalesceFieldContract:
             set(db._TOKEN_DELTA_SUM_FIELDS)
             | set(db._TOKEN_DELTA_COST_FIELDS)
             | set(db._TOKEN_DELTA_ROUTE_FIELDS)
-            | {"absolute"}  # control flag: absolute deltas never merge
+            | {
+                "absolute",  # control flag: absolute deltas never merge
+                "_usage_recorded_at",
+                "_usage_event_deltas",
+            }
         )
 
         unclassified = params - classified
@@ -547,7 +606,11 @@ class TestCoalesceFieldContract:
             f"control-flag set in this test) — unclassified kwargs are "
             f"silently dropped from merged deltas."
         )
-        phantom = classified - params - {"absolute"}
+        phantom = classified - params - {
+            "absolute",
+            "_usage_recorded_at",
+            "_usage_event_deltas",
+        }
         assert not phantom, (
             f"coalescing field lists reference kwargs update_token_counts "
             f"no longer accepts: {sorted(phantom)}"

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -132,6 +132,10 @@ def populated_db(db):
     db.end_session("s_old", end_reason="user_exit")
     db._conn.execute("UPDATE sessions SET ended_at = ? WHERE id = 's_old'", (now - 45 * day + 600,))
     db.update_token_counts("s_old", input_tokens=5000, output_tokens=2000)
+    db._conn.execute(
+        "UPDATE session_model_usage_events SET recorded_at = ? WHERE session_id = 's_old'",
+        (now - 45 * day,),
+    )
     db.append_message("s_old", role="user", content="old message")
     db.append_message("s_old", role="assistant", content="old reply")
 
@@ -292,6 +296,122 @@ class TestInsightsPopulated:
         assert models["deepseek-v4-pro"]["total_tokens"] == 48000
         assert models["claude-opus-4.8"]["total_tokens"] == 54000
 
+    def test_usage_window_counts_only_recent_deltas_from_long_lived_session(self, db):
+        """A session older than the window can still consume tokens today.
+
+        Window analytics must use timestamped usage deltas rather than either
+        excluding the whole session by ``started_at`` or charging its full
+        lifetime total to the current window.
+        """
+        now = time.time()
+        old = now - (10 * 86400)
+        cutoff = now - (8 * 86400)
+        db.create_session(session_id="long-lived", source="telegram", model="gpt-5.6-sol")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = 'long-lived'",
+            (old,),
+        )
+        db.update_token_counts(
+            "long-lived",
+            input_tokens=100,
+            cache_read_tokens=1_000,
+            model="gpt-5.6-sol",
+            billing_provider="openai-codex",
+            api_call_count=1,
+        )
+        db._conn.execute(
+            "UPDATE session_model_usage_events SET recorded_at = ? "
+            "WHERE session_id = 'long-lived'",
+            (old,),
+        )
+        db.update_token_counts(
+            "long-lived",
+            input_tokens=20,
+            cache_read_tokens=200,
+            actual_cost_usd=1.0,
+            cost_status="estimated",
+            cost_source="provider",
+            model="gpt-5.6-sol",
+            billing_provider="openai-codex",
+            api_call_count=1,
+        )
+        db._conn.commit()
+
+        event_rows = db._conn.execute(
+            "SELECT input_tokens, cache_read_tokens FROM session_model_usage_events "
+            "WHERE recorded_at >= ? ORDER BY id",
+            (cutoff,),
+        ).fetchall()
+        assert [tuple(row) for row in event_rows] == [(20, 200)]
+
+        report = InsightsEngine(db).generate(days=8)
+        assert report["empty"] is False
+        assert report["overview"]["total_input_tokens"] == 20
+        assert report["overview"]["total_cache_read_tokens"] == 200
+        assert report["overview"]["actual_cost"] == pytest.approx(1.0)
+        assert report["overview"]["total_sessions"] == 1
+        assert report["overview"]["avg_tokens_per_session"] == pytest.approx(220.0)
+        platform = next(row for row in report["platforms"] if row["platform"] == "telegram")
+        assert platform["sessions"] == 1
+        assert platform["input_tokens"] == 20
+        assert platform["cache_read_tokens"] == 200
+        assert platform["total_tokens"] == 220
+        assert report["activity"]["busiest_day"] is None
+        assert report["activity"]["busiest_hour"] is None
+        assert report["usage_coverage"]["window_complete"] is False
+        assert report["usage_coverage"]["exact_events_available"] is True
+        model = next(row for row in report["models"] if row["model"] == "gpt-5.6-sol")
+        assert model["api_calls"] == 1
+        assert model["cache_read_tokens"] == 200
+
+    def test_overview_message_average_uses_started_session_population(self, db):
+        """Started-at message totals must not be divided by usage-session count.
+
+        One old session with recent usage plus one newly started session with
+        four messages must keep the started-session average at four. Token
+        averages still use the exact-usage population.
+        """
+        now = time.time()
+        db.create_session(session_id="old-usage", source="cli", model="test-model")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = 'old-usage'",
+            (now - (10 * 86400),),
+        )
+        db.update_token_counts(
+            "old-usage",
+            input_tokens=50,
+            model="test-model",
+            billing_provider="test",
+            api_call_count=1,
+        )
+
+        db.create_session(session_id="new-started", source="cli", model="test-model")
+        for index in range(4):
+            db.append_message(
+                "new-started",
+                "user" if index % 2 == 0 else "assistant",
+                f"started-window message {index}",
+            )
+        db.update_token_counts(
+            "new-started",
+            input_tokens=10,
+            model="test-model",
+            billing_provider="test",
+            api_call_count=1,
+        )
+        db._conn.commit()
+
+        started_messages = db._conn.execute(
+            "SELECT message_count FROM sessions WHERE id = 'new-started'"
+        ).fetchone()[0]
+        assert started_messages == 4
+
+        overview = InsightsEngine(db).generate(days=8)["overview"]
+        assert overview["total_messages"] == 4
+        assert overview["avg_messages_per_session"] == pytest.approx(4.0)
+        assert overview["total_sessions"] == 2
+        assert overview["total_input_tokens"] == 60
+        assert overview["avg_tokens_per_session"] == pytest.approx(30.0)
 
     def test_overview_cost_matches_per_model_stored_cost(self, db):
         db.create_session(session_id="cost", source="cli", model="model-a")

--- a/tests/agent/test_usage_window.py
+++ b/tests/agent/test_usage_window.py
@@ -1,0 +1,151 @@
+"""Behavior gates for the restored local exact-accounting reader."""
+import sqlite3
+import time
+
+from agent.usage_window import aggregate_model_usage, aggregate_window_usage, get_usage_window_coverage, get_window_usage_rows
+from hermes_state import SessionDB
+from hermes_state_common import SCHEMA_VERSION, USAGE_EVENTS_COVERAGE_START_KEY
+from hermes_cli.session_recovery import recover_session_database
+
+
+def test_legacy_fallback_and_exact_events_do_not_overlap(tmp_path):
+    db = SessionDB(db_path=tmp_path / "usage.db")
+    try:
+        db.create_session("legacy", "cli", model="legacy-model")
+        db._conn.execute("UPDATE sessions SET input_tokens=100, api_call_count=1 WHERE id='legacy'")
+        db.create_session("exact", "telegram", model="exact-model")
+        db.update_token_counts("exact", input_tokens=20, api_call_count=1)
+        db.record_auxiliary_usage("exact", "vision", model="vision-model", input_tokens=5)
+        cutoff = time.time() - 100
+        rows = get_window_usage_rows(db._conn, cutoff)
+        _, _, totals = aggregate_window_usage(rows)
+        assert totals["total_input"] == 125
+        assert totals["total_sessions"] == 2
+        assert get_usage_window_coverage(db._conn, cutoff, usage_rows=rows)["legacy_fallback_used"] is True
+        assert {row["source"] for row in rows} == {"cli", "telegram"}
+        scoped = get_window_usage_rows(db._conn, cutoff, "telegram")
+        assert {row["session_id"] for row in scoped} == {"exact"}
+        assert {row["source"] for row in scoped} == {"telegram"}
+        assert sum(row["input_tokens"] for row in scoped) == 25
+    finally:
+        db.close()
+
+
+def test_model_aggregation_preserves_auxiliary_task_dimension():
+    rows = [
+        {
+            "session_id": "s1", "model": "shared-model", "billing_provider": "provider", "task": "",
+            "input_tokens": 10, "output_tokens": 2, "recorded_at": 1,
+        },
+        {
+            "session_id": "s1", "model": "shared-model", "billing_provider": "provider", "task": "compression",
+            "input_tokens": 3, "output_tokens": 1, "recorded_at": 2,
+        },
+    ]
+
+    result = aggregate_model_usage(rows, [{"model": "shared-model", "billing_provider": "provider", "tool_calls": 4}])
+    by_task = {row["task"]: row for row in result}
+    assert set(by_task) == {"", "compression"}
+    assert by_task[""]["tool_calls"] == 4
+    assert by_task["compression"]["tool_calls"] == 0
+    assert by_task["compression"]["input_tokens"] == 3
+    assert by_task["compression"]["avg_tokens_per_session"] == 0
+
+
+def test_preledger_database_is_readable_without_migration(tmp_path):
+    path = tmp_path / "legacy.db"
+    db = SessionDB(db_path=path)
+    db.create_session("legacy", "cli", model="legacy-model")
+    db._conn.execute("UPDATE sessions SET input_tokens=7 WHERE id='legacy'")
+    db._conn.execute("DROP TABLE session_model_usage_events")
+    db._conn.commit()
+    db.close()
+    conn = sqlite3.connect(f"file:{path.as_posix()}?mode=ro", uri=True)
+    try:
+        rows = get_window_usage_rows(conn, time.time() - 100)
+        assert sum(row["input_tokens"] for row in rows) == 7
+        assert get_usage_window_coverage(conn, time.time() - 100, usage_rows=rows)["exact_events_available"] is False
+        assert conn.execute("SELECT 1 FROM sqlite_master WHERE name='session_model_usage_events'").fetchone() is None
+    finally:
+        conn.close()
+
+
+def test_recovery_invalidates_coverage_when_event_table_is_missing(tmp_path):
+    source = tmp_path / "source-missing-events.db"
+    output = tmp_path / "recovered-missing-events.db"
+    db = SessionDB(db_path=source)
+    try:
+        db.create_session("legacy", "cli")
+        db.update_token_counts("legacy", input_tokens=3)
+        db._conn.execute(
+            "UPDATE state_meta SET value='1234567890' WHERE key=?",
+            (USAGE_EVENTS_COVERAGE_START_KEY,),
+        )
+        db._conn.execute("DROP TABLE session_model_usage_events")
+        db._conn.commit()
+    finally:
+        db.close()
+
+    result = recover_session_database(source, output, work_dir=tmp_path)
+    assert result["verified"] is True
+    historical_cutoff = 1234567890.0
+    conn = sqlite3.connect(output)
+    try:
+        coverage = get_usage_window_coverage(conn, historical_cutoff)
+        marker = conn.execute(
+            "SELECT value FROM state_meta WHERE key=?",
+            (USAGE_EVENTS_COVERAGE_START_KEY,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert marker is not None
+    assert coverage["coverage_start"] is not None
+    assert coverage["coverage_start"] > historical_cutoff
+    assert coverage["window_complete"] is False
+    for _ in range(2):
+        reopened = SessionDB(db_path=output)
+        try:
+            after = get_usage_window_coverage(reopened._conn, historical_cutoff)
+        finally:
+            reopened.close()
+        assert after["coverage_start"] == coverage["coverage_start"]
+        assert after["window_complete"] is False
+
+    post = SessionDB(db_path=output)
+    try:
+        post.create_session("post-recovery", "cli")
+        post.update_token_counts("post-recovery", input_tokens=2, api_call_count=1)
+        fresh = get_usage_window_coverage(post._conn, coverage["coverage_start"])
+    finally:
+        post.close()
+    assert fresh["window_complete"] is True
+    assert fresh["coverage_start"] == coverage["coverage_start"]
+
+
+def test_recovery_preserves_coverage_and_official_schema_version(tmp_path):
+    source, output = tmp_path / "source.db", tmp_path / "recovered.db"
+    db = SessionDB(db_path=source)
+    db.create_session("accounted", "cli")
+    db.update_token_counts("accounted", input_tokens=3)
+    db._conn.execute("UPDATE state_meta SET value='1234567890' WHERE key=?", (USAGE_EVENTS_COVERAGE_START_KEY,))
+    db._conn.commit()
+    db.close()
+    result = recover_session_database(source, output, work_dir=tmp_path)
+    assert result["verified"]
+    conn = sqlite3.connect(output)
+    try:
+        assert conn.execute("SELECT value FROM state_meta WHERE key=?", (USAGE_EVENTS_COVERAGE_START_KEY,)).fetchone()[0] == "1234567890"
+        assert conn.execute("SELECT version FROM schema_version").fetchone()[0] == SCHEMA_VERSION
+        assert conn.execute("SELECT SUM(input_tokens) FROM session_model_usage_events").fetchone()[0] == 3
+    finally:
+        conn.close()
+    for _ in range(2):
+        reopened = SessionDB(db_path=output)
+        try:
+            preserved = reopened._conn.execute(
+                "SELECT value FROM state_meta WHERE key=?",
+                (USAGE_EVENTS_COVERAGE_START_KEY,),
+            ).fetchone()
+        finally:
+            reopened.close()
+        assert preserved[0] == "1234567890"

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -12,8 +12,9 @@ from types import SimpleNamespace
 import pytest
 
 import hermes_state
+from agent.usage_window import get_usage_window_coverage
 from hermes_state import SessionDB
-from hermes_state_common import FTS_STORAGE_VERSION, SCHEMA_VERSION
+from hermes_state_common import FTS_STORAGE_VERSION, SCHEMA_VERSION, USAGE_EVENTS_COVERAGE_START_KEY
 from hermes_cli import session_recovery
 from hermes_cli.session_recovery import (
     SessionRecoverySafetyError,
@@ -299,6 +300,330 @@ def _corrupt_table_root(path: Path, root_page: int) -> None:
     # a fully failed sessions copy while leaving the messages b-tree intact.
     data[header_offset + 3 : header_offset + 5] = b"\xff\xff"
     path.write_bytes(data)
+
+
+def test_recovery_preserves_timestamped_usage_events(tmp_path: Path) -> None:
+    """The exact rolling-window ledger is canonical recovery data."""
+    source = tmp_path / "usage-events-source.db"
+    output = tmp_path / "usage-events-recovered.db"
+
+    db = SessionDB(db_path=source)
+    try:
+        db.create_session("usage-event-session", "cli")
+        db.update_token_counts(
+            "usage-event-session",
+            model="test/model",
+            billing_provider="test-provider",
+            input_tokens=10,
+            cache_read_tokens=90,
+            api_call_count=1,
+        )
+        db._conn.execute(
+            "UPDATE state_meta SET value = ? WHERE key = ?",
+            ("1234567890", USAGE_EVENTS_COVERAGE_START_KEY),
+        )
+        expected = dict(
+            db._conn.execute(
+                "SELECT session_id, recorded_at, model, input_tokens, "
+                "cache_read_tokens, api_call_count "
+                "FROM session_model_usage_events"
+            ).fetchone()
+        )
+    finally:
+        db.close()
+
+    report = recover_session_database(source, output, work_dir=tmp_path)
+
+    copied = report["copy"]["session_model_usage_events"]
+    assert copied["status"] == "complete"
+    assert copied["copied_rows"] == 1
+    assert report["copy"]["sessions"]["status"] == "complete"
+    conn = sqlite3.connect(str(output))
+    try:
+        conn.row_factory = sqlite3.Row
+        recovered = dict(
+            conn.execute(
+                "SELECT session_id, recorded_at, model, input_tokens, "
+                "cache_read_tokens, api_call_count "
+                "FROM session_model_usage_events"
+            ).fetchone()
+        )
+        coverage = conn.execute(
+            "SELECT value FROM state_meta WHERE key = ?",
+            (USAGE_EVENTS_COVERAGE_START_KEY,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert recovered == expected
+    assert coverage is not None
+    assert coverage[0] == "1234567890"
+    for _ in range(2):
+        reopened = SessionDB(db_path=output)
+        try:
+            preserved = reopened._conn.execute(
+                "SELECT value FROM state_meta WHERE key = ?",
+                (USAGE_EVENTS_COVERAGE_START_KEY,),
+            ).fetchone()
+        finally:
+            reopened.close()
+        assert preserved is not None
+        assert preserved[0] == "1234567890"
+
+
+def test_partial_recovery_invalidates_coverage_when_parent_sessions_are_missing(
+    tmp_path: Path,
+) -> None:
+    """A complete event copy is not exact coverage once parent sessions are gone.
+
+    ``get_window_usage_rows()`` inner-joins sessions. If a session row is
+    missing — and reconstruction cannot rebuild it — copied events become
+    unusable after orphan cleanup while the event table still reports
+    complete. Incomplete parent recovery (placeholder reconstruction)
+    is the same honesty failure even when the join later succeeds.
+    """
+    source = tmp_path / "partial-usage-parents.db"
+    output = tmp_path / "partial-usage-parents-recovered.db"
+
+    db = SessionDB(db_path=source)
+    try:
+        db.create_session("kept-session", "cli")
+        db.update_token_counts(
+            "kept-session",
+            model="test/model",
+            input_tokens=5,
+            api_call_count=1,
+        )
+        db.create_session("lost-parent", "cli")
+        db.update_token_counts(
+            "lost-parent",
+            model="test/model",
+            input_tokens=7,
+            api_call_count=1,
+        )
+        db.create_session("doomed-session", "cli")
+        db.append_message("doomed-session", "user", "surviving transcript")
+        db.update_token_counts(
+            "doomed-session",
+            model="test/model",
+            input_tokens=3,
+            api_call_count=1,
+        )
+        db._conn.execute(
+            "UPDATE state_meta SET value = ? WHERE key = ?",
+            ("1234567890", USAGE_EVENTS_COVERAGE_START_KEY),
+        )
+        db._conn.commit()
+    finally:
+        db.close()
+
+    conn = sqlite3.connect(str(source), isolation_level=None)
+    try:
+        conn.execute(
+            "DELETE FROM sessions WHERE id IN ('lost-parent', 'doomed-session')"
+        )
+    finally:
+        conn.close()
+
+    report = recover_session_database(
+        source,
+        output,
+        work_dir=tmp_path,
+        allow_partial=True,
+    )
+
+    events = report["copy"]["session_model_usage_events"]
+    assert events["status"] == "complete"
+    assert events["copied_rows"] == 3
+    assert report["copy"]["sessions"]["status"] == "complete"
+    cleanup = report["orphan_cleanup"]
+    assert cleanup["sessions_reconstructed"] == 1
+    assert cleanup["session_model_usage_events_removed"] == 1
+
+    verify = sqlite3.connect(str(output))
+    try:
+        usable = verify.execute(
+            "SELECT COUNT(*) FROM session_model_usage_events AS events "
+            "INNER JOIN sessions ON sessions.id = events.session_id"
+        ).fetchone()[0]
+        usable_ids = {
+            row[0]
+            for row in verify.execute(
+                "SELECT events.session_id "
+                "FROM session_model_usage_events AS events "
+                "INNER JOIN sessions ON sessions.id = events.session_id"
+            )
+        }
+        min_surviving = verify.execute(
+            "SELECT MIN(events.recorded_at) FROM session_model_usage_events AS events "
+            "INNER JOIN sessions ON sessions.id = events.session_id"
+        ).fetchone()[0]
+        historical_cutoff = float(min_surviving)
+        coverage = get_usage_window_coverage(verify, historical_cutoff)
+    finally:
+        verify.close()
+    assert usable == 2
+    assert usable < events["copied_rows"]
+    assert usable_ids == {"kept-session", "doomed-session"}
+    assert coverage["coverage_start"] is not None
+    assert coverage["coverage_start"] > historical_cutoff
+    assert coverage["window_complete"] is False
+    for _ in range(2):
+        reopened = SessionDB(db_path=output)
+        try:
+            after = get_usage_window_coverage(reopened._conn, historical_cutoff)
+        finally:
+            reopened.close()
+        assert after["coverage_start"] == coverage["coverage_start"]
+        assert after["window_complete"] is False
+
+    post = SessionDB(db_path=output)
+    try:
+        post.create_session("post-recovery", "cli")
+        post.update_token_counts(
+            "post-recovery",
+            model="test/model",
+            input_tokens=1,
+            api_call_count=1,
+        )
+        fresh = get_usage_window_coverage(post._conn, after["coverage_start"])
+    finally:
+        post.close()
+    assert fresh["window_complete"] is True
+    assert fresh["coverage_start"] == coverage["coverage_start"]
+
+
+def test_partial_recovery_historical_window_stays_incomplete_across_sessiondb_reopens(
+    tmp_path: Path,
+) -> None:
+    """Incomplete recovery must not become exact after a normal SessionDB reopen.
+
+    Parent counterexample: survivor event=100, lost-parent event=300, old
+    marker=50, cutoff=200. Deleting the coverage key lets schema init recreate
+    it from MIN(event)=100 and report window_complete=True over a known gap.
+    """
+    source = tmp_path / "reopen-source.db"
+    output = tmp_path / "reopen-recovered.db"
+    survivor_at, lost_at, old_marker, cutoff = 100.0, 300.0, 50.0, 200.0
+
+    db = SessionDB(db_path=source)
+    try:
+        db.create_session("survivor", "cli")
+        db.update_token_counts(
+            "survivor",
+            model="test/model",
+            input_tokens=5,
+            api_call_count=1,
+        )
+        db.create_session("lost-parent", "cli")
+        db.update_token_counts(
+            "lost-parent",
+            model="test/model",
+            input_tokens=7,
+            api_call_count=1,
+        )
+        db._conn.execute(
+            "UPDATE session_model_usage_events SET recorded_at = ? WHERE session_id = ?",
+            (survivor_at, "survivor"),
+        )
+        db._conn.execute(
+            "UPDATE session_model_usage_events SET recorded_at = ? WHERE session_id = ?",
+            (lost_at, "lost-parent"),
+        )
+        db._conn.execute(
+            "UPDATE state_meta SET value = ? WHERE key = ?",
+            (str(old_marker), USAGE_EVENTS_COVERAGE_START_KEY),
+        )
+        db._conn.commit()
+    finally:
+        db.close()
+
+    conn = sqlite3.connect(str(source), isolation_level=None)
+    try:
+        conn.execute("DELETE FROM sessions WHERE id = 'lost-parent'")
+    finally:
+        conn.close()
+
+    report = recover_session_database(
+        source,
+        output,
+        work_dir=tmp_path,
+        allow_partial=True,
+    )
+    assert report["copy"]["session_model_usage_events"]["status"] == "complete"
+    assert report["orphan_cleanup"]["session_model_usage_events_removed"] == 1
+
+    raw = sqlite3.connect(str(output))
+    try:
+        before = get_usage_window_coverage(raw, cutoff)
+        remaining = raw.execute(
+            "SELECT session_id, recorded_at FROM session_model_usage_events "
+            "ORDER BY recorded_at"
+        ).fetchall()
+    finally:
+        raw.close()
+    assert remaining == [("survivor", survivor_at)]
+    assert before["window_complete"] is False
+    assert before["coverage_start"] is not None
+    assert before["coverage_start"] > cutoff
+    assert before["coverage_start"] != survivor_at
+    assert before["coverage_start"] != old_marker
+
+    last = before
+    for _ in range(2):
+        reopened = SessionDB(db_path=output)
+        try:
+            last = get_usage_window_coverage(reopened._conn, cutoff)
+            marker = reopened._conn.execute(
+                "SELECT value FROM state_meta WHERE key = ?",
+                (USAGE_EVENTS_COVERAGE_START_KEY,),
+            ).fetchone()
+        finally:
+            reopened.close()
+        assert last["window_complete"] is False
+        assert last["coverage_start"] == before["coverage_start"]
+        assert marker is not None
+        assert float(marker[0]) == before["coverage_start"]
+        assert last["coverage_start"] != survivor_at
+
+    live = SessionDB(db_path=output)
+    try:
+        live.create_session("fresh", "cli")
+        live.update_token_counts(
+            "fresh",
+            model="test/model",
+            input_tokens=1,
+            api_call_count=1,
+        )
+        fresh = get_usage_window_coverage(live._conn, last["coverage_start"])
+    finally:
+        live.close()
+    assert fresh["window_complete"] is True
+    assert fresh["coverage_start"] == before["coverage_start"]
+
+
+def test_partial_orphan_cleanup_reports_usage_event_removal(tmp_path: Path) -> None:
+    """Orphan event rows are cleaned and reported like lifetime usage rows."""
+    db_path = tmp_path / "orphan-usage-event.db"
+    SessionDB(db_path=db_path).close()
+
+    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    try:
+        conn.execute("PRAGMA foreign_keys=OFF")
+        conn.execute(
+            "INSERT INTO session_model_usage_events "
+            "(session_id, recorded_at, model, input_tokens) VALUES (?, ?, ?, ?)",
+            ("missing-session", 123.0, "test/model", 7),
+        )
+        cleanup = session_recovery._cleanup_partial_orphans(conn)
+        remaining = conn.execute(
+            "SELECT COUNT(*) FROM session_model_usage_events"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    assert cleanup["session_model_usage_events_removed"] == 1
+    assert cleanup["total_removed_or_relinked"] >= 1
+    assert remaining == 0
 
 
 def test_snapshot_blocks_connections_opened_during_the_copy(

--- a/tests/hermes_cli/test_session_recovery_lost_and_found.py
+++ b/tests/hermes_cli/test_session_recovery_lost_and_found.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import pytest
 
 from hermes_state import SessionDB
-from hermes_cli import session_recovery
+from hermes_cli import session_lost_and_found, session_recovery
 from hermes_cli.session_lost_and_found import (
     STUB_TITLE_PREFIX,
     classify_lost_and_found_row,
@@ -41,6 +41,46 @@ from hermes_cli.session_lost_and_found import find_sqlite3_cli
 # .recover needs a sqlite3 shell built with sqlite_dbpage — PATH presence
 # alone is not enough (Ubuntu CI ships a build without it).
 HAVE_SQLITE3_CLI = find_sqlite3_cli() is not None
+
+
+def test_direct_table_copy_preserves_timestamped_usage_events(
+    tmp_path: Path,
+) -> None:
+    """Rows attributed by .recover must include the exact usage ledger."""
+    source = tmp_path / "direct-source.db"
+    destination = tmp_path / "direct-destination.db"
+
+    db = SessionDB(db_path=source)
+    try:
+        db.create_session("direct-usage-session", "cli")
+        db.update_token_counts(
+            "direct-usage-session",
+            model="test/model",
+            input_tokens=3,
+            cache_read_tokens=30,
+            api_call_count=1,
+        )
+    finally:
+        db.close()
+    SessionDB(db_path=destination).close()
+
+    source_conn = sqlite3.connect(str(source), isolation_level=None)
+    destination_conn = sqlite3.connect(str(destination), isolation_level=None)
+    try:
+        destination_conn.execute("PRAGMA foreign_keys=OFF")
+        copied = session_lost_and_found._copy_direct_tables(
+            source_conn, destination_conn
+        )
+        event = destination_conn.execute(
+            "SELECT session_id, input_tokens, cache_read_tokens, api_call_count "
+            "FROM session_model_usage_events"
+        ).fetchone()
+    finally:
+        source_conn.close()
+        destination_conn.close()
+
+    assert copied["session_model_usage_events"] == 1
+    assert event == ("direct-usage-session", 3, 30, 1)
 
 
 # ── physical corruption helpers ─────────────────────────────────────────────

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3082,6 +3082,132 @@ class TestNewEndpoints:
         mock_generate.assert_not_called()
         assert any(tool["tool"] == "read_file" for tool in resp.json()["tools"])
 
+    def test_analytics_usage_includes_recent_delta_from_old_session(self):
+        """The dashboard's day window follows usage time, not session birth."""
+        import time
+        from hermes_state import SessionDB
+
+        now = time.time()
+        old = now - (10 * 86400)
+        db = SessionDB()
+        try:
+            db.create_session(
+                session_id="old-live-usage",
+                source="telegram",
+                model="gpt-5.6-sol",
+            )
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ? WHERE id = 'old-live-usage'",
+                (old,),
+            )
+            db.update_token_counts(
+                "old-live-usage",
+                input_tokens=100,
+                cache_read_tokens=1_000,
+                model="gpt-5.6-sol",
+                billing_provider="openai-codex",
+                api_call_count=1,
+            )
+            db._conn.execute(
+                "UPDATE session_model_usage_events SET recorded_at = ? "
+                "WHERE session_id = 'old-live-usage'",
+                (old,),
+            )
+            db.update_token_counts(
+                "old-live-usage",
+                input_tokens=20,
+                cache_read_tokens=200,
+                model="gpt-5.6-sol",
+                billing_provider="openai-codex",
+                api_call_count=1,
+            )
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/analytics/usage?days=8")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["totals"]["total_input"] == 20
+        assert data["totals"]["total_cache_read"] == 200
+        assert data["totals"]["total_api_calls"] == 1
+        assert data["daily"][-1]["cache_read_tokens"] == 200
+        assert data["usage_coverage"]["window_complete"] is False
+        assert data["usage_coverage"]["exact_events_available"] is True
+
+        models_resp = self.client.get("/api/analytics/models?days=8")
+        assert models_resp.status_code == 200
+        models_data = models_resp.json()
+        model = next(
+            row for row in models_data["models"]
+            if row["model"] == "gpt-5.6-sol"
+        )
+        assert model["cache_read_tokens"] == 200
+        assert model["api_calls"] == 1
+        assert models_data["totals"]["total_input"] == 20
+        assert models_data["totals"]["total_cache_read"] == 200
+        assert models_data["totals"]["total_api_calls"] == 1
+        assert models_data["usage_coverage"]["coverage_start"] == data["usage_coverage"]["coverage_start"]
+        assert models_data["usage_coverage"]["window_complete"] is False
+        assert models_data["usage_coverage"]["exact_events_available"] is True
+        assert models_data["usage_coverage"]["legacy_fallback_used"] is False
+
+    def test_models_analytics_preserves_aux_task_rows(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(
+                "aux-task-model",
+                source="cli",
+                model="shared-model",
+            )
+            db.update_token_counts(
+                "aux-task-model",
+                input_tokens=10,
+                model="shared-model",
+                billing_provider="provider",
+                api_call_count=1,
+            )
+            db.record_auxiliary_usage(
+                "aux-task-model",
+                "compression",
+                model="shared-model",
+                billing_provider="provider",
+                input_tokens=3,
+            )
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/analytics/models?days=7")
+        assert resp.status_code == 200
+        rows = [
+            row for row in resp.json()["models"]
+            if row["model"] == "shared-model"
+        ]
+        assert {row.get("aux_task") for row in rows} == {None, "compression"}
+
+    def test_models_analytics_keeps_empty_provider_row_separate_from_aux_row(self):
+        from hermes_cli.web_routers.analytics import _fold_session_only_rows
+
+        rows = [
+            dict(model="model", billing_provider="", task="", sessions=1, input_tokens=0, output_tokens=0),
+            dict(model="model", billing_provider="provider", task="title_generation", sessions=1, input_tokens=10, output_tokens=0),
+        ]
+
+        folded = _fold_session_only_rows(rows)
+        assert len(folded) == 2
+        assert next(row for row in folded if not row["billing_provider"])["sessions"] == 1
+        assert next(row for row in folded if row["task"] == "title_generation")["sessions"] == 1
+
+        main_only = [
+            dict(model="model", billing_provider="", task="", sessions=1, input_tokens=0, output_tokens=0),
+            dict(model="model", billing_provider="provider", task="", sessions=1, input_tokens=10, output_tokens=0),
+        ]
+        folded_main_only = _fold_session_only_rows(main_only)
+        assert len(folded_main_only) == 1
+        assert folded_main_only[0]["sessions"] == 2
+        assert folded_main_only[0]["avg_tokens_per_session"] == 5
+
 # ---------------------------------------------------------------------------
 # Desktop-owned loopback backends are not gated by dashboard.public_url (#96490)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Record timestamped usage deltas instead of attributing an entire long-lived session to its start date. Share exact event-window accounting between Insights and dashboard analytics, preserve model/auxiliary task distinctions, and retain a non-overlapping legacy fallback with explicit coverage metadata.

Keep message averages on the started-session population while token/cost statistics use the usage-event population. Recovery preserves event data and invalidates incomplete coverage based on both parent sessions and usable event rows. Incomplete recovery stamps a conservative recovery-time boundary that survives normal SessionDB reopen rather than silently reinterpreting surviving events as a complete history.

## Verification
- Canonical runner on native Windows: 4 affected test files, **70 passed, 0 failed, 2 skipped** (Insights, usage windows, recovery and lost-and-found recovery).
- Prior same-byte tests for untouched async-accounting and dashboard API paths: **16 and 5 passed** respectively.
- Reproduced the message-average error and the recovery/reopen false-completeness counterexample before correction; replayed the real temporary-DB recovery/reopen path successfully afterward.
- Healthy recovery preserves its old coverage marker across reopen; historical incomplete windows stay incomplete and new post-recovery windows can become exact.
- Focused Ruff and `git diff --check` pass.
- No full-repository or completed upstream-CI claim.

## Scope and compatibility
The shared read-only window helpers live in the focused `agent/usage_window.py` module; persistence/schema, recovery and API adaptation remain in their existing owning modules. No new external dependency, profile configuration, live database migration operation or memory-provider special case is introduced by this PR submission. Existing databases gain the additive ledger through the standard schema path; pre-ledger history is not fabricated as exact events.
