### PR TITLE
fix(windows): exclude the WSL launcher stub from bash candidates

### DIFF
--- a/tests/tools/test_find_shell.py
+++ b/tests/tools/test_find_shell.py
@@ -7,12 +7,17 @@ when ``~/.bash_profile`` contained ``exec /bin/zsh -l``.
 
 import os
 import platform
+import shutil
 import subprocess
 from unittest.mock import patch
 
 import pytest
 
-from tools.environments.local import _find_bash, _find_shell
+from tools.environments.local import (
+    _find_bash,
+    _find_shell,
+    _windows_bash_candidates,
+)
 
 
 class TestFindShellPrefersUserShell:
@@ -275,3 +280,53 @@ class TestMacosLoginShellSwallowRegression:
             stdin=subprocess.DEVNULL, capture_output=True, text=True,
         )
         assert marker.exists(), f"_find_shell()={shell} swallowed the command"
+
+
+class TestWindowsBashCandidatesExcludeWslStub:
+    """#103398: the bash.exe stub in the Windows system directory is the WSL
+    launcher. It passes _bash_starts (it is a working bash *inside WSL*),
+    but /c/... and /d/... do not exist there, so selecting it makes every
+    snapshot command fail with ENOENT. The which("bash") fallback must skip
+    it and let the structured "Git Bash not found" error surface instead."""
+
+    @staticmethod
+    def _fake_roots(tmp_path, monkeypatch):
+        """Point every known Git root and %SystemRoot% at an empty tmp tree."""
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "lad"))
+        monkeypatch.setenv("ProgramFiles", str(tmp_path / "pf"))
+        monkeypatch.setenv("ProgramFiles(x86)", str(tmp_path / "pf86"))
+        monkeypatch.setenv("SystemRoot", str(tmp_path / "sysroot"))
+        monkeypatch.delenv("WINDIR", raising=False)
+
+    def test_which_fallback_wsl_stub_is_excluded(self, tmp_path, monkeypatch):
+        self._fake_roots(tmp_path, monkeypatch)
+        stub = tmp_path / "sysroot" / "System32" / "bash.exe"
+        stub.parent.mkdir(parents=True)
+        stub.touch()
+        monkeypatch.setattr(shutil, "which", lambda _: str(stub))
+
+        assert _windows_bash_candidates(None) == []
+
+    def test_git_bash_candidate_kept_while_wsl_stub_dropped(
+        self, tmp_path, monkeypatch
+    ):
+        self._fake_roots(tmp_path, monkeypatch)
+        git_bash = tmp_path / "git" / "bin" / "bash.exe"
+        git_bash.parent.mkdir(parents=True)
+        git_bash.touch()
+        stub = tmp_path / "sysroot" / "System32" / "bash.exe"
+        stub.parent.mkdir(parents=True)
+        stub.touch()
+        monkeypatch.setenv("HERMES_GIT_BASH_PATH", str(git_bash))
+        monkeypatch.setattr(shutil, "which", lambda _: str(stub))
+
+        assert _windows_bash_candidates(str(git_bash)) == [str(git_bash)]
+
+    def test_path_bash_kept_when_not_the_wsl_stub(self, tmp_path, monkeypatch):
+        self._fake_roots(tmp_path, monkeypatch)
+        other_bash = tmp_path / "tools" / "bash.exe"
+        other_bash.parent.mkdir(parents=True)
+        other_bash.touch()
+        monkeypatch.setattr(shutil, "which", lambda _: str(other_bash))
+
+        assert _windows_bash_candidates(None) == [str(other_bash)]

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -359,7 +359,19 @@ def _windows_bash_candidates(custom: "str | None") -> list[str]:
     raw = [custom or "", *(os.path.join(r, "bash.exe") for r in roots if r)]
     candidates = list(dict.fromkeys(c for c in raw if c and os.path.isfile(c)))
     found = shutil.which("bash")
-    if found and found not in candidates:
+    # The bash.exe stub in the Windows system directory is the WSL launcher:
+    # it is a working bash *inside WSL*, where /c/... and /d/... do not exist,
+    # so selecting it makes every command fail with ENOENT even though the
+    # probe passes. Exclude it and let the structured "Git Bash not found"
+    # error surface instead (#103398). Resolve via %SystemRoot% (fallback
+    # %WINDIR%) so non-C:\ Windows installs are covered too.
+    wsl_stub = os.path.join(
+        getenv("SystemRoot") or getenv("WINDIR") or r"C:\Windows",
+        "System32", "bash.exe",
+    )
+    if (found
+            and os.path.normcase(found) != os.path.normcase(wsl_stub)
+            and found not in candidates):
         candidates.append(found)
     return candidates
 


### PR DESCRIPTION
When the Git Bash probe fails under cold-start contention, `_find_bash()`
falls through to `shutil.which("bash")`, which on WSL co-install machines
resolves to the **System32 launcher stub**. That stub passes `_bash_starts`
(it is a working bash *inside WSL*), but `/c/...` and `/d/...` do not exist
there — the session snapshot then runs under the WSL filesystem view and
every command fails with ENOENT while the terminal tool burns its whole
executor timeout (#103398). Live capture during a failing window:
`System32ash.exe` + `wsl.exe` + `wslhost.exe` spawned together, and the
error signature is byte-identical when running the same snapshot commands
under `C:\Windows\System32ash.exe`.

## What this PR does

Exclude the stub from `_windows_bash_candidates()`'s `shutil.which("bash")`
fallback — resolved via `%SystemRoot%` (fallback `%WINDIR%`) so non-`C:\`
Windows installs are covered, `normcase` on both sides — and let the
existing structured **"Git Bash not found"** error surface instead. When the
Git Bash probe passes, behavior is unchanged.

## Notes

- Complements #83413 (probe stdin inheritance) and #103402 (probe
  kill-tree): those fix the hang; this fixes the silent degradation when the
  probe still fails.
- Refs #103398, #74982, #47837 (the original WSL-ordering report — the
  known-locations fix from #56384 remains intact).
- Includes regression tests: WSL stub excluded / Git Bash candidate kept
  while stub dropped / non-stub PATH bash kept.

Environment: Windows 10 19045 x64, Git for Windows 2.49.0, WSL Ubuntu-24.04
co-installed. Full ACP wire logs and process captures available.
