### PR TITLE
feat(matrix): include image dimensions in m.image info

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -21,6 +21,7 @@ import asyncio
 import array
 import inspect
 from contextlib import suppress
+import io
 import logging
 import mimetypes
 import os
@@ -133,6 +134,22 @@ def _matrix_transcode_voice_to_ogg(path: str) -> Optional[str]:
 
 
 _MATRIX_BANG_COMMAND_RE = re.compile(r"^!([A-Za-z][A-Za-z0-9_-]*)(?=$|\s)(.*)$", re.DOTALL)
+
+
+def _image_dimensions(data: bytes) -> Optional[tuple[int, int]]:
+    """Display width/height of an image, honoring EXIF orientation; None when unreadable.
+
+    Clients (Element X on phones and watches especially) size an ``m.image`` from
+    ``info.w``/``info.h``; without them a full-width card renders as a thumbnail.
+    """
+    try:
+        from PIL import Image, ImageOps
+        with Image.open(io.BytesIO(data)) as img:
+            w, h = ImageOps.exif_transpose(img).size
+        return (w, h) if w and h else None
+    except Exception as exc:
+        logger.debug("Matrix: could not measure image dimensions: %s", exc)
+        return None
 
 
 def _resolve_matrix_bang_command(name: str) -> str | None:
@@ -1673,6 +1690,8 @@ class MatrixAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(exc))
         msg_content: Dict[str, Any] = {
             "msgtype": msgtype, "body": caption or filename, "info": {"mimetype": content_type, "size": len(data)}}
+        if msgtype == "m.image" and (dims := _image_dimensions(data)):
+            msg_content["info"]["w"], msg_content["info"]["h"] = dims
         if encrypted_file is not None:
             msg_content["file"] = {**encrypted_file.serialize(), "url": str(mxc_url)}
         else:

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1426,6 +1426,46 @@ class TestMatrixSyncLoop:
 class TestMatrixUploadAndSend:
 
     @pytest.mark.asyncio
+    async def test_image_info_includes_dimensions(self):
+        """m.image info carries w/h so clients can size the image instead of a thumbnail."""
+        import io
+        from PIL import Image
+
+        buf = io.BytesIO()
+        Image.new("RGB", (1280, 720)).save(buf, format="PNG")
+        adapter = _make_adapter()
+        mock_client = MagicMock()
+        mock_client.upload_media = AsyncMock(return_value="mxc://example.org/card")
+        mock_client.send_message_event = AsyncMock(return_value="$event")
+        adapter._client = mock_client
+
+        result = await adapter._upload_and_send(
+            "!room:example.org", buf.getvalue(), "card.png", "image/png", "m.image",
+        )
+
+        assert result.success is True
+        info = mock_client.send_message_event.await_args.args[2]["info"]
+        assert (info["w"], info["h"]) == (1280, 720)
+        assert info["mimetype"] == "image/png"
+
+    @pytest.mark.asyncio
+    async def test_image_info_omits_dimensions_when_unreadable(self):
+        """Unreadable image bytes still send, without w/h, exactly as before."""
+        adapter = _make_adapter()
+        mock_client = MagicMock()
+        mock_client.upload_media = AsyncMock(return_value="mxc://example.org/x")
+        mock_client.send_message_event = AsyncMock(return_value="$event")
+        adapter._client = mock_client
+
+        result = await adapter._upload_and_send(
+            "!room:example.org", b"not an image", "x.png", "image/png", "m.image",
+        )
+
+        assert result.success is True
+        info = mock_client.send_message_event.await_args.args[2]["info"]
+        assert "w" not in info and "h" not in info
+
+    @pytest.mark.asyncio
     async def test_upload_encrypted_room_uses_file_payload(self):
         """Encrypted rooms should use 'file' key with crypto metadata."""
         adapter = _make_adapter()


### PR DESCRIPTION
## What does this PR do?

Outgoing `m.image` events now include `info.w` and `info.h`. Until now the
`info` block carried only `mimetype` and `size`.

The motivation is readability on small screens. Element X uses the declared
dimensions to size an image in the timeline. Without them, a full-width status
or weather card is shown as a small thumbnail that has to be tapped to read.
With them, the card is scaled to the timeline width and can be read at a glance.
I use this daily on Element X on iPhone, Apple Watch, and macOS.

Dimensions are read from the plaintext bytes with Pillow, which is already a
core dependency. EXIF orientation is applied so a rotated camera JPEG reports
its display dimensions. If the bytes cannot be read as an image, the event is
sent without `w` and `h`, exactly as before, and the reason is logged at debug
level.

## Related Issue

None. I searched open and closed PRs and issues and did not find an existing
change for this.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/matrix/adapter.py`: new `_image_dimensions()` helper;
  `_upload_and_send()` sets `info.w` and `info.h` for `m.image`.
- `tests/gateway/test_matrix.py`: two tests in `TestMatrixUploadAndSend`. A
  generated 1280x720 PNG produces `w=1280, h=720`. Unreadable image bytes sent
  as `m.image` still succeed and carry no `w` or `h`.

## How to Test

1. `pytest tests/gateway/test_matrix.py -q`
2. Send an image from Hermes to a Matrix room and view the event source in
   Element X. `content.info` now includes `w` and `h`.
3. Open the room on an iPhone or Apple Watch. The image renders at timeline
   width rather than as a thumbnail.

I also checked an 800x600 JPEG with EXIF orientation 6. It reports `w=600,
h=800`, which is the display orientation.

The Matrix test file passes locally (114 tests). I have not run the full suite
on this branch locally and am leaving that to CI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before and after screenshots from Element X available on request.
