### PR TITLE
fix(context): one oversized @file no longer refuses the whole turn — tool-readable path fallback (#61987, salvage #102740)

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -195,7 +195,13 @@ async def preprocess_context_references_async(
     # Expand concurrently (each ref is independent; several @url: refs would otherwise
     # serialize web_extract round-trips). gather preserves order, so warnings/blocks
     # are assembled in ref order; the token-budget check runs once afterwards.
-    tasks = (_expand_reference(ref, cwd_path, url_fetcher=url_fetcher, allowed_root=allowed_root_path) for ref in refs)
+    hard_limit = max(1, int(context_length * 0.50))
+    soft_limit = max(1, int(context_length * 0.25))
+    tasks = (
+        _expand_reference(ref, cwd_path, url_fetcher=url_fetcher, allowed_root=allowed_root_path,
+                          max_inline_tokens=hard_limit)
+        for ref in refs
+    )
     expanded = await asyncio.gather(*tasks)
     warnings = [warning for warning, _ in expanded if warning]
     blocks = [block for _, block in expanded if block]
@@ -204,8 +210,6 @@ async def preprocess_context_references_async(
         message=message, original_message=message, references=refs, warnings=warnings, injected_tokens=injected_tokens
     )
 
-    hard_limit = max(1, int(context_length * 0.50))
-    soft_limit = max(1, int(context_length * 0.25))
     if injected_tokens > hard_limit:
         warnings.append(f"@ context injection refused: {injected_tokens} tokens exceeds the 50% hard limit ({hard_limit}).")
         result.blocked = True
@@ -235,11 +239,12 @@ _GIT_REFERENCE_ARGS: dict[str, Callable[[ContextReference], list[str]]] = {
 
 
 async def _expand_reference(
-    ref: ContextReference, cwd: Path, *, url_fetcher: UrlFetcher = None, allowed_root: Path | None = None
+    ref: ContextReference, cwd: Path, *, url_fetcher: UrlFetcher = None, allowed_root: Path | None = None,
+    max_inline_tokens: int | None = None,
 ) -> Expansion:
     try:
         if ref.kind in ("file", "folder"):
-            return _expand_path_reference(ref, cwd, allowed_root=allowed_root)
+            return _expand_path_reference(ref, cwd, allowed_root=allowed_root, max_inline_tokens=max_inline_tokens)
         if ref.kind in _GIT_REFERENCE_ARGS:
             git_args = _GIT_REFERENCE_ARGS[ref.kind](ref)
             return _expand_git_reference(ref, cwd, git_args, "git " + " ".join(git_args))
@@ -261,7 +266,8 @@ async def _expand_reference(
     return f"{ref.raw}: unsupported reference type", None
 
 
-def _expand_path_reference(ref: ContextReference, cwd: Path, *, allowed_root: Path | None = None) -> Expansion:
+def _expand_path_reference(ref: ContextReference, cwd: Path, *, allowed_root: Path | None = None,
+                           max_inline_tokens: int | None = None) -> Expansion:
     """``@file:`` / ``@folder:``: resolve, allow-check, then inline text / binary stub / listing."""
     is_folder = ref.kind == "folder"
     path = _resolve_path(cwd, ref.target, allowed_root=allowed_root)
@@ -281,7 +287,17 @@ def _expand_path_reference(ref: ContextReference, cwd: Path, *, allowed_root: Pa
     if ref.line_start is not None:
         text = "\n".join(text.splitlines()[max(ref.line_start - 1, 0):ref.line_end or ref.line_start])
     lang = _FENCE_LANGUAGES.get(path.suffix.lower(), "")
-    return None, f"📄 {ref.raw} ({estimate_tokens_rough(text)} tokens)\n```{lang}\n{text}\n```"
+    text_tokens = estimate_tokens_rough(text)
+    block = f"📄 {ref.raw} ({text_tokens} tokens)\n```{lang}\n{text}\n```"
+    if max_inline_tokens is not None and estimate_tokens_rough(block) > max_inline_tokens:
+        # One oversized file used to poison the aggregate check and refuse the whole
+        # turn (#61987); the file stays readable via the agent's tools instead.
+        return (
+            f"{ref.raw}: {text_tokens} tokens is too large to inline safely; "
+            "the agent received a tool-readable path instead",
+            _oversized_text_reference_block(ref, path, text_tokens),
+        )
+    return None, block
 
 
 def _run_quiet(cmd: list[str], cwd: Path, timeout: int, env: dict | None = None) -> subprocess.CompletedProcess:
@@ -447,6 +463,27 @@ def _binary_reference_block(ref: ContextReference, path: Path) -> str:
         f"It is available on disk at `{visible}`. Use your tools to work with it "
         f"(read or convert it, extract its text, or view/render it as needed); "
         f"do not tell the user the file type is unsupported."
+    )
+
+
+def _oversized_text_reference_block(ref: ContextReference, path: Path, text_tokens: int) -> str:
+    try:
+        size = format_bytes(path.stat().st_size)
+    except OSError:
+        size = "unknown size"
+    try:
+        from tools.terminal_tool import _ensure_terminal_env_bridged
+        _ensure_terminal_env_bridged()
+        from tools.credential_files import to_agent_visible_cache_path
+        visible = to_agent_visible_cache_path(str(path))
+    except Exception:
+        visible = str(path)
+    return (
+        f"📎 {ref.raw} (text file, {size}, approximately {text_tokens} tokens) - "
+        "too large to inline safely. "
+        f"It is available on disk at `{visible}`. "
+        "Use read_file with a narrow line range, search_files, or terminal/code tools "
+        "to inspect only the relevant parts; do not load the entire file into context."
     )
 
 

--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -288,16 +288,15 @@ def _expand_path_reference(ref: ContextReference, cwd: Path, *, allowed_root: Pa
         text = "\n".join(text.splitlines()[max(ref.line_start - 1, 0):ref.line_end or ref.line_start])
     lang = _FENCE_LANGUAGES.get(path.suffix.lower(), "")
     text_tokens = estimate_tokens_rough(text)
-    block = f"📄 {ref.raw} ({text_tokens} tokens)\n```{lang}\n{text}\n```"
-    if max_inline_tokens is not None and estimate_tokens_rough(block) > max_inline_tokens:
+    # Check BEFORE building the fenced block: an oversized file is not going to be
+    # inlined, so don't build a second MB-scale string just to discard it.
+    if max_inline_tokens is not None and text_tokens > max_inline_tokens:
         # One oversized file used to poison the aggregate check and refuse the whole
-        # turn (#61987); the file stays readable via the agent's tools instead.
-        return (
-            f"{ref.raw}: {text_tokens} tokens is too large to inline safely; "
-            "the agent received a tool-readable path instead",
-            _oversized_text_reference_block(ref, path, text_tokens),
-        )
-    return None, block
+        # turn (#61987); the file stays readable via the agent's tools instead. The
+        # block alone carries the message (same shape as the binary path) — a warning
+        # would duplicate it in "--- Context Warnings ---".
+        return None, _oversized_text_reference_block(ref, path, text_tokens)
+    return None, f"📄 {ref.raw} ({text_tokens} tokens)\n```{lang}\n{text}\n```"
 
 
 def _run_quiet(cmd: list[str], cwd: Path, timeout: int, env: dict | None = None) -> subprocess.CompletedProcess:
@@ -441,12 +440,7 @@ def _iter_visible_entries(path: Path, cwd: Path, limit: int) -> list[Path]:
     return output
 
 
-def _binary_reference_block(ref: ContextReference, path: Path) -> str:
-    mime = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
-    try:
-        size = format_bytes(path.stat().st_size)
-    except OSError:
-        size = "unknown size"
+def _agent_visible_path(path: Path) -> str:
     # Under a container backend the host path dangles inside the sandbox: translate staged
     # files to their auto-mounted cache path; fall back to the host path (local backend /
     # translation failure). Run the idempotent TERMINAL_ENV bridge first so in-process
@@ -455,35 +449,42 @@ def _binary_reference_block(ref: ContextReference, path: Path) -> str:
         from tools.terminal_tool import _ensure_terminal_env_bridged
         _ensure_terminal_env_bridged()
         from tools.credential_files import to_agent_visible_cache_path
-        visible = to_agent_visible_cache_path(str(path))
+        return to_agent_visible_cache_path(str(path))
     except Exception:
-        visible = str(path)
-    return (
-        f"📎 {ref.raw} ({mime}, {size}) — binary file, not inlined as text. "
-        f"It is available on disk at `{visible}`. Use your tools to work with it "
-        f"(read or convert it, extract its text, or view/render it as needed); "
-        f"do not tell the user the file type is unsupported."
-    )
+        return str(path)
 
 
-def _oversized_text_reference_block(ref: ContextReference, path: Path, text_tokens: int) -> str:
+def _on_disk_reference_block(ref: ContextReference, path: Path, descriptor: str, reason: str, guidance: str) -> str:
+    """Shared 📎 shape: the file was not inlined, but it IS on disk where the agent's
+    tools run — hand the model the path and a nudge instead of a dead-end warning."""
     try:
         size = format_bytes(path.stat().st_size)
     except OSError:
         size = "unknown size"
-    try:
-        from tools.terminal_tool import _ensure_terminal_env_bridged
-        _ensure_terminal_env_bridged()
-        from tools.credential_files import to_agent_visible_cache_path
-        visible = to_agent_visible_cache_path(str(path))
-    except Exception:
-        visible = str(path)
     return (
-        f"📎 {ref.raw} (text file, {size}, approximately {text_tokens} tokens) - "
-        "too large to inline safely. "
-        f"It is available on disk at `{visible}`. "
-        "Use read_file with a narrow line range, search_files, or terminal/code tools "
-        "to inspect only the relevant parts; do not load the entire file into context."
+        f"📎 {ref.raw} ({descriptor}, {size}) — {reason} "
+        f"It is available on disk at `{_agent_visible_path(path)}`. {guidance}"
+    )
+
+
+def _binary_reference_block(ref: ContextReference, path: Path) -> str:
+    mime = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+    return _on_disk_reference_block(
+        ref, path,
+        descriptor=mime,
+        reason="binary file, not inlined as text.",
+        guidance="Use your tools to work with it (read or convert it, extract its text, "
+                 "or view/render it as needed); do not tell the user the file type is unsupported.",
+    )
+
+
+def _oversized_text_reference_block(ref: ContextReference, path: Path, text_tokens: int) -> str:
+    return _on_disk_reference_block(
+        ref, path,
+        descriptor=f"text file, approximately {text_tokens} tokens",
+        reason="too large to inline safely.",
+        guidance="Use read_file with a narrow line range, search_files, or terminal/code tools "
+                 "to inspect only the relevant parts; do not load the entire file into context.",
     )
 
 

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -139,7 +139,9 @@ def test_oversized_text_file_falls_back_to_tool_readable_path(tmp_path: Path):
     assert "too large to inline safely" in result.message
     assert "read_file" in result.message
     assert "FULL-CONTENT-MARKER" not in result.message
-    assert any("tool-readable path instead" in warning for warning in result.warnings)
+    # The fallback block alone carries the message — a companion warning would
+    # repeat "too large to inline safely" under --- Context Warnings ---.
+    assert not result.warnings
 
 
 def test_file_line_range_is_applied_before_oversized_fallback(tmp_path: Path):

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -121,6 +121,65 @@ def test_missing_file_becomes_warning(sample_repo: Path):
     assert "not found" in result.message.lower()
 
 
+def test_oversized_text_file_falls_back_to_tool_readable_path(tmp_path: Path):
+    from agent.context_references import preprocess_context_references
+
+    payload = tmp_path / "large.txt"
+    payload.write_text("FULL-CONTENT-MARKER\n" + ("x" * 8_000), encoding="utf-8")
+
+    result = preprocess_context_references(
+        f"Inspect @file:{payload.name}",
+        cwd=tmp_path,
+        context_length=1_000,
+    )
+
+    assert result.expanded
+    assert not result.blocked
+    assert str(payload) in result.message
+    assert "too large to inline safely" in result.message
+    assert "read_file" in result.message
+    assert "FULL-CONTENT-MARKER" not in result.message
+    assert any("tool-readable path instead" in warning for warning in result.warnings)
+
+
+def test_file_line_range_is_applied_before_oversized_fallback(tmp_path: Path):
+    from agent.context_references import preprocess_context_references
+
+    payload = tmp_path / "large.txt"
+    payload.write_text(
+        "first line\nsecond line\n" + "\n".join("x" * 200 for _ in range(100)),
+        encoding="utf-8",
+    )
+
+    result = preprocess_context_references(
+        f"Inspect @file:{payload.name}:1-2",
+        cwd=tmp_path,
+        context_length=1_000,
+    )
+
+    assert result.expanded
+    assert not result.blocked
+    assert "first line\nsecond line" in result.message
+    assert "too large to inline safely" not in result.message
+
+
+def test_multiple_individually_safe_files_still_obey_aggregate_limit(tmp_path: Path):
+    from agent.context_references import preprocess_context_references
+
+    for name in ("first.txt", "second.txt"):
+        (tmp_path / name).write_text("x" * 1_200, encoding="utf-8")
+
+    result = preprocess_context_references(
+        "Inspect @file:first.txt and @file:second.txt",
+        cwd=tmp_path,
+        context_length=1_000,
+    )
+
+    assert result.blocked
+    assert not result.expanded
+    assert "context injection refused" in "\n".join(result.warnings)
+
+
 def test_binary_reference_block_maps_host_attachment_to_container_path(tmp_path: Path, monkeypatch):
     """Docker backend: a staged binary attachment's host path is rendered as the
     bind-mounted in-container path so the agent's tools can read it.
@@ -149,6 +208,33 @@ def test_binary_reference_block_maps_host_attachment_to_container_path(tmp_path:
     # Default container base for the docker backend is /root/.hermes.
     assert "/root/.hermes/attachments/archive.zip" in result.message
     assert "binary file, not inlined" in result.message
+
+
+def test_oversized_text_reference_maps_host_attachment_to_container_path(
+    tmp_path: Path, monkeypatch
+):
+    from agent.context_references import preprocess_context_references
+
+    hermes_home = tmp_path / ".hermes"
+    attachments = hermes_home / "attachments"
+    attachments.mkdir(parents=True)
+    payload = attachments / "large.txt"
+    payload.write_text("x" * 8_000, encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+    result = preprocess_context_references(
+        f"Read the attachment @file:{payload}",
+        cwd=tmp_path,
+        context_length=1_000,
+    )
+
+    assert result.expanded
+    assert not result.blocked
+    attached_context = result.message.split("--- Attached Context ---", 1)[1]
+    assert "/root/.hermes/attachments/large.txt" in attached_context
+    assert "too large to inline safely" in result.message
 
 
 def test_binary_reference_block_keeps_host_path_on_local_backend(tmp_path: Path, monkeypatch):

--- a/tests/gateway/test_context_ref_expansion_runtime.py
+++ b/tests/gateway/test_context_ref_expansion_runtime.py
@@ -190,3 +190,28 @@ async def test_at_reference_ignores_global_context_for_runtime_route_override(mo
         event=MessageEvent(text="@file:note", source=source), source=source, history=[]
     )
     assert captured["config_context_length"] is None
+
+
+@pytest.mark.asyncio
+async def test_oversized_file_reference_reaches_gateway_as_tool_readable_path(
+    tmp_path, monkeypatch
+):
+    runner = _make_runner()
+    source = _source()
+    _patch_runtime_resolution(monkeypatch)
+
+    payload = tmp_path / "large.txt"
+    payload.write_text("FULL-CONTENT-MARKER\n" + ("x" * 300_000), encoding="utf-8")
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+    result = await runner._prepare_inbound_message_text(
+        event=MessageEvent(text=f"Inspect @file:{payload.name}", source=source),
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    assert str(payload) in result
+    assert "too large to inline safely" in result
+    assert "FULL-CONTENT-MARKER" not in result
+    assert "context injection refused" not in result


### PR DESCRIPTION
A single oversized `@file:` attachment no longer refuses the whole turn — it degrades to a tool-readable path block the agent can work with (`read_file` ranges, `search_files`, terminal), while the aggregate 50% hard limit for many medium files is preserved.

Salvage of #102740 by @helix4u (cherry-picked to preserve authorship; the pick was re-applied onto the post-#102117 `_expand_path_reference` structure), closes #61987, related to #57486.

## Changes

- **Commit 1 (@helix4u, cherry-picked):** thread `max_inline_tokens=hard_limit` into per-ref expansion; a text file whose fenced block would exceed 50% of the model context returns an on-disk path block instead of inlining. Line ranges are applied before the size check; binary/folder/url/git/plugin paths untouched; container path translation reused.
- **Commit 2 (follow-up, simplify pass):** check text tokens *before* building the fenced block (no second MB-scale string, one token estimate instead of two); drop the companion warning so the model doesn't read "too large to inline safely" twice (Context Warnings + Attached Context); extract `_on_disk_reference_block` + `_agent_visible_path` shared by the binary and oversized blocks (stat/format_bytes/OSError fallback and container translation were copy-pasted).

## Validation

| Check | Result |
|---|---|
| Focused tests (`run_tests.sh`, 2 files) | 20 passed |
| Sibling `tests/test_tui_gateway_server.py` | 636 passed, 1 failed — same failure on `origin/main` (pre-existing, unrelated) |
| Mutation check (revert source to `origin/main`) | 3 new-behavior tests fail on base; line-range + aggregate-limit tests pass (preserved behavior) — restored byte-identical |
| Live E2E probe (real imports, temp `HERMES_HOME`) | oversized → `blocked=False`, path block, content NOT inlined; small file inlines; `:1-1` range inlines; two medium files summing >50% → still `blocked=True` with "context injection refused" |
| Ruff / windows-footguns | clean |

Root cause: the 50% budget check ran once after the gather, so one huge file poisoned every ref in the message and the turn dead-ended even though the file was on disk where the agent's tools run.
