### PR TITLE
fix: Cross-profile TERMINAL_* leak in multi-profile serve: cron tick pins a routed profile's docker backend into os.environ, hijacking the launch profile's sessions (#102769)

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -398,7 +398,9 @@ def _reapply_terminal_config_bridge(home_path: Path) -> None:
     ``apply_terminal_config_to_env`` (also used by terminal_tool and the TUI/dashboard launchers) so the
     semantics can't drift between sites."""
     try:
-        if Path(home_path).resolve() != _process_hermes_home().resolve():
+        from hermes_constants import get_process_hermes_home
+
+        if Path(home_path).resolve() != get_process_hermes_home().resolve():
             return
         from hermes_cli.config import apply_terminal_config_to_env
 


### PR DESCRIPTION
## What Problem This Solves
Fixes #102769 — Cross-profile TERMINAL_* leak in multi-profile serve: cron tick pins a routed profile's docker backend into os.environ, hijacking the launch profile's sessions. Minimal diff, single shared guard, no new deps.

## Evidence
- Repro: local repro shows before→after.
- Related suites pass (see worktree 102769).

Closes #102769