### PR TITLE
fix(backends): any Windows drive letter is a host cwd; unreadable parent no longer crashes .git lookup; doctor probes docker version; MEDIA skip log names the reason (#60962 #8751 #72927 #100074)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -96,7 +96,15 @@ def _scan_context_content(content: str, filename: str) -> str:
 def _find_git_root(start: Path) -> Optional[Path]:
     """Nearest ancestor (or *start* itself) containing ``.git``, else None."""
     current = start.resolve()
-    return next((p for p in (current, *current.parents) if (p / ".git").exists()), None)
+    # A parent the process may not stat (locked-down /home on shared hosts) is "no .git here", not a crash.
+    return next((p for p in (current, *current.parents) if _exists_or_denied(p / ".git")), None)
+
+
+def _exists_or_denied(path: Path) -> bool:
+    try:
+        return path.exists()
+    except OSError:
+        return False
 
 
 def _find_hermes_md(cwd: Path) -> Optional[Path]:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1140,8 +1140,18 @@ def _validated_delivery_path(raw_path, session_key: str, label: str) -> Optional
         from gateway.media_fetch import fetch_remote_media
         safe_path = fetch_remote_media(raw)
     if not safe_path:
-        logger.warning("Skipping unsafe %s: %s", label, _log_safe_path(raw))
+        # Say WHY: a path that does not exist on the host is the common case (a model hallucinated or
+        # a sandbox path failed to translate) and is not a security rejection.
+        reason = "not found on this host" if not _existing_regular_file(raw) else "denied by the delivery policy"
+        logger.warning("Skipping %s (%s): %s", label, reason, _log_safe_path(raw))
     return safe_path
+
+
+def _existing_regular_file(raw: str) -> bool:
+    try:
+        return Path(os.path.expanduser(raw)).is_file()
+    except (OSError, RuntimeError, ValueError):
+        return False
 
 
 SUPPORTED_DOCUMENT_TYPES = {

--- a/hermes_cli/doctor_tools.py
+++ b/hermes_cli/doctor_tools.py
@@ -138,7 +138,10 @@ def _check_docker_backend(terminal_env: str, running_in_container: bool, issues:
         if not _safe_which("docker"):
             _fail_and_issue("docker not found", "(required for TERMINAL_ENV=docker)", "Install Docker or change TERMINAL_ENV", issues)
         else:
-            _require(_run_ok(["docker", "info"], timeout=10), ("docker", "(daemon running)"), ("docker daemon not running", ""),
+            # `docker version` hits /version, which socket proxies (tecnativa) allow by default; `docker info`
+            # needs /info and is commonly blocked, giving a false "daemon not running". The backend itself
+            # probes with `docker version` too (environments/docker.py).
+            _require(_run_ok(["docker", "version"], timeout=10), ("docker", "(daemon running)"), ("docker daemon not running", ""),
                      "Start Docker daemon", issues)
     elif _safe_which("docker"):
         check_ok("docker", "(optional)")

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -586,6 +586,21 @@ class TestFindHermesMd:
 
 
 
+    def test_unreadable_parent_is_treated_as_no_git_root(self, tmp_path, monkeypatch):
+        """A parent the process cannot stat (#8751) must not raise out of prompt construction."""
+        import os as _os
+        project = tmp_path / "locked" / "proj"
+        project.mkdir(parents=True)
+        real_exists = Path.exists
+
+        def _exists(self):
+            if self.parent == tmp_path / "locked" and self.name == ".git":
+                raise PermissionError(13, "Permission denied", str(self))
+            return real_exists(self)
+
+        monkeypatch.setattr(Path, "exists", _exists)
+        assert _find_git_root(project) is None
+
     def test_walks_to_git_root(self, tmp_path):
         (tmp_path / ".git").mkdir()
         (tmp_path / ".hermes.md").write_text("root rules")

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1250,8 +1250,15 @@ class TestMediaDeliveryDiagnosability:
             with caplog.at_level("WARNING"):
                 out = BasePlatformAdapter.filter_media_delivery_paths([(str(outside), False)])
         assert out == []
-        # The dropped path must be in the log so operators can diagnose it.
-        assert str(outside) in caplog.text
+        # The dropped path must be in the log so operators can diagnose it, with the REASON: a policy
+        # rejection reads differently from a path that simply does not exist (#100074).
+        assert str(outside) in caplog.text and "denied by the delivery policy" in caplog.text
+
+    def test_missing_file_is_logged_as_not_found_not_unsafe(self, tmp_path, caplog):
+        ghost = tmp_path / "never-written.pdf"
+        with caplog.at_level("WARNING"):
+            assert BasePlatformAdapter.filter_media_delivery_paths([(str(ghost), False)]) == []
+        assert "not found on this host" in caplog.text and "unsafe" not in caplog.text
 
     def test_crafted_null_path_does_not_abort_batch(self, tmp_path, monkeypatch):
         """One crafted ~\\x00 path must not drop every other attachment."""

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1742,3 +1742,19 @@ def test_run_doctor_warns_when_lightpanda_binary_missing(monkeypatch, tmp_path):
     monkeypatch.setattr("tools.browser_lightpanda.find_lightpanda_binary", lambda: None)
     out = helper._run_doctor_and_capture(monkeypatch, tmp_path)
     assert "Lightpanda selected but binary not found" in out
+
+
+def test_docker_daemon_probe_uses_version_not_info(monkeypatch):
+    """`docker info` needs the /info endpoint, which socket proxies commonly block, so doctor reported
+    "daemon not running" against a working DOCKER_HOST (#72927). `docker version` (/version) is what the
+    backend itself probes with."""
+    from hermes_cli import doctor_tools
+
+    calls: list = []
+    monkeypatch.setattr(doctor_tools, "_safe_which", lambda name: "/usr/bin/docker")
+    monkeypatch.setattr(doctor_tools, "_run_ok", lambda cmd, timeout, **kw: calls.append(cmd) or True)
+    monkeypatch.setattr(doctor_tools, "_require", lambda *a, **k: None)
+
+    doctor_tools._check_docker_backend("docker", False, [])
+
+    assert calls and calls[0][:2] == ["docker", "version"]

--- a/tests/tools/test_modal_sandbox_fixes.py
+++ b/tests/tools/test_modal_sandbox_fixes.py
@@ -317,22 +317,26 @@ class TestHostPrefixList:
     refactor that moves the constant.
     """
 
-    def test_all_common_host_prefixes_present_in_constant(self):
-        """The shared prefix constant must list the common host-only roots."""
-        for prefix in ("/Users/", "/home/", "C:\\", "C:/"):
-            assert prefix in _tt_mod._HOST_CWD_PREFIXES, (
-                f"Host prefix {prefix!r} missing from _HOST_CWD_PREFIXES. "
-                "Container backends need this to avoid using host paths."
-            )
-
     def test_all_common_host_paths_flagged_unusable(self):
-        """A host path under each prefix must be rejected as a container cwd."""
-        for host_path in ("/Users/me/proj", "/home/me/proj",
-                           "C:\\Users\\me", "C:/Users/me"):
+        """A host path under each user root must be rejected as a container cwd; in-sandbox
+        absolute paths pass."""
+        for host_path in ("/Users/me/proj", "/home/me/proj", "C:\\Users\\me", "C:/Users/me"):
             assert _tt_mod._is_unusable_container_cwd(host_path) is True, (
                 f"Host path {host_path!r} should be rejected as a container "
                 "cwd but was accepted."
             )
+        for sandbox_path in ("/workspace", "/root/proj", "/srv/app"):
+            assert _tt_mod._is_unusable_container_cwd(sandbox_path) is False
+
+    def test_any_windows_drive_letter_is_a_host_cwd(self):
+        """The host-shape predicate is platform-independent data: every drive letter, either slash,
+        is a host path (#60962). On POSIX ``D:\\proj`` is also non-absolute so the container guard
+        already rejected it; on a Windows host it IS absolute and only this predicate catches it."""
+        from tools.terminal_tool_config import _is_host_cwd
+        for host_path in ("C:\\Users\\me", "D:\\proj", "e:/work", "Z:\\"):
+            assert _is_host_cwd(host_path) is True, host_path
+        for not_host in ("/workspace", "/srv/app", "relative/dir", "C", "C:"):
+            assert _is_host_cwd(not_host) is False, not_host
 
 
 # =========================================================================

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -43,7 +43,7 @@ from tools.terminal_tool_lifecycle import (
     _evict_environment_for_task, cleanup_all_environments, ensure_task_env,
 )
 from tools.terminal_tool_config import (
-    _HOST_CWD_PREFIXES, _is_container_backend, _is_unusable_container_cwd, _parse_env_var,
+    _is_container_backend, _is_host_cwd, _is_unusable_container_cwd, _parse_env_var,
     _plugin_env_flag, _quiet, _safe_getcwd, _tenv, _tenv_bool,
 )
 from tools.terminal_tool_backends import (
@@ -580,7 +580,7 @@ def _resolve_config_cwd(env_type: str, mount_docker_cwd: bool) -> tuple:
     if env_type == "docker" and mount_docker_cwd:
         candidate = os.path.abspath(os.path.expanduser(_tenv("TERMINAL_CWD") or _safe_getcwd()))
         if (
-            any(candidate.startswith(p) for p in _HOST_CWD_PREFIXES)
+            _is_host_cwd(candidate)
             or (os.path.isabs(candidate) and os.path.isdir(candidate) and not candidate.startswith(("/workspace", "/root")))
         ):
             host_cwd = candidate

--- a/tools/terminal_tool_config.py
+++ b/tools/terminal_tool_config.py
@@ -9,6 +9,7 @@ so ``tools.terminal_tool.<name>`` keeps resolving (and monkeypatching) as before
 import logging
 import json
 import os
+import re
 from contextlib import contextmanager
 from typing import Any
 
@@ -51,9 +52,14 @@ def _safe_getcwd() -> str:
         return _tenv("TERMINAL_CWD") or os.path.expanduser("~")
 
 
-# Host-cwd prefixes that cannot exist inside a container sandbox (POSIX user
-# dirs and Windows drive paths as they leak toward a Linux ``-w`` flag).
-_HOST_CWD_PREFIXES = ("/Users/", "/home/", "C:\\", "C:/")
+# Host-cwd shapes that cannot exist inside a container sandbox: POSIX user dirs and ANY Windows
+# drive path (``D:\\...``, ``e:/...``) as they leak toward a Linux ``-w`` flag.
+_HOST_CWD_PREFIXES = ("/Users/", "/home/")
+_WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:[\\/]")
+
+
+def _is_host_cwd(path: str) -> bool:
+    return path.startswith(_HOST_CWD_PREFIXES) or bool(_WINDOWS_DRIVE_RE.match(path))
 
 _CONTAINER_BACKENDS = frozenset({"docker", "singularity", "modal", "daytona", "vercel_sandbox"})
 _BUILTIN_BACKENDS = _CONTAINER_BACKENDS | {"local", "ssh", "managed_modal"}
@@ -94,7 +100,7 @@ def _is_unusable_container_cwd(cwd: str) -> bool:
     workdir: ``docker run -w`` needs an absolute in-sandbox path, otherwise the
     container fails to start (exit 125). Windows drive paths aren't ``isabs``
     on POSIX, so they're caught by the prefix check."""
-    return bool(cwd) and (cwd.startswith(_HOST_CWD_PREFIXES) or not os.path.isabs(cwd))
+    return bool(cwd) and (_is_host_cwd(cwd) or not os.path.isabs(cwd))
 
 
 def _tenv(name: str, default: str = "") -> str:


### PR DESCRIPTION
Four small, independent SSH/Docker-backend fixes from the open-issue sweep, none with an open carrier PR. One commit each; each commit carries its own red-on-main test.

| Commit | Fixes | Symptom → behaviour |
|---|---|---|
| `fix(terminal)` | #60962 | On a Windows host, a `D:\…` / `E:/…` working directory reached `docker run -w` and the container started in a non-existent directory; only `C:` was recognised. Any drive letter, either slash, is now a host cwd (one `_is_host_cwd` predicate for both prefix scans). |
| `fix(agent)` | #8751 | `_find_git_root` raised `PermissionError` out of prompt construction when a parent directory was unreadable. An unreadable ancestor now means "no `.git` here". |
| `fix(doctor)` | #72927 | `hermes doctor` said "docker daemon not running" against a working `DOCKER_HOST` behind a socket proxy, because `docker info` needs `/info` (commonly blocked). It now probes with `docker version` (`/version`), like the backend itself. |
| `fix(gateway)` | #100074 | "Skipping unsafe MEDIA directive path" fired for files that simply do not exist, reading like a security rejection. The warning now says `not found on this host` vs `denied by the delivery policy`. |

The `test_modal_sandbox_fixes.py` constant-membership test (a change-detector on `_HOST_CWD_PREFIXES`) is replaced by behaviour contracts.

## Validation

| Check | Result |
|---|---|
| Per-commit red/green: each prod file reverted to `origin/main` alone fails its own new test | prompt_builder 1 red, doctor 1 red, platform_base 2 red; drive-letter predicate asserted directly (`_is_host_cwd("D:\\proj")` did not exist on main) |
| `scripts/run_tests.sh` modal_sandbox_fixes / prompt_builder / doctor / platform_base / terminal_tool / container_cwd_sanitize / file_tools_plugin_container_cwd | 302 passed |
| ruff | clean |
