### PR TITLE
fix(desktop): confirm guarded auxiliary model assignments

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -3,6 +3,8 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import { MemoryRouter } from 'react-router'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { $notifications, clearNotifications } from '@/store/notifications'
+
 // Radix Select calls scrollIntoView on its items when the content opens; jsdom
 // doesn't implement it (nor hasPointerCapture / releasePointerCapture), so stub
 // them to let the dropdown open in tests.
@@ -83,6 +85,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup()
   vi.clearAllMocks()
+  clearNotifications()
   profileSwitchHandler = null
 })
 
@@ -408,6 +411,131 @@ describe('ModelSettings', () => {
 
     // Banner present on load, no switch required.
     expect(await screen.findByText(/still run on/)).toBeTruthy()
+  })
+})
+
+describe('ModelSettings auxiliary selection guard', () => {
+  const guardedMain = { provider: 'nous', model: 'hermes-4-contributor' }
+
+  beforeEach(() => {
+    getGlobalModelInfo.mockResolvedValue(guardedMain)
+    getAuxiliaryModels.mockResolvedValue({
+      main: guardedMain,
+      tasks: [{ task: 'vision', provider: 'auto', model: '', base_url: '' }]
+    })
+  })
+
+  async function waitForConfirmToast() {
+    return vi.waitFor(() => {
+      const toast = $notifications.get().find(item => item.id.startsWith('model-warning-confirm-'))
+
+      expect(toast).toBeDefined()
+
+      return toast!
+    })
+  }
+
+  it('prompts and retries Set to main when the backend demands confirm', async () => {
+    setModelAssignment
+      .mockResolvedValueOnce({
+        ok: false,
+        scope: 'auxiliary',
+        ...guardedMain,
+        confirm_required: true,
+        confirm_message: 'Confirm this data-training model.'
+      })
+      .mockResolvedValueOnce({ ok: true, scope: 'auxiliary', ...guardedMain, tasks: ['vision'] })
+
+    await renderModelSettings()
+    const loadCount = getAuxiliaryModels.mock.calls.length
+
+    fireEvent.click((await screen.findAllByRole('button', { name: 'Set to main' }))[0])
+
+    const confirm = await waitForConfirmToast()
+
+    expect(getAuxiliaryModels.mock.calls.length).toBe(loadCount)
+    expect(setModelAssignment).toHaveBeenCalledTimes(1)
+
+    confirm.action?.onClick()
+
+    await waitFor(() =>
+      expect(setModelAssignment).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          scope: 'auxiliary',
+          task: 'vision',
+          ...guardedMain,
+          confirm_expensive_model: true
+        })
+      )
+    )
+    await waitFor(() => expect(getAuxiliaryModels.mock.calls.length).toBeGreaterThan(loadCount))
+  })
+
+  it('does not treat ok:false as a successful aux assignment', async () => {
+    setModelAssignment.mockResolvedValueOnce({
+      ok: false,
+      scope: 'auxiliary',
+      provider: 'nous',
+      model: 'hermes-4',
+      confirm_message: 'Could not pin that auxiliary model.'
+    })
+
+    await renderModelSettings()
+    const loadCount = getAuxiliaryModels.mock.calls.length
+
+    fireEvent.click((await screen.findAllByRole('button', { name: 'Set to main' }))[0])
+
+    expect(await screen.findByText('Could not pin that auxiliary model.')).toBeTruthy()
+    expect(getAuxiliaryModels.mock.calls.length).toBe(loadCount)
+    expect(setModelAssignment).toHaveBeenCalledTimes(1)
+  })
+
+  it('resets auxiliary slots without sending the guarded main model', async () => {
+    await renderModelSettings()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Reset all to main' }))
+
+    await waitFor(() =>
+      expect(setModelAssignment).toHaveBeenCalledWith({
+        model: '',
+        provider: '',
+        scope: 'auxiliary',
+        task: '__reset__'
+      })
+    )
+  })
+
+  it('prompts and retries Change-Apply when the backend demands confirm', async () => {
+    setModelAssignment
+      .mockResolvedValueOnce({
+        ok: false,
+        scope: 'auxiliary',
+        ...guardedMain,
+        confirm_required: true,
+        confirm_message: 'Confirm this data-training model.'
+      })
+      .mockResolvedValueOnce({ ok: true, scope: 'auxiliary', ...guardedMain, tasks: ['vision'] })
+
+    await renderModelSettings()
+    await screen.findByText('Vision')
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Change' })[0])
+    const applyButtons = screen.getAllByRole('button', { name: 'Apply' })
+    fireEvent.click(applyButtons[applyButtons.length - 1])
+
+    const confirm = await waitForConfirmToast()
+    confirm.action?.onClick()
+
+    await waitFor(() =>
+      expect(setModelAssignment).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          scope: 'auxiliary',
+          task: 'vision',
+          ...guardedMain,
+          confirm_expensive_model: true
+        })
+      )
+    )
   })
 })
 

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -13,8 +13,7 @@ import {
   getRecommendedDefaultModel,
   saveHermesConfig,
   saveMoaModels,
-  setEnvVar,
-  setModelAssignment
+  setEnvVar
 } from '@/hermes'
 import type {
   AuxiliaryModelsResponse,
@@ -28,7 +27,7 @@ import { isCodeSkewRestartRequired } from '@/lib/code-skew-error'
 import { AlertTriangle, Cpu, Loader2 } from '@/lib/icons'
 import { DEFAULT_REASONING_EFFORT, REASONING_EFFORT_VALUES } from '@/lib/reasoning-effort'
 import { cn } from '@/lib/utils'
-import { setMainModelAssignment } from '@/store/cron-model-impact'
+import { assignModelWithConfirm, setMainModelAssignment } from '@/store/cron-model-impact'
 import { notifyError, readableError } from '@/store/notifications'
 import { startManualLocalEndpoint, startManualOnboarding, startManualProviderOAuth } from '@/store/onboarding'
 
@@ -712,7 +711,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
       setError('')
 
       try {
-        await setModelAssignment(
+        await assignModelWithConfirm(
           {
             model: mainModel.model,
             provider: mainModel.provider,
@@ -742,7 +741,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
       setError('')
 
       try {
-        await setModelAssignment(
+        await assignModelWithConfirm(
           {
             model: auxDraft.model,
             provider: auxDraft.provider,
@@ -786,10 +785,11 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
     setError('')
 
     try {
-      await setModelAssignment(
+      // __reset__ ignores model, but a non-empty model still trips the selection guard.
+      await assignModelWithConfirm(
         {
-          model: mainModel.model,
-          provider: mainModel.provider,
+          model: '',
+          provider: '',
           scope: 'auxiliary',
           task: '__reset__'
         },

--- a/apps/desktop/src/store/cron-model-impact.test.ts
+++ b/apps/desktop/src/store/cron-model-impact.test.ts
@@ -13,6 +13,7 @@ vi.mock('@/hermes', () => ({
 }))
 
 import {
+  assignModelWithConfirm,
   CRON_MODEL_IMPACT_NOTIFICATION_ID,
   invalidateCronModelImpactScope,
   setMainModelAssignment
@@ -285,6 +286,75 @@ describe('setMainModelAssignment', () => {
     dismissNotification(CRON_MODEL_IMPACT_NOTIFICATION_ID)
 
     expect($notifications.get()).toEqual([])
+    expect(setModelAssignment).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('assignModelWithConfirm', () => {
+  it('retries an auxiliary assignment with confirm_expensive_model after the user accepts', async () => {
+    const confirmResponse = {
+      ok: false,
+      scope: 'auxiliary',
+      provider: 'nous',
+      model: 'hermes-4-contributor',
+      confirm_required: true,
+      confirm_message: 'Confirm this data-training model.'
+    } satisfies ModelAssignmentResponse
+
+    setModelAssignment.mockResolvedValueOnce(confirmResponse)
+    setModelAssignment.mockResolvedValueOnce({
+      ok: true,
+      scope: 'auxiliary',
+      provider: 'nous',
+      model: 'hermes-4-contributor',
+      tasks: ['vision']
+    } satisfies ModelAssignmentResponse)
+
+    const pending = assignModelWithConfirm({
+      scope: 'auxiliary',
+      task: 'vision',
+      provider: 'nous',
+      model: 'hermes-4-contributor'
+    })
+
+    const confirm = await waitForConfirmToast()
+
+    confirm.action?.onClick()
+    await pending
+
+    expect(setModelAssignment).toHaveBeenNthCalledWith(1, {
+      scope: 'auxiliary',
+      task: 'vision',
+      provider: 'nous',
+      model: 'hermes-4-contributor'
+    })
+    expect(setModelAssignment).toHaveBeenLastCalledWith({
+      scope: 'auxiliary',
+      task: 'vision',
+      provider: 'nous',
+      model: 'hermes-4-contributor',
+      confirm_expensive_model: true
+    })
+    expect($notifications.get().some(item => item.id === CRON_MODEL_IMPACT_NOTIFICATION_ID)).toBe(false)
+  })
+
+  it('throws on ok:false instead of treating the assignment as saved', async () => {
+    setModelAssignment.mockResolvedValueOnce({
+      ok: false,
+      scope: 'auxiliary',
+      provider: 'nous',
+      model: 'hermes-4',
+      confirm_message: 'Could not pin that auxiliary model.'
+    } satisfies ModelAssignmentResponse)
+
+    await expect(
+      assignModelWithConfirm({
+        scope: 'auxiliary',
+        task: 'vision',
+        provider: 'nous',
+        model: 'hermes-4'
+      })
+    ).rejects.toThrow('Could not pin that auxiliary model.')
     expect(setModelAssignment).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/desktop/src/store/cron-model-impact.ts
+++ b/apps/desktop/src/store/cron-model-impact.ts
@@ -144,20 +144,15 @@ function publishImpact(impact: CronModelImpact, profile: string, connection: str
   })
 }
 
-export async function setMainModelAssignment(
-  request: Omit<ModelAssignmentRequest, 'scope'>,
+export async function assignModelWithConfirm(
+  request: ModelAssignmentRequest,
   scopeProfile?: null | string,
   options?: { skipConfirmPrompt?: boolean }
 ): Promise<ModelAssignmentResponse> {
-  const { connection, generation } = beginCronModelImpactAssignment()
-  const profile = profileIdentity()
-
   // Only pass the extra arg when a scope override exists, so unscoped callers
   // keep the exact legacy call shape.
-  const assign = (body: Omit<ModelAssignmentRequest, 'scope'>) =>
-    scopeProfile == null
-      ? setModelAssignment({ ...body, scope: 'main' })
-      : setModelAssignment({ ...body, scope: 'main' }, scopeProfile)
+  const assign = (body: ModelAssignmentRequest) =>
+    scopeProfile == null ? setModelAssignment(body) : setModelAssignment(body, scopeProfile)
 
   let result = await assign(request)
 
@@ -186,6 +181,18 @@ export async function setMainModelAssignment(
   } else if (result.ok !== true) {
     throw new Error(result.confirm_message?.trim() || translateNow('cron.modelImpact.saveFailed'))
   }
+
+  return result
+}
+
+export async function setMainModelAssignment(
+  request: Omit<ModelAssignmentRequest, 'scope'>,
+  scopeProfile?: null | string,
+  options?: { skipConfirmPrompt?: boolean }
+): Promise<ModelAssignmentResponse> {
+  const { connection, generation } = beginCronModelImpactAssignment()
+  const profile = profileIdentity()
+  const result = await assignModelWithConfirm({ ...request, scope: 'main' }, scopeProfile, options)
 
   // A scoped assignment targets ANOTHER profile's backend: its cron impact
   // belongs to that profile, and the review action would open the ACTIVE


### PR DESCRIPTION
## What does this PR do?

Desktop Settings → Models lets you pin auxiliary slots with Set to main, Change → Apply, or Reset all to main. Those three callers posted to `POST /api/model/set` and then refreshed even when the backend answered `{ok:false, confirm_required:true}` for a guarded main model (`*-contributor` and similar). Main Apply already prompts and retries with `confirm_expensive_model: true`; the auxiliary buttons looked like no-ops.

Reset made it worse: the UI sent the guarded main model on `task: '__reset__'`. The backend ignores that model and writes `provider: auto`, but the selection guard still runs whenever `model` is non-empty, so Reset never reached the apply path.

Auxiliary Set-to-main / Apply / Reset now go through the same confirm-and-retry helper as the main slot. `__reset__` sends empty `model`/`provider` (same as the web Models page). `ok: false` throws instead of refreshing the old values.

## Related Issue

Fixes #103506

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/cron-model-impact.ts` — extract `assignModelWithConfirm`; `setMainModelAssignment` still owns cron-impact publishing
- `apps/desktop/src/app/settings/model-settings.tsx` — aux Set-to-main, Apply, and Reset use that helper; Reset no longer sends the guarded model
- `apps/desktop/src/store/cron-model-impact.test.ts` — aux confirm retry and `ok:false` throw
- `apps/desktop/src/app/settings/model-settings.test.tsx` — additive cases for Set to main, Change-Apply, Reset payload, and silent `ok:false`

## How to Test

```
cd apps/desktop
npx vitest run src/store/cron-model-impact.test.ts src/app/settings/model-settings.test.tsx
# 41 passed
npx tsc --noEmit -p tsconfig.json
# clean
```

Not runtime-tested against a live `*-contributor` catalog row (no paid Nous session in this environment).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
