### PR TITLE
fix(sessions): preserve imported title provenance

### DIFF
--- a/hermes_state_portability.py
+++ b/hermes_state_portability.py
@@ -18,7 +18,7 @@ logger = logging.getLogger("hermes_state")
 
 _IMPORT_SESSION_TEXT_FIELDS = (
     "source", "user_id", "model", "system_prompt", "end_reason", "cwd", "git_branch", "git_repo_root",
-    "billing_provider", "billing_base_url", "billing_mode", "cost_status", "cost_source", "pricing_version", "title",
+    "billing_provider", "billing_base_url", "billing_mode", "cost_status", "cost_source", "pricing_version", "title", "title_source",
 )
 # ``role`` is validated separately (non-empty string).
 _IMPORT_MESSAGE_TEXT_FIELDS = (
@@ -35,7 +35,7 @@ _IMPORT_SESSION_INSERT_SQL = """INSERT INTO sessions (
                            cwd, git_branch, git_repo_root,
                            billing_provider, billing_base_url, billing_mode,
                            estimated_cost_usd, actual_cost_usd, cost_status, cost_source,
-                           pricing_version, title, api_call_count, archived
+                           pricing_version, title, title_source, api_call_count, archived
                        )
                        VALUES (
                            :id, :source, :user_id, :model, :model_config,
@@ -45,13 +45,13 @@ _IMPORT_SESSION_INSERT_SQL = """INSERT INTO sessions (
                            :reasoning_tokens, :cwd, :git_branch, :git_repo_root,
                            :billing_provider, :billing_base_url, :billing_mode,
                            :estimated_cost_usd, :actual_cost_usd, :cost_status,
-                           :cost_source, :pricing_version, :title,
+                           :cost_source, :pricing_version, :title, :title_source,
                            :api_call_count, :archived
                        )"""
 # Columns copied verbatim from the payload; typed columns are converted below.
 _IMPORT_PASSTHROUGH_COLS = (
     "user_id", "model", "model_config", "end_reason", "cwd", "git_branch", "git_repo_root", "billing_provider",
-    "billing_base_url", "billing_mode", "cost_status", "cost_source", "pricing_version", "title",
+    "billing_base_url", "billing_mode", "cost_status", "cost_source", "pricing_version", "title", "title_source",
 )
 _IMPORT_INT_COLS = (
     "input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens", "reasoning_tokens", "api_call_count",
@@ -335,6 +335,9 @@ class SessionPortabilityMixin:
         clean_session["model_config"] = self._import_json_object_or_none(clean_session.get("model_config"), "model_config")
         for field in ("parent_session_id", *_IMPORT_SESSION_TEXT_FIELDS):
             clean_session[field] = self._import_text_or_none(clean_session.get(field), field)
+        title_source = clean_session.get("title_source")
+        if title_source is not None and title_source not in self._TITLE_SOURCE_RANK:
+            raise ValueError(f"invalid title_source: {title_source!r}")
         clean_messages: List[Dict[str, Any]] = []
         for message_index, message in enumerate(messages):
             clean_message = dict(message)

--- a/tests/test_session_import_title_provenance.py
+++ b/tests/test_session_import_title_provenance.py
@@ -1,0 +1,54 @@
+"""Session portability must preserve title ownership and upgrade behavior."""
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.mark.parametrize("source", ["derived", "llm", "user", None])
+def test_export_import_preserves_title_authority(tmp_path, source):
+    donor = SessionDB(tmp_path / "donor.db")
+    restored = SessionDB(tmp_path / "restored.db")
+    try:
+        session_id = "portable-title"
+        donor.create_session(session_id, "cli")
+        title = "Investigate the failing build"
+        if source in ("derived", "llm"):
+            donor.set_auto_title(session_id, title, source=source)
+        else:
+            donor.set_session_title(session_id, title)
+        payload = donor.export_session(session_id)
+        assert payload is not None
+        if source is None:
+            # Older exports predate provenance; keep their user-title protection.
+            payload.pop("title_source")
+        assert restored.import_sessions([payload])["ok"]
+        assert restored.get_session_title(session_id) == title
+        restored_source = restored.get_session_title_source(session_id)
+        upgraded = restored.set_auto_title(
+            session_id, "Diagnose build failure", source="llm"
+        )
+        assert upgraded == (source == "derived")
+        assert restored_source == source
+        assert restored.get_session_title(session_id) == (
+            "Diagnose build failure" if upgraded else title
+        )
+    finally:
+        restored.close()
+        donor.close()
+
+
+@pytest.mark.parametrize("source", ["unknown", {"source": "derived"}])
+def test_invalid_title_provenance_rejects_whole_import(tmp_path, source):
+    db = SessionDB(tmp_path / "target.db")
+    try:
+        result = db.import_sessions([
+            {"id": "valid", "messages": []},
+            {"id": "invalid", "title": "Imported title", "title_source": source, "messages": []},
+        ])
+        assert not result["ok"]
+        assert result["imported"] == 0
+        assert db.get_session("valid") is None
+        assert db.get_session("invalid") is None
+    finally:
+        db.close()


### PR DESCRIPTION
## What does this PR do?
Preserve `title_source` when importing an exported session. Export already includes the field, but import drops it, leaving SQL NULL. NULL intentionally ranks like a legacy user title, so an imported **derived** title can no longer be upgraded by the automatic LLM titler.

The fix carries provenance through the existing typed validation, parameter payload and INSERT statement. Missing/NULL provenance retains legacy user-title protection; malformed provenance is rejected before any rows are imported. No schema migration or export format change is needed.

## Related Issue / duplicate check
No matching issue found. Compared the original provenance work (#81985), import validation (#63956), metadata round-trip work (#76206), and session repair/restore work (#86743); this is specifically the dropped import `title_source` field, not those changes.

## Type of Change
- [x] Bug fix (non-breaking)

## Changes Made
- `hermes_state_portability.py`: validate and persist `title_source` using the existing provenance ranks.
- `tests/test_session_import_title_provenance.py`: exercise real `SessionDB` export/import between temporary SQLite files, title-upgrade behavior, legacy exports, and atomic rejection of invalid provenance.

## How to Test
Baseline: `1e69c12b64dba4090eddffeae27f5a147068d34b`.

```bash
scripts/run_tests.sh tests/test_session_import_title_provenance.py
scripts/run_tests.sh tests/test_session_import_title_provenance.py tests/test_hermes_state.py tests/hermes_state/test_canonical_title_guard.py tests/agent/test_title_generator.py
```

- Reproduction: create a session, `set_auto_title(..., source="derived")`, export it, import into a second database, then try `set_auto_title(..., source="llm")`. Baseline refuses the upgrade; this patch allows it. LLM/user titles and pre-provenance exports remain protected.
- Final added tests on unchanged production baseline: **5 failed, 1 passed**. Patched: **6 passed**.
- Broader targeted run: **309 passed, 1 failed**. Unchanged baseline: **303 passed, the same 1 failed**. The shared pre-existing failure is `tests/test_hermes_state.py::TestFTS5Search::test_search_projection_skips_context_enrichment_queries` (context-query trace-count assertion). No new failures; this is **not** a claim that the full suite is green.
- Test boundary: real SQLite and public SessionDB APIs; no live model, messaging, or gateway E2E run.

## Checklist
- [x] Read CONTRIBUTING.md and applicable AGENTS.md guidance.
- [x] Searched open/closed issues and PRs by symptom and affected symbols; inspected related diffs.
- [x] Conventional commit; only this fix and its regression tests.
- [x] Added focused behavioral tests (two test functions, parametrized over compatibility/validation boundaries).
- [x] Tested on macOS with Python 3.11 using the canonical isolated runner.
- [x] `git diff --check`; independent code-only review and added-line privacy/security scan.
- [ ] Full repository test suite passes — not claimed; targeted results and limitations are stated above.
- [x] Documentation/config/schema changes: N/A, except the clarified helper docstring where relevant.
- [x] Cross-platform impact considered; no platform-specific production APIs added. Windows/Linux not executed here.

AI-assisted contribution; the reproduction and regression results below were executed locally, not inferred from static review. No production credentials or profile/session data were used.
