### PR TITLE
file_sync: Windows sync_back no longer drops remote sandbox edits (#76267, salvage #76268)

### DIFF
--- a/tests/tools/test_file_sync_back.py
+++ b/tests/tools/test_file_sync_back.py
@@ -457,3 +457,44 @@ class TestSyncBackSizeCap:
         # Default cap (2 GiB) is far above our tiny tar; extraction should proceed
         mgr.sync_back(hermes_home=tmp_path / ".hermes")
         assert Path(host_file).read_bytes() == b"remote_version"
+
+
+class TestSyncBackWindowsHost:
+    """#76267: sync_back on a Windows host. The staging tar must be reopenable for writing by
+    the backend (NamedTemporaryFile held an exclusive handle → PermissionError), and remote
+    keys/parents must stay POSIX (relpath/Path stringify with backslashes on Windows, so no
+    staged file ever matched its mapping and every edit was dropped as "no host mapping")."""
+
+    def test_backend_can_reopen_the_tar_path_for_writing(self, tmp_path):
+        """Contract on every host: the download callback receives a path nothing else holds open."""
+        seen = {}
+
+        def download(dest: Path) -> None:
+            buf = io.BytesIO()
+            with tarfile.open(fileobj=buf, mode="w") as tar:
+                info = tarfile.TarInfo(name="root/.hermes/skill.py")
+                info.size = 2
+                tar.addfile(info, io.BytesIO(b"v2"))
+            with open(dest, "wb") as fh:  # the SSH/Modal backends write exactly like this
+                fh.write(buf.getvalue())
+            seen["dest"] = dest
+
+        host_file = tmp_path / "host" / "skill.py"
+        _write_file(host_file, b"v1")
+        mgr = _make_manager(tmp_path, [(str(host_file), "/root/.hermes/skill.py")], bulk_download_fn=download)
+        mgr._pushed_hashes["/root/.hermes/skill.py"] = _sha256_bytes(b"v1")
+        mgr.sync_back(hermes_home=tmp_path / ".hermes")
+        assert host_file.read_bytes() == b"v2"
+        assert not seen["dest"].exists()  # staging tar removed after use
+
+    @pytest.mark.windows_only
+    def test_posix_remote_keys_match_on_windows(self, tmp_path):
+        host_file = tmp_path / "host" / "skill.py"
+        _write_file(host_file, b"v1")
+        mapping = [(str(host_file), "/root/.hermes/skills/a/skill.py")]
+        mgr = _make_manager(tmp_path, mapping, bulk_download_fn=_make_download_fn({
+            "root/.hermes/skills/a/skill.py": b"v2", "root/.hermes/skills/a/new.md": b"new"}))
+        mgr._pushed_hashes["/root/.hermes/skills/a/skill.py"] = _sha256_bytes(b"v1")
+        mgr.sync_back(hermes_home=tmp_path / ".hermes")
+        assert host_file.read_bytes() == b"v2"  # relpath key was 'root\\.hermes\\...' → skipped
+        assert (tmp_path / "host" / "new.md").read_bytes() == b"new"  # _infer_host_path parent match

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -302,12 +302,16 @@ class FileSyncManager:
         except Exception:
             file_mapping = []
 
-        with tempfile.NamedTemporaryFile(suffix=".tar") as tf:
-            self._bulk_download_fn(Path(tf.name))
+        # mkstemp + close: NamedTemporaryFile keeps an exclusive handle on Windows, so the
+        # backend's open(dest, "wb") / write_bytes on the same path raised PermissionError.
+        fd, tar_path = tempfile.mkstemp(suffix=".tar")
+        os.close(fd)
+        try:
+            self._bulk_download_fn(Path(tar_path))
 
             # A misbehaving sandbox could produce an arbitrarily large tar.
             try:
-                tar_size = os.path.getsize(tf.name)
+                tar_size = os.path.getsize(tar_path)
             except OSError:
                 tar_size = 0
             if tar_size > _SYNC_BACK_MAX_BYTES:
@@ -317,7 +321,7 @@ class FileSyncManager:
                 return
 
             with tempfile.TemporaryDirectory(prefix="hermes-sync-back-") as staging:
-                with tarfile.open(tf.name) as tar:
+                with tarfile.open(tar_path) as tar:
                     tar.extractall(staging, filter="data")
 
                 upload_only = self._upload_only_host_paths | _credential_host_paths()
@@ -325,13 +329,19 @@ class FileSyncManager:
                 for dirpath, _dirnames, filenames in os.walk(staging):
                     for fname in filenames:
                         staged_file = os.path.join(dirpath, fname)
-                        remote_path = "/" + os.path.relpath(staged_file, staging)
+                        # Remote keys are POSIX; relpath uses host separators (backslashes on Windows).
+                        remote_path = "/" + Path(os.path.relpath(staged_file, staging)).as_posix()
                         applied += self._apply_staged_file(staged_file, remote_path, file_mapping, upload_only)
 
                 if applied:
                     logger.info("sync_back: applied %d changed file(s)", applied)
                 else:
                     logger.debug("sync_back: no remote changes detected")
+        finally:
+            try:
+                os.unlink(tar_path)
+            except OSError:
+                pass
 
     def _apply_staged_file(
         self, staged_file: str, remote_path: str, file_mapping: list[tuple[str, str]], upload_only_host_paths: set[str],
@@ -377,9 +387,9 @@ class FileSyncManager:
         for host, remote in file_mapping or []:
             if self._is_upload_only_host_path(host, upload_only_host_paths):
                 continue
-            remote_dir = str(Path(remote).parent)
+            remote_dir = posixpath.dirname(remote)  # remote paths are POSIX even on a Windows host
             if remote_path.startswith(remote_dir + "/"):
-                return str(Path(host).parent) + remote_path[len(remote_dir):]
+                return str(Path(host).parent / remote_path[len(remote_dir) + 1:])
         return None
 
     @staticmethod


### PR DESCRIPTION
On a Windows host, `FileSyncManager.sync_back` now copies remote sandbox edits (skills, config, cache) back onto the host instead of silently dropping them at teardown. Salvage of #76268 by @fangliquanflq (authorship preserved; re-applied on the current `file_sync.py`). Fixes #76267.

## Root cause

Two stacked Windows-only failures:
1. The staging tar was a `NamedTemporaryFile` held open while the backend's `bulk_download_fn` reopened the same path for writing — `PermissionError` (exclusive handle). Now `mkstemp` + close, unlinked in `finally`.
2. Staged member keys came from `os.path.relpath` and mapping parents from `Path(remote).parent`; both stringify with backslashes on Windows, so no staged file ever matched its POSIX remote key and every edit was skipped as "no host mapping". Keys use `as_posix()`, parents `posixpath.dirname`, and the inferred host path is joined with the host's `Path`.

## Validation

| Check | Result |
|---|---|
| Cross-host contract test (download callback reopens the tar path for writing; tar removed after) | red on main (only on Windows), green here on every host |
| `windows_only` test: POSIX keys + parent inference on a real Windows host | runs in the Windows lane |
| `ntpath` proof of the old keys: main computed `/root\.hermes\skills\a\skill.py` for a `/root/.hermes/skills/a/skill.py` mapping | branch computes the POSIX key |
| `run_tests.sh` file_sync / ssh / modal suites, `check-windows-footguns.py --all` | 82 passed, 0 footguns |
