### PR TITLE
fix(dashboard): read session token at request time, not at mount_spa() import

### DIFF
--- a/hermes_cli/web_server_dashboard.py
+++ b/hermes_cli/web_server_dashboard.py
@@ -102,7 +102,11 @@ def mount_spa(application: FastAPI):
     with a missing dist per-request (404 JSON / ``check_dir=False``), so a long-lived
     ``--skip-build`` process recovers the moment a build appears on disk — no restart.
     """
-    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, _SESSION_TOKEN, app
+    # Late-bound: _SESSION_TOKEN is rebound by _apply_ssh_session_token() AFTER this
+    # module-level mount_spa() runs, so it must be read per-request, never captured
+    # here -- capturing made Desktop SSH serve a stale token and 401 every /api/* call.
+    import hermes_cli.web_server as _ws
+    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, app
 
     # `hermes serve` is the headless backend: it must NEVER serve the browser SPA, even if a
     # dist is lying around, so only the JSON-RPC/WS/API surface is reachable.
@@ -120,7 +124,7 @@ def mount_spa(application: FastAPI):
             if full_path == "" and not gated:
                 return HTMLResponse(
                     "<!doctype html><html><head><script>"
-                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(_SESSION_TOKEN)};"
+                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(_ws._SESSION_TOKEN)};"
                     "window.__HERMES_AUTH_REQUIRED__=false;"
                     f"</script></head><body>{_HEADLESS_MSG}</body></html>",
                     headers=_NO_STORE,
@@ -151,7 +155,7 @@ def mount_spa(application: FastAPI):
             return JSONResponse({"error": "Frontend not built. Run: cd web && npm run build"}, status_code=404)
         chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
         gated = bool(getattr(app.state, "auth_required", False))
-        token_js = "" if gated else f'window.__HERMES_SESSION_TOKEN__="{_SESSION_TOKEN}";'
+        token_js = "" if gated else f'window.__HERMES_SESSION_TOKEN__="{_ws._SESSION_TOKEN}";'
         bootstrap_script = (
             f"<script>{token_js}"
             f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -216,6 +216,29 @@ class TestSessionTokenInjection:
         assert ws.app is original_app
         assert ws._SESSION_TOKEN == original_token
 
+    def test_headless_root_serves_token_applied_after_mount(self, monkeypatch):
+        """Desktop SSH: ``mount_spa(app)`` runs at import time, but the SSH session
+        token is applied later in ``start_web_server`` via ``_apply_ssh_session_token``.
+        The served ``__HERMES_SESSION_TOKEN__`` must be the *current* token, not the
+        one captured at mount — a stale capture made the desktop adopt a token the
+        backend then rejected (every /api/* 401'd).
+        """
+        from fastapi import FastAPI
+        from starlette.testclient import TestClient
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setenv("HERMES_SERVE_HEADLESS", "1")
+        original_token = ws._SESSION_TOKEN
+        try:
+            application = FastAPI()
+            _web_server_dashboard.mount_spa(application)  # captures token here (bug) ...
+            ws._apply_ssh_session_token("ssh-token-applied-after-mount")  # ... applied later
+            body = TestClient(application).get("/").text
+            assert "ssh-token-applied-after-mount" in body
+            assert original_token not in body
+        finally:
+            ws._apply_ssh_session_token(original_token)
+
     def test_falls_back_to_random_token(self, monkeypatch):
         import hermes_cli.web_server as ws
 


### PR DESCRIPTION
## Problem

Desktop SSH remote connections (`hermes serve --isolated --ssh-session-token-file ... --ssh-owner-nonce ...`) come up "ready" but every `/api/*` call returns **401 Unauthorized**. The UI never gets a profile list.

## Root cause

`mount_spa(app)` is called at module import time (`hermes_cli/web_server.py:975`). Inside it, `web_server_dashboard.py:105` imports `_SESSION_TOKEN` **by value**, and both inject sites (`no_frontend` headless root page and `_serve_index`) close over that captured value.

The SSH session token is applied later, in `start_web_server()` → `_apply_ssh_session_token()` (`web_server.py:1351`), which rebinds the module global. The closures never see it.

Result: the headless `/` page serves the import-time `secrets.token_urlsafe(32)` fallback (43 chars), while `_has_valid_session_token` compares against the desktop-minted SSH token (64 hex chars). The desktop's served-token adoption then picks up the stale token, so the `backend.lock.json` fingerprint looks self-consistent while every gated request 401s.

## Reproduce (before)

```
hermes serve --isolated --host 127.0.0.1 --port 0 --ssh-session-token-file <64-hex token file> --ssh-owner-nonce <nonce>
curl -s http://127.0.0.1:<port>/ | grep -o '__HERMES_SESSION_TOKEN__=[^;]*'   # 43-char token, not the 64-hex one
curl -H "X-Hermes-Session-Token: <served token>" http://127.0.0.1:<port>/api/profiles   # 401
```

## Fix

Late-bind through the module object (`_ws._SESSION_TOKEN`) at both inject sites so the served token is always the current one. Three-line change.

## Test

`TestSessionTokenInjection::test_headless_root_serves_token_applied_after_mount` drives `mount_spa()` → `_apply_ssh_session_token()` → `GET /` and asserts the applied token is served. Fails on the old code (serves the import-time token), passes with the fix.

Verified end to end on a macOS → macOS (Tailscale) desktop SSH connection: served token is 64 hex, `/api/profiles`, `/api/profiles/active`, `/api/profiles/sessions` all 200, profile list renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)