### PR TITLE
feat(terminal): typed coding-session registration at launch

### DIFF
--- a/skills/autonomous-ai-agents/codex/SKILL.md
+++ b/skills/autonomous-ai-agents/codex/SKILL.md
@@ -56,6 +56,9 @@ terminal(command="cd $(mktemp -d) && git init && codex exec 'Build a snake game 
 terminal(command="codex exec --sandbox workspace-write 'Refactor the auth module'", workdir="~/project", background=true, pty=true)
 # Returns session_id
 
+# Tag the worker so later model controls can target it (ids/model names only)
+terminal(command="codex exec --sandbox workspace-write 'Refactor the auth module'", workdir="~/project", background=true, pty=true, coding_backend="codex", coding_model="gpt-5.2")
+
 # Monitor progress
 process(action="poll", session_id="<id>")
 process(action="log", session_id="<id>")

--- a/skills/autonomous-ai-agents/opencode/SKILL.md
+++ b/skills/autonomous-ai-agents/opencode/SKILL.md
@@ -79,6 +79,9 @@ For iterative work requiring multiple exchanges, start the TUI in background:
 terminal(command="opencode", workdir="~/project", background=true, pty=true)
 # Returns session_id
 
+# Tag the worker so later model controls can target it (ids/model names only)
+terminal(command="opencode", workdir="~/project", background=true, pty=true, coding_backend="opencode", coding_session_id="<opencode-session-id>")
+
 # Send a prompt
 process(action="submit", session_id="<id>", data="Implement OAuth refresh flow and add tests")
 

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -428,7 +428,9 @@ class TestStubSchemaDrift(unittest.TestCase):
     # Parameters that are internal (injected by the handler, not user-facing)
     _INTERNAL_PARAMS = {"task_id", "user_task"}
     # Parameters intentionally blocked in the sandbox
-    _BLOCKED_TERMINAL_PARAMS = {"background", "pty", "notify", "notify_on_complete", "watch_patterns"}
+    _BLOCKED_TERMINAL_PARAMS = {"background", "pty", "notify", "notify_on_complete", "watch_patterns",
+                                "coding_backend", "coding_backend_version", "coding_session_id",
+                                "coding_model", "coding_capabilities", "coding_resume_command"}
 
     def test_stubs_cover_all_schema_params(self):
         """Every user-facing parameter in the real schema must appear in the

--- a/tests/tools/test_process_coding_session.py
+++ b/tests/tools/test_process_coding_session.py
@@ -1,0 +1,192 @@
+"""Slice-1 contracts for the typed coding-agent descriptor (#103194).
+
+Covers: constructor defaults (ordinary processes unchanged), normalize
+hygiene (unknown backends degrade, never raises), launch plumbing through
+``_new_session`` (the single writer both spawn paths share), checkpoint
+round-trip + backward compat with pre-field checkpoints, redaction (no env
+or token material ever lands in the descriptor), the effective-model
+readback stub, and the terminal dispatch foreground guard.
+"""
+
+import json
+
+import pytest
+
+from tools.process_registry import (
+    ProcessRegistry,
+    ProcessSession,
+    _CHECKPOINT_DEFAULTS,
+    _CHECKPOINT_FIELDS,
+    coding_session_effective_model,
+    normalize_coding_descriptor,
+)
+
+
+def test_descriptor_defaults_to_untyped():
+    """Ordinary processes behave exactly as before: all coding_* empty."""
+    s = ProcessSession(id="proc_x", command="echo hi")
+    assert s.coding_backend == ""
+    assert s.coding_backend_version == ""
+    assert s.coding_session_id == ""
+    assert s.coding_model == ""
+    assert s.coding_capabilities == []
+    assert s.coding_resume_command == ""
+    assert coding_session_effective_model(s) == ""
+
+
+def test_normalize_coding_descriptor_passthrough():
+    out = normalize_coding_descriptor(
+        backend="Opencode", version="v1.2", session_id="ses_abc",
+        model="gpt-5", capabilities=["hot_switch", " structured_api ", ""],
+        resume_command="opencode attach ses_abc")
+    assert out == {
+        "coding_backend": "opencode",
+        "coding_backend_version": "v1.2",
+        "coding_session_id": "ses_abc",
+        "coding_model": "gpt-5",
+        "coding_capabilities": ["hot_switch", "structured_api"],
+        "coding_resume_command": "opencode attach ses_abc",
+    }
+
+
+def test_normalize_coding_descriptor_degrades_safely():
+    """Unknown backends become untyped; garbage never raises."""
+    assert normalize_coding_descriptor(backend="tmux")["coding_backend"] == ""
+    degraded = normalize_coding_descriptor(backend="tmux", model="x")
+    assert degraded["coding_model"] == ""
+    assert normalize_coding_descriptor(backend=None)["coding_backend"] == ""
+    assert normalize_coding_descriptor(
+        backend="codex", capabilities="hot_switch")["coding_capabilities"] == []
+    # Never raises, whatever rides in.
+    assert normalize_coding_descriptor(
+        backend=object(), version=object(), session_id=object(), model=object(),
+        capabilities=object(), resume_command=object())["coding_backend"] == ""
+
+
+def test_new_session_plumbs_descriptor():
+    """The single writer both spawn paths share normalizes once, here."""
+    s = ProcessRegistry._new_session(
+        "codex --ask", "t1", "sa-1", "sk", "/tmp",
+        coding_backend="codex", coding_session_id="thr_1", coding_model="gpt-5.2",
+        coding_capabilities=["hot_switch"], coding_resume_command="codex resume thr_1")
+    assert (s.coding_backend, s.coding_session_id, s.coding_model) == ("codex", "thr_1", "gpt-5.2")
+    assert s.coding_capabilities == ["hot_switch"]
+    assert s.coding_resume_command == "codex resume thr_1"
+    assert s.owner_task_id == "sa-1"  # ownership untouched
+    assert coding_session_effective_model(s) == "gpt-5.2"
+
+
+def test_spawn_signatures_accept_descriptor():
+    """spawn_local/spawn_via_env expose the same optional kwargs (one writer)."""
+    import inspect
+
+    from tools.process_registry import ProcessRegistry as PR
+
+    for name in ("spawn_local", "spawn_via_env"):
+        params = inspect.signature(getattr(PR, name)).parameters
+        for field in ("coding_backend", "coding_backend_version", "coding_session_id",
+                      "coding_model", "coding_capabilities", "coding_resume_command"):
+            assert field in params, f"{name} missing {field}"
+            assert params[field].default in ("", None), f"{name}.{field} must default empty"
+
+
+def test_checkpoint_fields_cover_descriptor():
+    """Persisted verbatim; old checkpoints (keys absent) load as untyped."""
+    for field in ("coding_backend", "coding_backend_version", "coding_session_id",
+                  "coding_model", "coding_capabilities", "coding_resume_command"):
+        assert field in _CHECKPOINT_FIELDS
+    assert _CHECKPOINT_DEFAULTS["coding_backend"] == ""
+    assert _CHECKPOINT_DEFAULTS["coding_capabilities"] == []
+
+
+def test_recover_restores_descriptor_and_tolerates_old_entries(tmp_path, monkeypatch):
+    """Crash recovery round-trips the descriptor; pre-field entries default."""
+    import tools.process_registry as pr
+
+    monkeypatch.setattr(pr, "CHECKPOINT_PATH", tmp_path / "processes.json")
+    monkeypatch.setattr(ProcessRegistry, "_host_pid_is_ours", lambda self, pid, st: True)
+    entries = [
+        {"session_id": "proc_new", "pid": 424242, "pid_scope": "host",
+         "command": "codex", "task_id": "t", "owner_task_id": "t",
+         "coding_backend": "codex", "coding_backend_version": "v9",
+         "coding_session_id": "thr_9", "coding_model": "gpt-5",
+         "coding_capabilities": ["hot_switch"], "coding_resume_command": "codex resume thr_9"},
+        {"session_id": "proc_old", "pid": 424243, "pid_scope": "host",
+         "command": "echo hi", "task_id": "t", "owner_task_id": "t"},
+    ]
+    (tmp_path / "processes.json").write_text(json.dumps(entries), encoding="utf-8")
+    reg = ProcessRegistry()
+    assert reg.recover_from_checkpoint() == 2
+    new = reg._running["proc_new"]
+    assert (new.coding_backend, new.coding_session_id, new.coding_model) == ("codex", "thr_9", "gpt-5")
+    assert new.coding_capabilities == ["hot_switch"]
+    assert new.detached is True
+    old = reg._running["proc_old"]
+    assert old.coding_backend == "" and old.coding_capabilities == []
+
+
+def test_descriptor_never_captures_env_or_tokens():
+    """Launch env and token-bearing argv must not leak into the descriptor:
+    only explicitly passed ids/model names are stored."""
+    secret_env = {"OPENAI_API_KEY": "sk-super-secret", "GH_TOKEN": "gho_secret"}
+    s = ProcessRegistry._new_session(
+        "codex --key gho_secret-value", "t1", "sa-1", "sk", "/tmp",
+        coding_backend="codex", coding_model="gpt-5", coding_session_id="thr_1")
+    blob = "|".join([s.coding_backend, s.coding_backend_version, s.coding_session_id,
+                     s.coding_model, ",".join(s.coding_capabilities), s.coding_resume_command])
+    assert "sk-super-secret" not in blob and "gho_secret" not in blob
+    for key in secret_env:
+        assert key not in blob
+    # And the checkpoint entry carries no env mapping either.
+    entry = {"session_id": s.id, **{f: getattr(s, f) for f in _CHECKPOINT_FIELDS}}
+    assert "OPENAI_API_KEY" not in json.dumps(entry)
+
+
+def test_background_spawn_forwards_descriptor():
+    """terminal_tool_background._spawn passes coding_* to the registry call."""
+    from tools.terminal_tool_background import _spawn
+
+    seen = {}
+
+    class FakeRegistry:
+        def spawn_local(self, **kwargs):
+            seen.update(kwargs)
+            session = ProcessSession(id="proc_fake", command=kwargs["command"])
+            for key in ("coding_backend", "coding_backend_version", "coding_session_id",
+                        "coding_model", "coding_capabilities", "coding_resume_command"):
+                setattr(session, key, kwargs.get(key) or ([] if key == "coding_capabilities" else ""))
+            return session
+
+    session = _spawn(FakeRegistry(), env=None, env_type="local", command="codex",
+                     cwd="/tmp", effective_task_id="t", task_id="t", session_key="sk",
+                     effective_pty=False, coding_backend="codex", coding_session_id="thr_1",
+                     coding_model="gpt-5")
+    assert seen["coding_backend"] == "codex"
+    assert seen["coding_session_id"] == "thr_1"
+    assert session.coding_model == "gpt-5"
+
+
+def test_terminal_schema_documents_coding_params():
+    """Model-facing schema exposes the six optional params (background-only)."""
+    from tools.terminal_tool import TERMINAL_SCHEMA
+
+    props = TERMINAL_SCHEMA["parameters"]["properties"]
+    for field in ("coding_backend", "coding_backend_version", "coding_session_id",
+                  "coding_model", "coding_capabilities", "coding_resume_command"):
+        assert field in props, f"schema missing {field}"
+        assert "background" in props[field]["description"]
+    assert TERMINAL_SCHEMA["parameters"].get("required") == ["command"]
+
+
+def test_terminal_dispatch_rejects_coding_params_on_foreground():
+    """coding_* on a foreground call fails with the corrected call (same shape
+    as the notify/pty guards), never silently ignored."""
+    from tools.terminal_tool import _handle_terminal
+
+    result = _handle_terminal(
+        {"command": "echo hi", "coding_backend": "codex"}, task_id="t")
+    import json as _json
+
+    body = _json.loads(result)
+    assert body.get("exit_code", 0) != 0 or "error" in body
+    assert "background" in _json.dumps(body)

--- a/tests/tools/test_terminal_task_cwd.py
+++ b/tests/tools/test_terminal_task_cwd.py
@@ -171,6 +171,12 @@ def test_background_command_prefers_recorded_session_cwd_over_init_time_cwd(monk
         "session_key": task_id,
         "env_vars": {},
         "use_pty": False,
+        "coding_backend": "",
+        "coding_backend_version": "",
+        "coding_session_id": "",
+        "coding_model": "",
+        "coding_capabilities": None,
+        "coding_resume_command": "",
     }]
 
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -336,6 +336,17 @@ class ProcessSession:
     # Session-db id of the spawning conversation; lets the gateway drop completions whose
     # session was closed at a user boundary (/new) instead of injecting into the NEW one.
     parent_session_id: str = ""
+    # Typed coding-agent descriptor (#103194 slice 1): identifies a background
+    # Codex/OpenCode worker WITHOUT parsing the shell command. All default
+    # empty = ordinary processes behave exactly as before. Only non-secret
+    # metadata is ever stored here (backend/version/session id/model name/
+    # resume template) — never env, tokens, or launch credentials.
+    coding_backend: str = ""              # "" | "codex" | "opencode"
+    coding_backend_version: str = ""      # backend release/pin when known
+    coding_session_id: str = ""           # external session/thread id
+    coding_model: str = ""                # effective model as recorded at launch
+    coding_capabilities: List[str] = field(default_factory=list)  # e.g. "hot_switch", "structured_api"
+    coding_resume_command: str = ""       # resume template (e.g. "codex resume <id>"), not the raw launch line
     notify_on_complete: bool = False            # Queue agent notification on exit
     watch_patterns: List[str] = field(default_factory=list)
     _watch_hits: int = field(default=0, repr=False)          # total matches delivered
@@ -370,15 +381,53 @@ class ProcessSession:
 
 # Watcher routing fields, in event-dict key order (``watcher_<key>`` on the session).
 _WATCHER_ROUTE_KEYS = ("platform", "chat_id", "user_id", "user_name", "thread_id", "message_id")
+# Backends the typed coding-agent descriptor accepts. Anything else normalizes
+# to "" (untyped process) rather than failing the launch.
+_CODING_BACKENDS = frozenset({"codex", "opencode"})
+
+
+def normalize_coding_descriptor(
+    backend: Any = "", version: Any = "", session_id: Any = "", model: Any = "",
+    capabilities: Any = None, resume_command: Any = "",
+) -> Dict[str, Any]:
+    """Sanitize launch-time coding-agent metadata into the ``coding_*`` descriptor
+    shape. Unknown backends degrade to untyped (""), non-string scalars coerce
+    via str(), capability lists drop blanks. Never raises — a bad descriptor
+    must not break the spawn it rides on."""
+    clean_backend = str(backend or "").strip().lower()
+    if clean_backend not in _CODING_BACKENDS:
+        if clean_backend:
+            logger.warning("unknown coding_backend %r ignored (expected codex|opencode)", backend)
+        return {"coding_backend": "", "coding_backend_version": "", "coding_session_id": "",
+                "coding_model": "", "coding_capabilities": [], "coding_resume_command": ""}
+    items = capabilities if isinstance(capabilities, (list, tuple)) else []
+    return {
+        "coding_backend": clean_backend,
+        "coding_backend_version": str(version or "").strip(),
+        "coding_session_id": str(session_id or "").strip(),
+        "coding_model": str(model or "").strip(),
+        "coding_capabilities": [str(c).strip() for c in items if str(c).strip()][:16],
+        "coding_resume_command": str(resume_command or "").strip(),
+    }
+
+
+def coding_session_effective_model(session: "ProcessSession") -> str:
+    """Effective model of a coding session as currently known. Slice-1 protocol
+    stub (#103194): returns the model recorded at launch. Slices 2-3 fill in
+    live backend readback (backend readback wins on conflict) without changing
+    the descriptor schema."""
+    return session.coding_model if session.coding_backend else ""
 # Session fields persisted verbatim in the crash-recovery checkpoint (plus
 # ``session_id``; ``command`` is redacted and ``owner_task_id`` defaulted on write).
 _CHECKPOINT_FIELDS = (
     "command", "pid", "pid_scope", "host_start_time", "systemd_unit", "cwd",
     "started_at", "task_id", "owner_task_id", "session_key",
     *(f"watcher_{k}" for k in _WATCHER_ROUTE_KEYS), "watcher_interval",
-    "parent_session_id", "notify_on_complete", "watch_patterns")
+    "parent_session_id", "notify_on_complete", "watch_patterns",
+    "coding_backend", "coding_backend_version", "coding_session_id", "coding_model",
+    "coding_capabilities", "coding_resume_command")
 _CHECKPOINT_DEFAULTS = {
-    f.name: ([] if f.name == "watch_patterns" else f.default)
+    f.name: ([] if f.name in ("watch_patterns", "coding_capabilities") else f.default)
     for f in ProcessSession.__dataclass_fields__.values()
     if f.name in _CHECKPOINT_FIELDS
 }
@@ -738,10 +787,17 @@ class ProcessRegistry:
 
     @staticmethod
     def _new_session(command, task_id, owner_task_id, session_key, cwd, **extra) -> ProcessSession:
+        descriptor = normalize_coding_descriptor(
+            backend=extra.pop("coding_backend", ""),
+            version=extra.pop("coding_backend_version", ""),
+            session_id=extra.pop("coding_session_id", ""),
+            model=extra.pop("coding_model", ""),
+            capabilities=extra.pop("coding_capabilities", None),
+            resume_command=extra.pop("coding_resume_command", ""))
         return ProcessSession(
             id=f"proc_{uuid.uuid4().hex[:12]}", command=command, task_id=task_id,
             owner_task_id=owner_task_id or task_id, session_key=session_key, cwd=cwd,
-            started_at=time.time(), **extra)
+            started_at=time.time(), **descriptor, **extra)
 
     @staticmethod
     def _env_temp_dir(env: Any) -> str:
@@ -816,10 +872,14 @@ class ProcessRegistry:
 
     def spawn_local(
         self, command: str, cwd: str = None, task_id: str = "", session_key: str = "",
-        env_vars: dict = None, use_pty: bool = False, owner_task_id: str = "") -> ProcessSession:
+        env_vars: dict = None, use_pty: bool = False, owner_task_id: str = "",
+        coding_backend: str = "", coding_backend_version: str = "", coding_session_id: str = "",
+        coding_model: str = "", coding_capabilities=None, coding_resume_command: str = "") -> ProcessSession:
         """Spawn a background process locally (TERMINAL_ENV=local; other backends use
         spawn_via_env()). ``use_pty`` requests a pseudo-terminal via ptyprocess/pywinpty
-        for interactive CLIs, falling back to a plain pipe when unavailable or failing."""
+        for interactive CLIs, falling back to a plain pipe when unavailable or failing.
+        The ``coding_*`` params optionally tag a Codex/OpenCode worker with its typed
+        descriptor (#103194); all default empty = ordinary process, unchanged behavior."""
         # Bash parses ``A && B &`` as ``(A && B) &`` — a subshell that holds our stdout
         # pipe open forever when B is a long-running server. The rewriter turns it into
         # ``A && { B & }``. Lazy import: terminal_tool imports this module.
@@ -827,7 +887,11 @@ class ProcessRegistry:
         from tools.terminal_tool_sudo import _rewrite_compound_background as _rewrite_bg
 
         safe_command = _rewrite_bg(command)
-        session = self._new_session(command, task_id, owner_task_id, session_key, _resolve_safe_cwd(cwd or os.getcwd()))
+        session = self._new_session(
+            command, task_id, owner_task_id, session_key, _resolve_safe_cwd(cwd or os.getcwd()),
+            coding_backend=coding_backend, coding_backend_version=coding_backend_version,
+            coding_session_id=coding_session_id, coding_model=coding_model,
+            coding_capabilities=coding_capabilities, coding_resume_command=coding_resume_command)
         pty_scope_attempted = False
         if use_pty:
             try:
@@ -892,12 +956,19 @@ class ProcessRegistry:
 
     def spawn_via_env(
         self, env: Any, command: str, cwd: str = None, task_id: str = "", session_key: str = "",
-        timeout: int = 10, owner_task_id: str = "") -> ProcessSession:
+        timeout: int = 10, owner_task_id: str = "",
+        coding_backend: str = "", coding_backend_version: str = "", coding_session_id: str = "",
+        coding_model: str = "", coding_capabilities=None, coding_resume_command: str = "") -> ProcessSession:
         """Spawn a background process inside a non-local backend's sandbox.
         The command is wrapped to capture its in-sandbox PID and redirect output to a
         log file that later execute() calls poll. No live pipe or stdin, but it runs in
-        the correct sandbox context."""
-        session = self._new_session(command, task_id, owner_task_id, session_key, cwd, env_ref=env, pid_scope="sandbox")
+        the correct sandbox context. The ``coding_*`` params tag a Codex/OpenCode
+        worker exactly like :meth:`spawn_local`."""
+        session = self._new_session(
+            command, task_id, owner_task_id, session_key, cwd, env_ref=env, pid_scope="sandbox",
+            coding_backend=coding_backend, coding_backend_version=coding_backend_version,
+            coding_session_id=coding_session_id, coding_model=coding_model,
+            coding_capabilities=coding_capabilities, coding_resume_command=coding_resume_command)
         temp_dir = self._env_temp_dir(env)
         log_path, pid_path, exit_path = (f"{temp_dir}/hermes_bg_{session.id}.{ext}" for ext in ("log", "pid", "exit"))
         q = shlex.quote

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1119,6 +1119,12 @@ def terminal_tool(
     notify_on_complete: bool = False,
     watch_patterns: Optional[List[str]] = None,
     _host_local: bool = False,
+    coding_backend: str = "",
+    coding_backend_version: str = "",
+    coding_session_id: str = "",
+    coding_model: str = "",
+    coding_capabilities: Optional[List[str]] = None,
+    coding_resume_command: str = "",
 ) -> str:
     """Execute *command* in the configured terminal environment; returns a JSON string.
 
@@ -1132,6 +1138,11 @@ def terminal_tool(
     use it only for rare one-shot signals on long-lived processes.
     ``_host_local`` forces the local backend for Hermes-owned control-plane
     children (kept in a separate env cache from the configured backend).
+    The ``coding_*`` params (background launches only) tag a Codex/OpenCode
+    worker with its typed session descriptor (#103194): backend kind, version,
+    external session id, effective model, capability flags, and resume template.
+    All default empty = ordinary process. Only ids and model names are stored —
+    never env, tokens, or launch credentials.
     """
     try:
         plan = _plan_execution(
@@ -1160,6 +1171,10 @@ def terminal_tool(
                 effective_pty=pty and not pty_disabled, notify_on_complete=notify_on_complete,
                 watch_patterns=watch_patterns, approval_note=verdict.note,
                 pty_disabled_reason=_PTY_DISABLED_REASON if pty_disabled else None,
+                coding_backend=coding_backend, coding_backend_version=coding_backend_version,
+                coding_session_id=coding_session_id, coding_model=coding_model,
+                coding_capabilities=coding_capabilities,
+                coding_resume_command=coding_resume_command,
             )
         return _run_foreground(
             command, env, plan,
@@ -1222,10 +1237,35 @@ TERMINAL_SCHEMA = {
                     {"type": "boolean"},
                     {"type": "array", "items": {"type": "string"}}
                 ]
-            }
+            },
             # Legacy aliases (unadvertised, still accepted): notify_on_complete
             # (bool) and watch_patterns (list). notify=true|[...] maps onto
             # them in the dispatch wrapper; explicit notify wins on conflict.
+            "coding_backend": {
+                "type": "string",
+                "description": "With background=true: tag this Codex/OpenCode worker with its backend kind ('codex' or 'opencode') so later model controls can target it. Omit for ordinary processes."
+            },
+            "coding_backend_version": {
+                "type": "string",
+                "description": "With background=true: backend release/pin of the coding worker, when known. Optional."
+            },
+            "coding_session_id": {
+                "type": "string",
+                "description": "With background=true: the worker's external session/thread id, when known at launch. Optional."
+            },
+            "coding_model": {
+                "type": "string",
+                "description": "With background=true: effective model of the coding worker as launched. Optional; only ids and model names are stored, never credentials."
+            },
+            "coding_capabilities": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "With background=true: capability flags of the coding worker (e.g. 'hot_switch', 'structured_api'). Optional."
+            },
+            "coding_resume_command": {
+                "type": "string",
+                "description": "With background=true: resume template for re-entering the coding session after a restart (e.g. 'codex resume <id>'). Stored as a template, never derived from the launch line. Optional."
+            }
         },
         "required": ["command"]
     }
@@ -1262,6 +1302,14 @@ def _handle_terminal(args, **kw):
                 "tracked background process). Retry as terminal(command=..., "
                 "background=true, pty=true)."
             )
+        if any(args.get(f"coding_{key}") for key in (
+                "backend", "backend_version", "session_id", "model",
+                "capabilities", "resume_command")):
+            return tool_error(
+                "coding_* params only apply to background commands (they tag "
+                "the tracked coding-worker session). Retry as "
+                "terminal(command=..., background=true, coding_backend=...)."
+            )
     if notify is not None:
         if isinstance(notify, bool):
             notify_on_complete = notify
@@ -1284,6 +1332,12 @@ def _handle_terminal(args, **kw):
         pty=args.get("pty", False),
         notify_on_complete=notify_on_complete,
         watch_patterns=watch_patterns,
+        coding_backend=args.get("coding_backend", ""),
+        coding_backend_version=args.get("coding_backend_version", ""),
+        coding_session_id=args.get("coding_session_id", ""),
+        coding_model=args.get("coding_model", ""),
+        coding_capabilities=args.get("coding_capabilities"),
+        coding_resume_command=args.get("coding_resume_command", ""),
     )
 
 

--- a/tools/terminal_tool_background.py
+++ b/tools/terminal_tool_background.py
@@ -86,9 +86,15 @@ def _stamp_gateway_routing(proc_session, get_session_env) -> None:
 
 
 def _spawn(process_registry, *, env, env_type, command, cwd, effective_task_id, task_id,
-           session_key, effective_pty):
+           session_key, effective_pty, coding_backend="", coding_backend_version="",
+           coding_session_id="", coding_model="", coding_capabilities=None,
+           coding_resume_command=""):
     common = dict(command=command, cwd=cwd, task_id=effective_task_id,
-                  owner_task_id=task_id or effective_task_id, session_key=session_key)
+                  owner_task_id=task_id or effective_task_id, session_key=session_key,
+                  coding_backend=coding_backend, coding_backend_version=coding_backend_version,
+                  coding_session_id=coding_session_id, coding_model=coding_model,
+                  coding_capabilities=coding_capabilities,
+                  coding_resume_command=coding_resume_command)
     if env_type == "local":
         return process_registry.spawn_local(
             env_vars=env.env if hasattr(env, 'env') else None, use_pty=effective_pty, **common)
@@ -130,7 +136,9 @@ def spawn_background_process(
     *, command: str, env: Any, env_type: str, effective_task_id: str, task_id: Optional[str],
     session_key: str, workdir: Optional[str], cwd: str, effective_pty: bool,
     notify_on_complete: bool, watch_patterns: Optional[List[str]], approval_note: Optional[str],
-    pty_disabled_reason: Optional[str],
+    pty_disabled_reason: Optional[str], coding_backend: str = "",
+    coding_backend_version: str = "", coding_session_id: str = "", coding_model: str = "",
+    coding_capabilities=None, coding_resume_command: str = "",
 ) -> str:
     """Spawn *command* as a tracked background process and return the JSON result.
 
@@ -149,7 +157,10 @@ def spawn_background_process(
         proc_session = _spawn(
             process_registry, env=env, env_type=env_type, command=command, cwd=effective_cwd,
             effective_task_id=effective_task_id, task_id=task_id, session_key=session_key,
-            effective_pty=effective_pty,
+            effective_pty=effective_pty, coding_backend=coding_backend,
+            coding_backend_version=coding_backend_version, coding_session_id=coding_session_id,
+            coding_model=coding_model, coding_capabilities=coding_capabilities,
+            coding_resume_command=coding_resume_command,
         )
         result_data = {"output": "Background process started", "session_id": proc_session.id,
                        "pid": proc_session.pid, "exit_code": 0, "error": None}


### PR DESCRIPTION
## What does this PR do?

Slice 1 of #103194, implementing the endorsed plan from the issue thread: launches can now register a typed, owner-scoped Codex/OpenCode session descriptor without parsing shell commands and without persisting secrets.

- `ProcessSession` gains `coding_backend` (`""` | `"codex"` | `"opencode"`), `coding_backend_version`, `coding_session_id`, `coding_model`, `coding_capabilities`, `coding_resume_command` — all default empty, so ordinary processes behave exactly as before.
- One writer, no new tool: `spawn_local`/`spawn_via_env` accept the same optional params and forward through `_new_session`, which normalizes once (unknown backends degrade to untyped with a warning; never raises, so a bad descriptor can't break the spawn). Existing `session_key`/`owner_task_id` scoping is untouched.
- The `terminal` tool exposes six documented optional params (background-only; foreground use fails with the corrected call, same shape as the notify/pty guards).
- Checkpoint round-trips the descriptor with defaults, so pre-field checkpoints load as untyped; command redaction (#77484) is untouched and only ids/model names are ever stored — never env, tokens, or launch credentials.
- `coding_session_effective_model()` is the readback protocol stub returning the recorded model; slices 2–3 fill in live backend readback (readback wins) without changing the descriptor schema again.
- Codex/OpenCode skills document the new launch params.

Out of scope by design (later slices): backend catalog validation, live effective-model readback adapters, `/model --coding-session` targeting with precedence/busy-gate rules.

## Related Issue

Relates to #103194 (slice 1 of the phased plan agreed in the thread; does not close the issue)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/process_registry.py`: descriptor fields, `normalize_coding_descriptor()`, `coding_session_effective_model()` stub, checkpoint fields/defaults, spawn signatures + forwarding
- `tools/terminal_tool_background.py`: `_spawn`/`spawn_background_process` pass-through
- `tools/terminal_tool.py`: function params, dispatch mapping + foreground guard, `TERMINAL_SCHEMA` properties
- `skills/autonomous-ai-agents/codex/SKILL.md`, `skills/autonomous-ai-agents/opencode/SKILL.md`: launch-tagging docs
- `tests/tools/test_process_coding_session.py`: 11 contract tests

## How to Test

1. `pytest tests/tools/test_process_coding_session.py -q` — 11 passed (fail without the fix: collection ImportError on stashed implementation).
2. `pytest tests/tools/test_process_registry.py tests/tools/test_notify_on_complete.py tests/tools/test_terminal_foreground_timeout_cap.py tests/tools/test_watch_patterns.py tests/tools/test_process_schema_diet.py -q` — 157 passed, 4 skipped.
3. `pytest tests/skills/test_authoring_standards.py -q` — 1172 passed.
4. `ruff check tools/` — clean.
5. Manual: `terminal(command="sleep 30", background=true, coding_backend="codex", coding_session_id="thr_1", coding_model="gpt-5")` → `process(action="poll")` shows a tracked session; descriptor survives checkpoint recovery with `detached=True`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted suites: see above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — Codex/OpenCode skill launch docs
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure metadata plumbing, platform-independent; PTY/sandbox spawn paths unchanged)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — schema properties documented inline
