### PR TITLE
test(desktop): accept expected errors in fake packaged boot

### DIFF
--- a/apps/desktop/e2e/launch-packaged-app.spec.ts
+++ b/apps/desktop/e2e/launch-packaged-app.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from './test'
+import { allowErrorBanners, expect, test } from './test'
 
 import {
   PACKAGED_BINARY_PATH,
@@ -136,6 +136,11 @@ test('HUD composer remains fully inside the transparent window', async () => {
 })
 
 test('boot progress overlay fades out or shows error state', async () => {
+  // This fixture intentionally has no real backend. Its accepted terminal
+  // state includes the connection-error banner asserted below, so the shared
+  // unexpected-error guard must not reject that deliberate branch.
+  allowErrorBanners()
+
   const page = fixture!.page
   await page.waitForFunction(
     () => {
@@ -166,6 +171,10 @@ test('boot progress overlay fades out or shows error state', async () => {
 })
 
 test('can capture a screenshot for the CI artifact', async () => {
+  // The preceding terminal-state test may leave its accepted boot-error
+  // overlay visible; this artifact intentionally captures either outcome.
+  allowErrorBanners()
+
   if (!fixture) {
     test.skip(true, 'Previous test failed — no app running')
 


### PR DESCRIPTION
## What does this PR do?

The packaged fake-boot fixture deliberately runs without a real backend. Its accepted terminal state includes the connection-error banner asserted by the test, but the shared unexpected-error guard was still rejecting that deliberate branch. This opts only the terminal-state and screenshot cases into the existing `allowErrorBanners()` escape hatch; every other packaged test keeps the strict guard.

## Related Issue

N/A — found while validating the v2026.8.31 packaged Desktop fixture.

## Type of Change

- [x] ✅ Tests (improving test coverage)

## Changes Made

- Update `apps/desktop/e2e/launch-packaged-app.spec.ts` to allow the expected banner in the two deliberate no-backend cases.
- Keep the existing assertion that the overlay either disappears or reports a connection error.

## How to Test

1. Build the packaged Desktop fixture.
2. Run `npx playwright test e2e/launch-packaged-app.spec.ts --reporter=list`.
3. Confirm all six cases pass while unexpected error banners remain guarded in the other cases.

Local evidence before rebasing onto current `main`: targeted Playwright spec passed 6/6; E2E TypeScript check and `git diff --check` passed. The package lock is byte-identical on the rebased head. Exact-head GitHub checks are intentionally pending after ready-for-review publication.

## Checklist

### Code

- [x] Commit uses Conventional Commits.
- [x] Searched open and closed PRs for this fix; no duplicate found.
- [x] PR contains one related test-file change.
- [ ] Full Python suite (not applicable to this TypeScript E2E-only change).
- [x] Tested on macOS.

### Documentation & Housekeeping

- [x] Documentation: N/A.
- [x] Config examples: N/A.
- [x] Architecture/workflow docs: N/A.
- [x] Cross-platform impact considered: fixture-only test guard using an existing helper.
- [x] Tool descriptions/schemas: N/A.
