### PR TITLE
fix: [Bug] Manual /compress commits but live TUI session never reloads the compressed message list (history keeps growing; status bar context % stays stale) (#102780)

### DIFF
--- a/tui_gateway/session_compression.py
+++ b/tui_gateway/session_compression.py
@@ -262,6 +262,19 @@ def _compress_session_history(
         compressed = rejoin_compressed_head_and_tail(compressed, tail)
     with session["history_lock"]:
         if int(session.get("history_version", 0)) != history_version:
+            # A turn landed while compaction ran (the ~120s frontend timeout invites exactly this):
+            # the DB commit above already archived the snapshot, so dropping the result strands the
+            # live list on the stale base until restart (#102780). Rebase instead — replay the
+            # concurrently appended tail onto the compressed base. Non-append mutations
+            # (rewind/undo) still take the drop path so we never clobber them.
+            current = list(session.get("history", []))
+            if len(current) > len(before_messages) and current[: len(before_messages)] == before_messages:
+                merged = rejoin_compressed_head_and_tail(compressed, current[len(before_messages):])
+                session["history"] = merged
+                session["history_version"] = int(session.get("history_version", 0)) + 1
+                logger.info("Manual compress rebased onto %d concurrent message(s): %d->%d live",
+                            len(current) - len(before_messages), len(current), len(merged))
+                return len(before_messages) - len(compressed), _get_usage(agent)
             # External mutation during compaction — drop the result so we don't clobber concurrent edits.
             finalize_context_engine_compression_notification(agent, committed=False)
             return 0, _get_usage(agent)


### PR DESCRIPTION
## What Problem This Solves
Fixes #102780 — [Bug] Manual /compress commits but live TUI session never reloads the compressed message list (history keeps growing; status bar context % stays stale). Minimal diff, single shared guard, no new deps.

## Evidence
- Repro: local repro shows before→after.
- Related suites pass (see worktree 102780).

Closes #102780