### PR TITLE
fix(desktop): open clicked compression tip instead of ancestor

### DIFF
--- a/apps/desktop/src/app/open-session.test.ts
+++ b/apps/desktop/src/app/open-session.test.ts
@@ -106,8 +106,18 @@ describe('openSession', () => {
 
   it('in-place focuses main when already selected and not on a page', () => {
     focusOpenSession.mockReturnValue('main')
+    $selectedStoredSessionId.set('s1')
     openSession('s1', navigate)
     expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it('routes a newly clicked compression tip when main still names an ancestor', () => {
+    focusOpenSession.mockReturnValue('main')
+    $selectedStoredSessionId.set('compression-parent')
+
+    openSession('active-tip', navigate)
+
+    expect(navigate).toHaveBeenCalledWith('/c/active-tip')
   })
 
   it('in-place routes when the main session is covered by a page', () => {

--- a/apps/desktop/src/app/open-session.ts
+++ b/apps/desktop/src/app/open-session.ts
@@ -165,7 +165,15 @@ export function openSession(
   // otherwise load it into main. From a full page (artifacts, skills, …) a
   // `'main'` hit still has to route back: fronting the workspace tab alone
   // leaves the page showing.
-  if (focusedSessionNeedsRoute(focusOpenSession(storedSessionId, workspaceScope), $workspaceIsPage.get())) {
+  const focused = focusOpenSession(storedSessionId, workspaceScope)
+
+  // Lineage matching may focus main when its route still names an older
+  // compression segment. Canonicalize that route to the clicked tip: the
+  // explicit resume request is consumed only once its id matches the route.
+  const mainRouteNamesAnotherSegment =
+    focused === 'main' && $selectedStoredSessionId.get() !== storedSessionId
+
+  if (mainRouteNamesAnotherSegment || focusedSessionNeedsRoute(focused, $workspaceIsPage.get())) {
     navigate(sessionRoute(storedSessionId))
   }
 }


### PR DESCRIPTION
## What does this PR do?

Desktop now routes the main chat to the exact compression tip selected in the sidebar, even when lineage matching finds that an older segment is already focused. Without this change, the queued resume request can be ignored and the runtime remains bound to the older ancestor.

### Symptom

Clicking the active tip of a repeatedly compressed conversation can leave Desktop displaying and running the earlier ancestor already bound to the main chat.

### Impact

Affected users can continue work in an older conversation segment while believing they opened the active tip. The persisted session data remains intact.

### Bug Cause

**Trigger:** `apps/desktop/src/app/open-session.ts:168` / `openSession` / main focus resolves by compression lineage while the selected stored id still names an ancestor.

**Causal chain:**
1. The sidebar queues a resume for the clicked live tip and asks the shared session door to open it.
2. `focusOpenSession` recognizes that the ancestor already on main belongs to the same lineage, so `openSession` focuses main without changing the route.
3. `useRouteResume` only consumes an explicit resume once its id matches the routed id, so the tip request is ignored and the ancestor runtime remains bound.

**Why it is wrong:** lineage equivalence is correct for avoiding duplicate tabs, but it cannot replace exact route identity at the resume boundary.

**Working sibling / contrast:** opening the tip through a direct session URL works because the route already contains the tip id, allowing the queued resume to target it.

**Ruled out:** the session list projection and backend resume resolver both return the live tip for the reported chain; the id is lost at the renderer focus-to-route seam instead.

### Fix

When lineage matching focuses main but its selected stored id differs from the clicked id, `openSession` now canonicalizes the route to the clicked tip. Existing exact-id main focus and tile focus remain navigation no-ops.

## Related Issue

Fixes #103456

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/open-session.ts` - route exact compression-tip selections before the resume effect runs.
- `apps/desktop/src/app/open-session.test.ts` - cover the ancestor-focused, tip-clicked regression while preserving the exact-id no-op contract.

## How to Test

1. Build a conversation with multiple compression continuations.
2. Keep an older segment selected on main, then click the sidebar row for the active tip.
3. Confirm the route and runtime bind to the clicked tip.
4. Run the focused automated checks:

```bash
cd apps/desktop
npx vitest run src/app/open-session.test.ts src/app/session/hooks/use-route-resume.test.tsx
npm run typecheck
npx eslint src/app/open-session.ts src/app/open-session.test.ts
```

The focused Vitest run passes 43 tests. TypeScript type checking and targeted ESLint checks pass. The full UI suite was also attempted; 7216 tests passed and 11 unrelated existing tests failed across six untouched files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant desktop tests and checks described above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - renderer logic is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - covered by the focused renderer regression test.
