### PR TITLE
fix(agent): keep gpt-6-astra max reasoning on the codex transport

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1391,7 +1391,7 @@ class _CodexCompletionsAdapter:
             # ``enabled: False`` leaves reasoning/include unset (Codex still thinks by default).
             if isinstance(reasoning_cfg, dict) and reasoning_cfg.get("enabled") is not False:
                 # Truthy-only: Codex 400s on e.g. {"effort": null}, so falsy → default. Shared
-                # per-model clamp with the main transport ("max" is gpt-5.6-only; "minimal"/"ultra" rejected).
+                # per-model clamp with the main transport ("max" needs gpt-5.6/gpt-6-astra; "minimal"/"ultra" rejected).
                 from agent.reasoning_effort import clamp_effort, codex_supported_efforts
                 effort = clamp_effort(reasoning_cfg.get("effort") or "medium", codex_supported_efforts(model))
                 resp_kwargs["reasoning"] = {"effort": effort, "summary": "auto"}

--- a/agent/reasoning_effort.py
+++ b/agent/reasoning_effort.py
@@ -27,10 +27,13 @@ EFFORT_LADDER: tuple[str, ...] = ("none", "minimal", "low", "medium", "high", "x
 #: Widest OpenAI-compatible wire vocabulary (OpenRouter, Nous Portal).
 OPENAI_COMPAT_WIRE_EFFORTS: tuple[str, ...] = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
 
-#: OpenAI/Codex Responses per model generation (live-verified): ``minimal`` is rejected by
-#: both (clamps to low); ``max`` is gpt-5.6-only.
+#: OpenAI/Codex Responses per model generation: ``minimal`` is rejected by all of
+#: them (clamps to low); ``max`` needs gpt-5.6 or gpt-6-astra (#68365, #103016).
 CODEX_GPT56_EFFORTS: tuple[str, ...] = ("none", "low", "medium", "high", "xhigh", "max")
 CODEX_LEGACY_EFFORTS: tuple[str, ...] = ("none", "low", "medium", "high", "xhigh")
+#: Astra speaks low..max (#103016) but, unlike gpt-5.6, rejects ``none`` — a configured
+#: ``none``/``minimal`` clamps down to ``low`` instead of leaking to the wire and 400ing.
+CODEX_ASTRA_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh", "max")
 
 #: xAI Responses — Grok 4.6+ accepts xhigh; older Grok tops out at high.
 XAI_GROK46_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh")
@@ -79,8 +82,16 @@ META_AI_EFFORTS: tuple[str, ...] = ("minimal", "low", "medium", "high", "xhigh")
 
 
 def codex_supported_efforts(model: Optional[str]) -> tuple[str, ...]:
-    """Supported effort set for an OpenAI/Codex Responses model."""
-    return CODEX_GPT56_EFFORTS if "gpt-5.6" in (model or "").lower() else CODEX_LEGACY_EFFORTS
+    """Supported effort set for an OpenAI/Codex Responses model.
+
+    The astra substring covers the whole catalog family — ``gpt-6-astra`` plus the
+    ``-pro``/``-fast``/``-flex`` combinations (see models_catalog_static) — without
+    matching on a bare ``astra`` that a future unrelated slug could contain.
+    """
+    m = (model or "").lower()
+    if "gpt-6-astra" in m:
+        return CODEX_ASTRA_EFFORTS
+    return CODEX_GPT56_EFFORTS if "gpt-5.6" in m else CODEX_LEGACY_EFFORTS
 
 
 def kimi_supported_efforts(model: Optional[str]) -> tuple[str, ...]:

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -13,7 +13,7 @@ from typing import Any, Callable, Optional
 from agent.reasoning_effort import (
     ACTUAL_RELAY_EFFORTS, XAI_GROK46_EFFORTS, XAI_LEGACY_EFFORTS, clamp_effort,
     # Same declared vocabulary + shared clamp as the main Codex transport (agent.reasoning_effort):
-    # per-model — "max" is gpt-5.6-only, "minimal"/"ultra" always rejected (live-verified, #68365).
+    # per-model — "max" needs gpt-5.6 or gpt-6-astra; "minimal"/"ultra" always rejected (#68365, #103016).
     codex_supported_efforts,
 )
 from agent.transports.base import ProviderTransport

--- a/tests/agent/test_reasoning_effort_module.py
+++ b/tests/agent/test_reasoning_effort_module.py
@@ -25,6 +25,7 @@ from agent.reasoning_effort import (
     KIMI_K3_OVERRIDES,
     OPENAI_COMPAT_WIRE_EFFORTS,
     clamp_effort,
+    codex_supported_efforts,
     kimi_supported_efforts,
     requested_effort,
 )
@@ -136,12 +137,46 @@ class TestGlm52Vocabulary:
 
 
 class TestCodexVocabulary:
+    def test_astra_supports_max(self):
+        assert "max" in codex_supported_efforts("gpt-6-astra")
+
+    def test_astra_rejects_none(self):
+        # Astra speaks low..max (#103016) but, unlike gpt-5.6, rejects ``none``:
+        # the set must not offer it, and a configured none/minimal clamps to low
+        # instead of leaking to the wire and 400ing.
+        from agent.reasoning_effort import CODEX_ASTRA_EFFORTS
+
+        assert codex_supported_efforts("gpt-6-astra") is CODEX_ASTRA_EFFORTS
+        assert "none" not in CODEX_ASTRA_EFFORTS
+        assert clamp_effort("none", CODEX_ASTRA_EFFORTS) == "low"
+        assert clamp_effort("minimal", CODEX_ASTRA_EFFORTS) == "low"
+
+    def test_astra_whole_catalog_family_matches(self):
+        # The substring must cover the pro/fast/flex combinations the catalog
+        # ships (models_catalog_static) without matching on a bare "astra".
+        for model in (
+            "gpt-6-astra",
+            "gpt-6-astra-pro",
+            "openai/gpt-6-astra-pro-fast",
+            "openai/gpt-6-astra-flex",
+        ):
+            assert "max" in codex_supported_efforts(model), model
+
+    def test_astra_max_is_not_clamped(self):
+        assert clamp_effort("max", codex_supported_efforts("gpt-6-astra")) == "max"
+
+    def test_legacy_model_excludes_max(self):
+        assert "max" not in codex_supported_efforts("gpt-5.5")
+
+    def test_gpt_56_still_accepts_none(self):
+        assert "none" in codex_supported_efforts("gpt-5.6")
+
     def test_minimal_and_ultra(self):
         assert clamp_effort("minimal", CODEX_GPT56_EFFORTS) == "low"
         assert clamp_effort("ultra", CODEX_GPT56_EFFORTS) == "max"
 
     def test_per_model_max_support(self):
-        """Live-verified (Aug 2026, #68365): 'max' is gpt-5.6-only — gpt-5.5
+        """Live-verified (Aug 2026, #68365): gpt-5.6 accepts 'max', but gpt-5.5
         rejects it ("Supported values are: 'none','low','medium','high',
         'xhigh'"); 'minimal' is rejected by both generations."""
         from agent.reasoning_effort import (
@@ -171,3 +206,33 @@ class TestRequestedEffort:
         assert requested_effort({"enabled": False, "effort": "high"}) is None
         assert requested_effort("not-a-dict") is None
         assert requested_effort({"effort": ""}) is None
+
+
+class TestCodexTransportResolveReasoning:
+    """End-to-end through the Codex transport's real decision point (#103556).
+
+    ``_resolve_reasoning`` is where a stored session effort meets the wire on the
+    openai-codex route: it must keep astra's ``max`` (the reported bug) and demote
+    astra's unsupported ``none`` to ``low`` instead of leaking it to the wire.
+    """
+
+    def test_astra_max_reaches_the_wire(self):
+        from agent.transports.codex import _resolve_reasoning
+
+        effort, enabled = _resolve_reasoning(
+            "gpt-6-astra", {"reasoning_config": {"enabled": True, "effort": "max"}})
+        assert (effort, enabled) == ("max", True)
+
+    def test_astra_none_clamps_to_low_on_the_wire(self):
+        from agent.transports.codex import _resolve_reasoning
+
+        effort, enabled = _resolve_reasoning(
+            "gpt-6-astra", {"reasoning_config": {"enabled": True, "effort": "none"}})
+        assert (effort, enabled) == ("low", True)
+
+    def test_legacy_clamp_unchanged_through_transport(self):
+        from agent.transports.codex import _resolve_reasoning
+
+        effort, enabled = _resolve_reasoning(
+            "gpt-5.5", {"reasoning_config": {"enabled": True, "effort": "max"}})
+        assert (effort, enabled) == ("xhigh", True)


### PR DESCRIPTION
## What does this PR do?

`codex_supported_efforts()` recognized only `gpt-5.6` as the generation that accepts `max`, so `gpt-6-astra` resolved to `CODEX_LEGACY_EFFORTS` (ceiling `xhigh`) and `clamp_effort()` silently downgraded a stored `max` to `xhigh` on the openai-codex transport while the session (and the Desktop UI) kept showing MAX (#103556).

This PR gives astra its own set with the level list the astra tracking issue documents (#103016: `low|medium|high|xhigh|max`):

- `max` reaches the wire unchanged — the reported bug.
- **Astra rejects `none`** (unlike gpt-5.6): a configured `none`/`minimal` clamps down to `low` instead of leaking to the wire and 400ing. Reusing the gpt-5.6 set (which contains `none`) would forward `none` verbatim and fail every such request.
- The `"gpt-6-astra"` substring covers the whole catalog family — `gpt-6-astra`, `-pro`, `-fast`, `-flex` and their combinations (as shipped in `models_catalog_static`) — without matching on a bare `astra` that a future unrelated slug could contain.
- The three stale "``max`` is gpt-5.6-only" comments (`agent/reasoning_effort.py`, `agent/transports/codex.py`, `agent/auxiliary_client.py`) are corrected, so the next reader won't "fix" the bug back in.

Both consumers pick the fix up through the shared function: the Codex transport's `_resolve_reasoning()` and the auxiliary-client clamp.

**Relationship to the earlier open #103570** (same root cause): that PR introduced the astra-specific set idea — correct, and kept here. This PR adds on top of it:

| | #103570 | this PR |
|---|---|---|
| astra set excludes `none` | yes | yes, plus `none`/`minimal` → `low` clamp behavior tested |
| model matching | bare `"astra"` substring (matches any future unrelated slug containing it) | `"gpt-6-astra"` substring — covers the full pro/fast/flex family, tested per-form |
| gpt-5.6 `none` regression guard | — | tested (`none` still passes for gpt-5.6) |
| transport-level verification | — | `_resolve_reasoning()` end-to-end: astra `max` reaches the wire, astra `none` clamps to `low`, legacy `max`→`xhigh` unchanged |
| stale comments in consumers (`transports/codex.py`, `auxiliary_client.py`) | — | updated |

Happy to fold any of this into #103570 instead if the maintainer prefers a single carrier — the tests and the none-clamp behavior are the parts worth keeping regardless of which PR lands.

## Related Issue

Fixes #103556

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/reasoning_effort.py`
  - new `CODEX_ASTRA_EFFORTS = ("low", "medium", "high", "xhigh", "max")` with the none-rejection rationale documented
  - `codex_supported_efforts()`: astra branch (full-family substring) ahead of the gpt-5.6 / legacy split; docstring updated
- `agent/transports/codex.py`, `agent/auxiliary_client.py` — stale "max is gpt-5.6-only" comments corrected
- `tests/agent/test_reasoning_effort_module.py` — regression matrix:
  - astra set contains `max`; `none`/`minimal` clamp to `low`
  - catalog family per-form (`gpt-6-astra`, `-pro`, `openai/gpt-6-astra-pro-fast`, `-flex`)
  - legacy (`gpt-5.5`) still excludes `max`; gpt-5.6 still accepts `none`
  - transport end-to-end via `_resolve_reasoning()`: astra `max`→`max` on the wire, astra `none`→`low`, legacy `max`→`xhigh`

## How to Test

1. `.venv/bin/python -m pytest tests/agent/test_reasoning_effort_module.py tests/agent/test_reasoning_effort_wire_translation.py -q` → 42 passed
2. Before the fix, the astra tests fail with exactly the reported symptom (set excludes `max`; clamp yields `xhigh`)
3. Broader: `.venv/bin/python -m pytest tests/agent/ -q -k "reasoning or effort or codex"` → 725 passed, 1 skipped
4. End-to-end shape: select `gpt-6-astra` on `openai-codex`, set reasoning MAX, build a request through the Codex Responses path — resolved `reasoning.effort` stays `max`; set reasoning to none — request goes out as `low`, no 400

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#103570 found — differences documented above, offered to fold in)
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the relevant test files and all pass (42 passed targeted; 725 passed, 1 skipped on the broader reasoning/codex selection)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Python 3.11)

### Documentation & Housekeeping

- [x] N/A (no config keys, docs, or workflow changes)
