### PR TITLE
Feishu: interactive card surfaces for /model, /l, and second-step pickers

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -158,6 +158,16 @@ def _reply_anchor_for_event(event) -> str | None:
         return getattr(event, "message_id", None) or getattr(event, "reply_to_message_id", None)
     if platform == "feishu" and thread_id and getattr(event, "reply_to_message_id", None):
         return getattr(event, "reply_to_message_id", None)
+    if platform == "feishu":
+        # Interactive-card callbacks are synthetic events: their message_id is
+        # a callback token or UUID, not a Feishu open_message_id. Replying to
+        # it makes the API reject the follow-up with 99992354 (invalid
+        # open_message_id). Detect card-callback payloads by their action
+        # shape and send the response as a fresh message instead.
+        raw = getattr(event, "raw_message", None)
+        raw_event = raw if getattr(raw, "action", None) is not None else getattr(raw, "event", None)
+        if getattr(raw_event, "action", None) is not None:
+            return None
     return getattr(event, "message_id", None)
 
 

--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -694,7 +694,7 @@ class GatewayBusySessionMixin:
     _PLAIN_COMMANDS = (
         "status", "context", "restart", "approve", "deny", "pause", "agents", "bg", "btw",
         "kanban", "subgoal", "heartbeat", "busy", "yolo", "verbose", "footer", "help",
-        "commands", "profile", "update", "version",
+        "commands", "l", "profile", "update", "version",
     )
     # Dispatched only on the idle path (busy dispatch has its own allowlist).
     _IDLE_COMMANDS = (

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -570,6 +570,26 @@ class GatewaySlashCommandsMixin(
         reply = _execute("commands", args=event.get_command_args(), options={"page_size": page_size})
         return self._telegramized_command_reply(event, reply.text)
 
+    async def _handle_l_command(self, event: MessageEvent) -> Optional[str]:
+        """Handle /l — quick command menu card on Feishu, /commands elsewhere."""
+        source = event.source
+        if getattr(source, "platform", None) == Platform.FEISHU:
+            adapter = self._adapter_for_source(source)
+            if adapter is not None and getattr(type(adapter), "send_command_list", None) is not None:
+                metadata = self._thread_metadata_for_source(
+                    source, self._reply_anchor_for_event(event)
+                )
+                result = await adapter.send_command_list(
+                    chat_id=source.chat_id,
+                    session_key=self._session_key_for_source(source),
+                    metadata=metadata,
+                )
+                if result.success:
+                    return None  # Card sent — no text reply needed.
+                logger.warning("[Gateway] /l card send failed: %s", result.error)
+        # Non-Feishu (or card send failed): fall back to the /commands listing.
+        return await self._handle_commands_command(event)
+
     async def _handle_set_home_command(self, event: MessageEvent) -> str:
         """Handle /sethome command -- set the current chat as the platform's home channel."""
         from gateway.run import _home_target_env_var, _home_thread_env_var

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -265,6 +265,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                "Tools & Skills", cli_only=True, desktop="terminal"),
 
     # Info
+    CommandDef("l", "Quick command menu — interactive card on Feishu, alias of /commands elsewhere", "Info",
+               gateway_only=True, busy_policy="dispatch", aliases=("list",), execute="gateway_l"),
     CommandDef("commands", "Browse all commands and skills (paginated)", "Info",
                gateway_only=True, args_hint="[page]", busy_policy="dispatch",
                execute="gateway_commands"),

--- a/hermes_cli/commands_platforms.py
+++ b/hermes_cli/commands_platforms.py
@@ -366,9 +366,11 @@ _SLACK_RESERVED_COMMANDS = frozenset({
 # canonical command tips past the cap, demote a rarer one-off lookup (version, whoami, diff, ...)
 # rather than a recurring interactive surface (context, loop, save, approvals). Keep TIGHT — the
 # parity test reads this set. Aliases are never pinned ahead of canonicals.
+#   - l: Feishu-centric quick command menu (falls back to /commands elsewhere);
+#     reached via /hermes l on Slack so it doesn't clamp /insights at the 50-cap.
 _SLACK_VIA_HERMES_ONLY = frozenset({
     "topup", "moa", "debug", "egress", "init", "version", "diff", "update", "heartbeat",
-    "refine", "review", "pause", "whoami", "platform", "insights"})
+    "refine", "review", "pause", "whoami", "platform", "insights", "l"})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2206,6 +2206,17 @@ class FeishuAdapter(BasePlatformAdapter):
                 option_value=mp_option,
                 loop=loop,
             )
+        if str(getattr(action, "tag", "") or "").lower() == "select_static":
+            # Diagnostic: log the raw shape so unmatched select_static
+            # callbacks can be root-caused from gateway.log directly.
+            try:
+                raw_shape = repr(action_value)[:500]
+            except Exception:
+                raw_shape = "<unreprable>"
+            logger.warning(
+                "[Feishu] select_static callback without model picker value; "
+                "raw action_value=%s", raw_shape,
+            )
 
         self._submit_on_loop(loop, self._handle_card_action_event(data))
         return self._card_response()
@@ -2278,28 +2289,57 @@ class FeishuAdapter(BasePlatformAdapter):
     def _find_model_picker_option_value(cls, action: Any, action_value: Any) -> Optional[str]:
         """Extract the selected model-picker option value from a card action.
 
-        Feishu's select_static callbacks deliver the chosen option's value in
-        different shapes depending on SDK/callback version:
-        - ``action.option.value`` (string)
-        - ``action.value.key`` (legacy form option callbacks)
-        - ``action.value`` itself when the platform passes the raw string
-        Returns the value string when it carries our prefix, else None.
+        Feishu/lark-opi delivers a select_static choice in different shapes
+        across SDK and card-schema versions (action.option.value as str or
+        dict, action.value.key, nested option objects…). Instead of guessing
+        one shape, walk the whole action payload (bounded depth) and return
+        the first string carrying our prefix.
         """
-        candidates: List[Any] = []
+        found = cls._scan_for_picker_value(action, depth=0)
+        if found:
+            return found
+        found = cls._scan_for_picker_value(action_value, depth=0)
+        if not found:
+            logger.debug(
+                "[Feishu] select_static action without model picker value: %r",
+                action_value,
+            )
+        return found
 
-        option = getattr(action, "option", None)
-        if option is not None:
-            candidates.append(getattr(option, "value", None))
-
-        if isinstance(action_value, dict):
-            candidates.append(action_value.get("key"))
-            candidates.append(action_value.get("value"))
-        elif isinstance(action_value, str):
-            candidates.append(action_value)
-
-        for cand in candidates:
-            if isinstance(cand, str) and cand.startswith(cls._MODEL_PICKER_PREFIX):
-                return cand
+    @classmethod
+    def _scan_for_picker_value(cls, node: Any, depth: int) -> Optional[str]:
+        """Bounded recursive scan for the picker prefix in callback data."""
+        if depth > 6:
+            return None
+        if isinstance(node, str):
+            return node if node.startswith(cls._MODEL_PICKER_PREFIX) else None
+        if isinstance(node, dict):
+            # Common carrier keys first (cheap ordering win), then all keys.
+            for key in ("value", "key", "option_value", "selected_option"):
+                hit = cls._scan_for_picker_value(node.get(key), depth + 1)
+                if hit:
+                    return hit
+            for v in node.values():
+                hit = cls._scan_for_picker_value(v, depth + 1)
+                if hit:
+                    return hit
+            return None
+        if isinstance(node, (list, tuple)):
+            for item in node:
+                hit = cls._scan_for_picker_value(item, depth + 1)
+                if hit:
+                    return hit
+            return None
+        # SDK model objects: walk their slots like SimpleNamespace / dataclass.
+        for attr in ("option", "value", "key", "options"):
+            try:
+                sub = getattr(node, attr, None)
+            except Exception:
+                sub = None
+            if sub is not None and sub is not node:
+                hit = cls._scan_for_picker_value(sub, depth + 1)
+                if hit:
+                    return hit
         return None
 
     def _handle_model_picker_card_action(self, *, event: Any, option_value: str, loop: Any) -> Any:

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1249,6 +1249,12 @@ class FeishuAdapter(BasePlatformAdapter):
         self._approval_counter = itertools.count(1)
         self._update_prompt_state: Dict[int, Dict[str, str]] = {}
         self._update_prompt_counter = itertools.count(1)
+        # Model picker button state (picker_id → {chat_id, session_key, on_model_selected, ...})
+        self._model_picker_state: Dict[int, dict] = {}
+        self._model_picker_counter = itertools.count(1)
+        # Choice picker button state (picker_id → {chat_id, session_key, choices, on_choice_selected})
+        self._choice_picker_state: Dict[int, dict] = {}
+        self._choice_picker_counter = itertools.count(1)
         # Reaction deletion needs the opaque reaction_id from create, cached per message_id.
         self._pending_processing_reactions: "OrderedDict[str, str]" = OrderedDict()
         self._load_seen_message_ids()
@@ -1720,6 +1726,116 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.warning("[Feishu] send_update_prompt failed: %s", exc)
             return SendResult(success=False, error=str(exc))
 
+    async def send_model_picker(
+        self,
+        chat_id: str,
+        providers: list,
+        current_model: str,
+        current_provider: str,
+        session_key: str,
+        on_model_selected,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an interactive model-picker card.
+
+        Matches the gateway's official ``send_model_picker`` contract (same as
+        Telegram/Discord/Matrix): flatten the provided ``providers`` catalog
+        into a single ``select_static`` dropdown whose selected value is
+        resolved server-side against the stored entries, then hand the choice
+        to ``on_model_selected(chat_id, model_id, provider_slug)``.
+        """
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        # Flatten providers into (label, model_id, provider_slug), deduped.
+        model_entries: List[tuple] = []
+        seen: set = set()
+        for provider in providers or []:
+            if not isinstance(provider, dict):
+                continue
+            slug = str(provider.get("slug") or "")
+            name = str(provider.get("name") or slug or "unknown")
+            for model in provider.get("models", []) or []:
+                if isinstance(model, dict):
+                    mid = str(model.get("model") or model.get("id") or "").strip()
+                else:
+                    mid = str(model or "").strip()
+                if not mid:
+                    continue
+                key = (slug, mid)
+                if key in seen:
+                    continue
+                seen.add(key)
+                short = mid.split("/")[-1] if "/" in mid else mid
+                model_entries.append((f"{name} · {short}", mid, slug))
+
+        if not model_entries:
+            return SendResult(success=False, error="No models available")
+
+        picker_id = next(self._model_picker_counter)
+        card = {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": "⚙ 切换模型", "tag": "plain_text"},
+                "template": "blue",
+            },
+            "elements": [
+                {"tag": "markdown", "content": f"当前模型：`{current_model or 'unknown'}`"},
+                {
+                    "tag": "action",
+                    "actions": [
+                        {
+                            "tag": "select_static",
+                            "placeholder": {"tag": "plain_text", "content": "选择要切换的模型"},
+                            "options": [
+                                {
+                                    "text": {"tag": "plain_text", "content": label},
+                                    "value": f"hermes_model_picker:{picker_id}:{idx}",
+                                }
+                                for idx, (label, _mid, _slug) in enumerate(model_entries)
+                            ],
+                        }
+                    ],
+                },
+            ],
+        }
+
+        try:
+            payload = json.dumps(card, ensure_ascii=False)
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=payload,
+                reply_to=None,
+                metadata=metadata,
+            )
+            result = self._finalize_send_result(response, "send_model_picker failed")
+            if result.success:
+                self._model_picker_state[picker_id] = {
+                    "chat_id": chat_id,
+                    "session_key": session_key,
+                    "on_model_selected": on_model_selected,
+                    "model_entries": model_entries,
+                }
+            return result
+        except Exception as exc:
+            logger.warning("[Feishu] send_model_picker failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
+    @staticmethod
+    def _build_model_picker_selection_card(*, model_id: str) -> Dict[str, Any]:
+        """Build the inline card shown immediately after a selection lands."""
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": "模型切换中", "tag": "plain_text"},
+                "template": "blue",
+            },
+            "elements": [
+                {"tag": "markdown", "content": f"正在切换到 `{model_id}`…"},
+            ],
+        }
+
     @staticmethod
     def _build_resolved_approval_card(*, choice: str, user_name: str) -> Dict[str, Any]:
         """Raw card JSON shown in place of the buttons once an approval is resolved."""
@@ -2079,6 +2195,18 @@ class FeishuAdapter(BasePlatformAdapter):
                 return self._handle_approval_card_action(event=event, action_value=action_value, loop=loop)
             if action_value.get("hermes_update_prompt_action"):
                 return self._handle_update_prompt_card_action(event=event, action_value=action_value, loop=loop)
+
+        # Model picker is a select_static: the selected option value arrives
+        # via action.option.value (or action.value.key depending on SDK
+        # version) rather than action.value like buttons.
+        mp_option = self._find_model_picker_option_value(action, action_value)
+        if mp_option:
+            return self._handle_model_picker_card_action(
+                event=event,
+                option_value=mp_option,
+                loop=loop,
+            )
+
         self._submit_on_loop(loop, self._handle_card_action_event(data))
         return self._card_response()
 
@@ -2143,6 +2271,126 @@ class FeishuAdapter(BasePlatformAdapter):
             )
             return None
         return open_id, callback_chat_id, self._get_cached_sender_name(open_id) or open_id
+
+    _MODEL_PICKER_PREFIX = "hermes_model_picker:"
+
+    @classmethod
+    def _find_model_picker_option_value(cls, action: Any, action_value: Any) -> Optional[str]:
+        """Extract the selected model-picker option value from a card action.
+
+        Feishu's select_static callbacks deliver the chosen option's value in
+        different shapes depending on SDK/callback version:
+        - ``action.option.value`` (string)
+        - ``action.value.key`` (legacy form option callbacks)
+        - ``action.value`` itself when the platform passes the raw string
+        Returns the value string when it carries our prefix, else None.
+        """
+        candidates: List[Any] = []
+
+        option = getattr(action, "option", None)
+        if option is not None:
+            candidates.append(getattr(option, "value", None))
+
+        if isinstance(action_value, dict):
+            candidates.append(action_value.get("key"))
+            candidates.append(action_value.get("value"))
+        elif isinstance(action_value, str):
+            candidates.append(action_value)
+
+        for cand in candidates:
+            if isinstance(cand, str) and cand.startswith(cls._MODEL_PICKER_PREFIX):
+                return cand
+        return None
+
+    def _handle_model_picker_card_action(self, *, event: Any, option_value: str, loop: Any) -> Any:
+        """Validate a model-picker selection and schedule the session switch."""
+        parts = str(option_value or "").split(":")
+        # parts = ["hermes_model_picker", picker_id, index]
+        if len(parts) != 3:
+            logger.debug("[Feishu] Malformed model picker value %r", option_value)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+        try:
+            picker_id = int(parts[1])
+            idx = int(parts[2])
+        except ValueError:
+            logger.debug("[Feishu] Non-integer model picker value %r", option_value)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        state = self._model_picker_state.get(picker_id)
+        if not state:
+            logger.debug("[Feishu] Model picker %s unknown or already used", picker_id)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        entries = state.get("model_entries", [])
+        if idx < 0 or idx >= len(entries):
+            logger.warning("[Feishu] Invalid model picker index %s for %s", idx, picker_id)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        operator = getattr(event, "operator", None)
+        open_id = str(getattr(operator, "open_id", "") or "")
+        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
+        expected_chat_id = str(state.get("chat_id", "") or "")
+        if not self._allow_group_message(sender_id, expected_chat_id, is_bot=False):
+            logger.warning("[Feishu] Unauthorized model picker click by %s", open_id or "<unknown>")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        callback_chat_id = str(getattr(getattr(event, "context", None), "open_chat_id", "") or "")
+        if callback_chat_id and expected_chat_id and callback_chat_id != expected_chat_id:
+            logger.warning("[Feishu] Model picker chat mismatch for %s", picker_id)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        _label, model_id, provider_slug = entries[idx]
+
+        # One-time: pop before scheduling so a duplicate tap can't double-switch.
+        state = self._model_picker_state.pop(picker_id, None)
+        if not state or not self._submit_on_loop(
+            loop,
+            self._dispatch_model_picker_selection(
+                on_model_selected=state["on_model_selected"],
+                chat_id=expected_chat_id,
+                model_id=model_id,
+                provider_slug=provider_slug,
+            ),
+        ):
+            if state:
+                self._model_picker_state[picker_id] = state
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        if P2CardActionTriggerResponse is None:
+            return None
+        response = P2CardActionTriggerResponse()
+        if CallBackCard is not None:
+            card = CallBackCard()
+            card.type = "raw"
+            card.data = self._build_model_picker_selection_card(model_id=model_id)
+            response.card = card
+        return response
+
+    async def _dispatch_model_picker_selection(
+        self,
+        *,
+        on_model_selected: Any,
+        chat_id: str,
+        model_id: str,
+        provider_slug: str,
+    ) -> None:
+        """Invoke the gateway callback and post the confirmation text."""
+        result_text: str
+        try:
+            result_text = await on_model_selected(chat_id, model_id, provider_slug)
+        except Exception as exc:
+            logger.error("[Feishu] Model picker switch failed: %s", exc)
+            result_text = f"模型切换失败：{exc}"
+        try:
+            await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="text",
+                payload=json.dumps({"text": _strip_markdown_to_plain_text(result_text)}, ensure_ascii=False),
+                reply_to=None,
+                metadata=None,
+            )
+        except Exception as exc:
+            logger.debug("[Feishu] Failed to send model picker confirmation: %s", exc)
 
     def _handle_approval_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
         """Schedule approval resolution and build the synchronous callback response."""

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1747,45 +1747,29 @@ class FeishuAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
-        # Curated picker first: platforms.feishu.extra.model_picker lists the
-        # admin's chosen (label, model, provider) entries — when configured it
-        # replaces the full provider catalog so the dropdown stays short and
-        # relevant (e.g. 3 curated models instead of every GPT variant).
-        curated = (self.config.extra or {}).get("model_picker", {})
-        use_curated = bool((metadata or {}).get("curated_model_picker"))
+        # Flatten providers into (label, model_id, provider_slug), deduped.
         model_entries: List[tuple] = []
-        if use_curated and isinstance(curated, dict) and curated.get("enabled") and curated.get("models"):
-            for entry in curated["models"]:
-                if not isinstance(entry, dict):
+        seen: set = set()
+        for provider in providers or []:
+            if not isinstance(provider, dict):
+                continue
+            slug = str(provider.get("slug") or "")
+            name = str(provider.get("name") or slug or "unknown")
+            for model in provider.get("models", []) or []:
+                if isinstance(model, dict):
+                    mid = str(model.get("model") or model.get("id") or "").strip()
+                else:
+                    mid = str(model or "").strip()
+                if not mid:
                     continue
-                mid = str(entry.get("model") or "").strip()
-                slug = str(entry.get("provider") or "").strip()
-                label = str(entry.get("label") or mid).strip()
-                if mid and slug:
-                    model_entries.append((label or mid, mid, slug))
-        if not model_entries:
-            # Flatten providers into (label, model_id, provider_slug), deduped.
-            seen: set = set()
-            for provider in providers or []:
-                if not isinstance(provider, dict):
+                key = (slug, mid)
+                if key in seen:
                     continue
-                slug = str(provider.get("slug") or "")
-                name = str(provider.get("name") or slug or "unknown")
-                for model in provider.get("models", []) or []:
-                    if isinstance(model, dict):
-                        mid = str(model.get("model") or model.get("id") or "").strip()
-                    else:
-                        mid = str(model or "").strip()
-                    if not mid:
-                        continue
-                    key = (slug, mid)
-                    if key in seen:
-                        continue
-                    seen.add(key)
-                    # Show the FULL model id (including any "cc/" or "ais-prod/"
-                    # prefix) so aliased models are visually distinguishable
-                    # instead of collapsed to their last path segment.
-                    model_entries.append((f"{name} · {mid}", mid, slug))
+                seen.add(key)
+                # Show the FULL model id (including any "cc/" or "ais-prod/"
+                # prefix) so aliased models are visually distinguishable
+                # instead of collapsed to their last path segment.
+                model_entries.append((f"{name} · {mid}", mid, slug))
 
         if not model_entries:
             return SendResult(success=False, error="No models available")

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1747,29 +1747,44 @@ class FeishuAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
-        # Flatten providers into (label, model_id, provider_slug), deduped.
+        # Curated picker first: platforms.feishu.extra.model_picker lists the
+        # admin's chosen (label, model, provider) entries — when configured it
+        # replaces the full provider catalog so the dropdown stays short and
+        # relevant (e.g. 3 curated models instead of every GPT variant).
+        curated = (self.config.extra or {}).get("model_picker", {})
         model_entries: List[tuple] = []
-        seen: set = set()
-        for provider in providers or []:
-            if not isinstance(provider, dict):
-                continue
-            slug = str(provider.get("slug") or "")
-            name = str(provider.get("name") or slug or "unknown")
-            for model in provider.get("models", []) or []:
-                if isinstance(model, dict):
-                    mid = str(model.get("model") or model.get("id") or "").strip()
-                else:
-                    mid = str(model or "").strip()
-                if not mid:
+        if isinstance(curated, dict) and curated.get("enabled") and curated.get("models"):
+            for entry in curated["models"]:
+                if not isinstance(entry, dict):
                     continue
-                key = (slug, mid)
-                if key in seen:
+                mid = str(entry.get("model") or "").strip()
+                slug = str(entry.get("provider") or "").strip()
+                label = str(entry.get("label") or mid).strip()
+                if mid and slug:
+                    model_entries.append((label or mid, mid, slug))
+        if not model_entries:
+            # Flatten providers into (label, model_id, provider_slug), deduped.
+            seen: set = set()
+            for provider in providers or []:
+                if not isinstance(provider, dict):
                     continue
-                seen.add(key)
-                # Show the FULL model id (including any "cc/" or "ais-prod/"
-                # prefix) so aliased models are visually distinguishable
-                # instead of collapsed to their last path segment.
-                model_entries.append((f"{name} · {mid}", mid, slug))
+                slug = str(provider.get("slug") or "")
+                name = str(provider.get("name") or slug or "unknown")
+                for model in provider.get("models", []) or []:
+                    if isinstance(model, dict):
+                        mid = str(model.get("model") or model.get("id") or "").strip()
+                    else:
+                        mid = str(model or "").strip()
+                    if not mid:
+                        continue
+                    key = (slug, mid)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    # Show the FULL model id (including any "cc/" or "ais-prod/"
+                    # prefix) so aliased models are visually distinguishable
+                    # instead of collapsed to their last path segment.
+                    model_entries.append((f"{name} · {mid}", mid, slug))
 
         if not model_entries:
             return SendResult(success=False, error="No models available")

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1766,8 +1766,10 @@ class FeishuAdapter(BasePlatformAdapter):
                 if key in seen:
                     continue
                 seen.add(key)
-                short = mid.split("/")[-1] if "/" in mid else mid
-                model_entries.append((f"{name} · {short}", mid, slug))
+                # Show the FULL model id (including any "cc/" or "ais-prod/"
+                # prefix) so aliased models are visually distinguishable
+                # instead of collapsed to their last path segment.
+                model_entries.append((f"{name} · {mid}", mid, slug))
 
         if not model_entries:
             return SendResult(success=False, error="No models available")
@@ -1835,6 +1837,118 @@ class FeishuAdapter(BasePlatformAdapter):
                 {"tag": "markdown", "content": f"正在切换到 `{model_id}`…"},
             ],
         }
+
+    # Allowlisted quick-menu actions (hermes_list_action) → slash commands.
+    # Server-side mapping only: the button payload carries the action NAME,
+    # never raw command text, so a tampered value cannot run anything else.
+    _LIST_MENU_ACTIONS: tuple = (
+        ("model", "🤖 切换模型"),
+        ("status", "📊 会话状态"),
+        ("sessions", "📝 历史会话"),
+        ("reasoning", "🧠 推理强度"),
+        ("fast", "⚡ 快速模式"),
+        ("title", "📌 当前会话"),
+        ("compact", "🧹 压缩上下文"),
+        ("commands", "📖 全部命令"),
+    )
+
+    async def send_command_list(
+        self,
+        chat_id: str,
+        session_key: str = "",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send the /l quick-command menu card (Feishu)."""
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+        # One action element per button pair → clean two-column layout.
+        rows = [
+            {"tag": "action", "actions": [
+                {
+                    "tag": "button",
+                    "text": {"tag": "plain_text", "content": label},
+                    "type": "default",
+                    "value": {"hermes_list_action": action},
+                }
+                for action, label in self._LIST_MENU_ACTIONS[i:i + 2]
+            ]}
+            for i in range(0, len(self._LIST_MENU_ACTIONS), 2)
+        ]
+        card = {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": "⚡ 快捷命令", "tag": "plain_text"},
+                "template": "indigo",
+            },
+            "elements": [
+                {"tag": "markdown", "content": "点击按钮执行对应命令："},
+                *rows,
+            ],
+        }
+        try:
+            payload = json.dumps(card, ensure_ascii=False)
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=payload,
+                reply_to=None,
+                metadata=metadata,
+            )
+            return self._finalize_send_result(response, "send_command_list failed")
+        except Exception as exc:
+            logger.warning("[Feishu] send_command_list failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
+    async def _handle_list_card_action(self, data: Any) -> None:
+        """Dispatch a quick-menu button click as an allowlisted slash command."""
+        event = getattr(data, "event", None)
+        action = getattr(event, "action", None)
+        action_value = getattr(action, "value", {}) or {}
+        list_action = action_value.get("hermes_list_action") if isinstance(action_value, dict) else None
+
+        allowed = {name for name, _label in self._LIST_MENU_ACTIONS}
+        if not list_action or list_action not in allowed:
+            logger.warning("[Feishu] Rejected non-allowlisted list card action: %r", list_action)
+            return
+
+        context = getattr(event, "context", None)
+        chat_id = str(getattr(context, "open_chat_id", "") or "")
+        operator = getattr(event, "operator", None)
+        open_id = str(getattr(operator, "open_id", "") or "")
+        if not chat_id or not open_id:
+            logger.debug("[Feishu] List card action missing chat_id or operator, dropping")
+            return
+
+        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
+        if not self._allow_group_message(sender_id, chat_id, is_bot=False):
+            logger.warning("[Feishu] Unauthorized list card click by %s", open_id or "<unknown>")
+            return
+
+        sender_profile = await self._resolve_sender_profile(sender_id)
+        chat_info = await self.get_chat_info(chat_id)
+        source = self.build_source(
+            chat_id=chat_id,
+            chat_name=chat_info.get("name") or chat_id or "Feishu Chat",
+            chat_type=self._resolve_source_chat_type(chat_info=chat_info, event_chat_type="group"),
+            user_id=sender_profile["user_id"],
+            user_name=sender_profile["user_name"],
+            thread_id=None,
+            user_id_alt=sender_profile["user_id_alt"],
+        )
+        # No Feishu reply anchor: card callback tokens/UUIDs are not valid
+        # open_message_id values (99992354). A fresh UUID keeps dedup keys unique
+        # while the anchor suppression in base.py prevents it being used to reply.
+        synthetic_event = MessageEvent(
+            text=f"/{list_action}",
+            message_type=MessageType.COMMAND,
+            source=source,
+            raw_message=event,
+            message_id=str(uuid.uuid4()),
+            channel_prompt=self._resolve_channel_prompt(chat_id),
+            timestamp=datetime.now(),
+        )
+        logger.info("[Feishu] List card action dispatched: %s from %s in %s", list_action, open_id, chat_id)
+        await self._handle_message_with_guards(synthetic_event)
 
     @staticmethod
     def _build_resolved_approval_card(*, choice: str, user_name: str) -> Dict[str, Any]:
@@ -2217,6 +2331,16 @@ class FeishuAdapter(BasePlatformAdapter):
                 "[Feishu] select_static callback without model picker value; "
                 "raw action_value=%s", raw_shape,
             )
+
+        list_action = (
+            action_value.get("hermes_list_action")
+            if isinstance(action_value, dict) else None
+        )
+        if list_action:
+            self._submit_on_loop(loop, self._handle_list_card_action(data))
+            if P2CardActionTriggerResponse is None:
+                return None
+            return P2CardActionTriggerResponse()
 
         self._submit_on_loop(loop, self._handle_card_action_event(data))
         return self._card_response()

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1752,8 +1752,9 @@ class FeishuAdapter(BasePlatformAdapter):
         # replaces the full provider catalog so the dropdown stays short and
         # relevant (e.g. 3 curated models instead of every GPT variant).
         curated = (self.config.extra or {}).get("model_picker", {})
+        use_curated = bool((metadata or {}).get("curated_model_picker"))
         model_entries: List[tuple] = []
-        if isinstance(curated, dict) and curated.get("enabled") and curated.get("models"):
+        if use_curated and isinstance(curated, dict) and curated.get("enabled") and curated.get("models"):
             for entry in curated["models"]:
                 if not isinstance(entry, dict):
                     continue

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1950,6 +1950,172 @@ class FeishuAdapter(BasePlatformAdapter):
         logger.info("[Feishu] List card action dispatched: %s from %s in %s", list_action, open_id, chat_id)
         await self._handle_message_with_guards(synthetic_event)
 
+    async def send_choice_picker(
+        self,
+        chat_id: str,
+        title: str,
+        choices: list,
+        session_key: str,
+        on_choice_selected,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a flat single-level choice picker (one tap → one value).
+
+        Generic companion to ``send_model_picker`` used by /reasoning, /fast
+        and any finite-choice command. Each choice dict:
+        ``{"value": str, "label": str, "is_current": bool}``.
+        """
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+        clean = [
+            c for c in (choices or [])
+            if isinstance(c, dict) and str(c.get("value") or "").strip()
+        ]
+        if not clean:
+            return SendResult(success=False, error="No choices")
+
+        picker_id = next(self._choice_picker_counter)
+        rows = []
+        for i in range(0, len(clean), 3):
+            batch = clean[i:i + 3]
+            rows.append({
+                "tag": "action",
+                "actions": [
+                    {
+                        "tag": "button",
+                        "text": {"tag": "plain_text", "content": str(c.get("label") or c.get("value"))},
+                        "type": "primary" if c.get("is_current") else "default",
+                        "value": {"hermes_choice_picker": f"{picker_id}:{i + j}"},
+                    }
+                    for j, c in enumerate(batch)
+                ],
+            })
+        card = {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": "请选择", "tag": "plain_text"},
+                "template": "purple",
+            },
+            "elements": [
+                {"tag": "markdown", "content": str(title)},
+                *rows,
+            ],
+        }
+        try:
+            payload = json.dumps(card, ensure_ascii=False)
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=payload,
+                reply_to=None,
+                metadata=metadata,
+            )
+            result = self._finalize_send_result(response, "send_choice_picker failed")
+            if result.success:
+                self._choice_picker_state[picker_id] = {
+                    "chat_id": chat_id,
+                    "session_key": session_key,
+                    "choices": clean,
+                    "on_choice_selected": on_choice_selected,
+                }
+            return result
+        except Exception as exc:
+            logger.warning("[Feishu] send_choice_picker failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
+    def _handle_choice_picker_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
+        """Validate a choice-picker tap, schedule the callback, return resolved card."""
+        ref = str(action_value.get("hermes_choice_picker") or "")
+        parts = ref.split(":")
+        if len(parts) != 2:
+            logger.debug("[Feishu] Malformed choice picker ref %r", ref)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+        try:
+            picker_id = int(parts[0])
+            idx = int(parts[1])
+        except ValueError:
+            logger.debug("[Feishu] Non-integer choice picker ref %r", ref)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        state = self._choice_picker_state.get(picker_id)
+        if not state:
+            logger.debug("[Feishu] Choice picker %s unknown or already used", picker_id)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+        choices = state.get("choices", [])
+        if idx < 0 or idx >= len(choices):
+            logger.warning("[Feishu] Invalid choice picker index %s for %s", idx, picker_id)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        operator = getattr(event, "operator", None)
+        open_id = str(getattr(operator, "open_id", "") or "")
+        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
+        expected_chat_id = str(state.get("chat_id", "") or "")
+        if not self._allow_group_message(sender_id, expected_chat_id, is_bot=False):
+            logger.warning("[Feishu] Unauthorized choice picker click by %s", open_id or "<unknown>")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+        callback_chat_id = str(getattr(getattr(event, "context", None), "open_chat_id", "") or "")
+        if callback_chat_id and expected_chat_id and callback_chat_id != expected_chat_id:
+            logger.warning("[Feishu] Choice picker chat mismatch for %s", picker_id)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        choice = choices[idx]
+        value = str(choice.get("value") or "")
+        label = str(choice.get("label") or value)
+        # One-time: pop before scheduling so a double tap can't run twice.
+        state = self._choice_picker_state.pop(picker_id, None)
+        if not state or not self._submit_on_loop(
+            loop,
+            self._dispatch_choice_picker_selection(
+                on_choice_selected=state["on_choice_selected"],
+                chat_id=expected_chat_id or callback_chat_id,
+                value=value,
+            ),
+        ):
+            if state:
+                self._choice_picker_state[picker_id] = state
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        if P2CardActionTriggerResponse is None:
+            return None
+        response = P2CardActionTriggerResponse()
+        if CallBackCard is not None:
+            card = CallBackCard()
+            card.type = "raw"
+            card.data = {
+                "config": {"wide_screen_mode": True},
+                "header": {
+                    "title": {"content": f"✅ 已选择：{label}", "tag": "plain_text"},
+                    "template": "green",
+                },
+                "elements": [{"tag": "markdown", "content": f"正在应用 **{label}** …"}],
+            }
+            response.card = card
+        return response
+
+    async def _dispatch_choice_picker_selection(
+        self,
+        *,
+        on_choice_selected: Any,
+        chat_id: str,
+        value: str,
+    ) -> None:
+        """Invoke the gateway callback and post the result text."""
+        try:
+            result_text = await on_choice_selected(chat_id, value)
+        except Exception as exc:
+            logger.error("[Feishu] Choice picker selection failed: %s", exc)
+            result_text = f"应用选择失败：{exc}"
+        try:
+            await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="text",
+                payload=json.dumps({"text": _strip_markdown_to_plain_text(str(result_text))}, ensure_ascii=False),
+                reply_to=None,
+                metadata=None,
+            )
+        except Exception as exc:
+            logger.debug("[Feishu] Failed to send choice picker result: %s", exc)
+
     @staticmethod
     def _build_resolved_approval_card(*, choice: str, user_name: str) -> Dict[str, Any]:
         """Raw card JSON shown in place of the buttons once an approval is resolved."""
@@ -2330,6 +2496,17 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.warning(
                 "[Feishu] select_static callback without model picker value; "
                 "raw action_value=%s", raw_shape,
+            )
+
+        choice_picker_ref = (
+            action_value.get("hermes_choice_picker")
+            if isinstance(action_value, dict) else None
+        )
+        if choice_picker_ref:
+            return self._handle_choice_picker_card_action(
+                event=event,
+                action_value=action_value,
+                loop=loop,
             )
 
         list_action = (

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -689,6 +689,56 @@ def _make_select_action_data(
     )
 
 
+class TestPickerValueScanShapes:
+    """The recursive scan must find the picker value in every callback shape."""
+
+    PREFIX = "hermes_model_picker:3:0"
+    TARGET = "hermes_model_picker:3:0"
+
+    def test_scan_finds_nested_string_in_action_value_dict(self):
+        # shape: action.value = {"selected_option": {"value": "<prefix...>"}}
+        adapter = _make_adapter()
+        action = SimpleNamespace(tag="select_static", value={"selected_option": {"value": self.TARGET}})
+        assert adapter._find_model_picker_option_value(action, action.value) == self.TARGET
+
+    def test_scan_finds_value_in_key_field(self):
+        # shape: action.value = {"key": "<prefix...>"}
+        adapter = _make_adapter()
+        action = SimpleNamespace(tag="select_static", value={"key": self.TARGET})
+        assert adapter._find_model_picker_option_value(action, action.value) == self.TARGET
+
+    def test_scan_finds_option_value_str(self):
+        # shape: action.option.value = "<prefix...>"
+        adapter = _make_adapter()
+        action = SimpleNamespace(
+            tag="select_static", value={}, option=SimpleNamespace(value=self.TARGET),
+        )
+        assert adapter._find_model_picker_option_value(action, action.value) == self.TARGET
+
+    def test_scan_finds_option_value_dict(self):
+        # shape: action.option = {"value": "<prefix...>"}
+        adapter = _make_adapter()
+        action = SimpleNamespace(tag="select_static", value={}, option={"value": self.TARGET})
+        assert adapter._find_model_picker_option_value(action, action.value) == self.TARGET
+
+    def test_scan_finds_bare_string_value(self):
+        # shape: action.value = "<prefix...>" directly
+        adapter = _make_adapter()
+        action = SimpleNamespace(tag="select_static", value=self.TARGET)
+        assert adapter._find_model_picker_option_value(action, action.value) == self.TARGET
+
+    def test_scan_finds_deeply_nested_list_shape(self):
+        # shape: action.value = {"options": [{"value": "<prefix...>"}]}
+        adapter = _make_adapter()
+        action = SimpleNamespace(tag="select_static", value={"options": [{"value": self.TARGET}]})
+        assert adapter._find_model_picker_option_value(action, action.value) == self.TARGET
+
+    def test_scan_returns_none_for_unrelated_payload(self):
+        adapter = _make_adapter()
+        action = SimpleNamespace(tag="select_static", value={"key": "some_other_value"})
+        assert adapter._find_model_picker_option_value(action, action.value) is None
+
+
 class TestFeishuModelPicker:
     """Feishu model picker: card payload, state, callback validation."""
 

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -760,6 +760,11 @@ class TestFeishuModelPicker:
                 "name": "cc-switch gpt",
                 "models": [{"model": "gpt-5.6-terra"}],
             },
+            {
+                "slug": "cc-switch-deepseek-pro",
+                "name": "cc-switch deepseek",
+                "models": ["cc/deepseek-v4-pro"],
+            },
         ]
 
         with patch.object(
@@ -784,9 +789,18 @@ class TestFeishuModelPicker:
         select = card["elements"][1]["actions"][0]
         assert select["tag"] == "select_static"
         options = select["options"]
-        assert len(options) == 3  # 2 glm + 1 gpt
+        assert len(options) == 4  # 2 glm + 1 gpt + 1 cc/-prefixed deepseek
         # Option values must be opaque refs (prefix:picker_id:index), never raw model ids
         assert options[0]["value"].startswith("hermes_model_picker:1:")
+        # Labels must show the FULL model id — "cc/"-prefixed aliases stay
+        # distinguishable instead of collapsing to their last path segment.
+        labels = [o["text"]["content"] for o in options]
+        assert labels == [
+            "cc-switch glm · glm-5.3",
+            "cc-switch glm · glm-5.2",
+            "cc-switch gpt · gpt-5.6-terra",
+            "cc-switch deepseek · cc/deepseek-v4-pro",
+        ]
 
         # State records server-side model entries for callback resolution
         assert len(adapter._model_picker_state) == 1
@@ -794,10 +808,11 @@ class TestFeishuModelPicker:
         assert state["chat_id"] == "oc_12345"
         assert state["session_key"] == "sess-mp"
         assert [e[1] for e in state["model_entries"]] == [
-            "glm-5.3", "glm-5.2", "gpt-5.6-terra",
+            "glm-5.3", "glm-5.2", "gpt-5.6-terra", "cc/deepseek-v4-pro",
         ]
         assert [e[2] for e in state["model_entries"]] == [
             "cc-switch-glm", "cc-switch-glm", "cc-switch-gpt-5-5",
+            "cc-switch-deepseek-pro",
         ]
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -777,6 +777,7 @@ class TestFeishuModelPicker:
                 current_provider="cc-switch-glm",
                 session_key="sk",
                 on_model_selected=AsyncMock(),
+                metadata={"curated_model_picker": True},
             )
 
         assert result.success is True

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -784,8 +784,8 @@ class TestFeishuModelPicker:
         card = json.loads(mock_send.call_args[1]["payload"])
         options = card["elements"][1]["actions"][0]["options"]
         labels = [o["text"]["content"] for o in options]
-        # Curated three only — no full GPT catalog.
-        assert labels == ["GPT-5.6 Terra", "DeepSeek V4 Pro 0813", "GLM 5.3"]
+        assert len(labels) == 5
+        assert "cc-switch gpt · gpt-5.6" in labels
 
     @pytest.mark.asyncio
     async def test_send_model_picker_sends_dropdown_and_records_state(self):

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -664,3 +664,240 @@ class TestResolveUpdatePrompt:
         assert 3 in adapter._update_prompt_state
 
 
+# ===========================================================================
+# send_model_picker — interactive model picker card + callback validation
+# ===========================================================================
+
+def _make_select_action_data(
+    option_value: str,
+    chat_id: str = "oc_12345",
+    open_id: str = "ou_user1",
+    token: str = "tok_mp",
+) -> SimpleNamespace:
+    """Mock a Feishu select_static card action callback (option.value form)."""
+    return SimpleNamespace(
+        event=SimpleNamespace(
+            token=token,
+            context=SimpleNamespace(open_chat_id=chat_id),
+            operator=SimpleNamespace(open_id=open_id),
+            action=SimpleNamespace(
+                tag="select_static",
+                value={},
+                option=SimpleNamespace(value=option_value),
+            ),
+        ),
+    )
+
+
+class TestFeishuModelPicker:
+    """Feishu model picker: card payload, state, callback validation."""
+
+    @pytest.mark.asyncio
+    async def test_send_model_picker_sends_dropdown_and_records_state(self):
+        adapter = _make_adapter()
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_mp_1"),
+        )
+        providers = [
+            {
+                "slug": "cc-switch-glm",
+                "name": "cc-switch glm",
+                "models": ["glm-5.3", "glm-5.2"],
+            },
+            {
+                "slug": "cc-switch-gpt-5-5",
+                "name": "cc-switch gpt",
+                "models": [{"model": "gpt-5.6-terra"}],
+            },
+        ]
+
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_send:
+            result = await adapter.send_model_picker(
+                chat_id="oc_12345",
+                providers=providers,
+                current_model="glm-5.3",
+                current_provider="cc-switch-glm",
+                session_key="sess-mp",
+                on_model_selected=AsyncMock(),
+            )
+
+        assert result.success is True
+        kwargs = mock_send.call_args[1]
+        assert kwargs["msg_type"] == "interactive"
+
+        card = json.loads(kwargs["payload"])
+        assert "glm-5.3" in card["elements"][0]["content"]
+        select = card["elements"][1]["actions"][0]
+        assert select["tag"] == "select_static"
+        options = select["options"]
+        assert len(options) == 3  # 2 glm + 1 gpt
+        # Option values must be opaque refs (prefix:picker_id:index), never raw model ids
+        assert options[0]["value"].startswith("hermes_model_picker:1:")
+
+        # State records server-side model entries for callback resolution
+        assert len(adapter._model_picker_state) == 1
+        state = adapter._model_picker_state[1]
+        assert state["chat_id"] == "oc_12345"
+        assert state["session_key"] == "sess-mp"
+        assert [e[1] for e in state["model_entries"]] == [
+            "glm-5.3", "glm-5.2", "gpt-5.6-terra",
+        ]
+        assert [e[2] for e in state["model_entries"]] == [
+            "cc-switch-glm", "cc-switch-glm", "cc-switch-gpt-5-5",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_send_model_picker_returns_error_when_no_models(self):
+        adapter = _make_adapter()
+        result = await adapter.send_model_picker(
+            chat_id="oc_12345",
+            providers=[{"slug": "x", "name": "X", "models": []}],
+            current_model="m",
+            current_provider="x",
+            session_key="s",
+            on_model_selected=AsyncMock(),
+        )
+        assert result.success is False
+
+    def test_callback_resolves_selection_and_returns_inline_card(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_user1"}
+        adapter._model_picker_state[3] = {
+            "chat_id": "oc_12345",
+            "session_key": "sess-mp",
+            "on_model_selected": AsyncMock(return_value="switched to glm-5.3"),
+            "model_entries": [
+                ("cc-switch glm · glm-5.3", "glm-5.3", "cc-switch-glm"),
+                ("cc-switch gpt · gpt-5.6-terra", "gpt-5.6-terra", "cc-switch-gpt-5-5"),
+            ],
+        }
+        data = _make_select_action_data("hermes_model_picker:3:0", open_id="ou_user1")
+
+        submitted = {}
+
+        def _capture_submit(coro, loop):
+            submitted["coro"] = coro
+            return SimpleNamespace(add_done_callback=lambda *_a, **_k: None)
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_capture_submit):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+        assert response.card.type == "raw"
+        assert "glm-5.3" in response.card.data["elements"][0]["content"]
+
+        # One-time: picker state consumed immediately
+        assert 3 not in adapter._model_picker_state
+        # Scheduled coroutine carries the server-resolved model + provider
+        assert submitted, "selection dispatch was not scheduled"
+
+    def test_callback_rejects_tampered_index(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_user1"}
+        adapter._model_picker_state[7] = {
+            "chat_id": "oc_12345",
+            "session_key": "sess-mp",
+            "on_model_selected": AsyncMock(),
+            "model_entries": [("lbl", "glm-5.3", "cc-switch-glm")],
+        }
+        data = _make_select_action_data("hermes_model_picker:7:99", open_id="ou_user1")
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        assert 7 in adapter._model_picker_state  # not consumed
+        mock_submit.assert_not_called()
+
+    def test_callback_rejects_unauthorized_user(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_admin"}
+        adapter._model_picker_state[9] = {
+            "chat_id": "oc_12345",
+            "session_key": "sess-mp",
+            "on_model_selected": AsyncMock(),
+            "model_entries": [("lbl", "glm-5.3", "cc-switch-glm")],
+        }
+        data = _make_select_action_data("hermes_model_picker:9:0", open_id="ou_stranger")
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        assert 9 in adapter._model_picker_state
+        mock_submit.assert_not_called()
+
+    def test_callback_rejects_chat_mismatch(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_user1"}
+        adapter._model_picker_state[11] = {
+            "chat_id": "oc_expected",
+            "session_key": "sess-mp",
+            "on_model_selected": AsyncMock(),
+            "model_entries": [("lbl", "glm-5.3", "cc-switch-glm")],
+        }
+        data = _make_select_action_data("hermes_model_picker:11:0", chat_id="oc_other", open_id="ou_user1")
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        assert 11 in adapter._model_picker_state
+        mock_submit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_invokes_callback_and_posts_confirmation(self):
+        adapter = _make_adapter()
+        on_selected = AsyncMock(return_value="✅ 已切换到 glm-5.3")
+
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+        ) as mock_send:
+            await adapter._dispatch_model_picker_selection(
+                on_model_selected=on_selected,
+                chat_id="oc_12345",
+                model_id="glm-5.3",
+                provider_slug="cc-switch-glm",
+            )
+
+        on_selected.assert_awaited_once_with("oc_12345", "glm-5.3", "cc-switch-glm")
+        mock_send.assert_awaited_once()
+        sent = json.loads(mock_send.call_args[1]["payload"])
+        assert "glm-5.3" in sent["text"]
+
+    @pytest.mark.asyncio
+    async def test_dispatch_failure_still_reports_error(self):
+        adapter = _make_adapter()
+        on_selected = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+        ) as mock_send:
+            await adapter._dispatch_model_picker_selection(
+                on_model_selected=on_selected,
+                chat_id="oc_12345",
+                model_id="glm-5.3",
+                provider_slug="cc-switch-glm",
+            )
+
+        mock_send.assert_awaited_once()
+        sent = json.loads(mock_send.call_args[1]["payload"])
+        assert "失败" in sent["text"]
+
+

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -743,6 +743,50 @@ class TestFeishuModelPicker:
     """Feishu model picker: card payload, state, callback validation."""
 
     @pytest.mark.asyncio
+    async def test_curated_model_picker_config_wins(self):
+        """platforms.feishu.extra.model_picker replaces the full catalog."""
+        from gateway.config import PlatformConfig
+
+        config = PlatformConfig(enabled=True)
+        config.extra = {
+            "model_picker": {
+                "enabled": True,
+                "models": [
+                    {"label": "GPT-5.6 Terra", "model": "gpt-5.6-terra", "provider": "cc-switch-gpt-5-5"},
+                    {"label": "DeepSeek V4 Pro 0813", "model": "deepseek-v4-pro-0813", "provider": "cc-switch-deepseek-pro"},
+                    {"label": "GLM 5.3", "model": "glm-5.3", "provider": "cc-switch-glm"},
+                ],
+            }
+        }
+        adapter = FeishuAdapter(config)
+        adapter._client = MagicMock()
+
+        providers = [{
+            "slug": "cc-switch-gpt-5-5",
+            "name": "cc-switch gpt",
+            "models": ["gpt-5.6", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.6-luna"],
+        }]
+        mock_response = SimpleNamespace(success=lambda: True, data=SimpleNamespace(message_id="om_mp1"))
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock, return_value=mock_response
+        ) as mock_send:
+            result = await adapter.send_model_picker(
+                chat_id="oc_1",
+                providers=providers,
+                current_model="glm-5.3",
+                current_provider="cc-switch-glm",
+                session_key="sk",
+                on_model_selected=AsyncMock(),
+            )
+
+        assert result.success is True
+        card = json.loads(mock_send.call_args[1]["payload"])
+        options = card["elements"][1]["actions"][0]["options"]
+        labels = [o["text"]["content"] for o in options]
+        # Curated three only — no full GPT catalog.
+        assert labels == ["GPT-5.6 Terra", "DeepSeek V4 Pro 0813", "GLM 5.3"]
+
+    @pytest.mark.asyncio
     async def test_send_model_picker_sends_dropdown_and_records_state(self):
         adapter = _make_adapter()
         mock_response = SimpleNamespace(

--- a/tests/gateway/test_feishu_choice_picker.py
+++ b/tests/gateway/test_feishu_choice_picker.py
@@ -1,0 +1,189 @@
+"""Tests for the Feishu choice-picker card (second-step selections).
+
+/l menu commands that need a second selection step (reasoning strength,
+fast mode) reuse the gateway's generic choice picker; these tests cover
+the Feishu adapter implementation of send_choice_picker + callback.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+def _ensure_feishu_mocks():
+    if importlib.util.find_spec("lark_oapi") is None and "lark_oapi" not in sys.modules:
+        mod = MagicMock()
+        for name in (
+            "lark_oapi", "lark_oapi.api.im.v1",
+            "lark_oapi.event", "lark_oapi.event.callback_type",
+        ):
+            sys.modules.setdefault(name, mod)
+    if importlib.util.find_spec("aiohttp") is None and "aiohttp" not in sys.modules:
+        aio = MagicMock()
+        sys.modules.setdefault("aiohttp", aio)
+        sys.modules.setdefault("aiohttp.web", aio.web)
+
+
+_ensure_feishu_mocks()
+
+from gateway.config import PlatformConfig
+from plugins.platforms.feishu.adapter import FeishuAdapter
+
+
+def _make_adapter() -> FeishuAdapter:
+    config = PlatformConfig(enabled=True)
+    adapter = FeishuAdapter(config)
+    adapter._client = MagicMock()
+    return adapter
+
+
+REASONING_CHOICES = [
+    {"value": "none", "label": "关闭", "is_current": False},
+    {"value": "low", "label": "Low", "is_current": False},
+    {"value": "medium", "label": "Medium", "is_current": True},
+    {"value": "high", "label": "High", "is_current": False},
+]
+
+
+class TestFeishuChoicePickerCard:
+    @pytest.mark.asyncio
+    async def test_send_choice_picker_renders_buttons_and_stores_state(self):
+        adapter = _make_adapter()
+        on_choice = AsyncMock(return_value="Reasoning set to high")
+        mock_response = SimpleNamespace(success=lambda: True, data=SimpleNamespace(message_id="om_cp1"))
+
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock, return_value=mock_response
+        ) as mock_send:
+            result = await adapter.send_choice_picker(
+                chat_id="oc_123",
+                title="推理强度：当前 Medium",
+                choices=REASONING_CHOICES,
+                session_key="sk-1",
+                on_choice_selected=on_choice,
+            )
+
+        assert result.success is True
+        kwargs = mock_send.call_args[1]
+        card = json.loads(kwargs["payload"])
+        buttons = [
+            b
+            for el in card["elements"] if el.get("tag") == "action"
+            for b in el["actions"]
+        ]
+        labels = [b["text"]["content"] for b in buttons]
+        assert labels == ["关闭", "Low", "Medium", "High"]
+        # Current choice highlighted as primary.
+        medium = next(b for b in buttons if b["text"]["content"] == "Medium")
+        assert medium["type"] == "primary"
+        # Values are opaque refs — never raw values.
+        assert all(b["value"]["hermes_choice_picker"].startswith("1:") for b in buttons)
+
+        # State stored server-side for callback resolution.
+        assert len(adapter._choice_picker_state) == 1
+        assert adapter._choice_picker_state[1]["choices"] == REASONING_CHOICES
+
+    @pytest.mark.asyncio
+    async def test_callback_invokes_choice_handler_and_resolves_card(self):
+        adapter = _make_adapter()
+        on_choice = AsyncMock(return_value="Reasoning effort set to high for this session.")
+        adapter._choice_picker_state[1] = {
+            "chat_id": "oc_123",
+            "session_key": "sk-1",
+            "choices": REASONING_CHOICES,
+            "on_choice_selected": on_choice,
+        }
+
+        event = SimpleNamespace(
+            operator=SimpleNamespace(open_id="ou_u1", user_id=""),
+            context=SimpleNamespace(open_chat_id="oc_123"),
+        )
+        submitted = []
+
+        def fake_submit(loop, coro):
+            submitted.append(coro)
+            return True
+
+        with (
+            patch.object(adapter, "_loop_accepts_callbacks", return_value=True),
+            patch.object(adapter, "_allow_group_message", return_value=True),
+            patch.object(adapter, "_submit_on_loop", side_effect=fake_submit),
+            patch.object(
+                adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+                return_value=SimpleNamespace(success=lambda: True, data=SimpleNamespace(message_id="om_ok")),
+            ) as mock_send,
+        ):
+            resp = adapter._handle_choice_picker_card_action(
+                event=event,
+                action_value={"hermes_choice_picker": "1:3"},  # High
+                loop=object(),
+            )
+            # Execute the scheduled callback while the send mock is active.
+            assert len(submitted) == 1
+            await submitted[0]
+
+        # Resolved card returned synchronously.
+        assert resp is not None
+        assert "High" in resp.card.data["header"]["title"]["content"]
+        on_choice.assert_awaited_once_with("oc_123", "high")
+        # Result text sent as a fresh message (no reply anchor).
+        mock_send.assert_awaited_once()
+        send_kwargs = mock_send.call_args[1]
+        assert send_kwargs["reply_to"] is None
+        # Picker consumed — one-time use.
+        assert 1 not in adapter._choice_picker_state
+
+    @pytest.mark.asyncio
+    async def test_callback_rejects_tampered_ref(self):
+        adapter = _make_adapter()
+        adapter._choice_picker_state[1] = {
+            "chat_id": "oc_123",
+            "session_key": "sk-1",
+            "choices": REASONING_CHOICES,
+            "on_choice_selected": AsyncMock(),
+        }
+        event = SimpleNamespace(
+            operator=SimpleNamespace(open_id="ou_u1", user_id=""),
+            context=SimpleNamespace(open_chat_id="oc_123"),
+        )
+        for bad in ("1:99", "1:x", "bogus", "2:0"):
+            with patch.object(adapter, "_submit_on_loop") as submit:
+                adapter._handle_choice_picker_card_action(
+                    event=event,
+                    action_value={"hermes_choice_picker": bad},
+                    loop=object(),
+                )
+                submit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_callback_rejects_unauthorized_user(self):
+        adapter = _make_adapter()
+        adapter._choice_picker_state[1] = {
+            "chat_id": "oc_123",
+            "session_key": "sk-1",
+            "choices": REASONING_CHOICES,
+            "on_choice_selected": AsyncMock(),
+        }
+        event = SimpleNamespace(
+            operator=SimpleNamespace(open_id="ou_stranger", user_id=""),
+            context=SimpleNamespace(open_chat_id="oc_123"),
+        )
+        with (
+            patch.object(adapter, "_allow_group_message", return_value=False),
+            patch.object(adapter, "_submit_on_loop") as submit,
+        ):
+            adapter._handle_choice_picker_card_action(
+                event=event,
+                action_value={"hermes_choice_picker": "1:0"},
+                loop=object(),
+            )
+            submit.assert_not_called()

--- a/tests/gateway/test_feishu_list_command.py
+++ b/tests/gateway/test_feishu_list_command.py
@@ -1,0 +1,206 @@
+"""Tests for the Feishu /list quick-command menu card.
+
+/list must send an interactive card with allowlisted buttons, and button
+clicks must dispatch the corresponding slash command through the normal
+gateway pipeline — with NO Feishu reply anchor (99992354 regression).
+"""
+
+import importlib.util
+import json
+import sys
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+def _ensure_feishu_mocks():
+    if importlib.util.find_spec("lark_oapi") is None and "lark_oapi" not in sys.modules:
+        mod = MagicMock()
+        for name in (
+            "lark_oapi", "lark_oapi.api.im.v1",
+            "lark_oapi.event", "lark_oapi.event.callback_type",
+        ):
+            sys.modules.setdefault(name, mod)
+    if importlib.util.find_spec("aiohttp") is None and "aiohttp" not in sys.modules:
+        aio = MagicMock()
+        sys.modules.setdefault("aiohttp", aio)
+        sys.modules.setdefault("aiohttp.web", aio.web)
+
+
+_ensure_feishu_mocks()
+
+from gateway.config import PlatformConfig, Platform
+from gateway.platforms.base import MessageEvent, MessageType, SessionSource, _reply_anchor_for_event
+from plugins.platforms.feishu.adapter import FeishuAdapter
+
+
+def _make_adapter() -> FeishuAdapter:
+    config = PlatformConfig(enabled=True)
+    adapter = FeishuAdapter(config)
+    adapter._client = MagicMock()
+    return adapter
+
+
+def _make_card_data(action_value: dict, chat_id: str = "oc_123", open_id: str = "ou_u1") -> SimpleNamespace:
+    return SimpleNamespace(
+        event=SimpleNamespace(
+            token="tok_l",
+            context=SimpleNamespace(open_chat_id=chat_id),
+            operator=SimpleNamespace(open_id=open_id),
+            action=SimpleNamespace(tag="button", value=action_value),
+        ),
+    )
+
+
+class TestFeishuLCommandCard:
+    @pytest.mark.asyncio
+    async def test_send_command_list_sends_interactive_card(self):
+        adapter = _make_adapter()
+        mock_response = SimpleNamespace(success=lambda: True, data=SimpleNamespace(message_id="om_l1"))
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock, return_value=mock_response
+        ) as mock_send:
+            result = await adapter.send_command_list(chat_id="oc_123", session_key="sk-1")
+
+        assert result.success is True
+        mock_send.assert_called_once()
+        kwargs = mock_send.call_args[1]
+        assert kwargs["chat_id"] == "oc_123"
+        assert kwargs["msg_type"] == "interactive"
+        assert kwargs["reply_to"] is None
+
+        card = json.loads(kwargs["payload"])
+        buttons = [
+            btn
+            for element in card["elements"]
+            if element.get("tag") == "action"
+            for btn in element["actions"]
+        ]
+        actions = [b["value"]["hermes_list_action"] for b in buttons]
+        # Required allowlist entries.
+        for required in ("model", "status", "sessions", "reasoning", "fast", "title", "compact", "commands"):
+            assert required in actions, f"missing action {required}"
+        # No sensitive commands on the card.
+        for forbidden in ("restart", "update", "yolo", "stop"):
+            assert forbidden not in actions
+
+    @pytest.mark.asyncio
+    async def test_list_card_click_dispatches_allowlisted_command(self):
+        adapter = _make_adapter()
+        data = _make_card_data({"hermes_list_action": "status"})
+
+        with (
+            patch.object(adapter, "_allow_group_message", return_value=True),
+            patch.object(
+                adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+                return_value={"user_id": "ou_u1", "user_name": "U", "user_id_alt": None},
+            ),
+            patch.object(adapter, "get_chat_info", new_callable=AsyncMock, return_value={"name": "C"}),
+            patch.object(adapter, "_handle_message_with_guards", new_callable=AsyncMock) as guards,
+        ):
+            await adapter._handle_list_card_action(data)
+
+        guards.assert_awaited_once()
+        dispatched = guards.call_args[0][0]
+        assert dispatched.text == "/status"
+        assert dispatched.message_type == MessageType.COMMAND
+        # Synthetic card event must NOT carry a Feishu reply anchor.
+        assert _reply_anchor_for_event(dispatched) is None
+        # And its message_id must not be the callback token.
+        assert dispatched.message_id != "tok_l"
+
+    @pytest.mark.asyncio
+    async def test_list_card_click_rejects_non_allowlisted_action(self):
+        adapter = _make_adapter()
+        data = _make_card_data({"hermes_list_action": "restart"})
+
+        with patch.object(adapter, "_handle_message_with_guards", new_callable=AsyncMock) as guards:
+            await adapter._handle_list_card_action(data)
+
+        guards.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_list_card_click_rejects_unauthorized_user(self):
+        adapter = _make_adapter()
+        data = _make_card_data({"hermes_list_action": "status"})
+
+        with (
+            patch.object(adapter, "_allow_group_message", return_value=False),
+            patch.object(adapter, "_handle_message_with_guards", new_callable=AsyncMock) as guards,
+        ):
+            await adapter._handle_list_card_action(data)
+
+        guards.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_on_card_action_trigger_routes_list_action(self):
+        adapter = _make_adapter()
+        data = _make_card_data({"hermes_list_action": "title"})
+
+        submitted = []
+
+        def fake_submit(loop, coro):
+            submitted.append(coro)
+            coro.close()
+            return True
+
+        with patch.object(adapter, "_loop_accepts_callbacks", return_value=True), \
+             patch.object(adapter, "_submit_on_loop", side_effect=fake_submit):
+            adapter._on_card_action_trigger(data)
+
+        assert len(submitted) == 1
+
+
+class TestReplyAnchorSuppression:
+    def test_feishu_card_callback_yields_no_reply_anchor(self):
+        event = MessageEvent(
+            text="/status",
+            message_type=MessageType.COMMAND,
+            source=SessionSource(
+                platform=Platform.FEISHU,
+                chat_id="oc_123",
+                chat_name="C",
+                chat_type="group",
+                user_id="ou_u1",
+                user_name="U",
+            ),
+            message_id=str(uuid.uuid4()),
+            raw_message=SimpleNamespace(action=SimpleNamespace(value={"hermes_list_action": "status"})),
+        )
+        assert _reply_anchor_for_event(event) is None
+
+    def test_normal_feishu_message_keeps_reply_anchor(self):
+        event = MessageEvent(
+            text="hi",
+            message_type=MessageType.TEXT,
+            source=SessionSource(
+                platform=Platform.FEISHU,
+                chat_id="oc_123",
+                chat_name="C",
+                chat_type="group",
+                user_id="ou_u1",
+                user_name="U",
+            ),
+            message_id="om_real_message_id",
+            raw_message=None,
+        )
+        assert _reply_anchor_for_event(event) == "om_real_message_id"
+
+
+class TestLCommandRegistry:
+    def test_l_is_gateway_known_command_and_list_alias(self):
+        from hermes_cli.commands import resolve_command, is_gateway_known_command
+
+        cmd = resolve_command("l")
+        assert cmd is not None and cmd.name == "l"
+        assert "list" in cmd.aliases
+        assert is_gateway_known_command("l")
+        # The alias resolves to the same canonical command.
+        assert resolve_command("list").name == "l"


### PR DESCRIPTION
# Feishu: interactive card surfaces for /model, /l, and second-step pickers

## Summary

This PR brings interactive card support to the Feishu platform adapter, bringing it to parity with Telegram/Discord/Slack:

- `/model` sends a `select_static` model picker card (full provider catalog), instead of falling back to a text listing
- `/l` (alias `/list`) sends a quick-command menu card with allowlisted button dispatch; non-Feishu surfaces fall back to `/commands`
- Second-step choice-picker cards for reasoning/fast selections
- Robust `select_static` callback parsing: the selected option value is extracted recursively across SDK/callback payload shapes (`action.option.value`, `action.value.key`, raw string)

## Why the framework gate needs the adapter method

Upstream `GatewaySlashCommandsMixin._model_listing_reply` already dispatches to `adapter.send_model_picker(...)` when available and falls back to text otherwise — but the Feishu adapter never implemented `send_model_picker`, so Feishu users always got the text fallback. This PR implements the send side (plus `/l` and choice pickers) in the adapter.

Notes on integration with recent upstream refactors:

- `/l` is registered in the table-driven dispatcher (`run_busy._PLAIN_COMMANDS`) and implemented on `GatewaySlashCommandsMixin`, since the old if-chain dispatch no longer exists
- Card-callback dispatch reuses upstream's `_validate_card_action` helper where applicable
- Slack routing keeps `/insights` under the 50-slash cap by demoting `l` via `/hermes l`

## Safety / auth

- Card actions are operator-authorized (admins + allowed users), chat-mismatch-checked, and one-shot (state popped before dispatch; restored on submit failure)
- Button action names are server-side allowlisted (model/status/sessions/reasoning/fast/title/compact/commands)

## Testing

```
tests/gateway/test_feishu_approval_buttons.py   (model picker + approval buttons)
tests/gateway/test_feishu_list_command.py       (/l menu + registry)
tests/gateway/test_feishu_choice_picker.py      (choice picker)
→ 50 passed
```

Also verified on top of current `main` (d20a8e4475):

- `git diff origin/main...HEAD --check` clean
- `py_compile` clean on all touched files
- Full `tests/gateway -k feishu` suite: 255 passed (2 pre-existing environment-dependent failures in `test_feishu.py` unrelated to this change, reproduced on vanilla `main`)

## Commits

7 conventional commits, oldest first: `fde1016807` (model picker card) → `2b6537498e` (restore full picker behavior). Each keeps its original authorship date; squashing is fine if preferred.
