### PR TITLE
fix(update): do not classify successful update receipt as unfinished when stop_reason is recorded

### DIFF
--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -81,9 +81,8 @@ def _receipt_looks_unfinished(receipt: dict) -> bool:
     """True when *receipt* is from an update that did not finish cleanly."""
     gateway_restart = receipt.get("gateway_restart")
     return bool(
-        receipt.get("stop_reason")
-        or receipt.get("exit_code") not in (0, None)
-        or receipt.get("outcome") in ("failed", "partial", "running")
+        receipt.get("exit_code") not in (0, None)
+        or receipt.get("outcome") in ("failed", "partial", "running", "refused")
         or (isinstance(gateway_restart, dict) and gateway_restart.get("incomplete"))
     )
 

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -254,6 +254,86 @@ def test_successful_receipt_with_pre_update_plan_shas_does_not_retrigger(
     assert update_cmd._pending_fleet_restart_needed() is False
 
 
+def test_receipt_looks_unfinished_predicate():
+    """Clean updates recording stop_reason must not look unfinished (#103590)."""
+    # Success cases with stop_reason set at exit boundaries
+    assert update_cmd_fleet._receipt_looks_unfinished({
+        "exit_code": 0,
+        "outcome": "success",
+        "stop_reason": "completed at command boundary",
+        "gateway_restart": {"incomplete": False},
+    }) is False
+
+    assert update_cmd_fleet._receipt_looks_unfinished({
+        "exit_code": 0,
+        "outcome": "success",
+        "stop_reason": "sys.exit(0)",
+        "gateway_restart": {"incomplete": False},
+    }) is False
+
+    # Genuinely unfinished / failed cases
+    assert update_cmd_fleet._receipt_looks_unfinished({
+        "exit_code": 1,
+        "outcome": "failed",
+        "stop_reason": "KeyboardInterrupt: ",
+    }) is True
+
+    assert update_cmd_fleet._receipt_looks_unfinished({
+        "exit_code": 2,
+        "outcome": "refused",
+        "stop_reason": "image-marker",
+    }) is True
+
+    assert update_cmd_fleet._receipt_looks_unfinished({
+        "exit_code": 0,
+        "outcome": "partial",
+        "gateway_restart": {"incomplete": True},
+    }) is True
+
+    assert update_cmd_fleet._receipt_looks_unfinished({
+        "exit_code": 0,
+        "outcome": "running",
+    }) is True
+
+
+def test_successful_receipt_with_stop_reason_and_empty_fleet_does_not_retrigger(
+    monkeypatch,
+):
+    """Clean update with empty fleet and stop_reason does not trigger catch-up (#103590)."""
+    disk_sha = "n" * 40
+    old_sha = "o" * 40
+    monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: disk_sha)
+    monkeypatch.setattr(update_cmd_fleet, "_current_checkout_sha", lambda: disk_sha)
+
+    receipt_dir = get_hermes_home() / "logs" / "update_receipts"
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / "latest.json").write_text(
+        json.dumps(
+            {
+                "exit_code": 0,
+                "outcome": "success",
+                "stop_reason": "completed at command boundary",
+                "plan": {
+                    "expected_sha": old_sha,
+                    "runtimes": [
+                        {
+                            "kind": "gateway",
+                            "profile": "default",
+                            "pid": 1,
+                            "code_sha": old_sha,
+                        }
+                    ],
+                },
+                "fleet": [],
+                "gateway_restart": {"incomplete": False},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert update_cmd._pending_fleet_restart_needed() is False
+
+
 def test_stale_fleet_matrix_on_latest_receipt_is_pending(monkeypatch):
     disk_sha = "n" * 40
     monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: disk_sha)


### PR DESCRIPTION
Fixes #103590

_receipt_looks_unfinished() treated any non-empty stop_reason as evidence that an update did not finish cleanly. However, successful updates write stop_reason: 'completed at command boundary' (or 'sys.exit(0)'). This caused cleanly-completed updates to evaluate as unfinished, falling through to check pre-pull plan runtimes and falsely triggering stale-runtime warnings on startup.

Remove receipt.get('stop_reason') as an unfinished failure condition, relying on outcome, exit_code, and gateway_restart.incomplete to authoritatively determine completion status, and add regression tests.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Resolves Issue #103590 where `_receipt_looks_unfinished()` treated the presence of any non-empty `stop_reason` as evidence that an update did not finish cleanly. Successful updates write `stop_reason: "completed at command boundary"` (or `"sys.exit(0)"`), causing clean updates to be misclassified as unfinished. With an empty `fleet` matrix, this fell through to compare pre-pull `plan.runtimes` SHAs, falsely displaying persistent `⚠ A previous hermes update pulled new code but did not restart running gateways` warnings on every startup. This fix removes `receipt.get("stop_reason")` from the unfinished predicate, relying on `outcome`, `exit_code`, and `gateway_restart.incomplete` to authoritatively determine completion status.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #103590

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `hermes_cli/update_cmd_fleet.py`: In `_receipt_looks_unfinished()`, removed `receipt.get("stop_reason")` and added `"refused"` to the abnormal outcomes check.
- `tests/hermes_cli/test_update_fleet_restart_pending.py`: Added `test_receipt_looks_unfinished_predicate` and `test_successful_receipt_with_stop_reason_and_empty_fleet_does_not_retrigger` regression tests.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `pytest tests/hermes_cli/test_update_fleet_restart_pending.py -k "test_receipt_looks_unfinished_predicate or test_successful_receipt"`
2. `pytest tests/hermes_cli/test_update_receipt.py tests/hermes_cli/test_update_contract.py`
3. Verified all test suites pass with zero regressions.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Python 3.11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

