### PR TITLE
fix(agent): treat 402 with retry signals as rate limit, not billing

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -663,12 +663,18 @@ def _status_5xx(c: _Ctx) -> Verdict:
     return _first_match(c.msg, _OVERFLOW_AS_5XX_RULES) or _V_SERVER_ERROR
 
 
-def _classify_402(error_msg: str, result_fn: Callable[..., Any]) -> Any:
-    """Disambiguate 402: "usage limit, try again in 5 minutes" is a periodic quota, not billing."""
-    transient = any(p in error_msg for p in _USAGE_LIMIT_PATTERNS) and any(
-        p in error_msg for p in _USAGE_LIMIT_TRANSIENT_SIGNALS
-    )
-    return result_fn(**(_V_RATE_LIMIT if transient else _V_BILLING))
+def _classify_402(
+    error_msg: str, result_fn: Callable[..., Any], body: Optional[dict] = None, response_headers=None,
+) -> Any:
+    """A reset/retry signal distinguishes temporary 402 throttles from exhausted credits."""
+    # Message-text signals keep the historical conjunction (usage-limit wording AND a
+    # transient marker): "try again"/"wait" alone is ordinary billing copy, not a reset
+    # promise. Body/header signals cannot rely on wording, so they pass an empty message
+    # to isolate the payload/header scan from the (already checked) message path.
+    msg_signal = any(p in error_msg for p in _USAGE_LIMIT_PATTERNS) and any(
+        p in error_msg for p in _USAGE_LIMIT_TRANSIENT_SIGNALS)
+    payload_signal = _has_usage_limit_transient_signal("", body or {}, response_headers)
+    return result_fn(**(_V_RATE_LIMIT if msg_signal or payload_signal else _V_BILLING))
 
 
 def _classify_400(c: _Ctx) -> Verdict:
@@ -722,7 +728,8 @@ def _classify_400(c: _Ctx) -> Verdict:
 # retry-safe (RFC 9110 §15.5.9; proxies emit it when generation outruns the
 # read window). Unlisted 4xx → format_error, 5xx → server_error.
 _STATUS_HANDLERS: Dict[int, Callable[[_Ctx], Verdict]] = {
-    400: _classify_400, 401: lambda c: _V_AUTH_ROTATE, 402: lambda c: _classify_402(c.msg, dict),
+    400: _classify_400, 401: lambda c: _V_AUTH_ROTATE,
+    402: lambda c: _classify_402(c.msg, dict, c.body, c.headers),
     403: _status_403, 404: _status_404, 408: lambda c: _V_TIMEOUT, 413: lambda c: _V_PAYLOAD_TOO_LARGE,
     429: _status_429, 500: _status_5xx, 502: _status_5xx,
     503: lambda c: _first_match(c.msg, _OVERFLOW_AS_5XX_RULES) or _V_OVERLOADED,
@@ -741,11 +748,21 @@ def _has_usage_limit_transient_signal(error_msg: str, body: dict, response_heade
     if any(pattern in error_msg for pattern in _USAGE_LIMIT_TRANSIENT_SIGNALS):
         return True
     payloads = [p for p in (body, _error_obj(body)) if isinstance(p, dict)]
+    # OpenRouter can wrap its payload in error.body and preserve HTTP headers
+    # only in metadata.headers; SDKs may also expose the unwrapped payload.
+    payloads += [p["body"] for p in payloads if isinstance(p.get("body"), dict)]
     if any(payload.get(f) not in (None, "") for payload in payloads for f in _RESET_FIELDS):
         return True
-    if response_headers and hasattr(response_headers, "get"):
-        return any(response_headers.get(h) not in (None, "") for h in _RESET_HEADERS)
-    return False
+    header_sources = [response_headers]
+    for payload in payloads:
+        metadata = payload.get("metadata")
+        if isinstance(metadata, dict):
+            header_sources.append(metadata.get("headers"))
+    return any(
+        headers.get(h) not in (None, "")
+        for headers in header_sources if headers and hasattr(headers, "get")
+        for h in _RESET_HEADERS
+    )
 
 
 def _model_id_missing_known_prefix(model: str, provider: str) -> bool:

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -217,6 +217,78 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.billing
         assert result.retryable is False
 
+    def test_402_openrouter_in_flight_budget_with_nested_retry_after(self):
+        e = MockAPIError(
+            "Payment Required",
+            status_code=402,
+            body={
+                "error": {
+                    "status_code": 402,
+                    "body": {
+                        "message": (
+                            "This request would exceed your available credits given your current "
+                            "in-flight requests. Retry after in-flight requests settle, or add credits."
+                        ),
+                        "code": 402,
+                        "metadata": {
+                            "reason": "in_flight_budget_exhausted",
+                            "limit_source": "openrouter_in_flight_budget",
+                            "remedy_hint": (
+                                "Retry after your in-flight requests settle "
+                                "(see the Retry-After header). ..."
+                            ),
+                            "headers": {"Retry-After": "120"},
+                        },
+                    },
+                },
+            },
+        )
+
+        result = classify_api_error(e, provider="openrouter")
+
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+
+    def test_402_insufficient_credits_without_retry_signal_is_billing(self):
+        e = MockAPIError("insufficient credits", status_code=402)
+
+        result = classify_api_error(e, provider="openrouter")
+
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+
+    def test_402_billing_wording_with_bare_try_again_stays_billing(self):
+        # "try again"/"wait" alone is ordinary billing copy, not a reset promise:
+        # the message path needs usage-limit wording AND a transient marker.
+        e = MockAPIError(
+            "insufficient credits - add credits and try again", status_code=402,
+        )
+
+        result = classify_api_error(e, provider="openrouter")
+
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+
+    def test_402_payment_required_wait_for_settlement_stays_billing(self):
+        e = MockAPIError(
+            "payment required, wait for invoice settlement", status_code=402,
+        )
+
+        result = classify_api_error(e, provider="openrouter")
+
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+
+    def test_402_with_response_retry_after_is_rate_limit(self):
+        e = MockAPIError(
+            "insufficient credits", status_code=402, headers={"Retry-After": "120"},
+        )
+
+        result = classify_api_error(e, provider="openrouter")
+
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

A 402 carrying an explicit retry signal was classified as terminal billing exhaustion, so unattended runs (cron, scheduled jobs) aborted instead of backing off. On OpenRouter this turns a transient in-flight-budget throttle — where the provider explicitly says "Retry after in-flight requests settle" and stamps `Retry-After: 120` — into a dead job (#102517).

Root cause: the 402 status handler passed only the error-message string to `_classify_402`, discarding both the response body and headers, so the existing `_has_usage_limit_transient_signal()` helper was never consulted on this path. OpenRouter additionally nests its header snapshot at `error.body.metadata.headers`, which the helper's flat field scan did not reach.

The fix routes the full context through: `_classify_402` now receives the body and response headers and delegates transient/retry detection to the existing helper, extended to unwrap nested `body` payloads and `metadata.headers`. Classification is deliberately conservative on both signal paths:

- **Message text** keeps the historical conjunction (usage-limit wording AND a transient marker) — "try again"/"wait" alone is ordinary billing copy ("insufficient credits … try again", "payment required, wait for settlement"), not a reset promise, and stays terminal `billing`.
- **Body/header signals** cannot rely on wording, so a retry marker in payload fields (incl. nested `metadata.headers`) or real HTTP headers alone marks the 402 retryable.

Side effect worth noting: `_status_429`'s quota-wall disambiguation shares `_has_usage_limit_transient_signal()` and therefore also gains the nested-payload/header awareness — a 429 carrying `Retry-After` in a nested body is now correctly rate_limit rather than billing. Direction is right and it is covered by the shared helper's tests.

**Relationship to the earlier open #102519** (same issue, same root-cause diagnosis — that PR found the mechanism first): side-by-side of the current states:

| | #102519 | this PR |
|---|---|---|
| message-path guard | a transient signal alone is authoritative — `"insufficient credits … try again"` / `"payment required, wait for settlement"` classify as retryable | historical conjunction kept (usage-limit wording AND transient marker); bare billing copy stays terminal, two negative tests pin it |
| nested payload signals | body/header fields scanned flat — the issue's actual shape (`error.body.metadata.headers["Retry-After"]`) is not reached | `error.body` unwrap + `metadata.headers` retry-header scan, tested with the issue's exact body |
| mergeable against main | currently conflicting | based on current main |

If the maintainer prefers #102519 as the carrier, the nested-unwrap and the conjunction guard are the two pieces worth folding in from here — happy to contribute them to that PR instead.

## Related Issue

Fixes #102517

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py`
  - `_classify_402()` accepts `body` / `response_headers`; message-text path keeps the usage-limit ∧ transient conjunction, payload/header path is isolated via an empty message
  - `_STATUS_HANDLERS[402]` passes `c.body` and `c.headers` through
  - `_has_usage_limit_transient_signal()` unwraps `error.body` payloads and reads retry headers from `metadata.headers` when the SDK only preserved them there
- `tests/agent/test_error_classifier.py` — regression tests:
  - 402 with the OpenRouter in-flight-budget body (nested `metadata.headers["Retry-After"]`) → rate_limit
  - bare 402 "insufficient credits" with no transient signal → billing
  - billing wording + bare "try again" / "wait for settlement" (no usage-limit wording) → still billing
  - 402 with a real HTTP `Retry-After: 120` response header → rate_limit

## How to Test

1. `.venv/bin/python -m pytest tests/agent/test_error_classifier.py -q` → 128 passed
2. Before the fix, the retry-signal tests fail: both signal scenarios were misclassified as non-retryable billing exhaustion
3. Broader: `.venv/bin/python -m pytest tests/agent/ -q -k "error or classif or 402 or billing"` → 456 passed (1 pre-existing LSP-toolchain failure on this machine, reproducible on unmodified `main`)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the relevant test files and all pass (126 passed in `test_error_classifier.py`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Python 3.11)

### Documentation & Housekeeping

- [x] N/A (no config keys, docs, or workflow changes)
