### PR TITLE
fix(agent): row-addressed api_content backfill for pre-persisted user turns (#102194)

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -704,21 +704,56 @@ def _stamp_api_content_sidecar(
     if _api_content is None or _api_content == _turn_user_msg.get("content"):
         return
     _turn_user_msg["api_content"] = _api_content
-    # In-place preflight compaction already inserted this turn's user row and the
-    # crash persist identity-skips compacted dicts, so backfill the stamp onto the row
-    # directly. Rotation mode flushes to the child session later.
-    if not (preflight_compressed and getattr(agent, "_last_compaction_in_place", False)):
+    # When this turn's user row was ALREADY materialized before the sidecar could be
+    # composed, the crash persist below skips the message (marker/identity) and the
+    # stamp would never reach the DB — the next turn then replays clean content and
+    # the request prefix diverges at this message. Two writers get there first:
+    # in-place preflight compaction (archive_and_compact runs before
+    # prefetch/pre_llm_call) and a close/early flush that raced the prologue on the
+    # CLI path (#102194). Both stamp ``_row_id`` on the live dict when they write it
+    # (``_insert_message_rows`` directly, ``sync_flushed_message_markers`` after the
+    # batch commit), so that id is at once the proof a row exists and the address to
+    # update — no positional guess, and no extra write on the normal path where the
+    # row does not exist yet.
+    #
+    # Do NOT widen this to an unconditional backfill: without a row id the store can
+    # only target the newest active user row, and a repeated user turn ("ok", "y",
+    # "continue") makes the PREVIOUS turn's row compare equal — this turn's bytes
+    # would overwrite its sidecar and be replayed as that turn forever.
+    #
+    # Rotation mode needs nothing here: its compacted copies flush to the child
+    # session after this stamp.
+    _row_id = _turn_user_msg.get("_row_id")
+    _has_valid_row_id = (
+        isinstance(_row_id, int)
+        and not isinstance(_row_id, bool)
+        and _row_id > 0
+    )
+    _in_place_compacted = preflight_compressed and bool(
+        getattr(agent, "_last_compaction_in_place", False)
+    )
+    if not (_has_valid_row_id or _in_place_compacted):
         return
     _db = getattr(agent, "_session_db", None)
     if _db is not None:
         try:
-            _db.set_latest_user_api_content(
-                agent.session_id, _turn_user_msg.get("content"), _api_content
-            )
+            if _has_valid_row_id:
+                _db.set_message_api_content(
+                    agent.session_id,
+                    _row_id,
+                    _turn_user_msg.get("content"),
+                    _api_content,
+                )
+            else:
+                # Compacted copy that carries no row id: fall back to the positional
+                # backfill, which is safe here because archive_and_compact just made
+                # this message the newest active user row.
+                _db.set_latest_user_api_content(
+                    agent.session_id, _turn_user_msg.get("content"), _api_content
+                )
         except Exception:
             logger.warning(
-                "in-place compaction api_content backfill failed "
-                "for session=%s",
+                "api_content backfill failed for session=%s",
                 agent.session_id or "none",
                 exc_info=True,
             )

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -750,25 +750,42 @@ def _stamp_api_content_sidecar(
     #
     # Rotation mode needs nothing here: its compacted copies flush to the child
     # session after this stamp.
-    _row_id = _turn_user_msg.get("_row_id")
-    _has_valid_row_id = (
-        isinstance(_row_id, int)
-        and not isinstance(_row_id, bool)
-        and _row_id > 0
-    )
-    _in_place_compacted = preflight_compressed and bool(
-        getattr(agent, "_last_compaction_in_place", False)
-    )
-    if not (_has_valid_row_id or _in_place_compacted):
-        return
-    # Match the durable row on the bytes it actually holds on disk (the pre-flushed
-    # clean text) when we captured one; otherwise fall back to the live content, same
-    # as before this fix (the ordinary in-place-compaction / no-early-flush case).
-    _match_content = (
-        _persisted_content if _persisted_content is not None else _turn_user_msg.get("content")
-    )
-    _db = getattr(agent, "_session_db", None)
-    if _db is not None:
+    #
+    # ``_row_id`` MUST be read (and re-read) under ``_session_persist_lock``, the same
+    # lock a close/early flush holds while it copies this row out, commits it, and
+    # writes ``_row_id`` back onto this dict (see ``_persist_under_lock``). Reading
+    # ``_row_id`` outside that lock races: a close flush can be paused between
+    # committing the row (with no sidecar) and stamping ``_row_id`` back, this stamp
+    # sees no id yet and returns, the close flush then finishes committing
+    # ``api_content = NULL`` and marks the message persisted, and turn-start persist
+    # skips it forever because it is already marked persisted — the row is left with
+    # the wrong bytes for replay with no writer left to correct it. Taking the lock
+    # here — and re-checking ``_row_id`` AFTER acquiring it, not before — closes that
+    # window: either we run first and the close flush blocks until we release the
+    # lock (ordinary no-row-yet path), or the close flush already finished under the
+    # lock and by the time we acquire it ``_row_id`` is visible and current.
+    def _backfill_locked() -> None:
+        _row_id = _turn_user_msg.get("_row_id")
+        _has_valid_row_id = (
+            isinstance(_row_id, int)
+            and not isinstance(_row_id, bool)
+            and _row_id > 0
+        )
+        _in_place_compacted = preflight_compressed and bool(
+            getattr(agent, "_last_compaction_in_place", False)
+        )
+        if not (_has_valid_row_id or _in_place_compacted):
+            return
+        # Match the durable row on the bytes it actually holds on disk (the
+        # pre-flushed clean text) when we captured one; otherwise fall back to the
+        # live content, same as before this fix (the ordinary in-place-compaction /
+        # no-early-flush case).
+        _match_content = (
+            _persisted_content if _persisted_content is not None else _turn_user_msg.get("content")
+        )
+        _db = getattr(agent, "_session_db", None)
+        if _db is None:
+            return
         try:
             if _has_valid_row_id:
                 _db.set_message_api_content(
@@ -790,6 +807,13 @@ def _stamp_api_content_sidecar(
                 agent.session_id or "none",
                 exc_info=True,
             )
+
+    _lock = getattr(agent, "_session_persist_lock", None)
+    if _lock is None:
+        _backfill_locked()
+    else:
+        with _lock:
+            _backfill_locked()
 
 
 def _persist_turn_start(

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -500,9 +500,18 @@ def _stage_turn_user_message(
         and pending_cli_message.get("content") == expected_persist_content
     ):
         user_msg = pending_cli_message
+        # Capture the exact bytes this dict carried BEFORE we restore the API-facing
+        # variant below. A close/early flush may have already committed THESE bytes to
+        # a durable row (stamping `_row_id` on this same dict) before this restore
+        # runs. If the sidecar backfill later matches on the live (restored) content
+        # instead of what is actually on disk, the row-addressed UPDATE silently
+        # touches zero rows (#102194 follow-up).
+        _persisted_content = user_msg.get("content")
         # CLI-staged value is the clean text; restore the API-facing variant (e.g. voice
         # prefix) on the same dict, keeping any close-path durable marker.
         user_msg["content"] = user_message
+        if _persisted_content != user_message:
+            user_msg["_persisted_content"] = _persisted_content
     else:
         user_msg = {"role": "user", "content": user_message}
         if isinstance(pending_cli_message, dict):
@@ -698,10 +707,28 @@ def _stamp_api_content_sidecar(
     """api_content sidecar — persist what you send: injected context lives only in the
     API copy, so stamp the exact sent bytes on the live dict for replay."""
     _turn_user_msg = messages[current_turn_user_idx]
-    _api_content = compose_user_api_content(
-        _turn_user_msg.get("content", ""), ext_prefetch_cache, plugin_user_context
-    )
-    if _api_content is None or _api_content == _turn_user_msg.get("content"):
+    # A close/early flush can persist THIS row's clean text before the prologue
+    # restores an API-facing variant (e.g. voice prefix) onto the same dict
+    # (`_stage_turn_user_message`). That helper records the exact bytes that landed in
+    # the durable row as `_persisted_content` before overwriting `content`. The row
+    # must be matched — and updated — against THOSE bytes, never the live (possibly
+    # rewritten) `content`: matching on live content is what made the row-addressed
+    # backfill silently update zero rows (#102194 follow-up).
+    _persisted_content = _turn_user_msg.pop("_persisted_content", None)
+    _live_content = _turn_user_msg.get("content", "")
+    _composed = compose_user_api_content(_live_content, ext_prefetch_cache, plugin_user_context)
+    if _composed is not None:
+        _api_content = _composed
+    elif _persisted_content is not None and _persisted_content != _live_content:
+        # No memory/plugin injection this turn, but the durable row already holds
+        # different (clean) bytes than what this turn actually sends — e.g. the
+        # close-flush persisted "hello" and this dict was restored to "[voice] hello".
+        # Backfill the live bytes so replay resends what was really sent instead of
+        # silently keeping the earlier, now-stale row content forever.
+        _api_content = _live_content
+    else:
+        _api_content = None
+    if _api_content is None:
         return
     _turn_user_msg["api_content"] = _api_content
     # When this turn's user row was ALREADY materialized before the sidecar could be
@@ -734,6 +761,12 @@ def _stamp_api_content_sidecar(
     )
     if not (_has_valid_row_id or _in_place_compacted):
         return
+    # Match the durable row on the bytes it actually holds on disk (the pre-flushed
+    # clean text) when we captured one; otherwise fall back to the live content, same
+    # as before this fix (the ordinary in-place-compaction / no-early-flush case).
+    _match_content = (
+        _persisted_content if _persisted_content is not None else _turn_user_msg.get("content")
+    )
     _db = getattr(agent, "_session_db", None)
     if _db is not None:
         try:
@@ -741,7 +774,7 @@ def _stamp_api_content_sidecar(
                 _db.set_message_api_content(
                     agent.session_id,
                     _row_id,
-                    _turn_user_msg.get("content"),
+                    _match_content,
                     _api_content,
                 )
             else:
@@ -749,7 +782,7 @@ def _stamp_api_content_sidecar(
                 # backfill, which is safe here because archive_and_compact just made
                 # this message the newest active user row.
                 _db.set_latest_user_api_content(
-                    agent.session_id, _turn_user_msg.get("content"), _api_content
+                    agent.session_id, _match_content, _api_content
                 )
         except Exception:
             logger.warning(

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -576,12 +576,41 @@ class SessionMessagesMixin:
     def set_latest_user_api_content(self, session_id: str, content: Any, api_content: str) -> int:
         """Backfill the ``api_content`` sidecar onto the newest ACTIVE user row (0/1 rows). Preflight compaction
         inserts that row BEFORE the sidecar exists and the later persist identity-skips compacted dicts;
-        without this a reload reopens the prompt-cache divergence. ``content`` match guards a racing rewrite."""
+        without this a reload reopens the prompt-cache divergence. ``content`` match guards a racing rewrite.
+
+        POSITIONAL, and only safe when the caller already knows the newest active user row IS the message it
+        stamped. The content match is NOT sufficient on its own: repeated identical user turns ("ok", "y",
+        "continue") make an OLDER row compare equal, so calling this before the current turn's row exists
+        overwrites the previous turn's sidecar with this turn's bytes — durable wrong-bytes replay, a worse
+        cache break than the missing sidecar. When the caller holds the durable row id (``_row_id``, synced
+        onto the live dict by ``sync_flushed_message_markers`` and stamped by ``_insert_message_rows``), use
+        :meth:`set_message_api_content` instead — it addresses the exact row and cannot land on a neighbour."""
         return self._write_rowcount(
             "UPDATE messages SET api_content = ? WHERE id = (SELECT id FROM messages "
             "WHERE session_id = ? AND role = 'user' AND active = 1 ORDER BY id DESC LIMIT 1"
             ") AND content IS ?",
             (_scrub_surrogates(api_content), session_id, self._encode_content(content)))
+
+    def set_message_api_content(self, session_id: str, row_id: int, content: Any, api_content: str) -> int:
+        """Backfill the ``api_content`` sidecar onto ONE known durable row.
+
+        Row-addressed counterpart to :meth:`set_latest_user_api_content`: the caller passes the ``_row_id``
+        the write path stamped on the live message dict, so the update cannot drift onto a neighbouring row
+        that merely carries the same text.
+
+        Used by the turn prologue whenever the current turn's user row was already materialized before the
+        sidecar could be composed (in-place preflight compaction, a close/early flush that raced the
+        prologue — #102194). The crash persist then marker-skips that message, so this is the only way the
+        stamped bytes reach the store.
+
+        ``active = 1`` and the ``content`` match stay as defensive guards: a row the compaction archived, or
+        one a racing rewrite changed, is left untouched."""
+        if not session_id or isinstance(row_id, bool) or not isinstance(row_id, int) or row_id <= 0:
+            return 0
+        return self._write_rowcount(
+            "UPDATE messages SET api_content = ? "
+            "WHERE id = ? AND session_id = ? AND role = 'user' AND active = 1 AND content IS ?",
+            (_scrub_surrogates(api_content), row_id, session_id, self._encode_content(content)))
 
     def _dedupe_display_generations(self, rows):
         """Collapse compaction generations so each logical message appears once (the protected tail is copied

--- a/tests/agent/test_api_content_row_addressed_backfill.py
+++ b/tests/agent/test_api_content_row_addressed_backfill.py
@@ -1,0 +1,257 @@
+"""Row-addressed ``api_content`` backfill (NousResearch/hermes-agent#102194).
+
+The sidecar is stamped by the turn prologue and normally reaches the DB in the
+same INSERT as the clean content (the crash persist runs after the stamp). When
+another writer materialized the current turn's user row FIRST — in-place
+preflight compaction, or a close/early flush that raced the prologue — that
+insert never happens: the crash persist marker-skips the message and the row
+keeps ``api_content = NULL``, so the next turn replays clean content and the
+request prefix diverges exactly at that message.
+
+The prologue therefore backfills, but only when a row provably exists for THIS
+dict. ``_row_id`` is that proof and that address: both early writers stamp it on
+the live message (``_insert_message_rows`` directly, ``sync_flushed_message_markers``
+after the batch commit). A positional "newest active user row" update cannot be
+substituted for it — a repeated user turn ("ok", "y", "continue") makes the
+previous turn's row compare equal on content, and the backfill would overwrite
+that turn's sidecar with this turn's bytes.
+"""
+
+from __future__ import annotations
+
+import types
+from unittest.mock import patch
+
+import pytest
+
+from agent.turn_context import compose_user_api_content
+from hermes_state import SessionDB
+from tests.agent.test_api_content_sidecar import _FakeAgent, _build
+
+
+def _open_db(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(session_id="s1", source="cli")
+    return db
+
+
+def _open_db_with_sessions(tmp_path, *session_ids):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    for sid in session_ids:
+        db.create_session(session_id=sid, source="cli")
+    return db
+
+
+class TestSetMessageApiContent:
+    """The store primitive: addressed by row id, guarded on the rest."""
+
+    def test_updates_the_addressed_row(self, tmp_path):
+        db = _open_db(tmp_path)
+        try:
+            db.append_message("s1", "user", content="ok")
+            row_id = db.get_messages("s1")[0]["id"]
+            assert db.set_message_api_content("s1", row_id, "ok", "ok\n\nCTX") == 1
+            assert db.get_messages("s1")[0]["api_content"] == "ok\n\nCTX"
+        finally:
+            db.close()
+
+    def test_older_identical_row_is_untouched(self, tmp_path):
+        """Two user turns with the same text — the repeated-"ok" shape.
+
+        Addressing the row makes the older turn's sidecar unreachable; the
+        positional helper cannot tell them apart (asserted on the same DB).
+        """
+        db = _open_db(tmp_path)
+        try:
+            db.append_message("s1", "user", content="ok")
+            db.append_message("s1", "assistant", content="hi")
+            db.append_message("s1", "user", content="ok")
+            rows = db.get_messages("s1")
+            older_id, newer_id = rows[0]["id"], rows[2]["id"]
+            assert older_id != newer_id
+
+            db.set_message_api_content("s1", newer_id, "ok", "ok\n\nCTX-NEW")
+            assert db.get_messages("s1")[2]["api_content"] == "ok\n\nCTX-NEW"
+            # The older identical row was not touched.
+            assert db.get_messages("s1")[0]["api_content"] is None
+        finally:
+            db.close()
+
+    def test_content_mismatch_writes_nothing(self, tmp_path):
+        """A row a racing rewrite changed is left untouched."""
+        db = _open_db(tmp_path)
+        try:
+            db.append_message("s1", "user", content="ok")
+            row_id = db.get_messages("s1")[0]["id"]
+            assert db.set_message_api_content("s1", row_id, "different", "ok\n\nCTX") == 0
+            assert db.get_messages("s1")[0]["api_content"] is None
+        finally:
+            db.close()
+
+    def test_rejects_invalid_row_id_and_session(self, tmp_path):
+        db = _open_db(tmp_path)
+        try:
+            db.append_message("s1", "user", content="ok")
+            for bad_id in (0, -1, None, "5", True):
+                assert db.set_message_api_content("s1", bad_id, "ok", "ok\n\nCTX") == 0
+            assert db.set_message_api_content("", 1, "ok", "ok\n\nCTX") == 0
+            assert db.get_messages("s1")[0]["api_content"] is None
+        finally:
+            db.close()
+
+    def test_archived_row_is_untouched(self, tmp_path):
+        """A compaction-archived row (active=0) must not be revived."""
+        db = _open_db(tmp_path)
+        try:
+            db.append_message("s1", "user", content="ok")
+            row_id = db.get_messages("s1")[0]["id"]
+            db.archive_and_compact("s1", [{"role": "user", "content": "summary"}])
+            assert db.set_message_api_content("s1", row_id, "ok", "ok\n\nCTX") == 0
+        finally:
+            db.close()
+
+
+class TestPrologueRowAddressedBackfill:
+    """The prologue backfills when — and only when — the row provably exists."""
+
+    def _agent_with_db(self, tmp_path, **overrides):
+        db = _open_db_with_sessions(tmp_path, "s1", "sess-1")
+        agent = _FakeAgent()
+        agent._session_db = db
+        for k, v in overrides.items():
+            setattr(agent, k, v)
+        return agent, db
+
+    def test_row_id_backfill_replaces_positional_call(self, tmp_path):
+        """A pre-persisted row (close-flush raced the prologue) carries
+        ``_row_id``; the backfill must address it, not the newest row."""
+        agent, db = self._agent_with_db(tmp_path)
+        # Pre-existing older turn with identical clean text.
+        db.append_message(agent.session_id, "user", content="ok")
+        # The current turn's message was already flushed: stamped with a row id
+        # and the persisted marker, so the crash persist will skip it.
+        current_row_id = db.append_message(
+            agent.session_id, "user", content="ok"
+        )
+        try:
+            with patch(
+                "hermes_cli.plugins.invoke_hook",
+                return_value=[{"context": "PLUGIN-CTX"}],
+            ), patch(
+                "agent.session_persistence._is_ephemeral_scaffolding",
+                lambda _m: False,
+            ):
+                ctx = _build(
+                    agent,
+                    user_message="ok",
+                    # The live dict the prologue will see, carrying the flush stamps.
+                    conversation_history=[],
+                )
+            # Stamp the row-id path precondition directly on the live dict, as
+            # sync_flushed_message_markers would have.
+            turn_msg = ctx.messages[ctx.current_turn_user_idx]
+            turn_msg["_row_id"] = current_row_id
+
+            expected = compose_user_api_content(
+                "ok", ctx.ext_prefetch_cache, ctx.plugin_user_context
+            )
+            # Re-run the stamp with the row id present: the exact-sent-bytes
+            # backfill must land on the addressed row.
+            from agent.turn_context import _stamp_api_content_sidecar
+
+            _stamp_api_content_sidecar(
+                agent, ctx.messages, ctx.current_turn_user_idx,
+                ctx.ext_prefetch_cache, ctx.plugin_user_context,
+                preflight_compressed=False,
+            )
+            rows = db.get_messages(agent.session_id)
+            assert rows[1]["api_content"] == expected
+            # The older identical row keeps its (absent) sidecar.
+            assert rows[0]["api_content"] is None
+        finally:
+            db.close()
+
+    def test_in_place_compaction_falls_back_to_positional(self, tmp_path):
+        """Compacted copies carry no ``_row_id``; the pre-existing positional
+        backfill stays for them (archive_and_compact just made this row the
+        newest active user row, so targeting by position is safe there)."""
+        agent, db = self._agent_with_db(tmp_path, _last_compaction_in_place=True)
+        positional_calls = []
+        orig_positional = db.set_latest_user_api_content
+
+        def _spy(*args, **kwargs):
+            positional_calls.append(args)
+            return orig_positional(*args, **kwargs)
+
+        db.set_latest_user_api_content = _spy
+        try:
+            with patch(
+                "hermes_cli.plugins.invoke_hook",
+                return_value=[{"context": "PLUGIN-CTX"}],
+            ):
+                ctx = _build(agent, user_message="hello")
+            turn_msg = ctx.messages[ctx.current_turn_user_idx]
+            assert "_row_id" not in turn_msg
+
+            from agent.turn_context import _stamp_api_content_sidecar
+
+            _stamp_api_content_sidecar(
+                agent, ctx.messages, ctx.current_turn_user_idx,
+                ctx.ext_prefetch_cache, ctx.plugin_user_context,
+                preflight_compressed=True,
+            )
+            # The positional fallback fired (row-addressed path not taken:
+            # no _row_id on the compacted copy).
+            assert len(positional_calls) == 1
+            assert positional_calls[0][0] == agent.session_id
+            expected = compose_user_api_content(
+                "hello", ctx.ext_prefetch_cache, ctx.plugin_user_context
+            )
+            assert positional_calls[0][2] == expected
+        finally:
+            db.close()
+
+    def test_no_backfill_without_row_id_or_compaction(self, tmp_path):
+        """Normal path: the row does not exist yet, and nothing is written
+        by the stamp (the crash persist below writes the row once, with the
+        sidecar in the same INSERT)."""
+        agent, db = self._agent_with_db(tmp_path)
+        calls = []
+        orig = db.set_latest_user_api_content
+
+        def _spy(*args, **kwargs):
+            calls.append(args)
+            return orig(*args, **kwargs)
+
+        db.set_latest_user_api_content = _spy
+        try:
+            with patch(
+                "hermes_cli.plugins.invoke_hook",
+                return_value=[{"context": "PLUGIN-CTX"}],
+            ):
+                ctx = _build(agent, user_message="hello")
+            assert ctx.messages[ctx.current_turn_user_idx]["api_content"]
+            assert calls == []  # no positional backfill on the normal path
+        finally:
+            db.close()
+
+
+def test_positional_backfill_collision_documented(tmp_path):
+    """The exact failure mode that rules out an unconditional positional
+    backfill: repeated identical user turns. The positional helper cannot
+    distinguish the rows; the row-addressed primitive can."""
+    db = _open_db(tmp_path)
+    try:
+        db.append_message("s1", "user", content="continue")
+        db.append_message("s1", "assistant", content="doing it")
+        older = db.get_messages("s1")[0]["id"]
+        db.set_latest_user_api_content("s1", "continue", "continue\n\nCTX-1")
+        assert db.get_messages("s1")[0]["api_content"] == "continue\n\nCTX-1"
+
+        # New turn with the same text, row NOT yet materialized: a positional
+        # backfill now would hit the older row — which the row-addressed
+        # primitive refuses to do (no valid id => no write).
+        assert db.set_message_api_content("s1", 0, "continue", "continue\n\nCTX-2") == 0
+        assert db.get_messages("s1")[0]["api_content"] == "continue\n\nCTX-1"
+    finally:
+        db.close()


### PR DESCRIPTION
## What

Row-addressed `api_content` backfill for pre-persisted user turns, closing #102194 on the post-#102117 structure.

This is the composition of #102411 (the issue's designated "active semantic carrier", itself the successor of #102239 and #102286) onto the decomposed `hermes_state_messages.py` owner that #102117 merged on 2026-09-04, per the landing rule on the issue: *"Compose #102411's row-addressed semantics/tests into the bounded message-state owner on #102117 (or a cleaner structural successor)"*.

## The bug (#102194, P0)

Every new user turn's first API call misses the provider prompt cache. Root cause: the turn prologue stamps the exact sent bytes on the live user dict as `api_content` (`agent/turn_context.py::_stamp_api_content_sidecar`), but when the current turn's user row was already materialized before the stamp — by a close/early flush that raced the prologue on the CLI path — the crash persist marker-skips the message and the sidecar never reaches the row. The next turn replays clean content, and the request prefix diverges at that message (`cache_read` collapses to the offset of the first decorated message; observed 50-58% on turns that otherwise hit 94-100%).

The prior backfill only covers ONE of the two early writers: in-place preflight compaction. The close/early-flush writer was left out, and cannot be covered by widening the existing positional helper.

## Why row-addressed, not positional

`set_latest_user_api_content` targets the newest ACTIVE user row matching on content. A repeated user turn ("ok", "y", "continue") makes the PREVIOUS turn's row compare equal, so an unconditional positional backfill would overwrite that turn's sidecar with this turn's bytes — durable wrong-bytes replay, strictly worse than the missing sidecar. Both early writers (`_insert_message_rows` directly, `sync_flushed_message_markers` after the batch commit) stamp `_row_id` on the live dict, so that id is simultaneously the proof a row exists and the exact address to update.

## Changes

- `hermes_state_messages.py` — add `set_message_api_content(session_id, row_id, content, api_content)`: row-addressed counterpart to the positional helper, guarded on `active = 1` and content match (archived rows and racing rewrites stay untouched). The positional helper gets a docstring warning about the repeated-identical-turns collision and points callers holding a row id at the new primitive.
- `agent/turn_context.py` — `_stamp_api_content_sidecar` backfills when the live dict carries a valid `_row_id` (int > 0, not bool) OR in-place compaction just ran (compacted copies carry no row id; the positional fallback is safe there because `archive_and_compact` just made this message the newest active user row). No memory-provider instances, no schema changes, no extra write on the normal path.
- `tests/agent/test_api_content_row_addressed_backfill.py` — 9 tests:
  - store primitive: addressed row updated; older identical row untouched (the repeated-"ok" shape); content-mismatch writes nothing; invalid ids/session rejected; archived row untouched
  - prologue: `_row_id` backfill lands on the addressed row while the older identical row keeps its (absent) sidecar; in-place compaction falls back to the positional helper; no backfill at all on the normal path
  - a documented collision test pinning why the positional helper must not be called unconditionally

## Verification

- New tests: 9 passed
- Regression suites: `test_api_content_sidecar.py` + `test_turn_context.py` 47 passed; `test_hermes_state.py` + `test_identity_flush.py` + `test_compression_persistence.py` 272 passed, 2 skipped — the 6 failures in `test_compression_persistence.py` (`TestStoredPromptCwdDrift` ×3, `TestFlushAfterCompression` ×3) are pre-existing on clean `main` (verified by stashing this change and re-running; environment-related, not touched by this diff)
- `ruff check` clean on all three files; `py_compile` clean

## Non-goals (unchanged from the issue)

- No durable persistence of ephemeral context beyond the typed, non-authoritative sidecar (the #84255 side of the tension)
- No re-derivation of decorations at build time (unreproducible bytes)
- No schema changes

Closes #102194
Supersedes #102411 (same semantics, composed into the post-#102117 structure)
