### PR TITLE
fix(desktop): deny all permission requests from the OAuth/portal partitions

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -412,7 +412,7 @@ import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-market
 import { createWakeIndicatorWindowController } from './wake-indicator-window'
 import { enumerateWindowsFrontToBack, enumerationFailed, readWindowBelow } from './window-below'
 import { registrySshScopeForWindowRoute, WindowConnectionRouteRegistry } from './window-connection-route'
-import { createWindowOpenHandler } from './window-open-policy'
+import { createWindowOpenHandler, guardAuthSessionPermissions } from './window-open-policy'
 import { installWindowRendererLifecycle } from './window-renderer-lifecycle'
 import { createWindowRevealController } from './window-reveal'
 import {
@@ -7308,6 +7308,11 @@ function getOauthSession() {
 
   oauthSession = session.fromPartition(OAUTH_SESSION_PARTITION)
 
+  // No permission is ever legitimate for completing sign-in; remote IDP/portal
+  // content must not be able to request notifications/geolocation/etc. from
+  // the auth windows (installMediaPermissions covers only defaultSession).
+  guardAuthSessionPermissions(oauthSession, 'oauth', rememberLog)
+
   return oauthSession
 }
 
@@ -7346,6 +7351,9 @@ function getOauthSessionForUrl(url) {
 
   if (!sess) {
     sess = session.fromPartition(partition)
+    // Per-connection OAuth jars get the same deny-all permission guard as
+    // the legacy shared partition — their windows are sign-in-only too.
+    guardAuthSessionPermissions(sess, `oauth:${partition}`, rememberLog)
     oauthSessionsByPartition.set(partition, sess)
   }
 

--- a/apps/desktop/electron/window-open-policy.ts
+++ b/apps/desktop/electron/window-open-policy.ts
@@ -56,3 +56,50 @@ export function createWindowOpenHandler(
     return { action: 'deny' }
   }
 }
+
+/**
+ * Deny EVERY permission request from the OAuth/portal auth partitions.
+ *
+ * `installMediaPermissions` wires a permission request/check handler ONLY on
+ * `session.defaultSession` (a media-capture-only allowlist for voice
+ * conversations). The auth partitions get Chromium's default behavior, in
+ * which remote IDP/portal content in the auth windows can request and
+ * receive notifications, geolocation, midi, clipboard-read, and more —
+ * permission prompts from a sign-in flow the user never sanctioned.
+ *
+ * No permission is ever legitimate for completing sign-in (every consumer is
+ * a cookie read after a navigation), so deny-all is the correct policy —
+ * stricter than the default session's media-only allowlist.
+ */
+export function guardAuthSessionPermissions(
+  partitionSession: {
+    setPermissionRequestHandler: (
+      handler: (webContents: unknown, permission: string, callback: (granted: boolean) => void, details: unknown) => void
+    ) => void
+    setPermissionCheckHandler?: (handler: (webContents: unknown, permission: string) => boolean) => void
+  },
+  label: string,
+  log?: (line: string) => void
+): void {
+  const deny = (permission: string) => {
+    log?.(`[auth-permission] ${label} denied: ${permission}`)
+  }
+
+  try {
+    partitionSession.setPermissionRequestHandler((_webContents, permission, callback) => {
+      deny(permission)
+      callback(false)
+    })
+
+    // Synchronous check handler: Chromium consults it directly on some
+    // platforms (e.g. getUserMedia on Windows); without it the check would
+    // consult the request handler's default and grant.
+    partitionSession.setPermissionCheckHandler?.((_webContents, permission) => {
+      deny(permission)
+
+      return false
+    })
+  } catch {
+    // best-effort; degraded environments must not take sign-in down
+  }
+}

--- a/tests-js/auth-partition-permissions.test.ts
+++ b/tests-js/auth-partition-permissions.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Security regression for the OAuth/portal partition permission guard:
+ * `installMediaPermissions` wires permission handlers ONLY on
+ * `session.defaultSession` (media-capture-only allowlist). The auth
+ * partitions (legacy shared + per-connection jars of #92183) got Chromium's
+ * default behavior, in which remote IDP/portal content in the auth windows
+ * can request and receive notifications, geolocation, midi, clipboard-read,
+ * and more — permission prompts from a sign-in flow the user never
+ * sanctioned. No permission is ever legitimate for completing sign-in, so
+ * the guard denies everything, on both the request and check handlers.
+ */
+
+import assert from 'node:assert/strict'
+
+import { describe, test } from 'vitest'
+
+import { guardAuthSessionPermissions } from '../apps/desktop/electron/window-open-policy'
+
+function makeFakePartitionSession() {
+  const calls = {
+    requestHandlers: [] as Array<(wc: unknown, perm: string, cb: (granted: boolean) => void, details: unknown) => void>,
+    checkHandlers: [] as Array<(wc: unknown, perm: string) => boolean>,
+    logs: [] as string[]
+  }
+
+  const partitionSession = {
+    setPermissionRequestHandler(handler: (wc: unknown, perm: string, cb: (granted: boolean) => void, details: unknown) => void) {
+      calls.requestHandlers.push(handler)
+    },
+    setPermissionCheckHandler(handler: (wc: unknown, perm: string) => boolean) {
+      calls.checkHandlers.push(handler)
+    }
+  }
+
+  return { partitionSession, calls }
+}
+
+describe('auth partition permission guard', () => {
+  test('denies every permission on both the request and the check handler', () => {
+    const { partitionSession, calls } = makeFakePartitionSession()
+    const logs: string[] = []
+
+    guardAuthSessionPermissions(partitionSession, 'oauth:persist:custom-1', (line: string) => logs.push(line))
+
+    assert.equal(calls.requestHandlers.length, 1)
+    assert.equal(calls.checkHandlers.length, 1)
+
+    const request = calls.requestHandlers[0]
+    const check = calls.checkHandlers[0]
+
+    // Every permission a compromised IDP/portal page might request is denied
+    // through the request handler — including the ones the default session
+    // deliberately allows for voice conversations (media).
+    const permissions = [
+      'notifications',
+      'geolocation',
+      'midi',
+      'midiSysex',
+      'clipboard-read',
+      'media',
+      'fullscreen',
+      'pointerLock',
+      'openExternal'
+    ]
+
+    for (const permission of permissions) {
+      let granted: boolean | undefined
+      request(null, permission, (value: boolean) => {
+        granted = value
+      }, {})
+      assert.equal(granted, false, `request handler must deny ${permission}`)
+      assert.equal(check(null, permission), false, `check handler must deny ${permission}`)
+    }
+
+    // The deny log carries the partition label and the permission name.
+    assert.ok(logs.length >= permissions.length)
+    assert.ok(logs.every(line => line.startsWith('[auth-permission] oauth:persist:custom-1 denied: ')))
+  })
+
+  test('a partition without a check handler installs only the request handler', () => {
+    // Not every Electron version surfaces setPermissionCheckHandler on
+    // partitions; the guard must not throw when it is absent.
+    const calls = { requestHandlers: [] as Array<(wc: unknown, perm: string, cb: (granted: boolean) => void) => void> }
+
+    const partitionSession = {
+      setPermissionRequestHandler(handler: (wc: unknown, perm: string, cb: (granted: boolean) => void) => void) {
+        calls.requestHandlers.push(handler)
+      }
+    }
+
+    assert.doesNotThrow(() => guardAuthSessionPermissions(partitionSession, 'oauth'))
+
+    let granted: boolean | undefined
+    calls.requestHandlers[0](null, 'geolocation', (value: boolean) => {
+      granted = value
+    })
+    assert.equal(granted, false)
+  })
+
+  test('a throwing session emitter is a no-op', () => {
+    // Degraded environments: a destroyed session emitter must not take the
+    // whole sign-in flow down with it.
+    assert.doesNotThrow(() =>
+      guardAuthSessionPermissions(
+        {
+          setPermissionRequestHandler() {
+            throw new Error('Object has been destroyed')
+          }
+        },
+        'oauth'
+      )
+    )
+  })
+})


### PR DESCRIPTION
## Summary

`installMediaPermissions` wires a permission request handler and a permission check handler **only on `session.defaultSession`** — a media-capture-only allowlist for voice conversations. The OAuth/portal **auth partitions** (the legacy shared partition plus the per-connection jars of #92183) get Chromium's **default behavior**, in which remote IDP/portal content loaded by the auth windows can request and receive `notifications`, `geolocation`, `midi`, `clipboard-read`, and more — **permission prompts from a sign-in flow the user never sanctioned**.

## Fix

No permission is ever legitimate for completing sign-in: every consumer of these partitions is a cookie read (`hasOauthSessionCookie`, `hasLivePortalSession`, `hasPortalAccessToken`) after a navigation.

New `guardAuthSessionPermissions(session, label, log)` in `window-open-policy.ts` denies every permission on **both** handlers, wired at **both** partition creation sites:

- `getOauthSession()` — legacy shared partition
- `getOauthSessionForUrl()` — per-connection jars (#92183)

| Handler | Purpose |
|---|---|
| `setPermissionRequestHandler` | the prompt-style path most platforms take |
| `setPermissionCheckHandler` | the synchronous path Chromium consults on some platforms (e.g. `getUserMedia` on Windows); without it the check consults the default and grants |

The check handler installs best-effort (optional chaining) so partitions that don't surface it on some Electron versions keep the request-handler deny; a destroyed session emitter is a no-op so degraded environments never lose sign-in. Deny log lines carry the partition label (`[auth-permission] oauth:persist:custom-1 denied: geolocation`).

## Tests

New file `tests-js/auth-partition-permissions.test.ts` (3 tests, real policy module, fake partition session):

1. Denies every permission (`notifications`, `geolocation`, `midi`, `midiSysex`, `clipboard-read`, `media`, `fullscreen`, `pointerLock`, `openExternal`) on both handlers — including `media`, which the default session deliberately allows for voice conversations — with the label + permission name in the deny log
2. A partition without `setPermissionCheckHandler` still installs the request-handler deny
3. A throwing session emitter is a no-op (degraded environments must not lose sign-in)

## Verification

- `vitest run auth-partition-permissions.test.ts window-open-policy.test.ts`: **5/5 passed**
- `tsc -p tsconfig.electron.json --noEmit`: **clean**
- `eslint electron/window-open-policy.ts`: **clean**

Third arm of the auth-window remote-content hardening, companions: #103610 (window-open deny) and #103630 (download cancellation) — this PR closes the permission side of the same exposure.