### PR TITLE
fix(gateway): redeliver a flood-refused final reply once the penalty passes

### DIFF
--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+import re
 import sqlite3
 import threading
 import time
@@ -62,10 +63,34 @@ FLOOD_RETRY_DEFAULT_SECONDS = 60.0
 FLOOD_RETRY_CAP_SECONDS = 15 * 60.0
 FLOOD_RETRY_SLACK_SECONDS = 2.0
 
+# The canonical prefix above is what the adapters produce for a flood they decide not to sleep. It is
+# not the only shape that reaches this ledger. PTB raises ``RetryAfter``, whose own text reads
+# "Flood control exceeded. Retry in 185 seconds", and that text is what lands in ``last_error``
+# whenever a send fails on a path that has not been normalized, or was written by an older build
+# before it was. Such a row has to be recognised too: unrecognised, it is treated as an ordinary
+# failure, so no redelivery timer is armed for it and a boot sweep claims it immediately instead of
+# adopting it until its deadline, spending the one attempt inside the penalty that caused it.
+# Matching requires the "flood control" wording as well as the delay, so an unrelated error that
+# merely suggests retrying is never mistaken for a flood.
+_RAW_FLOOD_RE = re.compile(r"flood control exceeded.*?retry in\s+(\d+(?:\.\d+)?)", re.IGNORECASE)
+
+
+def _raw_flood_wait(text: str) -> Optional[float]:
+    """Seconds asked for by a flood error still carrying the platform's own wording, else ``None``."""
+    match = _RAW_FLOOD_RE.search(text or "")
+    if not match:
+        return None
+    try:
+        return float(match.group(1))
+    except (TypeError, ValueError):
+        return None
+
 
 def is_flood_error(error: Any) -> bool:
-    """True for the adapters' fail-closed flood result (``flood_control:<seconds>``)."""
-    return str(error or "").strip().lower().startswith(FLOOD_ERROR_PREFIX)
+    """True for a flood refusal: the adapters' fail-closed ``flood_control:<seconds>`` result, or a
+    row still carrying the platform's own flood wording (see ``_RAW_FLOOD_RE``)."""
+    text = str(error or "").strip().lower()
+    return text.startswith(FLOOD_ERROR_PREFIX) or _raw_flood_wait(text) is not None
 
 
 def flood_wait_seconds(error: Any, default: float = FLOOD_RETRY_DEFAULT_SECONDS) -> float:
@@ -77,6 +102,12 @@ def flood_wait_seconds(error: Any, default: float = FLOOD_RETRY_DEFAULT_SECONDS)
             wait = float(text[len(FLOOD_ERROR_PREFIX):].strip())
         except ValueError:
             wait = default
+    else:
+        # A row still carrying the platform's own flood wording states its delay just as precisely,
+        # and the deadline must use it rather than the generic default.
+        raw = _raw_flood_wait(text)
+        if raw is not None:
+            wait = raw
     return wait if wait > 0 else default
 
 

--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -51,12 +51,12 @@ FLOOD_MARKER = ("♻️ Recovered reply — the messaging platform's rate limit 
 # failures. Permanent rejects (blocked bot, bad auth, missing chat) must not be retried on reconnect.
 _RUNTIME_RETRYABLE_ERRORS = frozenset({"send_path_degraded"})
 
-# A final send the platform refused with flood control is the other transient case: a 429 means the refused
-# request was never accepted, and the platform said how long to wait. Adapters fail such sends closed as
-# ``flood_control:<seconds>`` on
-# purpose (#91969) so that this ledger owns the wait instead of the send coroutine sleeping through it.
-# Before this the row simply sat in ``failed`` until the next restart's sweep, which then redelivered it
-# hours late under the "gateway restarted during delivery" marker (ledger-flood-retry).
+# A final send the platform refused with flood control is the other transient case: a 429 means the
+# refused request was never accepted, and the platform said how long to wait. Adapters fail such sends
+# closed as ``flood_control:<seconds>`` on purpose (#91969) so that this ledger owns the wait instead of
+# the send coroutine sleeping through it. Before this the row simply sat in ``failed`` until the next
+# restart's sweep, which then redelivered it hours late under the "gateway restarted during delivery"
+# marker.
 FLOOD_ERROR_PREFIX = "flood_control:"
 FLOOD_RETRY_DEFAULT_SECONDS = 60.0
 FLOOD_RETRY_CAP_SECONDS = 15 * 60.0
@@ -305,7 +305,14 @@ def sweep_recoverable(now: Optional[float] = None, *, deliverable_platforms: Opt
     must only be spent on a real send, else a platform that failed to connect burns one attempt per boot
     and hits the cap having never been sent once (the stale cutoff still bounds untouched rows).
     ``deliverable_targets`` further scopes multiplexed gateways by exact ``(platform, adapter_profile)``
-    so one connected bot cannot spend another disconnected bot's retry budget."""
+    so one connected bot cannot spend another disconnected bot's retry budget.
+
+    A flood-refused row still inside its wait is adopted (owner re-stamped, no attempt spent) and
+    returned flagged ``adopted`` with its ``not_before``: the caller clears its session's resume flag
+    like any other claimed row, since the answer is in the ledger, but must not send it; the flood
+    timer does once the wait has passed. A legacy row without ``adapter_profile`` is normalised to
+    ``'default'`` on claim or adoption (the caller only accepts such rows when it is not multiplexed),
+    because the runtime sweep matches profiles exactly and could otherwise never claim it."""
     now, (pid, started) = now if now is not None else time.time(), _owner_stamp()
     claimed: List[Dict[str, Any]] = []
     with _DB_LOCK, _transaction() as conn:
@@ -332,17 +339,25 @@ def sweep_recoverable(now: Optional[float] = None, *, deliverable_platforms: Opt
             if flood_row and now < flood_not_before(updated_at, last_error):
                 # Still inside the platform's wait: adopt the dead owner's row without spending an attempt
                 # (state and error kept) so this process's flood timer can claim it once the wait passes.
-                conn.execute(
+                cursor = conn.execute(
                     """UPDATE delivery_obligations
-                       SET owner_pid=?, owner_started_at=?
+                       SET owner_pid=?, owner_started_at=?,
+                           adapter_profile=COALESCE(adapter_profile, 'default')
                        WHERE obligation_id=? AND (owner_pid IS ? OR owner_pid=?)""",
                     (pid, started, oid, owner_pid, owner_pid))
+                if cursor.rowcount:
+                    claimed.append({
+                        "obligation_id": oid, "session_key": session_key, "platform": platform,
+                        "chat_id": chat_id, "thread_id": thread_id, "content": content,
+                        "profile": adapter_profile or "default", "attempts": attempts,
+                        "adopted": True, "not_before": flood_not_before(updated_at, last_error)})
                 continue
             # A claimed flood row is resent as a fresh attempt: clear the stale refusal so an interrupted
             # resend is seen as 'attempting' with no error by the next boot and gets the marker.
             cursor = conn.execute(
                 """UPDATE delivery_obligations
                    SET owner_pid=?, owner_started_at=?, attempts=attempts+1, updated_at=?,
+                       adapter_profile=COALESCE(adapter_profile, 'default'),
                        state=CASE WHEN ? THEN 'attempting' ELSE state END,
                        last_error=CASE WHEN ? THEN NULL ELSE last_error END
                    WHERE obligation_id=? AND (owner_pid IS ? OR owner_pid=?)""",
@@ -352,7 +367,8 @@ def sweep_recoverable(now: Optional[float] = None, *, deliverable_platforms: Opt
                 # rejection, a flood refusal whose earlier chunks the platform may have accepted) carries
                 # the marker.
                 claimed.append(_claimed_row(oid, session_key, platform, chat_id, thread_id, content, attempts,
-                                            adapter_profile, needs_marker=state != "pending", flood=flood_row))
+                                            adapter_profile or "default", needs_marker=state != "pending",
+                                            flood=flood_row))
     return claimed
 
 

--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -39,10 +39,83 @@ _MAX_ROWS = 500
 RECOVERED_MARKER = "♻️ Recovered reply — the gateway restarted during delivery, so this may be a duplicate:\n\n"
 RECONNECTED_MARKER = ("♻️ Recovered reply — the messaging platform reconnected after the original "
                       "delivery failed, so this may be a duplicate:\n\n")
+# A chunked reply refused by flood control: the platform may have accepted the first chunk(s) before
+# refusing the rest, and the send result does not say which landed. Neither of the markers above tells
+# the truth here (no restart, no reconnect), so the rate limit gets its own.
+FLOOD_MARKER = ("♻️ Recovered reply — the messaging platform's rate limit refused the original before "
+                "every part was accepted, so this may repeat some of it:\n\n")
 
 # Runtime replay is fail-closed: only errors whose send contract proves they are transient reconnect
 # failures. Permanent rejects (blocked bot, bad auth, missing chat) must not be retried on reconnect.
 _RUNTIME_RETRYABLE_ERRORS = frozenset({"send_path_degraded"})
+
+# A final send the platform refused with flood control is the other transient case, and an unambiguous
+# one: a 429 means the message was never accepted, so redelivering it needs no duplicate marker, and the
+# platform said how long to wait. Adapters fail such sends closed as ``flood_control:<seconds>`` on
+# purpose (#91969) so that this ledger owns the wait instead of the send coroutine sleeping through it.
+# Before this the row simply sat in ``failed`` until the next restart's sweep, which then redelivered it
+# hours late under the "gateway restarted during delivery" marker (ledger-flood-retry).
+FLOOD_ERROR_PREFIX = "flood_control:"
+FLOOD_RETRY_DEFAULT_SECONDS = 60.0
+FLOOD_RETRY_CAP_SECONDS = 15 * 60.0
+FLOOD_RETRY_SLACK_SECONDS = 2.0
+# Telegram's message cap in UTF-16 code units. A reply that fits in one message is one request, so a flood
+# refusal of it proves nothing reached the chat. A longer reply is chunked and the send result does not say
+# which chunks landed before the refusal, so those keep the duplicate marker.
+FLOOD_SINGLE_MESSAGE_UNITS = 4096
+
+
+def is_flood_error(error: Any) -> bool:
+    """True for the adapters' fail-closed flood result (``flood_control:<seconds>``)."""
+    return str(error or "").strip().lower().startswith(FLOOD_ERROR_PREFIX)
+
+
+def flood_wait_seconds(error: Any, default: float = FLOOD_RETRY_DEFAULT_SECONDS) -> float:
+    """The wait the platform asked for, read from ``flood_control:<seconds>``; ``default`` when unreadable."""
+    text = str(error or "").strip().lower()
+    wait = default
+    if text.startswith(FLOOD_ERROR_PREFIX):
+        try:
+            wait = float(text[len(FLOOD_ERROR_PREFIX):].strip())
+        except ValueError:
+            wait = default
+    return wait if wait > 0 else default
+
+
+def flood_retry_delay(seconds: Any) -> float:
+    """How long a redelivery timer sleeps for a wait of ``seconds``: capped so a huge or bogus value cannot
+    park the timer for hours (the row's own deadline, not the timer, decides eligibility when it fires),
+    plus a little slack so the timer lands after the deadline rather than on it."""
+    try:
+        wait = float(seconds)
+    except (TypeError, ValueError):
+        wait = FLOOD_RETRY_DEFAULT_SECONDS
+    return min(max(wait, 0.0), FLOOD_RETRY_CAP_SECONDS) + FLOOD_RETRY_SLACK_SECONDS
+
+
+def flood_not_before(updated_at: Any, last_error: Any) -> float:
+    """Earliest moment a flood-refused row may be resent: the refusal's timestamp (``mark_failed`` sets
+    ``updated_at``) plus the platform's wait. Enforced by the sweeps so neither an early timer nor a
+    reconnect sweep spends a redelivery attempt inside the penalty window."""
+    try:
+        stamp = float(updated_at or 0.0)
+    except (TypeError, ValueError):
+        stamp = 0.0
+    return stamp + flood_wait_seconds(last_error)
+
+
+def _utf16_units(text: Any) -> int:
+    return len(str(text or "").encode("utf-16-le")) // 2
+
+
+def flood_non_delivery_is_certain(last_error: Any, content: Any) -> bool:
+    """A flood refusal proves non-delivery only for a reply that went out as one message."""
+    return is_flood_error(last_error) and _utf16_units(content) <= FLOOD_SINGLE_MESSAGE_UNITS
+
+
+def _runtime_retryable(last_error: Any) -> bool:
+    text = str(last_error or "").strip().lower()
+    return text in _RUNTIME_RETRYABLE_ERRORS or is_flood_error(text)
 
 
 def _db_path():
@@ -217,11 +290,14 @@ def _update_state(obligation_id: str, state: str, error: str = "") -> None:
 
 
 def _claimed_row(oid, session_key, platform, chat_id, thread_id, content, attempts, profile, *,
-                 needs_marker: bool, runtime: bool = False) -> Dict[str, Any]:
-    """Claimed-row dict handed back for redelivery; ``runtime`` adds the reconnect-marker fields."""
+                 needs_marker: bool, runtime: bool = False, flood: bool = False) -> Dict[str, Any]:
+    """Claimed-row dict handed back for redelivery. A marked row names its own cause: ``flood`` (a chunked
+    reply the rate limit refused part-way) gets FLOOD_MARKER at boot or at runtime, a ``runtime`` reconnect
+    replay gets RECONNECTED_MARKER, and a boot-recovered crash keeps the runner's restart marker default."""
+    marker = FLOOD_MARKER if flood else (RECONNECTED_MARKER if runtime else None)
     return {"obligation_id": oid, "session_key": session_key, "platform": platform, "chat_id": chat_id,
             "thread_id": thread_id, "content": content, "needs_marker": needs_marker,
-            **({"marker": RECONNECTED_MARKER} if runtime else {}), "profile": profile,
+            **({"marker": marker} if needs_marker and marker else {}), "profile": profile,
             **({"runtime_recovery": True} if runtime else {}), "attempts": attempts + 1}
 
 
@@ -243,12 +319,12 @@ def sweep_recoverable(now: Optional[float] = None, *, deliverable_platforms: Opt
         rows = conn.execute(
             """SELECT obligation_id, session_key, platform, chat_id, thread_id,
                       content, state, attempts, created_at,
-                      owner_pid, owner_started_at, adapter_profile
+                      owner_pid, owner_started_at, adapter_profile, last_error, updated_at
                FROM delivery_obligations
                WHERE state IN ('pending', 'attempting', 'failed')"""
         ).fetchall()
         for (oid, session_key, platform, chat_id, thread_id, content, state, attempts, created_at,
-             owner_pid, owner_started_at, adapter_profile) in rows:
+             owner_pid, owner_started_at, adapter_profile, last_error, updated_at) in rows:
             if _owner_alive(owner_pid, owner_started_at):
                 continue  # a live gateway still owns this row
             if attempts >= MAX_ATTEMPTS or (now - created_at) > STALE_AFTER_SECONDS:  # exhausted -> abandoned
@@ -259,15 +335,32 @@ def sweep_recoverable(now: Optional[float] = None, *, deliverable_platforms: Opt
             if ((deliverable_platforms is not None and platform not in deliverable_platforms)
                     or (deliverable_targets is not None and (platform, adapter_profile) not in deliverable_targets)):
                 continue  # no adapter this boot — claiming would spend an attempt on a no-op
+            flood_row = state == "failed" and is_flood_error(last_error)
+            if flood_row and now < flood_not_before(updated_at, last_error):
+                # Still inside the platform's wait: adopt the dead owner's row without spending an attempt
+                # (state and error kept) so this process's flood timer can claim it once the wait passes.
+                conn.execute(
+                    """UPDATE delivery_obligations
+                       SET owner_pid=?, owner_started_at=?
+                       WHERE obligation_id=? AND (owner_pid IS ? OR owner_pid=?)""",
+                    (pid, started, oid, owner_pid, owner_pid))
+                continue
+            # A claimed flood row is resent as a fresh attempt: clear the stale refusal so an interrupted
+            # resend is seen as 'attempting' with no error by the next boot and gets the marker.
             cursor = conn.execute(
                 """UPDATE delivery_obligations
-                   SET owner_pid=?, owner_started_at=?, attempts=attempts+1,
-                       updated_at=?
+                   SET owner_pid=?, owner_started_at=?, attempts=attempts+1, updated_at=?,
+                       state=CASE WHEN ? THEN 'attempting' ELSE state END,
+                       last_error=CASE WHEN ? THEN NULL ELSE last_error END
                    WHERE obligation_id=? AND (owner_pid IS ? OR owner_pid=?)""",
-                (pid, started, now, oid, owner_pid, owner_pid))
-            if cursor.rowcount:  # pending = never started, redeliver plainly; else carry marker
+                (pid, started, now, 1 if flood_row else 0, 1 if flood_row else 0, oid, owner_pid, owner_pid))
+            if cursor.rowcount:
+                # pending = never started, redeliver plainly; a flood refusal of a single-message reply =
+                # never accepted, likewise plain; anything else (crashed mid-await, other rejection, a
+                # chunked reply the platform may have partly accepted) carries the marker.
+                plain = state == "pending" or (flood_row and flood_non_delivery_is_certain(last_error, content))
                 claimed.append(_claimed_row(oid, session_key, platform, chat_id, thread_id, content, attempts,
-                                            adapter_profile, needs_marker=state != "pending"))
+                                            adapter_profile, needs_marker=not plain, flood=flood_row))
     return claimed
 
 
@@ -292,14 +385,14 @@ def sweep_failed_for_runtime(platform: str, now: Optional[float] = None, *,
         rows = conn.execute(
             """SELECT obligation_id, session_key, platform, chat_id, thread_id,
                       content, attempts, created_at, owner_pid,
-                      owner_started_at, last_error, adapter_profile
+                      owner_started_at, last_error, adapter_profile, updated_at
                FROM delivery_obligations
                WHERE state='failed' AND platform=?""", (platform,)).fetchall()
         for (oid, session_key, row_platform, chat_id, thread_id, content, attempts, created_at,
-             owner_pid, owner_started_at, last_error, adapter_profile) in rows:
+             owner_pid, owner_started_at, last_error, adapter_profile, updated_at) in rows:
             # Exact process-start matching prevents PID reuse from stealing work.
             if (adapter_profile != expected_profile or owner_pid != pid or owner_started_at != started
-                    or str(last_error or "").strip().lower() not in _RUNTIME_RETRYABLE_ERRORS):
+                    or not _runtime_retryable(last_error)):
                 continue
             owner_guard = (now, oid, owner_pid, owner_started_at)
             if attempts >= MAX_ATTEMPTS or (now - created_at) > STALE_AFTER_SECONDS:  # exhausted -> abandoned
@@ -309,15 +402,48 @@ def sweep_failed_for_runtime(platform: str, now: Optional[float] = None, *,
                        WHERE obligation_id=? AND state='failed'
                          AND owner_pid IS ? AND owner_started_at IS ?""", owner_guard)
                 continue
+            if is_flood_error(last_error) and now < flood_not_before(updated_at, last_error):
+                continue  # the platform's wait has not passed; the flood timer comes back for it
+            # The claim clears the stale error: this is a fresh attempt, and if it is interrupted the next
+            # boot must see 'attempting' with no proof of non-delivery, hence the marker.
             cursor = conn.execute(
                 """UPDATE delivery_obligations
-                   SET state='attempting', attempts=attempts+1, updated_at=?
+                   SET state='attempting', attempts=attempts+1, updated_at=?, last_error=NULL
                    WHERE obligation_id=? AND state='failed'
                      AND owner_pid IS ? AND owner_started_at IS ?""", owner_guard)
             if cursor.rowcount:
+                # A reconnect-retryable failure's ack may have been lost, so it carries the marker; a flood
+                # refusal of a single-message reply was never accepted, so it is redelivered plainly.
                 claimed.append(_claimed_row(oid, session_key, row_platform, chat_id, thread_id, content,
-                                            attempts, adapter_profile, needs_marker=True, runtime=True))
+                                            attempts, adapter_profile,
+                                            needs_marker=not flood_non_delivery_is_certain(last_error, content),
+                                            runtime=True, flood=is_flood_error(last_error)))
     return claimed
+
+
+def pending_flood_retries(now: Optional[float] = None) -> List[Dict[str, Any]]:
+    """This process's flood-refused rows that still await redelivery, one entry per adapter identity
+    with the earliest deadline (``not_before``). The runner arms one redelivery timer per entry, so a
+    row adopted at boot, skipped because its wait had not passed, or refused again is never stranded.
+    Rows past the attempts cap or stale cutoff are left for the sweeps to abandon."""
+    now, (pid, started) = now if now is not None else time.time(), _owner_stamp()
+    if started is None:
+        return []
+    with _DB_LOCK, _transaction() as conn:
+        rows = conn.execute(
+            """SELECT platform, adapter_profile, updated_at, last_error, attempts, created_at
+               FROM delivery_obligations
+               WHERE state='failed' AND owner_pid IS ? AND owner_started_at IS ?""", (pid, started)).fetchall()
+    earliest: Dict[tuple, float] = {}
+    for platform, adapter_profile, updated_at, last_error, attempts, created_at in rows:
+        if not is_flood_error(last_error) or attempts >= MAX_ATTEMPTS or (now - created_at) > STALE_AFTER_SECONDS:
+            continue
+        due = flood_not_before(updated_at, last_error)
+        key = (platform, adapter_profile or "default")
+        if key not in earliest or due < earliest[key]:
+            earliest[key] = due
+    return [{"platform": platform, "profile": profile, "not_before": due}
+            for (platform, profile), due in sorted(earliest.items())]
 
 
 def _prune(now: Optional[float] = None) -> None:

--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -39,19 +39,21 @@ _MAX_ROWS = 500
 RECOVERED_MARKER = "♻️ Recovered reply — the gateway restarted during delivery, so this may be a duplicate:\n\n"
 RECONNECTED_MARKER = ("♻️ Recovered reply — the messaging platform reconnected after the original "
                       "delivery failed, so this may be a duplicate:\n\n")
-# A chunked reply refused by flood control: the platform may have accepted the first chunk(s) before
-# refusing the rest, and the send result does not say which landed. Neither of the markers above tells
-# the truth here (no restart, no reconnect), so the rate limit gets its own.
-FLOOD_MARKER = ("♻️ Recovered reply — the messaging platform's rate limit refused the original before "
-                "every part was accepted, so this may repeat some of it:\n\n")
+# A reply refused by flood control may have gone out as several requests (the adapter chunks long replies,
+# and MarkdownV2 escaping alone can push a reply that fits one message into two), and the platform may have
+# accepted the first chunk(s) before refusing the rest; the send result does not say which landed. The raw
+# length of the stored text says nothing about that, so every flood redelivery carries a marker, and neither
+# of the markers above tells the truth here (no restart, no reconnect): the rate limit gets its own.
+FLOOD_MARKER = ("♻️ Recovered reply — the messaging platform's rate limit refused the original, so part of "
+                "it may already have arrived above:\n\n")
 
 # Runtime replay is fail-closed: only errors whose send contract proves they are transient reconnect
 # failures. Permanent rejects (blocked bot, bad auth, missing chat) must not be retried on reconnect.
 _RUNTIME_RETRYABLE_ERRORS = frozenset({"send_path_degraded"})
 
-# A final send the platform refused with flood control is the other transient case, and an unambiguous
-# one: a 429 means the message was never accepted, so redelivering it needs no duplicate marker, and the
-# platform said how long to wait. Adapters fail such sends closed as ``flood_control:<seconds>`` on
+# A final send the platform refused with flood control is the other transient case: a 429 means the refused
+# request was never accepted, and the platform said how long to wait. Adapters fail such sends closed as
+# ``flood_control:<seconds>`` on
 # purpose (#91969) so that this ledger owns the wait instead of the send coroutine sleeping through it.
 # Before this the row simply sat in ``failed`` until the next restart's sweep, which then redelivered it
 # hours late under the "gateway restarted during delivery" marker (ledger-flood-retry).
@@ -59,10 +61,6 @@ FLOOD_ERROR_PREFIX = "flood_control:"
 FLOOD_RETRY_DEFAULT_SECONDS = 60.0
 FLOOD_RETRY_CAP_SECONDS = 15 * 60.0
 FLOOD_RETRY_SLACK_SECONDS = 2.0
-# Telegram's message cap in UTF-16 code units. A reply that fits in one message is one request, so a flood
-# refusal of it proves nothing reached the chat. A longer reply is chunked and the send result does not say
-# which chunks landed before the refusal, so those keep the duplicate marker.
-FLOOD_SINGLE_MESSAGE_UNITS = 4096
 
 
 def is_flood_error(error: Any) -> bool:
@@ -102,15 +100,6 @@ def flood_not_before(updated_at: Any, last_error: Any) -> float:
     except (TypeError, ValueError):
         stamp = 0.0
     return stamp + flood_wait_seconds(last_error)
-
-
-def _utf16_units(text: Any) -> int:
-    return len(str(text or "").encode("utf-16-le")) // 2
-
-
-def flood_non_delivery_is_certain(last_error: Any, content: Any) -> bool:
-    """A flood refusal proves non-delivery only for a reply that went out as one message."""
-    return is_flood_error(last_error) and _utf16_units(content) <= FLOOD_SINGLE_MESSAGE_UNITS
 
 
 def _runtime_retryable(last_error: Any) -> bool:
@@ -290,15 +279,19 @@ def _update_state(obligation_id: str, state: str, error: str = "") -> None:
 
 
 def _claimed_row(oid, session_key, platform, chat_id, thread_id, content, attempts, profile, *,
-                 needs_marker: bool, runtime: bool = False, flood: bool = False) -> Dict[str, Any]:
-    """Claimed-row dict handed back for redelivery. A marked row names its own cause: ``flood`` (a chunked
-    reply the rate limit refused part-way) gets FLOOD_MARKER at boot or at runtime, a ``runtime`` reconnect
-    replay gets RECONNECTED_MARKER, and a boot-recovered crash keeps the runner's restart marker default."""
+                 needs_marker: bool, runtime: bool = False, flood: bool = False,
+                 last_error: Optional[str] = None) -> Dict[str, Any]:
+    """Claimed-row dict handed back for redelivery. A marked row names its own cause: ``flood`` (a reply
+    the rate limit refused, possibly after accepting part of it) gets FLOOD_MARKER at boot or at runtime, a
+    ``runtime`` reconnect replay gets RECONNECTED_MARKER, and a boot-recovered crash keeps the runner's
+    restart marker default. ``last_error`` is the row's pre-claim error, carried so a runtime claim that is
+    released unsent goes back to ``failed`` with the same error and keeps its retry eligibility."""
     marker = FLOOD_MARKER if flood else (RECONNECTED_MARKER if runtime else None)
     return {"obligation_id": oid, "session_key": session_key, "platform": platform, "chat_id": chat_id,
             "thread_id": thread_id, "content": content, "needs_marker": needs_marker,
             **({"marker": marker} if needs_marker and marker else {}), "profile": profile,
-            **({"runtime_recovery": True} if runtime else {}), "attempts": attempts + 1}
+            **({"runtime_recovery": True} if runtime else {}),
+            **({"last_error": last_error} if last_error else {}), "attempts": attempts + 1}
 
 
 def sweep_recoverable(now: Optional[float] = None, *, deliverable_platforms: Optional[set] = None,
@@ -355,12 +348,11 @@ def sweep_recoverable(now: Optional[float] = None, *, deliverable_platforms: Opt
                    WHERE obligation_id=? AND (owner_pid IS ? OR owner_pid=?)""",
                 (pid, started, now, 1 if flood_row else 0, 1 if flood_row else 0, oid, owner_pid, owner_pid))
             if cursor.rowcount:
-                # pending = never started, redeliver plainly; a flood refusal of a single-message reply =
-                # never accepted, likewise plain; anything else (crashed mid-await, other rejection, a
-                # chunked reply the platform may have partly accepted) carries the marker.
-                plain = state == "pending" or (flood_row and flood_non_delivery_is_certain(last_error, content))
+                # pending = never started, redeliver plainly; anything else (crashed mid-await, other
+                # rejection, a flood refusal whose earlier chunks the platform may have accepted) carries
+                # the marker.
                 claimed.append(_claimed_row(oid, session_key, platform, chat_id, thread_id, content, attempts,
-                                            adapter_profile, needs_marker=not plain, flood=flood_row))
+                                            adapter_profile, needs_marker=state != "pending", flood=flood_row))
     return claimed
 
 
@@ -374,8 +366,8 @@ def sweep_failed_for_runtime(platform: str, now: Optional[float] = None, *,
     rejected with ``send_path_degraded`` would stay stranded when only the adapter reconnects; this closes
     that gap without weakening ownership: only rows stamped to this exact process instance, only
     allowlisted transient errors, same attempts/staleness bounds, every update guarded by the prior owner
-    stamp and ``failed`` state. Claimed rows always carry the reconnect marker (the failed send's ack is
-    not safe to infer)."""
+    stamp and ``failed`` state. Claimed rows always carry a marker (the failed send's ack is not safe to
+    infer): the reconnect one, or the rate-limit one for a flood-refused row."""
     now, (pid, started) = now if now is not None else time.time(), _owner_stamp()
     if started is None:  # PID alone cannot distinguish this process from a stale row left after PID
         return []        # reuse; runtime replay is optional, so fail closed (startup recovery remains).
@@ -412,12 +404,12 @@ def sweep_failed_for_runtime(platform: str, now: Optional[float] = None, *,
                    WHERE obligation_id=? AND state='failed'
                      AND owner_pid IS ? AND owner_started_at IS ?""", owner_guard)
             if cursor.rowcount:
-                # A reconnect-retryable failure's ack may have been lost, so it carries the marker; a flood
-                # refusal of a single-message reply was never accepted, so it is redelivered plainly.
+                # The failed send's ack may have been lost (reconnect) or its earlier chunks accepted
+                # (flood): every runtime redelivery carries a marker. The pre-claim error rides along so a
+                # claim released unsent keeps its flood retry eligibility.
                 claimed.append(_claimed_row(oid, session_key, row_platform, chat_id, thread_id, content,
-                                            attempts, adapter_profile,
-                                            needs_marker=not flood_non_delivery_is_certain(last_error, content),
-                                            runtime=True, flood=is_flood_error(last_error)))
+                                            attempts, adapter_profile, needs_marker=True, runtime=True,
+                                            flood=is_flood_error(last_error), last_error=last_error))
     return claimed
 
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3752,7 +3752,7 @@ class BasePlatformAdapter(ABC):
         replacement adapter live, trigger another redelivery sweep (the watcher's may have run
         before this failure landed; atomic claiming keeps it idempotent). On a flood-control refusal
         arm the runner's timed redelivery, so the reply goes out once the penalty has passed instead
-        of waiting for the next restart (ledger-flood-retry)."""
+        of waiting for the next restart."""
         try:
             from gateway.delivery_ledger import is_flood_error, mark_delivered, mark_failed
             if getattr(result, "success", False):

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3750,9 +3750,11 @@ class BasePlatformAdapter(ABC):
         delivery_adapter: "BasePlatformAdapter") -> None:
         """Mark the ledger row delivered/failed (best-effort). On ``send_path_degraded`` with a
         replacement adapter live, trigger another redelivery sweep (the watcher's may have run
-        before this failure landed; atomic claiming keeps it idempotent)."""
+        before this failure landed; atomic claiming keeps it idempotent). On a flood-control refusal
+        arm the runner's timed redelivery, so the reply goes out once the penalty has passed instead
+        of waiting for the next restart (ledger-flood-retry)."""
         try:
-            from gateway.delivery_ledger import mark_delivered, mark_failed
+            from gateway.delivery_ledger import is_flood_error, mark_delivered, mark_failed
             if getattr(result, "success", False):
                 await asyncio.to_thread(mark_delivered, obligation_id)
                 return
@@ -3765,6 +3767,11 @@ class BasePlatformAdapter(ABC):
                 if live is not delivery_adapter and callable(redeliver):
                     await redeliver(event.source.platform,
                                     profile=getattr(delivery_adapter, "_owner_profile", None))
+            elif is_flood_error(error):
+                schedule = getattr(self.gateway_runner, "_schedule_flood_redelivery", None)
+                if callable(schedule):
+                    schedule(event.source.platform,
+                             profile=getattr(delivery_adapter, "_owner_profile", None), error=error)
         except Exception:
             logger.debug("delivery ledger update failed", exc_info=True)
 

--- a/gateway/run_startup.py
+++ b/gateway/run_startup.py
@@ -291,11 +291,15 @@ class GatewayStartupMixin:
         return claimed
 
     @staticmethod
-    async def _release_runtime_claim_quiet(obligation_id, log_fmt: str) -> None:
-        """Release a runtime delivery-ledger claim as ``send_path_degraded``; log-only on failure."""
+    async def _release_runtime_claim_quiet(obligation_id, log_fmt: str, error: str = "send_path_degraded") -> None:
+        """Release an unsent runtime delivery-ledger claim; log-only on failure. ``error`` is what the row
+        goes back to ``failed`` with: the claim's own pre-claim error when the caller knows it, so a
+        flood-refused row keeps its ``flood_control:<seconds>`` and stays on the flood timer's list (the
+        release re-stamps ``updated_at``, so it waits the platform's figure once more); else
+        ``send_path_degraded`` (ledger-flood-retry)."""
         from gateway.delivery_ledger import release_runtime_claim
         try:
-            await asyncio.to_thread(release_runtime_claim, obligation_id, "send_path_degraded")
+            await asyncio.to_thread(release_runtime_claim, obligation_id, error)
         except Exception:
             logger.debug(log_fmt, obligation_id, exc_info=True)
 
@@ -438,7 +442,8 @@ class GatewayStartupMixin:
         # attempt; startup claims keep their state (attempts cap + stale cutoff bound retries).
         if adapter is None and row.get("runtime_recovery"):
             await self._release_runtime_claim_quiet(
-                row["obligation_id"], "failed to release undispatched runtime obligation %s"
+                row["obligation_id"], "failed to release undispatched runtime obligation %s",
+                error=row.get("last_error") or "send_path_degraded",
             )
         return adapter
 
@@ -471,7 +476,8 @@ class GatewayStartupMixin:
         for row in claimed:
             if row["obligation_id"] not in sendable_ids:
                 await self._release_runtime_claim_quiet(
-                    row["obligation_id"], "failed to release runtime delivery claim %s"
+                    row["obligation_id"], "failed to release runtime delivery claim %s",
+                    error=row.get("last_error") or "send_path_degraded",
                 )
         return await self._redeliver_claimed_obligations(sendable)
 

--- a/gateway/run_startup.py
+++ b/gateway/run_startup.py
@@ -258,7 +258,8 @@ class GatewayStartupMixin:
         A session with a recoverable obligation already produced its answer — the turn completed and only
         delivery is owed — so clearing ``resume_pending`` here prevents the resume path from re-running (and
         re-paying for) a turn whose output we hold, regardless of how long the sends ahead of redelivery
-        take (#91969).
+        take (#91969). Flood-refused rows adopted inside their wait come back flagged ``adopted``: their
+        flags are cleared here too, and ``_redeliver_claimed_obligations`` leaves them to the timer.
         """
         try:
             from gateway.delivery_ledger import ledger_enabled, sweep_recoverable
@@ -296,7 +297,7 @@ class GatewayStartupMixin:
         goes back to ``failed`` with: the claim's own pre-claim error when the caller knows it, so a
         flood-refused row keeps its ``flood_control:<seconds>`` and stays on the flood timer's list (the
         release re-stamps ``updated_at``, so it waits the platform's figure once more); else
-        ``send_path_degraded`` (ledger-flood-retry)."""
+        ``send_path_degraded``."""
         from gateway.delivery_ledger import release_runtime_claim
         try:
             await asyncio.to_thread(release_runtime_claim, obligation_id, error)
@@ -305,7 +306,7 @@ class GatewayStartupMixin:
 
     def _schedule_flood_redelivery(self, platform, *, profile: Optional[str] = None, error: str = "",
                                    wait_seconds: Optional[float] = None):
-        """Retry a flood-refused final reply once the platform's penalty has passed (ledger-flood-retry).
+        """Retry a flood-refused final reply once the platform's penalty has passed.
 
         Adapters fail a flood-controlled final send closed as ``flood_control:<seconds>`` so the send
         coroutine never sleeps a long penalty (#91969), on the understanding that the delivery ledger
@@ -316,34 +317,45 @@ class GatewayStartupMixin:
         row whose own deadline has passed and leaves the rest, and the timer re-arms for whatever is
         still waiting, so a capped sleep or a shorter sibling never sends early. Bounded like every
         redelivery by the ledger's attempts cap and stale cutoff. Returns the delay, or None when a timer
-        for this identity is already waiting."""
+        for this identity is already waiting with an earlier or equal deadline."""
         from gateway.delivery_ledger import flood_retry_delay, flood_wait_seconds
         pvalue = getattr(platform, "value", str(platform))
         key = (pvalue, profile or "default")
         pending = getattr(self, "_flood_redelivery_tasks", None)
         if pending is None:
             pending = self._flood_redelivery_tasks = {}
+        slots = getattr(self, "_flood_redelivery_slots", None)
+        if slots is None:
+            slots = self._flood_redelivery_slots = {}
         existing = pending.get(key)
         try:
             caller_task = asyncio.current_task()
         except RuntimeError:
             caller_task = None
+        delay = flood_retry_delay(wait_seconds if wait_seconds is not None else flood_wait_seconds(error))
+        due_at = time.time() + delay
         # One live timer per identity, except that the running timer itself (a refusal during its sweep,
         # rows still inside their wait afterwards) may arm its successor into the slot: a timer must never
         # block its own re-arm, and the slot stays occupied until the task ends so nothing observing it
-        # mistakes a sweep in progress for a finished timer.
+        # mistakes a sweep in progress for a finished timer. A timer still asleep is replaced by a shorter
+        # one (a 10s refusal must not wait behind a 185s sibling); the shorter timer re-arms for the longer
+        # row after its sweep, so the longer wait is kept, only not imposed on both.
         if existing is not None and not existing.done() and existing is not caller_task:
-            return None
-        delay = flood_retry_delay(wait_seconds if wait_seconds is not None else flood_wait_seconds(error))
+            waiting = slots.get(key)
+            if waiting is None or not waiting["sleeping"] or due_at >= waiting["due_at"] - 1.0:
+                return None
+            existing.cancel()
+        slot = {"due_at": due_at, "sleeping": True}
 
         async def _redeliver_after_wait():
             try:
                 await asyncio.sleep(delay)
+                slot["sleeping"] = False
                 if not getattr(self, "_running", True):
                     return
                 target = platform if isinstance(platform, Platform) else Platform(pvalue)
                 await self._redeliver_failed_obligations_for_platform(target, profile=profile)
-                self._arm_flood_timers_for_waiting_rows()
+                await self._arm_flood_timers_for_waiting_rows()
             except asyncio.CancelledError:
                 raise
             except Exception:
@@ -351,6 +363,7 @@ class GatewayStartupMixin:
             finally:
                 if pending.get(key) is asyncio.current_task():
                     pending.pop(key, None)
+                    slots.pop(key, None)
 
         try:
             task = asyncio.get_running_loop().create_task(
@@ -358,17 +371,18 @@ class GatewayStartupMixin:
         except RuntimeError:
             return None
         pending[key] = task
+        slots[key] = slot
         logger.info("Flood control refused a final reply on %s (%s); ledger redelivery scheduled in %.0fs",
                     key[0], key[1], delay)
         return delay
 
-    def _arm_flood_timers_for_waiting_rows(self) -> int:
+    async def _arm_flood_timers_for_waiting_rows(self) -> int:
         """Arm a redelivery timer for every adapter identity that still owns a flood-refused row: rows
         adopted from a dead owner at boot, rows a sweep skipped because their wait had not passed, rows
         refused again on redelivery. Best-effort; returns how many timers were armed."""
         try:
             from gateway.delivery_ledger import pending_flood_retries
-            waiting = pending_flood_retries()
+            waiting = await asyncio.to_thread(pending_flood_retries)
         except Exception:
             logger.debug("could not list waiting flood-refused rows", exc_info=True)
             return 0
@@ -396,6 +410,10 @@ class GatewayStartupMixin:
             return 0
         redelivered = 0
         for row in claimed:
+            if row.get("adopted"):
+                # Adopted at boot inside its flood wait: its resume flag is cleared with the others, and
+                # the timer armed below sends it once the platform's deadline has passed.
+                continue
             adapter = await self._obligation_adapter(row)
             if adapter is None:
                 continue
@@ -423,7 +441,7 @@ class GatewayStartupMixin:
         # Whatever is still waiting on a flood penalty (adopted at boot, skipped as not yet due, refused
         # again just now) gets a timer, so no flood-refused reply waits for the next restart.
         with _log_suppressed(logging.DEBUG, "arming flood redelivery timers failed", exc_info=True):
-            self._arm_flood_timers_for_waiting_rows()
+            await self._arm_flood_timers_for_waiting_rows()
         return redelivered
 
     async def _obligation_adapter(self, row: dict):

--- a/gateway/run_startup.py
+++ b/gateway/run_startup.py
@@ -299,12 +299,92 @@ class GatewayStartupMixin:
         except Exception:
             logger.debug(log_fmt, obligation_id, exc_info=True)
 
+    def _schedule_flood_redelivery(self, platform, *, profile: Optional[str] = None, error: str = "",
+                                   wait_seconds: Optional[float] = None):
+        """Retry a flood-refused final reply once the platform's penalty has passed (ledger-flood-retry).
+
+        Adapters fail a flood-controlled final send closed as ``flood_control:<seconds>`` so the send
+        coroutine never sleeps a long penalty (#91969), on the understanding that the delivery ledger
+        owns the wait. Nothing did: the row sat in ``failed`` until the next restart's sweep, which then
+        redelivered it hours late under the "gateway restarted during delivery" marker. This arms one
+        timer per adapter identity that runs the existing runtime sweep after the wait (read from
+        ``error``, or given as ``wait_seconds`` for rows already in the ledger). The sweep claims every
+        row whose own deadline has passed and leaves the rest, and the timer re-arms for whatever is
+        still waiting, so a capped sleep or a shorter sibling never sends early. Bounded like every
+        redelivery by the ledger's attempts cap and stale cutoff. Returns the delay, or None when a timer
+        for this identity is already waiting."""
+        from gateway.delivery_ledger import flood_retry_delay, flood_wait_seconds
+        pvalue = getattr(platform, "value", str(platform))
+        key = (pvalue, profile or "default")
+        pending = getattr(self, "_flood_redelivery_tasks", None)
+        if pending is None:
+            pending = self._flood_redelivery_tasks = {}
+        existing = pending.get(key)
+        try:
+            caller_task = asyncio.current_task()
+        except RuntimeError:
+            caller_task = None
+        # One live timer per identity, except that the running timer itself (a refusal during its sweep,
+        # rows still inside their wait afterwards) may arm its successor into the slot: a timer must never
+        # block its own re-arm, and the slot stays occupied until the task ends so nothing observing it
+        # mistakes a sweep in progress for a finished timer.
+        if existing is not None and not existing.done() and existing is not caller_task:
+            return None
+        delay = flood_retry_delay(wait_seconds if wait_seconds is not None else flood_wait_seconds(error))
+
+        async def _redeliver_after_wait():
+            try:
+                await asyncio.sleep(delay)
+                if not getattr(self, "_running", True):
+                    return
+                target = platform if isinstance(platform, Platform) else Platform(pvalue)
+                await self._redeliver_failed_obligations_for_platform(target, profile=profile)
+                self._arm_flood_timers_for_waiting_rows()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.debug("flood-control redelivery for %s failed", key, exc_info=True)
+            finally:
+                if pending.get(key) is asyncio.current_task():
+                    pending.pop(key, None)
+
+        try:
+            task = asyncio.get_running_loop().create_task(
+                _redeliver_after_wait(), name="flood-redelivery:%s:%s" % key)
+        except RuntimeError:
+            return None
+        pending[key] = task
+        logger.info("Flood control refused a final reply on %s (%s); ledger redelivery scheduled in %.0fs",
+                    key[0], key[1], delay)
+        return delay
+
+    def _arm_flood_timers_for_waiting_rows(self) -> int:
+        """Arm a redelivery timer for every adapter identity that still owns a flood-refused row: rows
+        adopted from a dead owner at boot, rows a sweep skipped because their wait had not passed, rows
+        refused again on redelivery. Best-effort; returns how many timers were armed."""
+        try:
+            from gateway.delivery_ledger import pending_flood_retries
+            waiting = pending_flood_retries()
+        except Exception:
+            logger.debug("could not list waiting flood-refused rows", exc_info=True)
+            return 0
+        armed = 0
+        now = time.time()
+        for item in waiting:
+            try:
+                if self._schedule_flood_redelivery(
+                        item["platform"], profile=item["profile"], wait_seconds=item["not_before"] - now) is not None:
+                    armed += 1
+            except Exception:
+                logger.debug("could not arm a flood redelivery timer for %r", item, exc_info=True)
+        return armed
+
     async def _redeliver_claimed_obligations(self, claimed: list) -> int:
         """Redeliver final responses for claimed rows (network half of the split): runs inside the
         bounded boot-send task, so a flood-limited send can be abandoned by the restore gate without
         reopening the turn-replay window. Returns the redelivered count."""
-        if not claimed:
-            return 0
+        # No early return on an empty claim: the boot sweep may have ADOPTED flood-refused rows that are
+        # not due yet, and those still need their timer armed below.
         try:
             from gateway.delivery_ledger import RECOVERED_MARKER, mark_delivered, mark_failed
         except Exception:
@@ -336,6 +416,10 @@ class GatewayStartupMixin:
                     await asyncio.to_thread(
                         mark_failed, row["obligation_id"], str(getattr(result, "error", "") or "send failed")
                     )
+        # Whatever is still waiting on a flood penalty (adopted at boot, skipped as not yet due, refused
+        # again just now) gets a timer, so no flood-refused reply waits for the next restart.
+        with _log_suppressed(logging.DEBUG, "arming flood redelivery timers failed", exc_info=True):
+            self._arm_flood_timers_for_waiting_rows()
         return redelivered
 
     async def _obligation_adapter(self, row: dict):

--- a/gateway/run_startup.py
+++ b/gateway/run_startup.py
@@ -355,7 +355,7 @@ class GatewayStartupMixin:
                     return
                 target = platform if isinstance(platform, Platform) else Platform(pvalue)
                 await self._redeliver_failed_obligations_for_platform(target, profile=profile)
-                await self._arm_flood_timers_for_waiting_rows()
+                self._arm_flood_timers_for_waiting_rows()
             except asyncio.CancelledError:
                 raise
             except Exception:
@@ -376,13 +376,19 @@ class GatewayStartupMixin:
                     key[0], key[1], delay)
         return delay
 
-    async def _arm_flood_timers_for_waiting_rows(self) -> int:
+    def _arm_flood_timers_for_waiting_rows(self) -> int:
         """Arm a redelivery timer for every adapter identity that still owns a flood-refused row: rows
         adopted from a dead owner at boot, rows a sweep skipped because their wait had not passed, rows
-        refused again on redelivery. Best-effort; returns how many timers were armed."""
+        refused again on redelivery. Best-effort; returns how many timers were armed.
+
+        The ledger read is synchronous on purpose. A running timer clears its slot right after this
+        call, and a concurrent flood refusal's ``_schedule_flood_redelivery`` is declined while that
+        slot is occupied; reading in a worker thread would let that refusal's row be recorded during
+        the yield, after this snapshot was taken but before the slot is freed, and its timer request
+        would be lost. A single indexed SELECT on a small table does not need to leave the loop."""
         try:
             from gateway.delivery_ledger import pending_flood_retries
-            waiting = await asyncio.to_thread(pending_flood_retries)
+            waiting = pending_flood_retries()
         except Exception:
             logger.debug("could not list waiting flood-refused rows", exc_info=True)
             return 0
@@ -441,7 +447,7 @@ class GatewayStartupMixin:
         # Whatever is still waiting on a flood penalty (adopted at boot, skipped as not yet due, refused
         # again just now) gets a timer, so no flood-refused reply waits for the next restart.
         with _log_suppressed(logging.DEBUG, "arming flood redelivery timers failed", exc_info=True):
-            await self._arm_flood_timers_for_waiting_rows()
+            self._arm_flood_timers_for_waiting_rows()
         return redelivered
 
     async def _obligation_adapter(self, row: dict):

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3302,6 +3302,15 @@ class TelegramAdapter(BasePlatformAdapter):
                             _send_attempt + 1, wait, safe_send_error)
                         await asyncio.sleep(wait)
                         continue
+                    # Retries exhausted and still flooded. Fail closed the same way a long penalty
+                    # does: raising here handed the caller the platform's own wording instead of the
+                    # canonical result, so the delivery ledger did not recognise the row as a flood
+                    # refusal, armed no redelivery timer, and the reply waited for the next restart.
+                    logger.warning(
+                        "[%s] Telegram flood control on send persisted across %d attempts; failing "
+                        "closed so the delivery ledger owns the wait: %s",
+                        self.name, _send_attempt + 1, safe_send_error)
+                    return _flood_cap_result(wait)
                 raise
 
     async def _retrigger_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]]) -> None:
@@ -3514,6 +3523,14 @@ class TelegramAdapter(BasePlatformAdapter):
                 except Exception as retry_err:
                     safe_retry_error = _redact_telegram_error_text(retry_err)
                     logger.error("[%s] Edit retry failed after flood wait: %s", self.name, safe_retry_error)
+                    retry_wait = getattr(retry_err, "retry_after", None)
+                    if retry_wait is not None or "retry after" in str(retry_err).lower():
+                        # Still flooded after the inline wait, and typically for much longer than the
+                        # first refusal asked for. Fail closed canonically so the ledger arms its
+                        # timer on this delay rather than storing the platform's raw wording, which
+                        # it would read as an ordinary failure and never redeliver.
+                        return _flood_cap_result(
+                            float(retry_wait) if retry_wait is not None else wait)
                     return SendResult(success=False, error=safe_retry_error)
             safe_error = _redact_telegram_error_text(e)
             # Transient network errors must not permanently disable progress-message editing.

--- a/tests/gateway/test_delivery_ledger_flood_retry.py
+++ b/tests/gateway/test_delivery_ledger_flood_retry.py
@@ -16,10 +16,12 @@ Now:
 - the runner arms one timer per adapter identity; the slot stays occupied until the
   timer ends, only the running timer may arm its successor into it, and it re-arms
   for whatever is still waiting;
-- a flood refusal of a single-message reply proves non-delivery, so that redelivery
-  carries no duplicate marker; a chunked reply may have been partly accepted and
-  carries one that names the rate limit; a claimed row's stale refusal is cleared so an interrupted resend is
-  seen as uncertain by the next boot;
+- every flood redelivery carries a marker that names the rate limit (the platform may
+  have accepted earlier chunks, and the stored text's raw length cannot tell: MarkdownV2
+  escaping alone can turn a one-message reply into two requests); a claimed row's stale
+  refusal is cleared so an interrupted resend is seen as uncertain by the next boot; a
+  claim released unsent (resume flag not clearable, adapter gone) keeps its flood error
+  and so its place on the timer;
 - at boot, a dead owner's not-yet-due flood row is adopted rather than resent early.
 """
 
@@ -146,18 +148,28 @@ def test_flood_not_before_is_the_refusal_time_plus_the_platform_wait():
     assert dl.flood_not_before(None, "flood_control:9") == pytest.approx(9.0)
 
 
-def test_non_delivery_is_certain_only_for_a_single_message_reply():
-    assert dl.flood_non_delivery_is_certain("flood_control:9", "x" * 4096) is True
-    assert dl.flood_non_delivery_is_certain("flood_control:9", "x" * 4097) is False
-    assert dl.flood_non_delivery_is_certain("flood_control:9", "\U0001F600" * 2049) is False, "UTF-16 units, not chars"
-    assert dl.flood_non_delivery_is_certain("send_path_degraded", "x") is False
+@pytest.mark.parametrize("content", ["x" * 10, "." * 3000, "word " * 1200])
+def test_every_flood_redelivery_carries_the_rate_limit_marker(clock, monkeypatch, content):
+    """Raw length proves nothing about how many requests the adapter made: MarkdownV2 escaping turns 3000
+    dots into 6000 UTF-16 units, two Telegram messages, and the send result does not say which chunk was
+    refused. So there is no length-based certainty; the marker is unconditional, at runtime and at boot."""
+    _record("ob-runtime", content=content)
+    dl.mark_failed("ob-runtime", "flood_control:9")
+    (runtime_row,) = dl.sweep_failed_for_runtime("telegram", now=T0 + 20)
+    assert runtime_row["needs_marker"] is True and runtime_row["marker"] == dl.FLOOD_MARKER
+
+    _record("ob-boot", content=content)
+    dl.mark_failed("ob-boot", "flood_control:9")
+    monkeypatch.setattr(dl, "_owner_alive", lambda pid, started: False)
+    boot_rows = {row["obligation_id"]: row for row in dl.sweep_recoverable(now=T0 + 20)}
+    assert boot_rows["ob-boot"]["needs_marker"] is True and boot_rows["ob-boot"]["marker"] == dl.FLOOD_MARKER
 
 
 # ---------------------------------------------------------------------------
 # The runtime sweep: which rows it claims, when, and how it marks them.
 # ---------------------------------------------------------------------------
 
-def test_runtime_sweep_claims_a_due_flood_row_plainly_and_clears_the_stale_refusal(clock):
+def test_runtime_sweep_claims_a_due_flood_row_under_the_rate_limit_marker_and_clears_the_stale_refusal(clock):
     _record("ob-flood")
     dl.mark_failed("ob-flood", "flood_control:185.0")
     _record("ob-degraded")
@@ -168,10 +180,12 @@ def test_runtime_sweep_claims_a_due_flood_row_plainly_and_clears_the_stale_refus
     claimed = {row["obligation_id"]: row for row in dl.sweep_failed_for_runtime("telegram", now=T0 + 200)}
 
     assert set(claimed) == {"ob-flood", "ob-degraded"}, "a permanent rejection must never be replayed"
-    assert claimed["ob-flood"]["needs_marker"] is False, "a 429 of a single message was never accepted"
-    assert "marker" not in claimed["ob-flood"]
+    assert claimed["ob-flood"]["needs_marker"] is True
+    assert claimed["ob-flood"]["marker"] == dl.FLOOD_MARKER
+    assert claimed["ob-flood"]["last_error"] == "flood_control:185.0", "the pre-claim error rides along for a release"
     assert claimed["ob-degraded"]["needs_marker"] is True
     assert claimed["ob-degraded"]["marker"] == dl.RECONNECTED_MARKER
+    assert claimed["ob-degraded"]["last_error"] == "send_path_degraded"
     flood = _row("ob-flood")
     assert flood["state"] == "attempting" and flood["attempts"] == 1
     assert flood["last_error"] is None, "the claim is a fresh attempt; the old refusal must not survive it"
@@ -219,7 +233,7 @@ def test_boot_sweep_adopts_a_dead_owners_flood_row_inside_its_wait(clock, monkey
     assert dl.pending_flood_retries(now=T0 + 30)[0]["not_before"] == pytest.approx(T0 + 185)
 
 
-def test_boot_sweep_resends_a_due_flood_row_plainly_and_a_midsend_row_with_the_marker(clock, monkeypatch):
+def test_boot_sweep_resends_a_due_flood_row_under_the_rate_limit_marker_and_a_midsend_row_under_the_restart_one(clock, monkeypatch):
     _record("ob-flood")
     dl.mark_failed("ob-flood", "flood_control:185.0")
     _record("ob-midsend")  # crashed mid-await: the platform MAY have it
@@ -227,8 +241,10 @@ def test_boot_sweep_resends_a_due_flood_row_plainly_and_a_midsend_row_with_the_m
 
     claimed = {row["obligation_id"]: row for row in dl.sweep_recoverable(now=T0 + 300)}
 
-    assert claimed["ob-flood"]["needs_marker"] is False
+    assert claimed["ob-flood"]["needs_marker"] is True
+    assert claimed["ob-flood"]["marker"] == dl.FLOOD_MARKER
     assert claimed["ob-midsend"]["needs_marker"] is True
+    assert "marker" not in claimed["ob-midsend"], "a crash mid-send is the runner's restart marker"
     flood = _row("ob-flood")
     assert flood["state"] == "attempting" and flood["last_error"] is None and flood["attempts"] == 1
 
@@ -245,12 +261,12 @@ def test_boot_sweep_keeps_the_marker_for_a_chunked_flood_refused_reply(clock, mo
 
 
 def test_an_interrupted_flood_resend_gets_the_marker_on_the_next_boot(clock, monkeypatch):
-    """Runtime claim, platform accepts, process dies before mark_delivered: the next boot must not treat
-    the old refusal as proof of non-delivery."""
+    """Runtime claim, platform accepts, process dies before mark_delivered: the next boot must see an
+    ordinary interrupted send (restart marker), not a flood row."""
     _record("ob-flood")
     dl.mark_failed("ob-flood", "flood_control:9")
     (claimed,) = dl.sweep_failed_for_runtime("telegram", now=T0 + 20)
-    assert claimed["needs_marker"] is False
+    assert claimed["marker"] == dl.FLOOD_MARKER
     monkeypatch.setattr(dl, "_owner_alive", lambda pid, started: False)  # that process is gone
 
     (recovered,) = dl.sweep_recoverable(now=T0 + 60)
@@ -315,7 +331,7 @@ async def test_schedule_flood_redelivery_does_nothing_after_shutdown(monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_timer_delivers_the_refused_reply_plainly_end_to_end(fake_sleep):
+async def test_timer_delivers_the_refused_reply_under_the_rate_limit_marker_end_to_end(fake_sleep):
     _record("ob-flood", content="Here is the plan for today.")
     dl.mark_failed("ob-flood", "flood_control:185.0")
     adapter = _adapter(success=True)
@@ -325,8 +341,8 @@ async def test_timer_delivers_the_refused_reply_plainly_end_to_end(fake_sleep):
     await _drain_timers(runner)
 
     sent = adapter.send.call_args.kwargs
-    assert sent["content"] == "Here is the plan for today."
-    assert "Recovered reply" not in sent["content"]
+    assert sent["content"] == dl.FLOOD_MARKER + "Here is the plan for today."
+    assert "restarted" not in sent["content"] and "reconnected" not in sent["content"]
     assert _row("ob-flood")["state"] == "delivered"
     assert fake_sleep == [pytest.approx(187.0)]
 
@@ -396,7 +412,7 @@ async def test_a_shorter_sibling_timer_does_not_send_the_longer_row_early(fake_s
     await _drain_timers(runner)
 
     contents = [c.kwargs["content"] for c in adapter.send.await_args_list]
-    assert contents == ["short one", "long one"]
+    assert contents == [dl.FLOOD_MARKER + "short one", dl.FLOOD_MARKER + "long one"]
     assert fake_sleep[0] == pytest.approx(12.0)
     assert fake_sleep[1] == pytest.approx(175.0), "re-armed for the longer row's REMAINING wait, plus slack"
     assert _row("ob-short")["attempts"] == 1 and _row("ob-long")["attempts"] == 1
@@ -415,8 +431,43 @@ async def test_boot_redelivery_arms_a_timer_for_an_adopted_flood_row(fake_sleep,
     assert n == 0, "nothing is due at boot"
     assert len(runner._flood_redelivery_tasks) == 1
     await _drain_timers(runner)
-    assert adapter.send.call_args.kwargs["content"] == "adopted at boot"
+    assert adapter.send.call_args.kwargs["content"] == dl.FLOOD_MARKER + "adopted at boot"
     assert _row("ob-flood")["state"] == "delivered"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_resume_flag_clear_keeps_the_flood_row_on_the_timer(fake_sleep):
+    """Review finding on the first cut: the unsent claim was released as ``send_path_degraded``, which
+    dropped the row from ``pending_flood_retries`` and ended the timer, stranding the reply until a reconnect
+    or restart. Released with its own flood error, it waits the platform's figure again and is then sent."""
+    _record("ob-flood", content="the plan")
+    dl.mark_failed("ob-flood", "flood_control:30")
+    adapter = _adapter(success=True)
+    runner = _runner(adapter)
+    runner._async_session_store.clear_resume_pending = AsyncMock(
+        side_effect=[RuntimeError("session store locked"), None])
+
+    runner._schedule_flood_redelivery(Platform.TELEGRAM, error="flood_control:30")
+    await _drain_timers(runner)
+
+    assert adapter.send.await_count == 1
+    assert _row("ob-flood") == {"state": "delivered", "attempts": 1, "last_error": None, "owner_pid": os.getpid()}, \
+        "the released claim spent no attempt"
+    assert fake_sleep == [pytest.approx(32.0), pytest.approx(32.0)], "re-armed for the platform's figure, not dropped"
+
+
+@pytest.mark.asyncio
+async def test_a_runtime_claim_whose_adapter_vanished_is_released_with_its_flood_error(clock):
+    _record("ob-flood")
+    dl.mark_failed("ob-flood", "flood_control:9")
+    (row,) = dl.sweep_failed_for_runtime("telegram", now=T0 + 20)
+    runner = _runner(_adapter())
+    runner.adapters = {}  # the reconnect that armed the timer is gone again
+
+    assert await runner._obligation_adapter(row) is None
+
+    assert _row("ob-flood") == {"state": "failed", "attempts": 0, "last_error": "flood_control:9", "owner_pid": os.getpid()}
+    assert dl.pending_flood_retries()[0]["platform"] == "telegram", "still the flood timer's business"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_delivery_ledger_flood_retry.py
+++ b/tests/gateway/test_delivery_ledger_flood_retry.py
@@ -22,7 +22,10 @@ Now:
   refusal is cleared so an interrupted resend is seen as uncertain by the next boot; a
   claim released unsent (resume flag not clearable, adapter gone) keeps its flood error
   and so its place on the timer;
-- at boot, a dead owner's not-yet-due flood row is adopted rather than resent early.
+- at boot, a dead owner's not-yet-due flood row is adopted rather than resent early, and
+  returned flagged so its session's resume flag is cleared (the answer is in the ledger)
+  without the row being sent inside the penalty; a legacy row without a profile is
+  normalised to 'default' so the timer's runtime sweep can claim it.
 """
 
 from __future__ import annotations
@@ -73,6 +76,28 @@ def _row(oid):
             "SELECT state, attempts, last_error, owner_pid FROM delivery_obligations WHERE obligation_id=?", (oid,)
         ).fetchone()
     return None if r is None else {"state": r[0], "attempts": r[1], "last_error": r[2], "owner_pid": r[3]}
+
+
+def _owner(oid):
+    """(owner_pid, owner_started_at, adapter_profile) of a row."""
+    with dl._connect() as conn:
+        return conn.execute(
+            "SELECT owner_pid, owner_started_at, adapter_profile FROM delivery_obligations"
+            " WHERE obligation_id=?", (oid,)).fetchone()
+
+
+DEAD_OWNER = (999_999, 1)
+
+
+def _record_for_dead_owner(oid, error, **kwargs):
+    """A flood-refused row whose last owner is gone: what a restart finds in the ledger."""
+    live = dl._owner_stamp
+    dl._owner_stamp = lambda: DEAD_OWNER
+    try:
+        _record(oid, **kwargs)
+        dl.mark_failed(oid, error)
+    finally:
+        dl._owner_stamp = live
 
 
 def _runner(adapter):
@@ -221,16 +246,37 @@ def test_a_chunked_reply_refused_by_flood_control_keeps_the_marker(clock):
 # ---------------------------------------------------------------------------
 
 def test_boot_sweep_adopts_a_dead_owners_flood_row_inside_its_wait(clock, monkeypatch):
-    _record("ob-flood")
-    dl.mark_failed("ob-flood", "flood_control:185.0")
+    _record_for_dead_owner("ob-flood", "flood_control:185.0")
     monkeypatch.setattr(dl, "_owner_alive", lambda pid, started: False)
 
-    claimed = dl.sweep_recoverable(now=T0 + 30)
+    (adopted,) = dl.sweep_recoverable(now=T0 + 30)
 
-    assert claimed == [], "not due yet: resending now would burn an attempt inside the penalty"
+    assert adopted["adopted"] is True and adopted["not_before"] == pytest.approx(T0 + 185.0), \
+        "returned so the caller clears its resume flag, flagged so nothing sends it inside the penalty"
+    assert adopted["attempts"] == 0 and "marker" not in adopted
     row = _row("ob-flood")
-    assert row["state"] == "failed" and row["attempts"] == 0 and row["owner_pid"] == os.getpid()
-    assert dl.pending_flood_retries(now=T0 + 30)[0]["not_before"] == pytest.approx(T0 + 185)
+    assert row["state"] == "failed" and row["attempts"] == 0 and row["last_error"] == "flood_control:185.0"
+    assert _owner("ob-flood") == (os.getpid(), 202, "default"), "ownership moved from the dead process"
+
+
+def test_a_legacy_row_without_a_profile_is_normalised_so_the_timer_can_claim_it(clock, monkeypatch):
+    """Rows recorded before ``adapter_profile`` existed carry NULL. The boot sweep accepts them on a
+    non-multiplexed gateway, but the runtime sweep matches the profile exactly and the timer asks for
+    'default', so an adopted NULL row could only ever wake the timer without being sent."""
+    _record_for_dead_owner("ob-legacy", "flood_control:185.0")
+    with dl._connect() as conn:
+        conn.execute("UPDATE delivery_obligations SET adapter_profile=NULL WHERE obligation_id='ob-legacy'")
+    monkeypatch.setattr(dl, "_owner_alive", lambda pid, started: False)
+
+    (adopted,) = dl.sweep_recoverable(
+        now=T0 + 30, deliverable_platforms={"telegram"},
+        deliverable_targets={("telegram", "default"), ("telegram", None)})
+
+    assert adopted["profile"] == "default" and _owner("ob-legacy") == (os.getpid(), 202, "default")
+    assert dl.pending_flood_retries(now=T0 + 30) == [
+        {"platform": "telegram", "profile": "default", "not_before": pytest.approx(T0 + 185.0)}]
+    (claimed,) = dl.sweep_failed_for_runtime("telegram", now=T0 + 200, profile="default")
+    assert claimed["obligation_id"] == "ob-legacy" and claimed["marker"] == dl.FLOOD_MARKER
 
 
 def test_boot_sweep_resends_a_due_flood_row_under_the_rate_limit_marker_and_a_midsend_row_under_the_restart_one(clock, monkeypatch):
@@ -301,10 +347,10 @@ async def test_schedule_flood_redelivery_waits_then_runs_the_runtime_sweep(fake_
     runner._redeliver_failed_obligations_for_platform = AsyncMock(return_value=1)
 
     delay = runner._schedule_flood_redelivery(Platform.TELEGRAM, profile=None, error="flood_control:185.0")
-    again = runner._schedule_flood_redelivery(Platform.TELEGRAM, profile=None, error="flood_control:30")
+    again = runner._schedule_flood_redelivery(Platform.TELEGRAM, profile=None, error="flood_control:300")
 
     assert delay == pytest.approx(187.0)
-    assert again is None, "a second refusal while the timer is armed must not arm another"
+    assert again is None, "a refusal due no earlier than the armed timer must not arm another"
     assert len(runner._flood_redelivery_tasks) == 1
     await _drain_timers(runner)
 
@@ -365,7 +411,7 @@ async def test_a_chunked_reply_is_redelivered_under_the_rate_limit_marker(fake_s
 
 @pytest.mark.asyncio
 async def test_a_redelivery_refused_again_arms_a_successor_timer(fake_sleep):
-    """The bug Codex caught in the first cut: the running timer must not block its own re-arm."""
+    """A refusal during the sweep must not be blocked by the timer's own slot: it arms its successor."""
     _record("ob-flood")
     dl.mark_failed("ob-flood", "flood_control:10")
     adapter = _adapter(side_effect=[SendResult(success=False, error="flood_control:30.0"), SendResult(success=True)])
@@ -419,9 +465,52 @@ async def test_a_shorter_sibling_timer_does_not_send_the_longer_row_early(fake_s
 
 
 @pytest.mark.asyncio
+async def test_a_shorter_refusal_replaces_a_longer_timer_that_is_still_asleep(fake_sleep):
+    """Arrival order reversed: the 185s timer is armed first. Left alone it would hold the 10s row for
+    the full 185s. The shorter refusal replaces the sleeping timer and re-arms for the longer row."""
+    _record("ob-long", content="long one")
+    dl.mark_failed("ob-long", "flood_control:185")
+    _record("ob-short", content="short one")
+    dl.mark_failed("ob-short", "flood_control:10")
+    adapter = _adapter(success=True)
+    runner = _runner(adapter)
+
+    assert runner._schedule_flood_redelivery(Platform.TELEGRAM, error="flood_control:185") == pytest.approx(187.0)
+    assert runner._schedule_flood_redelivery(Platform.TELEGRAM, error="flood_control:10") == pytest.approx(12.0)
+    assert len(runner._flood_redelivery_tasks) == 1, "one live timer per identity, the shorter one"
+    await _drain_timers(runner)
+
+    contents = [c.kwargs["content"] for c in adapter.send.await_args_list]
+    assert contents == [dl.FLOOD_MARKER + "short one", dl.FLOOD_MARKER + "long one"]
+    assert fake_sleep == [pytest.approx(12.0), pytest.approx(175.0)], "the 187s sleep never happened"
+    assert _row("ob-short")["attempts"] == 1 and _row("ob-long")["attempts"] == 1
+    assert runner._flood_redelivery_tasks == {} and runner._flood_redelivery_slots == {}
+
+
+@pytest.mark.asyncio
+async def test_a_timer_already_sweeping_is_not_replaced(fake_sleep):
+    """Once the sleep is over the timer may be mid-send; a refusal arriving then arms nothing extra and
+    the successor logic (the running timer re-arming itself) takes over."""
+    runner = _runner(_adapter())
+    seen = []
+
+    async def _sweep(target, profile=None):
+        async def _refusal_from_another_task():
+            return runner._schedule_flood_redelivery(Platform.TELEGRAM, error="flood_control:1")
+
+        seen.append(await asyncio.create_task(_refusal_from_another_task()))
+        return 0
+
+    runner._redeliver_failed_obligations_for_platform = _sweep
+    runner._schedule_flood_redelivery(Platform.TELEGRAM, error="flood_control:60")
+    await _drain_timers(runner)
+
+    assert seen == [None], "a refusal from outside the running timer cannot cancel it mid-sweep"
+
+
+@pytest.mark.asyncio
 async def test_boot_redelivery_arms_a_timer_for_an_adopted_flood_row(fake_sleep, monkeypatch):
-    _record("ob-flood", content="adopted at boot")
-    dl.mark_failed("ob-flood", "flood_control:120")
+    _record_for_dead_owner("ob-flood", "flood_control:120", content="adopted at boot")
     monkeypatch.setattr(dl, "_owner_alive", lambda pid, started: False)
     adapter = _adapter(success=True)
     runner = _runner(adapter)
@@ -429,6 +518,10 @@ async def test_boot_redelivery_arms_a_timer_for_an_adopted_flood_row(fake_sleep,
     n = await runner._redeliver_pending_obligations()   # the boot path: claim + redeliver
 
     assert n == 0, "nothing is due at boot"
+    adapter.send.assert_not_awaited()
+    runner._async_session_store.clear_resume_pending.assert_awaited_once_with(
+        "agent:main:telegram:dm:5230977008"), "the answer is in the ledger: the turn must not be re-run"
+    assert _owner("ob-flood") == (os.getpid(), 202, "default")
     assert len(runner._flood_redelivery_tasks) == 1
     await _drain_timers(runner)
     assert adapter.send.call_args.kwargs["content"] == dl.FLOOD_MARKER + "adopted at boot"

--- a/tests/gateway/test_delivery_ledger_flood_retry.py
+++ b/tests/gateway/test_delivery_ledger_flood_retry.py
@@ -1,0 +1,468 @@
+"""A flood-refused final reply is redelivered once the penalty passes, plainly when that is safe.
+
+Adapters fail a flood-controlled final send closed as ``flood_control:<seconds>`` so
+the send coroutine never sleeps a long penalty (#91969). The comment there says the
+delivery ledger owns the wait. It did not: ``sweep_failed_for_runtime`` only replayed
+``send_path_degraded`` rows, so a flood-refused row sat in ``failed`` until the next
+restart's ``sweep_recoverable``, which redelivered it hours late under the "gateway
+restarted during delivery" marker. On 5 Sep 2026 a reply refused at 08:58 arrived at
+12:15 that way, labelled as a possible duplicate although the platform had never
+accepted it.
+
+Now:
+- ``flood_control:*`` rows are runtime-retryable, but only once their own deadline
+  (refusal time plus the platform's wait) has passed; neither an early timer nor a
+  reconnect sweep spends an attempt inside the penalty window;
+- the runner arms one timer per adapter identity; the slot stays occupied until the
+  timer ends, only the running timer may arm its successor into it, and it re-arms
+  for whatever is still waiting;
+- a flood refusal of a single-message reply proves non-delivery, so that redelivery
+  carries no duplicate marker; a chunked reply may have been partly accepted and
+  carries one that names the rate limit; a claimed row's stale refusal is cleared so an interrupted resend is
+  seen as uncertain by the next boot;
+- at boot, a dead owner's not-yet-due flood row is adopted rather than resent early.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time as _time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway import delivery_ledger as dl
+from gateway import run_startup
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import SendResult
+
+T0 = 1_700_000_000.0
+
+
+@pytest.fixture(autouse=True)
+def _fresh_db(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(dl, "_db_path", lambda: home / "state.db")
+    monkeypatch.setattr(dl, "_owner_stamp", lambda: (os.getpid(), 202))
+    yield
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    """A controllable wall clock shared by the ledger and the runner (both call ``time.time``)."""
+    now = [T0]
+    monkeypatch.setattr(_time, "time", lambda: now[0])
+    return now
+
+
+def _record(oid, *, platform="telegram", chat_id="5230977008", content="the final answer", profile=None):
+    dl.record_obligation(
+        obligation_id=oid, session_key=f"agent:main:{platform}:dm:{chat_id}", platform=platform,
+        chat_id=chat_id, thread_id=None, content=content, adapter_profile=profile)
+    dl.mark_attempting(oid)
+
+
+def _row(oid):
+    with dl._connect() as conn:
+        r = conn.execute(
+            "SELECT state, attempts, last_error, owner_pid FROM delivery_obligations WHERE obligation_id=?", (oid,)
+        ).fetchone()
+    return None if r is None else {"state": r[0], "attempts": r[1], "last_error": r[2], "owner_pid": r[3]}
+
+
+def _runner(adapter):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._profile_adapters = {}
+    runner._active_profile_name = lambda: "default"
+    runner._running = True
+    store = MagicMock()
+    store.clear_resume_pending = AsyncMock()
+    store._store = None
+    runner.session_store = None
+    runner._async_session_store = store
+    return runner
+
+
+def _adapter(success=True, error="", side_effect=None):
+    adapter = MagicMock()
+    if side_effect is not None:
+        adapter.send = AsyncMock(side_effect=side_effect)
+    else:
+        adapter.send = AsyncMock(return_value=SendResult(success=success, error=error))
+    return adapter
+
+
+async def _drain_timers(runner):
+    """Await every flood timer, including successors armed while awaiting."""
+    while runner._flood_redelivery_tasks:
+        await asyncio.gather(*list(runner._flood_redelivery_tasks.values()))
+
+
+# ---------------------------------------------------------------------------
+# Classification, waits, deadlines, certainty.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("error, expected", [
+    ("flood_control:185.0", True),
+    ("FLOOD_CONTROL:9", True),
+    ("send_path_degraded", False),
+    ("Forbidden: bot was blocked by the user", False),
+    ("", False),
+    (None, False),
+])
+def test_is_flood_error(error, expected):
+    assert dl.is_flood_error(error) is expected
+
+
+@pytest.mark.parametrize("error, expected", [
+    ("flood_control:185.0", 185.0),
+    ("flood_control:5820", 5820.0),        # a 97-minute penalty is kept as the platform stated it
+    ("flood_control:abc", 60.0),           # unreadable -> default
+    ("flood_control:0", 60.0),
+    ("send_path_degraded", 60.0),
+])
+def test_flood_wait_seconds(error, expected):
+    assert dl.flood_wait_seconds(error) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("seconds, expected", [
+    (185.0, 187.0),                        # the wait plus slack
+    (5820, 902.0),                         # capped: the timer wakes early and re-checks, it never sends early
+    (-5, 2.0),                             # already due -> just the slack
+    ("abc", 62.0),
+])
+def test_flood_retry_delay(seconds, expected):
+    assert dl.flood_retry_delay(seconds) == pytest.approx(expected)
+
+
+def test_flood_not_before_is_the_refusal_time_plus_the_platform_wait():
+    assert dl.flood_not_before(T0, "flood_control:185.0") == pytest.approx(T0 + 185.0)
+    assert dl.flood_not_before(None, "flood_control:9") == pytest.approx(9.0)
+
+
+def test_non_delivery_is_certain_only_for_a_single_message_reply():
+    assert dl.flood_non_delivery_is_certain("flood_control:9", "x" * 4096) is True
+    assert dl.flood_non_delivery_is_certain("flood_control:9", "x" * 4097) is False
+    assert dl.flood_non_delivery_is_certain("flood_control:9", "\U0001F600" * 2049) is False, "UTF-16 units, not chars"
+    assert dl.flood_non_delivery_is_certain("send_path_degraded", "x") is False
+
+
+# ---------------------------------------------------------------------------
+# The runtime sweep: which rows it claims, when, and how it marks them.
+# ---------------------------------------------------------------------------
+
+def test_runtime_sweep_claims_a_due_flood_row_plainly_and_clears_the_stale_refusal(clock):
+    _record("ob-flood")
+    dl.mark_failed("ob-flood", "flood_control:185.0")
+    _record("ob-degraded")
+    dl.mark_failed("ob-degraded", "send_path_degraded")
+    _record("ob-blocked")
+    dl.mark_failed("ob-blocked", "Forbidden: bot was blocked by the user")
+
+    claimed = {row["obligation_id"]: row for row in dl.sweep_failed_for_runtime("telegram", now=T0 + 200)}
+
+    assert set(claimed) == {"ob-flood", "ob-degraded"}, "a permanent rejection must never be replayed"
+    assert claimed["ob-flood"]["needs_marker"] is False, "a 429 of a single message was never accepted"
+    assert "marker" not in claimed["ob-flood"]
+    assert claimed["ob-degraded"]["needs_marker"] is True
+    assert claimed["ob-degraded"]["marker"] == dl.RECONNECTED_MARKER
+    flood = _row("ob-flood")
+    assert flood["state"] == "attempting" and flood["attempts"] == 1
+    assert flood["last_error"] is None, "the claim is a fresh attempt; the old refusal must not survive it"
+    assert _row("ob-blocked")["state"] == "failed"
+
+
+def test_runtime_sweep_leaves_a_flood_row_inside_its_wait_and_reports_its_deadline(clock):
+    _record("ob-short")
+    dl.mark_failed("ob-short", "flood_control:10")
+    _record("ob-long")
+    dl.mark_failed("ob-long", "flood_control:185")
+
+    claimed = dl.sweep_failed_for_runtime("telegram", now=T0 + 12)
+
+    assert [r["obligation_id"] for r in claimed] == ["ob-short"], "the 185s row is still inside its penalty"
+    assert _row("ob-long") == {"state": "failed", "attempts": 0, "last_error": "flood_control:185", "owner_pid": os.getpid()}
+    waiting = dl.pending_flood_retries(now=T0 + 12)
+    assert waiting == [{"platform": "telegram", "profile": "default", "not_before": pytest.approx(T0 + 185)}]
+
+
+def test_a_chunked_reply_refused_by_flood_control_keeps_the_marker(clock):
+    _record("ob-long-text", content="word " * 1200)  # ~6000 chars: two Telegram messages
+    dl.mark_failed("ob-long-text", "flood_control:9")
+
+    (row,) = dl.sweep_failed_for_runtime("telegram", now=T0 + 20)
+
+    assert row["needs_marker"] is True, "chunk 1 may have landed before chunk 2 was refused"
+    assert row["marker"] == dl.FLOOD_MARKER, "no reconnect happened; the marker must name the rate limit"
+
+
+# ---------------------------------------------------------------------------
+# The boot sweep: adopt what is not due, resend what is, stay honest after a crash.
+# ---------------------------------------------------------------------------
+
+def test_boot_sweep_adopts_a_dead_owners_flood_row_inside_its_wait(clock, monkeypatch):
+    _record("ob-flood")
+    dl.mark_failed("ob-flood", "flood_control:185.0")
+    monkeypatch.setattr(dl, "_owner_alive", lambda pid, started: False)
+
+    claimed = dl.sweep_recoverable(now=T0 + 30)
+
+    assert claimed == [], "not due yet: resending now would burn an attempt inside the penalty"
+    row = _row("ob-flood")
+    assert row["state"] == "failed" and row["attempts"] == 0 and row["owner_pid"] == os.getpid()
+    assert dl.pending_flood_retries(now=T0 + 30)[0]["not_before"] == pytest.approx(T0 + 185)
+
+
+def test_boot_sweep_resends_a_due_flood_row_plainly_and_a_midsend_row_with_the_marker(clock, monkeypatch):
+    _record("ob-flood")
+    dl.mark_failed("ob-flood", "flood_control:185.0")
+    _record("ob-midsend")  # crashed mid-await: the platform MAY have it
+    monkeypatch.setattr(dl, "_owner_alive", lambda pid, started: False)
+
+    claimed = {row["obligation_id"]: row for row in dl.sweep_recoverable(now=T0 + 300)}
+
+    assert claimed["ob-flood"]["needs_marker"] is False
+    assert claimed["ob-midsend"]["needs_marker"] is True
+    flood = _row("ob-flood")
+    assert flood["state"] == "attempting" and flood["last_error"] is None and flood["attempts"] == 1
+
+
+def test_boot_sweep_keeps_the_marker_for_a_chunked_flood_refused_reply(clock, monkeypatch):
+    _record("ob-long-text", content="word " * 1200)  # two Telegram messages; chunk 1 may have landed
+    dl.mark_failed("ob-long-text", "flood_control:9")
+    monkeypatch.setattr(dl, "_owner_alive", lambda pid, started: False)
+
+    (row,) = dl.sweep_recoverable(now=T0 + 300)
+
+    assert row["needs_marker"] is True
+    assert row["marker"] == dl.FLOOD_MARKER, "no restart interrupted this send; the marker must name the rate limit"
+
+
+def test_an_interrupted_flood_resend_gets_the_marker_on_the_next_boot(clock, monkeypatch):
+    """Runtime claim, platform accepts, process dies before mark_delivered: the next boot must not treat
+    the old refusal as proof of non-delivery."""
+    _record("ob-flood")
+    dl.mark_failed("ob-flood", "flood_control:9")
+    (claimed,) = dl.sweep_failed_for_runtime("telegram", now=T0 + 20)
+    assert claimed["needs_marker"] is False
+    monkeypatch.setattr(dl, "_owner_alive", lambda pid, started: False)  # that process is gone
+
+    (recovered,) = dl.sweep_recoverable(now=T0 + 60)
+
+    assert recovered["needs_marker"] is True
+    assert "marker" not in recovered, "the refusal was cleared by the claim: this is an ordinary restart recovery"
+
+
+# ---------------------------------------------------------------------------
+# The runner: timers wait the platform's figure, never block their own successor,
+# never send early, and stop at shutdown.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def fake_sleep(monkeypatch, clock):
+    """asyncio.sleep advances the shared clock instead of waiting."""
+    slept: list[float] = []
+    real_sleep = asyncio.sleep
+
+    async def _sleep(delay):
+        slept.append(delay)
+        clock[0] += delay
+        await real_sleep(0)
+
+    monkeypatch.setattr(run_startup.asyncio, "sleep", _sleep)
+    return slept
+
+
+@pytest.mark.asyncio
+async def test_schedule_flood_redelivery_waits_then_runs_the_runtime_sweep(fake_sleep):
+    runner = _runner(_adapter())
+    runner._redeliver_failed_obligations_for_platform = AsyncMock(return_value=1)
+
+    delay = runner._schedule_flood_redelivery(Platform.TELEGRAM, profile=None, error="flood_control:185.0")
+    again = runner._schedule_flood_redelivery(Platform.TELEGRAM, profile=None, error="flood_control:30")
+
+    assert delay == pytest.approx(187.0)
+    assert again is None, "a second refusal while the timer is armed must not arm another"
+    assert len(runner._flood_redelivery_tasks) == 1
+    await _drain_timers(runner)
+
+    assert fake_sleep == [pytest.approx(187.0)]
+    runner._redeliver_failed_obligations_for_platform.assert_awaited_once_with(Platform.TELEGRAM, profile=None)
+    assert runner._flood_redelivery_tasks == {}, "a finished timer frees its slot"
+
+
+@pytest.mark.asyncio
+async def test_schedule_flood_redelivery_does_nothing_after_shutdown(monkeypatch):
+    runner = _runner(_adapter())
+    runner._redeliver_failed_obligations_for_platform = AsyncMock(return_value=1)
+    real_sleep = asyncio.sleep
+
+    async def _sleep(delay):
+        runner._running = False  # the gateway stopped while the timer was waiting
+        await real_sleep(0)
+
+    monkeypatch.setattr(run_startup.asyncio, "sleep", _sleep)
+    runner._schedule_flood_redelivery("telegram", error="flood_control:5")
+    await _drain_timers(runner)
+
+    runner._redeliver_failed_obligations_for_platform.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_timer_delivers_the_refused_reply_plainly_end_to_end(fake_sleep):
+    _record("ob-flood", content="Here is the plan for today.")
+    dl.mark_failed("ob-flood", "flood_control:185.0")
+    adapter = _adapter(success=True)
+    runner = _runner(adapter)
+
+    runner._schedule_flood_redelivery(Platform.TELEGRAM, error="flood_control:185.0")
+    await _drain_timers(runner)
+
+    sent = adapter.send.call_args.kwargs
+    assert sent["content"] == "Here is the plan for today."
+    assert "Recovered reply" not in sent["content"]
+    assert _row("ob-flood")["state"] == "delivered"
+    assert fake_sleep == [pytest.approx(187.0)]
+
+
+@pytest.mark.asyncio
+async def test_a_chunked_reply_is_redelivered_under_the_rate_limit_marker(fake_sleep):
+    _record("ob-long-text", content="word " * 1200)  # two Telegram messages; chunk 1 may have landed
+    dl.mark_failed("ob-long-text", "flood_control:9")
+    adapter = _adapter(success=True)
+    runner = _runner(adapter)
+
+    runner._schedule_flood_redelivery(Platform.TELEGRAM, error="flood_control:9")
+    await _drain_timers(runner)
+
+    sent = adapter.send.call_args.kwargs["content"]
+    assert sent.startswith(dl.FLOOD_MARKER)
+    assert "reconnected" not in sent and "restarted" not in sent
+    assert _row("ob-long-text")["state"] == "delivered"
+
+
+@pytest.mark.asyncio
+async def test_a_redelivery_refused_again_arms_a_successor_timer(fake_sleep):
+    """The bug Codex caught in the first cut: the running timer must not block its own re-arm."""
+    _record("ob-flood")
+    dl.mark_failed("ob-flood", "flood_control:10")
+    adapter = _adapter(side_effect=[SendResult(success=False, error="flood_control:30.0"), SendResult(success=True)])
+    runner = _runner(adapter)
+
+    runner._schedule_flood_redelivery(Platform.TELEGRAM, error="flood_control:10")
+    await _drain_timers(runner)
+
+    assert adapter.send.await_count == 2
+    assert fake_sleep == [pytest.approx(12.0), pytest.approx(32.0)], "the successor waits the NEW refusal's figure"
+    assert _row("ob-flood")["state"] == "delivered"
+    assert _row("ob-flood")["attempts"] == 2
+    assert runner._flood_redelivery_tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_a_capped_timer_wakes_early_but_never_sends_early(fake_sleep):
+    """A 2000s penalty: the timer sleeps at most 15 min at a time, finds the row not yet due, re-arms for the
+    remainder, and sends exactly once when the platform's deadline has actually passed."""
+    _record("ob-flood")
+    dl.mark_failed("ob-flood", "flood_control:2000")
+    adapter = _adapter(success=True)
+    runner = _runner(adapter)
+
+    runner._schedule_flood_redelivery(Platform.TELEGRAM, error="flood_control:2000")
+    await _drain_timers(runner)
+
+    assert adapter.send.await_count == 1
+    assert fake_sleep == [pytest.approx(902.0), pytest.approx(902.0), pytest.approx(198.0)]
+    assert _row("ob-flood")["state"] == "delivered" and _row("ob-flood")["attempts"] == 1
+
+
+@pytest.mark.asyncio
+async def test_a_shorter_sibling_timer_does_not_send_the_longer_row_early(fake_sleep):
+    _record("ob-short", content="short one")
+    dl.mark_failed("ob-short", "flood_control:10")
+    _record("ob-long", content="long one")
+    dl.mark_failed("ob-long", "flood_control:185")
+    adapter = _adapter(success=True)
+    runner = _runner(adapter)
+
+    assert runner._schedule_flood_redelivery(Platform.TELEGRAM, error="flood_control:10") == pytest.approx(12.0)
+    assert runner._schedule_flood_redelivery(Platform.TELEGRAM, error="flood_control:185") is None
+    await _drain_timers(runner)
+
+    contents = [c.kwargs["content"] for c in adapter.send.await_args_list]
+    assert contents == ["short one", "long one"]
+    assert fake_sleep[0] == pytest.approx(12.0)
+    assert fake_sleep[1] == pytest.approx(175.0), "re-armed for the longer row's REMAINING wait, plus slack"
+    assert _row("ob-short")["attempts"] == 1 and _row("ob-long")["attempts"] == 1
+
+
+@pytest.mark.asyncio
+async def test_boot_redelivery_arms_a_timer_for_an_adopted_flood_row(fake_sleep, monkeypatch):
+    _record("ob-flood", content="adopted at boot")
+    dl.mark_failed("ob-flood", "flood_control:120")
+    monkeypatch.setattr(dl, "_owner_alive", lambda pid, started: False)
+    adapter = _adapter(success=True)
+    runner = _runner(adapter)
+
+    n = await runner._redeliver_pending_obligations()   # the boot path: claim + redeliver
+
+    assert n == 0, "nothing is due at boot"
+    assert len(runner._flood_redelivery_tasks) == 1
+    await _drain_timers(runner)
+    assert adapter.send.call_args.kwargs["content"] == "adopted at boot"
+    assert _row("ob-flood")["state"] == "delivered"
+
+
+# ---------------------------------------------------------------------------
+# The adapter hook: a flood-refused final send arms the timer; other outcomes do not.
+# ---------------------------------------------------------------------------
+
+def _telegram_adapter_with_runner():
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token", extra={}))
+    runner = MagicMock()
+    runner._schedule_flood_redelivery = MagicMock(return_value=187.0)
+    runner._redeliver_failed_obligations_for_platform = AsyncMock(return_value=0)
+    adapter.gateway_runner = runner
+    adapter._final_delivery_adapter = lambda source: adapter
+    return adapter, runner
+
+
+def _event():
+    return SimpleNamespace(source=SimpleNamespace(platform=Platform.TELEGRAM, chat_id="5230977008", thread_id=None),
+                           text="what should I eat", message_id="77")
+
+
+@pytest.mark.asyncio
+async def test_flood_refused_final_send_arms_the_timer():
+    adapter, runner = _telegram_adapter_with_runner()
+    _record("ob-x")
+
+    await adapter._finalize_delivery_obligation(
+        "ob-x", SendResult(success=False, error="flood_control:185.0"), _event(), adapter)
+
+    assert _row("ob-x")["state"] == "failed"
+    runner._schedule_flood_redelivery.assert_called_once_with(
+        Platform.TELEGRAM, profile=None, error="flood_control:185.0")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("result", [
+    SendResult(success=True),
+    SendResult(success=False, error="send_path_degraded"),
+    SendResult(success=False, error="Forbidden: bot was blocked by the user"),
+])
+async def test_other_outcomes_do_not_arm_the_flood_timer(result):
+    adapter, runner = _telegram_adapter_with_runner()
+    _record("ob-y")
+
+    await adapter._finalize_delivery_obligation("ob-y", result, _event(), adapter)
+
+    runner._schedule_flood_redelivery.assert_not_called()

--- a/tests/gateway/test_delivery_ledger_flood_retry.py
+++ b/tests/gateway/test_delivery_ledger_flood_retry.py
@@ -142,6 +142,13 @@ async def _drain_timers(runner):
     ("Forbidden: bot was blocked by the user", False),
     ("", False),
     (None, False),
+    # PTB's own RetryAfter wording, which is what a row carries when it was written by a send path
+    # that had not been normalized, or by an older build. Unrecognised, such a row gets no timer.
+    ("Flood control exceeded. Retry in 185 seconds", True),
+    ("flood control exceeded. retry in 30 seconds", True),
+    # The flood wording is required, not merely a delay: an unrelated error that suggests retrying
+    # must not be read as a flood refusal.
+    ("Bad Gateway; retry in 5 seconds", False),
 ])
 def test_is_flood_error(error, expected):
     assert dl.is_flood_error(error) is expected
@@ -153,6 +160,10 @@ def test_is_flood_error(error, expected):
     ("flood_control:abc", 60.0),           # unreadable -> default
     ("flood_control:0", 60.0),
     ("send_path_degraded", 60.0),
+    # The platform's own wording states the delay just as precisely as the canonical prefix, so the
+    # deadline must come from it rather than the generic default.
+    ("Flood control exceeded. Retry in 185 seconds", 185.0),
+    ("Bad Gateway; retry in 5 seconds", 60.0),
 ])
 def test_flood_wait_seconds(error, expected):
     assert dl.flood_wait_seconds(error) == pytest.approx(expected)
@@ -639,3 +650,64 @@ async def test_other_outcomes_do_not_arm_the_flood_timer(result):
     await adapter._finalize_delivery_obligation("ob-y", result, _event(), adapter)
 
     runner._schedule_flood_redelivery.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# The adapter normalizes every definite flood refusal, so the ledger sees one shape.
+# ---------------------------------------------------------------------------
+
+def _real_telegram_adapter():
+    """A real Telegram adapter with a stub bot, for driving the send and edit flood paths."""
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token", extra={}))
+    adapter._bot = MagicMock()
+    return adapter
+
+
+def test_a_persisted_row_with_the_platforms_own_wording_is_dated_from_it():
+    """The boot sweep decides adopt-or-claim from the row's deadline. Read as an ordinary failure, a
+    raw flood row is claimed at once and spends its one attempt inside the penalty that caused it."""
+    raw = "Flood control exceeded. Retry in 185 seconds"
+
+    assert dl.is_flood_error(raw) is True
+    assert dl.flood_wait_seconds(raw) == pytest.approx(185.0)
+    assert dl.flood_not_before(T0, raw) == pytest.approx(T0 + 185.0)
+
+
+@pytest.mark.asyncio
+async def test_a_short_flood_that_outlives_the_retries_fails_closed_canonically():
+    """A wait under the inline cap is slept and retried. When the flood is still there after the last
+    attempt the send used to raise, handing the caller the platform's wording instead of the
+    canonical result, so no redelivery timer was armed and the reply waited for the next restart."""
+    from telegram.error import RetryAfter
+
+    adapter = _real_telegram_adapter()
+    adapter._send_chunk_markdown_or_plain = AsyncMock(side_effect=RetryAfter(1))
+
+    result = await adapter._send_chunk_with_retries(
+        "5230977008", "the final answer", 0, None, None, None, False,
+        adapter._telegram_error_types())
+
+    assert isinstance(result, SendResult)
+    assert result.success is False
+    assert result.error == "flood_control:1.0"
+    assert dl.is_flood_error(result.error) is True
+    assert result.retry_after == pytest.approx(1.0)
+    assert adapter._send_chunk_markdown_or_plain.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_an_edit_still_flooded_after_the_inline_wait_fails_closed_canonically():
+    """The edit path sleeps a short wait once and retries. A retry that is refused again, typically
+    for far longer, must report the new delay canonically rather than as raw text."""
+    from telegram.error import RetryAfter
+
+    adapter = _real_telegram_adapter()
+    adapter._edit_text = AsyncMock(side_effect=[RetryAfter(1), RetryAfter(185)])
+
+    result = await adapter.edit_message("5230977008", "900", "the final answer")
+
+    assert result.success is False
+    assert result.error == "flood_control:185.0"
+    assert dl.flood_wait_seconds(result.error) == pytest.approx(185.0)

--- a/tests/gateway/test_delivery_ledger_flood_retry.py
+++ b/tests/gateway/test_delivery_ledger_flood_retry.py
@@ -1,4 +1,4 @@
-"""A flood-refused final reply is redelivered once the penalty passes, plainly when that is safe.
+"""A flood-refused final reply is redelivered once the penalty passes.
 
 Adapters fail a flood-controlled final send closed as ``flood_control:<seconds>`` so
 the send coroutine never sleeps a long penalty (#91969). The comment there says the
@@ -6,8 +6,8 @@ delivery ledger owns the wait. It did not: ``sweep_failed_for_runtime`` only rep
 ``send_path_degraded`` rows, so a flood-refused row sat in ``failed`` until the next
 restart's ``sweep_recoverable``, which redelivered it hours late under the "gateway
 restarted during delivery" marker. On 5 Sep 2026 a reply refused at 08:58 arrived at
-12:15 that way, labelled as a possible duplicate although the platform had never
-accepted it.
+12:15 that way, labelled as a possible duplicate although whether the platform had
+accepted any part of it was unknowable.
 
 Now:
 - ``flood_control:*`` rows are runtime-retryable, but only once their own deadline
@@ -484,6 +484,35 @@ async def test_a_shorter_refusal_replaces_a_longer_timer_that_is_still_asleep(fa
     assert contents == [dl.FLOOD_MARKER + "short one", dl.FLOOD_MARKER + "long one"]
     assert fake_sleep == [pytest.approx(12.0), pytest.approx(175.0)], "the 187s sleep never happened"
     assert _row("ob-short")["attempts"] == 1 and _row("ob-long")["attempts"] == 1
+    assert runner._flood_redelivery_tasks == {} and runner._flood_redelivery_slots == {}
+
+
+@pytest.mark.asyncio
+async def test_a_row_refused_while_the_timer_sweeps_is_armed_by_that_same_timer(fake_sleep):
+    """A final refused during the timer's own redelivery send lands in the ledger after the sweep
+    started. The timer's synchronous post-sweep arm reads the ledger once the sends are done and
+    picks it up, so the row is never left without a timer."""
+    _record("ob-first")
+    dl.mark_failed("ob-first", "flood_control:10")
+    adapter = _adapter(success=True)
+    runner = _runner(adapter)
+    fired = {"done": False}
+
+    async def _send(**kwargs):
+        if not fired["done"]:
+            fired["done"] = True
+            _record("ob-second", content="refused mid-sweep")
+            dl.mark_failed("ob-second", "flood_control:10")
+            # A concurrent refusal's schedule request is declined while this timer holds the slot.
+            runner._schedule_flood_redelivery(Platform.TELEGRAM, error="flood_control:10")
+        return SendResult(success=True, message_id="9")
+
+    adapter.send = AsyncMock(side_effect=_send)
+    runner._schedule_flood_redelivery(Platform.TELEGRAM, error="flood_control:10")
+    await _drain_timers(runner)
+
+    assert _row("ob-first")["state"] == "delivered"
+    assert _row("ob-second")["state"] == "delivered", "the mid-sweep refusal was armed by the same timer"
     assert runner._flood_redelivery_tasks == {} and runner._flood_redelivery_slots == {}
 
 


### PR DESCRIPTION
## What does this PR do?

The Telegram adapter fails a flood-controlled final send closed as
`SendResult(success=False, error="flood_control:<seconds>")` so the send
coroutine never sleeps a long penalty (#91969). The comment at that site says
the caller's retry machinery, the delivery ledger, owns the wait. The ledger
did not: `sweep_failed_for_runtime` only replays `send_path_degraded` rows, so
a flood-refused row sat in `failed` until the next restart, whose
`sweep_recoverable` then redelivered it prefixed with the restart marker
("Recovered reply, the gateway restarted during delivery, so this may be a
duplicate").

Observed on a live gateway:

```
2026-09-05 08:58:33 WARNING [Telegram] Telegram flood control on send (retry_after=185.0s > 5s); failing closed instead of sleeping: Flood control exceeded. Retry in 185 seconds
2026-09-05 08:58:33 WARNING [Telegram] Send failed: flood_control:185.0 - trying plain-text fallback
2026-09-05 08:58:33 ERROR   [Telegram] Fallback send also failed: flood_control:185.0
2026-09-05 12:15:22 INFO    Redelivered recovered final response to telegram:5230977008 (obligation fe45c84ed559fdd843425bbe, attempt 1)
```

The reply reached the user three hours late, only because the gateway happened
to restart, and under a marker describing a restart that had nothing to do with
it. Whether Telegram had accepted an earlier chunk of that reply is not knowable
from the logs, which is why the marker below says so.

## Related Issue

No existing issue. Reproduction and log evidence are above; #91969 is the
change that introduced the fail-closed flood result this completes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

`gateway/delivery_ledger.py`

- `flood_control:*` rows become runtime-retryable, but only once their own
  deadline has passed: the refusal's `updated_at` plus the platform's wait
  (`flood_not_before`). Neither an early timer nor a reconnect sweep spends a
  redelivery attempt inside the penalty window.
- Every flood redelivery carries its own marker: `FLOOD_MARKER` says the
  platform's rate limit refused the original, so part of it may already have
  arrived. The stored text's raw length cannot say how many requests the
  adapter made (MarkdownV2 escaping alone turns 3000 dots into two Telegram
  messages) and the send result does not say which chunk was refused, so there
  is no length-based "nothing was delivered" shortcut. The restart and reconnect
  markers would describe an event that never happened.
- A runtime claim released unsent (its resume flag could not be cleared, or its
  adapter vanished before dispatch) goes back to `failed` with its own pre-claim
  error instead of `send_path_degraded`, so a flood row stays on the flood
  timer's list and is retried after the platform's figure rather than stranded
  until a reconnect or restart.
- Claiming a flood row clears the stale refusal (`last_error` NULL, state
  `attempting`), so a resend interrupted before `mark_delivered` is seen as
  uncertain by the next boot and gets the marker as before.
- At boot, a dead owner's flood row that is not yet due is adopted (owner
  re-stamped, no attempt spent) instead of being resent early. The adopted row
  is returned to the caller flagged `adopted` with its `not_before`, so the
  caller clears its session's `resume_pending` flag exactly as it does for
  every other claimed row (the answer is in the ledger; the turn must not be
  re-run) while the row itself is left to the timer.
- A legacy row without `adapter_profile` (recorded before that column existed)
  is normalised to `default` when the boot sweep claims or adopts it. The boot
  sweep accepts such rows only on a non-multiplexed gateway, but the runtime
  sweep matches profiles exactly and the timer asks for `default`, so without
  this an adopted legacy row could only ever wake the timer without being sent.
- New `pending_flood_retries()` lists this process's waiting flood rows per
  adapter identity with the earliest deadline.

`gateway/run_startup.py`

- `_schedule_flood_redelivery` arms one timer per adapter identity that runs
  the existing runtime sweep after the wait. Sleeps are capped at 15 minutes;
  the row's deadline, not the timer, decides eligibility, so a capped timer
  wakes early, sends nothing, and re-arms for the remainder. The slot stays
  occupied until the timer ends and only the running timer may arm its
  successor into it, and the post-sweep re-arm reads the ledger synchronously so
  a refusal that lands during the sweep is picked up before the slot is freed.
  A timer that is still asleep is replaced when a shorter refusal arrives (a
  10s row must not wait behind a 185s sibling); the shorter timer re-arms for
  the longer row after its sweep.
- `_redeliver_claimed_obligations` skips adopted rows (their resume flags were
  cleared with the others) and arms the timers afterwards, so a boot with only
  adopted rows still gets its timer.
- `_arm_flood_timers_for_waiting_rows` runs after the boot redelivery pass and
  after every timer sweep, covering adopted rows, rows skipped as not yet due,
  and rows refused again. Timer-triggered runtime sweeps that find nothing to
  claim return early and rely on the timer's own re-arm. That re-arm reads the
  ledger synchronously so its snapshot cannot miss a row recorded by a
  concurrent flood refusal whose own timer request was declined while the slot
  was held.

`gateway/platforms/base.py`

- `_finalize_delivery_obligation` arms the timer on a `flood_control` failure,
  best-effort inside the existing try, alongside the `send_path_degraded`
  branch.

Deliberately unchanged: permanent rejections (blocked bot, bad auth, missing
chat) are never replayed by runtime recovery (the boot sweep's handling of
failed rows is as before); `send_path_degraded` handling is untouched.

## How to Test

1. `pytest tests/gateway/test_delivery_ledger_flood_retry.py -q` (43 tests).
   They drive the real ledger against an isolated `state.db` and the real
   `GatewayRunner` redelivery methods with a controllable clock shared by the
   ledger and the runner, and cover: the deadline (a 10s and a 185s refusal
   arriving together in either order, only the due row is sent and the timer
   re-arms for the other), a capped timer that wakes early and never sends
   early, a refusal during redelivery arming a successor, adoption at boot with
   ownership actually moving from a dead stamp, the adopted row's session
   having its resume flag cleared without the row being sent, the legacy
   NULL-profile row being claimable by the timer, the interrupted resend
   keeping its marker, the chunked reply keeping its marker, and the adapter
   hook.
2. `pytest tests/gateway/test_delivery_ledger.py tests/gateway/test_delivery_ledger_producer.py tests/gateway/test_restart_redelivery_dedup.py tests/gateway/test_platform_reconnect.py tests/gateway/test_silent_partial_delivery_95382.py tests/gateway/test_multiplex_adapter_registry.py -q`
   (130 tests, unchanged behaviour for every non-flood path).
3. Each guard was mutation-tested: removing any one of the deadline check, the
   stale-error clearing, the unconditional marker, the boot adoption, the
   adopted-row return, the profile normalisation, the timer cap, the successor
   arming, the sleeping-timer replacement or the adapter hook fails at least
   one test.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected gateway suites and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (tests) and Ubuntu 22.04 (live gateway on the box the incident came from)

### Documentation & Housekeeping

- [x] Relevant documentation updated: module docstrings and comments (no user-facing docs affected)
- [x] `cli-config.yaml.example`: N/A, no config keys added or changed
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A, no architecture or workflow change
- [x] Cross-platform impact considered: pure Python, no platform-specific code
