### PR TITLE
fix(agent): persist pre-flushed user context by exact row identity

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -704,24 +704,25 @@ def _stamp_api_content_sidecar(
     if _api_content is None or _api_content == _turn_user_msg.get("content"):
         return
     _turn_user_msg["api_content"] = _api_content
-    # In-place preflight compaction already inserted this turn's user row and the
-    # crash persist identity-skips compacted dicts, so backfill the stamp onto the row
-    # directly. Rotation mode flushes to the child session later.
-    if not (preflight_compressed and getattr(agent, "_last_compaction_in_place", False)):
+    # Early CLI flushes and in-place compaction stamp the committed row identity.
+    # A positional search on ordinary turns can overwrite an older identical prompt.
+    row_id = _turn_user_msg.get("_row_id")
+    has_row_id = isinstance(row_id, int) and not isinstance(row_id, bool) and row_id > 0
+    in_place = preflight_compressed and getattr(agent, "_last_compaction_in_place", False)
+    if not (has_row_id or in_place):
         return
-    _db = getattr(agent, "_session_db", None)
-    if _db is not None:
+    db = getattr(agent, "_session_db", None)
+    if db is not None:
         try:
-            _db.set_latest_user_api_content(
-                agent.session_id, _turn_user_msg.get("content"), _api_content
-            )
+            if has_row_id:
+                db.set_message_api_content(agent.session_id, row_id, _turn_user_msg.get("content"), _api_content)
+            else:
+                # Legacy compaction adapters may not expose row identities. Only
+                # this path proves the newest row already belongs to this turn.
+                db.set_latest_user_api_content(agent.session_id, _turn_user_msg.get("content"), _api_content)
         except Exception:
-            logger.warning(
-                "in-place compaction api_content backfill failed "
-                "for session=%s",
-                agent.session_id or "none",
-                exc_info=True,
-            )
+            logger.warning("api_content backfill failed for session=%s", agent.session_id or "none", exc_info=True)
+
 
 
 def _persist_turn_start(

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -583,6 +583,19 @@ class SessionMessagesMixin:
             ") AND content IS ?",
             (_scrub_surrogates(api_content), session_id, self._encode_content(content)))
 
+    def set_message_api_content(self, session_id: str, row_id: int, content: Any, api_content: str) -> int:
+        """Backfill only the durable user row stamped on the live turn dictionary.
+
+        Content alone cannot identify a turn: repeated prompts must never rewrite
+        a preceding turn's cached bytes. Archived or rewritten rows stay untouched.
+        """
+        if not session_id or isinstance(row_id, bool) or not isinstance(row_id, int) or row_id <= 0:
+            return 0
+        return self._write_rowcount(
+            "UPDATE messages SET api_content = ? WHERE id = ? AND session_id = ? "
+            "AND role = 'user' AND active = 1 AND content IS ?",
+            (_scrub_surrogates(api_content), row_id, session_id, self._encode_content(content)))
+
     def _dedupe_display_generations(self, rows):
         """Collapse compaction generations so each logical message appears once (the protected tail is copied
         into each generation: same role/content/timestamp, different ``active``/id); prefer the live row, then

--- a/tests/agent/test_api_content_row_addressed_backfill.py
+++ b/tests/agent/test_api_content_row_addressed_backfill.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from agent.session_persistence import SessionPersistenceMixin
 from agent.turn_context import _stamp_api_content_sidecar, compose_user_api_content
 from hermes_state import SessionDB
 
@@ -20,6 +21,11 @@ def test_early_persist_replays_exact_context_without_rewriting_identical_turn(
         db.append_message("session", "user", content="ok", api_content=old)
         db.append_message("session", "assistant", content="done")
         current = {"role": "user", "content": "ok"}
+        agent = SessionPersistenceMixin()
+        agent._session_db = db
+        agent._session_db_created = True
+        agent.session_id = "session"
+        agent._last_compaction_in_place = compacted
         if compacted:
             db.archive_and_compact(
                 "session",
@@ -30,11 +36,11 @@ def test_early_persist_replays_exact_context_without_rewriting_identical_turn(
                 ],
             )
         else:
-            current["_row_id"] = db.append_message("session", "user", content="ok")
-        current["_db_persisted"] = True
-        agent = SimpleNamespace(
-            _session_db=db, session_id="session", _last_compaction_in_place=compacted
-        )
+            # Exercise the same flush used by the CLI close safety net. The real
+            # batch writer must stamp the committed row identity onto this dict.
+            assert agent._flush_messages_to_session_db([current]) is True
+            assert current["_db_persisted"] is True
+            assert current["_row_id"] == db.get_messages("session")[-1]["id"]
         _stamp_api_content_sidecar(
             agent,
             [current],
@@ -61,12 +67,12 @@ def test_early_persist_replays_exact_context_without_rewriting_identical_turn(
         reopened.close()
 
 
-def test_unpersisted_turn_cannot_backfill_a_previous_identical_message(tmp_path):
+def test_backfill_guards_preserve_other_rows_and_accept_safe_unicode(tmp_path):
     db = SessionDB(db_path=tmp_path / "state.db")
     try:
         db.create_session("session", source="cli")
         old = "ok\n\nprevious context"
-        db.append_message("session", "user", content="ok", api_content=old)
+        archived_id = db.append_message("session", "user", content="ok", api_content=old)
         agent = SimpleNamespace(_session_db=db, session_id="session")
         for marker in ({}, {"_db_persisted": True}, {"_row_id": True}, {"_row_id": -1}):
             current = {"role": "user", "content": "ok", **marker}
@@ -74,5 +80,34 @@ def test_unpersisted_turn_cannot_backfill_a_previous_identical_message(tmp_path)
                 agent, [current], 0, "new context", "", preflight_compressed=False
             )
             assert db.get_messages_as_conversation("session")[0]["api_content"] == old
+
+        db.archive_and_compact("session", [{"role": "user", "content": "ok", "api_content": old}])
+        active_id = db.get_messages("session")[-1]["id"]
+        assistant_id = db.append_message("session", "assistant", content="ok")
+        db.create_session("other", source="cli")
+        other_id = db.append_message("other", "user", content="ok", api_content=old)
+        before = db.get_messages("session", include_inactive=True)
+        other_before = db.get_messages("other")
+        for session_id, row_id, content in (
+            ("other", active_id, "ok"), ("session", other_id, "ok"),
+            ("session", active_id, "changed"), ("session", assistant_id, "ok"),
+            ("session", archived_id, "ok"), ("session", other_id + 1000, "ok"),
+            ("session", True, "ok"), ("session", -1, "ok"),
+            ("session", str(active_id), "ok"), ("", active_id, "ok"),
+        ):
+            assert db.set_message_api_content(session_id, row_id, content, "wrong context") == 0
+        assert db.get_messages("session", include_inactive=True) == before
+        assert db.get_messages("other") == other_before
+
+        # sqlite cannot encode a lone surrogate: the successful write must scrub
+        # it without altering the display content or another row's sidecar.
+        assert db.set_message_api_content("session", active_id, "ok", "prefix\ud800suffix") == 1
+        after = db.get_messages("session", include_inactive=True)
+        changed = next(row for row in after if row["id"] == active_id)
+        assert changed["api_content"].startswith("prefix")
+        assert changed["api_content"].endswith("suffix")
+        changed["api_content"].encode("utf-8", errors="strict")
+        changed["api_content"] = old
+        assert after == before
     finally:
         db.close()

--- a/tests/agent/test_api_content_row_addressed_backfill.py
+++ b/tests/agent/test_api_content_row_addressed_backfill.py
@@ -1,0 +1,78 @@
+"""Persist wire context without changing another turn's cached prefix."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent.turn_context import _stamp_api_content_sidecar, compose_user_api_content
+from hermes_state import SessionDB
+
+
+@pytest.mark.parametrize("compacted", [False, True])
+def test_early_persist_replays_exact_context_without_rewriting_identical_turn(
+    tmp_path, compacted
+):
+    path = tmp_path / "state.db"
+    db = SessionDB(db_path=path)
+    try:
+        db.create_session("session", source="cli")
+        old = "ok\n\nprevious context"
+        db.append_message("session", "user", content="ok", api_content=old)
+        db.append_message("session", "assistant", content="done")
+        current = {"role": "user", "content": "ok"}
+        if compacted:
+            db.archive_and_compact(
+                "session",
+                [
+                    {"role": "user", "content": "ok", "api_content": old},
+                    {"role": "assistant", "content": "done"},
+                    current,
+                ],
+            )
+        else:
+            current["_row_id"] = db.append_message("session", "user", content="ok")
+        current["_db_persisted"] = True
+        agent = SimpleNamespace(
+            _session_db=db, session_id="session", _last_compaction_in_place=compacted
+        )
+        _stamp_api_content_sidecar(
+            agent,
+            [current],
+            0,
+            "remember this",
+            "plugin context",
+            preflight_compressed=compacted,
+        )
+    finally:
+        db.close()
+    reopened = SessionDB(db_path=path)
+    try:
+        users = [
+            m
+            for m in reopened.get_messages_as_conversation("session")
+            if m["role"] == "user"
+        ]
+        assert users[0]["api_content"] == old
+        assert users[-1]["content"] == "ok"
+        assert users[-1]["api_content"] == compose_user_api_content(
+            "ok", "remember this", "plugin context"
+        )
+    finally:
+        reopened.close()
+
+
+def test_unpersisted_turn_cannot_backfill_a_previous_identical_message(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("session", source="cli")
+        old = "ok\n\nprevious context"
+        db.append_message("session", "user", content="ok", api_content=old)
+        agent = SimpleNamespace(_session_db=db, session_id="session")
+        for marker in ({}, {"_db_persisted": True}, {"_row_id": True}, {"_row_id": -1}):
+            current = {"role": "user", "content": "ok", **marker}
+            _stamp_api_content_sidecar(
+                agent, [current], 0, "new context", "", preflight_compressed=False
+            )
+            assert db.get_messages_as_conversation("session")[0]["api_content"] == old
+    finally:
+        db.close()


### PR DESCRIPTION
## What does this PR do?

Fixes #102194. When a CLI user turn is persisted before injected context is composed, reopening the session now replays the exact context sent to the provider. Repeated prompts such as `ok` cannot cause the previous turn's sidecar to be overwritten.

## Changes Made

- Adapt #102411 by @JoaoMarcos44 to the current module layout, preserving the original commit author.
- Place the row-addressed store method in `hermes_state_messages.py`, resolving the predecessor's oversized-state-file blocker.
- Backfill known row identities in the turn-context helper; retain the existing in-place compaction fallback.
- Replace the predecessor's test suite with two behavioral tests, including a real database close/reopen and repeated-content protection.

## How to Test

`scripts/run_tests.sh tests/agent/test_api_content_row_addressed_backfill.py tests/agent/test_api_content_sidecar.py tests/agent/test_turn_context.py`

macOS: 50 tests passed. The early-persistence regression fails on current main before the fix; the compaction and unpersisted-turn controls pass. Ruff and diff whitespace checks pass. The full repository suite was not run locally.

This is an adaptation of the existing fix onto the decomposed codebase; it should not land alongside an independent copy of #102411.

Coverage also exercises the real session flush that stamps the committed row ID onto the live message dictionary, before context is attached. Store-level assertions cover session/content mismatches, archived and non-user rows, invalid row IDs, and lone-surrogate handling without changing other rows.
