### PR TITLE
fix(desktop): increase contrast for provider group headings in model picker (#103432)

### DIFF
--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -473,7 +473,7 @@ export function ModelCatalogMenu({
             return (
               <DropdownMenuGroup className="py-0.5" key={slug}>
                 <DropdownMenuItem
-                  className="group/label flex w-full items-center gap-1 px-2 pb-0.5 pt-0.5 text-[0.625rem] font-semibold uppercase tracking-wider text-(--ui-accent) cursor-pointer !bg-transparent focus:!bg-transparent"
+                  className="group/label flex w-full items-center gap-1 px-2 pb-0.5 pt-0.5 text-[0.625rem] font-semibold uppercase tracking-wider text-(--ui-text-secondary) cursor-pointer !bg-transparent focus:!bg-transparent"
                   onSelect={event => {
                     event.preventDefault()
                     toggleCollapsedProvider(slug)
@@ -612,7 +612,7 @@ export function ModelCatalogMenu({
           })}
           {!hasLocalGroup && shownDownloads.length > 0 && (
             <DropdownMenuGroup className="py-0.5" key="local-downloads">
-              <DropdownMenuLabel className="px-2 pb-0.5 pt-0.5 text-[0.625rem] font-semibold uppercase tracking-wider text-(--ui-accent)">
+              <DropdownMenuLabel className="px-2 pb-0.5 pt-0.5 text-[0.625rem] font-semibold uppercase tracking-wider text-(--ui-text-secondary)">
                 {copyPicker.localDownloadsHeading}
               </DropdownMenuLabel>
               {shownDownloads.map(job => (

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -473,7 +473,7 @@ export function ModelCatalogMenu({
             return (
               <DropdownMenuGroup className="py-0.5" key={slug}>
                 <DropdownMenuItem
-                  className="group/label flex w-full items-center gap-1 px-2 pb-0.5 pt-0.5 text-[0.625rem] font-semibold uppercase tracking-wider text-(--ui-text-tertiary) cursor-pointer !bg-transparent focus:!bg-transparent"
+                  className="group/label flex w-full items-center gap-1 px-2 pb-0.5 pt-0.5 text-[0.625rem] font-semibold uppercase tracking-wider text-(--ui-accent) cursor-pointer !bg-transparent focus:!bg-transparent"
                   onSelect={event => {
                     event.preventDefault()
                     toggleCollapsedProvider(slug)
@@ -612,7 +612,7 @@ export function ModelCatalogMenu({
           })}
           {!hasLocalGroup && shownDownloads.length > 0 && (
             <DropdownMenuGroup className="py-0.5" key="local-downloads">
-              <DropdownMenuLabel className="px-2 pb-0.5 pt-0.5 text-[0.625rem] font-semibold uppercase tracking-wider text-(--ui-text-tertiary)">
+              <DropdownMenuLabel className="px-2 pb-0.5 pt-0.5 text-[0.625rem] font-semibold uppercase tracking-wider text-(--ui-accent)">
                 {copyPicker.localDownloadsHeading}
               </DropdownMenuLabel>
               {shownDownloads.map(job => (

--- a/apps/desktop/src/components/model-visibility-dialog.tsx
+++ b/apps/desktop/src/components/model-visibility-dialog.tsx
@@ -124,7 +124,7 @@ export function ModelVisibilityDialog({
                 <div className="py-0.5" key={provider.slug}>
                   <div className="flex items-center gap-2 px-3 pb-0.5 pt-1">
                     <button
-                      className="group/label flex w-full items-center gap-1 pb-0.5 pt-0.5 text-left text-[0.625rem] font-semibold uppercase tracking-wider text-(--ui-accent) hover:bg-transparent"
+                      className="group/label flex w-full items-center gap-1 pb-0.5 pt-0.5 text-left text-[0.625rem] font-semibold uppercase tracking-wider text-(--ui-text-secondary) hover:bg-transparent"
                       onClick={() => toggleCollapsedProvider(provider.slug)}
                       type="button"
                     >

--- a/apps/desktop/src/components/model-visibility-dialog.tsx
+++ b/apps/desktop/src/components/model-visibility-dialog.tsx
@@ -124,7 +124,7 @@ export function ModelVisibilityDialog({
                 <div className="py-0.5" key={provider.slug}>
                   <div className="flex items-center gap-2 px-3 pb-0.5 pt-1">
                     <button
-                      className="group/label flex w-full items-center gap-1 pb-0.5 pt-0.5 text-left text-[0.625rem] font-semibold uppercase tracking-wider text-(--ui-text-tertiary) hover:bg-transparent"
+                      className="group/label flex w-full items-center gap-1 pb-0.5 pt-0.5 text-left text-[0.625rem] font-semibold uppercase tracking-wider text-(--ui-accent) hover:bg-transparent"
                       onClick={() => toggleCollapsedProvider(provider.slug)}
                       type="button"
                     >

--- a/apps/desktop/src/components/ui/dropdown-menu.tsx
+++ b/apps/desktop/src/components/ui/dropdown-menu.tsx
@@ -11,7 +11,7 @@ import { cn } from '@/lib/utils'
 // reads identically.
 export const dropdownMenuRow = 'gap-2 rounded-none px-2.5 py-1 text-xs'
 export const dropdownMenuSectionLabel =
-  'px-2.5 pt-1 pb-0.5 text-[0.625rem] font-medium uppercase tracking-wide text-(--ui-accent)'
+  'px-2.5 pt-1 pb-0.5 text-[0.625rem] font-medium uppercase tracking-wide text-(--ui-text-secondary)'
 
 // Keys that must reach Radix's menu handler (navigation/close). Everything else
 // is a filter keystroke and is stopped so the menu's typeahead doesn't hijack it.

--- a/apps/desktop/src/components/ui/dropdown-menu.tsx
+++ b/apps/desktop/src/components/ui/dropdown-menu.tsx
@@ -10,7 +10,8 @@ import { cn } from '@/lib/utils'
 // Reuse these instead of re-deriving per menu so every searchable/compact menu
 // reads identically.
 export const dropdownMenuRow = 'gap-2 rounded-none px-2.5 py-1 text-xs'
-export const dropdownMenuSectionLabel = 'px-2.5 pt-1 pb-0.5 text-[0.625rem] font-medium uppercase tracking-wide'
+export const dropdownMenuSectionLabel =
+  'px-2.5 pt-1 pb-0.5 text-[0.625rem] font-medium uppercase tracking-wide text-(--ui-accent)'
 
 // Keys that must reach Radix's menu handler (navigation/close). Everything else
 // is a filter keystroke and is stopped so the menu's typeahead doesn't hijack it.


### PR DESCRIPTION
## Summary
Fixes #103432

In the Desktop composer's model picker dropdown and the Edit Models visibility dialog, provider group headings previously used \	ext-(--ui-text-tertiary)\, which shares the same foreground-mix ladder as model names and makes it difficult to distinguish where one provider section ends and the next begins under low-luminance and monochrome themes.

Per review feedback regarding affordance (reserving accent colors for interactive elements) and contrast, this PR adopts the brighter neutral token \	ext-(--ui-text-secondary)\:
1. Updates \dropdownMenuSectionLabel\ in \pps/desktop/src/components/ui/dropdown-menu.tsx\ to include \	ext-(--ui-text-secondary)\.
2. Updates provider heading rows in \pps/desktop/src/app/shell/model-catalog-menu.tsx\ (\group/label\ and local downloads heading) to use \	ext-(--ui-text-secondary)\.
3. Updates provider heading rows in \pps/desktop/src/components/model-visibility-dialog.tsx\ to use \	ext-(--ui-text-secondary)\.

## Verification
- Verified all touchpoints consistently apply \	ext-(--ui-text-secondary)\ to avoid false interactive affordance while achieving clear visual hierarchy and contrast.
- Verified no broken syntax or unexpected regressions in surrounding JSX structures.