### PR TITLE
fix(state): exclude the cjk index family from the legacy FTS demote rename

### DIFF
--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -546,9 +546,11 @@ class SessionSearchMixin:
                     "AND (name LIKE 'messages_fts_%' ESCAPE '\\' "
                     "OR name LIKE 'messages_fts_trigram_%' ESCAPE '\\') "
                     # messages_fts_cjk* is an independent v23+ index, not part of the
-                    # demoted legacy layout: renaming it (or its shadow tables) breaks
-                    # the vtable constructor chain (#103647).
-                    "AND name NOT LIKE 'messages_fts_cjk%'"
+                    # demoted legacy layout: fts5's xRename renames the entire shadow
+                    # family in one step, so sweeping the cjk vtable here aborts the
+                    # loop on the next cjk shadow entry and drags _config — needed by
+                    # the vtable constructor — into the trash family (#103647).
+                    "AND name NOT LIKE 'messages\\_fts\\_cjk%' ESCAPE '\\'"
                 ).fetchall():
                     conn.execute(f"ALTER TABLE {row[0]} RENAME TO fts_v22_trash_{row[0]}")
             # Claim the backfill BEFORE the empty v23 tables exist so a crash before

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -544,7 +544,11 @@ class SessionSearchMixin:
                 for row in conn.execute(
                     "SELECT name FROM sqlite_master WHERE type = 'table' "
                     "AND (name LIKE 'messages_fts_%' ESCAPE '\\' "
-                    "OR name LIKE 'messages_fts_trigram_%' ESCAPE '\\')"
+                    "OR name LIKE 'messages_fts_trigram_%' ESCAPE '\\') "
+                    # messages_fts_cjk* is an independent v23+ index, not part of the
+                    # demoted legacy layout: renaming it (or its shadow tables) breaks
+                    # the vtable constructor chain (#103647).
+                    "AND name NOT LIKE 'messages_fts_cjk%'"
                 ).fetchall():
                     conn.execute(f"ALTER TABLE {row[0]} RENAME TO fts_v22_trash_{row[0]}")
             # Claim the backfill BEFORE the empty v23 tables exist so a crash before

--- a/tests/test_fts_cjk_bigram.py
+++ b/tests/test_fts_cjk_bigram.py
@@ -212,6 +212,85 @@ def test_legacy_v22_optimize_lands_on_cjk(cjk_so, tmp_path, monkeypatch):
         d.close()
 
 
+def test_optimize_demote_leaves_established_cjk_index_intact(cjk_so, tmp_path, monkeypatch):
+    """#103647: a legacy inline-FTS DB that ALSO carries an established (backfilled,
+    trigger-live) messages_fts_cjk index must demote without touching the cjk family.
+    The demote enumeration matches 'messages_fts_%', which sweeps the cjk vtable and
+    its shadow tables into the fts_v22_trash_* renames; renaming them breaks the
+    vtable constructor chain ('vtable constructor failed: messages_fts_cjk') and
+    aborts optimize-storage on every CJK-enabled host before any space is reclaimed."""
+    import time as _time
+
+    from hermes_state_common import SCHEMA_SQL
+    from hermes_state_fts import FTS_CJK_TABLE_SQL, FTS_CJK_TRIGGER_SQL
+
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(cjk_so))
+    db_path = tmp_path / "state.db"
+
+    # Hand-build the coexistence shape: legacy inline FTS + a live cjk index.
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.enable_load_extension(True)
+        conn.load_extension(str(cjk_so))
+        conn.executescript(SCHEMA_SQL)
+        conn.executescript("""
+            DROP TABLE IF EXISTS messages_fts;
+            DROP TABLE IF EXISTS messages_fts_trigram;
+            DROP VIEW IF EXISTS messages_fts_trigram_src;
+            CREATE VIRTUAL TABLE messages_fts USING fts5(content);
+            CREATE TRIGGER messages_fts_insert AFTER INSERT ON messages BEGIN
+                INSERT INTO messages_fts(rowid, content) VALUES (new.id, COALESCE(new.content,''));
+            END;
+        """)
+        # Established cjk index: tables + triggers, no backfill markers (complete).
+        conn.executescript(FTS_CJK_TABLE_SQL)
+        conn.executescript(FTS_CJK_TRIGGER_SQL)
+        conn.execute("DELETE FROM schema_version")
+        conn.execute("INSERT INTO schema_version (version) VALUES (10)")
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at) VALUES ('s1', 'cli', ?)",
+            (_time.time(),),
+        )
+        for role, content in (
+            ("user", "레거시 일본 메시지"),
+            ("assistant", "legacy english reply"),
+        ):
+            conn.execute(
+                "INSERT INTO messages (session_id, timestamp, role, content) "
+                "VALUES ('s1', ?, ?, ?)",
+                (_time.time(), role, content),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+    d = SessionDB(db_path=db_path)
+    try:
+        assert d.fts_optimize_available(), "legacy inline layout must be eligible"
+        assert d._fts_cjk_loaded
+        with d._lock:
+            cjk_triggers = d._conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' "
+                "AND name LIKE 'messages_fts_cjk_%'"
+            ).fetchone()[0]
+        assert cjk_triggers == 3, "cjk index is established and trigger-live"
+        result = d.optimize_fts_storage(vacuum=False)
+        assert result["ok"]
+        # The cjk index survives demote untouched: same tables, same service path.
+        assert d._fts_cjk_available
+        assert d.fts_cjk_rebuild_status() is None
+        assert d._describe_search_path("일본") == "fts_cjk"
+        assert d.search_messages("일본", limit=10)
+        with d._lock:
+            trash_cjk = d._conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master "
+                "WHERE name LIKE 'fts_v22_trash_messages_fts_cjk%'"
+            ).fetchone()[0]
+        assert trash_cjk == 0, "no cjk table may be renamed into the trash family"
+    finally:
+        d.close()
+
+
 def test_pure_latin_embedded_in_cjk_recovered_via_cjk_index(db):
     """#54242 residual: a pure-Latin query for a token embedded in CJK text
     (no whitespace) misses on unicode61; with the cjk index available the


### PR DESCRIPTION
## What does this PR do?

`hermes sessions optimize-storage` deterministically aborts on any DB that carries both a legacy inline FTS layout and an established (backfill-complete, trigger-live) `messages_fts_cjk` index: the demote stage's shadow-table enumeration matches `name LIKE 'messages_fts_%'`, which sweeps the `messages_fts_cjk` vtable and its shadow tables into the `fts_v22_trash_*` renames. Renaming the cjk vtable cascades to its shadow tables (including `messages_fts_cjk_config`, which the fts5 vtable constructor reads to restore its tokenizer), so the schema reload triggered by the rename fails with `vtable constructor failed: messages_fts_cjk` and the whole stage transaction rolls back — every re-run fails identically, making the documented ~60% space reclaim unreachable for CJK users.

The fix excludes the `messages_fts_cjk%` family from the demote enumeration. The cjk index is an independent v23+ structure, not part of the legacy v22-inline / v23-trigram layout being demoted, so the demote must not rename tables it doesn't own. This is the semantically scoped fix the issue reporter proposed as their preferred option; unlike loading the tokenizer on the demote connection, it also prevents the cjk index from being torn down as "trash" once the renames would succeed.

## Related Issue

Fixes #103647

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state_search.py` (`_demote_legacy_fts_to_trash` → `_stage`): add `AND name NOT LIKE 'messages_fts_cjk%'` to the shadow-table enumeration so the cjk vtable and its shadow tables stay outside the legacy demote renames (+ a comment stating the constraint).
- `tests/test_fts_cjk_bigram.py`: new regression test `test_optimize_demote_leaves_established_cjk_index_intact` that hand-builds the coexistence shape (legacy inline `messages_fts` + live `messages_fts_cjk` with its 3 triggers and no backfill markers) and asserts optimize completes, the cjk index keeps serving (`_describe_search_path` → `fts_cjk`), and no `fts_v22_trash_messages_fts_cjk*` table exists afterwards.

## How to Test

1. `pytest tests/test_fts_cjk_bigram.py::test_optimize_demote_leaves_established_cjk_index_intact -q` — on the parent commit it fails in `_stage` with `sqlite3.OperationalError: no such table: messages_fts_cjk_data` (the rename cascade consumes the pre-fetched shadow-table names; on the reporter's DB the same cascade surfaces as `vtable constructor failed: messages_fts_cjk`); with this PR it passes.
2. `pytest tests/test_fts_cjk_bigram.py tests/state/test_fts_trigram_cron_exclusion.py tests/test_wal_checkpoint_strategy.py tests/test_fts_update_of_narrowing.py -q` — Observed result: 36 passed.
3. `pytest tests/test_hermes_state.py -q` — Observed result: 259 passed, 2 skipped.
4. `ruff check hermes_state_search.py tests/test_fts_cjk_bigram.py` — Observed result: All checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6 (arm64), Python 3.11, SQLite 3.50.4

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

## Screenshots / Logs

Pre-fix failure (regression test on parent commit):

```
E               sqlite3.OperationalError: no such table: messages_fts_cjk_data
hermes_state_search.py:549: OperationalError
```

Post-fix: `1 passed in 6.29s` for the regression test; full `tests/test_hermes_state.py` green (259 passed, 2 skipped).
