### PR TITLE
fix(agent): Kimi Code fallback entries stop 404ing on /chat/completions (#77256, salvage #77304)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1797,8 +1797,10 @@ def _fallback_reason_text(reason: "FailoverReason | None") -> str:
 
 
 def _is_anthropic_wire_url(url: str) -> bool:
-    """Same host match as determine_api_mode() / _detect_api_mode_for_url()."""
-    return url.rstrip("/").lower().endswith("/anthropic") or base_url_hostname(url) == "api.anthropic.com"
+    """Same Messages-only host match as determine_api_mode() / _detect_api_mode_for_url(): api.anthropic.com,
+    a /anthropic suffix, or Kimi Code's api.kimi.com/coding (its /chat/completions 404s — #77256)."""
+    from hermes_cli.providers import host_mandated_api_mode
+    return host_mandated_api_mode(url) == "anthropic_messages"
 
 
 def _fallback_api_mode_hint(fb: dict, fb_provider: str, fb_base_url_hint: Optional[str]) -> tuple[bool, str]:

--- a/tests/run_agent/test_fallback_api_mode_preservation.py
+++ b/tests/run_agent/test_fallback_api_mode_preservation.py
@@ -159,6 +159,21 @@ class TestOriginalUrlDetection:
         assert agent.api_mode == "anthropic_messages"
         assert mock_rpc.call_args.kwargs["api_mode"] == "anthropic_messages"
 
+    def test_kimi_coding_hint_uses_the_messages_wire(self):
+        """api.kimi.com/coding serves Anthropic Messages only; the fallback must not POST
+        /chat/completions there (404, #77256). A lookalike host stays on chat_completions."""
+        fbs = [{"provider": "kimi-coding", "model": "kimi-for-coding",
+                "base_url": "https://api.kimi.com/coding/v1", "api_key": "k"}]
+        agent = _make_agent(fallback_model=fbs)
+        mock_rpc = _activate(agent, "https://api.kimi.com/coding", "kimi-for-coding")
+        assert agent.api_mode == "anthropic_messages"
+        assert mock_rpc.call_args.kwargs["api_mode"] == "anthropic_messages"
+
+        lookalike = "https://api.kimi.com.attacker.test/coding/v1"
+        agent = _make_agent(fallback_model=[{"provider": "custom", "model": "m", "base_url": lookalike, "api_key": "k"}])
+        _activate(agent, lookalike, "m")
+        assert agent.api_mode == "chat_completions"
+
 
 class TestPlainFallbackUnchanged:
     def test_plain_openrouter_fallback_stays_chat_completions(self):

--- a/tests/run_agent/test_fallback_api_mode_preservation.py
+++ b/tests/run_agent/test_fallback_api_mode_preservation.py
@@ -161,7 +161,7 @@ class TestOriginalUrlDetection:
 
     def test_kimi_coding_hint_uses_the_messages_wire(self):
         """api.kimi.com/coding serves Anthropic Messages only; the fallback must not POST
-        /chat/completions there (404, #77256). A lookalike host stays on chat_completions."""
+        /chat/completions there (404, #77256)."""
         fbs = [{"provider": "kimi-coding", "model": "kimi-for-coding",
                 "base_url": "https://api.kimi.com/coding/v1", "api_key": "k"}]
         agent = _make_agent(fallback_model=fbs)
@@ -169,6 +169,7 @@ class TestOriginalUrlDetection:
         assert agent.api_mode == "anthropic_messages"
         assert mock_rpc.call_args.kwargs["api_mode"] == "anthropic_messages"
 
+    def test_kimi_lookalike_host_stays_chat_completions(self):
         lookalike = "https://api.kimi.com.attacker.test/coding/v1"
         agent = _make_agent(fallback_model=[{"provider": "custom", "model": "m", "base_url": lookalike, "api_key": "k"}])
         _activate(agent, lookalike, "m")


### PR DESCRIPTION
A `fallback_providers` entry pointing at Kimi Code (`api.kimi.com/coding`) now activates on the Anthropic Messages wire instead of POSTing `/chat/completions` to an endpoint that 404s it.

Salvage of #77304 by @RelaxJonh (cherry-picked to preserve authorship); the regression-test idea from the closed duplicate #77308 by @RerankerGuo is covered by the new invariant test. Fixes #77256.

## Root cause

`try_activate_fallback` derived the fallback `api_mode` from its own two-host heuristic (`api.anthropic.com` / trailing `/anthropic`), which lagged the primary path's `_detect_api_mode_for_url()` — the primary path already knew Kimi Code is Messages-only. So the chain switched correctly and then every fallback turn failed with HTTP 404.

## Change

- `agent/chat_completion_helpers.py::_is_anthropic_wire_url` now routes through `hermes_cli.providers.host_mandated_api_mode()` — the single Messages-only host table the primary path (`determine_api_mode`) already uses — so the fallback path cannot drift from it again. Exact-hostname matching, so `api.kimi.com.attacker.test/coding` stays on `chat_completions`. Behaviour for every previously-Anthropic URL is unchanged (Anthropic branches run before the Responses/Bedrock ones in that table).
- 2 invariant tests in `tests/run_agent/test_fallback_api_mode_preservation.py`: Kimi Code hint → `anthropic_messages` (and forwarded to `resolve_provider_client`); lookalike host → `chat_completions`. Red on `origin/main`, green here.

## Validation

| Check | Result |
|---|---|
| Live repro (real `AIAgent._try_activate_fallback`, temp `HERMES_HOME`) | main: kimi-coding w/ explicit base_url, w/ registry base_url, and `custom`→kimi all `chat_completions`; branch: all three `anthropic_messages`. Lookalike host and explicit `api_mode: chat_completions` stay `chat_completions` on both |
| Regression probe (minimax `/anthropic`, openrouter, `anthropic` no base_url, `nous` + `anthropic/*`) | byte-identical main vs branch |
| `scripts/run_tests.sh tests/run_agent/` | 1969 passed; 1 pre-existing failure (`test_qwen_oauth_auto_fallthrough_on_auth_failure`, fails identically on `origin/main` f58fcc81) |
| ruff / compat pointers | clean |
