### PR TITLE
fix(doctor): bound npm audit process trees

### DIFF
--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -395,6 +395,7 @@ def _legacy_kill_process_tree(proc: "subprocess.Popen") -> None:
 def bounded_probe_run(
     argv: Sequence[str], *, timeout: float, errors: str = "replace",
     env: "Mapping[str, str] | None" = None,
+    cwd: str | os.PathLike[str] | None = None,
 ) -> "subprocess.CompletedProcess[str] | None":
     """Deadlock-safe ``subprocess.run(argv, capture_output=True, timeout=…)`` for fail-open probes.
 
@@ -406,14 +407,15 @@ def bounded_probe_run(
     launcher shim, ``conhost.exe`` under wmic/powershell) holding duplicates of the captured stdout/stderr
     handles, so the pipes never reach EOF and the reader-thread join blocks forever. The wmic /
     ``Get-CimInstance Win32_Process`` gateway scan hit exactly this during ``hermes update`` on slow-WMI
-    machines (#87134); the git probes hit it first (#68609 / #66037).
+    machines (#87134); the git probes hit it first (#68609 / #66037). ``cwd`` is forwarded for
+    probes, such as workspace-scoped npm audits, that must run from a specific directory.
     """
     _popen_kwargs: dict = {"creationflags": windows_hide_flags()} if IS_WINDOWS else {"process_group": 0}
     try:
         proc = subprocess.Popen(
             list(argv), stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.DEVNULL,
             text=True, encoding="utf-8", errors=errors,
-            env=dict(env) if env is not None else None, **_popen_kwargs)
+            env=dict(env) if env is not None else None, cwd=cwd, **_popen_kwargs)
     except Exception:
         return None
     try:

--- a/hermes_cli/doctor_tools.py
+++ b/hermes_cli/doctor_tools.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import subprocess
 import sys
+from hermes_cli._subprocess_compat import bounded_probe_run
 from hermes_cli.doctor_platform import _system_package_install_cmd
 from hermes_cli.doctor_report import Finding, _fail_and_issue, check_bool, check_info, check_ok, check_warn, doctor_check
 from hermes_cli.vercel_auth import describe_vercel_auth
@@ -361,8 +362,13 @@ def _audit_one(npm_bin: str, npm_dir, label: str, audit_extra: list[str], issues
     import json
     try:
         # Resolved absolute path so Windows can execute npm.cmd (CreateProcessW can't run bare .cmd names).
-        audit_result = subprocess.run([npm_bin, "audit", "--json", *audit_extra], cwd=str(npm_dir),
-                                      capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=30)
+        audit_result = bounded_probe_run(
+            [npm_bin, "audit", "--json", *audit_extra],
+            cwd=str(npm_dir),
+            timeout=30,
+        )
+        if audit_result is None:
+            return
         audit_data = json.loads(audit_result.stdout) if audit_result.stdout.strip() else {}
         counts = audit_data.get("metadata", {}).get("vulnerabilities", {})
         critical, high, moderate = (counts.get(k, 0) for k in ("critical", "high", "moderate"))

--- a/tests/hermes_cli/test_bounded_probe_run.py
+++ b/tests/hermes_cli/test_bounded_probe_run.py
@@ -20,6 +20,7 @@ descendant-survival cases live in ``test_git_probe_tree_kill.py`` and now
 exercise the same code path through the ``bounded_git_probe`` delegation.
 """
 
+import os
 import subprocess
 import sys
 import time
@@ -36,6 +37,17 @@ def test_success_returns_completed_process():
     assert result is not None
     assert result.returncode == 0
     assert result.stdout.strip() == "ok"
+
+
+def test_cwd_runs_probe_in_requested_directory(tmp_path):
+    result = bounded_probe_run(
+        [_PY, "-c", "import os; print(os.getcwd())"],
+        timeout=30,
+        cwd=tmp_path,
+    )
+    assert result is not None
+    assert result.returncode == 0
+    assert os.path.normcase(result.stdout.strip()) == os.path.normcase(str(tmp_path))
 
 
 def test_nonzero_exit_is_returned_not_swallowed():
@@ -66,6 +78,41 @@ def test_timeout_returns_none_within_bounded_time():
     # an indefinite hang, so any bound proves the property; keep it loose for
     # slow CI runners.
     assert elapsed < 30
+
+
+@pytest.mark.windows_only
+def test_windows_timeout_kills_launcher_descendant_holding_pipes(tmp_path):
+    """A timed-out .cmd launcher must not leave its pipe-owning child alive."""
+    import psutil
+
+    marker = tmp_path / "descendant.pid"
+    child = tmp_path / "pipe_holder.py"
+    child.write_text(
+        "import os, time\n"
+        "from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text(str(os.getpid()), encoding='utf-8')\n"
+        "time.sleep(300)\n",
+        encoding="utf-8",
+    )
+    launcher = tmp_path / "launcher.cmd"
+    launcher.write_text(
+        f'@echo off\r\n"{_PY}" "{child}"\r\n',
+        encoding="utf-8",
+    )
+
+    result = bounded_probe_run([str(launcher)], timeout=2.0)
+    assert result is None
+    assert marker.exists(), "descendant never started"
+
+    child_pid = int(marker.read_text(encoding="utf-8"))
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline and psutil.pid_exists(child_pid):
+        time.sleep(0.05)
+
+    alive = psutil.pid_exists(child_pid)
+    if alive:
+        psutil.Process(child_pid).kill()
+    assert not alive, f"descendant {child_pid} survived probe timeout"
 
 
 def test_decode_errors_configurable():

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -26,6 +26,44 @@ from hermes_cli import doctor_config
 from tools import browser_tool_install as bt_install
 
 
+@pytest.fixture(autouse=True)
+def _disable_live_npm_audits(monkeypatch):
+    """Doctor unit tests must not access the npm registry."""
+    monkeypatch.setattr(doctor_tools, "bounded_probe_run", lambda *args, **kwargs: None, raising=False)
+
+
+def test_npm_audit_uses_bounded_probe_with_workspace_cwd(monkeypatch, tmp_path):
+    expected = SimpleNamespace(returncode=0, stdout="{}", stderr="")
+    calls = []
+
+    def fake_bounded_probe_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return expected
+
+    def reject_direct_run(*args, **kwargs):
+        raise AssertionError("npm audit must not use subprocess.run")
+
+    monkeypatch.setattr(doctor_tools, "bounded_probe_run", fake_bounded_probe_run)
+    monkeypatch.setattr(doctor_tools.subprocess, "run", reject_direct_run)
+
+    issues = []
+    doctor_tools._audit_one(
+        "npm.cmd",
+        tmp_path,
+        "web workspace",
+        ["--workspace", "web"],
+        issues,
+    )
+
+    assert calls == [
+        (
+            ["npm.cmd", "audit", "--json", "--workspace", "web"],
+            {"cwd": str(tmp_path), "timeout": 30},
+        )
+    ]
+    assert issues == []
+
+
 class TestDoctorPlatformHints:
     def test_termux_package_hint(self, monkeypatch):
         monkeypatch.setenv("TERMUX_VERSION", "0.118.3")


### PR DESCRIPTION
## What does this PR do?

`hermes doctor` ran `npm audit --json` with `subprocess.run(..., timeout=30)`. On Windows, `npm.cmd` can launch a `node.exe` descendant that inherits the captured stdout/stderr pipes. When the timeout kills only the `.cmd` launcher, the surviving descendant keeps those pipes open and Python can remain blocked while draining output.

This PR routes every Doctor npm audit variant through the existing deadlock-safe `bounded_probe_run` helper. The helper now accepts an optional `cwd`, preserving the audit workspace behavior while applying owned process-tree cleanup and a bounded output drain.

## Related Issue

No linked issue. I searched the repository's existing issues and PRs for this symptom and found no duplicate.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Add optional `cwd` forwarding to `hermes_cli._subprocess_compat.bounded_probe_run`.
- Run root, `web`, `ui-tui`, and WhatsApp npm audits through the shared bounded probe path in `hermes_cli/doctor_tools.py`.
- Keep Doctor unit tests offline by replacing live npm audits with a fail-open stub.
- Add real subprocess coverage for `cwd` forwarding and a Windows `.cmd` launcher whose descendant holds inherited pipes.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_bounded_probe_run.py tests/hermes_cli/test_doctor.py`.
2. On Windows, confirm the launcher/descendant regression test completes within its bound and the descendant PID no longer exists.
3. Run `hermes doctor` in a checkout with npm workspaces and confirm it reaches its final summary without leaving an `npm audit` `node.exe` process.

Verified on Windows 11:

- Targeted canonical suite: 80 passed, 1 skipped.
- `ruff check` on all four changed files: passed.
- `py_compile` on all four changed files: passed.
- `git diff --check`: passed.
- Real Doctor path: exited 0; post-run process scan found zero npm-audit Node processes.
- Independent review: no findings.

The full repository suite was not run. An additional unchanged Doctor test currently fails collection on native Windows because it calls unavailable `os.geteuid`; this PR does not modify that file.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; this is a subprocess lifecycle fix with automated and runtime verification.
