### PR TITLE
fix(computer-use): validate repairs and preserve custom drivers

### DIFF
--- a/hermes_cli/tools_config_cua.py
+++ b/hermes_cli/tools_config_cua.py
@@ -242,6 +242,9 @@ def _report_repair_or_upgrade(ok: bool, *, repair_existing: bool, binary, before
                               driver_cmd: str) -> bool:
     """Post-installer verdict: a repair must leave a usable contract; upgrades show before/after."""
     if ok and repair_existing:
+        # A same-version repair can replace bundle resources without changing
+        # the executable fingerprint. Never reuse the pre-repair failure.
+        _CUA_DRIVER_CONTRACT_CACHE.clear()
         repaired = _cua_driver_contract_status()
         if not repaired.get("ready"):
             return _fail("    cua-driver was reinstalled, but its runtime contract is still "
@@ -261,7 +264,8 @@ def install_cua_driver(upgrade: bool = False, require_confirmed_update: bool = F
     """Install or refresh the cua-driver binary used by Computer Use.
     Re-running the upstream installer (always the latest release tag) is the canonical upgrade.
     ``upgrade=False`` (toolset enable flow) keeps a compatible installation, repairs an
-    old/incomplete one and installs when missing; ``upgrade=True`` always refreshes."""
+    old/incomplete one and installs when missing; ``upgrade=True`` refreshes the
+    standard installation, but an explicit command override stays user-managed."""
     system = platform.system()
     if system not in ("Darwin", "Windows", "Linux"):
         if not upgrade:  # silent under `hermes update`, which calls this for every user
@@ -319,6 +323,12 @@ def install_cua_driver(upgrade: bool = False, require_confirmed_update: bool = F
                          f"    Repair it from an interactive terminal with: {_UPGRADE_CMD}",
                          warn=False)
         _print_info("    Repairing it with the current upstream installer.")
+
+    if override and upgrade:
+        _print_info("    HERMES_CUA_DRIVER_CMD selects a user-managed driver; skipping the "
+                    "standard installer. Update that binary directly, or unset the override "
+                    "before refreshing the standard driver.")
+        return True
 
     # upgrade=True path — refresh to the latest upstream release.
     if not _cua_install_target_writable():

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -11,6 +11,7 @@ must:
   complaint). Automatic Windows updates defer because the installer can prompt.
 * For ``upgrade=False``, keep compatible installations, repair old or
   incomplete installations, and install when missing.
+* Keep explicit command overrides user-managed, including during upgrades.
 
 The pre-install arch probe that used to live alongside this function was
 deleted (see the release-probe comment in tools_config_cua.py) — the upstream
@@ -25,7 +26,7 @@ from __future__ import annotations
 import json
 import sys
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -414,6 +415,69 @@ class TestInstallCuaDriverUpgrade:
             assert tools_config.install_cua_driver(upgrade=False) is True
 
         assert runner.call_args.kwargs["label"] == "Repairing"
+
+    def test_same_fingerprint_repair_checks_the_fresh_contract(self, monkeypatch, tmp_path):
+        from hermes_cli import tools_config_cua as tools_config
+        from tools.computer_use import cua_backend_driver
+
+        binary = tmp_path / "cua-driver"
+        binary.write_bytes(b"same-version-binary")
+        binary.chmod(0o755)
+        before = binary.stat()
+        incompatible = {"ready": False, "version": "0.20.0", "reason": "manifest unavailable"}
+        ready = {"ready": True, "version": "0.20.0", "reason": ""}
+        probe = Mock(side_effect=[incompatible, ready])
+        installer = Mock(return_value=True)
+
+        monkeypatch.delenv("HERMES_CUA_DRIVER_CMD", raising=False)
+        monkeypatch.setattr(tools_config, "_CUA_DRIVER_CONTRACT_CACHE", {})
+        monkeypatch.setattr(tools_config, "time", SimpleNamespace(monotonic=lambda: 100.0))
+        monkeypatch.setattr(tools_config, "_resolved_cua_driver_cmd", lambda: str(binary))
+        monkeypatch.setattr(tools_config, "_cua_driver_version", lambda _: "0.20.0")
+        monkeypatch.setattr(tools_config, "_cua_install_target_writable", lambda: True)
+        monkeypatch.setattr(tools_config.shutil, "which", lambda name: str(tmp_path / name))
+        monkeypatch.setattr(tools_config, "_run_cua_driver_installer", installer)
+        monkeypatch.setattr(cua_backend_driver, "cua_driver_runtime_contract_status", probe)
+
+        assert tools_config.install_cua_driver(upgrade=True) is True
+        assert installer.call_args.kwargs["label"] == "Repairing"
+        assert probe.call_count == 2
+        assert tools_config._cua_driver_contract_status(str(binary)) == ready
+        assert probe.call_count == 2, "the fresh verdict should become the new cached state"
+        after = binary.stat()
+        assert (after.st_mtime_ns, after.st_size) == (before.st_mtime_ns, before.st_size)
+
+    @pytest.mark.parametrize("require_confirmed_update", [False, True])
+    def test_compatible_explicit_override_is_not_refreshed(
+        self, monkeypatch, tmp_path, require_confirmed_update
+    ):
+        from hermes_cli import tools_config_cua as tools_config
+        from tools.computer_use import cua_backend_driver
+
+        binary = tmp_path / "custom-cua-driver"
+        binary.write_bytes(b"user-managed-driver")
+        binary.chmod(0o755)
+        checker = Mock(return_value={"update_available": True, "latest_version": "0.21.0"})
+        installer = Mock(return_value=True)
+
+        monkeypatch.setenv("HERMES_CUA_DRIVER_CMD", str(binary))
+        monkeypatch.setattr(tools_config, "_resolved_cua_driver_cmd", lambda: str(binary))
+        monkeypatch.setattr(
+            tools_config, "_cua_driver_contract_status",
+            lambda *_: {"ready": True, "version": "0.20.0", "reason": ""},
+        )
+        monkeypatch.setattr(tools_config, "_cua_driver_version", lambda _: "0.20.0")
+        monkeypatch.setattr(tools_config, "_cua_install_target_writable", lambda: True)
+        monkeypatch.setattr(tools_config.shutil, "which", lambda name: str(tmp_path / name))
+        monkeypatch.setattr(tools_config, "_run_cua_driver_installer", installer)
+        monkeypatch.setattr(cua_backend_driver, "cua_driver_update_check", checker)
+
+        assert tools_config.install_cua_driver(
+            upgrade=True, require_confirmed_update=require_confirmed_update
+        ) is True
+        checker.assert_not_called()
+        installer.assert_not_called()
+        assert binary.read_bytes() == b"user-managed-driver"
 
     def test_incompatible_explicit_override_is_not_replaced(self, monkeypatch):
         from hermes_cli import tools_config_cua as tools_config


### PR DESCRIPTION
## What does this PR do?

Fix two install/update boundary cases in the shared cua-driver installer:

- Clear the existing runtime-contract cache after a successful repair, before verifying the repaired installation. Repairing same-version bundle resources can leave the executable's path, modification time, and size unchanged. Reusing the 30-second pre-repair cache then falsely reports that a successful repair is still broken.
- Leave a compatible `HERMES_CUA_DRIVER_CMD` override user-managed during both explicit and automatic upgrades. Missing and incompatible overrides already fail with actionable instructions; compatible overrides should not continue into release checking and the standard installer, which does not own the selected custom binary.

This adds no new cache API or updater-specific lookup helper. The repair boundary invalidates the existing cache, and the shared install entry point enforces ownership.

## Related Issue

Follow-up to the auto-repair path introduced by #87923. Distinct from #69189, which addresses discovering standard installations when GUI PATH omits the driver directory; this PR does not duplicate that resolver change.

## Type of Change

- [x] Bug fix

## How to Test

From the repository root:

1. `scripts/run_tests.sh tests/hermes_cli/test_install_cua_driver.py tests/tools/test_computer_use_cua_macos_identity.py -j 2`
2. `ruff check hermes_cli/tools_config_cua.py tests/hermes_cli/test_install_cua_driver.py`

Verified against main `f58fcc8118d9db092ad60d363d4a28520e08ac5a`, on macOS 26.5.1 with Python 3.11.15:

- Before the fix: **3 new cases failed**. The same-fingerprint repair returns false, and both automatic/explicit custom-driver refresh cases call the release checker.
- After the fix: **69 passed, 0 failed, 24 skipped** across the two files. Existing Linux/Windows-only cases are the skipped cases on this Mac.
- Focused Ruff and Python compilation: **passed**.
- Independent staged-diff review and added-line static scans: no findings.
- The Windows-footgun checker reports one **pre-existing**, unchanged missing-encoding call in an install-lock test; the same diagnostic was reproduced on unmodified main. No suppression or unrelated fix was added.

The tests use the real cache and temporary executable files with mocked installer/runtime probes. The canonical runner isolates test homes. No real driver installation, upgrade, or native Windows/Linux run was performed.

## Checklist

- [x] Read contributing guide and searched existing PRs.
- [x] Conventional commit, scoped to these installer boundary cases.
- [x] One invariant test per bug; override coverage includes explicit and automatic refresh.
- [x] Real cache exercised; temporary files and mocked installers only.
- [x] Existing missing/incompatible override behavior is retained.
- [x] Installer docstring updated; no configuration/schema changes.
- [ ] Full Python suite / native Windows/Linux runs (not run).

## AI assistance

Prepared with Codex assistance. Tests, lint, compilation, and the baseline diagnostic comparison were executed locally; independent review did not run tests.
