### PR TITLE
fix(kanban): scratch decompose siblings must not share the root's workspace_path

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3597,19 +3597,26 @@ def _insert_decomposed_child(
     the dispatcher only ever sees a coherent graph); returns its id.
 
     Workspace: per-child override wins, else inherit the root's kind. Path
-    inherits only when kinds match (a 'dir' child must not point at the
-    root's worktree) and NEVER for worktrees — siblings dispatch concurrently
-    and one shared checkout would put them all on the first sibling's branch
-    with no lock; leaving it unset makes dispatch materialize a fresh
-    ``<repo>/.worktrees/<child-id>`` per child from the board anchor.
+    inherits only for ``dir`` (a shared directory is that kind's contract) and
+    NEVER for worktrees or scratch — siblings dispatch concurrently, and one
+    shared checkout would put them all on the first sibling's branch with no
+    lock, while a shared scratch path contradicts the kind's fresh-per-task,
+    auto-deleted-on-completion contract and pins every sibling to the root's
+    dir. Leaving the path unset lets dispatch materialize a fresh
+    ``<repo>/.worktrees/<child-id>`` / ``workspaces/<child-id>`` per child.
     """
     root_ws_kind = root_row["workspace_kind"] or "scratch"
     child_ws_kind = child.get("workspace_kind") or root_ws_kind
     if child.get("workspace_path"):
         child_ws_path = child.get("workspace_path")
-    elif child_ws_kind == "worktree":
+    elif child_ws_kind in ("worktree", "scratch"):
+        # Never share one workspace between siblings: both kinds are
+        # per-child by contract and siblings can be promoted and dispatched
+        # concurrently. Inheriting the root's literal path here (the old
+        # `child_ws_kind == root_ws_kind` arm) pinned all scratch siblings to
+        # the root's directory (#103303).
         child_ws_path = None
-    elif child_ws_kind == root_ws_kind:
+    elif child_ws_kind == root_ws_kind and root_ws_kind == "dir":
         child_ws_path = root_row["workspace_path"]
     else:
         child_ws_path = None

--- a/tests/hermes_cli/test_kanban_worktree_isolation.py
+++ b/tests/hermes_cli/test_kanban_worktree_isolation.py
@@ -103,6 +103,77 @@ def test_decompose_worktree_children_get_own_workspace(kanban_home):
 
 
 
+def test_decompose_scratch_children_get_own_workspace(kanban_home):
+    """Scratch siblings must not inherit the root's literal workspace_path.
+
+    Scratch is a fresh per-task dir under ``workspaces/<id>/`` auto-deleted
+    on completion; inheriting the root's path pinned every concurrently-
+    dispatched sibling into one shared directory (#103303).
+    """
+    with kbc.connect() as conn:
+        root = kb.create_task(conn, title="triage the batch", triage=True)
+        # A root that was ALREADY claimed materialized its scratch dir.
+        conn.execute(
+            "UPDATE tasks SET workspace_kind='scratch', "
+            "workspace_path='/tmp/workspaces/root' WHERE id = ?",
+            (root,),
+        )
+        conn.commit()
+
+        child_ids = kb.decompose_triage_task(
+            conn,
+            root,
+            root_assignee="orchestrator",
+            children=[
+                {"title": "part one", "assignee": "alice", "parents": []},
+                {"title": "part two", "assignee": "bob", "parents": [0]},
+            ],
+            author="decomposer",
+        )
+        assert child_ids is not None and len(child_ids) == 2
+
+        for cid in child_ids:
+            row = conn.execute(
+                "SELECT workspace_kind, workspace_path FROM tasks WHERE id = ?",
+                (cid,),
+            ).fetchone()
+            assert row["workspace_kind"] == "scratch"
+            # Path unset: dispatch materializes workspaces/<child-id> per child.
+            assert row["workspace_path"] is None
+            # And resolve_workspace must derive the per-child dir, not reuse
+            # the root's literal path.
+            task = kb.get_task(conn, cid)
+            resolved = kbw.resolve_workspace(task)
+            assert str(resolved).endswith(cid)
+
+
+def test_decompose_dir_children_still_share_root_path(kanban_home):
+    """dir-kind inheritance is intentional (a shared directory is the contract)."""
+    with kbc.connect() as conn:
+        root = kb.create_task(conn, title="operate on the shared dir", triage=True)
+        conn.execute(
+            "UPDATE tasks SET workspace_kind='dir', "
+            "workspace_path='C:/shared/ops' WHERE id = ?",
+            (root,),
+        )
+        conn.commit()
+
+        child_ids = kb.decompose_triage_task(
+            conn,
+            root,
+            root_assignee="orchestrator",
+            children=[{"title": "step a", "assignee": "alice", "parents": []}],
+            author="decomposer",
+        )
+        assert child_ids is not None
+        row = conn.execute(
+            "SELECT workspace_kind, workspace_path FROM tasks WHERE id = ?",
+            (child_ids[0],),
+        ).fetchone()
+        assert row["workspace_kind"] == "dir"
+        assert row["workspace_path"] == "C:/shared/ops"
+
+
 def test_resolve_worktree_falls_back_when_path_occupied(kanban_home, tmp_path):
     repo = _make_repo(tmp_path)
     occupied = _add_worktree(repo, repo / ".worktrees" / "sibling", "wt/sibling")


### PR DESCRIPTION
## Bug (from #103303)

`decompose_triage_task()` guarded `worktree` children against sharing one checkout, but the sibling rule `child_ws_kind == root_ws_kind` let `scratch` children inherit the root's LITERAL `workspace_path`. When the root was already claimed (its scratch dir materialized and persisted) before being decomposed, every scratch sibling was permanently pinned to the root's directory, and concurrently-dispatched workers wrote into one shared dir.

That contradicts the scratch kind's documented contract (fresh per-task dir under `workspaces/<id>/`, auto-deleted on completion) and re-creates the exact cross-task interference the worktree guard was added to prevent â€” the worktree branch's own comment states the invariant ("Never share one ... between siblings ... siblings can be promoted and dispatched concurrently") and it applies verbatim to scratch.

## Fix

Insert rule in `_insert_decomposed_child`:
- per-child override still wins
- `dir`-kind children still inherit the root's path â€” a shared directory IS that kind's contract
- `worktree` AND `scratch` children are left unset so dispatch materializes a fresh `workspaces/<child-id>` per child

## Tests (test_kanban_worktree_isolation.py)

- scratch siblings of an already-claimed root get `workspace_path` NULL and each `resolve_workspace()` derives its own `workspaces/<child-id>` dir
- dir-kind inheritance unchanged (positive test)
- existing worktree isolation + decompose DB suites stay green (6/6)

Full kanban selection: 303 passed with the change vs 301 on unmodified main (the 2 added tests); the 29 failures in the run are confirmed identical on unmodified main (environment skew in this Windows venv, untouched by this change).

Closes #103303
