### PR TITLE
feat(local-runtime): server_extra_args escape hatch for llama-server flags

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2292,7 +2292,9 @@ DEFAULT_CONFIG = {
         "region": "global",
     },
     # Managed llama.cpp runtime (docs: user-guide/local-models): official binaries, one supervised
-    # llama-server in router mode. No context/VRAM knobs by design.
+    # llama-server in router mode. No per-model context/VRAM knobs by design — per-model fit
+    # lives in presets; server_extra_args is the bounded escape hatch for machine-topology
+    # flags presets cannot express (e.g. which GPU serves on multi-GPU boxes).
     "local_runtime": {
         # Off = detection-only (Hermes still finds an external llama-server you run).
         "enabled": False,
@@ -2305,6 +2307,10 @@ DEFAULT_CONFIG = {
         "port": 0,  # Port for the managed server. 0 = pick a free port at spawn.
         # Extra ports detection probes for an external llama-server (besides 8080).
         "detect_ports": [],
+        # Extra llama-server flags, e.g. ["--main-gpu", "1"]. Appended verbatim after the
+        # managed flags; --host/--port/--api-key/--models-dir are refused (endpoint
+        # identity). Takes effect on the next server start (Stop, then Start). [] = stock.
+        "server_extra_args": [],
     },
     "_config_version": 40,  # Config schema version - bump this when adding new required fields
 }

--- a/hermes_cli/local_runtime/bootstrap.py
+++ b/hermes_cli/local_runtime/bootstrap.py
@@ -208,7 +208,8 @@ def ensure_local_runtime(config: dict, force: bool = False) -> "object | None":
     try:
         from hermes_cli.local_runtime.binaries import (
             default_tag, ensure_runtime_installed, installed_tags, select_backend)
-        from hermes_cli.local_runtime.supervisor import LlamaServerSupervisor
+        from hermes_cli.local_runtime.supervisor import (
+            LlamaServerSupervisor, normalize_server_extra_args)
 
         backend = section.get("backend", "auto")
         if backend == "auto":
@@ -236,7 +237,9 @@ def ensure_local_runtime(config: dict, force: bool = False) -> "object | None":
 
         sup = LlamaServerSupervisor(install_dir, mdir, preset_path=preset_path,
                                     models_max=int(section.get("models_max", 4)),
-                                    port=int(section.get("port", 0)) or None)
+                                    port=int(section.get("port", 0)) or None,
+                                    extra_args=normalize_server_extra_args(
+                                        section.get("server_extra_args")))
         try:
             sup.start()
         except Exception:

--- a/hermes_cli/local_runtime/supervisor.py
+++ b/hermes_cli/local_runtime/supervisor.py
@@ -90,6 +90,53 @@ def _stable_api_key() -> str:
     return key
 
 
+# Flags the supervisor itself manages — accepting them from user config would desync
+# supervised endpoint identity (base_url/api_key) or the models directory the router
+# serves, stranding resumed sessions the same way a rotated port/key does.
+_MANAGED_SERVER_FLAGS = frozenset({"--host", "--port", "--api-key", "--models-dir"})
+
+_MAX_SERVER_EXTRA_ARGS = 32
+_MAX_SERVER_EXTRA_ARG_LEN = 512
+
+
+def normalize_server_extra_args(value) -> list[str]:
+    """Sanitize the ``local_runtime.server_extra_args`` config value into the argv tail
+    appended after the supervisor's managed flags (last-wins on duplicates).
+
+    Keeps non-empty string items; drops non-list values, non-string/blank items, and
+    managed-identity flags (``--flag`` and ``--flag=value`` forms, plus a following
+    bare value such as the ``8080`` in ``["--port", "8080"]``). Bounds keep a typo
+    from becoming a fork-bomb-length command line. Never raises — a bad config value
+    must degrade to stock flags, never break boot.
+    """
+    if not isinstance(value, list):
+        if value not in (None, [], ""):
+            logger.warning("local_runtime.server_extra_args ignored: expected a list of flags")
+        return []
+    cleaned: list[str] = []
+    skip_next = False
+    for item in value:
+        if skip_next:
+            skip_next = False
+            if isinstance(item, str) and not item.strip().startswith("-"):
+                continue
+        if not isinstance(item, str):
+            continue
+        text = item.strip()
+        if not text or len(text) > _MAX_SERVER_EXTRA_ARG_LEN:
+            continue
+        head = text.split("=", 1)[0]
+        if head in _MANAGED_SERVER_FLAGS:
+            logger.warning("local_runtime.server_extra_args refused managed flag: %s", head)
+            if "=" not in text:
+                skip_next = True
+            continue
+        cleaned.append(text)
+        if len(cleaned) >= _MAX_SERVER_EXTRA_ARGS:
+            break
+    return cleaned
+
+
 class LlamaServerSupervisor:
     """Own one llama-server router process for the life of a Hermes session."""
 

--- a/hermes_cli/web_server_config.py
+++ b/hermes_cli/web_server_config.py
@@ -112,6 +112,14 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "OpenAI transcription model", "whisper-1", "gpt-4o-mini-transcribe", "gpt-4o-transcribe", "gpt-transcribe"
     ),
     "stt.elevenlabs.model_id": _select("ElevenLabs Scribe model", "scribe_v2", "scribe_v1"),
+    "local_runtime.server_extra_args": {
+        "type": "list",
+        "description": (
+            "Extra llama-server flags, e.g. --main-gpu 1 on multi-GPU machines. "
+            "Appended to the managed server argv; host/port/api-key/models-dir are refused. "
+            "Takes effect on the next server start (Stop, then Start in Local Models)."
+        ),
+    },
     "display.skin": _select("CLI visual theme", "default", "ares", "mono", "slate"),
     "dashboard.theme": _select(
         "Web dashboard visual theme", "default", "midnight", "ember", "mono", "cyberpunk", "rose"

--- a/tests/hermes_cli/test_local_runtime.py
+++ b/tests/hermes_cli/test_local_runtime.py
@@ -811,3 +811,120 @@ def test_bootstrap_failure_never_raises(tmp_path, monkeypatch):
         "hermes_cli.local_runtime.binaries.ensure_runtime_installed", boom)
     result = bootstrap.ensure_local_runtime({"local_runtime": {"enabled": True}})
     assert result is None  # no exception escaped
+
+
+# ── server_extra_args contracts (#103270) ────────────────────
+
+
+def test_normalize_server_extra_args_passthrough():
+    """Ordinary device/tuning flags survive verbatim (whitespace trimmed)."""
+    from hermes_cli.local_runtime.supervisor import normalize_server_extra_args
+
+    assert normalize_server_extra_args(["--main-gpu", "1"]) == ["--main-gpu", "1"]
+    assert normalize_server_extra_args(["  --ctx-size  ", "8192"]) == ["--ctx-size", "8192"]
+    assert normalize_server_extra_args(None) == []
+    assert normalize_server_extra_args([]) == []
+
+
+def test_normalize_server_extra_args_drops_managed_identity():
+    """--host/--port/--api-key/--models-dir would desync supervised endpoint
+    identity (the round-7 contract above) — refused in both --flag value and
+    --flag=value forms, including a following bare value."""
+    from hermes_cli.local_runtime.supervisor import normalize_server_extra_args
+
+    assert normalize_server_extra_args(["--port", "8080"]) == []
+    assert normalize_server_extra_args(["--api-key=hunter2"]) == []
+    assert normalize_server_extra_args(["--host", "0.0.0.0", "--main-gpu", "1"]) == ["--main-gpu", "1"]
+    assert normalize_server_extra_args(["--models-dir", "/tmp/x"]) == []
+
+
+def test_normalize_server_extra_args_hygiene_and_bounds():
+    """Non-lists degrade to stock; junk items drop; runaway lengths cap."""
+    from hermes_cli.local_runtime.supervisor import normalize_server_extra_args
+
+    assert normalize_server_extra_args("--main-gpu 1") == []
+    assert normalize_server_extra_args(42) == []
+    assert normalize_server_extra_args(["--main-gpu", 1, "", "   ", None]) == ["--main-gpu"]
+    assert normalize_server_extra_args(["--ok", "x" * 600]) == ["--ok"]
+    many = [f"--flag-{i}" for i in range(100)]
+    assert normalize_server_extra_args(many) == many[:32]
+
+
+def test_spawn_appends_extra_args_after_managed(tmp_path, monkeypatch):
+    """argv contract: managed flags first, user tail last (last-wins), no shell."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    from hermes_cli.local_runtime import supervisor as sup_mod
+
+    captured = {}
+
+    class _FakeProc:
+        pid = 4242
+
+        def poll(self):
+            return None
+
+    def _fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        assert isinstance(cmd, list)  # list-args, never a shell string
+        return _FakeProc()
+
+    monkeypatch.setattr(sup_mod.subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(sup_mod, "server_binary", lambda install_dir: tmp_path / "llama-server")
+
+    sup = sup_mod.LlamaServerSupervisor(
+        tmp_path / "i", tmp_path / "m", port=18434, extra_args=["--main-gpu", "1"])
+    sup._spawn()
+    cmd = captured["cmd"]
+    assert cmd[:3] == [str(tmp_path / "llama-server"), "--host", "127.0.0.1"]
+    assert cmd[-2:] == ["--main-gpu", "1"]
+    assert "--port" in cmd and "18434" in cmd
+
+
+def test_ensure_local_runtime_passes_extra_args(tmp_path, monkeypatch):
+    """Boot plumbing: config server_extra_args reaches the supervisor normalized."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    from hermes_cli.local_runtime import bootstrap
+
+    monkeypatch.setattr(bootstrap, "_SUPERVISOR", None)
+    monkeypatch.setattr(bootstrap, "_detect_gpu_vendor", lambda: "nvidia")
+    monkeypatch.setattr(
+        "hermes_cli.local_runtime.binaries.select_backend", lambda vendor: "cuda")
+    monkeypatch.setattr(
+        "hermes_cli.local_runtime.binaries.default_tag", lambda: "b10679")
+    monkeypatch.setattr(
+        "hermes_cli.local_runtime.binaries.installed_tags", lambda: ["b10679"])
+    monkeypatch.setattr(
+        "hermes_cli.local_runtime.binaries.ensure_runtime_installed",
+        lambda tag, backend, **k: tmp_path / "rt")
+    monkeypatch.setattr(bootstrap, "_generate_presets", lambda mdir, path: None)
+    monkeypatch.setattr(bootstrap, "_start_idle_sweeper", lambda sup: None)
+
+    seen = {}
+
+    class _FakeSupervisor:
+        base_url = "http://127.0.0.1:18434/v1"
+
+        def __init__(self, *a, **k):
+            seen.update(k)
+
+        def start(self):
+            return None
+
+    monkeypatch.setattr(
+        "hermes_cli.local_runtime.supervisor.LlamaServerSupervisor", _FakeSupervisor)
+    result = bootstrap.ensure_local_runtime({
+        "local_runtime": {"enabled": True, "server_extra_args": ["--main-gpu", "1", "--port", "9"]}},
+        force=True)
+    assert result is not None
+    assert seen.get("extra_args") == ["--main-gpu", "1"]
+
+
+def test_config_default_declares_server_extra_args():
+    """Relationship (not snapshot): the local_runtime section declares a list-typed
+    server_extra_args that the schema surfaces to Settings as a list field."""
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+    from hermes_cli.web_server_config import CONFIG_SCHEMA
+
+    section = DEFAULT_CONFIG["local_runtime"]
+    assert isinstance(section.get("server_extra_args"), list)
+    assert CONFIG_SCHEMA["local_runtime.server_extra_args"]["type"] == "list"

--- a/tests/hermes_cli/test_normalize_server_extra_args.py
+++ b/tests/hermes_cli/test_normalize_server_extra_args.py
@@ -1,0 +1,56 @@
+"""Tests for normalize_server_extra_args (#103533)."""
+
+from __future__ import annotations
+
+from hermes_cli.local_runtime.supervisor import normalize_server_extra_args
+
+
+def test_passes_valid_flags():
+    """Valid flags must pass through unchanged."""
+    result = normalize_server_extra_args(["--main-gpu", "0", "--no-mmap"])
+    assert result == ["--main-gpu", "0", "--no-mmap"]
+
+
+def test_refuses_managed_flags():
+    """Managed flags (--host, --port, etc.) must be dropped."""
+    result = normalize_server_extra_args(["--host", "0.0.0.0", "--port", "8080", "--main-gpu", "0"])
+    assert result == ["--main-gpu", "0"]
+
+
+def test_refuses_managed_flags_with_equals():
+    """Managed flags in --flag=value form must be dropped."""
+    result = normalize_server_extra_args(["--host=0.0.0.0", "--port=8080", "--main-gpu=0"])
+    assert result == ["--main-gpu=0"]
+
+
+def test_refuses_managed_flag_aliases():
+    """Alias forms (--api-key, --models-dir) must also be dropped."""
+    result = normalize_server_extra_args(["--api-key", "abc", "--models-dir", "/models"])
+    assert result == []
+
+
+def test_non_list_input_returns_empty():
+    """Non-list inputs (None, string, int) must return empty list."""
+    assert normalize_server_extra_args(None) == []
+    assert normalize_server_extra_args("") == []
+    assert normalize_server_extra_args("--main-gpu") == []
+
+
+def test_blank_and_non_string_items_are_skipped():
+    """Blank strings and non-string items must be filtered out."""
+    result = normalize_server_extra_args(["", "  ", 42, "--main-gpu", "0"])
+    assert result == ["--main-gpu", "0"]
+
+
+def test_overlong_args_are_truncated():
+    """Args exceeding _MAX_SERVER_EXTRA_ARG_LEN must be dropped."""
+    long_arg = "--" + "x" * 2000
+    result = normalize_server_extra_args([long_arg, "--main-gpu", "0"])
+    assert result == ["--main-gpu", "0"]
+
+
+def test_too_many_args_are_capped():
+    """More than _MAX_SERVER_EXTRA_ARGS items must be truncated."""
+    many = [f"--flag-{i}" for i in range(200)]
+    result = normalize_server_extra_args(many)
+    assert len(result) <= 128

--- a/website/docs/user-guide/local-models.md
+++ b/website/docs/user-guide/local-models.md
@@ -114,6 +114,10 @@ local_runtime:
   backend: auto      # auto | cuda | metal | vulkan | hip | cpu
   tag: b10362        # pinned llama.cpp release; Hermes updates it with
                      # each release after re-validation
+  server_extra_args: []  # extra llama-server flags, e.g. ["--main-gpu", "1"]
+                     # on multi-GPU machines. Takes effect on the next
+                     # server start (Stop, then Start in Local Models).
+                     # --host/--port/--api-key/--models-dir are refused.
 ```
 
 Models and runtime builds live under the Hermes home directory


### PR DESCRIPTION
## What does this PR do?

The managed llama-server had no way to receive machine-topology flags that presets cannot express (e.g. `--main-gpu` on multi-GPU boxes, ctx/offload tuning for low-VRAM systems). Per-model unload (eject) and full server stop already exist in the UI; this wires the existing-but-unfed supervisor `extra_args` plumbing through a bounded `config.yaml` knob.

`normalize_server_extra_args()` refuses endpoint-identity flags (`--host`/`--port`/`--api-key`/`--models-dir`, both `--flag value` and `--flag=value` forms) so a bad value can never desync `base_url`/`api_key` and strand resumed sessions; it never raises (bad config degrades to stock flags, never breaks boot). Applies on next server start (Stop, then Start). Settings renders it via the schema-derived list field.

## Related Issue

Fixes #103270

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/local_runtime/supervisor.py`: `normalize_server_extra_args()` + managed-flag deny list and bounds
- `hermes_cli/local_runtime/bootstrap.py`: pass normalized `server_extra_args` into `LlamaServerSupervisor` (all server-start paths funnel through `ensure_local_runtime`, single construction site)
- `hermes_cli/config_defaults.py`: `local_runtime.server_extra_args: []` (no `_config_version` bump — new keys deep-merge)
- `hermes_cli/web_server_config.py`: schema description override (auto-derived `list` type surfaces in Settings)
- `website/docs/user-guide/local-models.md`: documented the key
- `tests/hermes_cli/test_local_runtime.py`: 6 contract tests

## How to Test

1. `pytest tests/hermes_cli/test_local_runtime.py -q` — 59 passed (new tests fail on pre-fix code: verified via sabotage run stashing the fix — 4 fail, then all pass with it).
2. `pytest tests/hermes_cli/test_config.py -q` — 120 passed, 4 skipped.
3. Set `local_runtime.server_extra_args: ["--main-gpu", "1"]`, Stop then Start the server in Local Models, confirm the spawn line in `llama-server.log` carries the flags and `--port` etc. are refused with a warning.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted suites: see above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `local-models.md`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (the `local_runtime` section is not documented in the example file at all; docs live in `local-models.md`)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — flags are passed verbatim to llama-server on all platforms; managed-flag refusal is platform-independent — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
