### PR TITLE
fix(approval): approvals.deny is enforced inside isolated Docker/cloud sandboxes, not skipped by the container fast path (#91002, salvage #91029)

### DIFF
--- a/hermes_cli/approvals_test.py
+++ b/hermes_cli/approvals_test.py
@@ -50,12 +50,20 @@ def evaluate_command(command: str, env_type: str = "local") -> dict:
             "normalized_variants": variants,
         }
 
-    # 1. Isolated container backends skip every guard (fires BEFORE the hardline floor at runtime).
+    # 1. Isolated container backends skip every guard except the operator's approvals.deny
+    #    (fires BEFORE the hardline floor at runtime).
     if approval._should_skip_container_guards(env_type):
+        deny_pattern = approval_floors._match_user_deny_rule(command)
+        if deny_pattern is not None:
+            return result(
+                "user-deny", rule=deny_pattern,
+                detail="matches a user-defined approvals.deny rule in config.yaml "
+                       "(blocked even in an isolated container, under --yolo / mode=off)",
+            )
         return result(
             "allow",
             detail=(f"env_type '{env_type}' is an isolated container backend; "
-                    "the runtime skips all command guards for it"),
+                    "the runtime skips all command guards for it except approvals.deny"),
         )
 
     # 2. Hardline blocklist — never bypassable, even under yolo.

--- a/tests/tools/test_approval_deny_rules.py
+++ b/tests/tools/test_approval_deny_rules.py
@@ -117,11 +117,38 @@ class TestDenyOrdering:
         assert result["approved"] is False
         assert result.get("user_deny") is True
 
-    def test_container_backend_skips_deny(self, deny_config, clean_env):
-        """Isolated container backends bypass the whole guard stack (existing
-        contract) — deny rules protect the host, containers can't touch it."""
-        deny_config(["git push --force*"])
-        result = mod.check_dangerous_command("git push --force origin main", "docker")
+    @pytest.mark.parametrize(
+        "guard",
+        [mod.check_dangerous_command, mod.check_all_command_guards],
+    )
+    @pytest.mark.parametrize(
+        "env_type",
+        ["docker", "singularity", "modal", "daytona", "vercel_sandbox"],
+    )
+    def test_container_backend_cannot_skip_deny(
+            self, guard, env_type, deny_config, clean_env, monkeypatch):
+        deny_config(["*chmod*"], mode="off")
+        monkeypatch.setattr(mod, "_YOLO_MODE_FROZEN", True)
+
+        result = guard("chmod 600 /tmp/hermes-approval-deny-test", env_type)
+
+        assert result["approved"] is False
+        assert result.get("user_deny") is True
+
+    @pytest.mark.parametrize(
+        "guard",
+        [mod.check_dangerous_command, mod.check_all_command_guards],
+    )
+    @pytest.mark.parametrize(
+        "env_type",
+        ["docker", "singularity", "modal", "daytona", "vercel_sandbox"],
+    )
+    def test_container_backend_still_skips_non_denied_command(
+            self, guard, env_type, deny_config, clean_env):
+        deny_config(["*chmod*"])
+
+        result = guard("rm -rf build/", env_type)
+
         assert result["approved"] is True
 
     def test_benign_command_unaffected(self, deny_config, clean_env):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -857,6 +857,17 @@ def _should_skip_container_guards(env_type: str, has_host_access: bool = False) 
     return env_type in ("singularity", "modal", "daytona", "vercel_sandbox")
 
 
+def _user_deny_block(command: str) -> dict | None:
+    """The operator's ``approvals.deny`` rules are documented as never bypassable — not by yolo,
+    not by mode=off, and not by an isolated container either: they express intent about what the
+    agent may DO, not what it can reach, so they are evaluated before the container fast path."""
+    deny_pattern = _match_user_deny_rule(command)
+    if deny_pattern is None:
+        return None
+    logger.warning("User deny rule %r blocked command: %s", deny_pattern, command[:200])
+    return _user_deny_block_result(deny_pattern)
+
+
 def _floor_block(command: str, *, sudo_guard: bool = False) -> dict | None:
     """Unconditional floors, BEFORE yolo / mode=off / cron approve-mode so no
     session-level setting can bypass them: hardline catastrophic commands,
@@ -871,11 +882,7 @@ def _floor_block(command: str, *, sudo_guard: bool = False) -> dict | None:
         if is_sudo_guess:
             logger.warning("Sudo stdin guard block: %s (command: %s)", sudo_guess_desc, command[:200])
             return _sudo_stdin_block_result(sudo_guess_desc)
-    deny_pattern = _match_user_deny_rule(command)
-    if deny_pattern is not None:
-        logger.warning("User deny rule %r blocked command: %s", deny_pattern, command[:200])
-        return _user_deny_block_result(deny_pattern)
-    return None
+    return _user_deny_block(command)
 
 
 def check_dangerous_command(command: str, env_type: str,
@@ -885,7 +892,7 @@ def check_dangerous_command(command: str, env_type: str,
     a Docker sandbox that bind-mounts host paths must not skip approval.
     Returns ``{"approved": True/False, "message": str or None, ...}``."""
     if _should_skip_container_guards(env_type, has_host_access=has_host_access):
-        return _approved()
+        return _user_deny_block(command) or _approved()
     blocked = _floor_block(command)
     if blocked is not None:
         return blocked
@@ -976,7 +983,7 @@ def check_all_command_guards(command: str, env_type: str,
     force=True replay cannot bypass one check when only the other was shown to the user.
     ``has_host_access``: a Docker sandbox with bind-mounted host paths takes the normal flow."""
     if _should_skip_container_guards(env_type, has_host_access=has_host_access):
-        return _approved()
+        return _user_deny_block(command) or _approved()
 
     blocked = _floor_block(command, sudo_guard=True)
     if blocked is not None:


### PR DESCRIPTION
`approvals.deny` rules now block commands inside isolated containers (Docker without host mounts, singularity, modal, daytona, vercel) the same way they do on the host — including under `--yolo` and `approvals.mode: off`. The built-in dangerous-command heuristics still skip there, as intended.

Salvage of #91029 by @fangliquanflq (authorship preserved; re-applied onto the refactored `_floor_block` shape). Fixes #91002.

## Root cause

`check_dangerous_command` and `check_all_command_guards` returned `_approved()` from `_should_skip_container_guards(...)` before `_floor_block` ran, so the operator's deny list was never evaluated for an isolated backend. The deny list is documented as the one rule set nothing bypasses; it expresses what the agent may DO, not what it can reach.

## Change

- `_user_deny_block(command)` (extracted from `_floor_block`, now its deny step) runs before the container fast path in both entry points: `return _user_deny_block(command) or _approved()`.
- `hermes approvals test` (`hermes_cli/approvals_test.py`) mirrors the runtime order so the dry-run tool reports `user-deny` for a container backend instead of `allow`.
- The `execute_code` gate is untouched: on `main` the deny list is a shell-command floor and is not consulted there today.
- 2 parametrized invariant tests (both entry points × 5 isolated backends): denied command blocks under yolo; non-denied command still skips. Red on `origin/main` (10 cases).

## Validation

| Check | Result |
|---|---|
| Live, real Docker (OrbStack), `approvals.deny: ['*chmod*']`, yolo, no host mounts, real `terminal_tool` | main: `chmod` runs in the sandbox (`CHMOD-RAN`); branch: `BLOCKED: this command matches the user-defined deny rule '*chmod*'` |
| `scripts/run_tests.sh` approval deny-rules / approval / approvals_test suites | 165 passed (the 1 `test_approval.py` red fails identically on `origin/main`) |
| ruff | clean |
