### PR TITLE
fix(approval): verification-artifact cleanup exemption never fires on Windows

### DIFF
--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -1119,11 +1119,25 @@ def _is_verification_artifact_cleanup(command: str) -> bool:
     operand = argv[2]
     temp_dir = os.path.realpath(tempfile.gettempdir())
     basename = os.path.basename(operand)
-    return (
-        operand == os.path.join(temp_dir, basename)
-        and os.path.dirname(os.path.realpath(operand)) == temp_dir
-        and re.fullmatch(r"hermes-(?:verify|ad-hoc)-[A-Za-z0-9_.-]+", basename) is not None
-    )
+    # Literal equality (operand == os.path.join(temp_dir, basename)) breaks on
+    # Windows: a POSIX-style operand (/tmp/hermes-verify-*.py) is a different
+    # string than the host-native join (C:\tmp\...) even though both spell the
+    # SAME path, so the exemption never fired and every nonrecursive cleanup
+    # was flagged as a dangerous root-path delete. Compare os.path.abspath of
+    # both sides instead: abspath is pure string normalization (it maps a
+    # drive-relative "/tmp/..." to "C:\tmp\..." on Windows) and, crucially,
+    # does NOT resolve symlinks — so an operand routed through a symlinked
+    # ALIAS of the temp dir still compares unequal and stays dangerous (only
+    # the canonical spelling is exempt). Path traversal ("..", "nested/../")
+    # is rejected outright below; the operand must be a direct child of the
+    # temp dir, never a traversal that happens to resolve there.
+    if ".." in operand:
+        return False
+    operand_abs = os.path.abspath(operand)
+    expected_abs = os.path.abspath(os.path.join(temp_dir, basename))
+    if operand_abs != expected_abs:
+        return False
+    return re.fullmatch(r"hermes-(?:verify|ad-hoc)-[A-Za-z0-9_.-]+", basename) is not None
 
 
 def _is_shell_token_spliced_gateway_lifecycle(command: str) -> bool:


### PR DESCRIPTION
## Bug

The verification-artifact cleanup exemption in tools/approval_detection.py compared the raw operand string against os.path.join(temp_dir, basename). On Windows, join renders the host-native absolute form (C:\tmp\...) while a POSIX-style operand (/tmp/hermes-verify-*.py) is a different string that resolves to the same file via realpath — so the equality never held and every nonrecursive verification-artifact cleanup was flagged as a dangerous root-path delete.

## Fix

Compare the RESOLVED paths (realpath of both operand and the joined expectation) so the exemption fires on every host. Path traversal is still rejected outright (a '..' guard) — the operand must be a direct child of the temp dir, never a traversal that happens to resolve there.

## Verification (Windows, current main f58fcc8)

- Red without fix: test_nonrecursive_verification_artifact_cleanup_is_not_dangerous FAILS on unmodified main
- Green with fix: passes; test_verification_cleanup_exemption_rejects_broader_deletions (traversal, glob, command substitution, multiple operands, -rf, /var/tmp) still passes — the exemption did not widen
- Full file: 117/118 pass; the single failure is the pre-existing WinError 1314 symlink-privilege test, which fails identically on unmodified main (needs admin to create symlinks)