### PR TITLE
fix(agent): restore Bedrock primary without OpenAI key (#102860)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2105,6 +2105,12 @@ def _snapshot_primary_runtime(agent):
             "anthropic_base_url": agent._anthropic_base_url,
             "is_anthropic_oauth": agent._is_anthropic_oauth,
         })
+    # Bedrock needs region/guardrail so restore can rebuild without OPENAI_API_KEY.
+    if (agent.provider or "").strip().lower() == "bedrock" or agent.api_mode == "bedrock_converse":
+        if hasattr(agent, "_bedrock_region"):
+            agent._primary_runtime["_bedrock_region"] = agent._bedrock_region
+        if hasattr(agent, "_bedrock_guardrail_config"):
+            agent._primary_runtime["bedrock_guardrail_config"] = agent._bedrock_guardrail_config
 
 
 def _init_usage_state(agent):

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -920,6 +920,57 @@ def _rebuild_primary_client(agent, rt: Dict[str, Any], *, reason: str) -> None:
         # factory so the restored facade keeps the reference_callback relay wired at init — a bare
         # MoAClient() would silently stop emitting moa.reference/moa.aggregating display events (#53802).
         agent._anthropic_client = None
+    elif (agent.provider or "").strip().lower() == "bedrock":
+        api_mode = agent.api_mode or rt.get("api_mode", "")
+        if api_mode == "bedrock_converse":
+            # Bedrock Converse has no OpenAI client; it uses boto3 directly.
+            # Falls through to _create_openai_client would raise OPENAI_API_KEY.
+            from agent.agent_init import _bedrock_region_from_url
+            region = rt.get("_bedrock_region") or rt.get("bedrock_region")
+            if not region:
+                region = _bedrock_region_from_url(rt.get("base_url") or getattr(agent, "base_url", "") or "")
+            agent._bedrock_region = region
+            # Preserve guardrail config from snapshot when present; otherwise keep current.
+            if "bedrock_guardrail_config" in rt:
+                agent._bedrock_guardrail_config = rt.get("bedrock_guardrail_config")
+            elif "_bedrock_guardrail_config" in rt:
+                agent._bedrock_guardrail_config = rt.get("_bedrock_guardrail_config")
+            elif not hasattr(agent, "_bedrock_guardrail_config"):
+                agent._bedrock_guardrail_config = None
+            agent.client = None
+            agent._anthropic_client = None
+        elif api_mode == "anthropic_messages":
+            # Bedrock Claude via AnthropicBedrock SDK (SigV4, prompt caching).
+            try:
+                from agent.anthropic_adapter import build_anthropic_bedrock_client
+                from agent.agent_init import _bedrock_region_from_url
+                region = rt.get("_bedrock_region") or rt.get("bedrock_region")
+                if not region:
+                    region = _bedrock_region_from_url(rt.get("base_url") or getattr(agent, "base_url", "") or "")
+                agent._bedrock_region = region
+                agent._anthropic_client = build_anthropic_bedrock_client(region)
+                agent._anthropic_api_key = rt.get("anthropic_api_key", "aws-sdk")
+                agent._anthropic_base_url = rt.get("anthropic_base_url", rt.get("base_url", ""))
+                agent._is_anthropic_oauth = False
+                agent.api_key = rt.get("api_key", "aws-sdk")
+                agent.client = None
+            except Exception:
+                # Fall back to generic Anthropic rebuild if Bedrock SDK unavailable.
+                _build_anthropic_client_from_runtime(agent, rt)
+        else:
+            # Bedrock Mantle OpenAI-compatible endpoint (bedrock-mantle.*.api.aws).
+            # Snapshot client_kwargs already contains SigV4 http_client, but re-apply
+            # to ensure the region-derived auth is fresh.
+            try:
+                from agent.bedrock_adapter import configure_bedrock_openai_client_kwargs
+                kwargs = dict(rt.get("client_kwargs") or {})
+                configure_bedrock_openai_client_kwargs(
+                    kwargs, timeout=get_provider_request_timeout(agent.provider, agent.model)
+                )
+                agent.client = agent._create_openai_client(kwargs, reason=reason, shared=True)
+            except Exception:
+                agent.client = agent._create_openai_client(dict(rt.get("client_kwargs") or {}), reason=reason, shared=True)
+            agent._anthropic_client = None
     elif agent.api_mode == "anthropic_messages":
         _build_anthropic_client_from_runtime(agent, rt)
     else:


### PR DESCRIPTION
Fixes #102860

**Problem**
When `model.provider: bedrock` is primary (e.g. `nvidia.nemotron-super-3-120b` in `eu-west-1`) and a turn falls back to another provider, `restore_primary_runtime()` in `agent/agent_runtime_helpers.py` falls through to `_create_openai_client` which requires `OPENAI_API_KEY`. Bedrock uses AWS credentials, not an OpenAI key, so restore always fails with:

> Failed to restore primary runtime: The api_key client option must be set ...

The failure leaves `_fallback_activated=True` and `_fallback_index` stranded, permanently blocking the fallback chain.

**Root cause**
`_rebuild_primary_client` only special-cased `moa` and `anthropic_messages`; Bedrock (`bedrock_converse` and Bedrock+Claude via `AnthropicBedrock`) was missing and routed to the OpenAI path.

**Fix**
- `agent/agent_runtime_helpers.py::_rebuild_primary_client`: add a Bedrock-aware branch — `bedrock_converse` rebuilds `_bedrock_region`/guardrail with `client=None`, `anthropic_messages` rebuilds via `AnthropicBedrock`, mantle OpenAI path re-applies SigV4 before creating the OpenAI client.
- `agent/agent_init.py::_snapshot_primary_runtime`: persist `_bedrock_region` and `bedrock_guardrail_config` so restore has the region without parsing the URL.

Verified with a mocked `restore_primary_runtime` unit check for both Bedrock modes (no OpenAI client call, correct region/client) and `pytest tests/run_agent/test_primary_runtime_restore.py` (41 passed).