### PR TITLE
fix(oneshot): preserve configured prompt when composing skills

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -68,6 +68,21 @@ def _build_preloaded_skills_prompt(skills: object = None) -> str | None:
     return skills_prompt or None
 
 
+def _build_oneshot_system_prompt(
+    cfg: dict, skills_prompt: str | None = None
+) -> str | None:
+    """Compose the one-shot overlay with normal CLI/gateway precedence."""
+    from hermes_cli.config import resolve_ephemeral_system_prompt_from_config
+
+    configured_prompt = os.getenv(
+        "HERMES_EPHEMERAL_SYSTEM_PROMPT", ""
+    ) or resolve_ephemeral_system_prompt_from_config(cfg)
+    return (
+        "\n\n".join(part for part in (configured_prompt, skills_prompt) if part).strip()
+        or None
+    )
+
+
 def _configured_mcp_servers() -> tuple[set[str], set[str]]:
     """``(enabled, disabled)`` MCP server names from config; both empty on any error."""
     try:
@@ -380,6 +395,7 @@ def _run_agent(
     ensure_mcp_discovery_before_agent_build(logger=logging.getLogger(__name__), single_query=True)
 
     skills_prompt = _build_preloaded_skills_prompt(skills)
+    ephemeral_prompt = _build_oneshot_system_prompt(cfg, skills_prompt)
 
     session_db = _create_session_db_for_oneshot()
     # The try spans agent construction (not just ``chat``) so the store is always closed, even when
@@ -399,7 +415,7 @@ def _run_agent(
             session_db=session_db,
             credential_pool=runtime.get("credential_pool"),
             fallback_model=get_fallback_chain(cfg) or None,
-            ephemeral_system_prompt=skills_prompt,
+            ephemeral_system_prompt=ephemeral_prompt,
             # The only interactive callback wired: no user sits at a terminal. Sudo prompts gate on
             # HERMES_INTERACTIVE (never set), hook approval via HERMES_ACCEPT_HOOKS=1, dangerous
             # commands via HERMES_YOLO_MODE=1, skill secret capture degrades gracefully.

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -182,7 +182,16 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
     monkeypatch.setitem(
         sys.modules,
         "hermes_cli.config",
-        mod("hermes_cli.config", load_config=lambda: {"model": {"default": "m"}}),
+        mod(
+            "hermes_cli.config",
+            load_config=lambda: {
+                "model": {"default": "m"},
+                "agent": {"system_prompt": "CONFIG OVERLAY"},
+            },
+            resolve_ephemeral_system_prompt_from_config=lambda cfg: cfg["agent"][
+                "system_prompt"
+            ],
+        ),
     )
     monkeypatch.setitem(
         sys.modules,
@@ -214,7 +223,33 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
     assert not result.get("failed")
     assert captured["session_db"] is sentinel_db
     assert captured["enabled_toolsets"] == ["session_search"]
+    assert captured["ephemeral_system_prompt"] == "CONFIG OVERLAY"
     assert captured["prompt"] == "recall this"
+
+
+def test_oneshot_system_prompt_precedence_and_composition(monkeypatch):
+    from hermes_cli.oneshot import _build_oneshot_system_prompt
+
+    monkeypatch.delenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", raising=False)
+
+    global_cfg = {"agent": {"system_prompt": "GLOBAL"}}
+    assert _build_oneshot_system_prompt(global_cfg) == "GLOBAL"
+    assert _build_oneshot_system_prompt(global_cfg, "SKILL") == "GLOBAL\n\nSKILL"
+
+    personality_cfg = {
+        "display": {"personality": "helpful"},
+        "agent": {
+            "system_prompt": "GLOBAL",
+            "personalities": {"helpful": "PERSONALITY"},
+        },
+    }
+    assert _build_oneshot_system_prompt(personality_cfg) == "PERSONALITY"
+
+    monkeypatch.setenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", "ENV")
+    assert _build_oneshot_system_prompt(personality_cfg, "SKILL") == "ENV\n\nSKILL"
+
+    monkeypatch.delenv("HERMES_EPHEMERAL_SYSTEM_PROMPT")
+    assert _build_oneshot_system_prompt({}) is None
 
 
 def test_launch_tui_exports_model_provider_and_toolsets(monkeypatch, main_mod):


### PR DESCRIPTION
## What does this PR do?

`hermes -z --skills` currently passes only the generated skills prompt as `ephemeral_system_prompt`, which drops the configured environment/config/personality overlay resolved by the normal CLI and gateway paths.

This change resolves the configured overlay through the shared resolver and composes it before the one-shot skills prompt, separated by two newlines. Existing environment-over-config precedence remains unchanged, and runs without either overlay keep their current behavior.

This is the current-`main` patch-equivalent reconciliation of the work discussed in #34863, #69957, #84138, and #74646. Contributor credit is preserved in the commit's `Co-authored-by` trailers.

## Related PRs

Supersedes the stale/conflicting current-base integration paths in #69957 and #84138 while retaining their contributors' credit. Also reconciles the earlier work in #34863 and #74646.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/oneshot.py`: resolve and compose the configured overlay with the skills prompt.
- `tests/hermes_cli/test_tui_resume_flow.py`: cover overlay + skills composition and precedence without persisting the ephemeral prompt.

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_tui_resume_flow.py tests/hermes_cli/test_oneshot_skills.py tests/hermes_cli/test_oneshot_surrogate.py tests/hermes_cli/test_oneshot_usage_file.py -q`.
2. Run `ruff check .`.
3. Run `python scripts/check-windows-footguns.py --diff <base>`.

Observed locally: 18 targeted tests passed on Linux aarch64; Ruff, compileall, diff-check, Windows-footgun, patch-equivalence, clean-tree, and no-secret checks passed. A full-suite success is not claimed because the local managed environment lacks the optional `acp` dependency required during unrelated test collection.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing PRs and am submitting this as a credited current-main reconciliation
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — targeted tests pass; see environment limitation above
- [x] I've added tests for my changes
- [x] I've tested on Linux aarch64

### Documentation & Housekeeping

- [x] Documentation update — N/A
- [x] `cli-config.yaml.example` update — N/A; no config key changes
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no architecture/workflow changes
- [x] Cross-platform impact considered; change is pure Python prompt composition
- [x] Tool descriptions/schemas update — N/A

## Screenshots / Logs

No UI change. Fresh local loopback CLI, one-shot, and gateway verification was completed on the patch-equivalent runtime candidate. No provider E2E was run.