### PR TITLE
fix(cron): cronjob_manage unavailable to a cron job's own self-chaining call

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -258,8 +258,16 @@ def _tool_defs_cache_key(
 
     Covers every argument plus everything that changes the result without one:
     registry generation, config.yaml mtime/size (dynamic schemas), kanban
-    context, profile scope. check_fn results are TTL-cached in the registry.
-    """
+    context, profile scope, cron-session state. check_fn results are TTL-cached
+    in the registry, but a check_fn whose answer depends on HERMES_CRON_SESSION
+    (a per-task ContextVar, not a stable os.environ var — see
+    tools/cronjob_tools.py's check_cronjob_requirements) changes the tool list
+    itself across otherwise-identical toolset/config fingerprints. Without this
+    dimension, the FIRST call for a given fingerprint (often a non-cron probe,
+    since a long-lived gateway serves many session types) permanently caches
+    that answer for every later cron-session call with the same fingerprint —
+    cronjob_manage silently vanishing from every cron job for the gateway's
+    entire lifetime — confirmed via a live BigCaptain VPS deployment."""
     profile_scope = check_fn_cache_scope()
     if profile_scope == CHECK_FN_CACHE_BYPASS:
         return None
@@ -269,11 +277,17 @@ def _tool_defs_cache_key(
         cfg_fp = (cfg_stat.st_mtime_ns, cfg_stat.st_size)
     except (FileNotFoundError, OSError, ImportError):
         cfg_fp = None
+    try:
+        from gateway.session_context import get_session_env
+        from utils import is_truthy_value
+        cron_session = is_truthy_value(get_session_env("HERMES_CRON_SESSION"))
+    except Exception:
+        cron_session = False
     return (
         registry.current_scope_key(), frozenset(enabled_toolsets) if enabled_toolsets is not None else None,
         frozenset(disabled_toolsets) if disabled_toolsets else None, registry._generation, cfg_fp,
         bool(os.environ.get("HERMES_KANBAN_TASK")), bool(skip_tool_search_assembly),
-        _is_delegated_child_context(), _is_dispatcher_owned_worker(), profile_scope,
+        _is_delegated_child_context(), _is_dispatcher_owned_worker(), profile_scope, cron_session,
     )
 
 

--- a/tests/test_get_tool_definitions_cache_isolation.py
+++ b/tests/test_get_tool_definitions_cache_isolation.py
@@ -108,3 +108,41 @@ class TestQuietModeCacheIsolation:
             assert [future.result(timeout=2) for future in futures] == [[], []]
 
         assert len(model_tools._tool_defs_cache) == model_tools._TOOL_DEFS_CACHE_MAX
+
+
+class TestCronSessionCacheDimension:
+    """Regression tests: the quiet_mode cache key must vary with cron-session
+    state (HERMES_CRON_SESSION, a per-task ContextVar set only while a cron
+    job's own agent turn is running), not just toolset/config fingerprint.
+
+    Without this, the FIRST quiet_mode call for a given toolset fingerprint
+    (often a non-cron probe, since a long-lived gateway serves many session
+    types) permanently caches its check_fn-filtered tool list for every LATER
+    call with the same fingerprint — including genuinely cron-scoped calls
+    where HERMES_CRON_SESSION is bound and should unlock cronjob_manage.
+    Confirmed via a live deployment: cronjob_manage silently unavailable to
+    every cron job for the gateway process's entire lifetime.
+    """
+
+    def test_cron_session_and_non_cron_session_get_distinct_cache_entries(self):
+        from gateway.session_context import _VAR_MAP
+
+        var = _VAR_MAP["HERMES_CRON_SESSION"]
+
+        # Call 1: no cron session bound (e.g. an interactive/gateway probe).
+        model_tools.get_tool_definitions(enabled_toolsets=["cronjob"], quiet_mode=True)
+        assert len(model_tools._tool_defs_cache) == 1
+
+        # Call 2: identical toolset args, but HERMES_CRON_SESSION is now bound.
+        token = var.set("1")
+        try:
+            model_tools.get_tool_definitions(enabled_toolsets=["cronjob"], quiet_mode=True)
+        finally:
+            var.reset(token)
+
+        assert len(model_tools._tool_defs_cache) == 2, (
+            "a cron-session call reused a non-cron-session cache entry for the "
+            "same toolset fingerprint — cronjob_manage-style check_fns that key "
+            "off HERMES_CRON_SESSION will silently vanish for every cron job "
+            "after the first tool-list computation of the gateway's lifetime."
+        )

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -222,6 +222,73 @@ class TestCronjobRequirements:
         assert check_cronjob_requirements() is False
 
 
+class TestCronjobRequirementsInCronSession:
+    """HERMES_CRON_SESSION is a per-task ContextVar (cron/scheduler.py's session-context
+    binding), not a real os.environ var — a cron job's own agent session must still be able
+    to see cronjob_manage (self-chaining, e.g. ship-task's reschedule-self pattern), so
+    check_cronjob_requirements must read it via get_session_env, not env_var_enabled/os.getenv."""
+
+    def test_cron_session_contextvar_grants_access(self, monkeypatch):
+        from gateway.session_context import _VAR_MAP
+
+        for v in ("HERMES_INTERACTIVE", "HERMES_GATEWAY_SESSION", "HERMES_EXEC_ASK"):
+            monkeypatch.delenv(v, raising=False)
+        var = _VAR_MAP["HERMES_CRON_SESSION"]
+        token = var.set("1")
+        try:
+            assert check_cronjob_requirements() is True
+        finally:
+            var.reset(token)
+
+    def test_no_cron_session_and_no_other_flag_denies_access(self, monkeypatch):
+        for v in ("HERMES_INTERACTIVE", "HERMES_GATEWAY_SESSION", "HERMES_EXEC_ASK"):
+            monkeypatch.delenv(v, raising=False)
+        assert check_cronjob_requirements() is False
+
+
+class TestCronjobRequirementsNotCheckFnCached:
+    """check_cronjob_requirements must be registered via @no_cache_check_fn.
+
+    Regression test for a real bug: the registry's check_fn TTL cache (~30s) is keyed by
+    (fn, profile) with no session-type dimension, so a single-profile process (the common
+    case — multiplexing is opt-in) shares ONE cache slot across every session type. Without
+    @no_cache_check_fn, a non-cron probe evaluating False gets cached and served right back
+    to a genuinely-cron session's own call moments later (HERMES_CRON_SESSION binding is
+    irrelevant to the stale cache) — cronjob_manage silently vanishes from every cron job's
+    toolset despite the ContextVar being correctly set. Reproduced live against a real
+    BigCaptain VPS deployment before this test existed."""
+
+    def test_registered_as_no_cache_check_fn(self):
+        from tools.cronjob_tools import check_cronjob_requirements
+        from tools.registry import _NO_CACHE_CHECK_FNS
+
+        assert check_cronjob_requirements in _NO_CACHE_CHECK_FNS
+
+    def test_stale_false_from_other_session_does_not_poison_cron_session(self, monkeypatch):
+        """A prior non-cron call evaluating False must not suppress a cron session's own
+        call made immediately after, within the same TTL window."""
+        from gateway.session_context import _VAR_MAP
+        from tools.registry import invalidate_check_fn_cache, registry
+
+        for v in ("HERMES_INTERACTIVE", "HERMES_GATEWAY_SESSION", "HERMES_EXEC_ASK"):
+            monkeypatch.delenv(v, raising=False)
+        invalidate_check_fn_cache()
+
+        # Prime the cache with a False result (no session flags set at all).
+        assert registry.get_definitions({"cronjob_manage"}) == []
+
+        # Immediately after, in the same process/TTL window, bind the cron-session
+        # ContextVar exactly as cron/scheduler.py's _CronRunScope.enter() does.
+        var = _VAR_MAP["HERMES_CRON_SESSION"]
+        token = var.set("1")
+        try:
+            defs = registry.get_definitions({"cronjob_manage"})
+            assert len(defs) == 1
+            assert defs[0]["function"]["name"] == "cronjob_manage"
+        finally:
+            var.reset(token)
+
+
 class TestUnifiedCronjobTool:
     @pytest.fixture(autouse=True)
     def _setup_cron_dir(self, tmp_path, monkeypatch):

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -60,7 +60,7 @@ from tools.cronjob_job_args import (
     _validate_context_from_refs,
     _validate_cron_base_url,
     _validate_cron_script_path)
-from tools.registry import registry, tool_error
+from tools.registry import no_cache_check_fn, registry, tool_error
 
 
 def _dumps(payload: Dict[str, Any]) -> str:
@@ -983,14 +983,28 @@ Jobs run in a fresh session with no current-chat context, so prompts must be sel
 }
 
 
+@no_cache_check_fn
 def check_cronjob_requirements() -> bool:
-    """Available in interactive CLI mode and gateway/messaging platforms (the scheduler is
-    internal; no crontab needed). Flags must be explicitly truthy via ``env_var_enabled``."""
-    from utils import env_var_enabled
+    """Available in interactive CLI mode, gateway/messaging platforms (the scheduler is
+    internal; no crontab needed), and a running cron job's own agent session (self-chaining
+    via schedule updates, e.g. ship-task's reschedule-self pattern). Flags must be explicitly
+    truthy via ``env_var_enabled``; HERMES_CRON_SESSION is a per-task ContextVar (set by
+    cron/scheduler.py's session-context binding), not a real os.environ var, so it needs
+    ``get_session_env`` rather than ``env_var_enabled`` to be visible here.
+
+    Not check_fn-cached: the registry's ~30s TTL cache is keyed by (fn, profile) with no
+    session-type dimension, so a single-profile process (the common case — multiplexing is
+    opt-in) shares ONE cache slot across every session type. A non-cron probe evaluating
+    False within the last 30s would poison a genuinely-cron session's own check right after
+    HERMES_CRON_SESSION binds — this function is cheap (env/ContextVar reads only, no I/O),
+    so correctness matters far more than the cache's throughput win here."""
+    from utils import env_var_enabled, is_truthy_value
+    from gateway.session_context import get_session_env
     return (
         env_var_enabled("HERMES_INTERACTIVE")
         or env_var_enabled("HERMES_GATEWAY_SESSION")
         or env_var_enabled("HERMES_EXEC_ASK")
+        or is_truthy_value(get_session_env("HERMES_CRON_SESSION"))
     )
 
 


### PR DESCRIPTION
## Problem

A scheduled cron job's own agent session cannot use `cronjob_manage` — the tool
is unreachable (not in the direct tool list, and not found via `tool_search`
either) even though the exact same job was created and is running via the
internal scheduler. This breaks any cron job designed to reschedule/manage
itself — e.g. a "self-chaining" pipeline that processes one work item per
fire and reschedules itself a few minutes later via
`cronjob_manage(action='update', job_id=..., schedule='in 2m')` instead of
waiting for its full base cadence.

This PR fixes **three** independent, stacked bugs found while diagnosing this
against a real production deployment. Fixing only the first (or first two)
was not sufficient — each bug fully masks the fix below it, so a real cron
job run kept reporting the tool unavailable even after earlier fixes were
confirmed correct in isolation.

## Bug 1: wrong env var read path

`check_cronjob_requirements()` gates `cronjob_manage`'s availability by
checking three env vars via `env_var_enabled()` (a thin wrapper over
`os.getenv()`): `HERMES_INTERACTIVE`, `HERMES_GATEWAY_SESSION`,
`HERMES_EXEC_ASK`.

A running cron job's own session is scoped by a fourth variable,
`HERMES_CRON_SESSION` — but this one is bound as a per-task `ContextVar` (via
`gateway.session_context._VAR_MAP`, set in `cron/scheduler.py`'s
`_CronRunScope.enter()`), not a real `os.environ` entry. `env_var_enabled()`
can never see a ContextVar-only binding, so the check always fails for a
cron-triggered session.

**Fix:** also check `get_session_env("HERMES_CRON_SESSION")`.

## Bug 2: registry check_fn cache poisoned across session types

After fixing bug 1, a real simulated cron job trigger *still* reported
`cronjob_manage` as unavailable. The registry's `check_fn` TTL cache (~30s,
`tools/registry.py`) is keyed by `(fn, profile)` with **no session-type
dimension**. On a single-profile process (the common case — multiplexing is
opt-in), **one cache slot is shared across every session type**. A `False`
result from ANY non-cron context within the last 30 seconds gets served right
back to a genuinely cron-scoped call, even though `HERMES_CRON_SESSION` is
correctly bound at that point.

**Fix:** mark `check_cronjob_requirements` with `@no_cache_check_fn` (the
existing escape hatch already used by `memory_tool.py`'s
`check_memory_requirements`). The function is cheap — env/ContextVar reads
only, no I/O — so correctness matters more than the cache's throughput win.

## Bug 3: the outer `get_tool_definitions()` memo has the identical blind spot

Even with bugs 1 and 2 fixed, a real cron job run still couldn't see
`cronjob_manage` — traced via a debug print inside `check_cronjob_requirements`
confirming it was **never even being called** during the real run.

`model_tools.py`'s `quiet_mode` tool-definitions cache (`_tool_defs_cache`,
keyed by `_tool_defs_cache_key()`) sits **above** the registry's `check_fn`
cache and has the exact same gap: its key covers toolsets/config/profile-scope
but not cron-session state. The first call for a given toolset fingerprint
(often a non-cron probe — a long-lived gateway serves many session types)
permanently caches its already-resolved tool list for every later call with
that same fingerprint — including cron-scoped calls, and including the
`tool_search` bridge's own internal re-fetch
(`model_tools._dispatch_bridge_tool` -> `get_tool_definitions(...,
skip_tool_search_assembly=True)`, a distinct cache slot with the identical
blind spot).

**Fix:** fold cron-session state into `_tool_defs_cache_key()`'s tuple, so a
cron-session call gets its own cache entry distinct from a non-cron call with
the same toolset/config fingerprint.

## Found via / verified via

A real production deployment's self-chaining cron pipeline (Jira-ticket-to-PR
automation) successfully ran, implemented a ticket, and opened a real PR —
but then couldn't reschedule itself for the next ticket, because
`cronjob_manage` wasn't reachable in that session's toolset at all.

After each of the first two fixes, a live simulated reproduction (a throwaway
one-shot cron job whose prompt asked it to call `cronjob_manage` on itself)
kept failing with the same symptom — which is what led to finding the next
bug down. After all three fixes, reproduced the full real code path directly
(`model_tools._dispatch_bridge_tool` -> `tools.tool_search.dispatch_tool_search`),
simulating the exact real-world trigger order (a non-cron probe computes and
caches the tool list first, then a genuinely cron-scoped call follows) —
confirmed `cronjob_manage` is now found by `tool_search`.

## Testing

- `TestCronjobRequirementsInCronSession` (2 tests, bug 1): the
  `HERMES_CRON_SESSION` ContextVar grants access; no session flags set at all
  correctly denies it.
- `TestCronjobRequirementsNotCheckFnCached` (2 tests, bug 2): the function is
  registered as `no_cache_check_fn`; a stale `False` from a prior non-cron
  call does not poison an immediately-following cron-session call.
- `TestCronSessionCacheDimension` (1 test, bug 3): a cron-session call gets a
  distinct `_tool_defs_cache` entry from a non-cron call with the same
  toolset fingerprint.

All 5 new tests independently confirmed to **fail** without their
corresponding fix (checked by temporarily reverting each fix in isolation and
re-running), confirming they actually exercise each bug rather than passing
vacuously.

Full suite: 122/122 passed (`tests/tools/test_cronjob_tools.py`,
`tests/test_get_tool_definitions_cache_isolation.py`,
`tests/test_model_tools.py`, `tests/test_model_tools_async_bridge.py`). One
pre-existing unrelated failure in a different test file confirmed
pre-existing on clean `origin/main` via `git stash`, not caused by this
change.
