### PR TITLE
fix(update): do not treat successful stop_reason as unfinished receipt (#103590)

### DIFF
--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -80,10 +80,13 @@ def _current_checkout_sha() -> str | None:
 def _receipt_looks_unfinished(receipt: dict) -> bool:
     """True when *receipt* is from an update that did not finish cleanly."""
     gateway_restart = receipt.get("gateway_restart")
+    outcome = receipt.get("outcome")
+    exit_code = receipt.get("exit_code")
+    if outcome == "success" and exit_code in (0, None):
+        return False
     return bool(
-        receipt.get("stop_reason")
-        or receipt.get("exit_code") not in (0, None)
-        or receipt.get("outcome") in ("failed", "partial", "running")
+        exit_code not in (0, None)
+        or outcome in ("failed", "partial", "running")
         or (isinstance(gateway_restart, dict) and gateway_restart.get("incomplete"))
     )
 

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -254,6 +254,46 @@ def test_successful_receipt_with_pre_update_plan_shas_does_not_retrigger(
     assert update_cmd._pending_fleet_restart_needed() is False
 
 
+def test_successful_receipt_with_empty_fleet_and_stop_reason_is_not_unfinished(
+    monkeypatch,
+):
+    """Successful updates record stop_reason='completed at command boundary'.
+    When fleet is empty (e.g. desktop/single-profile), _receipt_looks_unfinished
+    must not classify it as unfinished and fall through to pre-pull plan SHAs."""
+    disk_sha = "n" * 40
+    old_sha = "o" * 40
+    monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: disk_sha)
+    monkeypatch.setattr(update_cmd_fleet, "_current_checkout_sha", lambda: disk_sha)
+
+    receipt = {
+        "outcome": "success",
+        "exit_code": 0,
+        "stop_reason": "completed at command boundary",
+        "fleet": [],
+        "plan": {
+            "runtimes": [
+                {
+                    "kind": "gateway",
+                    "profile": "default",
+                    "pid": 1,
+                    "code_sha": old_sha,
+                }
+            ],
+        },
+        "gateway_restart": {},
+    }
+    assert update_cmd_fleet._receipt_looks_unfinished(receipt) is False
+
+    receipt_dir = get_hermes_home() / "logs" / "update_receipts"
+    receipt_dir.mkdir(parents=True, exist_ok=True)
+    (receipt_dir / "latest.json").write_text(
+        json.dumps(receipt),
+        encoding="utf-8",
+    )
+    assert update_cmd_fleet._receipt_reports_stale_runtime() is False
+    assert update_cmd._pending_fleet_restart_needed() is False
+
+
 def test_stale_fleet_matrix_on_latest_receipt_is_pending(monkeypatch):
     disk_sha = "n" * 40
     monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: disk_sha)


### PR DESCRIPTION
## Summary

Fixes #103590

### Root Cause
`_receipt_looks_unfinished()` in `hermes_cli/update_cmd_fleet.py` checked `receipt.get("stop_reason")` as a truthy condition for an unfinished update. However, successful updates write `stop_reason: "completed at command boundary"` with `outcome: "success"` and `exit_code: 0`.

When an update completed cleanly on a desktop or single-profile environment with an empty `fleet: []` list, `_receipt_reports_stale_runtime()` fell through to compare against `plan.runtimes[].code_sha` (pre-pull SHAs captured before `git pull`), falsely reporting `_receipt_looks_unfinished = True` and printing `⚠ A previous hermes update pulled new code but did not restart running gateways` permanently.

### Changes
- In `hermes_cli/update_cmd_fleet.py::_receipt_looks_unfinished`: early return `False` when `outcome == "success"` and `exit_code in (0, None)`. Remove `stop_reason` from failure inference predicates so human-readable completion text doesn't trip failure checks.
- In `tests/hermes_cli/test_update_fleet_restart_pending.py`: added `test_successful_receipt_with_empty_fleet_and_stop_reason_is_not_unfinished` regression test.

### Validation
- `pytest tests/hermes_cli/test_update_fleet_restart_pending.py` — **16 passed in 49.46s**
- Clean git diff with zero regressions.

cc @teknium1
