### PR TITLE
fix(kanban): treat review transitions as terminal worker actions

### DIFF
--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -10,7 +10,16 @@ import os
 from typing import Any, Iterable, Optional
 
 
-_TERMINAL_KANBAN_TOOLS = frozenset({"kanban_complete", "kanban_block"})
+# Every tool here ends the CURRENT worker/reviewer run. A review transition is
+# terminal for that run even though the task itself is not yet done.
+_TERMINAL_KANBAN_TOOLS = frozenset(
+    {
+        "kanban_complete",
+        "kanban_block",
+        "kanban_request_review",
+        "kanban_request_changes",
+    }
+)
 
 _DEFAULT_MAX_ATTEMPTS = 2
 

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -74,6 +74,28 @@ def test_no_nudge_after_kanban_complete(clear_kanban_env):
     assert build_kanban_stop_nudge(messages=messages) is None
 
 
+@pytest.mark.parametrize("tool_name", ["kanban_request_review", "kanban_request_changes"])
+def test_no_nudge_after_review_transition(clear_kanban_env, tool_name):
+    """Review transitions end the current run even though the task remains open."""
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_review")
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "review-1",
+                    "type": "function",
+                    "function": {"name": tool_name, "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "name": tool_name, "tool_call_id": "review-1", "content": "ok"},
+    ]
+    assert session_called_kanban_terminal(messages) is True
+    assert build_kanban_stop_nudge(messages=messages) is None
+
+
 
 
 


### PR DESCRIPTION
## Symptom
A kanban worker that hands a card to review via `kanban_request_review` (or bounces it back with `kanban_request_changes`) is not recognized as having finished its run: `_TERMINAL_KANBAN_TOOLS` in `agent/kanban_stop.py` only contains `kanban_complete` and `kanban_block`, so the stop-nudge machinery keeps pushing the worker to act on a card it no longer owns.

## Fix
A review transition ends the CURRENT worker/reviewer run even though the task is not yet done — add both review transitions to the terminal set. Comment documents the run-vs-task distinction so the set doesn't drift.

## Tests
Invariant tests: each of the four tools terminates a run; a non-terminal kanban tool (e.g. claim) does not.