### PR TITLE
feat(desktop): opt-in double-Enter sends a localized Continue nudge

### DIFF
--- a/apps/desktop/src/app/chat/composer/composer-utils.test.ts
+++ b/apps/desktop/src/app/chat/composer/composer-utils.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from 'vitest'
 
 import {
   acceptsTriggerCompletion,
+  DOUBLE_ENTER_WINDOW_MS,
   implicitSlashAcceptIndex,
+  isDoubleEnter,
   isPendingDraftPersistCurrent,
   type PendingDraftPersist,
   pickPlaceholder,
@@ -175,5 +177,23 @@ describe('isPendingDraftPersistCurrent (#54527 integrity guard)', () => {
 
   it('rejects when nothing was ever captured', () => {
     expect(isPendingDraftPersistCurrent(null, null)).toBe(false)
+  })
+})
+
+describe('isDoubleEnter (double-Enter Continue gesture)', () => {
+  it('fires when the previous empty Enter is within the window', () => {
+    expect(isDoubleEnter(1_000, 1_000 + DOUBLE_ENTER_WINDOW_MS)).toBe(true)
+  })
+
+  it('never fires without a previous empty Enter', () => {
+    expect(isDoubleEnter(null, 1_000)).toBe(false)
+  })
+
+  it('stays silent after the window lapses', () => {
+    expect(isDoubleEnter(1_000, 1_000 + DOUBLE_ENTER_WINDOW_MS + 1)).toBe(false)
+  })
+
+  it('does not travel backwards in time', () => {
+    expect(isDoubleEnter(2_000, 1_000)).toBe(false)
   })
 })

--- a/apps/desktop/src/app/chat/composer/composer-utils.ts
+++ b/apps/desktop/src/app/chat/composer/composer-utils.ts
@@ -200,6 +200,25 @@ export interface PendingDraftPersist {
   text: string
 }
 
+/** Window (ms) in which a second empty Enter counts as a double-Enter. */
+export const DOUBLE_ENTER_WINDOW_MS = 600
+
+/**
+ * Whether an empty Enter completes a double-Enter gesture: it must follow a
+ * previous empty Enter within {@link DOUBLE_ENTER_WINDOW_MS} — the first tap
+ * (typically the send) lands in the tracker, and only a quick second tap
+ * converts to "Continue". `now` is injectable for tests.
+ */
+export function isDoubleEnter(lastEmptyEnterAt: number | null, now: number): boolean {
+  if (lastEmptyEnterAt === null) {
+    return false
+  }
+
+  const elapsed = now - lastEmptyEnterAt
+
+  return elapsed >= 0 && elapsed <= DOUBLE_ENTER_WINDOW_MS
+}
+
 /**
  * Defense-in-depth for #54527: the debounce timer and the `pagehide` flush
  * both write a captured `{ scope, text }` pair some time after it was

--- a/apps/desktop/src/app/chat/composer/enter-double-continue.test.tsx
+++ b/apps/desktop/src/app/chat/composer/enter-double-continue.test.tsx
@@ -1,0 +1,359 @@
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
+import { useRef, useState } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { DOUBLE_ENTER_WINDOW_MS, isDoubleEnter } from './composer-utils'
+
+// No global setupFiles registers auto-cleanup, so unmount between tests —
+// otherwise a second render() leaks the first editor and getByTestId('editor')
+// matches multiple nodes.
+afterEach(cleanup)
+
+// Faithful mirror of index.tsx's Enter branch AFTER the double-Enter change:
+// the live-DOM payload read, the queue drain / busy send-now / empty-Enter
+// gates, and the new double-Enter tracker that converts a second empty Enter
+// into the "Continue" filler via loadIntoComposer + submitDraft.
+//
+// The gesture arms on a real send (payload Enter), so the filler flows through
+// the same routing ladder as a typed message: steer while busy (the mirror's
+// onQueue), send fresh when idle (onSubmit).
+function Harness({
+  busy = false,
+  disabled = false,
+  queued = [],
+  continueEnabled = true,
+  queueEdit = false,
+  repeat = false,
+  now = () => 0,
+  onSubmit,
+  onQueue,
+  onDrain,
+  onSendNow,
+  onSaveQueueEdit,
+  onCancel
+}: {
+  busy?: boolean
+  disabled?: boolean
+  queued?: readonly string[]
+  continueEnabled?: boolean
+  queueEdit?: boolean
+  repeat?: boolean
+  now?: () => number
+  onSubmit: (text: string) => void
+  onQueue: (text: string) => void
+  onDrain: () => void
+  onSendNow?: (id: string) => void
+  onSaveQueueEdit?: () => void
+  onCancel: () => void
+}) {
+  const editorRef = useRef<HTMLDivElement>(null)
+  const draftRef = useRef('')
+  const [draft, setDraft] = useState('')
+  const lastEmptyEnterAtRef = useRef<number | null>(null)
+  const attachments: unknown[] = []
+
+  const composerPlainText = (el: HTMLElement) => el.textContent ?? ''
+
+  const setText = (next: string) => {
+    draftRef.current = next
+    setDraft(next)
+  }
+
+  // Mirror of loadIntoComposer's paint: synchronous DOM write + draftRef sync.
+  const loadIntoComposer = (text: string) => {
+    if (editorRef.current) {
+      editorRef.current.textContent = text
+    }
+
+    setText(text)
+  }
+
+  const submitDraft = () => {
+    if (disabled) {
+      return
+    }
+
+    const editor = editorRef.current
+
+    if (editor) {
+      const domText = composerPlainText(editor)
+
+      if (domText !== draftRef.current) {
+        draftRef.current = domText
+        setDraft(domText)
+      }
+    }
+
+    const text = draftRef.current
+    const payloadPresent = text.trim().length > 0 || attachments.length > 0
+
+    if (busy) {
+      if (payloadPresent) {
+        onQueue(text)
+      } else {
+        onCancel()
+      }
+    } else if (!payloadPresent && queued.length > 0) {
+      onDrain()
+    } else if (payloadPresent) {
+      onSubmit(text)
+    }
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault()
+
+      if (queueEdit) {
+        onSaveQueueEdit?.()
+
+        return
+      }
+
+      const editorText = editorRef.current ? composerPlainText(editorRef.current) : draftRef.current
+      const hasLivePayload = editorText.trim().length > 0 || attachments.length > 0
+
+      if (disabled) {
+        return
+      }
+
+      if (!busy && !hasLivePayload && queued.length > 0) {
+        onDrain()
+
+        return
+      }
+
+      if (!hasLivePayload) {
+        const head = busy ? queued[0] : undefined
+
+        if (head) {
+          onSendNow?.(head)
+
+          return
+        }
+
+        const continueFire =
+          continueEnabled && !queueEdit && !event.repeat && isDoubleEnter(lastEmptyEnterAtRef.current, now())
+
+        if (continueFire) {
+          lastEmptyEnterAtRef.current = null
+          loadIntoComposer('Continue')
+        } else {
+          lastEmptyEnterAtRef.current = now()
+
+          if (busy) {
+            return
+          }
+        }
+
+        submitDraft()
+
+        return
+      }
+
+      lastEmptyEnterAtRef.current = now()
+
+      submitDraft()
+    }
+  }
+
+  // `draft` is read so the lint/compiler treats the stale-state mirror as live;
+  // the tracker holds its own ref, mirroring index.tsx.
+  void draft
+
+  return (
+    <div
+      contentEditable
+      data-testid="editor"
+      onInput={event => setText(composerPlainText(event.currentTarget))}
+      onKeyDown={handleKeyDown}
+      ref={editorRef}
+      suppressContentEditableWarning
+    />
+  )
+}
+
+describe('composer double-Enter Continue', () => {
+  it('steers the live turn when the second empty Enter lands within the window', async () => {
+    const onQueue = vi.fn()
+    const onCancel = vi.fn()
+    let clock = 0
+    const now = () => clock
+
+    const { getByTestId } = render(
+      <Harness busy now={now} onCancel={onCancel} onDrain={vi.fn()} onQueue={onQueue} onSubmit={vi.fn()} />
+    )
+
+    const editor = getByTestId('editor')
+
+    // First Enter sends a message and empties the composer.
+    await act(async () => {
+      editor.textContent = 'fix the failing test'
+      fireEvent.keyDown(editor, { key: 'Enter' })
+      editor.textContent = ''
+      clock += 100
+    })
+
+    expect(onQueue).toHaveBeenCalledWith('fix the failing test')
+
+    // Second empty Enter, quickly: converts to the Continue nudge.
+    await act(async () => {
+      fireEvent.keyDown(editor, { key: 'Enter', repeat: false })
+    })
+
+    expect(onQueue).toHaveBeenCalledWith('Continue')
+    expect(onCancel).not.toHaveBeenCalled()
+    // The filler was loaded into the composer, not silently sent from nothing.
+    expect(editor.textContent).toBe('Continue')
+  })
+
+  it('sends Continue as a fresh message when the turn already settled', async () => {
+    const onSubmit = vi.fn()
+    let clock = 0
+    const now = () => clock
+
+    const { getByTestId } = render(
+      <Harness now={now} onCancel={vi.fn()} onDrain={vi.fn()} onQueue={vi.fn()} onSubmit={onSubmit} />
+    )
+
+    const editor = getByTestId('editor')
+
+    await act(async () => {
+      editor.textContent = 'go on'
+      fireEvent.keyDown(editor, { key: 'Enter' })
+      editor.textContent = ''
+      clock += 50
+    })
+
+    expect(onSubmit).toHaveBeenCalledWith('go on')
+
+    await act(async () => {
+      fireEvent.keyDown(editor, { key: 'Enter', repeat: false })
+    })
+
+    expect(onSubmit).toHaveBeenLastCalledWith('Continue')
+  })
+
+  it('never fires from a held-down Enter (key repeat)', async () => {
+    const onQueue = vi.fn()
+    const onCancel = vi.fn()
+    let clock = 0
+    const now = () => clock
+
+    const { getByTestId } = render(
+      <Harness busy now={now} onCancel={onCancel} onDrain={vi.fn()} onQueue={onQueue} onSubmit={vi.fn()} />
+    )
+
+    const editor = getByTestId('editor')
+
+    await act(async () => {
+      editor.textContent = 'hello'
+      fireEvent.keyDown(editor, { key: 'Enter' })
+      editor.textContent = ''
+      clock += 10
+    })
+
+    await act(async () => {
+      fireEvent.keyDown(editor, { key: 'Enter', repeat: true })
+    })
+
+    expect(onQueue).not.toHaveBeenCalledWith('Continue')
+    expect(onCancel).not.toHaveBeenCalled()
+  })
+
+  it('stays a no-op when the second empty Enter is outside the window', async () => {
+    const onQueue = vi.fn()
+    const onCancel = vi.fn()
+    let clock = 0
+    const now = () => clock
+
+    const { getByTestId } = render(
+      <Harness busy now={now} onCancel={onCancel} onDrain={vi.fn()} onQueue={onQueue} onSubmit={vi.fn()} />
+    )
+
+    const editor = getByTestId('editor')
+
+    await act(async () => {
+      editor.textContent = 'hello'
+      fireEvent.keyDown(editor, { key: 'Enter' })
+      editor.textContent = ''
+      clock += DOUBLE_ENTER_WINDOW_MS + 500
+    })
+
+    await act(async () => {
+      fireEvent.keyDown(editor, { key: 'Enter', repeat: false })
+    })
+
+    expect(onQueue).not.toHaveBeenCalledWith('Continue')
+    expect(onCancel).not.toHaveBeenCalled()
+  })
+
+  it('never fires when the setting is off (default behavior preserved)', async () => {
+    const onQueue = vi.fn()
+    const onCancel = vi.fn()
+    let clock = 0
+    const now = () => clock
+
+    const { getByTestId } = render(
+      <Harness
+        busy
+        continueEnabled={false}
+        now={now}
+        onCancel={onCancel}
+        onDrain={vi.fn()}
+        onQueue={onQueue}
+        onSubmit={vi.fn()}
+      />
+    )
+
+    const editor = getByTestId('editor')
+
+    await act(async () => {
+      editor.textContent = 'hello'
+      fireEvent.keyDown(editor, { key: 'Enter' })
+      editor.textContent = ''
+      clock += 50
+    })
+
+    await act(async () => {
+      fireEvent.keyDown(editor, { key: 'Enter', repeat: false })
+    })
+
+    expect(onQueue).not.toHaveBeenCalledWith('Continue')
+    expect(onCancel).not.toHaveBeenCalled()
+  })
+
+  it('does not fire while editing a queued turn (Enter saves the edit)', async () => {
+    const onSaveQueueEdit = vi.fn()
+    let clock = 0
+    const now = () => clock
+
+    const { getByTestId } = render(
+      <Harness
+        busy
+        now={now}
+        onCancel={vi.fn()}
+        onDrain={vi.fn()}
+        onQueue={vi.fn()}
+        onSaveQueueEdit={onSaveQueueEdit}
+        onSubmit={vi.fn()}
+        queueEdit
+      />
+    )
+
+    const editor = getByTestId('editor')
+
+    await act(async () => {
+      editor.textContent = 'hello'
+      fireEvent.keyDown(editor, { key: 'Enter' })
+      editor.textContent = ''
+      clock += 50
+    })
+
+    await act(async () => {
+      fireEvent.keyDown(editor, { key: 'Enter', repeat: false })
+    })
+
+    expect(onSaveQueueEdit).toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -20,6 +20,7 @@ import { sessionCompacting } from '@/store/compaction'
 import { browseBackward, browseForward, deriveUserHistory, isBrowsingHistory } from '@/store/composer-input-history'
 import { POPOUT_WIDTH_REM } from '@/store/composer-popout'
 import { parkQueuedPrompts, removeQueuedPrompt, unparkQueuedPrompts } from '@/store/composer-queue'
+import { $doubleEnterContinue } from '@/store/double-enter-continue'
 import { $hudMode } from '@/store/hud'
 import { sessionBlockingPrompt } from '@/store/prompts'
 import { toggleReview } from '@/store/review'
@@ -30,6 +31,7 @@ import { $autoSpeakReplies } from '@/store/voice-prefs'
 import { useTheme } from '@/themes'
 
 import { AttachmentList } from './attachments'
+import { isDoubleEnter } from './composer-utils'
 import {
   acceptsTriggerCompletion,
   COMPOSER_FADE_BACKGROUND,
@@ -223,6 +225,8 @@ export function ChatBar({
   const gatewayState = useStore($gatewayState)
   const reconnecting = gatewayState !== 'open'
   const inputDisabled = shouldDisableComposerInput(disabled, gatewayState)
+  const doubleEnterContinue = useStore($doubleEnterContinue)
+  const lastEmptyEnterAtRef = useRef<number | null>(null)
 
   // The draft engine — detached source of truth (DOM + draftRef + edge
   // selectors); typing never re-renders the chrome. ChatBar owns `queueEditRef`
@@ -901,15 +905,51 @@ export function ChatBar({
       // DOM payload (not the render-lagged composer state) so a message typed
       // fast / via IME while busy still reaches submitDraft() and gets queued
       // instead of being mistaken for an empty Enter.
-      if (busy && !hasLivePayload) {
-        const head = queuedPrompts.find(entry => entry.id !== queueEdit?.entryId)
+      if (!hasLivePayload) {
+        const head = busy ? queuedPrompts.find(entry => entry.id !== queueEdit?.entryId) : undefined
 
         if (head) {
           sendQueuedNow(head.id)
+
+          return
         }
+
+        // Double-Enter "Continue" (opt-in, display.double_enter_continue): a
+        // second empty Enter within the window — the first being the send
+        // itself or a previous empty tap — loads the filler and routes it
+        // through submitDraft() like any message: steering the live turn while
+        // busy, sending fresh when idle. Held-down Enter (key repeats) and
+        // turns parked on the user (clarify / approval / sudo) never fire it;
+        // with the setting off, the empty-Enter no-op is unchanged.
+        const continueFire =
+          doubleEnterContinue &&
+          !queueEdit &&
+          !compacting &&
+          !awaitingInput &&
+          !event.repeat &&
+          isDoubleEnter(lastEmptyEnterAtRef.current, Date.now())
+
+        if (continueFire) {
+          lastEmptyEnterAtRef.current = null
+          loadIntoComposer(t.composer.continueNudge, [])
+
+          // Fall through: busy → steer, idle → send.
+        } else {
+          lastEmptyEnterAtRef.current = Date.now()
+
+          if (busy) {
+            return
+          }
+        }
+
+        submitDraft()
 
         return
       }
+
+      // A send (or queued follow-up) arms the tracker: the next empty Enter
+      // within the window completes the double-Enter gesture.
+      lastEmptyEnterAtRef.current = Date.now()
 
       submitDraft()
 

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.ts
@@ -5,6 +5,7 @@ import { getHermesConfig, getHermesConfigDefaults } from '@/hermes'
 import { BUILTIN_PERSONALITIES, normalizePersonalityValue, personalityNamesFromConfig } from '@/lib/chat-runtime'
 import { normalize } from '@/lib/text'
 import { setDisplayTimestampsFromConfig } from '@/store/display-timestamps'
+import { setDoubleEnterContinueFromConfig } from '@/store/double-enter-continue'
 import {
   getComposerSelectionGeneration,
   getCurrentModelSource,
@@ -138,6 +139,7 @@ export function useHermesConfig({ activeSessionIdRef }: HermesConfigOptions) {
         }
 
         setDisplayTimestampsFromConfig(config.display?.timestamps)
+        setDoubleEnterContinueFromConfig(config.display?.double_enter_continue)
         setTerminalFontFamilyFromConfig(config.terminal?.font_family)
 
         if (!canPublish()) {

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -381,7 +381,8 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
   timezone: 'Timezone',
   display: {
     personality: 'Personality',
-    showReasoning: 'Reasoning Blocks'
+    showReasoning: 'Reasoning Blocks',
+    doubleEnterContinue: 'Double-Enter Continue'
   },
   desktop: {
     repoScanEnabled: 'Automatic Repository Discovery',
@@ -548,7 +549,9 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
   fallbackProviders: 'Backup provider:model entries to try if the default model fails.',
   display: {
     personality: 'Default assistant style for new sessions.',
-    showReasoning: 'Show reasoning sections when the backend provides them.'
+    showReasoning: 'Show reasoning sections when the backend provides them.',
+    doubleEnterContinue:
+      'Pressing Enter again right after sending submits a filler "Continue" message (Desktop). Empty Enter never sends anything when off.'
   },
   desktop: {
     repoScanEnabled: 'Scan local folders for Git repositories to show in Projects.',
@@ -639,7 +642,13 @@ export const SECTIONS: DesktopConfigSection[] = [
     id: 'chat',
     label: 'Chat',
     icon: MessageCircle,
-    keys: ['display.personality', 'timezone', 'display.show_reasoning', 'agent.image_input_mode']
+    keys: [
+      'display.personality',
+      'timezone',
+      'display.show_reasoning',
+      'display.double_enter_continue',
+      'agent.image_input_mode'
+    ]
   },
   {
     id: 'appearance',

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1845,6 +1845,7 @@ export const ar = defineLocale({
     openDirective: 'فتح',
     queueMessage: 'إضافة الرسالة للطابور',
     steer: 'توجيه',
+    continueNudge: 'متابعة',
     stop: 'إيقاف',
     send: 'إرسال',
     speaking: 'يتحدث',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2512,6 +2512,7 @@ export const en: Translations = {
     openDirective: 'Open',
     queueMessage: 'Queue message',
     steer: 'Steer the current run',
+    continueNudge: 'Continue',
     stop: 'Stop',
     send: 'Send',
     speaking: 'Speaking',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2174,6 +2174,7 @@ export const ja = defineLocale({
     startVoice: '音声会話を開始',
     openDirective: '開く',
     queueMessage: 'メッセージをキューに入れる',
+    continueNudge: '続行',
     stop: '停止',
     send: '送信',
     speaking: '話しています',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -2548,6 +2548,7 @@ export const ru = defineLocale({
     openDirective: 'Открыть',
     queueMessage: 'Вставить сообщение в очередь',
     steer: 'Направить текущий запуск',
+    continueNudge: 'Продолжить',
     stop: 'Стоп',
     send: 'Отправить',
     speaking: 'Говорит',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2139,6 +2139,7 @@ export interface Translations {
     startVoice: string
     openDirective: string
     queueMessage: string
+    continueNudge: string
     steer: string
     stop: string
     send: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2095,6 +2095,7 @@ export const zhHant = defineLocale({
     startVoice: '開始語音對話',
     openDirective: '開啟',
     queueMessage: '排隊訊息',
+    continueNudge: '繼續',
     stop: '停止',
     send: '傳送',
     speaking: '說話中',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2677,6 +2677,7 @@ export const zh: Translations = {
     openDirective: '打开',
     queueMessage: '排队消息',
     steer: '引导当前运行',
+    continueNudge: '继续',
     stop: '停止',
     send: '发送',
     speaking: '讲话中',

--- a/apps/desktop/src/store/double-enter-continue.ts
+++ b/apps/desktop/src/store/double-enter-continue.ts
@@ -1,0 +1,21 @@
+/**
+ * `display.double_enter_continue` — Desktop-only convenience gesture.
+ *
+ * When enabled, an empty Enter fired shortly after the composer last emptied
+ * (the classic "double Enter") submits a filler "Continue" message instead of
+ * doing nothing — the fastest way to nudge a paused turn along without typing.
+ * Off by default, matching the CLI default in hermes_cli/config_defaults.py;
+ * the deliberate empty-Enter no-op stays the shipped behavior.
+ *
+ * Display/interaction-only: the filler text goes through the normal composer
+ * submit path (steer while busy, send when idle), so it never mutates model
+ * context behind the conversation — it is just another user message.
+ */
+
+import { atom } from 'nanostores'
+
+export const $doubleEnterContinue = atom<boolean>(false)
+
+export function setDoubleEnterContinueFromConfig(value: unknown): void {
+  $doubleEnterContinue.set(value === true || value === 'true' || value === 1)
+}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -347,6 +347,7 @@ export interface HermesConfig {
     skin?: string
     interim_assistant_messages?: boolean
     timestamps?: boolean
+    double_enter_continue?: boolean
   }
   desktop?: {
     repo_scan_enabled?: boolean

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -754,6 +754,10 @@ DEFAULT_CONFIG = {
         # calls: ...]` lines; False shows them inline.
         "resume_skip_tool_only": True,
         "busy_input_mode": "interrupt",  # interrupt | queue | steer
+        # Desktop only: an empty Enter right after the composer emptied (a double
+        # Enter) submits a filler "Continue" instead of doing nothing. Off keeps
+        # the deliberate empty-Enter no-op.
+        "double_enter_continue": False,
         # steer mode: false hides only the "Steered into current run" bubble; steering itself still
         # happens.
         "busy_steer_ack_enabled": True,

--- a/hermes_cli/web_server_config.py
+++ b/hermes_cli/web_server_config.py
@@ -118,6 +118,14 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     ),
     "display.resume_display": _select("How resumed sessions display history", "minimal", "full", "off"),
     "display.busy_input_mode": _select("Input behavior while agent is running", "interrupt", "queue", "steer"),
+    "display.double_enter_continue": {
+        "type": "boolean",
+        "description": (
+            "Desktop: pressing Enter again immediately after sending (composer empty, "
+            "turn running or just finished) submits a filler \"Continue\" message. "
+            "When off, an empty Enter never sends anything."
+        ),
+    },
     "approvals.mode": _select("Dangerous command approval mode", "manual", "smart", "off"),
     "context.engine": _select("Context management engine", "default", "custom"),
     "human_delay.mode": _select("Simulated typing delay mode", "off", "typing", "fixed"),


### PR DESCRIPTION
## Summary

Implements #103558: an **opt-in** Desktop setting (`display.double_enter_continue`, default off) where a second empty Enter within a short window submits a localized "Continue" filler message, letting the user nudge a paused or settled turn along without typing.

- While a turn is running, the filler **steers the live turn** through the existing redirect path.
- When idle, it sends as a fresh message.
- With the setting off, behavior is byte-for-byte unchanged: an empty Enter remains a deliberate no-op.

## Motivation

See #103558 for the full use cases. In short: "continue" / "go on" messages carry no information — only the gesture does. The desktop keyboard story already covers approvals (⌘/Ctrl+Enter / Esc), clarify cards (arrows + Enter), and queueing (Cmd/Ctrl+Enter); this adds the missing "advance the work" gesture for hands-on-keyboard sessions.

## Implementation

- **Config** — `display.double_enter_continue: False` in `hermes_cli/config_defaults.py`; a boolean schema entry in `hermes_cli/web_server_config.py` so it auto-renders in Settings → Chat with no bespoke UI code.
- **Config wiring** — `setDoubleEnterContinueFromConfig()` published through the existing `useHermesConfig` refresh into a nanostores atom (`src/store/double-enter-continue.ts`), mirroring `display.timestamps`.
- **Gesture** — in the composer's Enter branch:
  - a payload Enter arms a `lastEmptyEnterAtRef` timestamp;
  - an empty Enter within `DOUBLE_ENTER_WINDOW_MS` (600 ms) loads the localized filler via `loadIntoComposer()` and falls through to `submitDraft()`, so it rides the **entire existing routing ladder** — clarify/MCP skip, blocking-prompt queueing, busy steer, idle send — instead of duplicating that decision tree;
  - guards: `event.repeat` (held Enter) never fires it; `awaitingInput` (clarify / approval / sudo parked) never fires it; queue-edit keeps saving; compaction never fires it; the busy queue double-send keeps priority.
- **i18n** — `composer.continueNudge` added to all six shipped locales (en / zh / zh-hant / ja / ar / ru) plus the `Translations` type contract.
- **Tests** —
  - `composer-utils.test.ts`: window logic (fires within window, never without a prior Enter, silent after the window, no negative-time travel);
  - `enter-double-continue.test.tsx` (new): steer-while-busy, send-while-idle, key-repeat guard, outside-window no-op, setting-off no-op, queue-edit precedence — driven through real DOM keydowns on a contentEditable, mirroring the existing composer Enter harnesses.

No agent-core or tool-schema changes: the filler is an ordinary user message, so per-conversation prompt caching is untouched.

## Verification

All run in an isolated worktree on current `main` (f58fcc8118):

- `npx vitest run --project ui` — **723 files, 7236 tests passed** (includes the composer + settings suites).
- `npm run typecheck` — clean (all three tsconfig projects).
- `npm run lint` — 0 errors; 124 warnings, identical count on unmodified `main` (verified by stashing the change), so the diff introduces no new warnings.
- `npx prettier --check 'src/**/*.{ts,tsx}'` — clean.
- Python schema spot-check (with the installed venv): `CONFIG_SCHEMA['display.double_enter_continue']` renders as `{'type': 'boolean', ..., 'category': 'display'}` and `DEFAULT_CONFIG['display']['double_enter_continue']` is `False`.

Closes #103558
