### PR TITLE
fix(cron): deliver routed profiles through their shared transport

### DIFF
--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -1061,7 +1061,7 @@ def _warn_live_lane_failure(job: dict, msg: str, is_relay: bool) -> None:
 
 def _resolve_target_transport(
     job: dict, platform, platform_name: str, target: dict, adapters, config):
-    """Resolve ``(transport, pconfig, runtime_adapter, target_adapters)`` for one target, or
+    """Resolve ``(transport, pconfig, runtime_adapter, target_adapters, config)`` for one target, or
     ``(None, error)`` when it cannot be served (relay-fronted with no live transport, or not
     configured/enabled)."""
     from gateway.delivery import resolve_delivery_transport
@@ -1072,6 +1072,21 @@ def _resolve_target_transport(
         # See #101113.
         shared = adapters.get(platform, target)
         target_adapters = {platform: shared} if shared is not None else {}
+        native_config = config.platforms.get(platform)
+        if shared is not None and (native_config is None or not native_config.enabled):
+            from dataclasses import replace
+            from gateway.config import PlatformConfig
+
+            # The satellite disables its OWN connector, not the owner's already
+            # authorized transport. Enable only this target-local view after the
+            # SharedRouteAdapters gate; never copy the owner's token/config.
+            owner_config = getattr(shared, "config", None)
+            if isinstance(owner_config, PlatformConfig) and owner_config.enabled:
+                target_config = (
+                    replace(native_config, enabled=True)
+                    if native_config is not None else PlatformConfig(enabled=True)
+                )
+                config = replace(config, platforms={**config.platforms, platform: target_config})
     transport = resolve_delivery_transport(platform, config, target_adapters)
     if transport is not None:
         pconfig = transport.config
@@ -1098,7 +1113,7 @@ def _resolve_target_transport(
             pconfig = PlatformConfig(enabled=True)
     elif not pconfig or not pconfig.enabled:
         return None, f"platform '{platform_name}' not configured/enabled"
-    return (transport, pconfig, runtime_adapter, target_adapters), None
+    return (transport, pconfig, runtime_adapter, target_adapters, config), None
 
 
 def _inchannel_surface_supported(runtime_adapter, platform_name: str) -> bool:
@@ -1514,7 +1529,7 @@ def _prepare_target_delivery(
     if resolved is None:
         _note_target_error(job, resolve_err, delivery_errors)
         return None
-    transport, pconfig, runtime_adapter, target_adapters = resolved
+    transport, pconfig, runtime_adapter, target_adapters, config = resolved
 
     # Live send needs a RUNNING loop, not just an adapter. Computed ONCE so the in_channel
     # thread_id clear below stays in lockstep with the seed (standalone cannot seed flat).
@@ -1558,6 +1573,13 @@ def _prepare_target_delivery(
             job, runtime_adapter, chat_id, loop) or None
         if opened_thread_id:
             thread_id = opened_thread_id
+    if isinstance(adapters, _preflight.SharedRouteAdapters) and runtime_adapter is not None:
+        # Continuable delivery may clear/change thread_id. Recheck the final
+        # destination so a topic-scoped route cannot become a chat-wide send.
+        final_target = {"chat_id": chat_id, "thread_id": thread_id}
+        if adapters.get(platform, final_target) is not runtime_adapter:
+            _note_target_error(job, "shared gateway route does not authorize final destination", delivery_errors)
+            return None
     return _TargetDelivery(
         job=job, platform=platform, platform_name=platform_name, chat_id=chat_id,
         thread_id=thread_id, transport=transport, pconfig=pconfig, runtime_adapter=runtime_adapter,
@@ -1697,6 +1719,14 @@ def _deliver_result(
             unverified_targets=unverified_targets,
         )
         if not delivered:
+            if isinstance(adapters, _preflight.SharedRouteAdapters) and t.runtime_adapter is not None:
+                # The shared connector owns the credential. A stopped loop or
+                # failed send must not fall through to standalone token lookup.
+                delivery_errors.extend(target_errors)
+                _note_target_error(
+                    job, f"shared gateway transport unavailable for {t.where}; "
+                    "no standalone credential fallback", delivery_errors)
+                continue
             _deliver_standalone(
                 t, cleaned_delivery_content, media_files, target_errors, delivery_errors)
 

--- a/tests/cron/test_shared_profile_delivery.py
+++ b/tests/cron/test_shared_profile_delivery.py
@@ -1,0 +1,231 @@
+"""Routed cron delivery uses the owner transport, not satellite credentials."""
+
+import asyncio
+from concurrent.futures import Future
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from cron import scheduler
+from cron.scheduler_preflight import (
+    SharedRouteAdapters,
+    _primary_profile_routes_for_current_home,
+)
+from gateway.config import Platform, PlatformConfig, load_gateway_config
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+@pytest.fixture
+def satellite(tmp_path, monkeypatch):
+    root = tmp_path / ".hermes"
+    home = root / "profiles" / "research"
+    home.mkdir(parents=True)
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    (root / "config.yaml").write_text(
+        yaml.safe_dump({
+            "gateway": {
+                "multiplex_profiles": True,
+                "profile_routes": [
+                    {
+                        "platform": "telegram",
+                        "chat_id": "-123",
+                        "thread_id": "3",
+                        "profile": "research",
+                    },
+                    {
+                        "platform": "telegram",
+                        "chat_id": "-456",
+                        "profile": "research",
+                        "enabled": False,
+                    },
+                    {"platform": "telegram", "chat_id": "-789", "profile": "other"},
+                ],
+            }
+        })
+    )
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({
+            "platforms": {
+                "telegram": {
+                    "enabled": False,
+                    "extra": {"cron_continuable_surface": "thread"},
+                },
+            }
+        })
+    )
+    token = set_hermes_home_override(str(home))
+    try:
+        yield home
+    finally:
+        reset_hermes_home_override(token)
+
+
+def deliver(
+    home,
+    target="telegram:-123:3",
+    *,
+    shared=True,
+    live=True,
+    adapter_enabled=True,
+    send_fails=False,
+):
+    sent = []
+
+    async def send(chat_id, content, metadata=None):
+        if send_fails:
+            raise RuntimeError("controlled transport failure")
+        sent.append((chat_id, content, metadata))
+        return {"success": True, "message_id": "fixture-message"}
+
+    adapter = SimpleNamespace(config=PlatformConfig(enabled=adapter_enabled), send=send)
+    adapters = {Platform.TELEGRAM: adapter}
+    if shared:
+        adapters = SharedRouteAdapters(
+            adapters, _primary_profile_routes_for_current_home()
+        )
+    loop = MagicMock()
+    loop.is_running.return_value = live
+
+    def submit(coro, _loop):
+        future = Future()
+        try:
+            future.set_result(asyncio.run(coro))
+        except Exception as exc:
+            future.set_exception(exc)
+        return future
+
+    # Real profile config loader, route lookup and DeliveryRouter. Only the event
+    # loop bridge and actual network transport are replaced; no bot credentials.
+    with (
+        patch.object(
+            scheduler, "load_config", return_value={"cron": {"wrap_response": False}}
+        ),
+        patch("asyncio.run_coroutine_threadsafe", side_effect=submit),
+        patch("tools.send_message_tool._send_to_platform") as standalone,
+    ):
+        error = scheduler._deliver_result(
+            {"id": "fixture-job", "deliver": target},
+            "fixture report",
+            adapters=adapters,
+            loop=loop,
+        )
+    standalone.assert_not_called()
+    return error, sent
+
+
+def test_disabled_satellite_uses_route_scoped_live_transport(satellite):
+    before = (satellite / "config.yaml").read_bytes()
+    error, sent = deliver(satellite)
+    assert error is None
+    assert len(sent) == 1
+    assert sent[0][0:2] == ("-123", "fixture report")
+    assert sent[0][2]["thread_id"] == "3"
+    assert (satellite / "config.yaml").read_bytes() == before
+    assert not load_gateway_config().platforms[Platform.TELEGRAM].enabled
+
+
+def test_credentialless_satellite_without_platform_block(satellite):
+    (satellite / "config.yaml").write_text("{}\n")
+    error, sent = deliver(satellite)
+    assert error is None
+    assert len(sent) == 1
+
+
+def test_target_config_preserves_satellite_settings_not_owner_credentials(satellite):
+    from cron.scheduler_delivery import _resolve_target_transport
+
+    config = load_gateway_config()
+    primary = SimpleNamespace(
+        config=PlatformConfig(enabled=True, token="owner-fixture")
+    )
+    shared = SharedRouteAdapters(
+        {Platform.TELEGRAM: primary},
+        _primary_profile_routes_for_current_home(),
+    )
+    resolved, error = _resolve_target_transport(
+        {"id": "fixture"},
+        Platform.TELEGRAM,
+        "telegram",
+        {"chat_id": "-123", "thread_id": "3"},
+        shared,
+        config,
+    )
+    assert error is None
+    assert resolved is not None
+    transport, pconfig, _, _, target_config = resolved
+    assert transport is not None
+    assert transport.adapter is primary
+    assert pconfig.enabled
+    assert pconfig.token != primary.config.token
+    assert pconfig.extra == config.platforms[Platform.TELEGRAM].extra
+    assert target_config is not config
+    assert not config.platforms[Platform.TELEGRAM].enabled
+
+
+@pytest.mark.parametrize(
+    "target", ["telegram:-999", "telegram:-456", "telegram:-789", "telegram:-123:4"]
+)
+def test_unrouted_disabled_other_profile_and_other_topic_stay_closed(satellite, target):
+    error, sent = deliver(satellite, target)
+    assert error and "not configured/enabled" in error
+    assert sent == []
+
+
+def test_target_override_does_not_leak_to_next_target(satellite):
+    error, sent = deliver(satellite, "telegram:-123:3,telegram:-999")
+    assert error and "not configured/enabled" in error
+    assert [item[0] for item in sent] == ["-123"]
+
+
+def test_continuable_mode_cannot_move_delivery_outside_authorized_topic(satellite):
+    from cron.scheduler_delivery import _prepare_target_delivery
+
+    config = load_gateway_config()
+    config.platforms[Platform.TELEGRAM].extra["cron_continuable_surface"] = "in_channel"
+    primary = SimpleNamespace(
+        config=PlatformConfig(enabled=True),
+        supports_inchannel_continuable=True,
+    )
+    shared = SharedRouteAdapters(
+        {Platform.TELEGRAM: primary},
+        _primary_profile_routes_for_current_home(),
+    )
+    origin = {"platform": "telegram", "chat_id": "-123", "thread_id": "3"}
+    errors = []
+    prepared = _prepare_target_delivery(
+        {"id": "fixture", "deliver": "origin", "origin": origin},
+        origin,
+        adapters=shared,
+        loop=SimpleNamespace(is_running=lambda: True),
+        config=config,
+        notify_delivery=False,
+        mirror_enabled=False,
+        mirror_text="fixture",
+        delivery_errors=errors,
+    )
+    assert prepared is None
+    assert errors and "route" in errors[0]
+
+
+def test_ordinary_adapter_map_does_not_bypass_disabled_config(satellite):
+    error, sent = deliver(satellite, shared=False)
+    assert error and "not configured/enabled" in error
+    assert sent == []
+
+
+def test_disabled_owner_adapter_is_not_revived(satellite):
+    error, sent = deliver(satellite, adapter_enabled=False)
+    assert error and "not configured/enabled" in error
+    assert sent == []
+
+
+@pytest.mark.parametrize("kwargs", [{"live": False}, {"send_fails": True}])
+def test_shared_transport_failure_never_uses_standalone_credentials(satellite, kwargs):
+    error, sent = deliver(satellite, **kwargs)
+    assert error
+    if kwargs.get("send_fails"):
+        assert "controlled transport failure" in error
+    assert sent == []

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -318,6 +318,16 @@ profile — a routed profile's job targeting an unrouted chat (or a chat routed
 to another profile) is never sent through the shared bot. Guild-only routes do
 not qualify a cron target; add a `chat_id` route for the delivery channel.
 
+The routed profile may leave its own platform connector disabled (for example,
+`platforms.telegram.enabled: false`) or omit its platform block entirely. It
+does not need a second bot or a copy of the primary bot token. The scheduler
+uses a target-local enabled view only after the shared-route adapter authorizes
+the destination; it does not enable the profile's connector or inherit the
+primary profile's settings. Other destinations and ordinary, non-shared
+disabled connectors keep their existing behavior. If the selected shared
+transport fails or its event loop is stopped, delivery reports an error rather
+than attempting standalone credential lookup.
+
 ## Start, stop, or restart all gateways at once
 
 The CLI ships with single-profile lifecycle commands. To act across every


### PR DESCRIPTION
## What does this PR do?

Fixes cron delivery for a credentialless profile served by a shared gateway bot when its own platform connector is explicitly disabled (or its platform block is absent).

The existing multiplex ticker already supplies a target-authorized `SharedRouteAdapters` view. However, `_resolve_target_transport()` passes the satellite's disabled platform config into `resolve_delivery_transport()`. The shared adapter is consequently rejected, and a successfully executed job ends with `platform 'telegram' not configured/enabled` instead of delivering its report.

This uses the existing shared-route mechanism rather than introducing another config/route resolver. Only after that mechanism selects an enabled owner adapter, create an enabled **target-local copy of the satellite config**. Carry that same copy into the real `DeliveryRouter`; do not copy the owner's token or platform settings, mutate the satellite config, or start another connector.

Two boundaries are covered as part of making the shared transport usable:
- Recheck the final destination after continuable delivery adjusts `thread_id`, so a topic-only grant cannot turn into a chat-wide send.
- If the selected shared transport fails or the loop is stopped, preserve the delivery error and do not fall back to standalone credential lookup.

## Related work

Follow-up to the shared-route delivery path referenced by #101113. Related to #89305, but narrower in authorization and addressing the **explicitly disabled satellite connector** as well as the missing-block case. Ordinary adapter maps retain their disabled-config gate. This is not the standalone worker ContextVar fix in #100522.

## Type of Change

- [x] Bug fix
- [x] Tests
- [x] Documentation update

## Changes Made

- `cron/scheduler_delivery.py`: target-local shared transport configuration; final destination recheck; no standalone fallback for a selected shared connector.
- `tests/cron/test_shared_profile_delivery.py`: real profile YAML loading, real route lookup and real `DeliveryRouter` under temporary homes. Only the event-loop bridge and network send are replaced.
- `website/docs/user-guide/multi-profile-gateways.md`: document disabled/absent satellite connectors and shared-transport failure behavior.

## Reproduction

1. Run a multiplex gateway with a primary bot and a route to a satellite profile, e.g. Telegram group `-123`, topic `3` → `research`.
2. In the satellite config, set `platforms.telegram.enabled: false`; do not copy the primary token into the satellite.
3. Deliver a satellite cron result to `telegram:-123:3` through the gateway's `SharedRouteAdapters`.
4. Before the fix, the job reports `platform 'telegram' not configured/enabled`. Afterward, the existing primary adapter sends the text to the authorized topic, while unrelated destinations remain rejected.

## Verification

- Fail-on-main on upstream `006b1beb00`: the initial regression suite produced **2 failed, 8 passed** (authorized delivery and multi-target delivery failed with the configured/enabled error).
- An additional failing test demonstrated the continuable-mode topic-clear boundary before adding the final-destination recheck.
- `scripts/run_tests.sh tests/cron/ tests/gateway/test_cron_delivery_housekeeping.py` — **1232 passed, 0 failed, 2 skipped** across 96 files (Linux). The new regression file contains 13 cases.
- `python3 -m ruff check cron/scheduler_delivery.py tests/cron/test_shared_profile_delivery.py`
- `git diff --check`

No real Telegram/network sends, gateway restarts, runtime configuration changes or model calls are performed by the regression tests. This PR does not claim a production delivery smoke test or the entire repository test suite.

## Security / scope

Only the three listed files are included. The reviewed diff contains no private profiles, user data, live credentials, local paths, or unrelated installation changes. Credential-looking fixture values are synthetic. Static diff inspection and pattern scan performed; no dedicated secret-scanner binary was available.

## Checklist

- [x] Searched existing PRs and current implementation
- [x] Conventional commit; one bug class; isolated worktree from current upstream
- [x] Regression tests and relevant documentation
- [x] Target-local config does not mutate persisted profile state or inherit owner credentials
- [x] Linux tests; no new OS-specific production dependencies
- [ ] Entire repository suite / live platform smoke test (not run)
