### PR TITLE
fix(desktop): poll full session list against legacy backends so external cli-source sessions surface (#103420)

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -991,6 +991,113 @@ describe('typing-aware sessions.changed deferral', () => {
   })
 })
 
+describe('legacy visible list polls (no change events)', () => {
+  // Dedicated harness: exposes the refresh spies the shared useSyncHarness
+  // hides behind inner vi.fn()s. Every param identity must stay stable across
+  // renders so the connect-reseed effect does not re-run and pollute counts.
+  function renderListPollSync(
+    refreshSessions: () => Promise<void>,
+    refreshMessagingSessions: () => Promise<void>
+  ) {
+    const stable = {
+      refreshActiveTranscript: async () => undefined,
+      refreshCronJobs: vi.fn(async () => undefined),
+      refreshCurrentModel: vi.fn(async () => undefined),
+      refreshHermesConfig: vi.fn(async () => undefined),
+      requestGateway: vi.fn(async () => ({ sessions: [] })) as never,
+      updateSessionState: vi.fn(
+        (
+          _sessionId: string,
+          updater: (state: ReturnType<typeof createClientSessionState>) => ReturnType<typeof createClientSessionState>
+        ) => updater(createClientSessionState(ACTIVE_STORED_ID))
+      )
+    }
+
+    return renderHook(() => {
+      useBackgroundSync({
+        activeConnectionId: 'local',
+        activeGatewayProfile: 'default',
+        activeIsMessaging: false,
+        activeSessionId: null,
+        activeStoredSessionId: null,
+        freshDraftReady: false,
+        gatewayState: 'open',
+        ...stable,
+        refreshMessagingSessions,
+        refreshSessions
+      })
+    })
+  }
+
+  it('polls the full list so an externally written local session surfaces on its own (#103420)', async () => {
+    vi.useFakeTimers()
+    $changeEventsAvailable.set(false)
+    const refreshSessions = vi.fn(async () => undefined)
+
+    renderListPollSync(refreshSessions, vi.fn(async () => undefined))
+    // Connect reseed fires once at mount...
+    await act(async () => Promise.resolve())
+    expect(refreshSessions).toHaveBeenCalledTimes(1)
+    refreshSessions.mockClear()
+
+    // ...the legacy poll stays quiet until its first interval...
+    await act(async () => {
+      vi.advanceTimersByTime(29_999)
+      await Promise.resolve()
+    })
+    expect(refreshSessions).not.toHaveBeenCalled()
+
+    // ...then re-pulls on its own cadence, so a cron/CLI-written cli-source
+    // session (or any external state.db writer) appears without user action.
+    await act(async () => {
+      vi.advanceTimersByTime(1)
+      await Promise.resolve()
+    })
+    expect(refreshSessions).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the #41827 messaging poll cadence untouched on the legacy backend', async () => {
+    vi.useFakeTimers()
+    $changeEventsAvailable.set(false)
+    const refreshSessions = vi.fn(async () => undefined)
+    const refreshMessagingSessions = vi.fn(async () => undefined)
+
+    renderListPollSync(refreshSessions, refreshMessagingSessions)
+    await act(async () => Promise.resolve())
+    refreshSessions.mockClear()
+    refreshMessagingSessions.mockClear()
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000)
+      await Promise.resolve()
+    })
+
+    // Messaging slices keep their own faster legacy cadence (10s x3 here)...
+    expect(refreshMessagingSessions).toHaveBeenCalledTimes(3)
+    // ...alongside the recents list poll (30s x1).
+    expect(refreshSessions).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not add the recents poll when the backend broadcasts change events', async () => {
+    vi.useFakeTimers()
+    $changeEventsAvailable.set(true)
+    const refreshSessions = vi.fn(async () => undefined)
+
+    renderListPollSync(refreshSessions, vi.fn(async () => undefined))
+    await act(async () => Promise.resolve())
+    refreshSessions.mockClear()
+
+    await act(async () => {
+      vi.advanceTimersByTime(60_000)
+      await Promise.resolve()
+    })
+
+    // sessions.changed ticks own the refresh on event-capable backends; the
+    // visible poll must not double it.
+    expect(refreshSessions).not.toHaveBeenCalled()
+  })
+})
+
 describe('isTypingBurstActive', () => {
   it('marks a burst warm for the quiet threshold and cold at it', () => {
     resetTypingActivityTracking()

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -290,6 +290,14 @@ export async function reconcileActiveTranscript({
 const CRON_POLL_INTERVAL_MS = 30_000
 const CRON_BACKSTOP_INTERVAL_MS = 5 * 60_000
 const MESSAGING_POLL_INTERVAL_MS = 10_000
+// The recents slice holds local-source sessions (cli/desktop/tui). External
+// writers (cron runs, CLI invocations, plugin helpers) INSERT into state.db
+// without ever signaling the desktop websocket, and the #41827 legacy poll
+// below covers messaging platforms only — so against an older backend the
+// recents slice stayed stale until a manual refresh (#103420). The full-list
+// pass is the heaviest poll in this file (see SESSIONS_LIST_TICK_GAP_MS), so
+// keep this slower than the messaging poll above.
+const SESSIONS_LIST_POLL_INTERVAL_MS = 30_000
 const ACTIVE_MESSAGING_SESSION_POLL_INTERVAL_MS = 5_000
 const ACTIVE_MESSAGING_SESSION_BACKSTOP_INTERVAL_MS = 30_000
 // Match the TUI's live-session refresh cadence. Auto-compression can rotate a
@@ -900,6 +908,21 @@ export function useBackgroundSync({
 
     return visiblePoll(MESSAGING_POLL_INTERVAL_MS, () => void refreshMessagingSessions())
   }, [changeEventsAvailable, gatewayState, refreshMessagingSessions])
+
+  // The recents slice against an older backend: the poll above covers
+  // messaging platforms only, so a session an EXTERNAL process writes with a
+  // local source id (cron-delivered `source=cli` sessions, CLI helpers,
+  // plugin spawns) never re-triggered the list until a manual refresh
+  // (#103420). Extend the same legacy visible poll to the full sidebar list;
+  // event-capable backends keep folding this into the trailing
+  // sessions.changed refresh above.
+  useEffect(() => {
+    if (gatewayState !== 'open' || changeEventsAvailable) {
+      return
+    }
+
+    return visiblePoll(SESSIONS_LIST_POLL_INTERVAL_MS, () => void refreshSessions())
+  }, [changeEventsAvailable, gatewayState, refreshSessions])
 
   // A fresh new-session draft (gateway open, no active session) re-pulls the
   // model + config so the composer pill reflects the profile default.


### PR DESCRIPTION
Closes #103420

## Summary

The Desktop sidebar did not surface sessions written by an **external process** when the session's `source` is a local/non-messaging id (`cli`, `desktop`, `tui`) — exactly what a cron-delivered session gets (`source='cli'`). The #41827 legacy poll covers **messaging platforms only** (Telegram / WeChat / Discord slices at a 10s cadence), so against a backend that does not broadcast `sessions.changed` change events, the recents/full-list slice stayed stale until a manual refresh.

## Fix

Extend the same legacy visible-poll pattern to the full session list: when the gateway is open and the backend has no change-event channel (`changeEventsAvailable === false`), `useBackgroundSync` now re-pulls `refreshSessions()` on its own cadence (`SESSIONS_LIST_POLL_INTERVAL_MS = 30s`).

- The 30s cadence is deliberately slower than the 10s messaging poll — the full-list pass is the heaviest poll in this file (see `SESSIONS_LIST_TICK_GAP_MS`).
- Event-capable backends are untouched: the `sessions.changed` trailing refresh already owns the list there, so no double refresh is added.

## Tests

New `describe('legacy visible list polls (no change events)')` block in `use-background-sync.test.ts` with a dedicated harness (stable param identities so the connect-reseed effect does not re-run):

1. Legacy backend: the recents poll re-pulls the full list on its own 30s cadence, so an externally written `source=cli` session surfaces without user action (#103420).
2. Legacy backend: the #41827 messaging poll cadence is untouched (10s ×3 over 30s) alongside the new list poll (30s ×1).
3. Event-capable backend: no recents poll is added (the 60s window shows zero extra `refreshSessions` calls).

Validation:

- `tsc -p . --noEmit` — clean
- `vitest run src/app/contrib/hooks/use-background-sync.test.ts` — 36 passed (2 files)
