### PR TITLE
fix: [Bug]: Bot relay timers spawn-storm profile backends against a full local pool — 30s retry loop with no backoff starves the slot pool and degrades the whole UI (typing focus loss) (#102913)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/relay.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/relay.test.ts
@@ -592,6 +592,60 @@ describe('the drain loop wires drain → deliver → reply', () => {
   })
 })
 
+describe('spawn-starvation backoff (#102913)', () => {
+  const drainsFor = (calls: RelayCall[], id: string) =>
+    calls.filter(call => call.method === 'bot_relay.outbox.drain' && call.connectionId === id)
+
+  it('cools down a starving connection’s polls after a slot-timeout, then retries', async () => {
+    const calls = respondWith(call => {
+      if (call.method === 'bot_relay.outbox.drain' && call.connectionId === 'b') {
+        throw new Error('Local backend start for "secretary" timed out while waiting for a free slot.')
+      }
+
+      return { envelopes: [] }
+    })
+
+    const { startBotRelay, stopBotRelay } = await loadRelay()
+
+    startBotRelay()
+    await pushAndSettle()
+    expect(drainsFor(calls, 'b')).toHaveLength(1)
+
+    // Next tick: b is cooling down (no new spawn), a polls as before.
+    await pushAndSettle()
+    expect(drainsFor(calls, 'b')).toHaveLength(1)
+    expect(drainsFor(calls, 'a').length).toBeGreaterThan(1)
+
+    // After the 5min cooldown the poll resumes instead of staying dark.
+    await vi.advanceTimersByTimeAsync(300_000)
+    await pushAndSettle()
+    expect(drainsFor(calls, 'b').length).toBeGreaterThan(1)
+
+    stopBotRelay()
+  })
+
+  it('leaves transient failures on the fast retry path — only starvation cools', async () => {
+    const calls = respondWith(call => {
+      if (call.method === 'bot_relay.outbox.drain' && call.connectionId === 'b') {
+        throw new Error('socket blip')
+      }
+
+      return { envelopes: [] }
+    })
+
+    const { startBotRelay, stopBotRelay } = await loadRelay()
+
+    startBotRelay()
+    await pushAndSettle()
+    await pushAndSettle()
+
+    // A blip is not a full pool: b is asked again on the very next drain.
+    expect(drainsFor(calls, 'b')).toHaveLength(2)
+
+    stopBotRelay()
+  })
+})
+
 describe('stop halts both loops', () => {
   it('leaves no timer able to reach the gateway after teardown', async () => {
     const calls = respondWith(() => ({ envelopes: [] }))

--- a/apps/desktop/src/plugins/hermes-bots/relay.ts
+++ b/apps/desktop/src/plugins/hermes-bots/relay.ts
@@ -128,6 +128,54 @@ interface RelayEnvelope {
   target_profile?: string
 }
 
+// #102913: relay polls must not spawn-storm a full local pool. Both polls
+// below are read-only, but they ride the ensure-spawn socket path, so every
+// tick re-queues a doomed spawn per starving profile (slot-timeout at
+// POOL_SLOT_WAIT_MS) — forever. Cool down exactly that failure signature per
+// connection+method; anything else (transient blip, unknown-method on older
+// backends) retries on the next tick as before, and a success clears it.
+// ponytail: fixed 5min cooldown; go exponential if starvation outlives it.
+const RELAY_SPAWN_COOLDOWN_MS = 300_000
+const relaySpawnCooldown = new Map<string, number>()
+
+function isSpawnStarvation(error: unknown): boolean {
+  const message = String((error as { message?: unknown })?.message ?? error ?? '')
+
+  return /free local slot|Local backend start/i.test(message)
+}
+
+/** requestProfile for the read-only polls: starvation failures back off, successes reset. */
+async function requestRelayPoll<T>(
+  connection: RelayConnection,
+  method: string,
+  params: Record<string, unknown>
+): Promise<T> {
+  const key = `${connection.id}::${method}`
+  const until = relaySpawnCooldown.get(key)
+
+  if (until !== undefined) {
+    if (until <= Date.now()) {
+      relaySpawnCooldown.delete(key)
+    } else {
+      throw new Error(`relay poll for "${connection.id}" (${method}) cooling down after a spawn timeout`)
+    }
+  }
+
+  try {
+    const res = await host.requestProfile<T>(connection.route, method, params)
+
+    relaySpawnCooldown.delete(key)
+
+    return res
+  } catch (error) {
+    if (isSpawnStarvation(error)) {
+      relaySpawnCooldown.set(key, Date.now() + RELAY_SPAWN_COOLDOWN_MS)
+    }
+
+    throw error
+  }
+}
+
 /** Reconcile retention with the CURRENT connection set: pin new connections,
  *  release removed ones. Runs on every drain/roster connection fetch. */
 function syncRelayRetention(connections: RelayConnection[]) {
@@ -208,7 +256,7 @@ async function relayConnections(): Promise<RelayConnection[]> {
  *  definitively offline → false runtime_offline refusals (#93091 item 2). */
 async function relayAgentsOn(connection: RelayConnection): Promise<RelayAgentRow[] | null> {
   try {
-    const res = await host.requestProfile<{ profiles?: RosterRow[] }>(connection.route, 'profiles.list', {
+    const res = await requestRelayPoll<{ profiles?: RosterRow[] }>(connection, 'profiles.list', {
       include_sessions: false
     })
 
@@ -346,8 +394,8 @@ async function drainRelayOutboxes() {
       let envelopes: RelayEnvelope[] = []
 
       try {
-        const res = await host.requestProfile<{ envelopes?: RelayEnvelope[] }>(
-          sender.route,
+        const res = await requestRelayPoll<{ envelopes?: RelayEnvelope[] }>(
+          sender,
           'bot_relay.outbox.drain',
           {}
         )
@@ -490,6 +538,8 @@ export function stopBotRelay() {
   // Unpin every relay-retained socket (#93594): with the relay stopped the
   // pooled entries return to dispose-at-refcount-0 semantics.
   releaseRelayRetention()
+  // A stale spawn cooldown must not delay the first poll after re-enable.
+  relaySpawnCooldown.clear()
 
   if (relay.rosterTimer !== null) {
     clearInterval(relay.rosterTimer)


### PR DESCRIPTION
## What Problem This Solves
Fixes #102913 — [Bug]: Bot relay timers spawn-storm profile backends against a full local pool — 30s retry loop with no backoff starves the slot pool and degrades the whole UI (typing focus loss). Minimal diff, single shared guard, no new deps.

## Evidence
- Repro: local repro shows before→after.
- Related suites pass (see worktree 102913).

Closes #102913