### PR TITLE
fix(desktop): persist recovered legacy tile owners

### DIFF
--- a/apps/desktop/src/store/session-states-owner-route-migration.test.ts
+++ b/apps/desktop/src/store/session-states-owner-route-migration.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const TILES_KEY = 'hermes.desktop.sessionTiles.v2'
+const OWNER_HINTS_KEY = 'hermes.desktop.sessionOwnerHints.v1'
+const ownerRoute = { connectionId: 'remote-a', profile: 'worker', targetProfile: 'worker' }
+const otherRoute = { connectionId: 'remote-b', profile: 'worker' }
+
+describe('persisted session tile owner recovery', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/')
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    window.history.replaceState(null, '', '/')
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+
+  it('persists only unambiguous hints and keeps the recovered route after hints expire', async () => {
+    window.localStorage.setItem(
+      OWNER_HINTS_KEY,
+      JSON.stringify([
+        ['legacy-session', ownerRoute],
+        ['explicit-session', ownerRoute],
+        ['ambiguous-session', ownerRoute],
+        ['ambiguous-session', otherRoute]
+      ])
+    )
+    window.localStorage.setItem(
+      TILES_KEY,
+      JSON.stringify({
+        default: [
+          { storedSessionId: 'legacy-session', workspaceMode: 'sessions' },
+          { storedSessionId: 'explicit-session', ownerRoute: otherRoute, workspaceMode: 'sessions' },
+          { storedSessionId: 'ambiguous-session', workspaceMode: 'sessions' }
+        ]
+      })
+    )
+
+    const states = await import('./session-states')
+
+    expect(states.sessionTileOwnerRoute('legacy-session')).toEqual(ownerRoute)
+    expect(states.sessionTileOwnerRoute('explicit-session')).toEqual(otherRoute)
+    expect(states.sessionTileOwnerRoute('ambiguous-session')).toBeUndefined()
+    expect(states.openTileGatewayScopes()).toEqual(new Set(['conn:remote-a::worker', 'conn:remote-b::worker']))
+
+    const persisted = JSON.parse(window.localStorage.getItem(TILES_KEY) ?? '{}')
+
+    expect(persisted.default[0].ownerRoute).toEqual(ownerRoute)
+    expect(persisted.default[1].ownerRoute).toEqual(otherRoute)
+    expect(persisted.default[2].ownerRoute).toBeUndefined()
+
+    window.localStorage.removeItem(OWNER_HINTS_KEY)
+    vi.resetModules()
+
+    const restored = await import('./session-states')
+
+    expect(restored.sessionTileOwnerRoute('legacy-session')).toEqual(ownerRoute)
+    expect(restored.foregroundSessionScopes()).toContain('conn:remote-a::worker')
+
+    // Hints learned after hydration also route an already mounted legacy tile.
+    const sessions = await import('./session')
+    sessions.setSessionOwnerHint('late-session', ownerRoute)
+    restored.$sessionTiles.set([{ storedSessionId: 'late-session' }])
+
+    expect(restored.sessionTileOwnerRoute('late-session')).toEqual(ownerRoute)
+    expect(restored.openTileGatewayScopes()).toEqual(new Set(['conn:remote-a::worker']))
+  })
+
+  it('does not rewrite shared tile storage while a pop-out window hydrates', async () => {
+    const saved = JSON.stringify({ default: [{ storedSessionId: 'legacy-session', workspaceMode: 'sessions' }] })
+
+    for (const windowKind of ['secondary', 'browser']) {
+      vi.resetModules()
+      window.history.replaceState(null, '', `/?win=${windowKind}`)
+      window.localStorage.setItem(OWNER_HINTS_KEY, JSON.stringify([['legacy-session', ownerRoute]]))
+      window.localStorage.setItem(TILES_KEY, saved)
+
+      const states = await import('./session-states')
+
+      expect(states.$sessionTiles.get()).toEqual([])
+      expect(window.localStorage.getItem(TILES_KEY)).toBe(saved)
+    }
+  })
+})

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -829,6 +829,7 @@ function parseTileList(value: unknown): StoredTile[] {
 function loadTilesByProfile(): Record<string, StoredTile[]> {
   const byProfile: Record<string, StoredTile[]> = {}
   const parsed = readJson<unknown>(TILES_KEY)
+  let recoveredOwnerRoute = false
 
   if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
     for (const [profile, list] of Object.entries(parsed as Record<string, unknown>)) {
@@ -866,6 +867,30 @@ function loadTilesByProfile(): Record<string, StoredTile[]> {
     byProfile[BOTS_TILE_BUCKET] = [
       ...new Map(byProfile[BOTS_TILE_BUCKET].map(tile => [tile.storedSessionId, tile])).values()
     ]
+  }
+
+  // Persist a proven unique hint before its bounded cache can evict it. Never
+  // infer a route from the bucket: profile names repeat across connections.
+  for (const [profile, tiles] of Object.entries(byProfile)) {
+    byProfile[profile] = tiles.map(tile => {
+      if (tile.ownerRoute) {
+        return tile
+      }
+
+      const ownerRoute = getSessionOwnerHint(tile.storedSessionId)
+
+      if (!ownerRoute) {
+        return tile
+      }
+
+      recoveredOwnerRoute = true
+
+      return { ...tile, ownerRoute }
+    })
+  }
+
+  if (recoveredOwnerRoute && !isSecondaryWindow() && !isBrowserWindow()) {
+    writeJson(TILES_KEY, byProfile)
   }
 
   writeJson(LEGACY_TILES_KEY, null)
@@ -935,8 +960,14 @@ export function patchSessionTile(storedSessionId: string, patch: Partial<Session
   saveTiles($sessionTiles.get().map(t => (t.storedSessionId === storedSessionId ? { ...t, ...patch } : t)))
 }
 
+function resolvedTileOwnerRoute(tile: Pick<SessionTile, 'ownerRoute' | 'storedSessionId'>): SessionOwnerRoute | undefined {
+  return tile.ownerRoute ?? getSessionOwnerHint(tile.storedSessionId)
+}
+
 export function sessionTileOwnerRoute(storedSessionId: string): SessionOwnerRoute | undefined {
-  return $sessionTiles.get().find(tile => tile.storedSessionId === storedSessionId)?.ownerRoute
+  const tile = $sessionTiles.get().find(candidate => candidate.storedSessionId === storedSessionId)
+
+  return tile ? resolvedTileOwnerRoute(tile) : undefined
 }
 
 /**
@@ -952,7 +983,7 @@ export function openTileGatewayScopes(): Set<string> {
   const scopes = new Set<string>()
 
   for (const tile of $sessionTiles.get()) {
-    const route = tile.ownerRoute
+    const route = resolvedTileOwnerRoute(tile)
 
     if (!route) {
       continue


### PR DESCRIPTION
## What does this PR do?

Recover exact owner routes for saved Desktop tiles written before tiles persisted those routes. Without recovery, an idle restored chat can lose the secondary gateway it needs or fail to route back to its owner.

- During tile hydration, copy only a **unique** existing session-owner hint onto a route-less tile and persist it in the primary window. This survives eventual hint-cache eviction.
- Preserve explicit routes. Leave ambiguous hints unresolved. Never infer ownership from the profile bucket, because separate connections may have the same profile name.
- Let tile owner lookup and the open-tile gateway keep-set use a unique hint learned after hydration.
- Pop-out session/browser windows do not rewrite shared tile storage.

## Related Issue

Distinct from merged #96110, which backfills backend session ownership, and open #96313, which extends foreground keep-set/resume behavior. This PR migrates renderer tile storage and does not duplicate the foreground keep-set change from #96313.

## Type of Change

- [x] Bug fix

## How to Test

From `apps/desktop`:

1. `npm run test:ui -- src/store/session-states-owner-route-migration.test.ts src/store/session-states.test.ts src/store/session-states-foreground-scopes.test.ts --maxWorkers=3`
2. `npm run typecheck`
3. `npx eslint src/store/session-states.ts src/store/session-states-owner-route-migration.test.ts`

Verified on macOS 26.5.1 against main `f58fcc8118d9db092ad60d363d4a28520e08ac5a`:

- On unmodified production code, the new recovery test fails because the restored tile has no owner route.
- After the fix: **86 tests passed** across three files.
- Full Desktop typecheck and focused ESLint: **passed**.
- Independent staged-diff review and added-line static scans: no blocking findings.

The two new invariant tests cover unambiguous recovery, explicit-route precedence, ambiguous-route rejection, persistence after hints disappear, late hints, and both pop-out window types. They use isolated jsdom local storage, not a live user's persisted workspace. Packaged-app E2E and full Python suites were not run.

## Checklist

- [x] Read contributing guide and searched existing PRs.
- [x] Conventional commit with only the tile owner recovery change.
- [x] Behavioral persistence and window-isolation tests.
- [x] No guessing from profile names or defaulting ambiguous routes to a connection.
- [x] No new configuration or backend schema; optional owner-route field already exists.
- [x] No platform-specific production APIs added.
- [ ] Packaged-app E2E / full Python suite (not run).

## AI assistance

Prepared with Codex assistance. Stated tests, typecheck, and lint ran locally; independent review did not run tests.
