### PR TITLE
feat(weixin): add use_provider_stt to trust WeChat's built-in voice transcription

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -521,7 +521,10 @@ def _coerce_bool(value: Any, default: bool = True) -> bool:
     return True if text in {"1", "true", "yes", "on"} else False if text in {"0", "false", "no", "off"} else default
 
 
-def _extract_text(item_list: List[Dict[str, Any]]) -> str:
+def _extract_text(
+    item_list: List[Dict[str, Any]],
+    use_provider_stt: bool = False,
+) -> str:
     for item in item_list:
         if item.get("type") == ITEM_TEXT:
             text = str((item.get("text_item") or {}).get("text") or "")
@@ -531,7 +534,7 @@ def _extract_text(item_list: List[Dict[str, Any]]) -> str:
                 title = ref.get("title") or ""
                 return f"[引用媒体: {title}]\n{text}".strip() if title else f"[引用媒体]\n{text}".strip()
             if ref_item:
-                parts = [p for p in (str(ref["title"]) if ref.get("title") else "", _extract_text([ref_item])) if p]
+                parts = [p for p in (str(ref["title"]) if ref.get("title") else "", _extract_text([ref_item], use_provider_stt)) if p]
                 if parts:
                     return f"[引用: {' | '.join(parts)}]\n{text}".strip()
             return text
@@ -548,7 +551,10 @@ def _extract_text(item_list: List[Dict[str, Any]]) -> str:
             # Use it, but preserve the voice origin so the agent can distinguish this from text the user
             # typed (#65022).
             voice_text = str(voice_item.get("text") or "")
-            if not (voice_item.get("media") or {}) and voice_text:
+            has_media = bool(voice_item.get("media") or {})
+            # When ``use_provider_stt`` is enabled the user explicitly trusts Weixin's
+            # transcription (accurate for most Chinese speakers), so use it directly.
+            if voice_text and (use_provider_stt or not has_media):
                 return f"[Voice transcription provided by Weixin]\n{voice_text}"
     return ""
 
@@ -726,6 +732,12 @@ class WeixinAdapter(BasePlatformAdapter):
         self._allow_from = self._coerce_list(_wx_secret("WEIXIN_ALLOWED_USERS", "") if allow_from is None else allow_from)
         self._group_allow_from = self._coerce_list(_wx_secret("WEIXIN_GROUP_ALLOWED_USERS", "") if group_allow_from is None else group_allow_from)
         self._split_multiline_messages = _coerce_bool(extra.get("split_multiline_messages") or os.getenv("WEIXIN_SPLIT_MULTILINE_MESSAGES"), default=False)
+        # When True, trust Weixin's built-in STT text for voice messages instead of
+        # downloading the raw audio and re-transcribing via the central STT pipeline.
+        # Weixin's STT is very accurate for Chinese audio (the dominant use case) but
+        # produces garbled output for other languages (#27300), so the default is False.
+        # Config: gateway.platforms.weixin.extra.use_provider_stt
+        self._use_provider_stt = _coerce_bool(extra.get("use_provider_stt"), default=False)
         # Text debounce batching (Telegram pattern): iLink delivers messages individually, so rapid bursts would each
         # trigger a separate agent run. 3s / 5s (after a ~2048-char split chunk) suit iLink's cadence.
         self._text_batch_delay_seconds = self._coerce_float_extra("text_batch_delay_seconds", 3.0)
@@ -888,7 +900,7 @@ class WeixinAdapter(BasePlatformAdapter):
             return
         # Secondary content-fingerprint dedup: upstream re-sends identical text under new message_ids.
         item_list = message.get("item_list") or []
-        text = _extract_text(item_list)
+        text = _extract_text(item_list, self._use_provider_stt)
         if text and self._dedup.is_duplicate(f"content:{sender_id}:{hashlib.md5(text.encode()).hexdigest()}"):
             logger.debug("[%s] Content-dedup: skipping duplicate message from %s", self.name, sender_id)
             return
@@ -971,6 +983,11 @@ class WeixinAdapter(BasePlatformAdapter):
         (never trust Tencent's ``voice_item.text``) so gateway/run.py's central STT re-transcribes."""
         item_key, timeout_seconds, cache_fn, mime, label = spec
         payload = item.get(item_key) or {}
+        # When ``use_provider_stt`` is enabled the user has explicitly opted in to
+        # trusting Weixin's transcription, so skip the voice download and let
+        # ``_extract_text`` surface the provider text as the message body.
+        if item_key == "voice_item" and self._use_provider_stt and str(payload.get("text") or "").strip():
+            return None, mime
         media = payload.get("media") or {}
         filename = str(payload.get("file_name") or "document.bin")
         mime = mime or mimetypes.guess_type(filename)[0] or "application/octet-stream"

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -880,3 +880,157 @@ class TestWeixinVoiceGatewayHandoff:
             "the wrong transcript instead of re-transcribing (#27300)."
         )
 
+
+class TestWeixinUseProviderSTT:
+    """Tests for the ``use_provider_stt`` config flag.
+
+    When enabled, the adapter trusts Weixin's built-in STT text for voice
+    messages instead of downloading the raw audio and re-transcribing via
+    the central STT pipeline.  This is useful for Chinese speakers where
+    Weixin's STT is already very accurate, avoiding an unnecessary
+    transcription round-trip.
+    """
+
+    def _make_voice_item(self, text: str = "") -> dict:
+        return {
+            "type": weixin.ITEM_VOICE,
+            "voice_item": {
+                "text": text,
+                "media": {
+                    "encrypt_query_param": "q",
+                    "aes_key": "a" * 32,
+                    "full_url": "https://example.invalid/voice.silk",
+                },
+            },
+        }
+
+    def _make_adapter(self, use_provider_stt: bool) -> WeixinAdapter:
+        return WeixinAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="test-token",
+                extra={"account_id": "test-account", "use_provider_stt": use_provider_stt},
+            )
+        )
+
+    def test_extract_text_returns_provider_text_when_enabled(self):
+        """When use_provider_stt=True, _extract_text returns Weixin's STT
+        text even when raw audio media is present."""
+        item_list = [self._make_voice_item(text="今天天气怎么样")]
+        result = weixin._extract_text(item_list, use_provider_stt=True)
+        assert result == (
+            "[Voice transcription provided by Weixin]\n"
+            "今天天气怎么样"
+        )
+
+    def test_extract_text_drops_provider_text_when_disabled(self):
+        """When use_provider_stt=False (default), _extract_text returns
+        empty for a voice item that has both text and media, forcing the
+        central STT pipeline to re-transcribe."""
+        item_list = [self._make_voice_item(text="今天天气怎么样")]
+        result = weixin._extract_text(item_list, use_provider_stt=False)
+        assert result == ""
+
+    def test_extract_text_returns_provider_text_when_no_media(self):
+        """Even with use_provider_stt=False, if no media is present the
+        provider text is the only content available — it must be returned
+        (existing #65022 behavior)."""
+        item = {
+            "type": weixin.ITEM_VOICE,
+            "voice_item": {"text": "只有文字没有音频"},
+        }
+        result = weixin._extract_text([item], use_provider_stt=False)
+        assert result == (
+            "[Voice transcription provided by Weixin]\n"
+            "只有文字没有音频"
+        )
+
+    @pytest.mark.asyncio
+    async def test_download_voice_skips_when_provider_stt_enabled(self, tmp_path, monkeypatch):
+        """When use_provider_stt=True and voice_item.text is present,
+        _download_media returns None (no download needed)."""
+        adapter = self._make_adapter(use_provider_stt=True)
+        adapter._cdn_base_url = "https://example.invalid"
+        adapter._poll_session = Mock()
+
+        download_called = False
+
+        async def _fake_download(session, *, cdn_base_url, encrypted_query_param,
+                                 aes_key_b64, full_url, timeout_seconds):
+            nonlocal download_called
+            download_called = True
+            return b"\x00FAKE"
+
+        monkeypatch.setattr(weixin, "_download_and_decrypt_media", _fake_download)
+
+        item = self._make_voice_item(text="你好")
+        result, _mime = await adapter._download_media(item, weixin._INBOUND_MEDIA[weixin.ITEM_VOICE])
+
+        assert result is None
+        assert not download_called, (
+            "_download_media should skip the download when use_provider_stt "
+            "is enabled and provider text is present."
+        )
+
+    @pytest.mark.asyncio
+    async def test_download_voice_downloads_when_provider_stt_disabled(self, tmp_path, monkeypatch):
+        """When use_provider_stt=False (default), _download_media still
+        downloads the audio even when voice_item.text is set."""
+        adapter = self._make_adapter(use_provider_stt=False)
+        adapter._cdn_base_url = "https://example.invalid"
+        adapter._poll_session = Mock()
+
+        monkeypatch.setattr(weixin, "cache_audio_from_bytes_async",
+                            AsyncMock(side_effect=lambda data, ext: str(tmp_path / f"voice.{ext.lstrip('.')}")))
+
+        async def _fake_download(session, *, cdn_base_url, encrypted_query_param,
+                                 aes_key_b64, full_url, timeout_seconds):
+            return b"\x00FAKE"
+
+        monkeypatch.setattr(weixin, "_download_and_decrypt_media", _fake_download)
+
+        item = self._make_voice_item(text="你好")
+        result, _mime = await adapter._download_media(item, weixin._INBOUND_MEDIA[weixin.ITEM_VOICE])
+
+        assert result is not None, (
+            "_download_media must still download the audio when "
+            "use_provider_stt is disabled (default behavior, #27300)."
+        )
+        assert result.endswith(".silk")
+
+    @pytest.mark.asyncio
+    async def test_download_voice_still_downloads_when_no_provider_text(self, tmp_path, monkeypatch):
+        """When use_provider_stt=True but voice_item.text is empty,
+        _download_media must still download the audio."""
+        adapter = self._make_adapter(use_provider_stt=True)
+        adapter._cdn_base_url = "https://example.invalid"
+        adapter._poll_session = Mock()
+
+        monkeypatch.setattr(weixin, "cache_audio_from_bytes_async",
+                            AsyncMock(side_effect=lambda data, ext: str(tmp_path / f"voice.{ext.lstrip('.')}")))
+
+        async def _fake_download(session, *, cdn_base_url, encrypted_query_param,
+                                 aes_key_b64, full_url, timeout_seconds):
+            return b"\x00FAKE"
+
+        monkeypatch.setattr(weixin, "_download_and_decrypt_media", _fake_download)
+
+        item = self._make_voice_item(text="")
+        result, _mime = await adapter._download_media(item, weixin._INBOUND_MEDIA[weixin.ITEM_VOICE])
+
+        assert result is not None, (
+            "_download_media must download the audio even when "
+            "use_provider_stt is enabled if the provider text is empty."
+        )
+
+    def test_config_default_is_false(self):
+        """The default for use_provider_stt must be False (preserve #27300
+        behavior for non-Chinese audio)."""
+        adapter = _make_adapter()
+        assert adapter._use_provider_stt is False
+
+    def test_config_reads_true_from_extra(self):
+        """use_provider_stt=True in config.extra must be picked up."""
+        adapter = self._make_adapter(use_provider_stt=True)
+        assert adapter._use_provider_stt is True
+

--- a/website/docs/user-guide/messaging/weixin.md
+++ b/website/docs/user-guide/messaging/weixin.md
@@ -125,6 +125,7 @@ Set these in `config.yaml` under `platforms.weixin.extra`:
 | `split_multiline_messages` | `false` | When `true`, split multi-line replies into multiple chat messages (legacy behavior). When `false`, keep multi-line replies as one message unless they exceed the length limit. |
 | `text_batch_delay_seconds` | `3.0` | Quiet period (seconds) before a buffered burst of rapid text messages is flushed as one combined request. iLink delivers messages individually, so this debounce avoids one agent invocation per fragment. Set `0` to dispatch each message immediately. |
 | `text_batch_split_delay_seconds` | `5.0` | Extended flush delay used when the latest fragment is near the split threshold (long messages iLink may have chunked). |
+| `use_provider_stt` | `false` | When `true`, trust WeChat's built-in speech-to-text for voice messages instead of downloading the raw audio and re-transcribing it via Hermes' own STT pipeline. WeChat's STT is very accurate for Chinese audio but produces garbled output for other languages, so the default is `false`. Enable this if you mainly receive Chinese voice messages and want to skip the extra transcription step. |
 
 ## Access Policies
 
@@ -195,7 +196,7 @@ The adapter receives media attachments from users, downloads them from the WeCha
 | **Images** | Downloaded, AES-decrypted, and cached as JPEG. |
 | **Video** | Downloaded, AES-decrypted, and cached as MP4. |
 | **Files** | Downloaded, AES-decrypted, and cached. Original filename is preserved. |
-| **Voice** | If a text transcription is available, it's extracted as text. Otherwise the audio (SILK format) is downloaded and cached. |
+| **Voice** | The raw audio (SILK format) is downloaded and re-transcribed by Hermes' own STT pipeline. WeChat's built-in transcription is ignored by default because it is unreliable for non-Chinese audio. Set `use_provider_stt: true` to trust WeChat's transcription directly and skip the download + re-transcription step (recommended for predominantly-Chinese conversations). |
 
 **Quoted messages:** Media from quoted (replied-to) messages is also extracted, so the agent has context about what the user is replying to.
 
@@ -327,7 +328,7 @@ Only one Weixin gateway instance can use a given token at a time. The adapter ac
 | Bot ignores group messages | Group policy defaults to `disabled`. Set `WEIXIN_GROUP_POLICY=open` or `allowlist` — but note that QR-login iLink bot identities (`...@im.bot`) typically cannot receive ordinary WeChat group messages at all. If the gateway logs show no raw inbound events for group messages, the limitation is on the iLink side, not in Hermes. |
 | Media download/upload fails | Ensure `cryptography` is installed. Check network access to `novac2c.cdn.weixin.qq.com` |
 | `Blocked unsafe URL (SSRF protection)` | The outbound media URL points to a private/internal address. Only public URLs are allowed |
-| Voice messages show as text | If WeChat provides a transcription, the adapter uses the text. This is expected behavior |
+| Voice messages show as text | By default the adapter downloads the raw audio and re-transcribes it via Hermes' STT pipeline, ignoring WeChat's built-in transcription (which is unreliable for non-Chinese audio). If you only receive Chinese voice messages and want to use WeChat's transcription directly, set `use_provider_stt: true` under `platforms.weixin.extra`. |
 | Messages appear duplicated | The adapter deduplicates by message ID. If you see duplicates, check if multiple gateway instances are running |
 | `iLink POST ... HTTP 4xx/5xx` | API error from the iLink service. Check your token validity and network connectivity |
 | Terminal QR code doesn't render | Reinstall with the messaging extra: `cd ~/.hermes/hermes-agent && uv pip install -e ".[messaging]"`. Alternatively, open the URL printed above the QR |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/weixin.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/weixin.md
@@ -123,6 +123,7 @@ hermes gateway
 | `allow_from` | `[]` | 允许发送私信的用户 ID（当 dm_policy=allowlist 时生效） |
 | `group_allow_from` | `[]` | 允许的群组 ID（当 group_policy=allowlist 时生效） |
 | `split_multiline_messages` | `false` | 为 `true` 时，将多行回复拆分为多条消息（旧版行为）；为 `false` 时，多行回复保持为单条消息，除非超出长度限制。 |
+| `use_provider_stt` | `false` | 为 `true` 时，直接信任微信内置的语音识别结果，而不再下载原始音频并用 Hermes 自己的 STT 流水线重新转写。微信的语音识别对中文非常准确，但对其他语言会产生乱码，因此默认值为 `false`。如果你主要接收中文语音消息，想跳过额外的转写步骤，可开启此项。 |
 
 ## 访问策略
 
@@ -174,7 +175,7 @@ WEIXIN_GROUP_ALLOWED_USERS=group_id_1,group_id_2
 | **图片** | 下载、AES 解密后缓存为 JPEG。 |
 | **视频** | 下载、AES 解密后缓存为 MP4。 |
 | **文件** | 下载、AES 解密后缓存，保留原始文件名。 |
-| **语音** | 若有文字转录，则提取为文本；否则下载音频（SILK 格式）并缓存。 |
+| **语音** | 下载原始音频（SILK 格式）并由 Hermes 自己的 STT 流水线重新转写。默认情况下会忽略微信内置的转录文本，因为它对非中文音频不可靠。设置 `use_provider_stt: true` 可直接信任微信的转录文本并跳过下载 + 重新转写步骤（推荐用于以中文为主的对话）。 |
 
 **引用消息：** 引用（回复）消息中的媒体也会被提取，以便代理了解用户回复的上下文。
 
@@ -306,7 +307,7 @@ iLink Bot API 要求在每条出站消息中回传 `context_token`（针对特�
 | Bot 忽略群消息 | 群组策略默认为 `disabled`。设置 `WEIXIN_GROUP_POLICY=open` 或 `allowlist`——但请注意，扫码登录的 iLink bot 身份（`...@im.bot`）通常根本无法接收普通微信群消息。若网关日志中没有群消息的原始入站事件，限制来自 iLink 侧，而非 Hermes。 |
 | 媒体下载/上传失败 | 确保已安装 `cryptography`。检查对 `novac2c.cdn.weixin.qq.com` 的网络访问 |
 | `Blocked unsafe URL (SSRF protection)` | 出站媒体 URL 指向私有/内部地址，仅允许公网 URL |
-| 语音消息显示为文本 | 若微信提供了转录文本，适配器会使用文本内容，这是预期行为 |
+| 语音消息显示为文本 | 默认情况下，适配器会下载原始音频并通过 Hermes 的 STT 流水线重新转写，忽略微信内置的转录文本（它对非中文音频不可靠）。如果你只接收中文语音消息，想直接使用微信的转录文本，请在 `platforms.weixin.extra` 下设置 `use_provider_stt: true`。 |
 | 消息出现重复 | 适配器通过消息 ID 去重。若仍出现重复，检查是否有多个网关实例在运行 |
 | `iLink POST ... HTTP 4xx/5xx` | iLink 服务返回 API 错误。检查 token 有效性和网络连通性 |
 | 终端二维码无法渲染 | 使用 messaging 扩展重新安装：`cd ~/.hermes/hermes-agent && uv pip install -e ".[messaging]"`。或者，打开二维码上方打印的 URL |


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Weixin's STT is highly accurate for Chinese audio but produces garbled output for other languages (#27300), so the adapter always downloaded the raw audio and re-transcribed it via the central STT pipeline, discarding the provider text.

Add a gateway.platforms.weixin.extra.use_provider_stt config flag (default false) that lets users opt in to trusting WeChat's transcription directly. When enabled, _extract_text surfaces the provider text as the message body and _download_voice skips the CDN download, avoiding the unnecessary transcription round-trip for predominantly-Chinese conversations.

Default behavior is unchanged to preserve the non-Chinese-audio protection from #27300.