### PR TITLE
fix(update): pending .update-incomplete marker routes the already-current path to venv repair

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -622,13 +622,22 @@ def _repair_current_checkout(
     # The Windows shim hand-off child is current BY DESIGN; its one job is the pending sync,
     # not venv health — without this it would print "Already up to date!" and skip it.
     handed_off_sync = os.environ.get(_m()._UPDATE_REEXEC_ENV) == "1"
+    # A pending ``.update-incomplete`` marker outranks the probe: the prior install died and
+    # the probe still passes, because an editable install resolves the probed modules against
+    # the new checkout while the venv stays on stale pins (#103532) — reporting success would
+    # strand the venv on old deps with exit 0 and a success receipt.
+    pending_install_marker = _m()._update_marker_path().exists()
     if handed_off_sync:
         print("→ Finishing the dependency install handed off by hermes.exe...")
     elif not healthy:
         print("⚠ Checkout is current, but the venv is unhealthy:")
         print(f"  {detail}")
         print("→ Repairing Python dependencies...")
-    if handed_off_sync or not healthy:
+    elif pending_install_marker:
+        print("⚠ Checkout is current, but a previous dependency install did not finish:")
+        print(f"  pending marker: {_m()._update_marker_path()}")
+        print("→ Repairing Python dependencies...")
+    if handed_off_sync or not healthy or pending_install_marker:
         current_checkout_complete = _repair_venv_on_current_checkout(
             assume_yes=assume_yes, gateway_mode=gateway_mode,
             pre_update_snapshot_id=pre_update_snapshot_id, desktop_dir=desktop_dir,

--- a/tests/hermes_cli/test_update_current_marker_repair.py
+++ b/tests/hermes_cli/test_update_current_marker_repair.py
@@ -1,0 +1,64 @@
+"""The already-current update path must honor a pending ``.update-incomplete`` marker (#103532).
+
+A prior ``hermes update`` whose dependency install failed (e.g. PyPI unreachable) leaves the
+marker behind. The next ``hermes update`` reaches the already-current branch, where the
+4-module import probe still passes — an editable install resolves the probed modules against
+the new checkout while the venv stays on stale pins. Without consulting the marker, the
+update printed "✓ Already up to date!" with exit 0 and a success receipt, masking the skew.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from hermes_cli import update_cmd
+
+
+def _run_repair_current_checkout(tmp_path: Path, *, marker: bool):
+    """Drive ``_repair_current_checkout`` with an inert environment; returns what ran."""
+    marker_path = tmp_path / ".update-incomplete"
+    if marker:
+        marker_path.write_text("started=probe pid=0\n")
+    calls = {"venv_repair": False, "node_repair": False}
+    with patch.object(update_cmd, "_venv_core_imports_healthy", return_value=(True, "")), \
+            patch.object(update_cmd, "_repair_venv_on_current_checkout") as venv_repair, \
+            patch.object(update_cmd, "_repair_node_deps_on_current_checkout") as node_repair, \
+            patch("hermes_cli.managed_uv.ensure_uv"), \
+            patch("hermes_cli.managed_uv.update_managed_uv"), \
+            patch.object(update_cmd, "_m") as m:
+        m.return_value._update_marker_path = lambda: marker_path
+        m.return_value._UPDATE_REEXEC_ENV = "HERMES_UPDATE_REEXEC"
+        venv_repair.return_value = True
+        node_repair.return_value = True
+        result = update_cmd._repair_current_checkout(
+            assume_yes=True, gateway_mode=False, pre_update_snapshot_id=None,
+            desktop_dir=None, had_desktop_app_before_update=False,
+            active_lazy_features=[], active_tool_dependencies=[],
+            upstream_checked=True, _windows_gateway_resume=None)
+        calls["venv_repair"] = venv_repair.called
+        calls["node_repair"] = node_repair.called
+    assert result is True
+    return calls
+
+
+def test_pending_marker_routes_to_venv_repair_despite_healthy_probe(tmp_path):
+    """Marker present + probe green ⇒ repair the venv, never report 'Already up to date!'."""
+    calls = _run_repair_current_checkout(tmp_path, marker=True)
+    assert calls["venv_repair"] is True
+    assert calls["node_repair"] is False
+
+
+def test_clean_checkout_keeps_already_up_to_date_path(tmp_path):
+    """No marker + probe green ⇒ the node-deps catch-up path still reports up to date."""
+    calls = _run_repair_current_checkout(tmp_path, marker=False)
+    assert calls["venv_repair"] is False
+    assert calls["node_repair"] is True
+
+
+def test_pending_marker_prints_hint(capsys, tmp_path):
+    """The marker branch surfaces why the repair is running."""
+    _run_repair_current_checkout(tmp_path, marker=True)
+    out = capsys.readouterr().out
+    assert "previous dependency install did not finish" in out
+    assert ".update-incomplete" in out


### PR DESCRIPTION
## What does this PR do?

`hermes update` on an already-current checkout could report `✓ Already up to date!` with exit 0 and a `success` receipt while a pending `.update-incomplete` marker still existed and the venv stayed on stale pins.

Root cause: `_repair_current_checkout` gated repair solely on `_venv_core_imports_healthy()` — a subprocess import of 4 core modules. On an editable install those modules resolve against the new checkout, so the probe passes while the venv's actual dependencies are old. The marker — the authoritative record that a prior dependency install died — was read only by the startup recovery paths, never by the already-current branch of the very process whose recovery just failed again.

The fix checks the marker in `_repair_current_checkout`: a pending marker routes through `_repair_venv_on_current_checkout`, which re-runs the install, clears the marker on success, and leaves it (with a failed receipt and non-zero exit) when the install fails again. The 4-module probe alone can no longer mask an interrupted install.

## Related Issue

Fixes #103532

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd.py` — `_repair_current_checkout` now also checks `_m()._update_marker_path().exists()`; `handed_off_sync or not healthy or pending_install_marker` routes to `_repair_venv_on_current_checkout`, with a dedicated hint printed for the marker-pending case.
- `tests/hermes_cli/test_update_current_marker_repair.py` — new regression tests: marker + green probe routes to venv repair (never "Already up to date!"), clean checkout keeps the existing node-deps path, and the marker branch prints the reason.

## How to Test

1. `./.venv/bin/python -m pytest tests/hermes_cli/test_update_current_marker_repair.py -v` — 3 passed.
2. Revert only the `update_cmd.py` change and re-run — `test_pending_marker_routes_to_venv_repair_despite_healthy_probe` and `test_pending_marker_prints_hint` fail, `test_clean_checkout_keeps_already_up_to_date_path` stays green (observed result: `2 failed, 1 passed`).
3. `./.venv/bin/python -m pytest tests/hermes_cli/test_update_current_node_repair.py tests/hermes_cli/test_update_interrupted_recovery.py tests/hermes_cli/test_update_config_migration_on_current_checkout.py tests/hermes_cli/test_update_handoff_desktop_rebuild.py tests/hermes_cli/test_update_sqlite_remediation.py tests/hermes_cli/test_checkout_mutation_guards.py -q` — 23 passed, no behavior change on adjacent paths.

Manual shape: interrupt an update during dependency install (marker written), then run `hermes update` again with the network still broken — the observed result is now the repair attempt failing with a `failed` receipt instead of `✓ Already up to date!` / exit 0.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
