### PR TITLE
fix(desktop): expand attached skill commands before submitting

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -322,6 +322,23 @@ describe('useComposerSubmit busy-turn routing', () => {
     expect(onCancel).not.toHaveBeenCalled()
   })
 
+  it('dispatches a busy skill with its attachments for expansion before queueing', async () => {
+    const attachment: ComposerAttachment = { id: 'doc', kind: 'file', label: 'notes.txt' }
+
+    const { hook, onSubmit, onSteer, queueCurrentDraft } = renderSubmitHook({
+      attachments: [attachment],
+      busy: true,
+      text: '/work inspect'
+    })
+
+    act(() => hook.result.current.submitDraft())
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith('/work inspect', expect.objectContaining({ attachments: [attachment] }))
+    )
+    expect(onSteer).not.toHaveBeenCalled()
+    expect(queueCurrentDraft).not.toHaveBeenCalled()
+  })
+
   it('queues an attachment-bearing follow-up while busy', () => {
     const attachment: ComposerAttachment = { id: 'doc', kind: 'file', label: 'notes.txt' }
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -2,6 +2,7 @@ import { type RefObject, useLayoutEffect, useRef } from 'react'
 
 import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
 import { SLASH_COMMAND_RE } from '@/lib/chat-runtime'
+import { isDesktopSlashExtensionCommand } from '@/lib/desktop-slash-commands'
 import { triggerHaptic } from '@/lib/haptics'
 import { hasClarifyRequest, skipClarifyRequest } from '@/store/clarify'
 import { clearSessionDraft, type ComposerAttachment } from '@/store/composer'
@@ -198,10 +199,10 @@ export function useComposerSubmit({
       // busy guard for commands that genuinely need an idle session (skill
       // /send directives).  Queuing them would make every slash command wait
       // for the current turn to finish, which is how the TUI never behaves.
-      if (!attachments.length && SLASH_COMMAND_RE.test(text.trim())) {
+      if (SLASH_COMMAND_RE.test(text.trim()) && (!attachments.length || isDesktopSlashExtensionCommand(text))) {
         triggerHaptic('submit')
         clearDraft()
-        dispatchSubmit(text)
+        dispatchSubmit(text, attachments.length ? attachments : undefined)
       } else if (!compacting && !blockingPrompt && !attachments.length && text.trim()) {
         // Cursor-style stop-and-correct: interrupt the live turn and redirect
         // it with this text. redirect() preserves the shown reasoning/work; if

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1681,6 +1681,61 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
     $queuedPromptsBySession.set({})
   })
 
+  it.each([false, true])('expands an attached skill and preserves its payload (busy=%s)', async busy => {
+    $queuedPromptsBySession.set({})
+    publishSessionState(RUNTIME_SESSION_ID, { ...createClientSessionState(RUNTIME_SESSION_ID), busy })
+    const attachment: ComposerAttachment = { id: 'notes', kind: 'file', label: 'notes.txt', refText: '@file:notes.txt' }
+
+    const requestGateway = vi.fn(
+      async (method: string) =>
+        (method === 'slash.exec'
+          ? { type: 'skill', name: 'work', message: 'Expanded skill instructions', display: '/work inspect' }
+          : {}) as never
+    )
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        busyRef={{ current: busy }}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+    await handle!.submitText('/work inspect', { attachments: [attachment] })
+    expect(requestGateway).toHaveBeenCalledWith('slash.exec', expect.objectContaining({ command: 'work inspect' }))
+
+    if (busy) {
+      expect(getQueuedPrompts(RUNTIME_SESSION_ID)).toEqual([
+        expect.objectContaining({
+          text: 'Expanded skill instructions',
+          attachments: [attachment],
+          displayText: '/work inspect'
+        })
+      ])
+      expect(requestGateway.mock.calls.map(([method]) => method)).not.toContain('prompt.submit')
+    } else {
+      expect(requestGateway).toHaveBeenCalledWith(
+        'prompt.submit',
+        expect.objectContaining({
+          text: expect.stringContaining('Expanded skill instructions')
+        }),
+        expect.any(Number)
+      )
+    }
+
+    if (!busy) {
+      expect(requestGateway).toHaveBeenCalledWith(
+        'prompt.submit',
+        expect.objectContaining({ text: expect.stringContaining('@file:notes.txt') }),
+        expect.any(Number)
+      )
+    }
+
+    dropSessionState(RUNTIME_SESSION_ID)
+    $queuedPromptsBySession.set({})
+  })
+
   it('renders a skill turn as its invocation — the expanded body never reaches a bubble', async () => {
     // A `/skill` dispatch's `message` is the whole skill body (model-facing
     // scaffolding). The agent must receive it verbatim; every UI surface —

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -9,6 +9,7 @@ import { stripAnsi } from '@/lib/ansi'
 import { type ChatMessage, textPart } from '@/lib/chat-messages'
 import { pathLabel, SLASH_COMMAND_RE } from '@/lib/chat-runtime'
 import { sanitizeComposerInput } from '@/lib/composer-input-sanitize'
+import { isDesktopSlashExtensionCommand } from '@/lib/desktop-slash-commands'
 import { triggerHaptic } from '@/lib/haptics'
 import { setMutableRef } from '@/lib/mutable-ref'
 import { normalize } from '@/lib/text'
@@ -609,11 +610,11 @@ export function usePromptActions({
       const visibleText = sanitizeComposerInput(rawText).trim()
       const attachments = options?.attachments ?? $composerAttachments.get()
 
-      if (!attachments.length && SLASH_COMMAND_RE.test(visibleText)) {
+      if (SLASH_COMMAND_RE.test(visibleText) && (!attachments.length || isDesktopSlashExtensionCommand(visibleText))) {
         triggerHaptic('selection')
         // Forward the explicit target (background queue drain, tile) — dropping
         // it ran the command against whatever chat happened to be in front.
-        await executeSlashCommand(visibleText, options?.sessionId ? { sessionId: options.sessionId } : undefined)
+        await executeSlashCommand(visibleText, { sessionId: options?.sessionId, attachments })
 
         return true
       }

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -614,7 +614,7 @@ export function usePromptActions({
         triggerHaptic('selection')
         // Forward the explicit target (background queue drain, tile) — dropping
         // it ran the command against whatever chat happened to be in front.
-        await executeSlashCommand(visibleText, { sessionId: options?.sessionId, attachments })
+        await executeSlashCommand(visibleText, { sessionId: options?.sessionId ?? undefined, attachments })
 
         return true
       }

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -187,7 +187,10 @@ export function useSlashCommand(deps: SlashCommandDeps) {
   const compressInFlightRef = useRef(new Set<string>())
 
   return useCallback(
-    async (rawCommand: string, options?: { sessionId?: string; recordInput?: boolean }) => {
+    async (
+      rawCommand: string,
+      options?: { sessionId?: string; recordInput?: boolean; attachments?: SubmitTextOptions['attachments'] }
+    ) => {
       // Resolve the session this command targets through the SHARED ladder that
       // submit.ts uses. A slash command runs backend commands against a runtime
       // session, and per-session state (`/goal`, `/usage`, `/status`) is keyed by
@@ -359,7 +362,9 @@ export function useSlashCommand(deps: SlashCommandDeps) {
             // whichever chat is now in front.
             const queueKey = resolveComposerSessionKey(storedSessionId, $sessions.get()) || storedSessionId || sessionId
 
-            if (enqueueQueuedPrompt(queueKey, { attachments: [], text: message, displayText })) {
+            if (
+              enqueueQueuedPrompt(queueKey, { attachments: options?.attachments ?? [], text: message, displayText })
+            ) {
               renderSlashOutput('session busy — message queued to send when the current turn finishes')
             } else {
               renderSlashOutput('session busy — /interrupt the current turn before sending this command')
@@ -376,7 +381,12 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           // its kickoff as a user message into whatever conversation was on
           // screen. Every other target the dispatcher serves (tile, background
           // queue drain, a session created by this very call) had the same leak.
-          await submitPromptText(message, { sessionId, storedSessionId, displayText })
+          await submitPromptText(message, {
+            sessionId,
+            storedSessionId,
+            displayText,
+            attachments: options?.attachments
+          })
         }
 
         try {


### PR DESCRIPTION
Desktop skill and extension slash commands now expand when the composer contains attachments. The idle path passes attachments with the expanded prompt; the busy path queues the expanded payload and its attachments together. The composer forwards attachments when dispatching the busy command, preserving the target session and invocation display text.

Fixes #103594. Built-in commands retain their existing attachment routing.

Validation: all 161 tests in the prompt-actions and composer-submit suites pass, including new idle/busy attachment cases. Those three new cases fail before the fix because slash dispatch is bypassed. Desktop TypeScript checks pass; targeted ESLint reports only the existing harness effect-dependency warning.
