### PR TITLE
fix(verify): clear workspace stale after hermes verify on another session

### DIFF
--- a/agent/verification_evidence.py
+++ b/agent/verification_evidence.py
@@ -501,6 +501,16 @@ def _insert_evidence(evidence: VerificationEvidence) -> dict[str, Any]:
             " changed_paths_json = '[]'",
             (e.session_id, e.root, event_id),
         )
+        # ``hermes verify`` proves the workspace, not a session. Share the
+        # pointer with every session that already has a row for this root so
+        # a CLI run under ``default`` can clear an editing session's stale flag.
+        if e.kind == "verify":
+            conn.execute(
+                "UPDATE verification_state"
+                " SET last_event_id = ?, last_edit_at = NULL, changed_paths_json = '[]'"
+                " WHERE root = ? AND session_id != ?",
+                (event_id, e.root, e.session_id),
+            )
         _prune_old_events(conn, session_id=e.session_id, root=e.root)
         conn.commit()
 
@@ -542,10 +552,31 @@ def mark_workspace_edited(
     return {"session_id": sid, "root": root, "last_edit_at": edited_at, "changed_paths": changed_paths}
 
 
+def _newest_workspace_verify(
+    conn: sqlite3.Connection, *, root: str, since: str | None
+) -> Optional[sqlite3.Row]:
+    """Latest ``hermes verify`` event for ``root``, optionally not older than ``since``."""
+    if since:
+        return conn.execute(
+            "SELECT * FROM verification_events"
+            " WHERE root = ? AND kind = 'verify' AND created_at >= ?"
+            " ORDER BY id DESC LIMIT 1",
+            (root, since),
+        ).fetchone()
+    return conn.execute(
+        "SELECT * FROM verification_events"
+        " WHERE root = ? AND kind = 'verify'"
+        " ORDER BY id DESC LIMIT 1",
+        (root,),
+    ).fetchone()
+
+
 def verification_status(*, session_id: str | None, cwd: str | Path | None) -> dict[str, Any]:
     """Return the best known verification state for a session/workspace.
 
-    Evidence recorded before the latest edit is reported as ``stale``.
+    Evidence recorded before the latest edit is reported as ``stale``. A
+    ``hermes verify`` event for the same ``root`` that is at least as new as
+    that edit satisfies the guard even if another session recorded it.
     """
     facts = _project_facts(cwd)
     if not facts:
@@ -564,13 +595,20 @@ def verification_status(*, session_id: str | None, cwd: str | Path | None) -> di
         event = None
         if state["last_event_id"] is not None:
             event = conn.execute("SELECT * FROM verification_events WHERE id = ?", (state["last_event_id"],)).fetchone()
+        last_edit_at = state["last_edit_at"]
+        stale = bool(event is not None and last_edit_at and last_edit_at > event["created_at"])
+        if event is None or stale:
+            shared = _newest_workspace_verify(conn, root=root, since=last_edit_at)
+            if shared is not None:
+                event = shared
+                stale = False
 
-    result = {
-        "evidence": None, "root": root, "session_id": sid, "changed_paths": _load_changed_paths(state["changed_paths_json"])
-    }
-    if event is None:
-        return {"status": "unverified", **result}
+        result = {
+            "evidence": None, "root": root, "session_id": sid,
+            "changed_paths": _load_changed_paths(state["changed_paths_json"]),
+        }
+        if event is None:
+            return {"status": "unverified", **result}
 
-    evidence = dict(event)
-    stale = bool(state["last_edit_at"]) and state["last_edit_at"] > evidence["created_at"]
-    return {"status": "stale" if stale else evidence["status"], **result, "evidence": evidence}
+        evidence = dict(event)
+        return {"status": "stale" if stale else evidence["status"], **result, "evidence": evidence}

--- a/agent/verification_evidence.py
+++ b/agent/verification_evidence.py
@@ -501,10 +501,9 @@ def _insert_evidence(evidence: VerificationEvidence) -> dict[str, Any]:
             " changed_paths_json = '[]'",
             (e.session_id, e.root, event_id),
         )
-        # ``hermes verify`` proves the workspace, not a session. Share the
-        # pointer with every session that already has a row for this root so
-        # a CLI run under ``default`` can clear an editing session's stale flag.
-        if e.kind == "verify":
+        # A full passing ``hermes verify`` proves the workspace. Partial or
+        # failed runs must not wipe another session's edit record (#103650).
+        if e.kind == "verify" and e.status == "passed" and e.scope == "full":
             conn.execute(
                 "UPDATE verification_state"
                 " SET last_event_id = ?, last_edit_at = NULL, changed_paths_json = '[]'"
@@ -555,17 +554,18 @@ def mark_workspace_edited(
 def _newest_workspace_verify(
     conn: sqlite3.Connection, *, root: str, since: str | None
 ) -> Optional[sqlite3.Row]:
-    """Latest ``hermes verify`` event for ``root``, optionally not older than ``since``."""
+    """Latest full passing ``hermes verify`` for ``root``, optionally not older than ``since``."""
     if since:
         return conn.execute(
             "SELECT * FROM verification_events"
-            " WHERE root = ? AND kind = 'verify' AND created_at >= ?"
+            " WHERE root = ? AND kind = 'verify' AND status = 'passed' AND scope = 'full'"
+            " AND created_at >= ?"
             " ORDER BY id DESC LIMIT 1",
             (root, since),
         ).fetchone()
     return conn.execute(
         "SELECT * FROM verification_events"
-        " WHERE root = ? AND kind = 'verify'"
+        " WHERE root = ? AND kind = 'verify' AND status = 'passed' AND scope = 'full'"
         " ORDER BY id DESC LIMIT 1",
         (root,),
     ).fetchone()

--- a/tests/agent/test_verification_evidence.py
+++ b/tests/agent/test_verification_evidence.py
@@ -10,6 +10,7 @@ from agent.verification_evidence import (
     classify_verification_command,
     mark_workspace_edited,
     record_terminal_result,
+    record_verify_run,
     verification_status,
 )
 
@@ -289,6 +290,34 @@ def test_file_tool_stales_evidence_by_session_id_for_absolute_edit(tmp_path, mon
 
 
 
+
+
+def test_workspace_verify_clears_stale_on_other_session(tmp_path, monkeypatch):
+    """A hermes verify pass is a property of the workspace, not the session
+    that ran the CLI (#103271)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _python_project(tmp_path)
+    changed = str(tmp_path / "changed.py")
+    mark_workspace_edited(session_id="s-edit", cwd=tmp_path, paths=[changed])
+    assert verification_status(session_id="s-edit", cwd=tmp_path)["status"] == "unverified"
+
+    event = record_verify_run(root=tmp_path, session_id="default", ok=True, output="all green")
+    assert event is not None
+    status = verification_status(session_id="s-edit", cwd=tmp_path)
+    assert status["status"] == "passed"
+    assert status["evidence"]["canonical_command"] == "hermes verify"
+
+
+def test_older_workspace_verify_does_not_clear_later_edit(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _python_project(tmp_path)
+    record_verify_run(root=tmp_path, session_id="default", ok=True, output="old pass")
+    mark_workspace_edited(
+        session_id="s-edit",
+        cwd=tmp_path,
+        paths=[str(tmp_path / "changed.py")],
+    )
+    assert verification_status(session_id="s-edit", cwd=tmp_path)["status"] == "unverified"
 
 
 def test_recording_expires_old_edit_only_state(tmp_path, monkeypatch):

--- a/tests/agent/test_verification_evidence.py
+++ b/tests/agent/test_verification_evidence.py
@@ -308,6 +308,35 @@ def test_workspace_verify_clears_stale_on_other_session(tmp_path, monkeypatch):
     assert status["evidence"]["canonical_command"] == "hermes verify"
 
 
+def test_targeted_partial_verify_does_not_clear_other_session(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _python_project(tmp_path)
+    record_verify_run(root=tmp_path, session_id="s-edit", ok=True)
+    mark_workspace_edited(session_id="s-edit", cwd=tmp_path, paths=[str(tmp_path / "a.py")])
+    assert verification_status(session_id="s-edit", cwd=tmp_path)["status"] == "stale"
+
+    record_verify_run(root=tmp_path, session_id=None, ok=True, scope="targeted")
+
+    status = verification_status(session_id="s-edit", cwd=tmp_path)
+    assert status["status"] == "stale"
+
+
+def test_failed_verify_does_not_erase_other_session_edit_record(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _python_project(tmp_path)
+    mark_workspace_edited(session_id="s-edit", cwd=tmp_path, paths=[str(tmp_path / "a.py")])
+
+    record_verify_run(root=tmp_path, session_id=None, ok=False)
+
+    row = sqlite3.connect(home / "verification_evidence.db").execute(
+        "SELECT last_edit_at, changed_paths_json FROM verification_state WHERE session_id='s-edit'"
+    ).fetchone()
+    assert row is not None
+    assert row[0] is not None
+    assert verification_status(session_id="s-edit", cwd=tmp_path)["status"] != "passed"
+
+
 def test_older_workspace_verify_does_not_clear_later_edit(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
     _python_project(tmp_path)

--- a/tests/verify/test_ledger_and_nudge_integration.py
+++ b/tests/verify/test_ledger_and_nudge_integration.py
@@ -120,6 +120,23 @@ def test_cli_run_uses_hermes_session_id_env(hermes_home, capsys, monkeypatch):
     assert verification_status(session_id="sess-42", cwd=project)["status"] == "passed"
 
 
+def test_cli_verify_clears_stale_on_editing_session(hermes_home, capsys):
+    """Standalone ``hermes verify`` records under default; the editing session
+    must still see a pass (#103271)."""
+    project = _workspace(hermes_home, manifest_recipe={"name": "Fake", "test": ["echo ok"]})
+    changed = str(project / "src" / "app.ts")
+    edit_session = "20260717_230325_f2d00d"
+    mark_workspace_edited(session_id=edit_session, cwd=project, paths=[changed])
+    assert verification_status(session_id=edit_session, cwd=project)["status"] == "unverified"
+    assert build_verify_on_stop_nudge(session_id=edit_session, changed_paths=[changed]) is not None
+
+    assert run_verify_command(make_args(project)) == 0
+
+    assert verification_status(session_id=edit_session, cwd=project)["status"] == "passed"
+    assert verification_status(session_id="default", cwd=project)["status"] == "passed"
+    assert build_verify_on_stop_nudge(session_id=edit_session, changed_paths=[changed]) is None
+
+
 # ---------------------------------------------------------------------------
 # closed loop: edit -> stop guard nudge -> hermes verify -> guard satisfied
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

`hermes verify` records evidence under `session_id=default` when `HERMES_SESSION_ID` is unset (the normal CLI path). File edits land under the real session id, so the verify-on-stop guard keeps reporting stale after a green verify and never clears.

A `kind=verify` event is a property of the workspace. This shares that event with every `verification_state` row for the same `root`, and `verification_status` also accepts a newer-or-equal `hermes verify` from another session when the session-local pointer is missing or older than the last edit. Terminal pytest/lint results stay session-scoped.

## Related Issue

Fixes #103271

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `agent/verification_evidence.py` — share `hermes verify` events across sessions for the same root; status lookup consults the newest workspace verify that is at least as new as `last_edit_at`
- `tests/agent/test_verification_evidence.py` — cross-session pass vs later edit
- `tests/verify/test_ledger_and_nudge_integration.py` — CLI `hermes verify` clears the editing session's stop-guard nudge

## How to Test

```text
cd /tmp/hermes-103271
uv run --extra dev python -m pytest tests/agent/test_verification_evidence.py tests/verify/test_ledger_and_nudge_integration.py tests/agent/test_verification_stop.py -q
# 50 passed
```

Not runtime-tested on Windows. The ledger is sqlite + ISO timestamps; no OS-specific paths in the change.

Did not run `pytest tests/ -q` (full suite).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 26.04 (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
