### PR TITLE
fix(weixin): classify whitespace-prefixed slash commands as COMMAND

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -560,7 +560,9 @@ def _message_type_from_media(media_types: List[str], text: str) -> MessageType:
     for prefix, message_type in _MIME_PREFIX_TYPES:
         if any(m.startswith(prefix) for m in media_types):
             return message_type
-    return MessageType.DOCUMENT if media_types else MessageType.COMMAND if text.startswith("/") else MessageType.TEXT
+    # lstrip: leading whitespace (mobile keyboards, Slack-style " /cmd" habits) must not demote a
+    # command to TEXT — TEXT is debounced/merged while COMMAND dispatches immediately.
+    return MessageType.DOCUMENT if media_types else MessageType.COMMAND if text.lstrip().startswith("/") else MessageType.TEXT
 
 
 def _load_sync_buf(hermes_home: str, account_id: str) -> str:

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -98,6 +98,16 @@ class TestMessageEventIsCommand:
         event = MessageEvent(text="/new")
         assert event.is_command() is True
 
+    @pytest.mark.parametrize("text", [" /restart", "\n/restart", "\t/restart", "  /new  "])
+    def test_leading_whitespace_is_still_a_command(self, text):
+        # Slack swallows a leading "/" (its own slash-command handling), so " /restart" is the
+        # only way the text reaches Hermes; mobile keyboards insert leading spaces/newlines.
+        assert MessageEvent(text=text).is_command() is True
+
+    @pytest.mark.parametrize("text", ["  hello", "\nhello /new", "   "])
+    def test_leading_whitespace_non_command_stays_text(self, text):
+        assert MessageEvent(text=text).is_command() is False
+
 
 class TestMessageEventGetCommand:
     def test_simple_command(self):
@@ -112,11 +122,40 @@ class TestMessageEventGetCommand:
         event = MessageEvent(text="hello")
         assert event.get_command() is None
 
+    @pytest.mark.parametrize(
+        "text,expected", [(" /restart", "restart"), ("\n/restart", "restart"), ("  /new  ", "new")]
+    )
+    def test_leading_whitespace_command_name(self, text, expected):
+        assert MessageEvent(text=text).get_command() == expected
+
+    def test_bot_suffix_stripped_with_leading_whitespace(self):
+        assert MessageEvent(text=" /cmd@botname").get_command() == "cmd"
+        assert MessageEvent(text="/cmd@botname").get_command() == "cmd"
+
+    def test_file_path_rejected_even_with_leading_whitespace(self):
+        assert MessageEvent(text="/path/to/file").get_command() is None
+        assert MessageEvent(text="  /path/to/file").get_command() is None
+
 
 class TestMessageEventGetCommandArgs:
     def test_command_with_args(self):
         event = MessageEvent(text="/new session id 123")
         assert event.get_command_args() == "session id 123"
+
+    def test_leading_whitespace_command_args(self):
+        event = MessageEvent(text="  /model gpt-6-astra")
+        assert event.get_command() == "model"
+        assert event.get_command_args() == "gpt-6-astra"
+
+    def test_ios_dash_normalization_with_leading_whitespace(self):
+        # iOS auto-corrects -- to em dash and - to en dash; normalization must survive lstrip.
+        event = MessageEvent(text=" /model \u2014force \u2013v gpt-6")
+        assert event.get_command_args() == "--force -v gpt-6"
+
+    def test_non_command_returns_raw_text_unmodified(self):
+        # get_command_args on a non-command returns self.text verbatim (leading space intact).
+        event = MessageEvent(text="  hello")
+        assert event.get_command_args() == "  hello"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -880,3 +880,38 @@ class TestWeixinVoiceGatewayHandoff:
             "the wrong transcript instead of re-transcribing (#27300)."
         )
 
+
+class TestWeixinMessageTypeClassification:
+    """``_message_type_from_media`` must classify a whitespace-prefixed command as COMMAND.
+
+    COMMAND dispatches immediately; TEXT is debounced/merged with adjacent messages.  A leading
+    space is not exotic: Slack swallows a leading "/" as its own slash command so users learn to
+    type " /restart", and mobile IMEs insert leading spaces/newlines.  ``MessageEvent`` already
+    lstrips before its ``startswith("/")`` check, so an unstripped check here silently disagrees
+    with the rest of the gateway about what counts as a command.
+    """
+
+    @pytest.mark.parametrize("text", ["/restart", " /restart", "\n/restart", "\t/new", "  /model gpt-6"])
+    def test_command_text_classifies_as_command(self, text):
+        assert weixin._message_type_from_media([], text) == MessageType.COMMAND
+
+    @pytest.mark.parametrize("text", ["hello", "  hello", "", "   ", "not /a/command"])
+    def test_non_command_text_classifies_as_text(self, text):
+        assert weixin._message_type_from_media([], text) == MessageType.TEXT
+
+    def test_classification_agrees_with_message_event(self):
+        # The invariant that matters: this helper and MessageEvent.is_command() must never
+        # disagree about whether a given body is a command.
+        for text in ("/restart", " /restart", "\n/new", "hello", "  hello", "   "):
+            helper_says_command = weixin._message_type_from_media([], text) == MessageType.COMMAND
+            assert helper_says_command is MessageEvent(text=text).is_command(), text
+
+    @pytest.mark.parametrize("media_types,expected", [
+        (["image/png"], MessageType.PHOTO),
+        (["video/mp4"], MessageType.VIDEO),
+        (["audio/ogg"], MessageType.VOICE),
+        (["application/pdf"], MessageType.DOCUMENT),
+    ])
+    def test_media_wins_over_command_text(self, media_types, expected):
+        # Media classification takes precedence even when the caption looks like a command.
+        assert weixin._message_type_from_media(media_types, " /restart") == expected


### PR DESCRIPTION
## The bug

`_message_type_from_media()` in `gateway/platforms/weixin.py` tested `text.startswith("/")` against the **raw** message body:

```python
return MessageType.DOCUMENT if media_types else MessageType.COMMAND if text.startswith("/") else MessageType.TEXT
```

So `" /restart"` (single leading space) was classified `MessageType.TEXT` instead of `MessageType.COMMAND`.

That distinction is behavioral, not cosmetic: **TEXT is debounced and merged** with adjacent messages, while **COMMAND dispatches immediately**. A whitespace-prefixed command was therefore silently absorbed into the chat stream and never ran — no error, no feedback, the command just quietly became conversation.

## Why leading whitespace is not an edge case

Two independent sources produce it constantly:

1. **Slack claims a leading `/` for its own slash-command handling.** A message typed as `/restart` is intercepted by Slack and never reaches the bot, so users learn to type `" /restart"` with a leading space as the only way to get the text through. On Slack the whitespace-prefixed form is the *normal* form.
2. **Mobile IMEs** routinely insert leading spaces and newlines, especially on reply/continuation.

## Root cause: drift from an existing contract

`MessageEvent` in `gateway/platforms/base.py` already handles this correctly — all three command helpers normalize before testing:

```python
def is_command(self) -> bool:
    return self.allow_gateway_control and (self.text or "").lstrip().startswith("/")
```

`get_command()` and `get_command_args()` do the same. Weixin's classifier had drifted from that contract, so the gateway could internally disagree with itself about whether a given body was a command.

## Adapter audit

Every `startswith("/")` under `gateway/platforms/` was reviewed:

| Site | Verdict |
|---|---|
| `weixin.py:563` `_message_type_from_media` | **BUG — fixed.** Unstripped inbound command classification. |
| `base.py:1583` `is_command` | OK — already lstrips. |
| `base.py:1646` plaintext-restart guard | OK — operates on `.strip()`ed text. |
| `whatsapp_common.py:281` | OK — already `.strip()`s. |
| `yuanbao.py:1156` `_classify` | OK — input is `_rewrite_slash_command()` output, which `.strip()`s. |
| `yuanbao.py:1015` command allowlist | OK — same pre-stripped `cmd_line`. |
| `yuanbao.py:1651`, `bluebubbles.py:122`, `msgraph_webhook.py:52`, `whatsapp_cloud.py:213`, `base.py:939` | Not applicable — URL/path/webhook-route normalization, not message text. |

Weixin was the only inbound classifier still disagreeing.

## Tests

**Falsification check** — with the one-line fix reverted, the new weixin tests fail exactly as expected and pass with it applied:

```
FAILED tests/gateway/test_weixin.py::TestWeixinMessageTypeClassification::test_command_text_classifies_as_command[ /restart]
FAILED tests/gateway/test_weixin.py::TestWeixinMessageTypeClassification::test_command_text_classifies_as_command[\n/restart]
FAILED tests/gateway/test_weixin.py::TestWeixinMessageTypeClassification::test_command_text_classifies_as_command[\t/new]
FAILED tests/gateway/test_weixin.py::TestWeixinMessageTypeClassification::test_command_text_classifies_as_command[  /model gpt-6]
FAILED tests/gateway/test_weixin.py::TestWeixinMessageTypeClassification::test_classification_agrees_with_message_event
========================= 5 failed, 42 passed in 3.44s =========================
```

The key test is a **behavior contract, not a snapshot** — it asserts the weixin classifier and `MessageEvent.is_command()` can never disagree about the same body, so this class of drift is caught rather than re-fixed per adapter:

```python
def test_classification_agrees_with_message_event(self):
    for text in ("/restart", " /restart", "\n/new", "hello", "  hello", "   "):
        helper_says_command = weixin._message_type_from_media([], text) == MessageType.COMMAND
        assert helper_says_command is MessageEvent(text=text).is_command(), text
```

Also added regression coverage in `tests/gateway/test_platform_base.py` locking in `MessageEvent`'s existing (previously untested) leading-whitespace behavior, including that the `@botname` suffix strip, file-path rejection, and iOS em/en-dash normalization all survive the lstrip.

Media classification still takes precedence over command-looking captions (PHOTO/VIDEO/VOICE/DOCUMENT), covered explicitly.

## Test output

Targeted:
```
=== Summary: 2 files, 168 tests passed, 0 failed (100% complete) in 5.0s (96 workers) ===
```

Full gateway suite, no regressions:
```
=== Summary: 772 files, 7785 tests passed, 0 failed, 24 skipped (100% complete) in 114.4s (96 workers) ===
```

## Scope note

Originally investigated as a `base.py` leading-whitespace bug reported from Slack. That turned out to already be fixed on `main` — the reporter's checkout was far behind. This PR is narrowed to the one site where the bug is genuinely still live on `main`.
