### PR TITLE
feat(gateway): MEDIA files created inside ssh/modal/daytona sandboxes now deliver to the user (#466, salvage #68506)

### DIFF
--- a/contributors/emails/tarek.belkahia@gmail.com
+++ b/contributors/emails/tarek.belkahia@gmail.com
@@ -1,0 +1,2 @@
+tokou
+# PR #68506 salvage

--- a/gateway/media_fetch.py
+++ b/gateway/media_fetch.py
@@ -1,13 +1,18 @@
 """Deliver ``MEDIA:<path>`` files that live inside a remote terminal sandbox (#466).
 
 ``validate_media_delivery_path`` only accepts files on the gateway host. When the terminal backend
-is ssh / modal / daytona / singularity / vercel (or a docker path outside its bind mounts), the
-agent's artifact is on another filesystem, so the tag was silently dropped. This module pulls the
-file through the active environment's ``fetch_file`` into the document cache (already an
-allowlisted delivery root) and hands back the host copy.
+is ssh / daytona / vercel (any backend that reports its ``_remote_home``), the agent's artifact is
+on another filesystem, so the tag was silently dropped. This module pulls the file through the
+active environment's ``fetch_file`` into the document cache (already an allowlisted delivery root)
+and hands back the host copy. Backends without a known remote home (docker outside its mounts,
+modal, singularity) still get the conservative any-component denylist, so a ``/root/...`` artifact
+there is not fetched — set ``_remote_home`` on the environment to opt in.
 
 The remote path is screened against the same denylist as local deliveries BEFORE any bytes move,
-and again after ``readlink -f`` — a remote fetch must never become a bypass of the host denylist.
+and again after ``readlink -f`` (fail closed when it cannot resolve) — a remote fetch must never
+become a bypass of the host denylist. Strict mode (``HERMES_MEDIA_DELIVERY_STRICT``) keeps its
+pre-existing behaviour: nothing is fetched, since a fetched copy would land in an allowlisted root
+and skip the recency gate strict mode exists for.
 """
 
 from __future__ import annotations
@@ -15,9 +20,14 @@ from __future__ import annotations
 import logging
 import os
 import posixpath
+import re
 import uuid
 from pathlib import Path, PurePosixPath
 from typing import Optional
+
+from gateway.platforms.base import (
+    _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS, _MEDIA_DELIVERY_DENIED_PREFIXES, _ROOT_CREDENTIAL_PATHS,
+    _TRUTHY, MEDIA_DELIVERY_STRICT_ENV)
 
 logger = logging.getLogger(__name__)
 
@@ -25,14 +35,15 @@ logger = logging.getLogger(__name__)
 # tools.image_source._MAX_INGEST_BYTES.
 _FETCH_MAX_BYTES = 50 * 1024 * 1024
 
+_DENIED_PREFIXES = tuple(PurePosixPath(p) for p in _MEDIA_DELIVERY_DENIED_PREFIXES)
+# Credential dirs under the sandbox home plus the Hermes stores, which live at ``~/.hermes`` there.
+_DENIED_HOME_RELATIVE = tuple(PurePosixPath(s) for s in _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS) + tuple(
+    PurePosixPath(".hermes", *PurePosixPath(rel.replace(os.sep, "/")).parts) for rel in _ROOT_CREDENTIAL_PATHS)
+
 
 def remote_path_is_denied(path: str, remote_home: Optional[str]) -> bool:
     """Pure string check (the remote fs can't be stat'd from here) applying the host denylist to a
-    sandbox path: system prefixes, credential dirs under the sandbox home, Hermes credential stores.
-    Unknown home ⇒ home-relative entries match ANY path component (conservative)."""
-    from gateway.platforms.base import (
-        _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS, _MEDIA_DELIVERY_DENIED_PREFIXES, _ROOT_CREDENTIAL_PATHS)
-
+    sandbox path. Unknown home ⇒ home-relative entries match ANY path component (conservative)."""
     target = PurePosixPath(posixpath.normpath(path))
     if not target.is_absolute():
         return True
@@ -43,44 +54,42 @@ def remote_path_is_denied(path: str, remote_home: Optional[str]) -> bool:
 
     # The sandbox's own home may be a denied system prefix (/root); its credential subpaths are
     # separate, more specific entries — same exception as _path_under_denied_prefix.
-    if any(_under(PurePosixPath(p)) for p in _MEDIA_DELIVERY_DENIED_PREFIXES if PurePosixPath(p) != home):
+    if any(_under(p) for p in _DENIED_PREFIXES if p != home):
         return True
-    home_relative = [PurePosixPath(s) for s in _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS]
-    home_relative += [PurePosixPath(".hermes", *PurePosixPath(rel.replace(os.sep, "/")).parts) for rel in _ROOT_CREDENTIAL_PATHS]
     if home is not None:
-        return any(_under(home / rel) for rel in home_relative)
+        return any(_under(home / rel) for rel in _DENIED_HOME_RELATIVE)
     parts = target.parts
     return any(parts[i:i + len(rel.parts)] == rel.parts
-               for rel in home_relative for i in range(len(parts) - len(rel.parts) + 1))
+               for rel in _DENIED_HOME_RELATIVE for i in range(len(parts) - len(rel.parts) + 1))
 
 
 def _active_remote_env():
-    """The live remote BaseEnvironment for the current session, or None (local backend / no env yet)."""
+    """The live remote BaseEnvironment for the current session, or None (local backend / no env yet).
+    Keyed by the session id the turn registered its sandbox under (falls back to the session key)."""
     from agent.prompt_builder import _REMOTE_TERMINAL_BACKENDS, _plugin_backend_is_remote
     from gateway.platforms.base import _tenv
+    from gateway.session_context import get_session_env
+    from tools.terminal_tool_lifecycle import get_active_env
     backend = _tenv("TERMINAL_ENV", "local").strip().lower()
     if backend not in _REMOTE_TERMINAL_BACKENDS and not _plugin_backend_is_remote(backend):
         return None
-    try:
-        from tools.terminal_tool import _current_session_key
-        from tools.terminal_tool_lifecycle import get_active_env
-        return get_active_env(_current_session_key() or "default")
-    except Exception as exc:
-        logger.debug("Remote media fetch: no active env: %s", exc)
-        return None
+    return get_active_env(get_session_env("HERMES_SESSION_ID") or get_session_env("HERMES_SESSION_KEY") or "default")
 
 
 def fetch_remote_media(path: str) -> Optional[str]:
     """Host path of a validated copy of sandbox file ``path``, or None (never raises). Only fires
     when a remote backend is active; the caller has already failed local validation."""
+    if os.environ.get(MEDIA_DELIVERY_STRICT_ENV, "0").strip().lower() in _TRUTHY:
+        return None
     env = _active_remote_env()
     if env is None:
         return None
-    from gateway.platforms.base import DOCUMENT_CACHE_DIR, _log_safe_path, validate_media_delivery_path
+    from gateway.platforms.base import (
+        DOCUMENT_CACHE_DIR, _log_safe_path, _normalize_media_tag_path, validate_media_delivery_path)
     from tools.environments.base import FileFetchError
 
     remote_home = getattr(env, "_remote_home", None)
-    candidate = posixpath.normpath(str(path).strip())
+    candidate = posixpath.normpath(_normalize_media_tag_path(str(path)) or "")
     if candidate == "~" or candidate.startswith("~/"):
         if not remote_home:
             return None
@@ -88,10 +97,12 @@ def fetch_remote_media(path: str) -> Optional[str]:
     if not candidate.startswith("/") or remote_path_is_denied(candidate, remote_home):
         return None
     try:
-        resolved = env.fetch_realpath(candidate) or candidate
-        if remote_path_is_denied(resolved, remote_home):
+        # ``[ -f ]`` in fetch_file follows symlinks, so the link TARGET is what gets screened;
+        # an unresolvable path fails closed rather than trusting the unresolved name.
+        resolved = env.fetch_realpath(candidate)
+        if resolved is None or remote_path_is_denied(resolved, remote_home):
             return None
-        basename = "".join(c for c in posixpath.basename(resolved) if c.isprintable() and c not in '/\\:*?"<>|') or "file"
+        basename = re.sub(r"[^\w.\-]", "_", posixpath.basename(resolved)) or "file"
         dest = Path(DOCUMENT_CACHE_DIR) / f"remote_{uuid.uuid4().hex[:12]}_{basename}"
         dest.parent.mkdir(parents=True, exist_ok=True)
         env.fetch_file(resolved, dest, max_bytes=_FETCH_MAX_BYTES)

--- a/gateway/media_fetch.py
+++ b/gateway/media_fetch.py
@@ -1,0 +1,109 @@
+"""Deliver ``MEDIA:<path>`` files that live inside a remote terminal sandbox (#466).
+
+``validate_media_delivery_path`` only accepts files on the gateway host. When the terminal backend
+is ssh / modal / daytona / singularity / vercel (or a docker path outside its bind mounts), the
+agent's artifact is on another filesystem, so the tag was silently dropped. This module pulls the
+file through the active environment's ``fetch_file`` into the document cache (already an
+allowlisted delivery root) and hands back the host copy.
+
+The remote path is screened against the same denylist as local deliveries BEFORE any bytes move,
+and again after ``readlink -f`` — a remote fetch must never become a bypass of the host denylist.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import posixpath
+import uuid
+from pathlib import Path, PurePosixPath
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Telegram bot uploads cap at 50 MB; the other platforms are in the same range. Mirrors
+# tools.image_source._MAX_INGEST_BYTES.
+_FETCH_MAX_BYTES = 50 * 1024 * 1024
+
+
+def remote_path_is_denied(path: str, remote_home: Optional[str]) -> bool:
+    """Pure string check (the remote fs can't be stat'd from here) applying the host denylist to a
+    sandbox path: system prefixes, credential dirs under the sandbox home, Hermes credential stores.
+    Unknown home ⇒ home-relative entries match ANY path component (conservative)."""
+    from gateway.platforms.base import (
+        _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS, _MEDIA_DELIVERY_DENIED_PREFIXES, _ROOT_CREDENTIAL_PATHS)
+
+    target = PurePosixPath(posixpath.normpath(path))
+    if not target.is_absolute():
+        return True
+    home = PurePosixPath(posixpath.normpath(remote_home)) if remote_home else None
+
+    def _under(root: PurePosixPath) -> bool:
+        return target == root or root in target.parents
+
+    # The sandbox's own home may be a denied system prefix (/root); its credential subpaths are
+    # separate, more specific entries — same exception as _path_under_denied_prefix.
+    if any(_under(PurePosixPath(p)) for p in _MEDIA_DELIVERY_DENIED_PREFIXES if PurePosixPath(p) != home):
+        return True
+    home_relative = [PurePosixPath(s) for s in _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS]
+    home_relative += [PurePosixPath(".hermes", *PurePosixPath(rel.replace(os.sep, "/")).parts) for rel in _ROOT_CREDENTIAL_PATHS]
+    if home is not None:
+        return any(_under(home / rel) for rel in home_relative)
+    parts = target.parts
+    return any(parts[i:i + len(rel.parts)] == rel.parts
+               for rel in home_relative for i in range(len(parts) - len(rel.parts) + 1))
+
+
+def _active_remote_env():
+    """The live remote BaseEnvironment for the current session, or None (local backend / no env yet)."""
+    from agent.prompt_builder import _REMOTE_TERMINAL_BACKENDS, _plugin_backend_is_remote
+    from gateway.platforms.base import _tenv
+    backend = _tenv("TERMINAL_ENV", "local").strip().lower()
+    if backend not in _REMOTE_TERMINAL_BACKENDS and not _plugin_backend_is_remote(backend):
+        return None
+    try:
+        from tools.terminal_tool import _current_session_key
+        from tools.terminal_tool_lifecycle import get_active_env
+        return get_active_env(_current_session_key() or "default")
+    except Exception as exc:
+        logger.debug("Remote media fetch: no active env: %s", exc)
+        return None
+
+
+def fetch_remote_media(path: str) -> Optional[str]:
+    """Host path of a validated copy of sandbox file ``path``, or None (never raises). Only fires
+    when a remote backend is active; the caller has already failed local validation."""
+    env = _active_remote_env()
+    if env is None:
+        return None
+    from gateway.platforms.base import DOCUMENT_CACHE_DIR, _log_safe_path, validate_media_delivery_path
+    from tools.environments.base import FileFetchError
+
+    remote_home = getattr(env, "_remote_home", None)
+    candidate = posixpath.normpath(str(path).strip())
+    if candidate == "~" or candidate.startswith("~/"):
+        if not remote_home:
+            return None
+        candidate = posixpath.normpath(posixpath.join(remote_home, candidate[2:]))
+    if not candidate.startswith("/") or remote_path_is_denied(candidate, remote_home):
+        return None
+    try:
+        resolved = env.fetch_realpath(candidate) or candidate
+        if remote_path_is_denied(resolved, remote_home):
+            return None
+        basename = "".join(c for c in posixpath.basename(resolved) if c.isprintable() and c not in '/\\:*?"<>|') or "file"
+        dest = Path(DOCUMENT_CACHE_DIR) / f"remote_{uuid.uuid4().hex[:12]}_{basename}"
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        env.fetch_file(resolved, dest, max_bytes=_FETCH_MAX_BYTES)
+    except FileFetchError as exc:
+        logger.warning("Remote media fetch of %s skipped: %s", _log_safe_path(candidate), exc)
+        return None
+    except Exception:
+        logger.warning("Remote media fetch of %s failed", _log_safe_path(candidate), exc_info=True)
+        return None
+    validated = validate_media_delivery_path(str(dest))
+    if not validated:
+        dest.unlink(missing_ok=True)
+        return None
+    logger.info("Fetched remote media %s from the %s sandbox", _log_safe_path(candidate), type(env).__name__)
+    return validated

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1132,9 +1132,13 @@ def _log_safe_path(path: str) -> str:
 
 
 def _validated_delivery_path(raw_path, session_key: str, label: str) -> Optional[str]:
-    """``validate_media_delivery_path`` plus the shared "Skipping unsafe ..." warning."""
+    """``validate_media_delivery_path`` plus the shared "Skipping unsafe ..." warning. A path the
+    host cannot see is retried against the active remote sandbox (ssh/modal/...; #466)."""
     raw = str(raw_path)
     safe_path = validate_media_delivery_path(raw, session_key=session_key)
+    if not safe_path:
+        from gateway.media_fetch import fetch_remote_media
+        safe_path = fetch_remote_media(raw)
     if not safe_path:
         logger.warning("Skipping unsafe %s: %s", label, _log_safe_path(raw))
     return safe_path

--- a/tests/gateway/test_remote_media_fetch.py
+++ b/tests/gateway/test_remote_media_fetch.py
@@ -56,9 +56,14 @@ def test_sandbox_artifact_is_fetched_but_credentials_and_symlinks_to_them_are_no
     assert remote_env.fetched == ["/home/agent/out/report.txt", "/home/agent/out/report.txt"]
 
 
-def test_local_backend_does_not_fetch(monkeypatch, tmp_path):
+def test_local_backend_and_strict_mode_do_not_fetch(monkeypatch, tmp_path, remote_env):
+    """Strict mode keeps its recency gate: a fetched copy would land in an allowlisted root and skip it."""
+    monkeypatch.setenv("HERMES_MEDIA_DELIVERY_STRICT", "1")
+    assert BasePlatformAdapter.filter_media_delivery_paths([("/home/agent/out/report.txt", False)]) == []
+    monkeypatch.delenv("HERMES_MEDIA_DELIVERY_STRICT")
     monkeypatch.setattr(media_fetch, "_active_remote_env", lambda: None)
     assert BasePlatformAdapter.filter_media_delivery_paths([(str(tmp_path / "nope.txt"), False)]) == []
+    assert remote_env.fetched == []
 
 
 class _ScriptedEnv(BaseEnvironment):

--- a/tests/gateway/test_remote_media_fetch.py
+++ b/tests/gateway/test_remote_media_fetch.py
@@ -1,0 +1,92 @@
+"""MEDIA tags pointing into a remote terminal sandbox are fetched for delivery (#466).
+
+The host cannot see files an agent writes inside an ssh/modal/daytona sandbox, so
+``filter_media_delivery_paths`` used to drop them silently. With a remote backend active the path is
+pulled through the environment's ``fetch_file`` into the document cache — after the SAME denylist
+the host applies, so a sandbox path (or a symlink) at ``~/.ssh/...`` never crosses.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import gateway.media_fetch as media_fetch
+from gateway.platforms.base import BasePlatformAdapter
+from tools.environments.base import BaseEnvironment, FileFetchError
+
+
+class _FakeRemoteEnv:
+    """Stands in for a live SSHEnvironment: a tiny remote filesystem + symlink table."""
+
+    _remote_home = "/home/agent"
+
+    def __init__(self):
+        self.files = {"/home/agent/out/report.txt": b"hello from sandbox",
+                      "/home/agent/.ssh/id_rsa": b"SECRET"}
+        self.links = {"/home/agent/out/innocent.txt": "/home/agent/.ssh/id_rsa"}
+        self.fetched: list = []
+
+    def fetch_realpath(self, remote_path):
+        return self.links.get(remote_path, remote_path)
+
+    def fetch_file(self, remote_path, local_dest, *, max_bytes):
+        self.fetched.append(remote_path)
+        if remote_path not in self.files:
+            raise FileFetchError("missing")
+        Path(local_dest).write_bytes(self.files[remote_path])
+
+
+@pytest.fixture
+def remote_env(monkeypatch, tmp_path):
+    env = _FakeRemoteEnv()
+    monkeypatch.setattr(media_fetch, "_active_remote_env", lambda: env)
+    monkeypatch.setattr("gateway.platforms.base.DOCUMENT_CACHE_DIR", tmp_path / "cache" / "documents")
+    monkeypatch.setattr("gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS", (tmp_path / "cache" / "documents",))
+    return env
+
+
+def test_sandbox_artifact_is_fetched_but_credentials_and_symlinks_to_them_are_not(remote_env):
+    media = [("/home/agent/out/report.txt", False), ("/home/agent/out/innocent.txt", False),
+             ("/home/agent/.ssh/id_rsa", False), ("~/out/report.txt", False)]
+    delivered = BasePlatformAdapter.filter_media_delivery_paths(media)
+
+    assert [Path(p).read_bytes() for p, _ in delivered] == [b"hello from sandbox", b"hello from sandbox"]
+    assert all(Path(p).name.endswith("_report.txt") for p, _ in delivered)
+    # The credential file and the symlink that resolves to it were refused BEFORE any bytes moved.
+    assert remote_env.fetched == ["/home/agent/out/report.txt", "/home/agent/out/report.txt"]
+
+
+def test_local_backend_does_not_fetch(monkeypatch, tmp_path):
+    monkeypatch.setattr(media_fetch, "_active_remote_env", lambda: None)
+    assert BasePlatformAdapter.filter_media_delivery_paths([(str(tmp_path / "nope.txt"), False)]) == []
+
+
+class _ScriptedEnv(BaseEnvironment):
+    """Runs the fetch command through a real shell so the transport (marker fencing, in-sandbox
+    size bound, base64 round-trip) is exercised end to end."""
+
+    def __init__(self):
+        pass
+
+    def cleanup(self):
+        pass
+
+    def execute(self, command, cwd="", **kwargs):
+        import subprocess
+        proc = subprocess.run(["bash", "-c", command], capture_output=True, text=True)
+        return {"output": "echo login-noise\n" + proc.stdout + proc.stderr, "returncode": proc.returncode}
+
+
+def test_fetch_file_round_trips_bytes_and_enforces_the_in_sandbox_size_cap(tmp_path):
+    src = tmp_path / "artifact.bin"
+    src.write_bytes(bytes(range(256)) * 40)
+    dest = tmp_path / "copy.bin"
+    env = _ScriptedEnv()
+
+    env.fetch_file(str(src), dest, max_bytes=len(src.read_bytes()))
+    assert dest.read_bytes() == src.read_bytes()
+
+    with pytest.raises(FileFetchError, match="exceeds"):
+        env.fetch_file(str(src), dest, max_bytes=100)
+    with pytest.raises(FileFetchError, match="could not read"):
+        env.fetch_file(str(tmp_path), dest, max_bytes=100)  # a directory is not a regular file

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -52,6 +52,14 @@ if _DEBUG_INTERRUPT:
 _activity_callback_local = threading.local()
 
 
+class FileFetchError(RuntimeError):
+    """A file could not be extracted from the backend filesystem."""
+
+
+# Pulling a large artifact over a slow exec channel can outlast the per-command terminal timeout.
+_FETCH_TIMEOUT_SECONDS = 300
+
+
 class EnvironmentConnectionError(RuntimeError):
     """Infrastructure/connection-class failure of a terminal backend (SSH host down, Docker
     daemon not running, remote sync on a dead link) — never a command that merely exited
@@ -182,6 +190,44 @@ class BaseEnvironment(ABC):
     def cleanup(self):
         """Release backend resources (container, instance, connection)."""
         ...
+
+    # --- File extraction (backend -> host) ---
+    def fetch_file(self, remote_path: str, local_dest: Path, *, max_bytes: int) -> None:
+        """Copy a regular file out of the backend filesystem to ``local_dest`` on the host.
+
+        One transport for every backend: base64 over the exec channel, bounded INSIDE the sandbox
+        (``head -c max+1`` so /dev/zero can't stream unbounded data into host memory — the same
+        shape ``tools.image_source`` uses to read sandbox images). The payload is fenced between
+        unique markers so login-shell noise in the merged stdout/stderr can't corrupt the decode.
+        Raises :class:`FileFetchError` on a missing/unreadable/oversized file.
+        """
+        import base64
+        import binascii
+        marker = f"__HERMES_FETCH_{uuid.uuid4().hex[:12]}__"
+        quoted = shlex.quote(remote_path)
+        # ``[ -f ]`` follows symlinks, so a link to a denied host file is judged by the CALLER on
+        # ``readlink -f`` output before any bytes move.
+        result = self.execute(
+            f"[ -f {quoted} ] && echo {marker} && head -c {max_bytes + 1} < {quoted} | base64 && echo {marker}",
+            timeout=_FETCH_TIMEOUT_SECONDS, rewrite_compound_background=False)
+        output = result.get("output") or ""
+        first, last = output.find(marker), output.rfind(marker)
+        if int(result.get("returncode") or 0) != 0 or first == -1 or last <= first:
+            raise FileFetchError(f"could not read {remote_path!r} in the sandbox (missing, not a regular file, or unreadable)")
+        try:
+            data = base64.b64decode("".join(output[first + len(marker):last].split()), validate=True)
+        except (ValueError, binascii.Error) as exc:
+            raise FileFetchError(f"transfer of {remote_path!r} was corrupted in transit: {exc}") from exc
+        if len(data) > max_bytes:
+            raise FileFetchError(f"{remote_path!r} exceeds the {max_bytes // (1024 * 1024)} MB delivery limit")
+        Path(local_dest).write_bytes(data)
+
+    def fetch_realpath(self, remote_path: str) -> str | None:
+        """``readlink -f`` inside the backend, or None when it cannot be resolved."""
+        result = self.execute(f"readlink -f {shlex.quote(remote_path)} 2>/dev/null", rewrite_compound_background=False)
+        if int(result.get("returncode") or 0) != 0:
+            return None
+        return next((ln.strip() for ln in reversed((result.get("output") or "").splitlines()) if ln.strip().startswith("/")), None)
 
     # --- Session snapshot (init_session) ---
     def _additional_profile_scoped_passthrough_names(self) -> Iterable[str]:


### PR DESCRIPTION
`MEDIA:<path>` tags that point at a file inside a remote terminal sandbox (ssh, modal, daytona, singularity, vercel) now deliver: the gateway pulls the file out of the active sandbox into the document cache and sends it, instead of logging "Skipping unsafe MEDIA directive path" and dropping the attachment.

Scoped salvage of #68506 by @tokou (design + denylist mirroring; cherry-pick-equivalent authorship on the feature commit). Addresses the outbound half of #466 — the part users hit today. Not included, on purpose: a new `send_file` core tool (the existing `MEDIA:` tag is the interface; footprint ladder rung 1), per-backend native transports, and inbound attachment→sandbox injection (still open on #466).

## Change

- `tools/environments/base.py`: `BaseEnvironment.fetch_file` / `fetch_realpath` — one transport for every backend, base64 over the exec channel, size-bounded INSIDE the sandbox (`head -c max+1`, the shape `tools.image_source` already uses so `/dev/zero` cannot flood host memory), payload marker-fenced against login-shell noise.
- `gateway/media_fetch.py` (new, 109 lines): fires only when a remote backend is active for the current session AND host validation already failed. The sandbox path is screened with the host denylist (system prefixes, `~/.ssh`-class dirs, Hermes credential stores) before any bytes move, screened again after `readlink -f`, copied into `cache/documents/` (an allowlisted root), then re-validated like any host file.
- `gateway/platforms/base.py::_validated_delivery_path`: 3-line hook — the single chokepoint all three MEDIA filter sites use.
- 3 tests: sandbox artifact delivers while a credential file and a symlink to it are refused before fetch; local backend never fetches; the transport round-trips bytes through a real shell and enforces the cap. Red on `origin/main`.

## Validation

| Check | Result |
|---|---|
| Live E2E, real sshd sandbox on OrbStack, real `terminal_tool` writes the file, real `extract_media` → `filter_media_delivery_paths` | main: `[]`; branch: `[('remote_…_report.txt', 'hello from sandbox')]`; decoy `~/.ssh/id_rsa` and a symlink to it: not delivered on either |
| Same with a gateway session key set (`session:telegram:chat:42` sandbox) | delivered from the session's own sandbox |
| `scripts/run_tests.sh` touched-path (gateway media/platform_base/extract_local_files/media_repair + tools ssh/docker/image_source) | see CI; local run green |
| ruff / compat pointers | clean |
