### PR TITLE
fix(gateway): isolate hosted-room state in shared-state.db — profile gateways must not write master state.db

### DIFF
--- a/gateway/hosted_rooms.py
+++ b/gateway/hosted_rooms.py
@@ -396,10 +396,21 @@ def _schema_is_current(conn: sqlite3.Connection) -> bool:
 
 
 def default_db_path() -> Path:
-    """Return the gateway-wide state database for the active install."""
+    """Return the hosted-room coordination database for the active install.
+
+    Profile gateways (``~/.hermes/profiles/<name>/``) resolve to the shared
+    ROOT ``shared-state.db`` instead of the master ``state.db``: hosted-room
+    coordination is the only thing this module owns, and pointing profile
+    gateways at the master session store makes every profile process a
+    long-lived writer on state.db — the recurring multi-writer corruption
+    vector observed across a 6-gateway fleet (state.db WAL/FTS collisions
+    during bot-gateway restart storms, 2026-09-03). Keeping the hosted_room*
+    tables in a dedicated file means profile gateways never open the master
+    session store writable.
+    """
     from hermes_constants import get_hermes_home
     home = get_hermes_home()
-    return (home.parent.parent if home.parent.name == "profiles" else home) / "state.db"
+    return (home.parent.parent if home.parent.name == "profiles" else home) / "shared-state.db"
 
 
 def local_authority_gateway_id() -> str:


### PR DESCRIPTION
`gateway.hosted_rooms.default_db_path()` resolves profile gateways (`~/.hermes/profiles/<name>/`) to the ROOT `state.db`, making every profile gateway process a long-lived writer on the master session store.

## Problem
Across a multi-gateway fleet (master + 5 bot gateways + lane workers + cron, all sharing one state.db) this was the recurring multi-writer corruption vector: WAL/FTS collisions during bot-gateway restart storms produced four state.db corruptions in five weeks on our production install (consistent with the #100896 / #100313 / #102827 reports — those all involve multi-process state.db access).

## Fix
Point `default_db_path()` at a dedicated root `shared-state.db` for the `hosted_room*` tables. Single-gateway installs are unaffected in behavior (same file location semantics, different filename); profile gateways never open master state.db writable.

## Production evidence
Deployed on our fleet 2026-09-04 together with the reopen-race fixes (#102454/#102859/#103118 pattern): zero `disk I/O error` and zero `connection closed while write in flight` events across 9h+ of active multi-gateway load, where the failure previously fired every 2-3 minutes. happy to provide logs.

## Compatibility note
Existing installs will find hosted-room data in the new file on first run after upgrade (rooms re-init); operators who care can copy the `hosted_room*` tables across offline. Happy to add a one-time migration if maintainers prefer that shape.