### PR TITLE
feat(matrix): opt-in processing of message edits as new agent turns

### DIFF
--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -1500,6 +1500,10 @@ class GatewayInboundMixin:
             reply_snippet = event.reply_to_text[:500]
             _who = " your previous message" if getattr(event, "reply_to_is_own_message", False) else ""
             message_text = f'[Replying to{_who}: "{reply_snippet}"]\n\n{message_text}'
+        if getattr(event, "metadata", None) and event.metadata.get("edited_message"):
+            # Platform edit forwarded as a new turn (e.g. Matrix ``process_edits``): flag it so the
+            # agent treats this as a correction/follow-up rather than an unrelated fresh prompt.
+            message_text = f"[Edited message — this corrects/replaces your previous prompt]\n\n{message_text}"
         return message_text
 
     async def _inbound_model_context_length(self, source: SessionSource, session_key: str) -> int:

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -3001,6 +3001,7 @@ def interactive_setup() -> None:
 
 _YAML_LOWER_KEYS = (
     ("require_mention", "MATRIX_REQUIRE_MENTION"), ("process_notices", "MATRIX_PROCESS_NOTICES"),
+    ("process_edits", "MATRIX_PROCESS_EDITS"),
     ("session_scope", "MATRIX_SESSION_SCOPE"), ("auto_thread", "MATRIX_AUTO_THREAD"),
     ("dm_mention_threads", "MATRIX_DM_MENTION_THREADS"))
 _YAML_LIST_KEYS = (

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -8,7 +8,7 @@ Env vars (config.yaml ``matrix:`` keys alias several — env wins):
   MATRIX_ALLOWED_USERS, MATRIX_ALLOWED_ROOMS (whitelist; DMs exempt), MATRIX_IGNORE_USER_PATTERNS
   (regexes for bridge ghosts), MATRIX_HOME_ROOM (cron delivery), MATRIX_REACTIONS (default true);
   MATRIX_REQUIRE_MENTION (default true), MATRIX_THREAD_REQUIRE_MENTION, MATRIX_FREE_RESPONSE_ROOMS,
-  MATRIX_PROCESS_NOTICES, MATRIX_ALLOW_ROOM_MENTIONS, MATRIX_ALLOW_PUBLIC_ROOMS (all default false);
+  MATRIX_PROCESS_NOTICES, MATRIX_PROCESS_EDITS, MATRIX_ALLOW_ROOM_MENTIONS, MATRIX_ALLOW_PUBLIC_ROOMS (all default false);
   MATRIX_AUTO_THREAD (default true), MATRIX_DM_AUTO_THREAD, MATRIX_DM_MENTION_THREADS,
   MATRIX_SESSION_SCOPE auto|room|thread; MATRIX_MAX_MESSAGE_LENGTH (default 16000),
   MATRIX_MAX_MEDIA_BYTES, MATRIX_ROOM_IDENTITY_TTL_SECONDS; MATRIX_APPROVAL_REQUIRE_SENDER (default
@@ -800,6 +800,7 @@ class MatrixAdapter(BasePlatformAdapter):
         raw_session_scope = os.getenv("MATRIX_SESSION_SCOPE", "auto").strip().lower()
         self._matrix_session_scope = raw_session_scope if raw_session_scope in {"auto", "room", "thread"} else "auto"
         self._process_notices: bool = _env_truthy("MATRIX_PROCESS_NOTICES", "false")
+        self._process_edits: bool = self._parse_process_edits(config)
         self._reactions_enabled: bool = os.getenv("MATRIX_REACTIONS", "true").lower() not in {"false", "0", "no"}
         self._pending_reactions: dict[tuple[str, str], str] = {}
         # Let the final message land before redacting reactions ("missing event" in some
@@ -872,6 +873,16 @@ class MatrixAdapter(BasePlatformAdapter):
         if configured is not None:
             return configured
         return os.getenv("MATRIX_THREAD_REQUIRE_MENTION", "false").lower() in {"true", "1", "yes", "on"}
+
+    @staticmethod
+    def _parse_process_edits(config) -> bool:
+        """process_edits from config.extra, else MATRIX_PROCESS_EDITS (default false). Opt-in:
+        forwards an ``m.replace`` edit of a user's own message as a new agent turn carrying the
+        corrected text, instead of the default of silently ignoring edits."""
+        configured = MatrixAdapter._configured_bool(config, "process_edits")
+        if configured is not None:
+            return configured
+        return _env_truthy("MATRIX_PROCESS_EDITS", "false")
 
     @staticmethod
     def _extract_server_ed25519(device_keys_obj: Any) -> Optional[str]:
@@ -1365,6 +1376,7 @@ class MatrixAdapter(BasePlatformAdapter):
                 "ignored_user_pattern_count": len(self._ignored_user_patterns),
                 "require_mention": self._require_mention, "free_response_room_count": len(self._free_rooms),
                 "allow_room_mentions": self._allow_room_mentions, "process_notices": self._process_notices,
+                "process_edits": self._process_edits,
                 "allow_public_rooms": _env_truthy("MATRIX_ALLOW_PUBLIC_ROOMS")},
             "media": {"max_media_bytes": self._max_media_bytes}}
 
@@ -1909,7 +1921,11 @@ class MatrixAdapter(BasePlatformAdapter):
             source_content = content.serialize() if hasattr(content, "serialize") else {}
             msgtype = str(content.msgtype) if hasattr(content, "msgtype") else ""
         relates_to = source_content.get("m.relates_to", {})
-        if relates_to.get("rel_type") == "m.replace":  # skip edits
+        if relates_to.get("rel_type") == "m.replace":
+            # Opt-in only (default: skip edits, unchanged behavior). The bot's own edits (e.g.
+            # outbound streaming updates) never reach here — _is_self_sender already returned above.
+            if self._process_edits and (msgtype == "m.text" or (msgtype == "m.notice" and self._process_notices)):
+                await self._handle_edit_message(room_id, sender, event_id, source_content, relates_to)
             return
         # m.notice is the conventional bot-response msgtype; ignoring it prevents bot-to-bot loops.
         if msgtype == "m.notice" and not self._process_notices:
@@ -2015,6 +2031,35 @@ class MatrixAdapter(BasePlatformAdapter):
             reply_to_author_name=reply_to_author_name,
             # Top-level sender fields mirror source.* — downstream prompt code reads them.
             user_id=sender, user_name=display_name, **extra)
+
+    async def _handle_edit_message(
+        self, room_id: str, sender: str, event_id: str, source_content: dict, relates_to: dict) -> None:
+        """process_edits (opt-in): forward the corrected body of an ``m.replace`` edit as a new
+        agent turn. Reuses the normal message gate (mention/thread/session/auth, all keyed off
+        ``m.new_content`` exactly as a fresh event would be) so an edit is authorized and routed
+        the same way a brand-new message from the same sender would be; the edit's own event_id
+        (checked by the caller before this point) gives per-edit dedup for free. Preserves the
+        original event as metadata rather than rewriting any prior turn."""
+        target_event_id = str(relates_to.get("event_id") or "")
+        if not target_event_id:
+            return
+        new_content = source_content.get("m.new_content")
+        if not isinstance(new_content, dict):
+            return
+        body = new_content.get("body", "") or ""
+        if not body:
+            return
+        # Threaded edits mirror the thread relation into m.new_content (MSC2676); the top-level
+        # relates_to on an edit is exclusively the m.replace pointer, never m.thread.
+        new_relates_to = new_content.get("m.relates_to")
+        if not isinstance(new_relates_to, dict):
+            new_relates_to = {}
+        msg_event = await self._build_inbound_event(
+            room_id, sender, event_id, body, new_content, new_relates_to,
+            metadata={"edited_message": True, "edited_message_original_id": target_event_id})
+        if msg_event is None:
+            return
+        await self.handle_message(msg_event)
 
     async def _handle_text_message(
         self, room_id: str, sender: str, event_id: str, event_ts: float, source_content: dict,

--- a/tests/gateway/test_matrix_process_edits.py
+++ b/tests/gateway/test_matrix_process_edits.py
@@ -2,6 +2,7 @@
 own message as a new agent turn (issue: incoming user edits are silently skipped by default).
 """
 
+import os
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -82,8 +83,9 @@ async def test_process_edits_enabled_via_env_forwards_corrected_body(monkeypatch
 
 @pytest.mark.asyncio
 async def test_process_edits_enabled_via_config_extra(monkeypatch):
-    """config.yaml ``matrix.process_edits: true`` (config.extra) works without the env var —
-    the dual config.extra/env path mirrors require_mention/thread_require_mention."""
+    """``_parse_process_edits`` prefers a directly-set ``config.extra["process_edits"]`` over the
+    env var. This does not by itself prove config.yaml's ``matrix.process_edits: true`` works —
+    see ``test_apply_yaml_config_bridges_process_edits`` for the real YAML→env bridge."""
     monkeypatch.delenv("MATRIX_PROCESS_EDITS", raising=False)
     monkeypatch.setenv("MATRIX_REQUIRE_MENTION", "false")
 
@@ -92,6 +94,19 @@ async def test_process_edits_enabled_via_config_extra(monkeypatch):
 
     await adapter._on_room_message(event)
     adapter.handle_message.assert_awaited_once()
+
+
+def test_apply_yaml_config_bridges_process_edits(monkeypatch):
+    """config.yaml's ``matrix.process_edits: true`` must reach ``MATRIX_PROCESS_EDITS`` via the
+    real ``apply_yaml_config_fn`` hook (``_apply_yaml_config``) — the same bridge that already
+    carries ``process_notices`` — not just via a hand-constructed ``PlatformConfig(extra=...)``."""
+    from plugins.platforms.matrix.adapter import _apply_yaml_config
+
+    monkeypatch.delenv("MATRIX_PROCESS_EDITS", raising=False)
+    seeded = _apply_yaml_config({}, {"process_edits": True})
+
+    assert seeded is None  # _apply_yaml_config always returns None; everything flows through env
+    assert os.environ["MATRIX_PROCESS_EDITS"] == "true"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_matrix_process_edits.py
+++ b/tests/gateway/test_matrix_process_edits.py
@@ -1,0 +1,113 @@
+"""Tests for opt-in Matrix ``process_edits``: forwarding an ``m.replace`` edit of a user's
+own message as a new agent turn (issue: incoming user edits are silently skipped by default).
+"""
+
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _make_adapter(process_edits=None):
+    """Create a MatrixAdapter with mocked config; process_edits set via config.extra when given."""
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    extra = {"homeserver": "https://matrix.example.org", "user_id": "@hermes:example.org"}
+    if process_edits is not None:
+        extra["process_edits"] = process_edits
+    config = PlatformConfig(enabled=True, token="syt_test_token", extra=extra)
+    adapter = MatrixAdapter(config)
+    adapter._text_batch_delay_seconds = 0
+    adapter.handle_message = AsyncMock()
+    adapter._startup_ts = time.time() - 10  # avoid startup grace filter
+    return adapter
+
+
+def _make_edit_event(
+    new_body,
+    target_event_id="$original",
+    sender="@alice:example.org",
+    event_id="$edit1",
+    room_id="!room1:example.org",
+    new_relates_to=None,
+):
+    """Build a fake ``m.replace`` edit event: fallback body plus ``m.new_content``."""
+    new_content = {"msgtype": "m.text", "body": new_body}
+    if new_relates_to:
+        new_content["m.relates_to"] = new_relates_to
+    content = {
+        "msgtype": "m.text",
+        "body": f"* {new_body}",
+        "m.new_content": new_content,
+        "m.relates_to": {"rel_type": "m.replace", "event_id": target_event_id},
+    }
+    return SimpleNamespace(
+        sender=sender, event_id=event_id, room_id=room_id,
+        timestamp=int(time.time() * 1000), content=content)
+
+
+@pytest.mark.asyncio
+async def test_process_edits_default_disabled_ignores_edit(monkeypatch):
+    """Default (opt-in not set): edits are silently ignored — today's behavior is unchanged."""
+    monkeypatch.delenv("MATRIX_PROCESS_EDITS", raising=False)
+    monkeypatch.setenv("MATRIX_REQUIRE_MENTION", "false")
+
+    adapter = _make_adapter()
+    event = _make_edit_event("corrected prompt")
+
+    await adapter._on_room_message(event)
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_process_edits_enabled_via_env_forwards_corrected_body(monkeypatch):
+    """Enabled via MATRIX_PROCESS_EDITS: the corrected m.new_content body becomes a new turn,
+    tagged with the original event id as metadata (not rewriting any prior turn)."""
+    monkeypatch.setenv("MATRIX_PROCESS_EDITS", "true")
+    monkeypatch.setenv("MATRIX_REQUIRE_MENTION", "false")
+
+    adapter = _make_adapter()
+    event = _make_edit_event("actually send it to bob", target_event_id="$original1", event_id="$edit1")
+
+    await adapter._on_room_message(event)
+    adapter.handle_message.assert_awaited_once()
+    msg = adapter.handle_message.await_args.args[0]
+    assert msg.text == "actually send it to bob"
+    assert msg.metadata.get("edited_message") is True
+    assert msg.metadata.get("edited_message_original_id") == "$original1"
+
+
+@pytest.mark.asyncio
+async def test_process_edits_enabled_via_config_extra(monkeypatch):
+    """config.yaml ``matrix.process_edits: true`` (config.extra) works without the env var —
+    the dual config.extra/env path mirrors require_mention/thread_require_mention."""
+    monkeypatch.delenv("MATRIX_PROCESS_EDITS", raising=False)
+    monkeypatch.setenv("MATRIX_REQUIRE_MENTION", "false")
+
+    adapter = _make_adapter(process_edits=True)
+    event = _make_edit_event("corrected via config")
+
+    await adapter._on_room_message(event)
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_process_edits_preserves_thread_from_new_content(monkeypatch):
+    """A threaded edit mirrors the thread relation into m.new_content (MSC2676); the top-level
+    relates_to on an edit is exclusively the m.replace pointer, so thread routing must read
+    m.new_content's own m.relates_to, not the edit's."""
+    monkeypatch.setenv("MATRIX_PROCESS_EDITS", "true")
+    monkeypatch.setenv("MATRIX_REQUIRE_MENTION", "false")
+
+    adapter = _make_adapter()
+    adapter._threads.mark("$thread_root")
+    event = _make_edit_event(
+        "corrected in-thread", new_relates_to={"rel_type": "m.thread", "event_id": "$thread_root"})
+
+    await adapter._on_room_message(event)
+    adapter.handle_message.assert_awaited_once()
+    msg = adapter.handle_message.await_args.args[0]
+    assert msg.source.thread_id == "$thread_root"

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -519,6 +519,7 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `MATRIX_FREE_RESPONSE_ROOMS` | Comma-separated room IDs where bot responds without `@mention` |
 | `MATRIX_IGNORE_USER_PATTERNS` | Comma-separated regular expressions for Matrix bridge/appservice ghost user IDs to ignore |
 | `MATRIX_PROCESS_NOTICES` | Process inbound Matrix `m.notice` events (default: `false`) |
+| `MATRIX_PROCESS_EDITS` | Forward an inbound `m.replace` edit of a user's message as a new agent turn carrying the corrected text (default: `false`) |
 | `MATRIX_SESSION_SCOPE` | Matrix session scope for project rooms: `auto`, `room`, or `thread` (default: `auto`) |
 | `MATRIX_TOOLS_ALLOW_REDACTION` | Allow Matrix message redaction tool execution (default: `false`) |
 | `MATRIX_TOOLS_ALLOW_INVITES` | Allow Matrix invite tool execution (default: `false`) |

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -94,6 +94,7 @@ matrix:
     - "^@telegram_"
     - "^@whatsapp_"
   process_notices: false          # Ignore m.notice by default
+  process_edits: false            # Ignore message edits (m.replace) by default
   session_scope: room             # auto|room|thread; room is recommended for project rooms
   auto_thread: true               # Auto-create threads for responses (default: true)
   dm_mention_threads: false       # Create thread when @mentioned in DM (default: false)


### PR DESCRIPTION
Fixes #103626

## Problem

Editing a message in Element/Matrix updates the visible conversation, but
Hermes never sees it as a new turn: `plugins/platforms/matrix/adapter.py`
explicitly returned on inbound `m.replace` events (`# skip edits`). Users had
to resend the corrected text as a brand-new message.

## Change

Adds an opt-in, disabled-by-default setting:

```yaml
matrix:
  process_edits: false   # set true to forward edits as new agent turns
```

or `MATRIX_PROCESS_EDITS=true` (dual config.extra/env path; the config.yaml
key is bridged to the env var via the same `_YAML_LOWER_KEYS` mechanism that
carries `process_notices`, which sits right next to it in the example above).

When enabled, an `m.replace` edit of a `m.text` (or, if `process_notices` is
also on, `m.notice`) message:

- Extracts the corrected body from `m.new_content` (the spec-mandated carrier
  of the replacement content) and forwards it as a new agent turn, tagged
  with `metadata["edited_message"] = True` and
  `metadata["edited_message_original_id"] = <original event id>` — the prior
  turn/history is never rewritten.
- Is gated through the *same* `_build_inbound_event` / `_resolve_message_context`
  path a brand-new message goes through, so mention/thread/room-allowlist/DM
  policy, and authorization are unchanged from a fresh message by the same
  sender.
- Gets per-edit dedup for free: `_is_duplicate_event(event_id)` (the edit's
  own event id) already runs before this code path, in `_on_room_message`.
- Never loops on the bot's own outbound edits (e.g. future streaming-edit
  work in #58728): `_is_self_sender(sender)` already returns before the
  `m.replace` branch is reached, unconditionally, for every event.
- Preserves thread routing for threaded conversations: a threaded edit
  mirrors the thread relation into `m.new_content` itself per MSC2676 (the
  edit event's *top-level* `m.relates_to` is exclusively the `m.replace`
  pointer), so thread detection reads `m.new_content`'s own `m.relates_to`.
- Gets a plain, generic "this is a correction" marker prepended to the model
  turn (`gateway/run_inbound.py::_prepend_inbound_reply_context`, the same
  helper that already injects `[Replying to: ...]` context for any platform)
  so the agent treats it as a follow-up rather than an unrelated fresh
  prompt — same mechanism as reply-context injection, extended rather than
  duplicated.
- With the setting absent or `false`: **byte-for-byte the same behavior as
  before** — edits are silently ignored.

## Scope note

The issue's acceptance list also asked for validating "the replacement
target and original sender" against forgery. I did not add a network
round-trip to fetch the original event and compare senders: the resulting
turn is always attributed to the *edit's own* sender/event, who already
passed every authorization gate a brand-new message from that sender would
have to pass (allowed rooms/users, mention policy, etc.) — there is no
privilege gained by crafting a bogus `m.replace` pointer, since we never read
anything about the target event's sender or content. Happy to add stricter
validation if a maintainer wants it, but it isn't needed to close the
concrete gap (the bot never sees a correction at all today).

## Testing

New file `tests/gateway/test_matrix_process_edits.py` (5 tests), following
the existing `_on_room_message` / mocked-`handle_message` pattern used by
`tests/gateway/test_matrix_mention.py`:

- `test_process_edits_default_disabled_ignores_edit` — regression guard: the
  opt-in default preserves today's behavior.
- `test_process_edits_enabled_via_env_forwards_corrected_body` — the core
  behavior: corrected body + edit metadata reach `handle_message`.
- `test_process_edits_enabled_via_config_extra` — `_parse_process_edits`
  prefers a directly-set `config.extra["process_edits"]` over the env var
  (unit-level precedence check, not a config.yaml integration test).
- `test_apply_yaml_config_bridges_process_edits` — drives the real
  `apply_yaml_config_fn` hook (`_apply_yaml_config`) with
  `{"process_edits": True}` and asserts `MATRIX_PROCESS_EDITS` is set. An
  earlier revision of this PR was missing `("process_edits",
  "MATRIX_PROCESS_EDITS")` from `_YAML_LOWER_KEYS`, so config.yaml's
  `matrix.process_edits: true` silently did nothing even though the docs and
  a hand-constructed `PlatformConfig(extra=...)` test both suggested it
  worked. Verified this test fails without the `_YAML_LOWER_KEYS` entry
  (`KeyError: 'MATRIX_PROCESS_EDITS'`) and passes with it.
- `test_process_edits_preserves_thread_from_new_content` — a threaded edit's
  `m.new_content.m.relates_to` (not the edit's own top-level relation) drives
  thread routing.

Confirmed the core feature is load-bearing by reverting just the two source
files (`git checkout HEAD~1 -- gateway/run_inbound.py
plugins/platforms/matrix/adapter.py`) and re-running:

```
$ python -m pytest tests/gateway/test_matrix_process_edits.py -v
...
FAILED test_process_edits_enabled_via_env_forwards_corrected_body - AssertionError: Expected mock to have been awaited once. Awaited 0 times.
FAILED test_process_edits_enabled_via_config_extra - AssertionError: Expected mock to have been awaited once. Awaited 0 times.
FAILED test_process_edits_preserves_thread_from_new_content - AssertionError: Expected mock to have been awaited once. Awaited 0 times.
3 failed, 1 passed in 0.65s
```

then restored the fix and re-ran clean (5 tests after the `_YAML_LOWER_KEYS`
fix and its regression test were added):

```
$ python -m pytest tests/gateway/test_matrix_process_edits.py -v
tests/gateway/test_matrix_process_edits.py::test_process_edits_default_disabled_ignores_edit PASSED
tests/gateway/test_matrix_process_edits.py::test_process_edits_enabled_via_env_forwards_corrected_body PASSED
tests/gateway/test_matrix_process_edits.py::test_process_edits_enabled_via_config_extra PASSED
tests/gateway/test_matrix_process_edits.py::test_apply_yaml_config_bridges_process_edits PASSED
tests/gateway/test_matrix_process_edits.py::test_process_edits_preserves_thread_from_new_content PASSED
5 passed in 0.56s
```

Full existing Matrix + reply-context suites pass with no regressions
(`tests/gateway/test_matrix.py`, `test_matrix_mention.py`,
`test_matrix_message_event_metadata.py`, `test_matrix_voice.py`,
`test_matrix_media_filename.py`, `test_reply_to_injection.py`,
`test_document_context_note.py`, `test_video_context_note.py`,
`test_context_ref_expansion_runtime.py`, `test_mixed_attachment_routing.py`),
plus a full `scripts/run_tests.sh tests/gateway/` run: 773 files, 0 failed.

`ruff check` clean on both changed source files; `ty check` reports the same
35 (adapter.py) / 119 (run_inbound.py) pre-existing diagnostics on unmodified
`main` as on this branch — zero new diagnostics introduced.

## AI assistance disclosure

This PR was written by an autonomous coding agent (Claude, via an
OSS-contribution pipeline), including the diff, the new test file, and this
description. The originating issue itself was also authored with AI
assistance per its "Prepared with AI assistance" footer.
