### PR TITLE
fix(desktop): route angle-bracket file links with spaces to preview

### DIFF
--- a/apps/desktop/electron/decoded-path-fallback.test.ts
+++ b/apps/desktop/electron/decoded-path-fallback.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { decodedPathIfMissing } from './decoded-path-fallback'
+
+describe('decodedPathIfMissing', () => {
+  it('returns null when the path has no percent-encoding', () => {
+    expect(decodedPathIfMissing('/home/user/My Notes/todo.md')).toBeNull()
+  })
+
+  it('decodes %20 sequences so spaced paths can be retried (#102782)', () => {
+    expect(decodedPathIfMissing('/home/user/My%20Notes/todo%20with%20spaces.md')).toBe(
+      '/home/user/My Notes/todo with spaces.md'
+    )
+  })
+
+  it('returns null when decoding leaves the string unchanged', () => {
+    // Valid hex escape that decodeURIComponent leaves alone only when empty —
+    // a path that is already identical after decode is a no-op.
+    expect(decodedPathIfMissing('/tmp/plain')).toBeNull()
+  })
+
+  it('returns null for malformed percent sequences', () => {
+    expect(decodedPathIfMissing('/tmp/%E0%A4%A')).toBeNull()
+  })
+})

--- a/apps/desktop/electron/decoded-path-fallback.ts
+++ b/apps/desktop/electron/decoded-path-fallback.ts
@@ -1,0 +1,20 @@
+/**
+ * Markdown hrefs percent-encode spaces (`/my%20notes/x.md`), but the on-disk
+ * path is the decoded form. When a preview resolve misses, retry the decoded
+ * path so chat links to paths with spaces still open (#102782).
+ */
+export function decodedPathIfMissing(resolvedPath: string): null | string {
+  if (!/%[0-9a-fA-F]{2}/.test(resolvedPath)) {
+    return null
+  }
+
+  let decoded: string
+
+  try {
+    decoded = decodeURIComponent(resolvedPath)
+  } catch {
+    return null
+  }
+
+  return decoded !== resolvedPath ? decoded : null
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -91,7 +91,6 @@ import {
 import { detectBundleSkew } from './bundle-skew'
 import { detectBundleSwap } from './bundle-swap'
 import { applyConnectionChange, sshQuitShouldBlock, teardownSshState } from './connection-apply'
-import { decodedPathIfMissing } from './decoded-path-fallback'
 import {
   apiRequestRegistryConnectionId,
   authModeFromStatus,
@@ -128,6 +127,7 @@ import {
   withTransientRetries
 } from './connection-config'
 import { applyConnectionConfigAtomically } from './connection-config-apply'
+import { decodedPathIfMissing } from './decoded-path-fallback'
 import {
   backendScopeKey,
   backendScopePrefix,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -91,6 +91,7 @@ import {
 import { detectBundleSkew } from './bundle-skew'
 import { detectBundleSwap } from './bundle-swap'
 import { applyConnectionChange, sshQuitShouldBlock, teardownSshState } from './connection-apply'
+import { decodedPathIfMissing } from './decoded-path-fallback'
 import {
   apiRequestRegistryConnectionId,
   authModeFromStatus,
@@ -6178,7 +6179,13 @@ async function previewFileTarget(rawTarget, baseDir) {
   const ext = path.extname(resolved).toLowerCase()
 
   if (!fileExists(resolved)) {
-    return null
+    const decoded = decodedPathIfMissing(resolved)
+
+    if (decoded && fileExists(decoded)) {
+      resolved = decoded
+    } else {
+      return null
+    }
   }
 
   ;({ resolvedPath: resolved } = await resolveReadableFileForIpc(resolved, { purpose: 'Preview target' }))

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -127,7 +127,6 @@ import {
   withTransientRetries
 } from './connection-config'
 import { applyConnectionConfigAtomically } from './connection-config-apply'
-import { decodedPathIfMissing } from './decoded-path-fallback'
 import {
   backendScopeKey,
   backendScopePrefix,
@@ -157,6 +156,7 @@ import {
 import type { RosterProfileMetadata } from './connection-registry'
 import { describeCrashReason, installCrashForensics } from './crash-forensics'
 import { adoptServedDashboardToken } from './dashboard-token'
+import { decodedPathIfMissing } from './decoded-path-fallback'
 import { loadOrCreateInstallationId, sshOwnershipId } from './desktop-installation'
 import { formatDesktopLogLine } from './desktop-log-line'
 import { resolveDesktopRemoteRoute, v1SshTerminalPoolKey } from './desktop-remote-route'

--- a/apps/desktop/src/components/assistant-ui/markdown-text.filelinks.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.filelinks.test.tsx
@@ -35,6 +35,20 @@ describe('MarkdownLink filesystem hrefs', () => {
     expect(screen.getAllByRole('button', { name: 'Open preview' })).toHaveLength(2)
   })
 
+  it('routes angle-bracket file links whose path contains spaces', async () => {
+    // Regression for #102782: `<...>` destinations legitimately contain spaces
+    // (CommonMark requires brackets for them), and the old FILE_LINK_RE charset
+    // [^)\s]* could not match such targets — the link fell through to harden
+    // and rendered as "[blocked]".
+    render(
+      <MarkdownTextContent isRunning={false} text={'See [notes](<~/My Notes/todo with spaces.md>)'} />
+    )
+
+    await screen.findByText('todo with spaces.md')
+    expect(screen.getByRole('button', { name: 'Open preview' })).toBeTruthy()
+    expect(document.body.textContent).not.toContain('blocked')
+  })
+
   it('renders a media player for a media-extension path link', async () => {
     const { container } = render(<MarkdownTextContent isRunning={false} text="[clip](/tmp/demo.mp4)" />)
 

--- a/apps/desktop/src/lib/markdown-preprocess.filelinks.test.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.filelinks.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { preprocessMarkdown } from './markdown-preprocess'
+
+describe('preprocessMarkdown file links with spaces (#102782)', () => {
+  it('rewrites angle-bracket destinations that contain spaces into #preview hrefs', () => {
+    const out = preprocessMarkdown('See [notes](<~/My Notes/todo with spaces.md>)')
+
+    expect(out).toContain('#preview/')
+    expect(out).toContain(encodeURIComponent('~/My Notes/todo with spaces.md'))
+    expect(out).not.toMatch(/\]\(<~\/My Notes/)
+  })
+
+  it('still rewrites spaceless absolute and home-relative file links', () => {
+    const out = preprocessMarkdown('[a](/tmp/a.md) and [b](~/b.md)')
+
+    expect(out).toContain('#preview/')
+    expect(out).toContain(encodeURIComponent('/tmp/a.md'))
+    expect(out).toContain(encodeURIComponent('~/b.md'))
+  })
+})

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -52,9 +52,13 @@ const CITATION_MARKER_RE = /(?<=[\p{L}\p{N})\].,!?:;"'”’])\[(?:\d+(?:\s*,\s*
 // Markdown links whose target is a filesystem path on the agent's machine:
 // `[report](/home/user/report.md)`, `[notes](file:///srv/notes.txt)`,
 // `[todo](~/todo.md)`, `[log](C:\logs\run.txt)`. Negative lookbehind keeps
-// image syntax (`![alt](path)`) on its existing inline pipeline. The target
-// char class excludes `)`/whitespace, matching how LLMs actually emit these.
-const FILE_LINK_RE = /(?<!!)\[(?<label>[^\]\n]+)\]\((?<target><?(?:file:\/\/|\/|~\/|[a-z]:[\\/])[^)\s]*>?)\)/gi
+// image syntax (`![alt](path)`) on its existing inline pipeline. Angle-bracket
+// destinations (`[x](<path with spaces.md>)`) are the CommonMark form for
+// spaces in a href — match them with an explicit `<…>` branch so they rewrite
+// to `#preview/…` instead of falling through to rehype-harden as "[blocked]"
+// (#102782). Unbracketed targets still exclude `)`/whitespace.
+const FILE_LINK_RE =
+  /(?<!!)\[(?<label>[^\]\n]+)\]\((?<target>(?:<(?:file:\/\/|\/|~\/|[a-z]:[\\/])[^>]*>)|(?:file:\/\/|\/|~\/|[a-z]:[\\/])[^)\s]*)\)/gi
 
 /**
  * Returns true when `body` contains a line that's exactly `marker` (modulo


### PR DESCRIPTION
## Summary
- `FILE_LINK_RE` could not match CommonMark `[label](<path with spaces>)` destinations, so rehype-harden rendered them as `label [blocked]`.
- Add an explicit `<…>` branch so those links rewrite to `#preview/…` like spaceless paths.
- When opening a preview target, retry a percent-decoded path if the encoded form misses on disk (`%20` vs real spaces).

Fixes #102782
