### PR TITLE
fix(docker): docker_network: false plus a --network flag in docker_extra_args no longer makes every container start fail (#100248, salvage #100256)

### DIFF
--- a/contributors/emails/david@davidkarban.cz
+++ b/contributors/emails/david@davidkarban.cz
@@ -1,0 +1,2 @@
+davidkarban
+# PR #100256 salvage

--- a/tests/tools/test_docker_network_config.py
+++ b/tests/tools/test_docker_network_config.py
@@ -59,7 +59,9 @@ def test_sibling_container_config_sites_carry_docker_network():
         assert sites >= 1, f"expected at least one container_config site in {module.__name__}"
 
 
-def _reuse_guard_harness(monkeypatch, *, existing_mode: str, network: bool):
+def _reuse_guard_harness(
+    monkeypatch, *, existing_mode: str, network: bool, extra_args=None
+):
     """Drive DockerEnvironment through the cross-process reuse path with a
     fake existing container whose NetworkMode is *existing_mode*.
 
@@ -96,6 +98,7 @@ def _reuse_guard_harness(monkeypatch, *, existing_mode: str, network: bool):
         timeout=60,
         task_id="reuse-guard-test",
         network=network,
+        extra_args=extra_args,
         persist_across_processes=True,
     )
     return commands
@@ -126,3 +129,25 @@ def test_reuse_skips_inspect_when_network_enabled(monkeypatch):
     assert not any(cmd[1] == "inspect" for cmd in commands)
     assert not any(cmd[1] == "rm" for cmd in commands)
     assert not any(cmd[1] == "run" for cmd in commands)
+
+
+def test_extra_args_network_none_emits_flag_once(monkeypatch):
+    """docker_network=false plus an operator ``--network none`` (either spelling) must emit the
+    flag ONCE: Docker rejects a repeated --network with exit 125, so both together made every
+    container start fail (#100248). Without an operator flag the implicit lockdown still applies."""
+    for extra in (["--network=none", "--user", "1009:1009"], ["--network", "none"], ["--user", "1009:1009"]):
+        commands = _reuse_guard_harness(monkeypatch, existing_mode="bridge", network=False, extra_args=list(extra))
+        run_cmd = next(cmd for cmd in commands if len(cmd) > 2 and cmd[1:3] == ["run", "-d"])
+        network_flags = [a for a in run_cmd if a in ("--network", "--net") or a.startswith(("--network=", "--net="))]
+        assert len(network_flags) == 1, (extra, run_cmd)
+        assert "--user" not in extra or "1009:1009" in run_cmd
+
+
+def test_contradictory_network_request_fails_closed(monkeypatch):
+    """docker_network=false with --network=host is contradictory: honouring the extra arg would
+    defeat the lockdown and the reuse guard (NetworkMode == "none") would churn the container
+    every startup. Fail loudly, naming both keys."""
+    import pytest
+
+    with pytest.raises(RuntimeError, match="docker_network"):
+        _reuse_guard_harness(monkeypatch, existing_mode="bridge", network=False, extra_args=["--network=host"])


### PR DESCRIPTION
With `terminal.docker_network: false` and `--network=none` (or `--network none`) also present in `docker_extra_args`, containers start again: the lockdown flag is emitted once. A contradictory `--network=host` fails closed with a message naming both keys instead of silently defeating the lockdown.

Salvage of #100256 by @davidkarban (authorship preserved; re-applied onto the refactored `_resource_args`). Fixes #100248.

## Root cause

`_resource_args` appended `--network=none` unconditionally for `docker_network: false`; the operator's `docker_extra_args` were appended verbatim after it. Docker rejects a repeated `--network` (`network "none" is specified multiple times`, exit 125), so the two together made `docker run` fail on every start.

## Change

- `_extra_args_network_mode()` parses `--network` / `--net` (both spellings) out of `docker_extra_args`; `_resource_args` emits the implicit flag only when the operator set none, skips it when both say `none`, and raises with both keys named when they contradict (the reuse guard requires `NetworkMode == "none"` and would churn a networked container every startup).
- 2 invariant tests (trimmed from the contributor's five): one network flag for either spelling and for the no-flag case; contradictory request fails closed. Red on `origin/main`.

## Validation

| Check | Result |
|---|---|
| Live, real Docker (OrbStack): `docker_network=false` + `docker_extra_args=["--network=none"]`, real `terminal_tool` | main: `docker run` exit 125 (`--network=none` twice in the argv), no container; branch: container starts, `echo alive` succeeds, no `eth0` |
| `scripts/run_tests.sh` docker network/environment/cgroup/session-isolation suites | 100 passed |
| ruff | clean |
