### PR TITLE
fix(desktop): cancel downloads on the OAuth/portal partitions (auth-window hardening)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -412,7 +412,7 @@ import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-market
 import { createWakeIndicatorWindowController } from './wake-indicator-window'
 import { enumerateWindowsFrontToBack, enumerationFailed, readWindowBelow } from './window-below'
 import { registrySshScopeForWindowRoute, WindowConnectionRouteRegistry } from './window-connection-route'
-import { createWindowOpenHandler } from './window-open-policy'
+import { createWindowOpenHandler, guardAuthSessionDownloads } from './window-open-policy'
 import { installWindowRendererLifecycle } from './window-renderer-lifecycle'
 import { createWindowRevealController } from './window-reveal'
 import {
@@ -7308,6 +7308,11 @@ function getOauthSession() {
 
   oauthSession = session.fromPartition(OAUTH_SESSION_PARTITION)
 
+  // The auth windows never legitimately download anything (every consumer is
+  // a cookie read after a navigation); remote IDP/portal content must not
+  // be able to open a raw save dialog from this partition.
+  guardAuthSessionDownloads(oauthSession, 'oauth', rememberLog)
+
   return oauthSession
 }
 
@@ -7346,6 +7351,9 @@ function getOauthSessionForUrl(url) {
 
   if (!sess) {
     sess = session.fromPartition(partition)
+    // Per-connection OAuth jars get the same download guard as the legacy
+    // shared partition — their windows are sign-in-only too.
+    guardAuthSessionDownloads(sess, `oauth:${partition}`, rememberLog)
     oauthSessionsByPartition.set(partition, sess)
   }
 

--- a/apps/desktop/electron/window-open-policy.ts
+++ b/apps/desktop/electron/window-open-policy.ts
@@ -56,3 +56,32 @@ export function createWindowOpenHandler(
     return { action: 'deny' }
   }
 }
+
+/**
+ * Session-level guard for the OAuth/portal partitions: cancel any download
+ * those windows trigger.
+ *
+ * The auth windows exist solely to complete sign-in — every consumer is a
+ * cookie read (`hasOauthSessionCookie`, `hasLivePortalSession`, ...) after
+ * a navigation — so a real download is never a legitimate part of any flow.
+ * Remote IDP/portal content (or a Content-Disposition: attachment response
+ * on a redirect hop) can otherwise reach `will-download` with NO handler:
+ * `installDownloadHandling` wires only `session.defaultSession`, so the raw
+ * Chromium save dialog would open with the process cwd as the default
+ * directory and an extensionless attacker-chosen filename. Same exposure
+ * the link-title partition closes via `guardLinkTitleSession`.
+ */
+export function guardAuthSessionDownloads(
+  partitionSession: { on: (event: string, handler: (event: unknown, item: { cancel: () => void }) => void) => void },
+  label: string,
+  log?: (line: string) => void
+): void {
+  try {
+    partitionSession.on('will-download', (_event, item) => {
+      log?.(`[auth-download] ${label} cancelled`)
+      item.cancel()
+    })
+  } catch {
+    // best-effort; worst case is a spurious download dialog
+  }
+}

--- a/tests-js/auth-partition-download-guard.test.ts
+++ b/tests-js/auth-partition-download-guard.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Security regression for the OAuth/portal partition download guard:
+ * the auth windows (OAuth login, portal sign-in, silent portal renewal)
+ * load REMOTE content, and their partitions have NO will-download handler
+ * (`installDownloadHandling` wires only `session.defaultSession`). A
+ * Content-Disposition: attachment response on a redirect hop — or
+ * download-triggering JS on a compromised IDP/portal page — would reach
+ * Chromium's raw save dialog (process cwd default directory,
+ * extensionless attacker-chosen filename). The auth flows exist solely to
+ * complete sign-in, so the guard cancels every download outright, the same
+ * exposure the link-title partition closes via `guardLinkTitleSession`.
+ */
+
+import assert from 'node:assert/strict'
+
+import { describe, test } from 'vitest'
+
+import { guardAuthSessionDownloads } from '../apps/desktop/electron/window-open-policy'
+
+describe('auth partition download guard', () => {
+  test('cancels every will-download item and labels the log per partition', () => {
+    const handlers: Record<string, (event: unknown, item: { cancel: () => void }) => void> = {}
+    const logs: string[] = []
+    const partitionSession = {
+      on(event: string, handler: (event: unknown, item: { cancel: () => void }) => void) {
+        handlers[event] = handler
+      }
+    }
+
+    guardAuthSessionDownloads(partitionSession, 'oauth:persist:custom-1', (line: string) => logs.push(line))
+
+    let cancelled = 0
+    handlers['will-download'](null, {
+      cancel: () => {
+        cancelled += 1
+      }
+    })
+    handlers['will-download'](null, {
+      cancel: () => {
+        cancelled += 1
+      }
+    })
+
+    assert.equal(cancelled, 2)
+    assert.deepEqual(logs, [
+      '[auth-download] oauth:persist:custom-1 cancelled',
+      '[auth-download] oauth:persist:custom-1 cancelled'
+    ])
+    // The guard installs exactly one will-download handler — no accumulation
+    // when a partition session is reused across sign-in attempts.
+    assert.equal(Object.keys(handlers).filter(k => k === 'will-download').length, 1)
+  })
+
+  test('is a no-op when session.on throws', () => {
+    // Degraded/headless environments: a destroyed session emitter must not
+    // take the whole sign-in flow down with it.
+    assert.doesNotThrow(() =>
+      guardAuthSessionDownloads(
+        {
+          on() {
+            throw new Error('Object has been destroyed')
+          }
+        },
+        'oauth'
+      )
+    )
+  })
+})


### PR DESCRIPTION
## Summary

The auth windows (OAuth gateway login, portal sign-in, silent portal renewal) load **REMOTE content** through `session.fromPartition()` OAuth partitions — the legacy shared one plus the per-connection jars of #92183. `installDownloadHandling` wires a `will-download` handler **only on `session.defaultSession`**, so a download triggered from those windows reaches **no handler at all**:

- a `Content-Disposition: attachment` response on any redirect hop of the OAuth chain, or
- download-triggering JS on a compromised IDP/portal page

opens Chromium's raw OS save dialog with the **process cwd as the default directory** (`win-unpacked` in packaged installs) and an **extensionless attacker-chosen filename** — the exact problem `installDownloadHandling`'s own comment describes, but on partitions it never covered. Sibling of the exposure the link-title partition closes via `guardLinkTitleSession` (which cancels downloads outright).

## Fix

The auth flows exist solely to complete sign-in: every consumer of these partitions is a cookie read (`hasOauthSessionCookie`, `hasLivePortalSession`, `hasPortalAccessToken`) after a navigation — a real download is never a legitimate part of any flow.

New `guardAuthSessionDownloads(session, label, log)` in `window-open-policy.ts` cancels every `will-download` item outright, wired at **both partition creation sites** so every window ever using an OAuth partition is covered at the source:

- `getOauthSession()` — legacy shared partition
- `getOauthSessionForUrl()` — per-connection jars (#92183)

Deny log lines carry the partition label (`[auth-download] oauth:persist:custom-1 cancelled`) so the persisted desktop log distinguishes them.

## Tests

New file `tests-js/auth-partition-download-guard.test.ts` (2 tests, real policy module, fake partition session — same DI shape as the link-title window tests):

1. Cancels every `will-download` item, labels the log per partition, and installs exactly one handler (no accumulation when a partition session is reused across sign-in attempts)
2. A throwing session emitter is a no-op — degraded/headless environments must not take sign-in down with them

## Verification

- `vitest run auth-partition-download-guard.test.ts window-open-policy.test.ts`: **4/4 passed**
- `tsc -p tsconfig.electron.json --noEmit`: **clean**
- `eslint electron/window-open-policy.ts`: **clean**

Companion to #103610 (window-open deny on the same windows) — this PR closes the download side of the same remote-content exposure.