### PR TITLE
fix(terminal): profile terminal scope serialises list/dict config as JSON, so docker_volumes/docker_env survive multiplexing (#101465, salvage #101479)

### DIFF
--- a/tests/tools/test_terminal_scope_multiplex.py
+++ b/tests/tools/test_terminal_scope_multiplex.py
@@ -183,3 +183,60 @@ def test_tui_and_cron_boundaries_bind_and_reset(tmp_path):
     with install_and_reset_profile_terminal_scope(home):  # cron fire helper
         assert terminal_env("TERMINAL_ENV") == "local"
     assert get_terminal_scope() is None
+
+
+def test_config_list_and_dict_values_are_json_not_repr(tmp_path):
+    """config.yaml list/dict terminal keys must be JSON so terminal_tool's
+    json.loads path succeeds. str() produces Python repr and drops the tool."""
+    from tools.terminal_scope import build_profile_terminal_scope
+
+    home = _profile(
+        tmp_path,
+        "docker-lists",
+        "\n".join(
+            [
+                "terminal:",
+                "  backend: docker",
+                "  docker_forward_env:",
+                "    - EMAIL_HOME_ADDRESS",
+                "  docker_volumes:",
+                "    - /tmp/a:/data",
+                "  docker_env:",
+                "    FOO: bar",
+                "  docker_extra_args:",
+                "    - --network=host",
+                "",
+            ]
+        ),
+    )
+    scope = build_profile_terminal_scope(home)
+    assert json.loads(scope["TERMINAL_DOCKER_FORWARD_ENV"]) == ["EMAIL_HOME_ADDRESS"]
+    assert json.loads(scope["TERMINAL_DOCKER_VOLUMES"]) == ["/tmp/a:/data"]
+    assert json.loads(scope["TERMINAL_DOCKER_ENV"]) == {"FOO": "bar"}
+    assert json.loads(scope["TERMINAL_DOCKER_EXTRA_ARGS"]) == ["--network=host"]
+
+    import gateway.run as gw
+    import tools.terminal_tool as tt
+
+    with gw._profile_runtime_scope(home):
+        cfg = tt._get_env_config()
+        assert cfg["docker_forward_env"] == ["EMAIL_HOME_ADDRESS"]
+        assert cfg["docker_volumes"] == ["/tmp/a:/data"]
+        assert cfg["docker_env"] == {"FOO": "bar"}
+        assert cfg["docker_extra_args"] == ["--network=host"]
+
+
+def test_dotenv_json_strings_stay_json_strings(tmp_path):
+    """The .env path already stores JSON text; str() must keep that payload."""
+    from tools.terminal_scope import build_profile_terminal_scope
+
+    home = _profile(
+        tmp_path,
+        "dotenv-json",
+        "terminal:\n  backend: docker\n",
+        'TERMINAL_DOCKER_FORWARD_ENV=["EMAIL_HOME_ADDRESS"]\n'
+        'TERMINAL_DOCKER_VOLUMES=["/tmp/a:/data"]\n',
+    )
+    scope = build_profile_terminal_scope(home)
+    assert json.loads(scope["TERMINAL_DOCKER_FORWARD_ENV"]) == ["EMAIL_HOME_ADDRESS"]
+    assert json.loads(scope["TERMINAL_DOCKER_VOLUMES"]) == ["/tmp/a:/data"]

--- a/tools/terminal_scope.py
+++ b/tools/terminal_scope.py
@@ -93,7 +93,7 @@ def build_profile_terminal_scope(hermes_home: "Any") -> Dict[str, str]:
     ``config.yaml`` ``terminal:``. Total by construction, so a bound scope never widens back to
     ambient authority. Raises :class:`TerminalPolicyUnavailable` if a present file is unreadable.
     """
-    from hermes_cli.config import TERMINAL_CONFIG_ENV_MAP
+    from hermes_cli.config import TERMINAL_CONFIG_ENV_MAP, _terminal_env_value
     from hermes_cli.config_defaults import DEFAULT_CONFIG
 
     home = Path(hermes_home)
@@ -106,7 +106,10 @@ def build_profile_terminal_scope(hermes_home: "Any") -> Dict[str, str]:
                 continue
             env_var = TERMINAL_CONFIG_ENV_MAP.get(cfg_key)
             if env_var:
-                scope[env_var] = str(value)
+                # List/dict config values must be JSON (same contract as
+                # apply_terminal_config_to_env). str() yields Python repr, which
+                # json.loads in terminal_tool rejects.
+                scope[env_var] = _terminal_env_value(value)
 
     _apply({**_TOOL_LEVEL_DEFAULTS, **(DEFAULT_CONFIG.get("terminal") or {})})
     env_path = home / ".env"


### PR DESCRIPTION
Under gateway multiplexing, a routed profile's `terminal.docker_volumes` / `docker_env` / `docker_forward_env` / `docker_extra_args` now reach the container: the per-turn scope carries them as JSON, which `terminal_tool`'s `json.loads` accepts, instead of Python `repr` text that it rejected (dropping the whole setting).

Salvage of #101479 by @rainbowgits (single commit, authorship preserved, applied clean). Fixes #101465. Duplicate #101472 by @liuhao1024 targets the same line.

## Change

- `tools/terminal_scope.py::build_profile_terminal_scope` uses `hermes_cli.config._terminal_env_value` — the same helper `apply_terminal_config_to_env` already uses for the process-env bridge — instead of `str(value)`.
- 2 invariant tests: config list/dict values round-trip through the scope into `_get_env_config()`; `.env` JSON strings are preserved as-is. Red on `origin/main`.

## Validation

| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/tools/test_terminal_scope_multiplex.py` | 10 passed |
| ruff / compat pointers | clean |
