### PR TITLE
fix(gateway): include XDG_RUNTIME_DIR and DBUS_SESSION_BUS_ADDRESS in system-scope systemd unit

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2362,6 +2362,15 @@ def _system_service_identity(run_as_user: str | None = None) -> tuple[str, str, 
     return username, grp.getgrgid(user_info.pw_gid).gr_name, user_info.pw_dir
 
 
+def _system_service_uid(username: str) -> int:
+    """Numeric uid of the system-service target user; its runtime dir is ``/run/user/<uid>``."""
+    import pwd
+    try:
+        return pwd.getpwnam(username).pw_uid  # windows-footgun: ok — POSIX systemd helper, never invoked on Windows
+    except KeyError as e:
+        raise ValueError(f"Unknown user: {username}") from e
+
+
 def _read_systemd_user_from_unit(unit_path: Path) -> str | None:
     if not unit_path.exists():
         return None
@@ -2774,10 +2783,16 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         path_entries = [e for e in _target_node_entries if e not in path_entries] + path_entries
         user_home = Path(home_dir)
         identity_lines = f"User={username}\nGroup={group_name}\n"
+        # Cron workers are launched via `systemd-run --user --scope`, which needs the target user's
+        # systemd/D-Bus session bus. A system service starts with a minimal environment (user-scope
+        # units inherit these from user@.service), so point at /run/user/<uid> explicitly.
+        uid = _system_service_uid(username)
         env_lines = (
             f'Environment="HOME={home_dir}"\n'
             f'Environment="USER={username}"\n'
             f'Environment="LOGNAME={username}"\n'
+            f'Environment="XDG_RUNTIME_DIR=/run/user/{uid}"\n'
+            f'Environment="DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{uid}/bus"\n'
         )
         wanted_by = "multi-user.target"
     else:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1246,6 +1246,7 @@ class TestSystemUnitHermesHome:
             "_system_service_identity",
             lambda run_as_user=None: ("alice", "alice", str(target_home)),
         )
+        monkeypatch.setattr(gateway_cli, "_system_service_uid", lambda username: 1000)
         monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: root_hermes)
         monkeypatch.setattr(gateway_cli, "_build_service_path_dirs", lambda: [])
 
@@ -1287,6 +1288,7 @@ class TestSystemUnitHermesHome:
             gateway_cli, "_system_service_identity",
             lambda run_as_user=None: ("alice", "alice", "/home/alice"),
         )
+        monkeypatch.setattr(gateway_cli, "_system_service_uid", lambda username: 1000)
         monkeypatch.setattr(
             gateway_cli, "_build_user_local_paths",
             lambda home, existing: [],
@@ -1304,6 +1306,67 @@ class TestSystemUnitHermesHome:
 
         hermes_home = str(gateway_cli.get_hermes_home().resolve())
         assert f'HERMES_HOME={hermes_home}' in unit
+
+
+class TestSystemUnitUserBusEnv:
+    """System units must reach the target user's systemd bus: cron workers spawn via
+    ``systemd-run --user --scope``, and a system service starts with a minimal environment."""
+
+    def test_system_unit_points_at_target_users_runtime_dir_and_bus(self, monkeypatch):
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/root")))
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(
+            gateway_cli, "_system_service_identity",
+            lambda run_as_user=None: ("alice", "alice", "/home/alice"),
+        )
+        monkeypatch.setattr(gateway_cli, "_system_service_uid", lambda username: 1234)
+        monkeypatch.setattr(
+            gateway_cli, "_build_user_local_paths",
+            lambda home, existing: [],
+        )
+
+        unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
+
+        assert 'Environment="XDG_RUNTIME_DIR=/run/user/1234"' in unit
+        assert 'Environment="DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1234/bus"' in unit
+
+    def test_system_unit_uid_comes_from_the_target_user_not_the_caller(self, monkeypatch):
+        seen: list[str] = []
+
+        def fake_uid(username):
+            seen.append(username)
+            return 4321
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/root")))
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(
+            gateway_cli, "_system_service_identity",
+            lambda run_as_user=None: ("alice", "alice", "/home/alice"),
+        )
+        monkeypatch.setattr(gateway_cli, "_system_service_uid", fake_uid)
+        monkeypatch.setattr(
+            gateway_cli, "_build_user_local_paths",
+            lambda home, existing: [],
+        )
+
+        unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
+
+        assert seen == ["alice"]
+        assert "/run/user/4321" in unit
+
+    def test_user_unit_leaves_runtime_dir_to_the_user_manager(self):
+        # user@.service already exports XDG_RUNTIME_DIR / DBUS_SESSION_BUS_ADDRESS to user units.
+        unit = gateway_cli.generate_systemd_unit(system=False)
+
+        assert "XDG_RUNTIME_DIR" not in unit
+        assert "DBUS_SESSION_BUS_ADDRESS" not in unit
+
+    def test_system_service_uid_resolves_via_passwd(self):
+        assert gateway_cli._system_service_uid("root") == 0
+
+    def test_system_service_uid_rejects_unknown_user(self):
+        with pytest.raises(ValueError, match="Unknown user"):
+            gateway_cli._system_service_uid("hermes-no-such-user-xyz")
 
 
 class TestSystemUnitRefreshSyncsHermesHome:
@@ -1330,6 +1393,7 @@ class TestSystemUnitRefreshSyncsHermesHome:
             "_system_service_identity",
             lambda run_as_user=None: ("alice", "alice", str(alice_home)),
         )
+        monkeypatch.setattr(gateway_cli, "_system_service_uid", lambda username: 1000)
         monkeypatch.setattr(
             gateway_cli, "_build_user_local_paths", lambda home, existing: []
         )
@@ -1650,6 +1714,7 @@ class TestProfileArg:
             "_system_service_identity",
             lambda run_as_user=None: ("alice", "alice", str(target_home)),
         )
+        monkeypatch.setattr(gateway_cli, "_system_service_uid", lambda username: 1000)
 
         unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
 
@@ -1740,6 +1805,7 @@ class TestSystemUnitPathRemapping:
             gateway_cli, "_system_service_identity",
             lambda run_as_user=None: ("alice", "alice", target_home),
         )
+        monkeypatch.setattr(gateway_cli, "_system_service_uid", lambda username: 1000)
 
         unit = gateway_cli.generate_systemd_unit(system=True)
 

--- a/tests/hermes_cli/test_systemd_watchdog_unit.py
+++ b/tests/hermes_cli/test_systemd_watchdog_unit.py
@@ -46,6 +46,7 @@ def test_system_unit_reads_watchdog_from_target_home(tmp_path, monkeypatch):
         "_system_service_identity",
         lambda _user: ("service", "service", str(tmp_path / "account")),
     )
+    monkeypatch.setattr(gateway_cli, "_system_service_uid", lambda _username: 1000)
     monkeypatch.setattr(
         gateway_cli,
         "_hermes_home_for_target_user",


### PR DESCRIPTION
Fixes #103705

## Problem

`hermes gateway install --system` generates a unit whose `[Service]` section sets `HOME`, `USER` and `LOGNAME` for the target user but not `XDG_RUNTIME_DIR` or `DBUS_SESSION_BUS_ADDRESS`. systemd starts system services with a minimal environment, so the gateway process has no way to reach the target user's systemd/D-Bus session bus. Cron workers are spawned through `systemd-run --user --scope` (`tools/process_registry.py`, `_systemd_scope_argv`), so every isolated-scope spawn fails on a system-scope install.

The existing `_ensure_user_systemd_env()` helper only patches `os.environ` of the *interactive CLI* process, so it does not help the service itself. User-scope units are unaffected because `user@.service` already exports both variables.

## Change

- `hermes_cli/gateway.py`
  - New `_system_service_uid(username)` helper (`pwd.getpwnam(...).pw_uid`, `ValueError` on unknown user, mirroring `_system_service_identity()`).
  - `generate_systemd_unit()` system branch now also emits:
    ```
    Environment="XDG_RUNTIME_DIR=/run/user/<uid>"
    Environment="DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/<uid>/bus"
    ```
    derived from the **target** user's uid (not the sudo caller's).
  - User-scope template unchanged.
- Tests
  - New `TestSystemUnitUserBusEnv` in `tests/hermes_cli/test_gateway_service.py`: system unit carries both vars for the target uid, uid is looked up for the target user, user unit does not carry them, helper resolves via passwd / rejects unknown users.
  - Existing tests that fake `_system_service_identity()` with a non-existent user now also fake `_system_service_uid()` (6 sites, including `test_systemd_watchdog_unit.py`).

Because the generated template changed, `systemd_unit_is_current()` will report existing system-scope units as stale and the normal refresh path will rewrite them — that is the intended way for installed hosts to pick up the fix.

`TimeoutStopSec` was reviewed and left alone: `resolve_systemd_timeout_stop_sec()` already covers `max(floor, max(drain, cron_drain + cleanup_reserve) + headroom)`.

## Testing

Ran `tests/hermes_cli/test_gateway_service.py test_systemd_watchdog_unit.py test_ensure_gateway_service.py test_gateway.py test_gateway_linger.py test_gateway_service_paths.py test_gateway_foreign_xdg_runtime.py`: 174 passed, 4 skipped. The one failure (`test_system_unit_includes_local_bin_in_path`) is pre-existing on this host — it calls `generate_systemd_unit(system=True)` with no `run_as_user` while the suite runs as root, so it trips the root-refusal `ValueError` before and after this change; it passes with `SUDO_USER=nobody`.

Also verified end to end with a real account: `generate_systemd_unit(system=True, run_as_user="nobody")` emits `XDG_RUNTIME_DIR=/run/user/65534` and `DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/65534/bus`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JvRxfrYg1wWEGjNnWqSvzh
