### PR TITLE
fix(delegate): byte-stable shared scaffold prefix for batch child prompts

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -147,6 +147,28 @@ class TestChildSystemPrompt(unittest.TestCase):
         self.assertIn("YOUR TASK", prompt)
         self.assertNotIn("CONTEXT", prompt)
 
+    def test_batch_scaffold_prefix_is_byte_stable(self):
+        """#103481: goal/context are per-child variance and must TRAIL the shared scaffold so a
+        delegate_task batch (max_concurrent_children > 1) shares one byte-identical system-prompt
+        prefix — providers with automatic prefix caching bill the scaffold once, not N times."""
+        p1 = _build_child_system_prompt("task alpha", "context one")
+        p2 = _build_child_system_prompt("task beta", "context two")
+        i1, i2 = p1.index("YOUR TASK:"), p2.index("YOUR TASK:")
+        self.assertEqual(i1, i2)
+        self.assertEqual(p1[:i1], p2[:i2])  # byte-identical scaffold before the first variant byte
+        self.assertIn("YOUR TASK:\ntask alpha", p1)
+        self.assertIn("CONTEXT:\ncontext one", p1)
+        self.assertIn("YOUR TASK:\ntask beta", p2)
+        self.assertIn("CONTEXT:\ncontext two", p2)
+        # Task text sits after the standing instructions (recency) but before the turn ends.
+        self.assertGreater(p1.index("YOUR TASK"), p1.index("Keep your final summary tight"))
+        self.assertLess(p1.index("YOUR TASK"), len(p1))
+
+    def test_context_absent_without_context_arg(self):
+        prompt = _build_child_system_prompt("Just the goal", None)
+        self.assertNotIn("CONTEXT", prompt)
+        self.assertTrue(prompt.rstrip().endswith("Just the goal"))
+
 class TestStripBlockedTools(unittest.TestCase):
     def test_removes_blocked_toolsets(self):
         result = _strip_blocked_tools(["terminal", "file", "delegation", "clarify", "memory", "code_execution"])

--- a/tools/delegate_tool_progress.py
+++ b/tools/delegate_tool_progress.py
@@ -152,10 +152,17 @@ def _build_child_system_prompt(
 ) -> str:
     """Focused system prompt for a child agent. role='orchestrator' appends a delegation-capability block (modeled on
     OpenClaw's buildSubagentSystemPrompt); its depth note is literal truth grounded in the passed config so the LLM
-    can't confabulate nesting."""
-    parts = ["You are a focused subagent working on a specific delegated task.", "", f"YOUR TASK:\n{goal}"]
-    if context and context.strip():
-        parts.append(f"\nCONTEXT:\n{context}")
+    can't confabulate nesting.
+
+    Byte-stable scaffold first, per-child variance LAST (#103481): ``goal``/``context`` differ per
+    child, so they are appended after every shared block (intro, workspace + context files,
+    completion instructions, role block). In a delegate_task batch (delegation.max_concurrent_children
+    > 1) every child's system prompt is then byte-identical up to the ``YOUR TASK`` marker, so
+    providers with automatic prefix caching (DeepSeek automatic prefix cache, Anthropic prompt
+    caching, ...) bill the shared scaffold as one cache-creation instead of N; only the trailing
+    task bytes are a per-child miss. The task text still reaches the model right before its first
+    user turn (run_conversation re-sends the goal as the initial user message)."""
+    parts = ["You are a focused subagent working on a specific delegated task.", ""]
     if workspace_path and str(workspace_path).strip():
         parts.append(
             "\nWORKSPACE PATH:\n"
@@ -182,6 +189,11 @@ def _build_child_system_prompt(
             + f"NOTE: You are at depth {child_depth}. The delegation tree is capped at max_spawn_depth={max_spawn_depth}. "
             + child_note
         )
+    # Per-child variance LAST so the shared scaffold prefix above stays byte-identical across a
+    # batch (#103481): every provider prefix-cache hit on the scaffold is reused by the siblings.
+    parts.append(f"\nYOUR TASK:\n{goal}")
+    if context and context.strip():
+        parts.append(f"\nCONTEXT:\n{context}")
     return "\n".join(parts)
 
 def _resolve_workspace_hint(parent_agent) -> Optional[str]:


### PR DESCRIPTION
## What

`_build_child_system_prompt` (`tools/delegate_tool_progress.py`) injected `goal`/`context` at the **top** of every child system prompt. In a `delegate_task` batch (`delegation.max_concurrent_children`, up to 32) each child's prompt diverged from byte ~40 onward, so providers with automatic prefix caching (DeepSeek automatic prefix cache, Anthropic prompt caching) treated every child as a cold prefix and billed the entire shared scaffold — role intro, workspace rules, project context files, completion instructions — as cache **creation** N times.

This PR moves the per-child variance (`YOUR TASK` / `CONTEXT`) to the **end** of the system prompt, after every shared block (the blocks were already hoisted to byte-identical module constants in 54bd822d93). In a uniform batch, children now share a byte-identical scaffold prefix: one cache entry serves all siblings, only the trailing task bytes miss.

**Behavioral change: none.** The goal already reaches each child as its initial user message (`_ChildRun.await_child` → `run_conversation(user_message=self.goal)` in `tools/delegate_tool_child_run.py`), so task visibility is unchanged — the system-prompt copy was redundant. Task text now sits after the standing instructions (recency), immediately before the first user turn.

## Verification

- New regression test `test_batch_scaffold_prefix_is_byte_stable` asserts two children with different goals/contexts share a byte-identical prefix ending exactly at the `YOUR TASK:` marker, and that the task text trails the completion instructions.
- `test_delegate.py`: **83 passed** (incl. the 2 new tests; existing prompt/orchestration tests are content assertions and stay green).
- E2E recipe (from #103481): run a 32-child batch against a prefix-caching provider before/after and compare `usage.prompt_cache_hit_tokens` — shared prefix hits should go from ~0 to scaffold-sized.

## Notes

Implements the cache-sharing core of #103481 item 1. The issue's further suggestion (move task variance into the first **user** message so the system prompt is 100% identical) remains open as a larger follow-up — this change gets the prefix-cache win with a minimal, transport-agnostic diff (no change to `run_conversation` / ACP / prefill plumbing). Evaluation items 2–4 are left for maintainers.

Real usage: this project is run daily with batched delegation; the shared-scaffold layout matches how the parent's own per-session prompt is already structured (stable system prefix, varying user turns).