### PR TITLE
fix(tools): fall back to real npx when multiple cache generations match

### DIFF
--- a/tests/tools/test_mcp_npx_cached_bin.py
+++ b/tests/tools/test_mcp_npx_cached_bin.py
@@ -56,6 +56,28 @@ def test_cached_package_resolves_to_its_binary(tmp_path):
     assert got == (str(target), [])
 
 
+@pytest.mark.parametrize("entry_order", [
+    ("old-cache", "new-cache"),
+    ("new-cache", "old-cache"),
+])
+def test_multiple_cache_generations_are_left_to_npx(tmp_path, monkeypatch, entry_order):
+    for entry, version in (("old-cache", "1.0.0"), ("new-cache", "2.0.0")):
+        _cache(
+            tmp_path,
+            package="mcp-linear",
+            deps={"mcp-linear": version},
+            bin_field={"mcp-linear": "dist/index.js"},
+            entry=entry,
+        )
+
+    # Neither filesystem order can tell us which generation npm would resolve.
+    with monkeypatch.context() as patch:
+        patch.setattr("tools.mcp_tool_config.os.listdir", lambda path: list(entry_order))
+        got = _npx_cached_bin(["-y", "mcp-linear"])
+
+    assert got is None
+
+
 def test_scoped_package_and_trailing_args_survive(tmp_path):
     target = _cache(
         tmp_path,

--- a/tools/mcp_tool_config.py
+++ b/tools/mcp_tool_config.py
@@ -173,8 +173,9 @@ def _npx_cached_bin(args: list) -> Optional[tuple]:
     for nothing (~48 MB private memory per MCP server, measured); Hermes already supervises the
     child (shared death supervisor). When the package is in npx's cache we spawn its binary
     directly. Deliberately conservative — None (caller keeps plain ``npx``, so a cold machine
-    still installs) for a cache miss, a version pin (``pkg@1.2.3``), extra npx flags, a manifest
-    without one obvious bin, or any unreadable cache entry. Returns ``(binary_path, remaining_args)``."""
+    still installs) for a cache miss, ambiguous multiple cache generations, a version pin
+    (``pkg@1.2.3``), extra npx flags, a manifest without one obvious bin, or any unreadable cache
+    entry. Returns ``(binary_path, remaining_args)``."""
     if not isinstance(args, list) or not args:
         return None
 
@@ -199,10 +200,13 @@ def _npx_cached_bin(args: list) -> Optional[tuple]:
     if not os.path.isdir(npx_root):
         return None
     try:
-        entries = os.listdir(npx_root)
+        entries = sorted(os.listdir(npx_root))
     except OSError:
         return None
 
+    matched = False
+    matched_entry = None
+    cached = None
     for entry in entries:
         manifest = os.path.join(npx_root, entry, "package.json")
         try:
@@ -212,6 +216,16 @@ def _npx_cached_bin(args: list) -> Optional[tuple]:
             continue
         if spec not in deps:
             continue
+        # Cache order cannot tell us which generation npm would resolve. A second
+        # matching manifest is ambiguity even when the first had no usable bin, so
+        # only a clean single-generation match keeps the fast path.
+        if matched:
+            logger.debug(
+                "npx fast path bypassed for %s: cache generations %s and %s both match; "
+                "letting real npx resolve", spec, matched_entry, entry)
+            return None
+        matched = True
+        matched_entry = entry
         pkg_json = os.path.join(npx_root, entry, "node_modules", spec, "package.json")
         try:
             with open(pkg_json, "r", encoding="utf-8") as fh:
@@ -227,8 +241,9 @@ def _npx_cached_bin(args: list) -> Optional[tuple]:
         bin_dir = os.path.join(npx_root, entry, "node_modules", ".bin")
         for candidate in _npx_bin_candidates(bin_dir, names[0]):
             if os.path.exists(candidate) and os.access(candidate, os.X_OK):
-                return candidate, rest[1:]
-    return None
+                cached = candidate, rest[1:]
+                break
+    return cached
 
 
 def _interpolate_env_vars(value):


### PR DESCRIPTION
## What does this PR do?

For unpinned `npx -y <package>` MCP server commands, `_npx_cached_bin()` scanned `~/.npm/_npx` in unsorted directory order and executed the first cache generation whose manifest contained the package. With multiple generations present, filesystem enumeration order decided which executable Hermes launches — it could silently run an older or otherwise unintended package generation, changing `npx` semantics (#102576).

The function's own docstring promises "deliberately conservative" behavior; ambiguity across generations violated that contract.

Fix (semantic, per the issue): when **multiple** cache generations match the unpinned spec, return `None` so the caller falls back to real `npx` resolution — Hermes must not guess which generation npm would resolve. A single-generation match keeps the existing fast path unchanged. The scan is also sorted as defense-in-depth so the outcome no longer depends on readdir order.

Two scoping decisions made explicit:
- Ambiguity is decided on *readable* matching manifests: a generation whose manifest is unreadable/corrupt cannot prove a match (npm itself would skip it too) and does not count toward ambiguity.
- The ambiguity fallback emits a `logger.debug` line naming both generations, so the fast path being bypassed is diagnosable instead of silently degrading to plain `npx`.

**Relationship to the earlier open #102578** (same issue, same semantic fix — multiple generations defer to real `npx`): that PR patches `tools/mcp_tool.py`, but `_npx_cached_bin()` has since moved to `tools/mcp_tool_config.py` in the compat/simplify wave, so as-is it edits the old location and won't reach the function the runtime imports (the triage note on both PRs flags the same drift). This PR patches the current definition site directly, adds the ambiguity-fallback debug log, and documents the corrupt-manifest scoping decision. Whichever PR lands, the other is happy to defer — the semantics are identical.

## Related Issue

Fixes #102576

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool_config.py`
  - `_npx_cached_bin()` enumerates `~/.npm/_npx` deterministically (`sorted(os.listdir(...))`)
  - a second matching generation short-circuits to `None` (fall back to `npx`) with a debug log naming both generations; the docstring's conservatism contract now covers the ambiguous multi-generation case
- `tests/tools/test_mcp_npx_cached_bin.py` — regression tests:
  - parametrized over both enumeration orders (`old-cache` first / `new-cache` first): two generations containing the package → `None`, never either generation's binary
  - single-generation match still resolves to the cached binary (fast path preserved)

## How to Test

1. `.venv/bin/python -m pytest tests/tools/test_mcp_npx_cached_bin.py -q` → 21 passed
2. Before the fix, the multi-generation tests fail: each ordering returns a different generation's binary
3. Manual shape: create two `~/.npm/_npx/<dir>` entries whose `package.json` dependencies both contain the same unpinned spec (e.g. versions 1.0.0 and 2.0.0, each with a valid `.bin` entry) → `_npx_cached_bin(["-y", "<spec>"])` returns `None`; with only one entry it returns that binary

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the relevant test files and all pass (21 passed in `test_mcp_npx_cached_bin.py`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Python 3.11)

### Documentation & Housekeeping

- [x] N/A (no config keys, docs, or workflow changes)
