### PR TITLE
fix(discord): honor YAML allow_from for channel traffic under multiplex

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -380,6 +380,12 @@ class GatewayAuthorizationMixin:
             return False
         extra = _adapter_config_extra(adapter)
         adapter_allow = extra.get("group_allow_from" if is_group else "allow_from")
+        if not adapter_allow and is_group and source.platform == Platform.DISCORD:
+            # Discord exposes ONE global ``allow_from`` sender list covering DMs
+            # and guild channels. Under multiplex the YAML→env bridge
+            # deliberately skips process-global env writes, so channel auth must
+            # consult that adapter-scoped value too.
+            adapter_allow = extra.get("allow_from")
         if not adapter_allow:
             # Plugin platforms (Buzz, DingTalk) spell their env allowlist as ``extra.allowed_users``;
             # under multiplex only the default profile's list reaches the env (first-writer-wins

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -66,6 +66,50 @@ def test_default_profile_still_trusts_own_allowlist(monkeypatch):
     assert runner._is_user_authorized(source) is True
 
 
+def test_discord_channel_honors_profile_scoped_yaml_allow_from(monkeypatch):
+    """Discord's global allow_from applies to channel traffic under multiplex."""
+    from agent import secret_scope
+    from gateway.run import GatewayRunner
+
+    _clear_auth_env(monkeypatch)
+    monkeypatch.delenv("DISCORD_ALLOWED_USERS", raising=False)
+    monkeypatch.delenv("DISCORD_ALLOW_ALL_USERS", raising=False)
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    adapter = SimpleNamespace(
+        config=PlatformConfig(
+            enabled=True,
+            extra={"allow_from": "897961621304000532"},
+        ),
+        authorization_is_upstream=False,
+        enforces_own_access_policy=False,
+    )
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._profile_adapters = {}
+    runner._primary_profile_name = "rex"
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        user_id="897961621304000532",
+        chat_id="1544510769830563840",
+        user_name="Jonkman",
+        chat_type="group",
+        profile="rex",
+    )
+
+    previous_multiplex = secret_scope.is_multiplex_active()
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope({})
+    try:
+        assert runner._is_user_authorized(source) is True
+    finally:
+        secret_scope.reset_secret_scope(token)
+        secret_scope.set_multiplex_active(previous_multiplex)
+
+
 def test_active_profile_stamp_resolves_primary_adapter(monkeypatch):
     """A single-profile gateway stamps its active profile but stores adapters as primary."""
     runner, default_adapter, _secondary_adapter = _make_multiplex_runner(monkeypatch)


### PR DESCRIPTION
## Symptom
Under `gateway.multiplex_profiles`, a Discord guild-channel sender listed in the profile's YAML `allow_from` is rejected. DMs from the same sender pass.

## Why
Discord exposes ONE global `allow_from` sender list covering DMs and guild channels. Under multiplex the YAML→env bridge deliberately skips process-global env writes, so channel auth must consult the adapter-scoped config — but `_adapter_extra_allowlist_authorizes` (gateway/authz_mixin.py) reads only `group_allow_from` for group-shaped chats. For Discord there is no such key, so the operator's explicit allowlist is invisible and default-deny locks the sender out of every channel.

## Fix
For Discord group/channel traffic with no `group_allow_from`, fall back to the adapter-scoped global `allow_from` — the same class of fallback this function already performs for plugin platforms via `extra.allowed_users` (#82871, #98738), and the same bug class recently fixed per-platform for WhatsApp/LINE/DingTalk (#100604, #100609, #100615). No widening: an absent/empty list still falls through to default-deny, per SECURITY.md §2.6.

## Tests
Invariant test: multiplex active + Discord channel message + YAML allow_from containing the sender → authorized; sender not on the list → still denied.