### PR TITLE
fix(agent): apply repetition guard to tool-call arguments (#103599)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3062,6 +3062,16 @@ class _StreamingCall:
                         arguments = repaired
                     else:
                         has_truncated_tool_args = True
+                else:
+                    from agent.repetition_guard import is_repetition_dominated
+                    if is_repetition_dominated(arguments):
+                        logger.warning(
+                            "Tool call '%s' arguments are repetition-dominated "
+                            "(degenerate model output); treating as a dropped "
+                            "tool call instead of executing.",
+                            tc["function"]["name"] or "?",
+                        )
+                        has_truncated_tool_args = True
             elif finish_reason is None:
                 # Name arrived, zero arg bytes, no finish_reason: unflagged this
                 # becomes a "stop" turn executing "{}" with no retry.

--- a/tests/agent/test_tool_call_repetition_guard.py
+++ b/tests/agent/test_tool_call_repetition_guard.py
@@ -1,0 +1,65 @@
+"""Unit tests for repetition guard on tool-call arguments (#103599).
+
+When a model gets stuck in a degenerate repetition loop inside tool call arguments,
+the arguments should be flagged as truncated rather than dispatched as valid commands.
+"""
+
+from __future__ import annotations
+
+import json
+
+from agent.chat_completion_helpers import _StreamingCall
+
+
+_INCIDENT_ECHO = "amen shalom salaam ... peace out yo wassup ... "
+
+
+def test_repetition_dominated_tool_call_arguments_flagged():
+    """Tool call arguments dominated by repeated text are flagged as truncated."""
+    # Build valid JSON with repetition-dominated command
+    repeating_cmd = "cat >> /tmp/g1.py <<'PYEOF'\n" + (_INCIDENT_ECHO * 100) + "\nPYEOF"
+    args_json = json.dumps({"command": repeating_cmd})
+
+    tool_calls_acc = {
+        0: {
+            "id": "call_123",
+            "type": "function",
+            "function": {
+                "name": "terminal",
+                "arguments": args_json,
+            },
+        }
+    }
+
+    mock_calls, has_truncated = _StreamingCall._assemble_tool_calls(
+        tool_calls_acc, finish_reason="stop"
+    )
+
+    assert mock_calls is not None
+    assert len(mock_calls) == 1
+    assert has_truncated is True
+
+
+def test_normal_tool_call_arguments_not_flagged():
+    """Normal tool call arguments (short or long unique content) are not flagged."""
+    normal_cmd = "python3 -c 'import sys; print(sys.version)'"
+    args_json = json.dumps({"command": normal_cmd})
+
+    tool_calls_acc = {
+        0: {
+            "id": "call_456",
+            "type": "function",
+            "function": {
+                "name": "terminal",
+                "arguments": args_json,
+            },
+        }
+    }
+
+    mock_calls, has_truncated = _StreamingCall._assemble_tool_calls(
+        tool_calls_acc, finish_reason="stop"
+    )
+
+    assert mock_calls is not None
+    assert len(mock_calls) == 1
+    assert has_truncated is False


### PR DESCRIPTION
## Summary

Fixes #103599

### Root Cause
`is_repetition_dominated()` in `agent/repetition_guard.py` was only checked for truncated visible text, while turns with tool calls were explicitly bypassed (`not _trunc_has_tool_calls`).

When a model in a degenerate repetition loop emits valid JSON whose payload is dominated by verbatim repeated fragments (e.g. repeated lines inside a shell command or script heredoc), Hermes parsed the JSON successfully and executed the degenerate command rather than routing it to the partial-stream-stub / drop / retry path.

### Changes
- In `agent/chat_completion_helpers.py::_StreamingCall::_assemble_tool_calls`: after validating that `arguments` is valid JSON, check `is_repetition_dominated(arguments)`. If repetition-dominated, log a warning and mark `has_truncated_tool_args = True` so it routes through `_build_partial_stream_stub(...)` instead of dispatching the degenerate command.
- In `tests/agent/test_tool_call_repetition_guard.py`: added unit tests validating that repetition-dominated tool call arguments are flagged as truncated while normal unique arguments pass through clean.

### Validation
- `pytest tests/agent/test_tool_call_repetition_guard.py` — **2 passed in 17.92s**
- `pytest tests/agent/test_repetition_guard.py tests/run_agent/test_continuation_repetition_guard.py` — **8 passed in 11.21s**
- Clean git diff with zero regressions.

cc @teknium1
