### PR TITLE
fix(skills): canonicalize usage ledger keys so counters aggregate

### DIFF
--- a/tests/tools/test_skill_usage_keys.py
+++ b/tests/tools/test_skill_usage_keys.py
@@ -53,6 +53,20 @@ def test_canonical_key_never_raises_and_degrades(skills_home):
     assert canonical_skill_key(object()) != ""
 
 
+def test_canonical_key_survives_hostile_input(skills_home):
+    """The never-raises contract holds for hostile __str__ and null bytes."""
+
+    class Hostile:
+        def __bool__(self):
+            return True
+
+        def __str__(self):
+            raise ValueError("boom")
+
+    assert canonical_skill_key(Hostile()) == ""
+    assert canonical_skill_key("a\0b/c") == "a\0b/c"
+
+
 def test_separator_split_aggregates_under_one_key(skills_home):
     """Issue split #1: `/` vs `\\` writes land on a single record."""
     bump_use("devops\\plain-skill")

--- a/tests/tools/test_skill_usage_keys.py
+++ b/tests/tools/test_skill_usage_keys.py
@@ -1,0 +1,107 @@
+"""Key-canonicalization contracts for skill usage telemetry (#103542).
+
+One canonical .usage.json key per skill: separators normalized, dir paths
+resolved to frontmatter names, pre-existing splits merged with counters
+summed. Uses an isolated HERMES_HOME; no network, no GPU.
+"""
+
+import json
+
+import pytest
+
+from tools.skill_usage import (
+    bump_use,
+    bump_view,
+    canonical_skill_key,
+    load_usage,
+    seed_record_if_missing,
+)
+
+
+@pytest.fixture()
+def skills_home(tmp_path, monkeypatch):
+    """Isolated skills tree with one nested skill (dir != frontmatter name)."""
+    home = tmp_path / ".hermes"
+    skills = home / "skills" / "devops" / "skill-router"
+    skills.mkdir(parents=True)
+    (skills / "SKILL.md").write_text(
+        "---\nname: sr\ndescription: Routes things.\n---\n\nBody.\n", encoding="utf-8")
+    plain = home / "skills" / "plain-skill"
+    plain.mkdir(parents=True)
+    (plain / "SKILL.md").write_text(
+        "---\nname: plain-skill\ndescription: Plain.\n---\n\nBody.\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def test_canonical_key_normalizes_separators(skills_home):
+    assert canonical_skill_key("devops\\plain-skill-not-a-dir") == "devops/plain-skill-not-a-dir"
+    assert canonical_skill_key("  devops/skill-router/ ") == "sr"  # resolves via the real dir
+    assert canonical_skill_key("sr") == "sr"
+
+
+def test_canonical_key_resolves_dir_to_frontmatter_name(skills_home):
+    assert canonical_skill_key("devops/skill-router") == "sr"
+    assert canonical_skill_key("devops\\skill-router") == "sr"
+
+
+def test_canonical_key_never_raises_and_degrades(skills_home):
+    assert canonical_skill_key("") == ""
+    assert canonical_skill_key(None) == ""
+    assert canonical_skill_key(42) == "42"
+    assert canonical_skill_key("no/such/dir") == "no/such/dir"
+    assert canonical_skill_key(object()) != ""
+
+
+def test_separator_split_aggregates_under_one_key(skills_home):
+    """Issue split #1: `/` vs `\\` writes land on a single record."""
+    bump_use("devops\\plain-skill")
+    bump_use("devops/plain-skill")
+    data = load_usage()
+    assert list(data) == ["devops/plain-skill"]
+    assert data["devops/plain-skill"]["use_count"] == 2
+
+
+def test_dirname_frontmatter_split_aggregates(skills_home):
+    """Issue split #2: dir-path writes resolve to the frontmatter name."""
+    for _ in range(3):
+        bump_use("devops/skill-router")
+    data = load_usage()
+    assert list(data) == ["sr"]
+    assert data["sr"]["use_count"] == 3
+
+
+def test_preexisting_split_heals_on_next_write(skills_home):
+    """Counters from both spellings sum; the duplicate key disappears."""
+    home = skills_home
+    usage_file = home / "skills" / ".usage.json"
+    usage_file.write_text(json.dumps({
+        "devops\\plain-skill": {"use_count": 1, "view_count": 0, "patch_count": 0,
+                                "last_used_at": "2026-01-01T00:00:00",
+                                "last_viewed_at": None, "last_patched_at": None,
+                                "created_at": None, "created_by": None, "pinned": False},
+        "devops/plain-skill": {"use_count": 2, "view_count": 0, "patch_count": 0,
+                               "last_used_at": "2026-09-01T00:00:00",
+                               "last_viewed_at": None, "last_patched_at": None,
+                               "created_at": None, "created_by": None, "pinned": False},
+    }), encoding="utf-8")
+    bump_use("devops/plain-skill")
+    data = load_usage()
+    assert list(data) == ["devops/plain-skill"]
+    assert data["devops/plain-skill"]["use_count"] == 4
+    assert data["devops/plain-skill"]["last_used_at"] >= "2026-09-01T00:00:00"
+
+
+def test_seed_uses_canonical_key(skills_home):
+    seed_record_if_missing("devops\\skill-router")
+    data = load_usage()
+    assert "sr" in data
+    assert "devops\\skill-router" not in data
+
+
+def test_view_and_use_share_the_record(skills_home):
+    bump_view("sr")
+    bump_use("sr")
+    data = load_usage()
+    assert data["sr"]["view_count"] == 1
+    assert data["sr"]["use_count"] == 1

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -394,14 +394,17 @@ def canonical_skill_key(skill_name: Any) -> str:
     frontmatter ``name:`` (directory name vs frontmatter name split). Plain
     (separator-free) names pass through untouched — no disk reads on the hot
     path. Never raises; unresolvable input degrades to the normalized text."""
-    text = str(skill_name or "").replace("\\", "/").strip().strip("/")
+    try:
+        text = str(skill_name or "").replace("\\", "/").strip().strip("/")
+    except (OSError, ValueError):
+        return ""
     if not text or "/" not in text:
         return text
     try:
         candidate = (_skills_dir() / text) if not Path(text).is_absolute() else Path(text)
         if candidate.is_dir() and (candidate / "SKILL.md").is_file():
             return _read_skill_name(candidate / "SKILL.md", fallback=text)
-    except OSError:
+    except (OSError, ValueError):
         pass
     return text
 

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -388,8 +388,52 @@ def _locked_update(skill_name: str, op: Callable[[Dict[str, Dict[str, Any]]], Tu
         return None
 
 
+def canonical_skill_key(skill_name: Any) -> str:
+    """One canonical .usage.json key per skill (#103542): separators normalized
+    to ``/``, and a path-shaped name resolving to a real skill dir maps to its
+    frontmatter ``name:`` (directory name vs frontmatter name split). Plain
+    (separator-free) names pass through untouched — no disk reads on the hot
+    path. Never raises; unresolvable input degrades to the normalized text."""
+    text = str(skill_name or "").replace("\\", "/").strip().strip("/")
+    if not text or "/" not in text:
+        return text
+    try:
+        candidate = (_skills_dir() / text) if not Path(text).is_absolute() else Path(text)
+        if candidate.is_dir() and (candidate / "SKILL.md").is_file():
+            return _read_skill_name(candidate / "SKILL.md", fallback=text)
+    except OSError:
+        pass
+    return text
+
+
+def _merge_duplicate_keys(data: Dict[str, Dict[str, Any]], canonical: str) -> None:
+    """Fold every key that canonicalizes to *canonical* into it (in place):
+    counters sum, latest timestamps win. Heals pre-fix splits (#103542)."""
+    if not canonical:
+        return
+    for key in [k for k in data if k != canonical and canonical_skill_key(k) == canonical]:
+        record = data.get(key)
+        if not isinstance(record, dict):
+            data.pop(key, None)
+            continue
+        target = data.setdefault(canonical, _empty_record())
+        for count_key in ("use_count", "view_count", "patch_count"):
+            target[count_key] = _non_negative_int(target.get(count_key)) + _non_negative_int(
+                record.get(count_key))
+        for ts_key in ("last_used_at", "last_viewed_at", "last_patched_at", "created_at"):
+            ours, theirs = target.get(ts_key), record.get(ts_key)
+            if theirs and (not ours or str(theirs) > str(ours)):
+                target[ts_key] = theirs
+        if record.get("pinned") and not target.get("pinned"):
+            target["pinned"] = True
+        if not target.get("created_by") and record.get("created_by"):
+            target["created_by"] = record["created_by"]
+        data.pop(key, None)
+
+
 def seed_record_if_missing(skill_name: str) -> None:
     """Baseline record for a curation-eligible skill so its inactivity clock starts at first sight, not epoch."""
+    skill_name = canonical_skill_key(skill_name)
     if skill_name and is_curation_eligible(skill_name):
         # load_usage() already dropped non-dict values, so "missing" == key absent; dirty only when inserted.
         def _seed(data):
@@ -399,10 +443,18 @@ def seed_record_if_missing(skill_name: str) -> None:
 
 def _mutate(skill_name: str, mutator, *, require_curation_eligible: bool = False) -> Any:
     """Load, apply *mutator(record)* in place, save; the mutator result (None if nothing landed). Telemetry is
-    recorded for ANY skill; lifecycle mutators pass ``require_curation_eligible=True`` (never write onto unmanaged)."""
+    recorded for ANY skill; lifecycle mutators pass ``require_curation_eligible=True`` (never write onto unmanaged).
+    Keys are canonicalized (#103542) and pre-existing duplicates folded in, so
+    counters aggregate under one key per skill."""
+    skill_name = canonical_skill_key(skill_name)
     if not skill_name:
         return None
-    return _locked_update(skill_name, lambda data: (mutator(data.setdefault(skill_name, _empty_record())), True),
+
+    def _apply(data):
+        _merge_duplicate_keys(data, skill_name)
+        return mutator(data.setdefault(skill_name, _empty_record())), True
+
+    return _locked_update(skill_name, _apply,
                           "skill_usage._mutate(%s) failed: %s",
                           (lambda: is_curation_eligible(skill_name)) if require_curation_eligible else None)
 


### PR DESCRIPTION
## What does this PR do?

The same skill was recorded in `skills/.usage.json` under multiple keys — backslash vs slash spellings on Windows (`devops\…` vs `devops/…`), and directory paths vs frontmatter `name:` (`skill-router` vs `sr`) — so usage-based views undercounted and the curator's inactivity clock misread heavily used skills as unused.

Adds `canonical_skill_key()`: separators normalized to `/`, path-shaped names resolving to a real skill dir mapped to frontmatter `name:`. Applied at the single write chokepoint (`_mutate`, plus `seed_record_if_missing`); pre-existing splits merge on the next write with counters summed and latest timestamps kept. Plain (separator-free) names take no disk reads; unresolvable input degrades to normalized text; the helper never raises so telemetry can never break a spawn/view.

## Related Issue

Fixes #103542

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skill_usage.py`: `canonical_skill_key()`, `_merge_duplicate_keys()`, wired into `_mutate` + `seed_record_if_missing`
- `tests/tools/test_skill_usage_keys.py`: 8 contract tests (both reported splits, heal-on-write, seed, never-raises)

## How to Test

1. `pytest tests/tools/test_skill_usage_keys.py -q` — 8 passed (fail without the fix: collection ImportError on stashed implementation).
2. `pytest tests/agent/test_curator.py tests/agent/test_curator_reports.py tests/agent/test_curator_activity.py tests/agent/test_skill_bundles.py tests/agent/test_org_skill_namespace.py -q` — 78 passed.
3. `ruff check tools/skill_usage.py` — clean.
4. Manual: on a Windows checkout with a split ledger, trigger any skill use and confirm the duplicate keys fold into one record with summed `use_count`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted suites: see above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (separator split covered by test; live Windows verification welcome)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavioral fix, docstrings inline)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the bug IS Windows-specific; the fix is platform-independent string handling plus a skills-dir probe
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
