### PR TITLE
fix(dashboard-auth): classify refresh rejections and throttle retry storms (#98338)

### DIFF
--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -360,6 +360,10 @@ def _reset_password_rate_limit() -> None:
 # on restart), same as the password limiter.
 _REFRESH_RATE_MAX_ATTEMPTS = 10
 _REFRESH_RATE_WINDOW_SEC = 60.0
+# Distinct-credential buckets are never evicted by the sliding window (only their
+# timestamps expire), so cap the table: beyond this, purge expired buckets, then
+# drop oldest-inserted. Best-effort bounds memory under token-rotation abuse.
+_REFRESH_RATE_MAX_BUCKETS = 4096
 _refresh_attempts: Dict[str, Deque[float]] = defaultdict(deque)
 _refresh_attempts_lock = threading.Lock()
 
@@ -369,12 +373,26 @@ def _refresh_token_bucket(refresh_token: str) -> str:
     return hashlib.sha256(refresh_token.encode("utf-8")).hexdigest()
 
 
+def _prune_refresh_buckets(cutoff: float) -> None:
+    """Drop expired buckets first, then oldest-inserted, until back under the cap.
+    Caller must hold ``_refresh_attempts_lock``."""
+    for key in [k for k, bucket in _refresh_attempts.items()
+                if not bucket or bucket[-1] < cutoff]:
+        del _refresh_attempts[key]
+        if len(_refresh_attempts) <= _REFRESH_RATE_MAX_BUCKETS:
+            return
+    while len(_refresh_attempts) > _REFRESH_RATE_MAX_BUCKETS:
+        _refresh_attempts.pop(next(iter(_refresh_attempts)))
+
+
 def _native_refresh_rate_limited(refresh_token: str) -> tuple[bool, float]:
     """``(limited, retry_after_sec)``; records the attempt when allowed. An empty
     token shares one bucket — fail-safe toward throttling."""
     now = time.monotonic()
     cutoff = now - _REFRESH_RATE_WINDOW_SEC
     with _refresh_attempts_lock:
+        if len(_refresh_attempts) > _REFRESH_RATE_MAX_BUCKETS:
+            _prune_refresh_buckets(cutoff)
         bucket = _refresh_attempts[_refresh_token_bucket(refresh_token)]
         while bucket and bucket[0] < cutoff:
             bucket.popleft()

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -17,6 +17,7 @@ allowlists the public ones.
 """
 from __future__ import annotations
 
+import hashlib
 import logging
 import threading
 import time
@@ -349,6 +350,46 @@ def _reset_password_rate_limit() -> None:
         _pw_attempts.clear()
 
 
+# --- Native refresh throttle -------------------------------------------------
+# Same sliding-window shape as the password limiter above, but keyed by
+# SHA-256 of the presented refresh token instead of client IP: one looping
+# client with a dead token must not be able to storm the Portal token endpoint
+# (#98338: 3,338 rejected refreshes at 3 req/s for 17h45m), while other devices
+# behind the same NAT IP keep their own budget. The raw token never leaves this
+# module as a dict key — only its hash. Best-effort and process-local (resets
+# on restart), same as the password limiter.
+_REFRESH_RATE_MAX_ATTEMPTS = 10
+_REFRESH_RATE_WINDOW_SEC = 60.0
+_refresh_attempts: Dict[str, Deque[float]] = defaultdict(deque)
+_refresh_attempts_lock = threading.Lock()
+
+
+def _refresh_token_bucket(refresh_token: str) -> str:
+    """Bucket key for a presented refresh token: hex SHA-256, never the token."""
+    return hashlib.sha256(refresh_token.encode("utf-8")).hexdigest()
+
+
+def _native_refresh_rate_limited(refresh_token: str) -> tuple[bool, float]:
+    """``(limited, retry_after_sec)``; records the attempt when allowed. An empty
+    token shares one bucket — fail-safe toward throttling."""
+    now = time.monotonic()
+    cutoff = now - _REFRESH_RATE_WINDOW_SEC
+    with _refresh_attempts_lock:
+        bucket = _refresh_attempts[_refresh_token_bucket(refresh_token)]
+        while bucket and bucket[0] < cutoff:
+            bucket.popleft()
+        if len(bucket) >= _REFRESH_RATE_MAX_ATTEMPTS:
+            return True, max(1.0, _REFRESH_RATE_WINDOW_SEC - (now - bucket[0]))
+        bucket.append(now)
+        return False, 0.0
+
+
+def _reset_native_refresh_rate_limit() -> None:
+    """Test-only: clear all native-refresh rate-limit buckets."""
+    with _refresh_attempts_lock:
+        _refresh_attempts.clear()
+
+
 class _PasswordLoginBody(BaseModel):
     provider: str
     username: str
@@ -484,9 +525,22 @@ class _NativeRefreshBody(BaseModel):
 async def auth_native_refresh(request: Request, body: _NativeRefreshBody):
     """Rotate a desktop-held refresh token (mirrors the gate's ``_attempt_refresh``): every
     provider rejecting the RT -> 401 ``session_expired`` (desktop re-logs); none rotated and one
-    unreachable -> 503."""
+    unreachable -> 503. Attempts are throttled per credential-hash (429 +
+    ``Retry-After`` once over budget) so one looping client cannot storm the
+    upstream token endpoint."""
     if not body.refresh_token:
         raise _http(400, "refresh_token required")
+    limited, retry_after = _native_refresh_rate_limited(body.refresh_token)
+    if limited:
+        _audit(request, AuditEvent.REFRESH_FAILURE, reason="rate_limited")
+        return JSONResponse(
+            {
+                "error": "rate_limited",
+                "detail": "Too many refresh attempts. Try again shortly.",
+            },
+            status_code=429,
+            headers={"Retry-After": str(int(retry_after))},
+        )
     try:
         session = scan_session_providers(
             body.provider, lambda p: p.refresh_session(refresh_token=body.refresh_token),

--- a/plugins/dashboard_auth/_shared.py
+++ b/plugins/dashboard_auth/_shared.py
@@ -117,6 +117,12 @@ def pkce_login_start(authorize_url: str, *, client_id: str, scope: str, redirect
         cookie_payload={"hermes_session_pkce": f"state={state};verifier={code_verifier}"})
 
 
+# OAuth token-rejection codes: the IDP's verdict on the credential itself. A 401/403
+# carrying anything else (WAF page, proxy envelope) stays transient — never force a
+# re-login on an ambiguous signal.
+_PERMANENT_TOKEN_ERRORS = frozenset({"invalid_grant", "invalid_token", "expired_token"})
+
+
 def parse_json_body(response: httpx.Response) -> Dict[str, Any]:
     """JSON object body, or ``{}`` for non-JSON content-type / parse error / non-dict."""
     if not response.headers.get("content-type", "").startswith("application/json"):
@@ -135,15 +141,15 @@ def exchange_token(
 
     A 400 (OAuth-shaped error envelope) raises ``bad_request_exc`` — ``InvalidCodeError``
     for the auth-code path, ``RefreshExpiredError`` for refresh — so the middleware's
-    distinct handling is preserved. A 401/403 *with* an OAuth error envelope is also a
-    credential verdict (the IDP understood the request and refused it: dead/foreign
-    token) and raises ``bad_request_exc`` — reporting it as ``ProviderError`` (503,
-    "transient") invites unbounded client retries against a token that can never
-    succeed (#98338). A 401/403 *without* an envelope stays ``ProviderError``: it may
-    be a WAF/proxy block, never a signal to force re-login. Any other non-200,
-    transport failure, missing ``token_key`` or non-bearer ``token_type`` raises
-    ``ProviderError``. Redirects are deliberately NOT followed: the body carries an
-    auth code / refresh token.
+    distinct handling is preserved. A 401/403 carrying a known OAuth token-rejection
+    code (``invalid_grant`` / ``invalid_token`` / ``expired_token``) is also a
+    credential verdict (dead/foreign token) and raises ``bad_request_exc`` —
+    reporting it as ``ProviderError`` (503, "transient") invites unbounded client
+    retries against a token that can never succeed (#98338). Any other 401/403
+    stays ``ProviderError``: it may be a WAF/proxy block, never a signal to force
+    re-login. Any other non-200, transport failure, missing ``token_key`` or
+    non-bearer ``token_type`` raises ``ProviderError``. Redirects are deliberately
+    NOT followed: the body carries an auth code / refresh token.
     """
     try:
         response = httpx.post(url, data=data, headers={**JSON_HEADERS, **(headers or {})}, timeout=TOKEN_ENDPOINT_TIMEOUT_SEC)
@@ -153,9 +159,9 @@ def exchange_token(
         error_code = parse_json_body(response).get("error", "invalid_request")
         raise bad_request_exc(f"{idp} rejected token request: {error_code}")
     if response.status_code in (401, 403):
-        envelope = parse_json_body(response)
-        if isinstance(envelope.get("error"), str):
-            raise bad_request_exc(f"{idp} rejected token request: {envelope['error']}")
+        error_code = parse_json_body(response).get("error")
+        if isinstance(error_code, str) and error_code.lower() in _PERMANENT_TOKEN_ERRORS:
+            raise bad_request_exc(f"{idp} rejected token request: {error_code}")
     if response.status_code != 200:
         raise ProviderError(f"{endpoint} returned {response.status_code}: {response.text[:200]!r}")
     payload = parse_json_body(response)

--- a/plugins/dashboard_auth/_shared.py
+++ b/plugins/dashboard_auth/_shared.py
@@ -135,9 +135,15 @@ def exchange_token(
 
     A 400 (OAuth-shaped error envelope) raises ``bad_request_exc`` — ``InvalidCodeError``
     for the auth-code path, ``RefreshExpiredError`` for refresh — so the middleware's
-    distinct handling is preserved. Any other non-200, transport failure, missing
-    ``token_key`` or non-bearer ``token_type`` raises ``ProviderError``. Redirects are
-    deliberately NOT followed: the body carries an auth code / refresh token.
+    distinct handling is preserved. A 401/403 *with* an OAuth error envelope is also a
+    credential verdict (the IDP understood the request and refused it: dead/foreign
+    token) and raises ``bad_request_exc`` — reporting it as ``ProviderError`` (503,
+    "transient") invites unbounded client retries against a token that can never
+    succeed (#98338). A 401/403 *without* an envelope stays ``ProviderError``: it may
+    be a WAF/proxy block, never a signal to force re-login. Any other non-200,
+    transport failure, missing ``token_key`` or non-bearer ``token_type`` raises
+    ``ProviderError``. Redirects are deliberately NOT followed: the body carries an
+    auth code / refresh token.
     """
     try:
         response = httpx.post(url, data=data, headers={**JSON_HEADERS, **(headers or {})}, timeout=TOKEN_ENDPOINT_TIMEOUT_SEC)
@@ -146,6 +152,10 @@ def exchange_token(
     if response.status_code == 400:
         error_code = parse_json_body(response).get("error", "invalid_request")
         raise bad_request_exc(f"{idp} rejected token request: {error_code}")
+    if response.status_code in (401, 403):
+        envelope = parse_json_body(response)
+        if isinstance(envelope.get("error"), str):
+            raise bad_request_exc(f"{idp} rejected token request: {envelope['error']}")
     if response.status_code != 200:
         raise ProviderError(f"{endpoint} returned {response.status_code}: {response.text[:200]!r}")
     payload = parse_json_body(response)

--- a/tests/hermes_cli/test_dashboard_auth_native_refresh_policy.py
+++ b/tests/hermes_cli/test_dashboard_auth_native_refresh_policy.py
@@ -1,0 +1,178 @@
+"""Refresh retry policy for the RFC 8252 native-app refresh path (Refs #98338).
+
+Defects 2–3: ``POST /auth/native/refresh`` fanned every inbound attempt out to
+the Portal token endpoint with no classification and no throttle — a dead
+refresh token rejected with 403 was reported as ``ProviderError`` (503,
+"transient"), so the client kept retrying at up to 3 req/s for 17h45m.
+
+Contract pinned here:
+  * a 401/403 carrying an OAuth error envelope is a *permanent* credential
+    rejection (``bad_request_exc`` — ``RefreshExpiredError`` on refresh), so a
+    dead token answers 401 ``session_expired`` instead of 503;
+  * a 401/403 *without* an envelope stays ``ProviderError`` (may be a WAF /
+    proxy, transient — never force a re-login on an ambiguous signal);
+  * 429 / 5xx / transport failures stay ``ProviderError`` (transient);
+  * inbound attempts are throttled per credential-hash (never per IP — NAT
+    households share IPs, see #98338 request #6), answering 429 with
+    ``Retry-After`` once over budget so one looping client cannot storm Portal.
+
+Run: scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_native_refresh_policy.py
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from hermes_cli import web_server
+from hermes_cli.dashboard_auth import (
+    clear_providers,
+    register_provider,
+)
+from hermes_cli.dashboard_auth import native_flow
+from hermes_cli.dashboard_auth.base import ProviderError, RefreshExpiredError
+from hermes_cli.dashboard_auth.routes import _reset_native_refresh_rate_limit
+from plugins.dashboard_auth._shared import exchange_token
+from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+
+
+def _mock_post(status_code: int, body, *, ctype: str = "application/json"):
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    if isinstance(body, dict):
+        resp.text = json.dumps(body)
+        resp.json = MagicMock(return_value=body)
+    else:
+        resp.text = body
+        resp.json = MagicMock(side_effect=ValueError("not json"))
+    resp.headers = {"content-type": ctype}
+    return resp
+
+
+def _exchange(status_code: int, body, **kwargs):
+    with patch(
+        "plugins.dashboard_auth._shared.httpx.post",
+        return_value=_mock_post(status_code, body, **kwargs),
+    ):
+        return exchange_token(
+            "https://portal.example.test/api/oauth/token",
+            {"grant_type": "refresh_token"},
+            bad_request_exc=RefreshExpiredError,
+            idp="Portal",
+            endpoint="Portal token endpoint",
+            token_key="access_token",
+            missing_msg="missing access_token",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Rejection classification (Defect 2 root cause)
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshRejectionClassification:
+    def test_403_with_oauth_envelope_is_permanent_rejection(self):
+        with pytest.raises(RefreshExpiredError):
+            _exchange(403, {"error": "invalid_grant"})
+
+    def test_401_with_oauth_envelope_is_permanent_rejection(self):
+        with pytest.raises(RefreshExpiredError):
+            _exchange(401, {"error": "invalid_token"})
+
+    def test_403_without_envelope_stays_transient(self):
+        # No JSON envelope: may be a WAF/proxy block, not a credential
+        # verdict — must not force a re-login on an ambiguous signal.
+        with pytest.raises(ProviderError):
+            _exchange(403, "<html>blocked</html>", ctype="text/html")
+
+    def test_429_and_500_stay_transient(self):
+        with pytest.raises(ProviderError):
+            _exchange(429, {"error": "rate_limited"})
+        with pytest.raises(ProviderError):
+            _exchange(500, {"error": "server_error"})
+
+
+# ---------------------------------------------------------------------------
+# Per-credential inbound throttle (Defect 2 storm stop)
+# ---------------------------------------------------------------------------
+
+
+class _CountingStubProvider(StubAuthProvider):
+    """Stub that counts refresh attempts so tests can prove Portal fan-out
+    stays bounded under a retry storm."""
+
+    def __init__(self):
+        super().__init__()
+        self.refresh_calls = 0
+
+    def refresh_session(self, *, refresh_token: str):
+        self.refresh_calls += 1
+        return super().refresh_session(refresh_token=refresh_token)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    native_flow._reset_for_tests()
+    _reset_native_refresh_rate_limit()
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    yield
+    native_flow._reset_for_tests()
+    _reset_native_refresh_rate_limit()
+    clear_providers()
+    web_server.app.state.auth_required = prev_required
+    web_server.app.state.bound_host = prev_host
+    web_server.app.state.bound_port = prev_port
+
+
+@pytest.fixture
+def storm_client():
+    provider = _CountingStubProvider()
+    clear_providers()
+    register_provider(provider)
+    web_server.app.state.bound_host = "fly-app.fly.dev"
+    web_server.app.state.bound_port = 443
+    web_server.app.state.auth_required = True
+    client = TestClient(
+        web_server.app, base_url="https://fly-app.fly.dev", follow_redirects=False
+    )
+    yield client, provider
+    clear_providers()
+
+
+class TestNativeRefreshThrottle:
+    def test_storm_from_one_credential_is_capped_with_429(self, storm_client):
+        client, provider = storm_client
+        last = None
+        for _ in range(25):
+            last = client.post(
+                "/auth/native/refresh",
+                json={"refresh_token": "dead-token-same", "provider": "stub"},
+            )
+        assert last is not None
+        assert last.status_code == 429
+        assert last.json()["error"] == "rate_limited"
+        assert int(last.headers["retry-after"]) > 0
+        # Portal fan-out stays at the budget: the storm never reaches providers.
+        assert provider.refresh_calls <= 10
+
+    def test_distinct_credential_unaffected_by_storm(self, storm_client):
+        client, provider = storm_client
+        for _ in range(25):
+            client.post(
+                "/auth/native/refresh",
+                json={"refresh_token": "dead-token-same", "provider": "stub"},
+            )
+        r = client.post(
+            "/auth/native/refresh",
+            json={"refresh_token": "other-dead-token", "provider": "stub"},
+        )
+        # A different credential is a different bucket: rejected on its own
+        # merits (401, dead token), not throttled by the first storm.
+        assert r.status_code == 401
+        assert r.json()["error"] == "session_expired"

--- a/tests/hermes_cli/test_dashboard_auth_native_refresh_policy.py
+++ b/tests/hermes_cli/test_dashboard_auth_native_refresh_policy.py
@@ -35,7 +35,12 @@ from hermes_cli.dashboard_auth import (
 )
 from hermes_cli.dashboard_auth import native_flow
 from hermes_cli.dashboard_auth.base import ProviderError, RefreshExpiredError
-from hermes_cli.dashboard_auth.routes import _reset_native_refresh_rate_limit
+from hermes_cli.dashboard_auth.routes import (
+    _REFRESH_RATE_MAX_BUCKETS,
+    _native_refresh_rate_limited,
+    _refresh_attempts,
+    _reset_native_refresh_rate_limit,
+)
 from plugins.dashboard_auth._shared import exchange_token
 from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
 
@@ -83,11 +88,17 @@ class TestRefreshRejectionClassification:
         with pytest.raises(RefreshExpiredError):
             _exchange(401, {"error": "invalid_token"})
 
-    def test_403_without_envelope_stays_transient(self):
-        # No JSON envelope: may be a WAF/proxy block, not a credential
-        # verdict — must not force a re-login on an ambiguous signal.
+    def test_403_with_unknown_envelope_code_stays_transient(self):
+        # A WAF/proxy JSON envelope without a known token-rejection code must
+        # not force a re-login — nor may a non-JSON block page.
+        with pytest.raises(ProviderError):
+            _exchange(403, {"error": "forbidden"})
         with pytest.raises(ProviderError):
             _exchange(403, "<html>blocked</html>", ctype="text/html")
+
+    def test_rejection_code_match_is_case_insensitive(self):
+        with pytest.raises(RefreshExpiredError):
+            _exchange(403, {"error": "Invalid_Grant"})
 
     def test_429_and_500_stay_transient(self):
         with pytest.raises(ProviderError):
@@ -176,3 +187,12 @@ class TestNativeRefreshThrottle:
         # merits (401, dead token), not throttled by the first storm.
         assert r.status_code == 401
         assert r.json()["error"] == "session_expired"
+
+    def test_bucket_table_stays_bounded(self):
+        # Token-rotation abuse must not grow the bucket table without limit.
+        for i in range(_REFRESH_RATE_MAX_BUCKETS + 500):
+            _native_refresh_rate_limited(f"rotated-token-{i}")
+        assert len(_refresh_attempts) <= _REFRESH_RATE_MAX_BUCKETS + 1
+        # The limiter still works after pruning.
+        limited, _ = _native_refresh_rate_limited("fresh-token-after-prune")
+        assert limited is False


### PR DESCRIPTION
## Summary

Refs #98338 (Defects 2-3, partial scope — other defects/requests intentionally out of scope).

Two coupled fixes on the native-refresh retry policy, the mechanism behind the 17h45m / 3,338-rejection storm:

- **Rejection classification** (`plugins/dashboard_auth/_shared.py::exchange_token`): every non-400 used to map to `ProviderError`, so a dead token rejected with 403 answered 503 'transient' and clients retried unbounded. A 401/403 carrying a known OAuth token-rejection code (`invalid_grant` / `invalid_token` / `expired_token`, case-insensitive) is now a permanent credential verdict (`bad_request_exc` — `RefreshExpiredError` on refresh → 401 `session_expired`). Any other 401/403 stays `ProviderError`: it may be a WAF/proxy block, never a signal to force re-login.
- **Per-credential inbound throttle** (`hermes_cli/dashboard_auth/routes.py::auth_native_refresh`): sliding-window (10/min, same shape as the existing `_password_rate_limited`) keyed by SHA-256 of the presented token — never by IP (NAT households share IPs, see issue request #6). Over budget → 429 + `Retry-After` + `REFRESH_FAILURE(reason=rate_limited)` audit, before any provider fan-out. Bucket table capped at 4096 (expired-then-oldest prune); raw tokens never stored.

## Test Plan

- [x] New: `tests/hermes_cli/test_dashboard_auth_native_refresh_policy.py` — 8 tests (rejection classes, storm capped at budget with 429 + Retry-After, distinct credential unaffected, bucket table bounded).
- [x] Sabotage-verified: classification tests fail on pre-fix `exchange_token`; storm test fails with the throttle wiring neutered; allowlist/cap tests fail with the hardening reverted.
- [x] Siblings green: native_flow, password_login, audit, middleware, nous/self_hosted/basic/drain provider suites. `test_dashboard_auth_gate.py` has 4 failures identical on clean `origin/main` (pre-existing, unrelated).
- [x] `ruff check` clean on all touched files (whole-file `ruff format` drift is pre-existing — left untouched).

```
scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_native_refresh_policy.py
```

## Risk

- A Portal 403 with a *non-allowlisted* JSON error code stays 503/transient (fail-safe toward retry, per #102455's WAF principle). Precision over recall by design.
- Aggressive-but-legit clients (many tabs, one RT) share the 10/min/credential budget — generous against real refresh cadences (hours), binding only under storms.

## Exclusions / follow-ups

- **Middleware cookie flow explicitly out of scope**: single pass per provider, browser-present, no storm exposure (audited).
- **Token-rotation evasion** (fresh garbage token per attempt = fresh bucket) is a known limitation of any per-credential throttle — belongs to the upcoming per-credential circuit-breaker PR, which adds per-IP storm detection.
- **Defect 1** (dual-logging) covered by fresh #98342 / #98417-neighbour #98344 — no competing PR opened.
- Doctor coverage (Defect 4) follows as its own PR.

Refs #98338
