### PR TITLE
fix(desktop): isolate private SSH forwarding policy

### DIFF
--- a/apps/desktop/electron/ssh-connection.test.ts
+++ b/apps/desktop/electron/ssh-connection.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { execFileSync, spawnSync } from 'node:child_process'
 import { EventEmitter } from 'node:events'
 import fs from 'node:fs'
 import os from 'node:os'
@@ -26,6 +27,59 @@ import {
   target,
   validateSshTarget
 } from './ssh-connection'
+
+const hasOpenSsh = spawnSync('ssh', ['-V'], { encoding: 'utf8' }).status === 0
+
+// Parse the actual OpenSSH policy without opening a connection. Checking for
+// a literal -L argument alone misses ClearAllForwardings discarding it.
+function effectiveForwards(args: string[], config = os.devNull): string[] {
+  return execFileSync('ssh', ['-G', '-F', config, ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
+    .split(/\r?\n/)
+    .filter(line => /^(?:local|remote|dynamic)forward /.test(line))
+    .map(line => line.replaceAll('[', '').replaceAll(']', ''))
+}
+
+test.skipIf(!hasOpenSsh)('command-only SSH calls do not inherit configured forwards', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-ssh-policy-'))
+  const config = path.join(dir, 'config')
+  const conn = { user: 'me', host: 'box', port: 22, keyPath: '', controlPath: path.join(dir, 'master.sock') }
+
+  try {
+    fs.writeFileSync(config, 'Host *\n  LocalForward 127.0.0.1:54100 127.0.0.1:54101\n')
+
+    for (const args of [
+      buildMasterArgs(conn),
+      buildExecArgs(conn, 'exit 0'),
+      buildExecArgs({ ...conn, controlPath: '' }, 'exit 0'),
+      buildInteractiveSshArgs(conn, '')
+    ]) {
+      assert.deepEqual(effectiveForwards(args, config), [], `configured forward leaked: ${args.join(' ')}`)
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test.skipIf(!hasOpenSsh)('mux forward and cancel keep only the explicitly requested tunnel', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-ssh-policy-'))
+  const config = path.join(dir, 'config')
+  const conn = { user: 'me', host: 'box', port: 22, keyPath: '', controlPath: path.join(dir, 'master.sock') }
+  const spec = forwardSpec(54200, 54201)
+
+  try {
+    fs.writeFileSync(
+      config,
+      'Host *\n  LocalForward 127.0.0.1:54100 127.0.0.1:54101\n  ClearAllForwardings yes\n'
+    )
+
+    for (const op of ['forward', 'cancel']) {
+      const args = buildControlArgs(conn, op, ['-L', spec])
+      assert.deepEqual(effectiveForwards(args, config), ['localforward 127.0.0.1:54200 127.0.0.1:54201'])
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
 
 test('redactSecrets scrubs the spawn-time session token env var', () => {
   const line = 'setsid env HERMES_DASHBOARD_SESSION_TOKEN=abc123deadbeef HERMES_DESKTOP=1 hermes dashboard'
@@ -559,6 +613,10 @@ test('no-mux: forward spawns a persistent -N -L child; cancel + close kill it', 
   assert.equal(tunnels.length, 1, 'one persistent tunnel child')
   assert.ok(tunnels[0].args.includes('-L'), 'tunnel child carries -L spec')
   assert.ok(!tunnels[0].args.some(a => /ControlPath/.test(a)))
+
+  if (hasOpenSsh) {
+    assert.deepEqual(effectiveForwards(tunnels[0].args), [`localforward 127.0.0.1:${localPort} 127.0.0.1:9119`])
+  }
 
   await conn.cancelForward(localPort, 9119)
   assert.ok(tunnels[0].child._killed, 'cancelForward kills the tunnel child')

--- a/apps/desktop/electron/ssh-connection.ts
+++ b/apps/desktop/electron/ssh-connection.ts
@@ -253,6 +253,8 @@ function target(user, host) {
 
 function buildExecArgs(conn, remoteCommand, connectTimeoutMs?) {
   return [
+    '-o',
+    'ClearAllForwardings=yes',
     ...baseSshOptions(conn.controlPath, connectTimeoutMs),
     ...hostArgs(conn),
     '--',
@@ -265,6 +267,11 @@ function buildControlArgs(conn, op, extra: string[] = [], connectTimeoutMs?) {
   return [
     '-O',
     op,
+    // The existing master already resolved aliases, keys and jump hosts.
+    // Do not reload configured forwards (or ClearAllForwardings, which would
+    // also discard the explicit -L below) for this socket-only operation.
+    '-F',
+    os.devNull,
     ...extra,
     ...baseSshOptions(conn.controlPath, connectTimeoutMs),
     ...hostArgs(conn),
@@ -281,6 +288,8 @@ function buildMasterArgs(conn, connectTimeoutMs?) {
     '-M',
     '-N',
     '-f',
+    '-o',
+    'ClearAllForwardings=yes',
     ...baseSshOptions(conn.controlPath, connectTimeoutMs),
     ...hostArgs(conn),
     '--',
@@ -297,6 +306,8 @@ function buildMasterArgs(conn, connectTimeoutMs?) {
 function buildInteractiveSshArgs(conn, remoteCwd, connectTimeoutMs?, remoteCommand?) {
   const args = [
     '-tt',
+    '-o',
+    'ClearAllForwardings=yes',
     ...baseSshOptions(conn.controlPath, connectTimeoutMs),
     ...hostArgs(conn),
     '--',


### PR DESCRIPTION
## What does this PR do?

Keep Desktop's private SSH control master and command invocations from inheriting unrelated `LocalForward` entries from the user's SSH configuration. A configured fixed port can already be occupied, causing `ExitOnForwardFailure=yes` to fail an otherwise valid Hermes connection.

- Use `ClearAllForwardings=yes` only on command-only invocations: master startup, exec/probe, and the interim interactive terminal. Normal SSH configuration still supplies aliases, authentication, and jump hosts there.
- For socket-only `-O` operations, use `-F` with Node's cross-platform `os.devNull`. The existing master already resolved the connection. Reloading user forwarding settings is unnecessary and can add unrelated tunnels or discard the requested `-L`.
- Do **not** put `ClearAllForwardings=yes` in shared base options: the no-mux tunnel uses those options, and OpenSSH would silently remove its explicit `-L` too.

## Related Issue

No separate issue. Searched existing PRs for `ClearAllForwardings`; no matching PR found.

## Type of Change

- [x] Bug fix

## How to Test

From `apps/desktop`:

1. `npm run test:desktop:platforms -- electron/ssh-connection.test.ts electron/remote-lifecycle.test.ts --maxWorkers=2`
2. `npm run typecheck`
3. `npx eslint electron/ssh-connection.ts electron/ssh-connection.test.ts`

Verified on macOS 26.5.1 with OpenSSH 10.2p1, against main `f58fcc8118d9db092ad60d363d4a28520e08ac5a`:

- On unmodified production code, the two new regressions fail: a command inherits a configured forward, and a mux command loses its requested tunnel to configured `ClearAllForwardings`.
- After the change: **162 tests passed** across the SSH connection and remote lifecycle files.
- Full Desktop typecheck and focused ESLint: **passed**.
- Independent staged-diff review: no blocking findings. Added-line static scans: no findings.

The regressions use real `ssh -G` parsing with disposable configuration files. They make no SSH connection and do not modify user configuration. They skip if OpenSSH is unavailable. The existing no-mux tunnel test now checks effective OpenSSH forwarding policy as well as raw arguments, protecting against accidentally clearing its explicit tunnel.

Actual remote-host and native Windows E2E connections were not run. The no-mux path is covered locally; its production forwarding arguments are unchanged.

## Checklist

- [x] Read contributing guide and searched existing PRs.
- [x] Conventional commit, scoped to this bug.
- [x] Two new behavioral regression tests, plus a stronger existing no-mux invariant.
- [x] Considered cross-platform behavior; used `os.devNull` instead of a hard-coded POSIX path.
- [x] No configuration schema, architecture, or tool documentation changes needed.
- [ ] Full Python suite (not run; Desktop-only change).
- [ ] Remote-host / native Windows E2E (not run).

## AI assistance

Prepared with Codex assistance. All verification stated above was run locally; independent review did not run tests.
