### PR TITLE
fix(desktop): show the Hermes icon in the update hand-off window

### DIFF
--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -235,7 +235,8 @@ for entry in data.get("LSHandlers", []):
 
 start_ui() {
   [ "$NO_UI" -eq 1 ] && return
-  local html="$SCRIPT_DIR/ui.html" py browser port="" i
+  local html="$SCRIPT_DIR/ui.html" icon="$SCRIPT_DIR/../../web/public/favicon.ico" py browser port="" i
+  [ -f "$icon" ] || icon=""
   py="${INSTALL_ROOT:+$INSTALL_ROOT/venv/bin/python3}"
   [ -x "${py:-/nonexistent}" ] || py="$(command -v python3 2>/dev/null)"
   browser="$(find_browser)"
@@ -257,7 +258,7 @@ start_ui() {
   # window showed ERR_CONNECTION_REFUSED for the whole run; upstream #66753).
   # stop_ui ends the server with SIGKILL instead — it is stateless HTTP.
   "$py" -c 'import os, signal, sys; os.setsid(); signal.signal(signal.SIGTERM, signal.SIG_IGN); signal.signal(signal.SIGHUP, signal.SIG_IGN); os.execv(sys.argv[1], sys.argv[1:])' \
-    "$py" "$SCRIPT_DIR/serve-ui.py" "$html" "$STATUS" "$STARTED_AT" > "$LOG_DIR/desktop-update-ui-port" 2>>"$LOG" &
+    "$py" "$SCRIPT_DIR/serve-ui.py" "$html" "$STATUS" "$STARTED_AT" "$icon" > "$LOG_DIR/desktop-update-ui-port" 2>>"$LOG" &
   UI_SERVER_PID=$!
   for i in $(seq 1 10); do
     port="$(tr -cd '0-9' < "$LOG_DIR/desktop-update-ui-port" 2>/dev/null)"

--- a/scripts/desktop-update/serve-ui.py
+++ b/scripts/desktop-update/serve-ui.py
@@ -1,9 +1,12 @@
 """Loopback shim server for the desktop update hand-off.
 
-Two GET routes: / serves ui.html, /progress serves the status file the
-orchestrator script writes ({"status": "running"|"done"|"error", ...}).
-Exists because a file:// page cannot receive events from a detached
-process. Prints the chosen ephemeral port on stdout, serves until killed.
+Three GET routes: / serves ui.html, /progress serves the status file the
+orchestrator script writes ({"status": "running"|"done"|"error", ...}),
+/favicon.ico serves the app icon so the chromeless browser app window is
+identifiable in the taskbar/window switcher instead of showing a generic
+default. Exists because a file:// page cannot receive events from a
+detached process. Prints the chosen ephemeral port on stdout, serves
+until killed.
 
 `elapsed_seconds` is stamped per request, not read from the status file:
 stages are minutes apart, so a value frozen at the last publish would sit
@@ -19,8 +22,17 @@ import time
 
 html_path, status_path = sys.argv[1], sys.argv[2]
 started_at = float(sys.argv[3]) if len(sys.argv) > 3 else time.time()
+icon_path = sys.argv[4] if len(sys.argv) > 4 else ""
 with open(html_path, "rb") as f:
     HTML = f.read()
+
+ICON = b""
+if icon_path:
+    try:
+        with open(icon_path, "rb") as f:
+            ICON = f.read()
+    except OSError:
+        pass
 
 
 def progress_body():
@@ -46,6 +58,8 @@ class Handler(http.server.BaseHTTPRequestHandler):
             ctype = "application/json; charset=utf-8"
         elif self.path == "/":
             body, ctype = HTML, "text/html; charset=utf-8"
+        elif self.path == "/favicon.ico" and ICON:
+            body, ctype = ICON, "image/x-icon"
         else:
             self.send_response(404)
             self.end_headers()

--- a/scripts/desktop-update/ui.html
+++ b/scripts/desktop-update/ui.html
@@ -24,6 +24,7 @@
 <head>
 <meta charset="utf-8">
 <title>Hermes</title>
+<link rel="icon" href="/favicon.ico">
 <style>
   :root {
     --background: #ffffff;

--- a/tests/test_desktop_update_shim_progress.py
+++ b/tests/test_desktop_update_shim_progress.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from urllib.error import HTTPError
 from urllib.request import urlopen
 
 import pytest
@@ -35,18 +36,29 @@ requires_posix_handoff = pytest.mark.skipif(
 @pytest.fixture
 def progress(tmp_path):
     """The real loopback server, over a status file the test drives."""
+    yield from _start_server(tmp_path, icon_path=None)
+
+
+@pytest.fixture
+def progress_with_icon(tmp_path):
+    """The real loopback server, with a favicon wired up like posix.sh does."""
+    icon = tmp_path / "favicon.ico"
+    icon.write_bytes(b"\x00\x01fake-icon-bytes\x02\x03")
+    yield from _start_server(tmp_path, icon_path=icon)
+
+
+def _start_server(tmp_path, icon_path):
     status = tmp_path / "hermes-update-status"
-    proc = subprocess.Popen(
-        [
-            sys.executable,
-            str(SHIM_DIR / "serve-ui.py"),
-            str(SHIM_DIR / "ui.html"),
-            str(status),
-            str(time.time()),
-        ],
-        stdout=subprocess.PIPE,
-        text=True,
-    )
+    args = [
+        sys.executable,
+        str(SHIM_DIR / "serve-ui.py"),
+        str(SHIM_DIR / "ui.html"),
+        str(status),
+        str(time.time()),
+    ]
+    if icon_path is not None:
+        args.append(str(icon_path))
+    proc = subprocess.Popen(args, stdout=subprocess.PIPE, text=True)
     try:
         port = int(proc.stdout.readline().strip())
 
@@ -60,6 +72,9 @@ def progress(tmp_path):
             def poll(self) -> dict:
                 with urlopen(f"http://127.0.0.1:{port}/progress", timeout=5) as r:
                     return json.loads(r.read())
+
+            def get(self, path: str):
+                return urlopen(f"http://127.0.0.1:{port}{path}", timeout=5)
 
         yield Progress()
     finally:
@@ -108,6 +123,23 @@ def test_unreadable_status_still_serves_a_running_state(progress):
 
     assert served["status"] == "running"
     assert served["elapsed_seconds"] >= 0
+
+
+def test_favicon_served_when_icon_path_given(progress_with_icon):
+    """The chromeless app window is identifiable, not a generic default icon."""
+    with progress_with_icon.get("/favicon.ico") as r:
+        assert r.status == 200
+        assert r.headers["Content-Type"] == "image/x-icon"
+        assert r.read() == b"\x00\x01fake-icon-bytes\x02\x03"
+
+
+def test_favicon_missing_when_no_icon_path_given(progress):
+    """No icon arg (old checkouts, missing asset) degrades to no favicon --
+    never a crash, matching every other optional shim input."""
+    with pytest.raises(HTTPError) as excinfo:
+        progress.get("/favicon.ico")
+
+    assert excinfo.value.code == 404
 
 
 # ── posix.sh: the stages it publishes at its own gates ─────────────────────


### PR DESCRIPTION
## What does this PR do?

Fixes #103629. The macOS/Linux desktop update hand-off shows a "chromeless
default-browser app window" (`scripts/desktop-update/posix.sh` spawning
`chrome/chromium --app=http://127.0.0.1:<port>/`, serving
`scripts/desktop-update/ui.html` over `scripts/desktop-update/serve-ui.py`)
while `hermes update` runs. That window never served a favicon, so instead
of the Hermes mark, the taskbar/window switcher showed a generic default
icon — exactly what the reporter saw on Ubuntu 26.04.1. Verified via
`grep -r icon scripts/desktop-update/`: zero hits before this change.

Chromium's `--app=` mode uses the page's favicon as the window's taskbar
icon (that's the whole point of "site-specific browser" app windows), so
serving one from the shim is enough to fix this — no Electron `BrowserWindow`
is even involved in this particular window (that's a separate, unrelated
in-app "Updating Hermes…" overlay that already looks fine).

## Changes Made

- `scripts/desktop-update/serve-ui.py` — accepts an optional 4th argv (icon
  file path); if given and readable, serves it at `GET /favicon.ico` as
  `image/x-icon`. Missing/unreadable icon degrades to a plain 404, matching
  every other optional input this shim already tolerates.
- `scripts/desktop-update/posix.sh` — `start_ui()` resolves the repo's
  existing `web/public/favicon.ico` (already used as the web app's own
  favicon) and passes it through to `serve-ui.py`; falls back to no icon if
  the file isn't there (old/partial checkouts).
- `scripts/desktop-update/ui.html` — adds `<link rel="icon" href="/favicon.ico">`.
- `tests/test_desktop_update_shim_progress.py` — extends the existing real
  (no-mock) `serve-ui.py` subprocess fixture with an icon-path variant, and
  adds two new tests: the icon is served correctly when a path is given, and
  the route cleanly 404s (not a crash) when it isn't.

Windows (`scripts/desktop-update/windows.ps1`) has its own in-process HTTP
listener and WinForms fallback that also don't set an icon today, but I
deliberately left that out of this PR: I can't execute or verify the
Windows-only WinForms path from this environment, and this repo's own test
suite treats `windows.ps1` execution as `windows_only` / CI-lane-only for
that reason (see `tests/test_desktop_update_windows_pipe_drain.py`). Happy
to follow up there if maintainers want it, ideally reviewed/tested by
someone on Windows.

## How to Test

```
source .venv/bin/activate   # venv with `pip install -e ".[all,dev]"`
scripts/run_tests.sh tests/test_desktop_update_shim_progress.py -v
```

Output:

```
Discovered 1 test files (~7 tests) under ['tests/test_desktop_update_shim_progress.py']; running with -j 8
[100.0% |     7/~7 | ✓7 | ✗0] ✓ tests/test_desktop_update_shim_progress.py (7✓, 4.5s)

=== Summary: 1 files, 7 tests passed, 0 failed (100% complete) in 4.5s (8 workers) ===
```

Proved the new test actually exercises the fix: with the three source files
reverted (`git stash` of `posix.sh`/`serve-ui.py`/`ui.html`, keeping only the
test change) the same run gives `1 failed, 6 passed` — the new
`test_favicon_served_when_icon_path_given` fails with `HTTPError: 404`,
while the new negative test (`test_favicon_missing_when_no_icon_path_given`)
and all pre-existing tests still pass, confirming the new test targets
exactly the added behavior. Restoring the fix returns it to `7 passed, 0 failed`.

Also ran, both clean:
```
ruff check scripts/desktop-update/serve-ui.py tests/test_desktop_update_shim_progress.py
ruff format --check scripts/desktop-update/serve-ui.py tests/test_desktop_update_shim_progress.py
shellcheck scripts/desktop-update/posix.sh   # no new findings vs. pre-existing SC2317/SC2034 info/warning noise
python3 scripts/check-windows-footguns.py --diff HEAD   # "No Windows footguns found"
```

## Platforms Tested

Linux (Ubuntu, matching the report) — ran the real `serve-ui.py` subprocess
end-to-end via the test suite above. Did not have access to macOS or Windows
hardware; the POSIX code path (`posix.sh`) is shared between macOS and Linux
and touches nothing platform-specific.

## Checklist

- [x] I've read the Contributing Guide
- [x] Commit message follows Conventional Commits
- [x] Searched existing PRs for a duplicate — none found referencing #103629 or this shim's favicon handling
- [x] PR contains only changes related to this fix
- [x] Ran `scripts/run_tests.sh tests/test_desktop_update_shim_progress.py` — all pass
- [x] Added tests for the change (and proved they fail without it)
- [x] Tested on Ubuntu (matches reporter's platform)

## AI assistance disclosure

This PR was prepared with the help of an AI coding agent (investigation,
implementation, and test verification), reviewed by me before submission.
