### PR TITLE
fix(matrix): warn when encrypted events are dropped with E2EE off

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -767,6 +767,7 @@ class MatrixAdapter(BasePlatformAdapter):
         self._password: str = config.extra.get("password", "") or _startup_env_secret("MATRIX_PASSWORD")
         self._e2ee_mode: str = _resolve_e2ee_mode(config.extra)
         self._encryption: bool = self._e2ee_mode != "off"
+        self._e2ee_off_warned_rooms: set = set()  # one visibility warning per room (#84693)
         self._device_id: str = config.extra.get("device_id", "") or os.getenv("MATRIX_DEVICE_ID", "")
         self._device_id_unverified: bool = False
         self._client: Any = None  # mautrix.client.Client
@@ -1265,6 +1266,10 @@ class MatrixAdapter(BasePlatformAdapter):
         client.add_event_handler(EventType.ROOM_MESSAGE, self._on_room_message, wait_sync=True)
         client.add_event_handler(EventType.REACTION, self._on_reaction, wait_sync=True)
         client.add_event_handler(IntEvt.INVITE, self._on_invite, wait_sync=True)
+        if not self._encryption:
+            # Without a crypto machine (mode off, or optional degraded by missing deps) the sync
+            # dispatcher finds no listener for m.room.encrypted and drops it silently (#84693).
+            client.add_event_handler(EventType.ROOM_ENCRYPTED, self._on_encrypted_event_e2ee_off, wait_sync=True)
         self._startup_ts = time.time()
         self._reset_clock_skew_detector()  # a reconnect after an NTP fix starts clean
         self._closing = False
@@ -1869,6 +1874,20 @@ class MatrixAdapter(BasePlatformAdapter):
                 "the startup grace filter to silently discard every incoming message. Run "
                 "`timedatectl set-ntp true` (or sync NTP) and restart the bot.", self._late_grace_drops, skew)
             self._clock_skew_warned = True
+
+    async def _on_encrypted_event_e2ee_off(self, event: Any) -> None:
+        """E2EE disabled or degraded: surface dropped m.room.encrypted events instead of failing
+        silently — a bot that joins an encrypted room and never replies otherwise leaves no log
+        line at all (#84693)."""
+        room_id = str(getattr(event, "room_id", "")) or "(unknown room)"
+        if room_id in self._e2ee_off_warned_rooms:
+            return
+        self._e2ee_off_warned_rooms.add(room_id)
+        reason = "E2EE dependencies are missing" if self._e2ee_mode != "off" else "E2EE is disabled"
+        logger.warning(
+            "Matrix: dropping encrypted event in %s — %s, so this room cannot be read. Set "
+            "MATRIX_E2EE_MODE=required (or MATRIX_ENCRYPTION=true) and restart to enable it. %s",
+            room_id, reason, "" if self._e2ee_mode == "off" else _E2EE_INSTALL_HINT)
 
     async def _on_room_message(self, event: Any) -> None:
         room_id = str(getattr(event, "room_id", ""))

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -3342,3 +3342,46 @@ class TestCryptoPickleKeyMigration:
         # start still sees a legacy-key account and retries the migration.
         store.put_account.assert_not_awaited()
         assert "retried on the next start" in caplog.text
+
+
+class TestMatrixEncryptedEventE2EEOff:
+    """E2EE-off adapters must surface dropped m.room.encrypted events instead of
+    discarding them silently — the "bot joins an encrypted room but never responds"
+    failure mode left no log line at all (#84693)."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+
+    @pytest.mark.asyncio
+    async def test_encrypted_event_warns_once_per_room(self, caplog):
+        import logging
+        evt = types.SimpleNamespace(room_id="!secret:example.org", sender="@alice:example.org")
+        with caplog.at_level(logging.WARNING, logger="plugins.platforms.matrix.adapter"):
+            await self.adapter._on_encrypted_event_e2ee_off(evt)
+            await self.adapter._on_encrypted_event_e2ee_off(evt)
+        warns = [r for r in caplog.records if "encrypted event" in r.getMessage()]
+        assert len(warns) == 1  # de-duplicated per room
+        assert "!secret:example.org" in warns[0].getMessage()
+        assert "MATRIX_E2EE_MODE" in warns[0].getMessage()
+
+    @pytest.mark.asyncio
+    async def test_encrypted_event_second_room_warns_again(self, caplog):
+        import logging
+        first = types.SimpleNamespace(room_id="!a:example.org", sender="@alice:example.org")
+        second = types.SimpleNamespace(room_id="!b:example.org", sender="@bob:example.org")
+        with caplog.at_level(logging.WARNING, logger="plugins.platforms.matrix.adapter"):
+            await self.adapter._on_encrypted_event_e2ee_off(first)
+            await self.adapter._on_encrypted_event_e2ee_off(second)
+        warns = [r for r in caplog.records if "encrypted event" in r.getMessage()]
+        assert len(warns) == 2
+
+    @pytest.mark.asyncio
+    async def test_encrypted_event_optional_mode_carries_install_hint(self, caplog):
+        import logging
+        self.adapter._e2ee_mode = "optional"  # connect() degraded it: deps were missing
+        evt = types.SimpleNamespace(room_id="!secret:example.org", sender="@alice:example.org")
+        with caplog.at_level(logging.WARNING, logger="plugins.platforms.matrix.adapter"):
+            await self.adapter._on_encrypted_event_e2ee_off(evt)
+        msg = next(r.getMessage() for r in caplog.records if "encrypted event" in r.getMessage())
+        assert "dependencies are missing" in msg
+        assert "pip install" in msg  # _E2EE_INSTALL_HINT


### PR DESCRIPTION
## What does this PR do?

When the Matrix adapter runs without a crypto machine — `MATRIX_ENCRYPTION`/`MATRIX_E2EE_MODE` unset (mode `off`, the documented default), or `optional` mode degraded by missing E2EE deps — incoming `m.room.encrypted` room events find no listener in the mautrix sync dispatcher and are dropped with **zero log output**. To the user this reads as "the bot joined my encrypted room and never responds", with nothing in `gateway.log` pointing at E2EE (#84693; the issue commenter narrowed it: unencrypted rooms work, encrypted rooms are silent).

This PR registers a `ROOM_ENCRYPTED` event handler in exactly that state which logs one warning per room stating the event was dropped, why (disabled vs deps missing), and the exact env vars to enable E2EE. It does not change any default behavior — it converts a silent failure into a diagnosable one, mirroring the existing fail-visible warnings for degraded-optional mode at connect time and the clock-skew silent-drop warning.

## Related Issue

Fixes #84693

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/matrix/adapter.py`: added `_on_encrypted_event_e2ee_off` handler (per-room de-duplicated warning with `MATRIX_E2EE_MODE`/`MATRIX_ENCRYPTION` guidance, plus the install hint when deps are the cause); registered under `EventType.ROOM_ENCRYPTED` in `connect()` only when `self._encryption` is false; added the `_e2ee_off_warned_rooms` set in `__init__`.
- `tests/gateway/test_matrix.py`: added `TestMatrixEncryptedEventE2EEOff` covering per-room de-duplication, second-room re-warning, and the deps-missing variant carrying the install hint.

## How to Test

1. `pytest tests/gateway/test_matrix.py -q` → 115 passed, including the 3 new tests (observed: `3 passed` for the new class, full file green).
2. With E2EE off (`MATRIX_ENCRYPTION` unset), send a message in an encrypted room to a connected bot → `gateway.log` now shows one `Matrix: dropping encrypted event in <room> — E2EE is disabled ... Set MATRIX_E2EE_MODE=required ...` warning per room instead of nothing; a second message in the same room logs nothing further (de-duplicated), a different room warns once.
3. With `MATRIX_E2EE_MODE=required` and deps installed, the handler is not registered — encrypted events keep flowing through the OlmMachine decryption dispatcher unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (the warning text itself names the env vars; the troubleshooting doc already covers enabling them)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure logging, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
