### PR TITLE
fix(agent): hydrate todo_list results from history

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1060,10 +1060,11 @@ class AIAgent(
 
     @classmethod
     def _assistant_has_todo_tool_call(cls, assistant_msg: Dict[str, Any], tool_call_id: str) -> bool:
-        """True when the assistant message issued a ``todo`` call with this id."""
+        """True for a ``todo_list`` (or legacy ``todo``) call with this id."""
         tool_calls = assistant_msg.get("tool_calls")
         return isinstance(tool_calls, list) and any(
-            cls._get_tool_call_id_static(tc) == tool_call_id and cls._get_tool_call_name_static(tc) == "todo"
+            cls._get_tool_call_id_static(tc) == tool_call_id
+            and cls._get_tool_call_name_static(tc) in ("todo_list", "todo")
             for tc in tool_calls
         )
 

--- a/tests/run_agent/test_todo_history_tool_names.py
+++ b/tests/run_agent/test_todo_history_tool_names.py
@@ -1,0 +1,82 @@
+"""Current and legacy todo calls must survive paired history hydration."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from hermes_constants import get_hermes_home
+from run_agent import AIAgent
+from tools.todo_tool import TODO_SCHEMA, TodoStore
+
+
+@pytest.fixture
+def agent():
+    (get_hermes_home() / "config.yaml").write_text(
+        "model:\n  default: test-model\n  provider: custom\n"
+        "  base_url: http://localhost:9/v1\n  context_length: 128000\n",
+        encoding="utf-8",
+    )
+    # Keep client/discovery offline; dispatch, TodoStore and hydration are real.
+    with (
+        patch("model_tools.get_tool_definitions", return_value=[
+            {"type": "function", "function": TODO_SCHEMA}
+        ]),
+        patch("model_tools.check_toolset_requirements", return_value={}),
+        patch("agent.process_bootstrap.OpenAI"),
+    ):
+        instance = AIAgent(
+            api_key="test", provider="custom", model="test-model",
+            base_url="http://localhost:9/v1", quiet_mode=True,
+            skip_context_files=True, skip_memory=True,
+        )
+        try:
+            yield instance
+        finally:
+            instance.close()
+
+
+@pytest.mark.parametrize("tool_name", [TODO_SCHEMA["name"], "todo"])
+def test_dispatched_todo_snapshot_survives_history_hydration(agent, tool_name):
+    todos = [{"id": "verify", "content": "Verify the change", "status": "in_progress"}]
+    result = agent._invoke_tool(TODO_SCHEMA["name"], {"todos": todos}, "test-task")
+    snapshot = agent._todo_store.snapshot()
+    assert snapshot["todos"] == todos
+    history = [
+        {"role": "assistant", "content": None, "tool_calls": [{
+            "id": "todo-call", "type": "function",
+            "function": {"name": tool_name, "arguments": json.dumps({"todos": todos})},
+        }]},
+        {"role": "tool", "tool_call_id": "todo-call", "content": result},
+    ]
+    # New agent per gateway message starts with an empty store.
+    agent._todo_store = TodoStore()
+    agent._hydrate_todo_store(history)
+    assert agent._todo_store.snapshot() == snapshot
+    injection = agent._todo_store.format_for_injection()
+    assert injection is not None and todos[0]["content"] in injection
+
+
+@pytest.mark.parametrize("break_pair", ["wrong_id", "wrong_tool", "missing_call", "user", "system"])
+def test_todo_snapshot_requires_matching_uninterrupted_call(agent, break_pair):
+    todos = [{"id": "verify", "content": "Verify the change", "status": "pending"}]
+    result = agent._invoke_tool(TODO_SCHEMA["name"], {"todos": todos}, "test-task")
+    history = [
+        {"role": "assistant", "tool_calls": [{
+            "id": "todo-call", "type": "function",
+            "function": {"name": TODO_SCHEMA["name"], "arguments": "{}"},
+        }]},
+        {"role": "tool", "tool_call_id": "todo-call", "content": result},
+    ]
+    if break_pair == "wrong_id":
+        history[-1]["tool_call_id"] = "other-call"
+    elif break_pair == "wrong_tool":
+        history[0]["tool_calls"][0]["function"]["name"] = "not_todo_list"
+    elif break_pair == "missing_call":
+        history.pop(0)
+    else:
+        history.insert(1, {"role": break_pair, "content": "new boundary"})
+    agent._todo_store = TodoStore()
+    agent._hydrate_todo_store(history)
+    assert agent._todo_store.snapshot() == {"todos": [], "revision": 0}
+    assert agent._todo_store.format_for_injection() is None


### PR DESCRIPTION
## What does this PR do?
Restore task snapshots from history for the currently advertised `todo_list` tool name while keeping the historical `todo` name compatible.

`_assistant_has_todo_tool_call` still only recognizes `todo`. A real `todo_list` dispatch produces a valid snapshot, but `_hydrate_todo_store` rejects its paired history result. A fresh agent therefore loses its pending/in-progress todo context on the next restored turn.

The change only broadens the exact accepted names. Call-ID matching, nearest-assistant matching, intervening user/system boundaries, size bounds and revision checks are unchanged.

## Related Issue / duplicate check
No matching rename/hydration fix found. Compared #83652 (hydration timing), #25945 (completed-item filtering) and #99644 (durable todo persistence); none adds the current name to the paired-call predicate.

## Type of Change
- [x] Bug fix (non-breaking)

## Changes Made
- `run_agent.py`: accept exactly `todo_list` or legacy `todo` in the existing paired-call predicate.
- `tests/run_agent/test_todo_history_tool_names.py`: create an agent with mocked client/discovery only; dispatch the real tool, reset its real TodoStore, replay paired history, and check both the restored snapshot and prompt injection. Reject wrong IDs/names, missing calls and user/system boundaries.

## How to Test
Baseline: `1e69c12b64dba4090eddffeae27f5a147068d34b`.

```bash
scripts/run_tests.sh tests/run_agent/test_todo_history_tool_names.py
scripts/run_tests.sh tests/run_agent/test_todo_history_tool_names.py tests/run_agent/test_run_agent.py tests/tools/test_todo_tool.py tests/tools/test_todo_nested.py tests/tools/test_todo_tool_type_coercion.py -k todo
```

- Added tests on unchanged production baseline: **1 failed, 6 passed**. Only the actual advertised `todo_list` hydration case fails; legacy and rejection cases pass.
- Patched todo-focused related run: **52 passed**; unchanged baseline without the added file: **45 passed**.
- Broader run of the same files **without `-k todo`**: **329 passed, 1 failed**; unchanged baseline: **322 passed, the same 1 failed**. Shared failure: `tests/run_agent/test_run_agent.py::TestAnthropicInterruptHandler::test_interruptible_anthropic_interrupt_never_closes_shared_client`. Both runs also emit the existing `_BarrierDB.flush_token_counts` thread warning. No new failures; not a full-suite-green claim.
- Test boundary: real imported agent dispatch, real TodoStore and hydration with mocked client/discovery, not a live gateway/model E2E run. The legacy-history fixture reuses a real current-tool result; it does not claim `_invoke_tool("todo", ...)` supports legacy dispatch.

## Checklist
- [x] Read CONTRIBUTING.md and applicable AGENTS.md guidance.
- [x] Searched open/closed issues and PRs by symptom and affected symbols; inspected related diffs.
- [x] Conventional commit; only this fix and its regression tests.
- [x] Added focused behavioral tests (two test functions, parametrized over compatibility/validation boundaries).
- [x] Tested on macOS with Python 3.11 using the canonical isolated runner.
- [x] `git diff --check`; independent code-only review and added-line privacy/security scan.
- [ ] Full repository test suite passes — not claimed; targeted results and limitations are stated above.
- [x] Documentation/config/schema changes: N/A, except the clarified helper docstring where relevant.
- [x] Cross-platform impact considered; no platform-specific production APIs added. Windows/Linux not executed here.

AI-assisted contribution; the reproduction and regression results below were executed locally, not inferred from static review. No production credentials or profile/session data were used.
