### PR TITLE
fix(buzz): authenticate protected imeta attachment downloads

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1552,10 +1552,19 @@ class BuzzAdapter(BasePlatformAdapter):
             return None
         import httpx
         try:
+            headers = {"Accept-Encoding": "identity", "User-Agent": "OpenAI File Downloader, XaiImageApiFetch/1.0"}
+            media_path = re.fullmatch(r"/media/([0-9a-f]{64})(?:\.[a-z0-9]{1,8}|\.thumb\.jpg)?", parsed_url.path)
+            # Extra attachment hosts are public sources, never recipients of relay credentials.
+            if origin == _attachment_origin(self.relay_url) and media_path:
+                headers["Authorization"] = _nostr_auth.build_blossom_get_auth_header(
+                    private_key=self._private_key, sha256=media_path[1],
+                )
+                if self._auth_tag:
+                    headers["x-auth-tag"] = self._auth_tag
             timeout = httpx.Timeout(_ATTACHMENT_DOWNLOAD_TIMEOUT)
             async with (
                 asyncio.timeout(_ATTACHMENT_DOWNLOAD_TIMEOUT),
-                httpx.AsyncClient(follow_redirects=False, timeout=timeout, headers={"Accept-Encoding": "identity"}) as client,
+                httpx.AsyncClient(follow_redirects=False, timeout=timeout, headers=headers) as client,
                 client.stream("GET", url) as response,
             ):
                 if response.status_code != 200:

--- a/plugins/platforms/buzz/nostr_auth.py
+++ b/plugins/platforms/buzz/nostr_auth.py
@@ -1,7 +1,8 @@
-"""Dependency-free Nostr signing (secp256k1 / BIP-340) for Buzz WebSocket authentication."""
+"""Dependency-free Nostr signing (secp256k1 / BIP-340) for Buzz authentication."""
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
 import secrets
@@ -167,11 +168,32 @@ def build_auth_event(
     tags: list[list[str]] = [["relay", relay_url], ["challenge", challenge]]
     if auth_tag_json.strip():
         tags.append(parse_auth_tag(auth_tag_json, "BUZZ_AUTH_TAG"))
+    return _build_signed_event(
+        private_key=private_key, kind=22242, tags=tags, content="", created_at=created_at,
+        auxiliary_randomness=auxiliary_randomness,
+    )
+
+
+def _build_signed_event(
+    *, private_key: str, kind: int, tags: list[list[str]], content: str,
+    created_at: Optional[int] = None, auxiliary_randomness: Optional[bytes] = None,
+) -> dict[str, Any]:
     pubkey = public_key_hex(private_key)
     timestamp = int(time.time()) if created_at is None else int(created_at)
-    serialized = json.dumps([0, pubkey, timestamp, 22242, tags, ""], separators=(",", ":"), ensure_ascii=False).encode()
+    serialized = json.dumps([0, pubkey, timestamp, kind, tags, content], separators=(",", ":"), ensure_ascii=False).encode()
     event_id = hashlib.sha256(serialized).digest()
     return {
-        "id": event_id.hex(), "pubkey": pubkey, "created_at": timestamp, "kind": 22242, "tags": tags, "content": "",
+        "id": event_id.hex(), "pubkey": pubkey, "created_at": timestamp, "kind": kind, "tags": tags, "content": content,
         "sig": schnorr_sign(event_id, private_key, auxiliary_randomness=auxiliary_randomness).hex(),
     }
+
+
+def build_blossom_get_auth_header(*, private_key: str, sha256: str) -> str:
+    """Sign a short-lived BUD-01 GET token for one blob, never the whole server."""
+    timestamp = int(time.time())
+    event = _build_signed_event(
+        private_key=private_key, kind=24242, content="Get media", created_at=timestamp,
+        tags=[["t", "get"], ["expiration", str(timestamp + 600)], ["x", sha256]],
+    )
+    encoded = base64.urlsafe_b64encode(json.dumps(event, separators=(",", ":")).encode()).decode().rstrip("=")
+    return f"Nostr {encoded}"

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -741,6 +741,91 @@ class TestPollingDedupe:
 
 
 class TestInboundAttachments:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("suffix", ["", ".png", ".thumb.jpg"])
+    async def test_protected_relay_attachment_uses_blob_scoped_auth(self, monkeypatch, suffix):
+        import httpx
+
+        payload = b"protected Buzz attachment"
+        digest = hashlib.sha256(payload).hexdigest()
+        real_async_client = httpx.AsyncClient
+        adapter = _make_adapter()
+        adapter._private_key = "00" * 31 + "03"
+        adapter._auth_tag = json.dumps(["auth", "b" * 64, "", "c" * 128])
+
+        def handler(request):
+            authorization = request.headers.get("Authorization", "")
+            if not authorization.startswith("Nostr "):
+                return httpx.Response(401)
+            encoded = authorization.removeprefix("Nostr ")
+            event = json.loads(base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4)))
+            assert event["kind"] == 24242
+            assert ["t", "get"] in event["tags"]
+            assert ["x", digest] in event["tags"]
+            assert not any(tag[0] == "server" for tag in event["tags"])
+            expiry = next(int(tag[1]) for tag in event["tags"] if tag[0] == "expiration")
+            assert event["created_at"] < expiry <= event["created_at"] + 600
+            canonical = [0, event["pubkey"], event["created_at"], event["kind"], event["tags"], event["content"]]
+            assert event["id"] == hashlib.sha256(json.dumps(canonical, separators=(",", ":"), ensure_ascii=False).encode()).hexdigest()
+            assert request.headers["x-auth-tag"] == adapter._auth_tag
+            assert request.headers["User-Agent"] == "OpenAI File Downloader, XaiImageApiFetch/1.0"
+            return httpx.Response(200, content=payload)
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: real_async_client(transport=httpx.MockTransport(handler), **kwargs))
+        cached = await adapter._download_attachment({
+            "url": f"https://test.relay/media/{digest}{suffix}", "sha256": digest,
+            "size": len(payload), "filename": "attachment.txt", "mime_type": "text/plain",
+        })
+        assert cached is not None
+        assert Path(cached.path).read_bytes() == payload
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("url", ["https://cdn.example/media/", "https://test.relay/public/"])
+    async def test_public_attachment_never_receives_relay_credentials(self, monkeypatch, url):
+        import httpx
+
+        payload = b"public attachment"
+        digest = hashlib.sha256(payload).hexdigest()
+        real_async_client = httpx.AsyncClient
+        adapter = _make_adapter({"attachment_hosts": ["cdn.example"]})
+        adapter._private_key = "00" * 31 + "03"
+        adapter._auth_tag = json.dumps(["auth", "b" * 64, "", "c" * 128])
+
+        def handler(request):
+            assert "Authorization" not in request.headers
+            assert "x-auth-tag" not in request.headers
+            return httpx.Response(200, content=payload)
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: real_async_client(transport=httpx.MockTransport(handler), **kwargs))
+        cached = await adapter._download_attachment({
+            "url": url + digest, "sha256": digest, "size": len(payload),
+            "filename": "attachment.txt", "mime_type": "text/plain",
+        })
+        assert cached is not None
+
+    @pytest.mark.asyncio
+    async def test_protected_attachment_does_not_follow_redirect(self, monkeypatch):
+        import httpx
+
+        digest = "a" * 64
+        real_async_client = httpx.AsyncClient
+        requests = []
+
+        def handler(request):
+            requests.append(request)
+            return httpx.Response(302, headers={"Location": "https://untrusted.example/leak"})
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: real_async_client(transport=httpx.MockTransport(handler), **kwargs))
+        adapter = _make_adapter()
+        adapter._private_key = "00" * 31 + "03"
+        cached = await adapter._download_attachment({
+            "url": f"https://test.relay/media/{digest}", "sha256": digest,
+            "size": 1, "filename": "attachment.txt", "mime_type": "text/plain",
+        })
+        assert cached is None
+        assert len(requests) == 1
+        assert requests[0].url.host == "test.relay"
+
 
     def test_imeta_total_declared_bytes_are_bounded(self):
         event = _event("bounded", content="@Chip files")

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -142,8 +142,11 @@ mismatches are rejected.
 The relay's own HTTPS origin is trusted automatically. If a community stores
 media on another public origin, add its exact `host` or `host:port` to
 `attachment_hosts` under `gateway.platforms.buzz.extra`. Non-default ports
-must be listed explicitly. Protected media that requires authenticated
-retrieval through the Buzz CLI is not handled by this native public-URL path.
+must be listed explicitly. Relay-origin `/media/{sha256}[.ext]` downloads use
+short-lived, blob-scoped Blossom GET authentication and the agent's configured
+owner attestation. Additional attachment hosts receive no relay credentials.
+The same size, digest, sender authorization, and no-redirect checks apply to
+both protected relay media and public attachments.
 
 ## Run the gateway
 


### PR DESCRIPTION
## What does this PR do?

Native `imeta` attachment downloads currently make an anonymous GET. On a relay that requires Blossom GET authentication, an authorized sender's valid attachment returns HTTP 401 and produces a failed-attachment notice. The separate text-URL localization path already uses authenticated CLI downloads; this fixes the bounded native `imeta` path.

Sign relay-origin `/media/{sha256}[.ext]` requests with short-lived, blob-scoped Blossom GET authentication and the configured owner attestation. Additional public attachment hosts receive no relay credentials. Existing sender authorization, exact-origin checks, no-redirect behavior, streaming byte limits, and SHA-256 verification stay in place.

## Related Issue

Follow-up to the native `imeta` path consolidated in #99432. No changes to the separate CLI text-URL localization path.

## Type of Change

- [x] Bug fix
- [x] Documentation update
- [x] Regression tests

## Changes Made

- Reuse the existing BIP-340 signer for kind-24242 Blossom GET events scoped by the requested blob hash, without a server-wide grant.
- Attach credentials only to canonical media URLs on the configured relay origin.
- Cover bare hashes, extensions, thumbnails, public-host credential isolation, and redirect rejection.

## How to Test

`HERMES_TEST_WORKERS=2 scripts/run_tests.sh tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py tests/gateway/test_buzz_authz.py tests/gateway/test_buzz_thread_topology.py -q`

Result: 238 passed. The three protected-download regression cases failed with HTTP 401 before the change. A live protected attachment failed anonymously and then downloaded through the patched adapter with exact size and SHA-256 verified. Ruff and `git diff --check` pass. Independent security review found no blockers.

## Checklist

- [x] Read the contribution guidance and searched existing PRs
- [x] Focused change with Conventional Commit
- [x] Regression coverage added and relevant local tests passed
- [ ] Full repository test suite run (not run; focused suite above)
- [x] Relevant documentation updated; no new configuration keys
- [x] Tested on Linux; uses the existing cross-platform Python/HTTPX path
