### PR TITLE
docker: reaper-detached containers are removed at exit instead of left behind (#86317, salvage #86344)

### DIFF
--- a/tests/tools/test_docker_teardown_drain.py
+++ b/tests/tools/test_docker_teardown_drain.py
@@ -1,0 +1,66 @@
+"""#86317: a container-teardown worker must be joined at exit even after the idle reaper popped its
+env out of ``_active_environments`` (the atexit drain only knew the registry, so ``docker rm`` for a
+detached env died with the interpreter and left a stopped, labeled container behind)."""
+
+import subprocess
+import threading
+
+import tools.environments.docker as docker_env
+import tools.terminal_tool as terminal_tool
+
+
+def _env_with_slow_teardown(monkeypatch, release: threading.Event, seen: list):
+    docker_env._cgroup_limits_ok = True
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+
+    def _run(cmd, **kwargs):
+        argv = list(cmd)
+        if argv[1] == "rm":
+            release.wait(5)  # the slow part: interpreter used to exit before it finished
+        if argv[1] in ("stop", "rm"):
+            seen.append(argv[1])
+        out = "fake-cid\n" if argv[1] == "run" else ""
+        return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+    monkeypatch.setattr(docker_env, "run_capture", lambda cmd, **kw: _run(cmd))
+    monkeypatch.setattr(docker_env.DockerEnvironment, "init_session", lambda self: None)
+    monkeypatch.setattr(docker_env.DockerEnvironment, "_remove_bind_dirs", lambda self: None)
+    return docker_env.DockerEnvironment(
+        image="python:3.11", cwd="/root", timeout=5, task_id="t-detach", persistent_filesystem=False,
+        persist_across_processes=False)
+
+
+def test_atexit_drain_joins_worker_of_env_already_popped_from_registry(monkeypatch):
+    release, seen = threading.Event(), []
+    env = _env_with_slow_teardown(monkeypatch, release, seen)
+    # The reaper's shape: pop first, then cleanup() — the registry no longer references env.
+    monkeypatch.setattr(terminal_tool, "_active_environments", {})
+    env.cleanup()
+    assert env._cleanup_thread.is_alive()
+
+    joined = {}
+
+    def _drain():
+        joined["result"] = None
+        terminal_tool._atexit_cleanup()
+        joined["result"] = True
+
+    drainer = threading.Thread(target=_drain)
+    drainer.start()
+    drainer.join(0.5)
+    assert drainer.is_alive(), "drain returned while a detached teardown worker was still running"
+    release.set()
+    drainer.join(5)
+    assert joined["result"] is True and seen == ["stop", "rm"]
+    assert not env._cleanup_thread.is_alive()
+
+
+def test_finished_workers_do_not_accumulate():
+    t = threading.Thread(target=lambda: None)
+    with docker_env._TEARDOWN_LOCK:
+        docker_env._TEARDOWN_THREADS.add(t)
+    t.start(); t.join()
+    assert docker_env.DockerEnvironment.wait_for_all_teardowns(timeout=1) is True
+    with docker_env._TEARDOWN_LOCK:
+        assert t not in docker_env._TEARDOWN_THREADS

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -16,6 +16,7 @@ import shutil
 import subprocess
 import sys
 import threading
+import time
 import uuid
 from pathlib import Path
 from typing import Optional
@@ -290,6 +291,11 @@ _RUN_TMPFS_EXEC = "--tmpfs", "/run:rw,exec,nosuid,size=64m"
 # su). Combined with no-new-privileges the dropped process cannot escalate
 # back. Skipped when --user is passed: the container already starts unprivileged.
 _PRIVDROP_CAP_ARGS = ["--cap-add", "SETUID", "--cap-add", "SETGID"]
+
+# Every ``cleanup()`` worker, independent of terminal_tool's active-env registry (see
+# ``wait_for_all_teardowns``).
+_TEARDOWN_THREADS: set[threading.Thread] = set()
+_TEARDOWN_LOCK = threading.Lock()
 
 _S6_INIT_ENTRYPOINTS = ("/init", "/package/admin/s6-overlay/command/init")
 
@@ -1035,6 +1041,8 @@ class DockerEnvironment(BaseEnvironment):
                     logger.warning(fail_msg, log_id, e)
 
         t = threading.Thread(target=_do_cleanup, daemon=True, name=f"hermes-cleanup-{log_id}")
+        with _TEARDOWN_LOCK:
+            _TEARDOWN_THREADS.add(t)
         t.start()
         self._cleanup_thread = t
         self._container_id = None
@@ -1043,6 +1051,24 @@ class DockerEnvironment(BaseEnvironment):
         # once the container itself is removed.
         if not self._persistent:
             self._remove_bind_dirs()
+
+    @staticmethod
+    def wait_for_all_teardowns(timeout: float = 15.0) -> bool:
+        """Join every in-flight teardown worker, including those of envs the idle reaper already
+        popped out of the active registry (their handles are otherwise unreachable at exit, so
+        ``docker rm`` died with the interpreter and left a stopped container behind — #86317).
+        Re-snapshots each pass: the reaper may start a worker while the drain runs."""
+        deadline = time.monotonic() + timeout
+        while True:
+            with _TEARDOWN_LOCK:
+                _TEARDOWN_THREADS.difference_update({t for t in _TEARDOWN_THREADS if not t.is_alive()})
+                pending = list(_TEARDOWN_THREADS)
+            if not pending:
+                return True
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False
+            pending[0].join(timeout=remaining)
 
     def wait_for_cleanup(self, timeout: float = 30.0) -> bool:
         """Block up to *timeout* seconds for the cleanup thread (atexit hook). True if it

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -21,6 +21,7 @@ import/patch target): ``terminal_tool_config`` (TERMINAL_* reads, ``_quiet``),
 import json
 import logging
 import os
+import sys
 import time
 import threading
 import atexit
@@ -715,6 +716,10 @@ def _atexit_cleanup():
             if wait_fn is not None:
                 with _quiet("wait_for_cleanup raised on exit"):  # never block shutdown on a bad backend
                     wait_fn(timeout=15.0)
+    # Workers of envs the idle reaper already detached are not in the registry (#86317).
+    if "tools.environments.docker" in sys.modules:
+        with _quiet("teardown drain raised on exit"):
+            sys.modules["tools.environments.docker"].DockerEnvironment.wait_for_all_teardowns(timeout=15.0)
 
 atexit.register(_atexit_cleanup)
 


### PR DESCRIPTION
Containers the idle reaper tore down while the process was exiting are now actually removed instead of being left behind as stopped (or still-running) labeled containers. Salvage of #86344 by @PRATHAMESH75 (authorship preserved on the fix commit). Fixes #86317.

## Root cause

`DockerEnvironment.cleanup()` runs `docker stop` + `docker rm -f` on a daemon thread and keeps the handle on the env. The idle reaper pops the env out of `_active_environments` *before* calling `cleanup()`, and the atexit drain only iterated that registry — so a detached env's worker was unreachable and died with the interpreter while the log said the environment was cleaned. The narrower race that remained after #20561 / #33645.

## Change

- Every teardown worker is also recorded in a module-level set in `docker.py`; `_atexit_cleanup` joins that set after its registry pass via `DockerEnvironment.wait_for_all_teardowns` (re-snapshotting each pass — the reaper can start a worker while the drain runs; finished workers are dropped so the set cannot grow across a long gateway life).
- Slim redo of the PR's mechanism: one shared set + one static drain hooked into the existing `terminal_tool` atexit, instead of a second `atexit` registration in `docker.py`. +97 lines vs +245; 2 tests vs 4.

## Validation

| Check | Result |
|---|---|
| Live, real Docker daemon: child process creates a sandbox, the reaper detaches + tears it down, the interpreter exits immediately; parent runs `docker ps -a` | `origin/main`: container **still `Up`** after the child exited (the worker died before even `docker stop` finished). Branch: **removed** |
| New tests (drain blocks on a detached worker; finished workers are dropped) | red on main, green here |
| `run_tests.sh` docker / terminal_tool suites, `check_subprocess_stdin.py` | 158 passed, clean |
