### PR TITLE
fix(desktop): voice conversation speaks only the current turn, not earlier replies (salvage #96622)

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useI18n } from '@/i18n'
 import { chatMessageText, collectUnspokenTurnSpeech } from '@/lib/chat-messages'
 import { triggerHaptic } from '@/lib/haptics'
-import { markAssistantIdSpoken, resolveSpokenReply } from '@/lib/spoken-reply'
+import { adoptSpokenReplySession, markAssistantIdSpoken, resolveSpokenReply } from '@/lib/spoken-reply'
 import { CONVERSATION_LEASE, READ_ALOUD_LEASE, syncTtsLease } from '@/lib/tts-lease'
 import { clearWakeIndicator, syncWakeIndicatorWithVoice } from '@/lib/wake-indicator'
 import { $voiceConversationStartRequest, takeVoiceConversationStart } from '@/store/composer'
@@ -65,7 +65,14 @@ export function useComposerVoice({
   const { $messages } = useComposerScope()
   const [voiceConversationActive, setVoiceConversationActive] = useState(false)
   const ownsWakeIndicatorRef = useRef(false)
+  const previousSessionIdRef = useRef(sessionId)
   const voiceStartRequest = useStore($voiceConversationStartRequest)
+
+  // eslint-disable-next-line no-restricted-syntax -- session-id adopt token, not an atom mirror
+  useEffect(() => {
+    adoptSpokenReplySession(previousSessionIdRef.current, sessionId)
+    previousSessionIdRef.current = sessionId
+  }, [sessionId])
 
   const { dictate, voiceActivityState, voiceStatus } = useVoiceRecorder({
     focusInput,

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -1342,6 +1342,19 @@ describe('collectUnspokenTurnSpeech', () => {
     expect(collectUnspokenTurnSpeech([assistant('a1', 'Done.')], 'a1')).toBeNull()
     expect(collectUnspokenTurnSpeech([user('u1', 'hello'), assistant('a1', '')], null)).toBeNull()
   })
+
+  it('does not replay earlier turns when the spoken id is missing or stale', () => {
+    const messages = [
+      user('u1', 'old question'),
+      assistant('a1', 'Previous output from last turn.'),
+      user('u2', 'new question'),
+      assistant('a2', 'Live reply only.')
+    ]
+
+    expect(collectUnspokenTurnSpeech(messages, null)?.text).toBe('Live reply only.')
+    expect(collectUnspokenTurnSpeech(messages, 'vanished-stream-id')?.text).toBe('Live reply only.')
+    expect(collectUnspokenTurnSpeech(messages, 'a1')?.text).toBe('Live reply only.')
+  })
 })
 
 describe('stripPendingClarifyProjectionForCache', () => {

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -1355,6 +1355,17 @@ describe('collectUnspokenTurnSpeech', () => {
     expect(collectUnspokenTurnSpeech(messages, 'vanished-stream-id')?.text).toBe('Live reply only.')
     expect(collectUnspokenTurnSpeech(messages, 'a1')?.text).toBe('Live reply only.')
   })
+
+  it('bounds to a hidden user turn too (widget intents render no bubble)', () => {
+    const messages = [
+      user('u1', 'old question'),
+      assistant('a1', 'Previous output from last turn.'),
+      { ...user('u2', 'widget intent'), hidden: true },
+      assistant('a2', 'Live reply only.')
+    ]
+
+    expect(collectUnspokenTurnSpeech(messages, null)?.text).toBe('Live reply only.')
+  })
 })
 
 describe('stripPendingClarifyProjectionForCache', () => {

--- a/apps/desktop/src/lib/chat-messages/parts.ts
+++ b/apps/desktop/src/lib/chat-messages/parts.ts
@@ -68,12 +68,26 @@ export interface UnspokenTurnSpeech {
  * selecting only one bubble silently drops everything after it. The blank-line
  * join is a sentence boundary for the server's cutter, so a sealed bubble's
  * tail is flushed as soon as the next bubble starts.
+ *
+ * If `lastSpokenId` is missing or stale (session id assigned mid-turn,
+ * live-tail rewrite missed), do **not** fall back to index -1 — that replays
+ * every earlier assistant turn as one speech string. Bound to the current
+ * turn (assistant bubbles after the last user message) instead. A slice with
+ * no user row (mid-turn interims only) still collects those assistants.
  */
 export function collectUnspokenTurnSpeech(
   messages: ChatMessage[],
   lastSpokenId: string | null
 ): UnspokenTurnSpeech | null {
-  const spokenIndex = lastSpokenId ? messages.findLastIndex(m => m.id === lastSpokenId) : -1
+  let spokenIndex = lastSpokenId ? messages.findLastIndex(m => m.id === lastSpokenId) : -1
+
+  if (spokenIndex < 0) {
+    const lastUser = messages.findLastIndex(m => m.role === 'user' && !m.hidden)
+
+    if (lastUser >= 0) {
+      spokenIndex = lastUser
+    }
+  }
 
   let id: string | null = null
   let pending = false

--- a/apps/desktop/src/lib/chat-messages/parts.ts
+++ b/apps/desktop/src/lib/chat-messages/parts.ts
@@ -72,8 +72,10 @@ export interface UnspokenTurnSpeech {
  * If `lastSpokenId` is missing or stale (session id assigned mid-turn,
  * live-tail rewrite missed), do **not** fall back to index -1 — that replays
  * every earlier assistant turn as one speech string. Bound to the current
- * turn (assistant bubbles after the last user message) instead. A slice with
- * no user row (mid-turn interims only) still collects those assistants.
+ * turn (assistant bubbles after the last user message) instead. Hidden user
+ * rows count: a widget intent or Bot Chat kickoff is a real turn for the
+ * agent even though no bubble renders. A slice with no user row (mid-turn
+ * interims only) still collects those assistants.
  */
 export function collectUnspokenTurnSpeech(
   messages: ChatMessage[],
@@ -82,7 +84,7 @@ export function collectUnspokenTurnSpeech(
   let spokenIndex = lastSpokenId ? messages.findLastIndex(m => m.id === lastSpokenId) : -1
 
   if (spokenIndex < 0) {
-    const lastUser = messages.findLastIndex(m => m.role === 'user' && !m.hidden)
+    const lastUser = messages.findLastIndex(m => m.role === 'user')
 
     if (lastUser >= 0) {
       spokenIndex = lastUser

--- a/apps/desktop/src/lib/chat-messages/parts.ts
+++ b/apps/desktop/src/lib/chat-messages/parts.ts
@@ -73,7 +73,7 @@ export interface UnspokenTurnSpeech {
  * live-tail rewrite missed), do **not** fall back to index -1 — that replays
  * every earlier assistant turn as one speech string. Bound to the current
  * turn (assistant bubbles after the last user message) instead. Hidden user
- * rows count: a widget intent or Bot Chat kickoff is a real turn for the
+ * rows count: a widget intent (`display_kind: hidden`) is a real turn for the
  * agent even though no bubble renders. A slice with no user row (mid-turn
  * interims only) still collects those assistants.
  */

--- a/apps/desktop/src/lib/spoken-reply.test.ts
+++ b/apps/desktop/src/lib/spoken-reply.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 import {
   absorbSpokenReplyRewrite,
+  adoptSpokenReplySession,
   assistantReplyOrdinal,
   clearSpokenRepliesForTests,
   isLiveTailReplyId,
@@ -88,5 +89,22 @@ describe('resolveSpokenReply', () => {
     expect(spoken?.id).toBe('durable-1')
     expect(assistantReplyOrdinal(nextTurn, 'assistant-stream-2')).toBe(1)
     expect(spoken?.ordinal).toBe(0)
+  })
+})
+
+describe('adoptSpokenReplySession', () => {
+  it('moves the null-session anchor onto the created session id', () => {
+    markAssistantIdSpoken(null, [assistant('a1')], 'a1')
+    adoptSpokenReplySession(null, 'session-created')
+
+    expect(spokenReplyOf('session-created')?.id).toBe('a1')
+  })
+
+  it('does not leak a spoken anchor from one real session into another', () => {
+    markAssistantIdSpoken('session-a', [assistant('a1')], 'a1')
+    adoptSpokenReplySession('session-a', 'session-b')
+
+    expect(spokenReplyOf('session-b')).toBeNull()
+    expect(spokenReplyOf('session-a')?.id).toBe('a1')
   })
 })

--- a/apps/desktop/src/lib/spoken-reply.test.ts
+++ b/apps/desktop/src/lib/spoken-reply.test.ts
@@ -98,6 +98,16 @@ describe('adoptSpokenReplySession', () => {
     adoptSpokenReplySession(null, 'session-created')
 
     expect(spokenReplyOf('session-created')?.id).toBe('a1')
+    // Moved, not copied: the next new chat (null session again) starts clean.
+    expect(spokenReplyOf(null)).toBeNull()
+  })
+
+  it('does not overwrite an anchor the created session already has', () => {
+    markAssistantIdSpoken(null, [assistant('a1')], 'a1')
+    markAssistantIdSpoken('session-created', [assistant('a1'), assistant('a2')], 'a2')
+    adoptSpokenReplySession(null, 'session-created')
+
+    expect(spokenReplyOf('session-created')?.id).toBe('a2')
   })
 
   it('does not leak a spoken anchor from one real session into another', () => {

--- a/apps/desktop/src/lib/spoken-reply.ts
+++ b/apps/desktop/src/lib/spoken-reply.ts
@@ -111,6 +111,31 @@ export function markAssistantIdSpoken(
   markSpokenReply(sessionId, { id, ordinal })
 }
 
+/**
+ * Carry the spoken anchor when a chat gets a real session id (null → created)
+ * mid voice-conversation. Do not copy across two real sessions — that would
+ * leak "already spoken" into a different transcript.
+ */
+export function adoptSpokenReplySession(
+  fromSessionId: string | null | undefined,
+  toSessionId: string | null | undefined
+): void {
+  const fromKey = sessionKey(fromSessionId)
+  const toKey = sessionKey(toSessionId)
+
+  if (fromKey === toKey || fromKey !== NO_SESSION) {
+    return
+  }
+
+  const from = lastSpokenBySession.get(fromKey)
+
+  if (!from || lastSpokenBySession.has(toKey)) {
+    return
+  }
+
+  lastSpokenBySession.set(toKey, from)
+}
+
 /** Current spoken anchor, migrated in place when the live row was rewritten. */
 export function resolveSpokenReply(
   sessionId: string | null | undefined,

--- a/apps/desktop/src/lib/spoken-reply.ts
+++ b/apps/desktop/src/lib/spoken-reply.ts
@@ -114,7 +114,9 @@ export function markAssistantIdSpoken(
 /**
  * Carry the spoken anchor when a chat gets a real session id (null → created)
  * mid voice-conversation. Do not copy across two real sessions — that would
- * leak "already spoken" into a different transcript.
+ * leak "already spoken" into a different transcript. The null-session entry is
+ * moved, not copied: left behind, it would mark the NEXT new chat's first reply
+ * as already spoken.
  */
 export function adoptSpokenReplySession(
   fromSessionId: string | null | undefined,
@@ -129,11 +131,15 @@ export function adoptSpokenReplySession(
 
   const from = lastSpokenBySession.get(fromKey)
 
-  if (!from || lastSpokenBySession.has(toKey)) {
+  if (!from) {
     return
   }
 
-  lastSpokenBySession.set(toKey, from)
+  lastSpokenBySession.delete(fromKey)
+
+  if (!lastSpokenBySession.has(toKey)) {
+    lastSpokenBySession.set(toKey, from)
+  }
 }
 
 /** Current spoken anchor, migrated in place when the live row was rewritten. */

--- a/apps/desktop/src/lib/spoken-reply.ts
+++ b/apps/desktop/src/lib/spoken-reply.ts
@@ -125,7 +125,7 @@ export function adoptSpokenReplySession(
   const fromKey = sessionKey(fromSessionId)
   const toKey = sessionKey(toSessionId)
 
-  if (fromKey === toKey || fromKey !== NO_SESSION) {
+  if (fromKey !== NO_SESSION || toKey === NO_SESSION) {
     return
   }
 
@@ -135,6 +135,7 @@ export function adoptSpokenReplySession(
     return
   }
 
+  // Dropped even when not adopted below: the anchor belongs to this chat.
   lastSpokenBySession.delete(fromKey)
 
   if (!lastSpokenBySession.has(toKey)) {

--- a/contributors/emails/patrickg21212@gmail.com
+++ b/contributors/emails/patrickg21212@gmail.com
@@ -1,0 +1,2 @@
+mcpeezy
+# PR #96622 salvage


### PR DESCRIPTION
Desktop voice conversation no longer re-reads earlier replies when the spoken-reply anchor is lost; it speaks the current turn only.

Salvage of #96622 by @mcpeezy — cherry-picked so authorship is preserved. The original branch conflicts with `main` only in the `use-composer-voice.ts` import block (`tts-lease` import added by #100881); resolved keep-both.

## What changed

- `collectUnspokenTurnSpeech` (`apps/desktop/src/lib/chat-messages/parts.ts`): when `lastSpokenId` is missing or stale, bound the speech slice to the assistant bubbles after the last user message instead of falling back to index `-1` (the whole transcript). (@mcpeezy)
- `adoptSpokenReplySession` (`apps/desktop/src/lib/spoken-reply.ts`): carry the null-session spoken anchor onto the created session id when a new chat gets its id mid-turn; null→real only, never real→real. Called from `use-composer-voice.ts` on `sessionId` change. (@mcpeezy)
- Follow-up commit (ours):
  - the turn bound counts hidden user rows too — a widget-intent / Bot Chat kickoff turn has no visible user bubble, and without this the old full-transcript replay reproduced on those turns;
  - adopt moves the null-session entry instead of copying it, so the next new chat (null session again) does not start with a stale "already spoken" anchor;
  - pins the "target already has an anchor → not overwritten" guard.

Root cause: the anchor map is keyed by session id, and a brand-new chat has `sessionId = null` until `session.create` returns; the first turn's anchor landed on the null key, the created session had none, and the selector's `-1` fallback concatenated every earlier assistant bubble into one speech string.

## Validation

| Check | Result |
|---|---|
| `vitest --environment jsdom` on the 5 voice/chat-messages test files | 98 passed (main: 93) |
| `tsc -b`, `eslint` on touched files | clean |
| Mutation: revert `parts.ts` fallback → contributor's test | red (`'Previous output…\n\nLive reply only.'`) |
| Mutation: contributor's `parts.ts` (`!m.hidden`) → hidden-user test | red |
| Mutation: copy-not-move / drop `has(toKey)` guard → new assertions | red / red |

Related open PRs #78194, #64390, #91391 touch the auto-speak (`pendingResponse`) selector, a different mechanism for the same symptom family; this PR leaves that path unchanged.

Closes #96622.
