### PR TITLE
fix(feishu): delete truncated stream previews on fallback

### DIFF
--- a/gateway/stream_consumer_fallback.py
+++ b/gateway/stream_consumer_fallback.py
@@ -99,7 +99,8 @@ class StreamFallbackMixin:
         sent_any_chunk = False
         for chunk in chunks:
             result = await self._send_with_flood_retry(
-                content=chunk, retry_log="Flood control on fallback send, retrying in %.1fs")
+                content=chunk, reply_to=self._initial_reply_to_id,
+                retry_log="Flood control on fallback send, retrying in %.1fs")
             if not result or not result.success:
                 # Partial continuation landed: do NOT set _final_response_sent (the
                 # gateway must still deliver the full answer); _already_sent only

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -63,7 +63,8 @@ _LARK_SDK_IMPORTS = (
     ("lark_oapi.api.im.v1", (
         "CreateFileRequest", "CreateFileRequestBody", "CreateImageRequest", "CreateImageRequestBody",
         "CreateMessageRequest", "CreateMessageRequestBody", "GetChatRequest", "GetMessageRequest",
-        "GetMessageResourceRequest", "P2ImMessageMessageReadV1", "ReplyMessageRequest", "ReplyMessageRequestBody",
+        "DeleteMessageRequest", "GetMessageResourceRequest", "P2ImMessageMessageReadV1",
+        "ReplyMessageRequest", "ReplyMessageRequestBody",
         "UpdateMessageRequest", "UpdateMessageRequestBody",
     )),
     ("lark_oapi.core", ("AccessTokenType", "HttpMethod")),
@@ -1632,6 +1633,23 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.error("[Feishu] Failed to edit message %s: %s", message_id, exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
+
+    async def delete_message(self, chat_id: str, message_id: str) -> bool:
+        """Delete a bot-posted message so stream-consumer fallback/fresh-final can
+        remove a truncated edit bubble instead of leaving it next to the full send.
+
+        Feishu has no ``delete_message`` today, so ``_delete_previews`` no-ops and a
+        failed finalize-edit + fallback send (#103068) keeps both bubbles.
+        """
+        if not self._client or not message_id:
+            return False
+        try:
+            request = self._build_delete_message_request(message_id)
+            response = await self._run_blocking(self._client.im.v1.message.delete, request)
+            return self._response_succeeded(response)
+        except Exception:
+            logger.debug("[Feishu] Failed to delete message %s", message_id, exc_info=True)
+            return False
 
     # Template attrs for the shared _format_exec_approval core. The card
     # header carries the title, so the text core starts at the code fence.
@@ -3835,6 +3853,10 @@ class FeishuAdapter(BasePlatformAdapter):
     @staticmethod
     def _build_update_message_request(message_id: str, request_body: Any) -> Any:
         return _sdk_build(UpdateMessageRequest, message_id=message_id, request_body=request_body)
+
+    @staticmethod
+    def _build_delete_message_request(message_id: str) -> Any:
+        return _sdk_build(DeleteMessageRequest, message_id=message_id)
 
     @staticmethod
     def _build_create_message_body(*, receive_id: str, msg_type: str, content: str, uuid_value: str) -> Any:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -286,6 +286,42 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         )
 
 
+@patch.dict(os.environ, {}, clear=True)
+class TestDeleteMessage(unittest.TestCase):
+    def test_delete_message_calls_im_message_delete(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        captured = {"ids": []}
+
+        class _MessageAPI:
+            def delete(self, request):
+                captured["ids"].append(getattr(request, "message_id", None))
+                return SimpleNamespace(success=lambda: True)
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch.object(adapter, "_run_blocking", side_effect=_direct):
+            ok = asyncio.run(adapter.delete_message("oc_chat", "om_preview"))
+
+        self.assertTrue(ok)
+        self.assertEqual(captured["ids"], ["om_preview"])
+
+    def test_delete_message_returns_false_when_disconnected(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = None
+        self.assertFalse(asyncio.run(adapter.delete_message("oc_chat", "om_preview")))
+
+
 class TestAdapterModule(unittest.TestCase):
     def test_load_settings_uses_sdk_defaults_for_invalid_ws_reconnect_values(self):
         from plugins.platforms.feishu.adapter import FeishuAdapter

--- a/tests/gateway/test_telegram_final_delivery.py
+++ b/tests/gateway/test_telegram_final_delivery.py
@@ -150,6 +150,28 @@ async def test_complete_preview_survives_long_flood_fallback_failure(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_full_fallback_resend_threads_and_deletes_truncated_preview():
+    """When the visible prefix is not a prefix of the final (Feishu post vs
+    cleaned text), fallback resends the whole answer. Thread it to the user
+    message and delete the truncated edit bubble (#103068)."""
+    adapter = _adapter()
+    adapter.send.return_value = SendResult(success=True, message_id="full-1")
+
+    consumer = GatewayStreamConsumer(
+        adapter, "chat-1", initial_reply_to_id="user-1",
+    )
+    consumer._message_id = "preview-1"
+    consumer._last_sent_text = "truncated snapshot"
+    consumer._already_sent = True
+    consumer._fallback_final_send = True
+
+    await consumer._send_fallback_final("full completed answer that does not start with the snapshot")
+
+    assert adapter.send.await_args.kwargs["reply_to"] == "user-1"
+    adapter.delete_message.assert_awaited()
+
+
+@pytest.mark.asyncio
 async def test_telegram_long_flood_result_keeps_retry_after():
     """The real adapter contract preserves the server delay for consumers."""
     class FloodError(Exception):


### PR DESCRIPTION
## What does this PR do?

Feishu DM streaming with `transport: edit` can leave two bubbles: a truncated edited preview and a full unthreaded final. The gateway then logs `Suppressing normal final send` because the stream consumer already marked the fallback send as delivered.

Two gaps:

1. Feishu had no `delete_message`, so `_delete_previews` no-ops. After a failed finalize-edit the fallback send posts the full answer and cannot remove the truncated preview.
2. `_send_fallback_final` omitted `reply_to`, so that full send was an unthreaded original.

This adds Feishu `im.v1.message.delete` and threads the fallback send to the originating user message. It does not take the card `PATCH` / `reply_mode` path in #97865.

## Related Issue

Fixes #103068

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `plugins/platforms/feishu/adapter.py` — `delete_message` via `DeleteMessageRequest`
- `gateway/stream_consumer_fallback.py` — fallback send passes `reply_to=self._initial_reply_to_id`
- `tests/gateway/test_feishu.py` — delete success / disconnected
- `tests/gateway/test_telegram_final_delivery.py` — full fallback resend threads and deletes the preview

## How to Test

```
uv run --extra dev python -m pytest tests/gateway/test_feishu.py::TestDeleteMessage tests/gateway/test_telegram_final_delivery.py -q
# 11 passed
```

Not runtime-tested against a live Feishu tenant.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
