### PR TITLE
fix(code-execution): a remote kernel is not reused across different sandbox tool sets — no more stale hermes_tools stubs (#97263, salvage #97265)

### DIFF
--- a/contributors/emails/2319582736@qq.com
+++ b/contributors/emails/2319582736@qq.com
@@ -1,0 +1,2 @@
+Liuzikaii
+# PR #97265 salvage

--- a/tests/tools/test_code_kernel_remote.py
+++ b/tests/tools/test_code_kernel_remote.py
@@ -74,10 +74,11 @@ def _cell(status="ok", stdout="", execution_count=1, **kw):
     return payload
 
 
-def _run(env, code="print(1)", *, task="t1", reset=False, timeout=10):
+def _run(env, code="print(1)", *, task="t1", reset=False, timeout=10,
+         tools=frozenset({"read_file"})):
     return execute_in_remote_kernel(
         code, env=env, env_type="ssh", task_env_id=task,
-        sandbox_tools=frozenset({"read_file"}), timeout=timeout,
+        sandbox_tools=tools, timeout=timeout,
         max_tool_calls=5, reset=reset,
     )
 
@@ -176,6 +177,19 @@ class TestDeathDetection(RemoteKernelBase):
 
 
 class TestOwnershipIsolation(RemoteKernelBase):
+    def test_changed_tool_set_spawns_kernel_with_fresh_stubs(self):
+        env = ScriptedEnv(_spawn_ok_handlers([_cell(), _cell()]))
+        _run(env, tools=frozenset({"read_file"}))
+        _run(env, tools=frozenset({"web_search"}))
+
+        self.assertEqual(len(_REMOTE_KERNELS), 2)
+        self.assertEqual(sum(1 for c in env.commands if "nohup" in c), 2)
+        keyed_tool_sets = {key[-1] for key in _REMOTE_KERNELS}
+        self.assertEqual(
+            keyed_tool_sets,
+            {("read_file",), ("web_search",)},
+        )
+
     def test_delegated_children_get_their_own_remote_kernels(self):
         """Same invariant as local (#94647 review fix): the child context
         qualifier must key a DIFFERENT remote kernel."""

--- a/tools/code_kernel_remote.py
+++ b/tools/code_kernel_remote.py
@@ -146,8 +146,10 @@ class RemoteKernel:
                 logger.debug(failure, exc_info=True)
 
 
-def _kernel_key(owner: str, env_type: str, task_env_id: str) -> Tuple:
-    return (owner, "remote", env_type, task_env_id)
+def _kernel_key(owner: str, env_type: str, task_env_id: str, sandbox_tools: frozenset) -> Tuple:
+    """The hermes_tools stub module is generated from ``sandbox_tools`` once, at spawn, so a kernel
+    is only reusable by calls with the SAME tool set; a different set gets its own kernel."""
+    return (owner, "remote", env_type, task_env_id, tuple(sorted(sandbox_tools)))
 
 
 # Registry + lock shared-shape with code_kernel; teardown runs outside the lock.
@@ -243,7 +245,7 @@ def _acquire_remote_kernel(env, env_type: str, owner: str, task_env_id: str,
                            idle_exit: int) -> Tuple[Optional[RemoteKernel], bool, bool, bool]:
     """Find/respawn the owner's kernel: (kernel|None, reused, state_reset, state_lost); reaps
     idle-expired entries on the way in."""
-    key = _kernel_key(owner, env_type, task_env_id)
+    key = _kernel_key(owner, env_type, task_env_id, sandbox_tools)
     state_lost = state_reset = False
     with _REGISTRY.lock:
         expired = _reap_unlocked(idle_exit)
@@ -309,7 +311,7 @@ def execute_in_remote_kernel(
         env, env_type, owner, task_env_id, sandbox_tools, reset=reset, idle_exit=idle_exit)
     if kernel is None:
         return None  # fail open to per-call
-    key = _kernel_key(owner, env_type, task_env_id)
+    key = _kernel_key(owner, env_type, task_env_id, sandbox_tools)
     kernel.last_used = time.monotonic()
     with _REGISTRY.lock:
         kernel.attached += 1


### PR DESCRIPTION
On docker/ssh/modal backends, an `execute_code` call whose sandbox tool set differs from the previous call's (a skill loaded, a toolset toggled) now gets a kernel with stubs generated for THAT set, instead of reusing the earlier kernel and its stale `hermes_tools` module.

Salvage of #97265 by @Liuzikaii (authorship preserved; re-applied onto the refactored `_acquire_remote_kernel`). Fixes #97263.

## Root cause

`code_kernel_remote._kernel_key` was `(owner, "remote", env_type, task_env_id)`, but the stub module the kernel imports is generated from `sandbox_tools` once, at spawn. Any later call with a different tool set matched the same key and reused the kernel.

## Change

- The sorted tool set is part of the kernel key at both call sites (`_acquire_remote_kernel`, `run_remote_kernel_cell`); the existing over-cap eviction handles the extra kernels.
- 1 invariant test: two calls with different tool sets produce two kernels (two spawns), keyed by their sets. Red on `origin/main`.

## Validation

| Check | Result |
|---|---|
| `scripts/run_tests.sh` code_kernel_remote / code_kernel / code_execution suites | 135 passed (the 1 `test_code_kernel.py` red fails identically on `origin/main`) |
| ruff | clean |
