### PR TITLE
fix(cli): escape session title and id in preload resumed session (#103602)

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -620,24 +620,24 @@ class CLIAgentSetupMixin:
             return False
         session_meta = self._session_db.get_session(self.session_id)
         if not session_meta:
-            self._console_print(f"[bold red]Session not found: {self.session_id}[/]")
+            self._console_print(f"[bold red]Session not found: {_escape(self.session_id)}[/]")
             self._console_print("[dim]Use a session ID from a previous CLI run (hermes sessions list).[/]")
             return False
         session_meta = self._follow_compression_chain(
             session_meta,
             lambda rid: self._console_print(
-                f"[dim]Session {self.session_id} was compressed into "
-                f"{rid}; resuming the descendant with your transcript.[/]"))
+                f"[dim]Session {_escape(self.session_id)} was compressed into "
+                f"{_escape(rid)}; resuming the descendant with your transcript.[/]"))
         resume_limit_error = self._resume_history_limit_error()
         if resume_limit_error:
             self._resume_history_error = resume_limit_error
-            self._console_print(f"[bold red]Cannot resume session:[/] {resume_limit_error}")
+            self._console_print(f"[bold red]Cannot resume session:[/] {_escape(resume_limit_error)}")
             return False
         restored, display_history = self._session_db.get_resume_conversations(self.session_id)
         accent_color = _accent_hex()
         if not restored:
             self._console_print(
-                f"[{accent_color}]Session {self.session_id} found but has no "
+                f"[{accent_color}]Session {_escape(self.session_id)} found but has no "
                 f"messages. Starting fresh.[/]")
             return False
         restored = [m for m in restored if m.get("role") != "session_meta"]
@@ -647,9 +647,9 @@ class CLIAgentSetupMixin:
         # Count only user-originated turns: legacy compaction handoffs are durable
         # role=user rows without display_kind.
         msg_count = len([m for m in self._resume_display_history if is_user_originated_turn(m)])
-        title_part = f' "{session_meta["title"]}"' if session_meta.get("title") else ""
+        title_part = f' "{_escape(session_meta["title"])}"' if session_meta.get("title") else ""
         self._console_print(
-            f"[{accent_color}]↻ Resumed session [bold]{self.session_id}[/bold]"
+            f"[{accent_color}]↻ Resumed session [bold]{_escape(self.session_id)}[/bold]"
             f"{title_part} "
             f"({msg_count} user message{'s' if msg_count != 1 else ''}, "
             f"{len(restored)} total messages)[/]")

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -300,6 +300,26 @@ class TestPreloadResumedSession:
 
         mock_db.reopen_session.assert_called_once_with("reopen_session")
 
+    def test_resumed_session_title_with_rich_markup_does_not_crash(self):
+        """A stored title containing Rich markup characters (like [/plan — plan mode]) must not crash with MarkupError."""
+        cli = _make_cli(resume="session_with_markup")
+        messages = [{"role": "user", "content": "hi"}]
+        mock_db = MagicMock()
+        mock_db.get_session.return_value = {
+            "id": "[special_session]",
+            "title": "[/plan — plan mode] [bold red]critical[/]",
+        }
+        mock_db.get_resume_conversations.return_value = (messages, messages)
+        mock_db.resolve_resume_session_id.return_value = "[special_session]"
+        cli._session_db = mock_db
+
+        buf = StringIO()
+        cli.console.file = buf
+        assert cli._preload_resumed_session() is True
+        output = buf.getvalue()
+        assert "Resumed session" in output
+        assert "[/plan — plan mode]" in output
+
     def test_rejects_runaway_transcript_before_history_load(self):
         from hermes_state import SessionResumeTooLargeError
 


### PR DESCRIPTION
## Summary

Fixes #103602

### Root Cause
In `hermes_cli/cli_agent_setup_mixin.py::_preload_resumed_session`, `session_meta["title"]`, `session_id`, `rid`, and `resume_limit_error` were interpolated directly into Rich markup strings passed to `self._console_print` without escaping.

When a session title contains Rich markup characters (such as `[/plan — plan mode]` produced by `/plan` or `[bold red]...[/]`), Rich's markup parser throws `rich.errors.MarkupError: closing tag '[/plan — plan mode]' at position 64 doesn't match any open tag`, crashing the CLI before chat input starts.

### Changes
- In `hermes_cli/cli_agent_setup_mixin.py::_preload_resumed_session`: wrap `session_meta["title"]`, `self.session_id`, `rid`, and `resume_limit_error` with `_escape(...)` when printing through Rich markup.
- In `tests/cli/test_resume_display.py`: added regression test `test_resumed_session_title_with_rich_markup_does_not_crash` verifying stored titles with unclosed or special markup tags load and print safely.

### Validation
- `pytest tests/cli/test_resume_display.py` — **19 passed in 12.99s**
- Clean git diff with zero regressions.

cc @teknium1
