### PR TITLE
fix(cli): stop named profiles from killing SSH-owned serves

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -559,7 +559,11 @@ def _lock_owned_serve_pids(base_dir: Path | None = None) -> set[int]:
     if base_dir is not None:
         roots = (base_dir,)
     else:
-        machine_root = get_desktop_ssh_runtime_root()
+        if sys.platform == "win32":
+            from hermes_cli.windows_ssh_runtime import _root
+            machine_root = _root()
+        else:
+            machine_root = get_desktop_ssh_runtime_root()
         configured_root = get_default_hermes_root() / _REMOTE_LOCK_SUBDIR
         roots = (machine_root,) if machine_root == configured_root else (machine_root, configured_root)
     for root in roots:

--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -10,6 +10,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from hermes_constants import get_default_hermes_root, get_desktop_ssh_runtime_root
+
 # Cmdline substrings identifying the long-lived server (``serve`` = the headless name Desktop
 # spawns; reaped on update for the same reason).
 _DASHBOARD_PATTERNS = tuple(
@@ -523,12 +525,6 @@ _REMOTE_LOCK_SUBDIR = "desktop-ssh"
 _HEX32 = set("0123456789abcdef")
 
 
-def _hermes_home_dir() -> Path:
-    """Resolved Hermes home (HERMES_HOME override or ~/.hermes)."""
-    override = os.environ.get("HERMES_HOME", "").strip()
-    return Path(override).expanduser() if override else Path.home() / ".hermes"
-
-
 def _is_hex(value: object, length: int) -> bool:
     return isinstance(value, str) and len(value) == length and not (set(value) - _HEX32)
 
@@ -556,29 +552,35 @@ def _valid_lockfile_payload(parsed: object, ownership_id: str) -> bool:
 
 
 def _lock_owned_serve_pids(base_dir: Path | None = None) -> set[int]:
-    """PIDs claimed by valid ``{hermes_home}/desktop-ssh/<ownershipId>/backend.lock.json`` records
+    """PIDs claimed by valid machine-level ``desktop-ssh`` ownership records
     (best-effort: a bad record contributes no PID; never raises)."""
     import json
-    root = base_dir if base_dir is not None else _hermes_home_dir() / _REMOTE_LOCK_SUBDIR
     owned: set[int] = set()
-    try:
-        entries = list(root.iterdir()) if root.is_dir() else []
-    except OSError:
-        return owned
-    for entry in entries:
-        ownership_id = entry.name
-        lock_path = entry / "backend.lock.json"
-        try:  # validateOwnershipId(): exactly 32 lowercase hex chars
-            if not entry.is_dir() or not _is_hex(ownership_id, 32) or not lock_path.is_file():
-                continue
-            data = lock_path.read_bytes()
-            if len(data) > 65536:
-                continue
-            parsed = json.loads(data)
-        except (OSError, UnicodeDecodeError, ValueError):
+    if base_dir is not None:
+        roots = (base_dir,)
+    else:
+        machine_root = get_desktop_ssh_runtime_root()
+        configured_root = get_default_hermes_root() / _REMOTE_LOCK_SUBDIR
+        roots = (machine_root,) if machine_root == configured_root else (machine_root, configured_root)
+    for root in roots:
+        try:
+            entries = list(root.iterdir()) if root.is_dir() else []
+        except OSError:
             continue
-        if _valid_lockfile_payload(parsed, ownership_id):
-            owned.add(parsed["pid"])  # validated as int above
+        for entry in entries:
+            ownership_id = entry.name
+            lock_path = entry / "backend.lock.json"
+            try:  # validateOwnershipId(): exactly 32 lowercase hex chars
+                if not entry.is_dir() or not _is_hex(ownership_id, 32) or not lock_path.is_file():
+                    continue
+                data = lock_path.read_bytes()
+                if len(data) > 65536:
+                    continue
+                parsed = json.loads(data)
+            except (OSError, UnicodeDecodeError, ValueError):
+                continue
+            if _valid_lockfile_payload(parsed, ownership_id):
+                owned.add(parsed["pid"])  # validated as int above
     return owned
 
 

--- a/hermes_cli/main_dashboard.py
+++ b/hermes_cli/main_dashboard.py
@@ -550,12 +550,11 @@ def _read_ssh_session_token_file(path: str) -> str:
     if not os.path.isabs(path):
         raise SystemExit("--ssh-session-token-file must be absolute")
 
-    # The Desktop client writes the token under the account's $HOME/.hermes/
-    # desktop-ssh, independent of HERMES_HOME and the active profile. Anchor
-    # validation there, NOT get_hermes_home(): a non-default profile or a Docker
-    # /opt/data root re-homes get_hermes_home() and would reject every token.
-    # See #69551.
-    token_root = Path.home() / ".hermes" / "desktop-ssh"
+    # Token validation and ownership-lock scanning must share the same
+    # machine-scoped authority, independent of HERMES_HOME and the active
+    # profile (#69551, #94032).
+    from hermes_constants import get_desktop_ssh_runtime_root
+    token_root = get_desktop_ssh_runtime_root()
     try:
         relative = Path(path).relative_to(token_root)
     except ValueError as exc:

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -52,11 +52,12 @@ def _get_platform_default_hermes_home() -> Path:
 
 
 def get_desktop_ssh_runtime_root() -> Path:
-    """Return the machine-scoped runtime root used by Desktop SSH.
+    """Return the machine-scoped runtime root used by POSIX Desktop SSH.
 
-    The Desktop writer expands the literal ``~/.hermes/desktop-ssh`` on the
-    target host. This path must never follow ``HERMES_HOME`` or a context-local
-    profile override: ownership records coordinate every profile on a machine.
+    The POSIX Desktop writer expands the literal ``~/.hermes/desktop-ssh`` on
+    the target host. This path must never follow ``HERMES_HOME`` or a
+    context-local profile override: ownership records coordinate every profile
+    on a machine. Native Windows SSH uses its separate platform runtime root.
     """
     return Path.home() / ".hermes" / "desktop-ssh"
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -51,6 +51,16 @@ def _get_platform_default_hermes_home() -> Path:
     return Path.home() / ".hermes"
 
 
+def get_desktop_ssh_runtime_root() -> Path:
+    """Return the machine-scoped runtime root used by Desktop SSH.
+
+    The Desktop writer expands the literal ``~/.hermes/desktop-ssh`` on the
+    target host. This path must never follow ``HERMES_HOME`` or a context-local
+    profile override: ownership records coordinate every profile on a machine.
+    """
+    return Path.home() / ".hermes" / "desktop-ssh"
+
+
 def _warn_profile_fallback_once() -> None:
     """Warn once when HERMES_HOME is unset but a non-default profile is sticky-active (wrong fallback)."""
     global _profile_fallback_warned

--- a/tests/hermes_cli/test_orphan_desktop_serve_reap.py
+++ b/tests/hermes_cli/test_orphan_desktop_serve_reap.py
@@ -175,7 +175,12 @@ def test_lock_owned_serve_pids_uses_machine_root_for_named_profile(
     )
 
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    monkeypatch.setenv("HERMES_HOME", str(machine_root / "profiles" / "reviewer"))
+    profile_home = machine_root / "profiles" / "reviewer"
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    (profile_home / "desktop-ssh" / oid).mkdir(parents=True)
+    (profile_home / "desktop-ssh" / oid / "backend.lock.json").write_text(
+        json.dumps(_valid_lock_payload(8888, oid, nonce))
+    )
 
     assert _lock_owned_serve_pids() == {7777}
 

--- a/tests/hermes_cli/test_orphan_desktop_serve_reap.py
+++ b/tests/hermes_cli/test_orphan_desktop_serve_reap.py
@@ -9,6 +9,7 @@ boot must clear those corpses without touching intentional fixed-port serves
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from unittest.mock import patch
 
 from hermes_cli.dashboard_procs import (
@@ -159,6 +160,24 @@ def test_lock_owned_serve_pids_reads_valid_backend_lock(tmp_path):
         json.dumps({**_valid_lock_payload(8888, other_oid, nonce), "schemaVersion": 99})
     )
     assert _lock_owned_serve_pids(base_dir=lock_root) == {7777}
+
+
+def test_lock_owned_serve_pids_uses_machine_root_for_named_profile(
+    tmp_path, monkeypatch
+):
+    oid = "f" * 32
+    nonce = "d" * 16
+    machine_root = tmp_path / ".hermes"
+    lock_root = machine_root / "desktop-ssh"
+    (lock_root / oid).mkdir(parents=True)
+    (lock_root / oid / "backend.lock.json").write_text(
+        json.dumps(_valid_lock_payload(7777, oid, nonce))
+    )
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(machine_root / "profiles" / "reviewer"))
+
+    assert _lock_owned_serve_pids() == {7777}
 
 
 def test_valid_lockfile_payload_rejects_wrong_owner_and_shape():


### PR DESCRIPTION
## What does this PR do?

Named-profile `hermes serve` startups no longer kill valid SSH-owned ephemeral serves from another profile. Desktop SSH ownership records are machine-scoped, so lock scanning no longer follows the active profile's `HERMES_HOME`.

This conflict-resolves and supersedes #94039 on current `main`. Both original commits were cherry-picked, preserving `fangliquanflq` as their author. The only adaptation is for intervening refactors and the current custom-root update-cleanup contract.

### Production reproduction

On macOS, starting a named-profile serve caused `_lock_owned_serve_pids()` to scan `<root>/profiles/<name>/desktop-ssh`. Desktop had written the valid ownership locks to the machine-level `~/.hermes/desktop-ssh`, so the reaper treated active SSH backends older than 180 seconds as orphans and terminated them. Hermes Desktop then repeatedly rebuilt SSH masters, forwards, and isolated serves.

## Related Issue

Fixes #94032
Supersedes #94039 because that branch is conflict-dirty against current `main`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_constants.py`: retain the original contributor's shared POSIX Desktop SSH runtime-root authority.
- `hermes_cli/main_dashboard.py`: use that authority for token validation after the `main.py` refactor.
- `hermes_cli/dashboard_procs.py`: scan machine-level ownership locks regardless of active profile, while retaining custom machine-root compatibility for update cleanup.
- `tests/hermes_cli/test_orphan_desktop_serve_reap.py`: prove a valid machine lock wins over a conflicting profile-local lock.

## How to Test

1. Set `HERMES_HOME` to `<machine-root>/profiles/<name>`.
2. Write a valid lock under the machine-level `desktop-ssh` root and a decoy under the profile root.
3. Run the focused process-management suites and confirm the machine-owned PID is spared.

```bash
scripts/run_tests.sh \
  tests/hermes_cli/test_orphan_desktop_serve_reap.py \
  tests/hermes_cli/test_ssh_session_token_parser.py \
  tests/hermes_cli/test_update_stale_dashboard.py \
  tests/hermes_cli/test_update_serve_generation_recovery.py
python3 scripts/check-windows-footguns.py --diff origin/main
```

Result on macOS: 120 passed, 3 host-specific skipped; no Windows footguns found.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] Commit messages follow Conventional Commits.
- [x] I searched existing issues and PRs; this is an attributed conflict-resolution of #94039.
- [x] The PR contains only changes related to this fix.
- [x] The affected suites pass through `scripts/run_tests.sh`.
- [x] Regression coverage is included.
- [x] Tested on macOS.

### Documentation & Housekeeping

- [x] Relevant docstrings were updated; user documentation is N/A.
- [x] `cli-config.yaml.example` is N/A; no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A.
- [x] Cross-platform impact was considered; Windows retains its separate runtime-root helper.
- [x] Tool descriptions/schemas are N/A.
