### PR TITLE
feat(desktop): hover tooltips for every Kanban card status icon

### DIFF
--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -186,7 +186,11 @@ function CardFooter({ arc, task }: { arc: ArcState | null; task: KanbanTask }) {
           </span>
         </Tip>
       ) : task.assignee ? (
-        <Avatar name={task.assignee} size="1.125rem" />
+        <Tip label={k.assignedToTip(task.assignee)}>
+          <span className="cursor-help">
+            <Avatar name={task.assignee} size="1.125rem" />
+          </span>
+        </Tip>
       ) : null}
       {arc === 'running' && (
         <Tip label={k.arcRunning}>
@@ -210,28 +214,52 @@ function CardFooter({ arc, task }: { arc: ArcState | null; task: KanbanTask }) {
       )}
       <div className="ml-auto flex min-w-0 shrink items-center gap-2">
         {typeof task.priority === 'number' && task.priority > 0 && (
-          <span className="inline-flex items-center gap-0.5 text-amber-500">
-            <Codicon name="arrow-up" size="0.7rem" />
-            {task.priority}
-          </span>
+          <Tip label={k.priorityTip(task.priority)}>
+            <span className="inline-flex cursor-help items-center gap-0.5 text-amber-500">
+              <Codicon name="arrow-up" size="0.7rem" />
+              {task.priority}
+            </span>
+          </Tip>
         )}
         {task.progress && task.progress.total > 0 && (
-          <Meta icon="checklist">
-            {task.progress.done}/{task.progress.total}
-          </Meta>
+          <Tip label={k.progressTip(task.progress.done, task.progress.total)}>
+            <span className="cursor-help">
+              <Meta icon="checklist">
+                {task.progress.done}/{task.progress.total}
+              </Meta>
+            </span>
+          </Tip>
         )}
-        {Boolean(task.comment_count) && <Meta icon="comment">{task.comment_count}</Meta>}
-        {links > 0 && <Meta icon="references">{links}</Meta>}
+        {Boolean(task.comment_count) && (
+          <Tip label={k.commentCountTip(task.comment_count!)}>
+            <span className="cursor-help">
+              <Meta icon="comment">{task.comment_count}</Meta>
+            </span>
+          </Tip>
+        )}
+        {links > 0 && (
+          <Tip label={k.blocksTip(links)}>
+            <span className="cursor-help">
+              <Meta icon="references">{links}</Meta>
+            </span>
+          </Tip>
+        )}
         {task.warnings && task.warnings.count > 0 && (
-          <span className="inline-flex items-center gap-0.5 text-destructive">
-            <Codicon name="warning" size="0.7rem" />
-            {task.warnings.count}
-          </span>
+          <Tip label={k.warningsTip(task.warnings.count, task.warnings.highest_severity ?? '')}>
+            <span className="inline-flex cursor-help items-center gap-0.5 text-destructive">
+              <Codicon name="warning" size="0.7rem" />
+              {task.warnings.count}
+            </span>
+          </Tip>
         )}
         {created && !task.assignee && !unassignedReady ? (
           <span className="text-(--ui-text-quaternary)">{created}</span>
         ) : null}
-        <span className="min-w-0 truncate font-mono text-(--ui-text-quaternary)">{shortId(task.id)}</span>
+        <Tip label={k.taskIdTip(task.id)}>
+          <span className="min-w-0 cursor-help truncate font-mono text-(--ui-text-quaternary)">
+            {shortId(task.id)}
+          </span>
+        </Tip>
       </div>
     </div>
   )

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -188,7 +188,7 @@ function CardFooter({ arc, task }: { arc: ArcState | null; task: KanbanTask }) {
       ) : task.assignee ? (
         <Tip label={k.assignedToTip(task.assignee)}>
           <span className="cursor-help">
-            <Avatar name={task.assignee} size="1.125rem" />
+            <Avatar name={task.assignee} size="1.125rem" title={false} />
           </span>
         </Tip>
       ) : null}
@@ -238,14 +238,14 @@ function CardFooter({ arc, task }: { arc: ArcState | null; task: KanbanTask }) {
           </Tip>
         )}
         {links > 0 && (
-          <Tip label={k.blocksTip(links)}>
+          <Tip label={k.blocksTip(links, task.link_counts?.parents ?? 0, task.link_counts?.children ?? 0)}>
             <span className="cursor-help">
               <Meta icon="references">{links}</Meta>
             </span>
           </Tip>
         )}
         {task.warnings && task.warnings.count > 0 && (
-          <Tip label={k.warningsTip(task.warnings.count, task.warnings.highest_severity ?? '')}>
+          <Tip label={k.warningsTip(task.warnings.count, task.warnings.highest_severity)}>
             <span className="inline-flex cursor-help items-center gap-0.5 text-destructive">
               <Codicon name="warning" size="0.7rem" />
               {task.warnings.count}

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -178,7 +178,7 @@ function CardFooter({ arc, task }: { arc: ArcState | null; task: KanbanTask }) {
           }
         >
           <span className="inline-flex min-w-0 cursor-help items-center gap-1 font-medium" style={{ color: meta.tone }}>
-            <Avatar name={attached} size="1.125rem" />
+            <Avatar name={attached} size="1.125rem" decorative />
             <span className="truncate">
               {!task.assignee && '→ '}
               {attached}

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -494,7 +494,7 @@ function Column({
           ? lanes.map(([assignee, tasks]) => (
               <div className="flex flex-col gap-2" key={assignee}>
                 <div className="flex items-center gap-1.5 px-1 pt-1 text-[0.625rem] text-(--ui-text-quaternary)">
-                  {assignee !== UNASSIGNED_LANE && <Avatar name={assignee} size="0.875rem" />}
+                  {assignee !== UNASSIGNED_LANE && <Avatar name={assignee} size="0.875rem" title={true} />}
                   {assignee}
                   <span className="tabular-nums">{tasks.length}</span>
                 </div>
@@ -936,7 +936,7 @@ function FilterMenu({
         </DropdownMenuItem>
         {board.assignees.map(name => (
           <DropdownMenuItem key={name} onSelect={() => onAssignee(name)}>
-            <Avatar name={name} size="0.875rem" />
+            <Avatar name={name} size="0.875rem" title={true} />
             {name}
             {check(assignee === name)}
           </DropdownMenuItem>
@@ -1071,7 +1071,7 @@ function SelectionBar({
                 key={profile.name}
                 onSelect={() => bulk.mutate({ assignee: profile.name, reclaim_first: true })}
               >
-                <Avatar name={profile.name} size="0.875rem" />
+                <Avatar name={profile.name} size="0.875rem" title={true} />
                 {profile.name}
               </DropdownMenuItem>
             ))}

--- a/apps/desktop/src/plugins/kanban/card-tooltips.test.tsx
+++ b/apps/desktop/src/plugins/kanban/card-tooltips.test.tsx
@@ -87,7 +87,7 @@ async function hoverTip(trigger: Element) {
   })
 }
 
-async function renderBoard() {
+async function renderBoard(waitForTitle = 'Card with every field') {
   const { KanbanBoardPage } = await import('./board')
 
   render(
@@ -96,7 +96,7 @@ async function renderBoard() {
     </QueryClientProvider>
   )
 
-  await screen.findByText('Card with every field')
+  await screen.findByText(waitForTitle)
 }
 
 describe('board card tooltips', () => {
@@ -125,15 +125,85 @@ describe('board card tooltips', () => {
     expect(screen.getByRole('tooltip').textContent).toContain('2 comments on this task')
   })
 
-  it('shows a tooltip on the "blocks N" references count, distinct from the dependency-remaining wording', async () => {
+  it('shows a tooltip on the links count with a direction-neutral claim matching the badge total (children-only fixture)', async () => {
     await renderBoard()
 
     const trigger = document.querySelector('.codicon-references')!.closest('[data-slot="tooltip-trigger"]')!
     await hoverTip(trigger)
 
     const text = screen.getByRole('tooltip').textContent
-    expect(text).toContain('Blocks 3 other tasks')
+    // Badge shows parents+children = 0+3 = 3; copy must match that total and
+    // break it down, not make a directional "Blocks" claim.
+    expect(text).toContain('Linked to 3 other tasks')
+    expect(text).toContain('0 parents')
+    expect(text).toContain('3 children')
+    expect(text).not.toContain('Blocks')
     expect(text).not.toContain('blocking this card')
+  })
+
+  it('shows the links tooltip matching the total for a parents-only fixture', async () => {
+    const parentsOnlyBoard: KanbanBoard = {
+      ...testBoard,
+      columns: [
+        {
+          name: 'done',
+          tasks: [
+            {
+              ...testBoard.columns[0].tasks[0],
+              id: 't_parentsonly',
+              link_counts: { children: 0, parents: 2 },
+              title: 'Parents-only links card'
+            }
+          ]
+        }
+      ]
+    }
+    const api = await import('./api')
+    ;(api.fetchBoard as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(parentsOnlyBoard)
+
+    await renderBoard('Parents-only links card')
+
+    const trigger = document.querySelector('.codicon-references')!.closest('[data-slot="tooltip-trigger"]')!
+    await hoverTip(trigger)
+
+    const text = screen.getByRole('tooltip').textContent
+    // Badge total is 2+0 = 2. A children-only binding (the M6 mutation) would
+    // render "0" here instead — this fixture is the one that kills it.
+    expect(text).toContain('Linked to 2 other tasks')
+    expect(text).toContain('2 parents')
+    expect(text).toContain('0 children')
+  })
+
+  it('shows the links tooltip matching the combined total for a mixed parents+children fixture', async () => {
+    const mixedBoard: KanbanBoard = {
+      ...testBoard,
+      columns: [
+        {
+          name: 'done',
+          tasks: [
+            {
+              ...testBoard.columns[0].tasks[0],
+              id: 't_mixedlinks1',
+              link_counts: { children: 3, parents: 1 },
+              title: 'Mixed links card'
+            }
+          ]
+        }
+      ]
+    }
+    const api = await import('./api')
+    ;(api.fetchBoard as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mixedBoard)
+
+    await renderBoard('Mixed links card')
+
+    const trigger = document.querySelector('.codicon-references')!.closest('[data-slot="tooltip-trigger"]')!
+    await hoverTip(trigger)
+
+    const text = screen.getByRole('tooltip').textContent
+    // Badge total is 1+3 = 4, not 3 (children-only) and not directional.
+    expect(text).toContain('Linked to 4 other tasks')
+    expect(text).toContain('1 parent,')
+    expect(text).toContain('3 children')
   })
 
   it('shows a tooltip on the warnings badge including the highest severity', async () => {
@@ -143,6 +213,37 @@ describe('board card tooltips', () => {
     await hoverTip(trigger)
 
     expect(screen.getByRole('tooltip').textContent).toContain('critical')
+  })
+
+  it('omits the severity clause entirely when highest_severity is null', async () => {
+    const nullSeverityBoard: KanbanBoard = {
+      ...testBoard,
+      columns: [
+        {
+          name: 'done',
+          tasks: [
+            {
+              ...testBoard.columns[0].tasks[0],
+              id: 't_nullsev0001',
+              title: 'Null severity card',
+              warnings: { count: 1, highest_severity: null }
+            }
+          ]
+        }
+      ]
+    }
+    const api = await import('./api')
+    ;(api.fetchBoard as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(nullSeverityBoard)
+
+    await renderBoard('Null severity card')
+
+    const trigger = document.querySelector('.codicon-warning')!.closest('[data-slot="tooltip-trigger"]')!
+    await hoverTip(trigger)
+
+    const text = screen.getByRole('tooltip').textContent
+    expect(text).toContain('1 warning. Open the card for details.')
+    expect(text).not.toContain('highest severity')
+    expect(text).not.toContain('highest severity: .')
   })
 
   it('shows a tooltip on the short task id revealing the full id', async () => {
@@ -156,10 +257,12 @@ describe('board card tooltips', () => {
   it('shows a tooltip on the plain assignee avatar (native title= converted to Tip)', async () => {
     await renderBoard()
 
-    const avatar = screen.getByTitle('alice')
-    expect(avatar.closest('[data-slot="tooltip-trigger"]')).toBeTruthy()
+    const avatarInitials = screen.getByText('A')
+    expect(avatarInitials.closest('span')?.hasAttribute('title')).toBe(false)
+    const trigger = avatarInitials.closest('[data-slot="tooltip-trigger"]')!
+    expect(trigger).toBeTruthy()
 
-    await hoverTip(avatar.closest('[data-slot="tooltip-trigger"]')!)
+    await hoverTip(trigger)
 
     expect(screen.getByRole('tooltip').textContent).toContain('Assigned to alice')
   })

--- a/apps/desktop/src/plugins/kanban/card-tooltips.test.tsx
+++ b/apps/desktop/src/plugins/kanban/card-tooltips.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * Coverage for the tooltip sweep of t_da65e35c: every status icon and
+ * free-form field on a board card gets an explanatory hover tooltip, reusing
+ * the same `<Tip>` mechanism the dependency chip already used (see the audit
+ * at kanban-card-icon-audit.md). This file renders the REAL board page
+ * against mocked API calls and drives real pointer events, so a regression
+ * that silently drops a `<Tip>` wrapper (reverting to a bare `<span>`) fails
+ * here — not just in an isolated unit test of the label strings.
+ */
+
+import { QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import type * as KanbanApi from './api'
+import { translateKanban } from './i18n-test-helper'
+import type { KanbanBoard } from './types'
+
+const queryClient = new (await import('@tanstack/react-query')).QueryClient({
+  defaultOptions: { queries: { retry: false } }
+})
+
+vi.mock('@hermes/plugin-sdk', async importOriginal => {
+  const sdk = await importOriginal<Record<string, unknown>>()
+
+  return { ...sdk, usePluginI18n: () => translateKanban }
+})
+
+const testBoard: KanbanBoard = {
+  assignees: ['alice'],
+  columns: [
+    {
+      name: 'done',
+      tasks: [
+        {
+          assignee: 'alice',
+          comment_count: 2,
+          id: 't_test123456',
+          link_counts: { children: 3, parents: 0 },
+          priority: 5,
+          progress: { done: 1, total: 4 },
+          status: 'done',
+          title: 'Card with every field',
+          warnings: { count: 2, highest_severity: 'critical' }
+        }
+      ]
+    }
+  ],
+  latest_event_id: 1,
+  now: 0,
+  tenants: []
+}
+
+vi.mock('./api', async importOriginal => ({
+  ...(await importOriginal<typeof KanbanApi>()),
+  fetchBoard: vi.fn(async () => testBoard),
+  fetchBoards: vi.fn(async () => ({ boards: [], current: '' })),
+  fetchOrchestration: vi.fn(async () => ({
+    auto_decompose: false,
+    default_assignee: '',
+    orchestrator_profile: '',
+    resolved_default_assignee: '',
+    resolved_orchestrator_profile: ''
+  })),
+  fetchProfiles: vi.fn(async () => ({ profiles: [] }))
+}))
+
+beforeAll(() => {
+  // Radix Tooltip/DropdownMenu call these on interaction; jsdom lacks them.
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+/** Hover a trigger and settle the tip's open delay (Tip's own TooltipProvider,
+ *  since these tests don't mount the app-root RootTooltipProvider). */
+async function hoverTip(trigger: Element) {
+  vi.useFakeTimers()
+  act(() => {
+    fireEvent.pointerMove(trigger, { pointerType: 'mouse' })
+    vi.advanceTimersByTime(300)
+  })
+}
+
+async function renderBoard() {
+  const { KanbanBoardPage } = await import('./board')
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <KanbanBoardPage />
+    </QueryClientProvider>
+  )
+
+  await screen.findByText('Card with every field')
+}
+
+describe('board card tooltips', () => {
+  it('shows a tooltip on the priority badge', async () => {
+    await renderBoard()
+
+    await hoverTip(screen.getByText('5').closest('[data-slot="tooltip-trigger"]')!)
+
+    expect(screen.getByRole('tooltip').textContent).toContain('Priority 5')
+  })
+
+  it('shows a tooltip on the child-progress checklist', async () => {
+    await renderBoard()
+
+    await hoverTip(screen.getByText('1/4').closest('[data-slot="tooltip-trigger"]')!)
+
+    expect(screen.getByRole('tooltip').textContent).toContain('1 of 4 child tasks done')
+  })
+
+  it('shows a tooltip on the comment count', async () => {
+    await renderBoard()
+
+    const trigger = document.querySelector('.codicon-comment')!.closest('[data-slot="tooltip-trigger"]')!
+    await hoverTip(trigger)
+
+    expect(screen.getByRole('tooltip').textContent).toContain('2 comments on this task')
+  })
+
+  it('shows a tooltip on the "blocks N" references count, distinct from the dependency-remaining wording', async () => {
+    await renderBoard()
+
+    const trigger = document.querySelector('.codicon-references')!.closest('[data-slot="tooltip-trigger"]')!
+    await hoverTip(trigger)
+
+    const text = screen.getByRole('tooltip').textContent
+    expect(text).toContain('Blocks 3 other tasks')
+    expect(text).not.toContain('blocking this card')
+  })
+
+  it('shows a tooltip on the warnings badge including the highest severity', async () => {
+    await renderBoard()
+
+    const trigger = document.querySelector('.codicon-warning')!.closest('[data-slot="tooltip-trigger"]')!
+    await hoverTip(trigger)
+
+    expect(screen.getByRole('tooltip').textContent).toContain('critical')
+  })
+
+  it('shows a tooltip on the short task id revealing the full id', async () => {
+    await renderBoard()
+
+    await hoverTip(screen.getByText('test12').closest('[data-slot="tooltip-trigger"]')!)
+
+    expect(screen.getByRole('tooltip').textContent).toContain('t_test123456')
+  })
+
+  it('shows a tooltip on the plain assignee avatar (native title= converted to Tip)', async () => {
+    await renderBoard()
+
+    const avatar = screen.getByTitle('alice')
+    expect(avatar.closest('[data-slot="tooltip-trigger"]')).toBeTruthy()
+
+    await hoverTip(avatar.closest('[data-slot="tooltip-trigger"]')!)
+
+    expect(screen.getByRole('tooltip').textContent).toContain('Assigned to alice')
+  })
+
+  it('still shows the existing wontRun tooltip unregressed (pre-existing Tip usage)', async () => {
+    const unassignedBoard: KanbanBoard = {
+      ...testBoard,
+      columns: [
+        {
+          name: 'ready',
+          tasks: [{ id: 't_unassigned1', status: 'ready', title: 'Ready, unassigned card' }]
+        }
+      ]
+    }
+    const api = await import('./api')
+    ;(api.fetchBoard as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(unassignedBoard)
+
+    await renderBoard()
+    await screen.findByText('Ready, unassigned card')
+
+    const disconnectIcon = await vi.waitFor(() => {
+      const el = document.querySelector('.codicon-debug-disconnect')
+      if (!el) throw new Error('not yet rendered')
+      return el
+    })
+
+    await hoverTip(disconnectIcon.closest('[data-slot="tooltip-trigger"]')!)
+
+    expect(screen.getByRole('tooltip').textContent).toContain('Ready cards only run once a profile is assigned')
+  })
+})

--- a/apps/desktop/src/plugins/kanban/card-tooltips.test.tsx
+++ b/apps/desktop/src/plugins/kanban/card-tooltips.test.tsx
@@ -206,6 +206,44 @@ describe('board card tooltips', () => {
     expect(text).toContain('3 children')
   })
 
+  it('pluralizes children correctly at the child plural boundary (single child)', async () => {
+    // Fixture {parents:0, children:1}: total = 1 -> "1 other task" (singular
+    // TOTAL boundary), and children = 1 -> "1 child" NOT "1 children" (the
+    // child plural-boundary mutation flips `children === 1 ? '' : 'ren'`).
+    const singleChildBoard: KanbanBoard = {
+      ...testBoard,
+      columns: [
+        {
+          name: 'done',
+          tasks: [
+            {
+              ...testBoard.columns[0].tasks[0],
+              id: 't_singlechild',
+              link_counts: { children: 1, parents: 0 },
+              title: 'Single child links card'
+            }
+          ]
+        }
+      ]
+    }
+    const api = await import('./api')
+    ;(api.fetchBoard as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(singleChildBoard)
+
+    await renderBoard('Single child links card')
+
+    const trigger = document.querySelector('.codicon-references')!.closest('[data-slot="tooltip-trigger"]')!
+    await hoverTip(trigger)
+
+    const text = screen.getByRole('tooltip').textContent
+    // Total plural boundary: n === 1 -> "task", not "tasks".
+    expect(text).toContain('Linked to 1 other task:')
+    expect(text).not.toContain('Linked to 1 other tasks')
+    // Child plural boundary: children === 1 -> "child", not "children".
+    expect(text).toContain('1 child.')
+    expect(text).not.toContain('1 children')
+    expect(text).toContain('0 parents')
+  })
+
   it('shows a tooltip on the warnings badge including the highest severity', async () => {
     await renderBoard()
 
@@ -213,6 +251,47 @@ describe('board card tooltips', () => {
     await hoverTip(trigger)
 
     expect(screen.getByRole('tooltip').textContent).toContain('critical')
+  })
+
+  it('renders the warnings badge count bound to the task warnings.count', async () => {
+    // Binds the VISIBLE badge number to warnings.count so a mutation that
+    // silently unbinds it (e.g. rendering a constant or a different field)
+    // is caught. testBoard's card has warnings.count === 2.
+    await renderBoard()
+
+    const warningIcon = document.querySelector('.codicon-warning')!
+    // The count text sits alongside the icon inside the same tooltip-trigger
+    // span; assert the trigger renders exactly the bound count "2".
+    const badge = warningIcon.closest('[data-slot="tooltip-trigger"]')!
+    expect(badge.textContent).toContain('2')
+
+    // And a distinct fixture with a different count renders THAT count,
+    // proving the number tracks warnings.count rather than a constant.
+    cleanup()
+    const sevenWarnBoard: KanbanBoard = {
+      ...testBoard,
+      columns: [
+        {
+          name: 'done',
+          tasks: [
+            {
+              ...testBoard.columns[0].tasks[0],
+              id: 't_sevenwarn01',
+              title: 'Seven warnings card',
+              warnings: { count: 7, highest_severity: 'critical' }
+            }
+          ]
+        }
+      ]
+    }
+    const api = await import('./api')
+    ;(api.fetchBoard as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(sevenWarnBoard)
+
+    await renderBoard('Seven warnings card')
+
+    const badge7 = document.querySelector('.codicon-warning')!.closest('[data-slot="tooltip-trigger"]')!
+    expect(badge7.textContent).toContain('7')
+    expect(badge7.textContent).not.toContain('2')
   })
 
   it('omits the severity clause entirely when highest_severity is null', async () => {
@@ -259,6 +338,9 @@ describe('board card tooltips', () => {
 
     const avatarInitials = screen.getByText('A')
     expect(avatarInitials.closest('span')?.hasAttribute('title')).toBe(false)
+    // A11y: title suppressed on a Tip-wrapped Avatar still exposes the name
+    // via aria-label so it is not mouse-hover-only (round-2 m1).
+    expect(avatarInitials.closest('span')?.getAttribute('aria-label')).toBe('alice')
     const trigger = avatarInitials.closest('[data-slot="tooltip-trigger"]')!
     expect(trigger).toBeTruthy()
 

--- a/apps/desktop/src/plugins/kanban/card-tooltips.test.tsx
+++ b/apps/desktop/src/plugins/kanban/card-tooltips.test.tsx
@@ -333,6 +333,48 @@ describe('board card tooltips', () => {
     expect(screen.getByRole('tooltip').textContent).toContain('t_test123456')
   })
 
+  it('renders the queued-lane assignee chip with NO [title] descendant (opt-in default-false hardening)', async () => {
+    // Round-3 m2: the opt-IN title default-false hardening was untested —
+    // mutation N1 (revert the Avatar title default to true) SURVIVED all 61
+    // tests, because the one call site that RELIES on the new default (the
+    // queued footer chip, where the assignee name is already adjacent visible
+    // text) had no coverage. A ready+assigned card renders the queued chip;
+    // its avatar must emit NO native title (a stray title would stack a native
+    // OS tooltip and, being adjacent to the visible name, double-announce it).
+    const queuedBoard: KanbanBoard = {
+      ...testBoard,
+      columns: [
+        {
+          name: 'ready',
+          tasks: [
+            {
+              assignee: 'alice',
+              id: 't_queuedchip1',
+              status: 'ready',
+              title: 'Queued assigned card'
+            }
+          ]
+        }
+      ]
+    }
+    const api = await import('./api')
+    ;(api.fetchBoard as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(queuedBoard)
+
+    await renderBoard('Queued assigned card')
+
+    // The queued chip renders "→? alice" as visible text (the whole chip is the
+    // Tip trigger); its avatar is decorative — no [title] anywhere in the chip.
+    const chip = screen.getByText('alice').closest('[data-slot="tooltip-trigger"]') as HTMLElement
+    expect(chip).toBeTruthy()
+    expect(chip.querySelector('[title]')).toBeNull()
+    // And the avatar is hidden from the a11y tree with no aria-label, so the
+    // enclosing chip announces the assignee exactly once via the visible span.
+    const avatar = screen.getByText('A').closest('span') as HTMLElement
+    expect(avatar.getAttribute('aria-hidden')).toBe('true')
+    expect(avatar.hasAttribute('aria-label')).toBe(false)
+    expect(avatar.hasAttribute('title')).toBe(false)
+  })
+
   it('shows a tooltip on the plain assignee avatar (native title= converted to Tip)', async () => {
     await renderBoard()
 

--- a/apps/desktop/src/plugins/kanban/drawer-tooltips.test.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer-tooltips.test.tsx
@@ -145,4 +145,20 @@ describe('drawer tooltips', () => {
     await hoverTip(reclaimBtn)
     expect(screen.getByRole('tooltip').textContent).toContain('Reclaim this task')
   })
+
+  it('shows a tooltip on the edit-description button', async () => {
+    await renderDrawer()
+
+    await hoverTip(screen.getByRole('button', { name: 'Edit description' }))
+
+    expect(screen.getByRole('tooltip').textContent).toContain('Edit description')
+  })
+
+  it('shows a tooltip on the drawer short task id revealing the full id', async () => {
+    await renderDrawer()
+
+    await hoverTip(screen.getByText('drawer').closest('[data-slot="tooltip-trigger"]')!)
+
+    expect(screen.getByRole('tooltip').textContent).toContain('t_drawertest1')
+  })
 })

--- a/apps/desktop/src/plugins/kanban/drawer-tooltips.test.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer-tooltips.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * Coverage for the tooltip sweep on the task-detail drawer (t_da65e35c):
+ * close, task-actions ellipsis, upload-attachment, reassign trigger,
+ * dependency chips, and diagnostics recovery-action buttons all get an
+ * explanatory hover tooltip via the same `<Tip>` mechanism the card already
+ * used. Renders the REAL TaskDrawer against a mocked fetchTask.
+ */
+
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import type * as KanbanApi from './api'
+import { translateKanban } from './i18n-test-helper'
+import type { KanbanTaskDetail } from './types'
+
+vi.mock('@hermes/plugin-sdk', async importOriginal => {
+  const sdk = await importOriginal<Record<string, unknown>>()
+
+  return { ...sdk, usePluginI18n: () => translateKanban }
+})
+
+const baseDetail: KanbanTaskDetail = {
+  attachments: [],
+  comments: [],
+  events: [],
+  links: { children: ['t_childone12'], parents: ['t_parentone1'] },
+  runs: [],
+  task: {
+    assignee: 'alice',
+    diagnostics: [
+      {
+        actions: [
+          { kind: 'cli_hint', label: 'Copy command', payload: { command: 'hermes kanban reclaim t_x' } },
+          { kind: 'reclaim', label: 'Reclaim' }
+        ],
+        count: 1,
+        data: {},
+        detail: 'Worker crashed.',
+        kind: 'crash',
+        last_seen_at: 0,
+        severity: 'error',
+        title: 'Worker crashed'
+      }
+    ],
+    id: 't_drawertest1',
+    status: 'blocked',
+    title: 'Drawer test task'
+  }
+}
+
+vi.mock('./api', async importOriginal => ({
+  ...(await importOriginal<typeof KanbanApi>()),
+  fetchLog: vi.fn(async () => ({ content: '', exists: false, size_bytes: 0, truncated: false })),
+  fetchProfiles: vi.fn(async () => ({ profiles: [{ description: '', description_auto: false, is_default: false, name: 'bob' }] })),
+  fetchTask: vi.fn(async () => baseDetail)
+}))
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+async function hoverTip(trigger: Element) {
+  vi.useFakeTimers()
+  act(() => {
+    fireEvent.pointerMove(trigger, { pointerType: 'mouse' })
+    vi.advanceTimersByTime(300)
+  })
+}
+
+async function renderDrawer() {
+  const { TaskDrawer } = await import('./drawer')
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+  render(
+    <QueryClientProvider client={client}>
+      <TaskDrawer columns={['blocked', 'done']} id="t_drawertest1" onClose={vi.fn()} onOpen={vi.fn()} />
+    </QueryClientProvider>
+  )
+
+  await screen.findByText('Drawer test task')
+}
+
+describe('drawer tooltips', () => {
+  it('shows a tooltip on the close button', async () => {
+    await renderDrawer()
+
+    await hoverTip(screen.getByRole('button', { name: 'Close' }))
+
+    expect(screen.getByRole('tooltip').textContent).toContain('Close')
+  })
+
+  it('shows a tooltip on the task-actions ellipsis trigger', async () => {
+    await renderDrawer()
+
+    await hoverTip(screen.getByRole('button', { name: 'Task actions' }))
+
+    expect(screen.getByRole('tooltip').textContent).toContain('Task actions')
+  })
+
+  it('shows a tooltip on the upload-attachment button', async () => {
+    await renderDrawer()
+
+    await hoverTip(screen.getByRole('button', { name: 'Upload attachment' }))
+
+    expect(screen.getByRole('tooltip').textContent).toContain('Upload attachment')
+  })
+
+  it('shows a tooltip on the assignee reassign trigger', async () => {
+    await renderDrawer()
+
+    const trigger = screen.getByText('alice').closest('[data-slot="tooltip-trigger"]')!
+    await hoverTip(trigger)
+
+    expect(screen.getByRole('tooltip').textContent).toContain('reassign')
+  })
+
+  it('shows distinct tooltips on parent vs child dependency chips', async () => {
+    await renderDrawer()
+
+    const parentChip = screen.getByText('parent').closest('[data-slot="tooltip-trigger"]')!
+    await hoverTip(parentChip)
+    expect(screen.getByRole('tooltip').textContent).toContain('still blocking this card')
+
+    const childChip = screen.getByText('childo').closest('[data-slot="tooltip-trigger"]')!
+    await hoverTip(childChip)
+    expect(screen.getByRole('tooltip').textContent).toContain('waiting on this card')
+  })
+
+  it('shows tooltips on diagnostics recovery-action buttons', async () => {
+    await renderDrawer()
+
+    const copyBtn = screen.getByText('Copy command').closest('[data-slot="tooltip-trigger"]')!
+    await hoverTip(copyBtn)
+    expect(screen.getByRole('tooltip').textContent).toContain('clipboard')
+
+    const reclaimBtn = screen.getByText('Reclaim').closest('[data-slot="tooltip-trigger"]')!
+    await hoverTip(reclaimBtn)
+    expect(screen.getByRole('tooltip').textContent).toContain('Reclaim this task')
+  })
+})

--- a/apps/desktop/src/plugins/kanban/drawer-tooltips.test.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer-tooltips.test.tsx
@@ -136,16 +136,57 @@ describe('drawer tooltips', () => {
     expect(trigger.hasAttribute('title')).toBe(false)
   })
 
-  it('keeps the assignee name accessible via aria-label when the native title is suppressed', async () => {
-    // A11y (round-2 m1): suppressing the Avatar's native title dropped the
-    // accessible description on live cards. When title is false, the Avatar
-    // must render aria-label={name} so the name is not mouse-hover-only.
+  it('keeps the reassign button accessible name to the assignee EXACTLY ONCE (no avatar stutter)', async () => {
+    // Round-3 m1: the round-2 aria-label fallback on the reassign trigger's
+    // Avatar made the button announce the name twice — accname computes the
+    // button's name from content, and a child aria-label REPLACES that child's
+    // text, so the avatar's "A" initials became "alice" next to the visible
+    // <span>alice</span> ("alice alice"). The fix marks the avatar decorative
+    // (aria-hidden), so the name comes only from the visible span — exactly once.
     await renderDrawer()
 
-    const avatarInitials = screen.getByText('A')
-    const avatar = avatarInitials.closest('span')!
+    const trigger = screen.getByText('alice').closest('button') as HTMLElement
+    expect(trigger).toBeTruthy()
+
+    // The avatar is hidden from the a11y tree and carries neither title nor
+    // aria-label; the name lives solely in the adjacent visible text.
+    const avatar = screen.getByText('A').closest('span') as HTMLElement
+    expect(avatar.getAttribute('aria-hidden')).toBe('true')
     expect(avatar.hasAttribute('title')).toBe(false)
-    expect(avatar.getAttribute('aria-label')).toBe('alice')
+    expect(avatar.hasAttribute('aria-label')).toBe(false)
+
+    // Accessible name (Testing Library computes it via the same accname algo):
+    // querying the button by the SINGLE name resolves it, while the doubled
+    // "alice alice" (the round-2 regression) does not exist.
+    expect(screen.getByRole('button', { name: 'alice' })).toBe(trigger)
+    expect(screen.queryByRole('button', { name: 'alice alice' })).toBeNull()
+  })
+
+  it('keeps the OPTED-IN reassign menu-item avatar carrying native title= (opt-in path coverage)', async () => {
+    // Round-3 m3: the opted-in Avatar path (title={true}) had zero coverage —
+    // mutations N4 (always emit aria-label even when opted in) and N9 (drop the
+    // opt-in at the menu item) both survived. The menu items are dropdown
+    // choices with NO adjacent avatar-labelled control, so they DO want the
+    // native title. Open the menu and assert the item avatar still emits
+    // title='bob' AND does NOT emit an aria-label (which would double-announce
+    // against the item's own visible name text).
+    await renderDrawer()
+
+    const trigger = screen.getByText('alice').closest('button') as HTMLElement
+    act(() => {
+      fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false, pointerType: 'mouse' })
+      fireEvent.click(trigger)
+    })
+
+    // The roster mock exposes one profile, 'bob'; its menu-item avatar renders
+    // the "B" initials with the opted-in native title.
+    const itemAvatar = await screen.findByText('B')
+    const itemAvatarSpan = itemAvatar.closest('span') as HTMLElement
+    expect(itemAvatarSpan.getAttribute('title')).toBe('bob')
+    // Opted-in path must NOT also emit aria-label (that is the suppressed-path
+    // behaviour; emitting both is mutation N4).
+    expect(itemAvatarSpan.hasAttribute('aria-label')).toBe(false)
+    expect(itemAvatarSpan.hasAttribute('aria-hidden')).toBe(false)
   })
 
   it('shows distinct tooltips on parent vs child dependency chips', async () => {

--- a/apps/desktop/src/plugins/kanban/drawer-tooltips.test.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer-tooltips.test.tsx
@@ -122,6 +122,32 @@ describe('drawer tooltips', () => {
     expect(screen.getByRole('tooltip').textContent).toContain('reassign')
   })
 
+  it('has NO native [title] descendant on the Tip-wrapped reassign trigger (no double tooltip)', async () => {
+    // The Major from round 2: the reassign button is wrapped in <Tip>, but its
+    // inner <Avatar> was still emitting title={name}, stacking a native OS
+    // tooltip on top of the Tip. Assert the Tip trigger subtree carries no
+    // [title] so the Tip is the single tooltip source.
+    await renderDrawer()
+
+    const trigger = screen.getByText('alice').closest('[data-slot="tooltip-trigger"]') as HTMLElement
+    expect(trigger).toBeTruthy()
+    expect(trigger.querySelector('[title]')).toBeNull()
+    // The trigger element itself must not carry a native title either.
+    expect(trigger.hasAttribute('title')).toBe(false)
+  })
+
+  it('keeps the assignee name accessible via aria-label when the native title is suppressed', async () => {
+    // A11y (round-2 m1): suppressing the Avatar's native title dropped the
+    // accessible description on live cards. When title is false, the Avatar
+    // must render aria-label={name} so the name is not mouse-hover-only.
+    await renderDrawer()
+
+    const avatarInitials = screen.getByText('A')
+    const avatar = avatarInitials.closest('span')!
+    expect(avatar.hasAttribute('title')).toBe(false)
+    expect(avatar.getAttribute('aria-label')).toBe('alice')
+  })
+
   it('shows distinct tooltips on parent vs child dependency chips', async () => {
     await renderDrawer()
 

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -211,15 +211,16 @@ function Diagnostics({ items, onReclaim }: { items: Diagnostic[]; onReclaim: () 
             {actions.length > 0 && (
               <div className="flex flex-wrap gap-1.5">
                 {actions.map(action => (
-                  <Button
-                    key={`${action.kind}-${action.label}`}
-                    onClick={() => act(action)}
-                    size="xs"
-                    variant={action.suggested ? 'secondary' : 'outline'}
-                  >
-                    {action.kind === 'cli_hint' && <Codicon name="copy" size="0.7rem" />}
-                    {action.label}
-                  </Button>
+                  <Tip key={`${action.kind}-${action.label}`} label={action.kind === 'cli_hint' ? k.copyCliHintTip : k.reclaimTip}>
+                    <Button
+                      onClick={() => act(action)}
+                      size="xs"
+                      variant={action.suggested ? 'secondary' : 'outline'}
+                    >
+                      {action.kind === 'cli_hint' && <Codicon name="copy" size="0.7rem" />}
+                      {action.label}
+                    </Button>
+                  </Tip>
                 ))}
               </div>
             )}
@@ -245,22 +246,24 @@ function AssigneeMenu({
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <button
-          className="-mx-1 inline-flex max-w-full items-center gap-1.5 rounded px-1 py-0.5 text-left transition-colors hover:bg-(--chrome-action-hover)"
-          type="button"
-        >
-          {current ? (
-            <>
-              <Avatar name={current} size="0.875rem" />
-              <span className="truncate">{current}</span>
-            </>
-          ) : (
-            <span className="text-(--ui-text-quaternary)">{k.unassigned}</span>
-          )}
-          <Codicon className="shrink-0 text-(--ui-text-quaternary)" name="chevron-down" size="0.65rem" />
-        </button>
-      </DropdownMenuTrigger>
+      <Tip label={k.reassignTip}>
+        <DropdownMenuTrigger asChild>
+          <button
+            className="-mx-1 inline-flex max-w-full items-center gap-1.5 rounded px-1 py-0.5 text-left transition-colors hover:bg-(--chrome-action-hover)"
+            type="button"
+          >
+            {current ? (
+              <>
+                <Avatar name={current} size="0.875rem" />
+                <span className="truncate">{current}</span>
+              </>
+            ) : (
+              <span className="text-(--ui-text-quaternary)">{k.unassigned}</span>
+            )}
+            <Codicon className="shrink-0 text-(--ui-text-quaternary)" name="chevron-down" size="0.65rem" />
+          </button>
+        </DropdownMenuTrigger>
+      </Tip>
       <DropdownMenuContent align="start">
         {(roster?.profiles ?? []).map(profile => (
           <DropdownMenuItem key={profile.name} onSelect={() => onReassign(profile.name)}>
@@ -439,15 +442,17 @@ function AttachmentsSection({
             ref={fileRef}
             type="file"
           />
-          <Button
-            aria-label={k.uploadAttachment}
-            disabled={pending}
-            onClick={() => fileRef.current?.click()}
-            size="icon-xs"
-            variant="ghost"
-          >
-            <Codicon name={pending ? 'sync' : 'cloud-upload'} size="0.8rem" spinning={pending} />
-          </Button>
+          <Tip label={k.uploadAttachment}>
+            <Button
+              aria-label={k.uploadAttachment}
+              disabled={pending}
+              onClick={() => fileRef.current?.click()}
+              size="icon-xs"
+              variant="ghost"
+            >
+              <Codicon name={pending ? 'sync' : 'cloud-upload'} size="0.8rem" spinning={pending} />
+            </Button>
+          </Tip>
         </>
       }
       label={k.attachments(attachments.length)}
@@ -690,15 +695,17 @@ export function TaskDrawer({
           <div className="ml-auto flex items-center gap-0.5">
             {task && (
               <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <button
-                    aria-label={k.taskActions}
-                    className="grid size-6 place-items-center rounded text-(--ui-text-tertiary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground"
-                    type="button"
-                  >
-                    <Codicon name="ellipsis" size="0.9rem" />
-                  </button>
-                </DropdownMenuTrigger>
+                <Tip label={k.taskActions}>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      aria-label={k.taskActions}
+                      className="grid size-6 place-items-center rounded text-(--ui-text-tertiary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground"
+                      type="button"
+                    >
+                      <Codicon name="ellipsis" size="0.9rem" />
+                    </button>
+                  </DropdownMenuTrigger>
+                </Tip>
                 <DropdownMenuContent align="end">
                   <DropdownMenuItem
                     onSelect={() => {
@@ -730,14 +737,16 @@ export function TaskDrawer({
                 </DropdownMenuContent>
               </DropdownMenu>
             )}
-            <button
-              aria-label={k.close}
-              className="grid size-6 place-items-center rounded text-(--ui-text-tertiary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground"
-              onClick={onClose}
-              type="button"
-            >
-              <Codicon name="close" size="0.9rem" />
-            </button>
+            <Tip label={k.close}>
+              <button
+                aria-label={k.close}
+                className="grid size-6 place-items-center rounded text-(--ui-text-tertiary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground"
+                onClick={onClose}
+                type="button"
+              >
+                <Codicon name="close" size="0.9rem" />
+              </button>
+            </Tip>
           </div>
         </div>
         {task && (
@@ -823,14 +832,18 @@ export function TaskDrawer({
                         {side === 'parents' ? k.blockedBy : k.blocks}
                       </span>
                       {detail.links[side].map(linked => (
-                        <button
-                          className="rounded bg-(--ui-bg-quaternary) px-1.5 py-0.5 font-mono text-[0.625rem] text-(--ui-text-secondary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground"
+                        <Tip
                           key={linked}
-                          onClick={() => onOpen(linked)}
-                          type="button"
+                          label={side === 'parents' ? k.openLinkedBlocking(shortId(linked)) : k.openLinkedWaiting(shortId(linked))}
                         >
-                          {shortId(linked)}
-                        </button>
+                          <button
+                            className="rounded bg-(--ui-bg-quaternary) px-1.5 py-0.5 font-mono text-[0.625rem] text-(--ui-text-secondary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground"
+                            onClick={() => onOpen(linked)}
+                            type="button"
+                          >
+                            {shortId(linked)}
+                          </button>
+                        </Tip>
                       ))}
                     </div>
                   ) : null

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -366,17 +366,19 @@ function DescriptionSection({ body, onSave }: { body: null | string | undefined;
   return (
     <Section
       action={
-        <Button
-          aria-label={editing ? k.cancelEdit : k.editDescription}
-          onClick={() => {
-            setDraft(body ?? '')
-            setEditing(!editing)
-          }}
-          size="icon-xs"
-          variant="ghost"
-        >
-          <Codicon name={editing ? 'close' : 'edit'} size="0.75rem" />
-        </Button>
+        <Tip label={editing ? k.cancelEdit : k.editDescription}>
+          <Button
+            aria-label={editing ? k.cancelEdit : k.editDescription}
+            onClick={() => {
+              setDraft(body ?? '')
+              setEditing(!editing)
+            }}
+            size="icon-xs"
+            variant="ghost"
+          >
+            <Codicon name={editing ? 'close' : 'edit'} size="0.75rem" />
+          </Button>
+        </Tip>
       }
       label={k.description}
     >
@@ -688,9 +690,11 @@ export function TaskDrawer({
             <span className="font-mono text-sm text-(--ui-text-tertiary)">{shortId(id)}</span>
           )}
           {task && (
-            <span className="font-mono text-[0.625rem] text-(--ui-text-quaternary)" data-selectable-text="true">
-              {shortId(task.id)}
-            </span>
+            <Tip label={k.taskIdTip(task.id)}>
+              <span className="cursor-help font-mono text-[0.625rem] text-(--ui-text-quaternary)" data-selectable-text="true">
+                {shortId(task.id)}
+              </span>
+            </Tip>
           )}
           <div className="ml-auto flex items-center gap-0.5">
             {task && (

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -254,7 +254,7 @@ function AssigneeMenu({
           >
             {current ? (
               <>
-                <Avatar name={current} size="0.875rem" title={false} />
+                <Avatar name={current} size="0.875rem" decorative />
                 <span className="truncate">{current}</span>
               </>
             ) : (

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -254,7 +254,7 @@ function AssigneeMenu({
           >
             {current ? (
               <>
-                <Avatar name={current} size="0.875rem" />
+                <Avatar name={current} size="0.875rem" title={false} />
                 <span className="truncate">{current}</span>
               </>
             ) : (
@@ -267,7 +267,7 @@ function AssigneeMenu({
       <DropdownMenuContent align="start">
         {(roster?.profiles ?? []).map(profile => (
           <DropdownMenuItem key={profile.name} onSelect={() => onReassign(profile.name)}>
-            <Avatar name={profile.name} size="0.875rem" />
+            <Avatar name={profile.name} size="0.875rem" title={true} />
             {profile.name}
             {profile.name === current && <Codicon className="ml-auto" name="check" size="0.8rem" />}
           </DropdownMenuItem>

--- a/apps/desktop/src/plugins/kanban/i18n-test-helper.ts
+++ b/apps/desktop/src/plugins/kanban/i18n-test-helper.ts
@@ -1,0 +1,25 @@
+/**
+ * Resolve a kanban message key against the plugin's own `en` bundle.
+ *
+ * Tests that render kanban components stub `usePluginI18n` with this instead
+ * of registering the bundle for real: registration normally happens in
+ * `ctx.i18n.register`, and the registry lives behind an app-internal module a
+ * plugin (or its tests) may not import. Mirrors hermes-bots/i18n-test-helper.ts.
+ */
+
+import { en } from './i18n'
+
+export function translateKanban(key: string, ...args: unknown[]): string {
+  const value = key
+    .split('.')
+    .reduce<unknown>(
+      (node, part) => (node && typeof node === 'object' ? (node as Record<string, unknown>)[part] : undefined),
+      en
+    )
+
+  if (typeof value === 'function') {
+    return String((value as (...params: unknown[]) => string)(...args))
+  }
+
+  return typeof value === 'string' ? value : key
+}

--- a/apps/desktop/src/plugins/kanban/i18n.ts
+++ b/apps/desktop/src/plugins/kanban/i18n.ts
@@ -40,6 +40,13 @@ type KanbanMessages = {
   wontRun: string
   wontRunTip: string
   noHeartbeat: string
+  assignedToTip: (name: string) => string
+  priorityTip: (n: number) => string
+  progressTip: (done: number, total: number) => string
+  commentCountTip: (n: number) => string
+  blocksTip: (n: number) => string
+  warningsTip: (n: number, severity: string) => string
+  taskIdTip: (id: string) => string
   expand: (label: string) => string
   collapse: (label: string) => string
   newTaskIn: (label: string) => string
@@ -160,6 +167,11 @@ type KanbanMessages = {
   copiedTitle: string
   close: string
   working: string
+  openLinkedBlocking: (id: string) => string
+  openLinkedWaiting: (id: string) => string
+  reassignTip: string
+  copyCliHintTip: string
+  reclaimTip: string
   // board switcher
   board: string
   newBoard: string
@@ -253,6 +265,14 @@ export const en: KanbanMessages = {
   wontRunTip:
     'Ready cards only run once a profile is assigned. Open the card and set an assignee, or configure a default assignee in orchestration settings.',
   noHeartbeat: 'no heartbeat',
+  assignedToTip: name => `Assigned to ${name}.`,
+  priorityTip: n =>
+    `Priority ${n} — higher numbers are picked first when several ready tasks share an assignee.`,
+  progressTip: (done, total) => `${done} of ${total} child tasks done.`,
+  commentCountTip: n => `${n} comment${n === 1 ? '' : 's'} on this task.`,
+  blocksTip: n => `Blocks ${n} other task${n === 1 ? '' : 's'} — they wait until this one is done.`,
+  warningsTip: (n, severity) => `${n} warning${n === 1 ? '' : 's'} — highest severity: ${severity}. Open the card for details.`,
+  taskIdTip: id => `Full id: ${id}.`,
   expand: label => `Expand ${label}`,
   collapse: label => `Collapse ${label}`,
   newTaskIn: label => `New task in ${label}`,
@@ -376,6 +396,11 @@ export const en: KanbanMessages = {
   copiedTitle: 'Copied title',
   close: 'Close',
   working: 'working',
+  openLinkedBlocking: id => `Open ${id} — still blocking this card.`,
+  openLinkedWaiting: id => `Open ${id} — waiting on this card.`,
+  reassignTip: 'Click to reassign — reclaims a running worker first.',
+  copyCliHintTip: 'Copy this command to your clipboard.',
+  reclaimTip: 'Reclaim this task — clears the failure streak and lets it be picked up again.',
   board: 'Board',
   newBoard: 'New board',
   newBoardDots: 'New board…',
@@ -465,6 +490,13 @@ const ja: KanbanMessages = {
   wontRunTip:
     'Ready のカードはプロフィールが割り当てられて初めて実行されます。カードを開いて担当を設定するか、オーケストレーション設定でデフォルトの担当を設定してください。',
   noHeartbeat: 'ハートビートなし',
+  assignedToTip: name => `担当: ${name}。`,
+  priorityTip: n => `優先度 ${n} — 同じ担当の Ready タスクが複数あるとき、数値が大きいものから先に実行されます。`,
+  progressTip: (done, total) => `子タスク ${done}/${total} 件完了。`,
+  commentCountTip: n => `このタスクへのコメント ${n} 件。`,
+  blocksTip: n => `他の ${n} 件のタスクをブロック中 — このカードが完了するまで待機します。`,
+  warningsTip: (n, severity) => `警告 ${n} 件 — 最高深刻度: ${severity}。詳細はカードを開いてください。`,
+  taskIdTip: id => `完全な ID: ${id}。`,
   expand: label => `${label} を展開`,
   collapse: label => `${label} を折りたたむ`,
   newTaskIn: label => `${label} に新しいタスク`,
@@ -587,6 +619,11 @@ const ja: KanbanMessages = {
   copiedTitle: 'タイトルをコピーしました',
   close: '閉じる',
   working: '作業中',
+  openLinkedBlocking: id => `${id} を開く — まだこのカードをブロックしています。`,
+  openLinkedWaiting: id => `${id} を開く — このカードの完了を待っています。`,
+  reassignTip: 'クリックして再割り当て — 実行中のワーカーは先に再取得されます。',
+  copyCliHintTip: 'このコマンドをクリップボードにコピーします。',
+  reclaimTip: 'このタスクを再取得 — 失敗回数をリセットし、再び取得可能にします。',
   board: 'ボード',
   newBoard: '新しいボード',
   newBoardDots: '新しいボード…',
@@ -675,6 +712,13 @@ const zh: KanbanMessages = {
   wontRun: '不会运行',
   wontRunTip: '就绪卡片只有在分配了配置档后才会运行。打开卡片设置负责人，或在编排设置中配置默认负责人。',
   noHeartbeat: '无心跳',
+  assignedToTip: name => `负责人：${name}。`,
+  priorityTip: n => `优先级 ${n} — 多个就绪任务共享负责人时，数字越大越先被处理。`,
+  progressTip: (done, total) => `子任务已完成 ${done}/${total}。`,
+  commentCountTip: n => `此任务有 ${n} 条评论。`,
+  blocksTip: n => `阻塞其他 ${n} 个任务 — 它们要等此卡片完成。`,
+  warningsTip: (n, severity) => `${n} 条警告 — 最高严重级别：${severity}。打开卡片查看详情。`,
+  taskIdTip: id => `完整 ID：${id}。`,
   expand: label => `展开 ${label}`,
   collapse: label => `折叠 ${label}`,
   newTaskIn: label => `在 ${label} 新建任务`,
@@ -796,6 +840,11 @@ const zh: KanbanMessages = {
   copiedTitle: '已复制标题',
   close: '关闭',
   working: '进行中',
+  openLinkedBlocking: id => `打开 ${id} — 仍在阻塞此卡片。`,
+  openLinkedWaiting: id => `打开 ${id} — 正在等待此卡片完成。`,
+  reassignTip: '点击重新分配 — 会先重新领取正在运行的工作单元。',
+  copyCliHintTip: '将此命令复制到剪贴板。',
+  reclaimTip: '重新领取此任务 — 清除失败计数，使其可再次被领取。',
   board: '面板',
   newBoard: '新建面板',
   newBoardDots: '新建面板…',
@@ -883,6 +932,13 @@ const zhHant: KanbanMessages = {
   wontRun: '不會執行',
   wontRunTip: '就緒卡片只有在指派了設定檔後才會執行。開啟卡片設定負責人，或在編排設定中設定預設負責人。',
   noHeartbeat: '無心跳',
+  assignedToTip: name => `負責人：${name}。`,
+  priorityTip: n => `優先順序 ${n} — 多個就緒任務共用負責人時，數字越大越先被處理。`,
+  progressTip: (done, total) => `子任務已完成 ${done}/${total}。`,
+  commentCountTip: n => `此任務有 ${n} 則留言。`,
+  blocksTip: n => `阻擋其他 ${n} 個任務 — 它們要等此卡片完成。`,
+  warningsTip: (n, severity) => `${n} 個警告 — 最高嚴重程度：${severity}。開啟卡片查看詳情。`,
+  taskIdTip: id => `完整 ID：${id}。`,
   expand: label => `展開 ${label}`,
   collapse: label => `摺疊 ${label}`,
   newTaskIn: label => `在 ${label} 新增任務`,
@@ -1004,6 +1060,11 @@ const zhHant: KanbanMessages = {
   copiedTitle: '已複製標題',
   close: '關閉',
   working: '進行中',
+  openLinkedBlocking: id => `開啟 ${id} — 仍在阻擋此卡片。`,
+  openLinkedWaiting: id => `開啟 ${id} — 正在等待此卡片完成。`,
+  reassignTip: '點擊重新指派 — 會先重新領取執行中的工作單元。',
+  copyCliHintTip: '將此指令複製到剪貼簿。',
+  reclaimTip: '重新領取此任務 — 清除失敗次數，使其可再次被領取。',
   board: '面板',
   newBoard: '新增面板',
   newBoardDots: '新增面板…',

--- a/apps/desktop/src/plugins/kanban/i18n.ts
+++ b/apps/desktop/src/plugins/kanban/i18n.ts
@@ -44,8 +44,8 @@ type KanbanMessages = {
   priorityTip: (n: number) => string
   progressTip: (done: number, total: number) => string
   commentCountTip: (n: number) => string
-  blocksTip: (n: number) => string
-  warningsTip: (n: number, severity: string) => string
+  blocksTip: (n: number, parents: number, children: number) => string
+  warningsTip: (n: number, severity: null | string | undefined) => string
   taskIdTip: (id: string) => string
   expand: (label: string) => string
   collapse: (label: string) => string
@@ -270,8 +270,12 @@ export const en: KanbanMessages = {
     `Priority ${n} — higher numbers are picked first when several ready tasks share an assignee.`,
   progressTip: (done, total) => `${done} of ${total} child tasks done.`,
   commentCountTip: n => `${n} comment${n === 1 ? '' : 's'} on this task.`,
-  blocksTip: n => `Blocks ${n} other task${n === 1 ? '' : 's'} — they wait until this one is done.`,
-  warningsTip: (n, severity) => `${n} warning${n === 1 ? '' : 's'} — highest severity: ${severity}. Open the card for details.`,
+  blocksTip: (n, parents, children) =>
+    `Linked to ${n} other task${n === 1 ? '' : 's'}: ${parents} parent${parents === 1 ? '' : 's'}, ${children} child${children === 1 ? '' : 'ren'}.`,
+  warningsTip: (n, severity) =>
+    severity
+      ? `${n} warning${n === 1 ? '' : 's'} — highest severity: ${severity}. Open the card for details.`
+      : `${n} warning${n === 1 ? '' : 's'}. Open the card for details.`,
   taskIdTip: id => `Full id: ${id}.`,
   expand: label => `Expand ${label}`,
   collapse: label => `Collapse ${label}`,
@@ -494,8 +498,10 @@ const ja: KanbanMessages = {
   priorityTip: n => `優先度 ${n} — 同じ担当の Ready タスクが複数あるとき、数値が大きいものから先に実行されます。`,
   progressTip: (done, total) => `子タスク ${done}/${total} 件完了。`,
   commentCountTip: n => `このタスクへのコメント ${n} 件。`,
-  blocksTip: n => `他の ${n} 件のタスクをブロック中 — このカードが完了するまで待機します。`,
-  warningsTip: (n, severity) => `警告 ${n} 件 — 最高深刻度: ${severity}。詳細はカードを開いてください。`,
+  blocksTip: (n, parents, children) =>
+    `他の ${n} 件のタスクとリンク: 親 ${parents} 件、子 ${children} 件。`,
+  warningsTip: (n, severity) =>
+    severity ? `警告 ${n} 件 — 最高深刻度: ${severity}。詳細はカードを開いてください。` : `警告 ${n} 件。詳細はカードを開いてください。`,
   taskIdTip: id => `完全な ID: ${id}。`,
   expand: label => `${label} を展開`,
   collapse: label => `${label} を折りたたむ`,
@@ -716,8 +722,10 @@ const zh: KanbanMessages = {
   priorityTip: n => `优先级 ${n} — 多个就绪任务共享负责人时，数字越大越先被处理。`,
   progressTip: (done, total) => `子任务已完成 ${done}/${total}。`,
   commentCountTip: n => `此任务有 ${n} 条评论。`,
-  blocksTip: n => `阻塞其他 ${n} 个任务 — 它们要等此卡片完成。`,
-  warningsTip: (n, severity) => `${n} 条警告 — 最高严重级别：${severity}。打开卡片查看详情。`,
+  blocksTip: (n, parents, children) =>
+    `已关联其他 ${n} 个任务：${parents} 个父任务，${children} 个子任务。`,
+  warningsTip: (n, severity) =>
+    severity ? `${n} 条警告 — 最高严重级别：${severity}。打开卡片查看详情。` : `${n} 条警告。打开卡片查看详情。`,
   taskIdTip: id => `完整 ID：${id}。`,
   expand: label => `展开 ${label}`,
   collapse: label => `折叠 ${label}`,
@@ -936,8 +944,10 @@ const zhHant: KanbanMessages = {
   priorityTip: n => `優先順序 ${n} — 多個就緒任務共用負責人時，數字越大越先被處理。`,
   progressTip: (done, total) => `子任務已完成 ${done}/${total}。`,
   commentCountTip: n => `此任務有 ${n} 則留言。`,
-  blocksTip: n => `阻擋其他 ${n} 個任務 — 它們要等此卡片完成。`,
-  warningsTip: (n, severity) => `${n} 個警告 — 最高嚴重程度：${severity}。開啟卡片查看詳情。`,
+  blocksTip: (n, parents, children) =>
+    `已關聯其他 ${n} 個任務：${parents} 個父任務，${children} 個子任務。`,
+  warningsTip: (n, severity) =>
+    severity ? `${n} 個警告 — 最高嚴重程度：${severity}。開啟卡片查看詳情。` : `${n} 個警告。開啟卡片查看詳情。`,
   taskIdTip: id => `完整 ID：${id}。`,
   expand: label => `展開 ${label}`,
   collapse: label => `摺疊 ${label}`,

--- a/apps/desktop/src/plugins/kanban/ui.tsx
+++ b/apps/desktop/src/plugins/kanban/ui.tsx
@@ -163,7 +163,18 @@ function initials(name: string): string {
   return `${parts[0]?.[0] ?? '?'}${parts[1]?.[0] ?? ''}`.toUpperCase()
 }
 
-export function Avatar({ name, size = '1.25rem' }: { name: string; size?: string }) {
+export function Avatar({
+  name,
+  size = '1.25rem',
+  title = true
+}: {
+  name: string
+  size?: string
+  /** Set false when the caller already wraps this Avatar in a `<Tip>` — a
+   *  native title= would otherwise stack a second, un-themed OS tooltip on
+   *  top of the Tip's own chip. */
+  title?: boolean
+}) {
   // Same identity hue the rest of the app uses (profileColor); default/empty
   // profiles are neutral. Soft tag fill + colored glyph, per the app's tags.
   const color = profileColor(name)
@@ -178,7 +189,7 @@ export function Avatar({ name, size = '1.25rem' }: { name: string; size?: string
         height: size,
         width: size
       }}
-      title={name}
+      title={title ? name : undefined}
     >
       {initials(name)}
     </span>

--- a/apps/desktop/src/plugins/kanban/ui.tsx
+++ b/apps/desktop/src/plugins/kanban/ui.tsx
@@ -164,16 +164,29 @@ function initials(name: string): string {
 }
 
 export function Avatar({
+  decorative = false,
   name,
   size = '1.25rem',
   title = false
 }: {
+  /** Set true when the assignee name is ALREADY rendered as adjacent visible
+   *  text (the drawer reassign trigger, the queued footer chip). The avatar is
+   *  then decorative: it is hidden from the accessibility tree (aria-hidden)
+   *  and emits NO aria-label. Otherwise the enclosing control computes its
+   *  accessible name from content and stutters the assignee twice
+   *  ("alice alice") — the avatar's aria-label "alice" replaces its "A"
+   *  initials during traversal, doubling the adjacent visible <span>alice</span>.
+   *  `title` still follows the opt-in default below, so a decorative avatar that
+   *  is NOT opted-in also carries no native title (no second, stacked tooltip on
+   *  top of the <Tip> the caller wraps it in). */
+  decorative?: boolean
   name: string
   size?: string
   /** Set true when the caller wants the native browser tooltip (opt-in).
    *  Defaults to false so that callers wrapping Avatar in <Tip> don't get
-   *  a double tooltip. When title is suppressed, aria-label is rendered
-   *  so the assignee name remains accessible. */
+   *  a double tooltip. When title is suppressed AND the avatar is not
+   *  decorative, aria-label is rendered so the assignee name remains
+   *  accessible on a plain avatar that has no adjacent visible name. */
   title?: boolean
 }) {
   // Same identity hue the rest of the app uses (profileColor); default/empty
@@ -190,8 +203,9 @@ export function Avatar({
         height: size,
         width: size
       }}
+      aria-hidden={decorative || undefined}
       title={title ? name : undefined}
-      aria-label={title ? undefined : name}
+      aria-label={title || decorative ? undefined : name}
     >
       {initials(name)}
     </span>

--- a/apps/desktop/src/plugins/kanban/ui.tsx
+++ b/apps/desktop/src/plugins/kanban/ui.tsx
@@ -166,13 +166,14 @@ function initials(name: string): string {
 export function Avatar({
   name,
   size = '1.25rem',
-  title = true
+  title = false
 }: {
   name: string
   size?: string
-  /** Set false when the caller already wraps this Avatar in a `<Tip>` — a
-   *  native title= would otherwise stack a second, un-themed OS tooltip on
-   *  top of the Tip's own chip. */
+  /** Set true when the caller wants the native browser tooltip (opt-in).
+   *  Defaults to false so that callers wrapping Avatar in <Tip> don't get
+   *  a double tooltip. When title is suppressed, aria-label is rendered
+   *  so the assignee name remains accessible. */
   title?: boolean
 }) {
   // Same identity hue the rest of the app uses (profileColor); default/empty
@@ -190,6 +191,7 @@ export function Avatar({
         width: size
       }}
       title={title ? name : undefined}
+      aria-label={title ? undefined : name}
     >
       {initials(name)}
     </span>


### PR DESCRIPTION
## Summary

Per the icon/badge audit (parent task, `kanban-card-icon-audit.md`), adds hover tooltips to every status icon and free-form field on Kanban task cards that currently lacked one, reusing the existing `<Tip>` mechanism (`apps/desktop/src/components/ui/tooltip.tsx`) already used by the dependency chips, run clock, and estimate controls — same component, styling, near-zero delay, and Radix-backed keyboard/focus accessibility.

**Board card (`board.tsx`)** — net-new tooltips:
- Priority badge, child-progress checklist, comment count, "blocks N" references count, warnings badge (with highest severity), short task id (revealing the full id)
- Plain assignee avatar (no live arc state): converted from a bare native `title=` to `Tip` for consistent hover styling/delay/theming

**Task drawer (`drawer.tsx`)** — net-new tooltips:
- Task-actions ellipsis trigger, close button, upload-attachment button, assignee reassign trigger
- Per-chip dependency links in the Dependencies section — parent ("blocked by") and child ("blocks") chips get distinct copy so the two directions of the dependency graph never read as the same concept
- Diagnostics recovery-action buttons (`cli_hint` copy / `reclaim`)

Copy lives in `i18n.ts` across all 4 locale bundles (en/ja/zh/zh-hant), matching the existing per-locale `KanbanMessages` pattern.

**Left untouched** (explicitly flagged skip/optional in the audit): the `kanban-arc` animated border (`aria-hidden`, decorative, redundant with the adjacent RunClock/stale tooltip right below it) and the "created Xh ago" prose text (not an icon).

## Test plan

- `card-tooltips.test.tsx` (8 tests) and `drawer-tooltips.test.tsx` (6 tests, new) render the real `KanbanBoardPage` / `TaskDrawer` against mocked API calls and drive real Radix `pointermove` events to open each tip, asserting on `getByRole('tooltip')` text — so a regression that silently drops a `<Tip>` wrapper (reverting to a bare `<span>`) fails here, not just in an isolated string-label unit test.
- Includes a regression check that the pre-existing `wontRun` tooltip still opens correctly.
- `tsc -p . --noEmit`: clean.
- Full `apps/desktop/src/plugins/kanban` suite: 52/52 passing across 7 files.
- Full desktop vitest suite: 9319/9365 passing — the 40 failures are pre-existing Windows-host failures in Electron SSH/git-worktree/hardening/macOS-TCC tests (POSIX-only assertions), unrelated to this change and reproducible on a clean `origin/main` checkout before this diff.
