### PR TITLE
feat(photon): conversational iMessage turns and approvals (salvage #103335)

### DIFF
--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -186,6 +186,17 @@ def mark_failed(obligation_id: str, error: str = "") -> None:
     _update_state(obligation_id, "failed", error=error)
 
 
+def mark_failed_with_content(obligation_id: str, content: str, error: str = "") -> None:
+    """Mark a partial delivery failed while retaining only the owed suffix."""
+    with _DB_LOCK, _transaction() as conn:
+        conn.execute(
+            """UPDATE delivery_obligations
+               SET content=?, state='failed', updated_at=?, last_error=?
+               WHERE obligation_id=?""",
+            (content, time.time(), error[:500] if error else None, obligation_id),
+        )
+
+
 def release_runtime_claim(obligation_id: str, error: str = "") -> bool:
     """Return an unsent runtime claim to ``failed`` without spending an attempt.
 

--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -186,15 +186,16 @@ def mark_failed(obligation_id: str, error: str = "") -> None:
     _update_state(obligation_id, "failed", error=error)
 
 
-def mark_failed_with_content(obligation_id: str, content: str, error: str = "") -> None:
-    """Mark a partial delivery failed while retaining only the owed suffix."""
-    with _DB_LOCK, _transaction() as conn:
-        conn.execute(
-            """UPDATE delivery_obligations
-               SET content=?, state='failed', updated_at=?, last_error=?
-               WHERE obligation_id=?""",
-            (content, time.time(), error[:500] if error else None, obligation_id),
-        )
+def mark_failed_from_result(obligation_id: str, result: Any, error: str = "") -> None:
+    """Mark failed; when the adapter delivered a prefix and reports the owed tail as
+    ``raw_response["undelivered_content"]`` (multi-bubble sends), keep only that tail so a
+    later redelivery cannot re-send what already landed."""
+    raw = getattr(result, "raw_response", None)
+    undelivered = raw.get("undelivered_content") if isinstance(raw, dict) else None
+    if isinstance(undelivered, str) and undelivered:
+        _update_state(obligation_id, "failed", error=error, content=undelivered)
+    else:
+        _update_state(obligation_id, "failed", error=error)
 
 
 def release_runtime_claim(obligation_id: str, error: str = "") -> bool:
@@ -218,13 +219,17 @@ def release_runtime_claim(obligation_id: str, error: str = "") -> bool:
     return bool(cursor.rowcount)
 
 
-def _update_state(obligation_id: str, state: str, error: str = "") -> None:
+def _update_state(obligation_id: str, state: str, error: str = "", content: Optional[str] = None) -> None:
+    set_content = ", content=?" if content is not None else ""
+    params = [state, time.time(), error[:500] if error else None]
+    if content is not None:
+        params.append(content)
     with _DB_LOCK, _transaction() as conn:
         conn.execute(
-            """UPDATE delivery_obligations
-               SET state=?, updated_at=?, last_error=?
+            f"""UPDATE delivery_obligations
+               SET state=?, updated_at=?, last_error=?{set_content}
                WHERE obligation_id=?""",
-            (state, time.time(), error[:500] if error else None, obligation_id))
+            (*params, obligation_id))
 
 
 def _claimed_row(oid, session_key, platform, chat_id, thread_id, content, attempts, profile, *,

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -60,7 +60,10 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     "signal": _TIER_LOW,
     "whatsapp": _TIER_MEDIUM,  # Baileys bridge supports /edit
     "whatsapp_cloud": _TIER_LOW,  # adapter lacks edit_message; promote once it lands
-    "photon": _TIER_LOW,  # permanent-message iMessage inboxes (no edit)
+    # iMessage is a conversational inbox: send the model's completed mid-turn
+    # commentary as separate bubbles instead of leaving the user at "typing..."
+    # until the full turn ends. Token streaming and operational chatter stay off.
+    "photon": {**_TIER_LOW, "interim_assistant_messages": True},
     "bluebubbles": _TIER_LOW,
     "weixin": _TIER_LOW,
     # Non-editable, but its native "stream" msgtype gives a typing animation + cumulative updates.

--- a/gateway/plaintext_approval.py
+++ b/gateway/plaintext_approval.py
@@ -1,0 +1,166 @@
+"""Conversational approval replies for plaintext messaging surfaces.
+
+On iMessage/SMS-style platforms there are no buttons and typing ``/approve`` reads
+like operating a machine, so a pending approval must also accept the way a person
+actually answers: "sure, go ahead", "yes please", "don't do that".
+
+Matching is deliberately **whole-message and table-driven**, never substring:
+
+* Substring matching is unsafe here. "no, don't go ahead" contains "go ahead",
+  and a substring matcher would approve a refusal. Requiring the entire
+  normalized message to equal a known phrase makes that class impossible.
+* No LLM is involved. The decision to execute a flagged command must stay
+  deterministic and auditable; a model must never be the thing that decides an
+  approval was granted.
+* Anything that does not match exactly returns ``None`` and falls through to
+  normal busy handling, so the approval keeps blocking (fail-safe) instead of
+  being resolved on a guess.
+
+The caller is responsible for the security gate: these phrases may only be
+consulted while ``tools.approval.has_blocking_approval(session_key)`` is true,
+so a conversational "sure" in ordinary chat can never fire a command.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import Dict, Optional, Tuple
+
+# (verb, args) for the synthesized slash command, matching the /approve and /deny
+# handlers' own argument grammar.
+_APPROVE_ONCE = ("approve", "")
+_APPROVE_SESSION = ("approve", "session")
+_APPROVE_ALWAYS = ("approve", "always")
+_DENY = ("deny", "")
+
+#: Whole-message phrases → (verb, args). Keys MUST be pre-normalized (lowercase,
+#: no punctuation, single-spaced) — :func:`_normalize` output is matched against
+#: them directly. Add only unambiguous answers; anything conditional
+#: ("yes but not the second one") must fall through to a human-readable re-ask.
+_PHRASES: Dict[str, Tuple[str, str]] = {
+    # -- affirmative, one operation ------------------------------------------
+    **dict.fromkeys(
+        (
+            "approve", "approved", "yes", "y", "ya", "yah", "yeah", "yep", "yup",
+            "ok", "okay", "k", "kk", "sure", "confirm", "confirmed", "affirmative",
+            "go", "go ahead", "goahead", "go for it", "do it", "just do it",
+            "please do", "please do it", "do it please", "yes do it",
+            "yes please", "please yes", "sure go ahead", "sure do it",
+            "ok go ahead", "okay go ahead", "yes go ahead", "yeah go ahead",
+            "yep go ahead", "go ahead please", "please go ahead",
+            "sounds good", "looks good", "fine", "thats fine", "that is fine",
+            "fine by me", "approve it", "approve that", "allow it", "permitted",
+            "you can", "you may", "you can do it", "green light", "proceed",
+            "carry on", "continue", "send it", "run it", "lgtm",
+        ),
+        _APPROVE_ONCE,
+    ),
+    # -- affirmative, remainder of the session --------------------------------
+    **dict.fromkeys(
+        (
+            "session", "approve session", "session approve",
+            "approve for this session", "approve for the session",
+            "yes for this session", "for this session",
+            "approve this session", "ok for this session",
+        ),
+        _APPROVE_SESSION,
+    ),
+    # -- affirmative, permanently -------------------------------------------
+    **dict.fromkeys(
+        (
+            "always", "always approve", "approve always", "always allow",
+            "allow always", "approve permanently", "permanently",
+            "yes always", "always yes", "dont ask again", "do not ask again",
+            "stop asking", "stop asking me", "always do this",
+        ),
+        _APPROVE_ALWAYS,
+    ),
+    # -- refusal -------------------------------------------------------------
+    **dict.fromkeys(
+        (
+            "deny", "denied", "no", "n", "nope", "nah", "negative",
+            "reject", "cancel", "cancel that", "cancel it", "abort", "stop",
+            "dont", "do not", "dont do it", "do not do it", "dont do that",
+            "do not do that", "dont run it", "do not run it", "no dont",
+            "no do not", "no dont do it", "no do not do it", "no dont do that",
+            "no do not do that", "no thanks", "no thank you", "not now",
+            "hold off", "hold on", "skip it", "skip that", "leave it",
+            "never mind", "nevermind", "forget it", "dont bother",
+            "do not bother", "no way", "denied for now", "not this time",
+            "no go", "dont approve", "do not approve",
+            # Compound refusals: a "no" prefix in front of an affirmative phrase is
+            # still a refusal. These must be enumerated because whole-message
+            # matching (deliberately) will not see the "no" in a substring pass.
+            "no dont go ahead", "no do not go ahead",
+            "no dont run it", "no do not run it",
+            "no dont approve", "no do not approve",
+            "no dont send it", "no do not send it",
+            "no dont proceed", "no do not proceed",
+            "dont go ahead", "do not go ahead",
+            "dont send it", "do not send it",
+            "dont proceed", "do not proceed",
+            "dont cancel", "do not cancel",
+            "no dont bother", "no do not bother",
+        ),
+        _DENY,
+    ),
+}
+
+# Tapback emoji carry the same intent as a one-word reply on iMessage.
+_EMOJI_PHRASES: Dict[str, Tuple[str, str]] = {
+    "\U0001f44d": _APPROVE_ONCE,   # 👍
+    "\u2705": _APPROVE_ONCE,       # ✅
+    "\U0001f44c": _APPROVE_ONCE,   # 👌
+    "\U0001f44e": _DENY,           # 👎
+    "\u274c": _DENY,               # ❌
+    "\U0001f6d1": _DENY,           # 🛑
+}
+
+# Longest phrase in the table; a message with more words cannot be a bare answer
+# and is left to normal handling rather than approximately matched.
+_MAX_PHRASE_WORDS = max(len(phrase.split()) for phrase in _PHRASES)
+
+# Punctuation and symbols are dropped before matching so "Sure!", "yes." and
+# "ok :)" all reduce to their bare phrase. Word characters and spaces survive.
+_STRIP_RE = re.compile(r"[^\w\s]", flags=re.UNICODE)
+_WS_RE = re.compile(r"\s+")
+
+
+def _normalize(text: str) -> str:
+    """Reduce a reply to a bare comparison key.
+
+    NFKC first so iOS smart punctuation folds (the curly apostrophe in "don't"
+    would otherwise survive as a distinct character and miss the table), then
+    strip punctuation/emoji, lowercase, and collapse whitespace.
+    """
+    folded = unicodedata.normalize("NFKC", text or "").replace("\u2019", "'").replace("\u02bc", "'")
+    folded = folded.replace("'", "")  # dont == don't, after the curly fold above
+    return _WS_RE.sub(" ", _STRIP_RE.sub(" ", folded)).strip().lower()
+
+
+def match_conversational_approval(text: str) -> Optional[Tuple[str, str]]:
+    """Map a plaintext reply to ``(verb, args)``, or ``None`` when it is not a
+    clean answer.
+
+    ``None`` is the safe outcome: the caller leaves the approval pending and the
+    user can answer again. Only an exact whole-message match resolves it.
+    """
+    raw = (text or "").strip()
+    if not raw:
+        return None
+    # A bare tapback/emoji reply, before punctuation stripping removes it.
+    if emoji_match := _EMOJI_PHRASES.get(raw):
+        return emoji_match
+    normalized = _normalize(raw)
+    if not normalized:
+        return None
+    # A question is a question, not an answer ("are you sure?" must not approve).
+    if "?" in raw:
+        return None
+    if len(normalized.split()) > _MAX_PHRASE_WORDS:
+        return None
+    return _PHRASES.get(normalized)
+
+
+__all__ = ["match_conversational_approval"]

--- a/gateway/plaintext_approval.py
+++ b/gateway/plaintext_approval.py
@@ -79,13 +79,17 @@ _PHRASES: Dict[str, Tuple[str, str]] = {
     # -- refusal -------------------------------------------------------------
     **dict.fromkeys(
         (
+            # "stop" / "abort" / "hold on" are deliberately absent: while an approval
+            # blocks they most likely mean "stop the agent", which the busy path already
+            # handles (interrupt / steer); denying just this one command would leave
+            # the turn running.
             "deny", "denied", "no", "n", "nope", "nah", "negative",
-            "reject", "cancel", "cancel that", "cancel it", "abort", "stop",
+            "reject", "cancel", "cancel that", "cancel it",
             "dont", "do not", "dont do it", "do not do it", "dont do that",
             "do not do that", "dont run it", "do not run it", "no dont",
             "no do not", "no dont do it", "no do not do it", "no dont do that",
             "no do not do that", "no thanks", "no thank you", "not now",
-            "hold off", "hold on", "skip it", "skip that", "leave it",
+            "hold off", "skip it", "skip that", "leave it",
             "never mind", "nevermind", "forget it", "dont bother",
             "do not bother", "no way", "denied for now", "not this time",
             "no go", "dont approve", "do not approve",

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3654,17 +3654,12 @@ class BasePlatformAdapter(ABC):
         replacement adapter live, trigger another redelivery sweep (the watcher's may have run
         before this failure landed; atomic claiming keeps it idempotent)."""
         try:
-            from gateway.delivery_ledger import mark_delivered, mark_failed, mark_failed_with_content
+            from gateway.delivery_ledger import mark_delivered, mark_failed_from_result
             if getattr(result, "success", False):
                 await asyncio.to_thread(mark_delivered, obligation_id)
                 return
             error = str(getattr(result, "error", "") or "")
-            raw = getattr(result, "raw_response", None)
-            undelivered = raw.get("undelivered_content") if isinstance(raw, dict) else None
-            if isinstance(undelivered, str) and undelivered:
-                await asyncio.to_thread(mark_failed_with_content, obligation_id, undelivered, error)
-            else:
-                await asyncio.to_thread(mark_failed, obligation_id, error)
+            await asyncio.to_thread(mark_failed_from_result, obligation_id, result, error)
             if error == "send_path_degraded":
                 redeliver = getattr(
                     self.gateway_runner, "_redeliver_failed_obligations_for_platform", None)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1839,6 +1839,12 @@ class BasePlatformAdapter(ABC):
     splits_long_messages: bool = False
     # Prefix users can always TYPE for Hermes commands ("!" where the client eats a leading "/").
     typed_command_prefix: str = "/"
+    # Button-less conversational surface (iMessage, SMS): approval prompts are worded in plain
+    # language ("reply yes") instead of advertising `/approve`, because a slash command reads as
+    # operating a machine in a text thread. The slash forms keep working either way — this only
+    # changes what we TELL the user to send. Adapters with interactive buttons leave this False and
+    # never reach the text fallback. Read generically via getattr() at the call site.
+    conversational_approval: bool = False
     # ``in_channel`` continuable-cron surface: job delivered FLAT, plain replies continue it via
     # the whole-channel bucket ``(platform, chat_id, None)``; needs a flat-reply outbound gate too
     # (Slack ``reply_in_thread: false``). False fails SAFE -> ``thread``.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3648,12 +3648,17 @@ class BasePlatformAdapter(ABC):
         replacement adapter live, trigger another redelivery sweep (the watcher's may have run
         before this failure landed; atomic claiming keeps it idempotent)."""
         try:
-            from gateway.delivery_ledger import mark_delivered, mark_failed
+            from gateway.delivery_ledger import mark_delivered, mark_failed, mark_failed_with_content
             if getattr(result, "success", False):
                 await asyncio.to_thread(mark_delivered, obligation_id)
                 return
             error = str(getattr(result, "error", "") or "")
-            await asyncio.to_thread(mark_failed, obligation_id, error)
+            raw = getattr(result, "raw_response", None)
+            undelivered = raw.get("undelivered_content") if isinstance(raw, dict) else None
+            if isinstance(undelivered, str) and undelivered:
+                await asyncio.to_thread(mark_failed_with_content, obligation_id, undelivered, error)
+            else:
+                await asyncio.to_thread(mark_failed, obligation_id, error)
             if error == "send_path_degraded":
                 redeliver = getattr(
                     self.gateway_runner, "_redeliver_failed_obligations_for_platform", None)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4103,6 +4103,13 @@ class BasePlatformAdapter(ABC):
         MarkdownV2); default returns content as-is."""
         return content
 
+    def fit_bubbles(self, bubbles: List[str]) -> List[str]:
+        """Per-message iMessage-style delivery: each bubble is one message, so only a bubble
+        that is itself over ``MAX_MESSAGE_LENGTH`` gets split (fence-aware), never merged."""
+        return [chunk for bubble in bubbles for chunk in (
+            [bubble] if len(bubble) <= self.MAX_MESSAGE_LENGTH
+            else self.truncate_message(bubble, self.MAX_MESSAGE_LENGTH))]
+
     @staticmethod
     def truncate_message(content: str, max_length: int = 4096,
                          len_fn: Optional["Callable[[str], int]"] = None) -> List[str]:

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -22,7 +22,7 @@ from gateway.platforms.base import (
     BasePlatformAdapter, MessageEvent, MessageType, SendResult,
     cache_image_from_bytes_async, cache_audio_from_bytes_async, cache_document_from_bytes_async)
 from .media_cache import ext_for_mime
-from gateway.platforms.helpers import compile_mention_patterns, strip_markdown
+from gateway.platforms.helpers import compile_mention_patterns, split_markdown_paragraphs, strip_markdown
 from utils import TRUTHY_STRINGS
 
 # Historical BlueBubbles mime→ext maps, preserved verbatim as overrides for the shared dispatch in
@@ -361,7 +361,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if not text:
             return SendResult(success=False, error="BlueBubbles send requires text")
         # Each paragraph becomes its own iMessage bubble; truncate any still too long.
-        paragraphs = [p.strip() for p in re.split(r'\n\s*\n', text) if p.strip()] or [text]
+        paragraphs = split_markdown_paragraphs(text) or [text]
         chunks = [c for para in paragraphs for c in (
             [para] if len(para) <= self.MAX_MESSAGE_LENGTH else self.truncate_message(para, self.MAX_MESSAGE_LENGTH))]
         last = SendResult(success=True)

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -110,6 +110,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     SUPPORTS_MESSAGE_EDITING = False
     MAX_MESSAGE_LENGTH = MAX_TEXT_LENGTH
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
+    conversational_approval = True  # iMessage: ask "reply yes", not "/approve"
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.BLUEBUBBLES)

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -362,9 +362,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if not text:
             return SendResult(success=False, error="BlueBubbles send requires text")
         # Each paragraph becomes its own iMessage bubble; truncate any still too long.
-        paragraphs = split_markdown_paragraphs(text) or [text]
-        chunks = [c for para in paragraphs for c in (
-            [para] if len(para) <= self.MAX_MESSAGE_LENGTH else self.truncate_message(para, self.MAX_MESSAGE_LENGTH))]
+        chunks = self.fit_bubbles(split_markdown_paragraphs(text) or [text])
         last = SendResult(success=True)
         for chunk in chunks:
             guid = await self._resolve_chat_guid(chat_id)

--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -346,6 +346,35 @@ def split_markdown_atoms(text: str) -> "list[str]":
     return atoms
 
 
+def split_markdown_paragraphs(text: str) -> "list[str]":
+    """Split on blank lines outside fenced code blocks.
+
+    Unlike :func:`split_markdown_atoms`, adjacent prose, fences, and tables stay
+    together unless the source contains an actual blank-line boundary.
+    """
+    paragraphs: "list[str]" = []
+    current_lines: "list[str]" = []
+    in_fence = False
+
+    def _flush_current() -> None:
+        paragraph = "\n".join(current_lines).strip()
+        if paragraph:
+            paragraphs.append(paragraph)
+        current_lines.clear()
+
+    for line in text.split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            current_lines.append(line)
+        elif not stripped and not in_fence:
+            _flush_current()
+        else:
+            current_lines.append(line)
+    _flush_current()
+    return paragraphs
+
+
 def infer_block_separator(prev_chunk: str, next_chunk: str) -> str:
     """``'\\n'`` when the boundary sits at a code fence or a continued table, else ``'\\n\\n'``."""
     prev_trimmed = prev_chunk.rstrip()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -583,9 +583,29 @@ def _redact_approval_command(cmd: "str | None") -> str:
 
 def _format_exec_approval_fallback(
     command: str, description: str, command_prefix: str, *, allow_permanent: bool = True,
-    allow_session: bool = True, smart_denied: bool = False) -> str:
-    """Render the text fallback from approval capabilities, not platform names."""
+    allow_session: bool = True, smart_denied: bool = False, conversational: bool = False) -> str:
+    """Render the text fallback from approval capabilities, not platform names.
+
+    ``conversational=True`` (button-less texting surfaces like iMessage, set from the
+    adapter's ``conversational_approval`` flag) asks in plain language instead of
+    advertising slash commands: on those platforms the user answers "yes" / "no" and
+    ``gateway.plaintext_approval`` resolves it. The slash forms still work — they are
+    simply not what we tell a person to type in a text message.
+    """
     cmd_preview = command[:200] + "..." if len(command) > 200 else command
+    if conversational:
+        heading = ("⚠️ I was blocked from doing this automatically. Want me to run it anyway?"
+                   if smart_denied else "⚠️ This needs your OK first:")
+        choices = ['Reply "yes" to do it this once']
+        if not smart_denied and allow_session:
+            choices.append('"for this session" to stop asking until we\'re done')
+            if allow_permanent:
+                choices.append('"always" to stop asking entirely')
+        choices.append('"no" to skip it')
+        return (
+            f"{heading}\n```\n{cmd_preview}\n```\nWhy: {description}\n\n"
+            + ", ".join(choices[:-1]) + f", or {choices[-1]}.")
+
     heading = ("⚠️ **Smart DENY — owner override for one operation:**" if smart_denied
                else "⚠️ **Dangerous command requires approval:**")
 

--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -367,15 +367,12 @@ class GatewayBusySessionMixin:
         await self._send_busy_reply(event, adapter, message)
 
     # Bare-word approval replies → (verb, args) for the synthesized slash command.
-    _PLAINTEXT_APPROVAL_WORDS: Dict[str, tuple] = {
-        **{w: ("approve", "") for w in ("approve", "yes", "ok", "okay", "confirm", "y", "👍")},
-        **{w: ("deny", "") for w in ("deny", "no", "reject", "cancel", "n", "👎")},
-        **{w: ("approve", "always") for w in ("always", "approve always", "always approve")},
-        **{w: ("approve", "session") for w in ("session", "approve session", "session approve")},
-    }
+    # Table + normalization live in gateway/plaintext_approval.py so the matcher can be
+    # unit-tested without a runner, and so the phrase set is one auditable list.
 
     async def _route_plaintext_approval_while_busy(self, event: MessageEvent, session_key: str) -> bool:
-        """Route a bare "yes"/"no" to the approval handlers while a dangerous-command approval blocks.
+        """Route a conversational "sure, go ahead" / "no" to the approval handlers while a
+        dangerous-command approval blocks.
 
         Returns True when the message was consumed as an approval response.
         """
@@ -384,11 +381,12 @@ class GatewayBusySessionMixin:
         # has_blocking_approval so a conversational "yes" never fires a command.
         try:
             from tools.approval import has_blocking_approval
+            from gateway.plaintext_approval import match_conversational_approval
             # --- Approval response routing (#46866) --- When the agent is blocked waiting for a
             # dangerous-command approval, plain-text responses like "yes" or "approve" must be routed to the
             # approval handler instead of being steered/queued/interrupted. Slash forms (/approve, /deny)
-            # already bypass to the runner at the base-adapter guard. This handles the bare-word forms
-            # (Signal/SMS users naturally type "yes" rather than "/approve"). Gating on
+            # already bypass to the runner at the base-adapter guard. This handles the conversational forms
+            # (iMessage/Signal/SMS users type "sure, go ahead", not "/approve"). Gating on
             # has_blocking_approval(session_key) is the disambiguator that keeps a conversational "yes" from
             # triggering a dangerous command when no approval is actually pending (design intent — see
             # run.py "Pending exec approvals are handled by /approve and /deny" note). We reuse the
@@ -397,8 +395,7 @@ class GatewayBusySessionMixin:
             # The busy-handler path does not auto-send that return, so we deliver it ourselves (mirroring
             # the draining-case send above).
             if event.allow_gateway_control and has_blocking_approval(session_key):
-                _raw_text = (event.text or "").strip().lower()
-                _match = self._PLAINTEXT_APPROVAL_WORDS.get(_raw_text)
+                _match = match_conversational_approval(event.text or "")
                 if _match is not None:
                     _verb, _normalized_args = _match
                     _approval_handler = (

--- a/gateway/run_startup.py
+++ b/gateway/run_startup.py
@@ -306,7 +306,8 @@ class GatewayStartupMixin:
         if not claimed:
             return 0
         try:
-            from gateway.delivery_ledger import RECOVERED_MARKER, mark_delivered, mark_failed
+            from gateway.delivery_ledger import (
+                RECOVERED_MARKER, mark_delivered, mark_failed, mark_failed_with_content)
         except Exception:
             logger.debug("delivery ledger import failed", exc_info=True)
             return 0
@@ -333,9 +334,14 @@ class GatewayStartupMixin:
                         row["platform"], row["chat_id"], row["obligation_id"], row["attempts"],
                     )
                 else:
-                    await asyncio.to_thread(
-                        mark_failed, row["obligation_id"], str(getattr(result, "error", "") or "send failed")
-                    )
+                    error = str(getattr(result, "error", "") or "send failed")
+                    raw = getattr(result, "raw_response", None)
+                    undelivered = raw.get("undelivered_content") if isinstance(raw, dict) else None
+                    if isinstance(undelivered, str) and undelivered:
+                        await asyncio.to_thread(
+                            mark_failed_with_content, row["obligation_id"], undelivered, error)
+                    else:
+                        await asyncio.to_thread(mark_failed, row["obligation_id"], error)
         return redelivered
 
     async def _obligation_adapter(self, row: dict):

--- a/gateway/run_startup.py
+++ b/gateway/run_startup.py
@@ -306,8 +306,7 @@ class GatewayStartupMixin:
         if not claimed:
             return 0
         try:
-            from gateway.delivery_ledger import (
-                RECOVERED_MARKER, mark_delivered, mark_failed, mark_failed_with_content)
+            from gateway.delivery_ledger import RECOVERED_MARKER, mark_delivered, mark_failed_from_result
         except Exception:
             logger.debug("delivery ledger import failed", exc_info=True)
             return 0
@@ -334,14 +333,9 @@ class GatewayStartupMixin:
                         row["platform"], row["chat_id"], row["obligation_id"], row["attempts"],
                     )
                 else:
-                    error = str(getattr(result, "error", "") or "send failed")
-                    raw = getattr(result, "raw_response", None)
-                    undelivered = raw.get("undelivered_content") if isinstance(raw, dict) else None
-                    if isinstance(undelivered, str) and undelivered:
-                        await asyncio.to_thread(
-                            mark_failed_with_content, row["obligation_id"], undelivered, error)
-                    else:
-                        await asyncio.to_thread(mark_failed, row["obligation_id"], error)
+                    await asyncio.to_thread(
+                        mark_failed_from_result, row["obligation_id"], result,
+                        str(getattr(result, "error", "") or "send failed"))
         return redelivered
 
     async def _obligation_adapter(self, row: dict):

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2345,15 +2345,21 @@ class GatewayTurnMixin:
         if source.platform == Platform.TELEGRAM and hasattr(adapter, "pause_typing_for_chat"):
             def _pause_typing_before_finalize(_adapter=adapter, _chat_id=source.chat_id) -> None:
                 _adapter.pause_typing_for_chat(_chat_id)
-        # Non-editing platforms (QQ, WeChat) skip streaming — the partial first message could never
-        # be updated — unless they have a native-streaming transport (WeCom msgtype "stream").
+        # Non-editing platforms (QQ, WeChat) skip token streaming because the
+        # partial first message could never be updated. Completed commentary
+        # can still use this consumer in buffer-only mode to send distinct
+        # messages, while native-streaming transports (WeCom msgtype "stream")
+        # keep their normal streaming path.
         _adapter_supports_edit = getattr(adapter, "SUPPORTS_MESSAGE_EDITING", True)
         _adapter_supports_native_stream = bool(getattr(adapter, "SUPPORTS_NATIVE_STREAMING", False))
-        if not _adapter_supports_edit and not _adapter_supports_native_stream and on_missing_cursor == "raise":
-            raise RuntimeError("skip streaming for non-editable platform")
+        _buffer_only = False
+        if not _adapter_supports_edit and not _adapter_supports_native_stream:
+            if on_missing_cursor == "raise":
+                raise RuntimeError("skip streaming for non-editable platform")
+            _buffer_only = True
         _effective_cursor = scfg.cursor if _adapter_supports_edit else ""
         # Some Matrix clients render the cursor as tofu: stream text, no cursor.
-        _buffer_only = source.platform == Platform.MATRIX
+        _buffer_only = _buffer_only or source.platform == Platform.MATRIX
         if _buffer_only:
             _effective_cursor = ""
         # Fresh-final applies to Telegram only (others edit in place cheaply).

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -803,7 +803,8 @@ class TurnRunner:
                 adapter = self._runner._adapter_for_source(ctx.source)
                 if adapter:
                     consumer_cfg, pause_typing_before_finalize = self._runner._build_stream_consumer_config(
-                        ctx.source, scfg, adapter, on_missing_cursor="raise",
+                        ctx.source, scfg, adapter,
+                        on_missing_cursor="fallback" if want_interim_messages else "raise",
                     )
                     stream_consumer = GatewayStreamConsumer(
                         adapter=adapter, chat_id=ctx.source.chat_id, config=consumer_cfg,

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1275,8 +1275,12 @@ class TurnRunner:
             except Exception as e:
                 logger.warning("Button-based approval failed, falling back to text: %s", e)
         # Plain-text prompt with the adapter's typed prefix (e.g. `!approve`): typed "/" is blocked
-        # in Slack threads and reserved by Matrix clients.
-        msg = _format_exec_approval_fallback(cmd, desc, getattr(adapter, "typed_command_prefix", "/"), **flags)
+        # in Slack threads and reserved by Matrix clients. Button-less texting surfaces
+        # (``conversational_approval``) get plain-language wording instead of slash instructions;
+        # gateway.plaintext_approval resolves the "yes"/"no" reply.
+        msg = _format_exec_approval_fallback(
+            cmd, desc, getattr(adapter, "typed_command_prefix", "/"),
+            conversational=bool(getattr(adapter, "conversational_approval", False)), **flags)
         try:
             # Mark as approval prompt so WeCom routes through the control lane.
             metadata = {**(ctx._status_thread_metadata or {}), "is_approval_prompt": True}

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -190,6 +190,9 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
         self._fallback_prefix = ""
         # Fallback sends only the missing tail after a partial overflow delivery.
         self._fallback_preserve_partial_messages = False
+        # Exact undelivered tail reported by a splitting adapter (Photon bubbles); wins over
+        # prefix arithmetic in _continuation_text, consumed by the next fallback final.
+        self._fallback_tail_override = ""
         self._segment_preview_message_ids: "set[str]" = set()
         # Tool-progress overlay (native only): shown in the bubble until text arrives.
         self._tool_progress_lines: list[str] = []
@@ -754,6 +757,7 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
         if tick.got_segment_break:
             self._fallback_final_send = False
             self._fallback_prefix = ""
+            self._fallback_tail_override = ""
             if not self._accumulated:
                 return False
         # Early `continue` skips the bottom-of-loop flush signal.

--- a/gateway/stream_consumer_fallback.py
+++ b/gateway/stream_consumer_fallback.py
@@ -49,6 +49,9 @@ class StreamFallbackMixin:
 
     def _continuation_text(self, final_text: str) -> str:
         """Return only the part of final_text the user has not already seen."""
+        tail_override, self._fallback_tail_override = self._fallback_tail_override, ""
+        if tail_override:
+            return tail_override
         prefix = self._fallback_prefix or self._visible_prefix()
         if prefix and final_text.startswith(prefix):
             return final_text[len(prefix):].lstrip()

--- a/gateway/stream_consumer_transport.py
+++ b/gateway/stream_consumer_transport.py
@@ -421,6 +421,19 @@ class StreamTransportMixin:
             chat_id=self.chat_id, content=text, reply_to=self._initial_reply_to_id,
             metadata=self._metadata_for_send(final=finalize, expect_edits=not finalize))
         if not result.success:
+            raw_response = getattr(result, "raw_response", None)
+            if isinstance(raw_response, dict) and raw_response.get("partial_bubble_delivery"):
+                delivered_prefix = raw_response.get("delivered_prefix")
+                if isinstance(delivered_prefix, str) and delivered_prefix:
+                    self._last_sent_text = delivered_prefix
+                    self._fallback_preserve_partial_messages = True
+                    self._enter_fallback_mode(delivered_prefix)
+                last_message_id = (raw_response.get("last_message_id")
+                                   or getattr(result, "message_id", None))
+                if last_message_id:
+                    self._adopt_message_id(str(last_message_id))
+                else:
+                    self._message_id = "__no_edit__"
             self._edit_supported = False
             return False
         self._already_sent = True

--- a/gateway/stream_consumer_transport.py
+++ b/gateway/stream_consumer_transport.py
@@ -422,18 +422,8 @@ class StreamTransportMixin:
             metadata=self._metadata_for_send(final=finalize, expect_edits=not finalize))
         if not result.success:
             raw_response = getattr(result, "raw_response", None)
-            if isinstance(raw_response, dict) and raw_response.get("partial_bubble_delivery"):
-                delivered_prefix = raw_response.get("delivered_prefix")
-                if isinstance(delivered_prefix, str) and delivered_prefix:
-                    self._last_sent_text = delivered_prefix
-                    self._fallback_preserve_partial_messages = True
-                    self._enter_fallback_mode(delivered_prefix)
-                last_message_id = (raw_response.get("last_message_id")
-                                   or getattr(result, "message_id", None))
-                if last_message_id:
-                    self._adopt_message_id(str(last_message_id))
-                else:
-                    self._message_id = "__no_edit__"
+            if isinstance(raw_response, dict) and raw_response.get("partial_overflow"):
+                self._adopt_partial_delivery(result, raw_response, text=text)
             self._edit_supported = False
             return False
         self._already_sent = True
@@ -496,6 +486,38 @@ class StreamTransportMixin:
         self._edit_supported = False
         self._already_sent = True
 
+    def _adopt_partial_delivery(self, result, raw_response: dict, *, text: str) -> None:
+        """Some chunks/bubbles of ``text`` landed but not all: retarget at the last delivered
+        message and enter fallback so got_done sends only the missing tail.
+
+        Adapters that split the text before sending (Photon bubbles) also report the exact
+        ``undelivered_content``; that is authoritative, because splitting may normalize the
+        text (URL lines hoisted, blank runs collapsed, markdown stripped) so the delivered
+        prefix is no longer a string prefix of ``text`` and prefix arithmetic would replay
+        every delivered bubble.
+        """
+        last_message_id = raw_response.get("last_message_id") or getattr(result, "message_id", None)
+        if last_message_id:
+            self._adopt_message_id(str(last_message_id))
+        elif not self._message_id:
+            self._adopt_message_id(None)
+        delivered_prefix = raw_response.get("delivered_prefix")
+        undelivered = raw_response.get("undelivered_content")
+        if isinstance(undelivered, str) and undelivered:
+            self._last_sent_text = delivered_prefix if isinstance(delivered_prefix, str) else ""
+            self._fallback_preserve_partial_messages = True
+            self._fallback_tail_override = undelivered
+            self._enter_fallback_mode(delivered_prefix or "")
+        elif isinstance(delivered_prefix, str) and delivered_prefix:
+            self._last_sent_text = delivered_prefix
+            self._fallback_preserve_partial_messages = text.startswith(delivered_prefix)
+            self._enter_fallback_mode(delivered_prefix)
+        else:
+            self._fallback_preserve_partial_messages = False
+            self._enter_fallback_mode(self._visible_prefix())
+        if getattr(result, "continuation_message_ids", ()):
+            self._notify_new_message()
+
     async def _on_edit_failure(self, result, text: str, *, finalize: bool, is_turn_final: bool,
                                ) -> bool:
         """Classify a failed edit: partial overflow, flood backoff, or fallback mode.  Always
@@ -514,20 +536,7 @@ class StreamTransportMixin:
         # duplicate #45517 fixed (#36965 / #25349).
         raw_response = getattr(result, "raw_response", None)
         if isinstance(raw_response, dict) and raw_response.get("partial_overflow"):
-            # Some overflow chunks landed but not the whole response: preserve the
-            # visible prefix so got_done sends the missing tail.
-            self._message_id = str(raw_response.get("last_message_id") or result.message_id
-                                   or self._message_id)
-            delivered_prefix = raw_response.get("delivered_prefix")
-            if isinstance(delivered_prefix, str) and delivered_prefix:
-                self._last_sent_text = delivered_prefix
-                self._fallback_preserve_partial_messages = text.startswith(delivered_prefix)
-                self._enter_fallback_mode(delivered_prefix)
-            else:
-                self._fallback_preserve_partial_messages = False
-                self._enter_fallback_mode(self._visible_prefix())
-            if getattr(result, "continuation_message_ids", ()):
-                self._notify_new_message()
+            self._adopt_partial_delivery(result, raw_response, text=text)
             return False
 
         # Flood control: adaptive backoff (double the interval); disable edits only

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -511,6 +511,7 @@ class PhotonAdapter(BasePlatformAdapter):
 
     MAX_MESSAGE_LENGTH = _MAX_MESSAGE_LENGTH
     SUPPORTS_MESSAGE_EDITING = False  # no edit API: streaming must not leave a stale cursor (▉)
+    conversational_approval = True  # iMessage: ask "reply yes", not "/approve"
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform("photon"))
@@ -1707,6 +1708,16 @@ def register(ctx) -> None:
             "blank-line-separated sections so each section becomes an iMessage bubble; "
             "use single line breaks within a section. Put every bare URL on its own line "
             "so it becomes a full link-preview card. "
+            "Honor the boundary of what was asked: research verbs like find, check, "
+            "look up, compare, or see mean report back, so confirm before any step that "
+            "spends money, sends a message on the user's behalf, cancels or books "
+            "something, or changes an account. "
+            "After finishing an action, close with a short receipt naming the concrete "
+            "result — confirmation number, final time, amount charged, who you contacted, "
+            "or what changed — never just 'done'. "
+            "If you get blocked on a login code, a CAPTCHA, or a step only the user can "
+            "complete, say exactly what you need in this thread and keep the rest of the "
+            "task ready to resume; do not abandon the work or restart from scratch. "
             "Markdown is rendered (bold, italics, lists, code), but keep "
             "formatting light and conversational. Recipient identifiers are "
             "E.164 phone numbers; never expose them in responses unless the "

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -1166,12 +1166,6 @@ class PhotonAdapter(BasePlatformAdapter):
 
     # -- Outbound ------------------------------------------------------------------
 
-    def _outgoing_chunks(self, content: str) -> List[str]:
-        bubbles = _outgoing_bubbles(content)
-        return [chunk for bubble in bubbles for chunk in (
-            [bubble] if len(bubble) <= self.MAX_MESSAGE_LENGTH
-            else self.truncate_message(bubble, self.MAX_MESSAGE_LENGTH))]
-
     @staticmethod
     def _bubble_send_result(message_ids: List[str]) -> SendResult:
         return SendResult(
@@ -1218,7 +1212,7 @@ class PhotonAdapter(BasePlatformAdapter):
         bubble returns the sidecar result untouched; a failure mid-way returns the
         partial-overflow result so callers retry only the undelivered tail.
         """
-        bubbles = [self.format_message(chunk) for chunk in self._outgoing_chunks(content)]
+        bubbles = [self.format_message(chunk) for chunk in self.fit_bubbles(_outgoing_bubbles(content))]
         if len(bubbles) == 1:
             return await send_one(bubbles[0])
         message_ids: List[str] = []

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -312,6 +312,41 @@ def _richlink_candidate(text: str) -> Optional[str]:
     return _url_only_candidate(text) if _markdown_enabled() else None
 
 
+def _outgoing_bubbles(text: str) -> List[str]:
+    """Split an iMessage reply into conversational bubbles.
+
+    Blank-line-separated response sections become individual messages, except
+    inside fenced code blocks. Bare URL lines become their own messages so
+    Photon can render native rich-link previews wherever a source appears.
+    """
+    from gateway.platforms.helpers import split_markdown_paragraphs
+
+    paragraphs = split_markdown_paragraphs(text)
+    bubbles: List[str] = []
+    for paragraph in paragraphs:
+        prose_lines: List[str] = []
+
+        def _flush_prose() -> None:
+            prose = "\n".join(prose_lines).strip()
+            if prose:
+                bubbles.append(prose)
+            prose_lines.clear()
+
+        in_fence = False
+        for line in paragraph.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("```"):
+                in_fence = not in_fence
+            url = None if in_fence else _url_only_candidate(stripped)
+            if url:
+                _flush_prose()
+                bubbles.append(url)
+            else:
+                prose_lines.append(line)
+        _flush_prose()
+    return bubbles or [text]
+
+
 def _format_richlink_content(content: Dict[str, Any]) -> str:
     url, title, summary = (str(content.get(k) or "").strip() for k in ("url", "title", "summary"))
     parts = [p for p in (title, summary if summary != title else "", url) if p]
@@ -1130,9 +1165,54 @@ class PhotonAdapter(BasePlatformAdapter):
 
     # -- Outbound ------------------------------------------------------------------
 
+    def _outgoing_chunks(self, content: str) -> List[str]:
+        bubbles = _outgoing_bubbles(content)
+        return [chunk for bubble in bubbles for chunk in (
+            [bubble] if len(bubble) <= self.MAX_MESSAGE_LENGTH
+            else self.truncate_message(bubble, self.MAX_MESSAGE_LENGTH))]
+
+    @staticmethod
+    def _bubble_send_result(message_ids: List[str]) -> SendResult:
+        return SendResult(
+            success=True,
+            message_id=message_ids[-1] if message_ids else None,
+            continuation_message_ids=tuple(message_ids[:-1]),
+            raw_response={"message_ids": message_ids},
+        )
+
+    @staticmethod
+    def _partial_bubble_result(
+        result: SendResult, message_ids: List[str], delivered_count: int, bubbles: List[str]
+    ) -> SendResult:
+        if not delivered_count:
+            return result
+        raw = dict(result.raw_response) if isinstance(result.raw_response, dict) else {}
+        raw.update({
+            "partial_bubble_delivery": True,
+            "message_ids": message_ids,
+            "delivered_bubbles": delivered_count,
+            "total_bubbles": len(bubbles),
+            "undelivered_content": "\n\n".join(bubbles[delivered_count:]),
+        })
+        result.raw_response = raw
+        return result
+
     async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None,
                    metadata: Optional[Dict[str, Any]] = None) -> SendResult:
-        return await self._sidecar_send(chat_id, self.format_message(content))
+        bubbles = [self.format_message(bubble) for bubble in self._outgoing_chunks(content)]
+        if len(bubbles) == 1:
+            return await self._sidecar_send(chat_id, bubbles[0])
+        message_ids: List[str] = []
+        delivered_count = 0
+        for bubble in bubbles:
+            result = await self._sidecar_send(chat_id, bubble)
+            if not result.success:
+                return self._partial_bubble_result(
+                    result, message_ids, delivered_count, bubbles)
+            delivered_count += 1
+            if result.message_id:
+                message_ids.append(str(result.message_id))
+        return self._bubble_send_result(message_ids)
 
     async def send_clarify(self, chat_id: str, question: str, choices: Optional[list], clarify_id: str,
                            session_key: str, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
@@ -1328,46 +1408,54 @@ class PhotonAdapter(BasePlatformAdapter):
 
     async def _send_with_retry(self, chat_id: str, content: str, reply_to: Optional[str] = None,
                                metadata: Any = None, max_retries: int = 1, base_delay: float = 2.0) -> SendResult:
-        """Retry sends without the generic Markdown banner (replies are markdown or
-        already-stripped plain text, so it never applies)."""
-        text = self.format_message(content)
+        """Deliver each bubble in order under one retry budget per bubble.
 
-        async def _send() -> SendResult:
-            return await self.send(chat_id=chat_id, content=text, reply_to=reply_to, metadata=metadata)
+        Splitting happens before Markdown stripping, so the plain-text kill switch
+        cannot turn blank lines inside a code fence into extra messages.
+        """
+        chunks = self._outgoing_chunks(content)
+        formatted = [self.format_message(chunk) for chunk in chunks]
+        use_richlinks = _markdown_enabled()
+        message_ids: List[str] = []
+        delivered_count = 0
 
-        result = await _send()
-        if result.success:
-            return result
-        if self._is_permanent_sidecar_failure(result):
-            return result  # structured failure already carries the user-facing explanation
-        error_str = result.error or ""
-        is_network = result.retryable or self._is_retryable_error(error_str)
-        if not is_network and self._is_timeout_error(error_str):
-            return result
-        if is_network:
-            for attempt in range(1, max_retries + 1):
-                delay = base_delay * (2 ** (attempt - 1))
-                logger.warning("[photon] Send failed (attempt %d/%d, retrying in %.1fs): %s",
-                               attempt, max_retries, delay, error_str)
-                await asyncio.sleep(delay)
-                result = await _send()
-                if result.success:
-                    return result
-                error_str = result.error or ""
-                if self._is_permanent_sidecar_failure(result):
-                    return result
-                if not (result.retryable or self._is_retryable_error(error_str)):
-                    break
-            else:
-                logger.error("[photon] Failed to deliver response after %d retries: %s", max_retries, error_str)
-                # Fall through to plain text; for URL-only responses this bypasses richlink()
-                # so a rich-link outage doesn't strand a sendable URL.
-        logger.warning("[photon] Send failed: %s - retrying plain-text message", error_str)
-        fallback_result = await self._sidecar_send(
-            chat_id, text[: self.MAX_MESSAGE_LENGTH], richlink=False, markdown=False)
-        if not fallback_result.success:
-            logger.error("[photon] Plain-text retry also failed: %s", fallback_result.error)
-        return fallback_result
+        for index, bubble in enumerate(formatted):
+            result = await self._sidecar_send(chat_id, bubble, richlink=use_richlinks)
+            error_str = result.error or ""
+            if not result.success and not self._is_permanent_sidecar_failure(result):
+                is_network = result.retryable or self._is_retryable_error(error_str)
+                if not (not is_network and self._is_timeout_error(error_str)):
+                    if is_network:
+                        for attempt in range(1, max_retries + 1):
+                            delay = base_delay * (2 ** (attempt - 1))
+                            logger.warning(
+                                "[photon] Send failed (attempt %d/%d, retrying in %.1fs): %s",
+                                attempt, max_retries, delay, error_str)
+                            await asyncio.sleep(delay)
+                            result = await self._sidecar_send(
+                                chat_id, bubble, richlink=use_richlinks)
+                            if result.success or self._is_permanent_sidecar_failure(result):
+                                break
+                            error_str = result.error or ""
+                            if not (result.retryable or self._is_retryable_error(error_str)):
+                                break
+                        if not result.success:
+                            logger.error(
+                                "[photon] Failed to deliver bubble after %d retries: %s",
+                                max_retries, error_str)
+                    if not result.success and not self._is_permanent_sidecar_failure(result):
+                        logger.warning(
+                            "[photon] Send failed: %s - retrying plain-text bubble", error_str)
+                        result = await self._sidecar_send(
+                            chat_id, bubble[: self.MAX_MESSAGE_LENGTH], richlink=False, markdown=False)
+            if not result.success:
+                return self._partial_bubble_result(
+                    result, message_ids, delivered_count, formatted)
+            delivered_count = index + 1
+            if result.message_id:
+                message_ids.append(str(result.message_id))
+
+        return self._bubble_send_result(message_ids)
 
     async def _post_send(self, path: str, body: Dict[str, Any], *, structured: bool = False) -> SendResult:
         """POST a send-like body and wrap the outcome as a SendResult. ``structured`` carries
@@ -1606,7 +1694,13 @@ def register(ctx) -> None:
         allow_update_command=True,
         platform_hint=(
             "You are communicating via Photon Spectrum (iMessage). "
-            "Treat replies like regular text messages — short and friendly. "
+            "Treat replies like regular text messages — short and friendly. When "
+            "the task requires tools or research, first send one brief natural "
+            "acknowledgment saying what you are about to do, then start the work. "
+            "Do not expose private reasoning. Structure the final answer as distinct "
+            "blank-line-separated sections so each section becomes an iMessage bubble; "
+            "use single line breaks within a section. Put every bare URL on its own line "
+            "so it becomes a full link-preview card. "
             "Markdown is rendered (bold, italics, lists, code), but keep "
             "formatting light and conversational. Recipient identifiers are "
             "E.164 phone numbers; never expose them in responses unless the "

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -1187,13 +1187,19 @@ class PhotonAdapter(BasePlatformAdapter):
         if not delivered_count:
             return result
         raw = dict(result.raw_response) if isinstance(result.raw_response, dict) else {}
+        delivered_prefix = "\n\n".join(bubbles[:delivered_count])
+        last_message_id = message_ids[-1] if message_ids else None
         raw.update({
             "partial_bubble_delivery": True,
             "message_ids": message_ids,
             "delivered_bubbles": delivered_count,
             "total_bubbles": len(bubbles),
+            "delivered_prefix": delivered_prefix,
+            "last_message_id": last_message_id,
             "undelivered_content": "\n\n".join(bubbles[delivered_count:]),
         })
+        result.message_id = last_message_id
+        result.continuation_message_ids = tuple(message_ids[:-1])
         result.raw_response = raw
         return result
 

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -21,7 +21,7 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
 if TYPE_CHECKING:  # type checkers see httpx as always-imported; runtime keeps it optional
@@ -1208,22 +1208,31 @@ class PhotonAdapter(BasePlatformAdapter):
         result.raw_response = raw
         return result
 
-    async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None,
-                   metadata: Optional[Dict[str, Any]] = None) -> SendResult:
-        bubbles = [self.format_message(bubble) for bubble in self._outgoing_chunks(content)]
+    async def _deliver_bubbles(
+        self, content: str, send_one: Callable[[str], Awaitable[SendResult]],
+    ) -> SendResult:
+        """Split ``content`` into bubbles and send them in order with ``send_one``.
+
+        Splitting happens before Markdown stripping, so the plain-text kill switch
+        cannot turn blank lines inside a code fence into extra messages. A single
+        bubble returns the sidecar result untouched; a failure mid-way returns the
+        partial-overflow result so callers retry only the undelivered tail.
+        """
+        bubbles = [self.format_message(chunk) for chunk in self._outgoing_chunks(content)]
         if len(bubbles) == 1:
-            return await self._sidecar_send(chat_id, bubbles[0])
+            return await send_one(bubbles[0])
         message_ids: List[str] = []
-        delivered_count = 0
-        for bubble in bubbles:
-            result = await self._sidecar_send(chat_id, bubble)
+        for delivered_count, bubble in enumerate(bubbles):
+            result = await send_one(bubble)
             if not result.success:
-                return self._partial_bubble_result(
-                    result, message_ids, delivered_count, bubbles)
-            delivered_count += 1
+                return self._partial_bubble_result(result, message_ids, delivered_count, bubbles)
             if result.message_id:
                 message_ids.append(str(result.message_id))
         return self._bubble_send_result(message_ids)
+
+    async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None,
+                   metadata: Optional[Dict[str, Any]] = None) -> SendResult:
+        return await self._deliver_bubbles(content, lambda bubble: self._sidecar_send(chat_id, bubble))
 
     async def send_clarify(self, chat_id: str, question: str, choices: Optional[list], clarify_id: str,
                            session_key: str, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
@@ -1419,54 +1428,43 @@ class PhotonAdapter(BasePlatformAdapter):
 
     async def _send_with_retry(self, chat_id: str, content: str, reply_to: Optional[str] = None,
                                metadata: Any = None, max_retries: int = 1, base_delay: float = 2.0) -> SendResult:
-        """Deliver each bubble in order under one retry budget per bubble.
-
-        Splitting happens before Markdown stripping, so the plain-text kill switch
-        cannot turn blank lines inside a code fence into extra messages.
-        """
-        chunks = self._outgoing_chunks(content)
-        formatted = [self.format_message(chunk) for chunk in chunks]
+        """Deliver each bubble in order, each under its own retry budget."""
         use_richlinks = _markdown_enabled()
-        message_ids: List[str] = []
-        delivered_count = 0
+        return await self._deliver_bubbles(
+            content,
+            lambda bubble: self._send_bubble_with_retry(
+                chat_id, bubble, max_retries=max_retries, base_delay=base_delay, richlink=use_richlinks),
+        )
 
-        for index, bubble in enumerate(formatted):
-            result = await self._sidecar_send(chat_id, bubble, richlink=use_richlinks)
-            error_str = result.error or ""
-            if not result.success and not self._is_permanent_sidecar_failure(result):
-                is_network = result.retryable or self._is_retryable_error(error_str)
-                if not (not is_network and self._is_timeout_error(error_str)):
-                    if is_network:
-                        for attempt in range(1, max_retries + 1):
-                            delay = base_delay * (2 ** (attempt - 1))
-                            logger.warning(
-                                "[photon] Send failed (attempt %d/%d, retrying in %.1fs): %s",
-                                attempt, max_retries, delay, error_str)
-                            await asyncio.sleep(delay)
-                            result = await self._sidecar_send(
-                                chat_id, bubble, richlink=use_richlinks)
-                            if result.success or self._is_permanent_sidecar_failure(result):
-                                break
-                            error_str = result.error or ""
-                            if not (result.retryable or self._is_retryable_error(error_str)):
-                                break
-                        if not result.success:
-                            logger.error(
-                                "[photon] Failed to deliver bubble after %d retries: %s",
-                                max_retries, error_str)
-                    if not result.success and not self._is_permanent_sidecar_failure(result):
-                        logger.warning(
-                            "[photon] Send failed: %s - retrying plain-text bubble", error_str)
-                        result = await self._sidecar_send(
-                            chat_id, bubble[: self.MAX_MESSAGE_LENGTH], richlink=False, markdown=False)
-            if not result.success:
-                return self._partial_bubble_result(
-                    result, message_ids, delivered_count, formatted)
-            delivered_count = index + 1
-            if result.message_id:
-                message_ids.append(str(result.message_id))
-
-        return self._bubble_send_result(message_ids)
+    async def _send_bubble_with_retry(self, chat_id: str, bubble: str, *, max_retries: int,
+                                      base_delay: float, richlink: bool) -> SendResult:
+        """One bubble: network errors get ``max_retries`` backed-off retries, then anything still
+        failing (except a permanent sidecar failure or a plain non-network timeout) is re-sent as
+        plain text so a rich-link/markdown outage never strands a sendable message."""
+        result = await self._sidecar_send(chat_id, bubble, richlink=richlink)
+        if result.success or self._is_permanent_sidecar_failure(result):
+            return result
+        error_str = result.error or ""
+        is_network = result.retryable or self._is_retryable_error(error_str)
+        if not is_network and self._is_timeout_error(error_str):
+            return result
+        if is_network:
+            for attempt in range(1, max_retries + 1):
+                delay = base_delay * (2 ** (attempt - 1))
+                logger.warning("[photon] Send failed (attempt %d/%d, retrying in %.1fs): %s",
+                               attempt, max_retries, delay, error_str)
+                await asyncio.sleep(delay)
+                result = await self._sidecar_send(chat_id, bubble, richlink=richlink)
+                if result.success or self._is_permanent_sidecar_failure(result):
+                    return result
+                error_str = result.error or ""
+                if not (result.retryable or self._is_retryable_error(error_str)):
+                    break
+            else:
+                logger.error("[photon] Failed to deliver bubble after %d retries: %s", max_retries, error_str)
+        logger.warning("[photon] Send failed: %s - retrying plain-text bubble", error_str)
+        return await self._sidecar_send(
+            chat_id, bubble[: self.MAX_MESSAGE_LENGTH], richlink=False, markdown=False)
 
     async def _post_send(self, path: str, body: Dict[str, Any], *, structured: bool = False) -> SendResult:
         """POST a send-like body and wrap the outcome as a SendResult. ``structured`` carries

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -1190,11 +1190,15 @@ class PhotonAdapter(BasePlatformAdapter):
         raw = dict(result.raw_response) if isinstance(result.raw_response, dict) else {}
         delivered_prefix = "\n\n".join(bubbles[:delivered_count])
         last_message_id = message_ids[-1] if message_ids else None
+        # Same contract Telegram/Discord emit for split overflow, so the stream consumer's
+        # single partial-delivery branch handles bubbles too. ``undelivered_content`` is the
+        # exact owed tail: splitting normalizes text, so the joined prefix need not be a
+        # string prefix of the original.
         raw.update({
-            "partial_bubble_delivery": True,
+            "partial_overflow": True,
             "message_ids": message_ids,
-            "delivered_bubbles": delivered_count,
-            "total_bubbles": len(bubbles),
+            "delivered_chunks": delivered_count,
+            "total_chunks": len(bubbles),
             "delivered_prefix": delivered_prefix,
             "last_message_id": last_message_id,
             "undelivered_content": "\n\n".join(bubbles[delivered_count:]),

--- a/tests/gateway/test_conversational_approval_imessage.py
+++ b/tests/gateway/test_conversational_approval_imessage.py
@@ -1,0 +1,233 @@
+"""Conversational approval on button-less texting surfaces (iMessage).
+
+Two contracts:
+
+1. The prompt a texting user sees asks for a plain-language reply, not
+   ``/approve``. Slash commands still work; they are not what we advertise.
+2. "sure, go ahead" typed into the thread resolves the real pending approval
+   through the canonical handler, and a refusal denies it — driven through
+   ``_handle_active_session_busy_message`` (the production path), with a real
+   ``_ApprovalEntry`` blocking, not a mocked matcher.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+
+
+class TestConversationalPromptWording:
+    """A text-message approval prompt must read like a question to a person."""
+
+    def _fallback(self, **kwargs):
+        from gateway.run import _format_exec_approval_fallback
+
+        return _format_exec_approval_fallback(
+            "rm -rf /tmp/cache", "deletes a directory tree", "/", **kwargs
+        )
+
+    def test_conversational_prompt_asks_for_plain_reply(self):
+        text = self._fallback(conversational=True)
+        assert '"yes"' in text
+        assert '"no"' in text
+        # The whole point: no slash-command instructions in a text message.
+        assert "/approve" not in text
+        assert "/deny" not in text
+
+    def test_conversational_prompt_still_shows_command_and_reason(self):
+        text = self._fallback(conversational=True)
+        assert "rm -rf /tmp/cache" in text
+        assert "deletes a directory tree" in text
+
+    def test_conversational_prompt_offers_the_scopes_it_has(self):
+        text = self._fallback(conversational=True, allow_session=True, allow_permanent=True)
+        assert "session" in text.lower()
+        assert "always" in text.lower()
+
+    def test_conversational_smart_deny_offers_only_one_operation(self):
+        text = self._fallback(conversational=True, smart_denied=True, allow_permanent=False)
+        assert '"yes"' in text
+        assert "always" not in text.lower()
+        assert "session" not in text.lower()
+
+    def test_slash_platforms_keep_slash_wording(self):
+        """Button/slash platforms must not regress into conversational wording."""
+        text = self._fallback(conversational=False)
+        assert "`/approve`" in text
+        assert "/deny" in text
+
+
+class TestImessageAdaptersOptIn:
+    def test_photon_declares_conversational_approval(self):
+        from gateway.config import PlatformConfig as PC
+        from plugins.platforms.photon.adapter import PhotonAdapter
+
+        adapter = PhotonAdapter(PC(enabled=True, token="", extra={}))
+        assert adapter.conversational_approval is True
+
+    def test_base_adapters_default_to_slash_wording(self):
+        from gateway.platforms.base import BasePlatformAdapter
+
+        assert BasePlatformAdapter.conversational_approval is False
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform("photon"), user_id="+15550001111", chat_id="space-1",
+        user_name="tester", chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(
+        text=text, message_type=MessageType.TEXT, source=_make_source(), message_id="m1",
+    )
+
+
+def _clear_approval_state():
+    from tools import approval as mod
+
+    mod._gateway_queues.clear()
+    mod._gateway_notify_cbs.clear()
+    mod._session_approved.clear()
+    mod._permanent_approved.clear()
+    mod._pending.clear()
+
+
+def _make_runner():
+    """Minimal GatewayRunner exercising the real busy-session handler."""
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform("photon"): PlatformConfig(enabled=True, token="***")}
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    adapter._send_with_retry = AsyncMock(
+        return_value=SimpleNamespace(success=True, message_id="reply1")
+    )
+    adapter._unwrap_ephemeral = lambda r: (r, 0) if isinstance(r, str) else (None, 0)
+    runner.adapters = {Platform("photon"): adapter}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._busy_ack_ts = {}
+    runner._draining = False
+    runner.session_store = None
+    runner._is_user_authorized = lambda _source: True
+    runner._busy_input_mode = "interrupt"
+    runner._busy_text_mode = "interrupt"
+    return runner, adapter
+
+
+def _register_blocking_approval(runner):
+    from tools.approval import _gateway_queues
+    from tools.approval_gateway_wait import _ApprovalEntry
+
+    session_key = runner._session_key_for_source(_make_source())
+    entry = _ApprovalEntry({"command": "rm -rf /tmp/cache"})
+    _gateway_queues.setdefault(session_key, []).append(entry)
+    return session_key, entry
+
+
+class TestConversationalRepliesResolveRealApprovals:
+    @pytest.mark.parametrize("reply", [
+        "sure, go ahead", "yes please", "do it", "ok go ahead", "sounds good",
+    ])
+    def test_affirmative_approves_once(self, reply):
+        _clear_approval_state()
+        try:
+            runner, adapter = _make_runner()
+            session_key, entry = _register_blocking_approval(runner)
+
+            handled = asyncio.run(
+                runner._handle_active_session_busy_message(_make_event(reply), session_key)
+            )
+
+            assert handled is True
+            assert entry.event.is_set()
+            assert entry.result == "once"
+            adapter._send_with_retry.assert_awaited()
+        finally:
+            _clear_approval_state()
+
+    @pytest.mark.parametrize("reply", ["no, don't go ahead", "don't do it", "never mind"])
+    def test_refusal_denies(self, reply):
+        _clear_approval_state()
+        try:
+            runner, _adapter = _make_runner()
+            session_key, entry = _register_blocking_approval(runner)
+
+            handled = asyncio.run(
+                runner._handle_active_session_busy_message(_make_event(reply), session_key)
+            )
+
+            assert handled is True
+            assert entry.event.is_set()
+            assert entry.result == "deny"
+        finally:
+            _clear_approval_state()
+
+    def test_session_scope_reply_approves_for_session(self):
+        _clear_approval_state()
+        try:
+            runner, _adapter = _make_runner()
+            session_key, entry = _register_blocking_approval(runner)
+
+            handled = asyncio.run(
+                runner._handle_active_session_busy_message(
+                    _make_event("for this session"), session_key
+                )
+            )
+
+            assert handled is True
+            assert entry.result == "session"
+        finally:
+            _clear_approval_state()
+
+    @pytest.mark.parametrize("reply", [
+        "are you sure?",
+        "yes but not the second one",
+        "go ahead and also delete the backups",
+    ])
+    def test_ambiguous_reply_leaves_approval_pending(self, reply):
+        """Fail-safe: an unclear answer must not resolve a flagged command."""
+        _clear_approval_state()
+        try:
+            runner, _adapter = _make_runner()
+            session_key, entry = _register_blocking_approval(runner)
+
+            asyncio.run(
+                runner._handle_active_session_busy_message(_make_event(reply), session_key)
+            )
+
+            assert not entry.event.is_set()
+            assert entry.result is None
+        finally:
+            _clear_approval_state()
+
+    def test_conversational_yes_with_no_pending_approval_is_not_consumed(self):
+        """The context gate: ordinary chat must never fire a command."""
+        _clear_approval_state()
+        try:
+            runner, _adapter = _make_runner()
+            session_key = runner._session_key_for_source(_make_source())
+
+            asyncio.run(
+                runner._handle_active_session_busy_message(
+                    _make_event("sure, go ahead"), session_key
+                )
+            )
+
+            from tools.approval import _gateway_queues
+
+            assert session_key not in _gateway_queues
+        finally:
+            _clear_approval_state()

--- a/tests/gateway/test_delivery_ledger.py
+++ b/tests/gateway/test_delivery_ledger.py
@@ -131,6 +131,37 @@ class TestStateMachine:
         _record()
         assert _row("ob-1")["state"] == "pending"
 
+    def test_partial_failure_persists_only_undelivered_suffix(self):
+        _record(content="first\n\nsecond")
+
+        dl.mark_failed_with_content("ob-1", "second", "connection reset")
+
+        row = _row("ob-1")
+        assert row is not None
+        assert row["state"] == "failed"
+        assert row["content"] == "second"
+        assert row["last_error"] == "connection reset"
+
+    @pytest.mark.asyncio
+    async def test_adapter_finalizer_persists_only_partial_send_suffix(self):
+        from gateway.platforms.base import BasePlatformAdapter, MessageEvent, SendResult
+
+        _record(content="first\n\nsecond")
+        adapter = MagicMock(spec=BasePlatformAdapter)
+        result = SendResult(
+            success=False,
+            error="connection reset",
+            raw_response={"undelivered_content": "second"},
+        )
+
+        await BasePlatformAdapter._finalize_delivery_obligation(
+            adapter, "ob-1", result, MagicMock(spec=MessageEvent), adapter)
+
+        row = _row("ob-1")
+        assert row is not None
+        assert row["state"] == "failed"
+        assert row["content"] == "second"
+
 
 class TestObligationId:
     def test_stable_and_distinct(self):

--- a/tests/gateway/test_delivery_ledger.py
+++ b/tests/gateway/test_delivery_ledger.py
@@ -134,7 +134,13 @@ class TestStateMachine:
     def test_partial_failure_persists_only_undelivered_suffix(self):
         _record(content="first\n\nsecond")
 
-        dl.mark_failed_with_content("ob-1", "second", "connection reset")
+        from gateway.platforms.base import SendResult
+
+        dl.mark_failed_from_result(
+            "ob-1",
+            SendResult(success=False, error="connection reset",
+                       raw_response={"undelivered_content": "second"}),
+            "connection reset")
 
         row = _row("ob-1")
         assert row is not None
@@ -561,7 +567,7 @@ class TestGatewayRedeliverySweep:
 
     @pytest.mark.parametrize(
         ("send_success", "ledger_method"),
-        [(True, "mark_delivered"), (False, "mark_failed")],
+        [(True, "mark_delivered"), (False, "mark_failed_from_result")],
     )
     @pytest.mark.asyncio
     async def test_slow_state_update_does_not_block_event_loop(

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -168,6 +168,42 @@ class TestPlatformDefaults:
         assert resolve_display_setting({}, "slack", "long_running_notifications") is False
         assert resolve_display_setting({}, "slack", "busy_ack_detail") is False
 
+    def test_photon_surfaces_real_interim_commentary_without_token_streaming(self):
+        """iMessage gets completed assistant thoughts, not permanent token fragments."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting({}, "photon", "interim_assistant_messages") is True
+        assert resolve_display_setting({}, "photon", "streaming") is False
+        assert resolve_display_setting({}, "photon", "tool_progress") == "off"
+        assert resolve_display_setting({}, "photon", "long_running_notifications") is False
+
+
+def test_non_editing_interim_consumer_is_buffer_only() -> None:
+    from gateway.config import StreamingConfig
+    from gateway.platforms.base import Platform, SessionSource
+    from gateway.run import GatewayRunner
+
+    class _PermanentMessageAdapter:
+        SUPPORTS_MESSAGE_EDITING = False
+        SUPPORTS_NATIVE_STREAMING = False
+
+    source = SessionSource(
+        platform=Platform("photon"),
+        chat_id="space-1",
+        chat_name="space-1",
+        chat_type="dm",
+        user_id="user-1",
+    )
+    cfg, _ = GatewayRunner.__new__(GatewayRunner)._build_stream_consumer_config(
+        source,
+        StreamingConfig(),
+        _PermanentMessageAdapter(),
+        on_missing_cursor="fallback",
+    )
+
+    assert cfg.buffer_only is True
+    assert cfg.cursor == ""
+
 
 # ---------------------------------------------------------------------------
 # Config migration: tool_progress_overrides → display.platforms

--- a/tests/gateway/test_fence_chunker.py
+++ b/tests/gateway/test_fence_chunker.py
@@ -15,6 +15,7 @@ from gateway.platforms.helpers import (
     merge_streaming_fences,
     split_at_paragraph_boundary,
     split_markdown_atoms,
+    split_markdown_paragraphs,
     split_markdown_table_row,
     split_text_fence_aware,
     text_has_unclosed_fence,
@@ -99,6 +100,15 @@ def test_atoms_fence_kept_whole():
     fence_atoms = [a for a in atoms if a.lstrip().startswith("```")]
     assert len(fence_atoms) == 1
     assert fence_atoms[0].rstrip().endswith("```")
+
+
+def test_markdown_paragraphs_split_only_on_blank_lines_outside_fences():
+    text = "Intro\n```python\na = 1\n\nb = 2\n```\nOutro\n\nNext"
+
+    assert split_markdown_paragraphs(text) == [
+        "Intro\n```python\na = 1\n\nb = 2\n```\nOutro",
+        "Next",
+    ]
 
 
 # ── streaming merge + separators ─────────────────────────────────────────────

--- a/tests/gateway/test_plaintext_approval_phrases.py
+++ b/tests/gateway/test_plaintext_approval_phrases.py
@@ -1,0 +1,127 @@
+"""Conversational approval matching (gateway/plaintext_approval.py).
+
+The security contract, in order of importance:
+
+1. A refusal must NEVER map to an approval. Substring matching would approve
+   "no, don't go ahead" because it contains "go ahead"; whole-message matching
+   makes that impossible. These are the tests that matter.
+2. Anything ambiguous returns None so the approval stays pending (fail-safe).
+3. Real conversational affirmatives and refusals resolve, so a person can answer
+   a text message the way they'd answer a person.
+"""
+
+import pytest
+
+from gateway.plaintext_approval import match_conversational_approval as m
+
+
+class TestRefusalsNeverApprove:
+    """The whole reason matching is whole-message: a refusal containing an
+    affirmative phrase must resolve as deny, never as approve."""
+
+    @pytest.mark.parametrize("reply", [
+        "no, don't go ahead",
+        "no do not go ahead",
+        "don't do it",
+        "do not do that",
+        "no, don't run it",
+        "nope",
+        "cancel that",
+        "never mind",
+        "hold off",
+        "no thanks",
+    ])
+    def test_refusal_resolves_as_deny(self, reply):
+        assert m(reply) == ("deny", "")
+
+    @pytest.mark.parametrize("reply", [
+        "no, don't go ahead",
+        "don't do it",
+        "do not do that",
+        "no dont approve",
+    ])
+    def test_refusal_is_never_an_approval(self, reply):
+        verb, _ = m(reply)
+        assert verb == "deny"
+
+
+class TestAffirmatives:
+    @pytest.mark.parametrize("reply", [
+        "yes", "yep", "yeah", "sure", "ok", "okay", "confirm",
+        "sure, go ahead", "go ahead", "yes please", "please do", "do it",
+        "just do it", "sounds good", "that's fine", "proceed", "send it",
+        "Sure!", "  yes  ", "OK.", "Yes, go ahead.", "go for it",
+    ])
+    def test_affirmative_approves_once(self, reply):
+        assert m(reply) == ("approve", "")
+
+    @pytest.mark.parametrize("reply", [
+        "for this session", "approve for this session", "session",
+        "yes for this session",
+    ])
+    def test_session_scope(self, reply):
+        assert m(reply) == ("approve", "session")
+
+    @pytest.mark.parametrize("reply", [
+        "always", "always approve", "don't ask again", "do not ask again",
+        "stop asking", "yes always",
+    ])
+    def test_permanent_scope(self, reply):
+        assert m(reply) == ("approve", "always")
+
+
+class TestAmbiguousFallsThrough:
+    """None = leave the approval pending. A conditional, a question, or a real
+    sentence is not an answer and must not resolve anything."""
+
+    @pytest.mark.parametrize("reply", [
+        "",
+        "   ",
+        "are you sure?",                      # question, even though it says "sure"
+        "is that ok?",                        # question containing "ok"
+        "yes but not the second one",         # conditional
+        "ok so what does that actually do",   # a real question opening with "ok"
+        "go ahead and also delete the backups",  # extra instruction, not a bare answer
+        "what happens if I say yes",
+        "sure thing, but check with me first",
+        "maybe",
+        "hmm",
+        "do it after you check the logs first please",
+    ])
+    def test_returns_none(self, reply):
+        assert m(reply) is None
+
+
+class TestSmartPunctuationAndTapbacks:
+    def test_ios_curly_apostrophe_folds(self):
+        # iOS autocorrects don't -> don\u2019t; both must reach the same phrase.
+        assert m("don\u2019t do it") == ("deny", "")
+        assert m("don't do it") == ("deny", "")
+
+    def test_thats_fine_with_curly_apostrophe(self):
+        assert m("that\u2019s fine") == ("approve", "")
+
+    @pytest.mark.parametrize("emoji,expected", [
+        ("\U0001f44d", ("approve", "")),
+        ("\u2705", ("approve", "")),
+        ("\U0001f44e", ("deny", "")),
+        ("\u274c", ("deny", "")),
+    ])
+    def test_tapback_emoji(self, emoji, expected):
+        assert m(emoji) == expected
+
+
+class TestVerbGrammarMatchesSlashHandlers:
+    """The returned (verb, args) is synthesized into "/approve <args>", so args
+    must be tokens the real handlers parse."""
+
+    def test_args_are_handler_tokens(self):
+        from gateway.slash_commands import _APPROVE_CHOICE_BY_ARG
+
+        for reply in ("always", "for this session"):
+            verb, args = m(reply)
+            assert verb == "approve"
+            assert args in _APPROVE_CHOICE_BY_ARG
+
+    def test_once_passes_empty_args(self):
+        assert m("yes") == ("approve", "")

--- a/tests/gateway/test_plaintext_approval_phrases.py
+++ b/tests/gateway/test_plaintext_approval_phrases.py
@@ -70,6 +70,15 @@ class TestAffirmatives:
         assert m(reply) == ("approve", "always")
 
 
+class TestAgentControlWordsAreNotApprovalAnswers:
+    """A bare "stop"/"abort" while an approval blocks means stop the AGENT (busy-path
+    interrupt/steer), not "deny this one command and keep going"."""
+
+    @pytest.mark.parametrize("reply", ["stop", "Stop!", "abort", "hold on"])
+    def test_falls_through_to_busy_handling(self, reply):
+        assert m(reply) is None
+
+
 class TestAmbiguousFallsThrough:
     """None = leave the approval pending. A conditional, a question, or a real
     sentence is not an answer and must not resolve anything."""

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1183,6 +1183,24 @@ async def test_display_streaming_does_not_enable_gateway_streaming(monkeypatch, 
     assert [call["content"] for call in adapter.sent] == ["I'll inspect the repo first."]
 
 
+@pytest.mark.asyncio
+async def test_photon_default_delivers_commentary_without_token_fragments(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        CommentaryAgent,
+        session_id="sess-photon-default-commentary",
+        platform=Platform("photon"),
+        chat_id="space-1",
+        chat_type="direct",
+        adapter_cls=NonEditingProgressCaptureAdapter,
+    )
+
+    assert result.get("already_sent") is not True
+    assert adapter.edits == []
+    assert [call["content"] for call in adapter.sent] == ["I'll inspect the repo first."]
+
+
 class TransformedStreamAgent:
     """Streams a response, then signals the gateway that a plugin hook
     (``transform_llm_output``) modified the final text after streaming

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -595,6 +595,41 @@ class TestFinalResponseDeliveryGuard:
         adapter.edit_message.assert_not_called()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("text, bubbles", [
+        # URL on its own single-newline line is hoisted into its own bubble, so the
+        # "\n\n"-joined delivered prefix is NOT a prefix of the buffered text.
+        ("See:\nhttps://example.com\nDone.", ["See:", "https://example.com", "Done."]),
+        # Splitting normalizes "\n\n\n" and trailing whitespace away.
+        ("A.  \n\n\nB.\n\nC.", ["A.", "B.", "C."]),
+    ])
+    async def test_first_send_partial_bubbles_never_replays_delivered_bubbles(self, text, bubbles):
+        """Partial multi-bubble failure must retry ONLY the undelivered tail, even when
+        bubble splitting rewrote the text so the delivered prefix no longer matches."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.base import SendResult
+        from plugins.platforms.photon.adapter import PhotonAdapter
+
+        adapter = PhotonAdapter(PlatformConfig(enabled=True, token="", extra={}))
+        adapter._sidecar_send = AsyncMock(side_effect=[
+            SendResult(success=True, message_id="m1"),
+            SendResult(success=True, message_id="m2"),
+            SendResult(success=False, error="third bubble failed"),
+            SendResult(success=True, message_id="m3"),
+        ])
+        adapter.edit_message = AsyncMock()
+
+        consumer = GatewayStreamConsumer(
+            adapter, "chat_1", StreamConsumerConfig(buffer_only=True, cursor=""))
+        consumer.on_delta(text)
+        consumer.finish()
+        await consumer.run()
+
+        sent = [call.args[1] for call in adapter._sidecar_send.await_args_list]
+        assert sent == bubbles + [bubbles[-1]], sent
+        assert consumer.final_response_sent
+        adapter.edit_message.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_split_overflow_failed_send_does_not_mark_final_sent(self):
         """Split-overflow path: if every chunk send fails on done frame,
         _final_response_sent must stay False so the gateway falls back."""

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -558,6 +558,45 @@ class TestFinalResponseDeliveryGuard:
     promotion can taint)."""
 
     @pytest.mark.asyncio
+    async def test_first_send_partial_bubbles_falls_back_to_missing_tail(self):
+        adapter = MagicMock()
+        adapter.send = AsyncMock(side_effect=[
+            SimpleNamespace(
+                success=False,
+                error="second bubble failed",
+                message_id="m1",
+                continuation_message_ids=(),
+                raw_response={
+                    "partial_bubble_delivery": True,
+                    "delivered_prefix": "First.",
+                    "undelivered_content": "Second.",
+                    "last_message_id": "m1",
+                },
+            ),
+            SimpleNamespace(success=True, message_id="m2"),
+        ])
+        adapter.edit_message = AsyncMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.platform = SimpleNamespace(value="photon")
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(buffer_only=True, cursor=""),
+        )
+
+        consumer.on_delta("First.\n\nSecond.")
+        consumer.finish()
+        await consumer.run()
+
+        assert [call.kwargs["content"] for call in adapter.send.await_args_list] == [
+            "First.\n\nSecond.",
+            "Second.",
+        ]
+        assert consumer.final_response_sent
+        adapter.edit_message.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_split_overflow_failed_send_does_not_mark_final_sent(self):
         """Split-overflow path: if every chunk send fails on done frame,
         _final_response_sent must stay False so the gateway falls back."""

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -559,25 +559,18 @@ class TestFinalResponseDeliveryGuard:
 
     @pytest.mark.asyncio
     async def test_first_send_partial_bubbles_falls_back_to_missing_tail(self):
-        adapter = MagicMock()
-        adapter.send = AsyncMock(side_effect=[
-            SimpleNamespace(
-                success=False,
-                error="second bubble failed",
-                message_id="m1",
-                continuation_message_ids=(),
-                raw_response={
-                    "partial_bubble_delivery": True,
-                    "delivered_prefix": "First.",
-                    "undelivered_content": "Second.",
-                    "last_message_id": "m1",
-                },
-            ),
-            SimpleNamespace(success=True, message_id="m2"),
+        from gateway.config import PlatformConfig
+        from gateway.platforms.base import SendResult
+        from plugins.platforms.photon.adapter import PhotonAdapter
+
+        adapter = PhotonAdapter(PlatformConfig(enabled=True, token="", extra={}))
+        adapter._sidecar_send = AsyncMock(side_effect=[
+            SendResult(success=True, message_id="m1"),
+            SendResult(success=False, error="second bubble failed"),
+            SendResult(success=True, message_id="m2"),
         ])
+        adapter.send = AsyncMock(wraps=adapter.send)
         adapter.edit_message = AsyncMock()
-        adapter.MAX_MESSAGE_LENGTH = 4096
-        adapter.platform = SimpleNamespace(value="photon")
 
         consumer = GatewayStreamConsumer(
             adapter,
@@ -591,6 +584,11 @@ class TestFinalResponseDeliveryGuard:
 
         assert [call.kwargs["content"] for call in adapter.send.await_args_list] == [
             "First.\n\nSecond.",
+            "Second.",
+        ]
+        assert [call.args[1] for call in adapter._sidecar_send.await_args_list] == [
+            "First.",
+            "Second.",
             "Second.",
         ]
         assert consumer.final_response_sent

--- a/tests/plugins/platforms/photon/test_rich_links.py
+++ b/tests/plugins/platforms/photon/test_rich_links.py
@@ -227,7 +227,10 @@ async def test_exhausted_partial_bubble_failure_is_not_replayed_from_start(
     assert adapter._sidecar_send.await_count == 3
     assert result.raw_response["partial_bubble_delivery"] is True
     assert result.raw_response["message_ids"] == ["m-1"]
+    assert result.raw_response["delivered_prefix"] == "First."
+    assert result.raw_response["last_message_id"] == "m-1"
     assert result.raw_response["undelivered_content"] == "Second."
+    assert result.message_id == "m-1"
 
 
 @pytest.mark.asyncio
@@ -262,6 +265,8 @@ async def test_null_message_id_still_counts_as_partial_delivery(
     assert result.success is False
     assert result.raw_response["partial_bubble_delivery"] is True
     assert result.raw_response["delivered_bubbles"] == 1
+    assert result.raw_response["delivered_prefix"] == "First."
+    assert result.raw_response["last_message_id"] is None
     assert result.raw_response["undelivered_content"] == "Second."
 
 

--- a/tests/plugins/platforms/photon/test_rich_links.py
+++ b/tests/plugins/platforms/photon/test_rich_links.py
@@ -8,6 +8,7 @@ that content type.
 from __future__ import annotations
 
 import base64
+from unittest.mock import AsyncMock
 from typing import Any, Dict, List, Tuple
 
 import pytest
@@ -89,6 +90,255 @@ async def test_mixed_prose_url_stays_on_markdown_send(
     assert path == "/send"
     assert body["format"] == "markdown"
     assert body["text"] == f"Read this: {_URL}"
+
+
+@pytest.mark.asyncio
+async def test_blank_line_paragraphs_and_trailing_urls_send_as_separate_bubbles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PHOTON_MARKDOWN", raising=False)
+    adapter = _make_adapter(monkeypatch)
+    calls = _capture_sidecar(adapter)
+
+    result = await adapter.send(
+        "+155****4567",
+        f"I found it.\n\nHere is the source:\n{_URL}\nhttps://example.com/second",
+    )
+
+    assert result.success is True
+    assert calls == [
+        ("/send", {"spaceId": "+155****4567", "text": "I found it.", "format": "markdown"}),
+        ("/send", {"spaceId": "+155****4567", "text": "Here is the source:", "format": "markdown"}),
+        ("/send-richlink", {"spaceId": "+155****4567", "url": _URL}),
+        ("/send-richlink", {"spaceId": "+155****4567", "url": "https://example.com/second"}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_bare_url_between_sections_becomes_a_native_preview_card(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PHOTON_MARKDOWN", raising=False)
+    adapter = _make_adapter(monkeypatch)
+    calls = _capture_sidecar(adapter)
+
+    await adapter.send(
+        "+155****4567",
+        f"Top pick:\n{_URL}\nWhy it wins.\n\nTwo practical things:\n- Start early.",
+    )
+
+    assert calls == [
+        ("/send", {"spaceId": "+155****4567", "text": "Top pick:", "format": "markdown"}),
+        ("/send-richlink", {"spaceId": "+155****4567", "url": _URL}),
+        ("/send", {"spaceId": "+155****4567", "text": "Why it wins.", "format": "markdown"}),
+        (
+            "/send",
+            {
+                "spaceId": "+155****4567",
+                "text": "Two practical things:\n- Start early.",
+                "format": "markdown",
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_url_only_line_inside_fence_stays_code_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PHOTON_MARKDOWN", raising=False)
+    adapter = _make_adapter(monkeypatch)
+    calls = _capture_sidecar(adapter)
+
+    await adapter.send("+155****4567", f"```text\n{_URL}\n```")
+
+    assert calls == [
+        (
+            "/send",
+            {
+                "spaceId": "+155****4567",
+                "text": f"```text\n{_URL}\n```",
+                "format": "markdown",
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_blank_lines_inside_fenced_code_stay_in_one_bubble(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PHOTON_MARKDOWN", raising=False)
+    adapter = _make_adapter(monkeypatch)
+    calls = _capture_sidecar(adapter)
+
+    await adapter.send(
+        "+155****4567",
+        "Before.\n\n```python\nfirst = 1\n\nsecond = 2\n```\n\nAfter.",
+    )
+
+    assert [body.get("text") for path, body in calls if path == "/send"] == [
+        "Before.",
+        "```python\nfirst = 1\n\nsecond = 2\n```",
+        "After.",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_partial_bubble_failure_retries_only_failed_bubble(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    sleep = AsyncMock()
+    monkeypatch.setattr(photon_adapter.asyncio, "sleep", sleep)
+    adapter._sidecar_send = AsyncMock(side_effect=[
+        photon_adapter.SendResult(success=True, message_id="m-1"),
+        photon_adapter.SendResult(success=False, error="connection reset", retryable=True),
+        photon_adapter.SendResult(success=True, message_id="m-2"),
+    ])
+
+    result = await adapter._send_with_retry("+155****4567", "First.\n\nSecond.")
+
+    assert result.success is True
+    assert [call.args[1] for call in adapter._sidecar_send.await_args_list] == [
+        "First.", "Second.", "Second.",
+    ]
+    sleep.assert_awaited_once_with(2.0)
+
+
+@pytest.mark.asyncio
+async def test_exhausted_partial_bubble_failure_is_not_replayed_from_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    monkeypatch.setattr(photon_adapter.asyncio, "sleep", AsyncMock())
+    failure = photon_adapter.SendResult(
+        success=False,
+        error="connection reset; retryable=false",
+        retryable=False,
+    )
+    adapter._sidecar_send = AsyncMock(side_effect=[
+        photon_adapter.SendResult(success=True, message_id="m-1"), failure, failure,
+    ])
+
+    result = await adapter._send_with_retry("+155****4567", "First.\n\nSecond.")
+
+    assert result.success is False
+    assert adapter._sidecar_send.await_count == 3
+    assert result.raw_response["partial_bubble_delivery"] is True
+    assert result.raw_response["message_ids"] == ["m-1"]
+    assert result.raw_response["undelivered_content"] == "Second."
+
+
+@pytest.mark.asyncio
+async def test_bubble_send_returns_all_message_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    adapter._sidecar_send = AsyncMock(side_effect=[
+        photon_adapter.SendResult(success=True, message_id="m-1"),
+        photon_adapter.SendResult(success=True, message_id="m-2"),
+    ])
+
+    result = await adapter.send("+155****4567", "First.\n\nSecond.")
+
+    assert result.success is True
+    assert result.message_id == "m-2"
+    assert result.continuation_message_ids == ("m-1",)
+
+
+@pytest.mark.asyncio
+async def test_null_message_id_still_counts_as_partial_delivery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    adapter._sidecar_send = AsyncMock(side_effect=[
+        photon_adapter.SendResult(success=True, message_id=None),
+        photon_adapter.SendResult(success=False, error="rejected"),
+    ])
+
+    result = await adapter.send("+155****4567", "First.\n\nSecond.")
+
+    assert result.success is False
+    assert result.raw_response["partial_bubble_delivery"] is True
+    assert result.raw_response["delivered_bubbles"] == 1
+    assert result.raw_response["undelivered_content"] == "Second."
+
+
+@pytest.mark.asyncio
+async def test_markdown_disabled_splits_before_stripping_fenced_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PHOTON_MARKDOWN", "false")
+    adapter = _make_adapter(monkeypatch)
+    calls = _capture_sidecar(adapter)
+
+    await adapter._send_with_retry(
+        "+155****4567",
+        "Before.\n\n```python\nfirst = 1\n\nsecond = 2\n```\n\nAfter.",
+    )
+
+    assert [body["text"] for path, body in calls if path == "/send"] == [
+        "Before.",
+        "first = 1\n\nsecond = 2",
+        "After.",
+    ]
+    assert all("format" not in body for path, body in calls if path == "/send")
+
+
+@pytest.mark.asyncio
+async def test_markdown_disabled_uses_plain_send_for_standalone_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PHOTON_MARKDOWN", "false")
+    adapter = _make_adapter(monkeypatch)
+    calls = _capture_sidecar(adapter)
+
+    await adapter._send_with_retry("+155****4567", _URL)
+
+    assert calls == [("/send", {"spaceId": "+155****4567", "text": _URL})]
+
+
+@pytest.mark.asyncio
+async def test_long_paragraph_is_split_before_sidecar_send(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    monkeypatch.setattr(adapter, "MAX_MESSAGE_LENGTH", 80)
+    next_id = 0
+
+    async def _send(*_args, **_kwargs):
+        nonlocal next_id
+        next_id += 1
+        return photon_adapter.SendResult(success=True, message_id=f"m-{next_id}")
+
+    adapter._sidecar_send = AsyncMock(side_effect=_send)
+
+    result = await adapter.send("+155****4567", "word " * 28)
+
+    assert result.success is True
+    sent = [call.args[1] for call in adapter._sidecar_send.await_args_list]
+    assert len(sent) > 1
+    assert all(len(chunk) <= adapter.MAX_MESSAGE_LENGTH for chunk in sent)
+
+
+@pytest.mark.asyncio
+async def test_partial_send_honors_zero_retry_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    adapter._sidecar_send = AsyncMock(side_effect=[
+        photon_adapter.SendResult(success=True, message_id="m-1"),
+        photon_adapter.SendResult(success=False, error="connection reset", retryable=True),
+        photon_adapter.SendResult(success=False, error="plain fallback rejected"),
+    ])
+
+    result = await adapter._send_with_retry(
+        "+155****4567", "First.\n\nSecond.", max_retries=0)
+
+    assert result.success is False
+    assert adapter._sidecar_send.await_count == 3
+    assert result.raw_response["undelivered_content"] == "Second."
 
 
 @pytest.mark.asyncio

--- a/tests/plugins/platforms/photon/test_rich_links.py
+++ b/tests/plugins/platforms/photon/test_rich_links.py
@@ -225,7 +225,7 @@ async def test_exhausted_partial_bubble_failure_is_not_replayed_from_start(
 
     assert result.success is False
     assert adapter._sidecar_send.await_count == 3
-    assert result.raw_response["partial_bubble_delivery"] is True
+    assert result.raw_response["partial_overflow"] is True
     assert result.raw_response["message_ids"] == ["m-1"]
     assert result.raw_response["delivered_prefix"] == "First."
     assert result.raw_response["last_message_id"] == "m-1"
@@ -263,8 +263,8 @@ async def test_null_message_id_still_counts_as_partial_delivery(
     result = await adapter.send("+155****4567", "First.\n\nSecond.")
 
     assert result.success is False
-    assert result.raw_response["partial_bubble_delivery"] is True
-    assert result.raw_response["delivered_bubbles"] == 1
+    assert result.raw_response["partial_overflow"] is True
+    assert result.raw_response["delivered_chunks"] == 1
     assert result.raw_response["delivered_prefix"] == "First."
     assert result.raw_response["last_message_id"] is None
     assert result.raw_response["undelivered_content"] == "Second."

--- a/website/docs/user-guide/messaging/photon.md
+++ b/website/docs/user-guide/messaging/photon.md
@@ -195,6 +195,23 @@ Common issues:
 - **Sidecar won't start** — confirm `node --version` is 18.17+ and that
   `hermes photon install-sidecar` completed without errors.
 
+## Conversation behavior
+
+Each Photon space maps to one persistent Hermes session. Normal messages keep
+using that session across gateway restarts, so routine conversation does not
+require `/resume` or `/new`. Hermes compresses older context automatically when
+context compression is enabled (the default). `/new` remains an explicit reset.
+
+For tasks that require tools or research, Hermes first sends a brief natural
+acknowledgment describing what it is about to do. This is visible commentary,
+not private reasoning. It then sends completed mid-turn commentary as work
+progresses and splits the final reply into conversational iMessage bubbles.
+Blank-line-separated sections become separate bubbles. Every bare URL on its own
+line becomes a separate native rich-link card, including links between text
+sections. Blank lines inside fenced code blocks stay in the same message. Set
+`PHOTON_MARKDOWN=false` to disable Markdown and rich-link rendering; section
+splitting still applies.
+
 ## Limits today
 
 - **Inbound attachments are metadata-only.** Inbound events carry the

--- a/website/docs/user-guide/messaging/photon.md
+++ b/website/docs/user-guide/messaging/photon.md
@@ -224,18 +224,22 @@ one thing in the thread and resumes the rest of the task.
 When a command needs your approval, Hermes asks in plain language instead of
 telling you to type a slash command:
 
-```
+````
 ⚠️ This needs your OK first:
+```
 rm -rf ~/.cache/build
+```
 Why: recursive delete
 
-Reply "yes" to do it this once, "for this session" to stop asking until we're
-done, "always" to stop asking entirely, or "no" to skip it.
-```
+Reply "yes" to do it this once, "for this session" to stop asking until we're done, "always" to stop asking entirely, or "no" to skip it.
+````
+
+(The blank line means it arrives as two bubbles: the command, then the question.)
 
 Answer the way you would answer a person: `yes`, `sure, go ahead`, `do it`,
 `no`, `don't do that`, or a 👍 / 👎 tapback. `for this session` and `always`
-widen the approval; `/approve` and `/deny` still work if you prefer them.
+widen the approval; `/approve` and `/deny` still work if you prefer them. A bare
+`stop` is not read as an answer — it still means stop the agent, as elsewhere.
 
 Two deliberate limits:
 

--- a/website/docs/user-guide/messaging/photon.md
+++ b/website/docs/user-guide/messaging/photon.md
@@ -212,6 +212,44 @@ sections. Blank lines inside fenced code blocks stay in the same message. Set
 `PHOTON_MARKDOWN=false` to disable Markdown and rich-link rendering; section
 splitting still applies.
 
+Hermes also treats research verbs as research: asking it to *find*, *check*, or
+*compare* something means it reports back rather than booking, buying, cancelling,
+or messaging on your behalf. When it does complete an action, it closes with a
+short receipt naming the concrete result (confirmation number, final time, amount,
+who it contacted). If it gets stuck on a login code or a CAPTCHA, it asks for that
+one thing in the thread and resumes the rest of the task.
+
+## Approving a flagged command
+
+When a command needs your approval, Hermes asks in plain language instead of
+telling you to type a slash command:
+
+```
+⚠️ This needs your OK first:
+rm -rf ~/.cache/build
+Why: recursive delete
+
+Reply "yes" to do it this once, "for this session" to stop asking until we're
+done, "always" to stop asking entirely, or "no" to skip it.
+```
+
+Answer the way you would answer a person: `yes`, `sure, go ahead`, `do it`,
+`no`, `don't do that`, or a 👍 / 👎 tapback. `for this session` and `always`
+widen the approval; `/approve` and `/deny` still work if you prefer them.
+
+Two deliberate limits:
+
+- Hermes only reads a reply as an approval **while a command is actually
+  waiting**. A conversational "sure" at any other moment is just conversation and
+  can never trigger a command.
+- Matching is exact and does not involve the model. Anything conditional or
+  unclear ("yes but not the second one", "are you sure?") leaves the command
+  waiting so you can answer again, rather than being resolved on a guess.
+
+Approval policy itself is unchanged and lives in
+[Security](/user-guide/security) (`approvals.mode`, default `smart`) — this is
+only how the question gets asked and answered over iMessage.
+
 ## Limits today
 
 - **Inbound attachments are metadata-only.** Inbound events carry the


### PR DESCRIPTION
## Summary

Photon/iMessage turns behave like texting: paragraph bubbles, bare URLs as rich-link cards, completed mid-turn commentary as separate bubbles, and approvals answered in plain language ("sure, go ahead" / "no") on button-less adapters — with a partial-send retry path that never replays already-delivered bubbles.

Salvage of #103335 by @SHL0MS (three commits cherry-picked, authorship preserved) plus six follow-up commits from review.

## Changes

Contributor commits (unchanged):
- `plugins/platforms/photon/adapter.py`: split replies into bubbles (`split_markdown_paragraphs`, URL-line isolation), per-bubble retry, `conversational_approval = True`, expanded platform hint
- `gateway/plaintext_approval.py` (new): whole-message, table-driven approval phrase matcher; replaces `_PLAINTEXT_APPROVAL_WORDS` in `run_busy.py`
- `gateway/run.py` / `run_turn_runner.py`: plain-language approval prompt for `conversational_approval` adapters (photon, bluebubbles)
- `gateway/display_config.py`: photon gets `interim_assistant_messages: True`; `run_turn.py` builds a buffer-only consumer for non-editing adapters when interim messages are on
- `gateway/delivery_ledger.py` + ledger callers: a partial failure persists only the undelivered suffix
- `gateway/platforms/helpers.py`: `split_markdown_paragraphs` (fence-aware), BlueBubbles migrated onto it
- docs: `website/docs/user-guide/messaging/photon.md`

Follow-ups (mine):
- **fix(photon): retry only the undelivered bubbles** — the consumer stored `delivered_prefix = "\n\n".join(formatted bubbles)` and relied on `final_text.startswith(prefix)`; splitting normalizes the text (URL lines hoisted, `\n\n\n`/trailing whitespace collapsed, markdown stripped under `PHOTON_MARKDOWN=false`), so the check failed in the common shapes and every delivered bubble was re-sent. Photon now emits the existing `partial_overflow` contract (same as Telegram/Discord) with `undelivered_content`; one `_adopt_partial_delivery` helper serves first-send and edit-failure; the reported tail is used verbatim as the fallback continuation. Regression tests for both shapes.
- **fix(approval): "stop" / "abort" / "hold on" are not deny words** — a texted "stop" while an approval blocks means stop the agent (busy-path interrupt/steer already handles it), not deny-this-command-and-keep-going.
- **refactor(photon): one bubble-delivery loop** for `send()` and `_send_with_retry()` (they had already drifted); retry ladder flattened, behavior-identical.
- **refactor(ledger): `mark_failed_from_result`** owns the undelivered-suffix selection (was pasted into `platforms/base.py` and `run_startup.py`); `_update_state` grows `content=` instead of a parallel UPDATE.
- **refactor(platforms): `BasePlatformAdapter.fit_bubbles`** shared by BlueBubbles and Photon.
- **docs(photon)**: approval example matches the real prompt output.

## Validation

| | Before (PR head) | After |
|---|---|---|
| 3 bubbles, 3rd fails, URL on own line | 6 sidecar sends: `See:`, URL, `Done.`, `See:`, URL, `Done.` (3 duplicates) | 4 sends: `See:`, URL, `Done.`, `Done.` |
| `PHOTON_MARKDOWN=false`, 2nd of 3 fails | full replay | only `Second code.` retried |
| bare "stop" while approval pending | `deny` (agent keeps running) | falls through to busy handling |
| ledger row after partial `_send_with_retry` | — (new) | `state=failed`, `content="**Second.**\n\nThird."` (real SQLite, E2E) |

- 482/482 in the touched test files (`run_tests.sh`), 1112/1113 across `tests/gateway -k 'approval|stream|photon|bluebubbles|busy|ledger|qq|wecom|signal|obligation|redeliver|overflow'` (the one failure, `test_gateway_shutdown::test_unexpected_signal_starts_teardown_after_bounded_interrupt_grace`, passes alone on both this branch and `origin/main` — timing flake under 16 workers).
- Mutation checks: reverting the consumer files to `origin/main` fails the 2 new partial-bubble tests (the PR's clean-case test still passes, as expected); reverting `plaintext_approval.py` to the PR head fails the 4 new stop/abort tests.
- ruff clean on all touched files; ty diagnostics unchanged vs `origin/main` per file.
- Phrase table: 147 phrases, no intra/cross-group collisions, all keys pre-normalized.

## Notes for review

- `_build_stream_consumer_config` no longer raises for non-editing adapters when interim messages are on, so qqbot (not in `_PLATFORM_DEFAULTS` → tier-high, `SUPPORTS_MESSAGE_EDITING=False`) also gets a buffer-only consumer for commentary. Commentary goes through the same `adapter.send`, so this should be benign, but it is a widening beyond photon.
- The photon `platform_hint` grew ~1000 chars of agent policy (confirm before spending money, receipts, CAPTCHA handling) that is not iMessage-specific. Left as the contributor wrote it; worth a maintainer call on whether it belongs in a per-platform hint.
- Overlaps #89840 (P5ina) on paragraph splitting only.

Closes #103335.
