### PR TITLE
feat(api_server): bind X-Hermes-Session-Key as HERMES_SESSION_USER_ID on /v1/runs

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3554,16 +3554,25 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
 
     @staticmethod
     def _bind_api_server_session(
-        *, chat_id: str = "", session_key: str = "", session_id: str = "",
+        *, chat_id: str = "", session_key: str = "", session_id: str = "", user_id: str = "",
         browser_control_principal: str = "", browser_control_transport_family: str = "",
         session_history_delivery: str = "") -> list:
         """Bind an API turn with push disabled and history delivery default-denied.
 
         Only routes whose continuation reads SessionDB may pass "1". An omitted
-        declaration or fingerprint-derived identity keeps delegation synchronous."""
+        declaration or fingerprint-derived identity keeps delegation synchronous.
+
+        ``user_id`` is the caller's identity as the route knows it (for ``/v1/runs`` the
+        ``X-Hermes-Session-Key`` gateway session key); it lands in ``HERMES_SESSION_USER_ID`` like
+        the webhook adapter's ``webhook:<route>`` so plugins and tools can tell who is behind the
+        turn. ``session_key`` is the *approval* key, which on ``/v1/runs`` is the run id.
+
+        See #10760.
+        """
         from gateway.session_context import set_session_vars
         return set_session_vars(
             platform="api_server", chat_id=chat_id, session_key=session_key, session_id=session_id,
+            user_id=user_id,
             browser_control_principal=browser_control_principal,
             browser_control_transport_family=browser_control_transport_family,
             async_delivery=False, cron_session="", session_history_delivery=session_history_delivery)

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -527,8 +527,12 @@ def _run_agent_sync(self, run: _RunLaunch, agent, approval_notify, *, _api_serve
             resets.append((set_current_session_key(run.approval_session_key), reset_current_session_key))
             # chat_id carries the raw session id like _run_agent() does; without it
             # tools.async_delegation sees no HERMES_SESSION_CHAT_ID and forces delegations sync.
+            # user_id: the X-Hermes-Session-Key the client sent — the only per-caller identity a
+            # /v1/runs turn has. session_key is the per-run approval key, so without this a
+            # pre_tool_call plugin cannot tell which end user it is acting for.
             session_tokens = self._bind_api_server_session(
                 chat_id=session_id or "", session_key=run.approval_session_key, session_id=session_id or "",
+                user_id=run.gateway_session_key or "",
                 browser_control_principal=run.browser_control_principal,
                 browser_control_transport_family=run.browser_control_transport_family,
                 # #98619 audited opt-in: the /v1/runs session id is wake-capable only when its

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -266,6 +266,82 @@ class TestStartRun:
         return agent
 
     @pytest.mark.asyncio
+    async def test_start_binds_gateway_session_key_as_user_id(self, auth_adapter):
+        """/v1/runs binds the caller's X-Hermes-Session-Key as HERMES_SESSION_USER_ID for the
+        duration of the turn. HERMES_SESSION_KEY on this route is the per-run approval key
+        (the run id), so without this binding a pre_tool_call plugin or a tool has no way to
+        tell which end user it is acting for. The webhook adapter already does the same with
+        ``webhook:<route>``."""
+        # X-Hermes-Session-Key is only honoured when an API key is configured (see _parse_session_key_header).
+        adapter = auth_adapter
+        app = _create_runs_app(adapter)
+        captured = {}
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+
+                def _capture_run(user_message=None, conversation_history=None, task_id=None):
+                    from gateway.session_context import get_session_env
+
+                    captured["user_id"] = get_session_env("HERMES_SESSION_USER_ID", "")
+                    captured["platform"] = get_session_env("HERMES_SESSION_PLATFORM", "")
+                    captured["session_key"] = get_session_env("HERMES_SESSION_KEY", "")
+                    return {"final_response": "done"}
+
+                mock_agent.run_conversation.side_effect = _capture_run
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "runs-user-sid"},
+                    headers={"Authorization": "Bearer sk-secret", "X-Hermes-Session-Key": "webui:dm:user-42"},
+                )
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+                await self._wait_completed(cli, run_id)
+
+        assert captured.get("platform") == "api_server"
+        assert captured.get("user_id") == "webui:dm:user-42", (
+            "runs route must expose the gateway session key as HERMES_SESSION_USER_ID"
+        )
+        # The approval key stays the run id — user identity must not leak into it.
+        assert captured.get("session_key") == run_id
+
+    @pytest.mark.asyncio
+    async def test_start_without_session_key_leaves_user_id_empty(self, adapter):
+        """No X-Hermes-Session-Key → HERMES_SESSION_USER_ID stays empty (not the run id, not the
+        session id): callers must not mistake a transcript scope for a user identity."""
+        app = _create_runs_app(adapter)
+        captured = {}
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+
+                def _capture_run(user_message=None, conversation_history=None, task_id=None):
+                    from gateway.session_context import get_session_env
+
+                    captured["user_id"] = get_session_env("HERMES_SESSION_USER_ID", "")
+                    return {"final_response": "done"}
+
+                mock_agent.run_conversation.side_effect = _capture_run
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "hello", "session_id": "runs-anon-sid"})
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+                await self._wait_completed(cli, run_id)
+
+        assert captured.get("user_id") == ""
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("body, expected", [
         ({"input": "hello", "author": {"id": "bot:dixie", "name": " dixie ", "is_bot": True, "role": "admin"}},
          {"id": "bot:dixie", "name": "dixie", "is_bot": True}),

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -623,6 +623,8 @@ X-Hermes-Session-Key: agent:main:webui:dm:user-42
 
 Rules: max 256 chars, control characters (`\r`, `\n`, `\x00`) are rejected, and the value is echoed back on responses (JSON + SSE). `/v1/capabilities` advertises support via `"session_key_header": "X-Hermes-Session-Key"`. Without the key, Honcho's `per-session` strategy produces a different scope per `session_id` — exactly the behavior Hermes had before.
 
+On `/v1/runs` the key is also bound as `HERMES_SESSION_USER_ID` for the duration of the turn (readable with `gateway.session_context.get_session_env`), the same slot the webhook adapter fills with `webhook:<route>`. Plugins and tools can use it to tell which end user a run is acting for — e.g. a `pre_tool_call` hook that pins a tenant id onto tool calls — since `HERMES_SESSION_KEY` on this route is the per-run approval key, not a user identity. Absent the header it stays empty.
+
 ## System Prompt Handling
 
 When a frontend sends a `system` message (Chat Completions) or `instructions` field (Responses API), hermes-agent **layers it on top** of its core system prompt. Your agent keeps all its tools, memory, and skills — the frontend's system prompt adds extra instructions.


### PR DESCRIPTION
## What does this PR do?

On `/v1/runs` the session contextvars carry the **per-run approval key** (the run id) in `HERMES_SESSION_KEY` and the raw session id in `HERMES_SESSION_CHAT_ID`, but nothing that identifies the *caller*. The `X-Hermes-Session-Key` header is the only per-user identity the route receives, yet it is reachable solely as `agent._gateway_session_key` — so a `pre_tool_call` plugin or a tool has no way to tell which end user a turn is acting for.

This binds the gateway session key as `HERMES_SESSION_USER_ID` for the duration of the turn, through the existing `_bind_api_server_session` chokepoint (new keyword `user_id`, default `""`). It mirrors what the webhook adapter already does with `webhook:<route>` in the same slot. Additive: other routes/platforms are unchanged, the approval key stays the run id, and without the header the value stays empty.

**Why:** multi-user frontends drive Hermes through `/v1/runs` with one `X-Hermes-Session-Key` per end user (the header the docs already recommend for per-channel memory). With this binding a plugin can scope tool calls per user — our use case is a `pre_tool_call` hook that pins a tenant id onto MCP calls so a shared MCP server can apply row-level security for the caller. Anything reading `get_session_env("HERMES_SESSION_USER_ID")` (`cronjob_job_args`, `kanban_tools`, `send_message_tool`, background-process watcher) also gets a real identity on this route instead of `""`.

## Related Issue

No existing issue; happy to open one if preferred. Related in spirit to #2971 (richer `/v1/runs` integration surface).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)
- [x] 📝 Documentation update

## Changes Made

- `gateway/platforms/api_server.py` — `_bind_api_server_session(..., user_id="")` forwards to `set_session_vars(user_id=...)`; docstring explains the slot.
- `gateway/platforms/api_server_runs.py` — the runs turn passes `user_id=run.gateway_session_key or ""`.
- `tests/gateway/test_api_server_runs.py` — two behaviour tests: with the header, `run_conversation` observes `HERMES_SESSION_USER_ID == "webui:dm:user-42"`, platform `api_server`, and `HERMES_SESSION_KEY == run_id` (identity must not leak into the approval key); without the header the value stays `""`.
- `website/docs/user-guide/features/api-server.md` — one paragraph under "Long-term memory scoping (`X-Hermes-Session-Key`)".

## How to Test

1. `pytest tests/gateway/test_api_server_runs.py -q` — the new test `test_start_binds_gateway_session_key_as_user_id` fails on `main` (`assert '' == 'webui:dm:user-42'`) and passes with this change.
2. Start the gateway with the API server enabled and an API key, then:
   ```bash
   curl -s -X POST localhost:8642/v1/runs -H "Authorization: Bearer $API_SERVER_KEY" \
     -H "X-Hermes-Session-Key: webui:dm:user-42" -H 'Content-Type: application/json' \
     -d '{"input":"hi"}'
   ```
   A plugin `pre_tool_call` hook calling `gateway.session_context.get_session_env("HERMES_SESSION_USER_ID")` now sees `webui:dm:user-42` during that run (previously `""`).
3. Ran `tests/gateway/test_api_server_runs.py`, `test_api_server.py`, `test_async_delivery_capability.py`, `test_browser_control_api.py`: 193 passed; `ruff check` clean on the touched files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected test files (`tests/gateway/test_api_server*.py`, 193 passed); full `pytest tests/ -q` not run locally
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Debian 12 container, Python 3.11) — also running in production behind a Next.js frontend

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A (contextvars only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
