### PR TITLE
fix(cli): keep radio choices visible below long descriptions (salvage #103350)

### DIFF
--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -657,7 +657,15 @@ def curses_radiolist(
 
     def _draw_header(stdscr, max_y, max_x, search=None, back_enabled=False):
         row = 1
-        for dline in desc_lines[: max(0, max_y - 2)]:  # ★ painted yellow to match rows
+        # Reserve title, hint, spacer, bottom margin, and up to five choices.
+        # A long description must not push the selected row off-screen.
+        choice_rows = min(max(1, len(items)), 5)
+        description_rows = max(0, max_y - 4 - choice_rows)
+        visible_description = desc_lines[:description_rows]
+        if len(desc_lines) > description_rows and visible_description:
+            hidden = len(desc_lines) - description_rows + 1
+            visible_description[-1] = f"  ... {hidden} more description lines (enlarge terminal)"
+        for dline in visible_description:  # ★ painted yellow to match rows
             _draw_description_line(stdscr, row, dline, max_x)
             row += 1
         hint = _search_hint(search, searchable, "ENTER/SPACE select", "ESC cancel", back_enabled)

--- a/tests/hermes_cli/test_curses_radiolist_viewport.py
+++ b/tests/hermes_cli/test_curses_radiolist_viewport.py
@@ -1,0 +1,97 @@
+"""Exercise radiolist rendering and navigation with a bounded terminal surface."""
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import curses_ui
+
+
+class Screen:
+    def __init__(self, keys, heights):
+        self.keys = iter(keys)
+        self.heights = iter(heights)
+        self.height = 24
+        self.frames = []
+
+    def clear(self):
+        self.rows = {}
+
+    def getmaxyx(self):
+        self.height = next(self.heights, self.height)
+        return self.height, 100
+
+    def addnstr(self, y, x, text, n, attr):
+        assert 0 <= y < self.height, f"off-screen write at row {y}"
+        self.rows[y] = self.rows.get(y, "") + text[:n]
+
+    def refresh(self):
+        self.frames.append(dict(self.rows))
+
+    def getch(self):
+        return next(self.keys)
+
+
+@pytest.fixture
+def run_menu(monkeypatch):
+    def run(keys, heights, *, description=None, selected=0):
+        screen = Screen(keys, heights)
+        curses = SimpleNamespace(
+            error=type("CursesError", (Exception,), {}),
+            A_BOLD=1, A_DIM=2, A_NORMAL=0,
+            KEY_UP=259, KEY_DOWN=258, KEY_LEFT=260, KEY_ENTER=343,
+            KEY_BACKSPACE=263,
+            has_colors=lambda: False, curs_set=lambda value: None,
+            wrapper=lambda draw: draw(screen),
+        )
+        monkeypatch.setitem(sys.modules, "curses", curses)
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr(curses_ui, "flush_stdin", lambda: None)
+        result = curses_ui.curses_radiolist(
+            "Select default model:", [f"model-{i:02}" for i in range(20)],
+            selected=selected, description=description, searchable=True,
+        )
+        return result, screen.frames
+    return run
+
+
+LONG_DESCRIPTION = "\n".join(f"Unavailable model {i}" for i in range(40))
+
+
+@pytest.mark.parametrize("height", [5, 8, 12, 24, 50])
+def test_long_description_keeps_selected_choice_and_hint_visible(run_menu, height):
+    result, frames = run_menu([10], [height], description=LONG_DESCRIPTION, selected=19)
+    assert result == 19
+    rows = list(frames[0].values())
+    assert any("model-19" in row and "\u2192" in row for row in rows)
+    assert any("/ search" in row for row in rows)
+    choices = [row for row in rows if "model-" in row]
+    assert len(choices) >= min(5, height - 4)
+    if 12 <= height < 50:
+        assert any("more description lines" in row for row in rows)
+    if height == 50:
+        assert all(f"Unavailable model {i}" in rows for i in range(40))
+
+
+def test_choice_scrolls_after_terminal_shrinks(run_menu):
+    result, frames = run_menu([258] * 19 + [10], [50, 12], description=LONG_DESCRIPTION)
+    assert result == 19
+    for index, frame in enumerate(frames):
+        assert any(f"model-{index:02}" in row and "\u2192" in row for row in frame.values())
+
+
+def test_search_result_stays_visible_with_long_description(run_menu):
+    result, frames = run_menu(
+        [ord("/"), ord("1"), ord("9"), 10], [12], description=LONG_DESCRIPTION)
+    assert result == 19
+    assert any("Search: 19" in row for row in frames[-1].values())
+    assert any("model-19" in row and "\u2192" in row for row in frames[-1].values())
+
+
+@pytest.mark.parametrize("description", [None, "First line\nSecond line"])
+def test_short_description_layout_is_unchanged(run_menu, description):
+    result, frames = run_menu([10], [24], description=description)
+    assert result == 0
+    start = 3 + (2 if description else 0)
+    assert "model-00" in frames[0][start]
+    assert not any("more description lines" in row for row in frames[0].values())

--- a/tests/hermes_cli/test_curses_radiolist_viewport.py
+++ b/tests/hermes_cli/test_curses_radiolist_viewport.py
@@ -67,6 +67,10 @@ def test_long_description_keeps_selected_choice_and_hint_visible(run_menu, heigh
     assert any("/ search" in row for row in rows)
     choices = [row for row in rows if "model-" in row]
     assert len(choices) >= min(5, height - 4)
+    if height < 12:
+        # No room for any description row: it is dropped entirely, notice included.
+        assert not any("Unavailable model" in row for row in rows)
+        assert not any("more description lines" in row for row in rows)
     if 12 <= height < 50:
         assert any("more description lines" in row for row in rows)
     if height == 50:


### PR DESCRIPTION
Keeps selectable rows visible when a curses radio menu has a long description — the Nous model picker puts the unavailable-models list and pricing there, and on a short terminal it consumed the whole viewport, hiding every model row while navigation still ran blindly.

Salvage of #103350 by @helix4u — commit cherry-picked onto current main to preserve authorship (the contributor's email→login mapping already exists in `contributors/`), with one test follow-up on top.

## Changes

- `hermes_cli/curses_ui.py` — `_draw_header` in `curses_radiolist` now reserves the title, key hint, spacer, bottom margin, and up to five choice rows before drawing description lines. When the description does not fit, its last visible line reports the omitted count. The budget is recalculated on every redraw, including terminal resize. Short descriptions and terminals large enough for the full description keep their existing layout (for `description=None` and short-description callers the rendered rows are identical to before on ≥12-row terminals).
- `tests/hermes_cli/test_curses_radiolist_viewport.py` — runs the real renderer and key loop against a bounded screen double: heights 5–50 with a 40-line description and 20 choices, resize-while-navigating, search-under-overflow, and unchanged short-description layout.
- Follow-up `test:` commit — pins the zero-budget branch (heights 5/8): no description content and no omission notice render, while choices and hint stay visible. The original parametrization exercised that branch without asserting it.

## Validation

- Live repro, tmux 100×12, real curses, the PR's own repro shape (20 models, 40-line description, selected=19):
  - base `origin/main`: 10 description lines, hint at the bottom, zero choice rows visible
  - branch: 2 description lines + `... 38 more description lines (enlarge terminal)` + hint + 5 choice rows with the cursor on the selected model
- Mutation check: reverting only the renderer fix fails 6 of the 9 viewport tests; the large-terminal and short-description controls still pass.
- `scripts/run_tests.sh` over the curses/menu test files: 50 passed, 0 failed; `ruff check --fix` and `check-windows-footguns.py --all` clean.
- CI on this PR is the final gate.

Root cause: the description was drawn with a budget of `max_y - 2`, leaving nothing for the choices.
