### PR TITLE
fix(cli): keep file logging alive in one-shot mode

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -174,9 +174,14 @@ def run_oneshot(
     JSON usage report even when the run fails. Returns the exit code; the caller owns process
     termination.
     """
-    # Silence every stdlib logger: AIAgent, tools and provider adapters log to stderr through the
-    # root logger. File handlers from setup_logging() keep working (level-independent).
-    logging.disable(logging.CRITICAL)
+    # Existing console handlers retain their streams across the redirects below. Silence only
+    # those handlers: a global disable would also block the queue feeding the forensic file logs.
+    # Root-mounted handlers only — a non-root logger's own console handler (e.g. the opt-in
+    # HERMES_PLUGINS_DEBUG stderr handler) is intentionally untouched; it holds the REAL stderr
+    # captured before the redirect, so its output never pollutes the -z stdout contract.
+    for handler in logging.getLogger().handlers:
+        if isinstance(handler, logging.StreamHandler) and not isinstance(handler, logging.FileHandler):
+            handler.setLevel(logging.CRITICAL + 1)
 
     # --provider without --model is ambiguous (the provider may not host the configured model, and
     # picking its catalog default hides the mismatch). Validate BEFORE the stderr redirect.

--- a/tests/hermes_cli/test_oneshot_file_logging.py
+++ b/tests/hermes_cli/test_oneshot_file_logging.py
@@ -1,0 +1,66 @@
+"""One-shot console silence must not suppress forensic file logs (#103056)."""
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize("response", ["", "final answer"], ids=["failure", "success"])
+def test_oneshot_preserves_file_logs_without_console_noise(tmp_path, response):
+    program = textwrap.dedent(
+        """
+        import logging
+        import sys
+
+        import hermes_cli.oneshot as oneshot
+        from hermes_logging import flush_log_queue, setup_logging, setup_verbose_logging
+
+        log_dir = setup_logging()
+        setup_verbose_logging()
+        root = logging.getLogger()
+        root.addHandler(logging.StreamHandler(sys.stdout))
+        root.addHandler(logging.FileHandler(log_dir / "direct.log", encoding="utf-8"))
+        response = sys.argv[1]
+
+        def run_agent(*args, **kwargs):
+            logger = logging.getLogger("run_agent")
+            logger.info("one-shot diagnostic")
+            logger.error("one-shot failure detail")
+            logger.critical("one-shot critical detail")
+            print("incidental stdout")
+            print("incidental stderr", file=sys.stderr)
+            return response, {"failed": not response}
+
+        oneshot._run_agent = run_agent
+        rc = oneshot.run_oneshot("hello")
+        flush_log_queue()
+        raise SystemExit(rc)
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", program, response],
+        cwd=Path(__file__).resolve().parents[2],
+        env={**os.environ, "HERMES_HOME": str(tmp_path)},
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == (0 if response else 2), result.stderr
+    assert result.stdout == (response + "\n" if response else "")
+    assert result.stderr == ""
+    logs = tmp_path / "logs"
+    agent_log = (logs / "agent.log").read_text(encoding="utf-8")
+    error_log = (logs / "errors.log").read_text(encoding="utf-8")
+    direct_log = (logs / "direct.log").read_text(encoding="utf-8")
+    for content in (agent_log, direct_log):
+        assert "one-shot diagnostic" in content
+    for content in (agent_log, error_log, direct_log):
+        assert "one-shot failure detail" in content
+        assert "one-shot critical detail" in content
+    assert "one-shot diagnostic" not in error_log


### PR DESCRIPTION
## What does this PR do?

One-shot mode (`hermes -z`) silenced logging with a process-wide `logging.disable(logging.CRITICAL)`. That is a root-level kill switch: it suppressed every logger at or below CRITICAL **including the forensic file handlers**, so a failed `-z` run left `agent.log` / `errors.log` empty — no trail to debug for the exact (cron / SSH / subprocess) users who depend on it (#103056). The adjacent comment claimed file logging survived; `logging.disable()` does not work that way.

The console-silencing **intent** is real and preserved: `-z` stdout must contain only the final response text (the mode's contract). The fix now raises the level of only the non-file `StreamHandler`s attached at that point, leaving file handlers (and the queue feeding them) fully operational. The stale comment is replaced with one describing the real mechanism.

## Related Issue

Fixes #103056

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/oneshot.py` — replace `logging.disable(logging.CRITICAL)` with a targeted pass that sets `CRITICAL + 1` only on non-file `StreamHandler`s of the root logger; comment updated to explain why a global disable would also block the file-log queue
- `tests/hermes_cli/test_oneshot_file_logging.py` (new) — regression tests running one-shot invocations hermetically (isolated `HERMES_HOME`):
  - a failing run writes the diagnostic trail to `logs/agent.log` and the failure/critical detail to both `agent.log` and `logs/errors.log`
  - the stdout contract holds on success and failure (final response text only, nothing else; stderr clean on the covered paths)

## How to Test

1. `.venv/bin/python -m pytest tests/hermes_cli/ -q -k oneshot` → 32 passed, 2 skipped
2. Before the fix, the new tests fail with exactly the reported symptom: log files exist but are empty
3. Manual smoke (no network needed):
   ```bash
   H=$(mktemp -d); HERMES_HOME=$H .venv/bin/python -m hermes_cli.main -z --model m --provider nonexistent 'hi'
   wc -c $H/logs/agent.log   # non-zero after the fix; 0 before
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the relevant test files and all pass (32 passed, 2 skipped across the oneshot selection)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Python 3.11)

### Documentation & Housekeeping

- [x] N/A (no config keys, docs, or workflow changes)
