### PR TITLE
i18n: translate mid-run busy notices, the working heartbeat and command-menu descriptions

### DIFF
--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -229,6 +229,16 @@ def get_language() -> str:
     return DEFAULT_LANGUAGE
 
 
+def has_key(key: str, lang: str | None = None) -> bool:
+    """True when *key* exists in the active (or given) language catalog or in
+    the English fallback -- i.e. when :func:`t` would return a real string
+    rather than the bare key path."""
+    target = _normalize_lang(lang) if lang else get_language()
+    if key in _load_catalog(target):
+        return True
+    return target != DEFAULT_LANGUAGE and key in _load_catalog(DEFAULT_LANGUAGE)
+
+
 def t(key: str, lang: str | None = None, **format_kwargs: Any) -> str:
     """Translate a dotted key to the active language.
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11230,48 +11230,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if start_ts:
                     elapsed_min = int((now - start_ts) / 60)
                     if elapsed_min > 0:
-                        status_parts.append(f"{elapsed_min} min elapsed")
+                        status_parts.append(t("gateway.busy.elapsed", minutes=elapsed_min))
                 if max_iter:
-                    status_parts.append(f"iteration {iteration}/{max_iter}")
+                    status_parts.append(t("gateway.busy.iteration", current=iteration, max=max_iter))
                 if current_tool:
-                    status_parts.append(f"running: {current_tool}")
+                    status_parts.append(t("gateway.busy.running", tool=current_tool))
             except Exception:
                 pass
 
         status_detail = f" ({', '.join(status_parts)})" if status_parts else ""
         if is_steer_mode:
-            message = (
-                f"⏩ Steered into current run{status_detail}. "
-                f"Your message arrives after the next tool call."
-            )
+            message = t("gateway.busy.steered", detail=status_detail)
         elif is_redirect_mode:
-            message = (
-                f"↪ Redirected current run{status_detail}. "
-                f"I'll adjust using your correction."
-            )
+            message = t("gateway.busy.redirected", detail=status_detail)
         elif is_queue_mode and demoted_for_subagents:
             # #30170 — explain the demotion so the user knows their
             # follow-up didn't accidentally kill the subagent and
             # discovers `/stop` as the explicit escape hatch.
-            message = (
-                f"⏳ Subagent working{status_detail} — your message is queued for "
-                f"when it finishes (use /stop to cancel everything)."
-            )
+            message = t("gateway.busy.subagent_queued", detail=status_detail)
         elif is_queue_mode and demoted_for_compression:
-            message = (
-                f"⏳ Compressing context{status_detail} — your message is queued for "
-                f"when it finishes (use /stop to cancel everything)."
-            )
+            message = t("gateway.busy.compressing_queued", detail=status_detail)
         elif is_queue_mode:
-            message = (
-                f"⏳ Queued for the next turn{status_detail}. "
-                f"I'll respond once the current task finishes."
-            )
+            message = t("gateway.busy.queued", detail=status_detail)
         else:
-            message = (
-                f"⚡ Interrupting current task{status_detail}. "
-                f"I'll respond to your message shortly."
-            )
+            message = t("gateway.busy.interrupting", detail=status_detail)
 
         # First-touch onboarding: the very first time a user sends a message
         # while the agent is busy, append a one-time hint explaining the
@@ -30940,7 +30922,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _parts = []
                         if _want_iteration_detail:
                             _parts.append(
-                                f"iteration {_a['api_call_count']}/{_a['max_iterations']}"
+                                t("gateway.busy.iteration", current=_a['api_call_count'], max=_a['max_iterations'])
                             )
                         _action = _a.get("current_tool") or _a.get("last_activity_desc")
                         if _action:
@@ -30952,7 +30934,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _heartbeat_text = (
                     _generic_status_phrase("status")
                     if _long_running_mode == "generic"
-                    else f"⏳ Working — {_elapsed_mins} min{_status_detail}"
+                    else t("gateway.busy.working", minutes=_elapsed_mins, detail=_status_detail)
                 )
                 try:
                     _notify_res = None

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -665,6 +665,23 @@ def _requires_argument(args_hint: str) -> bool:
     return args_hint.strip().startswith("<")
 
 
+def localized_description(cmd: CommandDef) -> str:
+    """Return the command description in the active UI language.
+
+    Catalog key is ``commands.<name>`` (locales/<lang>.yaml).  Commands without
+    a catalog entry keep their English ``CommandDef.description`` so plugin and
+    rarely-used commands never render as a bare key path.
+    """
+    try:
+        from agent.i18n import has_key, t
+        key = f"commands.{cmd.name}"
+        if has_key(key):
+            return t(key)
+    except Exception:
+        pass
+    return cmd.description
+
+
 def gateway_help_lines() -> list[str]:
     """Generate gateway help text lines from the registry."""
     overrides = _resolve_config_gates()
@@ -680,7 +697,7 @@ def gateway_help_lines() -> list[str]:
                 continue
             alias_parts.append(f"`/{a}`")
         alias_note = f" (alias: {', '.join(alias_parts)})" if alias_parts else ""
-        lines.append(f"`/{cmd.name}{args}` -- {cmd.description}{alias_note}")
+        lines.append(f"`/{cmd.name}{args}` -- {localized_description(cmd)}{alias_note}")
     return lines
 
 
@@ -742,7 +759,7 @@ def telegram_bot_commands(*, include_plugins: bool = True) -> list[tuple[str, st
         # the menu hurts discoverability (issue #24312).
         tg_name = _sanitize_telegram_name(cmd.name)
         if tg_name:
-            result.append((tg_name, cmd.description))
+            result.append((tg_name, localized_description(cmd)))
     if include_plugins:
         for name, description, args_hint in _iter_plugin_command_entries():
             if _requires_argument(args_hint):

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -20,6 +20,19 @@ approval:
   blocklist_message: "Hierdie opdrag is op die onvoorwaardelike blokkeerlys en kan nie goedgekeur word nie."
 
 gateway:
+  # Mid-run replies when a message arrives while the agent is busy, and the
+  # long-running heartbeat. {detail} is a pre-formatted " (…)" suffix.
+  busy:
+    steered: "⏩ Boodskap in die huidige lopie ingestuur{detail}. Dit kom ná die volgende hulpmiddel-oproep aan."
+    redirected: "↪ Huidige lopie herlei{detail}. Ek pas aan volgens jou regstelling."
+    subagent_queued: "⏳ Subagent werk{detail} — jou boodskap wag totdat dit klaar is (/stop kanselleer alles)."
+    compressing_queued: "⏳ Konteks word saamgepers{detail} — jou boodskap wag totdat dit klaar is (/stop kanselleer alles)."
+    queued: "⏳ In die tou vir die volgende beurt{detail}. Ek antwoord sodra die huidige taak klaar is."
+    interrupting: "⚡ Onderbreek die huidige taak{detail}. Ek antwoord binnekort op jou boodskap."
+    elapsed: "{minutes} min verstreke"
+    iteration: "iterasie {current}/{max}"
+    running: "besig: {tool}"
+    working: "⏳ Besig — {minutes} min{detail}"
   approval_expired: "⚠️ Goedkeuring het verval (die agent wag nie meer nie). Vra die agent om weer te probeer."
   draining:         "⏳ Wag vir {count} aktiewe agent(e) voor herbegin..."
   goal_cleared:     "✓ Doelwit verwyder."
@@ -456,3 +469,16 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "Sessie-databasis is nie beskikbaar"
     session_not_found:           "Sessie nie in databasis gevind nie."
     warn_passthrough:            "⚠️ {error}"
+
+# Slash-command descriptions shown in messenger command menus and /help.
+# Commands without an entry keep their English CommandDef.description.
+commands:
+  help: "Wys beskikbare opdragte (/help skills lys vaardigheid-opdragte, /help <teks> filter)"
+  new: "Begin 'n nuwe sessie (nuwe sessie-ID + geskiedenis)"
+  stop: "Stop alle lopende agtergrondprosesse"
+  status: "Wys sessie, model, tokens en konteks"
+  resume: "Hervat 'n vooraf benoemde sessie"
+  sessions: "Blaai deur en hervat vorige sessies"
+  model: "Verander model (vir die sessie; --global maak dit permanent)"
+  compress: "Pers gesprekskonteks saam ('here [N]' hou die laaste N beurte; --preview wys die plan)"
+  voice: "Skakel stemmodus aan of af"

--- a/locales/ar.yaml
+++ b/locales/ar.yaml
@@ -25,6 +25,19 @@ approval:
   blocklist_message: "هذا الأمر مدرج في قائمة الحظر غير المشروطة ولا يمكن الموافقة عليه."
 
 gateway:
+  # Mid-run replies when a message arrives while the agent is busy, and the
+  # long-running heartbeat. {detail} is a pre-formatted " (…)" suffix.
+  busy:
+    steered: "⏩ تم إدراج رسالتك في التشغيل الحالي{detail}. ستصل بعد استدعاء الأداة التالي."
+    redirected: "↪ تمت إعادة توجيه التشغيل الحالي{detail}. سأعدّل وفق تصحيحك."
+    subagent_queued: "⏳ الوكيل الفرعي يعمل{detail} — رسالتك في الانتظار حتى ينتهي (/stop لإلغاء كل شيء)."
+    compressing_queued: "⏳ جارٍ ضغط السياق{detail} — رسالتك في الانتظار حتى ينتهي (/stop لإلغاء كل شيء)."
+    queued: "⏳ في الانتظار للدور التالي{detail}. سأرد عند انتهاء المهمة الحالية."
+    interrupting: "⚡ جارٍ مقاطعة المهمة الحالية{detail}. سأرد على رسالتك قريبًا."
+    elapsed: "مضت {minutes} دقيقة"
+    iteration: "التكرار {current}/{max}"
+    running: "قيد التشغيل: {tool}"
+    working: "⏳ أعمل — {minutes} دقيقة{detail}"
   context:
     header:                "🧠 **Context Window**"
     model:                 "Model: `{model}`"
@@ -458,3 +471,16 @@ gateway:
     session_db_unavailable_prefix: "قاعدة بيانات الجلسات غير متاحة"
     session_not_found:           "لم يُعثر على الجلسة في قاعدة البيانات."
     warn_passthrough:            "⚠️ {error}"
+
+# Slash-command descriptions shown in messenger command menus and /help.
+# Commands without an entry keep their English CommandDef.description.
+commands:
+  help: "عرض الأوامر المتاحة (/help skills يعرض أوامر المهارات، /help <نص> للتصفية)"
+  new: "بدء جلسة جديدة (معرّف جلسة جديد + سجل جديد)"
+  stop: "إيقاف جميع العمليات العاملة في الخلفية"
+  status: "عرض معلومات الجلسة والنموذج والرموز والسياق"
+  resume: "استئناف جلسة مسماة سابقًا"
+  sessions: "تصفح الجلسات السابقة واستئنافها"
+  model: "تبديل النموذج (لهذه الجلسة؛ --global للحفظ الدائم)"
+  compress: "ضغط سياق المحادثة ('here [N]' يحتفظ بآخر N دور؛ --preview يعرض ما سيحدث)"
+  voice: "تشغيل أو إيقاف الوضع الصوتي"

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -20,6 +20,19 @@ approval:
   blocklist_message: "Dieser Befehl steht auf der unbedingten Sperrliste und kann nicht genehmigt werden."
 
 gateway:
+  # Mid-run replies when a message arrives while the agent is busy, and the
+  # long-running heartbeat. {detail} is a pre-formatted " (…)" suffix.
+  busy:
+    steered: "⏩ In den laufenden Durchgang eingesteuert{detail}. Deine Nachricht kommt nach dem nächsten Tool-Aufruf an."
+    redirected: "↪ Laufender Durchgang umgeleitet{detail}. Ich berücksichtige deine Korrektur."
+    subagent_queued: "⏳ Subagent arbeitet{detail} — deine Nachricht wartet, bis er fertig ist (/stop bricht alles ab)."
+    compressing_queued: "⏳ Kontext wird komprimiert{detail} — deine Nachricht wartet, bis das fertig ist (/stop bricht alles ab)."
+    queued: "⏳ Für den nächsten Zug eingereiht{detail}. Ich antworte, sobald die aktuelle Aufgabe fertig ist."
+    interrupting: "⚡ Aktuelle Aufgabe wird unterbrochen{detail}. Ich antworte gleich auf deine Nachricht."
+    elapsed: "{minutes} Min. vergangen"
+    iteration: "Iteration {current}/{max}"
+    running: "läuft: {tool}"
+    working: "⏳ Arbeite — {minutes} Min.{detail}"
   approval_expired: "⚠️ Genehmigung abgelaufen (Agent wartet nicht mehr). Bitten Sie den Agenten, es erneut zu versuchen."
   draining:         "⏳ Warte auf {count} aktive(n) Agent(en) vor dem Neustart..."
   goal_cleared:     "✓ Ziel gelöscht."
@@ -456,3 +469,16 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "Session-Datenbank nicht verfügbar"
     session_not_found:           "Session nicht in der Datenbank gefunden."
     warn_passthrough:            "⚠️ {error}"
+
+# Slash-command descriptions shown in messenger command menus and /help.
+# Commands without an entry keep their English CommandDef.description.
+commands:
+  help: "Verfügbare Befehle anzeigen (/help skills listet Skill-Befehle, /help <Text> filtert)"
+  new: "Neue Sitzung starten (neue Sitzungs-ID + Verlauf)"
+  stop: "Alle laufenden Hintergrundprozesse beenden"
+  status: "Sitzung, Modell, Token und Kontext anzeigen"
+  resume: "Eine zuvor benannte Sitzung fortsetzen"
+  sessions: "Frühere Sitzungen durchsuchen und fortsetzen"
+  model: "Modell wechseln (für die Sitzung; --global speichert dauerhaft)"
+  compress: "Gesprächskontext komprimieren ('here [N]' behält die letzten N Züge; --preview zeigt die Vorschau)"
+  voice: "Sprachmodus ein-/ausschalten"

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -1,9 +1,10 @@
 # Hermes static-message catalog -- English (baseline / source of truth)
 #
-# Only user-facing static messages from the CLI approval prompt and a handful
-# of gateway slash-command replies live here.  Agent-generated output, log
-# lines, error tracebacks, tool outputs, and slash-command descriptions stay
-# in English and are NOT translated -- see agent/i18n.py for scope rationale.
+# Only user-facing static messages from the CLI approval prompt, a handful of
+# gateway slash-command replies, the mid-run busy notices and the messenger
+# command-menu descriptions live here.  Agent-generated output, log lines,
+# error tracebacks and tool outputs stay in English and are NOT translated --
+# see agent/i18n.py for scope rationale.
 #
 # Keys are dotted paths; nesting below is purely for readability.  Values may
 # contain {placeholder} tokens for str.format substitution.  When adding a
@@ -30,6 +31,19 @@ approval:
   blocklist_message: "This command is on the unconditional blocklist and cannot be approved."
 
 gateway:
+  # Mid-run replies when a message arrives while the agent is busy, and the
+  # long-running heartbeat. {detail} is a pre-formatted " (…)" suffix.
+  busy:
+    steered: "⏩ Steered into current run{detail}. Your message arrives after the next tool call."
+    redirected: "↪ Redirected current run{detail}. I'll adjust using your correction."
+    subagent_queued: "⏳ Subagent working{detail} — your message is queued for when it finishes (use /stop to cancel everything)."
+    compressing_queued: "⏳ Compressing context{detail} — your message is queued for when it finishes (use /stop to cancel everything)."
+    queued: "⏳ Queued for the next turn{detail}. I'll respond once the current task finishes."
+    interrupting: "⚡ Interrupting current task{detail}. I'll respond to your message shortly."
+    elapsed: "{minutes} min elapsed"
+    iteration: "iteration {current}/{max}"
+    running: "running: {tool}"
+    working: "⏳ Working — {minutes} min{detail}"
   # Messenger replies to slash commands and implicit state changes.
   approval_expired: "⚠️ Approval expired (agent is no longer waiting). Ask the agent to try again."
   draining:         "⏳ Draining {count} active agent(s) before restart..."
@@ -469,3 +483,16 @@ gateway:
     session_db_unavailable_prefix: "Session database not available"
     session_not_found:           "Session not found in database."
     warn_passthrough:            "⚠️ {error}"
+
+# Slash-command descriptions shown in messenger command menus and /help.
+# Commands without an entry keep their English CommandDef.description.
+commands:
+  help: "Show available commands (/help skills lists skill commands, /help <text> filters)"
+  new: "Start a new session (fresh session ID + history)"
+  stop: "Kill all running background processes"
+  status: "Show session, model, token, and context info"
+  resume: "Resume a previously-named session"
+  sessions: "Browse and resume previous sessions"
+  model: "Switch model (session-scoped; --global to persist)"
+  compress: "Compress conversation context (add 'here [N]' to keep recent N turns; --preview shows what would happen)"
+  voice: "Toggle voice mode"

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -20,6 +20,19 @@ approval:
   blocklist_message: "Este comando está en la lista de bloqueo incondicional y no se puede aprobar."
 
 gateway:
+  # Mid-run replies when a message arrives while the agent is busy, and the
+  # long-running heartbeat. {detail} is a pre-formatted " (…)" suffix.
+  busy:
+    steered: "⏩ Mensaje inyectado en la ejecución actual{detail}. Llegará después de la próxima llamada a herramienta."
+    redirected: "↪ Ejecución actual redirigida{detail}. Ajustaré según tu corrección."
+    subagent_queued: "⏳ Subagente trabajando{detail} — tu mensaje queda en cola hasta que termine (/stop cancela todo)."
+    compressing_queued: "⏳ Comprimiendo contexto{detail} — tu mensaje queda en cola hasta que termine (/stop cancela todo)."
+    queued: "⏳ En cola para el siguiente turno{detail}. Responderé cuando termine la tarea actual."
+    interrupting: "⚡ Interrumpiendo la tarea actual{detail}. Responderé a tu mensaje en breve."
+    elapsed: "{minutes} min transcurridos"
+    iteration: "iteración {current}/{max}"
+    running: "ejecutando: {tool}"
+    working: "⏳ Trabajando — {minutes} min{detail}"
   approval_expired: "⚠️ La aprobación ha caducado (el agente ya no está esperando). Pida al agente que lo intente de nuevo."
   draining:         "⏳ Esperando a que terminen {count} agente(s) activo(s) antes de reiniciar..."
   goal_cleared:     "✓ Objetivo eliminado."
@@ -453,3 +466,16 @@ gateway:
     session_db_unavailable_prefix: "Base de datos de sesiones no disponible"
     session_not_found:           "Sesión no encontrada en la base de datos."
     warn_passthrough:            "⚠️ {error}"
+
+# Slash-command descriptions shown in messenger command menus and /help.
+# Commands without an entry keep their English CommandDef.description.
+commands:
+  help: "Mostrar comandos disponibles (/help skills lista comandos de skills, /help <texto> filtra)"
+  new: "Iniciar una sesión nueva (nuevo ID de sesión + historial)"
+  stop: "Detener todos los procesos en segundo plano"
+  status: "Mostrar sesión, modelo, tokens y contexto"
+  resume: "Reanudar una sesión guardada por nombre"
+  sessions: "Explorar y reanudar sesiones anteriores"
+  model: "Cambiar de modelo (para la sesión; --global lo guarda)"
+  compress: "Comprimir el contexto de la conversación ('here [N]' conserva los últimos N turnos; --preview muestra el plan)"
+  voice: "Activar o desactivar el modo de voz"

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -20,6 +20,19 @@ approval:
   blocklist_message: "Cette commande est sur la liste de blocage inconditionnel et ne peut pas être approuvée."
 
 gateway:
+  # Mid-run replies when a message arrives while the agent is busy, and the
+  # long-running heartbeat. {detail} is a pre-formatted " (…)" suffix.
+  busy:
+    steered: "⏩ Message injecté dans l'exécution en cours{detail}. Il arrivera après le prochain appel d'outil."
+    redirected: "↪ Exécution en cours redirigée{detail}. Je tiendrai compte de ta correction."
+    subagent_queued: "⏳ Sous-agent en cours{detail} — ton message est en attente jusqu'à sa fin (/stop annule tout)."
+    compressing_queued: "⏳ Compression du contexte{detail} — ton message est en attente jusqu'à la fin (/stop annule tout)."
+    queued: "⏳ En file pour le prochain tour{detail}. Je répondrai dès que la tâche en cours sera terminée."
+    interrupting: "⚡ Interruption de la tâche en cours{detail}. Je réponds à ton message dans un instant."
+    elapsed: "{minutes} min écoulées"
+    iteration: "itération {current}/{max}"
+    running: "en cours : {tool}"
+    working: "⏳ Je travaille — {minutes} min{detail}"
   approval_expired: "⚠️ Approbation expirée (l'agent n'attend plus). Demandez à l'agent de réessayer."
   draining:         "⏳ Vidage de {count} agent(s) actif(s) avant redémarrage..."
   goal_cleared:     "✓ Objectif effacé."
@@ -456,3 +469,16 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "Base de données de sessions indisponible"
     session_not_found:           "Session introuvable dans la base de données."
     warn_passthrough:            "⚠️ {error}"
+
+# Slash-command descriptions shown in messenger command menus and /help.
+# Commands without an entry keep their English CommandDef.description.
+commands:
+  help: "Afficher les commandes disponibles (/help skills liste les commandes de skills, /help <texte> filtre)"
+  new: "Démarrer une nouvelle session (nouvel ID + historique)"
+  stop: "Arrêter tous les processus en arrière-plan"
+  status: "Afficher la session, le modèle, les tokens et le contexte"
+  resume: "Reprendre une session nommée"
+  sessions: "Parcourir et reprendre les sessions précédentes"
+  model: "Changer de modèle (pour la session ; --global pour persister)"
+  compress: "Compresser le contexte de la conversation ('here [N]' garde les N derniers tours ; --preview montre le plan)"
+  voice: "Activer ou désactiver le mode vocal"

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -24,6 +24,19 @@ approval:
   blocklist_message: "Tá an t-ordú seo ar an liosta cosc gan choinníoll agus ní féidir é a cheadú."
 
 gateway:
+  # Mid-run replies when a message arrives while the agent is busy, and the
+  # long-running heartbeat. {detail} is a pre-formatted " (…)" suffix.
+  busy:
+    steered: "⏩ Teachtaireacht curtha isteach sa rith reatha{detail}. Sroichfidh sí tar éis an chéad ghlao uirlise eile."
+    redirected: "↪ Rith reatha atreoraithe{detail}. Cuirfidh mé do cheartú san áireamh."
+    subagent_queued: "⏳ Fo-ghníomhaire ag obair{detail} — tá do theachtaireacht i scuaine go dtí go gcríochnóidh sé (/stop chun gach rud a chealú)."
+    compressing_queued: "⏳ Comhthéacs á chomhbhrú{detail} — tá do theachtaireacht i scuaine go dtí go gcríochnóidh sé (/stop chun gach rud a chealú)."
+    queued: "⏳ I scuaine don chéad seal eile{detail}. Freagróidh mé nuair a bheidh an tasc reatha críochnaithe."
+    interrupting: "⚡ Ag cur isteach ar an tasc reatha{detail}. Freagróidh mé do theachtaireacht go luath."
+    elapsed: "{minutes} nóim caite"
+    iteration: "atriall {current}/{max}"
+    running: "ag rith: {tool}"
+    working: "⏳ Ag obair — {minutes} nóim{detail}"
   approval_expired: "⚠️ Tá an cead imithe in éag (níl an gníomhaire ag fanacht níos mó). Iarr ar an ngníomhaire iarracht eile a dhéanamh."
   draining:         "⏳ Ag fanacht le {count} gníomhaire(í) gníomhach roimh atosú..."
   goal_cleared:     "✓ Sprioc glanta."
@@ -460,3 +473,16 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "Níl bunachar sonraí na seisiún ar fáil"
     session_not_found:           "Seisiún gan a aimsiú sa bhunachar sonraí."
     warn_passthrough:            "⚠️ {error}"
+
+# Slash-command descriptions shown in messenger command menus and /help.
+# Commands without an entry keep their English CommandDef.description.
+commands:
+  help: "Taispeáin na horduithe atá ar fáil (/help skills: orduithe scileanna, /help <téacs>: scagadh)"
+  new: "Tosaigh seisiún nua (ID seisiúin nua + stair)"
+  stop: "Stop gach próiseas cúlra atá ag rith"
+  status: "Taispeáin seisiún, samhail, comharthaí agus comhthéacs"
+  resume: "Atosaigh seisiún a ainmníodh roimhe seo"
+  sessions: "Brabhsáil agus atosaigh seisiúin roimhe seo"
+  model: "Athraigh samhail (don seisiún; --global le sábháil)"
+  compress: "Comhbhrúigh comhthéacs an chomhrá ('here [N]' coinníonn na N seal deireanacha; --preview taispeánann an plean)"
+  voice: "Cas mód gutha air nó as"

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -20,6 +20,19 @@ approval:
   blocklist_message: "Ez a parancs a feltétel nélküli tiltólistán van, és nem hagyható jóvá."
 
 gateway:
+  # Mid-run replies when a message arrives while the agent is busy, and the
+  # long-running heartbeat. {detail} is a pre-formatted " (…)" suffix.
+  busy:
+    steered: "⏩ Üzenet beillesztve a futó feladatba{detail}. A következő eszközhívás után érkezik meg."
+    redirected: "↪ A futó feladat átirányítva{detail}. Figyelembe veszem a javításodat."
+    subagent_queued: "⏳ Alügynök dolgozik{detail} — az üzeneted sorban áll, amíg végez (/stop mindent leállít)."
+    compressing_queued: "⏳ Kontextus tömörítése{detail} — az üzeneted sorban áll, amíg végez (/stop mindent leállít)."
+    queued: "⏳ Sorban a következő körre{detail}. Válaszolok, amint a jelenlegi feladat elkészül."
+    interrupting: "⚡ Megszakítom a jelenlegi feladatot{detail}. Hamarosan válaszolok az üzenetedre."
+    elapsed: "{minutes} perc telt el"
+    iteration: "iteráció {current}/{max}"
+    running: "fut: {tool}"
+    working: "⏳ Dolgozom — {minutes} perc{detail}"
   approval_expired: "⚠️ A jóváhagyás lejárt (az ügynök már nem vár). Kérd meg az ügynököt, hogy próbálja újra."
   draining:         "⏳ {count} aktív ügynök befejezésére várunk az újraindítás előtt..."
   goal_cleared:     "✓ A cél törölve."
@@ -456,3 +469,16 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "A munkamenet-adatbázis nem érhető el"
     session_not_found:           "A munkamenet nem található az adatbázisban."
     warn_passthrough:            "⚠️ {error}"
+
+# Slash-command descriptions shown in messenger command menus and /help.
+# Commands without an entry keep their English CommandDef.description.
+commands:
+  help: "Elérhető parancsok (/help skills a képesség-parancsokat listázza, /help <szöveg> szűr)"
+  new: "Új munkamenet indítása (új azonosító + előzmények)"
+  stop: "Minden futó háttérfolyamat leállítása"
+  status: "Munkamenet, modell, tokenek és kontextus megjelenítése"
+  resume: "Korábban elnevezett munkamenet folytatása"
+  sessions: "Korábbi munkamenetek böngészése és folytatása"
+  model: "Modellváltás (a munkamenetre; --global tartósan)"
+  compress: "Beszélgetési kontextus tömörítése ('here [N]' megtartja az utolsó N kört; --preview előnézet)"
+  voice: "Hangmód be-/kikapcsolása"

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -20,6 +20,19 @@ approval:
   blocklist_message: "Questo comando è nella lista di blocco incondizionata e non può essere approvato."
 
 gateway:
+  # Mid-run replies when a message arrives while the agent is busy, and the
+  # long-running heartbeat. {detail} is a pre-formatted " (…)" suffix.
+  busy:
+    steered: "⏩ Messaggio inserito nell'esecuzione corrente{detail}. Arriverà dopo la prossima chiamata a strumento."
+    redirected: "↪ Esecuzione corrente reindirizzata{detail}. Terrò conto della tua correzione."
+    subagent_queued: "⏳ Subagente al lavoro{detail} — il tuo messaggio è in coda fino al termine (/stop annulla tutto)."
+    compressing_queued: "⏳ Compressione del contesto{detail} — il tuo messaggio è in coda fino al termine (/stop annulla tutto)."
+    queued: "⏳ In coda per il prossimo turno{detail}. Risponderò appena finisce l'attività corrente."
+    interrupting: "⚡ Interrompo l'attività corrente{detail}. Risponderò al tuo messaggio a breve."
+    elapsed: "{minutes} min trascorsi"
+    iteration: "iterazione {current}/{max}"
+    running: "in esecuzione: {tool}"
+    working: "⏳ Al lavoro — {minutes} min{detail}"
   approval_expired: "⚠️ Approvazione scaduta (l'agente non è più in attesa). Chiedi all'agente di riprovare."
   draining:         "⏳ Attendo il completamento di {count} agente/i attivo/i prima di riavviare..."
   goal_cleared:     "✓ Obiettivo cancellato."
@@ -456,3 +469,16 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "Database delle sessioni non disponibile"
     session_not_found:           "Sessione non trovata nel database."
     warn_passthrough:            "⚠️ {error}"
+
+# Slash-command descriptions shown in messenger command menus and /help.
+# Commands without an entry keep their English CommandDef.description.
+commands:
+  help: "Mostra i comandi disponibili (/help skills elenca i comandi delle skill, /help <testo> filtra)"
+  new: "Avvia una nuova sessione (nuovo ID + cronologia)"
+  stop: "Termina tutti i processi in background"
+  status: "Mostra sessione, modello, token e contesto"
+  resume: "Riprendi una sessione salvata per nome"
+  sessions: "Sfoglia e riprendi le sessioni precedenti"
+  model: "Cambia modello (per la sessione; --global per renderlo permanente)"
+  compress: "Comprimi il contesto della conversazione ('here [N]' mantiene gli ultimi N turni; --preview mostra il piano)"
+  voice: "Attiva o disattiva la modalità vocale"

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -20,6 +20,19 @@ approval:
   blocklist_message: "このコマンドは無条件ブロックリストに含まれており、承認できません。"
 
 gateway:
+  # Mid-run replies when a message arrives while the agent is busy, and the
+  # long-running heartbeat. {detail} is a pre-formatted " (…)" suffix.
+  busy:
+    steered: "⏩ 現在の実行に割り込みました{detail}。次のツール呼び出しの後に届きます。"
+    redirected: "↪ 現在の実行を方向転換しました{detail}。あなたの修正に合わせて調整します。"
+    subagent_queued: "⏳ サブエージェントが作業中{detail} — 完了までメッセージは待機します（/stop で全て中止）。"
+    compressing_queued: "⏳ コンテキストを圧縮中{detail} — 完了までメッセージは待機します（/stop で全て中止）。"
+    queued: "⏳ 次のターンに待機中{detail}。現在のタスクが終わり次第返信します。"
+    interrupting: "⚡ 現在のタスクを中断します{detail}。まもなくメッセージに返信します。"
+    elapsed: "{minutes} 分経過"
+    iteration: "イテレーション {current}/{max}"
+    running: "実行中: {tool}"
+    working: "⏳ 作業中 — {minutes} 分{detail}"
   approval_expired: "⚠️ 承認の有効期限が切れました（エージェントはもう待機していません）。エージェントに再試行を依頼してください。"
   draining:         "⏳ 再起動前に {count} 個のアクティブエージェントの終了を待っています..."
   goal_cleared:     "✓ 目標をクリアしました。"
@@ -456,3 +469,16 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "セッションデータベースが利用できません"
     session_not_found:           "データベースにセッションが見つかりません。"
     warn_passthrough:            "⚠️ {error}"
+
+# Slash-command descriptions shown in messenger command menus and /help.
+# Commands without an entry keep their English CommandDef.description.
+commands:
+  help: "利用可能なコマンドを表示（/help skills でスキルコマンド一覧、/help <テキスト> で絞り込み）"
+  new: "新しいセッションを開始（新しいセッション ID と履歴）"
+  stop: "実行中のバックグラウンドプロセスをすべて停止"
+  status: "セッション・モデル・トークン・コンテキスト情報を表示"
+  resume: "名前を付けたセッションを再開"
+  sessions: "過去のセッションを閲覧して再開"
+  model: "モデルを切り替え（セッション内のみ。--global で永続化）"
+  compress: "会話コンテキストを圧縮（'here [N]' で直近 N ターンを保持、--preview で結果を確認）"
+  voice: "音声モードの切り替え"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -20,6 +20,19 @@ approval:
   blocklist_message: "이 명령은 무조건 차단 목록에 있으며 승인할 수 없습니다."
 
 gateway:
+  # Mid-run replies when a message arrives while the agent is busy, and the
+  # long-running heartbeat. {detail} is a pre-formatted " (…)" suffix.
+  busy:
+    steered: "⏩ 현재 실행에 메시지를 끼워 넣었습니다{detail}. 다음 도구 호출 후에 전달됩니다."
+    redirected: "↪ 현재 실행을 방향 전환했습니다{detail}. 수정 내용을 반영하겠습니다."
+    subagent_queued: "⏳ 서브에이전트 작업 중{detail} — 완료될 때까지 메시지가 대기합니다 (/stop 으로 전부 취소)."
+    compressing_queued: "⏳ 컨텍스트 압축 중{detail} — 완료될 때까지 메시지가 대기합니다 (/stop 으로 전부 취소)."
+    queued: "⏳ 다음 차례에 대기 중{detail}. 현재 작업이 끝나면 답변하겠습니다."
+    interrupting: "⚡ 현재 작업을 중단합니다{detail}. 곧 메시지에 답변하겠습니다."
+    elapsed: "{minutes}분 경과"
+    iteration: "반복 {current}/{max}"
+    running: "실행 중: {tool}"
+    working: "⏳ 작업 중 — {minutes}분{detail}"
   approval_expired: "⚠️ 승인이 만료되었습니다 (에이전트가 더 이상 대기하지 않습니다). 에이전트에게 다시 시도하도록 요청하세요."
   draining:         "⏳ 재시작 전에 활성 에이전트 {count}명을 정리하는 중..."
   goal_cleared:     "✓ 목표가 삭제되었습니다."
@@ -456,3 +469,16 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "세션 데이터베이스를 사용할 수 없습니다"
     session_not_found:           "데이터베이스에서 세션을 찾을 수 없습니다."
     warn_passthrough:            "⚠️ {error}"
+
+# Slash-command descriptions shown in messenger command menus and /help.
+# Commands without an entry keep their English CommandDef.description.
+commands:
+  help: "사용 가능한 명령 표시 (/help skills 는 스킬 명령 목록, /help <텍스트> 는 필터)"
+  new: "새 세션 시작 (새 세션 ID + 기록)"
+  stop: "실행 중인 모든 백그라운드 프로세스 종료"
+  status: "세션, 모델, 토큰, 컨텍스트 정보 표시"
+  resume: "이름을 지정한 이전 세션 이어가기"
+  sessions: "이전 세션 찾아보기 및 이어가기"
+  model: "모델 전환 (세션 범위; --global 은 영구 저장)"
+  compress: "대화 컨텍스트 압축 ('here [N]' 은 최근 N턴 유지, --preview 는 미리보기)"
+  voice: "음성 모드 켜기/끄기"

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -20,6 +20,19 @@ approval:
   blocklist_message: "Este comando está na lista de bloqueio incondicional e não pode ser aprovado."
 
 gateway:
+  # Mid-run replies when a message arrives while the agent is busy, and the
+  # long-running heartbeat. {detail} is a pre-formatted " (…)" suffix.
+  busy:
+    steered: "⏩ Mensagem inserida na execução atual{detail}. Ela chega após a próxima chamada de ferramenta."
+    redirected: "↪ Execução atual redirecionada{detail}. Vou ajustar conforme sua correção."
+    subagent_queued: "⏳ Subagente trabalhando{detail} — sua mensagem fica na fila até ele terminar (/stop cancela tudo)."
+    compressing_queued: "⏳ Comprimindo contexto{detail} — sua mensagem fica na fila até terminar (/stop cancela tudo)."
+    queued: "⏳ Na fila para o próximo turno{detail}. Respondo assim que a tarefa atual terminar."
+    interrupting: "⚡ Interrompendo a tarefa atual{detail}. Respondo à sua mensagem em instantes."
+    elapsed: "{minutes} min decorridos"
+    iteration: "iteração {current}/{max}"
+    running: "executando: {tool}"
+    working: "⏳ Trabalhando — {minutes} min{detail}"
   approval_expired: "⚠️ A aprovação expirou (o agente já não está à espera). Peça ao agente para tentar novamente."
   draining:         "⏳ A aguardar que {count} agente(s) ativo(s) terminem antes de reiniciar..."
   goal_cleared:     "✓ Objetivo removido."
@@ -456,3 +469,16 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "Base de dados de sessões indisponível"
     session_not_found:           "Sessão não encontrada na base de dados."
     warn_passthrough:            "⚠️ {error}"
+
+# Slash-command descriptions shown in messenger command menus and /help.
+# Commands without an entry keep their English CommandDef.description.
+commands:
+  help: "Mostrar comandos disponíveis (/help skills lista comandos de skills, /help <texto> filtra)"
+  new: "Iniciar uma nova sessão (novo ID + histórico)"
+  stop: "Encerrar todos os processos em segundo plano"
+  status: "Mostrar sessão, modelo, tokens e contexto"
+  resume: "Retomar uma sessão salva pelo nome"
+  sessions: "Navegar e retomar sessões anteriores"
+  model: "Trocar de modelo (para a sessão; --global para persistir)"
+  compress: "Comprimir o contexto da conversa ('here [N]' mantém os últimos N turnos; --preview mostra o plano)"
+  voice: "Ativar ou desativar o modo de voz"

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -20,6 +20,19 @@ approval:
   blocklist_message: "Эта команда находится в безусловном списке блокировки и не может быть одобрена."
 
 gateway:
+  # Mid-run replies when a message arrives while the agent is busy, and the
+  # long-running heartbeat. {detail} is a pre-formatted " (…)" suffix.
+  busy:
+    steered: "⏩ Сообщение передано в текущий запуск{detail}. Агент увидит его после следующего вызова инструмента."
+    redirected: "↪ Текущий запуск перенаправлен{detail}. Учту вашу поправку."
+    subagent_queued: "⏳ Работает субагент{detail} — ваше сообщение в очереди до его завершения (/stop отменяет всё)."
+    compressing_queued: "⏳ Сжимаю контекст{detail} — ваше сообщение в очереди до завершения (/stop отменяет всё)."
+    queued: "⏳ В очереди на следующий ход{detail}. Отвечу, как только закончу текущую задачу."
+    interrupting: "⚡ Прерываю текущую задачу{detail}. Скоро отвечу на ваше сообщение."
+    elapsed: "прошло {minutes} мин"
+    iteration: "итерация {current}/{max}"
+    running: "выполняется: {tool}"
+    working: "⏳ Работаю — {minutes} мин{detail}"
   approval_expired: "⚠️ Срок одобрения истёк (агент больше не ожидает). Попросите агента повторить попытку."
   draining:         "⏳ Ожидание завершения {count} активных агент(ов) перед перезапуском..."
   goal_cleared:     "✓ Цель очищена."
@@ -456,3 +469,16 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "База данных сеансов недоступна"
     session_not_found:           "Сеанс не найден в базе данных."
     warn_passthrough:            "⚠️ {error}"
+
+# Slash-command descriptions shown in messenger command menus and /help.
+# Commands without an entry keep their English CommandDef.description.
+commands:
+  help: "Показать доступные команды (/help skills — команды навыков, /help <текст> — фильтр)"
+  new: "Начать новый разговор (новая сессия и история)"
+  stop: "Остановить все фоновые процессы"
+  status: "Показать сессию, модель, токены и контекст"
+  resume: "Продолжить сохранённую сессию по имени"
+  sessions: "Список прошлых сессий и возврат к ним"
+  model: "Сменить модель (для сессии; --global — навсегда)"
+  compress: "Сжать контекст разговора ('here [N]' — оставить последние N ходов; --preview — показать план)"
+  voice: "Включить или выключить голосовые ответы"

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -20,6 +20,19 @@ approval:
   blocklist_message: "Bu komut koşulsuz engelleme listesinde ve onaylanamaz."
 
 gateway:
+  # Mid-run replies when a message arrives while the agent is busy, and the
+  # long-running heartbeat. {detail} is a pre-formatted " (…)" suffix.
+  busy:
+    steered: "⏩ Mesaj mevcut çalıştırmaya yönlendirildi{detail}. Bir sonraki araç çağrısından sonra ulaşacak."
+    redirected: "↪ Mevcut çalıştırma yeniden yönlendirildi{detail}. Düzeltmeni dikkate alacağım."
+    subagent_queued: "⏳ Alt ajan çalışıyor{detail} — mesajın bitene kadar kuyrukta (/stop her şeyi iptal eder)."
+    compressing_queued: "⏳ Bağlam sıkıştırılıyor{detail} — mesajın bitene kadar kuyrukta (/stop her şeyi iptal eder)."
+    queued: "⏳ Sonraki tur için kuyruğa alındı{detail}. Mevcut görev bitince yanıtlayacağım."
+    interrupting: "⚡ Mevcut görev kesiliyor{detail}. Mesajına birazdan yanıt vereceğim."
+    elapsed: "{minutes} dk geçti"
+    iteration: "yineleme {current}/{max}"
+    running: "çalışıyor: {tool}"
+    working: "⏳ Çalışıyorum — {minutes} dk{detail}"
   approval_expired: "⚠️ Onay süresi doldu (ajan artık beklemiyor). Ajanın tekrar denemesini isteyin."
   draining:         "⏳ Yeniden başlatmadan önce {count} aktif ajan bekleniyor..."
   goal_cleared:     "✓ Hedef temizlendi."
@@ -456,3 +469,16 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "Oturum veritabanı kullanılamıyor"
     session_not_found:           "Oturum veritabanında bulunamadı."
     warn_passthrough:            "⚠️ {error}"
+
+# Slash-command descriptions shown in messenger command menus and /help.
+# Commands without an entry keep their English CommandDef.description.
+commands:
+  help: "Kullanılabilir komutları göster (/help skills beceri komutlarını listeler, /help <metin> filtreler)"
+  new: "Yeni oturum başlat (yeni oturum kimliği + geçmiş)"
+  stop: "Çalışan tüm arka plan işlemlerini durdur"
+  status: "Oturum, model, token ve bağlam bilgisini göster"
+  resume: "Adı verilen bir oturumu sürdür"
+  sessions: "Önceki oturumlara göz at ve sürdür"
+  model: "Modeli değiştir (oturum için; --global kalıcı yapar)"
+  compress: "Konuşma bağlamını sıkıştır ('here [N]' son N turu korur; --preview planı gösterir)"
+  voice: "Ses modunu aç/kapat"

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -20,6 +20,19 @@ approval:
   blocklist_message: "Ця команда є в безумовному списку блокування, її не можна схвалити."
 
 gateway:
+  # Mid-run replies when a message arrives while the agent is busy, and the
+  # long-running heartbeat. {detail} is a pre-formatted " (…)" suffix.
+  busy:
+    steered: "⏩ Повідомлення передано в поточний запуск{detail}. Агент побачить його після наступного виклику інструмента."
+    redirected: "↪ Поточний запуск перенаправлено{detail}. Врахую ваше виправлення."
+    subagent_queued: "⏳ Працює субагент{detail} — ваше повідомлення в черзі до його завершення (/stop скасовує все)."
+    compressing_queued: "⏳ Стискаю контекст{detail} — ваше повідомлення в черзі до завершення (/stop скасовує все)."
+    queued: "⏳ У черзі на наступний хід{detail}. Відповім, щойно закінчу поточне завдання."
+    interrupting: "⚡ Перериваю поточне завдання{detail}. Незабаром відповім на ваше повідомлення."
+    elapsed: "минуло {minutes} хв"
+    iteration: "ітерація {current}/{max}"
+    running: "виконується: {tool}"
+    working: "⏳ Працюю — {minutes} хв{detail}"
   approval_expired: "⚠️ Час схвалення минув (агент більше не очікує). Попросіть агента спробувати ще раз."
   draining:         "⏳ Очікування завершення {count} активних агент(ів) перед перезапуском..."
   goal_cleared:     "✓ Ціль очищено."
@@ -456,3 +469,16 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "База даних сеансів недоступна"
     session_not_found:           "Сеанс не знайдено в базі даних."
     warn_passthrough:            "⚠️ {error}"
+
+# Slash-command descriptions shown in messenger command menus and /help.
+# Commands without an entry keep their English CommandDef.description.
+commands:
+  help: "Показати доступні команди (/help skills — команди навичок, /help <текст> — фільтр)"
+  new: "Почати нову розмову (нова сесія та історія)"
+  stop: "Зупинити всі фонові процеси"
+  status: "Показати сесію, модель, токени та контекст"
+  resume: "Продовжити збережену сесію за назвою"
+  sessions: "Список минулих сесій і повернення до них"
+  model: "Змінити модель (для сесії; --global — назавжди)"
+  compress: "Стиснути контекст розмови ('here [N]' — залишити останні N ходів; --preview — показати план)"
+  voice: "Увімкнути або вимкнути голосові відповіді"

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -20,6 +20,19 @@ approval:
   blocklist_message: "此指令位於無條件封鎖清單中，無法被批准。"
 
 gateway:
+  # Mid-run replies when a message arrives while the agent is busy, and the
+  # long-running heartbeat. {detail} is a pre-formatted " (…)" suffix.
+  busy:
+    steered: "⏩ 已插入目前執行{detail}。你的訊息將在下一次工具呼叫後送達。"
+    redirected: "↪ 已重新導向目前執行{detail}。我會依你的更正進行調整。"
+    subagent_queued: "⏳ 子代理工作中{detail} — 你的訊息已排隊，待其完成後處理（/stop 可取消全部）。"
+    compressing_queued: "⏳ 正在壓縮上下文{detail} — 你的訊息已排隊，待其完成後處理（/stop 可取消全部）。"
+    queued: "⏳ 已排隊到下一輪{detail}。目前任務完成後我會回覆。"
+    interrupting: "⚡ 正在中斷目前任務{detail}。我很快會回覆你的訊息。"
+    elapsed: "已用 {minutes} 分鐘"
+    iteration: "第 {current}/{max} 輪"
+    running: "執行中：{tool}"
+    working: "⏳ 工作中 — {minutes} 分鐘{detail}"
   approval_expired: "⚠️ 批准已逾期（代理不再等待）。請讓代理重試。"
   draining:         "⏳ 正在等待 {count} 個活躍代理結束後重新啟動..."
   goal_cleared:     "✓ 目標已清除。"
@@ -456,3 +469,16 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "工作階段資料庫無法使用"
     session_not_found:           "資料庫中找不到此工作階段。"
     warn_passthrough:            "⚠️ {error}"
+
+# Slash-command descriptions shown in messenger command menus and /help.
+# Commands without an entry keep their English CommandDef.description.
+commands:
+  help: "顯示可用指令（/help skills 列出技能指令，/help <文字> 篩選）"
+  new: "開始新工作階段（新的工作階段 ID 和歷史）"
+  stop: "終止所有執行中的背景程序"
+  status: "顯示工作階段、模型、權杖和上下文資訊"
+  resume: "恢復先前命名的工作階段"
+  sessions: "瀏覽並恢復先前的工作階段"
+  model: "切換模型（僅目前工作階段；--global 永久保存）"
+  compress: "壓縮對話上下文（'here [N]' 保留最近 N 輪；--preview 預覽效果）"
+  voice: "切換語音模式"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -20,6 +20,19 @@ approval:
   blocklist_message: "此命令位于无条件拦截列表中，无法被批准。"
 
 gateway:
+  # Mid-run replies when a message arrives while the agent is busy, and the
+  # long-running heartbeat. {detail} is a pre-formatted " (…)" suffix.
+  busy:
+    steered: "⏩ 已插入当前运行{detail}。你的消息将在下一次工具调用后送达。"
+    redirected: "↪ 已重定向当前运行{detail}。我会按你的更正进行调整。"
+    subagent_queued: "⏳ 子代理工作中{detail} — 你的消息已排队，待其完成后处理（/stop 可取消全部）。"
+    compressing_queued: "⏳ 正在压缩上下文{detail} — 你的消息已排队，待其完成后处理（/stop 可取消全部）。"
+    queued: "⏳ 已排队到下一轮{detail}。当前任务完成后我会回复。"
+    interrupting: "⚡ 正在中断当前任务{detail}。我很快会回复你的消息。"
+    elapsed: "已用 {minutes} 分钟"
+    iteration: "第 {current}/{max} 轮"
+    running: "运行中：{tool}"
+    working: "⏳ 工作中 — {minutes} 分钟{detail}"
   approval_expired: "⚠️ 批准已过期（代理不再等待）。请让代理重试。"
   draining:         "⏳ 正在等待 {count} 个活跃代理结束后重启..."
   goal_cleared:     "✓ 目标已清除。"
@@ -456,3 +469,16 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "会话数据库不可用"
     session_not_found:           "数据库中未找到该会话。"
     warn_passthrough:            "⚠️ {error}"
+
+# Slash-command descriptions shown in messenger command menus and /help.
+# Commands without an entry keep their English CommandDef.description.
+commands:
+  help: "显示可用命令（/help skills 列出技能命令，/help <文本> 过滤）"
+  new: "开始新会话（新的会话 ID 和历史）"
+  stop: "终止所有正在运行的后台进程"
+  status: "显示会话、模型、令牌和上下文信息"
+  resume: "恢复之前命名的会话"
+  sessions: "浏览并恢复以前的会话"
+  model: "切换模型（仅当前会话；--global 永久保存）"
+  compress: "压缩对话上下文（'here [N]' 保留最近 N 轮；--preview 预览效果）"
+  voice: "切换语音模式"

--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -140,3 +140,30 @@ def test_locales_dir_env_override_ignored_when_missing(tmp_path, monkeypatch):
     assert result.name == "locales"
 
 
+
+
+# ---------------------------------------------------------------------------
+# Command-menu descriptions and busy notices (commands.*, gateway.busy.*)
+# ---------------------------------------------------------------------------
+
+
+def test_has_key_sees_english_fallback(monkeypatch):
+    monkeypatch.setenv("HERMES_LANGUAGE", "ru")
+    i18n.reset_language_cache()
+    assert i18n.has_key("gateway.busy.working")
+    assert i18n.has_key("commands.new")
+    assert not i18n.has_key("commands.no_such_command")
+
+
+def test_localized_description_falls_back_to_english_definition(monkeypatch):
+    from hermes_cli.commands import COMMAND_REGISTRY, localized_description
+
+    by_name = {c.name: c for c in COMMAND_REGISTRY}
+    monkeypatch.setenv("HERMES_LANGUAGE", "ru")
+    i18n.reset_language_cache()
+    assert localized_description(by_name["new"]) != by_name["new"].description
+    # No catalog entry -> the CommandDef text, never a bare key path.
+    assert localized_description(by_name["egress"]) == by_name["egress"].description
+    monkeypatch.setenv("HERMES_LANGUAGE", "en")
+    i18n.reset_language_cache()
+    assert localized_description(by_name["new"]) == by_name["new"].description


### PR DESCRIPTION
## What does this PR do?

Routes the last gateway strings a messenger user sees in everyday use through the i18n catalog:

- the six mid-run busy acks (`⏩ Steered into current run…`, `↪ Redirected current run…`, `⏳ Queued for the next turn…`, subagent / compression variants, `⚡ Interrupting current task…`) and their status fragments (`N min elapsed`, `iteration N/M`, `running: tool`);
- the long-running `⏳ Working — N min` heartbeat;
- slash-command descriptions for the Telegram/Discord/Slack command menus and gateway `/help`, via a new `commands.<name>` namespace and `localized_description()`.

With `display.language: ru` (or any of the 17 locales) a Telegram user now gets these in their language, same as the existing slash-command replies. Commands without a catalog entry keep their English `CommandDef.description`, so plugin and rarely used commands never render as a bare key path. Nine common commands are seeded (`help new stop status resume sessions model compress voice`); the rest can follow key by key.

## Related Issue

None. The i18n docs list command descriptions as out of scope; this extends the thin slice to the strings a non-English chat user meets on every busy turn.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/i18n.py`: `has_key()` helper (true when the active or English catalog has the key).
- `hermes_cli/commands.py`: `localized_description(cmd)`; used by `telegram_bot_commands()` and `gateway_help_lines()`.
- `gateway/run.py`: busy acks, status fragments and the working heartbeat use `t("gateway.busy.*", …)`.
- `locales/*.yaml` (all 17): `gateway.busy.*` (10 keys) and `commands.*` (9 keys).
- `tests/agent/test_i18n.py`: `has_key` and `localized_description` fallback tests; existing parity/placeholder tests cover the new keys.

## How to Test

1. `pytest tests/agent/test_i18n.py tests/hermes_cli/test_commands.py tests/gateway/test_busy_session_ack.py`
2. `HERMES_LANGUAGE=ru python -c "from agent.i18n import t; print(t('gateway.busy.working', minutes=6, detail=''))"` → `⏳ Работаю — 6 мин`
3. Run the Telegram gateway with `display.language: ru`, type `/` → menu descriptions for `/new`, `/status`, … are Russian; send a message while the agent is busy → the ack is Russian.

## Checklist

- [x] Tests pass locally
- [x] All 17 locales updated in the same commit
