### PR TITLE
fix(agent): keep empty stream chunks from postponing stale timeout

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2803,12 +2803,16 @@ class _StreamingCall:
 
     def _count_chunk(self, diag, chunk) -> None:
         """Stamp liveness for a real chunk; diagnostics are best-effort."""
-        self.last_chunk_time["t"] = time.time()
-        self.agent._touch_activity("receiving stream response")
+        from agent.stream_progress import chunk_has_progress
+
+        received_at = time.time()
+        if chunk_has_progress(chunk):
+            self.last_chunk_time["t"] = received_at
+            self.agent._touch_activity("receiving stream response")
         with contextlib.suppress(Exception):
             diag["chunks"] = int(diag.get("chunks", 0)) + 1
             if diag.get("first_chunk_at") is None:
-                diag["first_chunk_at"] = self.last_chunk_time["t"]
+                diag["first_chunk_at"] = received_at
             # Delta-length estimate: ~3x cheaper than repr() per chunk.
             diag["bytes"] = int(diag.get("bytes", 0)) + _estimate_chunk_bytes(chunk)
 

--- a/agent/stream_progress.py
+++ b/agent/stream_progress.py
@@ -1,0 +1,38 @@
+"""Inference progress on the Chat Completions and Anthropic Messages wires."""
+
+
+def _has_fields(value, *fields) -> bool:
+    return any(getattr(value, field, None) for field in fields)
+
+
+def chunk_has_progress(chunk) -> bool:
+    """Ignore empty/role-only deltas and pings, but retain reasoning and tools.
+
+    Protocol boundaries are progress too: a tool can start without arguments,
+    and a finish chunk can carry no text. Raw transport traffic alone is not
+    evidence that a provider is still generating a response.
+    """
+    choices = getattr(chunk, "choices", None)
+    if choices is not None:
+        for choice in choices:
+            if getattr(choice, "finish_reason", None):
+                return True
+            delta = getattr(choice, "delta", None)
+            if _has_fields(delta, "content", "reasoning_content", "reasoning", "reasoning_details", "refusal", "audio"):
+                return True
+            for tool in getattr(delta, "tool_calls", None) or ():
+                if getattr(tool, "id", None) or _has_fields(getattr(tool, "function", None), "name", "arguments"):
+                    return True
+            if _has_fields(getattr(delta, "function_call", None), "name", "arguments"):
+                return True
+        return False
+
+    # Anthropic's raw stream and its synthesized SDK delta events share this
+    # watchdog. Ping events and empty deltas must not extend its deadline.
+    if getattr(chunk, "type", None) in {
+        "message_start", "message_stop", "content_block_start", "content_block_stop",
+    }:
+        return True
+    return _has_fields(chunk, "text", "thinking", "partial_json", "signature") or _has_fields(
+        getattr(chunk, "delta", None), "text", "thinking", "partial_json", "signature", "stop_reason",
+    )

--- a/tests/agent/test_stream_progress_liveness.py
+++ b/tests/agent/test_stream_progress_liveness.py
@@ -1,0 +1,64 @@
+"""Transport keepalives must not postpone the inference-progress watchdog."""
+from types import SimpleNamespace as NS
+from unittest.mock import Mock
+
+import pytest
+from openai.types.chat import ChatCompletionChunk
+
+from agent.chat_completion_helpers import _StreamingCall
+
+
+def chunk(delta=None, finish_reason=None):
+    return ChatCompletionChunk(
+        id="test", object="chat.completion.chunk", created=0, model="test",
+        choices=[] if delta is None else [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
+    )
+
+
+def test_keepalives_remain_diagnostic_without_resetting_progress(monkeypatch):
+    clock = [100.0]
+    monkeypatch.setattr("agent.chat_completion_helpers.time.time", lambda: clock[0])
+    activity = Mock()
+    call = _StreamingCall(NS(_touch_activity=activity), {}, None)
+    diag = {}
+    for event in [chunk(), chunk({}), chunk({"role": "assistant", "content": ""}),
+                  chunk({"tool_calls": [{"index": 0}]}), NS(type="ping"),
+                  NS(type="content_block_delta", delta=NS(type="text_delta", text=""))]:
+        clock[0] += 60
+        call._count_chunk(diag, event)
+        assert call.last_chunk_time["t"] == 100.0
+    assert clock[0] - call.last_chunk_time["t"] > 240
+    assert diag["chunks"] == 6
+    assert diag["first_chunk_at"] == 160.0
+    activity.assert_not_called()
+
+    # Exercise the same monitor that closes the request after a quiet period.
+    done = [False]
+    call.agent.base_url = "https://example.com"
+    call.agent._interrupt_requested = False
+    call._stream_stale_timeout = 240
+    call._call_done = NS(is_set=lambda: done[0], wait=lambda **kwargs: None)
+    kill = Mock(side_effect=lambda elapsed: done.__setitem__(0, True))
+    monkeypatch.setattr(call, "_kill_stale_stream", kill)
+    call._monitor_loop()
+    kill.assert_called_once_with(clock[0] - 100.0)
+
+
+@pytest.mark.parametrize("event", [
+    chunk({"content": "answer"}), chunk({"reasoning_content": "thinking"}),
+    chunk({"reasoning": "thinking"}), chunk({}, "stop"),
+    chunk({"tool_calls": [{"index": 0, "id": "call_1"}]}),
+    chunk({"tool_calls": [{"index": 0, "function": {"arguments": "{"}}]}),
+    NS(type="content_block_delta", delta=NS(type="thinking_delta", thinking="reasoning")),
+    NS(type="content_block_delta", delta=NS(type="input_json_delta", partial_json="{")),
+    NS(type="message_start"), NS(type="message_stop"),
+])
+def test_output_and_protocol_progress_refresh_the_watchdog(monkeypatch, event):
+    clock = [100.0]
+    monkeypatch.setattr("agent.chat_completion_helpers.time.time", lambda: clock[0])
+    activity = Mock()
+    call = _StreamingCall(NS(_touch_activity=activity), {}, None)
+    clock[0] = 200.0
+    call._count_chunk({}, event)
+    assert call.last_chunk_time["t"] == clock[0]
+    activity.assert_called_once()


### PR DESCRIPTION
Empty Chat Completions chunks, role-only deltas, and Anthropic pings no longer reset the inference-progress watchdog. Text, reasoning, tool arguments, and protocol completion still extend its deadline. Transport diagnostics continue counting every received chunk independently.

Fixes #103571. The existing shared OpenAI/Anthropic monitor now receives a progress timestamp rather than a transport-traffic timestamp. This does not change the separate Responses transport.

Validation: 21 tests pass across the new progress regression and existing stale-stream circuit-breaker suites. The new keepalive regression fails on main (the timestamp advances on an empty chunk), then passes with the fix; it also exercises the monitor's stale-kill decision. Ruff and diff checks pass.
