### PR TITLE
fix(desktop): label sealed interim commentary as working and de-emphasize it

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -228,8 +228,22 @@ const AssistantMessageBody: FC<AssistantMessageProps & { collapsedNotice?: null 
     >
       {collapsedNotice ?? (
         <>
+          {isInterim && (
+            <div
+              className="flex items-center gap-1.5 px-(--message-text-indent) pb-1 text-[0.6875rem] font-medium uppercase tracking-wide text-muted-foreground/60"
+              data-slot="aui_interim-label"
+            >
+              <span className="size-1.5 rounded-full bg-muted-foreground/50" />
+              {t.assistant.thread.working}
+            </div>
+          )}
           <div
-            className="wrap-anywhere min-w-0 max-w-full overflow-hidden text-pretty text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground"
+            className={cn(
+              'wrap-anywhere min-w-0 max-w-full overflow-hidden text-pretty',
+              isInterim
+                ? 'text-[0.8125rem] leading-5 text-muted-foreground/80'
+                : 'text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground'
+            )}
             data-slot="aui_assistant-message-content"
           >
             {/* Todos render in the composer status stack now, not inline. */}

--- a/apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx
@@ -538,6 +538,37 @@ describe('assistant-ui streaming renderer', () => {
     expect(finalRoot?.querySelector('[data-slot="aui_msg-actions"]')).toBeTruthy()
   })
 
+  it('labels sealed interim commentary as working and de-emphasizes it, keeping the final reply full-weight', () => {
+    const { container } = render(
+      <TranscriptHarness
+        messages={[
+          userMessage(),
+          assistantInterimMessage('Let me check the files.'),
+          assistantInterimMessage('Now applying the patch.', 'assistant-interim-2'),
+          assistantMessage('All done — patch applied.', false)
+        ]}
+      />
+    )
+
+    const roots = [...container.querySelectorAll('[data-slot="aui_assistant-message-root"]')]
+    const interimRoots = roots.filter(root => root.querySelector('[data-slot="aui_interim-label"]'))
+    const finalRoot = roots.find(root => root.textContent?.includes('All done — patch applied.'))
+
+    // Every sealed interim carries the working label; the final reply does not.
+    expect(interimRoots).toHaveLength(2)
+    expect(interimRoots.every(root => root.textContent?.includes('Working'))).toBe(true)
+    expect(finalRoot?.querySelector('[data-slot="aui_interim-label"]')).toBeNull()
+
+    // Interim content is de-emphasized (smaller, muted); the final keeps the
+    // full-weight conversation text.
+    const interimContent = interimRoots[0]?.querySelector('[data-slot="aui_assistant-message-content"]')
+    const finalContent = finalRoot?.querySelector('[data-slot="aui_assistant-message-content"]')
+    expect(interimContent?.className).toContain('text-muted-foreground/80')
+    expect(interimContent?.className).toContain('text-[0.8125rem]')
+    expect(finalContent?.className).toContain('text-foreground')
+    expect(finalContent?.className).not.toContain('text-muted-foreground/80')
+  })
+
   it('puts the turn duration on the action bar row instead of a line of its own', () => {
     const settled = {
       ...assistantMessage('All done.', false),

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2516,6 +2516,7 @@ export const ar = defineLocale({
       thinking: 'يفكر...',
       thought: 'فكّر',
       thoughtBriefly: 'فكّر قليلاً',
+      working: 'يعمل',
       thoughtFor: duration => `فكّر لمدة ${duration}`,
       turnDuration: duration => `استغرقت هذه الجولة ${duration}`,
       today: time => `اليوم ${time}`,

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3356,6 +3356,7 @@ export const en: Translations = {
       thinking: 'Thinking',
       thought: 'Thought',
       thoughtBriefly: 'Thought briefly',
+      working: 'Working',
       thoughtFor: duration => `Thought for ${duration}`,
       turnDuration: duration => `This turn took ${duration}`,
       today: time => `Today, ${time}`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2956,6 +2956,7 @@ export const ja = defineLocale({
       thinking: '考え中',
       thought: '思考済み',
       thoughtBriefly: '少し思考',
+      working: '作業中',
       thoughtFor: duration => `${duration} 思考`,
       turnDuration: duration => `このターンの所要時間: ${duration}`,
       today: time => `今日 ${time}`,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2899,6 +2899,9 @@ export interface Translations {
       thinking: string
       thought: string
       thoughtBriefly: string
+      /** Label on a sealed interim commentary bubble (mid-turn working note,
+       *  not the turn's final answer). */
+      working: string
       thoughtFor: (duration: string) => string
       turnDuration: (duration: string) => string
       today: (time: string) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2853,6 +2853,7 @@ export const zhHant = defineLocale({
       thinking: '思考中',
       thought: '已思考',
       thoughtBriefly: '思考了片刻',
+      working: '工作中',
       thoughtFor: duration => `思考了 ${duration}`,
       turnDuration: duration => `本輪耗時 ${duration}`,
       today: time => `今天，${time}`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3504,6 +3504,7 @@ export const zh: Translations = {
       thinking: '思考中',
       thought: '已思考',
       thoughtBriefly: '思考了片刻',
+      working: '工作中',
       thoughtFor: duration => `思考了 ${duration}`,
       turnDuration: duration => `本轮耗时 ${duration}`,
       today: time => `今天，${time}`,


### PR DESCRIPTION
## What changed

Label each sealed interim bubble with a muted "Working" tag and de-emphasize its text, keeping the final reply full-weight.

- Add `aui_interim-label` slot with a muted "Working" label
- De-emphasize interim commentary text (reduced opacity) so the final answer stands out
- i18n strings for the label across all locales
- Tests: streaming.test.tsx asserts the interim bubble carries the muted label and the final reply stays full-weight

## Why

When the agent emits interim commentary during tool calls, the desktop UI shows it with the same visual weight as the final answer. Users reported "it answers three times" — the interim bubbles look like separate answers. This makes the interim state visually distinct.

## How to test

1. Run a query that triggers tool calls with interim commentary
2. Observe interim bubbles carry a muted "Working" label and reduced opacity
3. Final reply renders full-weight

## Related

Fixes #100776
Refs #98864

## Platforms tested

- Windows 11 / Hermes Desktop
- Unit tests: streaming.test.tsx (vitest)