### PR TITLE
fix(desktop): route host.warmProfile through the guarded prewarm resolver

### DIFF
--- a/apps/desktop/src/sdk/index.test.ts
+++ b/apps/desktop/src/sdk/index.test.ts
@@ -1,9 +1,60 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { host } from '@/sdk'
 import { setActiveSessionId, setAwaitingResponse, setBusy } from '@/store/session'
 import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
+
+// The warm path must route through the guarded prewarm resolver, not dial the
+// gateway directly: gateway.ts's openSecondaryCount and pool-limits' cap atom
+// are the two signals prewarmProfileBackend consults, so mocking them lets the
+// tests observe the guard's decision through the ONLY side effect that matters
+// — whether openGatewayForProfile was dialed.
+const warmMocks = vi.hoisted(() => ({
+  openGatewayForProfile: vi.fn(async (_profile: string) => undefined),
+  openSecondaryCount: vi.fn(() => 0)
+}))
+
+vi.mock('@/store/gateway', async importOriginal => ({
+  ...((await importOriginal()) as Record<string, unknown>),
+  openGatewayForProfile: warmMocks.openGatewayForProfile,
+  openSecondaryCount: warmMocks.openSecondaryCount
+}))
+
+vi.mock('@/store/pool-limits', async () => {
+  const { atom } = await import('nanostores')
+
+  return { $poolLimits: atom({ idleMs: 600_000, maxBackends: 3 }) }
+})
+
+describe('host.warmProfile pool-saturation contract', () => {
+  beforeEach(() => {
+    warmMocks.openGatewayForProfile.mockClear()
+    warmMocks.openSecondaryCount.mockReturnValue(0)
+  })
+
+  it('dials through the guarded path when a pool slot is free', () => {
+    warmMocks.openSecondaryCount.mockReturnValue(2)
+
+    host.warmProfile('warm-free-slot')
+
+    expect(warmMocks.openGatewayForProfile).toHaveBeenCalledWith('warm-free-slot')
+  })
+
+  it('skips the speculative spawn when every pool slot is occupied', () => {
+    warmMocks.openSecondaryCount.mockReturnValue(3)
+
+    host.warmProfile('warm-saturated')
+
+    expect(warmMocks.openGatewayForProfile).not.toHaveBeenCalled()
+  })
+
+  it('ignores blank profile names', () => {
+    host.warmProfile('   ')
+
+    expect(warmMocks.openGatewayForProfile).not.toHaveBeenCalled()
+  })
+})
 
 describe('host.state turn flags', () => {
   afterEach(() => {

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -65,6 +65,7 @@ import {
   newSessionInAgent,
   newSessionInProfile,
   normalizeProfileKey,
+  prewarmProfileBackend,
   refreshProfiles,
   selectProfile,
   setActiveProfile,
@@ -643,20 +644,25 @@ export const host = {
   },
 
   /** Pre-dial a profile's gateway socket in the background — pool-only, no
-   *  activation, no navigation, no scope change (openGatewayForProfile; it
-   *  already no-ops for shared-remote routes and the primary). Roster UIs
-   *  call this after mount so the FIRST click on an agent doesn't pay the
-   *  whole backend spawn + socket dial latency. Fire-and-forget: failures
-   *  are swallowed — the click path re-runs its own ensure and surfaces
-   *  errors properly. */
+   *  activation, no navigation, no scope change. Delegates to
+   *  prewarmProfileBackend so plugin surfaces get the SAME pool-saturation
+   *  guard, hover dwell, and per-profile throttle as the built-in rail
+   *  (#91545): a pointer sweep across a plugin roster (bot-row's
+   *  onPointerEnter fires with no dwell of its own) previously spawned at
+   *  pointer speed, filled the local backend pool past maxBackends, and left
+   *  the next profile's spawn queued until the 30s slot timeout — observed
+   *  as a profile surface that hangs forever while every other profile
+   *  renders. It already no-ops for shared-remote routes and the primary.
+   *  Fire-and-forget: failures are swallowed — the click path re-runs its
+   *  own ensure and surfaces errors properly. */
   warmProfile: (profile: string): void => {
     const name = (profile ?? '').trim()
 
-    if (!name || name === $activeGatewayProfile.get()) {
+    if (!name) {
       return
     }
 
-    void openGatewayForProfile(name).catch(() => undefined)
+    prewarmProfileBackend(name)
   },
 
   /** Delete a profile THROUGH the desktop's teardown-routed REST path — the


### PR DESCRIPTION
## What does this PR do?

`host.warmProfile` (the plugin SDK surface that `bot-row` calls on `onPointerEnter`) dialed `openGatewayForProfile` directly — bypassing the pool-saturation guard, hover dwell, and per-profile throttle that `prewarmProfileBackend` enforces for the built-in rail.

Consequence: a pointer sweep across a plugin roster spawns profile backends at pointer speed. With the pool at its default cap (3), the next profile's **real** spawn queues behind them and times out after 30s — the profile's surface then hangs on an endless spinner while every other profile renders fine. Reproduced on a 4-profile setup: `waiting for a free local slot (3/3 busy, 1 queued)` repeating every ~30s, self-healing only after the 10-minute idle reaper harvests the pool.

This PR delegates `warmProfile` to `prewarmProfileBackend`, so every speculative warm shares **one resolver and one policy** (the design guide's single-resolver rule). Behavior contract of the old SDK path is preserved: blank names are ignored, the active profile is a no-op, and failures stay swallowed (the click path re-runs its own ensure and owns error UX). Only the speculative head start is gated.

Behavior of `openRosterBot`/real clicks is untouched — they dial on demand exactly as before.

## Related Issue

Fixes #103631

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/sdk/index.ts` — `warmProfile` now delegates to `prewarmProfileBackend` (same saturation guard + 60s throttle + active-profile no-op as the rail hover path); blank-name guard preserved; import added
- `apps/desktop/src/sdk/index.test.ts` — contract tests for the warm path: dial passes through the guarded resolver when a slot is free, speculative spawn is skipped when every slot is occupied (3/3), blank names never dial

## How to Test

1. `cd apps/desktop && npx vitest run src/sdk/index.test.ts src/store/profile.test.ts src/plugins/hermes-bots/bot-row.test.tsx` — all green (14 + 26 tests)
2. Saturation proof: with 3 secondary profile backends open, sweep the pointer across the Bots roster, then open a 4th profile's settings — before this PR the page spins for 30s+; after it, the warm attempt is skipped and the real open proceeds once the user actually clicks
3. `npx tsc --noEmit -p tsconfig.json` — clean; `npx eslint src/sdk/index.ts src/sdk/index.test.ts` — clean; `npx prettier --check` — clean

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — *desktop TS change; the relevant vitest suites run green (above); Python suite untouched*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6 (Apple Silicon, arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A — *N/A (docstring of the SDK surface updated in place)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A — *N/A*
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A — *N/A*
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A — *renderer-only change, platform-agnostic*
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A — *N/A*

## Screenshots / Logs

Repro log (main, before fix) — 6 consecutive spawn timeouts for the 4th profile:

```
Profile backend "marketing" waiting for a free local slot (3/3 busy, 1 queued)
Hermes backend for profile "marketing" failed to start: Local backend start for "marketing" timed out while waiting for a free slot.
```

After the fix, a saturated pool yields no speculative spawn attempt at all (covered by the `skips the speculative spawn when every pool slot is occupied` contract test).
