### PR TITLE
fix(browser): close real-profile snapshot browsers on chat end and after crash

### DIFF
--- a/hermes_cli/lifecycle.py
+++ b/hermes_cli/lifecycle.py
@@ -47,6 +47,13 @@ def has_hook(hook_name: str) -> bool:
 def finalize_session(**kwargs: Any) -> List[Any]:
     """Notify observers and hard-close one core-owned Relay conversation."""
     _observe("on_session_finalize", **kwargs)
+    # Chat end / /new / Desktop close — not process exit. Release the snapshot
+    # browser so the next chat is not blocked on SingletonLock (#103591).
+    try:
+        from tools.browser_tool_real_profile import _terminate_real_profile_chrome
+        _terminate_real_profile_chrome()
+    except Exception:
+        logger.debug("real-profile chrome cleanup on session finalize failed", exc_info=True)
 
     session_id = str(kwargs.get("session_id") or "")
     if session_id:

--- a/tests/hermes_cli/test_lifecycle.py
+++ b/tests/hermes_cli/test_lifecycle.py
@@ -39,8 +39,15 @@ def test_finalize_session_closes_core_before_plugin_export(monkeypatch):
     monkeypatch.setattr(relay_runtime, "SESSION_COORDINATOR", coordinator)
     monkeypatch.setattr(relay_runtime, "current_profile_key", lambda: "profile-1")
 
+    terminated = []
+    monkeypatch.setattr(
+        "tools.browser_tool_real_profile._terminate_real_profile_chrome",
+        lambda: terminated.append(True),
+    )
+
     lifecycle.finalize_session(session_id="session-1", platform="cli")
 
+    assert terminated == [True]
     assert [call[0] for call in calls] == ["builtin", "core", "plugin"]
     assert calls[1][1] == {
         "profile_key": "profile-1",

--- a/tests/tools/test_browser_cleanup.py
+++ b/tests/tools/test_browser_cleanup.py
@@ -58,6 +58,7 @@ class TestBrowserCleanup:
                 return_value={"success": True},
             ) as mock_run,
             patch("tools.browser_tool.os.path.exists", return_value=False),
+            patch("tools.browser_tool_real_profile._terminate_real_profile_chrome") as mock_rp,
         ):
             bt_lifecycle.cleanup_browser("task-1")
 
@@ -65,6 +66,7 @@ class TestBrowserCleanup:
         assert "task-1" not in browser_tool._session_last_activity
         mock_stop.assert_called_once_with("task-1")
         mock_run.assert_called_once_with("task-1", "close", [], timeout=10)
+        mock_rp.assert_called_once_with()
 
 
     def test_emergency_cleanup_clears_all_tracking_state(self):

--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -1044,3 +1044,76 @@ class TestWindowsLockedProfileCopy:
         dst, err = bc.snapshot_real_profile("chrome", src=str(root))
         assert dst is None
         assert err and "login data" in err.lower() and "close" in err.lower()
+
+
+class TestRealProfileSessionCleanup:
+    """#103591: snapshot Brave must die on chat end / idle, and after a crashed owner."""
+
+    def test_cmdline_requires_user_data_dir_on_copy(self):
+        # Daily browser must never match — no --user-data-dir=<snapshot>.
+        copy = "/home/u/.hermes/browser-profile/brave-origin"
+        with patch("psutil.Process") as proc:
+            proc.return_value.cmdline.return_value = [
+                "/opt/brave-origin-bin/brave", "--ozone-platform=wayland"]
+            assert bt_real_profile._cmdline_bound_to_copy_dir(1, copy) is False
+            proc.return_value.cmdline.return_value = [
+                "/opt/brave-origin-bin/brave", f"--user-data-dir={copy}"]
+            assert bt_real_profile._cmdline_bound_to_copy_dir(1, copy) is True
+            # Windows argv uses backslashes; both sides must normalize.
+            win = r"C:\Users\u\.hermes\browser-profile\chrome"
+            proc.return_value.cmdline.return_value = [
+                r"C:\Brave\brave.exe", f"--user-data-dir={win}"]
+            assert bt_real_profile._cmdline_bound_to_copy_dir(1, win) is True
+
+    def test_orphan_reap_skips_live_owner(self, tmp_path, monkeypatch):
+        home = tmp_path / "hh"
+        monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: home)
+        owners = home / "browser-profile" / ".hermes-owners"
+        owners.mkdir(parents=True)
+        rec = {"copy_dir": str(tmp_path / "copy"), "chrome_pid": 4242,
+               "owner_pid": 111, "owner_start_time": 9, "chrome_start_time": 8}
+        (owners / "brave-origin.json").write_text(json.dumps(rec))
+        with patch.object(bt_real_profile, "_pid_is_ours", return_value=True), \
+             patch.object(bt_real_profile, "_kill_snapshot_chrome") as kill:
+            assert bt_real_profile._reap_orphaned_real_profile_browsers() == 0
+            kill.assert_not_called()
+            assert (owners / "brave-origin.json").exists()
+
+    def test_orphan_reap_kills_when_owner_dead(self, tmp_path, monkeypatch):
+        home = tmp_path / "hh"
+        copy = tmp_path / "copy"
+        copy.mkdir()
+        (copy / "SingletonLock").write_text("stale")
+        monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: home)
+        owners = home / "browser-profile" / ".hermes-owners"
+        owners.mkdir(parents=True)
+        rec = {"copy_dir": str(copy), "chrome_pid": 4242,
+               "owner_pid": 111, "owner_start_time": 9, "chrome_start_time": 8}
+        (owners / "brave-origin.json").write_text(json.dumps(rec))
+        with patch.object(bt_real_profile, "_pid_is_ours", return_value=False), \
+             patch.object(bt_real_profile, "_kill_snapshot_chrome", return_value=True) as kill:
+            assert bt_real_profile._reap_orphaned_real_profile_browsers() == 1
+            kill.assert_called_once()
+        assert not (owners / "brave-origin.json").exists()
+        assert not (copy / "SingletonLock").exists()
+
+    def test_terminate_kills_this_process_record_only(self, tmp_path, monkeypatch):
+        import tools.browser_tool as bt
+        home = tmp_path / "hh"
+        copy = tmp_path / "copy"
+        copy.mkdir()
+        monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: home)
+        owners = home / "browser-profile" / ".hermes-owners"
+        owners.mkdir(parents=True)
+        mine = {"copy_dir": str(copy), "chrome_pid": 7, "owner_pid": os.getpid()}
+        other = {"copy_dir": str(tmp_path / "other"), "chrome_pid": 8, "owner_pid": 1}
+        (owners / "chrome.json").write_text(json.dumps(mine))
+        (owners / "other.json").write_text(json.dumps(other))
+        bt._real_profile_cdp_cache["cdp"] = "http://127.0.0.1:1"
+        with patch.object(bt_real_profile, "_kill_snapshot_chrome", return_value=True) as kill, \
+             patch.object(bt_real_profile, "_agent_browser_close_session"):
+            bt_real_profile._terminate_real_profile_chrome()
+        kill.assert_called_once()
+        assert not (owners / "chrome.json").exists()
+        assert (owners / "other.json").exists()
+        assert "cdp" not in bt._real_profile_cdp_cache

--- a/tools/browser_tool_lifecycle.py
+++ b/tools/browser_tool_lifecycle.py
@@ -77,8 +77,8 @@ def _emergency_cleanup_all_sessions():
     _bt._cleanup_done = True
 
     # Own sessions first so their owner_pid files are gone before the reaper scans.
-    # Real-profile Chrome is launched directly (not by agent-browser), so the
-    # session cleanup never reaps it.
+    # Real-profile Chrome is launched directly (not by agent-browser); cleanup_browser
+    # now terminates it too, and atexit remains the last-resort process-exit path.
     _best_effort("Real-profile chrome cleanup on exit", _real_profile._terminate_real_profile_chrome)
     if _bt._active_sessions:
         _bt.logger.info("Emergency cleanup: closing %s active session(s)...", len(_bt._active_sessions))
@@ -357,6 +357,7 @@ def _reap_orphaned_browser_sessions():
         from tools.browser_lightpanda import reap_orphaned_lightpanda
         reap_orphaned_lightpanda()
     _best_effort("Lightpanda orphan reap", _reap_lp)
+    _best_effort("Real-profile orphan reap", _real_profile._reap_orphaned_real_profile_browsers)
 
     tmpdir = _bt._socket_safe_tmpdir()
     socket_dirs = []
@@ -555,6 +556,9 @@ def cleanup_browser(task_id: Optional[str] = None) -> None:
     for session_key in session_keys:
         _cleanup_single_browser_session(session_key)
     _drop_last_active_binding(task_id)
+    # Real-profile Chrome is not an agent-browser child; idle/session cleanup must
+    # terminate it explicitly or the snapshot dir stays locked (#103591).
+    _best_effort("Real-profile chrome cleanup", _real_profile._terminate_real_profile_chrome)
 
 
 def _kill_verified_daemon(socket_dir: str, session_name: str) -> bool:

--- a/tools/browser_tool_real_profile.py
+++ b/tools/browser_tool_real_profile.py
@@ -6,6 +6,7 @@ State (``_REAL_PROFILE_SESSION``, ``_real_profile_cdp_lock``, ``_real_profile_cd
 through ``_bt`` (resolved per call — never import ``tools.browser_tool`` at import time).
 """
 
+import json
 import os
 import re
 import subprocess
@@ -19,15 +20,172 @@ from tools import browser_tool_lightpanda_fallback as _lp
 from tools import browser_tool_session as _session
 
 _RP = "browser.use_real_profile is on, but "
+_OWNERS_DIRNAME = ".hermes-owners"
+_SNAPSHOT_LOCK_NAMES = ("SingletonLock", "SingletonSocket", "SingletonCookie", "DevToolsActivePort")
+
+
+def _owners_dir() -> str:
+    """Sidecar dir for snapshot-browser owner records (outside each Chrome user-data-dir)."""
+    from hermes_constants import get_hermes_home
+    path = get_hermes_home() / "browser-profile" / _OWNERS_DIRNAME
+    path.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(path, 0o700)
+    except OSError:
+        pass
+    return str(path)
+
+
+def _owner_record_path(copy_dir: str) -> str:
+    name = os.path.basename(os.path.normpath(copy_dir)) or "unknown"
+    return os.path.join(_owners_dir(), f"{name}.json")
+
+
+def _write_owner_record(copy_dir: str, chrome_pid: int) -> None:
+    """Persist enough identity for a later process to reap this snapshot browser after a crash."""
+    from tools.process_registry import ProcessRegistry
+    record = {
+        "copy_dir": copy_dir,
+        "chrome_pid": chrome_pid,
+        "chrome_start_time": ProcessRegistry._safe_host_start_time(chrome_pid),
+        "owner_pid": os.getpid(),
+        "owner_start_time": ProcessRegistry._safe_host_start_time(os.getpid()),
+    }
+    path = _owner_record_path(copy_dir)
+    try:
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(record, fh)
+        os.chmod(path, 0o600)
+    except OSError as e:
+        _origin().logger.debug("real-profile owner record write failed: %s", e)
+
+
+def _read_owner_records() -> list:
+    """``(path, record)`` for every readable owner sidecar. Bad JSON is skipped."""
+    try:
+        names = os.listdir(_owners_dir())
+    except OSError:
+        return []
+    out = []
+    for name in names:
+        if not name.endswith(".json"):
+            continue
+        path = os.path.join(_owners_dir(), name)
+        try:
+            with open(path, encoding="utf-8") as fh:
+                rec = json.load(fh)
+        except (OSError, ValueError):
+            continue
+        if isinstance(rec, dict) and rec.get("copy_dir") and rec.get("chrome_pid"):
+            out.append((path, rec))
+    return out
+
+
+def _pid_is_ours(pid, expected_start) -> bool:
+    """True when ``pid`` is alive and still the process we recorded (start-time match)."""
+    from tools.process_registry import ProcessRegistry
+    try:
+        pid = int(pid)
+    except (TypeError, ValueError):
+        return False
+    return ProcessRegistry._host_pid_is_ours(pid, expected_start)
+
+
+def _cmdline_bound_to_copy_dir(pid: int, copy_dir: str) -> bool:
+    """True only when the live process is the snapshot browser (``--user-data-dir=<copy>``).
+
+    Refuses the user's daily browser: that process never uses the hermes snapshot dir.
+    """
+    needle = f"--user-data-dir={os.path.normpath(copy_dir)}".replace("\\", "/")
+    try:
+        import psutil
+        cmd = " ".join(psutil.Process(pid).cmdline() or [])
+    except Exception:
+        try:
+            with open(f"/proc/{pid}/cmdline", "rb") as fh:
+                cmd = fh.read().replace(b"\x00", b" ").decode("utf-8", "replace")
+        except OSError:
+            return False
+    return needle in cmd.replace("\\", "/")
+
+
+def _clear_snapshot_lock_files(copy_dir: str) -> None:
+    """Remove Chrome's 'this dir is in use' markers after the snapshot browser is gone."""
+    for name in _SNAPSHOT_LOCK_NAMES:
+        try:
+            os.unlink(os.path.join(copy_dir, name))
+        except OSError:
+            pass
+
+
+def _kill_snapshot_chrome(pid, copy_dir: str, expected_start=None) -> bool:
+    """Tree-kill ``pid`` if it is still the snapshot browser on ``copy_dir``. False if refused."""
+    try:
+        pid = int(pid)
+    except (TypeError, ValueError):
+        return False
+    if not _cmdline_bound_to_copy_dir(pid, copy_dir):
+        return False
+    from tools.process_registry import ProcessRegistry
+    ProcessRegistry._terminate_host_pid(pid, expected_start=expected_start)
+    return True
+
+
+def _forget_real_profile_attach() -> None:
+    """Drop cached CDP and the agent-browser attach so the next launch is a fresh headed window."""
+    _bt = _origin()
+    _bt._real_profile_cdp_cache.pop("cdp", None)
+    try:
+        _agent_browser_close_session(_bt._REAL_PROFILE_SESSION)
+    except Exception:
+        pass
 
 
 def _terminate_real_profile_chrome() -> None:
-    """Terminate real-browser processes launched for real-profile sessions (idempotent, atexit-safe);
-    agent-browser only ATTACHED to them, so its own session cleanup never kills them."""
+    """Terminate real-browser processes launched for real-profile sessions (idempotent).
+
+    agent-browser only ATTACHED to them, so its own session cleanup never kills them.
+    Also kills snapshot browsers this process recorded on disk (Popen handle lost)
+    and clears the copy-dir lock files.
+    """
     from tools.browser_lightpanda import _terminate
     _bt = _origin()
     while _bt._real_profile_chrome_procs:
         _terminate(_bt._real_profile_chrome_procs.pop(), what="real-profile chrome")
+    for path, rec in _read_owner_records():
+        if rec.get("owner_pid") != os.getpid():
+            continue
+        copy_dir = rec["copy_dir"]
+        _kill_snapshot_chrome(rec.get("chrome_pid"), copy_dir, rec.get("chrome_start_time"))
+        _clear_snapshot_lock_files(copy_dir)
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+    _forget_real_profile_attach()
+
+
+def _reap_orphaned_real_profile_browsers() -> int:
+    """Kill snapshot browsers whose launching Hermes process is dead. Returns reaped count.
+
+    Live owners are left alone (another Hermes still owns that copy). Identity-checked
+    against ``--user-data-dir=<copy_dir>`` so a recycled PID cannot become a kill.
+    """
+    reaped = 0
+    for path, rec in _read_owner_records():
+        if _pid_is_ours(rec.get("owner_pid"), rec.get("owner_start_time")):
+            continue
+        copy_dir = rec["copy_dir"]
+        if _kill_snapshot_chrome(rec.get("chrome_pid"), copy_dir, rec.get("chrome_start_time")):
+            reaped += 1
+        _clear_snapshot_lock_files(copy_dir)
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+    if reaped:
+        _origin().logger.info("Reaped %d orphaned real-profile browser(s)", reaped)
+    return reaped
 
 
 def _cdp_http_ready(http_cdp: str) -> bool:
@@ -140,6 +298,8 @@ def _launch_real_profile_chrome(real_binary: str, copy_dir: str) -> Tuple[Option
     except (subprocess.SubprocessError, OSError) as e:
         return None, f"{_RP}the launch failed: {e}"
     _bt._real_profile_chrome_procs.append(chrome_proc)
+    if getattr(chrome_proc, "pid", None):
+        _write_owner_record(copy_dir, chrome_proc.pid)
 
     deadline = time.monotonic() + 30.0
     while time.monotonic() < deadline:

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -827,7 +827,7 @@ Headed mode does two things:
 1. **Launches Chromium with a visible window** (passes `--headed` to agent-browser in local mode).
 2. **Keeps the window open between turns.** Normally the browser session is cleaned up after every agent reply; in headed mode the per-turn cleanup is skipped so you can watch the agent work, intervene manually (sign-in challenges, CAPTCHAs), and keep login state warm across the conversation.
 
-Idle sessions are still reaped after `browser.inactivity_timeout` (default 120s of no browser activity), and all sessions are closed on shutdown. Headed mode only affects the local browser — cloud sessions (Browserbase) are unaffected.
+Idle sessions are still reaped after `browser.inactivity_timeout` (default 120s of no browser activity), and all sessions are closed on shutdown. A **real-profile** snapshot browser (the extra Chrome/Brave with your logins) is closed on idle, when the chat ends (`/new`, Desktop or dashboard close), and by the orphan sweep if Hermes dies uncleanly — not only when the Hermes process exits. Headed mode only affects the local browser — cloud sessions (Browserbase) are unaffected.
 
 ## Stealth Features
 


### PR DESCRIPTION
## What does this PR do?

Real-profile browsing launches the user's Chrome/Brave **directly** on a Hermes-owned snapshot copy (`~/.hermes/browser-profile/<browser>/`). agent-browser only attaches, so its session cleanup never kills that process. `_terminate_real_profile_chrome()` ran only on process `atexit`.

The leftover snapshot browser holds `SingletonLock`. The next chat then fails to reuse the copy and falls back to packaged Chromium (no logins). This happens when:

- Desktop / dashboard chat closes (app stays up)
- CLI `/new` (same process)
- Hermes crashes / is SIGKILL'd (no atexit)

This PR does **C + D** from #103591:

- **C:** close the snapshot browser on chat end (`finalize_session`: `/new`, Desktop, dashboard) **and** on idle (`cleanup_browser` / `inactivity_timeout`)
- **D:** persist an owner sidecar (`$HERMES_HOME/browser-profile/.hermes-owners/<browser>.json`) and reap the snapshot browser when the owning Hermes PID is gone

Kill is identity-checked against `--user-data-dir=<snapshot copy>`. The user's daily browser is never a match.

The snapshot **folder** is still kept (logins persist). Only the process and Chrome lock files are released.

## Related Issue

Fixes #103591

Related: #94946, #100855.

Overlap: #100998 also reaps orphaned directly-launched Chrome (D, more multi-owner / macOS Dock focused). This PR's unique piece is **C** (chat-end + idle). If #100998 merges first, D here can be dropped or rebased onto that owner store.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/browser_tool_real_profile.py` — owner sidecars, cmdline-bound kill, chat/idle terminate, orphan reap
- `tools/browser_tool_lifecycle.py` — terminate on idle cleanup; orphan reap from the existing sweep
- `hermes_cli/lifecycle.py` — terminate on `finalize_session` (CLI `/new`, Desktop, dashboard)
- `website/docs/user-guide/features/browser.md` — headed-mode lifetime
- Tests in `tests/tools/test_browser_real_profile.py`, `tests/tools/test_browser_cleanup.py`, `tests/hermes_cli/test_lifecycle.py`

## How to Test

1. `browser.use_real_profile: true` and `browser.headed: true`. Run a local `browser_navigate`.
2. CLI `/new` or close the Desktop/dashboard chat **without** exiting Hermes. The extra snapshot Chrome/Brave window should close; `SingletonLock` under `~/.hermes/browser-profile/<browser>/` should be gone. Daily Chrome/Brave must stay up.
3. Start a new chat and browse again — it should reuse the snapshot copy (logins still there), not fall back to packaged Chromium.
4. Crash path: kill -9 the Hermes that launched the snapshot browser, start Hermes again. The orphan sweep should close the leftover snapshot process (same `--user-data-dir` check).

Automated: `uv run --extra dev pytest tests/tools/test_browser_real_profile.py::TestRealProfileSessionCleanup tests/tools/test_browser_cleanup.py tests/hermes_cli/test_lifecycle.py tests/tools/test_browser_orphan_reaper.py tests/tools/test_browser_lightpanda.py -q` — 80 passed locally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux (Omarchy / Hyprland)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


Made with [Cursor](https://cursor.com)