### PR TITLE
fix(auth): persist profile single-use OAuth credentials when root store is empty (#103694)

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -756,7 +756,8 @@ def _write_through_provider_state_to_global_root(
 
 def _singleton_target_for_entry(pool: "CredentialPool", entry: "PooledCredential") -> Optional[Path]:
     """Root ``.anthropic_oauth.json`` when *entry* is a borrowed hermes_pkce row, else None."""
-    if entry.source != "hermes_pkce" or entry.id not in getattr(pool, "_borrowed_root_ids", ()):
+    borrowed_ids = getattr(pool, "_borrowed_root_ids", None) or ()
+    if entry.source != "hermes_pkce" or entry.id not in borrowed_ids:
         return None
     try:
         from agent.anthropic_credentials import _root_hermes_oauth_file
@@ -917,7 +918,7 @@ class CredentialPool:
         self._current_id: Optional[str] = None
         # Ids of rows read via the global-root fallback (single-use OAuth
         # providers only); set by load_pool(), consumed by add_entry().
-        self._borrowed_root_ids: Set[str] = set()
+        self._borrowed_root_ids: Optional[Set[str]] = None
         self._strategy = get_pool_strategy(provider)
         # RLock: _replace_entry/_persist self-acquire it so the DEFERRED
         # single-use-token refresh path (network I/O outside the lock by
@@ -2229,15 +2230,18 @@ class CredentialPool:
             entry = replace(entry, priority=_next_priority(self._entries))
             self._entries.append(entry)
             borrowed_ids = getattr(self, "_borrowed_root_ids", None)
-            if borrowed_ids:
+            if borrowed_ids is not None:
                 # ``hermes -p <profile> auth add <single-use provider>``: the
                 # profile claims its OWN credential. Persist only profile-owned
-                # rows — copying the borrowed root grant alongside would fork
+                # rows — copying any borrowed root grant alongside would fork
                 # its single-use refresh token (#100339). Once the profile owns
                 # rows, the root fallback for this provider is shadowed.
+                # When root has no rows yet (borrowed_ids is empty set), this
+                # fresh grant must persist to the profile store rather than
+                # routing to the update-only root merge (#103694).
                 self._entries = [e for e in self._entries if e.id not in borrowed_ids]
                 write_credential_pool(self.provider, [e.to_dict() for e in self._entries])
-                self._borrowed_root_ids = set()
+                self._borrowed_root_ids = None
             else:
                 self._persist()
             return entry

--- a/tests/agent/test_credential_pool_profile_oauth_fork.py
+++ b/tests/agent/test_credential_pool_profile_oauth_fork.py
@@ -254,6 +254,33 @@ def test_profile_auth_add_owns_only_its_own_rows(fleet):
     assert [e["id"] for e in fleet["rows"](fleet["root"])] == ["abc123"]
 
 
+def test_profile_auth_add_on_empty_root_persists_to_profile(fleet):
+    """Named profile adding a single-use credential when root store has no rows (#103694).
+
+    When root has no rows for the single-use provider (e.g. fresh root or unconfigured
+    provider), load_pool() records an empty borrowed_ids set. The profile's add_entry()
+    must persist the newly added credential to the profile store instead of silently
+    routing to update-only root merge.
+    """
+    from agent.credential_pool import AUTH_TYPE_OAUTH, PooledCredential, load_pool
+
+    root = fleet["root"]
+    (root / "auth.json").write_text(json.dumps({"version": 1, "providers": {}, "credential_pool": {}}))
+
+    fresh_profile = _profile(fleet, "fresh_profile")
+    fleet["use"](fresh_profile)
+    pool = load_pool("anthropic")
+    pool.add_entry(PooledCredential(
+        provider="anthropic", id="fresh001", label="fresh_auth", auth_type=AUTH_TYPE_OAUTH,
+        priority=0, source="manual:hermes_pkce", access_token="sk-ant-oat01-FRESH",
+        refresh_token="rt-fresh",
+    ))
+    assert fleet["rows"](fresh_profile) is not None, "credential was dropped without persisting (#103694)"
+    assert [e["id"] for e in fleet["rows"](fresh_profile)] == ["fresh001"]
+    assert fleet["rows"](root) is None
+
+
+
 def test_classic_mode_persist_is_unchanged(fleet):
     from agent.credential_pool import load_pool
 


### PR DESCRIPTION
## Summary
Fixes #103694.

When running `hermes -p <profile> auth add <provider> --type oauth` for a provider in `SINGLE_USE_REFRESH_POOL_PROVIDERS` (such as Anthropic, Codex, xAI) on a fresh install or named profile where the root store has no existing credentials for that provider, the CLI completed the OAuth flow and printed `Added ...`, but persisted nothing to either profile `auth.json` or root `auth.json`.

### Root Cause
1. `load_pool()` on a named profile sets `self._borrowed_root_ids = set(disk_ids)`. When root has no existing rows for the provider, `disk_ids` is empty, setting `_borrowed_root_ids = set()`.
2. In `add_entry()`, the guard previously checked:
   ```python
   borrowed_ids = getattr(self, "_borrowed_root_ids", None)
   if borrowed_ids:
   ```
   Because `bool(set())` is `False`, an empty set evaluated to falsy, bypassing `write_credential_pool()` and taking `else: self._persist()`.
3. `self._persist()` called `persist_pool_entries()`, which observed `not _profile_owns_pool_provider(provider)` and routed the payload to the update-only `_update_root_pool_rows()` on root.
4. Because root had no rows for the provider, `_update_root_pool_rows()` merged 0 rows and returned silently. The newly exchanged grant was lost.

### Fix
- Check `if borrowed_ids is not None:` in `add_entry()` so that profile-scoped pools persist their new credential directly to the profile store via `write_credential_pool()`, claiming row ownership and shadowing the root fallback.
- Initialize `self._borrowed_root_ids: Optional[Set[str]] = None` in `CredentialPool.__init__`.
- Reset `self._borrowed_root_ids = None` upon the profile claiming row ownership.
- Added unit test `test_profile_auth_add_on_empty_root_persists_to_profile` in `tests/agent/test_credential_pool_profile_oauth_fork.py`.

### Verification
- Added reproduction test in `test_credential_pool_profile_oauth_fork.py`: reproduces drop on parent commit, passes on this branch.
- Full test suite passed:
  - `tests/agent/test_credential_pool_profile_oauth_fork.py` (all tests pass)
  - `tests/hermes_cli/test_auth_commands.py` (28/28 pass)