### PR TITLE
fix: reset text continuation state after completed tool rounds

### DIFF
--- a/agent/turn_tool_round.py
+++ b/agent/turn_tool_round.py
@@ -39,6 +39,8 @@ class ToolRoundVerdict:
     failed: Any
     _turn_exit_reason: Any
     truncated_tool_call_retries: Any
+    length_continue_retries: Any
+    truncated_response_parts: Any
     result: Optional[Dict[str, Any]] = None
 
 
@@ -47,7 +49,7 @@ def run_tool_round(
     conversation_history: Any, api_call_count: Any, effective_task_id: Any, user_message: Any,
     system_message: Any, active_system_prompt: Any, compression_attempts: Any,
     max_compression_attempts: Any, final_response: Any, failed: Any, _turn_exit_reason: Any,
-    truncated_tool_call_retries: Any,
+    truncated_tool_call_retries: Any, length_continue_retries: Any, truncated_response_parts: Any,
 ) -> ToolRoundVerdict:
     """Execute one tool round in the exact original order. Persist-before-execute is a
     durability invariant: resume must see the executed block if a destructive tool restarts
@@ -61,6 +63,8 @@ def run_tool_round(
             active_system_prompt=active_system_prompt, compression_attempts=compression_attempts,
             final_response=final_response, failed=failed, _turn_exit_reason=_turn_exit_reason,
             truncated_tool_call_retries=truncated_tool_call_retries, result=result,
+            length_continue_retries=length_continue_retries,
+            truncated_response_parts=truncated_response_parts,
         )
 
     if not agent.quiet_mode:
@@ -177,6 +181,14 @@ def run_tool_round(
 
     # Reset per-turn retry counters so one truncation can't poison the turn.
     truncated_tool_call_retries = 0
+    # A validated, executed tool response settles the text continuation. The next
+    # response gets its own ceiling and must not inherit earlier commentary parts.
+    length_continue_retries = 0
+    truncated_response_parts = []
+    for fragment in messages:
+        if isinstance(fragment, dict):
+            fragment.pop("_length_continuation_fragment", None)
+            fragment.pop("_length_continuation_nudge", None)
     # Defer the paragraph break: _fire_stream_delta() prepends one "\n\n" when real
     # text arrives, so tool iterations don't stack blank lines.
     agent._stream_needs_break = True

--- a/tests/run_agent/test_continuation_ceiling_wedge.py
+++ b/tests/run_agent/test_continuation_ceiling_wedge.py
@@ -231,6 +231,66 @@ class TestContinuationCeilingWedge:
         assert "and the rest." in result2["final_response"]
 
 
+@pytest.mark.parametrize("fragment", ["", "Earlier commentary fragment."])
+def test_completed_tool_round_settles_length_continuation(loop_agent, fragment):
+    """Replay length -> completed tools -> length without a task-global ceiling.
+
+    The empty-text variant models reasoning-only truncations observed between
+    completed tool batches; visible fragments must not leak into the final answer.
+    """
+    from tests.run_agent.test_run_agent import _mock_response, _mock_tool_call
+
+    loop_agent.valid_tool_names = {"web_search"}
+    responses = []
+    for index in range(4):
+        responses.extend([
+            _mock_response(content=fragment, finish_reason="length"),
+            _mock_response(content="Checking.", finish_reason="tool_calls", tool_calls=[
+                _mock_tool_call(call_id=f"call_recovered_{index}"),
+            ]),
+        ])
+    responses.append(_mock_response(content="Verified answer.", finish_reason="stop"))
+    loop_agent.client.chat.completions.create.side_effect = responses
+    with patch("model_tools.handle_function_call", return_value='{"result": "ok"}') as tool:
+        result = _run(loop_agent, "Check four independent facts")
+
+    assert result["completed"] is True, result.get("error")
+    assert tool.call_count == 4
+    assert result["final_response"] == "Verified answer."
+    assert len([m for m in result["messages"] if m.get("role") == "tool"]) == 4
+
+
+@pytest.mark.parametrize("interrupted_tools", [False, True])
+def test_unresolved_continuation_keeps_ceiling_after_recovered_round(loop_agent, interrupted_tools):
+    """Incomplete tool responses cannot reset the ceiling or erase settled history."""
+    from tests.run_agent.test_run_agent import _mock_response, _mock_tool_call
+
+    loop_agent.valid_tool_names = {"web_search"}
+    responses = [
+        _mock_response(content="Settled commentary.", finish_reason="length"),
+        _mock_response(content="Checking.", finish_reason="tool_calls", tool_calls=[
+            _mock_tool_call(call_id="call_settled"),
+        ]),
+    ]
+    for index in range(4):
+        responses.append(_mock_response(content=f"Unresolved part {index}.", finish_reason="length"))
+        if interrupted_tools and index < 3:
+            responses.append(_mock_response(content="", finish_reason="length", tool_calls=[
+                _mock_tool_call(arguments='{"query":', call_id=f"call_incomplete_{index}"),
+            ]))
+    loop_agent.client.chat.completions.create.side_effect = responses
+    with patch("model_tools.handle_function_call", return_value='{"result": "ok"}') as tool:
+        result = _run(loop_agent, "Check then explain")
+
+    assert result["completed"] is False
+    assert "truncated after 4 continuation attempts" in result["error"]
+    assert tool.call_count == 1
+    assert "Settled commentary." not in result["final_response"]
+    assert "Unresolved part 3." in result["final_response"]
+    assert any(m.get("content") == "Settled commentary." for m in result["messages"])
+    assert loop_agent.client.chat.completions.create.call_count == len(responses)
+
+
 class TestTruncatedPartJoining:
     """#78577 — parts joined with no separator glued text together."""
 


### PR DESCRIPTION
## Summary
- Settle text-continuation state after a validated, persisted tool round executes, alongside the existing truncated-tool retry reset.
- Reset the response-local count and fragment buffer and unmark settled transcript entries. Preserve their visible content and the existing four-attempt ceiling for unresolved continuations.
- Do not reset on malformed/truncated tool responses, validation retries, persistence failures, or guardrail halts. No global token or iteration budget changes.

## Reproduction
A single conversation can produce `length -> tool_calls -> length -> tool_calls -> length -> tool_calls -> length`. Previously the fourth independent truncation exhausted a stale counter despite completed tool batches. Earlier commentary fragments could also contaminate the final answer or be removed by a later ceiling cleanup.

## Validation
- Four new parametrized regression cases fail on unpatched main and pass on this head.
- Canonical clean-environment runner: 8 focused files, 44 tests passed, zero failed (Windows Python 3.11).
- Local HTTP/SSE replay with real `read_file` tools and temporary Hermes home: baseline fails with the four-continuation error; corrected head makes 9 completion requests, executes 4 file reads, and returns the exact final answer. Synthetic provider fixture, not a live LLM claim.
- Independent read-only exact-head review: PASS on 54456f3c92f83e22565a3b79c635593556e31482, no security or logic findings.
- Wider tests/run_agent diagnostic was stopped after an incomplete long-running file. The 33 failures observed across 9 other files reproduce with exactly matching failed test IDs on the unpatched base. This is not a full-suite green claim.

No deployment or process restart has been performed.
