### PR TITLE
fix(desktop): harden the auth-flow windows and OAuth partitions (GHSA-9f4c-93c8-jc8g class)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -416,7 +416,12 @@ import {
   registrySshScopeForWindowRoute,
   WindowConnectionRouteRegistry
 } from './window-connection-route'
-import { createWindowOpenHandler } from './window-open-policy'
+import {
+  createWindowOpenHandler,
+  guardAuthSessionDownloads,
+  guardAuthSessionPermissions,
+  wireAuthWindowOpenPolicy
+} from './window-open-policy'
 import { installWindowRendererLifecycle } from './window-renderer-lifecycle'
 import { createWindowRevealController } from './window-reveal'
 import {
@@ -7312,6 +7317,13 @@ function getOauthSession() {
 
   oauthSession = session.fromPartition(OAUTH_SESSION_PARTITION)
 
+  // Auth partitions exist solely to complete sign-in: no download and no
+  // permission request is ever legitimate from their remote IDP/portal
+  // content. installDownloadHandling / installMediaPermissions wire only
+  // session.defaultSession, so these guards close the partition gap.
+  guardAuthSessionDownloads(oauthSession, 'oauth', rememberLog)
+  guardAuthSessionPermissions(oauthSession, 'oauth', rememberLog)
+
   return oauthSession
 }
 
@@ -7350,6 +7362,10 @@ function getOauthSessionForUrl(url) {
 
   if (!sess) {
     sess = session.fromPartition(partition)
+    // Per-connection OAuth jars get the same download + permission guards as
+    // the legacy shared partition — their windows are sign-in-only too.
+    guardAuthSessionDownloads(sess, `oauth:${partition}`, rememberLog)
+    guardAuthSessionPermissions(sess, `oauth:${partition}`, rememberLog)
     oauthSessionsByPartition.set(partition, sess)
   }
 
@@ -7619,6 +7635,11 @@ function openOauthLoginWindow(baseUrl, { silent = false } = {}) {
 
       return
     }
+
+    // GHSA-9f4c-93c8-jc8g class fix: the OAuth redirect chain navigates
+    // third-party IDP pages we do not initiate, so a window.open from that
+    // chain must never reach the OS browser. Deny unconditionally.
+    wireAuthWindowOpenPolicy(win, 'oauth', rememberLog)
 
     // Re-check the cookie jar on every successful navigation (the callback
     // redirect is the moment cookies get set) plus a low-frequency poll as a
@@ -8492,6 +8513,11 @@ function renewPortalAccessSilently() {
         return
       }
 
+      // GHSA-9f4c-93c8-jc8g class fix: this hidden window loads the remote
+      // portal, and any window.open reaching it from that content must be
+      // denied rather than opened. Deny unconditionally, log-only.
+      wireAuthWindowOpenPolicy(win, 'portal-renew', rememberLog)
+
       win.webContents.on('did-navigate', () => void checkCookie())
       win.webContents.on('did-redirect-navigation', () => void checkCookie())
       win.webContents.on('did-frame-navigate', () => void checkCookie())
@@ -8596,6 +8622,11 @@ function openPortalLoginWindow() {
 
       return
     }
+
+    // GHSA-9f4c-93c8-jc8g class fix: the portal sign-in page is remote
+    // content we do not initiate; a window.open from it must never reach the
+    // OS browser. Deny unconditionally, log-only.
+    wireAuthWindowOpenPolicy(win, 'portal', rememberLog)
 
     win.webContents.on('did-navigate', () => void checkCookie())
     win.webContents.on('did-redirect-navigation', () => void checkCookie())

--- a/apps/desktop/electron/window-open-policy.ts
+++ b/apps/desktop/electron/window-open-policy.ts
@@ -56,3 +56,101 @@ export function createWindowOpenHandler(
     return { action: 'deny' }
   }
 }
+
+/**
+ * Wire the always-deny window-open policy onto an auth-flow window
+ * (OAuth gateway login, portal sign-in, silent portal renewal).
+ *
+ * These windows load REMOTE content we do not initiate — the OAuth redirect
+ * chain passes through third-party IDP pages, and the portal page itself is
+ * fetched over the network — so a `window.open` reaching their webContents
+ * is content-driven, exactly the GHSA-9f4c-93c8-jc8g shape. The label
+ * distinguishes the deny log lines by flow.
+ */
+export function wireAuthWindowOpenPolicy(
+  win: { webContents: { setWindowOpenHandler: (handler: (details: WindowOpenRequestLike) => WindowOpenDecision) => void } },
+  label: string,
+  log?: (line: string) => void
+): void {
+  win.webContents.setWindowOpenHandler(
+    createWindowOpenHandler(origin => log?.(`[window-open] ${label} denied: ${origin}`))
+  )
+}
+
+/**
+ * Session-level guard for the OAuth/portal partitions: cancel any download
+ * those windows trigger.
+ *
+ * The auth windows exist solely to complete sign-in — every consumer is a
+ * cookie read (`hasOauthSessionCookie`, `hasLivePortalSession`, ...) after
+ * a navigation — so a real download is never a legitimate part of any flow.
+ * Remote IDP/portal content (or a Content-Disposition: attachment response
+ * on a redirect hop) can otherwise reach `will-download` with NO handler:
+ * `installDownloadHandling` wires only `session.defaultSession`, so the raw
+ * Chromium save dialog would open with the process cwd as the default
+ * directory and an extensionless attacker-chosen filename. Same exposure
+ * the link-title partition closes via `guardLinkTitleSession`.
+ */
+export function guardAuthSessionDownloads(
+  partitionSession: { on: (event: string, handler: (event: unknown, item: { cancel: () => void }) => void) => void },
+  label: string,
+  log?: (line: string) => void
+): void {
+  try {
+    partitionSession.on('will-download', (_event, item) => {
+      log?.(`[auth-download] ${label} cancelled`)
+
+      item.cancel()
+    })
+  } catch {
+    // best-effort; worst case is a spurious download dialog
+  }
+}
+
+/**
+ * Deny EVERY permission request from the OAuth/portal auth partitions.
+ *
+ * `installMediaPermissions` wires a permission request/check handler ONLY on
+ * `session.defaultSession` (a media-capture-only allowlist for voice
+ * conversations). The auth partitions get Chromium's default behavior, in
+ * which remote IDP/portal content in the auth windows can request and
+ * receive notifications, geolocation, midi, clipboard-read, and more —
+ * permission prompts from a sign-in flow the user never sanctioned.
+ *
+ * No permission is ever legitimate for completing sign-in (every consumer is
+ * a cookie read after a navigation), so deny-all is the correct policy —
+ * stricter than the default session's media-only allowlist.
+ */
+export function guardAuthSessionPermissions(
+  partitionSession: {
+    setPermissionRequestHandler: (
+      handler: (webContents: unknown, permission: string, callback: (granted: boolean) => void, details: unknown) => void
+    ) => void
+    setPermissionCheckHandler?: (handler: (webContents: unknown, permission: string) => boolean) => void
+  },
+  label: string,
+  log?: (line: string) => void
+): void {
+  const deny = (permission: string) => {
+    log?.(`[auth-permission] ${label} denied: ${permission}`)
+  }
+
+  try {
+    partitionSession.setPermissionRequestHandler((_webContents, permission, callback) => {
+      deny(permission)
+
+      callback(false)
+    })
+
+    // Synchronous check handler: Chromium consults it directly on some
+    // platforms (e.g. getUserMedia on Windows); without it the check would
+    // consult the request handler's default and grant.
+    partitionSession.setPermissionCheckHandler?.((_webContents, permission) => {
+      deny(permission)
+
+      return false
+    })
+  } catch {
+    // best-effort; degraded environments must not take sign-in down
+  }
+}

--- a/tests-js/auth-window-hardening.test.ts
+++ b/tests-js/auth-window-hardening.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Security regression for the auth-flow window hardening — the GHSA-9f4c-93c8-jc8g
+ * class on the OAuth/portal windows, plus the partition-level download and
+ * permission guards. The auth windows (OAuth gateway login, portal sign-in,
+ * silent portal renewal) load REMOTE content:
+ *
+ *   - the OAuth redirect chain navigates third-party IDP pages we do not initiate
+ *   - the portal pages are fetched over the network
+ *
+ * so content-driven `window.open`, downloads, and permission requests must all
+ * be denied — never opened / never granted as side effects. These tests import
+ * the REAL policy module main.ts wires the windows and partitions with.
+ */
+
+import assert from 'node:assert/strict'
+
+import { describe, test } from 'vitest'
+
+import {
+  guardAuthSessionDownloads,
+  guardAuthSessionPermissions,
+  wireAuthWindowOpenPolicy
+} from '../apps/desktop/electron/window-open-policy'
+
+function makeFakeAuthWindow() {
+  const calls = {
+    windowOpenHandlers: [] as Array<(details: { url: string }) => { action: string }>,
+    logs: [] as string[]
+  }
+
+  const win = {
+    webContents: {
+      setWindowOpenHandler(handler: (details: { url: string }) => { action: string }) {
+        calls.windowOpenHandlers.push(handler)
+      }
+    }
+  }
+
+  return { win, calls }
+}
+
+describe('auth window-open policy (GHSA-9f4c-93c8-jc8g class)', () => {
+  test('every auth flow installs exactly one always-deny handler', () => {
+    for (const label of ['oauth', 'portal', 'portal-renew']) {
+      const { win, calls } = makeFakeAuthWindow()
+      const logs: string[] = []
+
+      wireAuthWindowOpenPolicy(win, label, (line: string) => logs.push(line))
+
+      assert.equal(calls.windowOpenHandlers.length, 1)
+
+      const handler = calls.windowOpenHandlers[0]
+      assert.deepEqual(handler({ url: 'https://idp.attacker.test/login?next=steal' }), { action: 'deny' })
+      assert.deepEqual(handler({ url: 'file:///etc/passwd' }), { action: 'deny' })
+      assert.deepEqual(handler({ url: 'javascript:alert(1)' }), { action: 'deny' })
+
+      // The deny log names the flow and carries origin only — a signed URL
+      // or query token must never reach the persisted desktop log.
+      assert.ok(logs.length >= 1)
+      assert.ok(logs.every(line => line.startsWith(`[window-open] ${label} denied: `)))
+      assert.ok(logs.every(line => !line.includes('next=steal')))
+    }
+  })
+
+  test('a missing or throwing logger never degrades the deny', () => {
+    const silent = makeFakeAuthWindow()
+    wireAuthWindowOpenPolicy(silent.win, 'oauth')
+    assert.deepEqual(silent.calls.windowOpenHandlers[0]({ url: 'https://x.test/' }), { action: 'deny' })
+
+    const throwing = makeFakeAuthWindow()
+    wireAuthWindowOpenPolicy(throwing.win, 'portal', () => {
+      throw new Error('logging blew up')
+    })
+    assert.deepEqual(throwing.calls.windowOpenHandlers[0]({ url: 'https://x.test/' }), { action: 'deny' })
+  })
+})
+
+describe('auth partition download guard', () => {
+  test('cancels every will-download item and labels the log per partition', () => {
+    const handlers: Record<string, (event: unknown, item: { cancel: () => void }) => void> = {}
+    const logs: string[] = []
+
+    const partitionSession = {
+      on(event: string, handler: (event: unknown, item: { cancel: () => void }) => void) {
+        handlers[event] = handler
+      }
+    }
+
+    guardAuthSessionDownloads(partitionSession, 'oauth:persist:custom-1', (line: string) => logs.push(line))
+
+    let cancelled = 0
+
+    handlers['will-download'](null, {
+      cancel: () => {
+        cancelled += 1
+      }
+    })
+    handlers['will-download'](null, {
+      cancel: () => {
+        cancelled += 1
+      }
+    })
+
+    assert.equal(cancelled, 2)
+    assert.deepEqual(logs, [
+      '[auth-download] oauth:persist:custom-1 cancelled',
+      '[auth-download] oauth:persist:custom-1 cancelled'
+    ])
+    // The guard installs exactly one will-download handler — no accumulation
+    // when a partition session is reused across sign-in attempts.
+    assert.equal(Object.keys(handlers).filter(k => k === 'will-download').length, 1)
+  })
+
+  test('is a no-op when session.on throws', () => {
+    assert.doesNotThrow(() =>
+      guardAuthSessionDownloads(
+        {
+          on() {
+            throw new Error('Object has been destroyed')
+          }
+        },
+        'oauth'
+      )
+    )
+  })
+})
+
+describe('auth partition permission guard', () => {
+  function makeFakePartitionSession() {
+    const calls = {
+      requestHandlers: [] as Array<(wc: unknown, perm: string, cb: (granted: boolean) => void, details: unknown) => void>,
+      checkHandlers: [] as Array<(wc: unknown, perm: string) => boolean>
+    }
+
+    const partitionSession = {
+      setPermissionRequestHandler(handler: (wc: unknown, perm: string, cb: (granted: boolean) => void, details: unknown) => void) {
+        calls.requestHandlers.push(handler)
+      },
+      setPermissionCheckHandler(handler: (wc: unknown, perm: string) => boolean) {
+        calls.checkHandlers.push(handler)
+      }
+    }
+
+    return { partitionSession, calls }
+  }
+
+  test('denies every permission on both the request and the check handler', () => {
+    const { partitionSession, calls } = makeFakePartitionSession()
+    const logs: string[] = []
+
+    guardAuthSessionPermissions(partitionSession, 'oauth:persist:custom-1', (line: string) => logs.push(line))
+
+    assert.equal(calls.requestHandlers.length, 1)
+    assert.equal(calls.checkHandlers.length, 1)
+
+    const request = calls.requestHandlers[0]
+    const check = calls.checkHandlers[0]
+
+    // Every permission a compromised IDP/portal page might request is denied
+    // through the request handler — including the ones the default session
+    // deliberately allows for voice conversations (media).
+    const permissions = [
+      'notifications',
+      'geolocation',
+      'midi',
+      'midiSysex',
+      'clipboard-read',
+      'media',
+      'fullscreen',
+      'pointerLock',
+      'openExternal'
+    ]
+
+    for (const permission of permissions) {
+      let granted: boolean | undefined
+      request(null, permission, (value: boolean) => {
+        granted = value
+      }, {})
+      assert.equal(granted, false, `request handler must deny ${permission}`)
+      assert.equal(check(null, permission), false, `check handler must deny ${permission}`)
+    }
+
+    assert.ok(logs.length >= permissions.length)
+    assert.ok(logs.every(line => line.startsWith('[auth-permission] oauth:persist:custom-1 denied: ')))
+  })
+
+  test('a partition without a check handler installs only the request handler', () => {
+    const calls = {
+      requestHandlers: [] as Array<(wc: unknown, perm: string, cb: (granted: boolean) => void, details: unknown) => void>
+    }
+
+    const partitionSession = {
+      setPermissionRequestHandler(
+        handler: (wc: unknown, perm: string, cb: (granted: boolean) => void, details: unknown) => void
+      ) {
+        calls.requestHandlers.push(handler)
+      }
+    }
+
+    assert.doesNotThrow(() => guardAuthSessionPermissions(partitionSession, 'oauth'))
+
+    let granted: boolean | undefined
+    calls.requestHandlers[0](null, 'geolocation', (value: boolean) => {
+      granted = value
+    }, {})
+    assert.equal(granted, false)
+  })
+
+  test('a throwing session emitter is a no-op', () => {
+    assert.doesNotThrow(() =>
+      guardAuthSessionPermissions(
+        {
+          setPermissionRequestHandler() {
+            throw new Error('Object has been destroyed')
+          }
+        },
+        'oauth'
+      )
+    )
+  })
+})


### PR DESCRIPTION
## Summary

The GHSA-9f4c-93c8-jc8g hardening (`77ca6a6d12`, `b51c055a12`) wired the always-deny window-open policy into every `wireCommonWindowHandlers` window plus the link-title window — with the rationale that a window which "loads arbitrary user-linked pages on render, had no window-open handler at all" must deny. **Three windows were left out of that sweep, and they load REMOTE content — the strongest exposure of the class:**

| Window | Loads |
|---|---|
| `openOauthLoginWindow` | the OAuth redirect chain — **third-party IDP pages** we do not initiate |
| Silent portal renewal window | hidden window loading `portalBaseUrl` |
| Interactive portal sign-in window | `portalBaseUrl` |

And their session partitions carried **none** of the guards the default session or the link-title partition have:

| Gap | Effect on the auth windows |
|---|---|
| `installDownloadHandling` wires `will-download` only on `session.defaultSession` | a `Content-Disposition: attachment` response on any OAuth redirect hop (or download JS on a compromised IDP page) reached **no handler** — Chromium's raw save dialog with the **process cwd as default directory** and an **extensionless attacker-chosen filename** |
| `installMediaPermissions` wires permission handlers only on `session.defaultSession` | the auth partitions took Chromium's **default behavior — granting** `notifications`, `geolocation`, `midi`, `clipboard-read`, and more to remote IDP/portal content |

## Fix (all three arms, one PR)

1. **`wireAuthWindowOpenPolicy`** — always-deny window-open on all three auth windows (reuses `createWindowOpenHandler`: deny, origin-only log, throwing-observer-safe). Log lines carry the flow label.
2. **`guardAuthSessionDownloads`** — cancels every `will-download` item (same exposure `guardLinkTitleSession` closes), wired at **both** partition creation sites: `getOauthSession()` (legacy shared) and `getOauthSessionForUrl()` (per-connection jars, #92183).
3. **`guardAuthSessionPermissions`** — denies every permission on **both** the request handler (prompt path) and the check handler (the synchronous path Chromium consults for `getUserMedia` on Windows). Check handler installs best-effort; a partition without it keeps the request-handler deny.

No download and no permission is ever legitimate for completing sign-in: every consumer of these partitions is a cookie read (`hasOauthSessionCookie` / `hasLivePortalSession` / `hasPortalAccessToken`) after a navigation.

## Tests

New file `tests-js/auth-window-hardening.test.ts` (7 tests, real policy module, fake window/session DI — proven red on unpatched main: the helper imports don't exist without this change):

- each auth flow installs exactly one always-deny window-open handler; every scheme (https with query credentials, `file:`, `javascript:`) denies; the log carries the flow label with origin only — query tokens never reach the persisted log
- a missing or throwing logger never degrades the window-open deny
- downloads: every `will-download` item cancels, the log labels the partition, exactly one handler installs (no accumulation on partition reuse)
- a throwing session emitter is a no-op (degraded environments keep sign-in)
- permissions: every permission (`notifications`, `geolocation`, `midi`, `midiSysex`, `clipboard-read`, `media`, `fullscreen`, `pointerLock`, `openExternal`) denies on both handlers — including `media`, which the default session deliberately allows for voice conversations
- a partition without `setPermissionCheckHandler` still installs the request-handler deny
- a throwing permission emitter is a no-op

## Verification

- `vitest run auth-window-hardening.test.ts window-open-policy.test.ts`: **9/9 passed**
- `tsc -p tsconfig.electron.json --noEmit`: **clean**
- `eslint` on both touched areas: **clean (0 warnings)**
- `tests-js` tsc: only the pre-existing `@types/plist` local-environment error remains (present on unpatched main too)

Consolidates and supersedes my #103630 and #103655 (same files, conflicting branches) — this PR closes all three arms of the auth-window remote-content exposure.

Refs: GHSA-9f4c-93c8-jc8g (CVE-2026-70608), #92183 (per-connection jars)