### PR TITLE
feat(kanban): enrich triage specifier/decomposer prompts (ROUTING-CLASS + context)

### DIFF
--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -72,6 +72,14 @@ Rules:
   - Pick assignees from the roster by matching the task to the profile's
     DESCRIPTION (not just the name). When nothing matches well, use null
     and the system will route to the default_assignee.
+  - ROUTING-CLASS: if the task body carries an explicit "ROUTING-CLASS: <class>"
+    line near the top (research|build|ops|wiki|review), treat it as the
+    orchestrator's explicit routing decision and PREFER it over description
+    matching when choosing an assignee — pick the roster profile whose role
+    best fits that class.
+  - CONTEXT-SOURCES: if the body lists "CONTEXT-SOURCES: ...", the named
+    sources are authoritative context already gathered for this task (e.g. a
+    linked scouting pre-pass); rely on it and do not ask for more.
   - Each child task body is what a fresh worker will read with no other
     context — be specific about goal, approach, and acceptance criteria.
 

--- a/hermes_cli/kanban_specify.py
+++ b/hermes_cli/kanban_specify.py
@@ -65,7 +65,13 @@ _USER_TEMPLATE = """Task id: {task_id}
 Current title: {title}
 Current body:
 {body}
+{context}
 """
+
+# Cap for the context digest (recent comments + attachment manifest) appended
+# to the specifier prompt. Mirrors the body cap (4000) so per-card context
+# never grows the prompt past the size of the spec body it accompanies.
+_CONTEXT_MAX_CHARS = 4000
 
 
 @dataclass
@@ -84,6 +90,38 @@ def _truncate(text: str, limit: int) -> str:
     if len(text) <= limit:
         return text
     return text[: limit - 1] + "…"
+
+
+def _build_context(task_id: str) -> str:
+    """Recent comment thread + attachment manifest for the specifier prompt.
+
+    Per-card context (thread comments, attachments) currently reaches only the
+    dispatched worker, never the triage call (proposal Option C). Appending a
+    bounded digest here lets the specifier weigh operator notes and attached
+    files when it tightens a triage idea. Returns '' when the task has neither,
+    so the prompt is unchanged for the common case.
+    """
+    with kbc.connect_closing() as conn:
+        comments = kb.list_comments(conn, task_id)
+        attachments = kb.list_attachments(conn, task_id)
+    if not comments and not attachments:
+        return ""
+    parts: list[str] = []
+    if comments:
+        # Newest first so the most recent notes sit at the top; the head-
+        # keeping truncate below then preserves the most relevant comments.
+        thread = "\n".join(
+            f"- [{c.author or '?'}] {c.body.strip()}"
+            for c in reversed(comments[-10:])
+        )
+        parts.append("Recent comments on this task:\n" + thread)
+    if attachments:
+        manifest = "\n".join(
+            f"- {a.filename} ({a.size} bytes)"
+            for a in attachments
+        )
+        parts.append("Attachments on this task:\n" + manifest)
+    return _truncate("\n\n".join(parts), _CONTEXT_MAX_CHARS)
 
 
 _FENCE_RE = re.compile(r"^\s*```(?:json)?\s*|\s*```\s*$", re.IGNORECASE)
@@ -135,11 +173,12 @@ def _load_triage_task(task_id: str) -> tuple[Optional[kb.Task], str]:
 
 
 def _task_prompt_fields(task: kb.Task) -> dict[str, str]:
-    """Bounded ``task_id``/``title``/``body`` for the user prompt templates."""
+    """Bounded ``task_id``/``title``/``body``/``context`` for the user prompt templates."""
     return {
         "task_id": task.id,
         "title": _truncate(task.title or "", 400),
         "body": _truncate(task.body or "(no body)", 4000),
+        "context": _build_context(task.id),
     }
 
 

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -162,3 +162,16 @@ def test_decompose_returns_false_when_task_not_triage(kanban_home):
     assert "not in triage" in outcome.reason
 
 
+def test_decompose_system_prompt_honors_routing_class():
+    """Acceptance (b): the decomposer is told to honor an explicit ROUTING-CLASS.
+
+    Prompt-level fixture: the system prompt must instruct the decomposer to
+    prefer an explicit ROUTING-CLASS tag in the body over description matching
+    (proposal §5c), and must note CONTEXT-SOURCES handling.
+    """
+    prompt = decomp._SYSTEM_PROMPT
+    assert "ROUTING-CLASS" in prompt
+    assert "PREFER it over description" in prompt
+    assert "CONTEXT-SOURCES" in prompt
+
+

--- a/tests/hermes_cli/test_kanban_specify.py
+++ b/tests/hermes_cli/test_kanban_specify.py
@@ -97,6 +97,38 @@ def test_specify_task_happy_path(kanban_home):
 
 
 
+def test_specify_task_receives_comment_thread_and_attachments(kanban_home):
+    """Acceptance (a): per-card context reaches the triage call.
+
+    A triage task carrying a comment thread and attachments must have that
+    context forwarded in the specifier's user message — not just to the
+    dispatched worker (proposal Option C).
+    """
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="rough", triage=True)
+        kb.add_comment(conn, tid, "operator", "ROUTING-CLASS: build — check Discord facts first")
+        kb.add_comment(conn, tid, "operator", "Second note.")
+        kb.add_attachment(
+            conn, tid,
+            filename="spec.pdf", stored_path="/nonexistent/spec.pdf",
+            size=1234, uploaded_by="operator",
+        )
+
+    content = jsonlib.dumps({"title": "Refined", "body": "**Goal**\nok"})
+    p, mock_fn = _patch_aux_client(content)
+    with p:
+        outcome = spec.specify_task(tid, author="ace")
+    assert outcome.ok is True
+
+    call = mock_fn.call_args
+    user_msg = call.kwargs["messages"][1]["content"]
+    assert "Recent comments on this task:" in user_msg
+    assert "ROUTING-CLASS: build — check Discord facts first" in user_msg
+    assert "Second note." in user_msg
+    assert "Attachments on this task:" in user_msg
+    assert "spec.pdf (1234 bytes)" in user_msg
+
+
 # ---------------------------------------------------------------------------
 # CLI wiring — argparse + _cmd_specify
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Class-A implementation (proposal `triage-enrichment-proposal.md`, Option C + Section 5c):
minimal, prompt/template-only enrichment so the *triage* LLM sees the same per-card
context that dispatched workers already get.

1. **Specifier context** (`hermes_cli/kanban_specify.py`): `_USER_TEMPLATE` now carries the
   recent comment thread + attachment manifest via a new `_build_context` helper. Bounded to
   the existing body cap (4000 chars) so appending context never grows the prompt past the
   spec body it accompanies. Returns `''` when the task has neither comments nor attachments,
   keeping the common-case prompt unchanged. No schema/config/DB changes.
2. **Decomposer routing** (`hermes_cli/kanban_decompose.py`): `_SYSTEM_PROMPT` gains a rule to
   prefer an explicit `ROUTING-CLASS: <research|build|ops|wiki|review>` tag in the body over
   description matching when choosing an assignee, and a note that `CONTEXT-SOURCES: ...`
   context is authoritative (do not ask for more).

## Rebased

Rebased onto current `main` (`73ddf0672c`) and force-updated `feat/kanban-triage-enrichment`
on the fork. The branch now carries exactly one commit (this enrichment; the unrelated
session-resume commit previously inherited from the stale fork `main` was dropped so the PR
matches its stated scope). The prompt/template diff still lands on the current construction
sites in `kanban_specify.py` / `kanban_decompose.py` — including after upstream
`258fa9741c` ("retain Kanban decomposition identity..."), which only touched
`_apply_fanout`, not the template. Patch content is unchanged apart from upstream
line-offset drift.

## Test Plan

- New unit test: a triage task with a comment thread + attachment — the specifier's user
  message contains both (acceptance a).
- New prompt-level fixture: decomposer `_SYSTEM_PROMPT` instructs preferring ROUTING-CLASS
  over description matching and notes CONTEXT-SOURCES (acceptance b).
- Re-verified after rebase via `scripts/run_tests.sh` (scrubbed env): PR tests
  `tests/hermes_cli/test_kanban_{decompose,specify}.py` 7 passed / 0 failed, and the full
  `tests/hermes_cli/test_kanban*.py` + `tests/tools/test_kanban*.py` suite
  55 files / 372 passed / 0 failed (2 windows-only skipped on linux).
