### PR TITLE
fix(agent): reject repetitive arguments from dropped tool streams

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -38,6 +38,7 @@ from agent.message_content import flatten_message_text
 from agent.message_metadata import append_message, stamp_message_timestamp
 from agent.message_sanitization import (_sanitize_surrogates, _repair_tool_call_arguments)
 from agent.reasoning_summaries import separate_glued_reasoning_blocks
+from agent.repetition_guard import is_repetition_dominated
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
 from tools.terminal_tool_lifecycle import is_persistent_env
 from utils import base_url_host_matches, base_url_hostname, env_float, env_int
@@ -3060,6 +3061,14 @@ class _StreamingCall:
                         arguments = repaired
                     else:
                         has_truncated_tool_args = True
+                # Parseable JSON does not prove that a dropped stream completed its
+                # action. Treat degenerate argument loops as partial calls too.
+                # A provider-confirmed call may legitimately write repetitive data.
+                if finish_reason is None and is_repetition_dominated(arguments):
+                    logger.warning(
+                        "Tool call '%s' has repetition-dominated arguments without a "
+                        "finish_reason; treating as a dropped tool call.", tc["function"]["name"] or "?")
+                    has_truncated_tool_args = True
             elif finish_reason is None:
                 # Name arrived, zero arg bytes, no finish_reason: unflagged this
                 # becomes a "stop" turn executing "{}" with no retry.

--- a/tests/agent/test_repeated_dropped_tool_args.py
+++ b/tests/agent/test_repeated_dropped_tool_args.py
@@ -1,0 +1,70 @@
+"""Dropped streams must not dispatch repetition-dominated tool arguments."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from hermes_constants import PARTIAL_STREAM_STUB_ID
+from run_agent import AIAgent
+
+
+REPEATED_COMMAND = "cat >> /tmp/example.py <<'PYEOF'\n" + (
+    "# The model repeats this same rambling fragment instead of writing the script.\n" * 150
+) + "PYEOF"
+
+
+def _stream_response(monkeypatch, arguments, finish_reason=None):
+    agent = AIAgent(
+        api_key="test-key", base_url="https://example.com/v1", model="test/model",
+        quiet_mode=True, skip_context_files=True, skip_memory=True,
+    )
+    agent.api_mode = "chat_completions"
+    agent._interrupt_requested = False
+    monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+
+    def chunk(calls=None, reason=None):
+        delta = SimpleNamespace(content=None, tool_calls=calls, reasoning_content=None, reasoning=None)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(index=0, delta=delta, finish_reason=reason)],
+            model=None, usage=None,
+        )
+
+    def stream():
+        # A complete sibling must not run if the same action batch is discarded.
+        yield chunk([SimpleNamespace(index=0, id="sibling", function=SimpleNamespace(
+            name="read_file", arguments='{"path":"/tmp/example.py"}'))])
+        yield chunk([SimpleNamespace(index=1, id="write", function=SimpleNamespace(
+            name="terminal", arguments=arguments))])
+        if finish_reason:
+            yield chunk(reason=finish_reason)
+
+    client = MagicMock()
+    client.chat.completions.create.side_effect = lambda **kwargs: stream()
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **kwargs: client)
+    monkeypatch.setattr(agent, "_close_request_openai_client", lambda *args, **kwargs: None)
+    return agent._interruptible_streaming_api_call({})
+
+
+@pytest.mark.parametrize("repair_needed", [False, True], ids=["valid-json", "repairable-json"])
+def test_dropped_repetitive_arguments_never_reach_dispatch(monkeypatch, repair_needed):
+    arguments = json.dumps({"command": REPEATED_COMMAND})
+    if repair_needed:
+        arguments = arguments[:-1]  # Missing closing object, repairable by the existing helper.
+    response = _stream_response(monkeypatch, arguments)
+    assert response.id == PARTIAL_STREAM_STUB_ID
+    assert response.choices[0].message.tool_calls is None
+    assert set(response._dropped_tool_names) == {"read_file", "terminal"}
+
+
+@pytest.mark.parametrize("command,finish_reason", [
+    ("pwd", None),
+    ("\n".join(f"echo unique row {i}: value {i * 7}" for i in range(150)), None),
+    (REPEATED_COMMAND, "tool_calls"),
+])
+def test_healthy_or_confirmed_arguments_are_preserved(monkeypatch, command, finish_reason):
+    arguments = json.dumps({"command": command})
+    response = _stream_response(monkeypatch, arguments, finish_reason)
+    assert response.id != PARTIAL_STREAM_STUB_ID
+    assert response.choices[0].message.tool_calls[1].function.arguments == arguments


### PR DESCRIPTION
A Chat Completions stream can drop after emitting valid JSON dominated by repeated text inside a tool argument. JSON validation alone accepts it, so Hermes returns an executable tool call even though the provider never sent a finish_reason.

Reuse the existing repetition detector after argument validation/repair when finish_reason is absent. Degenerate arguments now take the existing partial-stream-stub path, which drops the entire action batch and gives the conversation loop its normal interrupted-stream recovery signal.

Closes #103599 for the reported dropped-stream incident. The check is deliberately limited to unconfirmed streams: a completed tool call can legitimately write repetitive source/data. Short and diverse arguments retain the existing behavior. No thresholds or retry budgets change. This affects the OpenAI-compatible Chat Completions path; the native Anthropic adapter already rejects tool-use blocks with no stop_reason.

Validation: both new dropped-stream cases failed on the base branch, then passed with the guard (valid JSON and repairable JSON, including a complete sibling call that must also be discarded). Three non-regression cases preserve short, diverse, and explicitly completed repetitive calls. The tests exercise the real agent streaming entry point with a simulated SDK boundary. Across the new tests and existing repetition, partial-stream, and streaming suites: 74 passed, 4 skipped. Ruff and git diff --check pass.
