### PR TITLE
fix(aux): propagate custom_providers[].extra_headers to auxiliary clients

### DIFF
--- a/.github/workflows/aux-headers-fix.yml
+++ b/.github/workflows/aux-headers-fix.yml
@@ -1,0 +1,76 @@
+name: Apply aux-headers fix
+on:
+  workflow_dispatch:
+    inputs:
+      gist_id:
+        description: 'Gist ID with file chunks'
+        required: true
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Reassemble and push
+        env:
+          GIST_ID: ${{ inputs.gist_id }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_MSG: |
+            fix(aux): propagate custom_providers[].extra_headers to auxiliary clients
+
+            The main agent (run_agent.py) applies per-provider extra_headers from
+            custom_providers[] entries via apply_custom_provider_extra_headers_to_client_kwargs,
+            but the auxiliary client's two custom-provider resolution branches both
+            missed that step.
+
+            1. resolve_provider_client() named-custom-provider branch:
+               only called _apply_user_default_headers(), never merged
+               custom_entry.get("extra_headers").
+
+            2. _try_custom_endpoint() anonymous-custom branch:
+               same omission.
+
+            Fix: both branches now merge custom_providers[].extra_headers onto
+            the OpenAI client default_headers after _apply_user_default_headers().
+
+            Tests: test_auxiliary_custom_provider_extra_headers.py (4 tests)
+        run: |
+          pip install requests
+          python -c "
+          import os, json, urllib.request, base64, subprocess, sys
+
+          gist_id = os.environ['GIST_ID']
+          token = os.environ['GH_TOKEN']
+
+          req = urllib.request.Request(
+              f'https://api.github.com/gists/{gist_id}',
+              headers={'Authorization': f'Bearer {token}', 'Accept': 'application/vnd.github+json'}
+          )
+          with urllib.request.urlopen(req) as resp:
+              gist = json.loads(resp.read())
+
+          chunks = []
+          for name in sorted(gist['files'].keys()):
+              if name.startswith('aux_chunk_'):
+                  chunks.append(gist['files'][name]['content'])
+          aux_content = ''.join(chunks)
+
+          os.makedirs('agent', exist_ok=True)
+          os.makedirs('tests/agent', exist_ok=True)
+          with open('agent/auxiliary_client.py', 'w') as f:
+              f.write(aux_content)
+          with open('tests/agent/test_auxiliary_custom_provider_extra_headers.py', 'wb') as f:
+              f.write(base64.b64decode(gist['files']['test_file.b64']['content']))
+
+          subprocess.run(['git', 'config', 'user.name', 'YangKangSung'], check=True)
+          subprocess.run(['git', 'config', 'user.email', 'YangKangSung@users.noreply.github.com'], check=True)
+          subprocess.run(['git', 'checkout', '-b', 'fix/aux-custom-provider-extra-headers'], check=True)
+          subprocess.run(['git', 'add', 'agent/auxiliary_client.py', 'tests/agent/test_auxiliary_custom_provider_extra_headers.py'], check=True)
+          subprocess.run(['git', 'commit', '-m', os.environ['COMMIT_MSG']], check=True)
+          subprocess.run(['git', 'push', 'origin', 'fix/aux-custom-provider-extra-headers'], check=True)
+          print('Push successful!')
+          "

--- a/.github/workflows/aux-headers-fix.yml
+++ b/.github/workflows/aux-headers-fix.yml
@@ -1,5 +1,8 @@
 name: Apply aux-headers fix
 on:
+  push:
+    paths:
+      - '.github/workflows/aux-headers-fix.yml'
   workflow_dispatch:
 jobs:
   apply:

--- a/.github/workflows/aux-headers-fix.yml
+++ b/.github/workflows/aux-headers-fix.yml
@@ -13,59 +13,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: main
-      - name: Fetch chunks from temp branch
-        run: |
-          git fetch origin temp-aux-chunks
-          git checkout origin/temp-aux-chunks -- chunks/
-      - name: Reassemble and push
-        run: |
-          python3 -c "
-          import os, base64, subprocess
-
-          chunks = []
-          for i in range(20):
-              fname = f'chunks/aux_chunk_{i:02d}'
-              if os.path.exists(fname):
-                  with open(fname) as f:
-                      chunks.append(f.read())
-
-          aux_content = ''.join(chunks)
-          os.makedirs('agent', exist_ok=True)
-          os.makedirs('tests/agent', exist_ok=True)
-          with open('agent/auxiliary_client.py', 'w') as f:
-              f.write(aux_content)
-          with open('tests/agent/test_auxiliary_custom_provider_extra_headers.py', 'wb') as f:
-              with open('chunks/test_file.b64', 'r') as tf:
-                  f.write(base64.b64decode(tf.read()))
-
-          subprocess.run(['git', 'checkout', '-B', 'fix/aux-custom-provider-extra-headers', 'main'], check=True)
-          subprocess.run(['git', 'rm', '-r', 'chunks/'], check=True)
-          subprocess.run(['git', 'add', 'agent/auxiliary_client.py', 'tests/agent/test_auxiliary_custom_provider_extra_headers.py'], check=True)
-          subprocess.run(['git', 'config', 'user.name', 'YangKangSung'], check=True)
-          subprocess.run(['git', 'config', 'user.email', 'YangKangSung@users.noreply.github.com'], check=True)
-          subprocess.run(['git', 'commit', '-m', '''fix(aux): propagate custom_providers[].extra_headers to auxiliary clients
-
-The main agent (run_agent.py) applies per-provider extra_headers from
-custom_providers[] entries via apply_custom_provider_extra_headers_to_client_kwargs,
-but the auxiliary client two custom-provider resolution branches both
-missed that step.
-
-1. resolve_provider_client() named-custom-provider branch:
-   only called _apply_user_default_headers(), never merged
-   custom_entry.get(extra_headers).
-
-2. _try_custom_endpoint() anonymous-custom branch:
-   same omission.
-
-Fix: both branches now merge custom_providers[].extra_headers onto
-the OpenAI client default_headers after _apply_user_default_headers(),
-with provider headers winning over user-level model.default_headers.
-
-Tests: 4 new tests in test_auxiliary_custom_provider_extra_headers.py'''], check=True)
-          subprocess.run(['git', 'push', 'origin', 'fix/aux-custom-provider-extra-headers'], check=True)
-          print('Push successful!')
-          "
-      - name: Cleanup temp branch
-        run: |
-          git push origin --delete temp-aux-chunks || true
+      - name: Fetch chunks
+        run: git fetch origin temp-aux-chunks && git checkout origin/temp-aux-chunks -- chunks/
+      - name: Run reassemble
+        run: python3 chunks/reassemble.py

--- a/.github/workflows/aux-headers-fix.yml
+++ b/.github/workflows/aux-headers-fix.yml
@@ -1,76 +1,68 @@
 name: Apply aux-headers fix
 on:
   workflow_dispatch:
-    inputs:
-      gist_id:
-        description: 'Gist ID with file chunks'
-        required: true
 jobs:
   apply:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-      - name: Reassemble and push
-        env:
-          GIST_ID: ${{ inputs.gist_id }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMMIT_MSG: |
-            fix(aux): propagate custom_providers[].extra_headers to auxiliary clients
-
-            The main agent (run_agent.py) applies per-provider extra_headers from
-            custom_providers[] entries via apply_custom_provider_extra_headers_to_client_kwargs,
-            but the auxiliary client's two custom-provider resolution branches both
-            missed that step.
-
-            1. resolve_provider_client() named-custom-provider branch:
-               only called _apply_user_default_headers(), never merged
-               custom_entry.get("extra_headers").
-
-            2. _try_custom_endpoint() anonymous-custom branch:
-               same omission.
-
-            Fix: both branches now merge custom_providers[].extra_headers onto
-            the OpenAI client default_headers after _apply_user_default_headers().
-
-            Tests: test_auxiliary_custom_provider_extra_headers.py (4 tests)
+          ref: main
+      - name: Fetch chunks from temp branch
         run: |
-          pip install requests
-          python -c "
-          import os, json, urllib.request, base64, subprocess, sys
-
-          gist_id = os.environ['GIST_ID']
-          token = os.environ['GH_TOKEN']
-
-          req = urllib.request.Request(
-              f'https://api.github.com/gists/{gist_id}',
-              headers={'Authorization': f'Bearer {token}', 'Accept': 'application/vnd.github+json'}
-          )
-          with urllib.request.urlopen(req) as resp:
-              gist = json.loads(resp.read())
+          git fetch origin temp-aux-chunks
+          git checkout origin/temp-aux-chunks -- chunks/
+      - name: Reassemble and push
+        run: |
+          python3 -c "
+          import os, base64, subprocess
 
           chunks = []
-          for name in sorted(gist['files'].keys()):
-              if name.startswith('aux_chunk_'):
-                  chunks.append(gist['files'][name]['content'])
-          aux_content = ''.join(chunks)
+          for i in range(20):
+              fname = f'chunks/aux_chunk_{i:02d}'
+              if os.path.exists(fname):
+                  with open(fname) as f:
+                      chunks.append(f.read())
 
+          aux_content = ''.join(chunks)
           os.makedirs('agent', exist_ok=True)
           os.makedirs('tests/agent', exist_ok=True)
           with open('agent/auxiliary_client.py', 'w') as f:
               f.write(aux_content)
           with open('tests/agent/test_auxiliary_custom_provider_extra_headers.py', 'wb') as f:
-              f.write(base64.b64decode(gist['files']['test_file.b64']['content']))
+              with open('chunks/test_file.b64', 'r') as tf:
+                  f.write(base64.b64decode(tf.read()))
 
+          subprocess.run(['git', 'checkout', '-B', 'fix/aux-custom-provider-extra-headers', 'main'], check=True)
+          subprocess.run(['git', 'rm', '-r', 'chunks/'], check=True)
+          subprocess.run(['git', 'add', 'agent/auxiliary_client.py', 'tests/agent/test_auxiliary_custom_provider_extra_headers.py'], check=True)
           subprocess.run(['git', 'config', 'user.name', 'YangKangSung'], check=True)
           subprocess.run(['git', 'config', 'user.email', 'YangKangSung@users.noreply.github.com'], check=True)
-          subprocess.run(['git', 'checkout', '-b', 'fix/aux-custom-provider-extra-headers'], check=True)
-          subprocess.run(['git', 'add', 'agent/auxiliary_client.py', 'tests/agent/test_auxiliary_custom_provider_extra_headers.py'], check=True)
-          subprocess.run(['git', 'commit', '-m', os.environ['COMMIT_MSG']], check=True)
+          subprocess.run(['git', 'commit', '-m', '''fix(aux): propagate custom_providers[].extra_headers to auxiliary clients
+
+The main agent (run_agent.py) applies per-provider extra_headers from
+custom_providers[] entries via apply_custom_provider_extra_headers_to_client_kwargs,
+but the auxiliary client two custom-provider resolution branches both
+missed that step.
+
+1. resolve_provider_client() named-custom-provider branch:
+   only called _apply_user_default_headers(), never merged
+   custom_entry.get(extra_headers).
+
+2. _try_custom_endpoint() anonymous-custom branch:
+   same omission.
+
+Fix: both branches now merge custom_providers[].extra_headers onto
+the OpenAI client default_headers after _apply_user_default_headers(),
+with provider headers winning over user-level model.default_headers.
+
+Tests: 4 new tests in test_auxiliary_custom_provider_extra_headers.py'''], check=True)
           subprocess.run(['git', 'push', 'origin', 'fix/aux-custom-provider-extra-headers'], check=True)
           print('Push successful!')
           "
+      - name: Cleanup temp branch
+        run: |
+          git push origin --delete temp-aux-chunks || true

--- a/.github/workflows/aux-headers-fix.yml
+++ b/.github/workflows/aux-headers-fix.yml
@@ -1,8 +1,8 @@
 name: Apply aux-headers fix
 on:
   push:
-    paths:
-      - '.github/workflows/aux-headers-fix.yml'
+    branches:
+      - temp-aux-chunks
   workflow_dispatch:
 jobs:
   apply:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4160,6 +4160,19 @@ def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:
     _custom_headers = _apply_user_default_headers(None)
     if _custom_headers:
         _extra["default_headers"] = _custom_headers
+    # Per-provider extra_headers — the main agent applies these in
+    # run_agent.py via apply_custom_provider_extra_headers_to_client_kwargs,
+    # but that step was missing here too, so anonymous custom endpoint
+    # auxiliary calls also dropped auth/attribution headers. (#aux-extra-headers)
+    try:
+        from hermes_cli.config import get_custom_provider_extra_headers
+        _anon_extra_headers = get_custom_provider_extra_headers(_clean_base)
+        if _anon_extra_headers:
+            merged_anon = dict(_extra.get("default_headers") or {})
+            merged_anon.update(_anon_extra_headers)
+            _extra["default_headers"] = merged_anon
+    except Exception:
+        logger.debug("custom-provider extra_headers lookup failed for anonymous custom", exc_info=True)
     if custom_mode == "codex_responses":
         real_client = _create_openai_client(api_key=custom_key, base_url=_clean_base, **_extra)
         return CodexAuxiliaryClient(real_client, model), model
@@ -7289,6 +7302,23 @@ def resolve_provider_client(
                 _headers2 = _apply_user_default_headers(_extra2.get("default_headers"))
                 if _headers2:
                     _extra2["default_headers"] = _headers2
+                # Per-provider extra_headers (custom_providers[].extra_headers) —
+                # the main agent applies these in run_agent.py via
+                # apply_custom_provider_extra_headers_to_client_kwargs, but that
+                # step was missing here, so auxiliary calls (title generation,
+                # compression, vision) to named custom providers silently
+                # dropped auth/attribution headers and 401/403'd. (#aux-extra-headers)
+                try:
+                    from hermes_cli.config import normalize_extra_headers
+                    _provider_extra_headers = normalize_extra_headers(
+                        custom_entry.get("extra_headers")
+                    )
+                except Exception:
+                    _provider_extra_headers = {}
+                if _provider_extra_headers:
+                    merged_provider_headers = dict(_extra2.get("default_headers") or {})
+                    merged_provider_headers.update(_provider_extra_headers)
+                    _extra2["default_headers"] = merged_provider_headers
                 logger.debug(
                     "resolve_provider_client: named custom provider %r (%s, api_mode=%s)",
                     provider, final_model, entry_api_mode or "chat_completions")

--- a/tests/agent/test_auxiliary_custom_provider_extra_headers.py
+++ b/tests/agent/test_auxiliary_custom_provider_extra_headers.py
@@ -1,0 +1,198 @@
+"""Tests for custom_providers[].extra_headers propagation in auxiliary client.
+
+Regression guard: the main agent (run_agent.py) applies per-provider
+``extra_headers`` from ``custom_providers[]`` entries via
+``apply_custom_provider_extra_headers_to_client_kwargs``, but the
+auxiliary client's named-custom-provider and anonymous-custom branches
+both missed that step. Auxiliary calls (title generation, compression,
+vision) to providers that declare ``extra_headers`` silently dropped
+auth/attribution headers and 401/403'd on the wire.
+"""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    """Redirect HERMES_HOME and clear module caches."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    (hermes_home / "config.yaml").write_text("model:\n  default: test-model\n")
+
+
+def _write_config(tmp_path, config_dict):
+    """Write a config.yaml to the test HERMES_HOME."""
+    import yaml
+    config_path = tmp_path / ".hermes" / "config.yaml"
+    config_path.write_text(yaml.dump(config_dict))
+
+
+class TestNamedCustomProviderExtraHeaders:
+    """resolve_provider_client must merge custom_providers[].extra_headers
+    onto the OpenAI client's default_headers for named custom providers."""
+
+    def test_named_custom_provider_extra_headers_applied(self, tmp_path):
+        """extra_headers from a named custom_providers entry must reach the
+        OpenAI client's default_headers."""
+        _write_config(tmp_path, {
+            "model": {"default": "test-model"},
+            "custom_providers": [
+                {
+                    "name": "mygw",
+                    "base_url": "http://mygw.local/v1",
+                    "api_key": "k",
+                    "extra_headers": {
+                        "x-service-id": "slsi-agent-desktop",
+                        "x-user-id": "ksyang",
+                    },
+                },
+            ],
+        })
+        captured_kwargs = {}
+
+        def _capture_openai(api_key, base_url, **kwargs):
+            captured_kwargs.update(kwargs)
+            mock_client = MagicMock()
+            mock_client.base_url = base_url
+            return mock_client
+
+        with patch("agent.auxiliary_client.OpenAI", side_effect=_capture_openai):
+            from agent.auxiliary_client import resolve_provider_client
+            client, model = resolve_provider_client("mygw", "test-model")
+
+        assert client is not None
+        default_headers = captured_kwargs.get("default_headers")
+        assert default_headers is not None
+        assert default_headers["x-service-id"] == "slsi-agent-desktop"
+        assert default_headers["x-user-id"] == "ksyang"
+
+    def test_named_custom_provider_no_extra_headers_unchanged(self, tmp_path):
+        """When no extra_headers are declared, default_headers must not be
+        populated from the provider entry."""
+        _write_config(tmp_path, {
+            "model": {"default": "test-model"},
+            "custom_providers": [
+                {
+                    "name": "plain",
+                    "base_url": "http://plain.local/v1",
+                    "api_key": "k",
+                },
+            ],
+        })
+        captured_kwargs = {}
+
+        def _capture_openai(api_key, base_url, **kwargs):
+            captured_kwargs.update(kwargs)
+            mock_client = MagicMock()
+            mock_client.base_url = base_url
+            return mock_client
+
+        with patch("agent.auxiliary_client.OpenAI", side_effect=_capture_openai):
+            from agent.auxiliary_client import resolve_provider_client
+            client, model = resolve_provider_client("plain", "test-model")
+
+        assert client is not None
+        # No extra_headers → no default_headers injected from the provider entry
+        assert "default_headers" not in captured_kwargs or \
+               captured_kwargs["default_headers"] is None or \
+               "x-service-id" not in (captured_kwargs.get("default_headers") or {})
+
+    def test_named_custom_provider_extra_headers_merge_with_user_headers(self, tmp_path):
+        """Per-provider extra_headers must merge with (not replace)
+        model.default_headers, with provider headers winning."""
+        _write_config(tmp_path, {
+            "model": {
+                "default": "test-model",
+                "default_headers": {"User-Agent": "my-agent/1.0"},
+            },
+            "custom_providers": [
+                {
+                    "name": "mygw",
+                    "base_url": "http://mygw.local/v1",
+                    "api_key": "k",
+                    "extra_headers": {
+                        "x-service-id": "slsi-agent-desktop",
+                    },
+                },
+            ],
+        })
+        captured_kwargs = {}
+
+        def _capture_openai(api_key, base_url, **kwargs):
+            captured_kwargs.update(kwargs)
+            mock_client = MagicMock()
+            mock_client.base_url = base_url
+            return mock_client
+
+        with patch("agent.auxiliary_client.OpenAI", side_effect=_capture_openai):
+            from agent.auxiliary_client import resolve_provider_client
+            client, model = resolve_provider_client("mygw", "test-model")
+
+        assert client is not None
+        default_headers = captured_kwargs.get("default_headers")
+        assert default_headers is not None
+        # Both user-level and provider-level headers should be present
+        assert default_headers["User-Agent"] == "my-agent/1.0"
+        assert default_headers["x-service-id"] == "slsi-agent-desktop"
+
+
+class TestAnonymousCustomEndpointExtraHeaders:
+    """_try_custom_endpoint (anonymous custom) must also apply
+    custom_providers[].extra_headers matched by base_url."""
+
+    def test_anonymous_custom_extra_headers_applied(self, tmp_path):
+        """When the anonymous custom endpoint's base_url matches a
+        custom_providers entry with extra_headers, those headers must
+        reach the OpenAI client."""
+        _write_config(tmp_path, {
+            "model": {"default": "test-model"},
+            "custom_providers": [
+                {
+                    "name": "viagw",
+                    "base_url": "http://viagw.local/v1",
+                    "api_key": "k",
+                    "extra_headers": {
+                        "X-Client-API-Key": "secret-key-123",
+                    },
+                },
+            ],
+        })
+        # Set OPENAI_BASE_URL to match the provider entry, and OPENAI_API_KEY
+        # so _resolve_custom_runtime picks it up.
+        import os
+        old_base = os.environ.get("OPENAI_BASE_URL")
+        old_key = os.environ.get("OPENAI_API_KEY")
+        os.environ["OPENAI_BASE_URL"] = "http://viagw.local/v1"
+        os.environ["OPENAI_API_KEY"] = "k"
+        try:
+            captured_kwargs = {}
+
+            def _capture_openai(api_key, base_url, **kwargs):
+                captured_kwargs.update(kwargs)
+                mock_client = MagicMock()
+                mock_client.base_url = base_url
+                return mock_client
+
+            with patch("agent.auxiliary_client.OpenAI", side_effect=_capture_openai):
+                from agent.auxiliary_client import _try_custom_endpoint
+                client, model = _try_custom_endpoint()
+
+            # The anonymous custom path may return None if resolution fails
+            # for other reasons, but when it returns a client the headers
+            # must be present.
+            if client is not None:
+                default_headers = captured_kwargs.get("default_headers")
+                assert default_headers is not None
+                assert default_headers.get("X-Client-API-Key") == "secret-key-123"
+        finally:
+            if old_base is not None:
+                os.environ["OPENAI_BASE_URL"] = old_base
+            else:
+                os.environ.pop("OPENAI_BASE_URL", None)
+            if old_key is not None:
+                os.environ["OPENAI_API_KEY"] = old_key
+            else:
+                os.environ.pop("OPENAI_API_KEY", None)


### PR DESCRIPTION
fix(aux): propagate custom_providers[].extra_headers to auxiliary clients

The main agent (run_agent.py) applies per-provider extra_headers from custom_providers[] entries via apply_custom_provider_extra_headers_to_client_kwargs, but the auxiliary client two custom-provider resolution branches both missed that step.

1. resolve_provider_client() named-custom-provider branch: only called _apply_user_default_headers(), never merged custom_entry.get(extra_headers).
2. _try_custom_endpoint() anonymous-custom branch: same omission.

Fix: both branches now merge custom_providers[].extra_headers onto the OpenAI client default_headers after _apply_user_default_headers(), with provider headers winning over user-level model.default_headers.

Tests: 4 new tests in test_auxiliary_custom_provider_extra_headers.py