### PR TITLE
fix: [Desktop] Profile-backend pool never drains: 3 slots vs ~60 profiles, long-lived serve/backend processes climb to ~99% CPU, app self-restarts (#102978)

### DIFF
--- a/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
+++ b/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
@@ -532,3 +532,100 @@ describe('reconnect fail-stop on a removed connection', () => {
     expect((result as unknown as { connectionState: string }).connectionState).toBe('open')
   })
 })
+
+describe('reconnect fail-stop on a saturated pool (#102978)', () => {
+  it('fail-stops a BACKGROUND secondary after straight pool-saturation timeouts', async () => {
+    // Saturated pool (3 slots vs a fleet of bots): every dial trips the 20s
+    // connect budget while keepalive-fresh holders never yield, so the loop
+    // used to re-queue a 30s ticket per attempt forever — the queue never
+    // drains and desktop.log floods. After several straight timeouts the
+    // background socket must give up; reopening the profile dials fresh.
+    let saturate = false
+
+    const getConnection = vi.fn(async (profile: string) => {
+      if (!saturate) {
+        return descriptorFor('legacy-local', String(profile))
+      }
+
+      throw new Error(`Timed out connecting to profile "${String(profile)}"`)
+    })
+
+    installDesktop({ getConnection })
+
+    await openGatewayForProfile('selena')
+    await openGatewayForProfile('writer')
+    expect(gatewayMocks.instances).toHaveLength(2)
+    saturate = true
+
+    const background = gatewayMocks.instances[0] as unknown as { connectionState: string }
+    background.connectionState = 'closed'
+
+    const callsAtSaturation = getConnection.mock.calls.length
+
+    // Fake timers: the fail-stop's own scheduleReconnect() timers must not
+    // fire mid-test and inflate the dial count — only explicit sweeps dial.
+    vi.useFakeTimers()
+
+    try {
+      for (let dial = 0; dial < 8; dial += 1) {
+        reconnectSecondaryGateways()
+        await vi.advanceTimersByTimeAsync(0)
+        expect(getConnection.mock.calls.length).toBe(callsAtSaturation + dial + 1)
+      }
+
+      // Disposed + evicted: a further sweep finds nothing to retry, while the
+      // foreground socket was never disturbed.
+      reconnectSecondaryGateways()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(getConnection.mock.calls.length).toBe(callsAtSaturation + 8)
+    } finally {
+      vi.useRealTimers()
+    }
+    expect((gatewayMocks.instances[1] as unknown as { connectionState: string }).connectionState).toBe('open')
+  })
+
+  it('spares the ACTIVE scope: a foreground chat out-waits pool saturation', async () => {
+    // Same saturation, but the user is staring at this chat — disposing it
+    // would strand the foreground on a transient stall, so it must keep
+    // retrying past the background fail-stop cap.
+    let saturate = false
+
+    const getConnection = vi.fn(async (profile: string) => {
+      if (!saturate) {
+        return descriptorFor('legacy-local', String(profile))
+      }
+
+      throw new Error(`Timed out connecting to profile "${String(profile)}"`)
+    })
+
+    installDesktop({ getConnection })
+
+    // ensureGatewayForProfile (not openGatewayForProfile): only the former
+    // activates the scope, and the spare branch keys off g.activeKey.
+    await ensureGatewayForProfile('selena')
+    saturate = true
+    ;(gatewayMocks.instances[0] as unknown as { connectionState: string }).connectionState = 'closed'
+
+    const callsAtSaturation = getConnection.mock.calls.length
+
+    // Drive via the sweep (the same path as the background test):
+    // ensureActiveGatewayOpen short-circuits on the mock's open state and
+    // never dials, so it cannot exercise the spare branch. Fake timers keep
+    // the loop's own scheduleReconnect() from inflating the count.
+    vi.useFakeTimers()
+
+    try {
+      for (let dial = 0; dial < 12; dial += 1) {
+        reconnectSecondaryGateways()
+        await vi.advanceTimersByTimeAsync(0)
+      }
+    } finally {
+      vi.useRealTimers()
+    }
+
+    // Twelve straight saturation timeouts — past the background fail-stop
+    // cap of 8 — and the foreground entry still dials every sweep: no
+    // fail-stop for the active scope.
+    expect(getConnection.mock.calls.length).toBe(callsAtSaturation + 12)
+  })
+})

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -73,6 +73,14 @@ interface Secondary {
   offState: () => void
   reconnectTimer: ReturnType<typeof setTimeout> | null
   reconnectAttempt: number
+  /**
+   * Straight connect-budget timeouts in a row (#102978). The pool gate parks
+   * saturated dials past the renderer's 20s budget, so consecutive hits mean
+   * the pool isn't draining for this socket; the reconnect loop fail-stops
+   * the BACKGROUND entry past the cap below instead of re-queueing forever.
+   * Reset on any successful open or non-timeout error.
+   */
+  consecutiveSaturatedDials: number
   reconnecting: boolean
   /** A material connection edit is waiting for live owners to drain. */
   pendingConnectionRedial: boolean
@@ -584,6 +592,8 @@ async function openSecondary(entry: Secondary): Promise<void> {
 
     entry.openedOnce = true
     openedScopes.add(entry.scope)
+    // A successful open breaks any saturation streak (#102978).
+    entry.consecutiveSaturatedDials = 0
 
     try {
       reconcileBusyAfterOpen?.()
@@ -660,6 +670,41 @@ async function reconnectSecondary(entry: Secondary): Promise<void> {
 
       return
     }
+    // Pool-saturation backpressure (#102978). The local pool has a hard cap
+    // (default 3) while a fleet of background bots can hold 60+ wantOpen
+    // secondaries: each dial parks a 30s pool ticket, keepalive-fresh holders
+    // never yield, and every attempt trips the 20s connect budget above — so
+    // this loop re-queues forever, the pool never drains, and desktop.log
+    // floods with "waiting for a free local slot". Straight connect-budget
+    // timeouts are effectively permanent for a BACKGROUND socket, so fail-stop
+    // like a removed connection above: dispose + evict, and reopening the
+    // profile dials fresh. The ACTIVE scope is spared — a foreground chat
+    // waits out the pool however long it takes.
+    // ponytail: fixed cap (~8 straight timeouts ≈ 4 min of zero progress),
+    // not adaptive backoff — shorter would strand bots in transient stalls,
+    // longer just delays the same call while the queue stays wedged.
+    if (isPoolConnectTimeout(error) && entry.scope !== g.activeKey) {
+      entry.consecutiveSaturatedDials += 1
+
+      if (entry.consecutiveSaturatedDials >= MAX_CONSECUTIVE_SATURATED_DIALS) {
+        entry.reconnecting = false
+        console.error(
+          `[gateway] pool saturated for scope="${entry.scope}" profile="${entry.profile}" ` +
+            `(${entry.consecutiveSaturatedDials} straight connect timeouts); giving up this background socket`
+        )
+        disposeSecondary(entry)
+
+        if (g.secondaries.get(entry.scope) === entry) {
+          g.secondaries.delete(entry.scope)
+        }
+
+        restoreActiveToPrimaryIfEvicted()
+
+        return
+      }
+    } else {
+      entry.consecutiveSaturatedDials = 0
+    }
     // Other transport failure → fall through to the backoff below.
   } finally {
     entry.reconnecting = false
@@ -689,6 +734,26 @@ function isMissingProfileError(error: unknown): boolean {
   return message.includes('no longer exists') || message.includes('is being deleted')
 }
 
+// Pool-saturation fail-stop budget (#102978): give up a background socket
+// after this many STRAIGHT connect-budget timeouts. One cycle ≈ 20s budget +
+// ≤15s backoff, so 8 ≈ 4 minutes of zero progress — far past transient
+// pressure (a healthy cold boot publishes in ~3s), far short of a wedged
+// pool's hours-long retry steady state.
+const MAX_CONSECUTIVE_SATURATED_DIALS = 8
+
+// The pool gate (ensureBackend) parks a saturated dial on a 30s ticket while
+// the renderer's per-attempt connect budget is 20s, so pool saturation
+// surfaces here as the connect-budget timeout — the slot message itself only
+// escapes on longer-patience paths, so match it too for completeness.
+function isPoolConnectTimeout(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? '')
+
+  return (
+    message.includes('Timed out connecting to profile') ||
+    message.includes('timed out while waiting for a free slot')
+  )
+}
+
 function createSecondary(profile: string, connectionId: null | string = null): Secondary {
   const gateway = new HermesGateway()
   const scope = registryBackendScopeKey(connectionId, profile)
@@ -706,6 +771,7 @@ function createSecondary(profile: string, connectionId: null | string = null): S
     offState: () => {},
     reconnectTimer: null,
     reconnectAttempt: 0,
+    consecutiveSaturatedDials: 0,
     reconnecting: false,
     pendingConnectionRedial: false,
     retained: false,


### PR DESCRIPTION
## What Problem This Solves
Fixes #102978 — [Desktop] Profile-backend pool never drains: 3 slots vs ~60 profiles, long-lived serve/backend processes climb to ~99% CPU, app self-restarts. Minimal diff, single shared guard, no new deps.

## Evidence
- Repro: local repro shows before→after.
- Related suites pass (see worktree 102978).

Closes #102978