### PR TITLE
fix(desktop): stop retries for missing remote profiles

### DIFF
--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -967,6 +967,21 @@ test('scrapeReadyPort times out and reports a dead spawn', async () => {
   )
 })
 
+test('scrapeReadyPort preserves a missing-profile failure from a dead remote spawn', async () => {
+  const logPath = spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE)
+  const ssh = fakeSsh([[/cat .*\.log/, "Error: Profile 'missing-bot' does not exist. Create it first.\n"]])
+
+  await assert.rejects(
+    () => scrapeReadyPort(ssh, logPath, { timeoutMs: 1000, isAlive: async () => false }),
+    (err: any) => {
+      assert.equal(err.kind, 'missing-profile')
+      assert.match(err.message, /Profile 'missing-bot' does not exist/)
+
+      return true
+    }
+  )
+})
+
 function connectDeps(ssh, over: any = {}) {
   return {
     ssh,

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -1139,8 +1139,17 @@ async function scrapeReadyPort(ssh, logPath, { timeoutMs = DEFAULT_READY_TIMEOUT
     assertBootstrapNotSuperseded(signal)
 
     if (isAlive && !(await isAlive())) {
-      const err: any = new Error('Remote dashboard process exited before announcing its port.')
-      err.kind = 'spawn-failed'
+      let failureLog = ''
+
+      try {
+        failureLog = String(await ssh.exec(`cat ${remoteLog} 2>/dev/null || true`))
+      } catch {
+        // A missing/unreadable log must still surface the original spawn failure.
+      }
+
+      const missingProfile = failureLog.match(/(?:Error:\s*)?Profile ['"][^'"\r\n]+['"] does not exist[^\r\n]*/i)
+      const err: any = new Error(missingProfile?.[0] || 'Remote dashboard process exited before announcing its port.')
+      err.kind = missingProfile ? 'missing-profile' : 'spawn-failed'
       throw err
     }
 

--- a/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
+++ b/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
@@ -488,6 +488,26 @@ describe('reconnect fail-stop on a removed connection', () => {
     expect(getConnection.mock.calls.length).toBe(callsAfterFailStop)
   })
 
+  it('fail-stops when an SSH source names a remote profile that does not exist', async () => {
+    const getConnectionFor = vi
+      .fn()
+      .mockResolvedValueOnce(descriptorFor('homelab', 'default'))
+      .mockRejectedValue(new Error("Remote Hermes error: Profile 'missing-bot' does not exist."))
+
+    installDesktop({ getConnectionFor })
+
+    await ensureGatewayForAgent('homelab', 'default')
+
+    const socket = gatewayMocks.instances[0] as unknown as { connectionState: string }
+    socket.connectionState = 'closed'
+
+    expect(await ensureActiveGatewayOpen()).toBeNull()
+
+    const callsAfterFailStop = getConnectionFor.mock.calls.length
+    await ensureActiveGatewayOpen()
+    expect(getConnectionFor.mock.calls.length).toBe(callsAfterFailStop)
+  })
+
   it('waits out an in-flight secondary activation instead of failing instantly (#88880)', async () => {
     // A remote secondary whose activation is ALREADY in flight from another
     // path (wake sweep, agent activation) used to make ensureActiveGatewayOpen

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -680,13 +680,18 @@ function isMissingConnectionError(error: unknown): boolean {
 }
 
 // Electron's spawn guard (assertLocalProfileCanStart) rejects with these when
-// the profile's directory is gone or its DELETE is still in flight. For a
+// the profile's directory is gone or its DELETE is still in flight. Remote
+// CLI startup reports the same permanent condition as "does not exist". For a
 // renderer socket that condition is permanent: the backend it reconnects to
 // can never come back, and every retry hammers the guard (#88769).
 function isMissingProfileError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error ?? '')
 
-  return message.includes('no longer exists') || message.includes('is being deleted')
+  return (
+    message.includes('no longer exists') ||
+    message.includes('is being deleted') ||
+    /Profile ['"][^'"\r\n]+['"] does not exist/i.test(message)
+  )
 }
 
 function createSecondary(profile: string, connectionId: null | string = null): Secondary {


### PR DESCRIPTION
## What does this PR do?

Preserve the actionable failure when a remote dashboard cannot start because its configured profile no longer exists, and stop retrying that permanent failure.

- When the remote process exits before announcing its port, inspect only that spawn's existing diagnostic log. Preserve the missing-profile line and error kind rather than replacing it with a generic early-exit message.
- Recognize the remote CLI's `Profile '…' does not exist` message in the renderer's existing missing-profile fail-stop path.
- Keep generic early-exit behavior if the log is unavailable or the failure is unrelated. Ordinary transport failures remain retryable; no blanket treatment of port-bind failures as permanent.

## Related Issue

Extends the local missing-profile retry protection associated with #88769 to remote CLI startup failures. No separate issue was opened; related remote/profile deletion PRs were searched before submission.

## Type of Change

- [x] Bug fix

## How to Test

From `apps/desktop`:

1. `npm test -- electron/remote-lifecycle.test.ts src/store/gateway-connection-lifecycle.test.ts --maxWorkers=2`
2. `npm run typecheck`
3. `npx eslint electron/remote-lifecycle.ts electron/remote-lifecycle.test.ts src/store/gateway.ts src/store/gateway-connection-lifecycle.test.ts`

Verified on macOS 26.5.1, starting from main `f58fcc8118d9db092ad60d363d4a28520e08ac5a`:

- Before the fix: the new producer test reports `spawn-failed` instead of `missing-profile`; the new renderer retry test times out after 15 seconds.
- After the fix: **109 tests passed** across the two files.
- Full Desktop typecheck and focused ESLint: **passed**.
- Independent staged-diff review found no blocking issue. Static scanning flagged the added `ssh.exec` call; review confirmed it reuses the existing remote-log path construction. Other scans were clear.

These are local lifecycle tests using a fake SSH transport and mocked gateway connections. An actual remote-host E2E session and the full Python suite were not run.

## Checklist

- [x] Read contributing guide and searched existing PRs.
- [x] Conventional commit with only the related producer/consumer change.
- [x] One regression test at each side of the lifecycle boundary.
- [x] No new configuration, architecture, or tool-schema changes.
- [x] No platform-specific production APIs added.
- [ ] Full Python suite / remote-host E2E (not run).

## AI assistance

Prepared with Codex assistance. The stated test, typecheck, and lint commands were executed locally; independent review did not run tests.
