### PR TITLE
fix(tools): backend-probe honours docker_network and execute_code sandboxes keep docker_extra_args/forward_env/env — one container_config shaper for every creator (#76906 #87995 #84027 #100019, salvage #62023)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -845,13 +845,6 @@ def _tenv_read(name: str, default: str = "") -> str:
 
 _BACKEND_IMAGE_KEYS = {b: f"{b}_image" for b in ("docker", "singularity", "modal", "daytona")}
 # (config key, default) pairs forwarded to _create_environment's container_config.
-_CONTAINER_CONFIG_DEFAULTS = (
-    ("container_cpu", 1), ("container_memory", 5120), ("container_disk", 51200), ("container_persistent", True),
-    ("modal_mode", "auto"), ("docker_volumes", []), ("docker_mount_cwd_to_workspace", False),
-    ("docker_forward_env", []), ("docker_env", {}), ("docker_run_as_host_user", False), ("docker_extra_args", []),
-    ("docker_shm_size", "1g"), ("docker_persist_across_processes", True), ("docker_shared_container_key", ""),
-    ("docker_orphan_reaper", True),
-)
 # Single-line POSIX probe; `2>/dev/null` keeps a missing binary from polluting output.
 _BACKEND_PROBE_CMD = (
     "printf 'os=%s\\nkernel=%s\\nhome=%s\\ncwd=%s\\nuser=%s\\n' \"$(uname -s 2>/dev/null || echo unknown)\" "
@@ -862,16 +855,17 @@ _BACKEND_PROBE_CMD = (
 
 def _run_backend_probe(env_type: str, terminal_tool) -> str:
     """Execute the probe command inside a freshly built backend; "" when it yields nothing."""
-    from tools.terminal_tool_backends import _create_environment, _ssh_config_from_config
+    from tools.terminal_tool_backends import _container_config_from_config, _create_environment, _ssh_config_from_config
     from tools.terminal_tool_lifecycle import _cleanup_env
 
     config = terminal_tool._get_env_config()
-    # Mirrors tools/terminal_tool.py's live-command assembly (`_create_environment` is the factory).
+    # Same container_config shaper as the live terminal path: a private copy of the key table here
+    # drifted (no docker_network) and gave the probe a bridge-networked container under lockdown.
     env = _create_environment(
         env_type=env_type, image=config.get(_BACKEND_IMAGE_KEYS[env_type], "") if env_type in _BACKEND_IMAGE_KEYS else "", cwd=config.get("cwd", ""),
         timeout=config.get("timeout", 180),
         ssh_config=_ssh_config_from_config(config) if env_type == "ssh" else None,
-        container_config=({k: config.get(k, d) for k, d in _CONTAINER_CONFIG_DEFAULTS}
+        container_config=(_container_config_from_config(config)
                           if terminal_tool._is_container_backend(env_type) else None),
         task_id="prompt-backend-probe", host_cwd=config.get("host_cwd"),
     )

--- a/contributors/emails/301893261+sagitario-jpn@users.noreply.github.com
+++ b/contributors/emails/301893261+sagitario-jpn@users.noreply.github.com
@@ -1,0 +1,2 @@
+sagitario-jpn
+# PR #62023 salvage

--- a/tests/tools/test_docker_network_config.py
+++ b/tests/tools/test_docker_network_config.py
@@ -18,45 +18,48 @@ def test_terminal_env_config_reads_docker_network_toggle(monkeypatch):
     assert config["docker_network"] is False
 
 
-def test_sibling_container_config_sites_carry_docker_network():
-    """Every container_config dict that carries docker_run_as_host_user must
-    also carry docker_network — otherwise that code path silently falls back
-    to networked containers while the terminal path honors the lockdown
-    (the probe/exec asymmetry reported on issue #46358).
-    """
-    import ast
-    import inspect
-
+def test_every_sandbox_creator_passes_the_full_container_config(monkeypatch):
+    """The terminal tool, execute_code and the prompt backend-probe must hand ``_create_environment``
+    the SAME container_config keys. Each used to keep a private (key, default) table and drifted:
+    the probe lost ``docker_network`` (bridge-networked probe under lockdown, #46358/#76906/#87995),
+    execute_code lost ``docker_extra_args``/``docker_forward_env``/``docker_env`` (#84027/#100019)."""
+    import agent.prompt_builder as prompt_builder
     import tools.code_execution_tool as code_execution_tool
-    import tools.file_tools as file_tools
+    import tools.terminal_tool_backends as backends
 
-    # file_tools no longer builds its own container_config: it goes through
-    # the shared _create_configured_env, which is what carries docker_network.
-    assert "_create_configured_env(" in inspect.getsource(file_tools)
+    config = {"env_type": "docker", "cwd": "/root", "timeout": 60, "docker_network": False,
+              "docker_extra_args": ["--user", "1009:1009"], "docker_forward_env": ["DATABASE_URL"],
+              "docker_env": {"FOO": "bar"}, "docker_image": "debian:bookworm-slim"}
+    expected = backends._container_config_from_config(config)
+    seen: list = []
 
-    for module in (terminal_tool, code_execution_tool):
-        tree = ast.parse(inspect.getsource(module))
-        sites = 0
-        for node in ast.walk(tree):
-            # Accept a dict literal or a (key, default) pair table that a dict
-            # comprehension is built from.
-            if isinstance(node, ast.Dict):
-                keys = {k.value for k in node.keys if isinstance(k, ast.Constant)}
-            elif isinstance(node, ast.Tuple) and node.elts and all(
-                isinstance(e, ast.Tuple) and len(e.elts) == 2 and isinstance(e.elts[0], ast.Constant)
-                for e in node.elts
-            ):
-                keys = {e.elts[0].value for e in node.elts}
-            else:
-                continue
-            if "docker_run_as_host_user" in keys:
-                sites += 1
-                assert "docker_network" in keys, (
-                    f"{module.__name__} builds a container_config with "
-                    f"docker_run_as_host_user but without docker_network "
-                    f"(line {node.lineno})"
-                )
-        assert sites >= 1, f"expected at least one container_config site in {module.__name__}"
+    class _Env:
+        cwd = "/root"
+
+        def execute(self, *a, **k):
+            return {"output": "", "returncode": 0}
+
+        def cleanup(self, **k):
+            pass
+
+    def _fake_create(**kwargs):
+        seen.append(kwargs["container_config"])
+        return _Env()
+
+    # Both creators late-import their collaborators from terminal_tool / terminal_tool_backends.
+    monkeypatch.setattr(backends, "_create_environment", _fake_create)
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_tool, "_select_image", lambda *a, **k: "img")
+    monkeypatch.setattr(terminal_tool, "_resolve_task_host_cwd", lambda *a, **k: None)
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {})
+    monkeypatch.setattr(terminal_tool, "_active_environments", {})
+
+    prompt_builder._run_backend_probe("docker", terminal_tool)
+    code_execution_tool._get_or_create_env("cc-task")
+
+    assert seen == [expected, expected]  # probe, then execute_code
+    assert expected["docker_network"] is False and expected["docker_extra_args"] == ["--user", "1009:1009"]
 
 
 def _reuse_guard_harness(

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -394,17 +394,10 @@ def _call(tool_name, args):
 
 # ---- Remote execution support (file-based RPC via terminal backend) ----
 
-# execute_code's container_config keys (a subset of terminal_tool's; the create path fills the rest).
-_CONTAINER_CONFIG_DEFAULTS = (
-    ("container_cpu", 1), ("container_memory", 5120), ("container_disk", 51200), ("container_persistent", True),
-    ("vercel_runtime", ""), ("docker_volumes", []), ("docker_run_as_host_user", False), ("docker_network", True),
-)
-
-
 def _get_or_create_env(task_id: str):
     """``(env, env_type)`` — the environment the terminal/file tools share for *task_id*, created on
     first use (same double-checked per-task lock pattern as file_tools._get_file_ops)."""
-    from tools.terminal_tool_backends import _create_environment, _ssh_config_from_config
+    from tools.terminal_tool_backends import _container_config_from_config, _create_environment, _ssh_config_from_config
     from tools.terminal_tool import (
         _active_environments, _env_lock, _get_env_config, _last_activity,
         _start_cleanup_thread, _creation_locks, _creation_locks_lock, _task_env_overrides,
@@ -431,7 +424,9 @@ def _get_or_create_env(task_id: str):
         overrides = _task_env_overrides.get(effective_task_id, {})
         container_config = None
         if _is_container_backend(env_type):
-            container_config = {key: config.get(key, default) for key, default in _CONTAINER_CONFIG_DEFAULTS}
+            # Shared shaper: execute_code's own key subset dropped docker_extra_args / docker_forward_env /
+            # docker_env, so a sandbox created from this path lost the operator's configured settings.
+            container_config = _container_config_from_config(config)
         logger.info("Creating new %s environment for execute_code task %s...",
                      env_type, effective_task_id[:8])
         env = _create_environment(


### PR DESCRIPTION
The prompt backend-probe container now honours `terminal.docker_network: false` (it was always bridge-networked), and a sandbox created from `execute_code` now carries the operator's `docker_extra_args`, `docker_forward_env` and `docker_env` — the same `container_config` the terminal tool has always passed.

Salvage of #62023 by @sagitario-jpn (the probe `docker_network` fix; authorship preserved), widened to the whole drift class. Fixes #76906, #87995, #84027, #100019. Supersedes the same-class carriers #99983 / #100042 / #90050 for the execute_code half.

## Root cause

Three sandbox creators each kept a private `(key, default)` table for `container_config` and drifted: `agent/prompt_builder.py` lacked `docker_network`; `tools/code_execution_tool.py` lacked `docker_extra_args`, `docker_forward_env`, `docker_env`. `tools/terminal_tool_backends._container_config_from_config` already existed as the terminal path's shaper (and is what `file_tools` uses via `_create_configured_env`).

## Change

- Both creators call `_container_config_from_config(config)`; the two private tables are deleted (−19/+8).
- The source-reading AST test in `tests/tools/test_docker_network_config.py` is replaced by a behaviour contract: with `_create_environment` faked, the probe and `execute_code` must pass exactly the terminal shaper's dict (including `docker_network: False` and the extra args). Red on `origin/main`.

## Validation

| Check | Result |
|---|---|
| Live, real Docker (OrbStack), `TERMINAL_DOCKER_NETWORK=false`, real `_run_backend_probe` with `docker run` argv captured | main: no `--network=none` in the probe's `docker run`; branch: present |
| `scripts/run_tests.sh` docker network / code_execution / prompt_builder / docker environment / file_tools container-config suites | 248 passed |
| ruff | clean |
