### PR TITLE
test(cli): make curses menu-loop tests fail fast on exhausted scripted input

### DIFF
--- a/tests/hermes_cli/test_curses_arrow_keys.py
+++ b/tests/hermes_cli/test_curses_arrow_keys.py
@@ -71,7 +71,9 @@ class ExhaustingStdscr(FakeStdscr):
 
     def getch(self):
         if not self.keys:
-            raise AssertionError("menu requested another key after enhanced Enter")
+            raise AssertionError(
+                "menu kept polling for input after its scripted keys were consumed"
+            )
         return self.keys.pop(0)
 
 
@@ -167,7 +169,7 @@ def test_enhanced_control_keys_dispatch_while_search_is_active(
     class NavigationDispatched(Exception):
         pass
 
-    fake = FakeStdscr([ord("/"), ord("g"), *enhanced_keys])
+    fake = ExhaustingStdscr([ord("/"), ord("g"), *enhanced_keys])
     events = []
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(curses, "wrapper", lambda draw: draw(fake))
@@ -225,7 +227,7 @@ def test_numbered_fallback_ctrl_c_dispatches_scoped_cancel(monkeypatch):
 
 
 def test_navigation_handler_programming_error_is_not_hidden_by_fallback(monkeypatch):
-    fake = FakeStdscr([13])
+    fake = ExhaustingStdscr([13])
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(curses, "wrapper", lambda draw: draw(fake))
     monkeypatch.setattr(curses, "curs_set", lambda _value: None)
@@ -247,10 +249,10 @@ def test_navigation_handler_programming_error_is_not_hidden_by_fallback(monkeypa
 def test_standalone_model_flow_renders_previous_and_reopens_provider(monkeypatch):
     from hermes_cli import main as main_mod
 
-    provider_screen = FakeStdscr([13])
-    model_back_screen = FakeStdscr([curses.KEY_LEFT])
-    provider_reselect_screen = FakeStdscr([13])
-    model_select_screen = FakeStdscr([13])
+    provider_screen = ExhaustingStdscr([13])
+    model_back_screen = ExhaustingStdscr([curses.KEY_LEFT])
+    provider_reselect_screen = ExhaustingStdscr([13])
+    model_select_screen = ExhaustingStdscr([13])
     screens = [
         provider_screen,
         model_back_screen,
@@ -298,7 +300,7 @@ def test_radiolist_dispatches_contextual_back_navigation(monkeypatch):
         pass
 
     events = []
-    fake = FakeStdscr([curses.KEY_LEFT])
+    fake = ExhaustingStdscr([curses.KEY_LEFT])
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(curses, "wrapper", lambda draw: draw(fake))
     monkeypatch.setattr(curses, "curs_set", lambda _value: None)
@@ -325,6 +327,8 @@ def test_radiolist_dispatches_contextual_escape_cancellation(monkeypatch):
     class Cancelled(BaseException):
         pass
 
+    # FakeStdscr (not ExhaustingStdscr): lone-ESC detection legitimately polls one
+    # more key and expects the -1 "no continuation byte" answer here.
     fake = FakeStdscr([27])
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(curses, "wrapper", lambda draw: draw(fake))


### PR DESCRIPTION
## What does this PR do?

Makes the curses menu-loop tests in `tests/hermes_cli/test_curses_arrow_keys.py` fail fast when their scripted key sequence is exhausted, instead of letting a broken navigation transition spin the menu redraw loop forever.

`FakeStdscr.getch()` answers `-1` indefinitely once its scripted keys run out (and `addnstr()` retains every redraw write), so a failed menu transition in these loop tests becomes an unbounded memory sink rather than a failing test — the OOM shape reported in #103733, where a directory-wide `pytest tests/hermes_cli/` run grew to ~9.4 GiB RAM + 14.2 GiB swap before the kernel killed it.

The file already contains `ExhaustingStdscr` (introduced alongside the enhanced-Enter regression test), which raises `AssertionError` as soon as the menu asks for another key after the scripted input is consumed. This PR switches the remaining menu-loop tests to it. The lone-ESC tests intentionally keep `FakeStdscr`, because `-1` is the protocol value that confirms a genuine lone ESC (`_decode_escape_sequence` polls one more byte and treats `-1` as "no continuation byte"), so those two call sites cannot use the exhausting fake; a comment now records that constraint.

The pure `read_menu_key` decode tests are single-shot calls with no redraw loop, so they keep `FakeStdscr` unchanged.

## Related Issue

Fixes #103733

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/hermes_cli/test_curses_arrow_keys.py`:
  - Switched the four menu-loop tests to `ExhaustingStdscr`: `test_enhanced_control_keys_dispatch_while_search_is_active`, `test_navigation_handler_programming_error_is_not_hidden_by_fallback`, `test_standalone_model_flow_renders_previous_and_reopens_provider` (all four screens), and `test_radiolist_dispatches_contextual_back_navigation`.
  - Generalized the `ExhaustingStdscr` exhaustion message ("menu kept polling for input after its scripted keys were consumed") since it now guards all menu-loop tests, not just the enhanced-Enter one.
  - Added a comment on `test_radiolist_dispatches_contextual_escape_cancellation` explaining why it must keep `FakeStdscr` (lone-ESC detection expects the `-1` continuation-byte answer).

## How to Test

1. `python -m pytest tests/hermes_cli/test_curses_arrow_keys.py -q` — Observed result: 22 passed in 1.00s.
2. Neighboring curses_ui consumers: `python -m pytest tests/hermes_cli/test_curses_radiolist_viewport.py tests/hermes_cli/test_curses_ui_search.py tests/hermes_cli/test_custom_provider_model_switch.py -q` — Observed result: 24 passed.
3. Fail-fast behavior (red-state proof): driving the real searchable `curses_radiolist` with a scripted sequence that runs out mid-flow (`['/', 'g']` with no enhanced Enter):
   - with the old `FakeStdscr` the menu redraw loop spins forever (demo process had to be SIGKILLed by an 8s watchdog — the unbounded-spin/OOM shape from the issue);
   - with `ExhaustingStdscr` it raises immediately: `AssertionError: menu kept polling for input after its scripted keys were consumed`.
4. `ruff check tests/hermes_cli/test_curses_arrow_keys.py` — should pass (All checks passed).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.14

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS, Linux) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (test file already skips on Windows via module-level `pytest.skip`)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
