### PR TITLE
fix(gateway): never treat Task Scheduler's SCM service as a gateway supervisor

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -781,6 +781,17 @@ def find_profile_gateway_processes(exclude_pids: set | None = None, *, strict: b
     return processes
 
 
+def _scheduled_task_gateway_supervisor_services() -> frozenset[str]:
+    """SCM services that supervise every Scheduled Task on the host, not Hermes.
+
+    A gateway started by a Hermes Scheduled Task (`hermes gateway install` on Windows)
+    keeps the Task Scheduler service in its ancestor chain while the task's bootstrap
+    is alive. These services can never be the gateway's dedicated supervisor, and the
+    updater must not `sc.exe stop` them (protected Windows services — Access denied).
+    """
+    return frozenset({"Schedule"})
+
+
 def find_windows_gateway_services(
     *, psutil_module=None, profile_processes: list[ProfileGatewayProcess] | None = None
 ) -> list[WindowsGatewayService]:
@@ -820,6 +831,12 @@ def find_windows_gateway_services(
             if service_status != "running":
                 if service_pid > 0:
                     indeterminate_services_by_pid.setdefault(service_pid, []).append((service_name, service_status))
+                continue
+            if service_name in _scheduled_task_gateway_supervisor_services():
+                # Task Scheduler's own SCM service supervises every scheduled task's
+                # bootstrap on this host — a Task-launched gateway reaches it by ancestry
+                # alone, so treating it as the gateway's supervisor makes the updater
+                # `sc.exe stop` a protected Windows service (Access denied) and abort.
                 continue
             if service_pid <= 0:
                 raise RuntimeError(f"Running SCM service {service_name} has no valid process ID")

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1159,6 +1159,53 @@ def test_find_windows_gateway_services_maps_verified_pid_tree(monkeypatch):
     ]
 
 
+def test_find_windows_gateway_services_ignores_task_scheduler_service(monkeypatch):
+    """Task Scheduler's own SCM service must never be treated as a gateway supervisor.
+
+    A gateway launched by a Hermes Scheduled Task reaches the Task Scheduler service
+    (`Schedule`) by ancestry alone while the task bootstrap is alive. Treating that as
+    SCM supervision made `hermes update` run `sc.exe stop Schedule` — Access denied on
+    a protected Windows service — and abort the whole update.
+    """
+    monkeypatch.setattr(gateway.sys, "platform", "win32")
+    profile = SimpleNamespace(profile="default", pid=300, create_time=300.0)
+
+    class FakeService:
+        def __init__(self, name, pid, status="running"):
+            self.name = name
+            self.pid = pid
+            self.status = status
+
+        def as_dict(self):
+            return {"name": self.name, "pid": self.pid, "status": self.status}
+
+    class FakeProcess:
+        def __init__(self, pid):
+            self.pid = pid
+
+        def parents(self):
+            # 100 = the svchost hosting the Task Scheduler service (`Schedule`)
+            return [FakeProcess(100)]
+
+        def children(self, recursive=False):
+            return [FakeProcess(300)]
+
+        def create_time(self):
+            return float(self.pid)
+
+    fake_psutil = SimpleNamespace(
+        win_service_iter=lambda: [FakeService("Schedule", 100)],
+        Process=FakeProcess,
+    )
+
+    # `Schedule` is filtered out of the supervisor candidates, so no service is
+    # found for this gateway: it is Task-supervised, not SCM-supervised.
+    assert gateway.find_windows_gateway_services(
+        psutil_module=fake_psutil,
+        profile_processes=[profile],
+    ) == []
+
+
 def test_find_windows_gateway_services_rejects_transitional_ancestor(monkeypatch):
     """A transitional service in the gateway ancestry remains fail-closed."""
     monkeypatch.setattr(gateway.sys, "platform", "win32")


### PR DESCRIPTION
`hermes update` on Windows no longer aborts with `Could not stop Windows gateway service Schedule: [SC] OpenService FAILED 5: Access is denied` when the gateway is installed as a Scheduled Task (`hermes gateway install`).

## Root cause

While the task's bootstrap is alive, a Task-launched gateway's ancestor chain ends at the svchost hosting the Task Scheduler's **own** SCM service:

```
16796 python.exe   <- gateway (pidfile-validated)
16516 python.exe
10872 hermes.exe   <- task bootstrap
 2844 svchost.exe  <- SCM service: Schedule
 1924 services.exe
```

`find_windows_gateway_services()` classifies a gateway as SCM-supervised when any ancestor PID matches a running SCM service. The svchost PID genuinely *is* `Schedule`'s service PID, so every identity check in `_stop_windows_gateway_service()` passes and the updater runs `sc.exe stop Schedule` — against the Windows Task Scheduler itself, a protected OS service it has no business stopping. `[SC] OpenService FAILED 5` follows, and `_pause_windows_gateways_for_update()` aborts before any code is pulled. Traceback and ancestry capture above are from a real Windows 11 install where every `hermes update` failed this way.

## Change

- `hermes_cli/gateway.py`: new `_scheduled_task_gateway_supervisor_services()` names the SCM services that supervise *every* scheduled task on the host (`Schedule`); `find_windows_gateway_services()` skips them when collecting supervisor candidates. Such a service can never be a gateway's dedicated supervisor, so a Task-launched gateway now matches no SCM service and falls through to the ordinary pause path (pidfile + argv capture), which stops and resumes it correctly.
- Transitional states keep the existing fail-closed behavior: a non-`running` `Schedule` still lands in `indeterminate_services_by_pid` and aborts the update rather than guessing.
- Regression test `test_find_windows_gateway_services_ignores_task_scheduler_service`: a gateway whose ancestor svchost hosts `Schedule` yields `[]` — no service for the updater to stop.

## Validation

| Check | Result |
|---|---|
| Focused tests (`tests/hermes_cli/test_gateway.py -k find_windows_gateway_services`) | 6 passed (5 existing + 1 new) |
| Sibling suites (`test_update_concurrent_quarantine.py`, `test_windows_gateway_cold_start_desktop_lifecycle.py`) | 39 passed |
| Mutation check (revert `hermes_cli/gateway.py` to `origin/main`) | new test fails on base; restored byte-identical |
| Live probe (Windows 11, real psutil SCM enumeration, real gateway PID 20072) | `find_windows_gateway_services()` -> no service; SCM still reports `Schedule` running (filter is scoped to the classifier, not the OS view) |
| `ruff check` on touched files | clean |

On the same machine, restarting the gateway outside the task (direct spawn, ancestry no longer crossing `Schedule`) let the identical updater run complete — confirming the ancestry classification as the trigger.
