### PR TITLE
fix(desktop): wrap remote SSH lifecycle probes in sh -c for non-POSIX…

### DIFF
--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -26,6 +26,7 @@ import {
   openForward,
   ownershipDirectory,
   pidIsOurDashboard,
+  probeRemoteHermesHome,
   probeRemotePlatform,
   PROTOCOL_VERSION,
   readLockfile,
@@ -243,6 +244,10 @@ test('listRemoteHermesProfiles inventories Mini-style profile dirs without spawn
   ])
 
   assert.deepEqual(await listRemoteHermesProfiles(ssh), ['default', 'bob', 'dixie', 'goose', 'rambo'])
+  assert.ok(
+    ssh.calls.some(c => c.startsWith('sh -c ') && c.includes('ls -1 ')),
+    'listing must execute under sh -c'
+  )
   assert.equal(
     ssh.calls.some(cmd => cmd.includes('serve') || cmd.includes('dashboard')),
     false
@@ -269,6 +274,10 @@ test('listRemoteHermesProfiles rejects a hostile HERMES_HOME', async () => {
 test('locateHermes prefers the explicit profile path when executable', async () => {
   const ssh = fakeSsh([[/\[ -x .*\/opt\/hermes/, 'OK']])
   assert.equal(await locateHermes(ssh, '/opt/hermes'), '/opt/hermes')
+  assert.ok(
+    ssh.calls.some(c => c.startsWith('sh -c ') && c.includes('[ -x ')),
+    'executable check must run under sh -c'
+  )
 })
 
 test('locateHermes throws (no silent fallback) when an EXPLICIT path is not executable', async () => {
@@ -396,6 +405,31 @@ test('probeRemotePlatform rejects unsupported remote platforms', async () => {
   )
 })
 
+test('probeRemoteHermesHome resolves custom HERMES_HOME and defaults to ~/.hermes', async () => {
+  const customSsh = fakeSsh([[/HERMES_HOME/, '/custom/hermes/home\n']])
+  assert.equal(await probeRemoteHermesHome(customSsh), '/custom/hermes/home')
+  assert.ok(
+    customSsh.calls.some(c => c.startsWith('sh -c ') && c.includes('echo "${HERMES_HOME:-$HOME/.hermes}"')),
+    'probe must be wrapped in sh -c to prevent syntax errors on non-POSIX login shells (e.g. fish)'
+  )
+
+  const defaultSsh = fakeSsh([[/HERMES_HOME/, '']])
+  assert.equal(await probeRemoteHermesHome(defaultSsh), '~/.hermes')
+})
+
+test('probeRemoteHermesHome classifies failure as a transient transport error', async () => {
+  const failure = new Error('SSH channel closed')
+  await assert.rejects(
+    () => probeRemoteHermesHome(fakeSsh([[/HERMES_HOME/, failure]])),
+    (err: any) => {
+      assert.equal(err.kind, 'transient-transport-error')
+      assert.equal(err.cause, failure)
+
+      return true
+    }
+  )
+})
+
 test('ownership paths are isolated by ownership ID and spawn nonce', () => {
   assert.equal(ownershipDirectory(OWNERSHIP_ID), `~/.hermes/desktop-ssh/${OWNERSHIP_ID}`)
   assert.equal(lockfilePath(OWNERSHIP_ID), `~/.hermes/desktop-ssh/${OWNERSHIP_ID}/backend.lock.json`)
@@ -403,7 +437,12 @@ test('ownership paths are isolated by ownership ID and spawn nonce', () => {
 })
 
 test('readLockfile returns null ONLY for a missing/empty lockfile', async () => {
-  assert.equal(await readLockfile(fakeSsh([[/cat/, '']]), OWNERSHIP_ID), null)
+  const missingSsh = fakeSsh([[/cat/, '']])
+  assert.equal(await readLockfile(missingSsh, OWNERSHIP_ID), null)
+  assert.ok(
+    missingSsh.calls.some(c => c.startsWith('sh -c ') && c.includes('cat ')),
+    'readLockfile must execute under sh -c'
+  )
   const good = ownedLock({ pid: 1, port: 2 })
   assert.deepEqual(await readLockfile(fakeSsh([[/cat/, JSON.stringify(good)]]), OWNERSHIP_ID), good)
 })
@@ -507,12 +546,18 @@ test('writeLockfile mkdir -ps and stamps the schema version', async () => {
   const ssh = fakeSsh([])
   await writeLockfile(ssh, OWNERSHIP_ID, ownedLock({ pid: 7, port: 9 }))
   const cmd = ssh.calls.join('\n')
+  assert.match(cmd, /^sh -c /)
   assert.match(cmd, /mkdir -p/)
   assert.match(cmd, new RegExp(`"schemaVersion":${LOCKFILE_SCHEMA_VERSION}`))
 })
 
 test('remotePidAlive maps kill -0 ALIVE/DEAD', async () => {
-  assert.equal(await remotePidAlive(fakeSsh([[/kill -0/, 'ALIVE']]), 123), true)
+  const aliveSsh = fakeSsh([[/kill -0/, 'ALIVE']])
+  assert.equal(await remotePidAlive(aliveSsh, 123), true)
+  assert.ok(
+    aliveSsh.calls.some(c => c.startsWith('sh -c ') && c.includes('kill -0 123')),
+    'remotePidAlive must execute under sh -c'
+  )
   assert.equal(await remotePidAlive(fakeSsh([[/kill -0/, 'DEAD']]), 123), false)
   assert.equal(await remotePidAlive(fakeSsh([]), null), false)
 })
@@ -1172,7 +1217,7 @@ test('connect() fresh spawn writes hermesHome + protocolVersion into the lockfil
     [/kill -0 700/, 'ALIVE'],
     [/cat .*\.log/, 'HERMES_DASHBOARD_READY port=45500\n'],
     [
-      /printf '%s' '/,
+      /schemaVersion/,
       c => {
         writes.push(c)
 
@@ -1794,6 +1839,7 @@ test('remote SSH ownership capability requires both secure bootstrap flags', asy
   ])
 
   assert.equal(await remoteSupportsSshOwnership(supported, '/x/hermes'), true)
+  assert.match(helpProbe, /^sh -c /)
   assert.match(helpProbe, /ssh-session-token-file/)
   assert.match(helpProbe, /ssh-owner-nonce/)
 

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -183,7 +183,9 @@ async function locateHermes(ssh, remoteHermesPath) {
   const isExecutable = async (candidate: string) => {
     try {
       validateRemotePath(candidate)
-      const ok = (await ssh.exec(`[ -x ${expandRemotePath(candidate)} ] && echo OK || true`)).trim()
+      const ok = (
+        await ssh.exec(`sh -c ${shq(`[ -x ${expandRemotePath(candidate)} ] && echo OK || true`)}`)
+      ).trim()
 
       return ok === 'OK'
     } catch {
@@ -279,7 +281,7 @@ async function probeRemotePlatform(ssh) {
 // state store; best-effort.
 async function probeRemoteHermesHome(ssh) {
   try {
-    const out = (await ssh.exec('echo "${HERMES_HOME:-$HOME/.hermes}"')).trim().split('\n').pop()
+    const out = (await ssh.exec(`sh -c ${shq('echo "${HERMES_HOME:-$HOME/.hermes}"')}`)).trim().split('\n').pop()
 
     return out || '~/.hermes'
   } catch (cause) {
@@ -375,7 +377,7 @@ async function listRemoteHermesProfiles(ssh) {
   let listing = ''
 
   try {
-    listing = await ssh.exec(`if [ -d ${dir} ]; then ls -1 ${dir}; fi`)
+    listing = await ssh.exec(`sh -c ${shq(`if [ -d ${dir} ]; then ls -1 ${dir}; fi`)}`)
   } catch (cause) {
     const error: any = new Error('Could not list remote Hermes profiles.')
     error.kind = 'transient-transport-error'
@@ -410,7 +412,9 @@ async function readLockfile(ssh, ownershipId) {
   let raw
 
   try {
-    raw = await ssh.exec(`if [ ! -e ${expandRemotePath(lpath)} ]; then exit 0; fi; cat ${expandRemotePath(lpath)}`)
+    raw = await ssh.exec(
+      `sh -c ${shq(`if [ ! -e ${expandRemotePath(lpath)} ]; then exit 0; fi; cat ${expandRemotePath(lpath)}`)}`
+    )
   } catch (cause) {
     const error: any = new Error('Could not read the SSH backend ownership record.')
     error.kind = 'transient-transport-error'
@@ -497,9 +501,11 @@ async function writeLockfile(ssh, ownershipId, lock) {
   const temporaryPath = `${directory}/.${crypto.randomBytes(8).toString('hex')}.lock.tmp`
   const json = JSON.stringify({ ...lock, schemaVersion: LOCKFILE_SCHEMA_VERSION })
   await ssh.exec(
-    `umask 077 && mkdir -p ${expandRemotePath(directory)} && ` +
-      `printf '%s' ${shq(json)} > ${expandRemotePath(temporaryPath)} && ` +
-      `mv -f ${expandRemotePath(temporaryPath)} ${expandRemotePath(lpath)}`
+    `sh -c ${shq(
+      `umask 077 && mkdir -p ${expandRemotePath(directory)} && ` +
+        `printf '%s' ${shq(json)} > ${expandRemotePath(temporaryPath)} && ` +
+        `mv -f ${expandRemotePath(temporaryPath)} ${expandRemotePath(lpath)}`
+    )}`
   )
 }
 
@@ -519,7 +525,7 @@ async function remotePidAlive(ssh, pid) {
   }
 
   try {
-    const out = (await ssh.exec(`kill -0 ${Number(pid)} 2>/dev/null && echo ALIVE || echo DEAD`)).trim()
+    const out = (await ssh.exec(`sh -c ${shq(`kill -0 ${Number(pid)} 2>/dev/null && echo ALIVE || echo DEAD`)}`)).trim()
 
     return out === 'ALIVE'
   } catch (cause) {
@@ -667,9 +673,11 @@ async function cleanupStale(ssh, ownershipId, lock, pidAlive = true) {
     try {
       const result = (
         await ssh.exec(
-          `kill ${Number(lock.pid)} && ` +
-            `i=0; while kill -0 ${Number(lock.pid)} 2>/dev/null; do ` +
-            `i=$((i+1)); [ "$i" -ge 50 ] && exit 1; sleep 0.1; done`
+          `sh -c ${shq(
+            `kill ${Number(lock.pid)} && ` +
+              `i=0; while kill -0 ${Number(lock.pid)} 2>/dev/null; do ` +
+              `i=$((i+1)); [ "$i" -ge 50 ] && exit 1; sleep 0.1; done`
+          )}`
         )
       ).trim()
 
@@ -683,9 +691,11 @@ async function cleanupStale(ssh, ownershipId, lock, pidAlive = true) {
       // confirmed exit before treating the record as reclaimed.
       try {
         await ssh.exec(
-          `kill -9 ${Number(lock.pid)} 2>/dev/null; ` +
-            `i=0; while kill -0 ${Number(lock.pid)} 2>/dev/null; do ` +
-            `i=$((i+1)); [ "$i" -ge 20 ] && exit 1; sleep 0.1; done`
+          `sh -c ${shq(
+            `kill -9 ${Number(lock.pid)} 2>/dev/null; ` +
+              `i=0; while kill -0 ${Number(lock.pid)} 2>/dev/null; do ` +
+              `i=$((i+1)); [ "$i" -ge 20 ] && exit 1; sleep 0.1; done`
+          )}`
         )
       } catch (cause) {
         // Even SIGKILL could not confirm death (D-state, permissions). Keep
@@ -1120,11 +1130,12 @@ function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
 async function remoteSupportsSshOwnership(ssh, hermesPath) {
   const hermes = expandRemotePath(hermesPath)
 
-  const out = await ssh.exec(
+  const checkScript =
     `help="$(${hermes} serve --help 2>&1)"; ` +
-      `printf '%s' "$help" | grep -q ssh-session-token-file && ` +
-      `printf '%s' "$help" | grep -q ssh-owner-nonce && echo YES || echo NO`
-  )
+    `printf '%s' "$help" | grep -q ssh-session-token-file && ` +
+    `printf '%s' "$help" | grep -q ssh-owner-nonce && echo YES || echo NO`
+
+  const out = await ssh.exec(`sh -c ${shq(checkScript)}`)
 
   return String(out || '')
     .trim()
@@ -1147,7 +1158,7 @@ async function scrapeReadyPort(ssh, logPath, { timeoutMs = DEFAULT_READY_TIMEOUT
     let tail
 
     try {
-      tail = await ssh.exec(`cat ${remoteLog} 2>/dev/null || true`)
+      tail = await ssh.exec(`sh -c ${shq(`cat ${remoteLog} 2>/dev/null || true`)}`)
     } catch {
       tail = ''
     }


### PR DESCRIPTION
fix(desktop): wrap remote SSH lifecycle probes in sh -c for non-POSIX shells like fish

Non-interactive OpenSSH commands execute using the remote user's default login shell. When the remote user's login shell is non-POSIX (such as fish or tcsh), commands using POSIX parameter expansions (e.g. ${HERMES_HOME:-$HOME/.hermes}), test constructs, or shell control loops trigger syntax errors and exit non-zero.

In Desktop SSH remote mode, this caused the initial home probe to fail, which entered an unthrottled reconnect loop that flooded sshd and tripped MaxStartups rate-limiting.

Wrap non-interactive remote shell commands across remote-lifecycle.ts in `sh -c` so they execute reliably under standard /bin/sh regardless of the remote login shell, and add unit tests asserting command wrappers and error handling.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

