### PR TITLE
fix(dashboard): isolate chat PTY profile home and HOME for dashboard chats (#103651)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -503,8 +503,11 @@ def _apply_profile_override() -> None:
     # we must still read active_profile — the user may have run
     # `hermes profile use` and the gateway should honour it (#22502).
     hermes_home_env = os.environ.get("HERMES_HOME", "")
-    if profile_name is None and hermes_home_env and Path(hermes_home_env).parent.name == "profiles":
-        return
+    if profile_name is None and hermes_home_env:
+        if Path(hermes_home_env).parent.name == "profiles":
+            return
+        if os.environ.get("HERMES_TUI_DASHBOARD") == "1":
+            return
 
     if profile_name is None and not _under_gateway_supervisor(argv):
         try:

--- a/hermes_cli/web_server_chat.py
+++ b/hermes_cli/web_server_chat.py
@@ -325,6 +325,9 @@ def _resolve_chat_argv(
     env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=True)
     if profile_dir is not None:
         env["HERMES_HOME"] = str(profile_dir)
+        from hermes_constants import apply_subprocess_home_env
+
+        apply_subprocess_home_env(env)
     try:
         from hermes_cli.config import (
             apply_terminal_config_to_env, read_raw_config, terminal_config_owned_env_vars)

--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -135,7 +135,7 @@ class HolographicMemoryProvider(MemoryProvider):
 
     def initialize(self, session_id: str, **kwargs) -> None:
         from hermes_constants import get_hermes_home
-        _hermes_home = str(get_hermes_home())
+        _hermes_home = str(kwargs.get("hermes_home") or get_hermes_home())
         db_path = self._config.get("db_path", _hermes_home + "/memory_store.db")
         if isinstance(db_path, str):  # expand $HERMES_HOME so paths resolve to the active profile
             db_path = db_path.replace("$HERMES_HOME", _hermes_home).replace("${HERMES_HOME}", _hermes_home)


### PR DESCRIPTION
Fixes #103651 — dashboard Chat PTY re-homed the `default` profile onto the sticky `active_profile`.

**Root cause 1 — import side effect:** `tui_gateway/methods_config.py` `setup.status` imports `hermes_cli.main` to reach `_has_any_provider_configured`. That import runs `_apply_profile_override()` at module level. For `HERMES_HOME=<root>` (the `default` profile, which has no `profiles/<name>` dir) step 1.5 did not treat the env as explicit, so it fell through to the sticky `active_profile` file and rewrote `HERMES_HOME` in-process. Session DB and model stayed on the correct home (cached earlier) while `HOME`-derived `cwd` and later `get_hermes_home()` for holographic memory saw the rewritten value — split across two profiles.

Fix: treat `HERMES_TUI_DASHBOARD=1` as an explicit dashboard resolver choice, mirroring the existing supervisor guard (#74872).

**Root cause 2 — stale HOME:** `_resolve_chat_argv` built the child env via `build_subprocess_env(inherit_profile_home=True)` (which derives `HOME` from the current home) *before* overriding `HERMES_HOME` to the selected profile. `HOME` was never recomputed, so `~` expansion for `cwd` used the launch profile's home for every profile, not just `default`.

Fix: recompute `HOME` via `apply_subprocess_home_env` after the override.

**Minor:** `agent/memory_manager.py` injects `hermes_home` into `initialize` kwargs but the holographic provider ignored it and called `get_hermes_home()` directly. Honor the injected value when present.

Verification:
- `HERMES_TUI_DASHBOARD=1` + `HERMES_HOME=<root>` survives `import hermes_cli.main`; without the flag sticky behavior unchanged.
- `_resolve_chat_argv(profile=...)` now yields a profile-consistent `HOME`.
- Holographic `initialize(hermes_home=...)` writes to that profile's `memory_store.db`.