### PR TITLE
fix(ssh): skill/config env passthrough reaches SSH shells via SendEnv (#14091, salvage #14414)

### DIFF
--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -297,4 +297,3 @@ class TestPersistentSSH:
         assert len(lines) == 1000
         assert lines[0] == "1"
         assert lines[-1] == "1000"
-

--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -76,6 +76,53 @@ class TestBuildSSHCommand:
         env = SSHEnvironment(host="h", user="u")
         assert env._build_ssh_command()[-1] == "u@h"
 
+    def _bare_env(self):
+        env = SSHEnvironment.__new__(SSHEnvironment)
+        env.control_socket, env.host, env.user, env.port, env.key_path = "/tmp/hermes-ssh-test.sock", "h", "u", 22, ""
+        return env
+
+    def _capture_run_bash(self, monkeypatch, env, cmd="echo ok"):
+        captured = {}
+
+        def _fake_popen(cmd, stdin_data=None, **kwargs):
+            captured["cmd"], captured["env"] = cmd, kwargs.get("env")
+            return MagicMock()
+
+        monkeypatch.setattr(ssh_env, "_popen_bash", _fake_popen)
+        env._run_bash(cmd)
+        return captured
+
+    def test_run_bash_forwards_passthrough_by_sendenv_never_in_remote_argv(self, monkeypatch):
+        """#14091: allowlisted names travel as ``-o SendEnv=NAME`` with values only in the ssh client env;
+        provider credentials on the allowlist stay behind; a .env value fills an unset shell var."""
+        import tools.env_passthrough as env_passthrough
+
+        env = self._bare_env()
+        monkeypatch.setenv("NEXTCLOUD_URL", "https://next.example")
+        monkeypatch.delenv("NEXTCLOUD_PASS", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-must-not-forward")
+        monkeypatch.setattr(env_passthrough, "get_all_passthrough",
+                            lambda: frozenset({"NEXTCLOUD_URL", "NEXTCLOUD_PASS", "OPENAI_API_KEY"}))
+        monkeypatch.setattr(ssh_env, "_load_hermes_env_vars", lambda: {"NEXTCLOUD_PASS": "from-dotenv"})
+
+        captured = self._capture_run_bash(monkeypatch, env)
+
+        sent = {a.split("=", 1)[1] for a in captured["cmd"] if a.startswith("SendEnv=")}
+        assert sent == {"NEXTCLOUD_URL", "NEXTCLOUD_PASS"}
+        assert captured["env"]["NEXTCLOUD_URL"] == "https://next.example"
+        assert captured["env"]["NEXTCLOUD_PASS"] == "from-dotenv"
+        remote_text = " ".join(captured["cmd"])
+        assert "https://next.example" not in remote_text and "from-dotenv" not in remote_text
+        assert "sk-must-not-forward" not in remote_text
+
+    def test_run_bash_without_passthrough_inherits_env_unchanged(self, monkeypatch):
+        import tools.env_passthrough as env_passthrough
+
+        monkeypatch.setattr(env_passthrough, "get_all_passthrough", lambda: frozenset())
+        captured = self._capture_run_bash(monkeypatch, self._bare_env())
+        assert not any(a.startswith("SendEnv=") for a in captured["cmd"])
+        assert captured["env"] is None
+
 
 class TestControlSocketPath:
     """Regression tests for issue #11840.
@@ -250,3 +297,4 @@ class TestPersistentSSH:
         assert len(lines) == 1000
         assert lines[0] == "1"
         assert lines[-1] == "1000"
+

--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -76,11 +76,6 @@ class TestBuildSSHCommand:
         env = SSHEnvironment(host="h", user="u")
         assert env._build_ssh_command()[-1] == "u@h"
 
-    def _bare_env(self):
-        env = SSHEnvironment.__new__(SSHEnvironment)
-        env.control_socket, env.host, env.user, env.port, env.key_path = "/tmp/hermes-ssh-test.sock", "h", "u", 22, ""
-        return env
-
     def _capture_run_bash(self, monkeypatch, env, cmd="echo ok"):
         captured = {}
 
@@ -97,7 +92,7 @@ class TestBuildSSHCommand:
         provider credentials on the allowlist stay behind; a .env value fills an unset shell var."""
         import tools.env_passthrough as env_passthrough
 
-        env = self._bare_env()
+        env = SSHEnvironment(host="h", user="u")
         monkeypatch.setenv("NEXTCLOUD_URL", "https://next.example")
         monkeypatch.delenv("NEXTCLOUD_PASS", raising=False)
         monkeypatch.setenv("OPENAI_API_KEY", "sk-must-not-forward")
@@ -119,7 +114,7 @@ class TestBuildSSHCommand:
         import tools.env_passthrough as env_passthrough
 
         monkeypatch.setattr(env_passthrough, "get_all_passthrough", lambda: frozenset())
-        captured = self._capture_run_bash(monkeypatch, self._bare_env())
+        captured = self._capture_run_bash(monkeypatch, SSHEnvironment(host="h", user="u"))
         assert not any(a.startswith("SendEnv=") for a in captured["cmd"])
         assert captured["env"] is None
 

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -28,7 +28,8 @@ from tools.environments.docker_egress import (
     check_forward_env_collisions, merge_egress_env,
 )
 from tools.environments.path_utils import sanitize_task_id_for_path
-from tools.environments.remote_common import bash_argv, load_hermes_env_vars, resolve_passthrough_env, run_capture
+from tools.environments.remote_common import (
+    bash_argv, client_env_with, load_hermes_env_vars, prepend_unset, resolve_passthrough_env, run_capture)
 
 logger = logging.getLogger(__name__)
 
@@ -760,7 +761,7 @@ class DockerEnvironment(BaseEnvironment):
         live in ``/proc/<pid>/environ`` instead, which is owner/root-only. Returns ``None`` (inherit as
         before) when there is nothing to add.
         """
-        return {**os.environ, **values} if values else None
+        return client_env_with(values)
 
     def _build_init_env_args(self) -> list[str]:
         """Name-only ``-e`` args for init_session so ``export -p`` captures docker_env
@@ -778,9 +779,8 @@ class DockerEnvironment(BaseEnvironment):
         return _name_only_env_args(exec_env)
 
     def _resolve_passthrough_env(self) -> tuple[dict[str, str], set[str]]:
-        """Forwarded values plus scoped names that must be unset; explicit docker_forward_env
-        entries bypass the blocklist (see ``remote_common.resolve_passthrough_env``)."""
-        return resolve_passthrough_env(self._forward_env, hermes_env_loader=lambda: _load_hermes_env_vars())
+        """See ``remote_common.resolve_passthrough_env``; explicit docker_forward_env bypasses the blocklist."""
+        return resolve_passthrough_env(self._forward_env, hermes_env_loader=_load_hermes_env_vars)
 
     def _build_runtime_env_args_with_unsets(self) -> tuple[list[str], tuple[str, ...], dict[str, str]]:
         """Runtime name-only forwarding args, names absent from scope, and the values
@@ -815,10 +815,7 @@ class DockerEnvironment(BaseEnvironment):
         elif self._profile_scoped_passthrough:
             runtime_args, unset_names, env_values = self._build_runtime_env_args_with_unsets()
             cmd.extend(runtime_args)
-        if unset_names:
-            quoted_names = " ".join(shlex.quote(name) for name in unset_names)
-            cmd_string = f"unset {quoted_names} 2>/dev/null || true\n{cmd_string}"
-        cmd += [self._container_id, *bash_argv(cmd_string, login)]
+        cmd += [self._container_id, *bash_argv(prepend_unset(cmd_string, unset_names), login)]
 
         client_env = self._docker_client_env(env_values)
         return _popen_bash(cmd, stdin_data, env=client_env) if client_env is not None else _popen_bash(cmd, stdin_data)

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -28,8 +28,7 @@ from tools.environments.docker_egress import (
     check_forward_env_collisions, merge_egress_env,
 )
 from tools.environments.path_utils import sanitize_task_id_for_path
-from tools.environments.remote_common import bash_argv, run_capture
-from tools.environments.local_env_policy import _HERMES_PROVIDER_ENV_BLOCKLIST, _is_hermes_internal_secret
+from tools.environments.remote_common import bash_argv, load_hermes_env_vars, resolve_passthrough_env, run_capture
 
 logger = logging.getLogger(__name__)
 
@@ -79,13 +78,8 @@ def _normalize_env_dict(env: dict | None) -> dict[str, str]:
     return normalized
 
 
-def _load_hermes_env_vars() -> dict[str, str]:
-    """Load ~/.hermes/.env values without failing Docker command execution."""
-    try:
-        from hermes_cli.config import load_env
-        return load_env() or {}
-    except Exception:
-        return {}
+# Module-level binding: tests patch ``docker._load_hermes_env_vars`` to fake the .env file.
+_load_hermes_env_vars = load_hermes_env_vars
 
 
 # Docker label values must match [a-zA-Z0-9_.-] and stay <=63 chars to round-trip
@@ -784,34 +778,9 @@ class DockerEnvironment(BaseEnvironment):
         return _name_only_env_args(exec_env)
 
     def _resolve_passthrough_env(self) -> tuple[dict[str, str], set[str]]:
-        """Forwarded values plus scoped names that must be unset. Explicit docker_forward_env
-        entries are an opt-in that wins over the Hermes secret blocklist; only implicit
-        passthrough keys are filtered (incl. Hermes-internal dynamic secrets)."""
-        exec_env: dict[str, str] = {}
-        passthrough_keys: set[str] = set()
-        resolve_passthrough_value = None
-        multiplex_active = False
-        is_global_env = lambda _name: False  # noqa: E731
-        try:
-            from tools.env_passthrough import get_all_passthrough, resolve_passthrough_value
-            from agent.secret_scope import _is_global_env as is_global_env, is_multiplex_active
-            multiplex_active = is_multiplex_active()
-            passthrough_keys = set(get_all_passthrough())
-        except Exception:
-            pass
-        implicit_forward = {k for k in passthrough_keys if not _is_hermes_internal_secret(k)}
-        forward_keys = set(self._forward_env) | (implicit_forward - _HERMES_PROVIDER_ENV_BLOCKLIST)
-        hermes_env = _load_hermes_env_vars() if forward_keys else {}
-        unset_names: set[str] = set()
-        for key in sorted(forward_keys):
-            value = os.getenv(key) or hermes_env.get(key)
-            if resolve_passthrough_value is not None:
-                value = resolve_passthrough_value(key, value)
-            if value is not None:
-                exec_env[key] = value
-            elif multiplex_active and not is_global_env(key) and _ENV_VAR_NAME_RE.fullmatch(key):
-                unset_names.add(key)
-        return exec_env, unset_names
+        """Forwarded values plus scoped names that must be unset; explicit docker_forward_env
+        entries bypass the blocklist (see ``remote_common.resolve_passthrough_env``)."""
+        return resolve_passthrough_env(self._forward_env, hermes_env_loader=lambda: _load_hermes_env_vars())
 
     def _build_runtime_env_args_with_unsets(self) -> tuple[list[str], tuple[str, ...], dict[str, str]]:
         """Runtime name-only forwarding args, names absent from scope, and the values

--- a/tools/environments/remote_common.py
+++ b/tools/environments/remote_common.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 import subprocess
 from typing import Callable, Iterable
 
@@ -29,7 +30,7 @@ def resolve_passthrough_env(explicit_forward: Iterable[str] = (),
     check; ``explicit_forward`` entries (docker_forward_env) are an operator opt-in that bypasses
     both. Each value is the routed profile's secret when multiplex is active; a name the active
     scope lacks is returned in the unset set so a shared sandbox cannot leak another profile's
-    value. ``hermes_env_loader`` is a parameter so each backend keeps its own patchable seam.
+    value.
     """
     passthrough_keys: set[str] = set()
     resolve_passthrough_value = None
@@ -56,6 +57,20 @@ def resolve_passthrough_env(explicit_forward: Iterable[str] = (),
         elif multiplex_active and not is_global_env(key) and _SHELL_ENV_NAME_RE.fullmatch(key):
             unset_names.add(key)
     return exec_env, unset_names
+
+
+def prepend_unset(cmd_string: str, names: Iterable[str]) -> str:
+    """Prefix ``cmd_string`` with ``unset`` of the profile-scoped names the remote shell must not see."""
+    names = sorted(names)
+    if not names:
+        return cmd_string
+    return f"unset {' '.join(shlex.quote(n) for n in names)} 2>/dev/null || true\n{cmd_string}"
+
+
+def client_env_with(values: dict[str, str]) -> dict[str, str] | None:
+    """Env for the docker/ssh CLIENT subprocess: forwarded values travel here (owner-readable
+    /proc/*/environ) while the argv carries names only; ``None`` = inherit when nothing to add."""
+    return {**os.environ, **values} if values else None
 
 
 def run_capture(cmd: list[str], *, timeout: float, check: bool = False, env: dict | None = None,

--- a/tools/environments/remote_common.py
+++ b/tools/environments/remote_common.py
@@ -2,7 +2,60 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
+from typing import Callable, Iterable
+
+from tools.environments.base_session_env import _SHELL_ENV_NAME_RE
+from tools.environments.local_env_policy import _HERMES_PROVIDER_ENV_BLOCKLIST, _is_hermes_internal_secret
+
+
+def load_hermes_env_vars() -> dict[str, str]:
+    """``~/.hermes/.env`` values, or ``{}`` — a broken .env must not fail command execution."""
+    try:
+        from hermes_cli.config import load_env
+        return load_env() or {}
+    except Exception:
+        return {}
+
+
+def resolve_passthrough_env(explicit_forward: Iterable[str] = (),
+                            hermes_env_loader: Callable[[], dict[str, str]] = load_hermes_env_vars,
+                            ) -> tuple[dict[str, str], set[str]]:
+    """Values to forward into a remote shell plus the scoped names that must be unset there.
+
+    Implicit passthrough (skill ``required_environment_variables`` + ``terminal.env_passthrough``)
+    is filtered through the Hermes provider-credential blocklist and the dynamic internal-secret
+    check; ``explicit_forward`` entries (docker_forward_env) are an operator opt-in that bypasses
+    both. Each value is the routed profile's secret when multiplex is active; a name the active
+    scope lacks is returned in the unset set so a shared sandbox cannot leak another profile's
+    value. ``hermes_env_loader`` is a parameter so each backend keeps its own patchable seam.
+    """
+    passthrough_keys: set[str] = set()
+    resolve_passthrough_value = None
+    multiplex_active = False
+    is_global_env = lambda _name: False  # noqa: E731
+    try:
+        from tools.env_passthrough import get_all_passthrough, resolve_passthrough_value
+        from agent.secret_scope import _is_global_env as is_global_env, is_multiplex_active
+        multiplex_active = is_multiplex_active()
+        passthrough_keys = set(get_all_passthrough())
+    except Exception:
+        pass
+    implicit_forward = {k for k in passthrough_keys if not _is_hermes_internal_secret(k)}
+    forward_keys = set(explicit_forward) | (implicit_forward - _HERMES_PROVIDER_ENV_BLOCKLIST)
+    hermes_env = hermes_env_loader() if forward_keys else {}
+    exec_env: dict[str, str] = {}
+    unset_names: set[str] = set()
+    for key in sorted(forward_keys):
+        value = os.getenv(key) or hermes_env.get(key)
+        if resolve_passthrough_value is not None:
+            value = resolve_passthrough_value(key, value)
+        if value is not None:
+            exec_env[key] = value
+        elif multiplex_active and not is_global_env(key) and _SHELL_ENV_NAME_RE.fullmatch(key):
+            unset_names.add(key)
+    return exec_env, unset_names
 
 
 def run_capture(cmd: list[str], *, timeout: float, check: bool = False, env: dict | None = None,

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -15,7 +15,8 @@ from tools.environments.base import BaseEnvironment, EnvironmentConnectionError
 from tools.environments.base_output import _popen_bash
 from tools.environments.file_sync import (
     FileSyncManager, iter_sync_files, quoted_mkdir_command, quoted_rm_command, unique_parent_dirs)
-from tools.environments.remote_common import bash_argv, load_hermes_env_vars, resolve_passthrough_env, run_capture
+from tools.environments.remote_common import (
+    bash_argv, client_env_with, load_hermes_env_vars, prepend_unset, resolve_passthrough_env, run_capture)
 
 logger = logging.getLogger(__name__)
 
@@ -255,11 +256,10 @@ class SSHEnvironment(BaseEnvironment):
         client's env carries the values, so secrets never enter the remote ``bash -c`` argv. The
         remote sshd must ``AcceptEnv`` them (#14091). Profile-scoped names missing from the active
         scope are unset remotely so a shared host cannot serve another profile's value."""
-        values, unset_names = resolve_passthrough_env(hermes_env_loader=lambda: _load_hermes_env_vars())
-        if unset_names:
-            cmd_string = f"unset {' '.join(shlex.quote(n) for n in sorted(unset_names))} 2>/dev/null || true\n{cmd_string}"
-        cmd = self._build_ssh_command(send_env=sorted(values)) + bash_argv(shlex.quote(cmd_string), login)
-        return _popen_bash(cmd, stdin_data, env={**os.environ, **values}) if values else _popen_bash(cmd, stdin_data)
+        values, unset_names = resolve_passthrough_env(hermes_env_loader=_load_hermes_env_vars)
+        cmd = self._build_ssh_command(send_env=values) + bash_argv(shlex.quote(prepend_unset(cmd_string, unset_names)), login)
+        client_env = client_env_with(values)
+        return _popen_bash(cmd, stdin_data, env=client_env) if client_env is not None else _popen_bash(cmd, stdin_data)
 
     def cleanup(self):
         if self._sync_manager:

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -9,12 +9,13 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+from typing import Iterable
 
 from tools.environments.base import BaseEnvironment, EnvironmentConnectionError
 from tools.environments.base_output import _popen_bash
 from tools.environments.file_sync import (
     FileSyncManager, iter_sync_files, quoted_mkdir_command, quoted_rm_command, unique_parent_dirs)
-from tools.environments.remote_common import bash_argv, run_capture
+from tools.environments.remote_common import bash_argv, load_hermes_env_vars, resolve_passthrough_env, run_capture
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +23,9 @@ logger = logging.getLogger(__name__)
 # fail the connection outright ('getsockname failed: Not a socket'). Skip multiplexing there.
 # Skip multiplexing there; each command pays a fresh connection but the backend works. See #73927.
 _SSH_MULTIPLEX = os.name != "nt"
+
+# Module-level binding: tests patch ``ssh._load_hermes_env_vars`` to fake the .env file.
+_load_hermes_env_vars = load_hermes_env_vars
 
 
 def _ensure_ssh_available() -> None:
@@ -45,6 +49,10 @@ class SSHEnvironment(BaseEnvironment):
     stdout markers. Uses SSH ControlMaster for connection reuse.
     """
 
+    # Passthrough values are re-forwarded on every command (see _run_bash), so like docker/local
+    # they stay out of the remote snapshot under multiplex.
+    _profile_scoped_passthrough = True
+
     def __init__(self, host: str, user: str, cwd: str = "~",
                  timeout: int = 60, port: int = 22, key_path: str = ""):
         super().__init__(cwd=cwd, timeout=timeout)
@@ -67,17 +75,38 @@ class SSHEnvironment(BaseEnvironment):
         self._sync_manager.sync(force=True)
         self.init_session()
 
+    def _control_socket_for(self, send_env: tuple[str, ...]) -> Path:
+        """One ControlMaster per SendEnv name-set, beside the plain target socket: a mux master only
+        relays the env names it was itself started with and silently drops the rest, so a passthrough
+        command must ride a master that knows its names. scp/sync/probes keep the plain socket."""
+        plain = Path(self.control_socket)
+        if not send_env:
+            return plain
+        # <target-id[:8]><names-hash[:8]>.sock: same length as the plain socket (macOS's 104-byte
+        # sun_path cap) and prefix-globbable so cleanup() finds every sibling without extra state.
+        digest = hashlib.sha256(" ".join(send_env).encode()).hexdigest()[:8]
+        return plain.with_name(f"{plain.stem[:8]}{digest}.sock")
+
+    def _control_sockets(self) -> list[Path]:
+        """The plain socket plus every SendEnv-set sibling (shared 8-char target prefix)."""
+        plain = Path(self.control_socket)
+        siblings = sorted(plain.parent.glob(f"{plain.stem[:8]}*.sock")) if plain.parent.is_dir() else []
+        return [plain, *(s for s in siblings if s != plain)]
+
     def _target_flags(self, port_flag: str) -> list:
         """Port/key flags shared by ssh (``-p``) and scp (``-P``)."""
         flags = [port_flag, str(self.port)] if self.port != 22 else []
         return flags + (["-i", self.key_path] if self.key_path else [])
 
-    def _build_ssh_command(self, extra_args: list | None = None) -> list:
+    def _build_ssh_command(self, extra_args: list | None = None, send_env: Iterable[str] = ()) -> list:
+        send_env = tuple(sorted(send_env))
         cmd = ["ssh"]
         if _SSH_MULTIPLEX:
-            cmd.extend(["-o", f"ControlPath={self.control_socket}",
+            cmd.extend(["-o", f"ControlPath={self._control_socket_for(send_env)}",
                         "-o", "ControlMaster=auto", "-o", "ControlPersist=300"])
         cmd.extend(["-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=accept-new", "-o", "ConnectTimeout=10"])
+        # Names only; values ride the ssh client's own environment (never the remote command text).
+        cmd.extend(arg for name in send_env for arg in ("-o", f"SendEnv={name}"))
         cmd.extend(self._target_flags("-p"))
         cmd.extend(extra_args or [])
         cmd.append(f"{self.user}@{self.host}")
@@ -221,15 +250,26 @@ class SSHEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False, timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
-        return _popen_bash(self._build_ssh_command() + bash_argv(shlex.quote(cmd_string), login), stdin_data)
+        """Forward the passthrough allowlist (skill ``required_environment_variables`` +
+        ``terminal.env_passthrough``) the way docker does: ``SendEnv`` carries the names, the ssh
+        client's env carries the values, so secrets never enter the remote ``bash -c`` argv. The
+        remote sshd must ``AcceptEnv`` them (#14091). Profile-scoped names missing from the active
+        scope are unset remotely so a shared host cannot serve another profile's value."""
+        values, unset_names = resolve_passthrough_env(hermes_env_loader=lambda: _load_hermes_env_vars())
+        if unset_names:
+            cmd_string = f"unset {' '.join(shlex.quote(n) for n in sorted(unset_names))} 2>/dev/null || true\n{cmd_string}"
+        cmd = self._build_ssh_command(send_env=sorted(values)) + bash_argv(shlex.quote(cmd_string), login)
+        return _popen_bash(cmd, stdin_data, env={**os.environ, **values}) if values else _popen_bash(cmd, stdin_data)
 
     def cleanup(self):
         if self._sync_manager:
             logger.info("SSH: syncing files from sandbox...")
             self._sync_manager.sync_back()
-        if self.control_socket.exists():
+        for socket in self._control_sockets():
+            if not socket.exists():
+                continue
             with contextlib.suppress(OSError, subprocess.SubprocessError):
-                cmd = ["ssh", "-o", f"ControlPath={self.control_socket}", "-O", "exit", f"{self.user}@{self.host}"]
+                cmd = ["ssh", "-o", f"ControlPath={socket}", "-O", "exit", f"{self.user}@{self.host}"]
                 subprocess.run(cmd, capture_output=True, timeout=5, stdin=subprocess.DEVNULL)
             with contextlib.suppress(OSError):
-                self.control_socket.unlink()
+                socket.unlink()

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -417,6 +417,14 @@ TERMINAL_SSH_USER=ubuntu
 
 **How it works:** Connects at init time with `BatchMode=yes` and `StrictHostKeyChecking=accept-new`. Persistent shell keeps a single `bash -l` process alive on the remote host, communicating via temporary files. Commands that need `stdin_data` or `sudo` automatically fall back to one-shot mode.
 
+**Skill / config env passthrough:** variables a skill declares in `required_environment_variables`, or that you list under `terminal.env_passthrough`, are forwarded with OpenSSH `SendEnv` — the names go on the `ssh` command line and the values travel in the client's environment, never in the remote command text. The remote `sshd` must accept them; add to `/etc/ssh/sshd_config` on the server and reload sshd:
+
+```
+AcceptEnv NEXTCLOUD_URL NEXTCLOUD_*      # or the names your skills need
+```
+
+Without a matching `AcceptEnv`, the server silently drops the variables and the remote shell sees them unset. Hermes provider credentials (`OPENAI_API_KEY`, …) are never forwarded even if listed. See [Env Var Passthrough](security.md#environment-variable-passthrough).
+
 ### Modal Backend
 
 Runs commands in a [Modal](https://modal.com) cloud sandbox. Each task gets an isolated VM with configurable CPU, memory, and disk. Filesystem can be snapshot/restored across sessions.

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -591,6 +591,7 @@ Paths are relative to `~/.hermes/`. Files are mounted to `/root/.hermes/` inside
 | **execute_code** | Blocks vars containing `KEY`, `TOKEN`, `SECRET`, `PASSWORD`, `CREDENTIAL`, `PASSWD`, `AUTH` in name; only allows safe-prefix vars through | ✅ Passthrough vars bypass both checks |
 | **terminal** (local) | Blocks explicit Hermes infrastructure vars (provider keys, gateway tokens, tool API keys) | ✅ Passthrough vars bypass the blocklist |
 | **terminal** (Docker) | No host env vars by default | ✅ Passthrough vars + `docker_forward_env` forwarded via `-e` |
+| **terminal** (SSH) | No host env vars by default | ✅ Passthrough vars forwarded via `SendEnv`; the remote `sshd_config` needs a matching `AcceptEnv` (see [SSH backend](configuration.md#ssh-backend)) |
 | **terminal** (Modal) | No host env/files by default | ✅ Credential files mounted; env passthrough via sync |
 | **MCP** | Blocks everything except safe system vars + explicitly configured `env` | ❌ Not affected by passthrough (use MCP `env` config instead) |
 


### PR DESCRIPTION
Skill `required_environment_variables` and `terminal.env_passthrough` now reach the SSH terminal backend — forwarded with OpenSSH `SendEnv`, values in the ssh client's environment, never in the remote command text.

Salvage of #14414 by @sgaofen (cherry-picked to preserve authorship; #14126 by @LeonSGP43 and the closed #14107/#14354 targeted the same gap — #14126 embedded values in the remote `bash -c` text, which this deliberately does not). Fixes #14091.

## Root cause

`SSHEnvironment._run_bash` spawned `ssh … bash -c <cmd>` with no env forwarding at all, while local and docker consumed the passthrough allowlist. A skill reported `setup_needed: false` and every remote command saw its variables unset.

## Change

- `tools/environments/remote_common.py`: `resolve_passthrough_env()` — the allowlist → provider-credential blocklist → `.env` fallback → secret-scope → unset-names walk that lived inline in `DockerEnvironment`, now shared. Plus `prepend_unset` / `client_env_with`, the two post-processing steps both backends apply to its output. Docker calls them; its behaviour is unchanged (probe: identical `_build_init_env_args()` output main vs branch).
- `tools/environments/ssh.py`: names go on the command line as `-o SendEnv=NAME`; values ride the client env (mirrors docker's #96268 shape). Hermes provider credentials (`OPENAI_API_KEY`, …) stay behind the same blocklist even when sshd would accept them. Under multiplex, names missing from the active profile's scope are `unset` remotely, as docker does. `_profile_scoped_passthrough = True` keeps forwarded values out of the remote snapshot under multiplex.
- ControlMaster: a mux master only relays the `SendEnv` names it was itself started with and silently drops the rest — found live, the shared master delivered nothing. Passthrough commands ride a sibling socket per name-set (same 16-hex length as the plain socket, so the macOS 104-byte `sun_path` cap from #11840 still holds); `cleanup()` closes every sibling.
- Docs: the remote `sshd_config` needs `AcceptEnv <names>` — added to the SSH backend section and the passthrough filter table. Without it the server drops the variables silently.
- 2 invariant tests (red on `origin/main`): allowlisted names go out via `SendEnv` with values only in the client env and absent from argv, provider key held back, `.env` fills an unset var; no passthrough → no `SendEnv`, env inherited.

## Validation

| Check | Result |
|---|---|
| Live E2E, real sshd (OrbStack `linuxserver/openssh-server`, `AcceptEnv NEXTCLOUD_* OPENAI_API_KEY`), real `SSHEnvironment.execute()` | main: `URL=[] PASS=[] OPENAI=[]`; branch: `URL=[https://next.example] PASS=[dotenv-secret] OPENAI=[]` |
| Value absent from remote `bash -c` argv (`/proc/$$/cmdline` on the remote) | 0 occurrences; remote shell sees the value |
| sshd without `AcceptEnv` | variables silently unset on both (documented) |
| ControlMaster reuse across 2 `execute()` calls; sockets after `cleanup()` | 2 sockets stable, 0 after cleanup |
| `scripts/run_tests.sh tests/tools/` (555 files) | 8422 passed; remaining failures fail identically on `origin/main` f58fcc81 (`test_process_registry` systemd rows, `test_voice_mode`, `test_file_tools`, …) |
| Mutation check on the final stack (ssh.py reverted to base) | guard test goes red |
| ruff / windows-footguns / compat pointers / subprocess stdin | clean, no new hits |
