### PR TITLE
fix(sessions): release stale active-session lease on cold resume

### DIFF
--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -544,6 +544,32 @@ def release_active_session(lease: ActiveSessionLease) -> None:
         lease.released = True
 
 
+def drop_lease_for_session(
+    session_id: str,
+    *, registry_home: str | Path | None = None,
+    profile_home: str | Path | None = None,
+) -> bool:
+    """Remove any active-session lease(s) for ``session_id`` from the on-disk registry.
+
+    Used when a cold resume re-attaches to a session whose in-memory entry was evicted:
+    the old lease (held by the now-evicted runtime's live_session_id) is stale and must
+    be cleared so the new surface can claim its own lease on the next submit.
+    """
+    target = str(session_id or "")
+    if not target:
+        return False
+    # Prefer the profile_home override if given (profile-scoped backend), else root.
+    home = profile_home if profile_home is not None else registry_home
+    state_path, lock_path = _lease_paths(registry_home=home)
+    with _FileLock(lock_path):
+        raw_entries = _read_entries(state_path, strict=True)
+        kept = [e for e in raw_entries if str(e.get("session_id") or "") != target]
+        if len(kept) != len(raw_entries):
+            _write_entries(state_path, kept)
+            return True
+    return False
+
+
 def transfer_active_session(
     lease: ActiveSessionLease, *, session_id: str, metadata: Optional[dict[str, Any]] = None
 ) -> bool:

--- a/tests/hermes_cli/test_active_sessions.py
+++ b/tests/hermes_cli/test_active_sessions.py
@@ -298,6 +298,115 @@ def test_transfer_under_profile_home_override_targets_acquisition_registry(
     assert [entry["session_id"] for entry in entries] == ["after"]
 
 
+def test_drop_lease_for_session_removes_stale_lease(tmp_path, monkeypatch):
+    """Cold resume should release a stale on-disk lease for the same session_key.
+
+    When a session is evicted from _sessions but the owning process is still
+    alive (e.g. idle TTL eviction), the on-disk lease persists. drop_lease_for_session
+    lets the cold-resume path clear it so a new surface can claim the lease.
+    """
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    lease, message = active_sessions.try_acquire_active_session(
+        session_id="session-to-take-over",
+        surface="desktop",
+        config={"max_concurrent_sessions": 1},
+        metadata={"live_session_id": "desktop-A-runtime"},
+        track_liveness=True,
+    )
+    assert message is None
+    assert lease is not None
+
+    snapshot = active_sessions.active_session_registry_snapshot()
+    assert len(snapshot) == 1
+    assert snapshot[0]["session_id"] == "session-to-take-over"
+
+    # Simulate the cold-resume path: drop the lease for this session_key
+    # (same pid is alive, but the session was evicted from memory)
+    dropped = active_sessions.drop_lease_for_session("session-to-take-over")
+    assert dropped is True
+
+    # The lease should now be gone — a new surface can claim it
+    snapshot = active_sessions.active_session_registry_snapshot()
+    assert len(snapshot) == 0
+
+    lease2, message2 = active_sessions.try_acquire_active_session(
+        session_id="session-to-take-over",
+        surface="desktop",
+        config={"max_concurrent_sessions": 1},
+        metadata={"live_session_id": "desktop-B-runtime"},
+        track_liveness=True,
+    )
+    assert message2 is None
+    assert lease2 is not None
+    lease2.release()
+
+
+def test_drop_lease_for_session_no_entry_is_noop(tmp_path, monkeypatch):
+    """Dropping a lease for a session with no existing lease is a no-op."""
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    dropped = active_sessions.drop_lease_for_session("no-such-session")
+    assert dropped is False
+
+
+def test_drop_lease_for_session_only_removes_target(tmp_path, monkeypatch):
+    """Dropping a lease for one session_key must not affect other sessions."""
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    lease_a, msg_a = active_sessions.try_acquire_active_session(
+        session_id="session-A", surface="desktop", config={"max_concurrent_sessions": 2},
+        metadata={"live_session_id": "ui-A"}, track_liveness=True,
+    )
+    assert msg_a is None
+    lease_b, msg_b = active_sessions.try_acquire_active_session(
+        session_id="session-B", surface="desktop", config={"max_concurrent_sessions": 2},
+        metadata={"live_session_id": "ui-B"}, track_liveness=True,
+    )
+    assert msg_b is None
+
+    dropped = active_sessions.drop_lease_for_session("session-A")
+    assert dropped is True
+
+    snapshot = {e["session_id"] for e in active_sessions.active_session_registry_snapshot()}
+    assert snapshot == {"session-B"}
+    lease_b.release()
+
+
+def test_drop_lease_for_session_under_profile_home(tmp_path, monkeypatch):
+    """Dropping a lease must target the profile home where it was acquired."""
+    root = tmp_path / "hermes"
+    profile = root / "profiles" / "worker"
+    profile.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    lease, error = active_sessions.try_acquire_active_session(
+        session_id="profile-session",
+        surface="desktop",
+        config={"max_concurrent_sessions": 2},
+        registry_home=profile,
+    )
+    assert lease is not None and error is None
+
+    # Lease should be in the profile registry, not root
+    profile_registry = profile / "runtime" / "active_sessions.json"
+    root_registry = root / "runtime" / "active_sessions.json"
+    assert active_sessions._read_entries(profile_registry)
+    assert active_sessions._read_entries(root_registry) == []
+
+    dropped = active_sessions.drop_lease_for_session(
+        "profile-session", profile_home=profile,
+    )
+    assert dropped is True
+
+    assert active_sessions._read_entries(profile_registry) == []
+    assert lease is not None
+    lease.released = True  # already released via drop
+
+
 def test_liveness_registry_corruption_fails_closed_without_overwrite(
     tmp_path, monkeypatch
 ):

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -805,6 +805,16 @@ def _(rid, params: dict) -> dict:
             live = _find_live_session_by_key(ctx.target, ctx.profile_home)
         if live is not None:
             return _resume_reuse_live(ctx, *live)
+        # Cold resume: session was evicted from _sessions. If a stale on-disk
+        # active-session lease lingers for this session_key (e.g. the previous
+        # runtime's process is still alive but evicted the session), clear it
+        # so this surface can claim its own lease on the next submit.
+        # See #101619.
+        with contextlib.suppress(Exception):
+            from hermes_cli.active_sessions import drop_lease_for_session
+            drop_lease_for_session(
+                ctx.target, profile_home=ctx.profile_home,
+            )
         if ctx.lazy:
             return _resume_lazy(ctx)
         if ctx.eager_build:


### PR DESCRIPTION
## What changed and why

Fixes the session ownership error where Computer B cannot submit messages to a session that was evicted from the backend's in-memory `_sessions` dict but still holds a stale on-disk lease in `active_sessions.json`.

When Computer A runs a desktop session on a shared `hermes serve` backend, it acquires an ownership lease in `active_sessions.json` keyed by `session_id`, `pid`, and `live_session_id`. If the session is evicted from the in-memory `_sessions` dict (idle TTL, LRU eviction), the backend process is still alive but the session is no longer present there. When Computer B cold-resumes the same session:

1. `session.resume` finds no live session in `_sessions` (fast-path miss)
2. Falls through to cold resume path
3. `prompt.submit` → `_ensure_active_session_slot` → `try_acquire_active_session()` 
4. Finds the stale lease from Computer A with a different `live_session_id`
5. `_is_same_writer()` returns False (same pid, different `live_session_id`)
6. Returns 4090 `SESSION_NOT_OWNED` — even though the session is not actually live

The lease tracks process liveness, not session presence in memory, so it survives eviction. This fix adds a `drop_lease_for_session()` helper and calls it during cold resume, right after the fast-path check and before any cold resume path.

**Changes:**
- `hermes_cli/active_sessions.py`: New `drop_lease_for_session()` function that removes all on-disk lease entries matching a given `session_id`, using the same file-lock mechanism as existing lease operations. Supports `profile_home` for profile-scoped registries.
- `tui_gateway/methods_session.py`: Call `drop_lease_for_session()` during cold resume, after fast-path check, before cold resume paths, wrapped in `contextlib.suppress(Exception)`.
- `tests/hermes_cli/test_active_sessions.py`: 4 new tests covering acquire/drop/re-acquire, no-op when no lease exists, selective removal, and profile-home scoping.

## How to test

```bash
# Run the active_sessions tests (includes 4 new tests)
scripts/run_tests.sh tests/hermes_ci/test_active_sessions.py

# Run broader session/reuse test suite
scripts/run_tests.sh tests/hermes_ci/test_active_sessions.py tests/tui_gateway/test_custom_provider_session_persistence.py tests/tui_gateway/test_undo_command.py tests/tui_gateway/test_session_resume_db_ownership.py
```

To manually verify: Run two desktop sessions connected to the same `hermes serve` backend, let one go idle until evicted from memory, then try to submit a message from the other — previously blocked with 4090 `SESSION_NOT_OWNED`, now succeeds.

## Platforms tested

- macOS 15.7.7 (development environment)

## Related issues

Fixes the session handoff error: `Session X already has a live owner (desktop, pid Y, running Zm). Only one surface at a time may run a session, because a second one would reason from a transcript that does not include the first one's work.`