### PR TITLE
fix(reasoning): include z-ai/ in static OpenRouter reasoning-prefix fallback

### DIFF
--- a/agent/reasoning_params.py
+++ b/agent/reasoning_params.py
@@ -14,7 +14,7 @@ from utils import base_url_host_matches
 # Static OpenRouter fallback when the live /v1/models capability cache is cold.
 _OPENROUTER_REASONING_PREFIXES = (
     "deepseek/", "anthropic/", "openai/", "x-ai/", "google/gemini-2", "google/gemma-4",
-    "qwen/qwen3", "tencent/hy", "xiaomi/",
+    "qwen/qwen3", "tencent/hy", "xiaomi/", "z-ai/",
 )
 
 # Probe results cache per (model, base_url). Definitive values cache permanently; an


### PR DESCRIPTION
One-line addition of `z-ai/` to `_OPENROUTER_REASONING_PREFIXES` in `agent/reasoning_params.py`.

## Problem
GLM models (`z-ai/glm-5.3-flash`) are **reasoning-mandatory** routes on OpenRouter (`supported_efforts: [max, high, low]`). With a cold `/v1/models` capability cache, `supports_reasoning` falls back to the static prefix list — without `z-ai/`, the GLM route fails the gate and the conversation loop falls back to deepseek mid-session (observed live 2026-09-01, GLM→deepseek flapping on a Hermes production fleet; fixed locally since and stable).

## Fix
Add `"z-ai/"` to the static tuple. No behavior change for any other model; probe/cached paths untouched.

## Testing
- Live production verification: GLM 5.3-flash stable on the prefix fallback with cold catalog (no fallback flap since 2026-09-01).
- Existing prefix-list tests pass unchanged.