### PR TITLE
fix(dashboard): serve live session token after SSH credential rotation

### DIFF
--- a/hermes_cli/web_server_dashboard.py
+++ b/hermes_cli/web_server_dashboard.py
@@ -90,6 +90,20 @@ _HEADLESS_MSG = (
 )
 
 
+def _live_session_token() -> str:
+    """Session token as currently served (lazy read).
+
+    ``serve --ssh-session-token-file`` applies the Desktop SSH credential AFTER
+    this module is imported, so an eager ``from ... import _SESSION_TOKEN``
+    keeps serving the pre-rotation random token while API auth enforces the new
+    one — Desktop SSH then 401s every credentialed call. Read it off the
+    owning module at request time instead.
+    """
+    from hermes_cli import web_server as _ws_mod
+
+    return _ws_mod._SESSION_TOKEN
+
+
 def mount_spa(application: FastAPI):
     """Mount the built SPA; unmatched paths fall back to index.html for client-side routing.
 
@@ -102,7 +116,7 @@ def mount_spa(application: FastAPI):
     with a missing dist per-request (404 JSON / ``check_dir=False``), so a long-lived
     ``--skip-build`` process recovers the moment a build appears on disk — no restart.
     """
-    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, _SESSION_TOKEN, app
+    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, app
 
     # `hermes serve` is the headless backend: it must NEVER serve the browser SPA, even if a
     # dist is lying around, so only the JSON-RPC/WS/API surface is reachable.
@@ -120,7 +134,7 @@ def mount_spa(application: FastAPI):
             if full_path == "" and not gated:
                 return HTMLResponse(
                     "<!doctype html><html><head><script>"
-                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(_SESSION_TOKEN)};"
+                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(_live_session_token())};"
                     "window.__HERMES_AUTH_REQUIRED__=false;"
                     f"</script></head><body>{_HEADLESS_MSG}</body></html>",
                     headers=_NO_STORE,
@@ -151,7 +165,7 @@ def mount_spa(application: FastAPI):
             return JSONResponse({"error": "Frontend not built. Run: cd web && npm run build"}, status_code=404)
         chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
         gated = bool(getattr(app.state, "auth_required", False))
-        token_js = "" if gated else f'window.__HERMES_SESSION_TOKEN__="{_SESSION_TOKEN}";'
+        token_js = "" if gated else f'window.__HERMES_SESSION_TOKEN__="{_live_session_token()}";'
         bootstrap_script = (
             f"<script>{token_js}"
             f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"


### PR DESCRIPTION
## Summary
Desktop SSH mode 401s every credentialed API call while boot reports ready. Root cause: `mount_spa()` binds `_SESSION_TOKEN` by value at import time, but `serve --ssh-session-token-file` applies the SSH credential afterwards. The `/` token page kept serving the pre-rotation random token while API auth enforced the new one, so served-token adoption picked up a token the backend rejects.

Fixes #102930

## Change
- `hermes_cli/web_server_dashboard.py`: new `_live_session_token()` helper reading `web_server._SESSION_TOKEN` at request time; used on both the headless token-only page and the dashboard SPA bootstrap path. Sibling readers (`web_deps.session_token`, `web_server_chat` function-level imports) already resolve lazily and are untouched.

## Test plan
- [x] Live E2E against a Linux remote: spawned `serve --isolated ... --ssh-session-token-file` exactly as Desktop does. Before: `/` served a token that 401d on `/api/profiles/active`. After: served token == minted file token (string MATCH) and the same endpoint returns 200 with it. Public `/api/status` 200 throughout.
- [x] `py_compile` clean on both ends.
- [ ] Repo pytest suite not run (no pytest in the local venv); leaving CI to cover it.