### PR TITLE
fix(bot-mode): match invitations to the target profile policy

### DIFF
--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import os
 import re
+from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from pathlib import Path
 from typing import Dict, Mapping, Optional
@@ -34,10 +35,11 @@ def is_multiplex_active() -> bool:
 
 
 _SECRET_SCOPE: ContextVar[Optional[Mapping[str, str]]] = ContextVar("_SECRET_SCOPE", default=None)
+_STRICT_SECRET_SCOPE: ContextVar[bool] = ContextVar("_STRICT_SECRET_SCOPE", default=False)
 
 
 class UnscopedSecretError(RuntimeError):
-    """A secret was read in multiplex mode with no scope installed.
+    """A secret was read in multiplex or strict mode with no scope installed.
 
     The fix is to wrap the call path in ``set_secret_scope(...)`` (the per-turn
     / per-adapter profile scope), not to widen the global allowlist.
@@ -56,6 +58,25 @@ def reset_secret_scope(token: Token) -> None:
 def current_secret_scope() -> Optional[Mapping[str, str]]:
     """The active secret mapping, or None when no scope is installed."""
     return _SECRET_SCOPE.get()
+
+
+@contextmanager
+def strict_secret_scope(secrets: Optional[Mapping[str, str]]):
+    """Make this context's mapping authoritative without changing deployment mode.
+
+    Scope setters/resetters cannot re-enable ambient fallback inside this block;
+    clearing the mapping makes credential reads fail closed. Global settings keep
+    their normal environment behavior. Both prior scope and strictness restore.
+    """
+    scope_token = set_secret_scope(secrets)
+    strict_token = _STRICT_SECRET_SCOPE.set(True)
+    try:
+        yield
+    finally:
+        try:
+            reset_secret_scope(scope_token)
+        finally:
+            _STRICT_SECRET_SCOPE.reset(strict_token)
 
 
 # Genuinely-global env vars: process/deployment settings, NOT profile secrets.
@@ -116,6 +137,8 @@ def get_secret(name: str, default: Optional[str] = None) -> Optional[str]:
     inject credentials via the process env (systemd, ``op run``), so the scope
     must stay a ``.env`` overlay, not a blindfold (otherwise cron 401s). With no
     scope: multiplex INACTIVE reads ``os.environ``; ACTIVE raises (fail closed).
+    ``strict_secret_scope`` opts this context into the same fail-closed behavior
+    without changing the single-profile default or process-global deployment mode.
     """
     if _is_global_env(name):
         return _environ_or(name, default)
@@ -124,11 +147,12 @@ def get_secret(name: str, default: Optional[str] = None) -> Optional[str]:
         val = scope.get(name)
         if val is not None:
             return val
-        return default if _MULTIPLEX_ACTIVE else _environ_or(name, default)
-    if _MULTIPLEX_ACTIVE:
+        return default if _MULTIPLEX_ACTIVE or _STRICT_SECRET_SCOPE.get() else _environ_or(name, default)
+    if _MULTIPLEX_ACTIVE or _STRICT_SECRET_SCOPE.get():
+        mode = "multiplexing is on" if _MULTIPLEX_ACTIVE else "a strict secret scope is active"
         raise UnscopedSecretError(
             f"get_secret({name!r}) called with no profile secret scope active "
-            f"while multiplexing is on. This credential read must run inside a "
+            f"while {mode}. This credential read must run inside a "
             f"set_secret_scope(...) block (the per-turn / per-adapter profile "
             f"scope). Reading os.environ here would risk leaking another "
             f"profile's value. See docs/design/multiplexing-gateway.md "

--- a/tests/tui_gateway/test_group_catalog_profile_scope.py
+++ b/tests/tui_gateway/test_group_catalog_profile_scope.py
@@ -1,0 +1,128 @@
+"""Foreign-profile catalogs use the target authority, not the launcher's secrets."""
+
+import os
+from contextvars import Context
+from types import SimpleNamespace
+
+import pytest
+
+from agent import secret_scope as secrets
+from gateway import hosted_room_execution_policy as policies
+from gateway.run import _profile_runtime_scope
+from hermes_constants import get_hermes_home, reset_hermes_home_override, set_hermes_home_override
+from tools.terminal_scope import get_terminal_scope, reset_terminal_scope, set_terminal_scope
+from tui_gateway import methods_groups
+
+
+@pytest.mark.parametrize('ambient_has_token,target_has_token', [(True, False), (False, True)])
+@pytest.mark.parametrize('fail', [False, True])
+def test_rpc_policy_matches_target_api_authority_and_restores_context(
+    tmp_path, monkeypatch, ambient_has_token, target_has_token, fail
+):
+    launcher, target = tmp_path / 'launcher', tmp_path / 'target'
+    launcher.mkdir()
+    target.mkdir()
+    (launcher / 'config.yaml').write_text('agent:\n  max_turns: 99\n')
+    (target / 'config.yaml').write_text('agent:\n  max_turns: 7\napprovals:\n  mode: manual\n')
+    (target / '.env').write_text('HASS_TOKEN=target-test-token\n' if target_has_token else '')
+    monkeypatch.setenv('HERMES_PROFILE', 'launcher')
+    if ambient_has_token:
+        monkeypatch.setenv('HASS_TOKEN', 'ambient-test-token')
+    else:
+        monkeypatch.delenv('HASS_TOKEN', raising=False)
+    monkeypatch.setattr(secrets, '_MULTIPLEX_ACTIVE', False)
+    monkeypatch.setattr(methods_groups, '_bound_server', SimpleNamespace(
+        _current_profile_name=lambda: 'launcher', _profile_home=lambda profile: target if profile == 'target' else launcher))
+    outer_secrets = {'OUTER_TEST_SECRET': 'outer'}
+    outer_terminal = {'TERMINAL_CWD': str(launcher)}
+    home_token = set_hermes_home_override(launcher)
+    secret_token = secrets.set_secret_scope(outer_secrets)
+    terminal_token = set_terminal_scope(outer_terminal)
+    real_resolver = policies.execution_policy_mapping
+    try:
+        # Simulate the API deployment mode only in this disposable test phase.
+        with monkeypatch.context() as api_process:
+            api_process.setattr(secrets, '_MULTIPLEX_ACTIVE', True)
+            with _profile_runtime_scope(target):
+                expected = real_resolver(target_profile='target')
+                target_terminal = dict(get_terminal_scope())
+        assert ('homeassistant' in expected['enabled_toolsets']) is target_has_token
+        assert expected['max_iterations'] == 7
+        environment = dict(os.environ)
+
+        def resolve_in_target(**kwargs):
+            actual = real_resolver(**kwargs)
+            assert actual == expected
+            assert get_hermes_home() == target
+            assert get_terminal_scope() == target_terminal
+            assert secrets.current_secret_scope() is not outer_secrets
+            assert secrets.is_multiplex_active() is False
+            if fail:
+                raise RuntimeError('forced resolver failure')
+            return actual
+
+        monkeypatch.setattr(policies, 'execution_policy_mapping', resolve_in_target)
+        try:
+            if fail:
+                with pytest.raises(RuntimeError, match='forced resolver failure'):
+                    methods_groups._profile_execution_policy('target')
+            else:
+                assert methods_groups._profile_execution_policy('target') == expected
+        finally:
+            assert get_hermes_home() == launcher
+            assert secrets.current_secret_scope() is outer_secrets
+            assert get_terminal_scope() is outer_terminal
+            assert secrets.is_multiplex_active() is False
+            assert os.environ == environment
+            assert secrets.get_secret('HASS_TOKEN') == ('ambient-test-token' if ambient_has_token else None)
+    finally:
+        reset_terminal_scope(terminal_token)
+        secrets.reset_secret_scope(secret_token)
+        reset_hermes_home_override(home_token)
+
+
+@pytest.mark.parametrize('multiplex', [False, True])
+def test_strict_scope_nested_clear_failure_and_default_compatibility(monkeypatch, multiplex):
+    monkeypatch.setattr(secrets, '_MULTIPLEX_ACTIVE', multiplex)
+    monkeypatch.setenv('AMBIENT_TEST_SECRET', 'ambient')
+    monkeypatch.setenv('API_SERVER_PORT', '8123')
+    outer = {'PROFILE_TEST_SECRET': 'outer'}
+    token = secrets.set_secret_scope(outer)
+    environment = dict(os.environ)
+    try:
+        expected_miss = 'fallback' if multiplex else 'ambient'
+        assert secrets.get_secret('AMBIENT_TEST_SECRET', 'fallback') == expected_miss
+        with pytest.raises(RuntimeError, match='outer failure'):
+            with secrets.strict_secret_scope({'PROFILE_TEST_SECRET': 'profile', 'API_SERVER_PORT': '9999'}):
+                assert secrets.get_secret('PROFILE_TEST_SECRET') == 'profile'
+                assert secrets.get_secret('AMBIENT_TEST_SECRET', 'fallback') == 'fallback'
+                assert secrets.get_secret('API_SERVER_PORT') == '8123'
+                assert secrets.is_multiplex_active() is multiplex
+                fresh_context = Context()
+                if multiplex:
+                    with pytest.raises(secrets.UnscopedSecretError):
+                        fresh_context.run(secrets.get_secret, 'AMBIENT_TEST_SECRET')
+                else:
+                    assert fresh_context.run(secrets.get_secret, 'AMBIENT_TEST_SECRET') == 'ambient'
+                with secrets.strict_secret_scope({'PROFILE_TEST_SECRET': 'nested'}):
+                    assert secrets.get_secret('PROFILE_TEST_SECRET') == 'nested'
+                    cleared = secrets.set_secret_scope(None)
+                    try:
+                        with pytest.raises(secrets.UnscopedSecretError):
+                            secrets.get_secret('AMBIENT_TEST_SECRET', 'fallback')
+                        assert secrets.get_secret('API_SERVER_PORT') == '8123'
+                    finally:
+                        secrets.reset_secret_scope(cleared)
+                    assert secrets.get_secret('PROFILE_TEST_SECRET') == 'nested'
+                with pytest.raises(RuntimeError, match='inner failure'):
+                    with secrets.strict_secret_scope({}):
+                        raise RuntimeError('inner failure')
+                assert secrets.get_secret('PROFILE_TEST_SECRET') == 'profile'
+                assert secrets.get_secret('AMBIENT_TEST_SECRET', 'fallback') == 'fallback'
+                raise RuntimeError('outer failure')
+        assert secrets.current_secret_scope() is outer
+        assert secrets.get_secret('AMBIENT_TEST_SECRET', 'fallback') == expected_miss
+        assert secrets.is_multiplex_active() is multiplex
+        assert os.environ == environment
+    finally:
+        secrets.reset_secret_scope(token)

--- a/tui_gateway/methods_groups.py
+++ b/tui_gateway/methods_groups.py
@@ -128,15 +128,15 @@ def _api_server_key(profile: str | None = None) -> str:
 def _profile_execution_policy(profile: str) -> dict:
     """Resolve execution policy under the exact multiplexed profile home."""
     from gateway.hosted_room_execution_policy import execution_policy_mapping
-    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
-    token = None
     if _bound_server is not None and profile not in {_current_profile(), _profile_name()}:
-        token = set_hermes_home_override(str(_foreign_profile_home(profile)))
-    try:
-        return execution_policy_mapping(target_profile=profile)
-    finally:
-        if token is not None:
-            reset_hermes_home_override(token)
+        from agent.secret_scope import current_secret_scope, strict_secret_scope
+        from gateway.run import _profile_runtime_scope
+        with _profile_runtime_scope(_foreign_profile_home(profile)):
+            # TUI need not be a process-wide multiplexer; this target still owns
+            # its credentials, including their absence, just as on the API side.
+            with strict_secret_scope(current_secret_scope()):
+                return execution_policy_mapping(target_profile=profile)
+    return execution_policy_mapping(target_profile=profile)
 
 
 def _room_link_run_storage_durable() -> bool:


### PR DESCRIPTION
## What Does This PR Do?

Some Bot combinations fall back to **Keep Desktop open** even though their gateways are reachable and support hosted Group Chats. The invitation and the gateway API can disagree about a named Bot's available tools, so the existing safety check correctly refuses the setup.

This fixes that disagreement at its source. The invitation now uses the target profile's own credentials when resolving its policy, including the absence of credentials. It no longer borrows the launching process's optional integrations for that calculation.

Genuine policy changes still require reauthorization. Catalogue comparison, grant validation, process-wide settings, and ordinary single-profile credential fallback remain unchanged. A foreign Bot that previously appeared to have an optional integration only because the launcher exposed its own credential will now correctly omit that integration until the target profile is configured.

## Related Issues

Found during the six-Bot field tests tracked in #97681; relevant to the Bot Mode bug classes in #94726. This is independently applicable to current `main`, not dependent on the remaining continuity, Files or messaging PRs. It does not close either umbrella issue.

## Changes Made

- Add an opt-in, context-local strict secret scope using the existing credential mapping and reset semantics.
- Resolve foreign-profile Group Chat policy inside that profile's complete runtime scope, without changing process globals.
- Add two invariant test functions covering both credential directions, nested scopes, cleared scopes, exceptions, caller defaults and context restoration.

## Validation

- Reproduced against `main@377118af86872773777e13c9b38dac65377f7320`: all four profile-policy regression cases fail before the fix.
- After the fix: **41 tests across four files pass**, with no automatic retries, using the canonical isolated runner.
- The live pre-fix observation used named profiles on a real gateway: the RPC invitation included an optional toolset that the target API excluded. No actual unauthorized tool execution or disclosure of credential values was observed.
- Focused source review completed. On the updated gateways, RPC invitation and authenticated API catalogs now agree for every profile checked.
- The same maximum-size six-Bot combination that previously fell back now creates as `Works without Desktop`; all six Bots settled exactly once in the real packaged Desktop.
- Three changed files; the largest is 528 lines. No dependencies, new model tools, Desktop redesign or global authentication-mode change.

![The repaired profile policy creating and settling a six-Bot hosted Group Chat](https://raw.githubusercontent.com/dokterdok/hermes-agent/01249c9880b78c1cf9c6c4ff06fa735c81dc6398/docs/issue-assets/hosted-six-clean-20260905.png)

<details>
<summary>Reproduction and focused test command</summary>

Give the launching process an optional integration credential, but omit it from a named target profile. Compare that profile's `groups.peer.invite` catalogue with its authenticated API capability probe. Reverse the credential placement as a positive control. Before the fix the policies disagree; afterward both use the target's authority. No credential should be copied between profiles as a workaround.

```sh
scripts/run_tests.sh -j 2 --file-retries 0 \
  tests/tui_gateway/test_group_catalog_profile_scope.py \
  tests/agent/test_secret_scope.py \
  tests/gateway/test_hosted_room_execution_policy.py \
  tests/gateway/test_api_server_multiplex_secret_scope.py
```

The tests use temporary profiles and dummy credentials, not production accounts. Live validation must retain the strict catalogue comparison and existing grants/reauthorization rules.

</details>

## Checklist

- [x] Focused bug fix, with current-main reproduction
- [x] Existing open/merged work and current source checked
- [x] Contributor history preserved; conventional commit
- [x] Added invariant tests; focused tests and diff checks pass on macOS
- [x] All changed source and test files are below 2,000 lines
- [x] Existing settings and ordinary credential behavior preserved
- [x] Fresh live validation of the updated gateways