### PR TITLE
chore(models): OpenRouter and Nous pickers drop the undated deepseek-v4-flash in favor of the 0731 snapshot

### DIFF
--- a/hermes_cli/models_catalog_static.py
+++ b/hermes_cli/models_catalog_static.py
@@ -35,7 +35,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
         "openai/gpt-5.6-terra", "openai/gpt-5.6-terra-pro", "openai/gpt-5.6-luna", "openai/gpt-5.6-luna-pro",
         "openai/gpt-5.5", "openai/gpt-5.5-pro", "openai/gpt-5.4-mini", "google/gemini-3.1-pro-preview",
         "google/gemini-3.8-flash", "google/gemini-3.7-flash", "x-ai/grok-4.6", "deepseek/deepseek-v4-pro",
-        "deepseek/deepseek-v4-pro-0813", "deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-flash-0731",
+        "deepseek/deepseek-v4-pro-0813", "deepseek/deepseek-v4-flash-0731",
         "qwen/qwen3.8-max-0902", "qwen/qwen3.8-flash", "moonshotai/kimi-k3", "minimax/minimax-m3", "z-ai/glm-5.3",
         "z-ai/glm-5.3-flash", "z-ai/glm-5.2", "xiaomi/mimo-v2.5-pro", "tencent/hy4-preview", "tencent/hy3",
         "stepfun/step-3.7-flash", "nvidia/nemotron-3-super-120b-a12b", "meta/muse-spark-1.2",

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-09-05T06:42:02Z",
+  "updated_at": "2026-09-05T09:33:43Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -127,10 +127,6 @@
         {
           "id": "deepseek/deepseek-v4-pro-0813",
           "description": "dated snapshot of v4-pro"
-        },
-        {
-          "id": "deepseek/deepseek-v4-flash",
-          "description": ""
         },
         {
           "id": "deepseek/deepseek-v4-flash-0731",
@@ -333,9 +329,6 @@
         },
         {
           "id": "deepseek/deepseek-v4-pro-0813"
-        },
-        {
-          "id": "deepseek/deepseek-v4-flash"
         },
         {
           "id": "deepseek/deepseek-v4-flash-0731"


### PR DESCRIPTION
## Summary
The OpenRouter and Nous Portal pickers no longer list the undated `deepseek/deepseek-v4-flash`; the flash tier is represented by the `deepseek-v4-flash-0731` snapshot alone (Nous also exposes the rolling `~deepseek/deepseek-v4-flash-latest` alias live).

Scoped delist: only the shared aggregator curated list changes. The bare `deepseek-v4-flash` id is deliberately KEPT everywhere it is the wire slug a provider actually serves, or provider-agnostic metadata for a manually-typed id:
- `_ALIBABA_TOKEN_PLAN_MODELS`, `opencode-go`, `commandcode` and `deepseek` plugin `fallback_models` / `default_aux_model`
- `DEFAULT_CONTEXT_LENGTHS`, `reasoning_timeouts.py`, `_OFFICIAL_DOCS_PRICING` snapshot rows
- `model_normalize.py` retired-alias mapping (`deepseek-chat` / `deepseek-reasoner` → `deepseek-v4-flash`)

## Changes
- `hermes_cli/models_catalog_static.py`: `OPENROUTER_MODELS` (derives `_PROVIDER_MODELS["nous"]`) drops `deepseek/deepseek-v4-flash`.
- `website/static/api/model-catalog.json`: regenerated via `scripts/build_model_catalog.py`.

## Validation
| | Result |
|---|---|
| Live probe (2026-09-05) | both aggregators still serve the bare slug; this is a curated-picker cleanup, not a shutdown response. Live-first merge can still surface it from `/v1/models`. |
| Targeted tests | `test_models` `test_model_catalog` `test_model_validation` `test_discord_model_picker_partition` `test_empty_model_fallback` `test_usage_pricing` `test_gmi_provider` `test_anthropic_picker_curated` → 234 passed |
| Fixture sweep | tests referencing `deepseek/deepseek-v4-flash` use it as an inert string (aliases, config values, mock returns), none depend on curated-list membership |

Follow-up (separate, pending Teknium's pointer): a Qwen entry reported as showing no price in the picker. Probe found every curated qwen slug priced on both aggregators; awaiting the exact slug.

## Infographic

![DeepSeek Flash dated only](https://v3b.fal.media/files/b/0aa93047/5s7Ik2K6ztu--GmRvAUdj_vX3iHRX6.png)
