### PR TITLE
fix(nous): adopt a same-account fresh key before expiry and start the keepalive in every process (620 hourly 401s → 0; review-found account takeover closed)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -433,6 +433,17 @@ def _finalize_routing(agent, api_mode, credential_pool):
     with suppress(Exception):
         agent._get_transport()
 
+    # The Nous agent key lives ~1 h. Without the proactive refresher every agent in the process
+    # discovers expiry reactively, on its own next request, all in the same minute: with 200
+    # in-process subagents that was a 401 storm each hour (620 in one run) and the credential
+    # pool benched the provider for all of them. The gateway and web server start this thread
+    # at boot; the CLI process (and everything spawned inside it) never did. Idempotent,
+    # process-wide, daemon.
+    if agent.provider == "nous":
+        with suppress(Exception):
+            from hermes_cli.nous_auth_keepalive import start_nous_auth_keepalive
+            start_nous_auth_keepalive()
+
     with suppress(Exception):
         from hermes_cli.model_normalize import (
             _AGGREGATOR_PROVIDERS, normalize_model_for_provider

--- a/agent/client_lifecycle.py
+++ b/agent/client_lifecycle.py
@@ -3,6 +3,7 @@ shared primary client, single-slot per-request client caches (owner-thread close
 credential refresh/rotation, route-derived default headers. Extracted from ``run_agent.py``, MRO unchanged."""
 import logging
 import threading
+import time
 from contextlib import suppress
 from typing import Any, Optional
 
@@ -542,6 +543,8 @@ class ClientLifecycleMixin:
         api_key, base_url = creds.get("api_key"), creds.get("base_url")
         if not _valid_credential_pair(api_key, base_url):
             return False
+        if str(api_key).strip() == str(self.api_key or "").strip():
+            return False  # store holds the same key: nothing to adopt, no client rebuild
         if self.api_mode == "anthropic_messages":
             self.api_key, self.base_url = api_key.strip(), base_url.strip().rstrip("/")
             self._anthropic_api_key, self._anthropic_base_url = self.api_key, self.base_url
@@ -550,6 +553,32 @@ class ClientLifecycleMixin:
         # Nous requests should not inherit OpenRouter-only attribution headers.
         self._client_kwargs.pop("default_headers", None)
         return self._adopt_openai_credentials(api_key, base_url, reason="nous_credential_refresh")
+
+    # Adopt a fresh key this many seconds before the one in hand expires. Wider than the store's
+    # own refresh skew (120 s) so the keepalive has normally already minted the replacement.
+    _NOUS_KEY_ADOPT_SKEW_S = 180
+
+    def _adopt_nous_key_before_expiry(self) -> bool:
+        """Swap in a fresh Nous agent key BEFORE the one in hand expires, so the request never 401s.
+
+        The agent key is a JWT; its ``exp`` is read locally (no network). Inside the skew the store
+        is re-read under the auth-store lock: the keepalive thread normally holds a fresh key already
+        (adopt, no POST), otherwise ONE refresh runs and every peer adopts its result. Before this,
+        every agent in a process learned about the hourly expiry from its own 401, all in the same
+        minute (620 in one 200-subagent run), and the pool benched the sole credential for all of
+        them. Returns True when a new key was adopted.
+        """
+        if getattr(self, "provider", "") != "nous" or not getattr(self, "api_key", None):
+            return False
+        try:
+            from hermes_cli.auth_constants import _decode_jwt_claims
+            exp = _decode_jwt_claims(self.api_key).get("exp")
+        except Exception:
+            return False
+        if not isinstance(exp, (int, float)) or exp - time.time() > self._NOUS_KEY_ADOPT_SKEW_S:
+            return False
+        return self._try_refresh_nous_client_credentials(force=False)
+
 
     def _resolve_env_credentials(self) -> Optional[tuple]:
         """Current ``.env``-sourced ``(api_key, base_url, default_base)`` for this provider, or ``None``.

--- a/agent/client_lifecycle.py
+++ b/agent/client_lifecycle.py
@@ -525,7 +525,7 @@ class ClientLifecycleMixin:
             return False
         return self._adopt_openai_credentials(api_key, base_url, reason=f"{self.provider}_credential_refresh")
 
-    def _try_refresh_nous_client_credentials(self, *, force: bool = True) -> bool:
+    def _try_refresh_nous_client_credentials(self, *, force: bool = True, require_account: str | None = None) -> bool:
         # Portal serves anthropic/* on the native Messages route, so either client kind may hold the expiring JWT.
         if self.provider != "nous" or self.api_mode not in ("chat_completions", "anthropic_messages"):
             return False
@@ -545,6 +545,18 @@ class ClientLifecycleMixin:
             return False
         if str(api_key).strip() == str(self.api_key or "").strip():
             return False  # store holds the same key: nothing to adopt, no client rebuild
+        if require_account is not None:
+            try:
+                from hermes_cli.auth_constants import _decode_jwt_claims
+                new_account = _decode_jwt_claims(str(api_key)).get("sub")
+            except Exception:
+                new_account = None
+            if str(new_account or "") != require_account:
+                logger.info(
+                    "Nous pre-expiry adoption skipped: the store's key belongs to a different account "
+                    "than the one in hand; keeping the current credential."
+                )
+                return False
         if self.api_mode == "anthropic_messages":
             self.api_key, self.base_url = api_key.strip(), base_url.strip().rstrip("/")
             self._anthropic_api_key, self._anthropic_base_url = self.api_key, self.base_url
@@ -567,17 +579,24 @@ class ClientLifecycleMixin:
         every agent in a process learned about the hourly expiry from its own 401, all in the same
         minute (620 in one 200-subagent run), and the pool benched the sole credential for all of
         them. Returns True when a new key was adopted.
+
+        Identity guard: the replacement must belong to the SAME account (``sub`` claim) as the key
+        in hand. The store holds the logged-in singleton; an agent running on an explicitly supplied
+        or pool-selected key for a different account must never be silently moved onto it (that
+        changes who is billed). When either side lacks a ``sub`` nothing is adopted here; the
+        reactive 401 path is unchanged.
         """
         if getattr(self, "provider", "") != "nous" or not getattr(self, "api_key", None):
             return False
         try:
             from hermes_cli.auth_constants import _decode_jwt_claims
-            exp = _decode_jwt_claims(self.api_key).get("exp")
+            claims = _decode_jwt_claims(self.api_key)
         except Exception:
             return False
-        if not isinstance(exp, (int, float)) or exp - time.time() > self._NOUS_KEY_ADOPT_SKEW_S:
+        exp, account = claims.get("exp"), claims.get("sub")
+        if not account or not isinstance(exp, (int, float)) or exp - time.time() > self._NOUS_KEY_ADOPT_SKEW_S:
             return False
-        return self._try_refresh_nous_client_credentials(force=False)
+        return self._try_refresh_nous_client_credentials(force=False, require_account=str(account))
 
 
     def _resolve_env_credentials(self) -> Optional[tuple]:

--- a/agent/turn_iteration_prep.py
+++ b/agent/turn_iteration_prep.py
@@ -50,6 +50,15 @@ def prepare_iteration(agent: Any,*, messages: Any, api_call_count: Any) -> Itera
     if agent._skill_nudge_interval > 0 and "skill_manage" in agent.valid_tool_names:
         agent._iters_since_skill += 1
 
+    # Nous agent keys live ~1 h and a single turn can run for hours: adopt the keepalive's fresh
+    # key before the one in hand expires (local JWT exp read; no network unless inside the skew)
+    # instead of letting this iteration's request 401. With many agents sharing the hour that
+    # 401 was a storm, and the pool benched the sole credential for all of them.
+    try:
+        agent._adopt_nous_key_before_expiry()
+    except Exception:
+        logger.debug("Nous key pre-expiry adoption failed", exc_info=True)
+
     # Drain a /steer sent during the last API call into the newest tool message so
     # it lands THIS iteration. Never put in a user message (breaks alternation).
     _pre_api_steer = agent._drain_pending_steer()

--- a/tests/agent/test_nous_key_pre_expiry_adoption.py
+++ b/tests/agent/test_nous_key_pre_expiry_adoption.py
@@ -1,0 +1,74 @@
+"""Nous agent keys live ~1 h. Every agent in a process must not learn about expiry from its own 401.
+
+In a 1,393-subagent run the hourly expiry produced 620 authentication_error 401s (177 in one hour) and
+the credential pool benched the sole credential for every worker at once; the CLI process never
+started the proactive keepalive, and nothing adopted a fresh key before a request was sent.
+"""
+import base64
+import json
+import time
+from unittest.mock import patch
+
+from agent.client_lifecycle import ClientLifecycleMixin
+
+
+def _jwt(exp: float) -> str:
+    def b64(o):
+        return base64.urlsafe_b64encode(json.dumps(o).encode()).rstrip(b"=").decode()
+    return f"{b64({'alg': 'none'})}.{b64({'exp': exp})}.sig"
+
+
+class _Agent(ClientLifecycleMixin):
+    def __init__(self, key):
+        self.provider, self.api_mode, self.api_key, self.base_url = "nous", "chat_completions", key, "https://inference-api.nousresearch.com/v1"
+        self._client_kwargs, self.adopted = {}, []
+
+    def _adopt_openai_credentials(self, api_key, base_url, *, reason):
+        self.adopted.append((api_key, reason))
+        self.api_key = api_key
+        return True
+
+
+def test_key_far_from_expiry_is_left_alone_without_touching_the_store():
+    agent = _Agent(_jwt(time.time() + 3000))
+    with patch("hermes_cli.auth.resolve_nous_runtime_credentials", side_effect=AssertionError("must not hit the store")):
+        assert agent._adopt_nous_key_before_expiry() is False
+    assert agent.adopted == []
+
+
+def test_key_inside_the_skew_adopts_the_stores_fresh_key_without_forcing_a_refresh():
+    agent = _Agent(_jwt(time.time() + 60))
+    calls = []
+
+    def resolve(**kw):
+        calls.append(kw)
+        return {"api_key": "fresh-key", "base_url": agent.base_url}
+
+    with patch("hermes_cli.auth.resolve_nous_runtime_credentials", side_effect=resolve):
+        assert agent._adopt_nous_key_before_expiry() is True
+    assert calls[0]["force_refresh"] is False  # the keepalive/peer refresh is adopted, never re-minted
+    assert agent.adopted == [("fresh-key", "nous_credential_refresh")]
+
+
+def test_same_key_back_from_the_store_is_not_readopted():
+    """No client rebuild when the store still holds the key in hand (refresh pending elsewhere)."""
+    key = _jwt(time.time() + 60)
+    agent = _Agent(key)
+    with patch("hermes_cli.auth.resolve_nous_runtime_credentials", return_value={"api_key": key, "base_url": agent.base_url}):
+        assert agent._adopt_nous_key_before_expiry() is False
+    assert agent.adopted == []
+
+
+def test_keepalive_thread_starts_when_an_agent_routes_to_nous(monkeypatch, tmp_path):
+    """Real construction path: the CLI process builds agents through AIAgent, never through the gateway boot."""
+    from run_agent import AIAgent
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hh"))
+    started = []
+    monkeypatch.setattr("hermes_cli.nous_auth_keepalive.start_nous_auth_keepalive", lambda: started.append(1))
+    AIAgent(api_key="k", base_url="https://inference-api.nousresearch.com/v1", provider="nous",
+            model="anthropic/claude-fable-5.1", quiet_mode=True, skip_context_files=True, skip_memory=True)
+    assert started == [1]
+    AIAgent(api_key="k", base_url="https://openrouter.ai/api/v1", provider="openrouter",
+            model="anthropic/claude-fable-5.1", quiet_mode=True, skip_context_files=True, skip_memory=True)
+    assert started == [1]

--- a/tests/agent/test_nous_key_pre_expiry_adoption.py
+++ b/tests/agent/test_nous_key_pre_expiry_adoption.py
@@ -12,10 +12,10 @@ from unittest.mock import patch
 from agent.client_lifecycle import ClientLifecycleMixin
 
 
-def _jwt(exp: float) -> str:
+def _jwt(exp: float, sub: str = "acct-A") -> str:
     def b64(o):
         return base64.urlsafe_b64encode(json.dumps(o).encode()).rstrip(b"=").decode()
-    return f"{b64({'alg': 'none'})}.{b64({'exp': exp})}.sig"
+    return f"{b64({'alg': 'none'})}.{b64({'exp': exp, 'sub': sub})}.sig"
 
 
 class _Agent(ClientLifecycleMixin):
@@ -40,14 +40,32 @@ def test_key_inside_the_skew_adopts_the_stores_fresh_key_without_forcing_a_refre
     agent = _Agent(_jwt(time.time() + 60))
     calls = []
 
+    fresh = _jwt(time.time() + 3600)  # same account A
+
     def resolve(**kw):
         calls.append(kw)
-        return {"api_key": "fresh-key", "base_url": agent.base_url}
+        return {"api_key": fresh, "base_url": agent.base_url}
 
     with patch("hermes_cli.auth.resolve_nous_runtime_credentials", side_effect=resolve):
         assert agent._adopt_nous_key_before_expiry() is True
     assert calls[0]["force_refresh"] is False  # the keepalive/peer refresh is adopted, never re-minted
-    assert agent.adopted == [("fresh-key", "nous_credential_refresh")]
+    assert agent.adopted == [(fresh, "nous_credential_refresh")]
+
+
+def test_a_fresh_key_for_a_different_account_is_never_adopted():
+    """Independent-review witness: an explicitly supplied account-A key near expiry was replaced by the
+    logged-in singleton's account-B key and the next real request went out as B. Identity is preserved."""
+    agent = _Agent(_jwt(time.time() + 60, sub="acct-A"))
+    other = _jwt(time.time() + 3600, sub="acct-B")
+    with patch("hermes_cli.auth.resolve_nous_runtime_credentials", return_value={"api_key": other, "base_url": agent.base_url}):
+        assert agent._adopt_nous_key_before_expiry() is False
+    assert agent.adopted == [] and agent.api_key != other
+
+
+def test_a_key_without_an_account_claim_is_left_alone_proactively():
+    agent = _Agent(_jwt(time.time() + 60, sub=""))
+    with patch("hermes_cli.auth.resolve_nous_runtime_credentials", side_effect=AssertionError("must not hit the store")):
+        assert agent._adopt_nous_key_before_expiry() is False
 
 
 def test_same_key_back_from_the_store_is_not_readopted():


### PR DESCRIPTION
Every process that routes to Nous now runs the proactive key keepalive, and each agent adopts a fresh agent key **before** the one in hand expires instead of learning about expiry from its own 401.

**Symptom.** The Nous agent key lives 3,599 s. In the 1,393-agent refactor run every in-process agent discovered the hourly expiry reactively, all in the same minute: **620 `authentication_error` 401s** in the logged window (177@21h, 166@22h, 101@23h, 86@00h), each a failed attempt the model never saw and invisible in the cost ledger (not counted in `api_call_count`). The credential pool read the burst as the sole credential failing and benched it for every worker at once; at 08:30 that storm took the parent process down (the crash we recovered from). Wall-clock cost: the 66-minute outage plus two dips, ~1.5 h of a 20.5 h run.

**Two gaps.**
- `hermes_cli/nous_auth_keepalive.py` (the proactive refresher) is started only by `gateway/run.py` and `hermes_cli/web_server.py`. The CLI process, and every subagent built inside it, never started it.
- Even with a fresh key in the store, nothing adopted it before a request. An agent sent whatever key it was constructed with until that key 401'd, and only then called `resolve_nous_runtime_credentials(force_refresh=True)`.

**Change.**
- `agent/agent_init.py::_finalize_routing`: when an agent resolves onto `provider == "nous"`, start the keepalive (idempotent, process-wide, daemon; the existing function).
- `agent/client_lifecycle.py::_adopt_nous_key_before_expiry`: the agent key is a JWT; `exp` is read locally (no network). Inside a 180 s skew the store is re-read under the auth-store lock with `force_refresh=False`, so the keepalive's or a peer's fresh key is adopted without a POST; when none exists, ONE refresh runs there instead of N reactive ones after N 401s. Called from `prepare_iteration` (each API call; a single turn can run for hours).
- `_try_refresh_nous_client_credentials` no longer rebuilds the client when the store returns the key already in hand.

**Behavior.** Cache-safe (no message mutation; the key is a header). Non-Nous providers untouched. Users see fewer `🔐 Nous agent key refreshed after 401. Retrying request...` lines and no hourly stall.

| Validation | Result |
|---|---|
| Live A/B: local server 401s any bearer except FRESH; store patched to hold FRESH; **40 agents** holding a JWT that expires in 30 s fire concurrently | **main: 40 × 401** then recover · **branch: 0 × 401**, same 40 successes |
| `tests/agent/` (522 files) + auth/nous CLI suites | 6,588 passed, 0 failed |
| `ruff`, footguns, `git diff --check` | clean |

Tests added (4): far from expiry the store is never touched; inside the skew the store's fresh key is adopted with `force_refresh=False`; the same key back from the store is not re-adopted (no client rebuild); a real `AIAgent` routed to `nous` starts the keepalive and one routed to `openrouter` does not.

Not in this PR: the classifier already returns `auth` (not `billing`) for the Nous 401 body, verified live; the pool's 401 handling is unchanged.

## Independent review (round 2)

An independent `/review` found a **credential-identity takeover (P1)** in the first version: the pre-request adoption called the singleton resolver unconditionally, so an agent running on an explicitly supplied (or pool-selected) **account-A** key near expiry was moved onto the logged-in **account-B** key from `auth.json` before the A key had failed, and the next real SDK request went out as B. That silently changes who is billed.

Fix: the adoption reads the `sub` claim of the key in hand and passes it as `require_account`; `_try_refresh_nous_client_credentials` refuses any replacement whose `sub` differs (INFO log, current key kept). A key with no `sub` is never adopted proactively. The reactive 401 path is unchanged.

Verified with the **reviewer's own live probe** (real `AIAgent` → real `prepare_iteration` → real `auth.json` transaction → real OpenAI SDK → loopback capture, no mocks):

| case | v1 | now |
|---|---|---|
| same-account, near expiry | A → A, adopted fresh | A → A, adopted fresh |
| **explicit account-A key, singleton holds B** | **A → B** | **A → A, not adopted** |
| far from expiry | untouched | untouched |
| 12 concurrent near-expiry agents | 0 × 401 | 0 × 401 |

Tests added: a fresh key for a different account is never adopted; a key without an account claim is left alone without touching the store.

## Infographic

![nous-key-expiry](https://v3b.fal.media/files/b/0aa92ebc/5r9LlYr8InqrIFgDl-3UB_L2bKwweI.png)

