### PR TITLE
fix(mcp-oauth): surface actionable guidance when a provider rejects the loopback redirect_uri

### DIFF
--- a/optional-mcps/gamma/manifest.yaml
+++ b/optional-mcps/gamma/manifest.yaml
@@ -11,6 +11,12 @@ source: https://developers.gamma.app/docs/gamma-mcp-server
 # (verified live: RFC 9728 protected-resource metadata -> AS metadata with
 # registration_endpoint); Hermes's MCP client + mcp_oauth_manager handle
 # discovery, PKCE, token exchange, and refresh.
+#
+# Gamma's registration_endpoint rejects any loopback redirect_uri
+# ("redirect_uri not allowed: http://127.0.0.1:<port>/callback") — it only
+# accepts a public HTTPS callback that Gamma allowlists out of band via
+# their custom MCP access form. A bare `auth: oauth` block cannot complete
+# DCR here; see post_install for the required oauth.redirect_uri override.
 
 transport:
   type: http
@@ -36,6 +42,17 @@ suggest:
     - gamma.app
 
 post_install: |
-  On first connection Hermes opens a browser to authorize with
-  Gamma (or run `hermes mcp login gamma`). Approve access,
-  then restart the session so tools load.
+  Gamma rejects Hermes's default loopback callback during registration —
+  you must supply a public HTTPS redirect URI that Gamma has allowlisted
+  for you (request one via their custom MCP access form) before login
+  will work:
+
+    mcp_servers:
+      gamma:
+        url: https://mcp.gamma.app/mcp
+        auth: oauth
+        oauth:
+          redirect_uri: "https://<your-allowlisted-host>/callback"
+
+  Then run `hermes mcp login gamma`, approve access, and restart the
+  session so tools load.

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -1123,3 +1123,16 @@ def test_humanize_non_registration_403_passthrough():
         )
         is None
     )
+
+
+def test_humanize_rejected_loopback_redirect_uri_suggests_oauth_redirect_uri():
+    from tools.mcp_oauth import humanize_oauth_registration_error
+
+    msg = humanize_oauth_registration_error(
+        "gamma",
+        RuntimeError("400 Bad Request: redirect_uri not allowed: http://127.0.0.1:27892/callback"),
+        server_url="https://mcp.gamma.app/mcp",
+    )
+    assert msg is not None
+    assert "oauth.redirect_uri" in msg
+    assert "hermes mcp login gamma" in msg

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -939,28 +939,36 @@ def _maybe_preregister_client(storage: "HermesTokenStorage", cfg: dict, client_m
 
 def humanize_oauth_registration_error(
     server_name: str, exc: BaseException | str, *, server_url: str | None = None) -> str | None:
-    """Turn a DCR 403/Forbidden into a useful next step; None for anything else so the caller keeps the
-    original text. Figma gates DCR on exact ``client_name`` (auto-set to ``Claude Code``), so this fires
-    when the user overrode it or an older Hermes is running."""
+    """Turn a DCR 403/Forbidden, or a rejected loopback redirect_uri, into a useful next step; None for
+    anything else so the caller keeps the original text. Figma gates DCR on exact ``client_name``
+    (auto-set to ``Claude Code``), so this fires when the user overrode it or an older Hermes is running."""
     msg = str(exc)
     lowered = msg.lower()
     looks_like_registration = ("403" in msg or "forbidden" in lowered) and (
         any(k in lowered for k in ("regist", "dcr", "dynamic client"))
         or lowered.strip() in {"forbidden", "403 forbidden", "http 403: forbidden"}
         or ("403" in msg and "forbidden" in lowered))
-    if not looks_like_registration:
-        return None
-    if _is_figma_remote_mcp(server_name, server_url):
+    if looks_like_registration:
+        if _is_figma_remote_mcp(server_name, server_url):
+            return (
+                f"'{server_name}' is Figma's remote MCP — DCR is allowlisted by exact client_name "
+                f"(\"{_FIGMA_DCR_CLIENT_NAME}\" and \"Codex\" work; most other names 403). Hermes defaults to "
+                f"client_name: {_FIGMA_DCR_CLIENT_NAME!r} automatically. If you set oauth.client_name yourself, "
+                f"change it to one of those, or clear it and re-run:\n  hermes mcp login {server_name}")
         return (
-            f"'{server_name}' is Figma's remote MCP — DCR is allowlisted by exact client_name "
-            f"(\"{_FIGMA_DCR_CLIENT_NAME}\" and \"Codex\" work; most other names 403). Hermes defaults to "
-            f"client_name: {_FIGMA_DCR_CLIENT_NAME!r} automatically. If you set oauth.client_name yourself, "
-            f"change it to one of those, or clear it and re-run:\n  hermes mcp login {server_name}")
-    return (
-        f"'{server_name}' only allows pre-approved OAuth clients — it rejected client registration (403), so no "
-        "browser flow can start. Options: set oauth.client_name to a name the provider allowlists, add a "
-        "pre-registered client (oauth: {client_id: ..., client_secret: ...}), or use the provider's stdio / "
-        "API-key / local server instead.")
+            f"'{server_name}' only allows pre-approved OAuth clients — it rejected client registration (403), so no "
+            "browser flow can start. Options: set oauth.client_name to a name the provider allowlists, add a "
+            "pre-registered client (oauth: {client_id: ..., client_secret: ...}), or use the provider's stdio / "
+            "API-key / local server instead.")
+    # Some providers (e.g. Gamma) reject loopback redirect_uris outright during DCR — they only
+    # accept a public HTTPS callback pre-allowlisted out of band, so no port/host tweak helps.
+    if "redirect_uri" in lowered and "not allowed" in lowered:
+        return (
+            f"'{server_name}' rejected the loopback redirect_uri during registration (\"{msg}\") — this "
+            "provider requires a public HTTPS callback that it allowlists out of band, not a localhost/"
+            "127.0.0.1 URI. Set oauth.redirect_uri to an allowlisted public HTTPS URL that proxies back to "
+            f"Hermes (oauth.redirect_port pins the local port it targets), then re-run:\n  hermes mcp login {server_name}")
+    return None
 
 
 def build_oauth_auth(server_name: str, server_url: str, oauth_config: dict | None = None) -> "OAuthClientProvider | None":


### PR DESCRIPTION
## What does this PR do?

Gamma's `optional-mcps/gamma/manifest.yaml` catalog entry ships a bare `auth: oauth` block, but Gamma's Dynamic Client Registration endpoint rejects any loopback redirect URI outright:

```
redirect_uri not allowed: http://127.0.0.1:27892/callback
```

`hermes mcp login gamma` (and the fallback port) always fail with this raw 400, with no indication that the fix is to point `oauth.redirect_uri` at a public HTTPS callback Gamma has allowlisted — a mechanism Hermes already supports for WAF/Tailscale-Funnel-style setups (`website/docs/user-guide/features/mcp.md`), but that `humanize_oauth_registration_error()` never recognized for this failure shape.

This PR:

1. Teaches `humanize_oauth_registration_error()` (`tools/mcp_oauth.py`) to recognize a "redirect_uri not allowed" DCR rejection and point the user at `oauth.redirect_uri`/`oauth.redirect_port`, instead of surfacing the raw HTTP 400. This is a generic detector (not Gamma-specific), so any other provider that rejects loopback callbacks the same way benefits too — mirrors the existing Figma 403 branch in the same function.
2. Documents the requirement directly in `optional-mcps/gamma/manifest.yaml` (comment + `post_install`), so users see the config they need before they even try to log in, rather than debugging a raw 400.

## Related Issue

Fixes #103521

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 📝 Documentation update

## Changes Made

- `tools/mcp_oauth.py`: `humanize_oauth_registration_error()` gains a branch for "redirect_uri not allowed" DCR errors, pointing at `oauth.redirect_uri`.
- `optional-mcps/gamma/manifest.yaml`: documents Gamma's public-HTTPS-only redirect requirement and shows the `oauth.redirect_uri` config needed to complete login.
- `tests/tools/test_mcp_oauth.py`: adds `test_humanize_rejected_loopback_redirect_uri_suggests_oauth_redirect_uri`, asserting the new message mentions `oauth.redirect_uri` and the re-run command.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_mcp_oauth.py -q` → `59 tests passed, 0 failed`.
2. Proved the new test is not a no-op: reverted `tools/mcp_oauth.py` to the pre-fix version (`git stash` of just that file) and reran `scripts/run_tests.sh tests/tools/test_mcp_oauth.py -k humanize -q`:
   ```
   FAILED tests/tools/test_mcp_oauth.py::test_humanize_rejected_loopback_redirect_uri_suggests_oauth_redirect_uri
   assert msg is not None
   E   assert None is not None
   1 failed, 1 passed, 57 deselected in 1.41s
   ```
   Restoring the fix turns this back to `2 tests passed, 0 failed`.
3. `ruff check tools/mcp_oauth.py tests/tools/test_mcp_oauth.py` → `All checks passed!`
4. `ty check tools/mcp_oauth.py` reports the same 5 pre-existing diagnostics (all in unrelated `_invalidate_tokens_on_client_change`/`_maybe_preregister_client` code, lines 902-936) as unmodified `upstream/main` — confirmed by re-running `ty check` with this diff stashed out. No new diagnostics introduced.
5. Also ran the adjacent catalog-manifest suites for a sanity check: `scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py tests/hermes_cli/test_mcp_catalog_env_boundary.py -q` → `45 tests passed, 0 failed`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/tools/test_mcp_oauth.py -q` and all tests pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform — CI environment (Linux) only; the Gamma DCR rejection itself was reported on Windows in the issue and is provider-side, so it is not reproduced locally, but the unit test exercises the exact error string from the issue's repro.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (the gamma manifest's own comments + `post_install`)
- [ ] I've updated `cli-config.yaml.example` — N/A, no new config keys (`oauth.redirect_uri`/`oauth.redirect_port` already exist)
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A, no architecture/workflow change
- [x] Cross-platform impact considered — pure string-matching/docs change, no platform-specific behavior
- [ ] Tool descriptions/schemas — N/A

## AI assistance disclosure

This PR was prepared with AI assistance (Claude Code), including the investigation of the existing `oauth.redirect_uri` mechanism, the code change, the new test, and this description. All test output above was actually run and captured from this environment.
