### PR TITLE
fix(update): include dependencies in Windows recovery instructions

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -848,7 +848,7 @@ def _result(
 
 
 def _repair_windows_preflight(
-    root: Path, live: Path, current: SQLiteRuntimeInfo) -> RuntimeRepairResult | None:
+    root: Path, live: Path, current: SQLiteRuntimeInfo, uv_bin: str) -> RuntimeRepairResult | None:
     """Defer the repair when Windows holders make the venv rename impossible; else ``None``."""
     blocked, detail = _windows_runtime_holders()
     if blocked:
@@ -859,15 +859,26 @@ def _repair_windows_preflight(
         # Structural, not transient: this process maps the live venv's own executable, so the
         # park rename fails identically on every run. Defer BEFORE provisioning — a candidate
         # staged for a cutover that can never run only leaks an incomplete generation.
+        # PowerShell single-quoted literals preserve spaces, dollar signs and apostrophes.
+        quoted_root = "'" + str(root).replace("'", "''") + "'"
+        quoted_uv = "'" + uv_bin.replace("'", "''") + "'"
         for line in (
             f"  ⚠ SQLite runtime repair deferred: {self_detail}.",
             # See #93032.
             "    Retrying `hermes update` from inside this venv cannot help: "
             "the mapped executable is released only when this process exits.",
-            "    To complete the repair, run the updater from an interpreter "
-            "that lives outside this venv, e.g.:",
-            f"      cd {root}",
-            "      <system Python> -m hermes_cli.main update",
+            "    After this updater exits, run these commands in PowerShell, "
+            "continuing only when each command succeeds:",
+            "    This installs the updater's dependencies in a temporary environment "
+            "outside the live venv (requires internet access).",
+            '      $repairEnv = Join-Path ([IO.Path]::GetTempPath()) ("hermes-updater-" + [guid]::NewGuid())',
+            f"      & {quoted_uv} venv --managed-python --python 3.11 $repairEnv",
+            '      $repairPython = Join-Path $repairEnv "Scripts\\python.exe"',
+            f"      & {quoted_uv} pip install --python $repairPython --editable {quoted_root}",
+            f"      Set-Location -LiteralPath {quoted_root}",
+            "      & $repairPython -m hermes_cli.main update",
+            "    After the update succeeds and exits, remove the temporary updater environment:",
+            "      Remove-Item -LiteralPath $repairEnv -Recurse -Force",
             "    Sessions stay protected meanwhile: Hermes keeps databases "
             "out of WAL mode on this SQLite build."):
             print(line)
@@ -952,7 +963,7 @@ def repair_vulnerable_runtime(
         # See #73109.
         _sweep_stale_runtime_backups(live, root=root)
         return _result("safe", current, sqlite_after=current.sqlite_version_string)
-    deferred = _repair_windows_preflight(root, live, current)
+    deferred = _repair_windows_preflight(root, live, current, uv_bin)
     if deferred is not None:
         return deferred
     runtime_root = root / _RUNTIME_DIR_NAME

--- a/tests/hermes_cli/test_managed_uv_recovery_commands.py
+++ b/tests/hermes_cli/test_managed_uv_recovery_commands.py
@@ -1,0 +1,69 @@
+"""Validate the printed recovery commands with Windows' actual shell parser."""
+
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from hermes_cli import managed_uv
+from hermes_cli.sqlite_runtime import SQLiteRuntimeInfo
+
+
+@pytest.mark.windows_only
+@pytest.mark.parametrize("directory", ["Hermes checkout", "Hermes' $data $(Write-Output injected)"])
+def test_recovery_commands_preserve_paths_and_share_updater_python(tmp_path, monkeypatch, capsys, directory):
+    root = tmp_path / directory
+    uv_bin = str(root / "tools" / "uv.exe")
+    current = SQLiteRuntimeInfo(
+        executable=root / "venv" / "Scripts" / "python.exe", base_prefix=root,
+        python_version=(3, 11, 15), sqlite_version=(3, 50, 4),
+        sqlite_version_string="3.50.4", sqlite_source_id="test",
+    )
+    # Isolate holder discovery: the subject is the recovery recipe it selects.
+    monkeypatch.setattr(managed_uv, "_windows_runtime_holders", lambda: (False, ""))
+    monkeypatch.setattr(managed_uv, "_windows_runtime_self_lock", lambda live: (True, "self-locked"))
+    result = managed_uv._repair_windows_preflight(root, root / "venv", current, uv_bin)
+    assert result.status == "skipped"
+    recipe = "\n".join(line.strip() for line in capsys.readouterr().out.splitlines() if line.startswith("      "))
+    recipe_file = tmp_path / "recovery.ps1"
+    recipe_file.write_text(recipe, encoding="utf-8-sig")
+    parser = tmp_path / "parse.ps1"
+    # Parse, never execute: no installs, updates or deletion run in this test.
+    parser.write_text(r'''
+param([string]$Recipe)
+$ErrorActionPreference = 'Stop'
+$tokens = $null
+$errors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile($Recipe, [ref]$tokens, [ref]$errors)
+if ($errors.Count) { throw ($errors | Out-String) }
+$commands = @($ast.FindAll({param($node) $node -is [System.Management.Automation.Language.CommandAst]}, $true) |
+    ForEach-Object {
+        [pscustomobject]@{parts = @($_.CommandElements | ForEach-Object {
+            if ($_ -is [System.Management.Automation.Language.StringConstantExpressionAst]) { $_.Value }
+            else { $_.Extent.Text }
+        })}
+    })
+ConvertTo-Json -InputObject $commands -Depth 5 -Compress
+''', encoding="utf-8-sig")
+    shell = shutil.which("pwsh") or shutil.which("powershell")
+    assert shell, "Windows recovery must be validated by PowerShell"
+    parsed = subprocess.run(
+        [shell, "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", str(parser), str(recipe_file)],
+        capture_output=True, text=True, check=True, timeout=30,
+    )
+    commands = [entry["parts"] for entry in json.loads(parsed.stdout)]
+    uv_calls = [parts for parts in commands if parts[0] == uv_bin]
+    venv, install = uv_calls
+    assert venv[1] == "venv"
+    assert install[1:3] == ["pip", "install"]
+    assert install[install.index("--editable") + 1] == str(root)
+    update = next(parts for parts in commands if parts[1:] == ["-m", "hermes_cli.main", "update"])
+    assert install[install.index("--python") + 1] == update[0]
+    assert commands.index(venv) < commands.index(install) < commands.index(update)
+    cd = next(parts for parts in commands if parts[0] == "Set-Location")
+    assert cd[cd.index("-LiteralPath") + 1] == str(root)
+    cleanup = next(parts for parts in commands if parts[0] == "Remove-Item")
+    assert cleanup[cleanup.index("-LiteralPath") + 1] == venv[-1]
+    assert commands.index(cleanup) > commands.index(update)
+    assert all(parts[0] != "Write-Output" for parts in commands)


### PR DESCRIPTION
When SQLite repair is deferred because Windows has the live venv mapped, the printed system-Python command fails before reaching the updater: that interpreter lacks Hermes dependencies.

Replace the incomplete workaround with PowerShell steps that use the already-resolved uv executable to create a unique temporary environment outside the live venv, install the checkout and its dependencies there, and invoke the updater from that environment. Quote checkout/executable paths for PowerShell and include cleanup after successful completion. The existing self-lock deferral and database protection remain in effect.

Closes #103601 (the explicit recovery-instructions option in the report).

Validation: reproduced startup failure in a fresh Python 3.11 environment (missing yaml); after installing the checkout into that separate environment with uv, `python -m hermes_cli.main update --help` and dependency imports succeed. The smoke used an isolated HERMES_HOME and did not run an update. Existing managed-runtime tests: 47 passed, 1 Windows-only test skipped locally. Ruff and git diff --check pass. The bootstrap was exercised on macOS; Windows directory replacement was not exercised locally.

A Windows-marked test now parses the emitted recipe using PowerShell itself, including paths with spaces, apostrophes, dollar signs and command-substitution-shaped text. It verifies literal path preservation, dependency installation before the update, the shared updater interpreter, and cleanup afterward. It never executes the recipe. Local managed-runtime tests: 47 passed, 3 Windows-only cases skipped; both native parser cases passed in Windows CI.
