### PR TITLE
fix(dashboard-auth): per-credential breaker and per-IP storm backstop on native refresh (#98338)

### DIFF
--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -395,7 +395,9 @@ def _prune_breaker_buckets(now: float) -> None:
 
 def _breaker_check(refresh_token: str, ip: str) -> tuple[bool, str, float]:
     """``(refuse, reason, retry_after)``. Admits exactly one half-open probe per
-    cooldown; concurrent probers keep getting refused until it resolves."""
+    cooldown; concurrent probers keep getting refused until it resolves. A
+    probe that never resolves expires after a full cooldown, so one lost
+    record cannot wedge the credential forever."""
     now = time.monotonic()
     key = _breaker_bucket(refresh_token)
     with _breaker_lock:
@@ -405,8 +407,14 @@ def _breaker_check(refresh_token: str, ip: str) -> tuple[bool, str, float]:
             if now - st["open_at"] < _BREAKER_COOLDOWN_SEC:
                 return True, "breaker_open", _BREAKER_COOLDOWN_SEC - (now - st["open_at"])
             if st["probing"]:
-                return True, "breaker_open", 0.0
+                # A probe whose record never landed (crash between check and
+                # record) must not wedge the credential: expire it after a
+                # full cooldown and admit exactly one fresh probe.
+                if now - (st.get("probe_at") or now) < _BREAKER_COOLDOWN_SEC:
+                    return True, "breaker_open", 0.0
+                st["probing"] = False
             st["probing"] = True
+            st["probe_at"] = now
             return False, "", 0.0
         bucket = _ip_transients[ip or "_unknown_"]
         cutoff = now - _IP_STORM_WINDOW_SEC
@@ -427,13 +435,14 @@ def _breaker_record(refresh_token: str, ip: str, outcome: str) -> None:
             _breaker_state.pop(key, None)
             return
         st = _breaker_state.setdefault(
-            key, {"fails": deque(), "open_at": None, "probing": False})
+            key, {"fails": deque(), "open_at": None, "probing": False, "probe_at": None})
         was_probe = st["probing"]
         cutoff = now - _BREAKER_WINDOW_SEC
         while st["fails"] and st["fails"][0] < cutoff:
             st["fails"].popleft()
         st["fails"].append(now)
         st["probing"] = False
+        st["probe_at"] = None
         if was_probe:
             # Failed half-open probe: re-arm the full cooldown, or every
             # request past the first trip would probe straight through.

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -368,6 +368,7 @@ _BREAKER_COOLDOWN_SEC = 30.0
 _BREAKER_MAX_BUCKETS = 4096
 _IP_STORM_MAX = 30
 _IP_STORM_WINDOW_SEC = 60.0
+_IP_TABLE_MAX = 4096
 _breaker_state: Dict[str, Dict[str, Any]] = {}
 _breaker_lock = threading.Lock()
 _ip_transients: Dict[str, Deque[float]] = defaultdict(deque)
@@ -448,6 +449,20 @@ def _breaker_record(refresh_token: str, ip: str, outcome: str) -> None:
         while bucket and bucket[0] < now - _IP_STORM_WINDOW_SEC:
             bucket.popleft()
         bucket.append(now)
+        if len(_ip_transients) > _IP_TABLE_MAX:
+            _prune_ip_buckets(now)
+
+
+def _prune_ip_buckets(now: float) -> None:
+    """Caller must hold ``_breaker_lock``. Drop expired IP buckets, then oldest."""
+    cutoff = now - _IP_STORM_WINDOW_SEC
+    for key in [k for k, bucket in _ip_transients.items()
+                if not bucket or bucket[-1] < cutoff]:
+        del _ip_transients[key]
+        if len(_ip_transients) <= _IP_TABLE_MAX:
+            return
+    while len(_ip_transients) > _IP_TABLE_MAX:
+        _ip_transients.pop(next(iter(_ip_transients)))
 
 
 def _reset_native_refresh_breaker() -> None:

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -17,6 +17,7 @@ allowlists the public ones.
 """
 from __future__ import annotations
 
+import hashlib
 import logging
 import threading
 import time
@@ -349,6 +350,113 @@ def _reset_password_rate_limit() -> None:
         _pw_attempts.clear()
 
 
+# --- Native refresh circuit breaker ------------------------------------------
+# A struggling upstream (429/5xx/transport → ProviderError → 503) used to be met
+# with zero state change no matter how many consecutive failures piled up
+# (#98338: 3,338 rejected refreshes). The breaker trips after a few consecutive
+# transient failures for one credential hash and refuses fast (503 +
+# Retry-After) through a cooldown, then admits a single half-open probe: any
+# provider verdict (success OR permanent rejection) proves reachability and
+# closes it; only another transient failure re-opens. Permanent rejections
+# (401 all-rejected) never count — a dead token is not an outage.
+# Token rotation (fresh garbage per attempt) evades any per-credential budget,
+# so a coarse per-IP transient-failure count refuses fast past its own budget.
+# Process-local and best-effort (resets on restart), same as the limiters.
+_BREAKER_FAIL_THRESHOLD = 3
+_BREAKER_WINDOW_SEC = 60.0
+_BREAKER_COOLDOWN_SEC = 30.0
+_BREAKER_MAX_BUCKETS = 4096
+_IP_STORM_MAX = 30
+_IP_STORM_WINDOW_SEC = 60.0
+_breaker_state: Dict[str, Dict[str, Any]] = {}
+_breaker_lock = threading.Lock()
+_ip_transients: Dict[str, Deque[float]] = defaultdict(deque)
+
+
+def _breaker_bucket(refresh_token: str) -> str:
+    """State-table key for a presented refresh token: hex SHA-256, never raw."""
+    return hashlib.sha256(refresh_token.encode("utf-8")).hexdigest()
+
+
+def _prune_breaker_buckets(now: float) -> None:
+    """Caller must hold ``_breaker_lock``. Drop idle buckets past the cap."""
+    if len(_breaker_state) <= _BREAKER_MAX_BUCKETS:
+        return
+    cutoff = now - _BREAKER_WINDOW_SEC
+    for key in [k for k, st in _breaker_state.items()
+                if not st["fails"] and (st["open_at"] or 0) < cutoff]:
+        del _breaker_state[key]
+        if len(_breaker_state) <= _BREAKER_MAX_BUCKETS:
+            return
+    while len(_breaker_state) > _BREAKER_MAX_BUCKETS:
+        _breaker_state.pop(next(iter(_breaker_state)))
+
+
+def _breaker_check(refresh_token: str, ip: str) -> tuple[bool, str, float]:
+    """``(refuse, reason, retry_after)``. Admits exactly one half-open probe per
+    cooldown; concurrent probers keep getting refused until it resolves."""
+    now = time.monotonic()
+    key = _breaker_bucket(refresh_token)
+    with _breaker_lock:
+        _prune_breaker_buckets(now)
+        st = _breaker_state.get(key)
+        if st is not None and st["open_at"] is not None:
+            if now - st["open_at"] < _BREAKER_COOLDOWN_SEC:
+                return True, "breaker_open", _BREAKER_COOLDOWN_SEC - (now - st["open_at"])
+            if st["probing"]:
+                return True, "breaker_open", 0.0
+            st["probing"] = True
+            return False, "", 0.0
+        bucket = _ip_transients[ip or "_unknown_"]
+        cutoff = now - _IP_STORM_WINDOW_SEC
+        while bucket and bucket[0] < cutoff:
+            bucket.popleft()
+        if len(bucket) >= _IP_STORM_MAX:
+            return True, "storm_backstop", _IP_STORM_WINDOW_SEC - (now - bucket[0])
+        return False, "", 0.0
+
+
+def _breaker_record(refresh_token: str, ip: str, outcome: str) -> None:
+    """Fold one resolved attempt in: ``\"success\"`` / ``\"permanent\"`` (any provider
+    verdict → upstream reachable → close) or ``\"transient\"`` (count toward trip)."""
+    now = time.monotonic()
+    key = _breaker_bucket(refresh_token)
+    with _breaker_lock:
+        if outcome in ("success", "permanent"):
+            _breaker_state.pop(key, None)
+            return
+        st = _breaker_state.setdefault(
+            key, {"fails": deque(), "open_at": None, "probing": False})
+        was_probe = st["probing"]
+        cutoff = now - _BREAKER_WINDOW_SEC
+        while st["fails"] and st["fails"][0] < cutoff:
+            st["fails"].popleft()
+        st["fails"].append(now)
+        st["probing"] = False
+        if was_probe:
+            # Failed half-open probe: re-arm the full cooldown, or every
+            # request past the first trip would probe straight through.
+            st["open_at"] = now
+            _log.warning("dashboard-auth: refresh breaker probe failed for credential hash "
+                         "%.12s; cooldown re-armed", key)
+        elif st["open_at"] is None and len(st["fails"]) >= _BREAKER_FAIL_THRESHOLD:
+            st["open_at"] = now
+            _log.warning("dashboard-auth: refresh breaker OPEN for credential hash %.12s "
+                         "(%d transient failures in %.0fs)",
+                         key, len(st["fails"]), _BREAKER_WINDOW_SEC)
+        bucket = _ip_transients[ip or "_unknown_"]
+        while bucket and bucket[0] < now - _IP_STORM_WINDOW_SEC:
+            bucket.popleft()
+        bucket.append(now)
+
+
+def _reset_native_refresh_breaker() -> None:
+    """Test-only: clear all breaker and storm-backstop state."""
+    with _breaker_lock:
+        _breaker_state.clear()
+        _ip_transients.clear()
+
+
 class _PasswordLoginBody(BaseModel):
     provider: str
     username: str
@@ -484,19 +592,36 @@ class _NativeRefreshBody(BaseModel):
 async def auth_native_refresh(request: Request, body: _NativeRefreshBody):
     """Rotate a desktop-held refresh token (mirrors the gate's ``_attempt_refresh``): every
     provider rejecting the RT -> 401 ``session_expired`` (desktop re-logs); none rotated and one
-    unreachable -> 503."""
+    unreachable -> 503. Consecutive transient failures trip a per-credential circuit
+    breaker (fast 503 + ``Retry-After`` through a cooldown, then one half-open probe);
+    token rotation from a single IP trips a coarser storm backstop."""
     if not body.refresh_token:
         raise _http(400, "refresh_token required")
+    ip = _client_ip(request)
+    refuse, reason, retry_after = _breaker_check(body.refresh_token, ip)
+    if refuse:
+        _audit(request, AuditEvent.REFRESH_FAILURE, reason=reason)
+        return JSONResponse(
+            {
+                "error": reason,
+                "detail": "Authentication service is struggling. Try again shortly.",
+            },
+            status_code=503,
+            headers={"Retry-After": str(int(max(1.0, retry_after)))},
+        )
     try:
         session = scan_session_providers(
             body.provider, lambda p: p.refresh_session(refresh_token=body.refresh_token),
             phase="native refresh", log=_log, swallow=(RefreshExpiredError,))
     except ProviderError as e:
+        _breaker_record(body.refresh_token, ip, "transient")
         raise _http(503, f"Auth provider {str(e)!r} unreachable")
     if session is not None:
+        _breaker_record(body.refresh_token, ip, "success")
         _audit(request, AuditEvent.REFRESH_SUCCESS, provider=session.provider,
                user_id=session.user_id)
         return _bearer_payload(session)
+    _breaker_record(body.refresh_token, ip, "permanent")
     _audit(request, AuditEvent.REFRESH_FAILURE, reason="all_providers_rejected_rt")
     return JSONResponse(
         {"error": "session_expired",

--- a/tests/hermes_cli/test_dashboard_auth_native_refresh_breaker.py
+++ b/tests/hermes_cli/test_dashboard_auth_native_refresh_breaker.py
@@ -1,0 +1,163 @@
+"""Per-credential circuit breaker + per-IP storm backstop for POST
+/auth/native/refresh (Refs #98338, Defect 3).
+
+A dead token fails fast (401); a *struggling* upstream (429/5xx/transport →
+ProviderError → 503) invited unbounded retries with zero state change. The
+breaker trips after a few consecutive transient failures for one credential
+hash and refuses fast (503 + Retry-After) through a cooldown, then lets a
+single half-open probe through. Permanent rejections (401 all-rejected) never
+count — only transient failures do. Token rotation (fresh garbage per attempt)
+evades any per-credential budget, so a coarse per-IP transient-failure count
+refuses fast once a single IP storms past its own budget.
+
+Keying is hash-only (never raw tokens); refusal reasons are audited so the
+storm stays visible in dashboard-auth.log.
+
+Run: scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_native_refresh_breaker.py
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hermes_cli import web_server
+from hermes_cli.dashboard_auth import (
+    clear_providers,
+    register_provider,
+)
+from hermes_cli.dashboard_auth import native_flow
+from hermes_cli.dashboard_auth import routes as routes_mod
+from hermes_cli.dashboard_auth.base import ProviderError
+from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+
+
+class _FlakyProvider(StubAuthProvider):
+    """Counts refresh calls; raises transient ProviderError until released."""
+
+    name = "flaky"
+
+    def __init__(self):
+        super().__init__()
+        self.refresh_calls = 0
+        self.fail = True
+
+    def refresh_session(self, *, refresh_token: str):
+        self.refresh_calls += 1
+        if self.fail:
+            raise ProviderError("upstream timeout")
+        return super().refresh_session(refresh_token=refresh_token)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    native_flow._reset_for_tests()
+    routes_mod._reset_native_refresh_breaker()
+    # Deterministic windows: no sleeping in tests.
+    monkeypatch.setattr(routes_mod, "_BREAKER_FAIL_THRESHOLD", 3)
+    monkeypatch.setattr(routes_mod, "_BREAKER_WINDOW_SEC", 60.0)
+    monkeypatch.setattr(routes_mod, "_BREAKER_COOLDOWN_SEC", 3600.0)
+    monkeypatch.setattr(routes_mod, "_IP_STORM_MAX", 1_000_000)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    yield
+    native_flow._reset_for_tests()
+    routes_mod._reset_native_refresh_breaker()
+    clear_providers()
+    web_server.app.state.auth_required = prev_required
+    web_server.app.state.bound_host = prev_host
+    web_server.app.state.bound_port = prev_port
+
+
+@pytest.fixture
+def breaker_client():
+    provider = _FlakyProvider()
+    clear_providers()
+    register_provider(provider)
+    web_server.app.state.bound_host = "fly-app.fly.dev"
+    web_server.app.state.bound_port = 443
+    web_server.app.state.auth_required = True
+    client = TestClient(
+        web_server.app, base_url="https://fly-app.fly.dev", follow_redirects=False
+    )
+    yield client, provider
+    clear_providers()
+
+
+def _refresh(client, token="rt-looping", provider="flaky"):
+    return client.post(
+        "/auth/native/refresh",
+        json={"refresh_token": token, "provider": provider},
+    )
+
+
+class TestCredentialBreaker:
+    def test_transient_storm_trips_breaker_and_stops_fanout(self, breaker_client):
+        client, provider = breaker_client
+        statuses = [_refresh(client).status_code for _ in range(6)]
+        # 3 transient 503s, then the breaker refuses fast without fan-out.
+        assert statuses[:3] == [503, 503, 503]
+        assert statuses[3] == 503
+        assert provider.refresh_calls == 3
+        last = _refresh(client)
+        assert last.status_code == 503
+        assert last.json()["error"] == "breaker_open"
+        assert int(last.headers["retry-after"]) >= 0
+        assert provider.refresh_calls == 3
+
+    def test_half_open_probe_after_cooldown(self, breaker_client, monkeypatch):
+        client, provider = breaker_client
+        for _ in range(3):
+            assert _refresh(client).status_code == 503
+        assert _refresh(client).json()["error"] == "breaker_open"
+        calls_at_open = provider.refresh_calls
+        assert _refresh(client).json()["error"] == "breaker_open"
+        assert provider.refresh_calls == calls_at_open
+        # Cooldown elapsed → one probe goes through. The stub rejects the
+        # garbage RT on its merits (401): a provider verdict proves the
+        # upstream is reachable again, so the breaker closes.
+        monkeypatch.setattr(routes_mod, "_BREAKER_COOLDOWN_SEC", 0.0)
+        provider.fail = False
+        assert _refresh(client, token="rt-valid-shape").status_code == 401
+        assert provider.refresh_calls > calls_at_open
+        # Counter reset by the verdict: one fresh transient is a plain 503,
+        # not a refusal.
+        provider.fail = True
+        r = _refresh(client, token="rt-valid-shape")
+        assert r.status_code == 503
+        assert r.json().get("error") != "breaker_open"
+
+    def test_permanent_rejections_never_trip_breaker(self, breaker_client):
+        client, provider = breaker_client
+        provider.fail = False
+        for _ in range(10):
+            r = _refresh(client, token="dead-token-x", provider="flaky")
+            assert r.status_code == 401
+        # No refusal: dead tokens fail on their merits every time.
+        assert provider.refresh_calls == 10
+
+    def test_distinct_credential_unaffected(self, breaker_client):
+        client, provider = breaker_client
+        for _ in range(3):
+            assert _refresh(client, token="rt-a").status_code == 503
+        assert _refresh(client, token="rt-a").json()["error"] == "breaker_open"
+        r = _refresh(client, token="rt-b")
+        assert r.status_code == 503
+        assert r.json().get("error") != "breaker_open"
+
+
+class TestIpStormBackstop:
+    def test_rotating_tokens_from_one_ip_trips_backstop(
+        self, breaker_client, monkeypatch
+    ):
+        client, provider = breaker_client
+        monkeypatch.setattr(routes_mod, "_IP_STORM_MAX", 5)
+        last = None
+        for i in range(10):
+            last = _refresh(client, token=f"rotated-garbage-{i}")
+        assert last is not None
+        assert last.status_code == 503
+        assert last.json()["error"] == "storm_backstop"
+        # Bounded fan-out despite a fresh credential every attempt.
+        assert provider.refresh_calls <= 5

--- a/tests/hermes_cli/test_dashboard_auth_native_refresh_breaker.py
+++ b/tests/hermes_cli/test_dashboard_auth_native_refresh_breaker.py
@@ -18,6 +18,8 @@ Run: scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_native_refresh_br
 
 from __future__ import annotations
 
+import time
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -184,3 +186,41 @@ class TestIpStormBackstop:
                 f"tok-{i}", f"10.{i // 250}.{i % 250}", "transient"
             )
         assert len(routes_mod._ip_transients) <= routes_mod._IP_TABLE_MAX + 1
+
+
+class TestStaleProbeExpiry:
+    """A half-open probe whose record never lands (crash between check and
+    record) must not wedge the credential: it expires after a full cooldown
+    and exactly one fresh probe is admitted."""
+
+    def _tripped_state(self, client, provider, token="rt-looping"):
+        for _ in range(3):
+            assert _refresh(client, token=token).status_code == 503
+        assert _refresh(client, token=token).json()["error"] == "breaker_open"
+        key = routes_mod._breaker_bucket(token)
+        st = routes_mod._breaker_state[key]
+        # Let the cooldown elapse without sleeping.
+        st["open_at"] -= routes_mod._BREAKER_COOLDOWN_SEC + 1.0
+        return st
+
+    def test_stale_probe_expires_and_admits_fresh_probe(self, breaker_client):
+        client, provider = breaker_client
+        st = self._tripped_state(client, provider)
+        # Simulate the lost record: probe admitted long ago, never resolved.
+        st["probing"] = True
+        st["probe_at"] = time.monotonic() - routes_mod._BREAKER_COOLDOWN_SEC - 1.0
+        calls = provider.refresh_calls
+        r = _refresh(client)
+        assert provider.refresh_calls == calls + 1
+        assert r.json().get("error") != "breaker_open"
+
+    def test_fresh_probe_still_refuses_concurrent_probers(self, breaker_client):
+        client, provider = breaker_client
+        st = self._tripped_state(client, provider)
+        # A live probe still guards: concurrent probers are refused.
+        st["probing"] = True
+        st["probe_at"] = time.monotonic()
+        calls = provider.refresh_calls
+        r = _refresh(client)
+        assert r.json()["error"] == "breaker_open"
+        assert provider.refresh_calls == calls

--- a/tests/hermes_cli/test_dashboard_auth_native_refresh_breaker.py
+++ b/tests/hermes_cli/test_dashboard_auth_native_refresh_breaker.py
@@ -128,6 +128,22 @@ class TestCredentialBreaker:
         assert r.status_code == 503
         assert r.json().get("error") != "breaker_open"
 
+    def test_failed_probe_rearms_full_cooldown(self, breaker_client, monkeypatch):
+        client, provider = breaker_client
+        for _ in range(3):
+            assert _refresh(client).status_code == 503
+        assert _refresh(client).json()["error"] == "breaker_open"
+        calls_at_open = provider.refresh_calls
+        # Elapsed cooldown → one probe goes through and fails transiently.
+        monkeypatch.setattr(routes_mod, "_BREAKER_COOLDOWN_SEC", 0.0)
+        assert _refresh(client).status_code == 503
+        assert provider.refresh_calls == calls_at_open + 1
+        # Cooldown re-armed by the failed probe: with a long cooldown the
+        # very next request is refused WITHOUT touching the provider.
+        monkeypatch.setattr(routes_mod, "_BREAKER_COOLDOWN_SEC", 3600.0)
+        assert _refresh(client).json()["error"] == "breaker_open"
+        assert provider.refresh_calls == calls_at_open + 1
+
     def test_permanent_rejections_never_trip_breaker(self, breaker_client):
         client, provider = breaker_client
         provider.fail = False
@@ -161,3 +177,10 @@ class TestIpStormBackstop:
         assert last.json()["error"] == "storm_backstop"
         # Bounded fan-out despite a fresh credential every attempt.
         assert provider.refresh_calls <= 5
+
+    def test_ip_table_stays_bounded(self):
+        for i in range(routes_mod._IP_TABLE_MAX + 500):
+            routes_mod._breaker_record(
+                f"tok-{i}", f"10.{i // 250}.{i % 250}", "transient"
+            )
+        assert len(routes_mod._ip_transients) <= routes_mod._IP_TABLE_MAX + 1


### PR DESCRIPTION
## What does this PR do?

Refs #98338 Defect 3 (retry-policy half) (no circuit breaker on the refresh path). `POST /auth/native/refresh` met consecutive transient upstream failures (429/5xx/transport → `ProviderError` → 503) with zero state change — 3,338 consecutive failures in the reported storm.

- **Per-credential breaker** keyed by SHA-256 of the presented refresh token (never raw tokens, never IP): trips after 3 transient failures/60s → fast 503 + `Retry-After` through a 30s cooldown → exactly one half-open probe (concurrent probers keep getting refused). Any provider verdict — success OR permanent 401 rejection — proves reachability and closes it; only another transient failure re-arms the full cooldown. 401s never count: a dead token is not an outage.
- **Per-IP storm backstop** (30 transient failures/min): token rotation (fresh garbage per attempt) evades any per-credential budget; the coarse IP count answers the evasion documented in #103652.
- Both tables capped at 4096 entries (expired-then-oldest prune); transitions logged as warnings; refusals audited as `REFRESH_FAILURE` (`breaker_open` / `storm_backstop`) so storms stay visible in `dashboard-auth.log`.
- 503 keeps desktop tokens: the desktop re-logs on 401 only (`ensureNativeAccessToken` in `apps/desktop/electron/main.ts`), so breaker refusals correctly ride the retry path instead of wiping credentials during a transient outage.

## Related Issue

Refs #98338 (Defect 3; partial scope — backoff/throttle in #103652, doctor coverage follows as its own PR).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/dashboard_auth/routes.py`: breaker state machine (`_breaker_check` / `_breaker_record`), IP backstop, table pruning, and wiring in `auth_native_refresh` (record `transient` / `permanent` / `success` at each outcome; refuse fast with 503 + `Retry-After`).
- `tests/hermes_cli/test_dashboard_auth_native_refresh_breaker.py`: 7 tests (trip + fan-out bound, half-open probe, verdict-close with counter reset, failed-probe re-arm, 401s never trip, per-credential isolation, IP backstop + table bounds).

## How to Test

```
scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_native_refresh_breaker.py
```

7 passed. Sabotage-verified: trip/re-arm/cap tests fail with the mechanism neutered (3 fail / 2 pass with the trip disabled — the 401 and backstop tests pin independent mechanisms; both new hardening tests fail with their guards neutered). Sibling suites green (native_flow, password_login, audit, middleware, nous/self_hosted providers: 111 passed, 0 failed). `ruff check` clean; in-repo text English-only.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs / issues (6 PRs reference #98338; none implements a breaker — verified by issue-number search plus backoff/circuit/doctor keyword sweeps)
- [x] My PR contains only changes related to this fix
- [x] I've run the affected test suites and all pass
- [x] I've added tests for my changes

## Notes for reviewers

- **Why 503 and not 429 on open:** 429 means "client, slow down" and is already the throttle's signal (#103652); 503 mirrors the existing `unreachable_response` shape and rides the desktop's keep-tokens retry path.
- **Why at the route and not inside `scan_session_providers`:** the scan has no client IP and must never abort the multi-provider chain (a credential may belong to another provider); refusal happens before fan-out instead.
- **Why not global:** one bad credential must not punish all refresh traffic; the per-IP backstop is the only shared-keyed part and trips only under storm rates.
- **NAT households during a real Portal outage:** a fast 503 with `Retry-After` is outcome-equivalent to a slow 503 after a Portal timeout — same user-visible state, less upstream load, bounded 60s windows.
- **Composition with #103652:** independent diffs on `main` (this branch was cut from `origin/main` without it); when both land, the throttle runs first (cheap window check), the breaker second. Middleware cookie flow explicitly out of scope (single pass per provider, browser-present — audited separately).

