### PR TITLE
fix(tui): restore stored session runtime on lazy and unroutable-provider resume

### DIFF
--- a/tests/tui_gateway/test_session_resume_runtime_restore.py
+++ b/tests/tui_gateway/test_session_resume_runtime_restore.py
@@ -1,0 +1,142 @@
+"""``session.resume`` must rebuild the agent with the STORED session runtime (#103498).
+
+During a disconnect -> reconnect window a stored session (e.g. ``gemini`` + thinking
+off) could resume with the profile DEFAULT model/thinking (e.g. ``vision-exp`` + high)
+while the persisted row stayed correct. The resumed runtime — not the row — was wrong.
+
+Pinned here, end to end through the real ``session.resume`` RPC + the real deferred
+agent build (``_start_agent_build``), with a fake ``_make_agent`` that honors the same
+override/default rule as the real one (an explicit ``reasoning_config_override`` wins,
+else the ambient default). Two holes, one contract:
+
+* a lazy resume upgraded by the first prompt rebuilt a pure profile-default agent
+  (the lazy record carried no overrides at all);
+* a stored provider that is no longer routable dropped the WHOLE overrides dict, so
+  the stored model/reasoning/tier silently reverted (only the dead provider pin may
+  fall back).
+
+The ``follow_profile_config`` case keeps following the profile (the #101514 direction
+is explicitly NOT changed by this fix).
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from tui_gateway import server
+
+STORED_MODEL = "gemini"
+STORED_REASONING_OFF = {"enabled": False}
+PROFILE_DEFAULT_MODEL = "vision-exp"
+
+_HISTORY = [{"role": "user", "content": "hello"}]
+
+
+class _FakeDB:
+    def __init__(self, row):
+        self._row = row
+
+    def get_session(self, _target):
+        return dict(self._row)
+
+    def get_session_by_title(self, _title):
+        return None
+
+    def reopen_session(self, _target):
+        pass
+
+    def get_messages_as_conversation(self, _target, **_kwargs):
+        return [dict(m) for m in _HISTORY]
+
+    def get_resume_conversations(self, _target):
+        return self.get_messages_as_conversation(_target), self.get_messages_as_conversation(_target)
+
+    def get_ancestor_display_prefix(self, _sid):
+        return []
+
+
+def _stored_row(**model_config):
+    return {
+        "id": "stored-1",
+        "title": "test chat",
+        "model": STORED_MODEL,
+        "billing_provider": "gemini",
+        "model_config": {"provider": "gemini", "reasoning_config": dict(STORED_REASONING_OFF), **model_config},
+        "message_count": 1,
+    }
+
+
+def _install(monkeypatch, row, *, routable):
+    """Fake the agent seam + ambient profile defaults."""
+    db = _FakeDB(row)
+    events = []
+
+    def fake_make_agent(_sid, _key, **kwargs):
+        override = kwargs.get("model_override") or {}
+        # Same rule as the real _make_agent: an explicit reasoning override wins,
+        # otherwise the agent falls back to the ambient (profile default) config.
+        return types.SimpleNamespace(
+            model=override.get("model") or PROFILE_DEFAULT_MODEL,
+            provider=(override.get("provider") or "vision-provider"),
+            reasoning_config=kwargs.get("reasoning_config_override", {"enabled": True, "effort": "high"}),
+        )
+
+    monkeypatch.setattr(server, "_profile_session_db", lambda _home: (db, False))
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_set_session_context", lambda *a: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+    monkeypatch.setattr(server, "_wire_session_agent", lambda *a: True)
+    monkeypatch.setattr(server, "_announce_built_agent", lambda *a: None)
+    monkeypatch.setattr(server, "_emit", lambda *a: events.append(a))
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda _sid: None)
+    monkeypatch.setattr(server, "_schedule_resume_hydration", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_maybe_schedule_auto_continue", lambda *a: None)
+    monkeypatch.setattr(server, "_is_routable_provider", lambda _p: routable)
+    # Ambient profile defaults DIFFER from the stored runtime: any leak reads as the default.
+    monkeypatch.setattr(server, "_config_model_target", lambda: (PROFILE_DEFAULT_MODEL, None))
+
+
+def _resume_and_build(monkeypatch, params, row, *, routable=True):
+    _install(monkeypatch, row, routable=routable)
+    before = set(server._sessions)
+    resp = server.handle_request({"id": "1", "method": "session.resume", "params": params})
+    assert resp is not None and "result" in resp, resp
+    sid = resp["result"]["session_id"]
+    session = server._sessions[sid]
+    try:
+        if session.get("resume_history_ready") is not None:
+            session["resume_history_ready"].set()  # transcript hydration is stubbed out
+        server._start_agent_build(sid, session)
+        session["_agent_build_thread"].join(timeout=15)
+        assert session.get("agent") is not None, session.get("agent_error")
+        return session["agent"]
+    finally:
+        for live_sid in set(server._sessions) - before:
+            server._sessions.pop(live_sid, None)
+
+
+@pytest.mark.parametrize(
+    ("params", "routable", "row_kwargs"),
+    [
+        ({"session_id": "stored-1"}, True, {}),
+        ({"session_id": "stored-1", "defer_history": True}, True, {}),
+        ({"session_id": "stored-1", "lazy": True}, True, {}),
+        ({"session_id": "stored-1"}, False, {"provider": "removed-provider", "billing_provider": "removed-provider"}),
+    ],
+    ids=["cold", "deferred", "lazy-upgrade", "unroutable-provider"],
+)
+def test_resume_restores_stored_model_and_thinking(monkeypatch, params, routable, row_kwargs):
+    agent = _resume_and_build(monkeypatch, params, _stored_row(**row_kwargs), routable=routable)
+    assert agent.model == STORED_MODEL
+    assert agent.reasoning_config == STORED_REASONING_OFF
+
+
+def test_follow_profile_config_session_still_follows_profile(monkeypatch):
+    agent = _resume_and_build(
+        monkeypatch, {"session_id": "stored-1"}, _stored_row(follow_profile_config=True), routable=True
+    )
+    assert agent.model == PROFILE_DEFAULT_MODEL

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -677,7 +677,8 @@ def _resume_lazy(ctx: _Resume) -> dict:
         history = ctx.child_history(repair=True)
     except Exception as e:
         return _err(ctx.rid, 5000, f"resume failed: {e}")
-    record = ctx.record(source, cwd, history, lazy=True, todo_state=_todo_state_from_history(history))
+    record = ctx.record(source, cwd, history, _stored_session_runtime_overrides(ctx.found) or None,
+                        lazy=True, todo_state=_todo_state_from_history(history))
     if (reused := ctx.claim(sid, record)) is not None:
         return reused
     # A child mid-run emits no session events — liveness comes from the relay registry.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -878,7 +878,8 @@ def _deferred_build_agent_kwargs(current: dict, session_db) -> dict:
     """_make_agent kwargs for a deferred (first-prompt) build. A lazy-resumed (watch) session carries the
     stored conversation id so the upgrade continues it; a cold deferred resume restores the full persisted
     runtime identity (like the eager resume's overrides splat) so the build can't drop the provider. No
-    stored runtime, or an unroutable provider → this session's picked model/effort/tier, else the default."""
+    stored runtime → this session's picked model/effort/tier, else the default. An unroutable stored
+    provider still restores the stored model/reasoning/tier — only the dead provider pin falls back."""
     kw = {"session_db": session_db, "context_cwd_is_launch_artifact": _context_cwd_is_launch_artifact(current),
           "platform_override": _session_source(current)}
     if resume_sid := current.get("resume_session_id"):
@@ -889,6 +890,15 @@ def _deferred_build_agent_kwargs(current: dict, session_db) -> dict:
     else:
         if override := current.get("model_override"):
             kw["model_override"] = override
+        if isinstance(resume_overrides, dict):
+            # A dead provider pin must fall back, but the stored model/reasoning/tier are still
+            # this session's identity (#103498): dropping the whole dict silently rebuilds the
+            # agent with the profile defaults while the persisted row stays correct.
+            kw.update({k: v for k, v in (("reasoning_config_override",
+                                          resume_overrides.get("reasoning_config_override")),
+                                         ("service_tier_override",
+                                          resume_overrides.get("service_tier_override")))
+                       if v is not None})
         kw.update({k: v for k, v in (("reasoning_config_override", current.get("create_reasoning_override")),
                                      ("service_tier_override", current.get("create_service_tier_override")))
                    if v is not None})


### PR DESCRIPTION
Fixes #103498.

By Bruno Bza (@BrunoBza).

## Problem

During a disconnect -> reconnect window, resuming an existing session could recreate the agent with the profile DEFAULT model/thinking instead of the session's persisted runtime config, while the persisted row stayed correct. Two holes in the resume-restore contract produced exactly that observable:

1. **Lazy resume dropped everything.** `_resume_lazy` recorded no runtime overrides, so the first-prompt upgrade build (`_start_agent_build` -> `_deferred_build_agent_kwargs`) created a pure profile-default agent — stored model AND thinking lost.
2. **Unroutable provider dropped everything.** In `_deferred_build_agent_kwargs`, a stored provider that no longer resolves (renamed/removed entry, bare billing class) failed the routability gate, and the fallback discarded the whole overrides dict — stored model/reasoning/tier reverted instead of just the dead provider pin.

## Fix

- `tui_gateway/methods_session.py`: `_resume_lazy` now records `_stored_session_runtime_overrides(ctx.found)` like the cold/deferred paths (empty for fresh watch windows and for the exempt `follow_profile_config` / room / Bot Chat sessions, so those paths are byte-for-byte unchanged).
- `tui_gateway/server.py`: the gate-fail branch of `_deferred_build_agent_kwargs` now carries the stored `reasoning_config_override` / `service_tier_override` forward (explicit create-params still win); only the dead provider pin falls back. Docstring updated.

Related work, not collisions: @_Ayoola's #101514 is the inverse direction (profile-following) — the exemptions it relies on are untouched; @aurorabotticus-svg's #102137 fixed the adjacent wrong-DB rebuild in the same file family.

## Tests

- `tests/tui_gateway/test_session_resume_runtime_restore.py`: end-to-end through the real `session.resume` RPC + deferred build — cold, deferred-history, lazy-upgrade, and unroutable-provider cases assert the rebuilt agent keeps the stored model + thinking; the `follow_profile_config` case asserts profile-following is preserved. The lazy-upgrade and unroutable-provider cases fail on base (red) and pass with the fix (green).
- Neighbor suites green via `scripts/run_tests.sh`: `tests/test_tui_gateway_server.py` (637), full `tests/tui_gateway/` (982), plus session-override persistence suites (76).