### PR TITLE
feat(providers): add BharatRouter as a listed provider

### DIFF
--- a/apps/desktop/public/bharatrouter.svg
+++ b/apps/desktop/public/bharatrouter.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#16aa51"/>
+  <path d="M20 14h16a11 11 0 0 1 6.5 19.9A11.5 11.5 0 0 1 37 50H20V14zm8 8v7h7a3.5 3.5 0 0 0 0-7h-7zm0 14v7h8.5a3.5 3.5 0 0 0 0-7H28z" fill="#fff"/>
+</svg>

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -68,6 +68,15 @@ export const PROVIDER_GROUPS: ProviderPrefix[] = [
     priority: 1
   },
   {
+    prefix: 'BHARATROUTER_',
+    name: 'BharatRouter',
+    description: 'India-resident OpenAI-compatible gateway (Krutrim, Sarvam + global)',
+    docsUrl: 'https://bharatrouter.com/console',
+    // Aggregator like OpenRouter; priority 2 keeps it near the top but just
+    // below the Fireworks/OpenRouter (priority 1) pair in the name sort.
+    priority: 2
+  },
+  {
     prefix: 'ANTHROPIC_',
     name: 'Anthropic',
     description: 'Claude API access (Sonnet, Opus, Haiku)',

--- a/apps/desktop/src/app/settings/providers-settings.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { runInTerminal } from '@/app/right-sidebar/store'
 import {
+  BharatRouterProviderRow,
   FEATURED_ID,
   FeaturedProviderRow,
   FireworksProviderRow,
@@ -207,6 +208,7 @@ function OAuthPicker({
           ))}
           <FireworksProviderRow onClick={onWantApiKey} />
           <OpenRouterProviderRow onClick={onWantApiKey} />
+          <BharatRouterProviderRow onClick={onWantApiKey} />
         </>
       )}
       {collapsible && (

--- a/apps/desktop/src/components/onboarding/index.tsx
+++ b/apps/desktop/src/components/onboarding/index.tsx
@@ -31,6 +31,7 @@ import type { ModelOptionProvider, OAuthProvider } from '@/types/hermes'
 
 import { DocsLink, FlowPanel, Status } from './flow'
 import {
+  BharatRouterProviderRow,
   FeaturedProviderRow,
   FireworksProviderRow,
   LocalModelsProviderRow,
@@ -40,6 +41,7 @@ import {
 } from './providers'
 
 export {
+  BharatRouterProviderRow,
   FeaturedProviderRow,
   FireworksProviderRow,
   KeyProviderRow,
@@ -81,6 +83,12 @@ const API_KEY_OPTIONS: ApiKeyOption[] = [
     name: 'OpenRouter',
     envKey: 'OPENROUTER_API_KEY',
     docsUrl: 'https://openrouter.ai/keys'
+  },
+  {
+    id: 'bharatrouter',
+    name: 'BharatRouter',
+    envKey: 'BHARATROUTER_API_KEY',
+    docsUrl: 'https://bharatrouter.com/console'
   },
   {
     id: 'openai',
@@ -513,6 +521,7 @@ export function Picker({ ctx }: { ctx: OnboardingContext }) {
               <ProviderRow key={p.id} onSelect={select} provider={p} />
             ))}
             <OpenRouterProviderRow onClick={() => openKeyForm('OPENROUTER_API_KEY')} />
+            <BharatRouterProviderRow onClick={() => openKeyForm('BHARATROUTER_API_KEY')} />
           </>
         ) : null}
       </div>

--- a/apps/desktop/src/components/onboarding/providers.tsx
+++ b/apps/desktop/src/components/onboarding/providers.tsx
@@ -95,6 +95,12 @@ export function FireworksProviderRow({ onClick }: { onClick: () => void }) {
   return <KeyProviderRow onClick={onClick} pitch={t.onboarding.fireworksPitch} title="Fireworks AI" />
 }
 
+export function BharatRouterProviderRow({ onClick }: { onClick: () => void }) {
+  const { t } = useI18n()
+
+  return <KeyProviderRow onClick={onClick} pitch={t.onboarding.bharatRouterPitch} title="BharatRouter" />
+}
+
 /** Onboarding row for the managed local runtime: no account, no key — the
  *  destination is the Local Models pane where install/download live. */
 export function LocalModelsProviderRow({ onClick }: { onClick: () => void }) {

--- a/apps/desktop/src/components/onboarding/providers.tsx
+++ b/apps/desktop/src/components/onboarding/providers.tsx
@@ -77,12 +77,15 @@ const PROVIDER_ROW_CLASS =
   'group flex w-full items-center justify-between gap-3 rounded-[6px] px-3 py-2.5 text-left transition-colors hover:bg-(--ui-control-hover-background)'
 
 /** Quick-key row for API-key providers (Fireworks leads the expanded list after Nous, OpenRouter further down). */
-export function KeyProviderRow({ onClick, pitch, title }: { onClick: () => void; pitch: string; title: string }) {
+export function KeyProviderRow({ onClick, pitch, title, icon }: { onClick: () => void; pitch: string; title: string; icon?: string }) {
   return (
     <RowButton className={PROVIDER_ROW_CLASS} onClick={onClick}>
-      <div className="min-w-0">
-        <span className="text-[length:var(--conversation-text-font-size)] font-semibold">{title}</span>
-        <p className="mt-1 text-xs leading-5 text-muted-foreground">{pitch}</p>
+      <div className="flex min-w-0 items-center gap-2">
+        {icon ? <img alt="" className="size-5 shrink-0 rounded" src={icon} /> : null}
+        <div className="min-w-0">
+          <span className="text-[length:var(--conversation-text-font-size)] font-semibold">{title}</span>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">{pitch}</p>
+        </div>
       </div>
       <ChevronRight className="size-4 text-muted-foreground transition group-hover:text-foreground" />
     </RowButton>
@@ -98,7 +101,7 @@ export function FireworksProviderRow({ onClick }: { onClick: () => void }) {
 export function BharatRouterProviderRow({ onClick }: { onClick: () => void }) {
   const { t } = useI18n()
 
-  return <KeyProviderRow onClick={onClick} pitch={t.onboarding.bharatRouterPitch} title="BharatRouter" />
+  return <KeyProviderRow icon={assetPath('bharatrouter.svg')} onClick={onClick} pitch={t.onboarding.bharatRouterPitch} title="BharatRouter" />
 }
 
 /** Onboarding row for the managed local runtime: no account, no key — the

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2134,6 +2134,7 @@ export const ar = defineLocale({
     connected: 'متصل',
     featuredPitch: 'اشتراك واحد، أكثر من 300 نموذج متقدم — الطريقة الموصى بها لتشغيل Hermes',
     fireworksPitch: 'نماذج مفتوحة سريعة مع استضافة Fireworks.',
+    bharatRouterPitch: 'India-resident OpenAI-compatible gateway — Krutrim, Sarvam + 140+ global models on one key',
     openRouterPitch: 'مفتاح واحد لمئات النماذج — خيار افتراضي جيد',
     apiKeyOptions: {
       openrouter: {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2890,6 +2890,7 @@ export const en: Translations = {
     connected: 'Connected',
     featuredPitch: 'One subscription, 300+ frontier models — the recommended way to run Hermes',
     fireworksPitch: 'Direct model API — Fireworks-hosted frontier models',
+    bharatRouterPitch: 'India-resident OpenAI-compatible gateway — Krutrim, Sarvam + 140+ global models on one key',
     localModelsTitle: 'Run models locally',
     localModelsPitch: 'No account needed — download a model and run it on this machine',
     openRouterPitch: 'One key, hundreds of models — a solid default',
@@ -2901,6 +2902,10 @@ export const en: Translations = {
       openrouter: {
         short: 'one key, many models',
         description: 'Hosts hundreds of models behind a single key. Good default for new installs.'
+      },
+      bharatrouter: {
+        short: 'India-resident gateway',
+        description: 'India-resident OpenAI-compatible gateway. Krutrim, Sarvam and 140+ global models on one key.'
       },
       openai: { short: 'GPT-class models', description: 'Direct access to OpenAI models.' },
       gemini: { short: 'Gemini models', description: 'Direct access to Google Gemini models.' },

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2521,6 +2521,7 @@ export const ja = defineLocale({
     connected: '接続済み',
     featuredPitch: '1 つのサブスクリプションで 300 以上の最先端モデル — Hermes を実行するための推奨方法',
     fireworksPitch: '直接モデル API — Fireworks がホストする最先端モデル',
+    bharatRouterPitch: 'India-resident OpenAI-compatible gateway — Krutrim, Sarvam + 140+ global models on one key',
     localModelsTitle: 'モデルをローカルで実行',
     localModelsPitch: 'アカウント不要——モデルをダウンロードしてこのマシンで実行',
     openRouterPitch: '1 つのキーで数百のモデル — 堅実なデフォルト',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -2926,6 +2926,7 @@ export const ru = defineLocale({
     connected: 'Подключено',
     featuredPitch: 'Одна подписка, 300+ передовых моделей — рекомендуемый способ запускать Hermes',
     fireworksPitch: 'Прямой API моделей — передовые модели на хостинге Fireworks',
+    bharatRouterPitch: 'India-resident OpenAI-compatible gateway — Krutrim, Sarvam + 140+ global models on one key',
     openRouterPitch: 'Один ключ, сотни моделей — надёжный вариант по умолчанию',
     apiKeyOptions: {
       fireworks: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2459,6 +2459,7 @@ export interface Translations {
     connected: string
     featuredPitch: string
     fireworksPitch: string
+    bharatRouterPitch: string
     localModelsTitle: string
     localModelsPitch: string
     openRouterPitch: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2429,6 +2429,7 @@ export const zhHant = defineLocale({
     connected: '已連線',
     featuredPitch: '一個訂閱，300+ 前沿模型 — 執行 Hermes 的建議方式',
     fireworksPitch: '直接模型 API — Fireworks 託管的前沿模型',
+    bharatRouterPitch: 'India-resident OpenAI-compatible gateway — Krutrim, Sarvam + 140+ global models on one key',
     localModelsTitle: '本地執行模型',
     localModelsPitch: '無需帳號——下載模型，在本機執行',
     openRouterPitch: '一個金鑰，數百個模型 — 穩定的預設選擇',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3047,6 +3047,7 @@ export const zh: Translations = {
     connected: '已连接',
     featuredPitch: '一个订阅，300+ 前沿模型 — 运行 Hermes 的推荐方式',
     fireworksPitch: '直接模型 API — Fireworks 托管的前沿模型',
+    bharatRouterPitch: 'India-resident OpenAI-compatible gateway — Krutrim, Sarvam + 140+ global models on one key',
     localModelsTitle: '本地运行模型',
     localModelsPitch: '无需账号——下载模型，在本机运行',
     openRouterPitch: '一个密钥，数百个模型 — 稳妥的默认选择',

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2406,6 +2406,10 @@ OPTIONAL_ENV_VARS = {
         "daemon)", "Actual Computer base URL (leave empty for hosted relay)", None, password=False),
     "FIREWORKS_API_KEY": _prov("Fireworks AI API key", "Fireworks AI API key",
         "https://app.fireworks.ai/settings/users/api-keys"),
+    "BHARATROUTER_API_KEY": _prov(
+        "BharatRouter API key (br-...) — India-resident OpenAI-compatible gateway",
+        "BharatRouter API key", "https://bharatrouter.com/console"),
+    "BHARATROUTER_BASE_URL": _base_url("BharatRouter"),
     "MINIMAX_API_KEY": _prov("MiniMax API key (international)", "MiniMax API key",
         "https://www.minimax.io/"),
     "MINIMAX_BASE_URL": _base_url("MiniMax"),

--- a/hermes_cli/models_catalog_static.py
+++ b/hermes_cli/models_catalog_static.py
@@ -310,6 +310,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [ProviderEntry(*row) for row in (
     ("nous", "Nous Portal", "Nous Portal (Everything your agent needs, 300+ models with bundled tool use)"),
     ("fireworks", "Fireworks AI", "Fireworks AI (OpenAI-compatible direct model API)"),
     ("openrouter", "OpenRouter", "OpenRouter (Pay-per-use API aggregator)"),
+    ("bharatrouter", "BharatRouter", "BharatRouter (India-resident OpenAI-compatible gateway: Krutrim, Sarvam + global)"),
     ("moa", "Mixture of Agents", "Mixture of Agents (named presets; aggregator acts after reference models)"),
     ("novita", "NovitaAI", "NovitaAI (Cloud: Model API, Agent Sandbox, GPU Cloud)"),
     ("lmstudio", "LM Studio", "LM Studio (Local desktop app with built-in model server)"),

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -75,6 +75,11 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
                          base_url_env_var="GMI_BASE_URL"),
     "fireworks": HermesOverlay(extra_env_vars=("FIREWORKS_API_KEY",),
                                base_url_override="https://api.fireworks.ai/inference/v1"),
+    # India-resident OpenAI-compatible aggregator (Krutrim, Sarvam + global). Discovery via
+    # {base_url}/models. models.dev doesn't list it, so the base URL is supplied here.
+    "bharatrouter": HermesOverlay(is_aggregator=True, extra_env_vars=("BHARATROUTER_API_KEY",),
+                                  base_url_override="https://api.bharatrouter.com/v1",
+                                  base_url_env_var="BHARATROUTER_BASE_URL"),
     "actual": HermesOverlay(transport="codex_responses", extra_env_vars=("ACTUAL_API_KEY", "ACTUAL_BASE_URL"),
                             base_url_override="https://api.actual.inc/v1", base_url_env_var="ACTUAL_BASE_URL"),
     "upstage": HermesOverlay(extra_env_vars=("UPSTAGE_API_KEY",), base_url_override="https://api.upstage.ai/v1",

--- a/plugins/model-providers/bharatrouter/__init__.py
+++ b/plugins/model-providers/bharatrouter/__init__.py
@@ -1,0 +1,24 @@
+"""BharatRouter provider profile. India-resident, OpenAI-compatible gateway
+(Krutrim, Sarvam + 140+ global models on one key). Keys are ``br-...``; the
+live catalog is discovered from ``{base_url}/models`` (GET /v1/models)."""
+
+from hermes_cli import __version__ as _HERMES_VERSION
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+bharatrouter = ProviderProfile(
+    name="bharatrouter", aliases=("bharat-router", "br"), display_name="BharatRouter",
+    description="BharatRouter — India-resident OpenAI-compatible gateway (Krutrim, Sarvam + global)",
+    signup_url="https://bharatrouter.com/console", env_vars=("BHARATROUTER_API_KEY",),
+    base_url="https://api.bharatrouter.com/v1", auth_type="api_key",
+    # Attribution headers (canonical Hermes set); via default_headers so they
+    # survive switch_model and credential rotation.
+    default_headers={
+        "HTTP-Referer": "https://hermes-agent.nousresearch.com",
+        "X-Title": "Hermes Agent",
+        "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
+    },
+)
+
+register_provider(bharatrouter)

--- a/plugins/model-providers/bharatrouter/plugin.yaml
+++ b/plugins/model-providers/bharatrouter/plugin.yaml
@@ -1,0 +1,5 @@
+name: bharatrouter-provider
+kind: model-provider
+version: 1.0.0
+description: BharatRouter — India-resident OpenAI-compatible gateway (Krutrim, Sarvam + global)
+author: Hermes Agent


### PR DESCRIPTION
## What
Adds **BharatRouter** as a listed provider, mirroring how **Fireworks AI** is wired — so it appears in the onboarding "Connect an account" screen and the Settings → Keys provider cards, with working model discovery.

BharatRouter is an India-resident, OpenAI-compatible AI gateway (one API over Krutrim, Sarvam and 140+ global models, INR billing, DPDP data-residency). It already speaks the OpenAI wire format with `GET /v1/models`, so Hermes's "Discover models" works out of the box.

## Changes (mirrors Fireworks / OpenRouter exactly)
**Desktop UI**
- `settings/constants.ts` — `BHARATROUTER_` entry in `PROVIDER_GROUPS`.
- `onboarding/providers.tsx` — `BharatRouterProviderRow` (mirrors `FireworksProviderRow`).
- `onboarding/index.tsx` — `API_KEY_OPTIONS` entry (`BHARATROUTER_API_KEY`) + rendered row.
- `settings/providers-settings.tsx` — rendered in the Keys "other providers" list.

**i18n** — `bharatRouterPitch` added to `types.ts`, `en.ts`, and the 5 locale files that define `fireworksPitch` (zh, zh-hant, ja, ru, ar).

**Backend (endpoint + discovery)**
- `hermes_cli/providers.py` — overlay (`base_url` `https://api.bharatrouter.com/v1`).
- `hermes_cli/config_defaults.py` — `BHARATROUTER_API_KEY` / `BHARATROUTER_BASE_URL` defaults.
- `hermes_cli/models_catalog_static.py` — `CANONICAL_PROVIDERS` entry (after OpenRouter).
- `plugins/model-providers/bharatrouter/` — provider plugin (base URL → `/v1/models` discovery).

## Notes
- **No logo asset** — matches Fireworks/OpenRouter (their cards are text-only). Happy to add a branded icon if you'd like one.
- **Local type-check/lint not run** in the contributor env — changes are pure additive mirrors of an existing working provider; your CI will validate. Glad to adjust to any conventions I missed.

16 files changed, +76.
