### PR TITLE
fix(agent): let a workspace-wide full verify clear a session's stale evidence

### DIFF
--- a/agent/verification_evidence.py
+++ b/agent/verification_evidence.py
@@ -568,11 +568,14 @@ def verification_status(*, session_id: str | None, cwd: str | Path | None) -> di
         if event is not None and state["last_edit_at"] and state["last_edit_at"] > event["created_at"]:
             # Session-keyed evidence is stale, but a shell-run `hermes verify`
             # records under session "default" (#103271) — the editing session's
-            # ledger never sees it. A passing full-scope run of this root after
-            # the edit proves the workspace green regardless of who ran it.
+            # ledger never sees it. A passing full-scope `hermes verify` of this
+            # root after the edit proves the workspace green regardless of who
+            # ran it. Only verify-kind events qualify: terminal runs reach
+            # scope="full" through the `_looks_like_target` heuristic, so a
+            # filtered run like `pnpm test --filter=web` can read as full.
             workspace_pass = conn.execute(
                 "SELECT * FROM verification_events"
-                " WHERE root = ? AND status = 'passed' AND scope = 'full' AND created_at > ?"
+                " WHERE root = ? AND kind = 'verify' AND status = 'passed' AND scope = 'full' AND created_at > ?"
                 " ORDER BY id DESC LIMIT 1",
                 (root, state["last_edit_at"]),
             ).fetchone()

--- a/agent/verification_evidence.py
+++ b/agent/verification_evidence.py
@@ -564,6 +564,18 @@ def verification_status(*, session_id: str | None, cwd: str | Path | None) -> di
         event = None
         if state["last_event_id"] is not None:
             event = conn.execute("SELECT * FROM verification_events WHERE id = ?", (state["last_event_id"],)).fetchone()
+        workspace_pass = None
+        if event is not None and state["last_edit_at"] and state["last_edit_at"] > event["created_at"]:
+            # Session-keyed evidence is stale, but a shell-run `hermes verify`
+            # records under session "default" (#103271) — the editing session's
+            # ledger never sees it. A passing full-scope run of this root after
+            # the edit proves the workspace green regardless of who ran it.
+            workspace_pass = conn.execute(
+                "SELECT * FROM verification_events"
+                " WHERE root = ? AND status = 'passed' AND scope = 'full' AND created_at > ?"
+                " ORDER BY id DESC LIMIT 1",
+                (root, state["last_edit_at"]),
+            ).fetchone()
 
     result = {
         "evidence": None, "root": root, "session_id": sid, "changed_paths": _load_changed_paths(state["changed_paths_json"])
@@ -573,4 +585,7 @@ def verification_status(*, session_id: str | None, cwd: str | Path | None) -> di
 
     evidence = dict(event)
     stale = bool(state["last_edit_at"]) and state["last_edit_at"] > evidence["created_at"]
+    if stale and workspace_pass is not None:
+        evidence = dict(workspace_pass)
+        stale = False
     return {"status": "stale" if stale else evidence["status"], **result, "evidence": evidence}

--- a/tests/agent/test_verification_evidence.py
+++ b/tests/agent/test_verification_evidence.py
@@ -431,3 +431,24 @@ def test_cross_session_failed_verify_does_not_clear_stale(tmp_path, monkeypatch)
 
     status = verification_status(session_id="conversation", cwd=tmp_path)
     assert status["status"] == "stale"
+
+
+def test_cross_session_full_terminal_run_does_not_clear_stale(tmp_path, monkeypatch):
+    """Only verify-kind events clear staleness across sessions. Terminal runs
+    reach scope="full" via the _looks_like_target heuristic — a filtered run
+    like `pnpm test --filter=web` reads as full but covers a subset, so it
+    must not upgrade another session's ledger to green."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    _verified_then_edited(tmp_path)
+
+    record_terminal_result(
+        command="pnpm test --filter=web",
+        cwd=tmp_path,
+        session_id="other-session",
+        exit_code=0,
+        output="green",
+    )
+
+    status = verification_status(session_id="conversation", cwd=tmp_path)
+    assert status["status"] == "stale"

--- a/tests/agent/test_verification_evidence.py
+++ b/tests/agent/test_verification_evidence.py
@@ -10,6 +10,7 @@ from agent.verification_evidence import (
     classify_verification_command,
     mark_workspace_edited,
     record_terminal_result,
+    record_verify_run,
     verification_status,
 )
 
@@ -350,3 +351,83 @@ def test_windows_backslash_ad_hoc_script_path_is_matched(tmp_path, monkeypatch):
     assert result is not None, (
         "Windows backslash path should be matched via posix=False fallback"
     )
+
+
+def _verified_then_edited(tmp_path, session_id="conversation"):
+    """In-session green evidence, then an edit: the per-session ledger now reads
+    stale — the exact state the stop guard consults."""
+    record_terminal_result(
+        command="pnpm test", cwd=tmp_path, session_id=session_id, exit_code=0, output="green",
+    )
+    assert verification_status(session_id=session_id, cwd=tmp_path)["status"] == "passed"
+    mark_workspace_edited(
+        session_id=session_id, cwd=tmp_path, paths=[str(tmp_path / "src" / "app.ts")],
+    )
+    assert verification_status(session_id=session_id, cwd=tmp_path)["status"] == "stale"
+
+
+def test_shell_verify_pass_clears_stale_state_from_editing_session(tmp_path, monkeypatch):
+    """A shell-run `hermes verify` has no session to thread and records under
+    "default" (verify_cmd.py reads HERMES_SESSION_ID only), while edits are
+    keyed to the real session (#103271). A passing full verification of the
+    root is a property of the workspace, so it must clear the editing
+    session's staleness instead of leaving it permanently stale."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    _verified_then_edited(tmp_path)
+
+    record_verify_run(root=tmp_path, session_id=None, ok=True)
+
+    status = verification_status(session_id="conversation", cwd=tmp_path)
+    assert status["status"] == "passed"
+    assert status["evidence"]["canonical_command"] == "hermes verify"
+    assert status["evidence"]["scope"] == "full"
+
+
+def test_edit_after_cross_session_verify_stays_stale(tmp_path, monkeypatch):
+    """The workspace-level pass only clears evidence older than the session's
+    latest edit — freshness comparison stays per-edit, not per-eternity."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    _verified_then_edited(tmp_path)
+
+    record_verify_run(root=tmp_path, session_id=None, ok=True)
+    mark_workspace_edited(
+        session_id="conversation",
+        cwd=tmp_path,
+        paths=[str(tmp_path / "src" / "app.ts")],
+    )
+
+    status = verification_status(session_id="conversation", cwd=tmp_path)
+    assert status["status"] == "stale"
+
+
+def test_cross_session_targeted_pass_does_not_clear_stale(tmp_path, monkeypatch):
+    """Only full-scope passes clear staleness across sessions; a targeted run
+    from another session never upgrades the workspace to green."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    _verified_then_edited(tmp_path)
+
+    record_terminal_result(
+        command="pnpm test -- tests/button.test.tsx",
+        cwd=tmp_path,
+        session_id="other-session",
+        exit_code=0,
+        output="green",
+    )
+
+    status = verification_status(session_id="conversation", cwd=tmp_path)
+    assert status["status"] == "stale"
+
+
+def test_cross_session_failed_verify_does_not_clear_stale(tmp_path, monkeypatch):
+    """A failed shell-run verify must not clear the editing session's staleness."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    _verified_then_edited(tmp_path)
+
+    record_verify_run(root=tmp_path, session_id=None, ok=False)
+
+    status = verification_status(session_id="conversation", cwd=tmp_path)
+    assert status["status"] == "stale"


### PR DESCRIPTION
## Summary

`hermes verify` run in the user's own shell has no session to thread: the CLI passes `session_id=os.environ.get("HERMES_SESSION_ID")` (`hermes_cli/verify_cmd.py:96-103`), and that env var is threaded to in-session tool subprocesses (`tools/terminal_tool_background.py:66`) and other agent-internal channels — not to a user's interactive shell. A shell-run verify therefore lands under `session_id="default"` (the `str(session_id or "default")` fallback in `agent/verification_evidence.py:474`).

File-edit tracking keys `verification_state` to the *editing* session (`tools/file_tools_read_tracking.py:261` — `mark_workspace_edited(session_id=session_id or task_id, ...)`), and the verify-on-stop guard reads that same session's row (`agent/verification_stop.py:107`). Result: an edit keyed to the real session stays **stale forever**, because every shell-run `hermes verify` adds another `default`-keyed row the guard never consults — the signal cannot be cleared by the intended action (#103271).

Fix: when the session-keyed evidence is stale, consult the newest passing **full-scope** verification of the same root recorded by **any** session after the edit. A green full verify is a property of the workspace, not of the session that ran it. Targeted runs — including shell-run targeted checks — and failed runs never clear staleness; the edit-only (no in-session evidence) branch keeps its existing `unverified` semantics (pinned by `test_recording_expires_old_edit_only_state`).

This implements **option 3** from the issue's suggested fixes (consult cross-session verify before reporting stale) — the conservative variant that doesn't change attribution semantics. Option 2 (keying freshness by `root` alone) would also flip edit-only sessions from `unverified` to `passed`, which reads like an intentional-design change better left to maintainer judgment; happy to rework in that direction if preferred.

Thanks @ramsubramaniandev for the precise root-cause analysis and the repro DB rows — the diagnosis saved this fix most of its archaeology.

## Changes

- `agent/verification_evidence.py` — in `verification_status`: when the session's state row reads stale, query the newest `status='passed' AND scope='full'` event for the same `root` with `created_at > last_edit_at`; if present, report it as the evidence (status `passed`). Single query inside the existing transaction; no schema change. The extra query only fires on the already-stale path (never on the happy path), and the events table is bounded by the existing prune caps; if a `root` index turns out to be wanted, that's a cheap follow-up rather than something to bundle here.
- `tests/agent/test_verification_evidence.py` — 4 regression tests (below).

## Validation

All via `scripts/run_tests.sh` (CI parity runner):

| Step | Result |
|---|---|
| New tests before fix | `test_shell_verify_pass_clears_stale_state_from_editing_session` **FAILED** (`'stale' == 'passed'`) — bug reproduced; 3 semantics-pinning tests passed |
| Full file after fix | `tests/agent/test_verification_evidence.py` **23 passed, 0 failed** |
| Mutation self-check | reverting the source hunk (tests kept) → running the new test **FAILED** again (`'stale' == 'passed'`); fix re-applied → green |
| Neighbors | `tests/agent/test_verification_stop.py` + `tests/agent/test_verification_stop_caching.py` + `tests/verify/test_verify_cmd.py` + `tests/tools/test_write_verification.py` — **29 passed, 0 failed** |
| Integration loop | `tests/verify/test_ledger_and_nudge_integration.py` — **14 passed, 0 failed** (edit → nudge → verify → satisfied closed loop) |
| FD safety | `tests/agent/test_verification_evidence_fd_leak.py` — **3 passed, 0 failed** |
| Lint | `ruff check agent/verification_evidence.py tests/agent/test_verification_evidence.py` — clean |

New tests:
1. `test_shell_verify_pass_clears_stale_state_from_editing_session` — the bug: in-session green → edit → shell verify (session `None` → `"default"`) → guard must report `passed` with the full verify as evidence.
2. `test_edit_after_cross_session_verify_stays_stale` — freshness stays per-edit: an edit *after* the workspace pass keeps the session stale.
3. `test_cross_session_targeted_pass_does_not_clear_stale` — targeted runs from other sessions never upgrade the workspace to green.
4. `test_cross_session_failed_verify_does_not_clear_stale` — failed shell verifies don't clear staleness.

## Related issue

Fixes #103271

## References

- Reporter's production DB rows (issue body): `verification_events` 59-61 under `default` vs `verification_state` keyed `20260717_230325_f2d00d` with `last_edit_at` newer than event 58.
- Independently confirmed on a second deployment: `~/.hermes/verification_evidence.db` holds 20+ `verification_state` rows keyed by real session ids with zero consultable `default`-keyed evidence (macOS, v0.20.5).
- The stop guard consumer: `agent/verification_stop.py:107` (`verification_status(session_id=session_id, cwd=cwd)`).
- Design-intent anchor: fa1a5c0485 ("Integrate verify subsystem with the existing verification stack") — the closed edit → nudge → verify → satisfied loop this fix restores for shell-run verifies.
