### PR TITLE
fix(update): install deps in the Windows self-lock workaround command

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -865,8 +865,12 @@ def _repair_windows_preflight(
             "    Retrying `hermes update` from inside this venv cannot help: "
             "the mapped executable is released only when this process exits.",
             "    To complete the repair, run the updater from an interpreter "
-            "that lives outside this venv, e.g.:",
+            "that lives outside this venv. That interpreter has none of Hermes' "
+            # A bare system interpreter does not have Hermes' dependencies, so
+            # `hermes_cli.main` fails on the first third-party import (#103601).
+            "dependencies installed yet, so install them first, e.g.:",
             f"      cd {root}",
+            "      <system Python> -m pip install -e \".[all]\"",
             "      <system Python> -m hermes_cli.main update",
             "    Sessions stay protected meanwhile: Hermes keeps databases "
             "out of WAL mode on this SQLite build."):

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -1424,6 +1424,17 @@ class TestWindowsRuntimeSelfLock:
             "the structural self-lock must not promise that retrying helps"
         )
         assert "outside" in out, "the deferral must point at an escape hatch"
+        # #103601: a bare system interpreter has none of Hermes' third-party
+        # dependencies (e.g. python-dotenv), so `hermes_cli.main` dies on its
+        # first import unless the workaround installs them first.
+        install_line = next(
+            (i for i, line in enumerate(out.splitlines()) if "pip install" in line), None)
+        assert install_line is not None, (
+            "the workaround must install Hermes' dependencies, not just swap the interpreter"
+        )
+        run_line = next(
+            i for i, line in enumerate(out.splitlines()) if "hermes_cli.main update" in line)
+        assert install_line < run_line, "dependencies must be installed before the updater runs"
 
     def test_non_self_locked_repair_proceeds(self, tmp_path, monkeypatch):
         """The guard must fail OPEN when the updater runs from outside the


### PR DESCRIPTION
Fixes #103601.

## Bug

On Windows, `hermes update` correctly detects it cannot replace the live
managed venv while the updater itself is executing from inside it, and
defers SQLite runtime repair with an instruction to rerun from an
interpreter outside that venv:

```
To complete the repair, run the updater from an interpreter that lives outside this venv, e.g.:
  cd C:\Users\me\AppData\Local\hermes\hermes-agent
  <system Python> -m hermes_cli.main update
```

That workaround is not actually usable as printed: a plain system Python
has none of Hermes' third-party dependencies installed, so
`hermes_cli.main` dies on its very first import:

```
ModuleNotFoundError: No module named 'dotenv'
```

(`hermes_cli/env_loader.py` imports `dotenv` at module import time, before
any update logic runs.)

## Fix

`hermes_cli/managed_uv.py::_repair_windows_preflight` now prints an extra
step that installs Hermes' dependencies into the system interpreter before
invoking the updater from it, using the same `.[all]` extras group the
normal in-venv dependency sync already installs
(`hermes_cli/update_cmd_deps.py::_sync_python_dependencies_after_pull` /
`hermes_cli/update_cmd.py::_repair_current_checkout`, both pass
`group="all"`):

```
To complete the repair, run the updater from an interpreter that lives outside this venv. That interpreter has none of Hermes' dependencies installed yet, so install them first, e.g.:
  cd C:\Users\me\AppData\Local\hermes\hermes-agent
  <system Python> -m pip install -e ".[all]"
  <system Python> -m hermes_cli.main update
```

This keeps the fix scoped to the message text only — it doesn't change the
self-lock detection logic (`_windows_runtime_self_lock`) or attempt the
larger "auto-bootstrap a temporary updater venv" feature the issue also
proposes as a preferred-but-larger alternative.

## Test plan

Extended the existing regression test for this deferral path
(`tests/hermes_cli/test_managed_uv.py::TestWindowsRuntimeSelfLock::test_self_lock_defers_repair_before_provisioning`)
to assert the printed workaround contains a `pip install` step before the
`hermes_cli.main update` invocation.

Confirmed it fails without the fix:

```
$ git checkout HEAD~1 -- hermes_cli/managed_uv.py
$ python -m pytest tests/hermes_cli/test_managed_uv.py -k test_self_lock_defers_repair_before_provisioning -q
...
E       AssertionError: the workaround must install Hermes' dependencies, not just swap the interpreter
E       assert None is not None
1 failed, 47 deselected in 0.91s
$ git checkout HEAD -- hermes_cli/managed_uv.py
```

And passes with the fix:

```
$ python -m pytest tests/hermes_cli/test_managed_uv.py -q
............s...................................                       [100%]
47 passed, 1 skipped in 0.77s
```

Also ran the neighboring self-lock suite and ruff on both changed files:

```
$ python -m pytest tests/hermes_cli/test_update_self_lock.py tests/hermes_cli/test_managed_uv.py -q
...............................s...................................    [100%]
66 passed, 1 skipped in 2.44s
$ python -m ruff check hermes_cli/managed_uv.py tests/hermes_cli/test_managed_uv.py
All checks passed!
```

## AI disclosure

This PR was written by an autonomous Claude-based coding agent (Claude
Code / Claude Sonnet 5), operating on the reported issue text and the
current `main` source. All test runs and output above were produced by
actually executing the commands shown, not transcribed from the issue.
