### PR TITLE
feat(desktop): advanced execution settings parity for cron jobs

### DIFF
--- a/apps/desktop/src/app/cron/cron-job-model.test.ts
+++ b/apps/desktop/src/app/cron/cron-job-model.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  cronAdvancedSummaryRows,
+  cronAdvancedUpdates,
   cronEditorUpdates,
+  emptyCronAdvancedValues,
+  formatRepeatTimes,
   jobIsScriptOnly,
+  parseCommaList,
   parseCronDeliveryTargets,
+  parseRepeatTimes,
+  seedCronAdvancedValues,
   toggleCronDeliveryTarget,
   validateCronEditor
 } from './cron-job-model'
@@ -34,6 +41,36 @@ describe('validateCronEditor', () => {
 
   it('still requires schedule for script-only jobs', () => {
     expect(validateCronEditor({ prompt: '', schedule: '', scriptOnlyJob: true })).toBe('schedule')
+  })
+
+  it('rejects setting both monitor script and monitor URL', () => {
+    expect(
+      validateCronEditor({
+        advanced: { ...emptyCronAdvancedValues(), monitorScript: 'check.sh', monitorUrl: 'https://x/y' },
+        prompt: 'go',
+        schedule: '0 9 * * *',
+        scriptOnlyJob: false
+      })
+    ).toBe('monitor')
+  })
+
+  it('rejects a non-numeric repeat', () => {
+    expect(
+      validateCronEditor({
+        advanced: { ...emptyCronAdvancedValues(), repeat: 'many' },
+        prompt: 'go',
+        schedule: '0 9 * * *',
+        scriptOnlyJob: false
+      })
+    ).toBe('repeat')
+    expect(
+      validateCronEditor({
+        advanced: { ...emptyCronAdvancedValues(), repeat: '3' },
+        prompt: 'go',
+        schedule: '0 9 * * *',
+        scriptOnlyJob: false
+      })
+    ).toBe(null)
   })
 })
 
@@ -117,5 +154,108 @@ describe('cronEditorUpdates', () => {
 
     expect('model' in updates).toBe(false)
     expect('provider' in updates).toBe(false)
+  })
+})
+
+describe('cron advanced helpers', () => {
+  it('parses comma lists with dedupe', () => {
+    expect(parseCommaList('web, file,web ,, ')).toEqual(['web', 'file'])
+    expect(parseCommaList('')).toEqual([])
+  })
+
+  it('round-trips stored repeat shapes', () => {
+    expect(formatRepeatTimes(null)).toBe('')
+    expect(formatRepeatTimes(undefined)).toBe('')
+    expect(formatRepeatTimes(5)).toBe('5')
+    expect(formatRepeatTimes({ completed: 2, times: 5 })).toBe('5')
+    expect(formatRepeatTimes({ completed: 0, times: null })).toBe('')
+    expect(parseRepeatTimes('')).toBe(null)
+    expect(parseRepeatTimes('3')).toBe(3)
+    expect(Number.isNaN(parseRepeatTimes('often'))).toBe(true)
+  })
+
+  it('seeds the form from a stored job', () => {
+    const seed = seedCronAdvancedValues({
+      attach_to_session: true,
+      context_from: ['abc123'],
+      enabled: true,
+      enabled_toolsets: ['web'],
+      id: 'j1',
+      monitor_url: 'https://x/y',
+      reasoning_effort: 'high',
+      repeat: { completed: 1, times: 4 },
+      skills: ['reporter'],
+      workdir: '/tmp/p'
+    })
+
+    expect(seed).toMatchObject({
+      attachToSession: true,
+      contextFrom: 'abc123',
+      enabledToolsets: 'web',
+      monitorScript: '',
+      monitorUrl: 'https://x/y',
+      reasoningEffort: 'high',
+      repeat: '4',
+      skills: 'reporter',
+      workdir: '/tmp/p'
+    })
+  })
+
+  it('sends every non-empty field on create', () => {
+    const updates = cronAdvancedUpdates(
+      { ...emptyCronAdvancedValues(), skills: 'reporter, researcher', repeat: '3', workdir: '/tmp/p' },
+      null
+    )
+
+    expect(updates).toMatchObject({
+      repeat: 3,
+      skills: ['reporter', 'researcher'],
+      workdir: '/tmp/p'
+    })
+    expect('enabled_toolsets' in updates).toBe(false)
+    expect('monitor_script' in updates).toBe(false)
+    expect('attach_to_session' in updates).toBe(false)
+  })
+
+  it('omits untouched fields on edit so stored values survive', () => {
+    const job = {
+      attach_to_session: true,
+      enabled: true,
+      id: 'j1',
+      skills: ['reporter'],
+      workdir: '/tmp/p'
+    }
+
+    const updates = cronAdvancedUpdates(seedCronAdvancedValues(job), job)
+
+    expect(updates).toEqual({})
+  })
+
+  it('sends only the changed field on edit, including clears', () => {
+    const job = { enabled: true, id: 'j1', skills: ['reporter'], workdir: '/tmp/p' }
+    const seed = seedCronAdvancedValues(job)
+
+    expect(cronAdvancedUpdates({ ...seed, workdir: '/tmp/q' }, job)).toEqual({ workdir: '/tmp/q' })
+    expect(cronAdvancedUpdates({ ...seed, workdir: '' }, job)).toEqual({ workdir: null })
+  })
+
+  it('summarizes only the effective settings', () => {
+    expect(cronAdvancedSummaryRows({ enabled: true, id: 'j1' })).toEqual([
+      { key: 'executionMode', value: 'agent' }
+    ])
+    expect(
+      cronAdvancedSummaryRows({
+        enabled: true,
+        id: 'j1',
+        no_agent: true,
+        repeat: { completed: 0, times: 2 },
+        script: 'echo hi',
+        skills: ['reporter']
+      })
+    ).toEqual([
+      { key: 'executionMode', value: 'script' },
+      { key: 'repeat', value: '2' },
+      { key: 'skills', value: 'reporter' }
+    ])
   })
 })

--- a/apps/desktop/src/app/cron/cron-job-model.ts
+++ b/apps/desktop/src/app/cron/cron-job-model.ts
@@ -7,9 +7,10 @@ export function jobIsScriptOnly(job: Pick<CronJob, 'no_agent' | 'script'>): bool
   return Boolean(job.no_agent) && Boolean(asText(job.script).trim())
 }
 
-export type CronEditorValidationError = 'prompt' | 'prompt_and_schedule' | 'schedule'
+export type CronEditorValidationError = 'monitor' | 'prompt' | 'prompt_and_schedule' | 'repeat' | 'schedule'
 
 export interface CronEditorValidationInput {
+  advanced?: CronAdvancedValues
   prompt: string
   schedule: string
   scriptOnlyJob: boolean
@@ -31,10 +32,21 @@ export function validateCronEditor(input: CronEditorValidationInput): CronEditor
     return 'prompt'
   }
 
+  const advanced = input.advanced ?? emptyCronAdvancedValues()
+
+  if (advanced.monitorScript.trim() && advanced.monitorUrl.trim()) {
+    return 'monitor'
+  }
+
+  if (Number.isNaN(parseRepeatTimes(advanced.repeat))) {
+    return 'repeat'
+  }
+
   return null
 }
 
 export interface CronEditorSaveValues {
+  advanced?: CronAdvancedValues
   deliver: string
   /** Per-job model override ('' = follow the global default at fire time). */
   model: string
@@ -43,6 +55,191 @@ export interface CronEditorSaveValues {
   /** Provider for the model override ('' = none). Always paired with model. */
   provider: string
   schedule: string
+}
+
+/** Advanced execution settings — the collapsed section. Text-first shapes keep
+ *  the form serializable; the updates builder converts to backend shapes. */
+export interface CronAdvancedValues {
+  /** Explicit session attach (checkbox). */
+  attachToSession: boolean
+  /** Job ids whose latest output chains into the prompt (comma-separated). */
+  contextFrom: string
+  /** Toolsets enabled for the run (comma-separated). */
+  enabledToolsets: string
+  /** Failure delivery override ('' = fall back to deliver). */
+  failureDeliver: string
+  /** Monitor source run first each tick; output change wakes the agent. */
+  monitorScript: string
+  /** ...or a URL monitor source (mutually exclusive with monitorScript). */
+  monitorUrl: string
+  /** Per-job reasoning pin ('' = none). Validated against the shared parser. */
+  reasoningEffort: string
+  /** Repeat count ('' = forever). */
+  repeat: string
+  /** Skills for the run (comma-separated). */
+  skills: string
+  /** Absolute cwd for tools/scripts. */
+  workdir: string
+}
+
+export function emptyCronAdvancedValues(): CronAdvancedValues {
+  return {
+    attachToSession: false,
+    contextFrom: '',
+    enabledToolsets: '',
+    failureDeliver: '',
+    monitorScript: '',
+    monitorUrl: '',
+    reasoningEffort: '',
+    repeat: '',
+    skills: '',
+    workdir: ''
+  }
+}
+
+/** Split a comma-separated form field into a clean list. */
+export function parseCommaList(value: string): string[] {
+  return [...new Set(
+    value.split(',').map(part => part.trim()).filter(Boolean)
+  )]
+}
+
+/** Stored repeat (bare number, {times, completed}, or null) → form text. */
+export function formatRepeatTimes(repeat: CronJob['repeat']): string {
+  if (repeat === null || repeat === undefined) {
+    return ''
+  }
+
+  const times = typeof repeat === 'number' ? repeat : repeat.times
+
+  return typeof times === 'number' && times > 0 ? String(times) : ''
+}
+
+/** Seed the advanced form from a stored job (edit mode). */
+export function seedCronAdvancedValues(job: CronJob): CronAdvancedValues {
+  const list = (value: unknown): string =>
+    Array.isArray(value)
+      ? value.filter(item => typeof item === 'string' && item.trim()).join(', ')
+      : typeof value === 'string' ? value : ''
+
+  return {
+    attachToSession: job.attach_to_session === true,
+    contextFrom: list(job.context_from),
+    enabledToolsets: list(job.enabled_toolsets),
+    failureDeliver: typeof job.failure_deliver === 'string' ? job.failure_deliver : '',
+    monitorScript: typeof job.monitor_script === 'string' ? job.monitor_script : '',
+    monitorUrl: typeof job.monitor_url === 'string' ? job.monitor_url : '',
+    reasoningEffort: typeof job.reasoning_effort === 'string' ? job.reasoning_effort : '',
+    repeat: formatRepeatTimes(job.repeat),
+    skills: list(job.skills),
+    workdir: typeof job.workdir === 'string' ? job.workdir : ''
+  }
+}
+
+/** Parse a repeat form value: '' → null (forever), digits → int, else NaN. */
+export function parseRepeatTimes(value: string): null | number {
+  const trimmed = value.trim()
+
+  if (!trimmed) {
+    return null
+  }
+
+  if (!/^\d+$/.test(trimmed)) {
+    return Number.NaN
+  }
+
+  const times = Number.parseInt(trimmed, 10)
+
+  return times > 0 ? times : null
+}
+
+/** Stable summary keys for the detail view's effective-settings rows. */
+export type CronAdvancedSummaryKey =
+  | 'attachToSession'
+  | 'contextFrom'
+  | 'enabledToolsets'
+  | 'executionMode'
+  | 'failureDeliver'
+  | 'monitor'
+  | 'reasoningEffort'
+  | 'repeat'
+  | 'skills'
+  | 'workdir'
+
+/** Read-only effective-settings rows for the job detail view (issue point 5):
+ *  only fields the backend actually has set. Execution mode derives from the
+ *  stored mode fields (script-only / monitor / agent) so the row is honest
+ *  even for jobs created via CLI/chat. */
+export function cronAdvancedSummaryRows(job: CronJob): { key: CronAdvancedSummaryKey; value: string }[] {
+  const rows: { key: CronAdvancedSummaryKey; value: string }[] = []
+  const text = (value: unknown): string => (typeof value === 'string' ? value.trim() : '')
+
+  const list = (value: unknown): string =>
+    Array.isArray(value)
+      ? value.filter(item => typeof item === 'string' && item.trim()).join(', ')
+      : text(value)
+
+  if (jobIsScriptOnly(job)) {
+    rows.push({ key: 'executionMode', value: 'script' })
+  } else if (text(job.monitor_script) || text(job.monitor_url)) {
+    rows.push({ key: 'executionMode', value: 'monitor' })
+  } else {
+    rows.push({ key: 'executionMode', value: 'agent' })
+  }
+
+  const repeatText = formatRepeatTimes(job.repeat)
+
+  if (repeatText) {
+    rows.push({ key: 'repeat', value: repeatText })
+  }
+
+  const skills = list(job.skills)
+
+  if (skills) {
+    rows.push({ key: 'skills', value: skills })
+  }
+
+  const toolsets = list(job.enabled_toolsets)
+
+  if (toolsets) {
+    rows.push({ key: 'enabledToolsets', value: toolsets })
+  }
+
+  const workdir = text(job.workdir)
+
+  if (workdir) {
+    rows.push({ key: 'workdir', value: workdir })
+  }
+
+  const contextFrom = list(job.context_from)
+
+  if (contextFrom) {
+    rows.push({ key: 'contextFrom', value: contextFrom })
+  }
+
+  const monitor = text(job.monitor_script) || text(job.monitor_url)
+
+  if (monitor) {
+    rows.push({ key: 'monitor', value: monitor })
+  }
+
+  if (job.attach_to_session === true) {
+    rows.push({ key: 'attachToSession', value: 'on' })
+  }
+
+  const reasoning = text(job.reasoning_effort)
+
+  if (reasoning) {
+    rows.push({ key: 'reasoningEffort', value: reasoning })
+  }
+
+  const failureDeliver = text(job.failure_deliver)
+
+  if (failureDeliver) {
+    rows.push({ key: 'failureDeliver', value: failureDeliver })
+  }
+
+  return rows
 }
 
 export function parseCronDeliveryTargets(value: string): string[] {
@@ -69,7 +266,10 @@ export function toggleCronDeliveryTarget(value: string, target: string, checked:
 }
 
 /** Build the API update payload, preserving an empty prompt on script-only jobs. */
-export function cronEditorUpdates(values: CronEditorSaveValues, options: { scriptOnlyJob: boolean }): CronJobUpdates {
+export function cronEditorUpdates(
+  values: CronEditorSaveValues,
+  options: { initial?: CronJob | null; scriptOnlyJob: boolean }
+): CronJobUpdates {
   const updates: CronJobUpdates = {
     deliver: values.deliver,
     name: values.name,
@@ -89,6 +289,98 @@ export function cronEditorUpdates(values: CronEditorSaveValues, options: { scrip
   if (!options.scriptOnlyJob) {
     updates.model = values.model.trim() || null
     updates.provider = values.provider.trim() || null
+  }
+
+  Object.assign(updates, cronAdvancedUpdates(values.advanced ?? emptyCronAdvancedValues(), options.initial ?? null))
+
+  return updates
+}
+
+/** Advanced-settings payload subset: the ten fields the collapsed section
+ *  owns. Both the create payload and the update payload accept these shapes
+ *  (backend normalizes null/'' to unset). */
+export interface CronAdvancedUpdateFields {
+  attach_to_session?: boolean | null
+  context_from?: string[]
+  enabled_toolsets?: string[]
+  failure_deliver?: null | string
+  monitor_script?: null | string
+  monitor_url?: null | string
+  reasoning_effort?: null | string
+  repeat?: null | number
+  skills?: string[]
+  workdir?: null | string
+}
+
+/** Build the advanced-settings update payload. Change-aware: fields the user
+ *  did not touch are omitted so editing an old job never clobbers stored
+ *  values the form never displayed (issue point 4). With no initial job
+ *  (create mode) every non-empty field is sent. */
+export function cronAdvancedUpdates(
+  advanced: CronAdvancedValues,
+  initial: CronJob | null
+): CronAdvancedUpdateFields {
+  const updates: CronAdvancedUpdateFields = {}
+  const seed = initial ? seedCronAdvancedValues(initial) : emptyCronAdvancedValues()
+  const changed = (key: keyof CronAdvancedValues): boolean => advanced[key] !== seed[key]
+
+  const skills = parseCommaList(advanced.skills)
+
+  if (!initial ? skills.length > 0 : changed('skills')) {
+    updates.skills = skills
+  }
+
+  const toolsets = parseCommaList(advanced.enabledToolsets)
+
+  if (!initial ? toolsets.length > 0 : changed('enabledToolsets')) {
+    updates.enabled_toolsets = toolsets
+  }
+
+  const contextFrom = parseCommaList(advanced.contextFrom)
+
+  if (!initial ? contextFrom.length > 0 : changed('contextFrom')) {
+    updates.context_from = contextFrom
+  }
+
+  const workdir = advanced.workdir.trim()
+
+  if (!initial ? Boolean(workdir) : changed('workdir')) {
+    updates.workdir = workdir || null
+  }
+
+  const monitorScript = advanced.monitorScript.trim()
+  const monitorUrl = advanced.monitorUrl.trim()
+
+  if (!initial ? Boolean(monitorScript) : changed('monitorScript')) {
+    updates.monitor_script = monitorScript || null
+  }
+
+  if (!initial ? Boolean(monitorUrl) : changed('monitorUrl')) {
+    updates.monitor_url = monitorUrl || null
+  }
+
+  const repeat = parseRepeatTimes(advanced.repeat)
+
+  if (!Number.isNaN(repeat) && (!initial ? repeat !== null : changed('repeat'))) {
+    // null clears a stored repeat back to forever; the backend preserves the
+    // completed counter on bare values.
+    updates.repeat = repeat
+  }
+
+  if (!initial ? advanced.attachToSession : changed('attachToSession')) {
+    updates.attach_to_session = advanced.attachToSession
+  }
+
+  const reasoning = advanced.reasoningEffort.trim().toLowerCase()
+
+  if (!initial ? Boolean(reasoning) : changed('reasoningEffort')) {
+    updates.reasoning_effort = reasoning || null
+  }
+
+  const failureDeliver = advanced.failureDeliver.trim()
+
+  if (!initial ? Boolean(failureDeliver) : changed('failureDeliver')) {
+    updates.failure_deliver = failureDeliver || null
   }
 
   return updates

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -17,6 +17,7 @@ import {
   DialogHeader,
   DialogTitle
 } from '@/components/ui/dialog'
+import { DisclosureCaret } from '@/components/ui/disclosure-caret'
 import { Field, FieldHint } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
 import {
@@ -76,9 +77,15 @@ import type { SetStatusbarItemGroup } from '../shell/statusbar-controls'
 import { BlueprintSlotControl, blueprintSlotHelp, cleanBlueprintFieldError, initialBlueprintValues } from './blueprints'
 import { mutateAndRefreshCronJobs, refreshCronJobs, triggerAndRefreshCronJobs } from './cron-actions'
 import {
+  type CronAdvancedSummaryKey,
+  cronAdvancedSummaryRows,
+  cronAdvancedUpdates,
+  type CronAdvancedValues,
   cronEditorUpdates,
+  emptyCronAdvancedValues,
   jobIsScriptOnly,
   parseCronDeliveryTargets,
+  seedCronAdvancedValues,
   toggleCronDeliveryTarget,
   validateCronEditor
 } from './cron-job-model'
@@ -146,6 +153,25 @@ function jobModel(job: CronJob): string {
 
 function jobProvider(job: CronJob): string {
   return asText(job.provider).trim()
+}
+
+/** Detail-view row for one effective-settings summary entry. Mode/attach
+ *  values render through copy so all locales stay consistent. */
+function cronAdvancedSummaryRow(
+  row: { key: CronAdvancedSummaryKey; value: string },
+  c: Translations['cron']
+): { label: string; value: string } {
+  if (row.key === 'executionMode') {
+    const modes = c.advanced.modes as Record<string, string>
+
+    return { label: c.advanced.summary.executionMode, value: modes[row.value] ?? row.value }
+  }
+
+  if (row.key === 'attachToSession') {
+    return { label: c.advanced.summary.attachToSession, value: c.advanced.onValue }
+  }
+
+  return { label: c.advanced.summary[row.key] ?? row.key, value: row.value }
 }
 
 function cronParts(expr: string): null | string[] {
@@ -564,7 +590,8 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
           schedule: values.schedule,
           name: values.name || undefined,
           deliver: values.deliver || DEFAULT_DELIVER,
-          ...(values.model.trim() ? { model: values.model.trim(), provider: values.provider.trim() || undefined } : {})
+          ...(values.model.trim() ? { model: values.model.trim(), provider: values.provider.trim() || undefined } : {}),
+          ...cronAdvancedUpdates(values.advanced ?? emptyCronAdvancedValues(), null)
         })
       )
 
@@ -585,7 +612,7 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
         refreshError,
         stale
       } = await mutateAndRefreshCronJobs(profile, () =>
-        updateCronJob(editor.job.id, cronEditorUpdates(values, { scriptOnlyJob }))
+        updateCronJob(editor.job.id, cronEditorUpdates(values, { initial: editor.job, scriptOnlyJob }))
       )
 
       if (stale || !updated) {
@@ -797,6 +824,9 @@ function CronJobDetail({
   const deliver = jobDeliver(job)
   const prompt = jobPrompt(job)
   const modelOverride = jobModel(job)
+  // Effective execution settings the backend actually has stored — including
+  // jobs created via CLI/chat that the editor never touched (issue point 5).
+  const advancedSummary = cronAdvancedSummaryRows(job)
 
   return (
     <PanelDetail>
@@ -822,7 +852,8 @@ function CronJobDetail({
             { label: c.last.replace(/:$/, ''), value: formatTime(job.last_run_at) },
             { label: c.next.replace(/:$/, ''), value: formatTime(job.next_run_at) },
             { label: c.deliverLabel, value: c.deliveryLabels[deliver] ?? deliver },
-            ...(modelOverride ? [{ label: c.modelLabel, value: modelOverride }] : [])
+            ...(modelOverride ? [{ label: c.modelLabel, value: modelOverride }] : []),
+            ...advancedSummary.map(row => cronAdvancedSummaryRow(row, c))
           ]}
         />
 
@@ -1049,6 +1080,16 @@ function CronEditorDialog({
   const [templateChoice, setTemplateChoice] = useState(CUSTOM_TEMPLATE)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<null | string>(null)
+  // Advanced execution settings (collapsed by default). Auto-opens when
+  // editing a job that already carries advanced settings, so CLI/chat-made
+  // jobs show their full effective config instead of hiding it.
+  const [advanced, setAdvanced] = useState<CronAdvancedValues>(() => emptyCronAdvancedValues())
+  const [showAdvanced, setShowAdvanced] = useState(false)
+
+  const setAdvancedField = (key: keyof CronAdvancedValues, value: boolean | string) => {
+    setAdvanced(prev => ({ ...prev, [key]: value }))
+    setError(null)
+  }
 
   // The blueprint catalog powers the create dialog's "Start from" dropdown; it's
   // meaningless when editing an existing job, so skip the fetch there.
@@ -1094,6 +1135,8 @@ function CronEditorDialog({
     setSchedulePreset(initial ? scheduleOptionForExpr(jobScheduleExpr(initial)).value : 'daily')
     setDeliver(initial ? jobDeliver(initial) : DEFAULT_DELIVER)
     setModelChoice(initial && jobModel(initial) ? `${jobProvider(initial)}:${jobModel(initial)}` : MODEL_DEFAULT_VALUE)
+    setAdvanced(initial ? seedCronAdvancedValues(initial) : emptyCronAdvancedValues())
+    setShowAdvanced(initial ? cronAdvancedSummaryRows(initial).length > 1 : false)
     setSlotValues({})
     setTemplateChoice(editor.mode === 'create' ? (editor.blueprintKey ?? CUSTOM_TEMPLATE) : CUSTOM_TEMPLATE)
     setError(null)
@@ -1142,6 +1185,7 @@ function CronEditorDialog({
     event.preventDefault()
 
     const validationError = validateCronEditor({
+      advanced,
       prompt,
       schedule,
       scriptOnlyJob
@@ -1153,7 +1197,11 @@ function CronEditorDialog({
           ? c.scheduleRequired
           : validationError === 'prompt'
             ? c.promptRequired
-            : c.promptScheduleRequired
+            : validationError === 'monitor'
+              ? c.advanced.monitorExclusive
+              : validationError === 'repeat'
+                ? c.advanced.repeatInvalid
+                : c.promptScheduleRequired
       )
 
       return
@@ -1170,6 +1218,7 @@ function CronEditorDialog({
 
     try {
       await onSave({
+        advanced,
         deliver,
         model: overrideModel,
         name: name.trim(),
@@ -1386,6 +1435,145 @@ function CronEditorDialog({
               </div>
             )}
 
+            <div className="rounded-md border border-input">
+              <button
+                aria-expanded={showAdvanced}
+                className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs font-medium text-foreground"
+                onClick={() => setShowAdvanced(prev => !prev)}
+                type="button"
+              >
+                <DisclosureCaret open={showAdvanced} />
+                {c.advanced.toggle}
+              </button>
+
+              {showAdvanced && (
+                <div className="grid gap-4 border-t border-input px-3 py-3">
+                  <div className="grid items-start gap-4 sm:grid-cols-2">
+                    <Field htmlFor="cron-repeat" label={c.advanced.repeatLabel} optional optionalLabel={c.optional}>
+                      <Input
+                        className="font-mono"
+                        id="cron-repeat"
+                        inputMode="numeric"
+                        onChange={event => setAdvancedField('repeat', event.target.value)}
+                        placeholder={c.advanced.repeatPlaceholder}
+                        value={advanced.repeat}
+                      />
+                    </Field>
+
+                    <Field htmlFor="cron-skills" label={c.advanced.skillsLabel} optional optionalLabel={c.optional}>
+                      <Input
+                        className="font-mono"
+                        id="cron-skills"
+                        onChange={event => setAdvancedField('skills', event.target.value)}
+                        placeholder={c.advanced.skillsPlaceholder}
+                        value={advanced.skills}
+                      />
+                    </Field>
+                  </div>
+
+                  <div className="grid items-start gap-4 sm:grid-cols-2">
+                    <Field htmlFor="cron-workdir" label={c.advanced.workdirLabel} optional optionalLabel={c.optional}>
+                      <Input
+                        className="font-mono"
+                        id="cron-workdir"
+                        onChange={event => setAdvancedField('workdir', event.target.value)}
+                        placeholder={c.advanced.workdirPlaceholder}
+                        value={advanced.workdir}
+                      />
+                    </Field>
+
+                    <Field htmlFor="cron-toolsets" label={c.advanced.toolsetsLabel} optional optionalLabel={c.optional}>
+                      <Input
+                        className="font-mono"
+                        id="cron-toolsets"
+                        onChange={event => setAdvancedField('enabledToolsets', event.target.value)}
+                        placeholder={c.advanced.toolsetsPlaceholder}
+                        value={advanced.enabledToolsets}
+                      />
+                    </Field>
+                  </div>
+
+                  <div className="grid items-start gap-4 sm:grid-cols-2">
+                    <Field htmlFor="cron-context-from" label={c.advanced.contextFromLabel} optional optionalLabel={c.optional}>
+                      <Input
+                        className="font-mono"
+                        id="cron-context-from"
+                        onChange={event => setAdvancedField('contextFrom', event.target.value)}
+                        placeholder={c.advanced.contextFromPlaceholder}
+                        value={advanced.contextFrom}
+                      />
+                    </Field>
+
+                    <Field htmlFor="cron-reasoning" label={c.advanced.reasoningLabel} optional optionalLabel={c.optional}>
+                      <Select
+                        onValueChange={next => setAdvancedField('reasoningEffort', next === '__none__' ? '' : next)}
+                        value={advanced.reasoningEffort || '__none__'}
+                      >
+                        <SelectTrigger className="h-9 rounded-md" id="cron-reasoning">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="__none__">{c.advanced.reasoningNone}</SelectItem>
+                          {['minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'].map(level => (
+                            <SelectItem className="font-mono" key={level} value={level}>
+                              {level}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </Field>
+                  </div>
+
+                  <div className="grid items-start gap-4 sm:grid-cols-2">
+                    <Field htmlFor="cron-monitor-script" label={c.advanced.monitorScriptLabel} optional optionalLabel={c.optional}>
+                      <Input
+                        className="font-mono"
+                        id="cron-monitor-script"
+                        onChange={event => setAdvancedField('monitorScript', event.target.value)}
+                        placeholder={c.advanced.monitorScriptPlaceholder}
+                        value={advanced.monitorScript}
+                      />
+                    </Field>
+
+                    <Field htmlFor="cron-monitor-url" label={c.advanced.monitorUrlLabel} optional optionalLabel={c.optional}>
+                      <Input
+                        className="font-mono"
+                        id="cron-monitor-url"
+                        onChange={event => setAdvancedField('monitorUrl', event.target.value)}
+                        placeholder={c.advanced.monitorUrlPlaceholder}
+                        value={advanced.monitorUrl}
+                      />
+                    </Field>
+                  </div>
+                  <FieldHint>{c.advanced.monitorHint}</FieldHint>
+
+                  <div className="grid items-start gap-4 sm:grid-cols-2">
+                    <Field htmlFor="cron-failure-deliver" label={c.advanced.failureDeliverLabel} optional optionalLabel={c.optional}>
+                      <Input
+                        className="font-mono"
+                        id="cron-failure-deliver"
+                        onChange={event => setAdvancedField('failureDeliver', event.target.value)}
+                        placeholder={c.advanced.failureDeliverPlaceholder}
+                        value={advanced.failureDeliver}
+                      />
+                    </Field>
+
+                    <div className="flex items-center gap-2 pt-6">
+                      <Checkbox
+                        checked={advanced.attachToSession}
+                        id="cron-attach"
+                        onCheckedChange={next => setAdvancedField('attachToSession', next === true)}
+                      />
+                      <label className="text-sm" htmlFor="cron-attach">
+                        {c.advanced.attachLabel}
+                      </label>
+                    </div>
+                  </div>
+                  <FieldHint>{c.advanced.restartHint}</FieldHint>
+                </div>
+              )}
+            </div>
+
             {error && (
               <div className="flex items-start gap-2 rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive">
                 <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
@@ -1416,6 +1604,7 @@ type EditorState =
   | { blueprintKey?: string; mode: 'create' }
 
 interface EditorValues {
+  advanced?: CronAdvancedValues
   deliver: string
   /** Per-job model override ('' = follow the global default). */
   model: string

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2259,6 +2259,50 @@ export const en: Translations = {
       failedLoad: 'Failed to load blueprints',
       emptyTitle: 'No blueprints available',
       emptyDesc: 'No automation blueprints are available on this backend.'
+    },
+    advanced: {
+      toggle: 'Advanced execution settings',
+      repeatLabel: 'Repeat',
+      repeatPlaceholder: 'Empty = forever',
+      repeatInvalid: 'Repeat must be a positive whole number (empty = forever).',
+      skillsLabel: 'Skills',
+      skillsPlaceholder: 'reporter, researcher',
+      workdirLabel: 'Working directory',
+      workdirPlaceholder: '/home/user/project',
+      toolsetsLabel: 'Enabled toolsets',
+      toolsetsPlaceholder: 'web, file',
+      contextFromLabel: 'Context from jobs',
+      contextFromPlaceholder: 'a1b2c3d4e5f6',
+      reasoningLabel: 'Reasoning effort',
+      reasoningNone: 'None (global default)',
+      monitorScriptLabel: 'Monitor script',
+      monitorScriptPlaceholder: '/home/user/bin/check.sh',
+      monitorUrlLabel: 'Monitor URL',
+      monitorUrlPlaceholder: 'https://example.com/status.json',
+      monitorHint: 'A monitor runs before each tick; the agent run is skipped while its output is unchanged. Script and URL are mutually exclusive.',
+      monitorExclusive: 'Pick either a monitor script or a monitor URL, not both.',
+      failureDeliverLabel: 'Failure delivery',
+      failureDeliverPlaceholder: 'Empty = same as Deliver to',
+      attachLabel: 'Attach run to its session',
+      restartHint: 'Advanced settings apply on the next run. Editing never clears values this form does not show.',
+      onValue: 'On',
+      modes: {
+        agent: 'Agent run',
+        monitor: 'Monitor-gated run',
+        script: 'Script-only run'
+      },
+      summary: {
+        attachToSession: 'Session attach',
+        contextFrom: 'Context from',
+        enabledToolsets: 'Toolsets',
+        executionMode: 'Execution',
+        failureDeliver: 'Failure delivery',
+        monitor: 'Monitor',
+        reasoningEffort: 'Reasoning',
+        repeat: 'Repeat',
+        skills: 'Skills',
+        workdir: 'Workdir'
+      }
     }
   },
 

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1934,6 +1934,50 @@ export const ja = defineLocale({
       failedLoad: 'ブレーンプリントの読み込みに失敗しました',
       emptyTitle: '利用できるブレーンプリントはありません',
       emptyDesc: 'このバックエンドで利用できる自動化ブレーンプリントはありません。'
+    },
+    advanced: {
+      toggle: '高度な実行設定',
+      repeatLabel: '繰り返し回数',
+      repeatPlaceholder: '空 = 無制限',
+      repeatInvalid: '繰り返し回数は正の整数で入力してください（空 = 無制限）。',
+      skillsLabel: 'スキル',
+      skillsPlaceholder: 'reporter, researcher',
+      workdirLabel: '作業ディレクトリ',
+      workdirPlaceholder: '/home/user/project',
+      toolsetsLabel: '有効なツールセット',
+      toolsetsPlaceholder: 'web, file',
+      contextFromLabel: '参照元ジョブ',
+      contextFromPlaceholder: 'a1b2c3d4e5f6',
+      reasoningLabel: 'リーズニング強度',
+      reasoningNone: 'なし（全体の既定値）',
+      monitorScriptLabel: 'モニタースクリプト',
+      monitorScriptPlaceholder: '/home/user/bin/check.sh',
+      monitorUrlLabel: 'モニター URL',
+      monitorUrlPlaceholder: 'https://example.com/status.json',
+      monitorHint: 'モニターは各ティックの前に実行され、出力が変わらない間はエージェント実行をスキップします。スクリプトと URL は排他です。',
+      monitorExclusive: 'モニタースクリプトとモニター URL のどちらか一方を選んでください。',
+      failureDeliverLabel: '失敗時の配信先',
+      failureDeliverPlaceholder: '空 =「配信先」と同じ',
+      attachLabel: '実行をそのセッションに紐付ける',
+      restartHint: '高度な設定は次回実行から適用されます。編集でフォームにない値が消えることはありません。',
+      onValue: 'オン',
+      modes: {
+        agent: 'エージェント実行',
+        monitor: 'モニター付き実行',
+        script: 'スクリプトのみ実行'
+      },
+      summary: {
+        attachToSession: 'セッション紐付け',
+        contextFrom: '参照元',
+        enabledToolsets: 'ツールセット',
+        executionMode: '実行方式',
+        failureDeliver: '失敗時の配信先',
+        monitor: 'モニター',
+        reasoningEffort: 'リーズニング',
+        repeat: '繰り返し回数',
+        skills: 'スキル',
+        workdir: '作業ディレクトリ'
+      }
     }
   },
 

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -2297,6 +2297,50 @@ export const ru = defineLocale({
       failedLoad: 'Не удалось загрузить шаблоны',
       emptyTitle: 'Шаблоны недоступны',
       emptyDesc: 'На этом бэкенде нет шаблонов автоматизации.'
+    },
+    advanced: {
+      toggle: 'Расширенные настройки выполнения',
+      repeatLabel: 'Повторы',
+      repeatPlaceholder: 'Пусто = бесконечно',
+      repeatInvalid: 'Число повторов — целое положительное число (пусто = бесконечно).',
+      skillsLabel: 'Навыки',
+      skillsPlaceholder: 'reporter, researcher',
+      workdirLabel: 'Рабочий каталог',
+      workdirPlaceholder: '/home/user/project',
+      toolsetsLabel: 'Наборы инструментов',
+      toolsetsPlaceholder: 'web, file',
+      contextFromLabel: 'Контекст из задач',
+      contextFromPlaceholder: 'a1b2c3d4e5f6',
+      reasoningLabel: 'Усилие рассуждений',
+      reasoningNone: 'Нет (глобальное значение)',
+      monitorScriptLabel: 'Скрипт монитора',
+      monitorScriptPlaceholder: '/home/user/bin/check.sh',
+      monitorUrlLabel: 'URL монитора',
+      monitorUrlPlaceholder: 'https://example.com/status.json',
+      monitorHint: 'Монитор запускается перед каждым тиком; запуск агента пропускается, пока вывод не изменился. Скрипт и URL взаимоисключающие.',
+      monitorExclusive: 'Выберите либо скрипт монитора, либо URL монитора.',
+      failureDeliverLabel: 'Доставка при сбое',
+      failureDeliverPlaceholder: 'Пусто = как в «Доставить в»',
+      attachLabel: 'Привязать запуск к его сессии',
+      restartHint: 'Расширенные настройки действуют со следующего запуска. Редактирование не стирает значения, которых нет в форме.',
+      onValue: 'Вкл',
+      modes: {
+        agent: 'Запуск агентом',
+        monitor: 'Запуск с монитором',
+        script: 'Только скрипт'
+      },
+      summary: {
+        attachToSession: 'Привязка к сессии',
+        contextFrom: 'Контекст из',
+        enabledToolsets: 'Инструменты',
+        executionMode: 'Выполнение',
+        failureDeliver: 'Доставка при сбое',
+        monitor: 'Монитор',
+        reasoningEffort: 'Рассуждения',
+        repeat: 'Повторы',
+        skills: 'Навыки',
+        workdir: 'Каталог'
+      }
     }
   },
   artifacts: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1914,6 +1914,50 @@ export interface Translations {
       emptyTitle: string
       emptyDesc: string
     }
+    advanced: {
+      toggle: string
+      repeatLabel: string
+      repeatPlaceholder: string
+      repeatInvalid: string
+      skillsLabel: string
+      skillsPlaceholder: string
+      workdirLabel: string
+      workdirPlaceholder: string
+      toolsetsLabel: string
+      toolsetsPlaceholder: string
+      contextFromLabel: string
+      contextFromPlaceholder: string
+      reasoningLabel: string
+      reasoningNone: string
+      monitorScriptLabel: string
+      monitorScriptPlaceholder: string
+      monitorUrlLabel: string
+      monitorUrlPlaceholder: string
+      monitorHint: string
+      monitorExclusive: string
+      failureDeliverLabel: string
+      failureDeliverPlaceholder: string
+      attachLabel: string
+      restartHint: string
+      onValue: string
+      modes: {
+        agent: string
+        monitor: string
+        script: string
+      }
+      summary: {
+        attachToSession: string
+        contextFrom: string
+        enabledToolsets: string
+        executionMode: string
+        failureDeliver: string
+        monitor: string
+        reasoningEffort: string
+        repeat: string
+        skills: string
+        workdir: string
+      }
+    }
   }
 
   artifacts: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1859,6 +1859,50 @@ export const zhHant = defineLocale({
       failedLoad: '載入藍圖失敗',
       emptyTitle: '沒有可用的藍圖',
       emptyDesc: '此後端上沒有可用的自動化藍圖。'
+    },
+    advanced: {
+      toggle: '進階執行設定',
+      repeatLabel: '重複次數',
+      repeatPlaceholder: '留空 = 無限',
+      repeatInvalid: '重複次數必須為正整數（留空 = 無限）。',
+      skillsLabel: '技能',
+      skillsPlaceholder: 'reporter, researcher',
+      workdirLabel: '工作目錄',
+      workdirPlaceholder: '/home/user/project',
+      toolsetsLabel: '啟用的工具集',
+      toolsetsPlaceholder: 'web, file',
+      contextFromLabel: '上下文來源工作',
+      contextFromPlaceholder: 'a1b2c3d4e5f6',
+      reasoningLabel: '推理強度',
+      reasoningNone: '無（跟隨全域預設）',
+      monitorScriptLabel: '監視指令碼',
+      monitorScriptPlaceholder: '/home/user/bin/check.sh',
+      monitorUrlLabel: '監視 URL',
+      monitorUrlPlaceholder: 'https://example.com/status.json',
+      monitorHint: '監視器在每次觸發前執行；輸出未變化時略過智慧體執行。指令碼與 URL 互斥。',
+      monitorExclusive: '監視指令碼與監視 URL 只能二選一。',
+      failureDeliverLabel: '失敗投遞',
+      failureDeliverPlaceholder: '留空 = 與「投遞到」相同',
+      attachLabel: '將執行附加到其工作階段',
+      restartHint: '進階設定在下次執行生效。編輯不會清除表單未顯示的值。',
+      onValue: '開',
+      modes: {
+        agent: '智慧體執行',
+        monitor: '監視門控執行',
+        script: '僅指令碼執行'
+      },
+      summary: {
+        attachToSession: '工作階段附加',
+        contextFrom: '上下文來源',
+        enabledToolsets: '工具集',
+        executionMode: '執行方式',
+        failureDeliver: '失敗投遞',
+        monitor: '監視器',
+        reasoningEffort: '推理強度',
+        repeat: '重複次數',
+        skills: '技能',
+        workdir: '工作目錄'
+      }
     }
   },
 

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2426,6 +2426,50 @@ export const zh: Translations = {
       failedLoad: '加载蓝图失败',
       emptyTitle: '没有可用的蓝图',
       emptyDesc: '此后端上没有可用的自动化蓝图。'
+    },
+    advanced: {
+      toggle: '高级执行设置',
+      repeatLabel: '重复次数',
+      repeatPlaceholder: '留空 = 无限',
+      repeatInvalid: '重复次数必须为正整数（留空 = 无限）。',
+      skillsLabel: '技能',
+      skillsPlaceholder: 'reporter, researcher',
+      workdirLabel: '工作目录',
+      workdirPlaceholder: '/home/user/project',
+      toolsetsLabel: '启用的工具集',
+      toolsetsPlaceholder: 'web, file',
+      contextFromLabel: '上下文来源任务',
+      contextFromPlaceholder: 'a1b2c3d4e5f6',
+      reasoningLabel: '推理强度',
+      reasoningNone: '无（跟随全局默认）',
+      monitorScriptLabel: '监视脚本',
+      monitorScriptPlaceholder: '/home/user/bin/check.sh',
+      monitorUrlLabel: '监视 URL',
+      monitorUrlPlaceholder: 'https://example.com/status.json',
+      monitorHint: '监视器在每次触发前运行；输出未变化时跳过智能体运行。脚本与 URL 互斥。',
+      monitorExclusive: '监视脚本与监视 URL 只能二选一。',
+      failureDeliverLabel: '失败投递',
+      failureDeliverPlaceholder: '留空 = 与“投递到”相同',
+      attachLabel: '将运行附加到其会话',
+      restartHint: '高级设置在下次运行生效。编辑不会清除表单未显示的值。',
+      onValue: '开',
+      modes: {
+        agent: '智能体运行',
+        monitor: '监视门控运行',
+        script: '仅脚本运行'
+      },
+      summary: {
+        attachToSession: '会话附加',
+        contextFrom: '上下文来源',
+        enabledToolsets: '工具集',
+        executionMode: '执行方式',
+        failureDeliver: '失败投递',
+        monitor: '监视器',
+        reasoningEffort: '推理强度',
+        repeat: '重复次数',
+        skills: '技能',
+        workdir: '工作目录'
+      }
     }
   },
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -889,6 +889,18 @@ export interface CronJob {
   schedule_display?: null | string
   script?: null | string
   state?: null | string
+  // Advanced execution settings (backend create_job/update_job contract).
+  attach_to_session?: boolean | null
+  base_url?: null | string
+  context_from?: null | string | string[]
+  enabled_toolsets?: null | string[]
+  failure_deliver?: null | string
+  monitor_script?: null | string
+  monitor_url?: null | string
+  reasoning_effort?: null | string
+  repeat?: null | number | { completed?: number; times?: null | number }
+  skills?: null | string[]
+  workdir?: null | string
 }
 
 export interface CronJobCreatePayload {
@@ -898,6 +910,22 @@ export interface CronJobCreatePayload {
   prompt: string
   provider?: string
   schedule: string
+  // Advanced execution settings (backend CronJobCreate contract; null behaves
+  // like unset — the backend normalizes it — so the change-aware updates
+  // builder can spread straight into creates).
+  attach_to_session?: boolean | null
+  base_url?: string
+  context_from?: string[]
+  enabled_toolsets?: string[]
+  failure_deliver?: null | string
+  monitor_script?: null | string
+  monitor_url?: null | string
+  no_agent?: boolean
+  reasoning_effort?: null | string
+  repeat?: null | number
+  script?: string
+  skills?: string[]
+  workdir?: null | string
 }
 
 export interface CronJobSchedule {
@@ -914,6 +942,20 @@ export interface CronJobUpdates {
   prompt?: string
   provider?: null | string
   schedule?: string
+  // Advanced execution settings (backend update_job contract).
+  attach_to_session?: boolean | null
+  base_url?: null | string
+  context_from?: string[]
+  enabled_toolsets?: string[]
+  failure_deliver?: null | string
+  monitor_script?: null | string
+  monitor_url?: null | string
+  no_agent?: boolean
+  reasoning_effort?: null | string
+  repeat?: null | number
+  script?: null | string
+  skills?: string[]
+  workdir?: null | string
 }
 
 // A cron delivery target from GET /api/cron/delivery-targets — the single

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -294,6 +294,14 @@ class CronJobCreate(BaseModel):
     enabled_toolsets: Optional[List[str]] = None
     workdir: Optional[str] = None
     no_agent: bool = False
+    # Advanced execution settings (Desktop parity with create_job): all optional,
+    # validated by create_job's own normalizers/invariants.
+    repeat: Optional[int] = None
+    attach_to_session: Optional[bool] = None
+    monitor_script: Optional[str] = None
+    monitor_url: Optional[str] = None
+    reasoning_effort: Optional[str] = None
+    failure_deliver: Optional[str] = None
 
 class CronJobUpdate(BaseModel):
     updates: dict

--- a/hermes_cli/web_server_cron.py
+++ b/hermes_cli/web_server_cron.py
@@ -258,7 +258,13 @@ def _create_cron_job_sync(body: CronJobCreate, profile: Optional[str] = None):
             context_from=context_from,
             enabled_toolsets=_cron_string_list(body.enabled_toolsets),
             workdir=_cron_optional_text(body.workdir),
-            no_agent=no_agent)
+            no_agent=no_agent,
+            repeat=body.repeat,
+            attach_to_session=body.attach_to_session,
+            monitor_script=_cron_optional_text(body.monitor_script),
+            monitor_url=_cron_optional_text(body.monitor_url),
+            reasoning_effort=_cron_optional_text(body.reasoning_effort),
+            failure_deliver=_cron_optional_text(body.failure_deliver))
     except HTTPException:
         raise
     except Exception as e:

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -1190,3 +1190,65 @@ async def test_create_cron_job_without_profile_defaults_when_unscoped(
 
     assert job["profile"] == "default"
     assert (isolated_profiles["default"] / "cron" / "jobs.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_create_cron_job_accepts_advanced_execution_fields(
+    isolated_profiles, tmp_path
+):
+    """Desktop parity (#103341): the dashboard create route forwards the advanced
+    execution settings to create_job, which validates them with its own
+    normalizers/invariants."""
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+
+    job = await _rt_cron.create_cron_job(
+        _web_models.CronJobCreate(
+            schedule="every 1h",
+            name="advanced-fields",
+            prompt="run it",
+            repeat=3,
+            skills=["reporter"],
+            workdir=str(workdir),
+            attach_to_session=True,
+            monitor_url="https://example.invalid/status.json",
+            reasoning_effort="high",
+            failure_deliver="local",
+        ),
+        profile="worker_alpha",
+    )
+
+    assert job["repeat"] == {"times": 3, "completed": 0}
+    assert job["skills"] == ["reporter"]
+    assert job["workdir"] == str(workdir)
+    assert job["attach_to_session"] is True
+    assert job["monitor_url"] == "https://example.invalid/status.json"
+    assert job["reasoning_effort"] == "high"
+    assert job["failure_deliver"] == "local"
+
+
+@pytest.mark.asyncio
+async def test_create_cron_job_rejects_conflicting_monitor_fields(
+    isolated_profiles,
+):
+    """Mode invariants hold through the dashboard door: monitor + no_agent fails
+    before anything is stored."""
+    scripts_dir = isolated_profiles["worker_alpha"] / "scripts"
+    scripts_dir.mkdir(exist_ok=True)
+    (scripts_dir / "collect.py").write_text("print('ok')\n", encoding="utf-8")
+
+    with pytest.raises(HTTPException) as exc:
+        await _rt_cron.create_cron_job(
+            _web_models.CronJobCreate(
+                schedule="every 1h",
+                name="bad-monitor",
+                prompt="run it",
+                monitor_url="https://example.invalid/status.json",
+                no_agent=True,
+                script="collect.py",
+            ),
+            profile="worker_alpha",
+        )
+
+    assert exc.value.status_code == 400
+    assert "monitor" in exc.value.detail


### PR DESCRIPTION
## What does this PR do?

The Desktop Scheduled Jobs editor covered name/prompt/schedule/delivery plus a model pin; every other first-class per-job capability (`repeat`, `skills`, `script`/`no_agent`, `context_from`, `enabled_toolsets`, `workdir`, `attach_to_session`, `monitor_script`/`monitor_url`, `reasoning_effort`, `failure_deliver`) required CLI/chat/config files, and editing an advanced job risked presenting an incomplete view of what will actually execute.

Adds a collapsed **Advanced execution settings** section reusing the existing backend contracts — no second scheduler or validator. Script-only and monitor modes are explicit with their mutually exclusive fields; the backend stays the source of truth for validation and schedule preview. Updates are change-aware (untouched fields omitted) so editing never clobbers stored values the form never displayed, including fields set by older clients. The detail view shows a read-only effective-settings summary that also covers CLI/chat-created jobs.

## Related Issue

Fixes #103341

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/web_models.py`: `CronJobCreate` gains six optional fields (`repeat`, `attach_to_session`, `monitor_script`, `monitor_url`, `reasoning_effort`, `failure_deliver`)
- `hermes_cli/web_server_cron.py`: `_create_cron_job_sync` normalizes + forwards them (mode invariants re-validated in `create_job`; the update door already accepted the rest via `update_job`)
- `apps/desktop/src/types/hermes.ts`: `CronJob`/`CronJobCreatePayload`/`CronJobUpdates` extended with the ten advanced fields
- `apps/desktop/src/app/cron/cron-job-model.ts`: advanced form values, seed/parse/format helpers, change-aware `cronAdvancedUpdates`, detail-view `cronAdvancedSummaryRows`, monitor/repeat validation
- `apps/desktop/src/app/cron/index.tsx`: collapsed Advanced section (DisclosureCaret, auto-opens when the job already carries advanced settings), submit wiring for create + edit, effective-settings rows on the detail view
- `apps/desktop/src/i18n/{en,zh,zh-hant,ru,ja}.ts` + `types.ts`: copy for the new section (ar falls back to English by design via `defineLocale`)
- `tests/hermes_cli/test_web_server_cron_profiles.py`: create-path accepts advanced fields; monitor+no_agent rejected with 400
- `apps/desktop/src/app/cron/cron-job-model.test.ts`: 9 new cases (validation, seed/parse, create/edit/change-aware updates incl. clears, summary rows)

## How to Test

1. `pytest tests/hermes_cli/test_web_server_cron_profiles.py -q` — 33 passed (new tests fail on pre-fix backend: verified via sabotage run stashing the backend change).
2. `npx vitest run src/app/cron/` — 41 passed.
3. `npx eslint src/app/cron/ ...` — clean; `npx tsc --noEmit -p tsconfig.json` — clean.
4. Manual: open Scheduled Jobs → New cron → Advanced execution settings → set repeat/skills/monitor → create; edit a CLI-created advanced job and confirm the section auto-opens with its values and untouched fields survive saving.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted suites: see above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (no user-docs page covers the cron editor field-by-field; inline hints carry the guidance)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (Desktop form + backend validation, platform-independent)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
