### PR TITLE
fix(kanban): decompose asks each child for its own repo, refuses unanchored worktree children

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3545,7 +3545,7 @@ def decompose_triage_task(
     now = int(time.time())
     with write_txn(conn):
         root_row = conn.execute(
-            "SELECT id, status, tenant, workspace_kind, workspace_path "
+            "SELECT id, status, tenant, workspace_kind, workspace_path, project_id "
             "FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
         if root_row is None or root_row["status"] != "triage":
@@ -3602,12 +3602,33 @@ def _insert_decomposed_child(
     and one shared checkout would put them all on the first sibling's branch
     with no lock; leaving it unset makes dispatch materialize a fresh
     ``<repo>/.worktrees/<child-id>`` per child from the board anchor.
+
+    A worktree child with neither a repo of its own nor a board anchor is
+    rejected rather than written: it cannot be dispatched at all, and the
+    root's repo is not a safe guess — one card fans out across repos.
     """
     root_ws_kind = root_row["workspace_kind"] or "scratch"
     child_ws_kind = child.get("workspace_kind") or root_ws_kind
+    child_project = child.get("project_id")
     if child.get("workspace_path"):
         child_ws_path = child.get("workspace_path")
     elif child_ws_kind == "worktree":
+        # The child named no repo of its own. Dispatch can still anchor it on
+        # the board's ``default_workdir``; with no board anchor either it has
+        # no repo to be checked out in, so it fails at spawn, burns its
+        # retries and parks as ``blocked`` behind a message that reads like an
+        # infrastructure fault. Refuse the fan-out here instead -- and do NOT
+        # fall back to the root's repo: one card routinely fans out across
+        # repos, so inheriting checks the work out into the wrong tree
+        # silently, which is worse than a loud stall.
+        if not (_board_meta_for(None).get("default_workdir") or "").strip():
+            raise ValueError(
+                f"decomposed child {child['title'].strip()[:60]!r} of {root_id} "
+                "is a worktree task with no repo: it named no 'repo' and this "
+                "board has no default_workdir to anchor it on. Give the child a "
+                "repo, or set a board default workdir. Inheriting the parent's "
+                "repo is not safe -- one card fans out across repos."
+            )
         child_ws_path = None
     elif child_ws_kind == root_ws_kind:
         child_ws_path = root_row["workspace_path"]
@@ -3618,12 +3639,12 @@ def _insert_decomposed_child(
     conn.execute(
         "INSERT INTO tasks "
         "(id, title, body, assignee, status, workspace_kind, "
-        " workspace_path, tenant, created_at, created_by) "
-        "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?)",
+        " workspace_path, project_id, tenant, created_at, created_by) "
+        "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?, ?)",
         (
             new_id, child["title"].strip(), body if isinstance(body, str) else None,
             _canonical_assignee(child.get("assignee")), child_ws_kind, child_ws_path,
-            root_row["tenant"], now, (author or "decomposer"),
+            child_project, root_row["tenant"], now, (author or "decomposer"),
         ),
     )
     _append_event(

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -54,6 +54,7 @@ Output a single JSON object with this exact shape:
         "title": "<concrete task title, imperative voice, <= 80 chars>",
         "body":  "<detailed spec for the worker on this child task>",
         "assignee": "<profile name from the roster, or null for default>",
+        "repo": "<repo name from the list below, or null when the child needs no checkout>",
         "parents": [<int>, ...]
       },
       ...
@@ -71,6 +72,12 @@ Rules:
   - Pick assignees from the roster by matching the task to the profile's
     DESCRIPTION (not just the name). When nothing matches well, use null
     and the system will route to the default_assignee.
+  - "repo" names the checkout the child works in. Pick it by matching the
+    child's own work, NOT by copying the parent's repo: one card routinely
+    fans out across repositories (a UI child and an API child belong to
+    different checkouts). Use null only when the child needs no repository
+    at all. A child that needs a checkout but names no repo cannot be
+    dispatched, and the decomposition is rejected.
   - Each child task body is what a fresh worker will read with no other
     context — be specific about goal, approach, and acceptance criteria.
 
@@ -102,6 +109,9 @@ Available profiles (assignees you may pick from):
 {roster}
 
 Default assignee (used when no profile fits a task): {default_assignee}
+
+Available repos (values you may use for "repo"):
+{repos}
 """
 
 
@@ -189,6 +199,58 @@ def _normalize_assignee_choice(assignee: object, *, default_assignee: str, valid
     return chosen if chosen in valid_names else default_assignee
 
 
+def _build_repos() -> list[dict]:
+    """``[{name, path, project_id}]`` for every registered project that has a
+    primary repo, so the decomposer can hand each child its own checkout.
+
+    An unreadable registry yields no choices rather than raising: the prompt
+    then offers no repos and anchoring falls back to the board default.
+    """
+    try:
+        from hermes_cli import projects_db as _pdb
+
+        with _pdb.connect_closing() as conn:
+            projects = _pdb.list_projects(conn)
+    except Exception:
+        logger.debug("decompose: project registry unreadable; offering no repo choices")
+        return []
+    return [
+        {"name": p.slug, "path": str(p.primary_path), "project_id": p.id}
+        for p in projects
+        if p.primary_path
+    ]
+
+
+def _format_repos(repos: list[dict]) -> str:
+    if not repos:
+        return '  (none registered — omit "repo" or set it to null)'
+    return "\n".join(f"  - {r['name']}: {r['path']}" for r in repos)
+
+
+def _resolve_repo_choice(task_id: str, idx: int, choice: object, repos: list[dict]) -> dict:
+    """Workspace fields for one child, or ``{}`` when it named no repo.
+
+    An unknown name is dropped with a log rather than fuzzy-matched: the DB
+    layer refuses an unanchored worktree child loudly, and a loud stall beats
+    checking the work out into whichever repo happened to look similar.
+    """
+    if not isinstance(choice, str) or not choice.strip():
+        return {}
+    wanted = choice.strip()
+    for repo in repos:
+        if wanted in (repo["name"], repo["path"]):
+            return {
+                "workspace_kind": "worktree",
+                "workspace_path": repo["path"],
+                "project_id": repo["project_id"],
+            }
+    logger.info(
+        "decompose: task %s child %d named unknown repo %r — leaving it unanchored",
+        task_id, idx, wanted,
+    )
+    return {}
+
+
 @dataclass
 class _Routing:
     """Config-derived routing context for one decomposition."""
@@ -198,6 +260,7 @@ class _Routing:
     auto_promote: bool
     roster: list[dict]
     valid_names: set[str]
+    repos: list[dict]
 
 
 def _load_routing() -> _Routing:
@@ -210,6 +273,7 @@ def _load_routing() -> _Routing:
         auto_promote=bool(kanban_cfg.get("auto_promote_children", True)),
         roster=roster,
         valid_names=valid_names,
+        repos=_build_repos(),
     )
 
 
@@ -256,10 +320,12 @@ def _clean_children(task_id: str, raw_tasks: list, routing: _Routing) -> tuple[l
         parents = entry.get("parents") or []
         if not isinstance(parents, list):
             parents = []
+        repo = _resolve_repo_choice(task_id, idx, entry.get("repo"), routing.repos)
         children.append({
             "title": title.strip()[:200],
             "body": body.strip() if isinstance(body, str) else "",
             "assignee": chosen,
+            **repo,
             # Drop non-int, out-of-range and self parent indices.
             "parents": [p for p in parents if isinstance(p, int) and 0 <= p < len(raw_tasks) and p != idx],
         })
@@ -315,6 +381,7 @@ def decompose_task(
             **_task_prompt_fields(task),
             roster=_format_roster(routing.roster),
             default_assignee=routing.default_assignee,
+            repos=_format_repos(routing.repos),
         ),
         max_tokens=4000, timeout=timeout or 180, log=logger,
     )

--- a/tests/hermes_cli/test_kanban_decompose_child_repo.py
+++ b/tests/hermes_cli/test_kanban_decompose_child_repo.py
@@ -1,0 +1,234 @@
+"""A decomposed child must name the repo it is checked out in.
+
+A ``workspace_kind=worktree`` child with no ``workspace_path`` is only
+dispatchable when the board carries a ``default_workdir``. On a multi-repo
+board there is none, so such a child used to be written anyway and then failed
+at spawn, burned its retries and parked as ``blocked`` behind a message that
+read like an infrastructure fault.
+
+Inheriting the root's repo is not the fix: measured against the tasks that hit
+this failure, the root's repo was the wrong checkout for 3 of the 17 whose
+outcome is known, every one of them a fan-out that crossed repos.
+
+A fresh board has ``default_workdir=None``, so these tests get the unanchored
+case for free; the one test that needs an anchor sets it through the same call
+the ``boards set-default-workdir`` command uses.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban_decompose as kd
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _triage(conn, **kw):
+    return kb.create_task(conn, title=kw.pop("title", "rough idea"), triage=True, **kw)
+
+
+def _decompose(tid, children):
+    with kbc.connect() as conn:
+        return kb.decompose_triage_task(
+            conn, tid, root_assignee="orchestrator", children=children, author="decomposer",
+        )
+
+
+def _anchor_the_board(path):
+    kb.write_board_metadata(kb.read_board_metadata()["slug"], default_workdir=str(path))
+
+
+# --------------------------------------------------------------------------
+# The child carries the repo it named.
+# --------------------------------------------------------------------------
+
+def test_a_child_keeps_the_repo_it_named(kanban_home, tmp_path):
+    repo = str(tmp_path / "code" / "frontend")
+    with kbc.connect() as conn:
+        tid = _triage(conn, title="ship a feature")
+
+    child_ids = _decompose(tid, [{
+        "title": "build the UI", "body": "", "assignee": "engineer", "parents": [],
+        "workspace_kind": "worktree", "workspace_path": repo, "project_id": "p_front",
+    }])
+
+    with kbc.connect() as conn:
+        child = kb.get_task(conn, child_ids[0])
+    assert child.workspace_kind == "worktree"
+    assert child.workspace_path == repo
+    assert child.project_id == "p_front"
+
+
+def test_siblings_may_sit_in_different_repos(kanban_home, tmp_path):
+    """The whole point: one card fans out across checkouts."""
+    front = str(tmp_path / "code" / "frontend")
+    back = str(tmp_path / "code" / "backend")
+    with kbc.connect() as conn:
+        tid = _triage(conn, title="ship a feature end to end")
+
+    child_ids = _decompose(tid, [
+        {"title": "the screen", "body": "", "assignee": "ui", "parents": [],
+         "workspace_kind": "worktree", "workspace_path": front, "project_id": "p_front"},
+        {"title": "the endpoint", "body": "", "assignee": "api", "parents": [],
+         "workspace_kind": "worktree", "workspace_path": back, "project_id": "p_back"},
+    ])
+
+    with kbc.connect() as conn:
+        paths = {kb.get_task(conn, cid).workspace_path for cid in child_ids}
+    assert paths == {front, back}
+
+
+def test_a_child_does_not_inherit_the_root_repo(kanban_home, tmp_path):
+    """Inheriting is the bug, not the fix — the child's own choice wins."""
+    root_repo = str(tmp_path / "code" / "frontend")
+    child_repo = str(tmp_path / "code" / "backend")
+    with kbc.connect() as conn:
+        tid = kb.create_task(
+            conn, title="root in the frontend", triage=True,
+            workspace_kind="worktree", workspace_path=root_repo,
+        )
+
+    child_ids = _decompose(tid, [{
+        "title": "backend work", "body": "", "assignee": "api", "parents": [],
+        "workspace_kind": "worktree", "workspace_path": child_repo, "project_id": "p_back",
+    }])
+
+    with kbc.connect() as conn:
+        child = kb.get_task(conn, child_ids[0])
+    assert child.workspace_path == child_repo
+    assert child.workspace_path != root_repo
+
+
+# --------------------------------------------------------------------------
+# An unanchored worktree child is refused — loudly, and atomically.
+# --------------------------------------------------------------------------
+
+def test_a_worktree_child_with_no_repo_is_refused(kanban_home):
+    with kbc.connect() as conn:
+        tid = _triage(conn, title="ship a feature")
+
+    with pytest.raises(ValueError, match="worktree task with no repo"):
+        _decompose(tid, [{
+            "title": "build it", "body": "", "assignee": "engineer", "parents": [],
+            "workspace_kind": "worktree",
+        }])
+
+
+def test_the_refusal_leaves_no_half_built_graph(kanban_home, tmp_path):
+    """The fan-out is one transaction: the good sibling must not survive."""
+    with kbc.connect() as conn:
+        tid = _triage(conn, title="ship a feature")
+        before = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+
+    with pytest.raises(ValueError):
+        _decompose(tid, [
+            {"title": "anchored", "body": "", "assignee": "a", "parents": [],
+             "workspace_kind": "worktree", "workspace_path": str(tmp_path / "repo")},
+            {"title": "unanchored", "body": "", "assignee": "b", "parents": [],
+             "workspace_kind": "worktree"},
+        ])
+
+    with kbc.connect() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == before
+        assert kb.get_task(conn, tid).status == "triage"
+
+
+def test_a_worktree_root_does_not_launder_its_children(kanban_home, tmp_path):
+    """The child inherits the *kind* from the root, so it must still be refused."""
+    with kbc.connect() as conn:
+        tid = kb.create_task(
+            conn, title="root in a repo", triage=True,
+            workspace_kind="worktree", workspace_path=str(tmp_path / "code" / "frontend"),
+        )
+
+    with pytest.raises(ValueError, match="worktree task with no repo"):
+        _decompose(tid, [{"title": "child", "body": "", "assignee": "a", "parents": []}])
+
+
+# --------------------------------------------------------------------------
+# Single-repo boards keep the upstream behaviour untouched.
+# --------------------------------------------------------------------------
+
+def test_a_board_default_workdir_still_anchors_the_child(kanban_home, tmp_path):
+    _anchor_the_board(tmp_path / "srv" / "repo")
+    with kbc.connect() as conn:
+        tid = _triage(conn, title="ship a feature")
+
+    child_ids = _decompose(tid, [{
+        "title": "build it", "body": "", "assignee": "engineer", "parents": [],
+        "workspace_kind": "worktree",
+    }])
+
+    with kbc.connect() as conn:
+        child = kb.get_task(conn, child_ids[0])
+    # Left unset on purpose: dispatch materializes a fresh worktree per child
+    # under the board anchor, so siblings never share one checkout.
+    assert child.workspace_path is None
+    assert child.workspace_kind == "worktree"
+
+
+def test_scratch_children_are_untouched(kanban_home):
+    with kbc.connect() as conn:
+        tid = _triage(conn, title="think about something")
+
+    child_ids = _decompose(tid, [{"title": "think", "body": "", "assignee": "a", "parents": []}])
+
+    with kbc.connect() as conn:
+        child = kb.get_task(conn, child_ids[0])
+    assert child.workspace_kind == "scratch"
+    assert child.project_id is None
+
+
+# --------------------------------------------------------------------------
+# The decomposer maps the model's repo name onto real workspace fields.
+# --------------------------------------------------------------------------
+
+REPOS = [
+    {"name": "vx-website-frontend", "path": "/code/website-frontend", "project_id": "p_a"},
+    {"name": "vx-processes", "path": "/code/internal_processes", "project_id": "p_b"},
+]
+
+
+def test_a_named_repo_becomes_workspace_fields():
+    assert kd._resolve_repo_choice("t_1", 0, "vx-processes", REPOS) == {
+        "workspace_kind": "worktree",
+        "workspace_path": "/code/internal_processes",
+        "project_id": "p_b",
+    }
+
+
+def test_a_repo_may_be_named_by_path():
+    assert kd._resolve_repo_choice("t_1", 0, "/code/website-frontend", REPOS)["project_id"] == "p_a"
+
+
+@pytest.mark.parametrize("choice", [None, "", "   ", 7, {"name": "x"}])
+def test_no_repo_named_leaves_the_child_alone(choice):
+    assert kd._resolve_repo_choice("t_1", 0, choice, REPOS) == {}
+
+
+def test_an_unknown_repo_is_dropped_not_guessed():
+    """'website' is a prefix of a real entry — a fuzzy match would pick it."""
+    assert kd._resolve_repo_choice("t_1", 0, "website", REPOS) == {}
+
+
+def test_the_prompt_offers_the_registered_repos():
+    rendered = kd._format_repos(REPOS)
+    assert "vx-website-frontend: /code/website-frontend" in rendered
+    assert "vx-processes: /code/internal_processes" in rendered
+
+
+def test_the_prompt_says_so_when_nothing_is_registered():
+    assert "none registered" in kd._format_repos([])

--- a/tests/hermes_cli/test_kanban_worktree_isolation.py
+++ b/tests/hermes_cli/test_kanban_worktree_isolation.py
@@ -68,7 +68,14 @@ def _add_worktree(repo: Path, target: Path, branch: str) -> Path:
     return target
 
 
-def test_decompose_worktree_children_get_own_workspace(kanban_home):
+def test_decompose_worktree_children_get_own_workspace(kanban_home, tmp_path):
+    # A worktree child with no repo of its own is anchored on the board's
+    # default_workdir; without one it cannot be checked out anywhere and the
+    # fan-out is refused (see test_kanban_decompose_child_repo.py). Set the
+    # anchor the way ``boards set-default-workdir`` does.
+    kb.write_board_metadata(
+        kb.read_board_metadata()["slug"], default_workdir=str(tmp_path / "repo"),
+    )
     with kbc.connect() as conn:
         root = kb.create_task(conn, title="build the feature", triage=True)
         conn.execute(


### PR DESCRIPTION
## Problem

`_insert_decomposed_child` silently wrote `workspace_kind=worktree` children
with no `workspace_path` **and no `project_id`** whenever a decomposed task
named no repo and the board had no `default_workdir` configured. The child
could never be dispatched: it failed at spawn, burned its retries, and parked
as `blocked` behind a "missing workdir" message that reads like an
infrastructure fault rather than a decompose-time mistake.

`project_id` was also never written at all by `_insert_decomposed_child`,
independent of the anchoring bug above.

## Why not just inherit the root's repo?

That was the first fix considered. Measured against every task that hit this
failure, the root's repo would have been the **wrong** checkout for 3 of 17
(18%) decomposed children with a known outcome — decomposition routinely fans
a single card out across repositories (e.g. a UI child and an API child
belonging to different checkouts). A silent checkout into the wrong repo is
worse than a loud stall at decompose time.

## Fix

- The decomposer's LLM contract now asks for a per-child `"repo"` (from the
  live registered-project list, injected into the prompt as `{repos}`).
- `_clean_children` resolves a named repo into `workspace_kind` /
  `workspace_path` / `project_id` via a new `_resolve_repo_choice`. An unknown
  repo name is dropped with a log rather than fuzzy-matched (a fuzzy match on
  a name like `"website"` could silently resolve to the wrong of several
  similarly-named repos).
- `_insert_decomposed_child` now writes `project_id`, and raises `ValueError`
  — inside the same transaction `decompose_triage_task` already uses — when a
  worktree child named no repo and the board has no `default_workdir`, instead
  of writing a half-anchored row that can never be dispatched.
- Single-repo boards with `default_workdir` configured are unaffected: an
  unanchored child still resolves to `workspace_path=None` and dispatch
  materializes `<repo>/.worktrees/<child-id>` from the board anchor, exactly
  as before.
- `test_kanban_worktree_isolation.py`'s
  `test_decompose_worktree_children_get_own_workspace` now configures a board
  `default_workdir`, since it exercises that anchored path explicitly rather
  than relying on an unanchored worktree child being silently accepted.

## Tests

New `test_kanban_decompose_child_repo.py` (14 cases): explicit per-child repo,
siblings on different repos, no inheritance from the root's repo, unknown repo
name dropped (not fuzzy-matched), loud atomic refusal of an unanchored
worktree child, and the board `default_workdir` anchor still working for a
child that names no repo.

```
tests/hermes_cli/test_kanban_decompose_child_repo.py .............. [100%]
tests/hermes_cli/test_kanban_decompose_db.py .......... [100%]
tests/hermes_cli/test_kanban_worktree_isolation.py ...... [100%]
22 passed
```

This is a companion to #103120 (`worktree_without_checkout_root` diagnostic):
that PR surfaces the mis-anchored task while it is still queued; this one
stops it from being created mis-anchored in the first place.
