### PR TITLE
fix(update): retire unfinished receipt after fleet restart catch-up

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -50,7 +50,7 @@ from hermes_cli.update_cmd_fleet import (  # noqa: F401
     _restart_gateway_fleet_after_update, _restart_launchd_gateway_after_update,
     _restart_macos_launchd_gateways, _restart_phase_failure_is_incomplete,
     _restart_systemd_gateway_units, _restart_systemd_gateway_units_best_effort,
-    _run_pending_fleet_restart, _service_restart_sec,
+    _retire_unfinished_fleet_restart_receipt, _run_pending_fleet_restart, _service_restart_sec,
     _service_unit_supports_graceful_sigusr1_restart, _surviving_gateway_pids_after_failed_restart,
     _systemctl, _systemctl_reset_and_restart, _verify_fleet_after_update,
     _wait_for_service_active, _warn_gateway_restart_phase_aborted,

--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -120,6 +120,17 @@ def _receipt_reports_stale_runtime(expected_sha: str | None = None) -> bool:
             for entry in fleet
         )
 
+    # A completed catch-up already restarted the fleet onto ``expected_sha``, so the
+    # pre-pull plan snapshot below is history, not a live obligation. SHA-matched: a
+    # later pull that advances HEAD owes its own restart (#98022).
+    catchup = receipt.get("fleet_restart_catchup")
+    if (
+        isinstance(catchup, dict)
+        and catchup.get("completed")
+        and str(catchup.get("expected_sha") or "") == str(expected_sha)
+    ):
+        return False
+
     if not _receipt_looks_unfinished(receipt):
         return False
     plan = receipt.get("plan")
@@ -282,6 +293,26 @@ def _run_pending_fleet_restart() -> bool:
         return False
 
 
+def _retire_unfinished_fleet_restart_receipt() -> None:
+    """Overwrite ``update_receipts/latest.json`` once a catch-up restarted the fleet.
+
+    ``_pending_fleet_restart_needed()`` triggers on the marker OR the unfinished receipt
+    pointer; clearing only the marker left an interrupted run's pre-pull
+    ``plan.runtimes[].code_sha`` in place as a live obligation, so every later
+    ``hermes update`` — already-up-to-date ones included — restarted the whole fleet
+    again. Only called after a COMPLETED restart; an incomplete catch-up must keep the
+    unfinished receipt. Never raises.
+
+    See #98022.
+    """
+    with _best_effort('Could not retire the unfinished update receipt: %s'):
+        from hermes_cli.update_cmd import _current_checkout_sha
+        from hermes_cli.update_receipt import record_fleet_restart_catchup
+        record_fleet_restart_catchup(
+            expected_sha=_current_checkout_sha() or "", detail="pending fleet restart completed",
+        )
+
+
 def _apply_pending_fleet_restart_catchup() -> None:
     """On an already-up-to-date ``hermes update``, finish a skipped restart.
 
@@ -296,6 +327,7 @@ def _apply_pending_fleet_restart_catchup() -> None:
     print("→ Running the pending fleet restart...")
     if _run_pending_fleet_restart():
         _clear_fleet_restart_pending_marker()
+        _retire_unfinished_fleet_restart_receipt()
         return
     print("  ⚠ Fleet restart incomplete. Recover with: hermes gateway restart")
     sys.exit(1)

--- a/hermes_cli/update_receipt.py
+++ b/hermes_cli/update_receipt.py
@@ -172,10 +172,19 @@ def finalize_update_receipt(outcome: str, fleet: list | None = None, stop_reason
             receipt.data["stop_reason"] = stop_reason
         if fleet is not None:
             receipt.data["fleet"] = fleet
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Could not finalize update receipt: %s", exc)
+        return None
+    return _persist_receipt(receipt.data)
+
+
+def _persist_receipt(data: dict[str, Any]) -> Optional[Path]:
+    """Write *data* as a timestamped receipt plus the ``latest.json`` pointer. Never raises."""
+    try:
         directory = _receipt_dir()
         directory.mkdir(parents=True, exist_ok=True)
         path = directory / f"update_{time.strftime('%Y%m%d_%H%M%S')}_{os.getpid()}.json"
-        body = json.dumps(receipt.data, indent=2, default=str)
+        body = json.dumps(data, indent=2, default=str)
         path.write_text(body, encoding="utf-8")
         with suppress(OSError):  # stable pointer for the dashboard/desktop
             (directory / "latest.json").write_text(body, encoding="utf-8")
@@ -184,6 +193,37 @@ def finalize_update_receipt(outcome: str, fleet: list | None = None, stop_reason
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("Could not write update receipt: %s", exc)
         return None
+
+
+def record_fleet_restart_catchup(expected_sha: str = "", detail: str = "") -> Optional[Path]:
+    """Retire the unfinished receipt that triggered a now-completed fleet-restart catch-up.
+
+    The catch-up's persistent trigger is a receipt's ``plan.runtimes[].code_sha``, captured
+    before that run's pull; once the catch-up has actually restarted the fleet onto
+    ``expected_sha`` those SHAs are history, not a live obligation, or every later
+    ``hermes update`` restarts the whole fleet again (#98022). Two writes, because two
+    receipts describe the obligation: the in-flight run's receipt is stamped in place (so
+    whatever finalizes it — including the command boundary, which overwrites
+    ``latest.json``) records the discharge, and a finished success receipt is persisted over
+    the pointer for the interrupted run that is still sitting there. Never raises.
+    """
+    stamp: dict[str, Any] = {
+        "completed": True, "at": _utc_now_iso(), "expected_sha": str(expected_sha or ""),
+    }
+    with suppress(Exception):
+        if _current is not None:
+            _current.data["fleet_restart_catchup"] = dict(stamp)
+    try:
+        receipt = UpdateReceipt()
+        receipt.step("pending_fleet_restart_catchup", True, detail)
+        receipt.gateway_restart_result(incomplete=False)
+        receipt.finalize("success")
+        receipt.data["exit_code"] = 0
+        receipt.data["fleet_restart_catchup"] = dict(stamp)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Could not build fleet-restart catch-up receipt: %s", exc)
+        return None
+    return _persist_receipt(receipt.data)
 
 
 def finalize_pending_update_receipt(exit_code: Optional[int] = None, stop_reason: str = "") -> Optional[Path]:

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -506,6 +506,81 @@ def test_already_up_to_date_runs_pending_restart_when_receipt_skewed(
     assert "did not restart running gateways" in out
 
 
+def test_successful_catchup_retires_the_unfinished_receipt(
+    monkeypatch, tmp_path, capsys
+):
+    """#98022: a completed catch-up must also retire its own trigger.
+
+    Clearing only ``fleet_restart_pending`` left the interrupted run's
+    ``latest.json`` — pre-pull ``plan.runtimes[].code_sha`` and all — in place,
+    so every later already-up-to-date ``hermes update`` restarted the fleet
+    again, forever.
+    """
+    args = _update_args()
+    _patch_update_deps(monkeypatch, tmp_path, _make_up_to_date_side_effect())
+
+    disk_sha = "e" * 40
+    old_sha = "7" * 40
+    monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: disk_sha)
+    monkeypatch.setattr(update_cmd_fleet, "_current_checkout_sha", lambda: disk_sha)
+    # The run's OWN plan snapshot is taken before the catch-up restarts anything, so
+    # it records the same pre-pull SHA the interrupted receipt does.
+    stale_plan = {
+        "expected_sha": disk_sha,
+        "runtimes": [
+            {"kind": "gateway", "profile": "default", "pid": 42, "code_sha": old_sha}
+        ],
+    }
+    monkeypatch.setattr(
+        "hermes_cli.update_inventory.collect_runtime_inventory",
+        lambda: SimpleNamespace(runtimes=[], to_dict=lambda: dict(stale_plan)),
+    )
+    receipt_dir = get_hermes_home() / "logs" / "update_receipts"
+    receipt_dir.mkdir(parents=True)
+    latest = receipt_dir / "latest.json"
+    latest.write_text(
+        json.dumps(
+            {
+                "exit_code": 1,
+                "stop_reason": "KeyboardInterrupt: ",
+                "outcome": "failed",
+                "plan": dict(stale_plan),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    runs = {"n": 0}
+
+    def _restart():
+        runs["n"] += 1
+        return True
+
+    monkeypatch.setattr(update_cmd, "_run_pending_fleet_restart", _restart)
+    monkeypatch.setattr(update_cmd_fleet, "_run_pending_fleet_restart", _restart)
+
+    hermes_main.cmd_update(args)
+
+    assert runs["n"] == 1
+    assert not update_cmd._fleet_restart_pending_marker_path().exists()
+    # The unfinished trigger is retired: whatever receipt now backs latest.json
+    # records the completed catch-up, so its pre-pull plan SHAs are history.
+    receipt = json.loads(latest.read_text(encoding="utf-8"))
+    assert receipt["fleet_restart_catchup"] == {
+        "completed": True,
+        "at": receipt["fleet_restart_catchup"]["at"],
+        "expected_sha": disk_sha,
+    }
+    assert update_cmd._pending_fleet_restart_needed() is False
+
+    # A second already-up-to-date update must not restart the fleet again.
+    capsys.readouterr()
+    hermes_main.cmd_update(args)
+
+    assert runs["n"] == 1
+    assert "did not restart running gateways" not in capsys.readouterr().out
+
+
 def test_already_up_to_date_skips_restart_when_nothing_pending(
     monkeypatch, tmp_path, capsys
 ):


### PR DESCRIPTION
## Summary

Fixes #98022.

A KeyboardInterrupt (or other unfinished) `hermes update` writes `update_receipts/latest.json` with `outcome: failed` and `plan.runtimes[].code_sha` captured before the pull. `#95294` catch-up (`_apply_pending_fleet_restart_catchup`) then restarts the fleet on the next already-up-to-date run, but it only cleared `fleet_restart_pending`. The unfinished pointer stayed, so `_receipt_reports_stale_runtime()` kept treating those pre-pull SHAs as a live obligation and **every later `hermes update` restarted the whole fleet**, even when git and the fleet were already current.

## Approach

- After a **completed** pending-fleet restart, stamp `fleet_restart_catchup` onto the in-flight receipt and persist a success receipt over `latest.json` (no `stop_reason`).
- `_receipt_reports_stale_runtime()` treats that stamp as discharge when `expected_sha` still matches HEAD. A later pull that advances HEAD still owes its own restart.
- Incomplete catch-up still exits 1 and does **not** retire the unfinished receipt.

Does not change `_receipt_looks_unfinished()` (that is #103590 / open PR #103613).

## Tests

- `tests/hermes_cli/test_update_fleet_restart_pending.py`: after a successful already-up-to-date catch-up on a KeyboardInterrupt `latest.json`, `_pending_fleet_restart_needed()` is False and a second update does not restart again.
- Sabotage: removing the retire call makes the new test fail (`KeyError: fleet_restart_catchup`).
- `scripts/run_tests.sh tests/hermes_cli/test_update_fleet_restart_pending.py tests/hermes_cli/test_update_receipt.py` — 39 passed.

## Platforms

Linux (ext4). No Windows-only or desktop-Electron path.

Fixes #98022
