### PR TITLE
fix(update): fleet check no longer fails with "no rows" after stopping unmapped/dashboard-only runtimes; receipts survive the module purge (#97332, #98436, salvage #97350 #92934)

### DIFF
--- a/contributors/emails/1244677795@qq.com
+++ b/contributors/emails/1244677795@qq.com
@@ -1,0 +1,1 @@
+bluefateludi

--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -1308,7 +1308,7 @@ def _fleet_probe_expected_runtimes(
     healthy, so zero rows is only proof-of-safety when NOTHING says a gateway existed
     pre-update. Signals: ``restarted_services``/``killed_pids``; ``pre_restart_pids``
     non-empty or None (same contract as ``_restart_phase_failure_is_incomplete``); plan
-    inventoried ≥1 runtime. ``windows_resume_token`` is deliberately EXCLUDED: it is
+    inventoried ≥1 ``kind == "gateway"`` runtime. ``windows_resume_token`` is deliberately EXCLUDED: it is
     pause/resume bookkeeping, not an inventory, and its entries don't map to probe rows
     (``unmapped`` Scheduled-Task gateways never publish gateway_state.json; a paused
     profile resumes DETACHED). Counting it made every Windows update that paused a
@@ -1326,7 +1326,11 @@ def _fleet_probe_expected_runtimes(
     if pre_restart_pids is None or pre_restart_pids:
         return True
     with suppress(Exception):
-        if pre_update_plan is not None and pre_update_plan.runtimes:
+        # Gateway-kind only: serve/dashboard plan records never publish a gateway_state.json
+        # row, so a dashboard-only plan cannot ground a rows-expected verdict (#97332).
+        if pre_update_plan is not None and any(
+            getattr(runtime, "kind", None) == "gateway" for runtime in pre_update_plan.runtimes
+        ):
             return True
     return False
 

--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -11,7 +11,7 @@ import os
 import subprocess
 import sys
 import time as _time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from hermes_cli.update_cmd_common import _best_effort
@@ -850,6 +850,18 @@ class _GatewayRestartOutcome:
     relaunched_profiles: list
     externally_supervised_profiles: list
     killed_pids: set
+    #: Gateways stopped with NO successor (no profile mapping / relaunch could not be armed);
+    #: the summary tells the user to restart them by hand, so the fleet probe must not expect
+    #: a row for them.
+    stopped_unmapped_pids: set = field(default_factory=set)
+
+    def fleet_probe_signals(self) -> tuple:
+        """``(pre_restart_pids, killed_pids)`` with the unmapped stops removed — the signals that
+        legitimately predict a fleet-matrix row."""
+        pre = self.pre_restart_gateway_pids
+        if pre is not None:
+            pre = [pid for pid in pre if pid not in self.stopped_unmapped_pids]
+        return pre, self.killed_pids - self.stopped_unmapped_pids
 
     def record_receipt(self, **extra) -> None:
         """Best-effort ``record_gateway_restart`` from the current bookkeeping."""
@@ -921,6 +933,7 @@ def _restart_manual_gateways(out: _GatewayRestartOutcome, _drain_budget) -> None
         with suppress(ProcessLookupError, PermissionError):
             os.kill(pid, _signal.SIGTERM)
             out.killed_pids.add(pid)
+            out.stopped_unmapped_pids.add(pid)
 
     if out.restarted_services or out.killed_pids:
         print()
@@ -1213,9 +1226,12 @@ def _verify_fleet_after_update(restart, *, _pre_update_plan, _windows_gateway_re
         # never fires on Windows (pause/resume populates neither), so a healthy
         # resumed gateway yielded zero rows and exit 0.
         # See #93406.
+        # A gateway stopped WITHOUT a successor ("Restart manually") publishes no row by design,
+        # so it must not count as an expected one — otherwise an update whose only live gateways
+        # were unmapped exits 1 with "no rows" after correctly stopping them.
+        _pre_restart, _killed = restart.fleet_probe_signals()
         _fleet_rows_expected = _m()._fleet_probe_expected_runtimes(
-            _pre_update_plan, restart.pre_restart_gateway_pids, _windows_gateway_resume, restart.restarted_services,
-            restart.killed_pids,
+            _pre_update_plan, _pre_restart, _windows_gateway_resume, restart.restarted_services, _killed,
         )
         _fleet_snapshot = _collect_fleet_snapshot(restart, _fleet_rows_expected)
         if print_fleet_version_matrix(_fleet_snapshot):

--- a/hermes_cli/update_cmd_maint.py
+++ b/hermes_cli/update_cmd_maint.py
@@ -36,6 +36,7 @@ _STALE_PURGE_PROTECTED = frozenset(
         "hermes_cli",
         "hermes_cli.main",
         "hermes_cli.update_cmd",
+        "hermes_cli.update_receipt",
         "hermes_cli.hermes_logging",
     }
     # The updater's own split modules are executing too.

--- a/hermes_cli/update_cmd_maint.py
+++ b/hermes_cli/update_cmd_maint.py
@@ -31,19 +31,14 @@ _STALE_PURGE_PREFIXES = "hermes_cli", "gateway", "tools", "tui_gateway", "agent"
 
 #: Modules EXECUTING the update survive the purge: evicting them buys nothing (running frames
 #: keep them alive) and reloading them mid-flight is the one genuinely unsafe move.
-_STALE_PURGE_PROTECTED = frozenset(
-    {
-        "hermes_cli",
-        "hermes_cli.main",
-        "hermes_cli.update_cmd",
-        "hermes_cli.update_receipt",
-        "hermes_cli.hermes_logging",
-    }
-    # The updater's own split modules are executing too.
-    | {f"hermes_cli.update_cmd_{c}" for c in (
-        "config", "deps", "fleet", "git", "maint", "stash", "windows", "zip",
-    )}
-)
+_STALE_PURGE_PROTECTED = frozenset({"hermes_cli", "hermes_cli.main", "hermes_cli.hermes_logging"})
+
+#: The updater's own module family (``update_cmd*``, ``update_receipt``, ``update_inventory``,
+#: ``update_lock``, ...) is protected as a prefix: these hold per-run state — the open receipt
+#: singleton, the pre-update plan's ``RuntimeRecord`` class identity, the lock — and evicting
+#: one swaps in a fresh module whose ``_current`` is None (receipt silently never written) or
+#: whose dataclass fails every ``isinstance`` against the plan built before the purge.
+_STALE_PURGE_PROTECTED_PREFIX = "hermes_cli.update_"
 
 _PRE_UPDATE_SNAPSHOT_KEEP = 1
 
@@ -90,6 +85,7 @@ def _purge_stale_hermes_modules() -> None:
         purged = [
             name for name in list(modules)
             if name not in _STALE_PURGE_PROTECTED
+            and not name.startswith(_STALE_PURGE_PROTECTED_PREFIX)
             # Root-package check: startswith() alone also matches unrelated ``gateway_foo``.
             and name.split(".", 1)[0] in _STALE_PURGE_PREFIXES
             and modules.pop(name, None) is not None

--- a/tests/hermes_cli/test_update_fleet_check_fail_closed.py
+++ b/tests/hermes_cli/test_update_fleet_check_fail_closed.py
@@ -201,3 +201,22 @@ class TestCallSiteWiring:
             "elif not _fleet_snapshot and (restarted_services or killed_pids):"
             not in src
         )
+
+
+def test_unmapped_stops_are_not_expected_rows():
+    # A gateway stopped WITHOUT a successor is listed under "Restart manually" and never
+    # publishes a row; counting it made the probe demand rows that cannot exist and the
+    # update exited 1 after correctly stopping every unmapped gateway.
+    from hermes_cli.update_cmd_fleet import _GatewayRestartOutcome
+
+    out = _GatewayRestartOutcome(
+        incomplete=False, phase_errors=[], pre_restart_gateway_pids=[101, 102], restarted_services=[],
+        failed_or_stale_units=[], relaunched_profiles=[], externally_supervised_profiles=[],
+        killed_pids={101, 102}, stopped_unmapped_pids={101, 102},
+    )
+    pre, killed = out.fleet_probe_signals()
+    assert not _fleet_probe_expected_runtimes(_plan([]), pre, None, out.restarted_services, killed)
+    # A relaunched profile gateway (not unmapped) still predicts a row.
+    out.stopped_unmapped_pids.discard(102)
+    pre, killed = out.fleet_probe_signals()
+    assert _fleet_probe_expected_runtimes(_plan([]), pre, None, out.restarted_services, killed)

--- a/tests/hermes_cli/test_update_fleet_check_fail_closed.py
+++ b/tests/hermes_cli/test_update_fleet_check_fail_closed.py
@@ -12,9 +12,11 @@ which never fires on Windows: ``_pause_windows_gateways_for_update`` /
 hoists the "should the probe have produced rows?" decision into
 ``_fleet_probe_expected_runtimes`` and keys it on the ROW-CAPABLE pre-update
 liveness signals: restart-phase bookkeeping, the pre-restart PID snapshot,
-and the pre-update plan inventory.  The Windows pause/resume token is
-deliberately NOT a signal — it is bookkeeping, not a runtime inventory, and
-its entries have no corresponding ``collect_fleet_versions()`` rows (see
+and the gateway-kind records in the pre-update plan inventory (the plan's
+serve/dashboard records are row-incapable for this probe, #97332).  The
+Windows pause/resume token is deliberately NOT a signal — it is bookkeeping,
+not a runtime inventory, and its entries have no corresponding
+``collect_fleet_versions()`` rows (see
 ``test_update_fleet_probe_resume_token.py``).  The same condition gates the
 2.0s settle sleep.
 """
@@ -24,7 +26,8 @@ from __future__ import annotations
 import inspect
 import types
 
-from hermes_cli.update_cmd import _fleet_probe_expected_runtimes
+from hermes_cli.main import _fleet_probe_expected_runtimes
+from hermes_cli.update_inventory import RuntimeRecord
 
 
 def _plan(runtimes):
@@ -34,17 +37,68 @@ def _plan(runtimes):
 class TestEmptySnapshotFailClosed:
     """Signals under which zero fleet rows means verification failure."""
 
-    def test_incomplete_when_pre_update_plan_saw_runtimes(self):
-        # (a) The plan inventoried a live runtime pre-update but the restart
-        # phase's POSIX bookkeeping is empty (e.g. Windows, or an
+    def test_incomplete_when_pre_update_plan_saw_gateway_runtimes(self):
+        # (a) The plan inventoried a live gateway runtime pre-update but the
+        # restart phase's POSIX bookkeeping is empty (e.g. Windows, or an
         # externally-supervised gateway). Zero rows must fail closed.
         assert (
             _fleet_probe_expected_runtimes(
-                _plan([object()]),
+                _plan([RuntimeRecord(kind="gateway", profile="default")]),
                 [],  # pre_restart_pids: probe saw nothing
                 None,  # no Windows resume token
                 [],  # restarted_services
                 set(),  # killed_pids
+            )
+            is True
+        )
+
+    def test_dashboard_only_plan_does_not_expect_rows(self):
+        # #97332: the plan inventory also carries kind="dashboard" records
+        # (#95576), but collect_fleet_versions() reports gateway identities
+        # only. A dashboard-only plan (gateway never started) cannot ground
+        # a rows-expected verdict — counting it made a successful update
+        # print the incomplete-verification warning and exit 1.
+        assert (
+            _fleet_probe_expected_runtimes(
+                _plan([RuntimeRecord(kind="dashboard", profile="default")]),
+                [],
+                None,
+                [],
+                set(),
+            )
+            is False
+        )
+
+    def test_serve_only_plan_does_not_expect_rows(self):
+        # Same row-incapable reasoning as the dashboard record above: a
+        # manually launched `hermes serve` backend never publishes the
+        # gateway_state.json row the fleet probe would need.
+        assert (
+            _fleet_probe_expected_runtimes(
+                _plan([RuntimeRecord(kind="serve", profile="default")]),
+                [],
+                None,
+                [],
+                set(),
+            )
+            is False
+        )
+
+    def test_mixed_plan_keys_on_gateway_record(self):
+        # A dashboard running alongside a real gateway still expects rows:
+        # the gateway record carries the expectation.
+        assert (
+            _fleet_probe_expected_runtimes(
+                _plan(
+                    [
+                        RuntimeRecord(kind="dashboard", profile="default"),
+                        RuntimeRecord(kind="gateway", profile="work"),
+                    ]
+                ),
+                [],
+                None,
+                [],
+                set(),
             )
             is True
         )
@@ -130,22 +184,14 @@ class TestCallSiteWiring:
     def _impl_source(self):
         from hermes_cli import update_cmd
 
-        # The fleet-version probe lives in the post-restart verifier that
-        # _cmd_update_impl calls; guard the wiring there.
-        return inspect.getsource(update_cmd._verify_fleet_after_update)
+        return inspect.getsource(update_cmd._cmd_update_impl)
 
     def test_settle_sleep_gated_on_expected_runtimes(self):
         src = self._impl_source()
         assert "_fleet_rows_expected = _m()._fleet_probe_expected_runtimes(" in src
         # The 2.0s settle window must key on the cross-platform signal, so a
-        # resumed Windows gateway gets its settle window too (#93406). The
-        # settle loop lives in _collect_fleet_snapshot, gated on that signal.
-        assert "_fleet_snapshot = _collect_fleet_snapshot(restart, _fleet_rows_expected)" in src
-        from hermes_cli import update_cmd_fleet
-
-        snap_src = inspect.getsource(update_cmd_fleet._collect_fleet_snapshot)
-        assert "if not rows_expected:\n" in snap_src
-        assert "_time.sleep(2.0)" in snap_src
+        # resumed Windows gateway gets its settle window too (#93406).
+        assert "if _fleet_rows_expected:\n" in src
         assert "if restarted_services or killed_pids:\n                _time.sleep" not in src
 
     def test_zero_row_guard_gated_on_expected_runtimes(self):

--- a/tests/hermes_cli/test_update_fleet_check_fail_closed.py
+++ b/tests/hermes_cli/test_update_fleet_check_fail_closed.py
@@ -52,56 +52,14 @@ class TestEmptySnapshotFailClosed:
             is True
         )
 
-    def test_dashboard_only_plan_does_not_expect_rows(self):
-        # #97332: the plan inventory also carries kind="dashboard" records
-        # (#95576), but collect_fleet_versions() reports gateway identities
-        # only. A dashboard-only plan (gateway never started) cannot ground
-        # a rows-expected verdict — counting it made a successful update
-        # print the incomplete-verification warning and exit 1.
-        assert (
-            _fleet_probe_expected_runtimes(
-                _plan([RuntimeRecord(kind="dashboard", profile="default")]),
-                [],
-                None,
-                [],
-                set(),
-            )
-            is False
-        )
-
-    def test_serve_only_plan_does_not_expect_rows(self):
-        # Same row-incapable reasoning as the dashboard record above: a
-        # manually launched `hermes serve` backend never publishes the
-        # gateway_state.json row the fleet probe would need.
-        assert (
-            _fleet_probe_expected_runtimes(
-                _plan([RuntimeRecord(kind="serve", profile="default")]),
-                [],
-                None,
-                [],
-                set(),
-            )
-            is False
-        )
-
-    def test_mixed_plan_keys_on_gateway_record(self):
-        # A dashboard running alongside a real gateway still expects rows:
-        # the gateway record carries the expectation.
-        assert (
-            _fleet_probe_expected_runtimes(
-                _plan(
-                    [
-                        RuntimeRecord(kind="dashboard", profile="default"),
-                        RuntimeRecord(kind="gateway", profile="work"),
-                    ]
-                ),
-                [],
-                None,
-                [],
-                set(),
-            )
-            is True
-        )
+    def test_plan_expectation_keys_on_gateway_kind_only(self):
+        # #97332: serve/dashboard plan records have no gateway_state.json row, so a
+        # dashboard-only or serve-only plan must not demand rows (that made a successful
+        # update exit 1); one gateway record alongside them still carries the expectation.
+        non_gateway = [RuntimeRecord(kind="dashboard", profile="default"), RuntimeRecord(kind="serve", profile="default")]
+        assert _fleet_probe_expected_runtimes(_plan(non_gateway), [], None, [], set()) is False
+        mixed = non_gateway + [RuntimeRecord(kind="gateway", profile="work")]
+        assert _fleet_probe_expected_runtimes(_plan(mixed), [], None, [], set()) is True
 
     def test_windows_resume_token_alone_is_not_expected(self):
         # (c) The Windows pause/resume token is EXCLUDED from the expectation
@@ -184,14 +142,22 @@ class TestCallSiteWiring:
     def _impl_source(self):
         from hermes_cli import update_cmd
 
-        return inspect.getsource(update_cmd._cmd_update_impl)
+        # The fleet-version probe lives in the post-restart verifier that
+        # _cmd_update_impl calls; guard the wiring there.
+        return inspect.getsource(update_cmd._verify_fleet_after_update)
 
     def test_settle_sleep_gated_on_expected_runtimes(self):
         src = self._impl_source()
         assert "_fleet_rows_expected = _m()._fleet_probe_expected_runtimes(" in src
         # The 2.0s settle window must key on the cross-platform signal, so a
-        # resumed Windows gateway gets its settle window too (#93406).
-        assert "if _fleet_rows_expected:\n" in src
+        # resumed Windows gateway gets its settle window too (#93406). The
+        # settle loop lives in _collect_fleet_snapshot, gated on that signal.
+        assert "_fleet_snapshot = _collect_fleet_snapshot(restart, _fleet_rows_expected)" in src
+        from hermes_cli import update_cmd_fleet
+
+        snap_src = inspect.getsource(update_cmd_fleet._collect_fleet_snapshot)
+        assert "if not rows_expected:\n" in snap_src
+        assert "_time.sleep(2.0)" in snap_src
         assert "if restarted_services or killed_pids:\n                _time.sleep" not in src
 
     def test_zero_row_guard_gated_on_expected_runtimes(self):
@@ -201,6 +167,7 @@ class TestCallSiteWiring:
             "elif not _fleet_snapshot and (restarted_services or killed_pids):"
             not in src
         )
+
 
 
 def test_unmapped_stops_are_not_expected_rows():

--- a/tests/hermes_cli/test_update_fleet_probe_resume_token.py
+++ b/tests/hermes_cli/test_update_fleet_probe_resume_token.py
@@ -33,7 +33,8 @@ from __future__ import annotations
 
 import types
 
-from hermes_cli.update_cmd import _fleet_probe_expected_runtimes
+from hermes_cli.main import _fleet_probe_expected_runtimes
+from hermes_cli.update_inventory import RuntimeRecord
 
 
 def _plan(runtimes):
@@ -86,7 +87,13 @@ class TestRowCapableSignalsStillCount:
     def test_plan_inventory_still_expects_rows_alongside_token(self):
         token = {"resume_needed": False, "unmapped": [{"pid": 99, "argv": ["x"]}]}
         assert (
-            _fleet_probe_expected_runtimes(_plan([object()]), [], token, [], set())
+            _fleet_probe_expected_runtimes(
+                _plan([RuntimeRecord(kind="gateway", profile="default")]),
+                [],
+                token,
+                [],
+                set(),
+            )
             is True
         )
 

--- a/tests/hermes_cli/test_update_stale_module_purge.py
+++ b/tests/hermes_cli/test_update_stale_module_purge.py
@@ -16,6 +16,8 @@ module graph from the updated checkout.
 
 from __future__ import annotations
 
+import importlib
+import json
 import sys
 import types
 
@@ -80,6 +82,31 @@ def test_purge_protects_executing_modules():
     assert sys.modules.get("hermes_cli.update_cmd") is update_cmd
     assert sys.modules.get("hermes_cli.main") is cli_main
     assert "hermes_cli" in sys.modules
+
+
+def test_purge_preserves_active_update_receipt(tmp_path, monkeypatch):
+    """A receipt begun before the post-pull purge must still be finalizable."""
+    import hermes_cli.update_receipt as receipt
+
+    receipt_dir = tmp_path / "update_receipts"
+    monkeypatch.setattr(receipt, "_receipt_dir", lambda: receipt_dir)
+    receipt._current = None
+    post_purge_receipt = receipt
+    try:
+        receipt.begin_update_receipt()
+        receipt.record_step("git_pull", True, "updated checkout")
+
+        cli_main._purge_stale_hermes_modules()
+        post_purge_receipt = importlib.import_module("hermes_cli.update_receipt")
+        path = post_purge_receipt.finalize_update_receipt("success")
+
+        assert path is not None and path.is_file()
+        latest = json.loads((receipt_dir / "latest.json").read_text(encoding="utf-8"))
+        assert latest["outcome"] == "success"
+        assert latest["steps"][0]["name"] == "git_pull"
+    finally:
+        receipt._current = None
+        post_purge_receipt._current = None
 
 
 def test_purge_leaves_prefix_lookalikes_alone():

--- a/tests/hermes_cli/test_update_stale_module_purge.py
+++ b/tests/hermes_cli/test_update_stale_module_purge.py
@@ -161,3 +161,14 @@ def test_stale_symbol_scenario_end_to_end():
         sys.modules.pop(name, None)
         if real is not None:
             sys.modules[name] = real
+
+
+def test_purge_keeps_plan_record_class_identity():
+    # The pre-update plan is built BEFORE the purge; reconciliation after it filters with
+    # ``isinstance(r, RuntimeRecord)``. An evicted ``update_inventory`` yields a fresh class,
+    # every record fails the check, and the plan-vs-execution report goes silently empty.
+    from hermes_cli.update_inventory import RuntimeRecord as before
+
+    cli_main._purge_stale_hermes_modules()
+    from hermes_cli.update_inventory import RuntimeRecord as after
+    assert after is before


### PR DESCRIPTION
A successful `hermes update` on a box whose only live gateways were unmapped (or dashboard-only) no longer exits 1 with "Fleet version check returned no rows even though gateway runtimes were expected — verification incomplete", and every completed update writes its receipt again.

Field report (Teknium's box, today): update pulled 4587 commits, stopped 24 manual gateway processes, then printed the "no rows" warning, exited 1, left `fleet_restart_pending` behind, and every following `hermes` start warned "A previous `hermes update` pulled new code but did not restart running gateways". No receipt had been written for any completed update since Aug 24.

## Changes

- **Unmapped stops are not expected rows** (`update_cmd_fleet.py`): a gateway with no profile mapping (or whose relaunch could not be armed) is SIGTERMed and listed under "Restart manually" — by design it has no successor and publishes no fleet row. It still counted in `killed_pids` and the pre-restart snapshot, so `_fleet_probe_expected_runtimes` demanded rows that could not exist. The outcome now tracks `stopped_unmapped_pids` and `fleet_probe_signals()` subtracts them; relaunched/systemd gateways still predict rows exactly as before.
- **Plan expectation keys on `kind == "gateway"` only** — salvage of #97350 by @liuhao1024 (fixes #97332; duplicate #97450): serve/dashboard plan records never publish a `gateway_state.json` row, so a dashboard-only plan cannot ground a rows-expected verdict.
- **Stale-module purge keeps the updater's own modules** — salvage of #92934 by @bluefateludi (fixes #98436; duplicate #98454 by @lEWFkRAD): `_purge_stale_hermes_modules` evicted `hermes_cli.update_receipt`, so the finalize call imported a fresh module with `_current is None` and silently wrote nothing. Widened here to the whole `hermes_cli.update_*` family by prefix: `update_inventory`'s `RuntimeRecord` has the same failure (plan built before the purge, `isinstance` reconciliation after it → empty runtime-outcome report).

## Validation

| Check | Base (`origin/main` @ 1e69c12b64) | This branch |
|---|---|---|
| A/B repro: real fake `gateway run` process with foreign `HERMES_HOME`, run through `_restart_manual_gateways` → fleet probe | `rows_expected=True snapshot=[]` → **VERDICT: BUG** | `rows_expected=False` → **VERDICT: FIXED** |
| A/B repro: `begin_update_receipt()` → purge → `finalize_update_receipt()` | `receipt_written=False plan_class_identity_kept=False` → **BUG** | both True → **FIXED** |
| New invariant tests (`test_unmapped_stops_are_not_expected_rows`, `test_purge_keeps_open_receipt_and_plan_identity`, `test_purge_keeps_plan_record_class_identity`, `test_plan_expectation_keys_on_gateway_kind_only`) | red | green |
| `scripts/run_tests.sh tests/hermes_cli/test_update*.py` (65 files) | 3 pre-existing failures in `test_update_yes_flag.py` (live-system guard blocks `os.kill` of a stray pytest-spawned `gateway restart` PID on this host; identical on base) | same 3, 786 passed |

Contributor tests trimmed to the invariant bar (3 near-identical #97350 cases folded into one); `TestCallSiteWiring` kept as on main.

## Infographic

![hermes-update-fleet-check-and-receipt](https://v3b.fal.media/files/b/0aa92c6a/zZabqzxSY3KDE88eqWSHA_mqDqyCfs.png)
