### PR TITLE
fix(terminal): let local workers exceed the fixed 4 GiB ceiling

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -363,6 +363,7 @@ terminal:
   # Desktop xterm font. Install the font locally; Nerd Fonts render Powerlevel10k glyphs.
   # font_family: "MesloLGS NF"  # Also accepts a CSS stack; blank uses bundled JetBrains Mono.
   timeout: 180
+  worker_memory_max_mb: 4096  # Local systemd worker ceiling; stricter host/cgroup limits still win.
   # HOME policy for tool subprocesses:
   #   auto    - default: host uses your real HOME; containers use HERMES_HOME/home
   #   real    - force your real OS-user HOME

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -271,6 +271,9 @@ DEFAULT_CONFIG = {
         # Menlo, Consolas, monospace"). Lets users use a Nerd Font without patching the app.
         "font_family": "",
         "timeout": 180,
+        # Ceiling for each gateway-spawned local worker's systemd scope. The effective MemoryMax
+        # remains bounded by the enclosing cgroup, half of physical RAM, and the legacy local guard.
+        "worker_memory_max_mb": 4096,
         # Seconds between SIGTERM and escalated SIGKILL for host process trees (browser daemons). 0
         # = SIGTERM only.
         "daemon_term_grace_seconds": 2.0,

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1881,7 +1881,7 @@ def test_worker_memory_limit_uses_configured_ceiling(monkeypatch):
     gib = 1024 * 1024 * 1024
     monkeypatch.setattr(
         cfg_mod,
-        "read_raw_config",
+        "load_config_readonly",
         lambda: {"terminal": {"worker_memory_max_mb": 8192}},
     )
     monkeypatch.setattr(
@@ -1906,7 +1906,7 @@ def test_worker_memory_limit_keeps_stricter_cgroup_bound(monkeypatch):
     gib = 1024 * 1024 * 1024
     monkeypatch.setattr(
         cfg_mod,
-        "read_raw_config",
+        "load_config_readonly",
         lambda: {"terminal": {"worker_memory_max_mb": 8192}},
     )
     monkeypatch.setattr(

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1874,6 +1874,56 @@ class TestReaderLoopOrphanedPipe:
 # =========================================================================
 # systemd cgroup isolation for gateway-spawned local executors (#70716)
 # =========================================================================
+def test_worker_memory_limit_uses_configured_ceiling(monkeypatch):
+    import hermes_cli.config as cfg_mod
+    import tools.process_registry as pr
+
+    gib = 1024 * 1024 * 1024
+    monkeypatch.setattr(
+        cfg_mod,
+        "read_raw_config",
+        lambda: {"terminal": {"worker_memory_max_mb": 8192}},
+    )
+    monkeypatch.setattr(
+        pr.Path,
+        "read_text",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("no cgroup")),
+    )
+    monkeypatch.setattr(
+        pr.os,
+        "sysconf",
+        lambda key: 8 * 1024 * 1024 if key == "SC_PHYS_PAGES" else 4096,
+        raising=False,
+    )
+
+    assert pr._worker_memory_max_bytes() == 8 * gib
+
+
+def test_worker_memory_limit_keeps_stricter_cgroup_bound(monkeypatch):
+    import hermes_cli.config as cfg_mod
+    import tools.process_registry as pr
+
+    gib = 1024 * 1024 * 1024
+    monkeypatch.setattr(
+        cfg_mod,
+        "read_raw_config",
+        lambda: {"terminal": {"worker_memory_max_mb": 8192}},
+    )
+    monkeypatch.setattr(
+        pr.Path,
+        "read_text",
+        lambda path, **_kwargs: "0::/gateway\n" if path.name == "cgroup" else str(6 * gib),
+    )
+    monkeypatch.setattr(
+        pr.os,
+        "sysconf",
+        lambda key: 8 * 1024 * 1024 if key == "SC_PHYS_PAGES" else 4096,
+        raising=False,
+    )
+
+    assert pr._worker_memory_max_bytes() == 6 * gib
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only: systemd scopes")
 class TestSystemdCgroupIsolation:
     """Verify spawn_local wraps the worker in ``systemd-run --user --scope``

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -88,9 +88,9 @@ _WORKER_MEMORY_MAX_CAP_BYTES = 4 * 1024 * 1024 * 1024
 def _worker_memory_max_cap_bytes() -> int:
     """Configured worker ceiling, falling back to the historical 4 GiB cap."""
     try:
-        from hermes_cli.config import DEFAULT_CONFIG, cfg_get, read_raw_config
+        from hermes_cli.config import DEFAULT_CONFIG, cfg_get, load_config_readonly
 
-        configured = cfg_get(read_raw_config(), "terminal", "worker_memory_max_mb")
+        configured = cfg_get(load_config_readonly(), "terminal", "worker_memory_max_mb")
         if configured is None:
             configured = DEFAULT_CONFIG["terminal"]["worker_memory_max_mb"]
         parsed = int(configured) * 1024 * 1024

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -85,11 +85,34 @@ _DEFAULT_WORKER_MEMORY_MAX_BYTES = 1024 * 1024 * 1024
 _WORKER_MEMORY_MAX_CAP_BYTES = 4 * 1024 * 1024 * 1024
 
 
+def _worker_memory_max_cap_bytes() -> int:
+    """Configured worker ceiling, falling back to the historical 4 GiB cap."""
+    try:
+        from hermes_cli.config import DEFAULT_CONFIG, cfg_get, read_raw_config
+
+        configured = cfg_get(read_raw_config(), "terminal", "worker_memory_max_mb")
+        if configured is None:
+            configured = DEFAULT_CONFIG["terminal"]["worker_memory_max_mb"]
+        parsed = int(configured) * 1024 * 1024
+    except Exception:
+        return _WORKER_MEMORY_MAX_CAP_BYTES
+    if parsed >= _MIN_WORKER_MEMORY_MAX_BYTES:
+        return parsed
+    logger.warning(
+        "Ignoring invalid terminal.worker_memory_max_mb=%r; "
+        "expected an integer representing at least %d MiB",
+        configured,
+        _MIN_WORKER_MEMORY_MAX_BYTES // (1024 * 1024),
+    )
+    return _WORKER_MEMORY_MAX_CAP_BYTES
+
+
 def _worker_memory_max_bytes() -> int:
     """Finite per-worker cgroup limit that can never widen host risk.
     ``TERMINAL_LOCAL_MEMORY_MAX_MB`` is honored only when it *tightens* the safe
     bound (min of the gateway's cgroup-v2 ``memory.max`` and half of physical RAM,
-    capped at 4 GiB), so an oversized override cannot exceed the enclosing slice.
+    capped by ``terminal.worker_memory_max_mb``), so an oversized override cannot
+    exceed the enclosing slice.
 
     The proposed local-memory-guard environment override is honored when it tightens the safe bound, so this
     isolation composes with PR #57121 instead of inventing a second knob.
@@ -108,6 +131,7 @@ def _worker_memory_max_bytes() -> int:
                 "Ignoring invalid TERMINAL_LOCAL_MEMORY_MAX_MB=%r; "
                 "expected an integer representing at least %d MiB",
                 override, _MIN_WORKER_MEMORY_MAX_BYTES // (1024 * 1024))
+    configured_cap = _worker_memory_max_cap_bytes()
     candidates: List[int] = []
     with suppress(OSError, ValueError):
         lines = Path("/proc/self/cgroup").read_text(encoding="utf-8").splitlines()
@@ -119,8 +143,12 @@ def _worker_memory_max_bytes() -> int:
                 candidates.append(int(raw_limit))
     with suppress(OSError, ValueError, TypeError):
         physical_bytes = int(os.sysconf("SC_PHYS_PAGES")) * int(os.sysconf("SC_PAGE_SIZE"))
-        candidates.append(min(_WORKER_MEMORY_MAX_CAP_BYTES, max(_MIN_WORKER_MEMORY_MAX_BYTES, physical_bytes // 2)))
-    safe_bound = min(candidates) if candidates else _DEFAULT_WORKER_MEMORY_MAX_BYTES
+        candidates.append(max(_MIN_WORKER_MEMORY_MAX_BYTES, physical_bytes // 2))
+    safe_bound = (
+        min(configured_cap, *candidates)
+        if candidates
+        else min(configured_cap, _DEFAULT_WORKER_MEMORY_MAX_BYTES)
+    )
     return min(override_bound, safe_bound) if override_bound else safe_bound
 
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -179,6 +179,7 @@ terminal:
   temp_dir: ""      # Session temp root; empty = TMPDIR, else ~/.hermes/cache/terminal
   font_family: ""   # Desktop terminal font; e.g. "MesloLGS NF"
   timeout: 180      # Per-command timeout in seconds
+  worker_memory_max_mb: 4096  # Ceiling for gateway-spawned local worker systemd scopes
   home_mode: auto   # auto | real | profile — subprocess HOME policy
   env_passthrough: []  # Env var names to forward to sandboxed execution (terminal + execute_code)
   singularity_image: "docker://nikolaik/python-nodejs:python3.11-nodejs20"  # Container image for Singularity backend
@@ -199,6 +200,8 @@ installs. Set `temp_dir` to an existing absolute path to redirect session
 temp anywhere else; user-set paths are never auto-pruned.
 
 `terminal.font_family` controls the embedded terminal in Hermes Desktop. It accepts either one locally installed family name (for example, `MesloLGS NF`) or a CSS font stack. Hermes appends its bundled JetBrains Mono stack as a fallback, and an empty value keeps the default. You can edit the same profile-scoped setting in **Settings → Appearance → Terminal Font**; no Google Fonts download or system-font permission is required.
+
+On Linux gateways managed by systemd, `terminal.worker_memory_max_mb` sets the per-worker `MemoryMax` ceiling for local background commands. The effective limit may be lower when the enclosing cgroup, half of physical RAM, or `TERMINAL_LOCAL_MEMORY_MAX_MB` imposes a stricter bound.
 
 For cloud sandboxes such as Modal, Daytona, and Vercel Sandbox, `container_persistent: true` means Hermes will try to preserve filesystem state across sandbox recreation. It does not promise that the same live sandbox, PID space, or background processes will still be running later.
 


### PR DESCRIPTION
## What does this PR do?

Local workers can now raise the historical 4 GiB systemd `MemoryMax` ceiling through `terminal.worker_memory_max_mb`. The default remains 4096 MiB, while stricter enclosing cgroup, half-physical-RAM, and legacy local guard limits continue to win.

### Symptom

Memory-heavy local workers can be OOM-killed at 4 GiB even when their host and enclosing cgroup have additional safe capacity.

### Impact

Operators running browser automation, Node builds, MCP processes, or other memory-heavy local workers must patch Hermes source to use more than 4 GiB per worker.

### Bug Cause

**Trigger:** `tools/process_registry.py:145` / `_worker_memory_max_bytes()` / physical-memory bound selection

**Causal chain:**
1. A supervised Linux gateway prepares a transient systemd scope for a local worker.
2. `_worker_memory_max_bytes()` clamps the half-physical-RAM candidate to a fixed 4 GiB constant.
3. `MemoryMax` cannot exceed 4 GiB, and `TERMINAL_LOCAL_MEMORY_MAX_MB` cannot raise it because that guard is intentionally applied as a minimum.

**Why it is wrong:** The fixed ceiling prevents operators from selecting a higher safe worker limit on larger hosts.

**Working sibling / contrast:** Lower limits already compose correctly because the enclosing cgroup and `TERMINAL_LOCAL_MEMORY_MAX_MB` are stricter-bound candidates.

**Ruled out:** Raising `TERMINAL_LOCAL_MEMORY_MAX_MB` cannot solve the issue; the existing code only uses it to tighten the computed safe bound.

### Fix

Read a persistent `terminal.worker_memory_max_mb` ceiling from `config.yaml`, default it to 4096 MiB, and include it in the same minimum calculation as the existing host and cgroup safety bounds. Document the option in the config example and user guide.

## Related Issue

Closes #103670

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/process_registry.py` - resolve the worker ceiling from config while preserving stricter safety bounds.
- `hermes_cli/config_defaults.py` - define the 4096 MiB default.
- `tests/tools/test_process_registry.py` - cover a raised ceiling and a stricter cgroup limit.
- `cli-config.yaml.example` and `website/docs/user-guide/configuration.md` - document the setting.

## How to Test

1. Set `terminal.worker_memory_max_mb: 8192` on a host with enough physical and cgroup memory.
2. Start a local background worker from a supervised Linux gateway and inspect its systemd scope `MemoryMax`.
3. Run the focused regression tests:

```bash
scripts/run_tests.sh tests/tools/test_process_registry.py -k worker_memory_limit
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the focused process registry tests and all selected tests pass
- [x] I've added tests for my changes
- [x] I've tested the bound-selection behavior on Windows 11; Linux systemd integration remains unchanged

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example`
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because architecture and workflows are unchanged
- [x] I've considered cross-platform impact; the option only affects Linux systemd worker scopes
- [x] Tool descriptions and schemas are N/A because no model tool contract changed
