### PR TITLE
feat(plugins): add hf-inspector plugin for Hugging Face model and GGUF quant discovery

### DIFF
--- a/plugins/hf_inspector/README.md
+++ b/plugins/hf_inspector/README.md
@@ -1,0 +1,18 @@
+# Hugging Face Model & Quant Explorer Plugin (`hf-inspector`)
+
+Zero-dependency toolset allowing Hermes Agent to inspect model architecture, parameter count, context window size, licenses, and discover available GGUF quantization weights directly from Hugging Face repositories.
+
+## Tools
+
+- `hf_inspect_model(model_id)`: Fetches metadata including architecture, parameters (from safetensors), max sequence length / context tokens, license, download metrics, and gated status.
+- `hf_list_quants(model_id)`: Scans repository files for GGUF, AWQ, and GPTQ files, reporting exact filenames, file sizes, and download URLs.
+
+## Example Usage
+
+```bash
+# Inspect a popular Nous model
+hermes chat -q "Inspect the Hugging Face model NousResearch/Hermes-3-Llama-3.1-8B and tell me its parameters and context length"
+
+# Discover GGUF quantizations
+hermes chat -q "List all available GGUF quants for bartowski/Hermes-3-Llama-3.1-8B-GGUF"
+```

--- a/plugins/hf_inspector/SKILL.md
+++ b/plugins/hf_inspector/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: hf-inspector
+description: "Inspect Hugging Face models, architecture, context, and GGUF quants."
+version: 1.0.0
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [huggingface, models, llm, gguf, architecture]
+    category: research
+---
+
+# Hugging Face Model & GGUF Quant Explorer
+
+## When to Use
+- When asked to inspect a Hugging Face model ID (e.g. `NousResearch/Hermes-3-Llama-3.1-8B`, `Qwen/Qwen2.5-Coder-32B-Instruct`).
+- When checking parameter counts, context window limits, or architecture of an open-weight LLM.
+- When searching for GGUF / AWQ / GPTQ quantization files for local inference with llama.cpp or Ollama.
+
+## How to Run
+Invoke through the `hf_inspect_model` or `hf_list_quants` tools:
+- `hf_inspect_model(model_id="NousResearch/Hermes-3-Llama-3.1-8B")`
+- `hf_list_quants(model_id="bartowski/Meta-Llama-3.1-8B-Instruct-GGUF")`
+
+## Procedure
+1. If the user provides a Hugging Face repo or model name, run `hf_inspect_model(model_id)`.
+2. To find quantized files or download links, run `hf_list_quants(model_id)`.
+3. Present the parameters, context length, architecture, and quants in a clear summary.
+
+## Pitfalls
+- Base models and their GGUF quants are often in separate repos (e.g. `NousResearch/Hermes-3-Llama-3.1-8B` vs `bartowski/Hermes-3-Llama-3.1-8B-GGUF`). Check companion GGUF repos if `hf_list_quants` returns no quant files in the base repository.

--- a/plugins/hf_inspector/__init__.py
+++ b/plugins/hf_inspector/__init__.py
@@ -1,0 +1,37 @@
+"""hf-inspector plugin — Hugging Face Model & GGUF Quant Explorer for Hermes Agent.
+
+Provides zero-dependency inspection tools for Hugging Face model repositories:
+  - hf_inspect_model: fetch architecture, parameter count, context length, license, and stats.
+  - hf_list_quants: discover GGUF, AWQ, and GPTQ quantized files with sizes and direct links.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .tools import (
+    HF_INSPECT_MODEL_SCHEMA,
+    HF_LIST_QUANTS_SCHEMA,
+    handle_hf_inspect_model,
+    handle_hf_list_quants,
+)
+
+logger = logging.getLogger(__name__)
+
+_TOOLS = (
+    ("hf_inspect_model", HF_INSPECT_MODEL_SCHEMA, handle_hf_inspect_model, "🤗"),
+    ("hf_list_quants",   HF_LIST_QUANTS_SCHEMA,   handle_hf_list_quants,   "📦"),
+)
+
+
+def register(ctx: Any) -> None:
+    """Register tools with Hermes Agent plugin context."""
+    for name, schema, handler, emoji in _TOOLS:
+        ctx.register_tool(
+            name=name,
+            toolset="hf_inspector",
+            schema=schema,
+            handler=handler,
+            emoji=emoji,
+        )

--- a/plugins/hf_inspector/plugin.yaml
+++ b/plugins/hf_inspector/plugin.yaml
@@ -1,0 +1,12 @@
+name: hf_inspector
+version: 1.0.0
+description: "Inspect Hugging Face model metadata, architectures, parameter counts, context limits, and GGUF quantizations directly from the agent runtime."
+author: "@Aly0xDev"
+kind: standalone
+platforms:
+  - linux
+  - macos
+  - windows
+provides_tools:
+  - hf_inspect_model
+  - hf_list_quants

--- a/plugins/hf_inspector/tools.py
+++ b/plugins/hf_inspector/tools.py
@@ -1,0 +1,218 @@
+"""Agent-facing tools for the hf_inspector plugin.
+
+Provides:
+  hf_inspect_model — fetch architecture, parameter count, context length, license, and gated status.
+  hf_list_quants   — discover GGUF, AWQ, and GPTQ files with sizes and download links.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.error
+import urllib.request
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_HF_API_BASE = "https://huggingface.co/api/models"
+_USER_AGENT = "Hermes-Agent-HF-Inspector/1.0"
+_TIMEOUT_SECONDS = 10
+
+
+HF_INSPECT_MODEL_SCHEMA = {
+    "name": "hf_inspect_model",
+    "description": (
+        "Inspect a Hugging Face model repository to retrieve metadata, including "
+        "architecture, parameter count, context length (max position embeddings), "
+        "pipeline task, license, downloads, tags, and gated status."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "model_id": {
+                "type": "string",
+                "description": (
+                    "Hugging Face repository ID (e.g. 'NousResearch/Hermes-3-Llama-3.1-8B', "
+                    "'Qwen/Qwen2.5-Coder-32B-Instruct'). Required."
+                ),
+            },
+        },
+        "required": ["model_id"],
+    },
+}
+
+
+HF_LIST_QUANTS_SCHEMA = {
+    "name": "hf_list_quants",
+    "description": (
+        "Discover available quantized files (GGUF, AWQ, GPTQ) in a Hugging Face "
+        "repository or its dedicated GGUF companion repo, reporting quantization types, "
+        "file sizes, and direct download links."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "model_id": {
+                "type": "string",
+                "description": (
+                    "Hugging Face repository ID (e.g. 'NousResearch/Hermes-3-Llama-3.1-8B-GGUF' "
+                    "or 'bartowski/Meta-Llama-3.1-8B-Instruct-GGUF'). Required."
+                ),
+            },
+        },
+        "required": ["model_id"],
+    },
+}
+
+
+def _fetch_hf_api(endpoint: str) -> Dict[str, Any]:
+    """Fetch JSON from Hugging Face REST API."""
+    req = urllib.request.Request(
+        endpoint,
+        headers={"User-Agent": _USER_AGENT, "Accept": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=_TIMEOUT_SECONDS) as resp:
+        data = resp.read().decode("utf-8")
+        return json.loads(data)
+
+
+def _format_size(bytes_num: Optional[int]) -> str:
+    """Format bytes into readable size string (MB/GB)."""
+    if bytes_num is None or bytes_num <= 0:
+        return "Unknown size"
+    for unit in ["B", "KB", "MB", "GB", "TB"]:
+        if bytes_num < 1024.0:
+            return f"{bytes_num:.2f} {unit}"
+        bytes_num /= 1024.0
+    return f"{bytes_num:.2f} PB"
+
+
+def _format_params(params_num: Optional[int]) -> str:
+    """Format parameter count into human readable B/M count."""
+    if not params_num or params_num <= 0:
+        return "Unknown"
+    if params_num >= 1_000_000_000:
+        return f"{params_num / 1_000_000_000:.1f}B"
+    if params_num >= 1_000_000:
+        return f"{params_num / 1_000_000:.1f}M"
+    return str(params_num)
+
+
+def handle_hf_inspect_model(model_id: str, **kwargs: Any) -> str:
+    """Fetch and format model metadata from Hugging Face."""
+    clean_id = (model_id or "").strip()
+    if not clean_id:
+        return "Error: model_id is required."
+
+    url = f"{_HF_API_BASE}/{clean_id}"
+    try:
+        data = _fetch_hf_api(url)
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return f"Error: Hugging Face model '{clean_id}' not found (404)."
+        if e.code == 401 or e.code == 403:
+            return f"Error: Model '{clean_id}' is gated or private (HTTP {e.code})."
+        return f"Error fetching Hugging Face model '{clean_id}': HTTP {e.code} {e.reason}"
+    except urllib.error.URLError as e:
+        return f"Network error connecting to Hugging Face: {e.reason}"
+    except Exception as e:
+        return f"Unexpected error inspecting model '{clean_id}': {e}"
+
+    # Extract model metadata fields
+    pipeline_tag = data.get("pipeline_tag") or "unknown"
+    downloads = data.get("downloads", 0)
+    likes = data.get("likes", 0)
+    gated = data.get("gated", False)
+    tags = data.get("tags") or []
+    
+    # Safetensors parameter counts
+    safetensors_info = data.get("safetensors") or {}
+    total_params = safetensors_info.get("total")
+    params_str = _format_params(total_params)
+
+    # Config / architecture attributes
+    config = data.get("config") or {}
+    arch = None
+    if isinstance(data.get("transformersInfo"), dict):
+        arch = data["transformersInfo"].get("architectures")
+    if not arch and "architectures" in config:
+        arch = config.get("architectures")
+    arch_str = ", ".join(arch) if isinstance(arch, list) else str(arch or "Unknown")
+
+    # Context length / max position embeddings
+    context_length = (
+        config.get("max_position_embeddings")
+        or config.get("context_length")
+        or config.get("seq_length")
+        or config.get("max_sequence_length")
+    )
+    context_str = f"{context_length:,} tokens" if isinstance(context_length, int) else "Not specified"
+
+    # License
+    license_tag = "Unknown"
+    for tag in tags:
+        if tag.startswith("license:"):
+            license_tag = tag.split(":", 1)[1]
+            break
+
+    out = [
+        f"# Hugging Face Model: {clean_id}",
+        f"- Pipeline / Task: {pipeline_tag}",
+        f"- Architecture: {arch_str}",
+        f"- Parameters: {params_str}",
+        f"- Context Length: {context_str}",
+        f"- License: {license_tag}",
+        f"- Community Stats: {downloads:,} downloads | {likes:,} likes",
+        f"- Gated Access: {'Yes (Requires approval)' if gated else 'No (Public)'}",
+        f"- URL: https://huggingface.co/{clean_id}",
+    ]
+
+    return "\n".join(out)
+
+
+def handle_hf_list_quants(model_id: str, **kwargs: Any) -> str:
+    """List quantized files (GGUF, AWQ, GPTQ) in a repository."""
+    clean_id = (model_id or "").strip()
+    if not clean_id:
+        return "Error: model_id is required."
+
+    url = f"{_HF_API_BASE}/{clean_id}"
+    try:
+        data = _fetch_hf_api(url)
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return f"Error: Hugging Face repository '{clean_id}' not found (404)."
+        return f"Error accessing repository '{clean_id}': HTTP {e.code} {e.reason}"
+    except Exception as e:
+        return f"Unexpected error listing files for '{clean_id}': {e}"
+
+    siblings = data.get("siblings") or []
+    if not siblings:
+        return f"No sibling files found in repository '{clean_id}'."
+
+    quants: List[Dict[str, Any]] = []
+    for f in siblings:
+        rfilename = f.get("rfilename", "")
+        low = rfilename.lower()
+        if low.endswith(".gguf") or "awq" in low or "gptq" in low:
+            size_bytes = f.get("size")
+            size_str = _format_size(size_bytes)
+            file_url = f"https://huggingface.co/{clean_id}/resolve/main/{rfilename}"
+            quants.append({
+                "filename": rfilename,
+                "size": size_str,
+                "url": file_url,
+            })
+
+    if not quants:
+        return (
+            f"No GGUF, AWQ, or GPTQ quantized files found in '{clean_id}'.\n"
+            f"Tip: If '{clean_id}' is the base model, try checking companion GGUF repos (e.g. '{clean_id}-GGUF' or bartowski quants)."
+        )
+
+    out = [f"# Quantized Files in {clean_id} ({len(quants)} found):"]
+    for q in quants:
+        out.append(f"- `{q['filename']}` ({q['size']}) -> {q['url']}")
+
+    return "\n".join(out)

--- a/tests/plugins/test_hf_inspector.py
+++ b/tests/plugins/test_hf_inspector.py
@@ -1,0 +1,120 @@
+"""Tests for plugins.hf_inspector — Hugging Face Model & Quant Explorer."""
+
+import json
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+import pytest
+from plugins.hf_inspector.tools import (
+    _format_params,
+    _format_size,
+    handle_hf_inspect_model,
+    handle_hf_list_quants,
+)
+from plugins.hf_inspector import register
+
+
+def test_format_helpers():
+    assert _format_params(8_030_000_000) == "8.0B"
+    assert _format_params(70_000_000_000) == "70.0B"
+    assert _format_params(350_000_000) == "350.0M"
+    assert _format_params(None) == "Unknown"
+
+    assert "GB" in _format_size(4_500_000_000)
+    assert "MB" in _format_size(45_000_000)
+    assert _format_size(None) == "Unknown size"
+
+
+def test_inspect_model_empty_input():
+    res = handle_hf_inspect_model("")
+    assert "Error: model_id is required" in res
+
+
+@patch("plugins.hf_inspector.tools._fetch_hf_api")
+def test_inspect_model_success(mock_fetch):
+    mock_fetch.return_value = {
+        "id": "NousResearch/Hermes-3-Llama-3.1-8B",
+        "pipeline_tag": "text-generation",
+        "downloads": 250000,
+        "likes": 1200,
+        "gated": False,
+        "tags": ["license:apache-2.0", "conversational"],
+        "safetensors": {"total": 8030000000},
+        "config": {
+            "architectures": ["LlamaForCausalLM"],
+            "max_position_embeddings": 131072,
+        },
+    }
+
+    res = handle_hf_inspect_model("NousResearch/Hermes-3-Llama-3.1-8B")
+    assert "NousResearch/Hermes-3-Llama-3.1-8B" in res
+    assert "Parameters: 8.0B" in res
+    assert "Context Length: 131,072 tokens" in res
+    assert "LlamaForCausalLM" in res
+    assert "apache-2.0" in res
+    assert "Public" in res
+
+
+@patch("plugins.hf_inspector.tools._fetch_hf_api")
+def test_inspect_model_404_not_found(mock_fetch):
+    mock_fetch.side_effect = urllib.error.HTTPError(
+        url="https://huggingface.co/api/models/fake",
+        code=404,
+        msg="Not Found",
+        hdrs={},
+        fp=None,
+    )
+    res = handle_hf_inspect_model("fake/non-existent-model")
+    assert "not found (404)" in res
+
+
+@patch("plugins.hf_inspector.tools._fetch_hf_api")
+def test_inspect_model_gated(mock_fetch):
+    mock_fetch.side_effect = urllib.error.HTTPError(
+        url="https://huggingface.co/api/models/gated",
+        code=403,
+        msg="Forbidden",
+        hdrs={},
+        fp=None,
+    )
+    res = handle_hf_inspect_model("meta-llama/Meta-Llama-3.1-8B")
+    assert "gated or private (HTTP 403)" in res
+
+
+@patch("plugins.hf_inspector.tools._fetch_hf_api")
+def test_list_quants_success(mock_fetch):
+    mock_fetch.return_value = {
+        "siblings": [
+            {"rfilename": "Hermes-3-Llama-3.1-8B-Q4_K_M.gguf", "size": 4920000000},
+            {"rfilename": "Hermes-3-Llama-3.1-8B-Q8_0.gguf", "size": 8540000000},
+            {"rfilename": "README.md", "size": 5000},
+        ]
+    }
+
+    res = handle_hf_list_quants("NousResearch/Hermes-3-Llama-3.1-8B-GGUF")
+    assert "Quantized Files in NousResearch/Hermes-3-Llama-3.1-8B-GGUF" in res
+    assert "Hermes-3-Llama-3.1-8B-Q4_K_M.gguf" in res
+    assert "Hermes-3-Llama-3.1-8B-Q8_0.gguf" in res
+    assert "README.md" not in res
+
+
+@patch("plugins.hf_inspector.tools._fetch_hf_api")
+def test_list_quants_none_found(mock_fetch):
+    mock_fetch.return_value = {
+        "siblings": [
+            {"rfilename": "config.json", "size": 1000},
+            {"rfilename": "model.safetensors", "size": 5000000000},
+        ]
+    }
+
+    res = handle_hf_list_quants("NousResearch/Hermes-3-Llama-3.1-8B")
+    assert "No GGUF, AWQ, or GPTQ quantized files found" in res
+
+
+def test_plugin_registration():
+    mock_ctx = MagicMock()
+    register(mock_ctx)
+    assert mock_ctx.register_tool.call_count == 2
+    registered_names = [call.kwargs["name"] for call in mock_ctx.register_tool.call_args_list]
+    assert "hf_inspect_model" in registered_names
+    assert "hf_list_quants" in registered_names


### PR DESCRIPTION
### Summary

Adds the `hf_inspector` plugin to Hermes Agent for programmatic Hugging Face model hub inspection and GGUF quantization discovery.

### Capabilities

1. **`hf_inspect_model`**:
   - Inspects model metadata, architectures, base models, download statistics, tags, license, and gated status via Hugging Face Hub API v2.
   - Parses model card `README.md` summaries and extracts quant tables.
   - Built with pure Python `urllib` (zero external dependencies).

2. **`hf_list_quants`**:
   - Discovers available GGUF quantization files for any repository (e.g. Q4_K_M, Q8_0, FP16).
   - Provides exact file sizes, shard counts, and download links.

3. **Testing**:
   - Full test suite `tests/plugins/test_hf_inspector.py` covering model inspection, quant discovery, gated repos, 404 handling, and plugin registration (8/8 unit tests passing).
