### PR TITLE
fix(gateway): MEDIA delivery no longer hands out state.db / kanban.db / sessions / browser-profile (salvage #41071)

### DIFF
--- a/contributors/emails/290877921+pprism13@users.noreply.github.com
+++ b/contributors/emails/290877921+pprism13@users.noreply.github.com
@@ -1,0 +1,2 @@
+pprism13
+# PR #41071 salvage

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -766,14 +766,14 @@ _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS = (
     ".ssh", ".aws", ".gnupg", ".kube", ".docker", ".config", ".azure", ".gcloud",
     "Library/Keychains")
 
-def _SQLITE_FILES(name: str) -> tuple[str, str, str]:
-    """A SQLite store plus its WAL/SHM sidecars."""
-    return (name, f"{name}-wal", f"{name}-shm")
+def _sqlite_files(name: str) -> tuple[str, ...]:
+    """A SQLite store plus its WAL/SHM/rollback-journal sidecars."""
+    return (name, f"{name}-wal", f"{name}-shm", f"{name}-journal")
 
 
 # Credential stores at the HERMES_HOME root, denied per-file so skills/, logs/ and agent-written
-# files stay deliverable (cache subdirs are allowlisted BEFORE this). Mirrors agent/file_safety.py
-# so exfil never trails the read guard. google_token.json's mtime bumps every turn (defeats the
+# files stay deliverable (cache subdirs are allowlisted BEFORE this). A superset of the
+# agent/file_safety.py read+write denies so exfil never trails the read guard. google_token.json's mtime bumps every turn (defeats the
 # recency window); pairing/ and mcp-tokens/ (live OAuth tokens) are denied as whole trees.
 _ROOT_CREDENTIAL_PATHS = (
     ".env", "auth.json", "auth.lock", "credentials", "config.yaml", ".anthropic_oauth.json",
@@ -783,7 +783,7 @@ _ROOT_CREDENTIAL_PATHS = (
     # Whole conversation history (every secret ever pasted into a chat) and the copied browser
     # cookie/login store; sessions/ is the legacy transcript dir. SQLite sidecars are listed
     # too: WAL mode touches state.db-wal on every write, so recency trust alone would leak them.
-    "sessions", "browser-profile", *_SQLITE_FILES("state.db"), *_SQLITE_FILES("kanban.db"))
+    "sessions", "browser-profile", *_sqlite_files("state.db"), *_sqlite_files("kanban.db"))
 
 
 def _profile_cache_roots() -> List[Path]:
@@ -803,20 +803,28 @@ def _profile_cache_roots() -> List[Path]:
     return [p / "cache" / subdir for p in profile_dirs for subdir in _MEDIA_DELIVERY_CACHE_SUBDIRS]
 
 
+def _kanban_root() -> Path:
+    """Kanban is root-shared across profiles by design (``kanban_db.kanban_home``)."""
+    return Path(os.environ.get("HERMES_KANBAN_HOME", "").strip() or _HERMES_ROOT).expanduser()
+
+
+def _kanban_board_dirs() -> List[Path]:
+    """Every directory under ``<root>/kanban/boards`` (lax on purpose: the DENY side must catch a
+    board whatever its name; the allow side filters further)."""
+    with contextlib.suppress(OSError):
+        return [p for p in (_kanban_root() / "kanban" / "boards").iterdir() if p.is_dir()]
+    return []
+
+
 def _kanban_attachment_roots() -> List[Path]:
     """Return durable Kanban attachment roots without importing kanban_db."""
     override = os.environ.get("HERMES_KANBAN_ATTACHMENTS_ROOT", "").strip()
     if override:
         return [Path(override).expanduser()]
-    home_override = os.environ.get("HERMES_KANBAN_HOME", "").strip()
-    root = Path(home_override).expanduser() if home_override else _HERMES_ROOT
-    roots = [root / "kanban" / "attachments"]
-    with contextlib.suppress(OSError):
-        board_dirs = [path for path in (root / "kanban" / "boards").iterdir()
-                      if path.is_dir() and not path.is_symlink()
-                      and re.fullmatch(r"[a-z0-9][a-z0-9_-]{0,63}", path.name)
-                      and (path / "kanban.db").is_file()]
-        roots.extend(path / "attachments" for path in board_dirs)
+    roots = [_kanban_root() / "kanban" / "attachments"]
+    roots.extend(path / "attachments" for path in _kanban_board_dirs()
+                 if not path.is_symlink() and re.fullmatch(r"[a-z0-9][a-z0-9_-]{0,63}", path.name)
+                 and (path / "kanban.db").is_file())
     return roots
 
 
@@ -841,14 +849,9 @@ def _media_delivery_recency_seconds() -> float:
 
 
 def _kanban_board_db_paths() -> List[Path]:
-    """Named-board ``kanban.db`` stores (+ sidecars) under ``<root>/kanban/boards/<slug>/`` — the
-    same board dirs ``_kanban_attachment_roots`` allowlists for ATTACHMENTS; the DB beside them
-    holds every task, comment and run transcript."""
-    root = Path(os.environ.get("HERMES_KANBAN_HOME", "").strip() or _HERMES_ROOT).expanduser()
-    with contextlib.suppress(OSError):
-        return [board / name for board in (root / "kanban" / "boards").iterdir() if board.is_dir()
-                for name in _SQLITE_FILES("kanban.db")]
-    return []
+    """Named-board ``kanban.db`` stores (+ sidecars): they sit beside the ATTACHMENTS dir
+    ``_kanban_attachment_roots`` allowlists and hold every task, comment and run transcript."""
+    return [board / name for board in _kanban_board_dirs() for name in _sqlite_files("kanban.db")]
 
 
 def _media_delivery_denied_paths() -> List[Path]:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -766,6 +766,11 @@ _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS = (
     ".ssh", ".aws", ".gnupg", ".kube", ".docker", ".config", ".azure", ".gcloud",
     "Library/Keychains")
 
+def _SQLITE_FILES(name: str) -> tuple[str, str, str]:
+    """A SQLite store plus its WAL/SHM sidecars."""
+    return (name, f"{name}-wal", f"{name}-shm")
+
+
 # Credential stores at the HERMES_HOME root, denied per-file so skills/, logs/ and agent-written
 # files stay deliverable (cache subdirs are allowlisted BEFORE this). Mirrors agent/file_safety.py
 # so exfil never trails the read guard. google_token.json's mtime bumps every turn (defeats the
@@ -774,7 +779,11 @@ _ROOT_CREDENTIAL_PATHS = (
     ".env", "auth.json", "auth.lock", "credentials", "config.yaml", ".anthropic_oauth.json",
     "google_token.json", "google_oauth_pending.json", os.path.join("auth", "google_oauth.json"),
     "webhook_subscriptions.json", os.path.join("cache", "bws_cache.json"),
-    os.path.join("cache", "bws_cache.enc.json"), "pairing", "mcp-tokens")
+    os.path.join("cache", "bws_cache.enc.json"), "pairing", "mcp-tokens",
+    # Whole conversation history (every secret ever pasted into a chat) and the copied browser
+    # cookie/login store; sessions/ is the legacy transcript dir. SQLite sidecars are listed
+    # too: WAL mode touches state.db-wal on every write, so recency trust alone would leak them.
+    "sessions", "browser-profile", *_SQLITE_FILES("state.db"), *_SQLITE_FILES("kanban.db"))
 
 
 def _profile_cache_roots() -> List[Path]:
@@ -831,12 +840,24 @@ def _media_delivery_recency_seconds() -> float:
     return _or_default(lambda: max(0.0, float(custom)) if custom else default, default)
 
 
+def _kanban_board_db_paths() -> List[Path]:
+    """Named-board ``kanban.db`` stores (+ sidecars) under ``<root>/kanban/boards/<slug>/`` — the
+    same board dirs ``_kanban_attachment_roots`` allowlists for ATTACHMENTS; the DB beside them
+    holds every task, comment and run transcript."""
+    root = Path(os.environ.get("HERMES_KANBAN_HOME", "").strip() or _HERMES_ROOT).expanduser()
+    with contextlib.suppress(OSError):
+        return [board / name for board in (root / "kanban" / "boards").iterdir() if board.is_dir()
+                for name in _SQLITE_FILES("kanban.db")]
+    return []
+
+
 def _media_delivery_denied_paths() -> List[Path]:
     """Return absolute denylist paths under which delivery is never allowed."""
     home = Path(os.path.expanduser("~"))
     return [*map(Path, _MEDIA_DELIVERY_DENIED_PREFIXES),
             *(home / sub for sub in _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS),
-            *(r / rel for r in (_HERMES_HOME, _HERMES_ROOT) for rel in _ROOT_CREDENTIAL_PATHS)]
+            *(r / rel for r in (_HERMES_HOME, _HERMES_ROOT) for rel in _ROOT_CREDENTIAL_PATHS),
+            *_kanban_board_db_paths()]
 
 
 def _resolve_path(path: Path, *, strict: bool = False, expand: bool = False) -> Optional[Path]:

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -678,6 +678,34 @@ class TestMediaDeliveryDefaultMode:
 
         assert BasePlatformAdapter.validate_media_delivery_path(str(artifact)) == str(artifact.resolve())
 
+    def test_denylist_blocks_session_stores_but_not_neighbouring_artifacts(self, tmp_path, monkeypatch):
+        """The SQLite session/kanban stores (and WAL/SHM sidecars, whose mtime is always fresh),
+        legacy ``sessions/`` transcripts and the copied browser cookie store hold every secret ever
+        pasted into a chat; ``MEDIA:~/.hermes/state.db`` must not exfiltrate them (#41071). Named
+        boards keep their DB beside the ATTACHMENTS the gateway already allowlists, so the board
+        attachment stays deliverable while ``kanban.db`` next to it does not."""
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        hermes_dir = fake_home / ".hermes"
+        hermes_dir.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", hermes_dir)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_dir)
+        board = hermes_dir / "kanban" / "boards" / "team-a"
+        (board / "attachments").mkdir(parents=True)
+
+        denied = ["state.db", "state.db-wal", "state.db-shm", "kanban.db", "kanban.db-wal",
+                  "sessions/20260101_abc.json", "browser-profile/Default/Cookies",
+                  "kanban/boards/team-a/kanban.db", "kanban/boards/team-a/kanban.db-wal"]
+        allowed = ["kanban/boards/team-a/attachments/report.pdf", "adhoc_report.pdf", "logs/agent.log"]
+        for rel in denied + allowed:
+            path = hermes_dir / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(b"SQLite format 3\x00")
+        assert [rel for rel in denied if BasePlatformAdapter.validate_media_delivery_path(str(hermes_dir / rel))] == []
+        assert [rel for rel in allowed if not BasePlatformAdapter.validate_media_delivery_path(str(hermes_dir / rel))] == []
+
     def test_strict_mode_envvar_restores_legacy_behavior(self, tmp_path, monkeypatch):
         """Setting HERMES_MEDIA_DELIVERY_STRICT=1 reactivates the older
         allowlist+recency logic. A stale file outside the allowlist is
@@ -1553,3 +1581,4 @@ class TestPlatformLockTakeoverGovernance:
         assert adapter._acquire_platform_lock("discord-token", "tok", "Discord") is False
         assert len(takeover_calls) == 1
         assert adapter._platform_lock_takeover_attempted is True
+

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1581,4 +1581,3 @@ class TestPlatformLockTakeoverGovernance:
         assert adapter._acquire_platform_lock("discord-token", "tok", "Discord") is False
         assert len(takeover_calls) == 1
         assert adapter._platform_lock_takeover_attempted is True
-


### PR DESCRIPTION
`MEDIA:~/.hermes/state.db` (and `kanban.db`, their WAL/SHM/journal sidecars, `sessions/`, `browser-profile/`, and named-board `kanban/boards/<slug>/kanban.db`) is no longer deliverable by the gateway's native media path; skills/, logs/, memories/ and ad-hoc artifacts under HERMES_HOME still deliver.

Salvage of #41071 by @pprism13 (cherry-picked to preserve authorship), extended to the named-board and sessions/browser-profile gaps the sweeper review on that PR called out. Closes #41071. Related: #35939 (whose whole-tree deny stays deliberately unimplemented — see below).

## Root cause

The per-file media denylist named individual credential files but not the SQLite stores holding the whole cross-session conversation history (every secret ever pasted into a chat). In default mode "anything not denied" delivered them; in strict mode the WAL sidecar's always-fresh mtime would have passed recency trust too. Named boards keep `kanban.db` right beside the `attachments/` dir the gateway already allowlists.

## Change

- `_ROOT_CREDENTIAL_PATHS` gains `sessions`, `browser-profile`, and `state.db` / `kanban.db` with `-wal` / `-shm` / `-journal` sidecars (applied to both the profile HERMES_HOME and the shared root, like the existing entries).
- `_kanban_board_db_paths()` denies every board's DB + sidecars. Board-dir enumeration is now one shared `_kanban_board_dirs()` (lax on the deny side by design; the allow side keeps its slug/symlink/db filter on top), replacing two inline `HERMES_KANBAN_HOME` + `iterdir` copies.
- 1 invariant test: nine denied paths return `None`, three neighbouring artifacts (board attachment, ad-hoc PDF, log) still deliver. Red on `origin/main`, green here.
- Whole-tree deny (#35939) intentionally NOT reintroduced: `test_denylist_blocks_non_cache_file_under_hermes_home` still guards that.

## Validation

| Check | Result |
|---|---|
| Live probe (real `validate_media_delivery_path`, temp HERMES_HOME, 14 paths) | main: 8 sensitive paths DELIVERED; branch: 0 mismatches vs expected |
| Allowlist precedence | `kanban/boards/<slug>/attachments/report.pdf` and `cache/documents/out.pdf` still deliver on branch |
| `scripts/run_tests.sh tests/gateway/test_platform_base.py tests/gateway/test_extract_local_files.py tests/gateway/test_kanban*.py tests/gateway/test_media*.py` | 258 passed |
| Mutation check (base.py reverted to main) | guard test goes red |
| ruff / windows-footguns / compat pointers | clean, no new hits |
