### PR TITLE
fix(desktop): unify statusbar Session timer on focus-since for tiles

### DIFF
--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -28,6 +28,7 @@ import {
   Zap
 } from '@/lib/icons'
 import { runtimeReadinessDisplay, type RuntimeReadinessResult } from '@/lib/runtime-readiness'
+import { resolveSessionTimerSince } from '@/lib/session-timer-since'
 import { cacheHitLabel, contextBarLabel, LiveDuration, tokensPerSecondLabel, usageContextLabel } from '@/lib/statusbar'
 import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
@@ -45,6 +46,7 @@ import {
   $selectedStoredSessionId,
   $sessions,
   $sessionStartedAt,
+  $tileSessionFocusStartedAt,
   $turnStartedAt,
   idsShareLineage,
   sessionMatchesStoredId
@@ -117,6 +119,7 @@ export function useStatusbarItems({
   const primaryUsage = useStore($currentUsage)
   const gatewayRestarting = useStore($gatewayRestarting)
   const primarySessionStartedAt = useStore($sessionStartedAt)
+  const tileSessionFocusStartedAt = useStore($tileSessionFocusStartedAt)
   const primaryTurnStartedAt = useStore($turnStartedAt)
 
   // The indicator must speak the same scope as the Spawn-tree panel it opens:
@@ -176,16 +179,14 @@ export function useStatusbarItems({
 
   const turnStartedAt = primaryFocused ? primaryTurnStartedAt : focusedTurnStartedAt
 
-  // A tile's session-start + cold cwd come from its stored row (the cache only
-  // knows runtime state). Only these scalars are read off `$sessions`, so
-  // select them — a whole-list `useStore` re-ran the hook on every session-list
-  // write (title updates, poll refreshes, archives).
-  const focusedRowStartedAt = useStoreSelector($sessions, sessions =>
-    focusedStoredSessionId
-      ? (sessions.find(s => sessionMatchesStoredId(s, focusedStoredSessionId))?.started_at ?? null)
-      : null
-  )
-
+  // A tile's cold cwd comes from its stored row (the cache only knows runtime
+  // state). Only these scalars are read off `$sessions`, so select them — a
+  // whole-list `useStore` re-ran the hook on every session-list write (title
+  // updates, poll refreshes, archives).
+  // Session timer deliberately does NOT use row.started_at here: that is the
+  // durable creation timestamp and made a day-old tile read as 23:03:00 while
+  // primary focus showed seconds (#103123). Tile focus stamps live in
+  // `$tileSessionFocusStartedAt` with the same "focused since" meaning.
   const focusedRowCwd = useStoreSelector($sessions, sessions => {
     if (!focusedStoredSessionId) {
       return ''
@@ -235,11 +236,12 @@ export function useStatusbarItems({
   const projectTree = useStore($projectTree)
   const projectName = useMemo(() => projectNameForCwd(currentCwd), [currentCwd, projectTree])
 
-  const sessionStartedAt = primaryFocused
-    ? primarySessionStartedAt
-    : focusedRowStartedAt
-      ? focusedRowStartedAt * 1000
-      : null
+  const sessionStartedAt = resolveSessionTimerSince({
+    focusedStoredSessionId,
+    primaryFocused,
+    primarySessionStartedAt,
+    tileFocus: tileSessionFocusStartedAt
+  })
 
   // The backend only knows a session's MEASURED occupancy once a turn has run
   // in this process, so a resumed conversation reports none and the gauge had

--- a/apps/desktop/src/lib/session-timer-since.test.ts
+++ b/apps/desktop/src/lib/session-timer-since.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+
+import { nextTileSessionFocusStamp, resolveSessionTimerSince } from './session-timer-since'
+
+describe('resolveSessionTimerSince', () => {
+  it('uses the primary focus stamp while the primary surface is focused', () => {
+    expect(
+      resolveSessionTimerSince({
+        focusedStoredSessionId: 'sess-primary',
+        primaryFocused: true,
+        primarySessionStartedAt: 1_000,
+        tileFocus: { since: 9_999, storedId: 'sess-tile' }
+      })
+    ).toBe(1_000)
+  })
+
+  it('uses the tile focus stamp for a focused tile instead of DB row age (#103123)', () => {
+    expect(
+      resolveSessionTimerSince({
+        focusedStoredSessionId: 'sess-tile',
+        primaryFocused: false,
+        primarySessionStartedAt: 1_000,
+        tileFocus: { since: 5_000, storedId: 'sess-tile' }
+      })
+    ).toBe(5_000)
+  })
+
+  it('hides the timer when the tile stamp belongs to a different session', () => {
+    expect(
+      resolveSessionTimerSince({
+        focusedStoredSessionId: 'sess-b',
+        primaryFocused: false,
+        primarySessionStartedAt: 1_000,
+        tileFocus: { since: 5_000, storedId: 'sess-a' }
+      })
+    ).toBeNull()
+  })
+})
+
+describe('nextTileSessionFocusStamp', () => {
+  it('stamps Date.now()-style focus time when a tile first gains focus', () => {
+    expect(nextTileSessionFocusStamp(null, 'sess-a', false, 42)).toEqual({
+      since: 42,
+      storedId: 'sess-a'
+    })
+  })
+
+  it('keeps the stamp while the same tile stays focused', () => {
+    const previous = { since: 42, storedId: 'sess-a' }
+
+    expect(nextTileSessionFocusStamp(previous, 'sess-a', false, 99)).toBe(previous)
+  })
+
+  it('re-stamps when focus moves to a sibling tile', () => {
+    expect(
+      nextTileSessionFocusStamp({ since: 42, storedId: 'sess-a' }, 'sess-b', false, 99)
+    ).toEqual({ since: 99, storedId: 'sess-b' })
+  })
+
+  it('leaves the prior stamp alone while primary is focused', () => {
+    const previous = { since: 42, storedId: 'sess-a' }
+
+    expect(nextTileSessionFocusStamp(previous, 'sess-primary', true, 99)).toBe(previous)
+  })
+})

--- a/apps/desktop/src/lib/session-timer-since.ts
+++ b/apps/desktop/src/lib/session-timer-since.ts
@@ -1,0 +1,56 @@
+/**
+ * Statusbar "Session" timer contract (#103123).
+ *
+ * Primary focus stamps `$sessionStartedAt` with Date.now() on every switch
+ * ("focused since"). Tile focus used to read the durable DB `started_at`, so
+ * the same control jumped from `0:05` to `23:03:00` when clicking a day-old
+ * tile. Both surfaces now share the focus-since meaning.
+ */
+
+export interface TileSessionFocusStamp {
+  since: number
+  storedId: string
+}
+
+/** Pick the LiveDuration `since` for the statusbar Session item. */
+export function resolveSessionTimerSince(input: {
+  focusedStoredSessionId: null | string
+  primaryFocused: boolean
+  primarySessionStartedAt: number | null
+  tileFocus: null | TileSessionFocusStamp
+}): number | null {
+  if (input.primaryFocused) {
+    return input.primarySessionStartedAt
+  }
+
+  const focused = input.focusedStoredSessionId
+  const tile = input.tileFocus
+
+  if (!focused || !tile || tile.storedId !== focused) {
+    return null
+  }
+
+  return tile.since
+}
+
+/**
+ * Stamp (or keep) the tile focus-since clock when the focused surface is a
+ * non-primary tile. Re-focusing a different tile resets the clock the same way
+ * primary activation re-stamps `$sessionStartedAt`.
+ */
+export function nextTileSessionFocusStamp(
+  previous: null | TileSessionFocusStamp,
+  focusedStoredSessionId: null | string,
+  primaryFocused: boolean,
+  now: number
+): null | TileSessionFocusStamp {
+  if (primaryFocused || !focusedStoredSessionId) {
+    return previous
+  }
+
+  if (previous?.storedId === focusedStoredSessionId) {
+    return previous
+  }
+
+  return { since: now, storedId: focusedStoredSessionId }
+}

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -32,8 +32,8 @@ import {
 } from '@/components/pane-shell/tree/store'
 import { $workspaceMode, resolveRememberedActivePane, workspaceScopeKey } from '@/components/pane-shell/workspace-scope'
 import type { WorkspaceMode } from '@/contrib/types'
-import { stableArray } from '@/lib/stable-array'
 import { nextTileSessionFocusStamp } from '@/lib/session-timer-since'
+import { stableArray } from '@/lib/stable-array'
 import { readJson, writeJson } from '@/lib/storage'
 import type { SessionInfo } from '@/types/hermes'
 

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -33,6 +33,7 @@ import {
 import { $workspaceMode, resolveRememberedActivePane, workspaceScopeKey } from '@/components/pane-shell/workspace-scope'
 import type { WorkspaceMode } from '@/contrib/types'
 import { stableArray } from '@/lib/stable-array'
+import { nextTileSessionFocusStamp } from '@/lib/session-timer-since'
 import { readJson, writeJson } from '@/lib/storage'
 import type { SessionInfo } from '@/types/hermes'
 
@@ -54,7 +55,8 @@ import {
   setActiveSessionStoredIdRotation,
   setAwaitingResponse,
   setBusy,
-  setSessions
+  setSessions,
+  setTileSessionFocusStartedAt
 } from './session'
 import { assertSessionOwnerResolved } from './session-owner-resolution'
 import {
@@ -1977,6 +1979,15 @@ $focusedStoredSessionId.listen(focused => {
     markSessionRead(focused)
     ackStoredSessionId(focused)
   }
+
+  // Statusbar Session timer: stamp "focused since" for non-primary tiles so
+  // they share the primary's contract instead of durable DB started_at (#103123).
+  const selected = $selectedStoredSessionId.get()
+  const primaryFocused = !focused || focused === selected
+
+  setTileSessionFocusStartedAt(previous =>
+    nextTileSessionFocusStamp(previous, focused, primaryFocused, Date.now())
+  )
 })
 
 // Cold-start restore is the one selection change that is NOT a navigation: the

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -1134,6 +1134,10 @@ export const $currentUsage = atom<UsageStats>({
   total: 0
 })
 export const $sessionStartedAt = atom<number | null>(null)
+// Tile surfaces never call setSessionStartedAt (that atom is primary-only).
+// Statusbar Session timer needs the same "focused since" contract for tiles
+// (#103123) — stamped when $focusedStoredSessionId lands on a non-primary tile.
+export const $tileSessionFocusStartedAt = atom<null | { since: number; storedId: string }>(null)
 export const $turnStartedAt = atom<number | null>(null)
 export const $introPersonality = atom('')
 export const $currentPersonality = atom('')
@@ -1476,6 +1480,9 @@ export const workspaceCwdForNewSession = (): string => {
 export const setCurrentBranch = (next: Updater<string>) => updateAtom($currentBranch, next)
 export const setCurrentUsage = (next: Updater<UsageStats>) => updateAtom($currentUsage, next)
 export const setSessionStartedAt = (next: Updater<number | null>) => updateAtom($sessionStartedAt, next)
+export const setTileSessionFocusStartedAt = (
+  next: Updater<null | { since: number; storedId: string }>
+) => updateAtom($tileSessionFocusStartedAt, next)
 export const setTurnStartedAt = (next: Updater<number | null>) => updateAtom($turnStartedAt, next)
 export const setIntroPersonality = (next: Updater<string>) => updateAtom($introPersonality, next)
 export const setCurrentPersonality = (next: Updater<string>) => updateAtom($currentPersonality, next)


### PR DESCRIPTION
## Summary
- Primary focus stamped `$sessionStartedAt` with `Date.now()` on every switch, while tile focus read durable DB `started_at` — the same Session item jumped from seconds to hours-old row age (e.g. `23:03:00`).
- Stamp non-primary tile focus into `$tileSessionFocusStartedAt` and resolve both surfaces through one “focused since” helper.
- Unit coverage for stamp/keep/re-stamp and statusbar `since` resolution.

Fixes #103123

