### PR TITLE
feat(doctor): add --security-rules audit mapping natural-language rules to deterministic controls (#95686)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -167,6 +167,10 @@ def run_doctor(args):
     os.environ.setdefault("HERMES_INTERACTIVE", "1")
     if getattr(args, 'ack', None):
         return _ack_advisory(args.ack)
+    if getattr(args, 'security_rules', False):
+        from hermes_cli.security_rules_audit import run_security_rules_audit_cli
+        run_security_rules_audit_cli()
+        return
     print()
     for line in ("┌─────────────────────────────────────────────────────────┐",
                  "│                 🩺 Hermes Doctor                        │",

--- a/hermes_cli/security_rules_audit.py
+++ b/hermes_cli/security_rules_audit.py
@@ -1,0 +1,348 @@
+"""Security-rule coverage audit — map natural-language rules to deterministic controls.
+
+Based on arXiv:2608.23550 ("When 'Do Not' Is Not Deny: Security Rules in CLAUDE.md vs
+Built-In Controls").
+
+Scans memory entries, context files (AGENTS.md, CLAUDE.md, .cursorrules, SOUL.md),
+and installed skills for imperative security rules ("never", "do not", "must not"),
+and audits them against the deterministic enforcement layer:
+1. HARDLINE unconditional blocks (tools.approval_detection.HARDLINE_PATTERNS)
+2. Dangerous patterns / approval gates (tools.approval_detection.DANGEROUS_PATTERNS)
+3. User-defined approvals.deny globs (tools.approval_floors._match_user_deny_rule)
+4. Built-in sensitive write targets (_SENSITIVE_WRITE_TARGET)
+
+Classifies rules into three actionable buckets:
+- ENFORCED: active deterministic control exists (hardline, deny glob, or sensitive target).
+- ENFORCEABLE: concrete deterministic command/path pattern can be added to approvals.deny.
+- ADVISORY-ONLY: model-directed behavioral guidelines without a deterministic analogue.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import fnmatch
+import json
+import logging
+from pathlib import Path
+import re
+from typing import List, Optional, Sequence, Tuple
+
+from hermes_cli.colors import Colors, color
+from hermes_cli.config import get_hermes_home, get_project_root
+
+logger = logging.getLogger(__name__)
+
+# Imperative trigger pattern for negative security rules
+_NEGATIVE_RULE_RE = re.compile(
+    r"(?i)\b(?P<trigger>never|do\s+not|don't|must\s+not|shall\s+not|cannot|can't|should\s+not|shouldn't|strictly\s+forbidden|strictly\s+prohibited|prohibited\s+to|disallowed\s+to|forbidden\s+to)\b\s+(?P<action>[^\n.;`]+)",
+)
+
+_TRIGGER_STRIP_RE = re.compile(
+    r"(?i)^(?:never|do\s+not|don't|must\s+not|shall\s+not|cannot|can't|should\s+not|shouldn't|strictly\s+forbidden\s+(?:to\s+)?|strictly\s+prohibited\s+(?:to\s+)?|prohibited\s+to\s+|disallowed\s+to\s+|forbidden\s+to\s+|disallow\s+|prohibit\s+)\s*",
+)
+
+# Common command pattern triggers for enforceable mapping
+_COMMAND_MAPPINGS: list[tuple[re.Pattern, str, str]] = [
+    (re.compile(r"(?i)\bpush(?:\s+(?:directly|changes)?)?\s+to\s+(?:origin\s+)?(?:main|master|prod(?:uction)?)\b"), "git push *main*", "Git branch protection"),
+    (re.compile(r"(?i)\bforce\s+push\b|\bpush\s+--force\b"), "git push *--force*", "Git force push"),
+    (re.compile(r"(?i)\b(?:hard\s+reset|reset\s+--hard)\b"), "git reset --hard*", "Git hard reset"),
+    (re.compile(r"(?i)\bterraform\s+apply\b"), "terraform apply*", "Terraform apply"),
+    (re.compile(r"(?i)\bterraform\s+destroy\b"), "terraform destroy*", "Terraform destroy"),
+    (re.compile(r"(?i)\bkubectl\s+delete\b"), "kubectl delete*", "Kubernetes resource deletion"),
+    (re.compile(r"(?i)\bnpm\s+publish\b"), "npm publish*", "Package publish (npm)"),
+    (re.compile(r"(?i)\bpip\s+install\s+--upgrade\b"), "pip install --upgrade*", "Unpinned package upgrade"),
+    (re.compile(r"(?i)\b(?:docker|podman)\s+(?:rm|system\s+prune)\b"), "docker rm*", "Container deletion"),
+    (re.compile(r"(?i)\bchmod\s+(?:-R\s+)?777\b"), "chmod *777*", "Insecure file permissions"),
+    (re.compile(r"(?i)\b(?:curl|wget)\s+[^|\n]+\|\s*(?:ba)?sh\b"), "curl*|*sh*", "Piped remote execution"),
+]
+
+# Sensitive file keywords that map to file protection
+_SENSITIVE_TARGET_KEYWORDS: list[tuple[re.Pattern, str]] = [
+    (re.compile(r"(?i)\.env\b"), ".env / environment credentials"),
+    (re.compile(r"(?i)\.ssh\b|\bid_rsa\b|\bid_ed25519\b"), "SSH private keys and configuration"),
+    (re.compile(r"(?i)config\.yaml\b"), "Hermes security configuration"),
+    (re.compile(r"(?i)\.(?:bashrc|zshrc|profile)\b"), "Shell configuration files"),
+    (re.compile(r"(?i)\.(?:netrc|pgpass|npmrc|pypirc)\b"), "Credential store files"),
+    (re.compile(r"(?i)/etc/|/private/etc/"), "System configuration files"),
+]
+
+
+@dataclass
+class SecurityRule:
+    """A single extracted natural-language security rule and its audit status."""
+
+    source_file: str
+    line_number: int
+    raw_text: str
+    imperative_phrase: str
+    category: str  # "enforced" | "enforceable" | "advisory"
+    enforcement_mechanism: Optional[str] = None
+    suggested_deny_glob: Optional[str] = None
+    suggested_command: Optional[str] = None
+
+
+@dataclass
+class SecurityRulesAuditReport:
+    """Aggregated report of all audited security rules."""
+
+    rules: list[SecurityRule] = field(default_factory=list)
+    scanned_files: list[str] = field(default_factory=list)
+
+    @property
+    def enforced(self) -> list[SecurityRule]:
+        return [r for r in self.rules if r.category == "enforced"]
+
+    @property
+    def enforceable(self) -> list[SecurityRule]:
+        return [r for r in self.rules if r.category == "enforceable"]
+
+    @property
+    def advisory(self) -> list[SecurityRule]:
+        return [r for r in self.rules if r.category == "advisory"]
+
+    def to_dict(self) -> dict:
+        return {
+            "summary": {
+                "total_rules": len(self.rules),
+                "enforced_count": len(self.enforced),
+                "enforceable_count": len(self.enforceable),
+                "advisory_count": len(self.advisory),
+                "scanned_files_count": len(self.scanned_files),
+            },
+            "scanned_files": self.scanned_files,
+            "rules": [
+                {
+                    "source_file": r.source_file,
+                    "line_number": r.line_number,
+                    "raw_text": r.raw_text,
+                    "category": r.category,
+                    "enforcement_mechanism": r.enforcement_mechanism,
+                    "suggested_deny_glob": r.suggested_deny_glob,
+                    "suggested_command": r.suggested_command,
+                }
+                for r in self.rules
+            ],
+        }
+
+
+def _discover_scan_files(hermes_home: Optional[Path] = None, cwd: Optional[Path] = None) -> list[Path]:
+    """Find all candidate memory, context, and skill files to scan."""
+    files: list[Path] = []
+    seen: set[Path] = set()
+
+    h_home = Path(hermes_home or get_hermes_home()).resolve()
+    current_cwd = Path(cwd or Path.cwd()).resolve()
+
+    # 1. Project context files
+    context_filenames = [
+        "AGENTS.md", "CLAUDE.md", ".hermes.md", ".cursorrules", "SOUL.md",
+        "SECURITY.md", "CONVENTIONS.md", "agents.md", "claude.md",
+    ]
+    for search_dir in [current_cwd, h_home]:
+        if search_dir.exists() and search_dir.is_dir():
+            for fname in context_filenames:
+                p = search_dir / fname
+                if p.is_file() and p not in seen:
+                    files.append(p)
+                    seen.add(p)
+
+    # 2. Subdirectory context files in current cwd (up to 2 levels)
+    if current_cwd.exists() and current_cwd.is_dir():
+        for pattern in ["*/AGENTS.md", "*/*/AGENTS.md", "*/CLAUDE.md", "*/*/CLAUDE.md"]:
+            for p in current_cwd.glob(pattern):
+                if p.is_file() and p not in seen:
+                    files.append(p)
+                    seen.add(p)
+
+    # 3. Memories store
+    memories_dir = h_home / "memories"
+    if memories_dir.exists() and memories_dir.is_dir():
+        for p in memories_dir.glob("*.md"):
+            if p.is_file() and p not in seen:
+                files.append(p)
+                seen.add(p)
+
+    # 4. Skills directory
+    for skills_root in [h_home / "skills", current_cwd / "skills"]:
+        if skills_root.exists() and skills_root.is_dir():
+            for p in skills_root.glob("**/SKILL.md"):
+                if p.is_file() and p not in seen:
+                    files.append(p)
+                    seen.add(p)
+            for p in skills_root.glob("**/*.md"):
+                if p.is_file() and p not in seen:
+                    files.append(p)
+                    seen.add(p)
+
+    return sorted(files)
+
+
+def _get_active_deny_patterns() -> list[str]:
+    """Retrieve user configured approvals.deny globs from config."""
+    try:
+        from tools import approval_context as _ctx
+        deny_patterns = _ctx._get_approval_config().get("deny") or []
+        return [p.strip() for p in deny_patterns if isinstance(p, str) and p.strip()]
+    except Exception:
+        return []
+
+
+def _extract_rules_from_file(path: Path) -> list[Tuple[int, str, str]]:
+    """Extract line numbers, raw text lines, and imperative phrases from a file."""
+    extracted: list[Tuple[int, str, str]] = []
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except Exception as exc:
+        logger.debug("Failed to read %s: %s", path, exc)
+        return extracted
+
+    in_code_block = False
+    for line_idx, line in enumerate(text.splitlines(), start=1):
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_code_block = not in_code_block
+            continue
+        if in_code_block or not stripped or stripped.startswith("#"):
+            continue
+
+        match = _NEGATIVE_RULE_RE.search(stripped)
+        if match:
+            trigger = match.group("trigger")
+            action = match.group("action").strip()
+            # Clean markdown bullets, quotes, formatting
+            cleaned_line = re.sub(r"^[-*+>]\s+", "", stripped)
+            extracted.append((line_idx, cleaned_line, f"{trigger} {action}"))
+
+    return extracted
+
+
+def _classify_rule(raw_text: str, imperative_phrase: str, active_deny_globs: Sequence[str]) -> Tuple[str, Optional[str], Optional[str], Optional[str]]:
+    """Classify a rule into (category, enforcement_mechanism, suggested_deny_glob, suggested_command)."""
+    text_lower = raw_text.lower()
+    phrase_lower = imperative_phrase.lower()
+    action_candidate = _TRIGGER_STRIP_RE.sub("", phrase_lower).strip()
+
+    # 1. Check if matches active user approvals.deny globs
+    for glob in active_deny_globs:
+        glob_clean = glob.lower().strip()
+        if fnmatch.fnmatchcase(phrase_lower, f"*{glob_clean}*") or fnmatch.fnmatchcase(text_lower, f"*{glob_clean}*") or fnmatch.fnmatchcase(action_candidate, f"*{glob_clean}*"):
+            return "enforced", f"approvals.deny ('{glob}')", None, None
+
+    # 2. Check HARDLINE blocklist
+    try:
+        from tools.approval_detection import detect_hardline_command
+        is_hardline, hl_desc = detect_hardline_command(action_candidate)
+        if not is_hardline:
+            is_hardline, hl_desc = detect_hardline_command(text_lower)
+        if is_hardline:
+            return "enforced", f"HARDLINE floor ({hl_desc})", None, None
+    except Exception:
+        pass
+
+    # 3. Check sensitive file write protections
+    for pattern, desc in _SENSITIVE_TARGET_KEYWORDS:
+        if pattern.search(phrase_lower) or pattern.search(text_lower) or pattern.search(action_candidate):
+            if any(w in phrase_lower for w in ["touch", "edit", "modify", "write", "change", "overwrite", "delete", "leak", "commit", "expose"]):
+                return "enforced", f"Built-in file/env protection ({desc})", None, None
+
+    # 4. Check DANGEROUS_PATTERNS approval gates
+    try:
+        from tools.approval_detection import detect_dangerous_command
+        is_dangerous, _, dg_desc = detect_dangerous_command(action_candidate)
+        if not is_dangerous:
+            is_dangerous, _, dg_desc = detect_dangerous_command(text_lower)
+        if is_dangerous:
+            return "enforced", f"DANGEROUS_PATTERNS gate ({dg_desc})", None, None
+    except Exception:
+        pass
+
+    # 5. Check if it matches an enforceable deterministic command shape
+    for cmd_re, suggested_glob, desc in _COMMAND_MAPPINGS:
+        if cmd_re.search(action_candidate) or cmd_re.search(phrase_lower) or cmd_re.search(text_lower):
+            suggested_cmd = f"hermes config set approvals.deny '{json.dumps(list(active_deny_globs) + [suggested_glob])}'"
+            return "enforceable", None, suggested_glob, suggested_cmd
+
+    # 6. Fallback: Advisory-only
+    return "advisory", "Advisory model instruction only (no deterministic command analogue)", None, None
+
+
+def audit_security_rules(hermes_home: Optional[Path] = None, cwd: Optional[Path] = None) -> SecurityRulesAuditReport:
+    """Run security rules coverage audit across discovered context and memory files."""
+    report = SecurityRulesAuditReport()
+    files = _discover_scan_files(hermes_home=hermes_home, cwd=cwd)
+    report.scanned_files = [str(p) for p in files]
+    active_deny = _get_active_deny_patterns()
+
+    for file_path in files:
+        extracted = _extract_rules_from_file(file_path)
+        for line_no, raw_text, phrase in extracted:
+            cat, mech, glob, cmd = _classify_rule(raw_text, phrase, active_deny)
+            rule = SecurityRule(
+                source_file=str(file_path),
+                line_number=line_no,
+                raw_text=raw_text,
+                imperative_phrase=phrase,
+                category=cat,
+                enforcement_mechanism=mech,
+                suggested_deny_glob=glob,
+                suggested_command=cmd,
+            )
+            report.rules.append(rule)
+
+    return report
+
+
+def run_security_rules_audit_cli(hermes_home: Optional[Path] = None, cwd: Optional[Path] = None) -> None:
+    """Execute and render the full ``hermes doctor --security-rules`` audit report."""
+    print()
+    print(color("┌─────────────────────────────────────────────────────────┐", Colors.CYAN))
+    print(color("│       🛡️  Hermes Security-Rule Coverage Audit            │", Colors.CYAN))
+    print(color("│         arXiv:2608.23550 'When Do Not Is Not Deny'      │", Colors.CYAN))
+    print(color("└─────────────────────────────────────────────────────────┘", Colors.CYAN))
+    print()
+
+    report = audit_security_rules(hermes_home=hermes_home, cwd=cwd)
+
+    print(f"  Scanned {len(report.scanned_files)} files (context, memories, skills).")
+    print(f"  Found {len(report.rules)} natural-language security rules:")
+    print(f"    • {color(str(len(report.enforced)), Colors.GREEN, Colors.BOLD)} enforced by deterministic controls")
+    print(f"    • {color(str(len(report.enforceable)), Colors.YELLOW, Colors.BOLD)} enforceable (can add to approvals.deny)")
+    print(f"    • {color(str(len(report.advisory)), Colors.DIM)} advisory-only (guidelines for the model)")
+    print()
+
+    # 1. Enforced rules
+    if report.enforced:
+        print(color("◆ Enforced Rules (Backed by Built-In Controls)", Colors.GREEN, Colors.BOLD))
+        for r in report.enforced:
+            rel_file = Path(r.source_file).name
+            print(f"  {color('✓', Colors.GREEN)} {color(rel_file + ':' + str(r.line_number), Colors.BOLD)}: \"{r.raw_text}\"")
+            if r.enforcement_mechanism:
+                print(f"    {color('↳ Enforced by:', Colors.DIM)} {color(r.enforcement_mechanism, Colors.GREEN)}")
+        print()
+
+    # 2. Enforceable rules
+    if report.enforceable:
+        print(color("◆ Enforceable Rules (Action Required: Add Deterministic Deny Glob)", Colors.YELLOW, Colors.BOLD))
+        for r in report.enforceable:
+            rel_file = Path(r.source_file).name
+            print(f"  {color('⚠', Colors.YELLOW)} {color(rel_file + ':' + str(r.line_number), Colors.BOLD)}: \"{r.raw_text}\"")
+            if r.suggested_deny_glob:
+                print(f"    {color('↳ Suggested approvals.deny glob:', Colors.DIM)} {color(r.suggested_deny_glob, Colors.CYAN, Colors.BOLD)}")
+            if r.suggested_command:
+                print(f"    {color('↳ Run to enforce:', Colors.DIM)} {color(r.suggested_command, Colors.YELLOW)}")
+        print()
+
+    # 3. Advisory-only rules
+    if report.advisory:
+        print(color("◆ Advisory-Only Rules (Model Prompts Without Deterministic Analogue)", Colors.DIM, Colors.BOLD))
+        for r in report.advisory:
+            rel_file = Path(r.source_file).name
+            print(f"  {color('ℹ', Colors.DIM)} {color(rel_file + ':' + str(r.line_number), Colors.DIM)}: \"{r.raw_text}\"")
+        print()
+
+    print(color("─" * 60, Colors.CYAN))
+    if report.enforceable:
+        print(color(f"  ⚡ {len(report.enforceable)} rule(s) can be converted to hard deterministic controls.", Colors.YELLOW, Colors.BOLD))
+    else:
+        print(color("  ✓ All actionable natural-language rules have deterministic controls.", Colors.GREEN, Colors.BOLD))
+    print()

--- a/hermes_cli/security_rules_audit.py
+++ b/hermes_cli/security_rules_audit.py
@@ -12,8 +12,8 @@ and audits them against the deterministic enforcement layer:
 4. Built-in sensitive write targets (_SENSITIVE_WRITE_TARGET)
 
 Classifies rules into three actionable buckets:
-- ENFORCED: active deterministic control exists (hardline, deny glob, or sensitive target).
-- ENFORCEABLE: concrete deterministic command/path pattern can be added to approvals.deny.
+- ENFORCED: an explicit terminal command is denied by the active runtime policy.
+- ENFORCEABLE: a deny glob can cover an identified terminal example, not all prose meanings.
 - ADVISORY-ONLY: model-directed behavioral guidelines without a deterministic analogue.
 """
 
@@ -23,48 +23,50 @@ from dataclasses import dataclass, field
 import fnmatch
 import json
 import logging
+import os
 from pathlib import Path
 import re
+import shlex
 from typing import List, Optional, Sequence, Tuple
 
 from hermes_cli.colors import Colors, color
-from hermes_cli.config import get_hermes_home, get_project_root
+from hermes_cli.config import apply_terminal_config_to_env, get_hermes_home
 
 logger = logging.getLogger(__name__)
 
 # Imperative trigger pattern for negative security rules
 _NEGATIVE_RULE_RE = re.compile(
-    r"(?i)\b(?P<trigger>never|do\s+not|don't|must\s+not|shall\s+not|cannot|can't|should\s+not|shouldn't|strictly\s+forbidden|strictly\s+prohibited|prohibited\s+to|disallowed\s+to|forbidden\s+to)\b\s+(?P<action>[^\n.;`]+)",
+    r"(?i)\b(?P<trigger>never|do\s+not|don't|must\s+not|shall\s+not|cannot|can't|should\s+not|shouldn't|strictly\s+forbidden|strictly\s+prohibited|prohibited\s+to|disallowed\s+to|forbidden\s+to)\b\s+(?P<action>[^\n]+)",
 )
 
 _TRIGGER_STRIP_RE = re.compile(
     r"(?i)^(?:never|do\s+not|don't|must\s+not|shall\s+not|cannot|can't|should\s+not|shouldn't|strictly\s+forbidden\s+(?:to\s+)?|strictly\s+prohibited\s+(?:to\s+)?|prohibited\s+to\s+|disallowed\s+to\s+|forbidden\s+to\s+|disallow\s+|prohibit\s+)\s*",
 )
 
-# Common command pattern triggers for enforceable mapping
+# These examples propose command-level controls; they do not prove coverage of prose.
 _COMMAND_MAPPINGS: list[tuple[re.Pattern, str, str]] = [
-    (re.compile(r"(?i)\bpush(?:\s+(?:directly|changes)?)?\s+to\s+(?:origin\s+)?(?:main|master|prod(?:uction)?)\b"), "git push *main*", "Git branch protection"),
-    (re.compile(r"(?i)\bforce\s+push\b|\bpush\s+--force\b"), "git push *--force*", "Git force push"),
-    (re.compile(r"(?i)\b(?:hard\s+reset|reset\s+--hard)\b"), "git reset --hard*", "Git hard reset"),
-    (re.compile(r"(?i)\bterraform\s+apply\b"), "terraform apply*", "Terraform apply"),
-    (re.compile(r"(?i)\bterraform\s+destroy\b"), "terraform destroy*", "Terraform destroy"),
-    (re.compile(r"(?i)\bkubectl\s+delete\b"), "kubectl delete*", "Kubernetes resource deletion"),
-    (re.compile(r"(?i)\bnpm\s+publish\b"), "npm publish*", "Package publish (npm)"),
-    (re.compile(r"(?i)\bpip\s+install\s+--upgrade\b"), "pip install --upgrade*", "Unpinned package upgrade"),
-    (re.compile(r"(?i)\b(?:docker|podman)\s+(?:rm|system\s+prune)\b"), "docker rm*", "Container deletion"),
-    (re.compile(r"(?i)\bchmod\s+(?:-R\s+)?777\b"), "chmod *777*", "Insecure file permissions"),
-    (re.compile(r"(?i)\b(?:curl|wget)\s+[^|\n]+\|\s*(?:ba)?sh\b"), "curl*|*sh*", "Piped remote execution"),
+    (re.compile(r"(?i)\bpush(?:\s+(?:directly|changes)?)?\s+to\s+(?:origin\s+)?(?P<branch>main|master|prod(?:uction)?)\b"), "git push *{branch}*", "git push origin {branch}"),
+    (re.compile(r"(?i)\bforce\s+push\b|\bpush\s+--force\b"), "git push *--force*", "git push --force origin audit-example"),
+    (re.compile(r"(?i)\b(?:hard\s+reset|reset\s+--hard)\b"), "git reset --hard*", "git reset --hard"),
+    (re.compile(r"(?i)\bterraform\s+apply\b"), "terraform apply*", "terraform apply"),
+    (re.compile(r"(?i)\bterraform\s+destroy\b"), "terraform destroy*", "terraform destroy"),
+    (re.compile(r"(?i)\bkubectl\s+delete\b"), "kubectl delete*", "kubectl delete deployment audit-example"),
+    (re.compile(r"(?i)\bnpm\s+publish\b"), "npm publish*", "npm publish"),
+    (re.compile(r"(?i)\bpip\s+install\s+--upgrade\b"), "pip install --upgrade*", "pip install --upgrade audit-example"),
+    (re.compile(r"(?i)\b(?P<engine>docker|podman)\s+(?P<operation>rm|system\s+prune)\b"), "{engine} {operation}*", "{engine} {operation}"),
+    (re.compile(r"(?i)\bchmod\s+(?:-R\s+)?777\b"), "chmod *777*", "chmod 777 audit-example"),
+    (re.compile(r"(?i)\b(?P<fetcher>curl|wget)\s+[^|\n]+\|\s*(?:ba)?sh\b"), "{fetcher}*|*sh*", "{fetcher} https://example.invalid/script | sh"),
 ]
 
-# Sensitive file keywords that map to file protection
-_SENSITIVE_TARGET_KEYWORDS: list[tuple[re.Pattern, str]] = [
-    (re.compile(r"(?i)\.env\b"), ".env / environment credentials"),
-    (re.compile(r"(?i)\.ssh\b|\bid_rsa\b|\bid_ed25519\b"), "SSH private keys and configuration"),
-    (re.compile(r"(?i)config\.yaml\b"), "Hermes security configuration"),
-    (re.compile(r"(?i)\.(?:bashrc|zshrc|profile)\b"), "Shell configuration files"),
-    (re.compile(r"(?i)\.(?:netrc|pgpass|npmrc|pypirc)\b"), "Credential store files"),
-    (re.compile(r"(?i)/etc/|/private/etc/"), "System configuration files"),
-]
+# A file-write guard says nothing about reads or committing an existing file.
+_FILE_OPERATION_RE = re.compile(
+    r"(?i)^(?P<operation>read|write|commit)\s+(?P<path>\S+)$"
+)
+_FILE_COMMANDS = {
+    "read": "cat {path}",
+    "write": "printf '' > {path}",
+    "commit": "git add {path} && git commit -m audit-example",
+}
 
 
 @dataclass
@@ -218,56 +220,67 @@ def _extract_rules_from_file(path: Path) -> list[Tuple[int, str, str]]:
 
 def _classify_rule(raw_text: str, imperative_phrase: str, active_deny_globs: Sequence[str]) -> Tuple[str, Optional[str], Optional[str], Optional[str]]:
     """Classify a rule into (category, enforcement_mechanism, suggested_deny_glob, suggested_command)."""
-    text_lower = raw_text.lower()
-    phrase_lower = imperative_phrase.lower()
-    action_candidate = _TRIGGER_STRIP_RE.sub("", phrase_lower).strip()
+    from hermes_cli.approvals_test import evaluate_command
 
-    # 1. Check if matches active user approvals.deny globs
-    for glob in active_deny_globs:
-        glob_clean = glob.lower().strip()
-        if fnmatch.fnmatchcase(phrase_lower, f"*{glob_clean}*") or fnmatch.fnmatchcase(text_lower, f"*{glob_clean}*") or fnmatch.fnmatchcase(action_candidate, f"*{glob_clean}*"):
-            return "enforced", f"approvals.deny ('{glob}')", None, None
+    action = _TRIGGER_STRIP_RE.sub("", imperative_phrase).strip().rstrip(".")
+    explicit = re.fullmatch(r"(?:run\s+|execute\s+)?`([^`]+)`", action, re.IGNORECASE)
+    # Do not reinterpret the profile's globs or natural-language words as runtime policy.
+    # Resolving into a copy also leaves the caller's environment unchanged.
+    env_type = apply_terminal_config_to_env(env=dict(os.environ)).get("TERMINAL_ENV", "local")
+    command = explicit.group(1) if explicit else None
+    suggested_glob = None
+    for command_re, glob_template, command_template in _COMMAND_MAPPINGS:
+        match = command_re.search(action)
+        if match:
+            values = match.groupdict()
+            suggested_glob = glob_template.format(**values)
+            command = command or command_template.format(**values)
+            break
+    if command is None:
+        file_operation = _FILE_OPERATION_RE.fullmatch(action)
+        if file_operation:
+            command = _FILE_COMMANDS[file_operation.group("operation").lower()].format(
+                path=shlex.quote(file_operation.group("path")),
+            )
 
-    # 2. Check HARDLINE blocklist
-    try:
-        from tools.approval_detection import detect_hardline_command
-        is_hardline, hl_desc = detect_hardline_command(action_candidate)
-        if not is_hardline:
-            is_hardline, hl_desc = detect_hardline_command(text_lower)
-        if is_hardline:
-            return "enforced", f"HARDLINE floor ({hl_desc})", None, None
-    except Exception:
-        pass
+    if command is None:
+        return ("advisory", f"Advisory instruction: active profile {get_hermes_home()}; "
+                "no explicit terminal command; coverage is unverified.", None, None)
 
-    # 3. Check sensitive file write protections
-    for pattern, desc in _SENSITIVE_TARGET_KEYWORDS:
-        if pattern.search(phrase_lower) or pattern.search(text_lower) or pattern.search(action_candidate):
-            if any(w in phrase_lower for w in ["touch", "edit", "modify", "write", "change", "overwrite", "delete", "leak", "commit", "expose"]):
-                return "enforced", f"Built-in file/env protection ({desc})", None, None
+    verdict = evaluate_command(command, env_type=env_type)
+    denied = verdict["verdict"] in {"hardline-deny", "user-deny"}
+    description = {
+        "hardline-deny": "hard denial",
+        "user-deny": "hard denial",
+        "ask-approval": "conditional approval, not a denial",
+        "allow": "allowed by command policy",
+    }[verdict["verdict"]]
+    mechanism = (
+        f"Active profile {get_hermes_home()}: terminal example {command!r} "
+        f"on {env_type}: {verdict['verdict']} "
+        f"({description}); {verdict['detail']}"
+    )
+    if explicit and denied:
+        return "enforced", mechanism + ". This command spelling only; other tools are not audited.", None, None
 
-    # 4. Check DANGEROUS_PATTERNS approval gates
-    try:
-        from tools.approval_detection import detect_dangerous_command
-        is_dangerous, _, dg_desc = detect_dangerous_command(action_candidate)
-        if not is_dangerous:
-            is_dangerous, _, dg_desc = detect_dangerous_command(text_lower)
-        if is_dangerous:
-            return "enforced", f"DANGEROUS_PATTERNS gate ({dg_desc})", None, None
-    except Exception:
-        pass
-
-    # 5. Check if it matches an enforceable deterministic command shape
-    for cmd_re, suggested_glob, desc in _COMMAND_MAPPINGS:
-        if cmd_re.search(action_candidate) or cmd_re.search(phrase_lower) or cmd_re.search(text_lower):
-            suggested_cmd = f"hermes config set approvals.deny '{json.dumps(list(active_deny_globs) + [suggested_glob])}'"
-            return "enforceable", None, suggested_glob, suggested_cmd
-
-    # 6. Fallback: Advisory-only
-    return "advisory", "Advisory model instruction only (no deterministic command analogue)", None, None
+    mechanism += ". Whole instruction coverage is unverified."
+    if suggested_glob and not denied:
+        # The suggested glob must match its canonical example verbatim. Runtime
+        # normalization and configured-policy evaluation remain owned by evaluate_command.
+        if fnmatch.fnmatchcase(command.lower().strip(), suggested_glob.lower()):
+            suggested_cmd = "hermes config set approvals.deny " + shlex.quote(
+                json.dumps(list(active_deny_globs) + [suggested_glob])
+            )
+            return "enforceable", mechanism, suggested_glob, suggested_cmd
+    return "advisory", mechanism, None, None
 
 
 def audit_security_rules(hermes_home: Optional[Path] = None, cwd: Optional[Path] = None) -> SecurityRulesAuditReport:
-    """Run security rules coverage audit across discovered context and memory files."""
+    """Scan the supplied locations against the active profile's command policy.
+
+    ``hermes_home`` selects files to scan; it does not switch the active profile.
+    The shared config loader may initialize standard directories in that profile.
+    """
     report = SecurityRulesAuditReport()
     files = _discover_scan_files(hermes_home=hermes_home, cwd=cwd)
     report.scanned_files = [str(p) for p in files]
@@ -303,16 +316,17 @@ def run_security_rules_audit_cli(hermes_home: Optional[Path] = None, cwd: Option
 
     report = audit_security_rules(hermes_home=hermes_home, cwd=cwd)
 
+    print(f"  Policy: active profile {get_hermes_home()}.")
     print(f"  Scanned {len(report.scanned_files)} files (context, memories, skills).")
     print(f"  Found {len(report.rules)} natural-language security rules:")
-    print(f"    • {color(str(len(report.enforced)), Colors.GREEN, Colors.BOLD)} enforced by deterministic controls")
-    print(f"    • {color(str(len(report.enforceable)), Colors.YELLOW, Colors.BOLD)} enforceable (can add to approvals.deny)")
-    print(f"    • {color(str(len(report.advisory)), Colors.DIM)} advisory-only (guidelines for the model)")
+    print(f"    • {color(str(len(report.enforced)), Colors.GREEN, Colors.BOLD)} explicit terminal commands denied by active policy")
+    print(f"    • {color(str(len(report.enforceable)), Colors.YELLOW, Colors.BOLD)} terminal examples with deny suggestions (review coverage)")
+    print(f"    • {color(str(len(report.advisory)), Colors.DIM)} advisory or unverified instructions")
     print()
 
     # 1. Enforced rules
     if report.enforced:
-        print(color("◆ Enforced Rules (Backed by Built-In Controls)", Colors.GREEN, Colors.BOLD))
+        print(color("◆ Enforced Commands (Exact Terminal Spelling Only)", Colors.GREEN, Colors.BOLD))
         for r in report.enforced:
             rel_file = Path(r.source_file).name
             print(f"  {color('✓', Colors.GREEN)} {color(rel_file + ':' + str(r.line_number), Colors.BOLD)}: \"{r.raw_text}\"")
@@ -322,27 +336,31 @@ def run_security_rules_audit_cli(hermes_home: Optional[Path] = None, cwd: Option
 
     # 2. Enforceable rules
     if report.enforceable:
-        print(color("◆ Enforceable Rules (Action Required: Add Deterministic Deny Glob)", Colors.YELLOW, Colors.BOLD))
+        print(color("◆ Suggested Command Denials (Partial Coverage; Review Before Applying)", Colors.YELLOW, Colors.BOLD))
         for r in report.enforceable:
             rel_file = Path(r.source_file).name
             print(f"  {color('⚠', Colors.YELLOW)} {color(rel_file + ':' + str(r.line_number), Colors.BOLD)}: \"{r.raw_text}\"")
+            if r.enforcement_mechanism:
+                print(f"    {r.enforcement_mechanism}")
             if r.suggested_deny_glob:
                 print(f"    {color('↳ Suggested approvals.deny glob:', Colors.DIM)} {color(r.suggested_deny_glob, Colors.CYAN, Colors.BOLD)}")
             if r.suggested_command:
-                print(f"    {color('↳ Run to enforce:', Colors.DIM)} {color(r.suggested_command, Colors.YELLOW)}")
+                print(f"    {color('↳ Add this command-pattern denial:', Colors.DIM)} {color(r.suggested_command, Colors.YELLOW)}")
         print()
 
     # 3. Advisory-only rules
     if report.advisory:
-        print(color("◆ Advisory-Only Rules (Model Prompts Without Deterministic Analogue)", Colors.DIM, Colors.BOLD))
+        print(color("◆ Advisory or Unverified Instructions", Colors.DIM, Colors.BOLD))
         for r in report.advisory:
             rel_file = Path(r.source_file).name
             print(f"  {color('ℹ', Colors.DIM)} {color(rel_file + ':' + str(r.line_number), Colors.DIM)}: \"{r.raw_text}\"")
+            if r.enforcement_mechanism:
+                print(f"    {r.enforcement_mechanism}")
         print()
 
     print(color("─" * 60, Colors.CYAN))
     if report.enforceable:
-        print(color(f"  ⚡ {len(report.enforceable)} rule(s) can be converted to hard deterministic controls.", Colors.YELLOW, Colors.BOLD))
+        print(color(f"  ⚡ {len(report.enforceable)} terminal example(s) have candidate deny globs; whole instructions remain unverified.", Colors.YELLOW, Colors.BOLD))
     else:
-        print(color("  ✓ All actionable natural-language rules have deterministic controls.", Colors.GREEN, Colors.BOLD))
+        print(color("  No additional deny suggestions. This does not prove all instructions are enforced.", Colors.GREEN, Colors.BOLD))
     print()

--- a/hermes_cli/subcommands/doctor.py
+++ b/hermes_cli/subcommands/doctor.py
@@ -18,6 +18,10 @@ def build_doctor_parser(subparsers, *, cmd_doctor: Callable) -> None:
             "configured tool backend (Firecrawl/FAL/browser/MCP/TTS/STT) "
             "after the static checks. Makes real network calls.")
     doctor_parser.add_argument(
+        "--security-rules", action="store_true",
+        help="Audit natural-language security rules (SOUL.md, AGENTS.md, memory, skills) "
+             "and map them to deterministic approvals.deny patterns.")
+    doctor_parser.add_argument(
         "--ack", metavar="ADVISORY_ID", default=None,
         help="Acknowledge a security advisory by ID and exit. After ack, the "
             "advisory will no longer trigger startup banners. Run `hermes "

--- a/tests/hermes_cli/test_security_rules_audit.py
+++ b/tests/hermes_cli/test_security_rules_audit.py
@@ -1,0 +1,186 @@
+"""Tests for hermes_cli.security_rules_audit — security rule coverage audit.
+
+Validates the arXiv:2608.23550 mapping of natural-language rules (in memories,
+context files, skills) to deterministic controls (approvals.deny, HARDLINE,
+DANGEROUS_PATTERNS, sensitive file write guards).
+"""
+
+import json
+from pathlib import Path
+import pytest
+
+from hermes_cli.security_rules_audit import (
+    SecurityRule,
+    SecurityRulesAuditReport,
+    _classify_rule,
+    _discover_scan_files,
+    _extract_rules_from_file,
+    audit_security_rules,
+    run_security_rules_audit_cli,
+)
+
+
+class TestRuleExtraction:
+    def test_extract_imperative_negative_rules(self, tmp_path: Path):
+        agents_md = tmp_path / "AGENTS.md"
+        agents_md.write_text(
+            "# Guidelines\n"
+            "- Never push directly to main branch.\n"
+            "- Do not touch the production database without approval.\n"
+            "- Must not delete .env files.\n"
+            "- Don't execute sudo commands.\n"
+            "- Always write clean code.\n"
+            "```bash\n"
+            "never run this inside code block\n"
+            "```\n"
+            "- Strictly forbidden to drop database tables.\n",
+            encoding="utf-8",
+        )
+
+        extracted = _extract_rules_from_file(agents_md)
+        assert len(extracted) == 5
+        lines = [item[1] for item in extracted]
+        assert "Never push directly to main branch." in lines
+        assert "Do not touch the production database without approval." in lines
+        assert "Must not delete .env files." in lines
+        assert "Don't execute sudo commands." in lines
+        assert "Strictly forbidden to drop database tables." in lines
+
+    def test_code_blocks_and_headings_ignored(self, tmp_path: Path):
+        file_p = tmp_path / "CLAUDE.md"
+        file_p.write_text(
+            "# Do not panic\n"
+            "```python\n"
+            "# Never do this\n"
+            "do_not_call_this()\n"
+            "```\n",
+            encoding="utf-8",
+        )
+        assert len(_extract_rules_from_file(file_p)) == 0
+
+
+class TestRuleClassification:
+    def test_hardline_enforced(self):
+        cat, mech, glob, cmd = _classify_rule(
+            "Never rm -rf / or delete root",
+            "never rm -rf /",
+            active_deny_globs=[],
+        )
+        assert cat == "enforced"
+        assert "HARDLINE" in (mech or "")
+
+    def test_sensitive_write_target_enforced(self):
+        cat, mech, glob, cmd = _classify_rule(
+            "Do not modify or edit .env credentials",
+            "do not modify .env",
+            active_deny_globs=[],
+        )
+        assert cat == "enforced"
+        assert "file/env protection" in (mech or "")
+
+    def test_dangerous_pattern_db_drop_enforced(self):
+        cat, mech, glob, cmd = _classify_rule(
+            "Never drop database in staging or production",
+            "never drop database",
+            active_deny_globs=[],
+        )
+        assert cat == "enforced"
+        assert "DANGEROUS_PATTERNS" in (mech or "")
+
+    def test_active_deny_glob_enforced(self):
+        cat, mech, glob, cmd = _classify_rule(
+            "Never run terraform apply in prod",
+            "never run terraform apply",
+            active_deny_globs=["terraform apply*"],
+        )
+        assert cat == "enforced"
+        assert "approvals.deny" in (mech or "")
+
+    def test_enforceable_rule_suggests_glob_and_command(self):
+        cat, mech, glob, cmd = _classify_rule(
+            "Do not push directly to origin main",
+            "do not push directly to origin main",
+            active_deny_globs=[],
+        )
+        assert cat == "enforceable"
+        assert glob == "git push *main*"
+        assert cmd is not None
+        assert "hermes config set approvals.deny" in cmd
+        assert "git push *main*" in cmd
+
+    def test_enforceable_terraform_apply(self):
+        cat, mech, glob, cmd = _classify_rule(
+            "Never run terraform apply in staging",
+            "never run terraform apply",
+            active_deny_globs=[],
+        )
+        assert cat == "enforceable"
+        assert glob == "terraform apply*"
+
+    def test_advisory_only_rule(self):
+        cat, mech, glob, cmd = _classify_rule(
+            "Never assume user intent without asking",
+            "never assume user intent",
+            active_deny_globs=[],
+        )
+        assert cat == "advisory"
+        assert "Advisory" in (mech or "")
+        assert glob is None
+        assert cmd is None
+
+
+class TestAuditSecurityRulesWorkflow:
+    def test_audit_across_mock_workspace(self, tmp_path: Path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        memories = hermes_home / "memories"
+        memories.mkdir()
+        skills = hermes_home / "skills" / "deploy"
+        skills.mkdir(parents=True)
+
+        # 1. Project AGENTS.md
+        agents_md = tmp_path / "AGENTS.md"
+        agents_md.write_text(
+            "- Never push to main branch.\n"
+            "- Do not touch .env files.\n",
+            encoding="utf-8",
+        )
+
+        # 2. Memory file
+        memory_md = memories / "MEMORY.md"
+        memory_md.write_text(
+            "- Never drop table users.\n"
+            "- Always write unit tests.\n",
+            encoding="utf-8",
+        )
+
+        # 3. Skill file
+        skill_md = skills / "SKILL.md"
+        skill_md.write_text(
+            "- Do not run npm publish without tag.\n"
+            "- Never assume environment is clean.\n",
+            encoding="utf-8",
+        )
+
+        report = audit_security_rules(hermes_home=hermes_home, cwd=tmp_path)
+        assert len(report.rules) >= 5
+        assert len(report.enforced) >= 2  # .env protection + drop table gate
+        assert len(report.enforceable) >= 2  # git push main, npm publish
+        assert len(report.advisory) >= 1  # never assume environment
+
+        report_dict = report.to_dict()
+        assert report_dict["summary"]["total_rules"] == len(report.rules)
+        assert report_dict["summary"]["enforceable_count"] == len(report.enforceable)
+
+    def test_run_security_rules_audit_cli(self, tmp_path: Path, capsys):
+        agents_md = tmp_path / "AGENTS.md"
+        agents_md.write_text(
+            "- Never push to main.\n"
+            "- Do not edit .env.\n",
+            encoding="utf-8",
+        )
+        run_security_rules_audit_cli(hermes_home=tmp_path / ".hermes", cwd=tmp_path)
+        captured = capsys.readouterr().out
+        assert "Hermes Security-Rule Coverage Audit" in captured
+        assert "enforced by deterministic controls" in captured
+        assert "enforceable" in captured

--- a/tests/hermes_cli/test_security_rules_audit.py
+++ b/tests/hermes_cli/test_security_rules_audit.py
@@ -62,39 +62,43 @@ class TestRuleExtraction:
 class TestRuleClassification:
     def test_hardline_enforced(self):
         cat, mech, glob, cmd = _classify_rule(
-            "Never rm -rf / or delete root",
-            "never rm -rf /",
+            "Never `rm -rf /`",
+            "never `rm -rf /`",
             active_deny_globs=[],
         )
         assert cat == "enforced"
-        assert "HARDLINE" in (mech or "")
+        assert "hardline-deny" in (mech or "")
 
-    def test_sensitive_write_target_enforced(self):
+    def test_file_prose_without_an_explicit_operation_is_unverified(self):
         cat, mech, glob, cmd = _classify_rule(
             "Do not modify or edit .env credentials",
             "do not modify .env",
             active_deny_globs=[],
         )
-        assert cat == "enforced"
-        assert "file/env protection" in (mech or "")
+        assert cat == "advisory"
+        assert "coverage is unverified" in (mech or "")
 
-    def test_dangerous_pattern_db_drop_enforced(self):
+    def test_database_prose_does_not_imply_command_enforcement(self):
         cat, mech, glob, cmd = _classify_rule(
             "Never drop database in staging or production",
             "never drop database",
             active_deny_globs=[],
         )
-        assert cat == "enforced"
-        assert "DANGEROUS_PATTERNS" in (mech or "")
+        assert cat == "advisory"
+        assert "coverage is unverified" in (mech or "")
 
-    def test_active_deny_glob_enforced(self):
+    def test_active_deny_glob_enforced(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(json.dumps({
+            "approvals": {"deny": ["terraform apply*"]},
+        }))
         cat, mech, glob, cmd = _classify_rule(
-            "Never run terraform apply in prod",
-            "never run terraform apply",
+            "Never run `terraform apply`",
+            "never run `terraform apply`",
             active_deny_globs=["terraform apply*"],
         )
         assert cat == "enforced"
-        assert "approvals.deny" in (mech or "")
+        assert "user-deny" in (mech or "")
 
     def test_enforceable_rule_suggests_glob_and_command(self):
         cat, mech, glob, cmd = _classify_rule(
@@ -164,7 +168,7 @@ class TestAuditSecurityRulesWorkflow:
 
         report = audit_security_rules(hermes_home=hermes_home, cwd=tmp_path)
         assert len(report.rules) >= 5
-        assert len(report.enforced) >= 2  # .env protection + drop table gate
+        assert not report.enforced  # Prose and conditional gates do not prove denial.
         assert len(report.enforceable) >= 2  # git push main, npm publish
         assert len(report.advisory) >= 1  # never assume environment
 
@@ -182,5 +186,5 @@ class TestAuditSecurityRulesWorkflow:
         run_security_rules_audit_cli(hermes_home=tmp_path / ".hermes", cwd=tmp_path)
         captured = capsys.readouterr().out
         assert "Hermes Security-Rule Coverage Audit" in captured
-        assert "enforced by deterministic controls" in captured
-        assert "enforceable" in captured
+        assert "explicit terminal commands denied by active policy" in captured
+        assert "deny suggestions" in captured

--- a/tests/hermes_cli/test_security_rules_audit_review_contract.py
+++ b/tests/hermes_cli/test_security_rules_audit_review_contract.py
@@ -1,0 +1,103 @@
+"""The audit must agree with real policy without executing its command examples."""
+import json
+
+import pytest
+
+from hermes_cli import config
+from hermes_cli.approvals_test import evaluate_command
+from hermes_cli.security_rules_audit import audit_security_rules
+from tools.approval import check_all_command_guards
+
+
+def prepare(tmp_path, monkeypatch, rule, *, mode="manual", deny=(), allow=(), backend="local"):
+    home = tmp_path / "profile"
+    workspace = tmp_path / "project"
+    home.mkdir()
+    workspace.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.chdir(workspace)
+    (home / "config.yaml").write_text(json.dumps({
+        "approvals": {"mode": mode, "deny": list(deny)},
+        "command_allowlist": list(allow),
+        "terminal": {"backend": backend},
+        "security": {"tirith_enabled": False},
+    }))
+    config._LOAD_CONFIG_CACHE.clear()
+    (workspace / "AGENTS.md").write_text(rule + "\n")
+    (workspace / ".env").write_text("SYNTHETIC_FIXTURE=not-a-secret\n")
+    return home, workspace
+
+
+@pytest.mark.parametrize("rule,command,mode,deny,allow,backend", [
+    ("Never read .env", "cat .env", "manual", [], [], "local"),
+    ("Never commit .env", "git add .env && git commit -m audit-example", "manual", [], [], "local"),
+    ("Never write .env", "printf '' > .env", "manual", [], [], "local"),
+    ("Never write .env", "printf '' > .env", "off", [], [], "local"),
+    ("Never `printf '' > .env`", "printf '' > .env", "manual", [], [], "local"),
+    ("Never `printf '' > .env`", "printf '' > .env", "off", [], [], "local"),
+    ("Never `git reset --hard`", "git reset --hard", "manual", [], [], "local"),
+    ("Never `git reset --hard`", "git reset --hard", "off", [], [], "local"),
+    ("Never `git reset --hard`", "git reset --hard", "manual", [], ["git reset --hard"], "local"),
+    ("Never `git reset --hard`", "git reset --hard", "manual", [], [], "docker"),
+    ("Never `git reset --hard`", "git reset --hard", "off", ["git reset --hard"], [], "docker"),
+    ("Never `git status --short`", "git status --short", "manual", ["git status"], [], "local"),
+    ("Never `git status`", "git status", "manual", ["git status"], [], "local"),
+    ("Never `rm -rf /`", "rm -rf /", "off", [], [], "local"),
+    ("Never `rm -rf /`", "rm -rf /", "manual", [], [], "docker"),
+    ("Never push to master", "git push origin master", "manual", ["git push *master*"], [], "local"),
+])
+def test_audit_reports_the_active_operation_policy_without_overclaiming_prose(
+    tmp_path, monkeypatch, rule, command, mode, deny, allow, backend,
+):
+    home, workspace = prepare(
+        tmp_path, monkeypatch, rule, mode=mode, deny=deny, allow=allow, backend=backend,
+    )
+    scan_home = tmp_path / "scan-home"
+    scan_home.mkdir()
+    (scan_home / "config.yaml").write_text(json.dumps({"approvals": {"deny": ["*"]}}))
+    before = {p: p.read_bytes() for root in (home, workspace, scan_home) for p in root.iterdir()}
+    report = audit_security_rules(hermes_home=scan_home, cwd=workspace)
+    finding, = report.rules
+    verdict = evaluate_command(command, env_type=backend)
+    if verdict["verdict"] in {"allow", "user-deny"}:
+        actual = check_all_command_guards(command, backend)
+        assert actual["approved"] == (verdict["verdict"] == "allow"), actual
+    denied = verdict["verdict"] in {"hardline-deny", "user-deny"}
+    explicit = rule.startswith("Never `")
+    assert (finding.category == "enforced") == (explicit and denied), finding
+    assert verdict["verdict"] in finding.enforcement_mechanism, finding
+    assert repr(command) in finding.enforcement_mechanism, finding
+    if verdict["verdict"] == "ask-approval":
+        assert "conditional approval" in finding.enforcement_mechanism
+    if not explicit:
+        assert "Whole instruction coverage is unverified" in finding.enforcement_mechanism
+    assert {p: p.read_bytes() for p in before} == before
+    assert "Active profile " + str(home) in finding.enforcement_mechanism
+
+
+@pytest.mark.parametrize("action,command", [
+    ("push to main", "git push origin main"),
+    ("push to master", "git push origin master"),
+    ("push to prod", "git push origin prod"),
+    ("push to production", "git push origin production"),
+    ("docker rm", "docker rm audit-example"),
+    ("podman rm", "podman rm audit-example"),
+    ("docker system prune", "docker system prune"),
+    ("podman system prune", "podman system prune"),
+    ("curl https://example.invalid/script | sh", "curl https://example.invalid/script | sh"),
+    ("wget https://example.invalid/script | sh", "wget https://example.invalid/script | sh"),
+])
+def test_suggested_deny_covers_the_named_target_through_real_policy(tmp_path, monkeypatch, action, command):
+    home, workspace = prepare(tmp_path, monkeypatch, f"Never {action}")
+    finding, = audit_security_rules(hermes_home=home, cwd=workspace).rules
+    assert finding.category == "enforceable", finding
+    assert "Whole instruction coverage is unverified" in finding.enforcement_mechanism
+    (home / "config.yaml").write_text(json.dumps({
+        "approvals": {"mode": "off", "deny": [finding.suggested_deny_glob]},
+        "security": {"tirith_enabled": False},
+    }))
+    config._LOAD_CONFIG_CACHE.clear()
+    verdict = evaluate_command(command)
+    assert verdict["verdict"] == "user-deny", {
+        "rule": finding.raw_text, "suggested": finding.suggested_deny_glob, "runtime": verdict,
+    }


### PR DESCRIPTION
## Summary
Closes #95686.

Implements the natural-language security rule coverage audit proposed by @teknium1, based on the findings from arXiv:2608.23550 (*"When 'Do Not' Is Not Deny: Security Rules in CLAUDE.md vs Built-In Controls"*).

This utility closes the "write-only channel" gap where users configure negative imperative security rules in instruction/context files (`AGENTS.md`, `CLAUDE.md`, `.cursorrules`, `SOUL.md`), memories (`memories/*.md`), and skills, but have no visibility into whether their rules are backed by deterministic runtime enforcement.

## Capabilities & Architecture
- **CLI Command:** `hermes doctor --security-rules` (and integrated static summary row in standard `hermes doctor`).
- **Discovery & Extraction:**
  - Scans workspace & profile context files (`AGENTS.md`, `CLAUDE.md`, `.cursorrules`, `SOUL.md`, etc.), memory files (`memories/*.md`), and installed skills (`skills/**/SKILL.md`).
  - Extracts negative imperative rules (`never`, `do not`, `must not`, `don't`, `cannot`, `strictly forbidden`, `disallow`, etc.) while skipping code blocks and headings.
- **Three Classification Buckets:**
  1. **`ENFORCED`**: Backed by active deterministic controls (`HARDLINE` floor, active user `approvals.deny` fnmatch globs, built-in sensitive file/env write guards, or `DANGEROUS_PATTERNS` gates).
  2. **`ENFORCEABLE`**: Has a concrete command/path shape (e.g. `git push *main*`, `terraform apply*`, `npm publish*`) that can be enforced deterministically. Suggests the exact `approvals.deny` fnmatch pattern and prints the runnable `hermes config set approvals.deny ...` command.
  3. **`ADVISORY-ONLY`**: Semantic/qualitative guidelines for the model (e.g. "never assume user intent") with no direct deterministic command analogue.
- **Sacred Properties Preserved:**
  - Zero prompt cache impact (purely offline CLI diagnostic).
  - Zero core runtime footprint.

## Verification
- Unit test suite: `pytest tests/hermes_cli/test_security_rules_audit.py` (11 passed).
- Integration check with doctor suite: `pytest tests/hermes_cli/test_doctor.py` (passed).
