### PR TITLE
fix: restore background process visibility across gateways

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -76,6 +76,7 @@ import {
   RICH_INPUT_SLOT
 } from './rich-editor'
 import { useComposerScope } from './scope'
+import { statusStackSessionKey } from './status-session-key'
 import { ComposerStatusStack } from './status-stack'
 import { CodingStatusRow } from './status-stack/coding-row'
 import { SuggestionPills } from './suggestion-pills'
@@ -175,10 +176,11 @@ export function ChatBar({
   const blockingPrompt = useStore(useMemo(() => sessionBlockingPrompt(sessionId ?? null), [sessionId]))
   const activeQueueSessionKey = queueSessionKey || sessionId || null
 
-  // Status items (subagents, background processes) are keyed by the RUNTIME
-  // session id — gateway events and process.list both speak that id. Only the
-  // queue uses the stored-session fallback key (prompts can queue pre-resume).
-  const statusSessionId = sessionId ?? null
+  // Status items (subagents, background processes) key off the RUNTIME session
+  // id — gateway events and a live process.list both speak that one — falling
+  // back to the durable conversation key when nothing is bound, so a stored
+  // messaging chat still discovers background work started on the gateway side.
+  const statusSessionId = statusStackSessionKey(sessionId, queueSessionKey)
 
   const composerTourMarker = useTourMarker('composer')
 

--- a/apps/desktop/src/app/chat/composer/status-session-key.test.ts
+++ b/apps/desktop/src/app/chat/composer/status-session-key.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { statusStackSessionKey } from './status-session-key'
+
+// The status stack polls `process.list` under whatever key it is handed. A
+// stored messaging conversation (a Telegram chat opened in Desktop) can sit with
+// NO live runtime id, and with `null` the stack never armed discovery at all —
+// the background job started on the gateway side stayed invisible.
+describe('statusStackSessionKey', () => {
+  it('prefers the live runtime id whenever there is one', () => {
+    expect(statusStackSessionKey('rt-1', 'stored-1')).toBe('rt-1')
+  })
+
+  it('falls back to the durable conversation key when no runtime is bound', () => {
+    expect(statusStackSessionKey(null, 'stored-1')).toBe('stored-1')
+  })
+
+  it('trims the durable key so padding never becomes a scope of its own', () => {
+    expect(statusStackSessionKey(null, '  stored-1  ')).toBe('stored-1')
+  })
+
+  it.each([null, undefined, '', '   '])('yields null when neither identity is usable (%p)', durable => {
+    expect(statusStackSessionKey(null, durable)).toBeNull()
+  })
+
+  it('never lets a blank runtime id shadow a usable durable key', () => {
+    expect(statusStackSessionKey('   ', 'stored-1')).toBe('stored-1')
+  })
+})

--- a/apps/desktop/src/app/chat/composer/status-session-key.ts
+++ b/apps/desktop/src/app/chat/composer/status-session-key.ts
@@ -1,0 +1,21 @@
+/**
+ * Which session identity the composer's status stack polls under.
+ *
+ * Background rows come from `process.list`, and a conversation has two identities:
+ * the RUNTIME session id (what gateway events and a live `process.list` speak) and
+ * the DURABLE stored key (the lineage root the composer already uses to scope its
+ * draft and queue). The runtime id wins whenever one is bound — it is the only one
+ * that resolves a live session on the backend.
+ *
+ * The fallback matters for messaging: a stored Telegram conversation can be open in
+ * Desktop with no runtime session at all, and passing `null` meant the stack armed
+ * no poll, so a `terminal(background=true)` job running on the gateway side was
+ * never discovered. The backend accepts the durable key only after proving it names
+ * a real stored conversation, so handing it over widens nothing.
+ */
+export function statusStackSessionKey(
+  runtimeSessionId: null | string | undefined,
+  durableSessionKey: null | string | undefined
+): null | string {
+  return (runtimeSessionId ?? '').trim() || (durableSessionKey ?? '').trim() || null
+}

--- a/apps/desktop/src/app/chat/composer/status-stack/background-discovery.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/background-discovery.test.tsx
@@ -1,0 +1,255 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import { $backgroundStatusBySession, resetBackgroundPollingGuard } from '@/store/composer-status'
+import { $gateway } from '@/store/gateway'
+
+import { ComposerStatusStack } from './index'
+
+// The stack measures itself into a surface var — jsdom has no ResizeObserver.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', ResizeObserverStub)
+
+const SID = 'sess-discovery'
+
+// Longer than any plausible idle discovery cadence, so the test pins "the stack
+// keeps asking while empty" rather than one tuned interval value.
+const PAST_IDLE_TICK_MS = 60_000
+
+// The fast running cadence is a safety net for silent exits; a discovery tick
+// must stay well below that rate.
+const RUNNING_POLL_WINDOW_MS = 20_000
+
+function renderStack(sessionId: null | string = SID) {
+  return render(
+    <MemoryRouter>
+      <I18nProvider configClient={null} initialLocale="en">
+        <ComposerStatusStack queue={null} sessionId={sessionId} />
+      </I18nProvider>
+    </MemoryRouter>
+  )
+}
+
+// A background process spawned through ANOTHER gateway client (a Telegram
+// `terminal(background=true)` job) reaches this window only through the shared
+// process registry — nothing broadcasts an event here. The poll used to be armed
+// only while a running row was already on screen, so with an empty stack nothing
+// ever asked again and the first row never appeared.
+describe('ComposerStatusStack background discovery', () => {
+  const listCalls = (request: ReturnType<typeof vi.fn>, sid = SID) =>
+    request.mock.calls.filter(([method, params]) => method === 'process.list' && params?.session_id === sid).length
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    resetBackgroundPollingGuard()
+    $backgroundStatusBySession.set({})
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+    $gateway.set(null as never)
+    $backgroundStatusBySession.set({})
+    resetBackgroundPollingGuard()
+  })
+
+  it('discovers a process that appears on a later poll, with no remount and no gateway event', async () => {
+    let processes: Record<string, unknown>[] = []
+    const request = vi.fn(async (method: string) => (method === 'process.list' ? { processes } : {}))
+
+    $gateway.set({ request } as never)
+    renderStack()
+
+    // Mount seed: the registry is still empty, exactly like the reported bug
+    // (the Desktop tile opened before the Telegram job started).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect($backgroundStatusBySession.get()[SID]).toBeUndefined()
+
+    // The job starts elsewhere. Nothing notifies this window.
+    processes = [{ command: 'sleep 600', peer: true, session_id: 'proc_e99debacd2eb', status: 'running' }]
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAST_IDLE_TICK_MS)
+    })
+
+    expect($backgroundStatusBySession.get()[SID]).toMatchObject([{ id: 'proc_e99debacd2eb', state: 'running' }])
+  })
+
+  it('polls the empty stack slowly and speeds up once a row is running', async () => {
+    let processes: Record<string, unknown>[] = []
+    const request = vi.fn(async (method: string) => (method === 'process.list' ? { processes } : {}))
+
+    $gateway.set({ request } as never)
+    renderStack()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RUNNING_POLL_WINDOW_MS)
+    })
+
+    const idleCalls = listCalls(request)
+
+    processes = [{ command: 'sleep 600', session_id: 'proc_running', status: 'running' }]
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RUNNING_POLL_WINDOW_MS)
+    })
+
+    // Same wall-clock window, many more polls: the existing fast cadence for a
+    // visible running row is preserved, and idle discovery is strictly slower.
+    expect(listCalls(request) - idleCalls).toBeGreaterThan(idleCalls)
+  })
+
+  it('never stacks a second timer for the same session and drops it on switch', async () => {
+    const request = vi.fn(async (method: string) => (method === 'process.list' ? { processes: [] } : {}))
+
+    $gateway.set({ request } as never)
+
+    const view = renderStack()
+    // A parent re-render with the SAME session must not arm another timer.
+    view.rerender(
+      <MemoryRouter>
+        <I18nProvider configClient={null} initialLocale="en">
+          <ComposerStatusStack queue={null} sessionId={SID} />
+        </I18nProvider>
+      </MemoryRouter>
+    )
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    // One mount seed for the pair of renders, not one per render.
+    const seed = listCalls(request)
+
+    expect(seed).toBe(1)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAST_IDLE_TICK_MS)
+    })
+
+    const ticksForOneStack = listCalls(request) - seed
+
+    expect(ticksForOneStack).toBeGreaterThan(0)
+
+    const twin = renderStack()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    const beforeSecondWindow = listCalls(request)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAST_IDLE_TICK_MS)
+    })
+
+    // Two mounted stacks tick exactly twice as often: one timer each, never two.
+    expect(listCalls(request) - beforeSecondWindow).toBe(ticksForOneStack * 2)
+
+    twin.unmount()
+    view.rerender(
+      <MemoryRouter>
+        <I18nProvider configClient={null} initialLocale="en">
+          <ComposerStatusStack queue={null} sessionId="sess-other" />
+        </I18nProvider>
+      </MemoryRouter>
+    )
+
+    const frozen = listCalls(request)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAST_IDLE_TICK_MS)
+    })
+
+    expect(listCalls(request)).toBe(frozen)
+    expect(listCalls(request, 'sess-other')).toBeGreaterThan(0)
+  })
+
+  it('stops polling after unmount so no timer leaks', async () => {
+    const request = vi.fn(async (method: string) => (method === 'process.list' ? { processes: [] } : {}))
+
+    $gateway.set({ request } as never)
+
+    const view = renderStack()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAST_IDLE_TICK_MS)
+    })
+
+    const whileMounted = listCalls(request)
+
+    expect(whileMounted).toBeGreaterThan(1)
+
+    view.unmount()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAST_IDLE_TICK_MS * 2)
+    })
+
+    expect(listCalls(request)).toBe(whileMounted)
+  })
+
+  it('drops peer mirrors when the stack stops watching a session, keeping local rows', async () => {
+    const processes = [
+      { command: 'local job', session_id: 'proc_mine', status: 'running' },
+      { command: 'their job', peer: true, session_id: 'proc_theirs', status: 'running' }
+    ]
+
+    const request = vi.fn(async (method: string) => (method === 'process.list' ? { processes } : {}))
+
+    $gateway.set({ request } as never)
+
+    const view = renderStack()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect($backgroundStatusBySession.get()[SID]?.map(i => i.id)).toEqual(['proc_mine', 'proc_theirs'])
+
+    // Crossing into the fast running cadence re-runs the poll effect; that must
+    // not be mistaken for "no longer watching".
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAST_IDLE_TICK_MS)
+    })
+
+    expect($backgroundStatusBySession.get()[SID]?.map(i => i.id)).toEqual(['proc_mine', 'proc_theirs'])
+
+    view.unmount()
+
+    // Nothing refreshes this session now, so the mirror would claim "running"
+    // forever; the locally-owned row stays, still fed by this window's events.
+    expect($backgroundStatusBySession.get()[SID]?.map(i => i.id)).toEqual(['proc_mine'])
+  })
+
+  it('never arms discovery against a runtime the gateway has latched gone', async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === 'process.list') {
+        throw new Error('session not found')
+      }
+
+      return {}
+    })
+
+    $gateway.set({ request } as never)
+    renderStack()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAST_IDLE_TICK_MS * 3)
+    })
+
+    // The mount seed 4001s once and latches; discovery must not become the
+    // storm the latch exists to stop.
+    expect(listCalls(request)).toBe(1)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -20,6 +20,8 @@ import {
   type ComposerStatusItem,
   dismissBackgroundProcess,
   groupStatusItems,
+  isSessionGone,
+  prunePeerBackgroundProcesses,
   refreshBackgroundProcesses,
   type StatusGroup,
   stopBackgroundProcess
@@ -32,9 +34,19 @@ import { openSessionInNewWindow } from '@/store/windows'
 import { PreviewStatusRow } from './preview-row'
 import { StatusItemRow } from './status-row'
 
-// Slow safety-net poll for silent exits (processes without notify_on_complete
-// emit no event when they die). Only armed while a running row is on screen.
+// Safety-net poll for silent exits (processes without notify_on_complete emit
+// no event when they die). Armed while a running row is on screen.
 const BACKGROUND_POLL_MS = 5_000
+
+// Idle cadence, armed while a live session is mounted with NO background row.
+// A `terminal(background=true)` job started through another gateway client
+// (Telegram, a second window, the CLI) reaches this window only through the
+// backend's shared process registry — it broadcasts no event here. Without a
+// poll while the stack is empty, the first row is never discovered, and the
+// fast tick above (which only starts once a row exists) is never armed.
+// Deliberately much slower: this is discovery, not liveness, and one timer runs
+// per mounted tile.
+const BACKGROUND_DISCOVERY_POLL_MS = 15_000
 
 // A localhost/loopback preview is only meaningful while its dev server is up, so
 // we tie it to a live background process rather than persisting dismissals or
@@ -109,11 +121,18 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
   // against that id. The latch is reset at the actual rebind seams instead —
   // gateway reconnect and runtime re-mint (see resetBackgroundPollingGuard
   // call sites in use-gateway-boot.ts and store/gateway.ts).
+  // Cleanup is keyed on the session alone — never on the poll cadence — so an
+  // unmount or a session switch drops that session's peer mirrors (nothing would
+  // refresh them again), while a fast/slow cadence flip leaves them untouched.
   useEffect(() => {
-    if (sessionId) {
-      void refreshBackgroundProcesses(sessionId)
-      void refreshSessionGoal(sessionId)
+    if (!sessionId) {
+      return
     }
+
+    void refreshBackgroundProcesses(sessionId)
+    void refreshSessionGoal(sessionId)
+
+    return () => prunePeerBackgroundProcesses(sessionId)
   }, [sessionId])
 
   const hasRunningBackground = groups.some(g => g.type === 'background' && g.items.some(i => i.state === 'running'))
@@ -122,15 +141,33 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
   // dead `localhost:5174` chips stick around. On-disk file previews are kept.
   const visiblePreviews = previews.filter(item => hasRunningBackground || !isLocalhostPreview(item.target))
 
+  // One timer, two cadences: fast while something is running (catch a silent
+  // exit), slow while the stack is empty (discover work created elsewhere).
+  // `pollMs` re-runs the effect, whose cleanup tears the old timer down first,
+  // so a session never holds two — and a parent re-render changes neither dep.
+  const pollMs = hasRunningBackground ? BACKGROUND_POLL_MS : BACKGROUND_DISCOVERY_POLL_MS
+
   useEffect(() => {
-    if (!sessionId || !hasRunningBackground) {
+    // The gone-latch still bounds this: a runtime id the gateway no longer holds
+    // answers 4001 forever, so never arm against one, and a session that dies
+    // mid-poll drops its own timer on the next tick. Discovery must not become
+    // the 4001 storm the latch exists to stop.
+    if (!sessionId || isSessionGone(sessionId)) {
       return
     }
 
-    const timer = setInterval(() => void refreshBackgroundProcesses(sessionId), BACKGROUND_POLL_MS)
+    const timer = setInterval(() => {
+      if (isSessionGone(sessionId)) {
+        clearInterval(timer)
+
+        return
+      }
+
+      void refreshBackgroundProcesses(sessionId)
+    }, pollMs)
 
     return () => clearInterval(timer)
-  }, [hasRunningBackground, sessionId])
+  }, [pollMs, sessionId])
 
   const openAgents = () => navigate(AGENTS_ROUTE)
 

--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.test.tsx
@@ -1,0 +1,45 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import type { ComposerStatusItem } from '@/store/composer-status'
+
+import { StatusItemRow } from './status-row'
+
+const backgroundItem = (overrides: Partial<ComposerStatusItem> = {}): ComposerStatusItem => ({
+  id: 'proc_abc',
+  state: 'running',
+  title: 'npm run dev',
+  type: 'background',
+  ...overrides
+})
+
+function renderRow(item: ComposerStatusItem, onStop = vi.fn()) {
+  render(
+    <I18nProvider configClient={null} initialLocale="en">
+      <StatusItemRow item={item} onStop={onStop} />
+    </I18nProvider>
+  )
+
+  return onStop
+}
+
+describe('StatusItemRow background actions', () => {
+  afterEach(cleanup)
+
+  it('offers Stop on a running process this gateway owns', () => {
+    renderRow(backgroundItem())
+
+    expect(screen.getByRole('button', { name: /stop/i })).toBeTruthy()
+  })
+
+  // A peer row is mirrored from another gateway process's registry: this
+  // backend holds no handle on that PID and refuses to signal it, so the
+  // control would be a button that can only ever fail.
+  it('offers no Stop on a row mirrored from a peer gateway', () => {
+    renderRow(backgroundItem({ peer: true }))
+
+    expect(screen.queryByRole('button', { name: /stop/i })).toBeNull()
+    expect(screen.getByText('npm run dev')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
@@ -98,10 +98,13 @@ export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOp
   const failed = item.state === 'failed'
   const running = item.state === 'running'
 
+  // A peer row mirrors a process owned by another gateway process: this backend
+  // holds no handle on that PID and refuses to signal it, so offering Stop would
+  // be a control that can only ever fail. Dismiss still works — it's local.
   const action =
     item.type === 'background'
       ? running
-        ? onStop && { label: s.stop, onClick: () => onStop(item.id) }
+        ? !item.peer && onStop && { label: s.stop, onClick: () => onStop(item.id) }
         : onDismiss && { label: s.dismiss, onClick: () => onDismiss(item.id) }
       : null
 

--- a/apps/desktop/src/store/composer-status.test.ts
+++ b/apps/desktop/src/store/composer-status.test.ts
@@ -5,6 +5,7 @@ import {
   $backgroundStatusBySession,
   dismissBackgroundProcess,
   isSessionGoneForBackgroundPolling,
+  prunePeerBackgroundProcesses,
   reconcileBackgroundProcesses,
   refreshBackgroundProcesses,
   resetBackgroundPollingGuard,
@@ -163,6 +164,77 @@ describe('reconcileBackgroundProcesses', () => {
     vi.advanceTimersByTime(5_000)
 
     expect(itemsOf('sess-arm')).toEqual([])
+  })
+
+  // A row mirrored from another gateway process is display/status only: this
+  // window holds no handle on that PID and must not offer an action it cannot
+  // perform (the backend refuses to signal a process it does not own).
+  it('marks rows mirrored from a peer gateway so they are not offered a Stop', () => {
+    reconcileBackgroundProcesses(SID, [{ ...running('mine') }, { ...running('theirs'), peer: true }])
+
+    expect(items().map(i => [i.id, i.peer ?? false])).toEqual([
+      ['mine', false],
+      ['theirs', true]
+    ])
+  })
+
+  // Nothing refreshes a session's rows once its stack unmounts, so a peer mirror
+  // left behind reports "running" forever — the sidebar keeps a hollow dot on a
+  // conversation whose foreign job may have finished long ago. Locally-owned rows
+  // are different: this window's own event stream still updates them.
+  it('drops only the peer mirrors when a session stops being watched', () => {
+    reconcileBackgroundProcesses(SID, [
+      { ...running('mine') },
+      { ...running('theirs'), peer: true },
+      { ...exited('theirs-done', 0), peer: true }
+    ])
+
+    prunePeerBackgroundProcesses(SID)
+
+    expect(items().map(i => i.id)).toEqual(['mine'])
+  })
+
+  it('never kills anything while pruning peer mirrors', async () => {
+    const request = vi.fn(async () => ({}))
+    $gateway.set({ request } as never)
+    reconcileBackgroundProcesses(SID, [{ ...running('theirs'), peer: true }])
+
+    prunePeerBackgroundProcesses(SID)
+    await Promise.resolve()
+
+    // We hold no handle on that PID; the owning gateway is still running it.
+    expect(request).not.toHaveBeenCalled()
+    $gateway.set(null as never)
+  })
+
+  it('lets a peer row come back on the next poll rather than latching it dismissed', () => {
+    reconcileBackgroundProcesses(SID, [{ ...running('theirs'), peer: true }])
+    prunePeerBackgroundProcesses(SID)
+
+    reconcileBackgroundProcesses(SID, [{ ...running('theirs'), peer: true }])
+
+    expect(items().map(i => i.id)).toEqual(['theirs'])
+  })
+
+  it('only ever prunes background rows, whatever else carries the flag', () => {
+    reconcileBackgroundProcesses(SID, [{ ...running('theirs'), peer: true }])
+    // Todos, subagents and goals reach the stack through their own stores; a
+    // `peer` flag arriving on one of those must never make it a prune target.
+    const foreign = { id: 'sub-1', peer: true, state: 'running', title: 'child', type: 'subagent' } as const
+    $backgroundStatusBySession.set({ [SID]: [...items(), foreign] })
+
+    prunePeerBackgroundProcesses(SID)
+
+    expect(items().map(i => i.id)).toEqual(['sub-1'])
+  })
+
+  it('is a no-op for a session with no peer rows', () => {
+    reconcileBackgroundProcesses('sess-nopeer', [running('a')])
+    const before = $backgroundStatusBySession.get()
+
+    prunePeerBackgroundProcesses('sess-nopeer')
+
+    expect($backgroundStatusBySession.get()).toBe(before)
   })
 })
 

--- a/apps/desktop/src/store/composer-status.ts
+++ b/apps/desktop/src/store/composer-status.ts
@@ -38,6 +38,10 @@ export interface ComposerStatusItem {
   id: string
   /** background process: captured stdout/stderr tail for the inline viewer. */
   output?: string
+  /** background process: mirrored from another gateway process's registry
+   *  (a Telegram job on the same conversation). Display/status only — this
+   *  backend holds no handle on that PID and refuses to signal it. */
+  peer?: boolean
   /** subagent: its own stored session id — row click opens that session window
    *  (livestreamed by the gateway's child-session mirror). */
   sessionId?: string
@@ -191,6 +195,7 @@ const sameStatusItem = (a: ComposerStatusItem, b: ComposerStatusItem) =>
   a.title === b.title &&
   a.output === b.output &&
   a.exitCode === b.exitCode &&
+  a.peer === b.peer &&
   a.currentTool === b.currentTool &&
   a.goalStatus === b.goalStatus &&
   a.todoStatus === b.todoStatus &&
@@ -292,6 +297,8 @@ interface GatewayProcessEntry {
   command?: string
   exit_code?: number
   output_tail?: string
+  /** Owned by another gateway process; older gateways never send it. */
+  peer?: boolean
   session_id?: string
   status?: string
 }
@@ -304,6 +311,7 @@ const toBackgroundItem = (proc: GatewayProcessEntry): ComposerStatusItem => {
     exitCode,
     id: proc.session_id ?? '',
     output: proc.output_tail || undefined,
+    peer: proc.peer === true,
     state: exited ? (exitCode ? 'failed' : 'done') : 'running',
     title: (proc.command ?? '').split('\n')[0]!.trim() || 'background process',
     type: 'background'
@@ -311,7 +319,7 @@ const toBackgroundItem = (proc: GatewayProcessEntry): ComposerStatusItem => {
 }
 
 const sameItem = (a: ComposerStatusItem, b: ComposerStatusItem) =>
-  a.state === b.state && a.title === b.title && a.output === b.output && a.exitCode === b.exitCode
+  a.state === b.state && a.title === b.title && a.output === b.output && a.exitCode === b.exitCode && a.peer === b.peer
 
 /**
  * Layout-stable sync of the registry snapshot into the store: existing rows
@@ -426,6 +434,45 @@ export async function refreshBackgroundProcesses(sid: string): Promise<void> {
   }
 }
 
+/**
+ * Stop tracking this session's PEER rows — mirrors of processes owned by another
+ * gateway process.
+ *
+ * Nothing refreshes a session's rows once its stack stops watching it, so a mirror
+ * left behind claims "running" forever and keeps the sidebar's background dot lit on
+ * a conversation whose foreign job may have finished long ago. Locally-owned rows
+ * stay: this window's own event stream still updates them.
+ *
+ * Deliberately not a dismissal. No kill goes out — we hold no handle on that PID and
+ * the backend refuses to signal it — and no dismissed-id is recorded, so the row
+ * reappears on the next poll if the peer is still running. Pending self-clear timers
+ * for the pruned rows are cancelled, or one firing later would latch the row
+ * dismissed and suppress exactly that reappearance.
+ */
+export function prunePeerBackgroundProcesses(sid: string) {
+  const list = $backgroundStatusBySession.get()[sid]
+
+  // `peer` only ever means "another gateway process owns this PROCESS"; requiring
+  // the type keeps the predicate honest if the flag ever appears on another kind
+  // of row, and states the one thing this prune is allowed to touch.
+  const isPeerRow = (item: ComposerStatusItem) => item.type === 'background' && item.peer === true
+
+  if (!list?.some(isPeerRow)) {
+    return
+  }
+
+  for (const item of list) {
+    if (isPeerRow(item)) {
+      cancelAutoDismiss(sid, item.id)
+    }
+  }
+
+  writeBackground(
+    sid,
+    list.filter(item => !isPeerRow(item))
+  )
+}
+
 /** X on a finished row: drop it now and keep it dropped across refreshes. */
 export function dismissBackgroundProcess(sid: string, id: string) {
   cancelAutoDismiss(sid, id)
@@ -500,7 +547,10 @@ export function resetSessionBackground(sid: string) {
   for (const item of list) {
     dismissed.add(item.id)
 
-    if (item.state === 'running') {
+    // A peer row's process was never spawned by the timeline being discarded
+    // (it belongs to another gateway process, which refuses our signal anyway):
+    // drop the row, don't ask for a kill that can only fail.
+    if (item.state === 'running' && !item.peer) {
       if (gateway && !isSessionGone(sid)) {
         void requestForOwnedSession(sid, ambientRequestFor(gateway), 'process.kill', {
           process_id: item.id,

--- a/tests/tools/test_background_session_lineage.py
+++ b/tests/tools/test_background_session_lineage.py
@@ -1,0 +1,184 @@
+"""Every background job records the conversation that spawned it.
+
+``ProcessSession.parent_session_id`` is the durable session-db id of the spawning
+chat. It is what lets another surface (Hermes Desktop on the same profile) match a
+``terminal(background=true)`` job started from Telegram back to the conversation the
+user is looking at, and it is what lets the gateway drop a completion whose session
+was closed at a ``/new`` boundary.
+
+It used to be stamped only on the way to configuring an async notification, so the
+DEFAULT launch — plain ``terminal(background=true)``, no ``notify_on_complete``, no
+``watch_patterns`` — left the field empty and the job was unattributable.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+import pytest
+
+import gateway.session_context as session_context
+import tools.process_registry as process_registry_module
+from tools.process_registry import ProcessSession
+from tools.terminal_tool_background import spawn_background_process
+
+DURABLE_ID = "20260901_120000_abcdef"
+
+_SESSION_ENV = {
+    "HERMES_SESSION_PLATFORM": "telegram",
+    "HERMES_SESSION_CHAT_ID": "4242",
+    "HERMES_SESSION_USER_ID": "u-1",
+    "HERMES_SESSION_USER_NAME": "ada",
+    "HERMES_SESSION_THREAD_ID": "",
+    "HERMES_SESSION_MESSAGE_ID": "m-9",
+    "HERMES_SESSION_ID": DURABLE_ID,
+}
+
+
+class _QuietPopen:
+    """A child that starts and then says nothing — the shape this bug needs."""
+
+    def __init__(self, *_args, **_kwargs) -> None:
+        self.pid = 424242
+        self.stdout = None
+        self.stdin = None
+        self.returncode = None
+
+    def poll(self):
+        return None
+
+
+class _Registry:
+    """Stand-in for the process registry: records the session it was handed."""
+
+    def __init__(self) -> None:
+        self.pending_watchers: list[dict[str, Any]] = []
+        self.spawned: ProcessSession | None = None
+
+    def spawn_local(self, *, command, cwd, task_id, owner_task_id, session_key, **_kw) -> ProcessSession:
+        self.spawned = ProcessSession(
+            id="proc_spawned1234", command=command, cwd=cwd, task_id=task_id,
+            owner_task_id=owner_task_id, session_key=session_key, pid=4242, started_at=time.time())
+        return self.spawned
+
+
+@pytest.fixture()
+def gateway_session(monkeypatch, tmp_path):
+    """A live messaging session: routing metadata bound, async delivery available."""
+    registry = _Registry()
+    monkeypatch.setattr(process_registry_module, "process_registry", registry)
+    monkeypatch.setattr(
+        session_context, "get_session_env", lambda name, default="": _SESSION_ENV.get(name, default))
+    monkeypatch.setattr(session_context, "async_delivery_supported", lambda: True)
+    return registry
+
+
+def _spawn(tmp_path, **overrides) -> dict:
+    kwargs = dict(
+        command="npm run dev", env=None, env_type="local", effective_task_id="t-telegram",
+        task_id="t-telegram", session_key="telegram:4242", workdir=None, cwd=str(tmp_path),
+        effective_pty=False, notify_on_complete=False, watch_patterns=None,
+        approval_note=None, pty_disabled_reason=None)
+    kwargs.update(overrides)
+    return json.loads(spawn_background_process(**kwargs))
+
+
+class TestBackgroundSessionLineage:
+    def test_silent_default_launch_records_the_spawning_conversation(self, gateway_session, tmp_path):
+        """The reported bug: no notification flags, so nothing stamped the lineage."""
+        result = _spawn(tmp_path)
+
+        assert result["exit_code"] == 0
+        assert gateway_session.spawned.parent_session_id == DURABLE_ID
+
+    def test_a_silent_job_still_asks_for_no_notification(self, gateway_session, tmp_path):
+        result = _spawn(tmp_path)
+
+        # Stamping identity must not quietly turn a silent job into a notifying one.
+        assert "notify_on_complete" not in result
+        assert gateway_session.spawned.notify_on_complete is False
+        assert gateway_session.spawned.watch_patterns == []
+        assert gateway_session.pending_watchers == []
+
+    def test_notifying_jobs_keep_their_routing_and_watcher(self, gateway_session, tmp_path):
+        result = _spawn(tmp_path, notify_on_complete=True)
+
+        assert result["notify_on_complete"] is True
+        session = gateway_session.spawned
+        assert session.parent_session_id == DURABLE_ID
+        assert (session.watcher_platform, session.watcher_chat_id) == ("telegram", "4242")
+        assert session.watcher_message_id == "m-9"
+        assert [w["session_id"] for w in gateway_session.pending_watchers] == ["proc_spawned1234"]
+
+    def test_lineage_survives_a_channel_that_cannot_deliver_async(
+        self, gateway_session, tmp_path, monkeypatch):
+        """A stateless runner loses the notification, not its identity."""
+        monkeypatch.setattr(session_context, "async_delivery_supported", lambda: False)
+
+        result = _spawn(tmp_path, notify_on_complete=True)
+
+        assert result["notify_on_complete"] is False
+        assert "notify_unsupported" in result
+        assert gateway_session.spawned.parent_session_id == DURABLE_ID
+
+    def test_a_quiet_job_publishes_its_lineage_to_the_shared_checkpoint(
+        self, monkeypatch, tmp_path):
+        """The checkpoint row is written when the process is REGISTERED, which happens
+        before the spawn caller stamps anything on it. A quiet job never emits output,
+        so nothing rewrites that row for the rest of its life and the durable id another
+        gateway matches on is missing from the only file both processes can see.
+        """
+        registry = process_registry_module.ProcessRegistry()
+        checkpoint = tmp_path / "processes.json"
+        monkeypatch.setattr(process_registry_module, "process_registry", registry)
+        monkeypatch.setattr(process_registry_module, "CHECKPOINT_PATH", checkpoint)
+        monkeypatch.setattr(
+            session_context, "get_session_env", lambda name, default="": _SESSION_ENV.get(name, default))
+        monkeypatch.setattr(session_context, "async_delivery_supported", lambda: True)
+        # A real registration through spawn_local, minus the child and its reader:
+        # the session stays running and quiet, exactly like the reported case.
+        monkeypatch.setattr(process_registry_module, "_find_shell", lambda: "/bin/sh")
+        monkeypatch.setattr(process_registry_module.subprocess, "Popen", _QuietPopen)
+        monkeypatch.setattr(
+            process_registry_module.ProcessRegistry, "_reader_loop", lambda self, session: None)
+
+        result = _spawn(tmp_path)
+
+        published = json.loads(checkpoint.read_text(encoding="utf-8"))
+        row = next(r for r in published if r["session_id"] == result["session_id"])
+        assert row["parent_session_id"] == DURABLE_ID
+
+    def test_a_quiet_notifying_job_publishes_its_routing_too(self, monkeypatch, tmp_path):
+        """Same staleness hit the watcher routing and the notification flags, which are
+        also stamped after registration and also live in the checkpoint."""
+        registry = process_registry_module.ProcessRegistry()
+        checkpoint = tmp_path / "processes.json"
+        monkeypatch.setattr(process_registry_module, "process_registry", registry)
+        monkeypatch.setattr(process_registry_module, "CHECKPOINT_PATH", checkpoint)
+        monkeypatch.setattr(
+            session_context, "get_session_env", lambda name, default="": _SESSION_ENV.get(name, default))
+        monkeypatch.setattr(session_context, "async_delivery_supported", lambda: True)
+        monkeypatch.setattr(process_registry_module, "_find_shell", lambda: "/bin/sh")
+        monkeypatch.setattr(process_registry_module.subprocess, "Popen", _QuietPopen)
+        monkeypatch.setattr(
+            process_registry_module.ProcessRegistry, "_reader_loop", lambda self, session: None)
+
+        result = _spawn(tmp_path, notify_on_complete=True)
+
+        published = json.loads(checkpoint.read_text(encoding="utf-8"))
+        row = next(r for r in published if r["session_id"] == result["session_id"])
+        assert row["notify_on_complete"] is True
+        assert row["watcher_platform"] == "telegram"
+        assert row["watcher_chat_id"] == "4242"
+
+    def test_a_session_with_no_conversation_id_stamps_nothing(
+        self, gateway_session, tmp_path, monkeypatch):
+        monkeypatch.setattr(session_context, "get_session_env", lambda name, default="": default)
+
+        _spawn(tmp_path)
+
+        # Empty is the honest answer; a placeholder would match other blank rows.
+        assert gateway_session.spawned.parent_session_id == ""
+        assert gateway_session.spawned.watcher_platform == ""

--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -149,11 +149,16 @@ class TestCheckpointNotify:
 
     def test_recover_defaults_false(self, registry, tmp_path):
         """Old checkpoint entries without the field default to False."""
+        from gateway.status import get_process_start_time
+
         checkpoint = tmp_path / "procs.json"
         checkpoint.write_text(json.dumps([{
             "session_id": "proc_live",
             "command": "sleep 999",
             "pid": os.getpid(),
+            # Recovery adopts a process into locally killable state, so it requires
+            # a start-time baseline to prove the PID was not recycled.
+            "host_start_time": get_process_start_time(os.getpid()),
             "task_id": "t1",
         }]))
         with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):

--- a/tests/tools/test_process_registry_peer_sync.py
+++ b/tests/tools/test_process_registry_peer_sync.py
@@ -315,6 +315,26 @@ class TestMultiWriterCheckpoint:
         with patch.object(process_registry_module, "_flock", side_effect=OSError("no locks available")):
             assert registry.sync_from_checkpoint() == 1
 
+    def test_windows_lock_seeds_a_fresh_lock_file(self, tmp_path, monkeypatch):
+        """Windows msvcrt locking needs a byte at the locked range."""
+        checkpoint = tmp_path / "processes.json"
+        lock_path = checkpoint.with_name(checkpoint.name + ".lock")
+        monkeypatch.setattr(process_registry_module, "CHECKPOINT_PATH", checkpoint)
+        monkeypatch.setattr(process_registry_module, "_IS_WINDOWS", True)
+        calls = []
+
+        def fake_flock(handle, *, lock):
+            calls.append(lock)
+            assert lock_path.stat().st_size >= 1
+
+        monkeypatch.setattr(process_registry_module, "_flock", fake_flock)
+
+        with process_registry_module._checkpoint_lock() as locked:
+            assert locked
+
+        assert calls == [True, False]
+        assert lock_path.read_bytes() == b" "
+
     def test_startup_recovery_leaves_a_live_owners_rows_alone(self, checkpoint):
         gateway_b = ProcessRegistry()
         _track(gateway_b, "proc_b")

--- a/tests/tools/test_process_registry_peer_sync.py
+++ b/tests/tools/test_process_registry_peer_sync.py
@@ -1,0 +1,491 @@
+"""Cross-gateway background-process visibility.
+
+A ``terminal(background=true)`` process spawned by the messaging gateway lives in
+THAT process's ``ProcessRegistry``; Hermes Desktop runs its own gateway with its
+own registry, so the row is invisible there. The shared crash-recovery checkpoint
+(``~/.hermes/processes.json``) is the only thing both processes see, so these
+tests pin the contract for importing a peer's rows from it:
+
+* only live host PIDs whose recorded ``host_start_time`` still matches are
+  adopted (a recycled PID must never be adopted, let alone signalled),
+* a peer mirror is display/status only: it never re-publishes the checkpoint,
+  never notifies, and never signals a PID this process does not own,
+* the persisted output tail is bounded and redacted even when the user turned
+  secret redaction off.
+"""
+
+import json
+import os
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+import agent.redact
+import tools.process_registry as process_registry_module
+import utils
+from gateway.status import get_process_start_time
+from tools.process_registry import (
+    CHECKPOINT_OUTPUT_TAIL_CHARS,
+    ProcessRegistry,
+    ProcessSession,
+)
+
+LIVE_PID = os.getpid()
+DEAD_PID = 999999999
+
+# Redaction fixtures. Both are shaped to trip a real pattern (the ``ghp_`` prefix
+# rule and the ENV-assignment rule) while spelling out on their face that they are
+# not credentials, so a scanner hit here is obviously a test string.
+FAKE_TOKEN = "ghp_00SYNTHETICNOTAREALTOKEN00"
+FAKE_SECRET = "SYNTHETICNOTAREALSECRET"
+
+
+@pytest.fixture()
+def registry():
+    return ProcessRegistry()
+
+
+@pytest.fixture()
+def checkpoint(tmp_path):
+    """Redirect the shared checkpoint at a temp file and hand back the path."""
+    path = tmp_path / "processes.json"
+    with patch("tools.process_registry.CHECKPOINT_PATH", path):
+        yield path
+
+
+def _peer_entry(**overrides) -> dict:
+    """A checkpoint entry as another gateway process would have written it."""
+    entry = {
+        "session_id": "proc_peerabc12345",
+        "command": "npm run dev",
+        "pid": LIVE_PID,
+        "pid_scope": "host",
+        "host_start_time": get_process_start_time(LIVE_PID),
+        "cwd": "/srv/app",
+        "started_at": time.time() - 30,
+        "task_id": "t-telegram",
+        "owner_task_id": "t-telegram",
+        "session_key": "telegram:4242",
+        "parent_session_id": "20260901_120000_abcdef",
+        "notify_on_complete": True,
+        "output_tail": "listening on :3000\n",
+    }
+    entry.update(overrides)
+    return entry
+
+
+def _write(checkpoint_path, *entries) -> None:
+    checkpoint_path.write_text(json.dumps(list(entries)), encoding="utf-8")
+
+
+def _ids(registry) -> set:
+    return {row["session_id"] for row in registry.list_sessions()}
+
+
+class TestPeerImport:
+    def test_live_peer_process_becomes_a_visible_detached_row(self, registry, checkpoint):
+        _write(checkpoint, _peer_entry())
+
+        registry.sync_from_checkpoint()
+
+        row = next(r for r in registry.list_sessions() if r["session_id"] == "proc_peerabc12345")
+        assert row["status"] == "running"
+        assert row["peer"] is True
+        assert row["detached"] is True
+        session = registry.get("proc_peerabc12345")
+        # The durable identities the desktop matches ownership on must survive.
+        assert session.session_key == "telegram:4242"
+        assert session.parent_session_id == "20260901_120000_abcdef"
+        assert session.output_buffer == "listening on :3000\n"
+
+    def test_recycled_or_dead_pid_is_never_adopted(self, registry, checkpoint):
+        _write(
+            checkpoint,
+            _peer_entry(session_id="proc_dead", pid=DEAD_PID),
+            # Alive, but the kernel start time proves it is a different process now.
+            _peer_entry(session_id="proc_recycled", host_start_time=1),
+            # Legacy entry with no identity baseline at all: liveness alone is not proof.
+            _peer_entry(session_id="proc_nobaseline", host_start_time=None),
+            # In-sandbox PIDs mean nothing on this host.
+            _peer_entry(session_id="proc_sandbox", pid_scope="sandbox"),
+        )
+
+        registry.sync_from_checkpoint()
+
+        assert _ids(registry) == set()
+
+    def test_locally_owned_rows_are_never_replaced_by_the_checkpoint(self, registry, checkpoint):
+        mine = ProcessSession(
+            id="proc_mine", command="真 command", session_key="desktop-key",
+            started_at=time.time(), output_buffer="local output")
+        registry._running[mine.id] = mine
+        _write(checkpoint, _peer_entry(session_id="proc_mine", command="spoofed", session_key="attacker"))
+
+        registry.sync_from_checkpoint()
+
+        assert registry.get("proc_mine") is mine
+        assert mine.command == "真 command"
+        assert mine.session_key == "desktop-key"
+        assert mine.output_buffer == "local output"
+
+    def test_repeated_sync_refreshes_the_tail_without_duplicating_rows(self, registry, checkpoint):
+        _write(checkpoint, _peer_entry())
+        registry.sync_from_checkpoint()
+        first = registry.get("proc_peerabc12345")
+
+        _write(checkpoint, _peer_entry(output_tail="listening on :3000\nrequest served\n"))
+        registry.sync_from_checkpoint()
+
+        assert len(registry.list_sessions()) == 1
+        assert registry.get("proc_peerabc12345") is first
+        assert first.output_buffer == "listening on :3000\nrequest served\n"
+
+    def test_peer_row_disappears_once_its_owner_stops_publishing_it(self, registry, checkpoint):
+        _write(checkpoint, _peer_entry())
+        registry.sync_from_checkpoint()
+        assert _ids(registry) == {"proc_peerabc12345"}
+
+        _write(checkpoint)  # owner finished the process and rewrote the checkpoint
+
+        registry.sync_from_checkpoint()
+
+        assert _ids(registry) == set()
+        assert registry.get("proc_peerabc12345") is None
+
+
+def _rows(checkpoint_path) -> dict:
+    """``session_id`` → row, as currently published in the shared checkpoint."""
+    return {
+        str(row.get("session_id")): row
+        for row in json.loads(checkpoint_path.read_text(encoding="utf-8"))
+    }
+
+
+def _track(registry, session_id: str, **kw) -> ProcessSession:
+    """Register a live, locally-owned process on *registry*."""
+    session = ProcessSession(
+        id=session_id, command=kw.pop("command", "npm run dev"), pid=LIVE_PID,
+        host_start_time=get_process_start_time(LIVE_PID), started_at=time.time(), **kw)
+    registry._running[session_id] = session
+    return session
+
+
+# ``~/.hermes/processes.json`` has one writer per gateway PROCESS (messaging
+# gateway, desktop backend, CLI) and they publish independently. A read-modify-
+# write that treats the file as its own would silently delete every other live
+# gateway's rows — and, since Desktop now renders peers from this file, delete
+# the user's visible background work along with the crash-recovery record.
+class TestMultiWriterCheckpoint:
+    def test_interleaved_publishes_preserve_every_live_owners_rows(self, checkpoint):
+        gateway_a, gateway_b = ProcessRegistry(), ProcessRegistry()
+        _track(gateway_a, "proc_a")
+        gateway_a._write_checkpoint()
+        _track(gateway_b, "proc_b")
+        gateway_b._write_checkpoint()
+
+        gateway_a._write_checkpoint()
+
+        assert set(_rows(checkpoint)) == {"proc_a", "proc_b"}
+
+    def test_owner_completion_removes_only_that_owners_row(self, checkpoint):
+        gateway_a, gateway_b = ProcessRegistry(), ProcessRegistry()
+        _track(gateway_a, "proc_a1")
+        _track(gateway_a, "proc_a2")
+        gateway_a._write_checkpoint()
+        _track(gateway_b, "proc_b1")
+        gateway_b._write_checkpoint()
+
+        gateway_a._running.pop("proc_a1")  # finished on A
+        gateway_a._write_checkpoint()
+
+        assert set(_rows(checkpoint)) == {"proc_a2", "proc_b1"}
+
+        # B republishing must not resurrect the row A just retired.
+        gateway_b._write_checkpoint()
+
+        assert set(_rows(checkpoint)) == {"proc_a2", "proc_b1"}
+
+    def test_rows_whose_tracked_process_is_gone_are_pruned(self, checkpoint):
+        _write(
+            checkpoint,
+            _peer_entry(session_id="proc_dead", pid=DEAD_PID),
+            _peer_entry(session_id="proc_live"),
+            # An in-sandbox row is unreadable without its owner, and no owner
+            # stamp means the writer is long gone.
+            _peer_entry(session_id="proc_sandbox", pid_scope="sandbox"),
+        )
+        gateway_a = ProcessRegistry()
+        _track(gateway_a, "proc_a")
+
+        gateway_a._write_checkpoint()
+
+        assert set(_rows(checkpoint)) == {"proc_a", "proc_live"}
+
+    def test_concurrent_writers_never_lose_a_row(self, checkpoint):
+        gateway_a, gateway_b = ProcessRegistry(), ProcessRegistry()
+        _track(gateway_a, "proc_a")
+        _track(gateway_b, "proc_b")
+        start = threading.Barrier(2)
+
+        def hammer(reg):
+            start.wait(5)
+            for _ in range(25):
+                reg._write_checkpoint()
+
+        threads = [threading.Thread(target=hammer, args=(reg,)) for reg in (gateway_a, gateway_b)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(30)
+
+        assert set(_rows(checkpoint)) == {"proc_a", "proc_b"}
+
+    def test_a_slow_write_never_resurrects_a_row_retired_meanwhile(self, checkpoint):
+        """Two overlapping writes from ONE registry.
+
+        ``_write_checkpoint`` snapshots the running set, then does the redaction and
+        disk work outside that snapshot's lock. A writer still carrying an older
+        snapshot must not land after the write that retired a row and put it back on
+        disk. The inter-process lock cannot help here — both writers are in THIS
+        process, so it only decides which of the two stale orderings wins.
+        """
+        registry = ProcessRegistry()
+        _track(registry, "proc_retired")
+        snapshot_taken = threading.Event()
+        retired_write_landed = threading.Event()
+        real_tail = process_registry_module._checkpoint_output_tail
+        real_json_write = utils.atomic_json_write
+
+        def stall_the_first_writer(text):
+            # Reached once the stale snapshot exists but before anything is written.
+            if not snapshot_taken.is_set():
+                snapshot_taken.set()
+                # Bounded: once serialized, the retiring write CANNOT land first, so
+                # this waits out the bound instead of hanging the suite.
+                retired_write_landed.wait(2.0)
+            return real_tail(text)
+
+        def note_empty_write(path, data, **kw):
+            real_json_write(path, data, **kw)
+            if not data:
+                retired_write_landed.set()
+
+        with patch.object(process_registry_module, "_checkpoint_output_tail", stall_the_first_writer), \
+                patch.object(utils, "atomic_json_write", note_empty_write):
+            stale_writer = threading.Thread(target=registry._write_checkpoint, daemon=True)
+            stale_writer.start()
+            assert snapshot_taken.wait(10), "the first writer never reached its snapshot"
+
+            registry._running.clear()  # the process finished
+            registry._write_checkpoint()
+
+            stale_writer.join(10)
+            assert not stale_writer.is_alive()
+
+        assert set(_rows(checkpoint)) == set()
+
+    def test_a_write_that_cannot_lock_is_skipped_rather_than_clobbering(self, checkpoint):
+        """Publishing is a read-modify-write. Doing it unsynchronized is exactly how
+        another gateway's row gets dropped, so an unavailable lock must cost us our
+        own update — recoverable on the next write — not someone else's row."""
+        gateway_b = ProcessRegistry()
+        _track(gateway_b, "proc_b")
+        gateway_b._write_checkpoint()
+
+        gateway_a = ProcessRegistry()
+        _track(gateway_a, "proc_a")
+        with patch.object(process_registry_module, "_flock", side_effect=OSError("no locks available")):
+            gateway_a._write_checkpoint()
+
+        assert set(_rows(checkpoint)) == {"proc_b"}
+
+        # Transient: the very next write publishes normally.
+        gateway_a._write_checkpoint()
+
+        assert set(_rows(checkpoint)) == {"proc_a", "proc_b"}
+
+    def test_reads_still_work_when_the_lock_is_unavailable(self, checkpoint):
+        """A read cannot destroy anything, and ``atomic_json_write`` already makes a
+        torn view unlikely — so discovery degrades rather than going blind."""
+        _write(checkpoint, _peer_entry())
+        registry = ProcessRegistry()
+
+        with patch.object(process_registry_module, "_flock", side_effect=OSError("no locks available")):
+            assert registry.sync_from_checkpoint() == 1
+
+    def test_startup_recovery_leaves_a_live_owners_rows_alone(self, checkpoint):
+        gateway_b = ProcessRegistry()
+        _track(gateway_b, "proc_b")
+        gateway_b._write_checkpoint()
+
+        # A second gateway booting must not adopt work another LIVE gateway is
+        # already driving — two owners would both believe they may kill it.
+        fresh = ProcessRegistry()
+
+        assert fresh.recover_from_checkpoint() == 0
+        assert set(_rows(checkpoint)) == {"proc_b"}
+
+    def test_orphaned_rows_from_a_dead_owner_are_still_recovered(self, checkpoint):
+        # Crash recovery is the whole reason this file exists: a row with no live
+        # owner and a live process must still be adopted at startup.
+        _write(checkpoint, _peer_entry(session_id="proc_orphan"))
+
+        assert ProcessRegistry().recover_from_checkpoint() == 1
+
+    def test_a_row_with_no_start_time_baseline_is_never_adopted(self, checkpoint):
+        """Adoption puts a process in local, KILLABLE state, and a recovered session
+        with no baseline makes ``_terminate_host_pid`` skip its identity check — so a
+        recycled PID would be tree-killed. Recovery must be as strict as mirroring."""
+        _write(checkpoint, _peer_entry(session_id="proc_unidentified", host_start_time=None))
+        adopter = ProcessRegistry()
+
+        assert adopter.recover_from_checkpoint() == 0
+        assert adopter.get("proc_unidentified") is None
+        # Nobody can act on it safely, so it is not left behind either.
+        assert set(_rows(checkpoint)) == set()
+
+    def test_adopting_an_orphan_leaves_exactly_one_row_for_it(self, checkpoint):
+        _write(checkpoint, _peer_entry(session_id="proc_orphan"))
+        adopter = ProcessRegistry()
+        adopter.recover_from_checkpoint()
+
+        adopter._write_checkpoint()
+
+        published = json.loads(checkpoint.read_text(encoding="utf-8"))
+        # The adopted row is republished under the NEW owner; the dead owner's
+        # copy must not linger beside it as a second row for the same process.
+        assert [row["session_id"] for row in published] == ["proc_orphan"]
+
+
+class TestPeerMirrorIsDisplayOnly:
+    def test_a_mirror_never_claims_the_owners_row(self, registry, checkpoint):
+        _write(checkpoint, _peer_entry())
+        registry.sync_from_checkpoint()
+        published = _rows(checkpoint)["proc_peerabc12345"]
+
+        registry._write_checkpoint()
+
+        # Preserved verbatim: this process renders the row but never becomes its
+        # author, so the owner's next update is still the authoritative one.
+        assert _rows(checkpoint) == {"proc_peerabc12345": published}
+
+    def test_our_own_published_rows_are_never_mirrored_back(self, registry, checkpoint):
+        _track(registry, "proc_mine1234")
+        registry._write_checkpoint()
+        registry._running.clear()
+
+        # The row is still on disk, stamped by us. Re-importing it would turn our
+        # own process into a "peer" we then refuse to kill.
+        assert registry.sync_from_checkpoint() == 0
+        assert registry.get("proc_mine1234") is None
+
+    def test_kill_refuses_to_signal_a_pid_this_process_does_not_own(self, registry, checkpoint):
+        _write(checkpoint, _peer_entry())
+        registry.sync_from_checkpoint()
+
+        with patch.object(ProcessRegistry, "_terminate_host_pid") as terminate:
+            result = registry.kill_process("proc_peerabc12345")
+
+        terminate.assert_not_called()
+        assert result["status"] == "error"
+        assert "another" in result["error"].lower()
+        # Still visible and still reported as running — we did not fake an exit.
+        assert registry.get("proc_peerabc12345").exited is False
+
+    def test_mirror_never_queues_a_completion_notification(self, registry, checkpoint):
+        _write(checkpoint, _peer_entry(notify_on_complete=True))
+        registry.sync_from_checkpoint()
+        session = registry.get("proc_peerabc12345")
+
+        # The owning gateway is the only party with a completion contract.
+        assert session.notify_on_complete is False
+        registry._move_to_finished(session)
+        assert registry.completion_queue.empty()
+
+    def test_mirror_is_excluded_from_local_lifecycle_bookkeeping(self, registry, checkpoint):
+        _write(checkpoint, _peer_entry())
+        registry.sync_from_checkpoint()
+
+        # kill_all / scale-to-zero / session-reset all reason about processes
+        # THIS gateway owns; a mirror must not answer for them.
+        assert registry.has_any_active() is False
+        assert registry.has_active_for_session("telegram:4242") is False
+        assert registry.count_running() == 0
+        with patch.object(ProcessRegistry, "_terminate_host_pid") as terminate:
+            assert registry.kill_all() == 0
+        terminate.assert_not_called()
+
+
+class TestCheckpointOutputTail:
+    def _running(self, registry, output: str, command: str = "npm run dev") -> ProcessSession:
+        session = ProcessSession(
+            id="proc_local1234", command=command, pid=LIVE_PID,
+            host_start_time=get_process_start_time(LIVE_PID),
+            started_at=time.time(), output_buffer=output)
+        registry._running[session.id] = session
+        return session
+
+    def test_tail_is_published_for_peers_and_bounded(self, registry, checkpoint):
+        self._running(registry, "x" * (CHECKPOINT_OUTPUT_TAIL_CHARS + 5_000) + "TAIL-END")
+
+        registry._write_checkpoint()
+
+        entry = json.loads(checkpoint.read_text(encoding="utf-8"))[0]
+        assert entry["output_tail"].endswith("TAIL-END")
+        assert len(entry["output_tail"]) <= CHECKPOINT_OUTPUT_TAIL_CHARS
+
+    def test_secrets_are_masked_even_when_the_user_disabled_redaction(
+        self, registry, checkpoint, monkeypatch):
+        monkeypatch.setattr(agent.redact, "_REDACT_ENABLED", False)
+        self._running(
+            registry,
+            f"connecting with {FAKE_TOKEN}\nDB_PASSWORD={FAKE_SECRET}\n",
+            command=f"deploy --token {FAKE_TOKEN} DB_PASSWORD={FAKE_SECRET}")
+
+        registry._write_checkpoint()
+
+        entry = json.loads(checkpoint.read_text(encoding="utf-8"))[0]
+        blob = entry["output_tail"] + entry["command"]
+        assert FAKE_TOKEN not in blob
+        # ENV/JSON assignments are secrets on this boundary too — the checkpoint
+        # is a file on disk that a peer gateway renders for the user.
+        assert FAKE_SECRET not in blob
+
+    def test_a_secret_straddling_the_tail_cut_is_still_masked(self, registry, checkpoint):
+        """Slicing before redacting decapitates ``DB_PASSWORD=`` at the cut, so the
+        pattern no longer matches and the value is published verbatim."""
+        value = FAKE_SECRET
+        # Place the cut exactly between the assignment's key and its value: the
+        # published tail then begins at the raw secret.
+        after = "z" * (CHECKPOINT_OUTPUT_TAIL_CHARS - len(value) - 1)
+        self._running(registry, "y" * 20_000 + f"DB_PASSWORD={value}\n" + after)
+
+        registry._write_checkpoint()
+
+        entry = json.loads(checkpoint.read_text(encoding="utf-8"))[0]
+        assert value not in entry["output_tail"]
+        assert len(entry["output_tail"]) <= CHECKPOINT_OUTPUT_TAIL_CHARS
+
+    def test_live_output_checkpointing_is_throttled_but_still_lands(self, registry, checkpoint):
+        session = self._running(registry, "")
+        writes = []
+        done = threading.Event()
+
+        def record(*_a, **_kw):
+            writes.append(session.output_buffer)
+            done.set()
+
+        with patch.object(ProcessRegistry, "_write_checkpoint", record):
+            for i in range(200):
+                registry._ingest_output(session, f"line {i}\n")
+            # Per-chunk writes would be 200 disk rewrites for one burst.
+            assert len(writes) < 20
+            burst_writes = len(writes)
+            done.clear()
+            # The tail of a burst must not be lost to the throttle window.
+            assert done.wait(10), "throttled tail was never flushed"
+
+        assert len(writes) > burst_writes
+        assert writes[-1].endswith("line 199\n")

--- a/tests/tui_gateway/test_process_scope.py
+++ b/tests/tui_gateway/test_process_scope.py
@@ -1,0 +1,218 @@
+"""``process.list`` / ``process.kill`` scoping across gateway processes.
+
+A ``terminal(background=true)`` job started for a Telegram conversation runs in
+the messaging gateway's own ``ProcessRegistry``. Desktop talks to a different
+gateway process, so its ``process.list`` used to see nothing: the local registry
+was filtered by an exact ``session_key`` match against a runtime row that never
+existed here.
+
+Contract pinned below:
+
+1. the handler imports peers from the shared checkpoint before answering,
+2. ownership is judged on the DURABLE conversation identity as well as the
+   runtime key, so an unrelated conversation still sees nothing,
+3. when the ephemeral runtime row is gone the handler may fall back to the
+   durable id — but only for the expected ``4001 session not found`` error, and
+   never for an empty or control-character id,
+4. ``process.kill`` uses exactly the same ownership rule.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from unittest.mock import patch
+
+import pytest
+
+from gateway.status import get_process_start_time
+from tools.process_registry import ProcessRegistry, ProcessSession
+import tui_gateway.server as server
+
+RID = "rid-1"
+DURABLE_ID = "20260901_120000_abcdef"
+LIVE_PID = os.getpid()
+
+
+@pytest.fixture()
+def registry(tmp_path):
+    """A private registry + checkpoint standing in for the process-wide pair."""
+    reg = ProcessRegistry()
+    with patch("tools.process_registry.process_registry", reg), \
+            patch("tools.process_registry.CHECKPOINT_PATH", tmp_path / "processes.json"):
+        reg.checkpoint_path = tmp_path / "processes.json"
+        yield reg
+
+
+def _track(registry, **kw) -> ProcessSession:
+    session = ProcessSession(id=kw.pop("id", "proc_local1234"), started_at=time.time(), **kw)
+    registry._running[session.id] = session
+    return session
+
+
+def _publish_peer(registry, **overrides) -> None:
+    entry = {
+        "session_id": "proc_peerabc12345",
+        "command": "npm run dev",
+        "pid": LIVE_PID,
+        "pid_scope": "host",
+        "host_start_time": get_process_start_time(LIVE_PID),
+        "started_at": time.time(),
+        "task_id": "t-telegram",
+        "owner_task_id": "t-telegram",
+        "session_key": "telegram:4242",
+        "parent_session_id": DURABLE_ID,
+        "output_tail": "listening on :3000\n",
+    }
+    entry.update(overrides)
+    registry.checkpoint_path.write_text(json.dumps([entry]), encoding="utf-8")
+
+
+def _list(params: dict) -> dict:
+    return server._methods["process.list"](RID, params)
+
+
+def _kill(params: dict) -> dict:
+    return server._methods["process.kill"](RID, params)
+
+
+def _ids(reply: dict) -> set:
+    return {row["session_id"] for row in reply["result"]["processes"]}
+
+
+class TestLiveRuntimeScope:
+    def test_own_processes_still_listed_with_an_output_tail(self, registry):
+        _track(registry, session_key="runtime-key", command="npm test", output_buffer="ok\n")
+        with patch.dict(server._sessions, {"s1": {"session_key": "runtime-key"}}, clear=True):
+            reply = _list({"session_id": "s1"})
+
+        row = reply["result"]["processes"][0]
+        assert row["session_id"] == "proc_local1234"
+        assert row["output_tail"] == "ok\n"
+
+    def test_peer_gateway_process_is_discovered_for_the_same_conversation(self, registry):
+        _publish_peer(registry)
+        # Desktop resumed the stored conversation, so its runtime session_key IS
+        # the durable id the peer stamped as parent_session_id.
+        with patch.dict(server._sessions, {"s1": {"session_key": DURABLE_ID}}, clear=True):
+            reply = _list({"session_id": "s1"})
+
+        row = next(r for r in reply["result"]["processes"] if r["session_id"] == "proc_peerabc12345")
+        assert row["status"] == "running"
+        assert row["output_tail"] == "listening on :3000\n"
+        assert row["peer"] is True
+
+    def test_a_session_homed_on_another_profile_gets_no_peer_rows(self, registry, tmp_path):
+        """``CHECKPOINT_PATH`` resolves once, against the launch profile. Rather than
+        serve one profile's process registry to another, the peer import is skipped —
+        profiles are independent islands, and local rows are unaffected."""
+        _publish_peer(registry)
+        _track(registry, session_key=DURABLE_ID, command="npm test")
+        session = {"session_key": DURABLE_ID, "profile_home": str(tmp_path / "profiles" / "work")}
+        with patch.dict(server._sessions, {"s1": session}, clear=True):
+            reply = _list({"session_id": "s1"})
+
+        assert _ids(reply) == {"proc_local1234"}
+
+    def test_a_launch_profile_session_still_imports_peers(self, registry):
+        _publish_peer(registry)
+        with patch.dict(server._sessions, {"s1": {"session_key": DURABLE_ID, "profile_home": None}}, clear=True):
+            reply = _list({"session_id": "s1"})
+
+        assert _ids(reply) == {"proc_peerabc12345"}
+
+    def test_unrelated_conversation_sees_nothing(self, registry):
+        _publish_peer(registry)
+        _track(registry, session_key="telegram:4242", command="npm test")
+        with patch.dict(server._sessions, {"s2": {"session_key": "20260101_000000_other"}}, clear=True):
+            reply = _list({"session_id": "s2"})
+
+        assert _ids(reply) == set()
+
+
+class _StoredSessions:
+    """Minimal state.db stand-in: only these ids are stored conversations."""
+
+    def __init__(self, *ids: str) -> None:
+        self._ids = set(ids)
+
+    def get_session(self, session_id: str):
+        return {"id": session_id} if session_id in self._ids else None
+
+
+class TestDurableFallback:
+    def test_durable_id_resolves_when_the_runtime_row_is_gone(self, registry):
+        _publish_peer(registry)
+        with patch.dict(server._sessions, {}, clear=True), \
+                patch.object(server, "_get_db", return_value=_StoredSessions(DURABLE_ID)):
+            reply = _list({"session_id": DURABLE_ID})
+
+        assert _ids(reply) == {"proc_peerabc12345"}
+
+    def test_fallback_does_not_leak_another_conversations_processes(self, registry):
+        _publish_peer(registry)
+        other = "20260101_000000_other"
+        with patch.dict(server._sessions, {}, clear=True), \
+                patch.object(server, "_get_db", return_value=_StoredSessions(DURABLE_ID, other)):
+            reply = _list({"session_id": other})
+
+        assert _ids(reply) == set()
+
+    def test_a_dead_runtime_id_still_gets_the_session_not_found_verdict(self, registry):
+        """The desktop's gone-latch and passive session heal hang off this 4001;
+        a reaped runtime id must never be reinterpreted as a durable scope."""
+        _publish_peer(registry)
+        with patch.dict(server._sessions, {}, clear=True), \
+                patch.object(server, "_get_db", return_value=_StoredSessions(DURABLE_ID)):
+            reply = _list({"session_id": "a1b2c3d4"})
+
+        assert reply["error"]["code"] == 4001
+        assert "result" not in reply
+
+    @pytest.mark.parametrize("bad", ["", "   ", "\x00", "sess\x07id", "sess\nid"])
+    def test_empty_and_control_character_ids_are_rejected(self, registry, bad):
+        _publish_peer(registry, parent_session_id=bad, session_key=bad)
+        # Even if such an id somehow named a stored row, it never reaches the lookup.
+        with patch.dict(server._sessions, {}, clear=True), \
+                patch.object(server, "_get_db", return_value=_StoredSessions(bad, bad.strip())):
+            reply = _list({"session_id": bad})
+
+        assert reply["error"]["code"] == 4001
+
+    def test_only_session_not_found_opens_the_fallback(self, registry):
+        _publish_peer(registry)
+        other = server._err(RID, 5032, "agent initialization timed out")
+        with patch.object(server, "_sess", return_value=(None, other)), \
+                patch.object(server, "_get_db", return_value=_StoredSessions(DURABLE_ID)):
+            reply = _list({"session_id": DURABLE_ID})
+
+        # A build failure is not permission to answer from the durable scope.
+        assert reply["error"]["code"] == 5032
+        assert "result" not in reply
+
+
+class TestKillScope:
+    def test_kill_rejects_a_process_owned_by_another_conversation(self, registry):
+        _track(registry, session_key="telegram:9999", command="npm run dev")
+        with patch.dict(server._sessions, {"s1": {"session_key": DURABLE_ID}}, clear=True):
+            reply = _kill({"session_id": "s1", "process_id": "proc_local1234"})
+
+        assert reply["error"]["code"] == 4044
+
+    def test_kill_accepts_a_process_matched_by_durable_identity(self, registry):
+        _track(registry, session_key="telegram:4242", parent_session_id=DURABLE_ID,
+               command="npm run dev", exited=True, exit_code=0)
+        with patch.dict(server._sessions, {"s1": {"session_key": DURABLE_ID}}, clear=True):
+            reply = _kill({"session_id": "s1", "process_id": "proc_local1234"})
+
+        assert reply["result"]["status"] == "already_exited"
+
+    def test_kill_of_a_peer_mirror_never_signals_the_foreign_pid(self, registry):
+        _publish_peer(registry)
+        with patch.dict(server._sessions, {"s1": {"session_key": DURABLE_ID}}, clear=True), \
+                patch.object(ProcessRegistry, "_terminate_host_pid") as terminate:
+            reply = _kill({"session_id": "s1", "process_id": "proc_peerabc12345"})
+
+        terminate.assert_not_called()
+        assert reply["result"]["status"] == "error"

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -333,7 +333,18 @@ def _checkpoint_lock():
     handle = None
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        handle = open(path, "a+b")
+        if _IS_WINDOWS:
+            # msvcrt.locking requires a byte to exist at the lock range. Seed a
+            # fresh file before opening it; a concurrent creator may win the race,
+            # in which case this write is harmless and the existing byte remains.
+            try:
+                if not path.exists() or path.stat().st_size == 0:
+                    path.write_bytes(b" ")
+            except OSError:
+                pass
+            handle = open(path, "r+b")
+        else:
+            handle = open(path, "a+b")
         _flock(handle, lock=True)
     except Exception as exc:
         logger.warning("Process checkpoint lock unavailable: %s", exc)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -5,7 +5,7 @@ Nothing runs on the host unless TERMINAL_ENV=local; other backends run in their 
 """
 
 import codecs
-from contextlib import suppress
+from contextlib import contextmanager, suppress
 import json
 import logging
 import os
@@ -41,6 +41,23 @@ CHECKPOINT_PATH = get_hermes_home() / "processes.json"
 MAX_OUTPUT_CHARS = 200_000      # rolling output buffer
 FINISHED_TTL_SECONDS = 1800     # keep finished processes 30 minutes
 MAX_PROCESSES = 64              # max tracked processes (LRU pruning)
+
+# Output tail published in the checkpoint for OTHER gateway processes to render
+# (messaging gateway spawns the job, Desktop shows it). Bounded well below
+# MAX_OUTPUT_CHARS: this is a display preview rewritten on disk while the process
+# runs, not the authoritative log, and it is what process.list already ships.
+CHECKPOINT_OUTPUT_TAIL_CHARS = 4_000
+# Extra left context redacted BEFORE the published tail is cut out of it. Slicing
+# first and redacting after decapitates any secret straddling the cut
+# (``DB_PASSWORD=`` on one side, the value on the other): the pattern no longer
+# matches and the value ships in the clear. Redacting a window this much wider
+# means the cut can only ever land inside text that was already scanned with full
+# left context — orders of magnitude more than the longest credential.
+CHECKPOINT_REDACT_CONTEXT_CHARS = 12_000
+# Floor between two output-driven checkpoint rewrites. A chunk landing inside the
+# window arms one trailing write, so a burst costs two rewrites instead of one
+# per chunk and the last line is still published.
+CHECKPOINT_OUTPUT_MIN_INTERVAL_SECONDS = 1.0
 
 # Watch-pattern rate limiting, PER SESSION: one watch-match notification per
 # WATCH_MIN_INTERVAL_SECONDS; a match inside the cooldown is dropped and counts as one
@@ -287,6 +304,53 @@ def format_uptime_short(seconds: int) -> str:
     return f"{hours}h {mins}m"
 
 
+def _flock(fh, *, lock: bool) -> None:
+    """Exclusive whole-file lock/unlock on ``fh`` (fcntl on POSIX, msvcrt on Windows).
+    Same primitive the other cross-process state files use (``gateway/status.py``,
+    ``cron/scheduler.py``, ``hermes_cli/active_sessions.py``)."""
+    if _IS_WINDOWS:
+        import msvcrt
+        fh.seek(0)
+        msvcrt.locking(fh.fileno(), msvcrt.LK_LOCK if lock else msvcrt.LK_UNLCK, 1)
+    else:
+        import fcntl
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX if lock else fcntl.LOCK_UN)
+
+
+@contextmanager
+def _checkpoint_lock():
+    """Hold the inter-process checkpoint lock; yields True when it is actually held.
+
+    ``processes.json`` has one writer per gateway PROCESS, so an unsynchronized
+    read-modify-write drops whatever another gateway published between our read and
+    our replace. Callers therefore get an honest verdict instead of a silent
+    downgrade: a WRITE must skip when this yields False (our own update is
+    republished by the next write; another owner's row, once dropped, is gone), while
+    a read may proceed — it destroys nothing, and ``atomic_json_write`` means the
+    worst case is a slightly stale view rather than a torn one.
+    """
+    path = CHECKPOINT_PATH.with_name(CHECKPOINT_PATH.name + ".lock")
+    handle = None
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        handle = open(path, "a+b")
+        _flock(handle, lock=True)
+    except Exception as exc:
+        logger.warning("Process checkpoint lock unavailable: %s", exc)
+        if handle is not None:
+            with suppress(Exception):
+                handle.close()
+        handle = None
+    try:
+        yield handle is not None
+    finally:
+        if handle is not None:
+            with suppress(Exception):
+                _flock(handle, lock=False)
+            with suppress(Exception):
+                handle.close()
+
+
 def _not_found(session_id: str) -> dict:
     return {"status": "not_found", "error": f"No process with ID {session_id}"}
 
@@ -296,6 +360,20 @@ def _output_tail(session: "ProcessSession", n: int) -> str:
     from tools.ansi_strip import strip_ansi
 
     return strip_ansi(session.output_buffer[-n:])
+
+
+def _checkpoint_output_tail(text: str) -> str:
+    """Bounded, force-redacted output tail as published in the shared checkpoint.
+
+    Redact FIRST over a window wider than what is published (see
+    ``CHECKPOINT_REDACT_CONTEXT_CHARS``), then cut the tail out of the redacted
+    text: every character that survives into the checkpoint was scanned with the
+    full left context a pattern needs, so a credential sitting across the cut is
+    masked instead of arriving headless and unmatched. The final slice bounds the
+    result whatever a mask expanded to.
+    """
+    window = text[-(CHECKPOINT_OUTPUT_TAIL_CHARS + CHECKPOINT_REDACT_CONTEXT_CHARS):]
+    return redact_sensitive_text(window, force=True, code_file=False)[-CHECKPOINT_OUTPUT_TAIL_CHARS:]
 
 
 @dataclass
@@ -321,6 +399,10 @@ class ProcessSession:
     output_buffer: str = ""                     # Rolling tail (last max_output_chars)
     max_output_chars: int = MAX_OUTPUT_CHARS
     detached: bool = False                      # Recovered from checkpoint (no pipe)
+    # Mirror of a process owned by ANOTHER gateway process, imported from the
+    # shared checkpoint for display only: never signalled, never notified on,
+    # never re-published (the owner is the sole author of its checkpoint entry).
+    peer_mirror: bool = False
     pid_scope: str = "host"                     # "host" for local/PTY PIDs, "sandbox" for env-local PIDs
     systemd_unit: str = ""                      # transient scope unit name when spawned under systemd-run
     # Watcher/notification routing (persisted for crash recovery)
@@ -396,7 +478,26 @@ class ProcessRegistry:
     def __init__(self):
         self._running: Dict[str, ProcessSession] = {}
         self._finished: Dict[str, ProcessSession] = {}
+        # Read-only mirrors of other gateway processes' live rows. Deliberately a
+        # separate store: everything that reasons about work THIS process owns
+        # (kill_all, scale-to-zero, session reset, checkpoint authorship) keeps
+        # reading _running only.
+        self._peers: Dict[str, ProcessSession] = {}
+        # Identity stamped on every checkpoint row we publish. ``owner_token`` says
+        # "this row is mine" exactly (no inference); ``owner_pid`` + start time let
+        # another gateway ask "is that writer still alive" without trusting a PID
+        # the kernel may have recycled onto a stranger.
+        self._owner_token = uuid.uuid4().hex
+        self._owner_pid = os.getpid()
+        self._owner_start_time = self._safe_host_start_time(self._owner_pid)
         self._lock = threading.Lock()
+        # Serializes this registry's own checkpoint writes end to end (snapshot →
+        # redact → merge → replace). The inter-process lock cannot order two writers
+        # inside ONE process: it would just pick which stale ordering wins.
+        self._checkpoint_write_lock = threading.Lock()
+        self._output_checkpoint_lock = threading.Lock()
+        self._last_output_checkpoint_at = 0.0
+        self._output_checkpoint_timer: Optional[threading.Timer] = None
         # Side-channel for check_interval watchers (gateway reads after agent run)
         self.pending_watchers: List[Dict[str, Any]] = []
         # Unified queue for all background events (distinguished by "type"); the CLI
@@ -444,6 +545,31 @@ class ProcessRegistry:
             return
         with suppress(Exception):
             sink(session, chunk)
+
+    def _checkpoint_live_output(self) -> None:
+        """Publish the redacted output tail so peer gateway processes can render it.
+        Rate-limited to ``CHECKPOINT_OUTPUT_MIN_INTERVAL_SECONDS``: a rewrite per
+        chunk turns a chatty dev server into continuous disk churn. A chunk that
+        lands inside the window arms a single trailing write instead of being
+        dropped, so the last line of a burst is never stranded off the checkpoint."""
+        with self._output_checkpoint_lock:
+            wait = self._last_output_checkpoint_at + CHECKPOINT_OUTPUT_MIN_INTERVAL_SECONDS - time.monotonic()
+            if wait > 0:
+                if self._output_checkpoint_timer is None:
+                    self._output_checkpoint_timer = timer = threading.Timer(
+                        wait, self._flush_output_checkpoint)
+                    timer.daemon = True
+                    timer.start()
+                return
+            self._last_output_checkpoint_at = time.monotonic()
+        self._write_checkpoint()
+
+    def _flush_output_checkpoint(self) -> None:
+        """Trailing write armed by :meth:`_checkpoint_live_output` (timer thread)."""
+        with self._output_checkpoint_lock:
+            self._output_checkpoint_timer = None
+            self._last_output_checkpoint_at = time.monotonic()
+        self._write_checkpoint()
 
     def _check_watch_patterns(self, session: ProcessSession, new_text: str) -> None:
         """Scan a freshly-read chunk for watch patterns and queue notifications.
@@ -625,7 +751,12 @@ class ProcessRegistry:
 
     def _refresh_detached_session(self, session: Optional[ProcessSession]) -> Optional[ProcessSession]:
         """Update recovered host-PID sessions when the underlying process has exited."""
-        if session is None or session.exited or not session.detached or session.pid_scope != "host":
+        # A peer mirror's lifecycle is re-derived from the checkpoint on every
+        # sync; moving it to _finished here would file another process's row into
+        # OUR stores (and back into the checkpoint we write).
+        if session is None or session.exited or session.peer_mirror:
+            return session
+        if not session.detached or session.pid_scope != "host":
             return session
         # A recycled PID (alive but not ours) counts as "our process exited" so a
         # later kill() can never tree-kill the stranger.
@@ -1091,6 +1222,7 @@ class ProcessRegistry:
                             session.output_buffer = session.output_buffer[-session.max_output_chars:]
                     self._check_watch_patterns(session, delta)
                     self._emit_output(session, delta)
+                    self._checkpoint_live_output()
 
                 check = env.execute(
                     f"kill -0 \"$(cat {q(pid_path)} 2>/dev/null)\" 2>/dev/null; echo $?", timeout=5)
@@ -1141,6 +1273,7 @@ class ProcessRegistry:
         session.append_output(text)
         self._check_watch_patterns(session, text)
         self._emit_output(session, text)
+        self._checkpoint_live_output()
 
     def _finish_exited(self, session: ProcessSession, exit_code) -> None:
         """Mark a reader-observed exit (a raced kill keeps its own code/reason) and finish."""
@@ -1381,7 +1514,8 @@ class ProcessRegistry:
         """Session by full ID or unique prefix (``proc_4dae`` / bare ``4dae``, like git
         short hashes); ambiguous or too-short prefixes resolve to None, never a guess."""
         with self._lock:
-            session = self._running.get(session_id) or self._finished.get(session_id)
+            session = (self._running.get(session_id) or self._finished.get(session_id)
+                       or self._peers.get(session_id))
         return self._refresh_detached_session(session if session is not None else self._resolve_prefix(session_id))
 
     def _resolve_prefix(self, session_id: str) -> Optional[ProcessSession]:
@@ -1396,7 +1530,7 @@ class ProcessRegistry:
             return None
         with self._lock:
             matches = [
-                s for store in (self._running, self._finished)
+                s for store in (self._running, self._finished, self._peers)
                 for sid, s in store.items() if sid.startswith(query)
             ]
         return matches[0] if len(matches) == 1 else None
@@ -1632,8 +1766,19 @@ class ProcessRegistry:
 
     def _signal_kill(self, session: ProcessSession, session_id: str, consume_output: bool) -> Optional[dict]:
         """Deliver the kill via PTY, local Popen tree, sandbox exec or recovered host
-        PID. Returns a final result dict when the kill cannot proceed (recycled/dead
-        recovered PID, or no runtime handle), else None."""
+        PID. Returns a final result dict when the kill cannot proceed (peer-owned
+        process, recycled/dead recovered PID, or no runtime handle), else None."""
+        if session.peer_mirror:
+            # The PID belongs to another gateway process's child. We have no
+            # handle on it and no way to tell a recycled number from the real
+            # thing beyond the owner's own bookkeeping, so signalling it here is
+            # exactly the tree-kill-a-stranger risk the identity checks exist to
+            # prevent. Ask through the gateway that owns it instead.
+            return {
+                "status": "error",
+                "error": "This process is owned by another Hermes gateway process; "
+                         "stop it from the surface that started it.",
+            }
         if session._pty:
             try:
                 session._pty.terminate(force=True)
@@ -1754,7 +1899,9 @@ class ProcessRegistry:
     def list_sessions(self, task_id: str = None, session_key: str = None) -> list:
         """Running and recently-finished processes for ``task_id`` and/or ``session_key``;
         cross-task entries sharing the gateway session (a forgotten preview server
-        blocking session reset) are flagged ``"session_scoped": true``.
+        blocking session reset) are flagged ``"session_scoped": true``; rows mirrored
+        from another gateway process (see :meth:`sync_from_checkpoint`) are flagged
+        ``"peer": true`` so callers know they are display-only.
 
         When ``task_id`` is given, processes for that task are included. When ``session_key`` is also given,
         session-scoped background processes (``background: true``) registered under that gateway session are
@@ -1762,7 +1909,8 @@ class ProcessRegistry:
         preview server that is blocking session reset (#29177).
         """
         with self._lock:
-            all_sessions = list(self._running.values()) + list(self._finished.values())
+            all_sessions = (list(self._running.values()) + list(self._finished.values())
+                            + list(self._peers.values()))
         all_sessions = [self._refresh_detached_session(s) for s in all_sessions]
         if task_id or session_key:
             all_sessions = [
@@ -1794,6 +1942,8 @@ class ProcessRegistry:
                 entry["exit_code"] = s.exit_code
             if s.detached:
                 entry["detached"] = True
+            if s.peer_mirror:
+                entry["peer"] = True
             result.append(entry)
         return result
 
@@ -1875,58 +2025,250 @@ class ProcessRegistry:
 
     # ----- Checkpoint (crash recovery) -----
 
+    def _row_is_mine(self, row: Dict[str, Any]) -> bool:
+        """Whether this registry authored *row* (exact identity, never inference)."""
+        return bool(self._owner_token) and row.get("owner_token") == self._owner_token
+
+    def _row_owner_alive(self, row: Dict[str, Any]) -> bool:
+        """Whether the gateway process that published *row* is still running.
+        Unstamped legacy rows answer False — an unknown writer is treated as gone,
+        which is what lets crash recovery adopt them."""
+        owner_pid = row.get("owner_pid")
+        return bool(owner_pid) and self._host_pid_is_ours(owner_pid, row.get("owner_start_time"))
+
+    def _row_process_identified(self, row: Dict[str, Any]) -> bool:
+        """Whether *row* still provably names the host process its author recorded.
+
+        The single identity rule behind mirroring, adoption and pruning alike. A
+        recorded ``host_start_time`` is REQUIRED, not merely compared: without a
+        baseline ``_host_pid_is_ours`` degrades to bare liveness, and a session
+        adopted on that basis also disables the identity check inside
+        ``_terminate_host_pid`` — so a recycled PID would be tree-killed by a later
+        ``process(action="kill")``. An unidentifiable row is actionable by nobody.
+        """
+        pid, recorded_start = row.get("pid"), row.get("host_start_time")
+        return bool(pid) and recorded_start is not None and self._host_pid_is_ours(pid, recorded_start)
+
+    def _row_is_garbage(self, row: Dict[str, Any]) -> bool:
+        """Whether *row* is useless to every reader and may be dropped.
+
+        A host row we cannot identify helps nobody — not this display, not the next
+        startup's recovery, both of which now refuse it. A non-host (in-sandbox) row
+        is meaningless without the environment handle its owner holds, so it survives
+        only while that owner does. Everything else is preserved untouched: an
+        identified live process with a dead owner is precisely what
+        ``recover_from_checkpoint`` exists to adopt, so pruning on owner death alone
+        would delete the feature.
+        """
+        if row.get("pid_scope", "host") != "host":
+            return not self._row_owner_alive(row)
+        return not self._row_process_identified(row)
+
+    def _merge_foreign_rows(
+        self, published: List[Dict[str, Any]], ours: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Rows in the checkpoint that belong to OTHER writers and must survive our
+        update.
+
+        Dropped: rows we authored (this write republishes them, so keeping the old
+        copies would resurrect anything we just retired), rows carrying an id we are
+        publishing ourselves — ``recover_from_checkpoint`` adopts an orphan under a
+        NEW owner stamp, and the dead owner's copy would otherwise linger as a
+        duplicate — and garbage (see :meth:`_row_is_garbage`).
+        """
+        claimed = {row.get("session_id") for row in ours}
+        return [
+            row for row in published
+            if not self._row_is_mine(row)
+            and row.get("session_id") not in claimed
+            and not self._row_is_garbage(row)
+        ]
+
     def _write_checkpoint(self, extra_entries: Optional[List[Dict[str, Any]]] = None):
-        """Write running process metadata to the checkpoint file atomically."""
+        """Publish our running processes into the shared checkpoint.
+
+        Read-modify-write under the inter-process lock: this file is written by
+        every gateway process on the profile, so our update replaces only the rows
+        we authored and leaves every other live owner's rows exactly as they are.
+
+        The whole snapshot→replace sequence also runs under an instance lock. The
+        running set is read before the redaction and disk work, so two writers from
+        THIS registry (a reader thread's live-output publish racing a completion)
+        could otherwise land in the wrong order and put a retired row back on disk.
+        """
         try:
-            with self._lock:
-                entries = []
-                for s in self._running.values():
-                    if s.exited:
-                        continue
-                    # Backfill the start time so recovery can detect PID recycling
-                    # even for sessions spawned before this field existed.
-                    if s.host_start_time is None and s.pid_scope == "host" and s.pid:
-                        s.host_start_time = self._safe_host_start_time(s.pid)
-                    entry = {"session_id": s.id, **{f: getattr(s, f) for f in _CHECKPOINT_FIELDS}}
-                    # Redact inline credentials before persisting (~/.hermes/processes.json).
-                    # Recovery uses command only for display (adoption re-validates the
-                    # PID, never re-runs it), so masking is lossless.
-                    # See #77484.
-                    entry["command"] = redact_sensitive_text(s.command, code_file=True)
-                    entry["owner_task_id"] = s.owner_task_id or s.task_id
-                    entries.append(entry)
-                if extra_entries:
-                    tracked_ids = {item.get("session_id") for item in entries}
-                    entries.extend(item for item in extra_entries if item.get("session_id") not in tracked_ids)
-            from utils import atomic_json_write
-            atomic_json_write(CHECKPOINT_PATH, entries)
+            with self._checkpoint_write_lock:
+                self._write_checkpoint_locked(extra_entries)
         except Exception as e:
             logger.debug("Failed to write checkpoint file: %s", e, exc_info=True)
 
-    def recover_from_checkpoint(self) -> int:
-        """On gateway startup, probe PIDs from the checkpoint file; returns how many
-        were recovered as detached sessions."""
+    def _write_checkpoint_locked(self, extra_entries: Optional[List[Dict[str, Any]]]) -> None:
+        """Body of :meth:`_write_checkpoint`; call only with ``_checkpoint_write_lock``."""
+        # Snapshot under the registry lock, serialize outside it: the redaction
+        # passes over each tail are far too much work to hold that lock through.
+        with self._lock:
+            live = [s for s in self._running.values() if not s.exited]
+        entries = []
+        for s in live:
+            # Backfill the start time so recovery can detect PID recycling
+            # even for sessions spawned before this field existed.
+            if s.host_start_time is None and s.pid_scope == "host" and s.pid:
+                s.host_start_time = self._safe_host_start_time(s.pid)
+            entry = {"session_id": s.id, **{f: getattr(s, f) for f in _CHECKPOINT_FIELDS}}
+            # Redact inline credentials before persisting (~/.hermes/processes.json).
+            # Recovery uses command only for display (adoption re-validates the
+            # PID, never re-runs it), so masking is lossless.
+            # ``force``: this file is a disk artifact another gateway process
+            # renders for the user, so it must not return raw secrets even
+            # when the user turned redaction off. ``code_file=False`` keeps the
+            # ENV/JSON assignment passes on — ``DB_PASSWORD=…`` in a command
+            # line or a log line is exactly what must not land here.
+            # See #77484.
+            entry["command"] = redact_sensitive_text(s.command, force=True, code_file=False)
+            entry["owner_task_id"] = s.owner_task_id or s.task_id
+            # Peer gateways have their own Python heap and cannot read our
+            # buffers; a bounded tail is what makes the row renderable there.
+            entry["output_tail"] = _checkpoint_output_tail(s.output_buffer)
+            entry.update(
+                owner_token=self._owner_token, owner_pid=self._owner_pid,
+                owner_start_time=self._owner_start_time)
+            entries.append(entry)
+        from utils import atomic_json_write
+        with _checkpoint_lock() as locked:
+            if not locked:
+                # Skipping costs us this publication, which the next write redoes.
+                # Writing anyway risks dropping another gateway's row for good.
+                logger.warning(
+                    "Skipping process checkpoint write: could not take the shared lock. "
+                    "%d running process(es) are unpublished until the next write.", len(entries))
+                return
+            entries.extend(self._merge_foreign_rows(self._read_checkpoint_rows(), entries))
+            if extra_entries:
+                tracked_ids = {item.get("session_id") for item in entries}
+                entries.extend(item for item in extra_entries if item.get("session_id") not in tracked_ids)
+            atomic_json_write(CHECKPOINT_PATH, entries)
+
+    def publish_checkpoint(self) -> None:
+        """Persist the current running set now.
+
+        Spawn callers finish a session AFTER the registry has already registered and
+        checkpointed it — session lineage, watcher routing and the notify/watch flags
+        are all stamped on the way back out, and all three are checkpoint fields. The
+        row written at registration is therefore incomplete, and for a quiet process
+        nothing else ever rewrites it. Callers publish once their metadata is final.
+        """
+        self._write_checkpoint()
+
+    @staticmethod
+    def _read_checkpoint_rows() -> List[Dict[str, Any]]:
+        """Parse the checkpoint WITHOUT taking the inter-process lock — for callers
+        that already hold it. ``[]`` when absent/unreadable/malformed."""
         if not CHECKPOINT_PATH.exists():
-            return 0
+            return []
         try:
             entries = json.loads(CHECKPOINT_PATH.read_text(encoding="utf-8"))
         except Exception:
+            return []
+        return [e for e in entries if isinstance(e, dict)] if isinstance(entries, list) else []
+
+    def _read_checkpoint_entries(self) -> List[Dict[str, Any]]:
+        """Parsed checkpoint rows, read under the inter-process lock so a concurrent
+        publisher's replace can never be observed half-applied. Unlike a write, a read
+        still proceeds when the lock is unavailable: it destroys nothing, and the
+        atomic replace means the worst case is a slightly stale view."""
+        with _checkpoint_lock():
+            return self._read_checkpoint_rows()
+
+    def sync_from_checkpoint(self) -> int:
+        """Mirror OTHER gateway processes' live rows from the shared checkpoint.
+
+        Desktop and the messaging gateway are separate Python processes with
+        separate registries; the checkpoint is the only thing both see. Each call
+        rebuilds the mirror set from the file, so a row the owner retired stops
+        being reported here on the next poll. Returns the number of mirrors held.
+
+        Adoption is deliberately strict: host scope only, and the PID must still
+        be the process the owner recorded (``host_start_time`` must be present AND
+        match). A PID alone proves nothing — the kernel recycles them — and a
+        mirror we could not identify would be a row pointing at a stranger.
+        Locally-owned ids are never overwritten: this process is authoritative for
+        the work it spawned.
+        """
+        mirrors: Dict[str, ProcessSession] = {}
+        for entry in self._read_checkpoint_entries():
+            process_id = str(entry.get("session_id") or "")
+            pid, recorded_start = entry.get("pid"), entry.get("host_start_time")
+            if not process_id or entry.get("pid_scope", "host") != "host":
+                continue
+            if not self._row_process_identified(entry):
+                continue
+            if self._row_is_mine(entry):
+                continue  # our own publication — mirroring it would make us a peer of ourselves
+            with self._lock:
+                if process_id in self._running or process_id in self._finished:
+                    continue  # ours; the checkpoint copy is our own publication
+                existing = self._peers.get(process_id)
+            if existing is not None:
+                # Keep object identity across polls (stable rows for readers) and
+                # refresh only what the owner republishes.
+                with existing._lock:
+                    existing.output_buffer = str(entry.get("output_tail") or "")[-MAX_OUTPUT_CHARS:]
+                mirrors[process_id] = existing
+                continue
+            mirrors[process_id] = ProcessSession(
+                id=process_id,
+                command=entry.get("command", "unknown"),
+                task_id=entry.get("task_id", ""),
+                owner_task_id=entry.get("owner_task_id", "") or entry.get("task_id", ""),
+                session_key=entry.get("session_key", ""),
+                parent_session_id=entry.get("parent_session_id", ""),
+                pid=pid,
+                host_start_time=recorded_start,
+                pid_scope="host",
+                systemd_unit=entry.get("systemd_unit", ""),
+                cwd=entry.get("cwd"),
+                started_at=entry.get("started_at", time.time()),
+                output_buffer=str(entry.get("output_tail") or "")[-MAX_OUTPUT_CHARS:],
+                detached=True,
+                peer_mirror=True,
+                # The owning gateway holds the completion contract and the watcher;
+                # a mirror that notified would double-deliver to the same user.
+                notify_on_complete=False,
+            )
+        with self._lock:
+            self._peers = mirrors
+            return len(self._peers)
+
+    def recover_from_checkpoint(self) -> int:
+        """On gateway startup, probe PIDs from the checkpoint file; returns how many
+        were recovered as detached sessions.
+
+        Only ORPHANED rows are adopted. A row whose publishing gateway is still
+        running belongs to that gateway: adopting it would give two processes a
+        handle on one child, each believing it may kill it. Those rows reach the
+        user through :meth:`sync_from_checkpoint` as read-only mirrors instead.
+        """
+        if not CHECKPOINT_PATH.exists():
             return 0
+        entries = self._read_checkpoint_entries()
         recovered = 0
         unresolved_scope_entries: List[Dict[str, Any]] = []
         for entry in entries:
             pid, pid_scope = entry.get("pid"), entry.get("pid_scope", "host")
             if not pid:
                 continue
+            if self._row_owner_alive(entry):
+                continue
             if pid_scope != "host":  # in-sandbox PIDs mean nothing once the env handle is gone
                 logger.info(
                     "Skipping recovery for non-host process: %s (pid=%s, scope=%s)",
                     entry.get("command", "unknown")[:60], pid, pid_scope)
                 continue
-            # Alive AND the same process: across a restart the kernel may have
-            # recycled the PID onto a stranger, and adopting it would let a later
-            # kill tree-kill e.g. a browser.
-            if not self._host_pid_is_ours(pid, entry.get("host_start_time")):
+            # Alive AND provably the same process: across a restart the kernel may
+            # have recycled the PID onto a stranger, and adopting it would let a
+            # later kill tree-kill e.g. a browser. A row with no recorded baseline
+            # cannot clear that bar (see ``_row_process_identified``).
+            if not self._row_process_identified(entry):
                 if self._is_host_pid_alive(pid):
                     logger.info(
                         "Not recovering session %s: pid %d is alive but its "

--- a/tools/terminal_tool_background.py
+++ b/tools/terminal_tool_background.py
@@ -5,6 +5,7 @@ returns the JSON result. Lazy ``tools.terminal_tool`` imports keep the origin's
 monkeypatch points authoritative.
 """
 
+import contextlib
 import json
 import logging
 from typing import Any, List, Optional
@@ -60,10 +61,6 @@ _ROUTING_FIELDS = (
     ("watcher_user_name", "HERMES_SESSION_USER_NAME"),
     ("watcher_thread_id", "HERMES_SESSION_THREAD_ID"),
     ("watcher_message_id", "HERMES_SESSION_MESSAGE_ID"),
-    # The spawning conversation's session-db id lets the gateway's completion
-    # pre-flight drop the notification if the user closed this session (/new)
-    # before the process finished, instead of injecting it into the NEW one.
-    ("parent_session_id", "HERMES_SESSION_ID"),
 )
 
 
@@ -72,6 +69,23 @@ def _looks_like_homebrew_ci_poller(command: str) -> bool:
     has_jq = " jq " in command or "| jq" in command or "$(jq" in command
     # `gh pr checks` doesn't emit JSON, so piping it to jq is confused intent.
     return "statusCheckRollup" in command or (has_gh and has_jq)
+
+
+def _stamp_session_lineage(proc_session) -> None:
+    """Record the spawning conversation's durable session-db id on the process.
+
+    Identity, not routing, so it is stamped for EVERY background job — including a
+    plain ``terminal(background=true)`` with no notification flags. Two things read
+    it: the gateway's completion pre-flight, which drops a notification whose session
+    the user closed at a ``/new`` boundary rather than injecting it into the new one;
+    and cross-surface ownership, which is how Hermes Desktop recognises a job started
+    from Telegram as belonging to the conversation on screen. Stamping it only while
+    configuring an async notification left every silent job unattributable.
+    """
+    with contextlib.suppress(Exception):
+        from gateway.session_context import get_session_env
+
+        proc_session.parent_session_id = get_session_env("HERMES_SESSION_ID", "") or ""
 
 
 def _stamp_gateway_routing(proc_session, get_session_env) -> None:
@@ -121,7 +135,7 @@ def _register_completion_watcher(process_registry, proc_session, session_key) ->
         "session_id": proc_session.id, "check_interval": 5, "session_key": session_key,
         "platform": proc_session.watcher_platform,
         **{attr.removeprefix("watcher_"): getattr(proc_session, attr)
-           for attr, _ in _ROUTING_FIELDS[:-1]},
+           for attr, _ in _ROUTING_FIELDS},
         "notify_on_complete": True, "parent_session_id": proc_session.parent_session_id,
     })
 
@@ -151,6 +165,9 @@ def spawn_background_process(
             effective_task_id=effective_task_id, task_id=task_id, session_key=session_key,
             effective_pty=effective_pty,
         )
+        # Before any notification decision: identity belongs to every job, not just
+        # the ones that will report back.
+        _stamp_session_lineage(proc_session)
         result_data = {"output": "Background process started", "session_id": proc_session.id,
                        "pid": proc_session.pid, "exit_code": 0, "error": None}
         if approval_note:
@@ -180,6 +197,13 @@ def spawn_background_process(
         if watch_patterns:
             proc_session.watch_patterns = list(watch_patterns)
             result_data["watch_patterns"] = proc_session.watch_patterns
+        # The registry checkpointed this session when it registered it — before the
+        # lineage, routing and notification stamps above, all of which are checkpoint
+        # fields. A quiet process never emits output, so nothing would rewrite that
+        # stale row for its whole life and no other surface could attribute it.
+        # Suppressed: backends and test doubles need not offer a checkpoint at all.
+        with contextlib.suppress(Exception):
+            process_registry.publish_checkpoint()
         return json.dumps(result_data, ensure_ascii=False)
     except Exception as e:
         return json.dumps({

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -233,19 +233,31 @@ for _name, (_code, _build) in _SIMPLE_RPCS.items():
     # Look the builder up at call time: bind_module rebinds the table's lambdas onto server globals.
     _rpc(_name, _code)(lambda rid, params, _n=_name: _ok(rid, _SIMPLE_RPCS[_n][1](params)))
 del _name, _code, _build
-_rpc("process.list", 5010, live_session=True)(
-    lambda rid, params, session: _ok(rid, {"processes": _session_processes(session)}))
 
 
-@_rpc("process.kill", live_session=True, fail_code=5010)
-def _(rid, params: dict, session) -> dict:
+@_rpc("process.list", 5010)
+def _(rid, params: dict) -> dict:
+    """Background processes for this conversation, live runtime or durable scope (``_process_scope_session``)."""
+    session, err = _process_scope_session(params, rid)
+    return err or _ok(rid, {"processes": _session_processes(session)})
+
+
+@_rpc("process.kill", fail_code=5010)
+def _(rid, params: dict) -> dict:
     """Kill ONE background process, scoped to the caller's session (unlike process.stop's kill_all)."""
+    session, err = _process_scope_session(params, rid)
+    if err:
+        return err
     proc_id = str(params.get("process_id") or "")
     if not proc_id:
         return _err(rid, 4012, "process_id required")
     registry = _tools_mod("tools.process_registry").process_registry
+    # Same peer import process.list does, so a row the user can SEE is a row this
+    # RPC can resolve; the registry itself refuses to signal a peer-owned PID.
+    with contextlib.suppress(Exception):
+        registry.sync_from_checkpoint()
     proc = registry.get(proc_id)
-    if proc is None or str(getattr(proc, "session_key", "") or "") != str(session.get("session_key") or ""):
+    if proc is None or not _process_owned_by_session(proc, str(session.get("session_key") or "")):
         return _err(rid, 4044, f"no such process: {proc_id}")
     return _ok(rid, registry.kill_process(proc_id))
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3054,19 +3054,114 @@ def _respond(rid, params, key, *, allow_expired=False):
 # ── Methods: tools & system ──────────────────────────────────────────
 
 
+def _process_owned_by_session(proc, session_key: str) -> bool:
+    """Whether a background process belongs to this conversation.
+
+    A conversation has more than one identity and the process carries all three: the gateway
+    ``session_key`` it was spawned under, the RAW spawning ``owner_task_id``, and
+    ``parent_session_id`` — the durable session-db id, which is exactly what ``session.resume``
+    binds as a Desktop session's own ``session_key``. Matching only the first is why a job started
+    from Telegram was invisible in Desktop even on the same conversation. An empty key matches
+    nothing (fail closed) so an unidentified caller never sees another conversation's work.
+    """
+    key = str(session_key or "")
+    return bool(key) and key in {
+        str(getattr(proc, "session_key", "") or ""),
+        str(getattr(proc, "owner_task_id", "") or ""),
+        str(getattr(proc, "parent_session_id", "") or ""),
+    }
+
+
+def _durable_process_scope_id(params: dict) -> str:
+    """Client-supplied conversation id usable as a durable process scope, or "".
+
+    Rejected: empty/whitespace-only and anything carrying a control character (this
+    string is matched against stored ownership fields and logged, so a malformed id
+    fails closed), then anything that does not name a real stored conversation in
+    this profile's ``state.db``.
+
+    That last check is load-bearing in both directions. A DEAD RUNTIME id must keep
+    getting the 4001 — the desktop's gone-latch and its passive session heal are both
+    hung off exactly that verdict (#94219, #98434), and reinterpreting the id as a
+    durable scope would answer "no processes" forever instead. And an arbitrary
+    string never gets probed against stored ownership fields at all.
+
+    Profile scope: with no live session there is no ``profile_home`` to consult, so
+    the lookup uses this process's own store. A conversation stored under another
+    profile is simply not found and keeps its 4001 — fail-closed, never a
+    cross-profile read (see :func:`_session_home_is_process_home`).
+    """
+    candidate = str(params.get("session_id") or "").strip()
+    if not candidate or any(ord(ch) < 32 or ord(ch) == 127 for ch in candidate):
+        return ""
+    try:
+        db = _get_db()
+        return candidate if db is not None and db.get_session(candidate) else ""
+    except Exception:
+        logger.debug("durable process scope lookup failed for %r", candidate, exc_info=True)
+        return ""
+
+
+def _process_scope_session(params: dict, rid):
+    """``(scope, None)`` or ``(None, error)`` for the process RPCs.
+
+    Normally the live runtime session. A messaging conversation the user is only *viewing* in
+    Desktop has no live runtime row here, and its background work lives in another gateway
+    process entirely — so on the ONE expected verdict (``4001 session not found``) fall back to a
+    scope keyed by the durable conversation id. Every other failure (agent build, validation)
+    propagates: those are not "this runtime is gone" and must not open a second lookup path.
+    The fallback widens nothing on its own — :func:`_process_owned_by_session` still has to prove
+    each row belongs to that conversation.
+    """
+    session, err = _sess(params, rid)
+    if not err:
+        return session, None
+    if (err.get("error") or {}).get("code") != 4001:
+        return None, err
+    durable = _durable_process_scope_id(params)
+    return ({"session_key": durable}, None) if durable else (None, err)
+
+
+def _session_home_is_process_home(session: dict) -> bool:
+    """Whether *session* belongs to the profile whose state THIS process is bound to.
+
+    ``tools.process_registry.CHECKPOINT_PATH`` resolves once, at import, against the
+    launch profile's ``HERMES_HOME`` — the module-constant pattern the root AGENTS.md
+    sanctions, and one this handler is in no position to reinterpret. Profiles are
+    independent islands by design, so a session homed elsewhere fails CLOSED: it
+    simply gets no peer rows, rather than being served another profile's process
+    registry. Making cross-profile discovery work means making that path resolve per
+    call inside the registry, which is a change to that module's contract and not
+    something to fake from here.
+    """
+    profile_home = session.get("profile_home")
+    if not profile_home:
+        return True  # launch profile — the one CHECKPOINT_PATH already points at
+    try:
+        return Path(profile_home).resolve() == Path(get_hermes_home()).resolve()
+    except Exception:
+        return False
+
+
 def _session_processes(session: dict) -> list:
-    """Background processes owned by this session (registry session_key match)."""
+    """Background processes owned by this session (any of its identities)."""
     # Drain completion notifications that arrived during this turn. The background poller handles
     # between-turn delivery; this is the safety net for events that arrived mid-turn. Ownership filter
     # (#42674, #35652): a turn finishing in session B must not consume an event that belongs to session A.
     # The registry requeues every addressed event this session cannot positively claim; the poller then
     # delivers it to a live owner or drops an orphan.
     from tools.process_registry import process_registry
+    # A process spawned in ANOTHER gateway process (messaging gateway, second desktop window, CLI)
+    # broadcasts nothing here; the shared checkpoint is the only channel between the two registries.
+    # Only this process's own profile checkpoint is readable — see _session_home_is_process_home.
+    if _session_home_is_process_home(session):
+        with contextlib.suppress(Exception):
+            process_registry.sync_from_checkpoint()
     key = str(session.get("session_key") or "")
     owned = []
     for entry in process_registry.list_sessions():
         proc = process_registry.get(entry["session_id"])
-        if proc is not None and str(getattr(proc, "session_key", "") or "") == key:
+        if proc is not None and _process_owned_by_session(proc, key):
             entry["output_tail"] = (proc.output_buffer or "")[-4000:]  # the 200-char list preview is too thin for the viewer
             owned.append(entry)
     return owned


### PR DESCRIPTION
## Summary

A background process started by another Hermes gateway process (for example Telegram) was written to the shared process checkpoint, but Hermes Desktop only polled after it already had a background row. The first row was therefore never discovered, and process operations were scoped only to the live runtime session.

This PR restores cross-gateway Background visibility while keeping process ownership and PID identity checks fail-closed.

## Changes

- Add idle discovery polling in the Desktop status stack while no Background row is visible; retain the faster polling cadence for visible running jobs and clean up both timers on unmount or session change.
- Use the durable conversation key when the selected messaging conversation has no mounted runtime session.
- Persist the spawning durable session lineage for every background job, including quiet jobs with no notification flags, and republish metadata after registration.
- Add a bounded, force-redacted output tail to the shared checkpoint so peer gateways can render live output without exposing credentials.
- Merge checkpoint updates under an inter-process lock so separate gateways do not erase one another's rows; serialize writes within one registry as well.
- Import peer-owned rows only after host PID/start-time validation. Peer rows are display-only and cannot be signalled by another gateway.
- Scope `process.list` and `process.kill` to the caller's routing key, owner task, or durable parent session; unrelated conversations remain isolated.

## Tests

- Python targeted suite: **79 passed, 0 failed** across the five changed/relevant test files.
- Desktop Vitest targeted suite: **448 passed, 0 failed** across 52 test files.
- Desktop TypeScript typecheck: passed for all three tsconfigs.
- Touched Desktop ESLint: **0 errors**; existing warnings only.
- Prettier check: passed.
- Ruff check: passed.
- Existing `tests/tools/test_process_registry.py` on Windows: **71 passed, 6 pre-existing platform-specific failures, 30 skipped**. The same six failures reproduce on a clean `upstream/main` checkout.

## Related issue

Related to #48339.

## Scope

This PR contains only the cross-gateway Background visibility, ownership, checkpoint, lineage, and regression-test changes. It does not include ACP/provider compatibility or contributor metadata changes.
