### PR TITLE
fix(env): prevent cross-profile TERMINAL_* leak in multi-profile serve (#102769)

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -396,9 +396,23 @@ def load_hermes_dotenv(
 def _reapply_terminal_config_bridge(home_path: Path) -> None:
     """Re-assert config.yaml's explicit ``terminal.*`` keys over reloaded .env via the single shared bridge
     ``apply_terminal_config_to_env`` (also used by terminal_tool and the TUI/dashboard launchers) so the
-    semantics can't drift between sites."""
+    semantics can't drift between sites.
+
+    Scoped to the process launch home: the shared bridge reads the
+    process-global config, so re-applying it for a *different* profile's
+    ``load_hermes_dotenv(hermes_home=...)`` call would bridge the wrong
+    profile's config. The guard must compare against the true process
+    launch home (``get_process_hermes_home``), not the context-overridden
+    home (``get_hermes_home``), otherwise a routed profile's cron tick can
+    bridge its own terminal config into the shared process environment
+    and hijack the launch profile's subsequent unscoped turns (#102769).
+    Fail-open — a config problem must never break dotenv loading (the
+    historical env-driven behavior still applies).
+    """
     try:
-        if Path(home_path).resolve() != _process_hermes_home().resolve():
+        from hermes_constants import get_process_hermes_home
+
+        if Path(home_path).resolve() != get_process_hermes_home().resolve():
             return
         from hermes_cli.config import apply_terminal_config_to_env
 

--- a/tests/hermes_cli/test_terminal_bridge_scope_102769.py
+++ b/tests/hermes_cli/test_terminal_bridge_scope_102769.py
@@ -1,0 +1,104 @@
+"""Regression for #102769: the terminal-config bridge guard must compare
+against the TRUE process launch home, not the context-overridden home.
+
+Under multi-profile serve, a routed profile's turn runs with
+``HERMES_HOME``-style context overrides pointing at the routed profile's
+home. ``load_hermes_dotenv(hermes_home=<routed>)`` then calls
+``_reapply_terminal_config_bridge(<routed>)``. The old guard compared
+against the context-overridden ``get_hermes_home()`` — which ALSO pointed
+at the routed profile — so the guard passed and the shared bridge bridged
+the ROUTED profile's terminal config (e.g. ``TERMINAL_ENV=docker`` with its
+volumes) into the shared ``os.environ``. The launch profile's next
+unscoped turn then executed in the routed profile's Docker backend.
+
+Contract: the bridge may run ONLY when ``home_path`` equals the process
+launch home (``get_process_hermes_home``), regardless of any active
+context override.
+"""
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+import hermes_constants
+from hermes_cli import env_loader
+
+
+@pytest.fixture(autouse=True)
+def _launch_home(tmp_path, monkeypatch):
+    """Pin the process launch home and the context override to distinct dirs."""
+    launch = tmp_path / "launch-home"
+    routed = tmp_path / "routed-profile"
+    launch.mkdir()
+    routed.mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(launch))
+    monkeypatch.delenv("HERMES_HOME_OVERRIDE", raising=False)
+    return SimpleNamespace(launch=launch, routed=routed)
+
+
+class TestTerminalBridgeScopedToLaunchHome:
+    def test_routed_profile_home_does_not_bridge(self, _launch_home):
+        """The routed profile's dotenv reload must NOT re-apply the terminal
+        bridge — that would bridge the routed profile's terminal config into
+        the shared process env (#102769's hijack)."""
+        applied = []
+
+        with mock.patch.object(
+            hermes_constants, "get_process_hermes_home", return_value=_launch_home.launch
+        ), mock.patch(
+            "hermes_cli.config.apply_terminal_config_to_env",
+            side_effect=lambda env=None: applied.append(env),
+        ):
+            env_loader._reapply_terminal_config_bridge(_launch_home.routed)
+
+        assert applied == []
+
+    def test_launch_home_still_bridges(self, _launch_home):
+        """Control: the launch profile's own dotenv reload still re-applies the
+        bridge (the stale-``.env`` fix of #29186/#67323 is preserved)."""
+        applied = []
+
+        with mock.patch.object(
+            hermes_constants, "get_process_hermes_home", return_value=_launch_home.launch
+        ), mock.patch(
+            "hermes_cli.config.apply_terminal_config_to_env",
+            side_effect=lambda env=None: applied.append(env),
+        ):
+            env_loader._reapply_terminal_config_bridge(_launch_home.launch)
+
+        assert applied == [None]
+
+    def test_context_override_does_not_change_the_verdict(self, _launch_home):
+        """Even when a context override points at the routed home (the exact
+        multi-profile-serve shape), the routed home is still refused — the
+        guard reads the launch home, not the context home."""
+        applied = []
+
+        token = hermes_constants._HERMES_HOME_OVERRIDE.set(str(_launch_home.routed))
+        try:
+            assert hermes_constants.get_hermes_home() == _launch_home.routed
+
+            with mock.patch.object(
+                hermes_constants, "get_process_hermes_home", return_value=_launch_home.launch
+            ), mock.patch(
+                "hermes_cli.config.apply_terminal_config_to_env",
+                side_effect=lambda env=None: applied.append(env),
+            ):
+                env_loader._reapply_terminal_config_bridge(_launch_home.routed)
+        finally:
+            hermes_constants._HERMES_HOME_OVERRIDE.reset(token)
+
+        assert applied == []
+
+    def test_fail_open_on_guard_error(self, _launch_home):
+        """A broken guard lookup must not break dotenv loading (fail-open)."""
+        with mock.patch.object(
+            hermes_constants,
+            "get_process_hermes_home",
+            side_effect=RuntimeError("boom"),
+        ):
+            env_loader._reapply_terminal_config_bridge(_launch_home.launch)  # must not raise


### PR DESCRIPTION
## Summary

**Cross-profile terminal hijack under multi-profile serve (#102769, P0 — data-integrity + security).**

`_reapply_terminal_config_bridge()`'s guard compared `home_path` against `get_hermes_home()` — the **context-overridden** home. Under multi-profile serve, a routed profile's turn (e.g. its cron tick) runs with the context override pointing at the routed profile's home, so its `load_hermes_dotenv(hermes_home=<routed>)` call passed the guard and the shared bridge bridged the **routed profile's** terminal config into the shared `os.environ`.

The launch profile's subsequent **unscoped turns then executed in the routed profile's Docker backend with its volumes** — commands run against another profile's containers, mounts, and credentials.

## Fix

Compare against `get_process_hermes_home()` — the true process **launch** home that ignores context overrides. The bridge may now run only for the launch profile's own dotenv reloads, regardless of any active routing override.

## Reproduction (proven red on current main)

New suite `tests/hermes_cli/test_terminal_bridge_scope_102769.py` (4 tests, invariant contracts — `hermes_cli/config.apply_terminal_config_to_env` is mock-observed so the test exercises the real guard, not the mock's opinion):

1. **`test_context_override_does_not_change_the_verdict`** — the incident witness. With a `HERMES_HOME_OVERRIDE` contextvar pointing at the routed home (the exact multi-profile-serve shape), the routed home is still refused. **Fails on unpatched main** (`AssertionError`: the bridge fired); passes with the fix.
2. `test_routed_profile_home_does_not_bridge` — routed home never bridges (the hijack).
3. `test_launch_home_still_bridges` — control: the launch profile's own reload still re-applies the bridge (the stale-`.env` fix of #29186/#67323 is preserved).
4. `test_fail_open_on_guard_error` — a broken guard lookup must not break dotenv loading (fail-open contract).

## Testing

- New suite: **4/4 passed**
- `tests/hermes_cli/test_env_loader.py`: **26/26 passed** (no regressions in the dotenv family)
- `ruff check`: clean

Fixes #102769

Companion leak-class fixes: #102752 (authz env reads), #102802 (credential leak, 19 adapters) — this PR closes the terminal-config arm.