### PR TITLE
fix(cli): accept cron create's prompt positional through top-level routing

### DIFF
--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -2,9 +2,27 @@
 
 from __future__ import annotations
 
+import argparse
 from typing import Callable
 
 from hermes_cli.subcommands._shared import add_accept_hooks_flag
+
+
+class _CronActionParser(argparse.ArgumentParser):
+    def __init__(self, *args, intermixed=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._intermixed = intermixed
+
+    def parse_known_args(self, args=None, namespace=None):
+        if not self._intermixed:
+            return super().parse_known_args(args, namespace)
+        # Subparser dispatch calls parse_known_args; intermixed parsing calls it
+        # twice internally, so those passes must use the ordinary implementation.
+        self._intermixed = False
+        try:
+            return self.parse_known_intermixed_args(args, namespace)
+        finally:
+            self._intermixed = True
 
 
 def _flag(parser, *names, help, **kw):
@@ -15,13 +33,16 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     """Attach the ``cron`` subcommand (and its sub-actions) to ``subparsers``."""
     cron_parser = subparsers.add_parser(
         "cron", help="Cron job management", description="Manage scheduled tasks")
-    cron_subparsers = cron_parser.add_subparsers(dest="cron_command")
+    cron_subparsers = cron_parser.add_subparsers(
+        dest="cron_command", parser_class=_CronActionParser)
 
     cron_list = cron_subparsers.add_parser("list", help="List scheduled jobs")
     _flag(cron_list, "--all", help="Include disabled jobs")
 
+    # Ordinary parsing consumes the optional prompt as absent at the first
+    # option after schedule. Only this leaf needs intermixed positionals.
     cron_create = cron_subparsers.add_parser(
-        "create", aliases=["add"], help="Create a scheduled job")
+        "create", aliases=["add"], help="Create a scheduled job", intermixed=True)
     cron_create.add_argument("schedule", help="Schedule like '30m', 'every 2h', or '0 9 * * *'")
     cron_create.add_argument(
         "prompt", nargs="?", help="Optional self-contained prompt or task instruction")

--- a/tests/hermes_cli/test_cron_parser_builder.py
+++ b/tests/hermes_cli/test_cron_parser_builder.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import argparse
 
+import pytest
+
 from hermes_cli.subcommands.cron import build_cron_parser
 
 
@@ -48,3 +50,109 @@ def test_cron_accept_hooks_flag_on_run_and_tick():
     assert ns.accept_hooks is True
     ns2 = parser.parse_args(["cron", "tick", "--accept-hooks"])
     assert ns2.accept_hooks is True
+
+
+@pytest.mark.parametrize(
+    "argv, expected",
+    [
+        pytest.param(
+            ["cron", "create", "0 3 * * *", "--name", "test-prompt-job",
+             "--deliver", "local", "Test prompt to see if positionals work"],
+            {"command": "cron", "cron_command": "create", "schedule": "0 3 * * *",
+             "name": "test-prompt-job", "deliver": "local",
+             "prompt": "Test prompt to see if positionals work"},
+            id="issue-multiword-prompt",
+        ),
+        pytest.param(
+            ["cron", "create", "0 3 * * *", "--name", "test-prompt-job",
+             "Single-word-prompt"],
+            {"prompt": "Single-word-prompt", "name": "test-prompt-job"},
+            id="issue-single-word-prompt",
+        ),
+        pytest.param(
+            ["cron", "add", "30m", "--name", "job", "alias prompt"],
+            {"cron_command": "add", "prompt": "alias prompt", "name": "job"},
+            id="create-alias",
+        ),
+        pytest.param(
+            ["cron", "create", "30m", "contiguous prompt", "--deliver", "local"],
+            {"prompt": "contiguous prompt", "deliver": "local"},
+            id="contiguous-positionals",
+        ),
+        pytest.param(
+            ["cron", "create", "30m", "--", "--literal-prompt"],
+            {"prompt": "--literal-prompt"}, id="end-of-options",
+        ),
+        pytest.param(
+            ["cron", "create", "--name", "job", "30m", "--skill", "first",
+             "prompt", "--skill", "second"],
+            {"schedule": "30m", "prompt": "prompt", "name": "job",
+             "skills": ["first", "second"]},
+            id="options-around-positionals",
+        ),
+        pytest.param(
+            ["cron", "create", "0 3 * * *", "--name", "test-prompt-job",
+             "--deliver", "local", "--no-agent", "--script", "x.sh"],
+            {"prompt": None, "no_agent": True, "script": "x.sh", "deliver": "local"},
+            id="script-without-prompt",
+        ),
+        pytest.param(
+            ["cron", "list", "--all"],
+            {"command": "cron", "cron_command": "list", "all": True},
+            id="flags-only-cron-action",
+        ),
+        pytest.param(
+            ["-c", "multi word session"],
+            {"command": None, "continue_last": "multi word session"},
+            id="quoted-session-name",
+        ),
+        pytest.param(
+            ["-c", "multi", "word", "session"],
+            {"command": None, "continue_last": "multi word session"},
+            id="coalesced-session-name",
+        ),
+        pytest.param(
+            ["-c", "model"],
+            {"command": None, "continue_last": "model"},
+            id="session-name-matching-command",
+        ),
+        pytest.param(
+            ["model"], {"command": "model"}, id="other-subcommand",
+        ),
+        pytest.param(
+            ["--version"], {"command": None, "version": True}, id="top-level-flag",
+        ),
+    ],
+)
+def test_cron_and_session_args_through_top_level_routing(argv, expected):
+    from hermes_cli.main import _build_cli_parser, _parse_cli_args
+
+    parser, subparsers = _build_cli_parser()
+    args = _parse_cli_args(parser, subparsers, argv)
+
+    for name, value in expected.items():
+        assert getattr(args, name) == value
+
+
+@pytest.mark.parametrize(
+    "argv, exit_code",
+    [
+        (["30m", "prompt", "extra"], 2),
+        (["30m", "--unknown", "prompt"], 2),
+        (["30m", "--name"], 2),
+        (["--name", "job"], 2),
+        (["--help"], 0),
+    ],
+)
+def test_cron_parser_remains_usable_after_exit(argv, exit_code):
+    from hermes_cli.main import _build_cli_parser, _parse_cli_args
+
+    parser, subparsers = _build_cli_parser()
+    with pytest.raises(SystemExit) as exc:
+        _parse_cli_args(parser, subparsers, ["cron", "create", *argv])
+    assert exc.value.code == exit_code
+
+    args = _parse_cli_args(
+        parser, subparsers, ["cron", "create", "30m", "--name", "job", "prompt"])
+    assert args.prompt == "prompt"
+    assert args.name == "job"


### PR DESCRIPTION
## What does this PR do?

`hermes cron create <schedule> [prompt]` failed with `unrecognized arguments` whenever a prompt positional was supplied, even a single quoted word (#102983):

```
$ hermes cron create "0 3 * * *" --name test-prompt-job --deliver local "Test prompt to see if positionals work"
hermes: error: unrecognized arguments: Test prompt to see if positionals work
```

Root cause (reproduced against the real top-level parse path): the `prompt` positional is declared `nargs="?"`. Plain argparse consumption sees the first option after `schedule` (`--name …`) and resolves the optional prompt as **absent** at that point; the trailing prompt token then becomes unrecognized, propagates up through the subparser chain, and surfaces at the top level (which is why the error banner showed top-level usage). It is not the subcommand-routing workaround or session-name coalescing — both were verified blameless.

**Reproduction note (version-dependent, likely why triage could not reproduce):** this is stdlib argparse behavior that changed in CPython 3.13. A minimal stdlib-only probe (top-level `--continue` nargs=`?` + `cron` → `create(schedule, prompt nargs=?, --name, --deliver)` + the issue's argv) yields `prompt=None, extra=['Test prompt']` on Python 3.10/3.11/3.12 and parses correctly (`prompt='Test prompt'`) only on 3.13. The fix makes behavior identical on every supported version (3.11–3.13) instead of depending on the interpreter.

Fix: only the `cron create`/`add` leaf gets `parse_known_intermixed_args()` (the stdlib's supported API for positionals interleaved with options) via a small `parser_class` used by the cron subparsers. The top-level argv pipeline is untouched.

**Relationship to the earlier open #103027** (same bug, different site): that PR repairs the leftover token at the `main.py` routing layer but only accepts exactly one unknown (`len(unknown) == 1`) — a **single-word** prompt. The issue's original command carries a multi-word prompt ("Test prompt to see if positionals work") and still fails under that repair. This PR's leaf-parser fix handles single- and multi-word prompts uniformly (argparse's own intermixed consumption, not a hand-rolled token patch), keeps misspelled flags failing normally, and leaves the top-level pipeline untouched. If the maintainer prefers the routing-layer approach, it needs the single-token restriction lifted to actually close #102983.

## Related Issue

Fixes #102983

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/subcommands/cron.py`
  - `_CronActionParser`: an `ArgumentParser` subclass whose `parse_known_args` dispatches to `parse_known_intermixed_args` when the leaf opted in (subparser dispatch and intermixed parsing's internal second pass both still take the ordinary implementation)
  - `create` (alias `add`) is constructed with `intermixed=True`; every other cron sub-action keeps default parsing
- `tests/hermes_cli/test_cron_parser_builder.py` — regression tests through the real `_build_cli_parser` + `_parse_cli_args` top-level routing:
  - both issue command shapes parse: `args.prompt` receives the full multi-word prompt (and the single-word variant), `--name`/`--deliver`/`schedule` intact
  - `--no-agent --script` variant (no prompt) still parses
  - non-regression guards: other subcommands (`model`), bare top-level flags (`--version`), and the existing `-c` multi-word session-name coalescing behavior

## How to Test

1. `.venv/bin/python -m pytest tests/hermes_cli/test_cron_parser_builder.py -q` → 21 passed
2. Before the fix, 4 tests fail, including both original issue commands
3. Manual: `hermes cron create "0 3 * * *" --name test-prompt-job --deliver local "Test prompt to see if positionals work"` now creates the job with the full prompt

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the relevant test files and all pass (21 passed in `test_cron_parser_builder.py`; wider `tests/hermes_cli/` targeted runs green apart from known local socket/toolchain environment failures reproducible on unmodified `main`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Python 3.11)

### Documentation & Housekeeping

- [x] N/A (no config keys, docs, or workflow changes)
