### PR TITLE
fix(gateway): stop launchd gateways from being reported offline

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -305,20 +305,24 @@ def _read_process_cmdline(pid: int) -> Optional[str]:
     return None
 
 
+def _normalized_command_tokens(command: str | None) -> list[str]:
+    """Split a process command line and normalize tokens for identity checks."""
+    if not command:
+        return []
+    try:
+        raw_tokens = shlex.split(command, posix=False)
+    except ValueError:
+        raw_tokens = command.split()
+    return [t.strip("\"'").replace("\\", "/").lower() for t in raw_tokens]
+
+
 def _gateway_command_subcommand(command: str | None) -> str | None:
     """Hermes gateway lifecycle subcommand from a command line, or None. No loose substring matches
     (``"gateway" in cmdline`` also matched ``gateway status`` / ``python -m tui_gateway``): needs a
     Hermes entrypoint plus the ``gateway`` subcommand, or a gateway-dedicated entrypoint. Tokenizes
     quote-aware (Windows paths with spaces); ``--profile``/``-p`` selectors are stripped anywhere in
     argv since ``_apply_profile_override`` removes them before argparse."""
-    if not command:
-        return None
-    try:
-        raw_tokens = shlex.split(command, posix=False)
-    except ValueError:
-        raw_tokens = command.split()
-    # Strip surrounding quotes, normalize slashes + case per token.
-    tokens = [t.strip("\"'").replace("\\", "/").lower() for t in raw_tokens]
+    tokens = _normalized_command_tokens(command)
     if not tokens:
         return None
     basenames = [t.rsplit("/", 1)[-1] for t in tokens]
@@ -385,19 +389,26 @@ def _command_line_belongs_to_profile(command: str, profile_home: Path) -> bool:
     ``hermes_cli.gateway._matches_current_profile``): a stale state file can record a PID recycled
     onto ANOTHER profile's live gateway. Named profiles carry ``-p``/``--profile <name>`` or
     ``HERMES_HOME=`` on argv; the default gateway runs bare. Separators normalized."""
-    command_lc = command.lower().replace("\\", "/")
+    tokens = _normalized_command_tokens(command)
     profile_name = _profile_name_for_home(profile_home)
     home_lc = str(profile_home).lower().replace("\\", "/")
+    selected_profiles: list[str] = []
+    explicit_homes: list[str] = []
+    for index, token in enumerate(tokens):
+        if token in ("--profile", "-p") and index + 1 < len(tokens):
+            selected_profiles.append(tokens[index + 1].strip("\"'"))
+        elif token.startswith(("--profile=", "-p=")):
+            selected_profiles.append(token.split("=", 1)[1].strip("\"'"))
+        elif token.startswith("hermes_home="):
+            explicit_homes.append(token.split("=", 1)[1].strip("\"'").rstrip("/"))
     if profile_name is not None and profile_name != "default":
         profile_lc = profile_name.lower()
-        return any(needle in command_lc for needle in (
-            f"--profile {profile_lc}", f"-p {profile_lc}", f"hermes_home={home_lc}"
-        ))
+        return profile_lc in selected_profiles or home_lc.rstrip("/") in explicit_homes
     # Default profile: accept unless argv names another profile or a conflicting explicit
     # HERMES_HOME= (its absence is not disqualifying -- HERMES_HOME usually arrives via the env).
-    if "--profile " in command_lc or " -p " in command_lc:
+    if selected_profiles:
         return False
-    return not ("hermes_home=" in command_lc and f"hermes_home={home_lc}" not in command_lc)
+    return not explicit_homes or home_lc.rstrip("/") in explicit_homes
 
 
 def _record_matches_live_gateway_pid(

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -981,14 +981,29 @@ def get_runtime_status_running_pid(
         return None
     if payload.get("gateway_state") in {None, "stopped", "startup_failed"}:
         return None
-    pid = _live_pid_from_record(payload)
-    if pid is None:
+    pid = _pid_from_record(payload)
+    if pid is None or not _pid_exists(pid):
         return None
     # Active-profile context: the record's hermes_home must match this process so a stale record
     # cannot lend another profile's identity.
     if expected_home is None and not _pid_record_belongs_to_current_profile(payload):
         return None
-    if not _record_matches_live_gateway_pid(payload, pid, expected_home=expected_home):
+
+    live_cmdline = _read_process_cmdline(pid)
+    if live_cmdline:
+        profile_home = expected_home or _get_process_hermes_home()
+        if not looks_like_gateway_runtime_command_line(live_cmdline):
+            return None
+        if not _command_line_belongs_to_profile(live_cmdline, profile_home):
+            return None
+        return pid
+
+    # If the OS cannot expose argv, retain the exact start-time guard before trusting the record.
+    # Destructive paths always keep their own exact guard; this exception is liveness-only and
+    # requires a readable live command line above to override a stale writer fingerprint.
+    if _start_times_conflict(payload.get("start_time"), _get_process_start_time(pid)):
+        return None
+    if not _record_looks_like_gateway(payload):
         return None
     return pid
 

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -347,6 +347,62 @@ class TestGatewayRuntimeStatus:
 
         assert status.get_runtime_status_running_pid(payload) == 139
 
+    @pytest.mark.parametrize(
+        "cmdline",
+        [
+            "hermes -p coder2 gateway run --replace",
+            "hermes_home=/opt/data/profiles/coder2 hermes gateway run --replace",
+        ],
+    )
+    def test_runtime_status_running_pid_rejects_profile_prefix_with_stale_start_time(
+        self, monkeypatch, cmdline
+    ):
+        payload = {
+            "pid": 139,
+            "gateway_state": "running",
+            "kind": "hermes-gateway",
+            "argv": ["hermes", "gateway", "run"],
+            "start_time": 100,
+        }
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: pid == 139)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 200)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: cmdline)
+
+        assert (
+            status.get_runtime_status_running_pid(
+                payload, expected_home=Path("/opt/data/profiles/coder")
+            )
+            is None
+        )
+
+    @pytest.mark.parametrize(
+        "cmdline",
+        [
+            "hermes --profile=coder gateway run --replace --external-supervisor",
+            "hermes_home=/opt/data/profiles/coder hermes gateway run --replace",
+        ],
+    )
+    def test_runtime_status_running_pid_accepts_exact_profile_with_stale_start_time(
+        self, monkeypatch, cmdline
+    ):
+        payload = {
+            "pid": 139,
+            "gateway_state": "running",
+            "kind": "hermes-gateway",
+            "argv": ["hermes", "gateway", "run"],
+            "start_time": 100,
+        }
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: pid == 139)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 200)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: cmdline)
+
+        assert (
+            status.get_runtime_status_running_pid(
+                payload, expected_home=Path("/opt/data/profiles/coder")
+            )
+            == 139
+        )
+
     def test_runtime_status_running_pid_keeps_start_time_guard_without_live_gateway_identity(
         self, monkeypatch
     ):

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -327,6 +327,45 @@ class TestGatewayRuntimeStatus:
                 == 139
             ), cmdline
 
+    def test_runtime_status_running_pid_prefers_live_gateway_cmdline_over_stale_start_time(
+        self, monkeypatch
+    ):
+        payload = {
+            "pid": 139,
+            "gateway_state": "running",
+            "kind": "hermes-gateway",
+            "argv": ["hermes", "gateway", "run"],
+            "start_time": 100,
+        }
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: pid == 139)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 200)
+        monkeypatch.setattr(
+            status,
+            "_read_process_cmdline",
+            lambda pid: "hermes gateway run --replace --external-supervisor",
+        )
+
+        assert status.get_runtime_status_running_pid(payload) == 139
+
+    def test_runtime_status_running_pid_keeps_start_time_guard_without_live_gateway_identity(
+        self, monkeypatch
+    ):
+        payload = {
+            "pid": 139,
+            "gateway_state": "running",
+            "kind": "hermes-gateway",
+            "argv": ["hermes", "gateway", "run"],
+            "start_time": 100,
+        }
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: pid == 139)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 200)
+
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: "python unrelated.py")
+        assert status.get_runtime_status_running_pid(payload) is None
+
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: None)
+        assert status.get_runtime_status_running_pid(payload) is None
+
 
     def test_command_line_belongs_to_profile_normalizes_separators(self):
         """A Windows argv renders HERMES_HOME with backslashes while the


### PR DESCRIPTION
## What does this PR do?

Launchd-managed gateways without a PID file are no longer reported as stopped when a stale runtime-status start-time fingerprint disagrees with the live process but the live command line proves that PID is the expected gateway. The fallback remains conservative: unrelated or unreadable command lines still require the exact start-time guard, and destructive PID paths are unchanged.

### Symptom

A healthy macOS gateway launched with `gateway run --replace --external-supervisor` can keep dispatching while CLI liveness reports `running=False` and warns that no gateway is running.

### Impact

Operators receive a false outage warning from commands such as `hermes kanban create`, which makes the shared gateway liveness probe unreliable for launch-service deployments.

### Bug Cause

**Trigger:** `gateway/status.py:972` / `get_runtime_status_running_pid()` checks a launch-service runtime record whose persisted `start_time` differs from the live process fingerprint.

**Causal chain:**
1. A launchd-managed gateway has no `gateway.pid`, so liveness reaches the runtime-status fallback.
2. `_live_pid_from_record()` rejects the PID on exact start-time inequality before inspecting its live command line.
3. `resolve_gateway_liveness()` exhausts its ladder and reports the healthy gateway as stopped.

**Why it is wrong:** For this read-only liveness decision, a readable live command line can directly establish that the currently live PID is a gateway for the expected profile. Treating a stale writer fingerprint as an unconditional rejection discards stronger current process evidence.

**Working sibling / contrast:** Runtime records with matching start times already reach command-line identity validation and are reported live.

**Ruled out:** A global tolerance was rejected because weakening exact start-time comparison in shared or destructive PID guards would reduce PID-reuse protection.

### Fix

The runtime-status fallback now validates an alive PID's readable live command line and profile before considering the persisted start time. Only a proven live gateway command line may override a mismatch. If argv is unavailable, the existing exact start-time and persisted-record checks remain mandatory. Regression tests cover both acceptance and fail-closed paths.

## Related Issue

Closes #103568

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/status.py` - let current gateway argv outrank stale start-time metadata only in the read-only runtime liveness fallback.
- `tests/gateway/test_status.py` - cover launchd mismatch acceptance and PID-reuse rejection when live gateway identity is absent.

## How to Test

1. Run the focused runtime-status liveness tests.
2. Confirm the mismatched start-time case returns the live PID only for a gateway-shaped command line.
3. Confirm unrelated and unreadable command lines still reject the mismatched PID.

```bash
scripts/run_tests.sh tests/gateway/test_status.py -k 'runtime_status_running_pid or command_line_belongs_to_profile'
scripts/run_tests.sh tests/gateway/test_status.py -k 'not ps_fallback_when_proc_unavailable'
C:/workspace/hermes-agent/.venv/Scripts/python.exe -m ruff check gateway/status.py tests/gateway/test_status.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test runner on the related tests and all selected tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; behavior is covered by the existing function contract and focused comments
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - the regression is exercised through the gateway liveness unit tests.
