### PR TITLE
fix(mcp): propagate an extended connect_timeout into config for OAuth probes

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -276,6 +276,13 @@ def _probe_single_server(
             connect_timeout = max(1.0, float(config.get("connect_timeout", 30)))
         except (TypeError, ValueError):
             connect_timeout = 30.0
+    # Deep transport code (tools/mcp_tool_transport.py::_negotiate_session) reads its OWN
+    # session.initialize() bound straight off config["connect_timeout"], independent of the
+    # `connect_timeout` param above. Callers that extend the param to give a user time to finish
+    # an OAuth browser flow (e.g. `hermes mcp login`'s 315s) left that inner bound at the
+    # (unrelated) 60s default, so the still-pending OAuth callback wait got cancelled mid-flow —
+    # surfacing as a retry that re-opens a second authorization against the same callback port.
+    config["connect_timeout"] = connect_timeout
 
     _ensure_mcp_loop()
     tools_found: List[Tuple[str, str]] = []

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -533,6 +533,34 @@ class TestProbeEnvResolution:
         assert tools == [("do_thing", "a tool")]
         assert seen["config"]["headers"]["Authorization"] == "Bearer jwt-token-xyz"
 
+    def test_probe_propagates_explicit_connect_timeout_to_config(self, monkeypatch):
+        """An explicit `connect_timeout=` override (e.g. `hermes mcp login`'s 315s, extended so a
+        user has time to finish an OAuth browser flow) must reach `config["connect_timeout"]` —
+        that's what tools/mcp_tool_transport.py::_negotiate_session bounds session.initialize()
+        with. Left stale at its unrelated 60s default, the still-pending OAuth callback wait gets
+        cancelled mid-flow well before the caller's intended deadline."""
+        import hermes_cli.mcp_config as mc
+
+        seen = {}
+
+        class _FakeServer:
+            _tools = []
+
+            async def shutdown(self):
+                return None
+
+        async def _fake_connect(name, config):
+            seen["config"] = config
+            return _FakeServer()
+
+        monkeypatch.setattr("tools.mcp_tool_discovery._connect_server", _fake_connect)
+
+        mc._probe_single_server(
+            "travelermd", {"url": "https://mcp.traveler.md/mcp", "auth": "oauth"}, connect_timeout=315.0
+        )
+
+        assert seen["config"]["connect_timeout"] == 315.0
+
 
 class TestProbeCapabilityGating:
     """The ``details`` probe must not fire prompts/list or resources/list at


### PR DESCRIPTION
## What does this PR do?

Fixes a timeout mismatch that truncates MCP OAuth logins to ~60 seconds
instead of the caller's intended (much longer) deadline, which is what
breaks OAuth against servers like `https://mcp.traveler.md/mcp` in #103633.

`hermes_cli/mcp_config.py::_probe_single_server()` takes a `connect_timeout`
parameter. Callers that need to give a human time to finish a browser OAuth
flow explicitly extend it — `_reauth_oauth_server()` (`hermes mcp login`) and
the dashboard-mediated flow (`_run_dashboard_mcp_oauth()`) both pass
`connect_timeout=max(configured, 315.0)`.

That parameter, however, only bounds the **outer**
`asyncio.wait_for(_connect_server(...), timeout=connect_timeout)` in
`_probe_single_server`. The deep transport code that actually negotiates the
MCP session —
`tools/mcp_tool_transport.py::MCPServerTask._negotiate_session()` — wraps
`session.initialize()` in its **own**, separate
`asyncio.wait_for(..., timeout=connect_timeout)`, where that `connect_timeout`
is read straight from `config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)`
(`tools/mcp_tool.py::_DEFAULT_CONNECT_TIMEOUT = 60`). Because
`_probe_single_server`'s override was never written back into the `config`
dict it hands down to `_connect_server`/`MCPServerTask`, that inner bound
stayed at the stale 60s default no matter what the caller asked for.

The OAuth authorization-code exchange happens *inside* that single
`session.initialize()` call (the SDK's `async_auth_flow` intercepts the
first request, does PRM/ASM discovery, opens the browser, and blocks on the
callback). So any real OAuth login that takes longer than ~60 seconds — the
overwhelmingly common case for a human clicking through a provider's
consent screen — gets its callback wait cancelled by the inner
`asyncio.wait_for`, well before the 300s/315s the caller intended. Hermes'
own initial-connect retry ladder then retries the connection from scratch,
re-entering the OAuth flow and re-opening a listener on the same cached
callback port while the previous attempt's teardown is still in flight —
which is exactly the "second `MCP OAuth: authorization required`" /
`OAuth callback port ... already in use` sequence from the issue, and (for
the dashboard flow) the flow silently flipping to `status: "error"` about a
minute after the URL was published, well under its configured 300s
`wait_for_callback` timeout.

## Related Issue

Fixes #103633

## Changes Made

- `hermes_cli/mcp_config.py::_probe_single_server()`: after resolving the
  effective `connect_timeout` (explicit override or config default), write
  it back into `config["connect_timeout"]` so the transport layer's own
  `session.initialize()` bound matches the timeout the caller actually
  asked for, instead of silently falling back to the unrelated 60s default.
- `tests/hermes_cli/test_mcp_config.py`: added
  `test_probe_propagates_explicit_connect_timeout_to_config`, asserting
  that an explicit `connect_timeout=315.0` override is visible in the
  `config` dict `_connect_server` receives.

## How to Test

1. `git checkout HEAD~1 -- hermes_cli/mcp_config.py` (reverts only the fix,
   keeping the new test) and run:
   ```
   .venv/bin/python -m pytest tests/hermes_cli/test_mcp_config.py -k test_probe_propagates_explicit_connect_timeout_to_config -q
   ```
   fails with `KeyError: 'connect_timeout'` — the override never reached
   the config the transport layer reads.
2. `git checkout HEAD -- hermes_cli/mcp_config.py` to restore the fix, same
   command now passes.
3. Full relevant suite:
   ```
   scripts/run_tests.sh tests/hermes_cli/test_mcp_config.py
   ```
   → `39 tests passed, 0 failed`.
   ```
   .venv/bin/python -m pytest tests/tools/test_mcp_oauth.py tests/tools/test_mcp_oauth_manager.py tests/hermes_cli/test_mcp_config.py tests/hermes_cli/test_mcp_catalog.py tests/tools/test_mcp_tool.py tests/tools/test_mcp_tool_401_handling.py tests/tools/test_mcp_transport_group_reconnect.py tests/hermes_cli/test_mcp_discovery_timing.py tests/hermes_cli/test_mcp_tools_config.py -q
   ```
   → `266 passed`.
4. `ruff check hermes_cli/mcp_config.py tests/hermes_cli/test_mcp_config.py` → `All checks passed!`

Platform tested: Linux (CI container).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix (no unrelated commits, no dependency/lockfile edits)
- [x] I've run the test suite and all tests pass
- [x] I've added a regression test proven to fail without the fix

---

Note: this fix was produced by an autonomous AI coding agent (root-caused by
tracing the timeout plumbing from `_probe_single_server` through
`MCPServerTask._negotiate_session`), then verified locally per the test plan
above.
