### PR TITLE
fix(agent): inherit the parent's full tool surface on the review fork (#103579)

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -822,6 +822,29 @@ def _fork_init_kwargs(agent: Any, rt: Dict[str, Any], routed: bool, max_iteratio
     return kwargs
 
 
+def _inherit_parent_tool_surface(review_agent: Any, agent: Any) -> None:
+    """Copy the parent's advertised tools for a same-model cache-parity fork.
+
+    The parent's array is the last outbound payload: ``agent.tools`` is read
+    directly at request time and is not mutated between review turns because
+    ``_skip_mcp_refresh`` blocks the between-turn MCP refresh. Dispatch remains
+    restricted by the thread whitelist. Copying the whole surface covers every
+    dynamically injected tool (memory-provider, late MCP, and plugin-registered),
+    not just memory tools.
+    """
+    parent_tools = getattr(agent, "tools", None)
+    if not isinstance(parent_tools, (list, tuple)) or not parent_tools:
+        return
+    review_agent.tools = copy.deepcopy(list(parent_tools))
+    review_agent.valid_tool_names = {
+        entry["function"]["name"]
+        for entry in review_agent.tools
+        if isinstance(entry, dict)
+        and isinstance(entry.get("function"), dict)
+        and isinstance(entry["function"].get("name"), str)
+    }
+
+
 def build_cache_parity_fork(
     agent: Any, task_cfg: Optional[Dict[str, Any]] = None, *, max_iterations: int,
     write_origin: str = "background_review",
@@ -867,6 +890,7 @@ def build_cache_parity_fork(
     if not _routed:
         review_agent._cached_system_prompt = agent._cached_system_prompt
         review_agent.session_start = agent.session_start
+        _inherit_parent_tool_surface(review_agent, agent)
     _detach_fork_compression(review_agent)
     # Compaction bounds a single request; this bounds the WHOLE review (checked in
     # conversation_loop via _review_input_budget_exhausted).

--- a/tests/run_agent/test_background_review_cache_parity.py
+++ b/tests/run_agent/test_background_review_cache_parity.py
@@ -101,6 +101,8 @@ def _make_recorder_class(captured=None, record_on_run=()):
             self.suppress_status_output = None
             self.session_start = None
             self.session_id = None
+            self.tools = None
+            self.valid_tool_names = set()
             self.ephemeral_system_prompt = kwargs.get("ephemeral_system_prompt")
 
         def run_conversation(self, *args, **kwargs):
@@ -273,6 +275,65 @@ def test_review_fork_pins_session_start_and_session_id():
 
 
 
+
+
+def test_unrouted_review_fork_inherits_entire_tool_surface():
+    """Unrouted forks preserve all advertised tools and their name index."""
+    import run_agent
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+    agent.tools = [
+        {"type": "function", "function": {"name": "base_tool"}},
+        {"type": "function", "function": {"name": "fact_store"}},
+        {"type": "function", "function": {"name": "fact_feedback"}},
+        {"type": "function", "function": {"name": "mcp_late_tool"}},
+        {"malformed": True},
+    ]
+    captured = {}
+    _Recorder = _make_recorder_class(
+        captured, record_on_run=("tools", "valid_tool_names")
+    )
+
+    with patch.object(run_agent, "AIAgent", _Recorder), \
+         patch("threading.Thread", _SyncThread):
+        agent._spawn_background_review(
+            messages_snapshot=[], review_memory=True, review_skills=False
+        )
+
+    assert captured["tools"] == agent.tools
+    assert captured["tools"] is not agent.tools
+    assert captured["tools"][0] is not agent.tools[0]
+    assert captured["valid_tool_names"] == {
+        "base_tool", "fact_store", "fact_feedback", "mcp_late_tool"
+    }
+    captured["tools"].append({"type": "function", "function": {"name": "new"}})
+    assert len(captured["tools"]) != len(agent.tools)
+
+
+def test_routed_review_fork_does_not_inherit_tool_surface():
+    """Routed forks use their own model-specific advertised surface."""
+    import run_agent
+    import agent.background_review as bg_review
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+    agent.tools = [{"type": "function", "function": {"name": "parent_tool"}}]
+    captured = {}
+    _Recorder = _make_recorder_class(captured, record_on_run=("tools",))
+    routed_runtime = {
+        "provider": "openrouter", "model": "aux-model", "api_key": "key",
+        "base_url": None, "api_mode": None, "credential_pool": None,
+        "request_overrides": {}, "max_tokens": None, "command": None,
+        "args": [], "routed": True,
+    }
+
+    with patch.object(run_agent, "AIAgent", _Recorder), \
+         patch.object(bg_review, "_resolve_review_runtime", return_value=routed_runtime), \
+         patch("threading.Thread", _SyncThread):
+        agent._spawn_background_review(
+            messages_snapshot=[], review_memory=True, review_skills=False
+        )
+
+    assert captured["tools"] is None
 
 
 def test_routed_review_fork_does_not_inherit_reasoning_config():


### PR DESCRIPTION
Closes #103579.

## Problem

`build_cache_parity_fork` promises the background-review fork's advertised `tools[]` is byte-identical to the parent's, so the fork reuses the warm provider prefix cache. It already inherits the parent's system prompt verbatim on the same-model path (`_cached_system_prompt` / `session_start`, from #25322 / PR #17276) — but it rebuilds the **tool surface** from toolsets alone.

So any tool injected onto the parent *after* base toolset construction is missing from the fork.

The reported instance is external memory-provider tools. The fork is built with `skip_memory=True` (`_fork_init_kwargs`) to avoid a second live provider instance (#5129); `_memory_manager` is therefore never constructed, `inject_memory_provider_tools` early-returns on its first gate (`agent/memory_manager.py` — `if not memory_manager or tools is None: return 0`), and `fact_store` / `fact_feedback` never reach the fork's request:

```
parent tools = base + memory-provider + context-engine   (31)
fork tools   = base + context-engine                     (29)
```

On providers whose prefix-cache key includes `tools[]`, every fork request then cold-reads (`cache_read=0` on a 66k-token request in the report).

## Why this fixes the mechanism, not just the site

Memory-provider tools are one instance of a general shape: **the fork rebuilds its surface from toolsets alone, so nothing injected onto the parent afterwards survives.** Four production sites mutate `agent.tools` after the base build:

| Injector | Site |
|---|---|
| base toolset build | `agent/agent_init.py:1048` |
| context-engine | `agent/agent_init.py:1965` |
| memory-provider | `agent/memory_manager.py` (via `agent_init.py:1296`) |
| bot-mode `message_agent` | `tools/bot_mode_dm.py:131-132` |
| MCP snapshot (replaces the array) | `tools/mcp_tool_agent.py:72,170` |

Inheriting the array closes the mechanism once, at the point where parity is already established for the system prompt.

**Scope, stated honestly:** memory-provider tools are the one instance demonstrably broken today. MCP is *not* a second live instance — `_skip_mcp_refresh = True` (set in this same function, enforced at `agent/turn_context.py:398`) already prevents the fork's array from diverging by freezing it. Context-engine tools survive because their init is not gated on `skip_memory`, which matches the issue's own `fork tools = base + context-engine` observation. So this is not a claim that several features are broken right now; it is a claim that the *condition* being tested should be "does the parent have an advertised surface", not "does this particular injector happen to be active".

That distinction is the practical argument against gating on `_memory_manager`: it is a proxy for the wrong question. A parent whose surface was shaped by any other injector gets no inheritance under that gate, even though the parity contract is identical. The `_skip_mcp_refresh` comment — *"would add late-connecting MCP tools and break tools[] parity"* — shows maintainers already reason about the whole surface as the parity unit, and this change makes the fork's construction agree with that.

`_inherit_parent_tool_surface()` copies the parent's array and rebuilds `valid_tool_names` from it. Notes on the details:

- **Order is preserved.** The parent's order is `base → memory-provider → context-engine`; a tail-append would produce different serialization and still miss the cache.
- **`deepcopy`** so the fork can never mutate the parent's live schemas.
- **Routed forks are excluded.** A different model means a different cache key, so they keep building their own surface (the same reason the system prompt is only inherited when `not _routed`).
- **Malformed entries are skipped** when building the name index rather than raising.

## This changes only what is ADVERTISED

Dispatch is untouched. The thread whitelist is installed *after* the fork is built (`_review_tool_whitelist` → `set_thread_tool_whitelist`) and its contract is explicit: *"DISPATCH-side only, so the advertised `tools[]` stays byte-identical to the parent's"* and *"The whitelist can only admit, never advertise"*. It is built from `get_tool_definitions(enabled_toolsets=["memory","skills"])` plus `read_file`/`search_files`, which never contains `fact_store`/`fact_feedback`. The fork advertises them and still cannot execute them.

Against the issue's acceptance criteria: (1) parity restored on the same cache scope; (2) no memory-provider instance is created — `skip_memory=True` is unchanged; (3) the dispatch whitelist still blocks the provider tools; (4) `valid_tool_names` stays consistent with the advertised array.

The #81014 gate is respected: this copies the parent's array, which was itself built through `memory_provider_tools_exposed()`. A session with the `memory` toolset gated off has no provider tools in the parent to copy, so nothing suppressed can be re-advertised.

## Tests

Two invariant tests in the existing `tests/run_agent/test_background_review_cache_parity.py`, driven through `_spawn_background_review` (the real path, not the helper in isolation):

1. **Unrouted fork inherits the entire surface** — asserts the fork's array equals the parent's *in order*, that it is a real copy (mutating the fork must not affect the parent), and that `valid_tool_names` matches the advertised names. The parent stub carries a base tool, a memory-provider pair, *and* an MCP-style late tool, so the test pins the bug class rather than the memory case; a malformed entry is included to cover the name-index skip.
2. **Routed fork does not inherit** — different model, different cache key.

No tool counts are asserted (change-detector), and no source text is read.

### Verification

RED without the fix — the one-line call site removed, tests kept:

```
>       assert captured["tools"] == agent.tools
E       AssertionError: assert None == [{'type': 'function', 'function': {'name': 'base_tool'}}, ...]
tests\run_agent\test_background_review_cache_parity.py:303: AssertionError
========================= 1 failed, 6 passed in 1.95s =========================
```

GREEN with it:

```
=== Summary: 1 files, 7 tests passed, 0 failed (100% complete) in 2.7s ===
```

Wider sweep across the background-review + memory-provider surface (`scripts/run_tests.sh`):

```
=== Summary: 10 files, 78 tests passed, 0 failed (100% complete) in 8.9s (24 workers) ===
```

## Relationship to other open work

- **#103581** (@0xalydev) targets the same issue at the same insertion point, gating the inheritance on `_memory_manager is not None`. The two are mutually exclusive. That gate is a lower-risk change — forks without a memory provider keep today's behavior byte-for-byte — and it fully satisfies the issue as filed. The argument for this PR instead is that `_memory_manager` tests a proxy condition rather than the parity condition (see the scope note above); if maintainers weigh the narrower blast radius higher, #103581 is the right merge and I'll close this. Credit to @0xalydev either way for identifying the fix site.
- **#99759** (grammar-compilation on llama.cpp-family backends) is not regressed. That issue notes the fork *already* advertises the parent's full toolset via `enabled_toolsets`, and its author explicitly writes that narrowing `tools[]` was *"rejected on cache-reuse economics"*, asking instead for a fix at schema-conversion time. Verified the copied schemas cannot introduce the reported shape: `grep -rn '\$ref\|anyOf' plugins/memory/` returns no matches.
- **#39746 / #59302 / #34759** whitelist memory-provider tools so the fork *can call* them — the opposite product decision from this issue's acceptance criteria, and a maintainer call. Worth noting they are currently no-ops regardless: a whitelist that "can only admit, never advertise" does nothing while the schema is absent, so this fix is a prerequisite either way.

Branched from current `main`.
