### PR TITLE
fix(desktop): Terminal pane opens on remote SSH backends — pool lookups use the key the tunnel was published under (#99666, #95472, #97345; salvage #95473 + #97356)

### DIFF
--- a/apps/desktop/electron/desktop-remote-route.test.ts
+++ b/apps/desktop/electron/desktop-remote-route.test.ts
@@ -3,7 +3,8 @@ import assert from 'node:assert/strict'
 import { test } from 'vitest'
 
 import { normalizeRegistry, REGISTRY_VERSION } from './connection-registry'
-import { resolveDesktopRemoteRoute } from './desktop-remote-route'
+import { backendScopeKey } from './connection-registry'
+import { resolveDesktopRemoteRoute, v1SshTerminalPoolKey } from './desktop-remote-route'
 
 const tokenA = { encoding: 'plain', value: 'token-a' }
 const tokenB = { encoding: 'plain', value: 'token-b' }
@@ -151,6 +152,46 @@ test('global SSH treats an omitted port as 22 and checks the primary route', () 
 
   assert.equal(route?.kind, 'ssh')
   assert.equal(route?.connectionId, 'ssh-primary')
+})
+
+test('v1 settings SSH pool key ignores registry identity tags', () => {
+  const route = resolveDesktopRemoteRoute({
+    config: { mode: 'ssh', remote: { mode: 'ssh', host: 'box.test', user: 'hermes' } },
+    profile: 'worker',
+    registry: registry('ssh-primary', [
+      { id: 'ssh-primary', kind: 'ssh', label: 'SSH primary', host: 'box.test', user: 'hermes', port: 22 }
+    ])
+  })
+
+  assert.ok(route)
+  assert.equal(route.kind, 'ssh')
+  assert.equal(route.connectionId, 'ssh-primary')
+  assert.equal(v1SshTerminalPoolKey(route, 'worker'), '')
+  assert.notEqual(v1SshTerminalPoolKey(route, 'worker'), backendScopeKey(route.connectionId, 'worker'))
+})
+
+test('v1 profile SSH pool key is the profile, not conn:id::profile', () => {
+  const ssh = {
+    mode: 'ssh',
+    host: 'box.test',
+    user: 'hermes',
+    port: 2222,
+    keyPath: '/keys/a',
+    remoteHermesPath: '/srv/hermes',
+    remoteProfile: 'worker'
+  }
+
+  const route = resolveDesktopRemoteRoute({
+    config: { mode: 'local', profiles: { worker: ssh } },
+    profile: 'worker',
+    registry: registry('local', [{ id: 'worker-ssh', kind: 'ssh', label: 'Worker SSH', ...ssh }])
+  })
+
+  assert.ok(route)
+  assert.equal(route.kind, 'ssh')
+  assert.equal(route.connectionId, 'worker-ssh')
+  assert.equal(v1SshTerminalPoolKey(route, 'worker'), 'worker')
+  assert.notEqual(v1SshTerminalPoolKey(route, 'worker'), backendScopeKey(route.connectionId, 'worker'))
 })
 
 test('profile route omits identity when two registry entries match exactly', () => {

--- a/apps/desktop/electron/desktop-remote-route.ts
+++ b/apps/desktop/electron/desktop-remote-route.ts
@@ -52,6 +52,22 @@ function withConnectionId<T extends object>(route: T, connectionId?: string): T 
 }
 
 /**
+ * Pool key used by v1 settings/profile SSH (`sshConnections`).
+ *
+ * Bootstrap stores the tunnel under sshScopeKey(profile or null).
+ * resolveDesktopRemoteRoute may also stamp a registry connectionId when
+ * the host matches a v2 row. That id is identity, not the pool key.
+ * Looking up backendScopeKey(connectionId, profile) misses the live tunnel.
+ */
+export function v1SshTerminalPoolKey(route: { source: string }, profile?: null | string): string {
+  if (route.source === 'profile') {
+    return connectionScopeKey(profile) || ''
+  }
+
+  return ''
+}
+
+/**
  * Select one remote route with the existing precedence and freeze any exact
  * registry identity before I/O. A null result means the profile resolves
  * locally. Invalid dial data remains the dialler's error, except the existing

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -411,7 +411,11 @@ import { isHermesOwnedVenvDaemon } from './venv-holder-select'
 import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-marketplace'
 import { createWakeIndicatorWindowController } from './wake-indicator-window'
 import { enumerateWindowsFrontToBack, enumerationFailed, readWindowBelow } from './window-below'
-import { registrySshScopeForWindowRoute, WindowConnectionRouteRegistry } from './window-connection-route'
+import {
+  registrySshPoolScopeByConnectionId,
+  registrySshScopeForWindowRoute,
+  WindowConnectionRouteRegistry
+} from './window-connection-route'
 import { createWindowOpenHandler } from './window-open-policy'
 import { installWindowRendererLifecycle } from './window-renderer-lifecycle'
 import { createWindowRevealController } from './window-reveal'
@@ -10315,7 +10319,18 @@ function activeSshTerminalTarget(webContentsId?: number) {
 
     const state = sshConnections.get(scope)
 
-    return state && state.ssh ? { ssh: state.ssh, scope } : 'pending'
+    if (state && state.ssh) {
+      return { ssh: state.ssh, scope }
+    }
+
+    // The pool's single writer publishes under the per-profile bootstrap key
+    // while stamping the entry with its registry connection id (#97345), so a
+    // composite-key miss must still resolve the live tunnel by that identity
+    // instead of reporting 'pending' forever.
+    const pooledScope = registrySshPoolScopeByConnectionId(sshConnections, windowRoute.connectionId)
+    const pooledState = pooledScope === null ? null : sshConnections.get(pooledScope)
+
+    return pooledState && pooledState.ssh ? { ssh: pooledState.ssh, scope: pooledScope } : 'pending'
   }
 
   const profile = windowRoute?.profile ?? primaryProfileKey()

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -158,7 +158,7 @@ import { describeCrashReason, installCrashForensics } from './crash-forensics'
 import { adoptServedDashboardToken } from './dashboard-token'
 import { loadOrCreateInstallationId, sshOwnershipId } from './desktop-installation'
 import { formatDesktopLogLine } from './desktop-log-line'
-import { resolveDesktopRemoteRoute } from './desktop-remote-route'
+import { resolveDesktopRemoteRoute, v1SshTerminalPoolKey } from './desktop-remote-route'
 import {
   buildPosixCleanupScript,
   buildWindowsCleanupScript,
@@ -10335,9 +10335,7 @@ function activeSshTerminalTarget(webContentsId?: number) {
     return null
   }
 
-  const scope = route.connectionId
-    ? backendScopeKey(route.connectionId, profile)
-    : sshScopeKey(route.source === 'profile' ? profile : null)
+  const scope = v1SshTerminalPoolKey(route, profile)
 
   const state = sshConnections.get(scope)
 

--- a/apps/desktop/electron/window-connection-route.test.ts
+++ b/apps/desktop/electron/window-connection-route.test.ts
@@ -4,6 +4,7 @@ import { test } from 'vitest'
 
 import {
   normalizeWindowConnectionRoute,
+  registrySshPoolScopeByConnectionId,
   registrySshScopeForWindowRoute,
   WindowConnectionRouteRegistry
 } from './window-connection-route'
@@ -119,4 +120,21 @@ test('uses the canonical default profile scope when a registry SSH route has no 
     ),
     'conn:source-b::default'
   )
+})
+
+test('recovers the bootstrap pool key a registry SSH tunnel was published under', () => {
+  const pool = new Map<string, any>([['', { registryConnectionId: 'source-b', ssh: { alive: true } }]])
+
+  assert.equal(registrySshPoolScopeByConnectionId(pool, 'source-b'), '')
+})
+
+test('does not match another connection, an unlabelled entry, or a torn-down tunnel', () => {
+  const pool = new Map<string, any>([
+    ['research', { registryConnectionId: 'source-a', ssh: { alive: true } }],
+    ['', { registryConnectionId: '', ssh: { alive: true } }],
+    ['worker', { registryConnectionId: 'source-b' }]
+  ])
+
+  assert.equal(registrySshPoolScopeByConnectionId(pool, 'source-b'), null)
+  assert.equal(registrySshPoolScopeByConnectionId(pool, 'source-c'), null)
 })

--- a/apps/desktop/electron/window-connection-route.ts
+++ b/apps/desktop/electron/window-connection-route.ts
@@ -40,6 +40,30 @@ export function registrySshScopeForWindowRoute(
   return backendScopeKey(route.connectionId, route.profile)
 }
 
+export interface RegistrySshPoolEntry {
+  registryConnectionId?: null | string
+  ssh?: unknown
+}
+
+// The sshConnections pool has a single writer that publishes every tunnel under
+// its per-profile bootstrap key while stamping the entry with the registry
+// connection that owns it. A registry-scoped lookup under the composite
+// backendScopeKey can therefore miss a live tunnel; this recovers the writer's
+// actual key from the stamped identity, the same match managedSshScopeRole
+// applies to pool entries.
+export function registrySshPoolScopeByConnectionId(
+  entries: Iterable<readonly [string, RegistrySshPoolEntry | undefined]>,
+  connectionId: string
+): null | string {
+  for (const [scope, entry] of entries) {
+    if (entry?.ssh && entry.registryConnectionId === connectionId) {
+      return scope
+    }
+  }
+
+  return null
+}
+
 export class WindowConnectionRouteRegistry {
   private readonly routes = new Map<number, WindowConnectionRoute>()
 


### PR DESCRIPTION
The Desktop Terminal pane opens on a remote SSH backend again. Both lookup branches of `activeSshTerminalTarget()` read the SSH pool under a key the pool's writer never uses, so the pane stayed at "Remote connection is not ready yet. Try again in a moment." forever while chat, sessions and profiles worked fine over the same tunnel.

Two complementary salvages, cherry-picked with authorship preserved: #95473 by @Adolanium (legacy/v1 route) and #97356 by @liuhao1024 (v2 registry route). Fixes #99666, #95472, #97345.

## Root cause

`bootstrapSshConnectionInner` publishes every tunnel under `sshScopeKey(profile)` — `''` for a registry/settings-sourced connection, the profile name for a profile-sourced one — and stamps the entry with `registryConnectionId`. The terminal reader looked up:

- v1 route: `backendScopeKey(route.connectionId, profile)` = `conn:<id>::<profile>` whenever the route carried a registry id (any `connections.json` row matching the settings host does), so the lookup missed.
- v2 route: `registrySshScopeForWindowRoute()` = the same composite key; same miss.

Probe on main for a primary SSH connection with a live tunnel: `v1 finds tunnel: false, v2 finds tunnel: false`. On this branch: both `true`.

## Change

- `desktop-remote-route.ts::v1SshTerminalPoolKey(route, profile)` — the writer's key for a v1 route (`profile` when sourced from a profile, else `''`), used by the v1 branch.
- `window-connection-route.ts::registrySshPoolScopeByConnectionId(pool, id)` — on a composite-key miss, recover the writer's actual key from the stamped `registryConnectionId` (the same identity `managedSshScopeRole` matches on).
- 4 tests across the two contributor commits, all invariant-shaped (reader key == writer key; recovery by stamped id; no cross-connection / torn-down match). All red on `origin/main`.

## Validation

| Check | Result |
|---|---|
| `vitest run` desktop-remote-route / window-connection-route / terminal-ipc / connection-apply / connection-registry | 142 passed; the 4 new tests fail on main (2 + 2) |
| `tsc --noEmit -p tsconfig.electron.json` | 0 errors |
| `main-boot-smoke.sh` on the full branch (bundled Electron main boots with `HERMES_DESKTOP_BOOT_FAKE=1`) | OK |
| Key-resolution probe main vs branch (real `resolveDesktopRemoteRoute` + real helpers, pool seeded like the writer does) | main: both branches miss; branch: both resolve |
