### PR TITLE
fix(desktop): bridge remote gateway WebSockets through main process for private-CA trust

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -451,6 +451,7 @@ import {
   writeSandboxMarker
 } from './windows-sandbox-fallback'
 import { installWindowsSystemCaTrust } from './windows-system-ca'
+import { installWebSocketBridge } from './ws-bridge'
 import { readWindowsUserEnvVar } from './windows-user-env'
 import { isPackagedInstallPath as isPackagedInstallPathUnderRoots } from './workspace-cwd'
 import { readWslWindowsClipboardImage } from './wsl-clipboard-image'
@@ -17910,6 +17911,10 @@ app.on('open-url', (event, url) => {
 })
 
 app.whenReady().then(() => {
+  // Remote gateway WebSockets dial from the main process via the `ws` package
+  // (node:tls honors NODE_EXTRA_CA_CERTS) because Chromium's renderer WS pool
+  // ignores --use-system-certificates and undici ignores NODE_EXTRA_CA_CERTS.
+  installWebSocketBridge()
   // Warm the login-shell PATH resolution immediately so it usually completes
   // before the backend start path awaits the same single-flight promise.
   void ensureLoginShellPath()

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -17914,7 +17914,9 @@ app.whenReady().then(() => {
   // Remote gateway WebSockets dial from the main process via the `ws` package
   // (node:tls honors NODE_EXTRA_CA_CERTS) because Chromium's renderer WS pool
   // ignores --use-system-certificates and undici ignores NODE_EXTRA_CA_CERTS.
-  installWebSocketBridge()
+  // Header resolution is the same main-owned store the renderer webRequest
+  // path uses, so per-connection headers survive the transport move.
+  installWebSocketBridge({ headersForUrl: headersForRemoteRequest })
   // Warm the login-shell PATH resolution immediately so it usually completes
   // before the backend start path awaits the same single-flight promise.
   void ensureLoginShellPath()

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -29,11 +29,12 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   getGatewayWsUrl: profile => ipcRenderer.invoke('hermes:gateway:ws-url', profile),
   // Remote WS bridge: main-process `ws`-package dials (private-CA trust; see
   // electron/ws-bridge.ts). Events stream back over 'hermes:ws-bridge:event'.
-  wsBridgeOpen: url => ipcRenderer.invoke('hermes:ws-bridge:open', url),
-  wsBridgeSend: (id, data, binary) => ipcRenderer.invoke('hermes:ws-bridge:send', id, data, binary),
-  wsBridgeClose: (id, code, reason) => ipcRenderer.invoke('hermes:ws-bridge:close', id, code, reason),
+  wsBridgeOpen: (url, token) => ipcRenderer.invoke('hermes:ws-bridge:open', url, token),
+  wsBridgeCancel: token => ipcRenderer.invoke('hermes:ws-bridge:cancel', token),
+  wsBridgeSend: (token, data, binary) => ipcRenderer.invoke('hermes:ws-bridge:send', token, data, binary),
+  wsBridgeClose: (token, code, reason) => ipcRenderer.invoke('hermes:ws-bridge:close', token, code, reason),
   onWsBridgeEvent: callback => {
-    const listener = (_event, id, payload) => callback(id, payload)
+    const listener = (_event, token, payload) => callback(token, payload)
     ipcRenderer.on('hermes:ws-bridge:event', listener)
 
     return () => ipcRenderer.removeListener('hermes:ws-bridge:event', listener)

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -27,6 +27,17 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   getPoolLimits: () => ipcRenderer.invoke('hermes:pool-limits:get'),
   setPoolLimits: limits => ipcRenderer.invoke('hermes:pool-limits:set', limits),
   getGatewayWsUrl: profile => ipcRenderer.invoke('hermes:gateway:ws-url', profile),
+  // Remote WS bridge: main-process `ws`-package dials (private-CA trust; see
+  // electron/ws-bridge.ts). Events stream back over 'hermes:ws-bridge:event'.
+  wsBridgeOpen: url => ipcRenderer.invoke('hermes:ws-bridge:open', url),
+  wsBridgeSend: (id, data, binary) => ipcRenderer.invoke('hermes:ws-bridge:send', id, data, binary),
+  wsBridgeClose: (id, code, reason) => ipcRenderer.invoke('hermes:ws-bridge:close', id, code, reason),
+  onWsBridgeEvent: callback => {
+    const listener = (_event, id, payload) => callback(id, payload)
+    ipcRenderer.on('hermes:ws-bridge:event', listener)
+
+    return () => ipcRenderer.removeListener('hermes:ws-bridge:event', listener)
+  },
   // Registry-scoped fresh WS URL: { connectionId, profile } → result shape of
   // getGatewayWsUrl, minted against that connection's backend.
   getGatewayWsUrlFor: payload => ipcRenderer.invoke('hermes:gateway:ws-url-for', payload),

--- a/apps/desktop/electron/ws-bridge.test.ts
+++ b/apps/desktop/electron/ws-bridge.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Tests for electron/ws-bridge.ts.
+ *
+ * Run with: node --test electron/ws-bridge.test.ts
+ * (Wired into npm test:desktop:platforms in package.json.)
+ *
+ * The bridge moves remote gateway wss:// dials from the renderer into the main
+ * process so node:tls (NODE_EXTRA_CA_CERTS) owns the TLS handshake. These tests
+ * pin the authority/lifecycle edges that move creates:
+ *
+ *  1. Main-owned per-URL headers reach the `ws` dial (the contract the
+ *     renderer webRequest.onBeforeSendHeaders path previously enforced).
+ *  2. send/close enforce WebContents ownership; owner destruction retires
+ *     that owner's sockets and pending dials.
+ *  3. A canceled dial token is never promoted into the live map — including
+ *     when the underlying ws opens AFTER the cancel (client connect timeout).
+ *  4. Events are emitted under the dial token, so concurrent sockets never
+ *     cross-deliver frames.
+ */
+
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { createWebSocketBridge, type WsLike } from './ws-bridge'
+
+// ── Doubles ──────────────────────────────────────────────────────────────
+
+function makeFakeIpc() {
+  const handlers = new Map<string, (...args: unknown[]) => unknown>()
+  return {
+    handlers,
+    ipc: { handle: (channel: string, fn: (...args: unknown[]) => unknown) => void handlers.set(channel, fn) } as never
+  }
+}
+
+function makeSender(label: string) {
+  const sent: Array<{ token: string; payload: unknown }> = []
+  const listeners = new Map<string, Array<() => void>>()
+  return {
+    label,
+    sent,
+    destroyed: false,
+    isDestroyed() { return this.destroyed },
+    send(_channel: string, token: string, payload: unknown) { sent.push({ token, payload }) },
+    once(event: string, fn: () => void) { (listeners.get(event) ?? listeners.set(event, []).get(event)!).push(fn) },
+    destroy() {
+      this.destroyed = true
+      for (const fn of listeners.get('destroyed') ?? []) fn()
+    }
+  }
+}
+
+function makeWsFactory() {
+  const instances: Array<FakeWs & { url: string; options: { headers?: Record<string, string> } }> = []
+
+  class FakeWs implements WsLike {
+    readyState = 0
+    sent: unknown[] = []
+    terminated = false
+    closed = false
+    url = ''
+    options: { headers?: Record<string, string> } = {}
+    private listeners = new Map<string, Array<(...args: never[]) => void>>()
+
+    constructor(url: string, options: { headers?: Record<string, string> } = {}) {
+      this.url = url
+      this.options = options
+      instances.push(this as never)
+    }
+    on(event: string, fn: (...args: never[]) => void) {
+      (this.listeners.get(event) ?? this.listeners.set(event, []).get(event)!).push(fn)
+    }
+    private emit(event: string, ...args: unknown[]) {
+      for (const fn of this.listeners.get(event) ?? []) fn(...(args as never[]))
+    }
+    send(data: unknown) { this.sent.push(data) }
+    close() { this.closed = true; this.readyState = 3 }
+    terminate() { this.terminated = true }
+    simulateOpen() { this.readyState = 1; this.emit('open') }
+    simulateMessage(data: string) { this.emit('message', data, false) }
+    simulateClose(code = 1000) { this.readyState = 3; this.emit('close', code, Buffer.from('')) }
+  }
+
+  return { instances, FakeWs }
+}
+
+const nextTick = () => new Promise(resolve => setImmediate(resolve))
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+test('main-owned headers are passed to the ws dial', async () => {
+  const { handlers, ipc } = makeFakeIpc()
+  const { instances, FakeWs } = makeWsFactory()
+  createWebSocketBridge({
+    ipc,
+    webSocketImpl: FakeWs as never,
+    headersForUrl: url => url.includes('gw.example') ? { 'cf-access-client-id': 'abc123' } : {}
+  }).install()
+
+  const sender = makeSender('a')
+  const openP = handlers.get('hermes:ws-bridge:open')!({ sender }, 'wss://gw.example/api/ws', 'tok-1') as Promise<{ ok: boolean }>
+  assert.equal(instances[0].options.headers?.['cf-access-client-id'], 'abc123')
+  instances[0].simulateOpen()
+  assert.deepEqual(await openP, { ok: true })
+})
+
+test('send/close enforce WebContents ownership; owner destruction retires its sockets', async () => {
+  const { handlers, ipc } = makeFakeIpc()
+  const { instances, FakeWs } = makeWsFactory()
+  const bridge = createWebSocketBridge({ ipc, webSocketImpl: FakeWs as never })
+  bridge.install()
+
+  const a = makeSender('a')
+  const b = makeSender('b')
+  const openP = handlers.get('hermes:ws-bridge:open')!({ sender: a }, 'wss://gw.example/api/ws', 'tok-a') as Promise<unknown>
+  instances[0].simulateOpen()
+  await openP
+  await nextTick()
+
+  // B cannot send or close A's socket
+  assert.deepEqual(handlers.get('hermes:ws-bridge:send')!({ sender: b }, 'tok-a', 'x', false), { ok: false })
+  assert.deepEqual(handlers.get('hermes:ws-bridge:close')!({ sender: b }, 'tok-a'), { ok: false })
+  assert.equal(instances[0].sent.length, 0)
+  assert.equal(instances[0].closed, false)
+
+  // A can send
+  assert.deepEqual(handlers.get('hermes:ws-bridge:send')!({ sender: a }, 'tok-a', 'hello', false), { ok: true })
+  assert.equal(instances[0].sent.length, 1)
+
+  // Owner destruction retires the socket and all future mutations fail
+  a.destroy()
+  assert.equal(instances[0].terminated, true)
+  assert.equal(bridge.sockets.size, 0)
+  assert.deepEqual(handlers.get('hermes:ws-bridge:send')!({ sender: a }, 'tok-a', 'y', false), { ok: false })
+})
+
+test('cancel before open is never promoted — even when ws opens late', async () => {
+  const { handlers, ipc } = makeFakeIpc()
+  const { instances, FakeWs } = makeWsFactory()
+  const bridge = createWebSocketBridge({ ipc, webSocketImpl: FakeWs as never })
+  bridge.install()
+
+  const sender = makeSender('a')
+  void (handlers.get('hermes:ws-bridge:open')!({ sender }, 'wss://gw.example/api/ws', 'tok-c') as Promise<unknown>)
+
+  // Renderer connect timeout fires: cancel the pending dial
+  assert.deepEqual(handlers.get('hermes:ws-bridge:cancel')!({ sender }, 'tok-c'), { ok: true })
+  assert.equal(instances[0].terminated, true)
+
+  // Underlying ws opens late anyway — must not be promoted, must be terminated
+  instances[0].readyState = 0
+  instances[0].terminated = false
+  instances[0].simulateOpen()
+  await nextTick()
+  assert.equal(bridge.sockets.size, 0)
+  assert.equal(instances[0].terminated, true)
+
+  // Nothing addressable under the token
+  assert.deepEqual(handlers.get('hermes:ws-bridge:send')!({ sender }, 'tok-c', 'x', false), { ok: false })
+})
+
+test('cancel from a non-owner sender is refused', async () => {
+  const { handlers, ipc } = makeFakeIpc()
+  const { instances, FakeWs } = makeWsFactory()
+  createWebSocketBridge({ ipc, webSocketImpl: FakeWs as never }).install()
+
+  const a = makeSender('a')
+  const b = makeSender('b')
+  void (handlers.get('hermes:ws-bridge:open')!({ sender: a }, 'wss://gw.example/api/ws', 'tok-d') as Promise<unknown>)
+  assert.deepEqual(handlers.get('hermes:ws-bridge:cancel')!({ sender: b }, 'tok-d'), { ok: false })
+  assert.equal(instances[0].terminated, false)
+})
+
+test('events carry the dial token end to end (concurrent sockets cannot cross-deliver)', async () => {
+  const { handlers, ipc } = makeFakeIpc()
+  const { instances, FakeWs } = makeWsFactory()
+  createWebSocketBridge({ ipc, webSocketImpl: FakeWs as never }).install()
+
+  const a = makeSender('a')
+  void (handlers.get('hermes:ws-bridge:open')!({ sender: a }, 'wss://gw.example/api/ws', 'tok-A') as Promise<unknown>)
+  void (handlers.get('hermes:ws-bridge:open')!({ sender: a }, 'wss://gw.example/api/ws', 'tok-B') as Promise<unknown>)
+
+  instances[0].simulateOpen() // tok-A
+  instances[1].simulateOpen() // tok-B
+  await nextTick()
+  instances[0].simulateMessage('frame-for-A')
+  await nextTick()
+
+  const byToken = (t: string) => a.sent.filter(e => e.token === t).map(e => (e.payload as { type: string; data?: string }))
+  assert.deepEqual(byToken('tok-A').map(p => p.type), ['open', 'message'])
+  assert.deepEqual(byToken('tok-B').map(p => p.type), ['open'])
+  assert.equal(byToken('tok-A')[1].data, 'frame-for-A')
+})
+
+test('remote close during connect resolves open as failure and emits close', async () => {
+  const { handlers, ipc } = makeFakeIpc()
+  const { instances, FakeWs } = makeWsFactory()
+  createWebSocketBridge({ ipc, webSocketImpl: FakeWs as never }).install()
+
+  const sender = makeSender('a')
+  const openP = handlers.get('hermes:ws-bridge:open')!({ sender }, 'wss://gw.example/api/ws', 'tok-e') as Promise<{ ok: boolean; error?: string }>
+  instances[0].simulateClose(1006)
+  const result = await openP
+  assert.equal(result.ok, false)
+  await nextTick()
+  assert.equal(sender.sent.some(e => e.token === 'tok-e' && (e.payload as { type: string }).type === 'close'), true)
+})
+
+test('duplicate or empty tokens are refused', async () => {
+  const { handlers, ipc } = makeFakeIpc()
+  const { instances, FakeWs } = makeWsFactory()
+  createWebSocketBridge({ ipc, webSocketImpl: FakeWs as never }).install()
+
+  const sender = makeSender('a')
+  const p1 = handlers.get('hermes:ws-bridge:open')!({ sender }, 'wss://gw.example/api/ws', 'dup') as Promise<unknown>
+  const p2 = handlers.get('hermes:ws-bridge:open')!({ sender }, 'wss://gw.example/api/ws', 'dup') as Promise<{ ok: boolean }>
+  assert.equal((await p2).ok, false)
+  const p3 = handlers.get('hermes:ws-bridge:open')!({ sender }, 'wss://gw.example/api/ws', '') as Promise<{ ok: boolean }>
+  assert.equal((await p3).ok, false)
+  instances[0].simulateOpen()
+  await p1
+})

--- a/apps/desktop/electron/ws-bridge.test.ts
+++ b/apps/desktop/electron/ws-bridge.test.ts
@@ -136,6 +136,24 @@ test('send/close enforce WebContents ownership; owner destruction retires its so
   assert.deepEqual(handlers.get('hermes:ws-bridge:send')!({ sender: a }, 'tok-a', 'y', false), { ok: false })
 })
 
+test('successful open does NOT terminate the socket (live socket stays usable)', async () => {
+  const { handlers, ipc } = makeFakeIpc()
+  const { instances, FakeWs } = makeWsFactory()
+  const bridge = createWebSocketBridge({ ipc, webSocketImpl: FakeWs as never })
+  bridge.install()
+
+  const sender = makeSender('a')
+  const openP = handlers.get('hermes:ws-bridge:open')!({ sender }, 'wss://gw.example/api/ws', 'tok-live') as Promise<{ ok: boolean }>
+  instances[0].simulateOpen()
+  assert.deepEqual(await openP, { ok: true })
+
+  // finalizeDial must not terminate on success — the socket is live traffic now.
+  assert.equal(instances[0].terminated, false)
+  assert.equal(bridge.sockets.size, 1)
+  assert.deepEqual(handlers.get('hermes:ws-bridge:send')!({ sender }, 'tok-live', 'ping', false), { ok: true })
+  assert.deepEqual(instances[0].sent, ['ping'])
+})
+
 test('cancel settles the original open IPC invoke with a terminal receipt', async () => {
   const { handlers, ipc } = makeFakeIpc()
   const { instances, FakeWs } = makeWsFactory()

--- a/apps/desktop/electron/ws-bridge.test.ts
+++ b/apps/desktop/electron/ws-bridge.test.ts
@@ -41,6 +41,7 @@ function makeSender(label: string) {
     label,
     sent,
     destroyed: false,
+    get destroyedListenerCount() { return (listeners.get('destroyed') ?? []).length },
     isDestroyed() { return this.destroyed },
     send(_channel: string, token: string, payload: unknown) { sent.push({ token, payload }) },
     once(event: string, fn: () => void) { (listeners.get(event) ?? listeners.set(event, []).get(event)!).push(fn) },
@@ -135,29 +136,70 @@ test('send/close enforce WebContents ownership; owner destruction retires its so
   assert.deepEqual(handlers.get('hermes:ws-bridge:send')!({ sender: a }, 'tok-a', 'y', false), { ok: false })
 })
 
-test('cancel before open is never promoted — even when ws opens late', async () => {
+test('cancel settles the original open IPC invoke with a terminal receipt', async () => {
   const { handlers, ipc } = makeFakeIpc()
   const { instances, FakeWs } = makeWsFactory()
   const bridge = createWebSocketBridge({ ipc, webSocketImpl: FakeWs as never })
   bridge.install()
 
   const sender = makeSender('a')
-  void (handlers.get('hermes:ws-bridge:open')!({ sender }, 'wss://gw.example/api/ws', 'tok-c') as Promise<unknown>)
+  const openP = handlers.get('hermes:ws-bridge:open')!({ sender }, 'wss://gw.example/api/ws', 'tok-settle') as Promise<{ ok: boolean; error?: string }>
 
-  // Renderer connect timeout fires: cancel the pending dial
-  assert.deepEqual(handlers.get('hermes:ws-bridge:cancel')!({ sender }, 'tok-c'), { ok: true })
+  assert.deepEqual(handlers.get('hermes:ws-bridge:cancel')!({ sender }, 'tok-settle'), { ok: true })
+  // The open invoke must publish its terminal settlement, not hang forever.
+  const result = await openP
+  assert.equal(result.ok, false)
+  assert.equal(bridge.pendingDials.size, 0)
+  assert.equal(bridge.sockets.size, 0)
   assert.equal(instances[0].terminated, true)
 
-  // Underlying ws opens late anyway — must not be promoted, must be terminated
-  instances[0].readyState = 0
+  // A late underlying open can neither promote nor double-settle.
   instances[0].terminated = false
+  instances[0].readyState = 0
   instances[0].simulateOpen()
   await nextTick()
   assert.equal(bridge.sockets.size, 0)
   assert.equal(instances[0].terminated, true)
+})
 
-  // Nothing addressable under the token
-  assert.deepEqual(handlers.get('hermes:ws-bridge:send')!({ sender }, 'tok-c', 'x', false), { ok: false })
+test('owner destruction settles a pending dial with a terminal receipt', async () => {
+  const { handlers, ipc } = makeFakeIpc()
+  const { instances, FakeWs } = makeWsFactory()
+  const bridge = createWebSocketBridge({ ipc, webSocketImpl: FakeWs as never })
+  bridge.install()
+
+  const sender = makeSender('a')
+  const openP = handlers.get('hermes:ws-bridge:open')!({ sender }, 'wss://gw.example/api/ws', 'tok-orphan') as Promise<{ ok: boolean; error?: string }>
+
+  sender.destroy()
+  const result = await openP
+  assert.equal(result.ok, false)
+  assert.equal(bridge.pendingDials.size, 0)
+  assert.equal(bridge.sockets.size, 0)
+  assert.equal(instances[0].terminated, true)
+
+  // Late open after teardown cannot promote.
+  instances[0].terminated = false
+  instances[0].readyState = 0
+  instances[0].simulateOpen()
+  await nextTick()
+  assert.equal(bridge.sockets.size, 0)
+  assert.equal(instances[0].terminated, true)
+})
+
+test('repeated dials from one sender register a single destroyed listener', async () => {
+  const { handlers, ipc } = makeFakeIpc()
+  const { instances, FakeWs } = makeWsFactory()
+  createWebSocketBridge({ ipc, webSocketImpl: FakeWs as never }).install()
+
+  const sender = makeSender('a')
+  for (let i = 0; i < 3; i++) {
+    void (handlers.get('hermes:ws-bridge:open')!({ sender }, 'wss://gw.example/api/ws', `tok-loop-${i}`) as Promise<unknown>)
+    instances[i].simulateOpen()
+    await nextTick()
+  }
+  // watchSender dedupes via WeakSet: exactly one destroyed hook per WebContents.
+  assert.equal(sender.destroyedListenerCount, 1)
 })
 
 test('cancel from a non-owner sender is refused', async () => {

--- a/apps/desktop/electron/ws-bridge.ts
+++ b/apps/desktop/electron/ws-bridge.ts
@@ -13,91 +13,205 @@
 // whose send/close are IPC invokes and whose events arrive over a per-socket
 // channel. Local ws://127.0.0.1 dials keep the native renderer WebSocket —
 // no TLS involved, no behavior change.
-import { ipcMain } from 'electron'
+//
+// Authority rules (moving the socket across the process boundary creates new
+// edges — these are the invariants that keep it safe):
+//   - Headers come from the MAIN-OWNED store (same resolution as the renderer
+//     webRequest path), never from renderer-supplied input.
+//   - The renderer supplies a dial token with open; every mutation (cancel/
+//     send/close) must present it, and every socket is additionally owned by
+//     the invoking WebContents. A renderer can never address another
+//     renderer's socket, and never a dial it didn't start.
+//   - A canceled dial token is never promoted into the live map, even if the
+//     underlying ws opens late (client connect timeout is 15s — one layer
+//     owns the deadline).
+//   - Every socket/dial owned by a destroyed WebContents is torn down with it.
+import type { IpcMain, WebContents } from 'electron'
 
 import WebSocket from 'ws'
 
-interface BridgeSocket {
-  ws: InstanceType<typeof WebSocket>
-  sender: Electron.WebContents
+// `electron` is a type-only import: the runtime value (ipcMain) is injected
+// through deps so this module loads under bare node:test. installWebSocketBridge
+// resolves the real ipcMain lazily via require at call time (Electron main only).
+
+interface LiveSocket {
+  ws: WebSocketLike
+  sender: WebContents
 }
 
-const sockets = new Map<number, BridgeSocket>()
-let nextId = 1
+interface PendingDial {
+  ws: WebSocketLike
+  sender: WebContents
+  token: string
+  canceled: boolean
+  watchdog: ReturnType<typeof setTimeout>
+}
+
+export interface WsLike {
+  readyState: number
+  send(data: unknown): void
+  close(code?: number, reason?: string): void
+  terminate(): void
+  on(event: 'open', fn: () => void): void
+  on(event: 'message', fn: (data: Buffer | string, isBinary: boolean) => void): void
+  on(event: 'error', fn: (err: Error) => void): void
+  on(event: 'close', fn: (code: number, reason: Buffer) => void): void
+}
+
+type WebSocketLike = WsLike
+
+export interface WebSocketBridgeDeps {
+  /** Main-owned, sanitized per-URL header resolution — the same source the
+   *  renderer webRequest.onBeforeSendHeaders path uses. */
+  headersForUrl?: (url: string) => Record<string, string>
+  /** DI seams for tests. */
+  ipc?: Pick<IpcMain, 'handle'>
+  webSocketImpl?: new (url: string, options?: { headers?: Record<string, string>; maxPayload?: number }) => WebSocketLike
+  /** Connect deadline. Default matches DEFAULT_CONNECT_TIMEOUT_MS in
+   *  apps/shared/src/json-rpc-gateway.ts — one layer must own the deadline or
+   *  a late open can be promoted after the client gave up on the socket. */
+  connectTimeoutMs?: number
+}
 
 const CHANNEL_EVENT = 'hermes:ws-bridge:event'
 
-export function installWebSocketBridge(): void {
-  ipcMain.handle('hermes:ws-bridge:open', (event, url: string) => {
-    return new Promise(resolve => {
-      const id = nextId++
-      let settled = false
-      let ws: InstanceType<typeof WebSocket>
-      try {
-        ws = new WebSocket(url, { maxPayload: 64 * 1024 * 1024 })
-      } catch (err) {
-        resolve({ ok: false, error: String(err) })
-        return
-      }
+function defaultIpcMain(): Pick<IpcMain, 'handle'> {
+  // Lazy require keeps `electron` out of the module graph under node:test.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  return (require('electron') as typeof import('electron')).ipcMain
+}
 
-      const send = (payload: unknown) => {
-        if (!event.sender.isDestroyed()) {
-          event.sender.send(CHANNEL_EVENT, id, payload)
-        }
-      }
+export function createWebSocketBridge(deps: WebSocketBridgeDeps = {}) {
+  const headersForUrl = deps.headersForUrl ?? (() => ({}))
+  const ipc = deps.ipc ?? defaultIpcMain()
+  const WsImpl = deps.webSocketImpl ?? (WebSocket as unknown as WebSocketBridgeDeps['webSocketImpl'])!
+  const connectTimeoutMs = deps.connectTimeoutMs ?? 15_000
 
-      ws.on('open', () => {
-        sockets.set(id, { ws, sender: event.sender })
-        // Register the socket, THEN resolve so the renderer learns the id,
-        // THEN emit open — any ordering where 'open' could fire before the
-        // renderer knows its id drops the event and hangs the client in
-        // 'connecting' forever.
-        if (!settled) {
-          settled = true
-          resolve({ ok: true, id })
-        }
-        // Defer past the renderer's promise microtask so id assignment lands
-        // before the open event is matched.
-        setImmediate(() => send({ type: 'open' }))
-      })
-      ws.on('message', (data: Buffer | string, isBinary: boolean) => {
-        send({ type: 'message', data: isBinary ? data.toString('base64') : String(data), binary: isBinary })
-      })
-      ws.on('error', (err: Error) => {
-        send({ type: 'error', message: err.message })
-      })
-      ws.on('close', (code: number, reason: Buffer) => {
-        sockets.delete(id)
-        send({ type: 'close', code, reason: reason.toString() })
-        if (!settled) {
-          settled = true
-          resolve({ ok: false, error: `WebSocket closed during connect (code ${code})` })
-        }
-      })
-      // Safety: if neither open nor close lands, don't hang the renderer dial.
-      setTimeout(() => {
-        if (!settled) {
-          settled = true
-          try { ws.terminate() } catch { /* already gone */ }
-          resolve({ ok: false, error: 'WebSocket connect timed out' })
-        }
-      }, 20_000)
-    })
-  })
+  const sockets = new Map<string, LiveSocket>()
+  const pendingDials = new Map<string, PendingDial>()
 
-  ipcMain.handle('hermes:ws-bridge:send', (_event, id: number, data: string, binary: boolean) => {
-    const entry = sockets.get(id)
-    if (!entry || entry.ws.readyState !== entry.ws.OPEN) return { ok: false }
-    entry.ws.send(binary ? Buffer.from(data, 'base64') : data)
-    return { ok: true }
-  })
-
-  ipcMain.handle('hermes:ws-bridge:close', (_event, id: number, code?: number, reason?: string) => {
-    const entry = sockets.get(id)
-    if (entry) {
-      sockets.delete(id)
-      try { entry.ws.close(code, reason) } catch { /* already gone */ }
+  const sendTo = (sender: WebContents, token: string, payload: unknown) => {
+    if (!sender.isDestroyed()) {
+      sender.send(CHANNEL_EVENT, token, payload)
     }
-    return { ok: true }
-  })
+  }
+
+  const retireOwned = (sender: WebContents) => {
+    for (const [token, entry] of sockets) {
+      if (entry.sender === sender) {
+        sockets.delete(token)
+        try { entry.ws.terminate() } catch { /* already gone */ }
+      }
+    }
+    for (const [token, dial] of pendingDials) {
+      if (dial.sender === sender) {
+        dial.canceled = true
+        clearTimeout(dial.watchdog)
+        pendingDials.delete(token)
+        try { dial.ws.terminate() } catch { /* already gone */ }
+      }
+    }
+  }
+
+  function install(): void {
+    ipc.handle('hermes:ws-bridge:open', (event, url: string, token: string) => {
+      return new Promise(resolve => {
+        const sender = event.sender
+        if (typeof token !== 'string' || token.length === 0 || pendingDials.has(token) || sockets.has(token)) {
+          resolve({ ok: false, error: 'invalid dial token' })
+          return
+        }
+        let ws: WebSocketLike
+        try {
+          ws = new WsImpl(url, {
+            headers: headersForUrl(url),
+            maxPayload: 64 * 1024 * 1024
+          })
+        } catch (err) {
+          resolve({ ok: false, error: String(err) })
+          return
+        }
+
+        const dial: PendingDial = {
+          ws,
+          sender,
+          token,
+          canceled: false,
+          watchdog: setTimeout(() => {
+            if (pendingDials.delete(token)) {
+              dial.canceled = true
+              try { ws.terminate() } catch { /* already gone */ }
+              resolve({ ok: false, error: 'WebSocket connect timed out' })
+            }
+          }, connectTimeoutMs)
+        }
+        pendingDials.set(token, dial)
+
+        sender.once('destroyed', () => retireOwned(sender))
+
+        ws.on('open', () => {
+          if (dial.canceled || !pendingDials.delete(token)) {
+            // Renderer gave up before the dial completed — never promote.
+            try { ws.terminate() } catch { /* already gone */ }
+            return
+          }
+          clearTimeout(dial.watchdog)
+          sockets.set(token, { ws, sender })
+          // Resolve BEFORE emitting open, and defer the open event past the
+          // renderer's promise microtask so its bookkeeping lands first —
+          // either race alone hangs the client in 'connecting' forever.
+          resolve({ ok: true })
+          setImmediate(() => sendTo(sender, token, { type: 'open' }))
+        })
+        ws.on('message', (data: Buffer | string, isBinary: boolean) => {
+          sendTo(sender, token, { type: 'message', data: isBinary ? data.toString('base64') : String(data), binary: isBinary })
+        })
+        ws.on('error', (err: Error) => {
+          sendTo(sender, token, { type: 'error', message: err.message })
+        })
+        ws.on('close', (code: number, reason: Buffer) => {
+          clearTimeout(dial.watchdog)
+          const wasPending = pendingDials.delete(token)
+          sockets.delete(token)
+          sendTo(sender, token, { type: 'close', code, reason: reason.toString() })
+          if (wasPending && !dial.canceled) {
+            resolve({ ok: false, error: `WebSocket closed during connect (code ${code})` })
+          }
+        })
+      })
+    })
+
+    // Cancel a CONNECTING dial (renderer connect timeout fired before open).
+    ipc.handle('hermes:ws-bridge:cancel', (event, token: string) => {
+      const dial = pendingDials.get(token)
+      if (!dial || dial.sender !== event.sender) return { ok: false }
+      dial.canceled = true
+      clearTimeout(dial.watchdog)
+      pendingDials.delete(token)
+      try { dial.ws.terminate() } catch { /* already gone */ }
+      return { ok: true }
+    })
+
+    ipc.handle('hermes:ws-bridge:send', (event, token: string, data: string, binary: boolean) => {
+      const entry = sockets.get(token)
+      if (!entry || entry.sender !== event.sender) return { ok: false }
+      if (entry.ws.readyState !== 1) return { ok: false }
+      entry.ws.send(binary ? Buffer.from(data, 'base64') : data)
+      return { ok: true }
+    })
+
+    ipc.handle('hermes:ws-bridge:close', (event, token: string, code?: number, reason?: string) => {
+      const entry = sockets.get(token)
+      if (!entry || entry.sender !== event.sender) return { ok: false }
+      sockets.delete(token)
+      try { entry.ws.close(code, reason) } catch { /* already gone */ }
+      return { ok: true }
+    })
+  }
+
+  return { install, sockets, pendingDials }
+}
+
+export function installWebSocketBridge(deps: WebSocketBridgeDeps = {}): void {
+  createWebSocketBridge(deps).install()
 }

--- a/apps/desktop/electron/ws-bridge.ts
+++ b/apps/desktop/electron/ws-bridge.ts
@@ -1,0 +1,103 @@
+// Remote WebSocket bridge: dials remote (wss://) gateway sockets from Electron's
+// MAIN process using the `ws` npm package, which honors NODE_EXTRA_CA_CERTS.
+//
+// Why this exists: two TLS clients in the app do NOT trust private CAs the way
+// the rest of the stack does —
+//   1. Chromium's WebSocket in the renderer ignores --use-system-certificates
+//      on Linux (URL loaders use the system store; the WS socket pool does not).
+//   2. Node's built-in undici WebSocket ignores NODE_EXTRA_CA_CERTS entirely.
+// The `ws` package uses node:tls, which honors NODE_EXTRA_CA_CERTS — verified
+// against a NullX-chain host: handshake completes, auth layer reachable.
+//
+// The bridge is a dumb frame pipe: the renderer gets a WebSocket-like object
+// whose send/close are IPC invokes and whose events arrive over a per-socket
+// channel. Local ws://127.0.0.1 dials keep the native renderer WebSocket —
+// no TLS involved, no behavior change.
+import { ipcMain } from 'electron'
+
+import WebSocket from 'ws'
+
+interface BridgeSocket {
+  ws: InstanceType<typeof WebSocket>
+  sender: Electron.WebContents
+}
+
+const sockets = new Map<number, BridgeSocket>()
+let nextId = 1
+
+const CHANNEL_EVENT = 'hermes:ws-bridge:event'
+
+export function installWebSocketBridge(): void {
+  ipcMain.handle('hermes:ws-bridge:open', (event, url: string) => {
+    return new Promise(resolve => {
+      const id = nextId++
+      let settled = false
+      let ws: InstanceType<typeof WebSocket>
+      try {
+        ws = new WebSocket(url, { maxPayload: 64 * 1024 * 1024 })
+      } catch (err) {
+        resolve({ ok: false, error: String(err) })
+        return
+      }
+
+      const send = (payload: unknown) => {
+        if (!event.sender.isDestroyed()) {
+          event.sender.send(CHANNEL_EVENT, id, payload)
+        }
+      }
+
+      ws.on('open', () => {
+        sockets.set(id, { ws, sender: event.sender })
+        // Register the socket, THEN resolve so the renderer learns the id,
+        // THEN emit open — any ordering where 'open' could fire before the
+        // renderer knows its id drops the event and hangs the client in
+        // 'connecting' forever.
+        if (!settled) {
+          settled = true
+          resolve({ ok: true, id })
+        }
+        // Defer past the renderer's promise microtask so id assignment lands
+        // before the open event is matched.
+        setImmediate(() => send({ type: 'open' }))
+      })
+      ws.on('message', (data: Buffer | string, isBinary: boolean) => {
+        send({ type: 'message', data: isBinary ? data.toString('base64') : String(data), binary: isBinary })
+      })
+      ws.on('error', (err: Error) => {
+        send({ type: 'error', message: err.message })
+      })
+      ws.on('close', (code: number, reason: Buffer) => {
+        sockets.delete(id)
+        send({ type: 'close', code, reason: reason.toString() })
+        if (!settled) {
+          settled = true
+          resolve({ ok: false, error: `WebSocket closed during connect (code ${code})` })
+        }
+      })
+      // Safety: if neither open nor close lands, don't hang the renderer dial.
+      setTimeout(() => {
+        if (!settled) {
+          settled = true
+          try { ws.terminate() } catch { /* already gone */ }
+          resolve({ ok: false, error: 'WebSocket connect timed out' })
+        }
+      }, 20_000)
+    })
+  })
+
+  ipcMain.handle('hermes:ws-bridge:send', (_event, id: number, data: string, binary: boolean) => {
+    const entry = sockets.get(id)
+    if (!entry || entry.ws.readyState !== entry.ws.OPEN) return { ok: false }
+    entry.ws.send(binary ? Buffer.from(data, 'base64') : data)
+    return { ok: true }
+  })
+
+  ipcMain.handle('hermes:ws-bridge:close', (_event, id: number, code?: number, reason?: string) => {
+    const entry = sockets.get(id)
+    if (entry) {
+      sockets.delete(id)
+      try { entry.ws.close(code, reason) } catch { /* already gone */ }
+    }
+    return { ok: true }
+  })
+}

--- a/apps/desktop/electron/ws-bridge.ts
+++ b/apps/desktop/electron/ws-bridge.ts
@@ -187,7 +187,6 @@ export function createWebSocketBridge(deps: WebSocketBridgeDeps = {}) {
           return
         }
         sockets.set(token, { ws, sender })
-        console.log(`[ws-bridge] open token=${token}`)
         // Resolve happened in finalizeDial; emit open deferred past the
         // renderer's promise microtask so its bookkeeping lands first —
         // either race alone hangs the client in 'connecting' forever.
@@ -197,11 +196,9 @@ export function createWebSocketBridge(deps: WebSocketBridgeDeps = {}) {
         sendTo(sender, token, { type: 'message', data: isBinary ? data.toString('base64') : String(data), binary: isBinary })
       })
       ws.on('error', (err: Error) => {
-        console.log(`[ws-bridge] error token=${token}: ${err.message}`)
         sendTo(sender, token, { type: 'error', message: err.message })
       })
       ws.on('close', (code: number, reason: Buffer) => {
-        console.log(`[ws-bridge] close token=${token} code=${code} reason=${reason.toString()}`)
         sockets.delete(token)
         sendTo(sender, token, { type: 'close', code, reason: reason.toString() })
         finalizeDial(token, { ok: false, error: `WebSocket closed during connect (code ${code})` })

--- a/apps/desktop/electron/ws-bridge.ts
+++ b/apps/desktop/electron/ws-bridge.ts
@@ -43,8 +43,11 @@ interface PendingDial {
   ws: WebSocketLike
   sender: WebContents
   token: string
-  canceled: boolean
   watchdog: ReturnType<typeof setTimeout>
+  /** The open IPC promise's resolver — settlement is a first-class,
+   *  idempotent operation owned by finalizeDial(). */
+  settle: (result: { ok: boolean; error?: string }) => void
+  settled: boolean
 }
 
 export interface WsLike {
@@ -89,11 +92,30 @@ export function createWebSocketBridge(deps: WebSocketBridgeDeps = {}) {
 
   const sockets = new Map<string, LiveSocket>()
   const pendingDials = new Map<string, PendingDial>()
+  // One destroyed-listener per WebContents, not per dial — a long-lived
+  // renderer that reconnects repeatedly must not accumulate listeners.
+  const retiredSenders = new WeakSet<WebContents>()
 
   const sendTo = (sender: WebContents, token: string, payload: unknown) => {
     if (!sender.isDestroyed()) {
       sender.send(CHANNEL_EVENT, token, payload)
     }
+  }
+
+  /** Single-owner, idempotent terminal settlement for a pending dial: clears
+   *  the watchdog, removes the pending entry, settles the open IPC result
+   *  exactly once, and terminates the transport. Every terminal path (open,
+   *  cancel, owner destruction, watchdog expiry, pre-open close) goes through
+   *  here — a canceled/settled token can never be promoted or double-settled. */
+  const finalizeDial = (token: string, result: { ok: boolean; error?: string }): PendingDial | null => {
+    const dial = pendingDials.get(token)
+    if (!dial || dial.settled) return null
+    dial.settled = true
+    clearTimeout(dial.watchdog)
+    pendingDials.delete(token)
+    try { dial.ws.terminate() } catch { /* already gone */ }
+    dial.settle(result)
+    return dial
   }
 
   const retireOwned = (sender: WebContents) => {
@@ -103,92 +125,90 @@ export function createWebSocketBridge(deps: WebSocketBridgeDeps = {}) {
         try { entry.ws.terminate() } catch { /* already gone */ }
       }
     }
-    for (const [token, dial] of pendingDials) {
+    for (const [token, dial] of [...pendingDials]) {
       if (dial.sender === sender) {
-        dial.canceled = true
-        clearTimeout(dial.watchdog)
-        pendingDials.delete(token)
-        try { dial.ws.terminate() } catch { /* already gone */ }
+        finalizeDial(token, { ok: false, error: 'Renderer destroyed during connect' })
       }
     }
   }
 
-  function install(): void {
-    ipc.handle('hermes:ws-bridge:open', (event, url: string, token: string) => {
-      return new Promise(resolve => {
-        const sender = event.sender
-        if (typeof token !== 'string' || token.length === 0 || pendingDials.has(token) || sockets.has(token)) {
-          resolve({ ok: false, error: 'invalid dial token' })
-          return
-        }
-        let ws: WebSocketLike
-        try {
-          ws = new WsImpl(url, {
-            headers: headersForUrl(url),
-            maxPayload: 64 * 1024 * 1024
-          })
-        } catch (err) {
-          resolve({ ok: false, error: String(err) })
-          return
-        }
+  const watchSender = (sender: WebContents) => {
+    if (retiredSenders.has(sender)) return
+    retiredSenders.add(sender)
+    sender.once('destroyed', () => retireOwned(sender))
+  }
 
-        const dial: PendingDial = {
+  function install(): void {
+    ipc.handle('hermes:ws-bridge:open', (event, url: string, token: string): Promise<{ ok: boolean; error?: string }> => {
+      const sender = event.sender
+      if (typeof token !== 'string' || token.length === 0 || pendingDials.has(token) || sockets.has(token)) {
+        return Promise.resolve({ ok: false, error: 'invalid dial token' })
+      }
+      let ws: WebSocketLike
+      try {
+        ws = new WsImpl(url, {
+          headers: headersForUrl(url),
+          maxPayload: 64 * 1024 * 1024
+        })
+      } catch (err) {
+        return Promise.resolve({ ok: false, error: String(err) })
+      }
+
+      let dial: PendingDial
+      const openPromise = new Promise<{ ok: boolean; error?: string }>(resolve => {
+        dial = {
           ws,
           sender,
           token,
-          canceled: false,
+          settled: false,
+          settle: resolve,
           watchdog: setTimeout(() => {
-            if (pendingDials.delete(token)) {
-              dial.canceled = true
-              try { ws.terminate() } catch { /* already gone */ }
-              resolve({ ok: false, error: 'WebSocket connect timed out' })
-            }
+            finalizeDial(token, { ok: false, error: 'WebSocket connect timed out' })
           }, connectTimeoutMs)
         }
-        pendingDials.set(token, dial)
-
-        sender.once('destroyed', () => retireOwned(sender))
-
-        ws.on('open', () => {
-          if (dial.canceled || !pendingDials.delete(token)) {
-            // Renderer gave up before the dial completed — never promote.
-            try { ws.terminate() } catch { /* already gone */ }
-            return
-          }
-          clearTimeout(dial.watchdog)
-          sockets.set(token, { ws, sender })
-          // Resolve BEFORE emitting open, and defer the open event past the
-          // renderer's promise microtask so its bookkeeping lands first —
-          // either race alone hangs the client in 'connecting' forever.
-          resolve({ ok: true })
-          setImmediate(() => sendTo(sender, token, { type: 'open' }))
-        })
-        ws.on('message', (data: Buffer | string, isBinary: boolean) => {
-          sendTo(sender, token, { type: 'message', data: isBinary ? data.toString('base64') : String(data), binary: isBinary })
-        })
-        ws.on('error', (err: Error) => {
-          sendTo(sender, token, { type: 'error', message: err.message })
-        })
-        ws.on('close', (code: number, reason: Buffer) => {
-          clearTimeout(dial.watchdog)
-          const wasPending = pendingDials.delete(token)
-          sockets.delete(token)
-          sendTo(sender, token, { type: 'close', code, reason: reason.toString() })
-          if (wasPending && !dial.canceled) {
-            resolve({ ok: false, error: `WebSocket closed during connect (code ${code})` })
-          }
-        })
       })
+      pendingDials.set(token, dial!)
+      watchSender(sender)
+
+      ws.on('open', () => {
+        if (!pendingDials.has(token)) {
+          // Already settled (cancel/timeout/teardown) — never promote.
+          try { ws.terminate() } catch { /* already gone */ }
+          return
+        }
+        const d = finalizeDial(token, { ok: true })
+        if (!d) {
+          try { ws.terminate() } catch { /* already gone */ }
+          return
+        }
+        sockets.set(token, { ws, sender })
+        // Resolve happened in finalizeDial; emit open deferred past the
+        // renderer's promise microtask so its bookkeeping lands first —
+        // either race alone hangs the client in 'connecting' forever.
+        setImmediate(() => sendTo(sender, token, { type: 'open' }))
+      })
+      ws.on('message', (data: Buffer | string, isBinary: boolean) => {
+        sendTo(sender, token, { type: 'message', data: isBinary ? data.toString('base64') : String(data), binary: isBinary })
+      })
+      ws.on('error', (err: Error) => {
+        sendTo(sender, token, { type: 'error', message: err.message })
+      })
+      ws.on('close', (code: number, reason: Buffer) => {
+        sockets.delete(token)
+        sendTo(sender, token, { type: 'close', code, reason: reason.toString() })
+        finalizeDial(token, { ok: false, error: `WebSocket closed during connect (code ${code})` })
+      })
+
+      return openPromise
     })
 
     // Cancel a CONNECTING dial (renderer connect timeout fired before open).
+    // Settlement flows through finalizeDial, so the original open IPC invoke
+    // receives its terminal receipt ({ ok: false }) instead of hanging forever.
     ipc.handle('hermes:ws-bridge:cancel', (event, token: string) => {
       const dial = pendingDials.get(token)
       if (!dial || dial.sender !== event.sender) return { ok: false }
-      dial.canceled = true
-      clearTimeout(dial.watchdog)
-      pendingDials.delete(token)
-      try { dial.ws.terminate() } catch { /* already gone */ }
+      finalizeDial(token, { ok: false, error: 'Dial canceled by renderer' })
       return { ok: true }
     })
 

--- a/apps/desktop/electron/ws-bridge.ts
+++ b/apps/desktop/electron/ws-bridge.ts
@@ -104,16 +104,21 @@ export function createWebSocketBridge(deps: WebSocketBridgeDeps = {}) {
 
   /** Single-owner, idempotent terminal settlement for a pending dial: clears
    *  the watchdog, removes the pending entry, settles the open IPC result
-   *  exactly once, and terminates the transport. Every terminal path (open,
-   *  cancel, owner destruction, watchdog expiry, pre-open close) goes through
-   *  here — a canceled/settled token can never be promoted or double-settled. */
+   *  exactly once, and — on FAILURE — terminates the transport. Every
+   *  terminal path (open, cancel, owner destruction, watchdog expiry,
+   *  pre-open close) goes through here — a canceled/settled token can never
+   *  be promoted or double-settled. A successful settlement must NOT
+   *  terminate: the socket moves to the live map (v3.1 bug: unconditional
+   *  terminate killed every dial 6ms after open — the "flapping" loop). */
   const finalizeDial = (token: string, result: { ok: boolean; error?: string }): PendingDial | null => {
     const dial = pendingDials.get(token)
     if (!dial || dial.settled) return null
     dial.settled = true
     clearTimeout(dial.watchdog)
     pendingDials.delete(token)
-    try { dial.ws.terminate() } catch { /* already gone */ }
+    if (!result.ok) {
+      try { dial.ws.terminate() } catch { /* already gone */ }
+    }
     dial.settle(result)
     return dial
   }
@@ -182,6 +187,7 @@ export function createWebSocketBridge(deps: WebSocketBridgeDeps = {}) {
           return
         }
         sockets.set(token, { ws, sender })
+        console.log(`[ws-bridge] open token=${token}`)
         // Resolve happened in finalizeDial; emit open deferred past the
         // renderer's promise microtask so its bookkeeping lands first —
         // either race alone hangs the client in 'connecting' forever.
@@ -191,9 +197,11 @@ export function createWebSocketBridge(deps: WebSocketBridgeDeps = {}) {
         sendTo(sender, token, { type: 'message', data: isBinary ? data.toString('base64') : String(data), binary: isBinary })
       })
       ws.on('error', (err: Error) => {
+        console.log(`[ws-bridge] error token=${token}: ${err.message}`)
         sendTo(sender, token, { type: 'error', message: err.message })
       })
       ws.on('close', (code: number, reason: Buffer) => {
+        console.log(`[ws-bridge] close token=${token} code=${code} reason=${reason.toString()}`)
         sockets.delete(token)
         sendTo(sender, token, { type: 'close', code, reason: reason.toString() })
         finalizeDial(token, { ok: false, error: `WebSocket closed during connect (code ${code})` })

--- a/apps/desktop/src/api/client.ts
+++ b/apps/desktop/src/api/client.ts
@@ -2,6 +2,8 @@ import { JsonRpcGatewayClient } from '@hermes/shared'
 
 import type { HermesApiRequest } from '@/global'
 
+import { gatewaySocketFactory } from '@/api/ws-bridge-socket'
+
 // Desktop startup fires a burst of read-only data calls (config, profiles,
 // model info/options, cron) the moment the backend passes readiness. On a
 // profile-heavy or remote install these can each take tens of seconds — e.g.
@@ -32,7 +34,8 @@ export class HermesGateway extends JsonRpcGatewayClient {
       connectErrorMessage: 'Could not connect to Hermes gateway',
       createRequestId: nextId => nextId,
       notConnectedErrorMessage: 'Hermes gateway is not connected',
-      requestTimeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS
+      requestTimeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
+      socketFactory: gatewaySocketFactory
     })
   }
 }

--- a/apps/desktop/src/api/ws-bridge-socket.test.ts
+++ b/apps/desktop/src/api/ws-bridge-socket.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for src/api/ws-bridge-socket.ts (renderer side of the WS bridge).
+ *
+ * Run with: npx vitest run src/api/ws-bridge-socket.test.ts
+ *
+ * Pins the renderer-side concurrency/lifecycle invariants:
+ *  1. Events are accepted only under the socket's own dial token — concurrent
+ *     socket A's frames never replay into socket B (finding: pre-id buffer
+ *     cross-contamination; fixed by token-tagged events end to end).
+ *  2. close() while CONNECTING cancels the main-process dial, and a late
+ *     open-result after close() closes the socket immediately (no orphan).
+ *  3. The IPC listener is removed on every terminal outcome — repeated
+ *     failure cycles don't accumulate listeners.
+ */
+
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { BridgedWebSocket } from './ws-bridge-socket'
+
+interface RecordedCall {
+  method: string
+  args: unknown[]
+}
+
+function makeBridgeApi() {
+  const calls: RecordedCall[] = []
+  const listeners = new Set<(token: string, payload: { type: string; data?: string; code?: number; reason?: string }) => void>()
+  const pendingOpens = new Map<string, (result: { ok: boolean; error?: string }) => void>()
+
+  const api = {
+    wsBridgeOpen: (url: string, token: string) => {
+      calls.push({ method: 'open', args: [url, token] })
+      return new Promise<{ ok: boolean; error?: string }>(resolve => pendingOpens.set(token, resolve))
+    },
+    wsBridgeCancel: (token: string) => {
+      calls.push({ method: 'cancel', args: [token] })
+      return Promise.resolve({ ok: true })
+    },
+    wsBridgeSend: (token: string, data: string, binary: boolean) => {
+      calls.push({ method: 'send', args: [token, data, binary] })
+      return Promise.resolve({ ok: true })
+    },
+    wsBridgeClose: (token: string, code?: number, reason?: string) => {
+      calls.push({ method: 'close', args: [token, code, reason] })
+      return Promise.resolve({ ok: true })
+    },
+    onWsBridgeEvent: (cb: (token: string, payload: { type: string; data?: string; code?: number; reason?: string }) => void) => {
+      listeners.add(cb)
+      return () => listeners.delete(cb)
+    }
+  }
+
+  return {
+    api,
+    calls,
+    listeners,
+    resolveOpen: (token: string, result = { ok: true }) => pendingOpens.get(token)!(result),
+    emit: (token: string, payload: { type: string; data?: string; code?: number; reason?: string }) => {
+      for (const cb of [...listeners]) cb(token, payload)
+    }
+  }
+}
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 0))
+
+function tokenOf(calls: RecordedCall[], method = 'open'): string {
+  const call = calls.find(c => c.method === method)
+  assert.ok(call, `expected ${method} call`)
+  return call!.args[1] as string ?? call!.args[0] as string
+}
+
+test('concurrent sockets receive only their own token-tagged events', async () => {
+  const { api, calls, emit, resolveOpen } = makeBridgeApi()
+  const a = new BridgedWebSocket('wss://gw/a', api as never, 'tok-A')
+  const b = new BridgedWebSocket('wss://gw/b', api as never, 'tok-B')
+
+  const aEvents: string[] = []
+  const bEvents: string[] = []
+  a.addEventListener('open', () => aEvents.push('open'))
+  a.addEventListener('message', e => aEvents.push(`msg:${(e as MessageEvent).data}`))
+  a.addEventListener('close', () => aEvents.push('close'))
+  b.addEventListener('open', () => bEvents.push('open'))
+  b.addEventListener('message', e => bEvents.push(`msg:${(e as MessageEvent).data}`))
+  b.addEventListener('close', () => bEvents.push('close'))
+
+  // A opens first; while B is still awaiting its open result, A traffic flows.
+  resolveOpen('tok-A')
+  await flush()
+  emit('tok-A', { type: 'open' })
+  emit('tok-A', { type: 'message', data: 'for-A' })
+  emit('tok-A', { type: 'close', code: 1000 })
+
+  resolveOpen('tok-B')
+  await flush()
+  emit('tok-B', { type: 'open' })
+  emit('tok-B', { type: 'message', data: 'for-B' })
+
+  assert.deepEqual(aEvents, ['open', 'msg:for-A', 'close'])
+  assert.deepEqual(bEvents, ['open', 'msg:for-B'])
+  assert.equal(calls.length >= 2, true)
+})
+
+test('close() while CONNECTING cancels the dial; late open-result closes immediately', async () => {
+  const { api, calls, resolveOpen } = makeBridgeApi()
+  const sock = new BridgedWebSocket('wss://gw/x', api as never, 'tok-X')
+
+  // Client connect timeout: close before open resolved.
+  sock.close()
+  const cancel = calls.find(c => c.method === 'cancel')
+  assert.ok(cancel, 'cancel issued for connecting socket')
+  assert.equal(cancel!.args[0], 'tok-X')
+
+  // The dial resolves OK anyway (server was slow, not dead) — must be closed
+  // immediately, never surfaced as open.
+  let opened = false
+  sock.addEventListener('open', () => { opened = true })
+  resolveOpen('tok-X', { ok: true })
+  await flush()
+  assert.equal(opened, false)
+  const close = calls.find(c => c.method === 'close')
+  assert.ok(close, 'late-opened socket closed')
+  assert.equal(close!.args[0], 'tok-X')
+  assert.equal(sock.readyState, 3)
+})
+
+test('terminal outcomes remove the IPC listener (no accumulation across failures)', async () => {
+  const { api, listeners, emit, resolveOpen } = makeBridgeApi()
+
+  // Cycle 1: open fails
+  const s1 = new BridgedWebSocket('wss://gw/1', api as never, 'tok-1')
+  assert.equal(listeners.size, 1)
+  resolveOpen('tok-1', { ok: false, error: 'dial refused' })
+  await flush()
+  assert.equal(listeners.size, 0)
+
+  // Cycle 2: opens, then remote close
+  const s2 = new BridgedWebSocket('wss://gw/2', api as never, 'tok-2')
+  assert.equal(listeners.size, 1)
+  resolveOpen('tok-2', { ok: true })
+  await flush()
+  emit('tok-2', { type: 'open' })
+  emit('tok-2', { type: 'close', code: 1000 })
+  assert.equal(listeners.size, 0)
+
+  // Cycle 3: local close
+  const s3 = new BridgedWebSocket('wss://gw/3', api as never, 'tok-3')
+  assert.equal(listeners.size, 1)
+  s3.close()
+  assert.equal(listeners.size, 0)
+})
+
+test('send only flows after open, under the socket token', async () => {
+  const { api, calls, emit, resolveOpen } = makeBridgeApi()
+  const sock = new BridgedWebSocket('wss://gw/s', api as never, 'tok-S')
+
+  sock.send('too-early')
+  resolveOpen('tok-S', { ok: true })
+  await flush()
+  emit('tok-S', { type: 'open' })
+  sock.send('hello')
+
+  const sends = calls.filter(c => c.method === 'send')
+  assert.equal(sends.length, 1)
+  assert.deepEqual(sends[0].args, ['tok-S', 'hello', false])
+})

--- a/apps/desktop/src/api/ws-bridge-socket.ts
+++ b/apps/desktop/src/api/ws-bridge-socket.ts
@@ -1,0 +1,143 @@
+// Renderer side of the remote WebSocket bridge (see electron/ws-bridge.ts).
+// socketFactory for JsonRpcGatewayClient: wss:// dials are piped through
+// Electron's main process (`ws` npm package, node:tls — honors
+// NODE_EXTRA_CA_CERTS); ws:// loopback keeps the native WebSocket.
+//
+// The client type is `WebSocketLike = WebSocket` and it drives sockets via
+// addEventListener('open'|'message'|'close'|'error') plus send/close/
+// readyState — BridgedWebSocket mirrors that EventTarget surface exactly.
+interface BridgeApi {
+  wsBridgeOpen: (url: string) => Promise<{ ok: boolean; id?: number; error?: string }>
+  wsBridgeSend: (id: number, data: string, binary: boolean) => Promise<{ ok: boolean }>
+  wsBridgeClose: (id: number, code?: number, reason?: string) => Promise<{ ok: boolean }>
+  onWsBridgeEvent: (
+    callback: (id: number, payload: { type: string; data?: string; binary?: boolean; code?: number; reason?: string }) => void
+  ) => () => void
+}
+
+function bridgeApi(): BridgeApi | null {
+  const api = (window as unknown as { hermesDesktop?: Partial<BridgeApi> }).hermesDesktop
+  return api && typeof api.wsBridgeOpen === 'function' ? (api as BridgeApi) : null
+}
+
+class BridgedWebSocket extends EventTarget {
+  readonly CONNECTING = 0
+  readonly OPEN = 1
+  readonly CLOSING = 2
+  readonly CLOSED = 3
+
+  readyState = 0
+  binaryType: 'blob' | 'arraybuffer' = 'arraybuffer'
+
+  private id: number | null = null
+  private readonly removeListener: () => void
+  private pending: Array<{ type: string; data?: string; binary?: boolean; code?: number; reason?: string }> = []
+
+  constructor(url: string, api: BridgeApi) {
+    super()
+    this.removeListener = api.onWsBridgeEvent((id, payload) => {
+      if (this.id === null) {
+        // Event arrived before wsBridgeOpen resolved and assigned our id.
+        // Buffer it — flushed in order once the id lands. Without this an
+        // 'open' racing the id assignment is dropped and the client hangs
+        // in 'connecting' forever.
+        this.pending.push(payload)
+        return
+      }
+      if (id !== this.id) return
+      this.dispatch(payload)
+    })
+
+    void api.wsBridgeOpen(url).then(result => {
+      if (!result.ok || result.id === undefined) {
+        this.readyState = 3
+        this.dispatchEvent(new Event('error'))
+        this.dispatchEvent(new CloseEvent('close', { code: 1006, reason: result.error ?? 'bridge dial failed' }))
+        return
+      }
+      this.id = result.id
+      for (const payload of this.pending) this.dispatch(payload)
+      this.pending = []
+    })
+  }
+
+  private dispatch(payload: { type: string; data?: string; binary?: boolean; code?: number; reason?: string }): void {
+    switch (payload.type) {
+      case 'open':
+        this.readyState = 1
+        this.dispatchEvent(new Event('open'))
+        break
+      case 'message':
+        this.dispatchEvent(
+          new MessageEvent('message', {
+            data: payload.binary ? base64ToArrayBuffer(payload.data ?? '') : (payload.data ?? '')
+          })
+        )
+        break
+      case 'error':
+        this.dispatchEvent(new Event('error'))
+        break
+      case 'close':
+        this.readyState = 3
+        this.dispatchEvent(new CloseEvent('close', { code: payload.code ?? 1006, reason: payload.reason ?? '' }))
+        break
+    }
+  }
+
+  send(data: string | ArrayBufferLike | Blob | ArrayBufferView): void {
+    if (this.id === null || this.readyState !== 1) return
+    const api = bridgeApi()
+    if (!api) return
+    if (typeof data === 'string') {
+      void api.wsBridgeSend(this.id, data, false)
+      return
+    }
+    if (data instanceof ArrayBuffer) {
+      void api.wsBridgeSend(this.id, arrayBufferToBase64(data), true)
+      return
+    }
+    if (ArrayBuffer.isView(data)) {
+      void api.wsBridgeSend(this.id, arrayBufferToBase64(data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer), true)
+      return
+    }
+    // Blob: async read then send.
+    void (data as Blob).arrayBuffer().then((buf: ArrayBuffer) => {
+      if (this.id !== null && this.readyState === 1) void api.wsBridgeSend(this.id, arrayBufferToBase64(buf), true)
+    })
+  }
+
+  close(code?: number, reason?: string): void {
+    if (this.readyState >= 2) return
+    this.readyState = 2
+    this.removeListener()
+    if (this.id !== null) {
+      const api = bridgeApi()
+      if (api) void api.wsBridgeClose(this.id, code, reason)
+    }
+    this.readyState = 3
+  }
+}
+
+function base64ToArrayBuffer(b64: string): ArrayBuffer {
+  const bin = atob(b64)
+  const bytes = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i)
+  return bytes.buffer
+}
+
+function arrayBufferToBase64(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf)
+  let bin = ''
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i])
+  return btoa(bin)
+}
+
+/** socketFactory for JsonRpcGatewayClient: bridge wss:// through the main
+ *  process (private-CA trust), keep native WebSocket for cleartext loopback. */
+export function gatewaySocketFactory(url: string): WebSocket {
+  const api = bridgeApi()
+  if (api && url.startsWith('wss://')) {
+    return new BridgedWebSocket(url, api) as unknown as WebSocket
+  }
+  return new WebSocket(url)
+}

--- a/apps/desktop/src/api/ws-bridge-socket.ts
+++ b/apps/desktop/src/api/ws-bridge-socket.ts
@@ -6,13 +6,31 @@
 // The client type is `WebSocketLike = WebSocket` and it drives sockets via
 // addEventListener('open'|'message'|'close'|'error') plus send/close/
 // readyState — BridgedWebSocket mirrors that EventTarget surface exactly.
+//
+// Concurrency/lifecycle invariants (multiple bridged sockets per renderer are
+// NORMAL — primary + per-profile secondaries):
+//   - Every dial carries a client-generated token; events arrive tagged by
+//     token, so socket A's frames can never replay into socket B.
+//   - close() while CONNECTING cancels the main-process dial by token —
+//     a canceled token is never promoted into main's live map.
+//   - The IPC listener is removed on EVERY terminal outcome (open-fail,
+//     remote close, local close) — reconnect cycles don't accumulate them.
 interface BridgeApi {
-  wsBridgeOpen: (url: string) => Promise<{ ok: boolean; id?: number; error?: string }>
-  wsBridgeSend: (id: number, data: string, binary: boolean) => Promise<{ ok: boolean }>
-  wsBridgeClose: (id: number, code?: number, reason?: string) => Promise<{ ok: boolean }>
+  wsBridgeOpen: (url: string, token: string) => Promise<{ ok: boolean; error?: string }>
+  wsBridgeCancel: (token: string) => Promise<{ ok: boolean }>
+  wsBridgeSend: (token: string, data: string, binary: boolean) => Promise<{ ok: boolean }>
+  wsBridgeClose: (token: string, code?: number, reason?: string) => Promise<{ ok: boolean }>
   onWsBridgeEvent: (
-    callback: (id: number, payload: { type: string; data?: string; binary?: boolean; code?: number; reason?: string }) => void
+    callback: (token: string, payload: BridgePayload) => void
   ) => () => void
+}
+
+interface BridgePayload {
+  type: string
+  data?: string
+  binary?: boolean
+  code?: number
+  reason?: string
 }
 
 function bridgeApi(): BridgeApi | null {
@@ -20,7 +38,9 @@ function bridgeApi(): BridgeApi | null {
   return api && typeof api.wsBridgeOpen === 'function' ? (api as BridgeApi) : null
 }
 
-class BridgedWebSocket extends EventTarget {
+let nextToken = 1
+
+export class BridgedWebSocket extends EventTarget {
   readonly CONNECTING = 0
   readonly OPEN = 1
   readonly CLOSING = 2
@@ -29,39 +49,46 @@ class BridgedWebSocket extends EventTarget {
   readyState = 0
   binaryType: 'blob' | 'arraybuffer' = 'arraybuffer'
 
-  private id: number | null = null
-  private readonly removeListener: () => void
-  private pending: Array<{ type: string; data?: string; binary?: boolean; code?: number; reason?: string }> = []
+  private readonly token: string
+  private removeListener: () => void
+  private terminated = false
 
-  constructor(url: string, api: BridgeApi) {
+  constructor(url: string, private readonly api: BridgeApi, token?: string) {
     super()
-    this.removeListener = api.onWsBridgeEvent((id, payload) => {
-      if (this.id === null) {
-        // Event arrived before wsBridgeOpen resolved and assigned our id.
-        // Buffer it — flushed in order once the id lands. Without this an
-        // 'open' racing the id assignment is dropped and the client hangs
-        // in 'connecting' forever.
-        this.pending.push(payload)
-        return
-      }
-      if (id !== this.id) return
+    this.token = token ?? `dial-${nextToken++}-${Math.random().toString(36).slice(2)}`
+    this.removeListener = api.onWsBridgeEvent((token, payload) => {
+      // Events are token-tagged end to end — unrelated sockets' frames are
+      // rejected from the start, including anything arriving before open
+      // resolved (the bridge emits open only after resolving, so ordering
+      // is: open-result promise, then events, all under our token).
+      if (token !== this.token) return
       this.dispatch(payload)
     })
 
-    void api.wsBridgeOpen(url).then(result => {
-      if (!result.ok || result.id === undefined) {
+    void api.wsBridgeOpen(url, this.token).then(result => {
+      if (this.terminated) {
+        // close() raced the dial resolution: if it opened anyway, shut it.
+        if (result.ok) void this.api.wsBridgeClose(this.token)
+        return
+      }
+      if (!result.ok) {
+        this.terminate()
         this.readyState = 3
         this.dispatchEvent(new Event('error'))
         this.dispatchEvent(new CloseEvent('close', { code: 1006, reason: result.error ?? 'bridge dial failed' }))
-        return
       }
-      this.id = result.id
-      for (const payload of this.pending) this.dispatch(payload)
-      this.pending = []
+      // On success the 'open' event arrives over the channel (deferred past
+      // this microtask by the bridge) and flips readyState in dispatch().
     })
   }
 
-  private dispatch(payload: { type: string; data?: string; binary?: boolean; code?: number; reason?: string }): void {
+  private terminate(): void {
+    if (this.terminated) return
+    this.terminated = true
+    this.removeListener()
+  }
+
+  private dispatch(payload: BridgePayload): void {
     switch (payload.type) {
       case 'open':
         this.readyState = 1
@@ -78,6 +105,7 @@ class BridgedWebSocket extends EventTarget {
         this.dispatchEvent(new Event('error'))
         break
       case 'close':
+        this.terminate()
         this.readyState = 3
         this.dispatchEvent(new CloseEvent('close', { code: payload.code ?? 1006, reason: payload.reason ?? '' }))
         break
@@ -85,35 +113,33 @@ class BridgedWebSocket extends EventTarget {
   }
 
   send(data: string | ArrayBufferLike | Blob | ArrayBufferView): void {
-    if (this.id === null || this.readyState !== 1) return
-    const api = bridgeApi()
-    if (!api) return
+    if (this.readyState !== 1 || this.terminated) return
     if (typeof data === 'string') {
-      void api.wsBridgeSend(this.id, data, false)
+      void this.api.wsBridgeSend(this.token, data, false)
       return
     }
     if (data instanceof ArrayBuffer) {
-      void api.wsBridgeSend(this.id, arrayBufferToBase64(data), true)
+      void this.api.wsBridgeSend(this.token, arrayBufferToBase64(data), true)
       return
     }
     if (ArrayBuffer.isView(data)) {
-      void api.wsBridgeSend(this.id, arrayBufferToBase64(data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer), true)
+      void this.api.wsBridgeSend(this.token, arrayBufferToBase64(data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer), true)
       return
     }
     // Blob: async read then send.
     void (data as Blob).arrayBuffer().then((buf: ArrayBuffer) => {
-      if (this.id !== null && this.readyState === 1) void api.wsBridgeSend(this.id, arrayBufferToBase64(buf), true)
+      if (this.readyState === 1 && !this.terminated) void this.api.wsBridgeSend(this.token, arrayBufferToBase64(buf), true)
     })
   }
 
   close(code?: number, reason?: string): void {
     if (this.readyState >= 2) return
     this.readyState = 2
-    this.removeListener()
-    if (this.id !== null) {
-      const api = bridgeApi()
-      if (api) void api.wsBridgeClose(this.id, code, reason)
-    }
+    this.terminate()
+    // Cancel covers a still-dialing token; close covers an established one —
+    // main no-ops whichever half doesn't apply, and enforces sender ownership.
+    void this.api.wsBridgeCancel(this.token)
+    void this.api.wsBridgeClose(this.token, code, reason)
     this.readyState = 3
   }
 }


### PR DESCRIPTION
## Problem

On Linux, the desktop app cannot complete a remote-gateway connection when the gateway's TLS chain roots in a private/homelab/corporate CA — even with the CA installed system-wide, `NODE_EXTRA_CA_CERTS` set, and `--use-system-certificates` in `desktop.electron_flags`. Every HTTPS leg succeeds (status probes, the full native-PKCE OAuth flow, `ws-ticket` minting) but the final `wss://` gateway dial fails the TLS handshake (`SSL handshake failure` proxy-side; opaque "Could not connect to Hermes gateway" client-side).

This is the Linux sibling of #57241 (macOS) — but with two additional TLS-client trust gaps that keychain harvesting (#57239) does not fix:

1. **Chromium's renderer WebSocket pool ignores `--use-system-certificates` on Linux.** Renderer fetch/XHR trusts the system store; `wss://` from the same renderer does not. This is the socket `JsonRpcGatewayClient` dials.
2. **Node's built-in undici WebSocket ignores `NODE_EXTRA_CA_CERTS`** (main-process `globalThis.WebSocket`, used by `gateway-ws-probe`). Verified on the bundled Node 26: `fetch()` to the same host → 200, `new WebSocket()` → instant 1006; `--use-openssl-ca`, `--use-system-ca`, and an explicit undici dispatcher Agent with the CA all still fail. Public-CA `wss://` hosts connect fine.

The `ws` npm package (node:tls) honors `NODE_EXTRA_CA_CERTS` and completes the handshake against the same chain.

## Fix

Route `wss://` gateway dials through Electron's main process via a dumb IPC frame pipe, using `ws` (already a repo dependency). `ws://` loopback dials keep the native renderer WebSocket — no TLS involved, zero behavior change for local backends.

- `electron/ws-bridge.ts` — main-process IPC handlers (`ws-bridge:open/send/close`) wrapping `ws`, per-socket event channels, 20s dial watchdog, sender-destruction guards
- `electron/preload.ts` — bridge surface on `hermesDesktop`
- `src/api/ws-bridge-socket.ts` — renderer-side `EventTarget`-shaped socket matching the `WebSocketLike` contract (`addEventListener`, `readyState`, `send` for string/ArrayBuffer/view/Blob, `close`) + `gatewaySocketFactory` (bridges `wss://` only)
- `src/api/client.ts` — pass `socketFactory` to `HermesGateway` (hook already exists in `GatewayClientOptions`)

### Ordering invariant (both halves required)

The bridge must resolve the socket id **before** emitting `open`, and the renderer must buffer events that arrive before id assignment. Either race alone drops `open` and hangs the client in "connecting" forever — the first version of this patch did exactly that; fixed via `setImmediate` after resolve in main + an event buffer flushed on id assignment in the renderer.

## Validation

- End-to-end on Debian 13 against a private-CA gateway (Authelia OIDC + HAProxy termination): full boot → OAuth sign-in → WS 101 upgrade → live chat streaming. Verified sockets held open client-side and 200/101s in the proxy log.
- `npx tsc -p apps/desktop/tsconfig.json --noEmit` clean.
- Local (`ws://127.0.0.1`) path untouched — factory only bridges `wss://`.

Refs #57241 (comment with full cross-platform diagnosis: https://github.com/NousResearch/hermes-agent/issues/57241#issuecomment-5552213206). Complementary to #57239 — that fixes Node `https` probes on macOS; this fixes the gateway data-plane socket on every platform.

## Notes for reviewers

- `ws` is bundled into `electron-main.mjs` (esbuild, not external) — no packaging changes needed; verified present in the built artifact.
- No new env vars; uses the existing `NODE_EXTRA_CA_CERTS` contract.
- One follow-up worth considering (not in this PR): the two `probeGatewayWebSocket` call sites in `main.ts` pass `globalThis.WebSocket` (undici) — they're loopback-only today, but if a remote WS probe is ever added it should use the same `ws` import.
