### PR TITLE
fix(kanban): reject an explicitly empty --chat-id at notify-subscribe time

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1061,6 +1061,11 @@ def _cmd_stats(args: argparse.Namespace) -> int:
 
 
 def _cmd_notify_subscribe(args: argparse.Namespace) -> int:
+    # argparse only enforces presence; an explicitly empty --chat-id (e.g. an unset
+    # shell variable expanding to "") can never deliver — the notifier retries the
+    # deterministic adapter failure and then silently drops the subscription.
+    if not (args.chat_id or "").strip():
+        return _err("--chat-id must be a non-empty chat identifier")
     with kbc.connect_closing() as conn:
         if kb.get_task(conn, args.task_id) is None:
             return _err(f"no such task: {args.task_id}")

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -182,3 +182,36 @@ def test_run_slash_reclaim_running_task(kanban_home):
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# /kanban notify-subscribe — an explicitly empty --chat-id must be rejected
+# up front (issue #103569)
+# ---------------------------------------------------------------------------
+
+
+def test_notify_subscribe_rejects_empty_chat_id(kanban_home):
+    """--chat-id is argparse-required, but an explicit empty value (an unset shell
+    variable expanding to "") passes argparse and can never deliver: the notifier
+    retries the deterministic adapter failure and then silently drops the
+    subscription. It must be rejected at subscribe time."""
+    import re
+    from hermes_cli import kanban_db_notify as kbn
+
+    out = kc.run_slash("create 'notify target task'")
+    m = re.search(r"(t_[a-f0-9]+)", out)
+    assert m
+    tid = m.group(1)
+
+    out = kc.run_slash(f"notify-subscribe {tid} --platform feishu --chat-id ''")
+    assert "non-empty" in out, out
+    out = kc.run_slash(f'notify-subscribe {tid} --platform feishu --chat-id "  "')
+    assert "non-empty" in out, out
+
+    # Nothing was stored for the rejected subscriptions.
+    with kbc.connect_closing() as conn:
+        assert kbn.list_notify_subs(conn, tid) == []
+
+    # A real chat id still subscribes.
+    out = kc.run_slash(f"notify-subscribe {tid} --platform feishu --chat-id oc_123")
+    assert "Subscribed feishu:oc_123" in out, out
+
+


### PR DESCRIPTION
## What does this PR do?

`hermes kanban notify-subscribe` (and the equivalent `/kanban` slash command, which shares the same handler) accepted an explicitly empty `--chat-id`. `argparse`'s `required=True` only proves the flag was passed, so a shell where the intended value came from an unset variable (`--chat-id "$FEISHU_CHAT_ID"` with the variable unset) silently stored `chat_id = ''`. Such a subscription can never deliver — the gateway notifier retries the deterministic adapter failure (e.g. Feishu `[230001] invalid receive_id`) 12 times, then drops the subscription row with only a WARNING log line, and the terminal notification is permanently lost (#103569).

This adds an up-front validation in `_cmd_notify_subscribe`: an empty or whitespace-only `chat_id` is rejected with a clear error before any DB access, mirroring the existing `_err` style of the handler. This is the CLI-validation half of #103569; the issue also suggests retry-classification and drop-event observability on the notifier side, which touch `gateway/kanban_watchers_notifier.py` where #101397 is actively reworking the same area, so they are intentionally left out of this PR.

## Related Issue

Fixes #103569

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban.py`: `_cmd_notify_subscribe` now rejects an empty/whitespace-only `chat_id` with `--chat-id must be a non-empty chat identifier` before opening the DB connection (fail fast on malformed input).
- `tests/hermes_cli/test_kanban_cli.py`: regression test `test_notify_subscribe_rejects_empty_chat_id` — empty (`''`) and whitespace-only (`"  "`) values are rejected, nothing is stored, and a real chat id still subscribes.

## How to Test

1. `pytest tests/hermes_cli/test_kanban_cli.py -q` → 5 passed (4 existing + 1 new).
2. Revert only `hermes_cli/kanban.py` and re-run `pytest tests/hermes_cli/test_kanban_cli.py::test_notify_subscribe_rejects_empty_chat_id` → Observed result: FAILED on main (the empty chat id is stored and `Subscribed feishu:` printed); passes with the fix.
3. Live check: `hermes kanban create 'x'` then `hermes kanban notify-subscribe <task_id> --platform feishu --chat-id ""` → Observed result: error `--chat-id must be a non-empty chat identifier`, exit 1, no subscription row created.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A