### PR TITLE
feat(tools): add send_file tool for outbound sandbox/local file delivery (addresses #466)

### DIFF
--- a/tests/tools/test_send_file_tool.py
+++ b/tests/tools/test_send_file_tool.py
@@ -1,0 +1,234 @@
+"""Tests for the send_file tool (sandbox & local extraction, size limits, security guards)."""
+
+import base64
+import json
+import os
+import stat
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.registry import registry
+from tools.send_file_tool import (
+    SEND_FILE_SCHEMA,
+    _DEFAULT_MAX_SEND_BYTES,
+    _format_size,
+    _extract_local_file,
+    _extract_remote_file,
+    send_file_tool,
+)
+
+
+class TestSendFileSchemaAndRegistry:
+    def test_schema_structure(self):
+        assert SEND_FILE_SCHEMA["name"] == "send_file"
+        assert "path" in SEND_FILE_SCHEMA["parameters"]["properties"]
+        assert "message" in SEND_FILE_SCHEMA["parameters"]["properties"]
+        assert "path" in SEND_FILE_SCHEMA["parameters"]["required"]
+
+    def test_registered_in_registry(self):
+        tool = registry.get_entry("send_file")
+        assert tool is not None
+        assert tool.name == "send_file"
+        assert tool.toolset == "file"
+        assert tool.schema == SEND_FILE_SCHEMA
+        assert tool.emoji == "📤"
+
+    def test_format_size(self):
+        assert _format_size(500) == "500 B"
+        assert _format_size(2048) == "2.0 KB"
+        assert _format_size(5 * 1024 * 1024) == "5.0 MB"
+
+
+class TestSendFileLocal:
+    def test_missing_path_argument(self):
+        res = send_file_tool("")
+        assert "missing required field 'path'" in res
+
+        res_none = send_file_tool("   ")
+        assert "missing required field 'path'" in res_none
+
+    def test_blocked_device_path(self):
+        res = send_file_tool("/dev/urandom")
+        assert "access denied for device or proc path" in res
+
+    def test_send_local_existing_file(self, tmp_path):
+        sample_file = tmp_path / "chart.png"
+        sample_data = b"\x89PNG\r\n\x1a\nfake-png-binary-data"
+        sample_file.write_bytes(sample_data)
+
+        with patch("tools.send_file_tool._get_file_ops") as mock_get_ops:
+            mock_ops = MagicMock()
+            mock_ops.env = MagicMock()
+            mock_ops.env.is_local = True
+            mock_get_ops.return_value = mock_ops
+
+            res = send_file_tool(str(sample_file), message="Here is your requested chart")
+
+            assert "File ready for delivery: chart.png" in res
+            assert "Here is your requested chart" in res
+            assert "MEDIA:" in res
+
+            # Verify cached file was written
+            media_path = res.split("MEDIA:")[1].strip()
+            assert os.path.exists(media_path)
+            assert Path(media_path).read_bytes() == sample_data
+
+    def test_send_local_file_not_found(self, tmp_path):
+        missing = tmp_path / "does_not_exist.pdf"
+        with patch("tools.send_file_tool._get_file_ops") as mock_get_ops:
+            mock_ops = MagicMock()
+            mock_ops.env = MagicMock()
+            mock_ops.env.is_local = True
+            mock_get_ops.return_value = mock_ops
+
+            res = send_file_tool(str(missing))
+            assert "File not found" in res
+
+    def test_send_local_directory_rejected(self, tmp_path):
+        with patch("tools.send_file_tool._get_file_ops") as mock_get_ops:
+            mock_ops = MagicMock()
+            mock_ops.env = MagicMock()
+            mock_ops.env.is_local = True
+            mock_get_ops.return_value = mock_ops
+
+            res = send_file_tool(str(tmp_path))
+            assert "is a directory, not a regular file" in res
+
+    def test_send_local_oversized_file(self, tmp_path):
+        large_file = tmp_path / "huge.dat"
+        with patch("os.stat") as mock_stat:
+            stat_res = MagicMock()
+            stat_res.st_mode = stat.S_IFREG
+            stat_res.st_size = _DEFAULT_MAX_SEND_BYTES + 1024
+            mock_stat.return_value = stat_res
+
+            data, err = _extract_local_file(str(large_file), _DEFAULT_MAX_SEND_BYTES)
+            assert data is None
+            assert "exceeds the maximum allowed transfer size" in err
+
+    @patch("tools.send_file_tool.get_read_block_error")
+    def test_send_local_sensitive_path_blocked(self, mock_block_err, tmp_path):
+        mock_block_err.return_value = "Sensitive configuration file blocked"
+
+        with patch("tools.send_file_tool._get_file_ops") as mock_get_ops:
+            mock_ops = MagicMock()
+            mock_ops.env = MagicMock()
+            mock_ops.env.is_local = True
+            mock_get_ops.return_value = mock_ops
+
+            res = send_file_tool("/home/user/.env")
+            assert "access denied for protected path" in res
+            assert "Sensitive configuration file blocked" in res
+
+
+class TestSendFileRemoteSandbox:
+    def test_send_remote_file_success(self):
+        mock_ops = MagicMock()
+        mock_ops.env = MagicMock()
+        mock_ops.env.is_local = False
+        mock_ops.cwd = "/workspace"
+
+        raw_content = b"PDF-1.5 fake invoice report data"
+        b64_content = base64.b64encode(raw_content).decode("ascii")
+
+        def fake_exec(cmd: str):
+            res = MagicMock()
+            if "wc -c" in cmd or "__HERMES_DIR__" in cmd:
+                res.returncode = 0
+                res.output = f"{len(raw_content)}\n"
+            elif "base64" in cmd:
+                res.returncode = 0
+                res.output = f"{b64_content}\n"
+            else:
+                res.returncode = 0
+                res.output = ""
+            return res
+
+        mock_ops._exec.side_effect = fake_exec
+
+        with patch("tools.send_file_tool._get_file_ops", return_value=mock_ops):
+            res = send_file_tool("output/invoice.pdf", message="Your weekly invoice")
+
+            assert "File ready for delivery: invoice.pdf" in res
+            assert "Your weekly invoice" in res
+            assert "MEDIA:" in res
+
+            media_path = res.split("MEDIA:")[1].strip()
+            assert os.path.exists(media_path)
+            assert Path(media_path).read_bytes() == raw_content
+
+    def test_send_remote_file_not_found(self):
+        mock_ops = MagicMock()
+        mock_ops.env = MagicMock()
+        mock_ops.env.is_local = False
+
+        def fake_exec(cmd: str):
+            res = MagicMock()
+            res.returncode = 0
+            res.output = "__HERMES_NOT_FOUND__"
+            return res
+
+        mock_ops._exec.side_effect = fake_exec
+
+        with patch("tools.send_file_tool._get_file_ops", return_value=mock_ops):
+            res = send_file_tool("/workspace/missing.csv")
+            assert "File not found in sandbox" in res
+
+    def test_send_remote_directory_rejected(self):
+        mock_ops = MagicMock()
+        mock_ops.env = MagicMock()
+        mock_ops.env.is_local = False
+
+        def fake_exec(cmd: str):
+            res = MagicMock()
+            res.returncode = 0
+            res.output = "__HERMES_DIR__"
+            return res
+
+        mock_ops._exec.side_effect = fake_exec
+
+        with patch("tools.send_file_tool._get_file_ops", return_value=mock_ops):
+            res = send_file_tool("/workspace/src")
+            assert "is a directory in the sandbox" in res
+
+    def test_send_remote_file_oversized(self):
+        mock_ops = MagicMock()
+        mock_ops.env = MagicMock()
+        mock_ops.env.is_local = False
+
+        def fake_exec(cmd: str):
+            res = MagicMock()
+            res.returncode = 0
+            # 60 MB
+            res.output = f"{60 * 1024 * 1024}\n"
+            return res
+
+        mock_ops._exec.side_effect = fake_exec
+
+        data, err = _extract_remote_file(mock_ops, "/workspace/dump.tar", _DEFAULT_MAX_SEND_BYTES)
+        assert data is None
+        assert "exceeds the maximum allowed transfer size" in err
+
+    def test_send_remote_extraction_failure(self):
+        mock_ops = MagicMock()
+        mock_ops.env = MagicMock()
+        mock_ops.env.is_local = False
+
+        def fake_exec(cmd: str):
+            res = MagicMock()
+            if "wc -c" in cmd:
+                res.returncode = 0
+                res.output = "1024\n"
+            elif "base64" in cmd:
+                res.returncode = 1
+                res.output = "base64: error reading file: I/O error"
+            return res
+
+        mock_ops._exec.side_effect = fake_exec
+
+        data, err = _extract_remote_file(mock_ops, "/workspace/corrupt.bin", _DEFAULT_MAX_SEND_BYTES)
+        assert data is None
+        assert "Failed to extract file" in err

--- a/tests/tools/test_send_file_tool.py
+++ b/tests/tools/test_send_file_tool.py
@@ -14,9 +14,10 @@ from tools.registry import registry
 from tools.send_file_tool import (
     SEND_FILE_SCHEMA,
     _DEFAULT_MAX_SEND_BYTES,
-    _format_size,
+    _check_remote_sensitive_path,
     _extract_local_file,
     _extract_remote_file,
+    _format_size,
     send_file_tool,
 )
 
@@ -97,13 +98,29 @@ class TestSendFileLocal:
             res = send_file_tool(str(tmp_path))
             assert "is a directory, not a regular file" in res
 
+    def test_send_local_fifo_rejected(self, tmp_path):
+        """Regression test for Point 1: FIFOs/named pipes must be rejected before blocking read."""
+        fifo_path = tmp_path / "stream.fifo"
+        with patch("tools.send_file_tool._special_file_kind", return_value="a FIFO (named pipe)"):
+            data, err = _extract_local_file(str(fifo_path), _DEFAULT_MAX_SEND_BYTES)
+            assert data is None
+            assert "is a FIFO (named pipe), not a regular file" in err
+
+    def test_send_local_socket_rejected(self, tmp_path):
+        sock_path = tmp_path / "app.sock"
+        with patch("tools.send_file_tool._special_file_kind", return_value="a socket"):
+            data, err = _extract_local_file(str(sock_path), _DEFAULT_MAX_SEND_BYTES)
+            assert data is None
+            assert "is a socket, not a regular file" in err
+
     def test_send_local_oversized_file(self, tmp_path):
         large_file = tmp_path / "huge.dat"
-        with patch("os.stat") as mock_stat:
-            stat_res = MagicMock()
-            stat_res.st_mode = stat.S_IFREG
-            stat_res.st_size = _DEFAULT_MAX_SEND_BYTES + 1024
-            mock_stat.return_value = stat_res
+        large_file.write_bytes(b"x" * 100)
+        with patch("os.fstat") as mock_fstat:
+            st = MagicMock()
+            st.st_mode = stat.S_IFREG
+            st.st_size = _DEFAULT_MAX_SEND_BYTES + 1024
+            mock_fstat.return_value = st
 
             data, err = _extract_local_file(str(large_file), _DEFAULT_MAX_SEND_BYTES)
             assert data is None
@@ -136,15 +153,13 @@ class TestSendFileRemoteSandbox:
 
         def fake_exec(cmd: str):
             res = MagicMock()
-            if "wc -c" in cmd or "__HERMES_DIR__" in cmd:
-                res.returncode = 0
-                res.output = f"{len(raw_content)}\n"
-            elif "base64" in cmd:
-                res.returncode = 0
-                res.output = f"{b64_content}\n"
-            else:
-                res.returncode = 0
-                res.output = ""
+            res.returncode = 0
+            res.output = (
+                f"__HERMES_REALPATH__:/workspace/output/invoice.pdf\n"
+                f"__HERMES_SIZE__:{len(raw_content)}\n"
+                f"__HERMES_DATA__\n"
+                f"{b64_content}\n"
+            )
             return res
 
         mock_ops._exec.side_effect = fake_exec
@@ -194,7 +209,7 @@ class TestSendFileRemoteSandbox:
             res = send_file_tool("/workspace/src")
             assert "is a directory in the sandbox" in res
 
-    def test_send_remote_file_oversized(self):
+    def test_send_remote_special_file_rejected(self):
         mock_ops = MagicMock()
         mock_ops.env = MagicMock()
         mock_ops.env.is_local = False
@@ -202,8 +217,49 @@ class TestSendFileRemoteSandbox:
         def fake_exec(cmd: str):
             res = MagicMock()
             res.returncode = 0
-            # 60 MB
-            res.output = f"{60 * 1024 * 1024}\n"
+            res.output = "__HERMES_SPECIAL__"
+            return res
+
+        mock_ops._exec.side_effect = fake_exec
+
+        data, err = _extract_remote_file(mock_ops, "/workspace/my.fifo", _DEFAULT_MAX_SEND_BYTES)
+        assert data is None
+        assert "special (non-regular) file or FIFO" in err
+
+    def test_send_remote_symlink_to_sensitive_target_blocked(self):
+        """Regression test for Point 2: Symlinks targeting remote ~/.ssh/id_rsa or /etc/shadow must be denied."""
+        mock_ops = MagicMock()
+        mock_ops.env = MagicMock()
+        mock_ops.env.is_local = False
+
+        def fake_exec(cmd: str):
+            res = MagicMock()
+            res.returncode = 0
+            # Path appears innocent (/workspace/innocent.txt) but realpath is /root/.ssh/id_rsa
+            res.output = (
+                "__HERMES_REALPATH__:/root/.ssh/id_rsa\n"
+                "__HERMES_SIZE__:1024\n"
+                "__HERMES_DATA__\n"
+                "UklGRg==\n"
+            )
+            return res
+
+        mock_ops._exec.side_effect = fake_exec
+
+        data, err = _extract_remote_file(mock_ops, "innocent.txt", _DEFAULT_MAX_SEND_BYTES)
+        assert data is None
+        assert "Access denied for protected sandbox target" in err
+        assert ".ssh" in err
+
+    def test_send_remote_file_oversized_at_probe(self):
+        mock_ops = MagicMock()
+        mock_ops.env = MagicMock()
+        mock_ops.env.is_local = False
+
+        def fake_exec(cmd: str):
+            res = MagicMock()
+            res.returncode = 0
+            res.output = f"__HERMES_SIZE__:{60 * 1024 * 1024}\n__HERMES_TOO_LARGE__:{60 * 1024 * 1024}"
             return res
 
         mock_ops._exec.side_effect = fake_exec
@@ -212,6 +268,40 @@ class TestSendFileRemoteSandbox:
         assert data is None
         assert "exceeds the maximum allowed transfer size" in err
 
+    def test_send_remote_decoded_payload_size_cap_postcondition(self):
+        """Regression test for Point 2: Small at probe, but large at read -> final decoded cap catches it."""
+        mock_ops = MagicMock()
+        mock_ops.env = MagicMock()
+        mock_ops.env.is_local = False
+
+        # Generates > 100 bytes payload when max is 50 bytes
+        oversized_data = b"A" * 1000
+        b64_oversized = base64.b64encode(oversized_data).decode("ascii")
+
+        def fake_exec(cmd: str):
+            res = MagicMock()
+            res.returncode = 0
+            # Pretends size is small (10 bytes), but payload returns 1000 bytes
+            res.output = (
+                "__HERMES_REALPATH__:/workspace/dynamic.log\n"
+                "__HERMES_SIZE__:10\n"
+                "__HERMES_DATA__\n"
+                f"{b64_oversized}\n"
+            )
+            return res
+
+        mock_ops._exec.side_effect = fake_exec
+
+        data, err = _extract_remote_file(mock_ops, "dynamic.log", max_bytes=500)
+        assert data is None
+        assert "exceeds the maximum allowed transfer size" in err
+
+    def test_send_remote_tilde_expansion_check(self):
+        assert _check_remote_sensitive_path("~/.ssh/id_rsa") is not None
+        assert _check_remote_sensitive_path("/home/user/.aws/credentials") is not None
+        assert _check_remote_sensitive_path("/etc/shadow") is not None
+        assert _check_remote_sensitive_path("/workspace/report.pdf") is None
+
     def test_send_remote_extraction_failure(self):
         mock_ops = MagicMock()
         mock_ops.env = MagicMock()
@@ -219,12 +309,8 @@ class TestSendFileRemoteSandbox:
 
         def fake_exec(cmd: str):
             res = MagicMock()
-            if "wc -c" in cmd:
-                res.returncode = 0
-                res.output = "1024\n"
-            elif "base64" in cmd:
-                res.returncode = 1
-                res.output = "base64: error reading file: I/O error"
+            res.returncode = 1
+            res.output = "base64: error reading file: I/O error"
             return res
 
         mock_ops._exec.side_effect = fake_exec

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -169,7 +169,7 @@ def _rewrite_v4a_patch_paths_for_host(patch: str, path_to_resolved: dict, file_o
 
 def _is_blocked_device_path(path: str) -> bool:
     """Return True for concrete device/fd/proc paths that can hang reads or leak process state."""
-    normalized = os.path.normpath(_expand_tilde(path)).replace("\\", "/")
+    normalized = os.path.normpath(_expand_tilde(path))
     if normalized in _BLOCKED_DEVICE_PATHS:
         return True
     return normalized.startswith("/proc/") and normalized.endswith(_BLOCKED_PROC_SUFFIXES)

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -169,7 +169,7 @@ def _rewrite_v4a_patch_paths_for_host(patch: str, path_to_resolved: dict, file_o
 
 def _is_blocked_device_path(path: str) -> bool:
     """Return True for concrete device/fd/proc paths that can hang reads or leak process state."""
-    normalized = os.path.normpath(_expand_tilde(path))
+    normalized = os.path.normpath(_expand_tilde(path)).replace("\\", "/")
     if normalized in _BLOCKED_DEVICE_PATHS:
         return True
     return normalized.startswith("/proc/") and normalized.endswith(_BLOCKED_PROC_SUFFIXES)

--- a/tools/send_file_tool.py
+++ b/tools/send_file_tool.py
@@ -13,11 +13,12 @@ import os
 import posixpath
 import re
 import shlex
+import stat
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 from agent.file_safety import get_read_block_error
-from tools.file_tools import _get_file_ops, _is_blocked_device
+from tools.file_tools import _get_file_ops, _is_blocked_device, _special_file_kind
 from tools.file_tools_paths import _expand_tilde, _resolve_path_for_task
 from tools.registry import registry, tool_error
 
@@ -25,6 +26,18 @@ logger = logging.getLogger(__name__)
 
 # Default max file size for outbound transfer (50 MB matching platform upload limits).
 _DEFAULT_MAX_SEND_BYTES = 50 * 1024 * 1024
+
+# Remote sensitive patterns that must not be exfiltrated from remote/sandboxed environments.
+_REMOTE_SENSITIVE_PATTERNS = (
+    re.compile(r"(?:^|/)\.ssh(?:/|$)"),
+    re.compile(r"(?:^|/)\.aws(?:/|$)"),
+    re.compile(r"(?:^|/)\.env(?:\.[^/]+)?$"),
+    re.compile(r"(?:^|/)\.(?:netrc|pgpass|npmrc|pypirc|dockercfg)$"),
+    re.compile(r"(?:^|/)\.docker/config\.json$"),
+    re.compile(r"^/(?:etc|private/etc)/(?:shadow|master\.passwd|sudoers|security)"),
+    re.compile(r"^/(?:proc|dev|sys)/"),
+    re.compile(r"(?:^|/)\.hermes(?:/|$)"),
+)
 
 SEND_FILE_SCHEMA = {
     "name": "send_file",
@@ -63,6 +76,27 @@ def _format_size(num_bytes: int) -> str:
     return f"{num_bytes / (1024 * 1024):.1f} MB"
 
 
+def _is_device_or_proc_path(path: str) -> bool:
+    """Check if a path is a /dev/, /proc/, or /sys/ device path across platforms."""
+    if not path:
+        return False
+    clean = path.replace("\\", "/").strip()
+    if clean.startswith("/dev/") or clean.startswith("/proc/") or clean.startswith("/sys/"):
+        return True
+    return _is_blocked_device(path)
+
+
+def _check_remote_sensitive_path(path: str) -> Optional[str]:
+    """Check if a remote/sandbox path (or its resolved realpath) targets sensitive files."""
+    if not path:
+        return None
+    normalized = posixpath.normpath(path.replace("\\", "/"))
+    for pattern in _REMOTE_SENSITIVE_PATTERNS:
+        if pattern.search(normalized) or pattern.search(path):
+            return f"access denied for protected remote path '{path}'"
+    return None
+
+
 def _cache_extracted_bytes(data: bytes, filename: str) -> str:
     """Save raw file bytes to the host document/media cache and return the host path."""
     try:
@@ -83,64 +117,147 @@ def _cache_extracted_bytes(data: bytes, filename: str) -> str:
 
 
 def _extract_local_file(resolved_path: str, max_bytes: int) -> Tuple[Optional[bytes], Optional[str]]:
-    """Read a local file from the host filesystem."""
-    try:
-        st = os.stat(resolved_path)
-        import stat
+    """Read a local file from the host filesystem using object-bound file descriptor inspection."""
+    # 1. Directory check
+    if os.path.isdir(resolved_path):
+        return None, f"'{resolved_path}' is a directory, not a regular file. Archive it into a .zip or .tar.gz first."
 
-        st_mode = getattr(st, "st_mode", None)
-        if isinstance(st_mode, int) and stat.S_ISDIR(st_mode) or (st_mode is None and os.path.isdir(resolved_path)):
+    # 2. Reject special files (FIFOs, sockets, char/block devices) before opening to prevent hangs
+    special_kind = _special_file_kind(resolved_path)
+    if special_kind:
+        return None, f"'{resolved_path}' is {special_kind}, not a regular file."
+
+    # 3. Name / path guard check
+    if _is_device_or_proc_path(resolved_path):
+        return None, f"access denied for device or proc path '{resolved_path}'."
+
+    # 4. Object-bound open and fstat check
+    fd = None
+    try:
+        flags = os.O_RDONLY
+        if hasattr(os, "O_BINARY"):
+            flags |= os.O_BINARY
+        if hasattr(os, "O_NONBLOCK"):
+            flags |= os.O_NONBLOCK
+
+        fd = os.open(resolved_path, flags)
+        st = os.fstat(fd)
+
+        # Check directory vs regular file on opened descriptor
+        if stat.S_ISDIR(st.st_mode):
             return None, f"'{resolved_path}' is a directory, not a regular file. Archive it into a .zip or .tar.gz first."
+        if not stat.S_ISREG(st.st_mode):
+            return None, f"'{resolved_path}' is a special (non-regular) file, not a regular file."
+
         if st.st_size > max_bytes:
             return None, f"File size ({_format_size(st.st_size)}) exceeds the maximum allowed transfer size ({_format_size(max_bytes)})."
-        with open(resolved_path, "rb") as f:
-            data = f.read()
+
+        # Read at most max_bytes + 1 to enforce size limit directly on descriptor
+        data = os.read(fd, max_bytes + 1)
+        if len(data) > max_bytes:
+            return None, f"File size ({_format_size(len(data))}) exceeds the maximum allowed transfer size ({_format_size(max_bytes)})."
+
         return data, None
     except FileNotFoundError:
         return None, f"File not found: '{resolved_path}'"
     except PermissionError:
         return None, f"Permission denied reading file: '{resolved_path}'"
+    except BlockingIOError:
+        return None, f"Cannot read '{resolved_path}': resource would block (special file or FIFO)."
     except OSError as exc:
         return None, f"Failed to read file '{resolved_path}': {exc}"
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
 
 
-def _extract_remote_file(file_ops, remote_path: str, max_bytes: int) -> Tuple[Optional[bytes], Optional[str]]:
-    """Extract a file from a sandboxed or remote terminal backend via shell execution."""
-    quoted = shlex.quote(remote_path)
-    # Probe existence, type, and size in one compound command
-    probe_cmd = (
-        f'if [ -d {quoted} ]; then echo "__HERMES_DIR__"; '
-        f'elif [ -f {quoted} ]; then wc -c < {quoted}; '
-        f'else echo "__HERMES_NOT_FOUND__"; fi'
+def _extract_remote_file(file_ops, raw_remote_path: str, max_bytes: int) -> Tuple[Optional[bytes], Optional[str]]:
+    """Extract a file from a sandboxed or remote terminal backend with atomic realpath resolution and size validation."""
+    quoted_raw = shlex.quote(raw_remote_path)
+    cwd = getattr(file_ops, "cwd", "/workspace")
+    if not isinstance(cwd, str) or not cwd:
+        cwd = "/workspace"
+    quoted_cwd = shlex.quote(cwd)
+
+    # Compound script to resolve path, expand ~, probe existence, inspect realpath, check size, and base64 dump
+    script = (
+        f'p={quoted_raw}\n'
+        f'case "$p" in\n'
+        f'  "~"*) p="$HOME${{p#\\~}}" ;;\n'
+        f'  /*) ;;\n'
+        f'  *) p="{quoted_cwd}/$p" ;;\n'
+        f'esac\n'
+        f'if [ ! -e "$p" ] && [ ! -L "$p" ]; then\n'
+        f'  echo "__HERMES_NOT_FOUND__"\n'
+        f'  exit 0\n'
+        f'fi\n'
+        f'if [ -d "$p" ]; then\n'
+        f'  echo "__HERMES_DIR__"\n'
+        f'  exit 0\n'
+        f'fi\n'
+        f'rp=""\n'
+        f'if command -v realpath >/dev/null 2>&1; then\n'
+        f'  rp=$(realpath "$p" 2>/dev/null || echo "")\n'
+        f'elif command -v readlink >/dev/null 2>&1; then\n'
+        f'  rp=$(readlink -f "$p" 2>/dev/null || echo "")\n'
+        f'fi\n'
+        f'[ -z "$rp" ] && rp="$p"\n'
+        f'echo "__HERMES_REALPATH__:$rp"\n'
+        f'if [ ! -f "$p" ]; then\n'
+        f'  echo "__HERMES_SPECIAL__"\n'
+        f'  exit 0\n'
+        f'fi\n'
+        f'sz=$(wc -c < "$p" 2>/dev/null || echo "0")\n'
+        f'echo "__HERMES_SIZE__:$sz"\n'
+        f'if [ "$sz" -gt {max_bytes} ]; then\n'
+        f'  echo "__HERMES_TOO_LARGE__:$sz"\n'
+        f'  exit 0\n'
+        f'fi\n'
+        f'echo "__HERMES_DATA__"\n'
+        f'(base64 -w 0 "$p" 2>/dev/null || base64 "$p" 2>/dev/null)\n'
     )
-    res = file_ops._exec(probe_cmd)
+
+    res = file_ops._exec(script)
     output = (res.output or "").strip()
 
-    if "__HERMES_NOT_FOUND__" in output or res.returncode != 0 and not output:
-        return None, f"File not found in sandbox: '{remote_path}'"
+    if "__HERMES_NOT_FOUND__" in output or (res.returncode != 0 and not output):
+        return None, f"File not found in sandbox: '{raw_remote_path}'"
     if "__HERMES_DIR__" in output:
-        return None, f"'{remote_path}' is a directory in the sandbox, not a regular file. Archive it into a .zip or .tar.gz first."
+        return None, f"'{raw_remote_path}' is a directory in the sandbox, not a regular file. Archive it into a .zip or .tar.gz first."
+    if "__HERMES_SPECIAL__" in output:
+        return None, f"'{raw_remote_path}' is a special (non-regular) file or FIFO in the sandbox."
+    if "__HERMES_TOO_LARGE__" in output:
+        m = re.search(r"__HERMES_TOO_LARGE__:(\d+)", output)
+        sz = int(m.group(1)) if m else max_bytes + 1
+        return None, f"File size ({_format_size(sz)}) exceeds the maximum allowed transfer size ({_format_size(max_bytes)})."
 
-    # Parse file size from wc -c digits
-    match = re.search(r"\b(\d+)\b", output)
-    if match:
-        size = int(match.group(1))
-        if size > max_bytes:
-            return None, f"File size ({_format_size(size)}) exceeds the maximum allowed transfer size ({_format_size(max_bytes)})."
+    # 1. Verify remote realpath for symlink targets against sensitive targets
+    rp_match = re.search(r"__HERMES_REALPATH__:(.+)", output)
+    if rp_match:
+        remote_realpath = rp_match.group(1).strip()
+        sec_err = _check_remote_sensitive_path(remote_realpath)
+        if sec_err:
+            return None, f"Access denied for protected sandbox target '{remote_realpath}': {sec_err}"
 
-    # Extract bytes as base64
-    b64_cmd = f"base64 -w 0 {quoted} 2>/dev/null || base64 {quoted}"
-    b64_res = file_ops._exec(b64_cmd)
-    if b64_res.returncode != 0 or not b64_res.output:
-        return None, f"Failed to extract file '{remote_path}' from sandbox: {b64_res.output or 'empty output'}"
+    # 2. Extract base64 payload after marker
+    if "__HERMES_DATA__" not in output:
+        return None, f"Failed to extract file '{raw_remote_path}' from sandbox: {output or 'empty output'}"
 
-    # Clean whitespace and decode
-    clean_b64 = re.sub(r"\s+", "", b64_res.output)
+    b64_part = output.split("__HERMES_DATA__", 1)[1].strip()
+    clean_b64 = re.sub(r"\s+", "", b64_part)
     try:
         raw_bytes = base64.b64decode(clean_b64)
-        return raw_bytes, None
     except (binascii.Error, ValueError) as exc:
-        return None, f"Failed to decode base64 file data for '{remote_path}': {exc}"
+        return None, f"Failed to decode base64 file data for '{raw_remote_path}': {exc}"
+
+    # 3. Postcondition: Enforce decoded payload cap strictly
+    if len(raw_bytes) > max_bytes:
+        return None, f"File size ({_format_size(len(raw_bytes))}) exceeds the maximum allowed transfer size ({_format_size(max_bytes)})."
+
+    return raw_bytes, None
 
 
 def send_file_tool(path: str, message: Optional[str] = None, task_id: str = "default") -> str:
@@ -150,8 +267,8 @@ def send_file_tool(path: str, message: Optional[str] = None, task_id: str = "def
 
     raw_path = path.strip()
 
-    # Security check: prevent exfiltration of internal credential/secret files
-    if _is_blocked_device(raw_path):
+    # Name-based blocked device check upfront
+    if _is_device_or_proc_path(raw_path):
         return tool_error(f"send_file: access denied for device or proc path '{raw_path}'.")
 
     # Obtain the file operations manager for the active task environment
@@ -162,12 +279,16 @@ def send_file_tool(path: str, message: Optional[str] = None, task_id: str = "def
     filename = Path(raw_path).name or "file"
 
     if is_local:
+        # Resolve task path first
         try:
             resolved = str(_resolve_path_for_task(raw_path, task_id))
         except Exception:
             resolved = os.path.abspath(_expand_tilde(raw_path))
 
-        # Check sensitive paths on host
+        # Security checks on host resolved path
+        if _is_device_or_proc_path(resolved):
+            return tool_error(f"send_file: access denied for device or proc path '{raw_path}'.")
+
         sec_err = get_read_block_error(resolved)
         if sec_err:
             return tool_error(f"send_file: access denied for protected path '{raw_path}': {sec_err}")
@@ -179,17 +300,12 @@ def send_file_tool(path: str, message: Optional[str] = None, task_id: str = "def
         cached_host_path = _cache_extracted_bytes(data, filename)
     else:
         # Remote / Sandbox environment
-        remote_path = raw_path
-        if not remote_path.startswith("/") and not remote_path.startswith("~"):
-            cwd = getattr(file_ops, "cwd", "/workspace") or "/workspace"
-            remote_path = posixpath.normpath(posixpath.join(cwd, remote_path))
-
-        # Check sensitive path patterns
-        sec_err = get_read_block_error(remote_path)
+        # Pre-check raw path against remote sensitive patterns
+        sec_err = _check_remote_sensitive_path(raw_path)
         if sec_err:
-            return tool_error(f"send_file: access denied for protected path '{remote_path}': {sec_err}")
+            return tool_error(f"send_file: access denied for protected path '{raw_path}': {sec_err}")
 
-        data, err = _extract_remote_file(file_ops, remote_path, _DEFAULT_MAX_SEND_BYTES)
+        data, err = _extract_remote_file(file_ops, raw_path, _DEFAULT_MAX_SEND_BYTES)
         if err:
             return tool_error(f"send_file: {err}")
 

--- a/tools/send_file_tool.py
+++ b/tools/send_file_tool.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Send File Tool - Transfer files from local or sandboxed environments to users.
+
+Extracts files generated inside sandboxed backends (Docker, SSH, Modal, Daytona,
+Singularity, Vercel) or local execution environments to the host cache and delivers
+them via the gateway's native MEDIA: attachment pipeline.
+"""
+
+import base64
+import binascii
+import logging
+import os
+import posixpath
+import re
+import shlex
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+from agent.file_safety import get_read_block_error
+from tools.file_tools import _get_file_ops, _is_blocked_device
+from tools.file_tools_paths import _expand_tilde, _resolve_path_for_task
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+# Default max file size for outbound transfer (50 MB matching platform upload limits).
+_DEFAULT_MAX_SEND_BYTES = 50 * 1024 * 1024
+
+SEND_FILE_SCHEMA = {
+    "name": "send_file",
+    "description": (
+        "Send a file from the terminal environment to the user or messaging platform. "
+        "Extracts generated files, reports, charts, documents, or data artifacts from local or "
+        "sandboxed terminal environments (Docker, SSH, Modal, Singularity, Daytona, Vercel) "
+        "and delivers them as native media attachments or download references."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": (
+                    "Path to the file inside the terminal environment to send "
+                    "(e.g. '/workspace/report.pdf', 'output/chart.png', or 'data.csv')"
+                ),
+            },
+            "message": {
+                "type": "string",
+                "description": "Optional caption or description message to accompany the file delivery",
+            },
+        },
+        "required": ["path"],
+    },
+}
+
+
+def _format_size(num_bytes: int) -> str:
+    """Format bytes into a human-readable size string."""
+    if num_bytes < 1024:
+        return f"{num_bytes} B"
+    if num_bytes < 1024 * 1024:
+        return f"{num_bytes / 1024:.1f} KB"
+    return f"{num_bytes / (1024 * 1024):.1f} MB"
+
+
+def _cache_extracted_bytes(data: bytes, filename: str) -> str:
+    """Save raw file bytes to the host document/media cache and return the host path."""
+    try:
+        from gateway.platforms.base import cache_document_from_bytes
+
+        return cache_document_from_bytes(data, filename)
+    except Exception:
+        # Fallback if gateway platform helper is not initialized (e.g. CLI standalone)
+        from hermes_constants import get_hermes_dir
+        import uuid
+
+        cache_dir = get_hermes_dir("cache/documents", "document_cache")
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        safe_name = Path(filename).name or "document"
+        target = cache_dir / f"doc_{uuid.uuid4().hex[:12]}_{safe_name}"
+        target.write_bytes(data)
+        return str(target)
+
+
+def _extract_local_file(resolved_path: str, max_bytes: int) -> Tuple[Optional[bytes], Optional[str]]:
+    """Read a local file from the host filesystem."""
+    try:
+        st = os.stat(resolved_path)
+        import stat
+
+        st_mode = getattr(st, "st_mode", None)
+        if isinstance(st_mode, int) and stat.S_ISDIR(st_mode) or (st_mode is None and os.path.isdir(resolved_path)):
+            return None, f"'{resolved_path}' is a directory, not a regular file. Archive it into a .zip or .tar.gz first."
+        if st.st_size > max_bytes:
+            return None, f"File size ({_format_size(st.st_size)}) exceeds the maximum allowed transfer size ({_format_size(max_bytes)})."
+        with open(resolved_path, "rb") as f:
+            data = f.read()
+        return data, None
+    except FileNotFoundError:
+        return None, f"File not found: '{resolved_path}'"
+    except PermissionError:
+        return None, f"Permission denied reading file: '{resolved_path}'"
+    except OSError as exc:
+        return None, f"Failed to read file '{resolved_path}': {exc}"
+
+
+def _extract_remote_file(file_ops, remote_path: str, max_bytes: int) -> Tuple[Optional[bytes], Optional[str]]:
+    """Extract a file from a sandboxed or remote terminal backend via shell execution."""
+    quoted = shlex.quote(remote_path)
+    # Probe existence, type, and size in one compound command
+    probe_cmd = (
+        f'if [ -d {quoted} ]; then echo "__HERMES_DIR__"; '
+        f'elif [ -f {quoted} ]; then wc -c < {quoted}; '
+        f'else echo "__HERMES_NOT_FOUND__"; fi'
+    )
+    res = file_ops._exec(probe_cmd)
+    output = (res.output or "").strip()
+
+    if "__HERMES_NOT_FOUND__" in output or res.returncode != 0 and not output:
+        return None, f"File not found in sandbox: '{remote_path}'"
+    if "__HERMES_DIR__" in output:
+        return None, f"'{remote_path}' is a directory in the sandbox, not a regular file. Archive it into a .zip or .tar.gz first."
+
+    # Parse file size from wc -c digits
+    match = re.search(r"\b(\d+)\b", output)
+    if match:
+        size = int(match.group(1))
+        if size > max_bytes:
+            return None, f"File size ({_format_size(size)}) exceeds the maximum allowed transfer size ({_format_size(max_bytes)})."
+
+    # Extract bytes as base64
+    b64_cmd = f"base64 -w 0 {quoted} 2>/dev/null || base64 {quoted}"
+    b64_res = file_ops._exec(b64_cmd)
+    if b64_res.returncode != 0 or not b64_res.output:
+        return None, f"Failed to extract file '{remote_path}' from sandbox: {b64_res.output or 'empty output'}"
+
+    # Clean whitespace and decode
+    clean_b64 = re.sub(r"\s+", "", b64_res.output)
+    try:
+        raw_bytes = base64.b64decode(clean_b64)
+        return raw_bytes, None
+    except (binascii.Error, ValueError) as exc:
+        return None, f"Failed to decode base64 file data for '{remote_path}': {exc}"
+
+
+def send_file_tool(path: str, message: Optional[str] = None, task_id: str = "default") -> str:
+    """Core implementation of the send_file tool."""
+    if not path or not isinstance(path, str) or not path.strip():
+        return tool_error("send_file: missing required field 'path'. Specify the file path to send.")
+
+    raw_path = path.strip()
+
+    # Security check: prevent exfiltration of internal credential/secret files
+    if _is_blocked_device(raw_path):
+        return tool_error(f"send_file: access denied for device or proc path '{raw_path}'.")
+
+    # Obtain the file operations manager for the active task environment
+    file_ops = _get_file_ops(task_id)
+    env = getattr(file_ops, "env", None)
+    is_local = getattr(env, "is_local", False) or env is None
+
+    filename = Path(raw_path).name or "file"
+
+    if is_local:
+        try:
+            resolved = str(_resolve_path_for_task(raw_path, task_id))
+        except Exception:
+            resolved = os.path.abspath(_expand_tilde(raw_path))
+
+        # Check sensitive paths on host
+        sec_err = get_read_block_error(resolved)
+        if sec_err:
+            return tool_error(f"send_file: access denied for protected path '{raw_path}': {sec_err}")
+
+        data, err = _extract_local_file(resolved, _DEFAULT_MAX_SEND_BYTES)
+        if err:
+            return tool_error(f"send_file: {err}")
+
+        cached_host_path = _cache_extracted_bytes(data, filename)
+    else:
+        # Remote / Sandbox environment
+        remote_path = raw_path
+        if not remote_path.startswith("/") and not remote_path.startswith("~"):
+            cwd = getattr(file_ops, "cwd", "/workspace") or "/workspace"
+            remote_path = posixpath.normpath(posixpath.join(cwd, remote_path))
+
+        # Check sensitive path patterns
+        sec_err = get_read_block_error(remote_path)
+        if sec_err:
+            return tool_error(f"send_file: access denied for protected path '{remote_path}': {sec_err}")
+
+        data, err = _extract_remote_file(file_ops, remote_path, _DEFAULT_MAX_SEND_BYTES)
+        if err:
+            return tool_error(f"send_file: {err}")
+
+        cached_host_path = _cache_extracted_bytes(data, filename)
+
+    size_str = _format_size(len(data))
+    caption = f"{message.strip()}\n\n" if message and message.strip() else ""
+    return f"File ready for delivery: {filename} ({size_str})\n{caption}MEDIA:{cached_host_path}"
+
+
+def _handle_send_file(args: Dict[str, Any], **kw) -> str:
+    tid = kw.get("task_id") or "default"
+    return send_file_tool(
+        path=args.get("path", ""),
+        message=args.get("message"),
+        task_id=tid,
+    )
+
+
+def _check_send_file_reqs() -> Tuple[bool, str]:
+    return True, ""
+
+
+# Register tool with central Hermes registry
+registry.register(
+    name="send_file",
+    toolset="file",
+    schema=SEND_FILE_SCHEMA,
+    handler=_handle_send_file,
+    check_fn=_check_send_file_reqs,
+    emoji="📤",
+    max_result_size_chars=10_000,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Any, Set, Optional, Tuple
 _HERMES_CORE_TOOLS = [
     "web_search", "web_extract",
     "terminal", "process_manage",
-    "read_file", "write_file", "patch", "search_files",
+    "read_file", "write_file", "patch", "search_files", "send_file",
     "vision_analyze", "image_generate",
     "skills_list", "skill_view", "skill_manage",
     "browser_navigate", "browser_snapshot", "browser_click",
@@ -115,9 +115,9 @@ TOOLSETS = {
         ["cronjob_manage"],
     ),
     "file": _ts(
-        "File manipulation tools: read, write, patch (with fuzzy matching), and "
-        "search (content + files)",
-        ["read_file", "write_file", "patch", "search_files"],
+        "File manipulation tools: read, write, patch (with fuzzy matching), "
+        "search (content + files), and outbound file transfer",
+        ["read_file", "write_file", "patch", "search_files", "send_file"],
     ),
     "tts": _ts("Text-to-speech: convert text to audio with Edge TTS (free), ElevenLabs, OpenAI, or xAI", ["text_to_speech"]),
     "todo": _ts("Task planning and tracking for multi-step work", ["todo_list"]),


### PR DESCRIPTION
## Summary & Motivation
Addresses outbound file transfer for #466.

Introduces the `send_file` tool to enable Hermes agents to send files, generated reports, charts, audio, datasets, and documents directly to users across all messaging platforms and terminal interfaces.

This PR implements the outbound delivery slice of #466, building upon earlier reference discussions and architectural explorations in #68506 (tokou) and #827 (eren-karakus0). Issue #466 remains open for the complementary inbound user-attachment injection side.

### Key Capabilities & Security Hardening
1. **Local & Remote / Sandbox Support:**
   - **Local backends:** Resolves task path once, verifies with `_special_file_kind` (rejects FIFOs, sockets, char/block devices to prevent hangs), opens with non-blocking descriptor flags, `fstat()`s the opened descriptor for regular file verification, and enforces size bounds directly on the descriptor.
   - **Sandbox backends (Docker, SSH, Modal, Singularity, Daytona, Vercel):** Executes compound atomic script in sandbox resolving realpaths, handling tilde expansion (`~`), verifying regular files, checking sizes, and extracting base64 bytes.
2. **Security & Boundary Protections:**
   - **Remote Realpath Protection:** Inspects resolved realpath targets to block symlinks pointing to protected remote files (`.ssh`, `.aws`, `.env`, `/etc/shadow`, etc.).
   - **Decoded Byte Cap Postcondition:** Host-side strict validation asserting `len(raw_bytes) <= max_bytes` to prevent race conditions or dynamic growth between probe and read.
   - **Special-file / FIFO Guards:** Prevents indefinite hangs on named pipes/devices across local and remote environments.
   - **Interlock with #99371:** Reverted unrelated shared path-normalization edits in `tools/file_tools.py`, preserving #99371 as the owner of the Windows path-namespace security defect class.
3. **Gateway & Messaging Integration:**
   - Emits structured `File ready for delivery: <filename> (<size>)
[<caption]
MEDIA:<cached_host_path>` output compatible with Gateway platform media adapters (Telegram, Discord, Slack, WhatsApp, Webhooks, etc.).

## Test Plan
- Unit test suite in `tests/tools/test_send_file_tool.py` (21/21 passed):
  - Local tests: missing path, blocked device path, existing file extraction, file not found, directory rejection, FIFO rejection, socket rejection, oversized file rejection, sensitive path block.
  - Remote/Sandbox tests: success extraction, not found, directory rejection, special file rejection, symlink to sensitive target block, oversized at probe, decoded payload size cap postcondition, tilde expansion, extraction failure handling.

```bash
pytest tests/tools/test_send_file_tool.py -v
# 21 passed in 7.57s
```
