### PR TITLE
fix(compression): enable Astra compaction on Codex OAuth

### DIFF
--- a/agent/native_compaction.py
+++ b/agent/native_compaction.py
@@ -1,9 +1,9 @@
-"""Native OpenAI Responses server-side compaction — gpt-5.6 on direct OpenAI routes only.
+"""Native OpenAI Responses server-side compaction on supported OpenAI routes.
 
 ``context_management=[{"type": "compaction", "compact_threshold": N}]`` makes the server
 summarize older context into an opaque ``compaction`` item once the input crosses N tokens.
-Deliberately narrow (live-verified): gpt-5.6 only (5.1/5.2 fail server-side with no
-structured rejection) on api.openai.com or the ChatGPT Codex backend. The local compressor
+Deliberately narrow: gpt-5.6 on api.openai.com or the ChatGPT Codex backend, plus exact
+gpt-6-astra on official Codex OAuth. The local compressor
 stays armed as fallback (native threshold clamped below the local trigger); compaction items
 ride the ``codex_reasoning_items`` sidecar. No transport imports (shared gate, no cycles).
 """
@@ -14,6 +14,7 @@ import logging
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlsplit
 
+from agent.codex_headers import is_official_codex_base_url
 from agent.context_compressor import is_compaction_summary_message
 from agent.message_content import flatten_message_text
 
@@ -27,9 +28,16 @@ DEFAULT_COMPACT_THRESHOLD = 200_000
 _ELIGIBLE_MODEL_MARKER = "gpt-5.6"
 
 
-def is_native_compaction_model(model: Optional[str]) -> bool:
-    """True when the model is in the gpt-5.6 family."""
-    return _ELIGIBLE_MODEL_MARKER in (model or "").lower()
+def is_native_compaction_model(
+    model: Optional[str], *, provider: Optional[str] = None, base_url: Optional[str] = None,
+) -> bool:
+    """Preserve gpt-5.6 eligibility; Astra additionally requires official Codex OAuth."""
+    model_name = (model or "").lower()
+    return _ELIGIBLE_MODEL_MARKER in model_name or (
+        model_name == "gpt-6-astra"
+        and (provider or "").strip().lower() == "openai-codex"
+        and is_official_codex_base_url(base_url or "")
+    )
 
 
 def resolve_native_compaction_capabilities(
@@ -38,7 +46,7 @@ def resolve_native_compaction_capabilities(
     """Resolve the native-compaction capability for a runtime destination (a resolved ``False``
     is distinct from "unresolved" and must survive model switches unchanged)."""
     direct_default = (provider or "").strip().lower() == "openai" and not base_url
-    return {"native_compaction": is_native_compaction_model(model) and (
+    return {"native_compaction": is_native_compaction_model(model, provider=provider, base_url=base_url) and (
         direct_default or is_direct_openai_route(base_url, is_codex_backend=is_codex_backend))}
 
 
@@ -116,7 +124,10 @@ def native_compaction_context_management(agent: Any, *, is_codex_backend: bool, 
     if getattr(agent, "compression_checkpoint_required", False) is True:
         _warn_native_compaction_suppressed_by_checkpoint_gate()
         return None
-    if is_xai_responses or is_github_responses or not is_native_compaction_model(getattr(agent, "model", None)):
+    if is_xai_responses or is_github_responses or not is_native_compaction_model(
+        getattr(agent, "model", None), provider=getattr(agent, "provider", None),
+        base_url=getattr(agent, "base_url", None),
+    ):
         return None
     trusted_proxy = bool(getattr(agent, "capabilities", {}).get("openai_native_compaction", False))
     if not trusted_proxy and not is_direct_openai_route(getattr(agent, "base_url", None), is_codex_backend=is_codex_backend):

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -665,7 +665,8 @@ compression:
 
   # Native OpenAI Responses server-side compaction (default: false). When true,
   # gpt-5.6-family models on the DIRECT OpenAI API (api.openai.com) or a ChatGPT
-  # Codex subscription compact server-side: OpenAI prunes older context into an
+  # Codex subscription, plus exact gpt-6-astra on official Codex OAuth, compact
+  # server-side: OpenAI prunes older context into an
   # encrypted checkpoint that Hermes replays on later turns. No other provider,
   # route, or model is affected. Hermes' local compression stays armed as the
   # fallback and still handles every non-eligible session.

--- a/tests/agent/test_astra_oauth_native_compaction.py
+++ b/tests/agent/test_astra_oauth_native_compaction.py
@@ -1,0 +1,86 @@
+"""Astra native management requires both the supported model and OAuth destination."""
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agent.native_compaction import (
+    native_compaction_context_management,
+    resolve_native_compaction_capabilities,
+)
+from run_agent import AIAgent
+
+
+@pytest.mark.parametrize("model,provider,base_url,eligible", [
+    ("gpt-6-astra", "openai-codex", "https://chatgpt.com/backend-api/codex", True),
+    ("GPT-6-ASTRA", "openai-codex", "https://chatgpt.com:443/backend-api/codex/", True),
+    ("gpt-6-astra", "openai", "https://api.openai.com/v1", False),
+    ("gpt-6-astra", "openai", "", False),
+    ("gpt-6-astra", "openai", "https://chatgpt.com/backend-api/codex", False),
+    ("gpt-6-astra", "openai-codex", "https://relay.example/v1", False),
+    ("gpt-6-astra", "openai-codex", "http://localhost:8080/v1", False),
+    ("gpt-6-astra", "openai-codex", "https://chatgpt.com.example/backend-api/codex", False),
+    ("gpt-6-astra", "openai-codex", "http://chatgpt.com/backend-api/codex", False),
+    ("gpt-6-astra", "openai-codex", "https://chatgpt.com:8443/backend-api/codex", False),
+    ("gpt-6-astra", "openai-codex", "https://chatgpt.com/backend-api/codex-other", False),
+    ("gpt-6-astra", "openai-codex", "https://chatgpt.com:invalid/backend-api/codex", False),
+    ("gpt-6-astra", "openai-codex", None, False),
+    ("gpt-6-astra-mini", "openai-codex", "https://chatgpt.com/backend-api/codex", False),
+    ("gpt-6-other", "openai-codex", "https://chatgpt.com/backend-api/codex", False),
+    ("gpt-5.6-sol", "openai", "https://api.openai.com/v1", True),
+    ("gpt-5.6-sol", "openai-codex", "https://chatgpt.com/backend-api/codex", True),
+])
+def test_destination_capability_and_request_gate_agree(model, provider, base_url, eligible):
+    is_codex = provider == "openai-codex"
+    resolved = resolve_native_compaction_capabilities(
+        model=model, provider=provider, base_url=base_url, is_codex_backend=is_codex,
+    )
+    assert resolved["native_compaction"] is eligible
+    agent = SimpleNamespace(
+        model=model, provider=provider, base_url=base_url,
+        codex_responses_native_compaction=True, compression_enabled=True,
+        capabilities={"openai_native_compaction": True},
+    )
+    # The request gate must also exclude Astra relays before runtime resolution,
+    # even when a proxy advertises support for native compaction.
+    for runtime in (None, resolved):
+        agent.runtime_capabilities = runtime
+        payload = native_compaction_context_management(agent, is_codex_backend=is_codex)
+        assert (payload is not None) is eligible
+
+
+@pytest.mark.parametrize("setting,value,enabled", [
+    (None, None, True),
+    ("codex_responses_native_compaction", False, False),
+    ("compression_enabled", False, False),
+    ("compression_checkpoint_required", True, False),
+    ("runtime_capabilities", {"native_compaction": False}, False),
+])
+def test_configured_agent_preserves_request_safety_gates(monkeypatch, setting, value, enabled):
+    Path(os.environ["HERMES_HOME"], "config.yaml").write_text(
+        "compression:\n  codex_responses_native: true\n"
+        "  codex_responses_compact_threshold: 999999\n  threshold_tokens: 204000\n"
+        "auxiliary:\n  title_generation:\n    enabled: false\n"
+    )
+    monkeypatch.setattr("model_tools.get_tool_definitions", lambda **kwargs: [])
+    agent: Any = AIAgent(
+        model="gpt-6-astra", provider="openai-codex", api_mode="codex_responses",
+        base_url="https://chatgpt.com/backend-api/codex", api_key="test-key",
+        quiet_mode=True, skip_context_files=True, skip_memory=True,
+        enabled_toolsets=[], save_trajectories=False,
+    )
+    try:
+        assert agent.runtime_capabilities["native_compaction"] is True
+        if setting:
+            setattr(agent, setting, value)
+        request = agent._build_api_kwargs([{"role": "user", "content": "Continue."}])
+        assert ("context_management" in request) is enabled
+        if enabled:
+            management = request["context_management"][0]
+            assert management["type"] == "compaction"
+            assert 1024 <= management["compact_threshold"] < agent.context_compressor.threshold_tokens
+    finally:
+        agent.close()

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -107,7 +107,7 @@ compression:
   codex_gpt55_autoraise: true  # gpt-5.5 on Codex OAuth: raise trigger to 85% (default: true)
   codex_gpt55_autoraise_notice: true  # Show the one-time autoraise notice (default: true)
   codex_app_server_auto: native  # native|hermes|off for Codex app-server thread compaction
-  codex_responses_native: false  # gpt-5.6 on direct OpenAI/Codex: server-side compaction (opt-in)
+  codex_responses_native: false  # Opt-in server compaction: gpt-5.6 on OpenAI/Codex; Astra on Codex OAuth
   codex_responses_compact_threshold: null  # Automatic server compaction trigger
   in_place: true             # Compact on the same session id, no rotation (default: true)
 
@@ -134,7 +134,7 @@ auxiliary:
 | `codex_gpt55_autoraise` | `true` | bool | Raise the trigger to 85% for gpt-5.5 on the ChatGPT Codex OAuth route (see below). Set `false` to keep the global `threshold` |
 | `codex_gpt55_autoraise_notice` | `true` | bool | Show the one-time Codex gpt-5.5 autoraise notice. Set `false` to keep the 85% autoraise but suppress the banner |
 | `codex_app_server_auto` | `native` | `native`, `hermes`, `off` | Thread-compaction mode for Codex app-server sessions (see below) |
-| `codex_responses_native` | `false` | bool | Opt in to OpenAI's server-side compaction on the Responses API. Engages only for gpt-5.6-family models on the direct OpenAI API or a ChatGPT Codex subscription (see below) |
+| `codex_responses_native` | `false` | bool | Opt in to OpenAI's server-side compaction on the Responses API. Engages for gpt-5.6-family models on the direct OpenAI API or a ChatGPT Codex subscription, and exact `gpt-6-astra` on official Codex OAuth (see below) |
 | `codex_responses_compact_threshold` | `null` | `null` or positive integer | `null` follows the resolved local compression trigger with an 8,192 token safety margin. A positive integer remains absolute and only clamps downward when required. Invalid values use automatic behavior. Automatic mode falls back to `200000` when no usable local trigger exists |
 | `in_place` | `true` | bool | Compact on the same session id instead of rotating to a new one (see below) |
 
@@ -250,7 +250,7 @@ Hermes' local transcript is never rewritten on this runtime — state.db records
 the compaction boundary while the visible transcript stays intact. All other
 routes (including Codex OAuth chat sessions) keep Hermes' summary compressor.
 
-### Native Responses compaction (gpt-5.6 on direct OpenAI / Codex subscription)
+### Native Responses compaction (gpt-5.6 and Astra on supported routes)
 
 OpenAI's Responses API supports server-side compaction: when a request includes
 `context_management: [{type: "compaction", compact_threshold: N}]` and the
@@ -264,12 +264,18 @@ client-side summary pass, and ZDR-friendly (`store: false`, no
 Opt in with `compression.codex_responses_native: true`. The gate is deliberately
 narrow, re-checked on every request:
 
-- **Models:** the gpt-5.6 family only. Other models fail server-side when the
-  field is present (gpt-5.1/5.2 return HTTP 500 or stall the stream — there is
-  no structured rejection to downgrade on, verified live Aug 2026).
+- **Models:** the gpt-5.6 family, plus exact `gpt-6-astra` on official Codex
+  subscription OAuth. Astra on the direct API, Astra variants and other GPT-6
+  models are excluded. gpt-5.1/5.2 return HTTP 500 or stall the stream when the
+  field is present (no structured rejection to downgrade on, verified live Aug 2026).
 - **Routes:** `api.openai.com` (OpenAI API key) or the ChatGPT Codex backend
   (Codex subscription OAuth) only. xAI, GitHub/Copilot, OpenRouter, relays, and
   local servers never see the field.
+
+For Astra, both the resolved `openai-codex` provider and an official HTTPS
+`chatgpt.com/backend-api/codex` endpoint are required. A trusted proxy override
+does not enable Astra compaction. This uses the existing automatic
+`context_management` path and does not add `configuration_update` history.
 
 Everything else about compression is unchanged: the local compressor stays
 armed as the fallback owner (the native threshold is clamped ~8K tokens below


### PR DESCRIPTION
## What does this PR do?

Astra conversations through an official ChatGPT Codex subscription can opt into automatic native compaction. Previously, the model gate suppressed `context_management` even with `compression.codex_responses_native: true`.

This is the focused OAuth eligibility change. Existing Sol behaviour, opt-in, checkpoint requirements, issuer checks and local fallback remain in place. Astra direct API, relays, trusted-proxy overrides and other GPT-6 variants remain excluded.

**Ready for review, but blocked from merge pending the native-preflight dependency and successful standalone acceptance after rebase.** Full-agent acceptance was verified on a separate local combination with the original author's updated native-preflight dependency and the CI support in #103736. Neither dependency is bundled in this four-file diff, and this branch alone does not claim to fix restored-checkpoint preflight.

## Related Issue

Fixes #103720.

Related: #100611, #100642, #103246, #103278, #103736.

The direct-API work in #103278 explicitly excludes OAuth and uses a separate path for reasoning-update history. This change uses the existing automatic `context_management` path without adding `configuration_update` history.

Dependency #100642 now handles checkpoint capture and fresh-process restoration at author head `bb1505a1194e72ec700fd72cbfdde33c7853ced2`, including the idle-compaction boundary. The [original gap report](https://github.com/NousResearch/hermes-agent/pull/100642#issuecomment-5552269012) is addressed by that author-owned change. Follow-up #103736 preserves those commits and adds only the contributor mapping and two fixture initialisations needed for CI. The dependency must be integrated with those CI fixes, followed by a rebase and standalone acceptance, before this PR is ready to merge.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/native_compaction.py`: require exact Astra, the resolved OAuth provider and the existing official-endpoint check in both eligibility paths.
- `tests/agent/test_astra_oauth_native_compaction.py`: cover route exclusions and real configuration/request safety gates.
- Update the example configuration and compression guide with the OAuth-only scope.

## How to Test

Run the focused and adjacent suite:

```bash
scripts/run_tests.sh tests/agent/test_astra_oauth_native_compaction.py \
  tests/run_agent/test_native_compaction.py \
  tests/run_agent/test_native_compaction_switch_capabilities.py \
  tests/agent/test_codex_responses_adapter.py \
  tests/agent/transports/test_codex_transport.py \
  tests/agent/test_context_compressor.py
```

Result on rebased feature head `113d15c51e6b0bb2d1670cdb3c6354cf018437a8`, based on main `431978d47b8018d6334e02c681bbdb70d1435cbb`: **387 passed**. The new Astra positive cases failed on base `21bcd0ce6c94da5b67a4ceab46dbd51fdcd29340`. Ruff, Python syntax and focused type checks passed. The final dependency head `250744e46c2c7f8330972a51346db882642896c4` passed 616 tests; additional combined gate and restoration checks passed 114 tests. These fresh runs overlap and are not a summed suite total. Reusing the restoration regression with Astra on this exact standalone feature head produced three expected failures before the provider call: local compression entered. This confirms the outstanding dependency rather than standalone acceptance.

Prior independent route, correctness, security and contract reviews found no concrete defect; range-diff confirms the rebase preserved the feature patch exactly. The additional adversarial pass covered the gate and call graph, but its full transition trace was incomplete.

Coverage limitation: exact Astra transitions through model switching and automatic fallback have no dedicated end-to-end regression; the shared resolver, initial construction and existing destination-capability tests are covered.

All required CI checks passed on the exact rebased head, with no failures or pending checks. [CI results](https://github.com/NousResearch/hermes-agent/pull/103718/checks).

## Checklist

### Code

- [x] Read the contributing guidance and followed conventional commits.
- [x] Searched existing issues and PRs for overlapping work.
- [x] Kept the diff focused and added behavioural regression coverage.
- [x] Tested on Linux using `scripts/run_tests.sh`.
- [ ] Full repository test suite run. Scoped results are listed above.

### Documentation & Housekeeping

- [x] Updated the relevant guide and example configuration comments.
- [x] Architecture/workflow guidance and tool schemas: no change needed.
- [x] Considered cross-platform impact; the change adds no host-specific behaviour.

## Screenshots / Logs

Fresh sanitised live receipt on final combined local head `a8d345553ed01c37b49621174fd8765e8b8e78b5`, including the author's updated #100642 and CI follow-up head `250744e46c2c7f8330972a51346db882642896c4`:

- Three official OAuth requests returned HTTP 200 through the real `AIAgent` and streaming transport.
- The initial answer was exactly `ACK`; three encrypted checkpoints were persisted after the completed synthetic tool result.
- A fresh process reopened SessionDB, preserved checkpoint bytes exactly and replayed them successfully.
- The restored wire request contained the original instruction and no plaintext copy of the test fact. The answer followed that instruction and recalled the fact.
- The tool ran once in total. There were no local compressor calls or local summary rows. Temporary auth and session storage were removed.

No paid direct-API calls, production activation or performance claim. The live receipt is combined-dependency evidence, not standalone acceptance of the feature branch.
