### PR TITLE
fix(windows): skip VBS gateway spawn when the profile gateway is already alive (#103597)

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -340,6 +340,16 @@ def _build_gateway_vbs_script(python_path: str, working_dir: str, hermes_home: s
     (#54220/#56747; the previous console-less pythonw.exe gateway forced exactly that per-descendant flash).
     No cmd.exe anywhere in the chain. Mirrors ``_build_gateway_cmd_script`` (same env + argv via
     ``_resolve_detached_python``).
+
+    Pre-launch guard (issue #103597): before ``sh.Run``, check this profile's own ``gateway.pid``
+    and verify that PID is still a live gateway process via a single-row WMI query. A stale PID
+    file, an unreadable WMI row, or any inspection error falls through to the normal spawn
+    (fail-open): the guard only suppresses the spawn when it positively identifies a live
+    gateway for THIS profile. The in-Python single-instance guard stays authoritative for the
+    residual race (two launchers firing the same millisecond); this VBS check only removes the
+    common autostart-duplicate (logon firing while a gateway is already stable). Both autostart
+    paths funnel through this script (Scheduled Task runs it directly; the Startup shim chains
+    to it), so one site covers the class.
     """
     python_exe_path, venv_dir, extra_pythonpath = _resolve_detached_python(python_path)
     # list2cmdline gives CreateProcess-correct quoting for WScript.Shell.Run.
@@ -363,6 +373,33 @@ def _build_gateway_vbs_script(python_path: str, working_dir: str, hermes_home: s
         f"  env.Item({q('PYTHONPATH')}) = {q(static_pythonpath)}",
         "End If",
         f"sh.CurrentDirectory = {q(working_dir)}",
+        # Pre-launch guard (issue #103597): skip the spawn when this profile's gateway is
+        # already alive. Fail-open by design — any inspection error resumes into sh.Run.
+        "On Error Resume Next",
+        "Dim fsoG, pidFileG, pidTextG, reG, matchesG, pidG, wmiG, procsG, procG, cmdG, skipLaunchG",
+        "skipLaunchG = False",
+        'Set fsoG = CreateObject("Scripting.FileSystemObject")',
+        'pidFileG = env.Item("HERMES_HOME") & "\\gateway.pid"',
+        "If fsoG.FileExists(pidFileG) Then",
+        "  pidTextG = fsoG.OpenTextFile(pidFileG, 1).ReadAll()",
+        "  Set reG = New RegExp",
+        '  reG.Pattern = """pid""\\s*:\\s*(\\d+)"',
+        "  reG.IgnoreCase = True",
+        "  Set matchesG = reG.Execute(pidTextG)",
+        "  If matchesG.Count > 0 Then",
+        "    pidG = CLng(matchesG(0).SubMatches(0))",
+        "    If pidG > 0 Then",
+        '      Set wmiG = GetObject("winmgmts:\\\\.\\root\\cimv2")',
+        '      Set procsG = wmiG.ExecQuery("SELECT CommandLine FROM Win32_Process WHERE ProcessId = " & pidG)',
+        "      For Each procG In procsG",
+        '        cmdG = LCase(procG.CommandLine & "")',
+        '        If InStr(cmdG, "gateway run") > 0 Or InStr(cmdG, "gateway restart") > 0 Then skipLaunchG = True',
+        "      Next",
+        "    End If",
+        "  End If",
+        "End If",
+        "On Error Goto 0",
+        "If skipLaunchG Then WScript.Quit 0",
         # Window style 0 = hidden; bWaitOnReturn False = detached/async.
         f"sh.Run {q(command_line)}, 0, False",
     ]

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -340,6 +340,51 @@ def test_gateway_vbs_script_is_console_less(monkeypatch):
     assert content.endswith("\r\n")
 
 
+def test_gateway_vbs_skips_launch_when_profile_gateway_alive(monkeypatch):
+    """The .vbs launcher must check its own profile's gateway.pid + live process
+    BEFORE sh.Run so logon autostart doesn't duplicate a running gateway
+    (issue #103597). Single site: Scheduled Task and Startup shim both funnel
+    through gateway.vbs."""
+    monkeypatch.setattr(
+        gateway_windows,
+        "_resolve_detached_python",
+        lambda exe: (r"C:\venv\Scripts\python.exe", Path(r"C:\venv"), []),
+    )
+    content = gateway_windows._build_gateway_vbs_script(
+        r"C:\venv\Scripts\python.exe",
+        r"C:\Hermes",
+        r"C:\Hermes",
+        "--profile work",
+    )
+    # Profile-scoped liveness probe: own HERMES_HOME's pid file + per-PID WMI check.
+    assert "gateway.pid" in content
+    assert "Win32_Process" in content
+    # The guard quits BEFORE the fire-and-forget spawn.
+    assert content.index("WScript.Quit") < content.index("sh.Run")
+    # The spawn itself is untouched (console-less detached invariant from #45599).
+    assert content.count("sh.Run") == 1
+    assert ", 0, False" in content
+
+
+def test_gateway_vbs_prelaunch_guard_fails_open(monkeypatch):
+    """A broken guard (missing pid file, dead WMI) must never suppress a
+    legitimate start: inspection errors resume into the normal spawn path."""
+    monkeypatch.setattr(
+        gateway_windows,
+        "_resolve_detached_python",
+        lambda exe: (r"C:\venv\Scripts\python.exe", Path(r"C:\venv"), []),
+    )
+    content = gateway_windows._build_gateway_vbs_script(
+        r"C:\venv\Scripts\python.exe",
+        r"C:\Hermes",
+        r"C:\Hermes",
+        "",
+    )
+    guard_at = content.index("gateway.pid")
+    assert content.index("On Error Resume Next") < guard_at < content.index("On Error Goto 0")
+    assert content.index("On Error Goto 0") < content.index("sh.Run")
+
+
 
 
 


### PR DESCRIPTION
Fixes #103597

## Problem
`_build_gateway_vbs_script()` emitted a launcher that fired
`sh.Run "...", 0, False` unconditionally. At logon, autostart (Scheduled
Task or Startup shim) spawned a second gateway for a profile that already
had one running — the in-Python single-instance guard runs after the spawn.
Task Scheduler's `IgnoreNew` doesn't help: the fire-and-forget task
completes instantly.

## Approach
Fail-open pre-launch guard in the generated `gateway.vbs`, before `sh.Run`:
read this profile's own `gateway.pid`, parse the PID, and quit only when a
single-row WMI query proves that PID is a live `gateway run` / `restart`
process. Any inspection failure (no pid file, garbage JSON, dead WMI, PID
recycled onto a non-gateway process) falls through to the normal spawn.
One site covers the class: the Scheduled Task runs `gateway.vbs` directly
and the Startup shim chains to it. The in-Python guard stays authoritative
for the residual same-millisecond race. `, 0, False` / no-console / no
`cmd.exe` (#45599) untouched.

Note: the issue's suggested `gateway_auto_watchdog._check_gateway_duplicates`
pattern doesn't exist in-tree — the guard mirrors `get_running_pid`'s
record + live-verification logic instead, in a VBS-safe subset.

## Tests
- 2 new contract tests (guard present/profile-scoped/ordered before
  `sh.Run`; `On Error Resume Next…Goto 0` fail-open ordering). Proven to
  fail on base (sabotage run) and pass with the fix.
- `tests/hermes_cli/test_gateway_windows.py`: 7/7 Linux.
- W11 host: 11/11 pytest + cscript harness executing the real guard —
  SKIP on live gateway-like PID, PROCEED on missing/bogus/garbage pid.

## How to Test
- `scripts/run_tests.sh tests/hermes_cli/test_gateway_windows.py`
- On Windows: install gateway autostart, start gateway, force the VBS to
  fire (logon or `wscript.exe gateway.vbs`) — no second process appears;
  stop the gateway and re-fire — it starts.

## Risk / Exclusions
- Worst case of a false SKIP: one autostart cycle deferred; manual
  `hermes gateway start` never touches the VBS path. Fail-open everywhere else.
- Out of scope: making `sh.Run` synchronous (#91097) and Startup-shim
  cleanup (#99638) — related issues, separate PRs.