### PR TITLE
fix(tools): a sandbox that cannot exec is reported as 'environment unavailable', not a false 'File not found' (#44750, salvage #44753)

### DIFF
--- a/contributors/emails/denis.redozubov@gmail.com
+++ b/contributors/emails/denis.redozubov@gmail.com
@@ -1,0 +1,2 @@
+dredozubov
+# PR #44753 salvage

--- a/tests/tools/test_file_ops_env_not_ready.py
+++ b/tests/tools/test_file_ops_env_not_ready.py
@@ -1,0 +1,41 @@
+"""A terminal environment that cannot run commands (container still starting, removed out-of-band,
+transport down) must surface as an environment error, never as "File not found": the model trusts
+a false negative for the rest of the session (#44750)."""
+
+import pytest
+
+from tools.file_operations import ShellFileOperations
+
+
+class _DeadEnv:
+    cwd = "/workspace"
+
+    def execute(self, command: str, cwd=None, **kwargs) -> dict:
+        return {"output": "Error: container is not running", "returncode": 125}
+
+
+class _HealthyEmptyEnv:
+    """Runs commands fine; the filesystem has no files."""
+    cwd = "/workspace"
+
+    def execute(self, command: str, cwd=None, **kwargs) -> dict:
+        if command.startswith("if [ -f"):
+            return {"output": "__hermes_missing__\n", "returncode": 0}
+        if command.startswith("test -e"):
+            return {"output": "not_found\n", "returncode": 0}
+        if command.startswith("echo "):
+            return {"output": command[5:].strip() + "\n", "returncode": 0}
+        return {"output": "", "returncode": 1}
+
+
+@pytest.mark.parametrize("op", ["read_file", "read_file_raw", "read_file_bytes", "search"])
+def test_dead_environment_is_reported_as_unavailable_not_missing(op):
+    ops = ShellFileOperations(_DeadEnv())
+    result = getattr(ops, op)("pattern", "state") if op == "search" else getattr(ops, op)("state/notes.md")
+    assert result.error and "File not found" not in result.error and "environment unavailable" in result.error.lower()
+
+
+@pytest.mark.parametrize("op", ["read_file", "read_file_raw", "read_file_bytes"])
+def test_healthy_environment_still_reports_missing_files(op):
+    result = getattr(ShellFileOperations(_HealthyEmptyEnv()), op)("state/notes.md")
+    assert result.error and "File not found" in result.error

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -441,19 +441,28 @@ class ShellFileOperations(LintMixin, SearchMixin, FileOperations):
         name-based blocklist can't cover a FIFO (a file TYPE at any path); ``[ -f ]``
         is a stat (symlinks followed) so it answers without touching content."""
         arg = self._escape_shell_arg(path)
+        # A missing path ECHOES its sentinel: a non-zero exit with no sentinel means the shell itself did
+        # not run (container still starting, removed out-of-band, transport down) — not a missing file.
+        # Reporting that as "File not found" made the model trust a false negative for the whole session.
         stat_result = self._exec(
             f"if [ -f {arg} ]; then wc -c < {arg} 2>/dev/null; "
             f"elif [ -e {arg} ]; then echo {NOT_REGULAR_SENTINEL}; "
-            f"else exit 1; fi")
-        if stat_result.exit_code != 0:
-            return 0, "missing"
+            f"else echo {MISSING_SENTINEL}; fi")
         stat_output = _strip_terminal_fence_leaks(stat_result.stdout).strip()
+        if stat_output == MISSING_SENTINEL:
+            return 0, "missing"
         if stat_output == NOT_REGULAR_SENTINEL:
             return 0, "not_regular"
+        if stat_result.exit_code != 0:
+            return 0, "env_unavailable"
         try:
             return int(stat_output), "ok"
         except ValueError:
             return 0, "bad_size"
+
+    def _env_unavailable_error(self, path: str) -> ReadResult:
+        return ReadResult(error=(f"Terminal environment unavailable: could not stat {path} "
+                                 "(the sandbox may still be starting or was removed). Retry shortly."))
 
     def _detect_binary(self, path: str) -> tuple[bool, Optional[bytes]]:
         """``(is_binary, sample_bytes)`` — byte-layer detection when the transport
@@ -812,6 +821,8 @@ class ShellFileOperations(LintMixin, SearchMixin, FileOperations):
             return self._read_file_missing(path, offset, limit)
         if status == "not_regular":
             return self._not_regular_error(path)
+        if status == "env_unavailable":
+            return self._env_unavailable_error(path)
         if self._is_image(path):  # never inlined — redirect to the vision tool
             return self._image_redirect_result(file_size)
         is_binary, sample_bytes = self._detect_binary(path)
@@ -964,6 +975,8 @@ class ShellFileOperations(LintMixin, SearchMixin, FileOperations):
             return self._suggest_similar_files(path)
         if status == "not_regular":
             return self._not_regular_error(path)
+        if status == "env_unavailable":
+            return self._env_unavailable_error(path)
         if self._is_image(path):
             return ReadResult(is_image=True, is_binary=True, file_size=file_size)
         is_binary, sample_bytes = self._detect_binary(path)
@@ -985,6 +998,8 @@ class ShellFileOperations(LintMixin, SearchMixin, FileOperations):
             return ReadResult(error=f"File not found: {path}")
         if status == "not_regular":
             return self._not_regular_error(path)
+        if status == "env_unavailable":
+            return self._env_unavailable_error(path)
         if status == "bad_size":
             return ReadResult(error=f"Could not determine file size: {path}")
         if max_bytes is not None and file_size > max_bytes:
@@ -1357,7 +1372,11 @@ class ShellFileOperations(LintMixin, SearchMixin, FileOperations):
                 error=(f"Invalid file search order {order!r}; expected "
                        "'discovery' or 'modified'."))
         path = self._expand_path(path)
-        if "not_found" in self._path_exists_probe(path):
+        exists_probe = self._path_exists_probe(path)
+        if "exists" not in exists_probe and "not_found" not in exists_probe:
+            return SearchResult(error=(f"Terminal environment unavailable: could not stat {path} "
+                                       "(the sandbox may still be starting or was removed). Retry shortly."))
+        if "not_found" in exists_probe:
             # Models often pass several paths in one string: search the parts that exist.
             multi = self._try_multi_path_search(
                 pattern, path, target, file_glob, limit, offset, output_mode, context, order)


### PR DESCRIPTION
`read_file`, `read_file_raw`, `read_file_bytes` and `search_files` no longer report a false "File not found" when the sandbox itself cannot run commands (docker container still starting, paused, removed, transport down); they report "Terminal environment unavailable … retry shortly" instead — so the model does not carry a false negative through the rest of the session.

Salvage of #44753 by @dredozubov (authorship preserved; re-applied onto the refactored `_probe_regular_file`). Fixes #44750.

## Root cause

`ShellFileOperations._probe_regular_file` treated ANY non-zero exit from the stat probe as `"missing"`. A shell that never ran (exit 125/126/127 from `docker exec`) is indistinguishable from `[ -e ]` failing that way. `search` had the same shape: its existence probe returning neither `exists` nor `not_found` fell through as not-found.

## Change

- The stat probe now echoes `MISSING_SENTINEL` for a genuinely missing path; a non-zero exit with neither sentinel is a new `"env_unavailable"` status, surfaced by the three readers via one `_env_unavailable_error`. `search` checks for either marker before deciding not-found.
- 2 parametrized invariant tests (7 cases): a dead env is "unavailable" for all four operations; a healthy env still says "File not found". Red on `origin/main` (6 cases).

## Validation

| Check | Result |
|---|---|
| Live, real Docker (OrbStack): `read_file` of `/etc/hostname` in a healthy container, then `docker pause` it and read again | main: `File not found: /etc/hostname`; branch: `Terminal environment unavailable: could not stat /etc/hostname (…) Retry shortly.` |
| `scripts/run_tests.sh` file_operations / file_tools / read_file / search_files suites | 214 passed (the 2 `test_file_tools.py` reds fail identically on `origin/main`) |
| ruff | clean |
