### PR TITLE
fix(update): stop treating a clean command-boundary stop_reason as an interrupted update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2262,6 +2262,7 @@ def cmd_update(args):
     # = not SystemExit-shaped, so real exceptions keep their traceback.
     _update_handoff_exit_code: int | None = None
     from hermes_cli.update_cmd import _cmd_update_impl
+    from hermes_cli.update_receipt import COMMAND_BOUNDARY_STOP_REASON
 
     try:
         _cmd_update_impl(args, gateway_mode=gateway_mode)
@@ -2279,7 +2280,7 @@ def cmd_update(args):
         _finalize_update_receipt(1, f"{type(_update_exc).__name__}: {_update_exc}")
         raise
     else:
-        _finalize_update_receipt(0, "completed at command boundary")
+        _finalize_update_receipt(0, COMMAND_BOUNDARY_STOP_REASON)
         _update_handoff_exit_code = 0
     finally:
         _update_lock.release()

--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -79,9 +79,15 @@ def _current_checkout_sha() -> str | None:
 
 def _receipt_looks_unfinished(receipt: dict) -> bool:
     """True when *receipt* is from an update that did not finish cleanly."""
+    from hermes_cli.update_receipt import COMMAND_BOUNDARY_STOP_REASON
+
     gateway_restart = receipt.get("gateway_restart")
+    # The command-boundary stop reason is what a CLEAN completion stamps (cmd_update's
+    # else-branch); treating it as dirty re-arms the #95294 catch-up on every startup
+    # once HEAD advances past a success receipt's pre-pull plan SHAs (#98022).
+    stop_reason = receipt.get("stop_reason")
     return bool(
-        receipt.get("stop_reason")
+        (stop_reason and stop_reason != COMMAND_BOUNDARY_STOP_REASON)
         or receipt.get("exit_code") not in (0, None)
         or receipt.get("outcome") in ("failed", "partial", "running")
         or (isinstance(gateway_restart, dict) and gateway_restart.get("incomplete"))

--- a/hermes_cli/update_receipt.py
+++ b/hermes_cli/update_receipt.py
@@ -20,6 +20,13 @@ logger = logging.getLogger(__name__)
 
 _RECEIPT_KEEP = 20  # keep the last N receipts per profile home
 
+#: The stop reason ``cmd_update``'s clean-completion boundary stamps on the receipt (its
+#: else-branch finalizer). Distinct from every failure-shaped reason ("sys.exit(1)",
+#: "KeyboardInterrupt: ", …) so ``_receipt_looks_unfinished`` can treat a clean boundary
+#: stop as finished — the boundary net is the FINALIZER OF RECORD for already-up-to-date
+#: runs and for pulls whose inner finalize already fired (exactly-once singleton pop).
+COMMAND_BOUNDARY_STOP_REASON = "completed at command boundary"
+
 # ``hermes update`` is a single-threaded CLI command; a module singleton lets the 7k-line updater
 # record steps from any depth without threading a handle through every helper.
 _current: Optional["UpdateReceipt"] = None

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -254,6 +254,63 @@ def test_successful_receipt_with_pre_update_plan_shas_does_not_retrigger(
     assert update_cmd._pending_fleet_restart_needed() is False
 
 
+def test_successful_command_boundary_receipt_without_fleet_does_not_retrigger(
+    monkeypatch,
+):
+    """A clean command-boundary stop is not an interrupted update (#98022).
+
+    cmd_update's else-branch stamps ``stop_reason='completed at command boundary'``
+    on every clean completion — including already-up-to-date runs whose plan SHAs
+    were captured pre-pull. Treating that truthy stop_reason as unfinished re-arms
+    the #95294 catch-up warning on every startup once HEAD advances.
+    """
+    disk_sha = "n" * 40
+    old_sha = "o" * 40
+    monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: disk_sha)
+    monkeypatch.setattr(update_cmd_fleet, "_current_checkout_sha", lambda: disk_sha)
+
+    receipt_dir = get_hermes_home() / "logs" / "update_receipts"
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / "latest.json").write_text(
+        json.dumps(
+            {
+                "exit_code": 0,
+                "outcome": "success",
+                "stop_reason": "completed at command boundary",
+                "plan": {
+                    "expected_sha": old_sha,
+                    "runtimes": [
+                        {
+                            "kind": "gateway",
+                            "profile": "default",
+                            "pid": 1,
+                            "code_sha": old_sha,
+                        }
+                    ],
+                },
+                "fleet": [],
+                "gateway_restart": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert update_cmd._pending_fleet_restart_needed() is False
+
+
+@pytest.mark.parametrize(
+    "receipt",
+    [
+        {"outcome": "success", "exit_code": 0, "stop_reason": "sys.exit(0)"},
+        {"outcome": "success", "stop_reason": "KeyboardInterrupt: "},
+        {"outcome": "failed", "exit_code": 1, "stop_reason": ""},
+    ],
+)
+def test_other_unfinished_receipt_shapes_remain_unfinished(receipt):
+    """Only the known clean command-boundary reason bypasses recovery."""
+    assert update_cmd._receipt_looks_unfinished(receipt) is True
+
+
 def test_stale_fleet_matrix_on_latest_receipt_is_pending(monkeypatch):
     disk_sha = "n" * 40
     monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: disk_sha)


### PR DESCRIPTION
## Summary

`cmd_update`'s clean-completion boundary stamps `stop_reason = "completed at command boundary"` on every successful `hermes update` — including already-up-to-date runs whose `plan.runtimes[].code_sha` values were captured **pre-pull**. `_receipt_looks_unfinished()` treats *any* truthy `stop_reason` as unfinished, so every success receipt is classified as an interrupted update. `_receipt_reports_stale_runtime()` then compares that receipt's pre-pull plan SHAs against the current checkout SHA, and once HEAD advances past the receipt, the mismatch permanently re-arms the #95294 pending-fleet-restart trigger (`_pending_fleet_restart_needed()` → the "did not restart running gateways" warning on every CLI/gateway startup, plus a redundant fleet restart on every update).

This is the second half of #98022 (P1). The first half — the stale-module purge orphaning the open receipt singleton so gateway-restarting updates wrote no receipt at all — landed in #103478. With receipts now persisting, the remaining failure mode is that any *existing* success receipt on disk (or the first clean run after upgrading) still re-arms the catch-up forever, because its clean boundary stop_reason keeps it classified as unfinished and its plan SHAs go stale the next time HEAD moves.

Fix: share a `COMMAND_BOUNDARY_STOP_REASON` constant between the boundary finalizer and the classifier. The clean marker is recognized as finished; every failure-shaped reason (`"sys.exit(1)"`, `"KeyboardInterrupt: "`, …) still counts as unfinished, so genuinely interrupted updates keep the catch-up armed.

Live-verified on the affected install (Linux v0.21.0 git + systemd): with both fixes, `hermes update` writes a fresh success receipt with the boundary stop_reason, `_pending_fleet_restart_needed()` returns False, and gateway/CLI startups are warning-free. Before the fix, the warning fired on every startup for days while the fleet was provably current (`gateway_state.json` `code_sha` == HEAD, live PID matching).

Salvages #97547 (tachyon-r) — same fix, re-landed on current main. Related: #95294, #92535.

Fixes #98022

## Test plan

- [x] `test_successful_command_boundary_receipt_without_fleet_does_not_retrigger` — RED on base (a clean boundary receipt with pre-pull plan SHAs re-triggers `_pending_fleet_restart_needed()`), GREEN with the fix.
- [x] `test_other_unfinished_receipt_shapes_remain_unfinished` — failure-shaped stop reasons (`sys.exit(0)`, `KeyboardInterrupt`) and failed outcomes still count as unfinished, so real interruptions keep the catch-up armed.
- [x] Existing suite `tests/hermes_cli/test_update_fleet_restart_pending.py` (19 tests) plus `test_update_receipt.py`, `test_update_receipt_endpoint.py`, `test_update_handoff_exit.py`, `test_update_stale_module_purge.py` — all green (61 tests) on top of current main (f58fcc8118, includes #103478).