### PR TITLE
fix(desktop-update): notify renderer-less success

### DIFF
--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -128,22 +128,27 @@ notify_fallback() { # status message — renderer-free recovery surface.
   # and must not eat the message). The GUARANTEED channel is the result
   # file: a manual/error outcome is durably marked and the next Desktop
   # boot surfaces it in a dialog (handoff-result.ts + main.ts).
-  case "$1" in manual|error) ;; *) return 0 ;; esac
+  # `done` is the renderer-less success path (#103058): publish "done" used
+  # to return here before any OS notification, so Chromium-less machines
+  # got silence until relaunch.
+  case "$1" in done|manual|error) ;; *) return 0 ;; esac
+  local _msg="$2"
+  [ "$1" = "done" ] && [ -z "$_msg" ] && _msg="Hermes update complete."
   if [ "$(uname)" = "Darwin" ]; then
-    /usr/bin/osascript -e "display notification \"$(printf '%s' "$2" | sed 's/"/\\"/g')\" with title \"Hermes update\"" 2>/dev/null && return 0
+    /usr/bin/osascript -e "display notification \"$(printf '%s' "$_msg" | sed 's/"/\\"/g')\" with title \"Hermes update\"" 2>/dev/null && return 0
   else
     if command -v notify-send >/dev/null 2>&1; then
-      notify-send -u critical "Hermes update" "$2" 2>/dev/null && return 0
+      notify-send -u critical "Hermes update" "$_msg" 2>/dev/null && return 0
     fi
     local p
     if command -v zenity >/dev/null 2>&1; then
-      zenity --warning --title="Hermes update" --text="$2" 2>/dev/null &
+      zenity --warning --title="Hermes update" --text="$_msg" 2>/dev/null &
       p=$!; sleep 1
       kill -0 "$p" 2>/dev/null && return 0
       wait "$p" 2>/dev/null
     fi
     if command -v kdialog >/dev/null 2>&1; then
-      kdialog --title "Hermes update" --sorry "$2" 2>/dev/null &
+      kdialog --title "Hermes update" --sorry "$_msg" 2>/dev/null &
       p=$!; sleep 1
       kill -0 "$p" 2>/dev/null && return 0
       wait "$p" 2>/dev/null
@@ -151,7 +156,7 @@ notify_fallback() { # status message — renderer-free recovery surface.
   fi
   # No immediate surface landed. The durable channel takes over: the result
   # is marked manual/failed and the next boot shows it in a real dialog.
-  log "NOTICE: no notification surface accepted; outcome reaches the user via the result dialog on next launch: $2"
+  log "NOTICE: no notification surface accepted; outcome reaches the user via the result dialog on next launch: $_msg"
 }
 
 write_status() { # status message -- atomic replace; the server reads per poll

--- a/tests/test_desktop_update_shim_progress.py
+++ b/tests/test_desktop_update_shim_progress.py
@@ -197,3 +197,47 @@ def test_retry_gate_publishes_a_distinct_stage(tmp_path):
         "Updating code and dependencies",
         "Retrying update",
     ]
+
+
+def _extract_notify_fallback(src: str) -> str:
+    start = src.index("notify_fallback() {")
+    end = src.index("\nwrite_status()", start)
+    return src[start:end].rstrip() + "\n"
+
+
+@requires_posix_handoff
+def test_notify_fallback_fires_on_done_without_a_shim(tmp_path):
+    """Renderer-less success publishes status=done; that must reach the OS notifier.
+
+    #103058: notify_fallback used to return immediately unless the status was
+    manual|error, so Chromium-less machines got silence until relaunch.
+    """
+    src = _extract_notify_fallback((SHIM_DIR / "posix.sh").read_text())
+    record = tmp_path / "osascript.log"
+    stub = tmp_path / "osascript"
+    stub.write_text(
+        "#!/bin/bash\n"
+        f"printf '%s\\n' \"$*\" >> '{record}'\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+    src = src.replace("/usr/bin/osascript", str(stub))
+    harness = tmp_path / "harness.sh"
+    harness.write_text(
+        "#!/bin/bash\n"
+        "set -u\n"
+        "log() { :; }\n"
+        "uname() { echo Darwin; }\n"
+        f"{src}\n"
+        "notify_fallback running 'should-not-notify'\n"
+        "notify_fallback done ''\n"
+        "notify_fallback error 'Update failed.'\n",
+        encoding="utf-8",
+    )
+    harness.chmod(0o755)
+    subprocess.run(["/bin/bash", str(harness)], check=True, timeout=10)
+    logged = record.read_text(encoding="utf-8")
+    assert "Hermes update complete." in logged
+    assert "Update failed." in logged
+    assert "should-not-notify" not in logged


### PR DESCRIPTION
## What does this PR do?

On machines without a Chromium-family default browser, the posix desktop-update hand-off skips the shim window and is supposed to notify via `notify_fallback`. That helper returned immediately unless the terminal status was `manual` or `error`. The success path publishes `done` with an empty message, so a 2–60 minute update produced no notification at all until the app relaunched.

`notify_fallback` now handles `done` as well, with a default "Hermes update complete." message when the caller passes an empty string.

## Related Issue

Fixes #103058

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `scripts/desktop-update/posix.sh` — `notify_fallback` accepts `done|manual|error`
- `tests/test_desktop_update_shim_progress.py` — Darwin notifier stub: `done` and `error` fire, `running` does not

## How to Test

```
uv run --extra dev python -m pytest tests/test_desktop_update_shim_progress.py -q
# 6 passed
```

Not runtime-tested on a Chromium-less macOS install.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
