### PR TITLE
fix(auth): stop fresh profile OAuth grants from being discarded

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2229,12 +2229,18 @@ class CredentialPool:
             entry = replace(entry, priority=_next_priority(self._entries))
             self._entries.append(entry)
             borrowed_ids = getattr(self, "_borrowed_root_ids", None)
-            if borrowed_ids:
+            claims_single_use_provider = (
+                self.provider in SINGLE_USE_REFRESH_POOL_PROVIDERS
+                and not _profile_owns_pool_provider(self.provider)
+            )
+            if borrowed_ids or claims_single_use_provider:
                 # ``hermes -p <profile> auth add <single-use provider>``: the
                 # profile claims its OWN credential. Persist only profile-owned
                 # rows — copying the borrowed root grant alongside would fork
-                # its single-use refresh token (#100339). Once the profile owns
-                # rows, the root fallback for this provider is shadowed.
+                # its single-use refresh token (#100339). Write directly rather
+                # than taking the borrowed-row update-only path, including when
+                # the root has no provider rows yet. Once the profile owns rows,
+                # the root fallback for this provider is shadowed.
                 self._entries = [e for e in self._entries if e.id not in borrowed_ids]
                 write_credential_pool(self.provider, [e.to_dict() for e in self._entries])
                 self._borrowed_root_ids = set()

--- a/tests/agent/test_credential_pool_profile_oauth_fork.py
+++ b/tests/agent/test_credential_pool_profile_oauth_fork.py
@@ -254,6 +254,26 @@ def test_profile_auth_add_owns_only_its_own_rows(fleet):
     assert [e["id"] for e in fleet["rows"](fleet["root"])] == ["abc123"]
 
 
+def test_profile_auth_add_persists_when_root_has_no_provider_rows(fleet):
+    from agent.credential_pool import AUTH_TYPE_OAUTH, PooledCredential, load_pool
+
+    root_store = json.loads((fleet["root"] / "auth.json").read_text())
+    del root_store["credential_pool"]["anthropic"]
+    (fleet["root"] / "auth.json").write_text(json.dumps(root_store))
+
+    kid = _profile(fleet, "kid")
+    fleet["use"](kid)
+    pool = load_pool("anthropic")
+    pool.add_entry(PooledCredential(
+        provider="anthropic", id="own001", label="mine", auth_type=AUTH_TYPE_OAUTH,
+        priority=0, source="manual:hermes_pkce", access_token="«redacted:sk-…»",
+        refresh_token="rt-mine",
+    ))
+
+    assert [e["id"] for e in fleet["rows"](kid)] == ["own001"]
+    assert fleet["rows"](fleet["root"]) is None
+
+
 def test_classic_mode_persist_is_unchanged(fleet):
     from agent.credential_pool import load_pool
 


### PR DESCRIPTION
## What does this PR do?

Named profiles can now persist a newly authorized single-use OAuth credential when the global root has no rows for that provider. Previously the CLI reported success after the one-time authorization code was consumed, but the credential was discarded because persistence entered a root update-only path with nothing to update.

### Symptom

After `hermes -p <profile> auth add anthropic --type oauth` completes successfully for a fresh provider, `auth list` remains empty and `auth status` reports logged out.

### Impact

The exchanged access and refresh tokens are lost even though the CLI prints `Added`. The user must repeat the entire browser authorization flow because the authorization code cannot be reused.

### Bug Cause

**Trigger:** `agent/credential_pool.py:2227` / `CredentialPool.add_entry()` when a named profile and the global root both lack rows for a single-use OAuth provider.

**Causal chain:**
1. `auth_add_command()` exchanges the one-time authorization code and appends a new in-memory pool entry.
2. With no profile-owned or borrowed rows, `add_entry()` calls `_persist()`, which routes the single-use provider to `_update_root_pool_rows()`.
3. The root merge is intentionally update-only, so it writes nothing when the root has no existing provider row, while the CLI still reports success.

**Why it is wrong:** A newly added credential establishes profile ownership. Treating it as a borrowed-row refresh silently drops a valid grant.

**Working sibling / contrast:** When the root already has a row, `load_pool()` records borrowed IDs and `add_entry()` already strips those rows and writes the new profile-owned credential directly.

**Ruled out:** The OAuth exchange is not the failure point; the credential exists in the in-memory pool before persistence, and the regression test reproduces the loss without network involvement.

### Fix

Treat adding a credential to an unowned single-use provider as an explicit ownership claim even when no borrowed IDs exist. Persist the new profile-owned rows directly while preserving the existing protection against copying root refresh tokens.

## Related Issue

Fixes #103694

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/credential_pool.py` - persist fresh single-use provider entries directly to the active profile store.
- `tests/agent/test_credential_pool_profile_oauth_fork.py` - cover a fresh profile and root with no provider rows using real auth-store I/O.

## How to Test

1. Start with a named profile and global root that have no Anthropic pool rows.
2. Add an Anthropic OAuth pool credential to the named profile.
3. Confirm the profile auth store contains the new row and the root remains unchanged.
4. Automated verification:

```bash
scripts/run_tests.sh tests/agent/test_credential_pool_profile_oauth_fork.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the related tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation is N/A
- [x] `cli-config.yaml.example` changes are N/A
- [x] `CONTRIBUTING.md` and `AGENTS.md` changes are N/A
- [x] I've considered cross-platform impact; the fix uses platform-neutral auth-store logic
- [x] Tool description and schema changes are N/A

## Screenshots / Logs

N/A
