### PR TITLE
feat(plugins): transform_tool_result may return a multimodal tool-result envelope

### DIFF
--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -56,7 +56,7 @@ behavior-affecting hooks:
 | --- | --- |
 | `pre_llm_call` | May return a string or `{"context": "..."}` to inject ephemeral context into the current user message. |
 | `pre_tool_call` | May return `{"action": "block", "message": "..."}` to block a tool before execution, or `{"action": "modify", "args": {...}}` to transform the tool's input arguments. |
-| `transform_tool_result` | May return a replacement tool result string after `post_tool_call`. |
+| `transform_tool_result` | May return a replacement tool result (a string, or a multimodal tool-result envelope) after `post_tool_call`. |
 | `transform_llm_output` | May return a replacement final assistant text string. |
 
 Telemetry plugins should treat these behavior-affecting returns as optional

--- a/model_tools.py
+++ b/model_tools.py
@@ -774,12 +774,27 @@ def _execute_tool(function_name: str, function_args: Dict[str, Any], original_ar
                                              **ids.hook_kwargs())
 
 
+def _is_multimodal_envelope(value) -> bool:
+    """A multimodal tool-result envelope, the shape ``browser_vision`` and
+    ``computer_use`` return: a dict with ``_multimodal: True`` and a list of
+    OpenAI-style content parts. The same predicate as
+    ``agent.tool_dispatch_helpers._is_multimodal_tool_result``, kept local so
+    this module adds no import of the dispatch layer."""
+    return (
+        isinstance(value, dict)
+        and value.get("_multimodal") is True
+        and isinstance(value.get("content"), list)
+    )
+
+
 def _apply_transform_tool_result_hook(function_name: str, function_args: Dict[str, Any], result: Any, duration_ms: int,
                                       ids: _CallIds) -> Any:
-    """transform_tool_result: plugins may replace the final result string.
+    """transform_tool_result: plugins may replace the final result with a string
+    or a multimodal tool-result envelope (so a plugin can attach an image).
 
     Runs after post_tool_call and before the result enters context. Fail-open;
-    first string return wins. Gated on has_hook so the no-listener path is cheap.
+    the first string or envelope return wins, any other return is ignored. Gated
+    on has_hook so the no-listener path is cheap.
     """
     try:
         from hermes_cli.lifecycle import has_hook, invoke_hook
@@ -788,7 +803,7 @@ def _apply_transform_tool_result_hook(function_name: str, function_args: Dict[st
             hook_results = invoke_hook("transform_tool_result", tool_name=function_name, args=function_args,
                                        result=result, **ids.hook_kwargs(), duration_ms=duration_ms,
                                        status=status, error_type=error_type, error_message=error_message)
-            return next((r for r in hook_results if isinstance(r, str)), result)
+            return next((r for r in hook_results if isinstance(r, str) or _is_multimodal_envelope(r)), result)
     except Exception as _hook_err:
         logger.debug("transform_tool_result hook error: %s", _hook_err)
     return result

--- a/tests/test_transform_tool_result_hook.py
+++ b/tests/test_transform_tool_result_hook.py
@@ -57,6 +57,33 @@ def _run_handle_function_call(
 
 
 
+def test_a_multimodal_envelope_return_replaces_result(monkeypatch):
+    """A hook may hand the model an image beside the result: it returns the same
+    multimodal envelope a tool like browser_vision returns (``_multimodal: True``
+    with OpenAI-style content parts). The envelope wins like a string does; a
+    plain dict is still ignored."""
+    envelope = {
+        "_multimodal": True,
+        "content": [
+            {"type": "text", "text": '{"output": "original", "second_look": true}'},
+            {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,AAAA"}},
+        ],
+        "text_summary": '{"output": "original", "second_look": true}',
+    }
+    out = _run_handle_function_call(
+        monkeypatch,
+        invoke_hook=lambda hook_name, **kw: [None, {"x": 1}, envelope, "later"],
+    )
+    assert out is envelope
+    # not an envelope: no `_multimodal` flag, or content that is not a list
+    out2 = _run_handle_function_call(
+        monkeypatch,
+        invoke_hook=lambda hook_name, **kw: [{"content": [{"type": "text", "text": "x"}]},
+                                            {"_multimodal": True, "content": "x"}, "string wins"],
+    )
+    assert out2 == "string wins"
+
+
 def test_first_valid_string_return_replaces_result(monkeypatch):
     out = _run_handle_function_call(
         monkeypatch,

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -440,7 +440,7 @@ Payload fields below are the exact event-specific fields supplied by each call s
 |---|---|---|---|---|
 | [`pre_tool_call`](#pre_tool_call) | Directive/control | Once before execution; first valid `block` or `approve` directive wins, and `modify` returns are shallow-merged into the tool arguments. | `tool_name`, `args`, `task_id`, `session_id`, `tool_call_id`, `turn_id`, `api_request_id`, `middleware_trace` | Raw arguments may contain user content, paths, commands, or secrets. |
 | `post_tool_call` | Observer | After blocked, error, or successful result; return ignored. | `tool_name`, `args`, `result`, `task_id`, `session_id`, `tool_call_id`, `turn_id`, `api_request_id`, `duration_ms`, `status`, `error_type`, `error_message`, `middleware_trace` | Result/error text may contain arbitrary tool or user content and secrets. |
-| `transform_tool_result` | Transform | After `post_tool_call`, before conversation append; first string replaces the result. | `tool_name`, `args`, `result`, `task_id`, `session_id`, `tool_call_id`, `turn_id`, `api_request_id`, `duration_ms`, `status`, `error_type`, `error_message` | Exposes the full model-bound result and arguments. |
+| `transform_tool_result` | Transform | After `post_tool_call`, before conversation append; the first string or multimodal tool-result envelope replaces the result. | `tool_name`, `args`, `result`, `task_id`, `session_id`, `tool_call_id`, `turn_id`, `api_request_id`, `duration_ms`, `status`, `error_type`, `error_message` | Exposes the full model-bound result and arguments. |
 | `transform_terminal_output` | Transform | After bounded foreground process capture, before final output limiting; first string replaces output. | `command`, `output`, `returncode`, `task_id`, `env_type` | Command/output may contain credentials. |
 | `pre_transcription` | Transform | Fired by the STT dispatcher after provider resolution and before any backend (built-in, command-type, or plugin-registered) is invoked; dict results are applied in registration order, last-writer-wins per field (`prompt`, `language`, `model`; `file_path` is read-only). | `file_path`, `provider`, `model`, `language`, `prompt`, `source` | The final prompt is uploaded to the configured STT provider with the audio — keep secrets out of hook returns. |
 | `pre_llm_call` | Directive/control | Once per turn before the loop; all valid string/`{"context": ...}` returns are joined and injected into the user message. | `session_id`, `task_id`, `turn_id`, `user_message`, `conversation_history`, `is_first_turn`, `model`, `platform`, `parent_session_id`, `sender_id` | Full user message and conversation history. |
@@ -1409,17 +1409,17 @@ Not every backend accepts a prompt. `local` maps it to faster-whisper's `initial
 
 ### `transform_tool_result`
 
-Fires **after** a tool returns and **before** the result is appended to the conversation. Lets a plugin rewrite ANY tool's result string — not just terminal output — before the model sees it.
+Fires **after** a tool returns and **before** the result is appended to the conversation. Lets a plugin rewrite ANY tool's result string — not just terminal output — before the model sees it, or attach an image to it.
 
 **Callback signature:**
 
 ```python
-def my_callback(tool_name: str, args: dict, result: str, task_id: str, **kwargs) -> str | None:
+def my_callback(tool_name: str, args: dict, result: str, task_id: str, **kwargs) -> str | dict | None:
 ```
 
 The full payload also includes `session_id`, `tool_call_id`, `turn_id`, `api_request_id`, `duration_ms`, `status`, `error_type`, and `error_message`. `result` is the final result returned by tool dispatch; it and `args` can contain arbitrary user/tool content and secrets.
 
-**Return value:** The first `str` replaces the result (including an empty string); `None` leaves it unchanged.
+**Return value:** The first `str` replaces the result (including an empty string); `None` leaves it unchanged. A multimodal tool-result envelope also replaces the result: `{"_multimodal": True, "content": [<OpenAI-style parts, e.g. a text part and an image_url part>], "text_summary": "<plain-text fallback>"}`, the shape `browser_vision` and `computer_use` return. That lets a plugin hand the model a screenshot beside a tool's result; providers that cannot take images in a tool result read `text_summary`. Any other dict is ignored.
 
 **Use cases:** Redact organization-specific PII from `web_extract` output, wrap long JSON tool responses in a summary header, inject retrieval-augmented hints into `read_file` results, rewrite `delegate_task` subagent reports into a project-specific schema.
 


### PR DESCRIPTION
## What does this PR do?

`transform_tool_result` takes only a string back from a plugin; every other return is ignored. So a plugin cannot attach an image to the result the model reads, although tools such as `browser_vision` and `computer_use` already hand the model a multimodal tool-result envelope (`{"_multimodal": True, "content": [...OpenAI-style parts...], "text_summary": "..."}`), and dispatch, history, trajectory saving and previews all handle that shape.

This PR lets the hook return that same envelope. `_apply_transform_tool_result_hook` accepts a string **or** an envelope, with the same first-valid-return-wins rule. Any other dict is still ignored, so existing plugins are unaffected; the no-listener path is unchanged.

Use case: a browser plugin judges a click result blind (the engine's "covered by" verdict, a pick that did not land) and attaches one viewport screenshot to that same result, so the model looks at the page instead of guessing, without a second round trip through `browser_vision`.

## Related Issue

None. I searched open and closed PRs and issues for `transform_tool_result`; the nearest ones (#72860, #85729, #19921) change when the hook fires or warns, not what it may return.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `model_tools.py`: `_is_multimodal_envelope` (the same predicate as `agent.tool_dispatch_helpers._is_multimodal_tool_result`, kept local so this module adds no import of the dispatch layer); `_apply_transform_tool_result_hook` accepts an envelope beside a string.
- `tests/test_transform_tool_result_hook.py`: an envelope return replaces the result; a plain dict, or a dict with `_multimodal` but a non-list `content`, is still skipped and a later string wins.
- `website/docs/user-guide/features/hooks.md`: the hook table row and the `transform_tool_result` section (signature `-> str | dict | None`, the return-value rule).
- `docs/observability/README.md`: the behavior-affecting-hooks table row.

## How to Test

1. `pytest tests/test_transform_tool_result_hook.py -q` — 6 passed (the new test is `test_a_multimodal_envelope_return_replaces_result`).
2. `pytest tests/test_model_tools.py tests/test_transform_llm_output_hook.py -q` — passes, except two `TestBridgeDispatch` tests that fail identically on clean `main` in my environment for a missing `snowballstemmer` module (unrelated to this change).
3. Register a `transform_tool_result` hook that returns `{"_multimodal": True, "content": [{"type": "text", "text": result}, {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}}], "text_summary": result}` for one tool; with a vision-capable main model the image reaches the model on that tool result.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran the hook and model_tools suites named above; not the whole tree
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A, pure Python
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
