### PR TITLE
fix(tools): file-tools env creation applies the container cwd guard to plugin container backends too (#101013, salvage #101389)

### DIFF
--- a/tests/tools/test_file_tools_plugin_container_cwd.py
+++ b/tests/tools/test_file_tools_plugin_container_cwd.py
@@ -1,0 +1,48 @@
+"""The file-tools env creation path applies the container cwd guard through the same predicate the
+terminal tool uses, so a plugin backend declaring ``is_container`` gets a host-path override
+sanitized exactly like docker does (#101013)."""
+
+import tools.file_tools as ft
+import tools.terminal_tool as terminal_tool
+import tools.terminal_tool_config as ttc
+
+
+def _capture_create(monkeypatch):
+    seen = {}
+
+    def _fake_create(config, env_type, **kwargs):
+        seen["cwd"] = kwargs["cwd"]
+        return object()
+
+    monkeypatch.setattr(terminal_tool, "_create_configured_env", _fake_create)
+    monkeypatch.setattr(terminal_tool, "_select_image", lambda *a, **k: None)
+    monkeypatch.setattr(terminal_tool, "_resolve_task_host_cwd", lambda *a, **k: None)
+    monkeypatch.setattr(terminal_tool, "get_session_cwd", lambda _tid: None)
+    return seen
+
+
+def test_plugin_container_backend_gets_the_same_host_cwd_guard_as_docker(monkeypatch, tmp_path):
+    host_cwd = str(tmp_path / "Users" / "me" / "workspace")
+    monkeypatch.setattr(terminal_tool, "_get_env_config",
+                        lambda: {"env_type": "mycloud", "cwd": "/workspace", "timeout": 60})
+    monkeypatch.setattr(terminal_tool, "resolve_task_overrides", lambda _tid: {"cwd": host_cwd})
+    monkeypatch.setattr(ttc, "_plugin_env_flag", lambda env_type, attr, default=False: attr == "is_container")
+    seen = _capture_create(monkeypatch)
+
+    env_type, _ = ft._create_terminal_env_for_file_ops("sess", "sess")
+
+    assert env_type == "mycloud"
+    assert seen["cwd"] == "/workspace"  # host override dropped, not fed to the sandbox
+
+
+def test_plugin_non_container_backend_keeps_the_host_cwd(monkeypatch, tmp_path):
+    host_cwd = str(tmp_path / "proj")
+    monkeypatch.setattr(terminal_tool, "_get_env_config",
+                        lambda: {"env_type": "myremote", "cwd": "/workspace", "timeout": 60})
+    monkeypatch.setattr(terminal_tool, "resolve_task_overrides", lambda _tid: {"cwd": host_cwd})
+    monkeypatch.setattr(ttc, "_plugin_env_flag", lambda env_type, attr, default=False: False)
+    seen = _capture_create(monkeypatch)
+
+    ft._create_terminal_env_for_file_ops("sess", "sess")
+
+    assert seen["cwd"] == host_cwd

--- a/tests/tools/test_file_tools_plugin_container_cwd.py
+++ b/tests/tools/test_file_tools_plugin_container_cwd.py
@@ -21,8 +21,8 @@ def _capture_create(monkeypatch):
     return seen
 
 
-def test_plugin_container_backend_gets_the_same_host_cwd_guard_as_docker(monkeypatch, tmp_path):
-    host_cwd = str(tmp_path / "Users" / "me" / "workspace")
+def test_plugin_container_backend_gets_the_same_host_cwd_guard_as_docker(monkeypatch):
+    host_cwd = "/Users/me/workspace"  # a host-shaped path (_HOST_CWD_PREFIXES), never valid in-sandbox
     monkeypatch.setattr(terminal_tool, "_get_env_config",
                         lambda: {"env_type": "mycloud", "cwd": "/workspace", "timeout": 60})
     monkeypatch.setattr(terminal_tool, "resolve_task_overrides", lambda _tid: {"cwd": host_cwd})

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -254,7 +254,7 @@ _file_ops_cache: dict = {}
 def _create_terminal_env_for_file_ops(raw_task_id: str, task_id: str):
     """Build the terminal environment for *task_id* via the shared ``_create_configured_env``,
     so a file tool that runs before any terminal command still gets the configured backend."""
-    from tools.terminal_tool_config import _CONTAINER_BACKENDS
+    from tools.terminal_tool_config import _is_container_backend
     from tools.terminal_tool import (
         _create_configured_env, _get_env_config, _is_unusable_container_cwd,
         _resolve_task_host_cwd, _select_image, get_session_cwd, resolve_task_overrides)
@@ -276,7 +276,7 @@ def _create_terminal_env_for_file_ops(raw_task_id: str, task_id: str):
     # reaches ``docker run -w <host-path>`` and the container starts in a directory that doesn't exist
     # inside the sandbox, so search_files and friends silently return empty results (#54447). Sanitize it
     # back to the already-validated config["cwd"] so the override can't bypass the guard.
-    if env_type in _CONTAINER_BACKENDS and _is_unusable_container_cwd(cwd):
+    if _is_container_backend(env_type) and _is_unusable_container_cwd(cwd):
         if cwd != config["cwd"]:
             logger.info(
                 "Ignoring host/relative cwd override %r for %s backend "


### PR DESCRIPTION
A file tool that runs before any terminal command on a plugin backend declaring `is_container` no longer hands the sandbox a raw host path as its workdir; it gets the same guard docker does.

Salvage of #101389 by @RelaxJonh (authorship preserved; re-applied onto the refactored `file_tools.py`). Fixes #101013.

## Root cause

`tools/file_tools.py::_create_terminal_env_for_file_ops` tested `env_type in _CONTAINER_BACKENDS` (the static built-in set) while every sibling site in `tools/terminal_tool.py` already uses `_is_container_backend()`, which also honours plugin-registered backends with `is_container=True`. From the file-tools creation path only, such a plugin backend skipped the host-cwd sanitisation.

## Change

- One predicate for the guard: `_is_container_backend(env_type)` from `tools.terminal_tool_config`, the module the terminal tool imports it from.
- 2 invariant tests: a plugin container backend gets the host-cwd override dropped; a plugin non-container backend keeps it. Red on `origin/main`.

## Validation

| Check | Result |
|---|---|
| `scripts/run_tests.sh` file_tools cwd / container-config / cwd-sanitize suites | 24 passed (the 2 `test_file_tools.py` reds fail identically on `origin/main`) |
| ruff | clean |
