### PR TITLE
feat(desktop): flag oversized chats with a red token figure + reset hint

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -21,6 +21,7 @@ import { middleClickHandlers } from '@/lib/middle-click'
 import { displayModelName } from '@/lib/model-status-label'
 import { sessionProjectLabel } from '@/lib/session-project-label'
 import { handoffOriginSource, sessionSourceLabel } from '@/lib/session-source'
+import { isLargeChat } from '@/lib/session-token-size'
 import { coarseElapsed } from '@/lib/time'
 import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
@@ -180,12 +181,17 @@ function SidebarSessionRowImpl({
   // tile opens or closes, and the boolean bails every unaffected row out.
   const openUnfocused = useStoreSelector($openStoredSessionIds, open => !isSelected && open.has(session.id))
   const totalTokens = session.input_tokens + session.output_tokens
+  // A chat past a full context window surfaces its token figure unbidden and in
+  // red (isLargeChat): the "start fresh" nudge has to reach a user who never
+  // turned the Tokens column on. When oversized it renders as its own red chip
+  // below, so the plain figure is suppressed here to avoid showing twice.
+  const oversized = isLargeChat(totalTokens)
   const cost = sessionCostUsd(session)
 
   // Tokens, cost and age share one figure rather than each claiming a column:
   // several switched on read as one number, not as a widening gutter.
   const figures = [
-    rowMeta.includes('tokens') && totalTokens > 0 ? compactNumber(totalTokens) : null,
+    rowMeta.includes('tokens') && totalTokens > 0 && !oversized ? compactNumber(totalTokens) : null,
     // Sub-cent spend rounds to "$0.00", which reads as a bug rather than as a
     // cheap session — below a cent the row says nothing at all.
     rowMeta.includes('cost') && cost >= 0.01 ? `$${cost.toFixed(2)}` : null
@@ -206,6 +212,27 @@ function SidebarSessionRowImpl({
 
   if (pr) {
     trailing.push({ key: 'pr', node: <PrTag pr={pr} /> })
+  }
+
+  // The red overflow figure: shown whenever a chat is oversized, independent of
+  // the Tokens column, so the warning reaches everyone. Its own chip (not a
+  // `figures` entry) so it can be red and carry the hover warning without
+  // recolouring the joined figure string. Placed before the figures/age slot so
+  // it reads left of the age.
+  if (oversized) {
+    trailing.push({
+      key: 'oversized',
+      node: (
+        <Tip label={r.largeChat} side="top">
+          <span
+            aria-label={r.largeChat}
+            className="pointer-events-auto whitespace-nowrap text-[0.625rem] font-medium leading-none text-destructive"
+          >
+            {compactNumber(totalTokens)}
+          </span>
+        </Tip>
+      )
+    })
   }
 
   const showAge = pinnedAge || card

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1811,6 +1811,7 @@ export const ar = defineLocale({
       waitingForAnswer: 'بانتظار إجابة',
       backgroundRunning: 'تعمل في الخلفية',
       draftSession: 'مسودة — لم تُرسل بعد',
+      largeChat: 'أصبحت هذه المحادثة كبيرة — بدء محادثة جديدة يبقي الردود سريعة وأقل تكلفة.',
       finishedUnread: 'اكتملت وفيها جديد',
       hideTabBar: 'إخفاء شريط التبويبات',
       openInNewTab: 'فتح في تبويب جديد',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2451,6 +2451,7 @@ export const en: Translations = {
       finishedUnread: 'Finished — unread',
       backgroundRunning: 'Background task running',
       draftSession: 'Draft — nothing sent yet',
+      largeChat: 'This chat is getting big — starting a fresh one keeps replies fast and cheaper.',
       handoffOrigin: platform => `Handed off from ${platform}`,
       ownedByProfile: profile => `Profile: ${profile}`,
       renamed: 'Renamed',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2117,6 +2117,7 @@ export const ja = defineLocale({
       finishedUnread: '完了 — 未読',
       backgroundRunning: 'バックグラウンドタスク実行中',
       draftSession: '下書き — 未送信',
+      largeChat: 'このチャットが大きくなってきました — 新しいチャットを始めると、応答が速く安いままになります。',
       handoffOrigin: platform => `${platform} から引き継ぎ`,
       ownedByProfile: profile => `プロファイル: ${profile}`,
       renamed: '名前を変更しました',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -2488,6 +2488,7 @@ export const ru = defineLocale({
       finishedUnread: 'Завершён — не прочитан',
       backgroundRunning: 'Фоновая задача выполняется',
       draftSession: 'Черновик — ещё ничего не отправлено',
+      largeChat: 'Этот чат становится большим — новый чат сохранит ответы быстрыми и дешёвыми.',
       handoffOrigin: platform => `Передано из ${platform}`,
       ownedByProfile: profile => `Профиль: ${profile}`,
       renamed: 'Переименовано',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2095,6 +2095,7 @@ export interface Translations {
       finishedUnread: string
       backgroundRunning: string
       draftSession: string
+      largeChat: string
       handoffOrigin: (platform: string) => string
       ownedByProfile: (profile: string) => string
       renamed: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2038,6 +2038,7 @@ export const zhHant = defineLocale({
       finishedUnread: '已完成 — 未讀',
       backgroundRunning: '背景任務執行中',
       draftSession: '草稿 — 尚未傳送',
+      largeChat: '此對話正在變大 — 新建一個對話能讓回覆保持又快又省。',
       handoffOrigin: platform => `從 ${platform} 轉接`,
       ownedByProfile: profile => `設定檔：${profile}`,
       renamed: '已重新命名',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2616,6 +2616,7 @@ export const zh: Translations = {
       finishedUnread: '已完成 — 未读',
       backgroundRunning: '后台任务运行中',
       draftSession: '草稿 — 尚未发送',
+      largeChat: '此对话正在变大 — 新建一个对话能让回复保持又快又省。',
       handoffOrigin: platform => `从 ${platform} 转接`,
       ownedByProfile: profile => `配置档：${profile}`,
       renamed: '已重命名',

--- a/apps/desktop/src/lib/session-token-size.test.ts
+++ b/apps/desktop/src/lib/session-token-size.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { isLargeChat, LARGE_CHAT_TOKENS } from './session-token-size'
+
+describe('isLargeChat', () => {
+  it('flags a chat at or above a full context window', () => {
+    expect(isLargeChat(LARGE_CHAT_TOKENS)).toBe(true)
+    expect(isLargeChat(LARGE_CHAT_TOKENS + 1)).toBe(true)
+    expect(isLargeChat(500_000)).toBe(true)
+  })
+
+  it('leaves a normal working chat alone', () => {
+    // The two sizes the feature was drawn from — busy, but the model is still
+    // comfortable — must NOT nag.
+    expect(isLargeChat(97_600)).toBe(false)
+    expect(isLargeChat(133_300)).toBe(false)
+    expect(isLargeChat(LARGE_CHAT_TOKENS - 1)).toBe(false)
+  })
+
+  it('degrades to "not large" for missing/empty/negative counts', () => {
+    expect(isLargeChat(0)).toBe(false)
+    expect(isLargeChat(undefined)).toBe(false)
+    expect(isLargeChat(null)).toBe(false)
+  })
+})

--- a/apps/desktop/src/lib/session-token-size.ts
+++ b/apps/desktop/src/lib/session-token-size.ts
@@ -1,0 +1,20 @@
+/**
+ * When a conversation's cumulative tokens (everything sent + everything
+ * generated, summed over the whole chat) cross a full model context window,
+ * every further turn re-reads the entire history: it is the slowest and most
+ * expensive the chat will ever be, and the model starts losing its earliest
+ * context. That is the point to start a fresh chat, so the sidebar surfaces the
+ * token figure — unbidden and in red — once a row crosses this line.
+ *
+ * 200k ≈ a full Claude context window. Deliberately NOT dollar-derived:
+ * per-session cost is 0 on subscription/OAuth auth, and the meaningful signal
+ * is "the model is full", which is a token count, not a price.
+ */
+export const LARGE_CHAT_TOKENS = 200_000
+
+/** True once a chat's total tokens cross {@link LARGE_CHAT_TOKENS}. Guards
+ *  against a missing/negative count so it degrades to "not large" rather than
+ *  throwing or false-flagging an empty row. */
+export function isLargeChat(totalTokens: null | number | undefined): boolean {
+  return typeof totalTokens === 'number' && totalTokens >= LARGE_CHAT_TOKENS
+}


### PR DESCRIPTION
## What this does

When a chat's **total tokens** (everything sent + everything generated, summed over the whole conversation) cross a full model context window (~200k), the sidebar row surfaces its token figure **on its own, in red**, with a hover tooltip suggesting a fresh chat. Below the threshold nothing changes.

Past a full context window every new turn re-reads the entire history: it is the slowest and most expensive the chat will ever be, and the model starts dropping its earliest context. That is the natural point to start over, so the row says so — to a user who has no idea any of this exists.

## Why this shape (changed from the original dot)

Hermes **already** shows this exact token figure in the sidebar, behind the filter menu's **Tokens** toggle. So instead of adding a new status dot, this reuses that figure:

- Below threshold: unchanged. With the Tokens toggle on, the figure shows in the normal muted colour, exactly as today.
- At/above threshold: the figure turns **red and appears even when the Tokens toggle is off**, so the warning reaches everyone — not only people who already opted into the column.

This also means the earlier reviewer note (the dot reported token *volume* while its tooltip said *expensive dollars*) no longer applies: the tooltip talks about chat **size / speed / cost of continuing**, and the trigger is an honest token-count threshold, not a provider-specific dollar figure.

## Notes

- `isLargeChat()` + `LARGE_CHAT_TOKENS` are exported and unit-tested; a missing/empty/negative count degrades to "not large" (never throws, never false-flags an empty row).
- Driven by token count, not `cost_usd`, so it works on subscription/OAuth auth where per-session dollar cost is always 0.
- `largeChat` tooltip string added across all 6 locales.
- **Display-only, no backend change:** `input_tokens`/`output_tokens` are already on the session-list row, and nothing here rebuilds prompts or touches caching.

## Tests

- `apps/desktop/src/lib/session-token-size.test.ts` — at/above a full window flags; 97.6k and 133.3k (normal working chats) do **not**; missing/empty/negative degrade to not-large. `npx vitest run` -> 3/3 pass.
- `npx tsc -p apps/desktop --noEmit` clean (validates JSX + the new i18n key across all locales).
