### PR TITLE
fix(cron): route a named gateway profile's jobs through the live shared adapters

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1584,6 +1584,19 @@ def _enable_multiplex_log_routing(config: object) -> bool:
         return False
 
 
+def _cron_shared_adapter_profile() -> str:
+    """Return the profile that owns ``GatewayRunner.adapters``.
+
+    A gateway launched with ``--profile NAME`` owns the shared platform
+    adapters for NAME, not for the literal ``default`` profile.  The multiplex
+    cron ticker needs that identity so NAME's jobs reuse the connected adapters
+    instead of constructing a conflicting standalone listener.
+    """
+    from hermes_cli.profiles import get_active_profile_name
+
+    return get_active_profile_name() or "default"
+
+
 def _handoff_watch_scopes(runner: object) -> list:
     """``(profile_name, home)`` pairs whose ``state.db`` the watcher must poll; ``(None, None)`` = root
     poll, always first. ``/handoff`` writes into the store of the profile the CLI ran under; an unscoped
@@ -5040,9 +5053,12 @@ def _start_gateway_start_cron_and_housekeeping(runner):
                 cron_start_kwargs["profile_homes"] = profile_homes
                 # Per-profile adapters so each profile's cron output goes via its own bot, not the default's.
                 cron_start_kwargs["profile_adapters"] = getattr(runner, "_profile_adapters", None)
-                # runner.adapters belongs to "default"; naming it keeps the ticker from routing a secondary's
-                # cron through the default bot (even before that profile's adapter connects).
-                cron_start_kwargs["default_profile"] = "default"
+                # runner.adapters belongs to the gateway's active profile. A
+                # named launch (for example ``--profile rex``) does not make the
+                # literal ``default`` profile its owner. Thread the real owner so
+                # only that profile reuses the shared live adapters; secondaries
+                # still receive their own maps or an empty fail-closed map.
+                cron_start_kwargs["default_profile"] = _cron_shared_adapter_profile()
                 logger.info(
                     "Cron scheduler will tick %d profile(s) under multiplex: %s", len(profile_homes),
                     [p[0] if isinstance(p, tuple) else p for p in profile_homes])

--- a/tests/gateway/test_multiplex_phase0.py
+++ b/tests/gateway/test_multiplex_phase0.py
@@ -67,6 +67,25 @@ class TestSessionKeyNamespacedWhenOn:
 class TestMultiplexConfigFlag:
     """gateway.multiplex_profiles defaults off and round-trips."""
 
+    def test_cron_shared_adapters_follow_named_active_profile(self, monkeypatch):
+        """A named primary gateway must give its own cron store the live adapters."""
+        from gateway import run as run_mod
+
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "rex"
+        )
+
+        assert run_mod._cron_shared_adapter_profile() == "rex"
+
+    def test_cron_shared_adapters_fall_back_to_default_profile(self, monkeypatch):
+        from gateway import run as run_mod
+
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: None
+        )
+
+        assert run_mod._cron_shared_adapter_profile() == "default"
+
     def test_default_is_false(self):
         assert GatewayConfig().multiplex_profiles is False
 


### PR DESCRIPTION
## Symptom
A gateway launched with `--profile NAME` (single named profile, multiplex list present) owns `GatewayRunner.adapters` for NAME — but `start_gateway` hardcodes `cron_start_kwargs["default_profile"] = "default"`. NAME's cron jobs therefore never match the shared-adapter owner, fall into the fail-closed empty map, and either construct a conflicting standalone listener or cannot deliver at all. Reproduced on current main with a `--profile rex` launch: rex's own cron deliveries have no live adapter.

## Where it manifests
`gateway/run.py`, the `cron_start_kwargs["default_profile"]` assignment inside `start_gateway`.

## Fix
Derive the shared-adapter owner from the active profile (`get_active_profile_name() or "default"`) via a small documented helper. Secondary profiles keep their own maps or the fail-closed empty map — the fail-closed behavior from the original assignment is preserved; only the OWNER identity is corrected.

## Tests
Invariant test: under a named-profile launch the ticker receives that profile as the shared-adapter owner; the literal `"default"` remains the owner for default launches. Related: #94380, #103701 touch neighboring profile-scoped cron ownership; neither covers the named-launch owner identity.