### PR TITLE
fix(verify): refuse compose recipes against a project with running containers

### DIFF
--- a/agent/verify/runner.py
+++ b/agent/verify/runner.py
@@ -182,6 +182,24 @@ def _run_start_phase(
     return ReadinessResult(url, ready, status, time.monotonic() - started, error, _tail(output))
 
 
+def _running_compose_containers(root: Path) -> list[str] | None:
+    """Names of currently-running containers for the compose project at *root*,
+    via ``docker compose ps`` (read-only; never mutates anything). ``None`` when the
+    check itself could not run (docker/compose unavailable, or not a compose
+    project here) -- callers must not treat that as "no running containers".
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "compose", "ps", "--status", "running", "--format", "{{.Name}}"],
+            cwd=root, capture_output=True, text=True, timeout=15, stdin=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
 def run_verify(
     root: Path, recipe: Recipe, phases: tuple[str, ...] | list[str] | None = None,
     phase_timeout: float = DEFAULT_PHASE_TIMEOUT, ready_timeout: float = DEFAULT_READY_TIMEOUT,
@@ -189,10 +207,33 @@ def run_verify(
     on_output: Callable[[str], None] | None = None,
 ) -> VerifyResult:
     """Run the selected command phases sequentially, then (unless ``skip_start`` or a
-    phase failed) boot ``recipe.start``, poll readiness, and tear the process group down."""
+    phase failed) boot ``recipe.start``, poll readiness, and tear the process group down.
+
+    A ``compose`` recipe refuses outright when the project already has running
+    containers: ``docker compose build`` + ``up`` replaces them on an image-hash
+    change, destroying any container-local state they carry -- this has caused a
+    real state-loss incident (#103567). The check is best-effort and read-only
+    (``docker compose ps``); when it cannot run at all, verify proceeds rather than
+    blocking on an unrelated environment gap, matching every other recipe kind's
+    behavior when its own tooling is unavailable."""
     root = Path(root)
     selected = tuple(phases) if phases else PHASE_ORDER + ("start",)
     result = VerifyResult(recipe_name=recipe.name)
+
+    if recipe.kind == "compose":
+        running = _running_compose_containers(root)
+        if running:
+            result.phases.append(PhaseResult(
+                phase="build", command=recipe.build[0] if recipe.build else "docker compose build",
+                exit_code=1, duration=0.0, output_tail=(
+                    "Refusing to run: this compose project already has running "
+                    f"container(s) ({', '.join(running)}). `docker compose build` + "
+                    "`up` would replace them on an image-hash change, destroying any "
+                    "container-local state they carry. If you intend to rebuild this "
+                    "live deployment, run `docker compose build`/`up` yourself."
+                ),
+            ))
+            return result
 
     for phase in PHASE_ORDER:
         if phase not in selected:

--- a/tests/verify/test_environment_and_runner.py
+++ b/tests/verify/test_environment_and_runner.py
@@ -4,6 +4,7 @@ import http.server
 import json
 import threading
 import time
+from unittest.mock import MagicMock, patch
 
 from agent.verify.environment import (
     load_manifest,
@@ -109,6 +110,90 @@ class TestRunner:
         recipe = Recipe(name="x", test=["cat marker.txt"])
         result = run_verify(tmp_path, recipe, skip_start=True)
         assert result.ok
+
+
+class TestComposeGuard:
+    """Regression for issue #103567: a compose recipe must refuse to run
+    against a project directory that's already a live compose deployment
+    with running containers -- ``docker compose build`` + ``up`` replaces
+    them on an image-hash change, destroying container-local state (a real
+    incident: a kanban worker's state DB was lost this way)."""
+
+    def _compose_recipe(self):
+        return Recipe(
+            name="docker-compose project", kind="compose",
+            build=["docker compose build"], start="docker compose up",
+            evidence=["Detected docker-compose.yml"],
+        )
+
+    def test_refuses_when_containers_are_running(self, tmp_path, monkeypatch):
+        fake_ps = MagicMock(returncode=0, stdout="myproject-db-1\nmyproject-web-1\n")
+        monkeypatch.setattr("subprocess.run", MagicMock(return_value=fake_ps))
+
+        result = run_verify(tmp_path, self._compose_recipe(), skip_start=True)
+
+        assert not result.ok
+        assert len(result.phases) == 1
+        assert "myproject-db-1" in result.phases[0].output_tail
+        assert "myproject-web-1" in result.phases[0].output_tail
+        assert "Refusing to run" in result.phases[0].output_tail
+
+    def test_does_not_actually_invoke_build_or_start_when_refusing(self, tmp_path, monkeypatch):
+        """The refusal must be a synthetic result -- the real build/start
+        commands (which would trigger the destructive replace) must never
+        actually be spawned."""
+        fake_ps = MagicMock(returncode=0, stdout="myproject-db-1\n")
+        calls: list[list[str] | str] = []
+
+        def tracking_run(cmd, *args, **kwargs):
+            calls.append(cmd)
+            return fake_ps
+
+        monkeypatch.setattr("subprocess.run", tracking_run)
+
+        run_verify(tmp_path, self._compose_recipe(), skip_start=False)
+
+        # Only the read-only "docker compose ps" probe ran -- never
+        # "docker compose build" or "docker compose up" as an actual subprocess.
+        assert len(calls) == 1
+        assert calls[0][:3] == ["docker", "compose", "ps"]
+
+    def test_proceeds_normally_with_no_running_containers(self, tmp_path, monkeypatch):
+        fake_ps = MagicMock(returncode=0, stdout="")
+        monkeypatch.setattr("subprocess.run", MagicMock(return_value=fake_ps))
+
+        with patch("agent.verify.runner._run_phase_command") as mock_phase:
+            mock_phase.return_value = MagicMock(ok=True, phase="build")
+            result = run_verify(tmp_path, self._compose_recipe(), phases=("build",))
+
+        assert mock_phase.called
+
+    def test_proceeds_when_the_docker_probe_itself_is_unavailable(self, tmp_path, monkeypatch):
+        """docker/compose not installed, or this isn't actually a compose
+        project's directory from docker's perspective -- must not block
+        verify on an unrelated environment gap."""
+        monkeypatch.setattr(
+            "subprocess.run",
+            MagicMock(side_effect=FileNotFoundError("docker not found")),
+        )
+
+        with patch("agent.verify.runner._run_phase_command") as mock_phase:
+            mock_phase.return_value = MagicMock(ok=True, phase="build")
+            result = run_verify(tmp_path, self._compose_recipe(), phases=("build",))
+
+        assert mock_phase.called
+
+    def test_non_compose_recipes_are_unaffected(self, tmp_path, monkeypatch):
+        """The guard is scoped to kind == "compose" only -- a Node/Python/etc.
+        recipe must never even check for running compose containers."""
+        probe = MagicMock()
+        monkeypatch.setattr("agent.verify.runner._running_compose_containers", probe)
+        recipe = Recipe(name="x", kind="node", build=["true"])
+
+        result = run_verify(tmp_path, recipe, skip_start=True)
+
+        assert result.ok
+        probe.assert_not_called()
 
     def test_result_to_dict(self, tmp_path):
         recipe = Recipe(name="x", test=["true"])


### PR DESCRIPTION
Fixes #103567.

## Root cause

`hermes verify`'s compose recipe unconditionally runs `docker compose build` + `up` against any directory containing a `docker-compose.yml`, with no check for whether that directory is already a live deployment. On an image-hash change, `docker compose up` replaces the running containers -- destroying any state on a container-local path or anonymous volume.

This caused a real incident: several kanban workers each ran `hermes verify` as routine self-verification against a workspace that was simultaneously a live compose deployment; the container carrying a live state DB was replaced (recovered from backup after a ~98 minute outage).

## Fix

Implemented the issue's "at minimum" suggested fix: before running any phase for a `kind == "compose"` recipe, check for running containers via `docker compose ps --status running` (read-only). If found, refuse outright with a clear message naming them, without ever invoking the real `build`/`start` commands. The refusal surfaces through the exact same `PhaseResult`/`VerifyResult` contract every other phase failure uses.

Best-effort: when the probe itself can't run (docker unavailable), verify proceeds normally rather than blocking on an unrelated gap. Scoped strictly to `kind == "compose"` -- every other recipe kind never even probes docker.

## Verification

Verified directly: constructed the exact reported scenario and confirmed `run_verify()` returns a failed result with no build/start subprocess ever spawned. Also verified the no-running-containers, docker-unavailable, and non-compose-recipe cases.

Added 5 regression tests following the existing file's established pattern. Verified as a genuine regression by reverting the guard and confirming the primary refusal test fails.

24/24 pass in the modified test file; 21/21 across two additional related test files (no regression).