### PR TITLE
docker: sandbox can start on snap-packaged Docker under AppArmor via terminal.docker_snap_compat (#9730)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -293,6 +293,7 @@ _TERMINAL_ENV_MAPPINGS = {
         "ssh_host", "ssh_user", "ssh_port", "ssh_key", "container_cpu", "container_memory",
         "container_disk", "container_persistent", "docker_volumes", "docker_env", "docker_extra_args",
         "docker_shm_size", "docker_mount_cwd_to_workspace", "docker_network", "docker_run_as_host_user",
+        "docker_snap_compat",
         "docker_persist_across_processes", "docker_shared_container_key", "docker_orphan_reaper",
         "sandbox_dir", "persistent_shell",
     )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1841,6 +1841,7 @@ def _bridge_terminal_config_to_env(_terminal_cfg: dict) -> None:
         "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
         "docker_network": "TERMINAL_DOCKER_NETWORK",
         "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
+        "docker_snap_compat": "TERMINAL_DOCKER_SNAP_COMPAT",
         "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
         "docker_shared_container_key": "TERMINAL_DOCKER_SHARED_CONTAINER_KEY",
         "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2055,7 +2055,7 @@ TERMINAL_CONFIG_ENV_MAP = {
             "daytona_image", "vercel_runtime", "ssh_host", "ssh_user", "ssh_port", "ssh_key",
             "container_cpu", "container_memory", "container_disk", "container_persistent",
             "docker_volumes", "docker_env", "docker_mount_cwd_to_workspace", "docker_network",
-            "docker_extra_args", "docker_shm_size", "docker_run_as_host_user",
+            "docker_extra_args", "docker_shm_size", "docker_run_as_host_user", "docker_snap_compat",
             "docker_persist_across_processes", "docker_shared_container_key",
             "docker_orphan_reaper", "sandbox_dir", "persistent_shell")}}
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -332,6 +332,10 @@ DEFAULT_CONFIG = {
         # default for images whose entrypoints must start as root (e.g. the bundled Hermes image,
         # which drops to `hermes` via s6-setuidgid). When on, SETUID/SETGID caps are omitted.
         "docker_run_as_host_user": False,
+        # Snap-packaged Docker under AppArmor (Ubuntu cloud images; LP#1908448) refuses to exec
+        # anything under `--init` or `--security-opt no-new-privileges` ("operation not
+        # permitted"). True drops those two flags; every other hardening stays. See #9730.
+        "docker_snap_compat": False,
         # Trusted profiles sharing one Docker container identity; empty = per-profile boundary.
         "docker_shared_container_key": "",
         # Keep a long-lived bash shell across execute() calls so cwd/env/shell variables survive.

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -56,6 +56,7 @@ def _make_dummy_env(**kwargs):
         persist_across_processes=kwargs.get("persist_across_processes", True),
         shared_container_key=kwargs.get("shared_container_key", ""),
         shm_size=kwargs.get("shm_size", docker_env._DEFAULT_SHM_SIZE),
+        snap_compat=kwargs.get("snap_compat", False),
     )
 
 
@@ -483,6 +484,27 @@ def test_security_args_include_setuid_setgid_for_privdrop(monkeypatch):
     }
     assert "SETUID" in added, "SETUID cap missing — image privilege-drop will fail"
     assert "SETGID" in added, "SETGID cap missing — image privilege-drop will fail"
+
+
+def test_snap_compat_drops_only_init_and_no_new_privileges(monkeypatch):
+    """#9730: snap-packaged Docker under AppArmor turns ``--init`` and ``no-new-privileges`` into
+    "exec: operation not permitted" for every process in the container. The opt-out drops exactly
+    those two flags; cap-drop, tmpfs hardening and the privdrop caps are unchanged."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+
+    def run_args(**kw):
+        calls = _mock_subprocess_run(monkeypatch)
+        _make_dummy_env(**kw)
+        return next(c[0] for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run")
+
+    default, compat = run_args(), run_args(snap_compat=True)
+    assert "--init" in default and "no-new-privileges" in default
+    assert "--init" not in compat and "no-new-privileges" not in compat
+
+    def strip(argv):  # everything except the two flags and the random container name
+        return [a for a in argv if a not in ("--init", "--security-opt", "no-new-privileges") and not a.startswith("hermes-")]
+
+    assert strip(default) == strip(compat)
 
 
 # ── run_as_host_user tests ────────────────────────────────────────

--- a/tests/tools/test_terminal_config_env_sync.py
+++ b/tests/tools/test_terminal_config_env_sync.py
@@ -321,3 +321,12 @@ def test_docker_forward_env_is_bridged_everywhere():
     assert "docker_forward_env" in _gateway_env_map_keys()
     assert "docker_forward_env" in _save_config_env_sync_keys()
     assert "TERMINAL_DOCKER_FORWARD_ENV" in _terminal_tool_env_var_names()
+
+
+def test_docker_snap_compat_is_bridged_everywhere():
+    """#9730: ``terminal.docker_snap_compat`` must reach the container on the CLI, gateway and
+    ``hermes config set`` paths, like every other docker_* key (see docker_extra_args above)."""
+    assert "docker_snap_compat" in _cli_env_map_keys()
+    assert "docker_snap_compat" in _gateway_env_map_keys()
+    assert "docker_snap_compat" in _save_config_env_sync_keys()
+    assert "TERMINAL_DOCKER_SNAP_COMPAT" in _terminal_tool_env_var_names()

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -239,7 +239,6 @@ _BASE_SECURITY_ARGS = [
     "--cap-add", "DAC_OVERRIDE",
     "--cap-add", "CHOWN",
     "--cap-add", "FOWNER",
-    "--security-opt", "no-new-privileges",
     "--tmpfs", "/tmp:rw,nosuid,size=512m",
     "--tmpfs", "/var/tmp:rw,noexec,nosuid,size=256m"]
 
@@ -295,9 +294,15 @@ _PRIVDROP_CAP_ARGS = ["--cap-add", "SETUID", "--cap-add", "SETGID"]
 _S6_INIT_ENTRYPOINTS = ("/init", "/package/admin/s6-overlay/command/init")
 
 
-def _build_security_args(run_as_host_user: bool, run_exec: bool = False) -> list[str]:
-    """Security/cap/tmpfs args for the privilege mode; ``run_exec`` mounts /run exec for s6 images."""
-    args = list(_BASE_SECURITY_ARGS) + list(_RUN_TMPFS_EXEC if run_exec else _RUN_TMPFS_NOEXEC)
+_NO_NEW_PRIVILEGES_ARGS = ["--security-opt", "no-new-privileges"]
+
+
+def _build_security_args(run_as_host_user: bool, run_exec: bool = False, snap_compat: bool = False) -> list[str]:
+    """Security/cap/tmpfs args for the privilege mode; ``run_exec`` mounts /run exec for s6 images.
+    ``snap_compat`` drops no-new-privileges: snap-packaged Docker's AppArmor profile turns it into
+    "exec: operation not permitted" for every process in the container (#9730, LP#1908448)."""
+    args = list(_BASE_SECURITY_ARGS) + ([] if snap_compat else list(_NO_NEW_PRIVILEGES_ARGS))
+    args += list(_RUN_TMPFS_EXEC if run_exec else _RUN_TMPFS_NOEXEC)
     return args if run_as_host_user else args + list(_PRIVDROP_CAP_ARGS)
 
 
@@ -501,7 +506,8 @@ class DockerEnvironment(BaseEnvironment):
         extra_args: list = None,
         persist_across_processes: bool = True,
         shm_size: str = _DEFAULT_SHM_SIZE,
-        shared_container_key: str = ""):
+        shared_container_key: str = "",
+        snap_compat: bool = False):
         if cwd == "~":
             cwd = "/root"
         super().__init__(cwd=cwd, timeout=timeout)
@@ -547,7 +553,12 @@ class DockerEnvironment(BaseEnvironment):
                 "Docker: image %s uses /init (s6-overlay) as entrypoint — "
                 "skipping --init and mounting /run with exec.",
                 image)
-        security_args = _build_security_args(run_as_host_user and bool(user_args), run_exec=image_uses_s6_init)
+        security_args = _build_security_args(
+            run_as_host_user and bool(user_args), run_exec=image_uses_s6_init, snap_compat=snap_compat)
+        self._snap_compat = snap_compat
+        if snap_compat:
+            logger.warning(
+                "docker_snap_compat: running without --init and no-new-privileges (snap Docker under AppArmor)")
 
         logger.info("Docker volume_args: %s", volume_args)
         # docker_extra_args go last so they can override defaults.
@@ -751,7 +762,7 @@ class DockerEnvironment(BaseEnvironment):
             # own /init PID 1, so adding --init there creates two competing inits and breaks startup
             # (#34628).
             self._docker_exe, "run", "-d",
-            *([] if self._image_uses_s6_init else ["--init"]),
+            *([] if self._image_uses_s6_init or self._snap_compat else ["--init"]),
             "--name", name,
             *label_args,
             "-w", workdir,

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -654,6 +654,7 @@ def _get_env_config() -> Dict[str, Any]:
         "docker_volumes": docker_volumes,
         "docker_env": docker_env,
         "docker_run_as_host_user": _tenv_bool("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false"),
+        "docker_snap_compat": _tenv_bool("TERMINAL_DOCKER_SNAP_COMPAT", "false"),
         "docker_network": _tenv_bool("TERMINAL_DOCKER_NETWORK", "true"),
         "docker_extra_args": docker_extra_args,
         "docker_shm_size": docker_shm_size,

--- a/tools/terminal_tool_backends.py
+++ b/tools/terminal_tool_backends.py
@@ -40,7 +40,7 @@ _CONTAINER_KEYS = (
     ("docker_volumes", []), ("docker_mount_cwd_to_workspace", False), ("docker_forward_env", []),
     ("docker_env", {}), ("docker_run_as_host_user", False), ("docker_extra_args", []),
     ("docker_shm_size", "1g"), ("docker_network", True), ("docker_persist_across_processes", True),
-    ("docker_shared_container_key", ""), ("docker_orphan_reaper", True),
+    ("docker_shared_container_key", ""), ("docker_orphan_reaper", True), ("docker_snap_compat", False),
 )
 _DOCKER_KWARGS = (
     ("volumes", "docker_volumes", []), ("auto_mount_cwd", "docker_mount_cwd_to_workspace", False),
@@ -48,6 +48,7 @@ _DOCKER_KWARGS = (
     ("run_as_host_user", "docker_run_as_host_user", False), ("network", "docker_network", True),
     ("extra_args", "docker_extra_args", []), ("persist_across_processes", "docker_persist_across_processes", True),
     ("shared_container_key", "docker_shared_container_key", ""), ("shm_size", "docker_shm_size", "1g"),
+    ("snap_compat", "docker_snap_compat", False),
 )
 
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -289,6 +289,7 @@ terminal:
   docker_image: "nikolaik/python-nodejs:python3.11-nodejs20"
   docker_mount_cwd_to_workspace: false  # Mount launch dir into /workspace
   docker_run_as_host_user: false   # See "Running container as host user" below
+  docker_snap_compat: false        # See "Snap-packaged Docker (AppArmor)" below
   docker_forward_env:              # Host env vars to forward into container
     - "GITHUB_TOKEN"
   docker_env:                      # Literal env vars to inject (KEY=value)
@@ -377,6 +378,7 @@ Every key under `terminal:` has an env-var override of the form `TERMINAL_<KEY_U
 | `TERMINAL_DOCKER_EXTRA_ARGS` | `docker_extra_args` | JSON array |
 | `TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE` | `docker_mount_cwd_to_workspace` | `true` / `false` |
 | `TERMINAL_DOCKER_RUN_AS_HOST_USER` | `docker_run_as_host_user` | `true` / `false` |
+| `TERMINAL_DOCKER_SNAP_COMPAT` | `docker_snap_compat` | `true` / `false` — default `false` |
 | `TERMINAL_DOCKER_NETWORK` | `docker_network` | `true` / `false` — default `true`; `false` = `--network=none` |
 | `TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES` | `docker_persist_across_processes` | `true` / `false` — default `true` |
 | `TERMINAL_DOCKER_SHARED_CONTAINER_KEY` | `docker_shared_container_key` | Explicit shared identity for trusted profiles; empty by default |
@@ -615,6 +617,24 @@ terminal:
 When enabled, Hermes appends `--user $(id -u):$(id -g)` to the `docker run` command so files written into bind-mounted directories (`/workspace`, `/root`, anything in `docker_volumes`) are owned by your host user, not root. The trade-off: the container can no longer `apt install` or write to root-owned paths like `/root/.npm` — use a base image whose `HOME` is owned by a non-root user (or add your required tooling at image build time) if you need both.
 
 Leave this `false` (the default) for backwards-compatible behavior. Turn it on when your workflow is mostly "edit mounted host files" and you're tired of `sudo chown -R`.
+
+### Snap-packaged Docker (AppArmor)
+
+On hosts where Docker was installed as a snap (common on Ubuntu cloud images, e.g. Azure VMs), the snap's AppArmor confinement rejects two of the sandbox's hardening flags and the container dies at start:
+
+```
+exec /sbin/docker-init: operation not permitted     # --init
+exec /usr/bin/sleep: operation not permitted        # --security-opt no-new-privileges
+```
+
+This is a snapd limitation ([LP#1908448](https://bugs.launchpad.net/snapd/+bug/1908448)), not something Hermes can probe around. Either install Docker from Docker's apt repository instead of the snap (preferred — all hardening stays on), or opt in:
+
+```yaml
+terminal:
+  docker_snap_compat: true   # drops --init and no-new-privileges; cap-drop, tmpfs, PID limits stay
+```
+
+With it on, zombie processes inside the sandbox are not reaped by an init and a setuid binary inside the container can regain privileges; a warning is logged at container start.
 
 ### Optional: Mount the Launch Directory into `/workspace`
 


### PR DESCRIPTION
`terminal.docker_snap_compat: true` lets the Docker sandbox start on hosts where Docker is installed as a snap under AppArmor (Ubuntu cloud images, Azure VMs), where the container otherwise dies at start. Fixes #9730.

## Root cause

The snap's AppArmor confinement rejects two of our hardening flags (snapd [LP#1908448](https://bugs.launchpad.net/snapd/+bug/1908448)): `--init` fails with `exec /sbin/docker-init: operation not permitted`, and with that removed `--security-opt no-new-privileges` fails every exec the same way (`exec /usr/bin/sleep: operation not permitted`). Both were reported and bisected in the issue thread by @gilbertl / @Ek0n. Nothing observable from the client distinguishes this host before the first `docker run`, and `docker_extra_args` can only add flags, not remove ours — so this is an explicit opt-out, not auto-detection.

## Change

- `_build_security_args(..., snap_compat)` omits `no-new-privileges`; `_run_command` omits `--init`. Everything else (cap-drop ALL, tmpfs hardening, PID/cpu/memory limits, SETUID/SETGID privdrop caps) is unchanged; a warning is logged at container start.
- Key bridged on every path the other `docker_*` keys use: CLI env map, gateway env map, `hermes config set` sync, `terminal_tool` env read, the shared `container_config` shaper (so the prompt-builder probe and `execute_code` carry it too), `DEFAULT_CONFIG`.
- Docs: new "Snap-packaged Docker (AppArmor)" section recommending Docker's apt repo first, then the opt-out with its trade-offs.
- 2 tests: the flag removes exactly those two argv entries (argv otherwise identical); the key is bridged on all four config paths.

## Validation

| Check | Result |
|---|---|
| Live, real Docker daemon: `terminal.docker_snap_compat: true` in a temp `HERMES_HOME` → `_create_environment` → `docker inspect` | `HostConfig.Init: None`, `SecurityOpt: None`, `CapDrop: ['ALL']`, `exec` runs |
| Same probe on `origin/main` (key unknown) | `Init: True`, `SecurityOpt: ['no-new-privileges']` — hardened default, so existing installs are unaffected |
| Mutation: force `no-new-privileges` back on with the flag set | the new test goes red |
| `run_tests.sh` docker / terminal_tool / prompt_builder / config suites | 385 passed |
