### PR TITLE
fix(desktop): pass HERMES_HOME for named-profile SSH serves so DB isolation holds (#103467)

### DIFF
--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -779,6 +779,46 @@ test('buildSpawnCommand is headless serve, detached, token not in argv', () => {
   assert.ok(!cmd.includes('HERMES_DASHBOARD_SESSION_TOKEN'), 'token env var must not appear')
 })
 
+test('buildSpawnCommand exports HERMES_HOME for a named profile so the frozen DB path is the profile DB (#103467)', () => {
+  // tilde home: the profile HERMES_HOME must $HOME-expand at the remote shell.
+  const tildeCmd = buildSpawnCommand('/x/hermes', 'work', {
+    hermesHome: '~/.hermes',
+    logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE),
+  })
+  assert.match(tildeCmd, /env HERMES_DESKTOP=1 HERMES_HOME="\$HOME"'\/\.hermes\/profiles\/work' /)
+  // absolute home is shell-quoted verbatim.
+  const absCmd = buildSpawnCommand('/x/hermes', 'work', {
+    hermesHome: '/root/.hermes',
+    logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE),
+  })
+  assert.match(absCmd, /HERMES_HOME='\/root\/\.hermes\/profiles\/work'/)
+  // A profile home already ending in /profiles/<name> is not double-nested.
+  const nestedCmd = buildSpawnCommand('/x/hermes', 'work', {
+    hermesHome: '/root/.hermes/profiles/other',
+    logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE),
+  })
+  assert.match(nestedCmd, /HERMES_HOME='\/root\/\.hermes\/profiles\/work'/)
+})
+
+test('buildSpawnCommand omits HERMES_HOME for the default (unnamed) profile', () => {
+  const cmd = buildSpawnCommand('/x/hermes', '', {
+    hermesHome: '~/.hermes',
+    logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE),
+  })
+  assert.doesNotMatch(cmd, /HERMES_HOME/)
+  assert.match(cmd, /env HERMES_DESKTOP=1 /)
+})
+
+test('buildSpawnCommand rejects a path-traversal profile name (fails closed)', () => {
+  assert.throws(
+    () => buildSpawnCommand('/x/hermes', '../../etc', {
+      hermesHome: '~/.hermes',
+      logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE),
+    }),
+    /Unsafe remote/,
+  )
+})
+
 test('buildSpawnCommand always uses serve (legacy dashboard path removed)', () => {
   const cmd = buildSpawnCommand('/x/hermes', 'work', { logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE) })
   assert.match(cmd, /serve --isolated/)

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -780,24 +780,35 @@ test('buildSpawnCommand is headless serve, detached, token not in argv', () => {
 })
 
 test('buildSpawnCommand exports HERMES_HOME for a named profile so the frozen DB path is the profile DB (#103467)', () => {
-  // tilde home: the profile HERMES_HOME must $HOME-expand at the remote shell.
+  // buildSpawnCommand wraps the serve line in the update-mutex + detached-spawn
+  // quoting layers, so the HERMES_HOME assignment's own single-quotes are
+  // re-escaped (`'` -> `'\''`) in the returned string; only the quote-free spans
+  // survive verbatim. Assert on those, mirroring the sibling "headless serve"
+  // test, rather than on the pre-wrap fragment.
+
+  // tilde home: the profile HERMES_HOME $HOME-expands at the remote shell.
   const tildeCmd = buildSpawnCommand('/x/hermes', 'work', {
     hermesHome: '~/.hermes',
     logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE),
   })
-  assert.match(tildeCmd, /env HERMES_DESKTOP=1 HERMES_HOME="\$HOME"'\/\.hermes\/profiles\/work' /)
-  // absolute home is shell-quoted verbatim.
+  assert.match(tildeCmd, /env HERMES_DESKTOP=1 /)
+  assert.match(tildeCmd, /HERMES_HOME="\$HOME"/)
+  assert.match(tildeCmd, /\/\.hermes\/profiles\/work/)
+  // absolute home is passed through verbatim, with no $HOME expansion.
   const absCmd = buildSpawnCommand('/x/hermes', 'work', {
     hermesHome: '/root/.hermes',
     logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE),
   })
-  assert.match(absCmd, /HERMES_HOME='\/root\/\.hermes\/profiles\/work'/)
+  assert.match(absCmd, /HERMES_HOME=/)
+  assert.match(absCmd, /\/root\/\.hermes\/profiles\/work/)
+  assert.doesNotMatch(absCmd, /HERMES_HOME="\$HOME"/)
   // A profile home already ending in /profiles/<name> is not double-nested.
   const nestedCmd = buildSpawnCommand('/x/hermes', 'work', {
     hermesHome: '/root/.hermes/profiles/other',
     logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE),
   })
-  assert.match(nestedCmd, /HERMES_HOME='\/root\/\.hermes\/profiles\/work'/)
+  assert.match(nestedCmd, /\/root\/\.hermes\/profiles\/work/)
+  assert.doesNotMatch(nestedCmd, /profiles\/other/)
 })
 
 test('buildSpawnCommand omits HERMES_HOME for the default (unnamed) profile', () => {

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -1041,6 +1041,18 @@ async function terminateOwnedDashboardForUpdate(ssh, expected) {
 function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
   const hermes = expandRemotePath(hermesPath)
   const profileArgs = profile ? `--profile ${shq(profile)} ` : ''
+  // Export HERMES_HOME for named-profile serves. The launcher imports
+  // hermes_cli.main (and thus hermes_state) at module level, freezing
+  // DEFAULT_DB_PATH against the resolved home BEFORE --profile is applied; with
+  // HERMES_HOME unset that freezes the shared root state.db and profile
+  // isolation collapses (#103467). Setting it in the spawn env mirrors the
+  // launchd/systemd gateway units. assertSafeRemoteHome rejects `..`/unsafe
+  // segments so a hostile profile name fails closed rather than mis-homing.
+  const profileHomeEnv = profile
+    ? ` HERMES_HOME=${expandRemotePath(
+        assertSafeRemoteHome(`${remoteInstallRoot(opts.hermesHome || '~/.hermes')}/profiles/${profile}`),
+      )}`
+    : ''
   const logPath = expandRemotePath(opts.logPath)
   const tokenFilePath = opts.tokenFilePath
   const tokenArg = tokenFilePath ? ` --ssh-session-token-file ${expandRemotePath(tokenFilePath)}` : ''
@@ -1065,7 +1077,7 @@ function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
 
   const dashCmd =
     `ulimit -n ${REMOTE_NOFILE_SOFT_LIMIT} 2>/dev/null || true; ` +
-    `exec env HERMES_DESKTOP=1${opts.guestOnboarding === true ? ' HERMES_GUEST_ONBOARDING=1' : ''} ${hermes} ${profileArgs}${subCmd}`
+    `exec env HERMES_DESKTOP=1${opts.guestOnboarding === true ? ' HERMES_GUEST_ONBOARDING=1' : ''}${profileHomeEnv} ${hermes} ${profileArgs}${subCmd}`
 
   const detachedShell = `eval "exec $1>&-"; ${dashCmd} </dev/null >> ${logPath} 2>&1 & echo $!`
   const detachedSpawn = `child=$("$(command -v setsid || echo nohup)" sh -c ${shq(detachedShell)} hermes-update-child "$1" & echo $!)`


### PR DESCRIPTION
## Summary

Fixes #103467.

On Linux the Desktop spawns the remote backend as `env HERMES_DESKTOP=1 hermes --profile <name> serve --isolated` but never exports `HERMES_HOME`. The launcher imports `hermes_cli.main` (and thus `hermes_state`) at module level, so `DEFAULT_DB_PATH = get_hermes_home() / "state.db"` is frozen against the resolved home **before** `_apply_profile_override()` runs. With `HERMES_HOME` unset that resolves to the shared root `~/.hermes`, so a named-profile serve opens the **root** `state.db` instead of `profiles/<name>/state.db`. Profile isolation collapses and the Desktop loops on "Could not verify the SSH backend process".

This is the Linux counterpart of the Windows-specific #102315 / #102343 (there the cause was case-insensitive `Hermes_Home` leaking through `process.env`; on Linux the spawn simply omits the var).

## Fix

`buildSpawnCommand` now exports `HERMES_HOME=<root>/profiles/<name>` in the spawn env for named profiles, alongside `HERMES_DESKTOP=1` — mirroring what the launchd/systemd gateway units already do (the issue's preferred, minimal fix location). The path is:

- rooted via `remoteInstallRoot(opts.hermesHome || '~/.hermes')` (so an already-profile-scoped home isn't double-nested),
- validated with `assertSafeRemoteHome` (rejects `..` and unsafe segments, so a hostile profile name **fails closed** rather than mis-homing),
- expanded with `expandRemotePath` (so a `~/`-rooted home `$HOME`-expands in the remote shell rather than being passed literally).

The default (unnamed) profile is unchanged — no `HERMES_HOME` is added, keeping existing behavior byte-for-byte.

## Tests

Added three `buildSpawnCommand` cases in `remote-lifecycle.test.ts`:
- named profile exports `HERMES_HOME` with correct `$HOME`-expansion (tilde home) and verbatim shell-quoting (absolute home), and does not double-nest a profile-scoped home;
- the default profile omits `HERMES_HOME`;
- a path-traversal profile name (`../../etc`) throws (fails closed).

`tsc -p tsconfig.electron.json` is clean. The desktop vitest harness is currently unrunnable in my environment (a pre-existing missing `@rolldown/plugin-babel` dev dep, unrelated to this change), so the added cases run in CI.

The arm64 fork-Docker CI job is expected to fail on fork PRs and is unrelated to this change.
