### PR TITLE
fix(serve): serve the live session token in the headless token page (#103001)

### DIFF
--- a/hermes_cli/web_server_dashboard.py
+++ b/hermes_cli/web_server_dashboard.py
@@ -102,7 +102,9 @@ def mount_spa(application: FastAPI):
     with a missing dist per-request (404 JSON / ``check_dir=False``), so a long-lived
     ``--skip-build`` process recovers the moment a build appears on disk — no restart.
     """
-    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, _SESSION_TOKEN, app
+    from hermes_cli import web_server as _web_server
+
+    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, app
 
     # `hermes serve` is the headless backend: it must NEVER serve the browser SPA, even if a
     # dist is lying around, so only the JSON-RPC/WS/API surface is reachable.
@@ -120,7 +122,7 @@ def mount_spa(application: FastAPI):
             if full_path == "" and not gated:
                 return HTMLResponse(
                     "<!doctype html><html><head><script>"
-                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(_SESSION_TOKEN)};"
+                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(_web_server._SESSION_TOKEN)};"
                     "window.__HERMES_AUTH_REQUIRED__=false;"
                     f"</script></head><body>{_HEADLESS_MSG}</body></html>",
                     headers=_NO_STORE,
@@ -151,7 +153,7 @@ def mount_spa(application: FastAPI):
             return JSONResponse({"error": "Frontend not built. Run: cd web && npm run build"}, status_code=404)
         chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
         gated = bool(getattr(app.state, "auth_required", False))
-        token_js = "" if gated else f'window.__HERMES_SESSION_TOKEN__="{_SESSION_TOKEN}";'
+        token_js = "" if gated else f'window.__HERMES_SESSION_TOKEN__="{_web_server._SESSION_TOKEN}";'
         bootstrap_script = (
             f"<script>{token_js}"
             f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5066,6 +5066,37 @@ class TestServeIndexMissingIndex:
         assert "SPA-rebuilt" in resp.text
 
 
+    def test_spa_index_tracks_post_mount_token_override(
+        self, tmp_path, monkeypatch
+    ):
+        """Same invariant as the headless token page, through _serve_index with
+        a real dist: the SPA bootstrap must reflect a post-mount token override.
+        """
+        client, _dist = TestServeIndexMissingIndex._client_with_dist(
+            tmp_path, monkeypatch, write_index=True
+        )
+        import json as _json
+        import re
+        import uuid
+
+        import hermes_cli.web_server as ws
+
+        original = ws._SESSION_TOKEN
+        adopted = uuid.uuid4().hex * 2
+        try:
+            ws._apply_ssh_session_token(adopted)
+            resp = client.get("/chat")
+            assert resp.status_code == 200
+            match = re.search(
+                r'window\.__HERMES_SESSION_TOKEN__\s*=\s*("(?:\\.|[^"\\])*")',
+                resp.text,
+            )
+            assert match, resp.text
+            assert _json.loads(match.group(1)) == adopted
+        finally:
+            ws._apply_ssh_session_token(original)
+
+
 class TestHeadlessServeTokenPage:
     """Headless `hermes serve` must serve the Desktop token handshake page
     at `/` when the dashboard auth gate is off (#94227).
@@ -5124,6 +5155,31 @@ class TestHeadlessServeTokenPage:
             assert resp.status_code == 404
             assert "web UI disabled" in resp.json()["error"]
             assert ws._SESSION_TOKEN not in resp.text
+
+    def test_token_page_tracks_post_mount_token_override(self, monkeypatch):
+        """Mount happens before start_server applies the --ssh-session-token-file
+        token; the served token page must reflect that post-mount override.
+        """
+        import re
+        import uuid
+
+        client, ws = self._headless_client(monkeypatch, gated=False)
+        original = ws._SESSION_TOKEN
+        adopted = uuid.uuid4().hex * 2
+        try:
+            ws._apply_ssh_session_token(adopted)
+            resp = client.get("/")
+            assert resp.status_code == 200
+            match = re.search(
+                r'window\.__HERMES_SESSION_TOKEN__\s*=\s*("(?:\\.|[^"\\])*")',
+                resp.text,
+            )
+            assert match, resp.text
+            import json as _json
+
+            assert _json.loads(match.group(1)) == adopted
+        finally:
+            ws._apply_ssh_session_token(original)
 
 
 class TestHashedAssetCacheHeaders:


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop SSH remote regression from #103001.

`mount_spa()` bound `_SESSION_TOKEN` at import time, but the Desktop SSH path applies the `--ssh-session-token-file` token **after** mount via `_apply_ssh_session_token()`. The headless token page at `/` therefore served the stale import-time token, the desktop adopted it, and every authenticated `/api/` call returned `401 {"detail":"Unauthorized"}` — remote SSH mode was unusable while SSH handshake, dashboard spawn, and tunnel all succeeded.

The fix reads the module attribute at request time — the same late binding the in-module auth comparisons (`_has_valid_session_token`) already use, so the served token and the enforced token can no longer diverge.

Regressed in 2497ec5126 (the `mount_spa` extraction turned a late-bound read into an import-time copy).

## Related Issue

Fixes #103001

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server_dashboard.py` — `mount_spa()` reads `_SESSION_TOKEN` via the module attribute at request time (headless token page + SPA `_serve_index`), instead of the import-time copy.
- `tests/hermes_cli/test_web_server.py` — two invariant tests: the headless token page and the SPA index must each track a post-mount token override (both proven red on base, green with fix).

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_web_server.py -k TestHeadlessServeTokenPage` — 4 passed (new test is red on base, green with fix).
2. Live E2E on macOS (arm64 desktop host + arm64 remote backend, both git installs at the same commit): connect Desktop via SSH remote —
   - before: `GET /` served a 43-char token, `GET /api/profiles` with it → 401, renderer spammed `refreshProfiles failed ... 401`;
   - after: `GET /` serves the 64-hex token-file token, `GET /api/profiles` → 200, desktop connects and works.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (single commit, 2 files)
- [x] I've run the touched test file: `187 passed` (`scripts/run_tests.sh` per-file isolation on the full `tests/hermes_cli/test_web_server.py`)
- [x] I've added tests for my changes (invariant test, proven red on base)
- [x] I've tested on my platform: macOS 26.6 (arm64), both desktop host and remote backend

### Documentation & Housekeeping

- [x] N/A — no config keys, no docs, no architecture/workflow changes

## Screenshots / Logs

Live verification on the affected backend (remote `hermes serve --isolated --ssh-session-token-file ...`):

```
before:  GET /                -> __HERMES_SESSION_TOKEN__=<43-char import-time token>
         GET /api/profiles    -> 401 {"detail":"Unauthorized"}   (with served token)
after:   GET /                -> __HERMES_SESSION_TOKEN__=<64-hex token-file token>
         GET /api/profiles    -> 200                                (with served token)
```