### PR TITLE
fix(desktop): preserve reader context across refreshes

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/composer-caret-stability.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/composer-caret-stability.test.tsx
@@ -1,0 +1,106 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { clearSessionDraft, type ComposerAttachment, mainComposerScope } from '@/store/composer'
+
+import type { QueueEditState } from '../composer-utils'
+import { caretOffsetInEditor, placeCaretAtOffset, renderComposerContents, RICH_INPUT_SLOT } from '../rich-editor'
+import { ComposerScopeProvider, MAIN_COMPOSER_SCOPE } from '../scope'
+
+import { useComposerDraft } from './use-composer-draft'
+
+const mockComposerApi = { setText: vi.fn() }
+
+vi.mock('@assistant-ui/react', () => ({
+  useAui: () => ({ composer: () => mockComposerApi }),
+  useAuiState: (selector: (state: { composer: { text: string } }) => unknown) => selector({ composer: { text: '' } }),
+  useComposerRuntime: () => ({
+    getState: () => ({ text: '' }),
+    subscribe: () => () => undefined
+  })
+}))
+
+type Restore = (text: string, attachments: ComposerAttachment[]) => void
+
+function Harness({ onReady }: { onReady: (editor: HTMLDivElement | null, restore: Restore) => void }) {
+  const { editorRef, loadIntoComposer } = useComposerDraft({
+    activeQueueSessionKey: 'session-caret',
+    focusKey: null,
+    inputDisabled: false,
+    queueEditRef: { current: null as QueueEditState | null },
+    sessionId: 'session-caret'
+  })
+
+  return (
+    <div
+      contentEditable
+      data-slot={RICH_INPUT_SLOT}
+      ref={el => {
+        editorRef.current = el
+        onReady(el, loadIntoComposer)
+      }}
+      suppressContentEditableWarning
+    />
+  )
+}
+
+/** Mount the hook against a real contenteditable, then hand back the editor and
+ *  the restore path with the caret parked mid-text — the state the user is in
+ *  when a background tick re-runs a draft restore under them. */
+function mountWithCaretAt(text: string, offset: number) {
+  let editor: HTMLDivElement | null = null
+  let restore: Restore = () => undefined
+
+  render(
+    <ComposerScopeProvider value={MAIN_COMPOSER_SCOPE}>
+      <Harness
+        onReady={(el, fn) => {
+          editor = el
+          restore = fn
+        }}
+      />
+    </ComposerScopeProvider>
+  )
+
+  const el = editor as unknown as HTMLDivElement
+
+  act(() => {
+    renderComposerContents(el, text, { trailingCommitted: true })
+    el.focus()
+    placeCaretAtOffset(el, offset)
+  })
+
+  return { editor: el, restore }
+}
+
+// A restore that re-runs under a focused editor used to call
+// renderComposerContents + placeCaretEnd unconditionally: the composer flashed
+// and the caret landed at the bottom. Anything that re-triggers the restore on
+// a timer (sessions.changed is floored to 2s server-side; a gateway reconnect
+// storm re-runs it far faster) turned that into a caret jump every couple of
+// seconds while typing.
+describe('composer restore does not disturb a live caret', () => {
+  afterEach(() => {
+    cleanup()
+    mainComposerScope.clear()
+    clearSessionDraft('session-caret')
+  })
+
+  it('leaves the DOM and the caret untouched when the restored text is what the editor already shows', () => {
+    const { editor, restore } = mountWithCaretAt('hello world', 5)
+    const before = Array.from(editor.childNodes)
+
+    act(() => restore('hello world', []))
+
+    expect(Array.from(editor.childNodes)).toEqual(before)
+    expect(caretOffsetInEditor(editor)).toBe(5)
+  })
+
+  it('keeps the caret where the user left it when a restore does change the text', () => {
+    const { editor, restore } = mountWithCaretAt('hello world', 5)
+
+    act(() => restore('hello world and then some', []))
+
+    expect(caretOffsetInEditor(editor)).toBe(5)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -40,8 +40,10 @@ import {
 } from '../focus'
 import { type InlineRefInput, insertInlineRefsIntoEditor } from '../inline-refs'
 import {
+  caretOffsetInEditor,
   composerPlainText,
   normalizeComposerEditorDom,
+  placeCaretAtOffset,
   placeCaretEnd,
   REF_RE,
   renderComposerContents
@@ -135,19 +137,26 @@ export function useComposerDraft({
   }, [])
 
   // The single write path for programmatic draft mutations: mirror → AUI state →
-  // repaint the editor (caret to end). Repaints even while focused — inserts /
-  // restores run mid-focus, and the runtime sync only repaints an unfocused
-  // editor — so the visible text never lags the store.
+  // Repaint even while focused so inserts/restores never lag the store. A
+  // background restore must not rewrite identical DOM or move a live caret;
+  // explicit inserts still place the caret at the end.
   const paintDraft = useCallback(
-    (next: string, focus = true) => {
+    (next: string, focus = true, preserveCaret = false) => {
       draftRef.current = next
       setComposerText(next)
 
       const editor = editorRef.current
 
-      if (editor) {
+      if (editor && sanitizeComposerInput(composerPlainText(editor)) !== next) {
+        const caret = preserveCaret && document.activeElement === editor ? caretOffsetInEditor(editor) : null
+
         renderComposerContents(editor, next, { trailingCommitted: true })
-        placeCaretEnd(editor)
+
+        if (caret === null) {
+          placeCaretEnd(editor)
+        } else {
+          placeCaretAtOffset(editor, Math.min(caret, next.length))
+        }
       }
 
       if (focus) {
@@ -254,7 +263,7 @@ export function useComposerDraft({
     }
 
     attachmentScope.$attachments.set(cloneAttachments(attachments))
-    paintDraft(text, false)
+    paintDraft(text, false, true)
   }
 
   const clearDraft = useCallback(() => {

--- a/apps/desktop/src/app/contrib/hooks/stored-id-alias-flap.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/stored-id-alias-flap.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { createClientSessionState } from '@/lib/chat-runtime'
+import {
+  $activeSessionId,
+  $activeSessionStoredIdRotation,
+  $messagingSessions,
+  $selectedStoredSessionId,
+  $sessions,
+  setActiveSessionStoredIdRotation
+} from '@/store/session'
+import { $sessionStates, clearAllSessionStates, publishSessionState } from '@/store/session-states'
+import type { SessionInfo } from '@/types/hermes'
+
+import { rehydrateLiveSessionStatuses } from './use-background-sync'
+
+/**
+ * Auto-compression rotates a conversation's tip id while its lineage root
+ * stays constant, and the gateway's surfaces do not all rename at once:
+ * `session.active_list` keeps reporting the session_key the runtime was
+ * started with while the sidebar rows (and session.info) carry the rotated
+ * tip. Both names ALIAS the same conversation — `sessionMatchesStoredId`
+ * resolves either against the same row.
+ *
+ * The live-status rehydrate used to compare those names with `!==` and
+ * republish the snapshot's alias over the renderer's on EVERY poll. Each
+ * republish ran handleTransition's rotation detector, which emitted a
+ * stored-id "rotation" for what is actually the same conversation; the
+ * route-follow effect then chased it and moved $selectedStoredSessionId.
+ * With the renderer-side paths (reconcile / session.info) writing the other
+ * alias back between polls, the selection flapped A→B→A forever — once per
+ * sessions.changed beat — and every flap re-ran the transcript's
+ * settle-to-bottom effect, yanking the reader to the newest message (the
+ * 10s "scroll to bottom while idle" bug).
+ */
+describe('rehydrateLiveSessionStatuses — lineage-alias stored ids must not rotate', () => {
+  const row = {
+    id: 'tip-2',
+    _lineage_root_id: 'root-1',
+    last_active: 1000,
+    profile: 'default',
+    title: 'compressed conversation'
+  } as unknown as SessionInfo
+
+  beforeEach(() => {
+    $sessions.set([row])
+    $messagingSessions.set([])
+    $activeSessionId.set('runtime-x')
+    $selectedStoredSessionId.set('tip-2')
+    setActiveSessionStoredIdRotation(null)
+  })
+
+  afterEach(() => {
+    clearAllSessionStates()
+    $sessions.set([])
+    $activeSessionId.set(null)
+    $selectedStoredSessionId.set(null)
+    setActiveSessionStoredIdRotation(null)
+  })
+
+  it('does not oscillate when snapshot and renderer paths keep writing different aliases', () => {
+    publishSessionState('runtime-x', { ...createClientSessionState('tip-2'), busy: true })
+    setActiveSessionStoredIdRotation(null)
+
+    const rotations: string[] = []
+
+    const unbind = $activeSessionStoredIdRotation.listen(event => {
+      if (event) {
+        rotations.push(`${event.previousStoredSessionId}->${event.nextStoredSessionId}`)
+      }
+    })
+
+    // Two idle beats: each beat = one active_list rehydrate (root alias) and
+    // one renderer-side republish of the tip alias (session.info / reconcile).
+    for (let beat = 0; beat < 2; beat += 1) {
+      rehydrateLiveSessionStatuses({
+        sessions: [{ id: 'runtime-x', session_key: 'root-1', status: 'working' }]
+      })
+
+      expect($activeSessionStoredIdRotation.get()).toBeNull()
+      expect($sessionStates.get()['runtime-x']?.storedSessionId).toBe('tip-2')
+
+      const current = $sessionStates.get()['runtime-x']!
+      publishSessionState('runtime-x', { ...current, storedSessionId: 'tip-2' })
+    }
+
+    unbind()
+
+    expect(rotations).toEqual([])
+  })
+
+  it('still rotates for a genuinely different conversation id', () => {
+    publishSessionState('runtime-x', { ...createClientSessionState('tip-2'), busy: true })
+    setActiveSessionStoredIdRotation(null)
+
+    // No row aliases tip-2 with unrelated-9: this is a real handoff.
+    rehydrateLiveSessionStatuses({
+      sessions: [{ id: 'runtime-x', session_key: 'unrelated-9', status: 'working' }]
+    })
+
+    expect($activeSessionStoredIdRotation.get()).toEqual({
+      nextStoredSessionId: 'unrelated-9',
+      previousStoredSessionId: 'tip-2',
+      runtimeSessionId: 'runtime-x'
+    })
+  })
+})

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -28,6 +28,7 @@ import {
   SESSION_WATCHDOG_TIMEOUT_MS,
   setSessionStalled
 } from '@/store/session-states'
+import type { SessionInfo } from '@/types/hermes'
 
 import type { ClientSessionState } from '../../types'
 import type { GatewayRequester } from '../types'
@@ -48,6 +49,18 @@ export function resolveActiveTranscriptSession(storedSessionId: string): ActiveT
   const ownerRoute = getSessionOwnerHint(storedSessionId)
 
   return ownerRoute ? { ownerRoute, profile: ownerRoute.profile } : undefined
+}
+
+/** The live tip and compression-lineage root can name the same conversation. */
+function storedIdsAliasSameSession(a: string, b: string): boolean {
+  if (a === b) {
+    return true
+  }
+
+  const aliases = (rows: readonly Pick<SessionInfo, '_lineage_root_id' | 'id'>[]) =>
+    rows.some(row => sessionMatchesStoredId(row, a) && sessionMatchesStoredId(row, b))
+
+  return aliases(ownerLookupSessionRows())
 }
 
 export interface ActiveTranscriptRefreshDeps {
@@ -384,17 +397,25 @@ export function rehydrateLiveSessionStatuses(
 
   for (const session of response.sessions ?? []) {
     const runtimeSessionId = session.id?.trim()
-    const storedSessionId = session.session_key?.trim()
+    const snapshotStoredSessionId = session.session_key?.trim()
     const needsInput = session.status === 'waiting'
     const working = session.status === 'working' || needsInput
 
-    if (!runtimeSessionId || !storedSessionId) {
+    if (!runtimeSessionId || !snapshotStoredSessionId) {
       continue
     }
 
     seen.add(runtimeSessionId)
 
     const existing = $sessionStates.get()[runtimeSessionId]
+
+    // active_list can retain the runtime's launch-time root while session.info
+    // and the renderer already use its compressed tip. Republishing that alias
+    // on every poll emits false rotations and repeatedly re-homes the chat.
+    const storedSessionId =
+      existing?.storedSessionId && storedIdsAliasSameSession(existing.storedSessionId, snapshotStoredSessionId)
+        ? existing.storedSessionId
+        : snapshotStoredSessionId
 
     // A turn we just submitted is not yet running as far as the backend is
     // concerned, so the snapshot honestly reports it idle — but the local

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -627,6 +627,42 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     scrollRef.current?.removeAttribute('data-editing')
   }, [scrollRef])
 
+  // The library's wheel handler matches overflow === 'auto'/'scroll', but
+  // this viewport computes to 'hidden auto'. Release its lock through the
+  // public API before streaming resize-follow pulls an upward reader down.
+  useEffect(() => {
+    const el = scrollRef.current
+
+    if (!el) {
+      return undefined
+    }
+
+    const onWheel = (event: WheelEvent) => {
+      if (event.deltaY >= 0 || el.scrollHeight <= el.clientHeight) {
+        return
+      }
+
+      // A nested code/output scroller with room above owns the gesture.
+      for (
+        let node = event.target instanceof Element ? event.target : null;
+        node && node !== el;
+        node = node.parentElement
+      ) {
+        const { overflowY } = getComputedStyle(node)
+
+        if ((overflowY === 'auto' || overflowY === 'scroll') && node.scrollTop > 0) {
+          return
+        }
+      }
+
+      stopScroll()
+    }
+
+    el.addEventListener('wheel', onWheel, { passive: true })
+
+    return () => el.removeEventListener('wheel', onWheel)
+  }, [scrollRef, stopScroll])
+
   // Inline edit grows a sticky bubble. Escape before focus/layout so the
   // resize-follow can't snap scrollTop; native anchoring holds the viewport.
   const beginEditHold = useCallback(() => {

--- a/apps/desktop/src/components/assistant-ui/thread/wheel-escape.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/wheel-escape.test.tsx
@@ -1,0 +1,164 @@
+// The transcript must release use-stick-to-bottom's lock when the reader
+// scrolls up.
+//
+// The library's own wheel escape walks up from the wheel target until
+// `getComputedStyle(el).overflow` is exactly 'scroll' or 'auto'. This viewport
+// is `overflow-x-hidden overflow-y-auto`, which Chromium computes as
+// 'hidden auto' — verified in real Chromium, control: a plain `overflow-y:auto`
+// computes to 'auto' and would have matched. So the walk never reaches the
+// viewport, the escape is dead code, and every content-growth tick of a
+// streaming turn jammed a scrolled-up reader back to the newest message.
+import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Thread } from '.'
+
+const stopScroll = vi.fn()
+const scrollToBottom = vi.fn()
+
+vi.mock('use-stick-to-bottom', () => {
+  const makeRef = () => {
+    const ref = ((node: HTMLElement | null) => {
+      ref.current = node
+    }) as ((node: HTMLElement | null) => void) & { current: HTMLElement | null }
+
+    ref.current = null
+
+    return ref
+  }
+
+  const scrollRef = makeRef()
+  const contentRef = makeRef()
+
+  return {
+    useStickToBottom: () => ({
+      contentRef,
+      escapedFromLock: false,
+      isAtBottom: true,
+      isNearBottom: true,
+      scrollRef,
+      scrollToBottom,
+      state: {},
+      stopScroll
+    })
+  }
+})
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => window.setTimeout(() => cb(performance.now()), 0))
+vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
+vi.stubGlobal('CSS', { escape: (s: string) => s })
+
+Element.prototype.scrollTo = function scrollTo() {}
+
+Element.prototype.animate = function animate() {
+  return { cancel() {}, finished: Promise.resolve() } as unknown as Animation
+}
+
+const createdAt = new Date('2026-05-01T00:00:00.000Z')
+
+const messages: ThreadMessage[] = [
+  {
+    attachments: [],
+    content: [{ text: 'question', type: 'text' }],
+    createdAt,
+    id: 'u1',
+    metadata: { custom: {} },
+    role: 'user'
+  } as ThreadMessage,
+  {
+    content: [{ text: 'a long streamed answer', type: 'text' }],
+    createdAt,
+    id: 'a1',
+    metadata: { custom: {}, steps: [], unstable_annotations: [], unstable_data: [], unstable_state: null },
+    role: 'assistant',
+    status: { type: 'running' }
+  } as ThreadMessage
+]
+
+function Harness() {
+  const runtime = useExternalStoreRuntime<ThreadMessage>({ isRunning: true, messages, onNew: async () => {} })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  )
+}
+
+/** jsdom reports every box as 0×0; the handler needs a scrollable viewport. */
+function makeScrollable(el: HTMLElement, { client = 100, scroll = 900 } = {}) {
+  Object.defineProperty(el, 'scrollHeight', { configurable: true, value: scroll })
+  Object.defineProperty(el, 'clientHeight', { configurable: true, value: client })
+}
+
+function viewportOf(container: HTMLElement) {
+  const el = container.querySelector<HTMLElement>('[data-slot="aui_thread-viewport"]')
+
+  if (!el) {
+    throw new Error('thread viewport not found')
+  }
+
+  return el
+}
+
+describe('transcript releases the stick-to-bottom lock on scroll-up', () => {
+  beforeEach(() => {
+    stopScroll.mockClear()
+    scrollToBottom.mockClear()
+  })
+
+  afterEach(cleanup)
+
+  it('escapes only for an upward wheel on a scrollable viewport', async () => {
+    const { container, findByText } = render(<Harness />)
+
+    await findByText('a long streamed answer')
+
+    const viewport = viewportOf(container)
+
+    makeScrollable(viewport)
+    stopScroll.mockClear()
+
+    viewport.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: 120 }))
+
+    expect(stopScroll).not.toHaveBeenCalled()
+
+    viewport.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: -120 }))
+
+    expect(stopScroll).toHaveBeenCalled()
+  })
+
+  it('leaves the gesture to a nested scroller that still has room above', async () => {
+    const { container, findByText } = render(<Harness />)
+
+    await findByText('a long streamed answer')
+
+    const viewport = viewportOf(container)
+
+    makeScrollable(viewport)
+
+    const nested = window.document.createElement('div')
+
+    nested.style.overflowY = 'auto'
+    Object.defineProperty(nested, 'scrollTop', { configurable: true, value: 40 })
+    viewport.append(nested)
+    stopScroll.mockClear()
+
+    nested.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: -120 }))
+
+    expect(stopScroll).not.toHaveBeenCalled()
+
+    Object.defineProperty(nested, 'scrollTop', { configurable: true, value: 0 })
+    nested.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: -120 }))
+
+    expect(stopScroll).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Preserves the reader's position during Desktop background refreshes and streaming. It forward-ports three related fixes carried in a local installation onto current main (`f58fcc8118d9db092ad60d363d4a28520e08ac5a`).

- Draft restoration currently rewrites the contenteditable DOM and moves an active caret to the end, including when the text is unchanged. Avoid the unnecessary rewrite and preserve the caret offset for changed-text restores. Explicit insertions retain their existing focus behavior.
- `sessions.active_list` may report a conversation's compression-lineage root after the renderer has moved to its tip. Recognize aliases using the existing owner-scoped session rows instead of emitting a false stored-ID rotation on every poll. Unrelated IDs still rotate normally.
- The scrolling library's wheel escape checks `overflow` for an exact `auto`/`scroll` match, whereas this viewport computes to `hidden auto`. Release follow mode through `stopScroll()` for an upward wheel gesture. Leave downward gestures and nested scrollers with room above alone.

## Related Issue

No separate issue. Existing PRs were checked: #100333 addresses caret movement during DOM normalization, #101771 addresses resume/model-picker focus churn, and #70029 addresses stale inline-edit holds. This change addresses draft restoration, status alias hydration, and viewport wheel escape instead.

## Type of Change

- [x] Bug fix

## How to Test

From `apps/desktop`:

1. `npm run test:ui -- src/app/chat/composer/hooks src/app/chat/composer/rich-editor.test.ts src/app/contrib/hooks src/components/assistant-ui/thread --maxWorkers=4`
2. `npm run typecheck`

Verification on macOS 26.5.1:

- The initial regression cases on unmodified main failed at the expected caret, alias-rotation, and upward-wheel assertions (5 failures). Redundant cases were then consolidated to two invariant tests per bug.
- With the fixes: **55 test files, 394 tests passed**.
- Final rerun of the three new regression files: **6 tests passed**.
- Full Desktop typecheck: **passed**.
- Focused ESLint: **0 errors**, with the same two pre-existing `stashAt` hook-dependency warnings also reproduced on unmodified main.
- Independent staged-diff review found no blocking issue. Added-line scans found no hard-coded secrets or unsafe execution patterns.

The wheel tests exercise the real thread component with the scrolling library mocked; they verify escape calls, not a packaged-app or real-browser scrolling outcome. Full Python and packaged Desktop E2E suites were not run for this renderer-only change.

## Checklist

- [x] Read the contributing guide.
- [x] Conventional commit; only related fixes and tests.
- [x] Searched existing PRs.
- [x] Added behavioral regression tests.
- [x] Tested on macOS; no platform-specific production APIs added.
- [x] No configuration, tool-schema, or architecture changes requiring documentation updates.
- [ ] Full Python suite (not run; renderer-only change).
- [ ] Packaged-app/browser E2E verification (not run).

## AI assistance

Prepared with Codex assistance. Test results above were executed locally; independent review is additional evidence, not a claim of live-app verification.
