### PR TITLE
fix(tools): truncation footers give the agent a path readable from inside docker/modal/ssh sandboxes (#72389 #81984 #77015, salvage #72429)

### DIFF
--- a/contributors/emails/92574114+JonthanaHanh@users.noreply.github.com
+++ b/contributors/emails/92574114+JonthanaHanh@users.noreply.github.com
@@ -1,0 +1,2 @@
+JonthanaHanh
+# PR #72429 salvage

--- a/tests/tools/test_truncation_footer_sandbox_paths.py
+++ b/tests/tools/test_truncation_footer_sandbox_paths.py
@@ -1,0 +1,41 @@
+"""Truncation footers tell the AGENT where the full text lives, and the agent's read_file runs inside
+the active terminal backend: under docker the mounted cache is at /root/.hermes, so a host path in the
+footer is unreadable from the sandbox (#72389, #81984, #77015)."""
+
+import os
+import re
+
+import tools.browser_tool_snapshot as browser_tool_snapshot
+import tools.delegate_tool_results as delegate_tool_results
+import tools.web_tools_truncate as web_tools_truncate
+
+
+def _footer_path(text: str) -> str:
+    """Every truncation footer tells the agent how to page the full text via ``read_file path="..."``."""
+    return re.search(r'read_file path="([^"]+)"', text).group(1)
+
+
+def test_truncation_footers_render_the_sandbox_visible_cache_path(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    body = "\n".join(f"row {i}" for i in range(5000))
+
+    web_out, _ = web_tools_truncate._truncate_with_footer(body, "https://example.com/doc", 3000)
+    snap_out = browser_tool_snapshot._truncate_snapshot(body, 3000)
+    deleg_out, _ = delegate_tool_results._trim_summary_with_footer(body, 3000, 0)
+
+    for text, subdir in ((web_out, "cache/web"), (snap_out, "cache/web"), (deleg_out, "cache/delegation")):
+        path = _footer_path(text)
+        assert path.startswith(f"/root/.hermes/{subdir}/"), path
+        # The bytes still live on the host under HERMES_HOME; only the rendered path is translated.
+        assert os.path.exists(str(home / subdir / os.path.basename(path)))
+
+
+def test_local_backend_footer_keeps_the_host_path(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    body = "\n".join(f"row {i}" for i in range(5000))
+    out, _ = web_tools_truncate._truncate_with_footer(body, "https://example.com/doc", 3000)
+    assert _footer_path(out).startswith(str(home))

--- a/tools/browser_tool_snapshot.py
+++ b/tools/browser_tool_snapshot.py
@@ -79,6 +79,10 @@ def _truncate_snapshot(snapshot_text: str, max_chars: Optional[int] = None) -> s
         return snapshot_text
 
     stored_path = _store_full_snapshot(snapshot_text)
+    if stored_path:
+        # Agent-visible path: read_file runs inside the active backend (#72389).
+        from tools.credential_files import to_agent_visible_cache_path
+        stored_path = to_agent_visible_cache_path(stored_path)
 
     lines = snapshot_text.split('\n')
     result: list[str] = []

--- a/tools/delegate_tool_results.py
+++ b/tools/delegate_tool_results.py
@@ -200,6 +200,10 @@ def _trim_summary_with_footer(summary: str, cap: int, task_index: int) -> tuple[
         tail = tail[nl + 1:]
 
     spill_path = _spill_summary_to_file(task_index, summary)
+    if spill_path:
+        # Agent-visible path: the parent's read_file runs inside the active backend (#81984, #77015).
+        from tools.credential_files import to_agent_visible_cache_path
+        spill_path = to_agent_visible_cache_path(spill_path)
     footer_lines = [
         "", "─" * 8 + " [SUMMARY TRUNCATED] " + "─" * 8,
         f"Showing {len(head):,} chars (head) + {len(tail):,} chars (tail) "

--- a/tools/web_tools_truncate.py
+++ b/tools/web_tools_truncate.py
@@ -99,6 +99,11 @@ def _truncate_with_footer(content: str, url: str, char_limit: int) -> tuple[str,
         tail = tail[nl + 1:]
 
     stored_path = _store_full_text(url, content)
+    if stored_path:
+        # The footer is read by the AGENT, whose read_file runs inside the active backend: render the
+        # path where docker/modal/ssh/... see the mounted cache, not the host path (#72389, #81984).
+        from tools.credential_files import to_agent_visible_cache_path
+        stored_path = to_agent_visible_cache_path(stored_path)
     footer_lines = [
         "", "─" * 8 + " [TRUNCATED] " + "─" * 8,
         f"Showing {len(head):,} chars (head) + {len(tail):,} chars (tail) "


### PR DESCRIPTION
When `web_extract`, `browser_snapshot` or `delegate_task` truncate their output, the footer's `read_file path="..."` now names the path the ACTIVE BACKEND sees (`/root/.hermes/cache/...` under docker/modal, `~/.hermes/cache/...` under ssh/daytona/vercel) instead of the host path — so the agent can actually page the full text from inside the sandbox.

Salvage of #72429 by @JonthanaHanh (the `web_extract` sites; authorship preserved), widened to every truncation footer. Fixes #72389, #81984, #77015.

## Root cause

The full text is spilled under `HERMES_HOME/cache/{web,delegation}`, which `credential_files._CACHE_DIRS` mounts read-only into docker/modal and syncs for ssh/daytona/vercel — the bytes were there. The footer rendered the host path, which does not exist in the sandbox, so `read_file` said "File not found". `tool_result_storage` already translates through `credential_files.to_agent_visible_cache_path`; the three footer writers did not.

## Change

- `web_tools_truncate._truncate_with_footer`, `browser_tool_snapshot._truncate_snapshot`, `delegate_tool_results._trim_summary_with_footer`: translate the spilled path through `to_agent_visible_cache_path` (local/singularity unchanged by that helper).
- 2 invariant tests: under `TERMINAL_ENV=docker` all three footers point under `/root/.hermes/<cache subdir>/` while the bytes remain on the host; under `local` the host path is kept. Red on `origin/main`.

## Validation

| Check | Result |
|---|---|
| Live, real Docker (OrbStack): `web_extract`-style truncation, then `head` the footer path inside the sandbox via the real `terminal_tool` | main: footer = host `/var/folders/.../cache/web/...`, read fails; branch: footer = `/root/.hermes/cache/web/...`, read succeeds |
| `scripts/run_tests.sh` web_tools_truncate / browser_tool_snapshot / delegate / tool_result_storage / credential_files suites | 313 passed (the 1 `test_delegate.py` red fails identically on `origin/main`) |
| ruff | clean |
