### PR TITLE
fix(desktop-update): stop Windows progress window spinning after completion

### DIFF
--- a/apps/desktop/scripts/desktop-update-ui.test.mjs
+++ b/apps/desktop/scripts/desktop-update-ui.test.mjs
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import { JSDOM } from 'jsdom'
+import { afterEach, test, vi } from 'vitest'
+
+// Execute the shipped page, including its inline script, rather than matching
+// source strings or testing a second implementation of the progress client.
+const html = fs.readFileSync(new URL('../../../scripts/desktop-update/ui.html', import.meta.url), 'utf8')
+const windows = []
+
+function openPage(fetch) {
+  vi.useFakeTimers()
+  const dom = new JSDOM(html, {
+    url: 'http://127.0.0.1:12345/',
+    runScripts: 'dangerously',
+    beforeParse(window) {
+      window.fetch = fetch
+      window.AbortController = AbortController
+      window.setTimeout = setTimeout
+      window.clearTimeout = clearTimeout
+      window.requestAnimationFrame = () => 1
+      window.cancelAnimationFrame = () => {}
+    }
+  })
+  windows.push(dom.window)
+  return dom.window.document
+}
+
+afterEach(() => {
+  windows.splice(0).forEach(window => window.close())
+  vi.useRealTimers()
+})
+
+test.each(['done', 'manual', 'error'])('renders %s before acknowledging terminal delivery', async status => {
+  let document
+  const requests = []
+  const receipt = '550e8400-e29b-41d4-a716-446655440000'
+  const fetch = vi.fn(async (url, options) => {
+    requests.push(url)
+    if (url.startsWith('/ack/')) {
+      assert.equal(options.method, 'POST')
+      assert.equal(document.body.className, status === 'error' ? 'error' : 'done')
+      assert.notEqual(document.getElementById('title').textContent, 'Updating Hermes')
+      return { ok: true }
+    }
+    return { ok: true, json: async () => ({ status, receipt, message: 'The updater result' }) }
+  })
+  document = openPage(fetch)
+  await vi.advanceTimersByTimeAsync(1000)
+  assert.equal(document.body.className, status === 'error' ? 'error' : 'done')
+  assert.notEqual(document.getElementById('title').textContent, 'Updating Hermes')
+  assert.deepEqual(requests, ['/progress', `/ack/${receipt}`])
+})
+
+test.each(['disconnect', 'hung', 'hung-body', 'http', 'invalid'])('bounds %s progress failures without inventing an update outcome', async failure => {
+  let attempts = 0
+  const fetch = vi.fn((_url, options) => {
+    attempts++
+    if (attempts === 1) {
+      return Promise.resolve({ ok: true, json: async () => ({ status: 'running', message: 'Installing dependencies' }) })
+    }
+    if (failure === 'hung' || failure === 'hung-body') {
+      const pending = () => new Promise((_resolve, reject) => {
+        options.signal?.addEventListener('abort', () => reject(new Error('timeout')), { once: true })
+      })
+      return failure === 'hung' ? pending() : Promise.resolve({ ok: true, json: pending })
+    }
+    if (failure === 'http') return Promise.resolve({ ok: false })
+    if (failure === 'invalid') return Promise.resolve({ ok: true, json: async () => ({}) })
+    return Promise.reject(new Error('connection refused'))
+  })
+  const document = openPage(fetch)
+  await vi.advanceTimersByTimeAsync(20_000)
+  assert.equal(document.body.className, 'disconnected')
+  assert.equal(document.getElementById('title').textContent, 'Update status unavailable')
+  assert.match(document.getElementById('line').textContent, /Check Hermes/)
+  assert.ok(attempts <= 4, `unbounded retry loop: ${attempts}`)
+})
+
+test.each(['legacy', 'transient', 'ack-failure'])('preserves terminal truth with %s servers', async mode => {
+  let attempts = 0
+  const fetch = vi.fn(async url => {
+    if (url.startsWith('/ack/')) throw new Error('server already stopped')
+    if (++attempts === 1 && mode === 'transient') throw new Error('temporary disconnect')
+    return { ok: true, json: async () => ({ status: 'done', ...(mode === 'ack-failure' ? { receipt: 'test-receipt' } : {}) }) }
+  })
+  const document = openPage(fetch)
+  await vi.advanceTimersByTimeAsync(20_000)
+  assert.equal(document.body.className, 'done')
+  assert.equal(document.getElementById('title').textContent, 'Update complete')
+})
+
+test('continues displaying a healthy long update while progress remains reachable', async () => {
+  const fetch = vi.fn(async () => ({ ok: true, json: async () => ({ status: 'running', message: 'Building Desktop' }) }))
+  const document = openPage(fetch)
+  await vi.advanceTimersByTimeAsync(60_000)
+  assert.equal(document.body.className, '')
+  assert.equal(document.getElementById('title').textContent, 'Updating Hermes')
+  assert.equal(document.getElementById('line').textContent, 'Building Desktop')
+})

--- a/scripts/ci/classify_changes.py
+++ b/scripts/ci/classify_changes.py
@@ -67,6 +67,8 @@ import subprocess
 import sys
 
 _FRONTEND = ("ui-tui/", "web/", "apps/")  # TS typecheck-matrix packages
+# Shipped page outside those packages, exercised by the desktop Electron suite.
+_FRONTEND_FILES = {"scripts/desktop-update/ui.html"}
 _ROOT_NPM = {"package.json", "package-lock.json"}  # shifts every package's tree
 _DOCKER_META = ("docker/", ".hadolint.yml", "Dockerfile") # docker setup
 _NIX_PATHS = ("nix/",) # nix files
@@ -214,7 +216,10 @@ def classify(files: list[str]) -> dict[str, bool]:
     files = [f.strip() for f in files if f.strip()]
     python = any(not _py_irrelevant(f) for f in files)
     python_prod = any(not _py_irrelevant(f) and not _py_test_only(f) for f in files)
-    frontend = any(f.startswith(_FRONTEND) or f in _ROOT_NPM for f in files)
+    frontend = any(
+        f.startswith(_FRONTEND) or f in _ROOT_NPM or f in _FRONTEND_FILES
+        for f in files
+    )
     deps = any(f == "pyproject.toml" for f in files)
     npm_lock = any(f.split("/")[-1] == "package-lock.json" for f in files)
     docker_meta = any(f.startswith(_DOCKER_META) for f in files)

--- a/scripts/desktop-update/ui.html
+++ b/scripts/desktop-update/ui.html
@@ -99,8 +99,8 @@
     font-size: 11px;
     color: var(--foreground);
   }
-  body.done #loader, body.error #loader { display: none; }
-  body.done #glyph, body.error #glyph { display: flex; }
+  body.done #loader, body.error #loader, body.disconnected #loader { display: none; }
+  body.done #glyph, body.error #glyph, body.disconnected #glyph { display: flex; }
 </style>
 </head>
 <body>
@@ -205,6 +205,7 @@
   const glyphEl = document.getElementById('glyph')
   const defaultLine = lineEl.textContent   /* what a stage-less run says */
   let settled = false
+  let failures = 0
 
   const elapsedText = s =>
     s < 60 ? `${s}s elapsed` : `${Math.floor(s / 60)}m ${s % 60}s elapsed`
@@ -226,7 +227,8 @@
     } else if (state.status === 'done') {
       settle('done')
       glyphEl.textContent = '\u2713'
-      lineEl.textContent = 'Opening Hermes\u2026'
+      titleEl.textContent = 'Update complete'
+      lineEl.textContent = 'Opening Hermes\u2026\nYou can close this window.'
     } else if (state.status === 'manual') {
       // Update landed but Hermes will NOT reopen itself (package skew,
       // sandbox helper, launch rejected). The orchestrator leaves this
@@ -243,13 +245,43 @@
     }
   }
 
+  async function request(url, options = {}) {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 5000)
+    try {
+      const response = await fetch(url, { ...options, cache: 'no-store', signal: controller.signal })
+      if (!response.ok) throw new Error('Progress request failed')
+      // Keep the deadline active while reading the body too: receiving
+      // headers alone does not prove that the progress server is responsive.
+      return options.method === 'POST' ? null : await response.json()
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+
   async function poll() {
     try {
-      const res = await fetch('/progress', { cache: 'no-store' })
-      if (res.ok) apply(await res.json())
+      const state = await request('/progress')
+      if (!state || !['running', 'done', 'manual', 'error'].includes(state.status)) {
+        throw new Error('Invalid progress response')
+      }
+      failures = 0
+      apply(state)
+      // The Windows server can now wait for delivery instead of guessing
+      // that one polling interval was enough. Older/POSIX servers omit this
+      // receipt. Apply first so a failed acknowledgement cannot hide a result.
+      if (settled && typeof state.receipt === 'string' && state.receipt) {
+        await request(`/ack/${encodeURIComponent(state.receipt)}`, { method: 'POST' })
+      }
     } catch {
-      // Server gone: hold the last known state. The orchestrator owns
-      // closing this window; the relaunched Desktop owns the result.
+      if (!settled && ++failures >= 3) {
+        // A vanished server is not evidence of success OR failure. Leave an
+        // honest, finite state even if the browser refuses the close request.
+        settle('disconnected')
+        glyphEl.textContent = '!'
+        titleEl.textContent = 'Update status unavailable'
+        lineEl.textContent = 'The progress connection was lost.\nCheck Hermes for the update result. You can close this window.'
+      }
     }
     if (!settled) setTimeout(poll, 400)
   }

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -108,6 +108,8 @@ $script:UiState = [hashtable]::Synchronized(@{
     status     = "running"      # running | done | manual | error
     message    = $script:UiStage
     clock      = $script:UiStopwatch
+    receipt    = $null
+    acknowledged_receipt = $null
 })
 $script:UiServer = $null     # @{ Listener; Runspace; PowerShell; Port; BrowserProc; Profile }
 
@@ -190,15 +192,26 @@ function Start-UiServer([string]$HtmlPath) {
                     $request = $reader.ReadLine()
                     # Drain headers so the client doesn't see a reset mid-send.
                     while ($true) { $h = $reader.ReadLine(); if ($null -eq $h -or $h -eq "") { break } }
-                    if ($request -match "^GET /progress") {
+                    if ($request -match "^GET /progress HTTP/1\.[01]$") {
                         $elapsed = [Math]::Floor($State.clock.Elapsed.TotalSeconds)
                         $snapshot = @{
                             status          = $State.status
                             message         = $State.message
                             elapsed_seconds = $elapsed
+                            receipt         = $State.receipt
                         } | ConvertTo-Json -Compress
                         Send-Response $stream "200 OK" "application/json; charset=utf-8" ([System.Text.Encoding]::UTF8.GetBytes($snapshot))
-                    } elseif ($request -match "^GET / ") {
+                    } elseif ($request -match "^POST /ack/([^ /?]+) HTTP/1\.[01]$") {
+                        $receipt = $Matches[1]
+                        if ($State.status -in @("done", "manual", "error") -and $State.receipt -and $receipt -ceq $State.receipt) {
+                            # Flush acceptance before waking the owner that will
+                            # close the listener. No request body is needed.
+                            Send-Response $stream "204 No Content" "text/plain" ([byte[]]@())
+                            $State.acknowledged_receipt = $receipt
+                        } else {
+                            Send-Response $stream "409 Conflict" "text/plain" ([System.Text.Encoding]::ASCII.GetBytes("unknown terminal receipt"))
+                        }
+                    } elseif ($request -match "^GET / HTTP/1\.[01]$") {
                         Send-Response $stream "200 OK" "text/html; charset=utf-8" $HtmlBytes
                     } else {
                         Send-Response $stream "404 Not Found" "text/plain" ([System.Text.Encoding]::ASCII.GetBytes("not found"))
@@ -283,11 +296,26 @@ function Stop-UiServer([switch]$LeaveWindow) {
 }
 
 function Publish-UiEvent([string]$Status, [string]$Message) {
-    # The event the shim listens for. One beat of poll latency (400ms) before
-    # teardown so the page actually renders the terminal state.
+    # A background browser can miss a fixed 900ms delivery window. Retain the
+    # terminal event until the page acknowledges applying this exact receipt.
+    # Older/headless clients cannot acknowledge, so teardown remains bounded.
+    $receipt = [Guid]::NewGuid().ToString('N')
+    $script:UiState.receipt = $receipt
+    $script:UiState.acknowledged_receipt = $null
     $script:UiState.message = $Message
     $script:UiState.status = $Status
-    if ($script:UiServer) { Start-Sleep -Milliseconds 900 }
+    if ($script:UiServer) {
+        $deliveryWait = [System.Diagnostics.Stopwatch]::StartNew()
+        while ($script:UiState.acknowledged_receipt -cne $receipt -and $deliveryWait.Elapsed.TotalSeconds -lt 10) {
+            Start-Sleep -Milliseconds 50
+            if ($script:Ui) { [System.Windows.Forms.Application]::DoEvents() }
+        }
+        if ($script:UiState.acknowledged_receipt -ceq $receipt) {
+            Write-HandoffLog "shim: terminal state '$Status' acknowledged by the window"
+        } else {
+            Write-HandoffLog "shim: terminal state '$Status' was not acknowledged within 10s; closing the progress server"
+        }
+    }
 }
 
 function Get-UiElapsedText {
@@ -309,6 +337,8 @@ function Publish-UiProgress([string]$Message) {
     $script:UiStage = $Message
     $script:UiState.message = $Message
     $script:UiState.status = "running"
+    $script:UiState.receipt = $null
+    $script:UiState.acknowledged_receipt = $null
     if ($script:Ui) {
         try {
             $script:Ui.Sub.Text = Get-UiProgressLine

--- a/tests/ci/test_classify_changes.py
+++ b/tests/ci/test_classify_changes.py
@@ -153,6 +153,12 @@ CASES = {
         ["scripts/desktop-update/windows.ps1"],
         _lanes(python=True, desktop_updater=True),
     ),
+    # The shipped updater page is exercised by the desktop Electron suite;
+    # a page-only change must run that suite as well as the server tests.
+    "updater ui.html → frontend + desktop_updater": (
+        ["scripts/desktop-update/ui.html"],
+        _lanes(python=True, frontend=True, desktop_updater=True),
+    ),
     "desktop-update test → desktop_updater": (
         ["tests/test_desktop_update_windows_progress.py"],
         _lanes(python=True, python_prod=False, scan=True, desktop_updater=True),

--- a/tests/test_desktop_update_windows_ui_delivery.py
+++ b/tests/test_desktop_update_windows_ui_delivery.py
@@ -1,0 +1,92 @@
+"""The real Windows update server retains terminal events until acknowledged."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+import pytest
+
+pytestmark = pytest.mark.windows_only
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts/desktop-update/windows.ps1"
+
+
+@contextmanager
+def _server(tmp_path: Path, *, failed: bool = False):
+    powershell = shutil.which("powershell.exe")
+    assert powershell, "Windows updater tests require Windows PowerShell."
+    env = os.environ.copy()
+    env.update(TEMP=str(tmp_path), TMP=str(tmp_path), HERMES_SELFTEST_HOLD_SECONDS="0")
+    env.pop("HERMES_SELFTEST_FAIL", None)
+    if failed:
+        env["HERMES_SELFTEST_FAIL"] = "1"
+    output_path = tmp_path / "ui-delivery.log"
+    with output_path.open("wb") as output:
+        process = subprocess.Popen(
+            [powershell, "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", str(SCRIPT), "-SelfTestUi", "-NoUi"],
+            env=env,
+            stdout=output,
+            stderr=subprocess.STDOUT,
+            creationflags=subprocess.CREATE_NO_WINDOW,
+        )
+    try:
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            text = output_path.read_text(encoding="utf-8", errors="replace")
+            match = re.search(r"SELF-TEST: shim at (http://127\.0\.0\.1:\d+/)", text)
+            if match:
+                yield process, match.group(1)
+                return
+            if process.poll() is not None:
+                break
+            time.sleep(0.05)
+        pytest.fail(f"Update server did not publish a serving URL: {text}")
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=5)
+
+
+def _request(url: str, *, post: bool = False):
+    request = Request(url, data=b"" if post else None, method="POST" if post else "GET")
+    return urlopen(request, timeout=3)
+
+
+@pytest.mark.parametrize("failed", [False, True], ids=["complete", "failed"])
+def test_delayed_client_receives_terminal_state_before_acknowledging(tmp_path: Path, failed: bool) -> None:
+    with _server(tmp_path, failed=failed) as (process, url):
+        # A background browser can miss the former 900ms terminal-state window.
+        time.sleep(2)
+        assert process.poll() is None, "the updater discarded its final state before the delayed client received it"
+        with _request(url + "progress") as response:
+            state = json.load(response)
+        assert state["status"] == ("error" if failed else "done")
+        receipt = state["receipt"]
+        assert isinstance(receipt, str) and receipt
+
+        with pytest.raises(HTTPError) as wrong:
+            _request(url + "ack/not-the-published-receipt", post=True)
+        assert wrong.value.code == 409
+        assert process.poll() is None, "an unrelated acknowledgement must not dispose the window's state"
+
+        for route, post in [("progress-other", False), ("ack/" + receipt, False), ("ack/" + receipt + "/extra", True)]:
+            with pytest.raises(HTTPError) as invalid:
+                _request(url + route, post=post)
+            assert invalid.value.code == 404
+
+        with _request(url + "ack/" + receipt, post=True) as response:
+            assert response.status == 204
+        assert process.wait(timeout=15) == 0
+
+
+def test_no_client_does_not_keep_the_update_process_alive_forever(tmp_path: Path) -> None:
+    with _server(tmp_path) as (process, _url):
+        assert process.wait(timeout=25) == 0


### PR DESCRIPTION
## Problem and resulting behavior

**Evidence clarification:** The September 5 logs record updater exit 0 and Desktop relaunch in about eight and a half minutes. They do **not** show a non-exiting installer in that run. My reported symptom was the small Desktop update window appearing stuck without an error or clear completion. Its final DOM, polling sequence, and closure were not captured, so the specific cause of that morning's window behavior remains unconfirmed. Separately, the isolated reproduction below proves that terminal-event delivery can fail and leave the window displaying an update in progress after the updater exits. This PR addresses that reproduced defect; it does not prove a failed installation or identify the cause of every reported hang.

**Fixes #103747.** A Windows Desktop update can finish and relaunch the app while its small progress window continues spinning forever. The handoff server exposed its terminal event for only 900ms; a delayed browser poll missed it, and the client ignored connection failure indefinitely. A terminal/CLI update does not exercise this surface.

Windows now retains the terminal event until the page acknowledges applying that exact event, with a 10-second maximum for absent or older clients. The page has a 5-second request/body deadline and three consecutive failure attempts; exhausted communication becomes **Update status unavailable**, with the spinner stopped and no invented success/failure. A successful event changes the heading to **Update complete**, so a rejected browser-close request cannot leave a misleading running display.

## Contract and scope

- `running -> done | manual | error` remains owned by the orchestrator. This does not move installation or relaunch authority into the page.
- `/progress` supplies an unpredictable terminal receipt; the page applies the state before `POST /ack/<receipt>`. Wrong receipts receive 409, malformed/wrong-method routes receive 404.
- Missing ACK is bounded and logged. Lost ACK responses cannot erase a displayed terminal result.
- Older/POSIX servers omit receipts and remain compatible. Temporary fetch failures recover; reachable long-running updates remain running.
- No dependency, process-killing, updater ownership, database, configuration, or signed-installer change. The update scripts are repository-delivered.

The new native test executes the production PowerShell server. The client tests execute the shipped HTML and its inline script in jsdom; they do not match source text. Full isolated reproduction, field timeline, expected/actual behavior, and closure gates are in #103747.

## Verification

Pinned validation base: `9dd6634c5635321cf38840cc30e9b51226689128`; final head: `b91038e442dbf316c2eb2bc0a44684e647a43a8e`. Original RED reproduction base: `431978d47b8018d6334e02c681bbdb70d1435cbb`. The intervening upstream changes affect Docker code, not this delivery protocol.

| Layer | Before | After |
| --- | --- | --- |
| Native Windows delayed terminal reader | 2 failed, 1 passed; server had already exited before delayed success/error readers | 3 passed: delayed success, delayed error, bounded absent-client teardown; wrong receipt/route checks included |
| Actual HTML client regression | 7 assertion failures: terminal title/ACK missing and transport loss never settles | 12 passed across success/manual/error, refused/hung headers/hung body/non-2xx/invalid responses, older servers, transient failure, lost ACK, and healthy long updates |
| Adjacent Electron gates, markers and result tests | Existing coverage | 45 passed, 1 platform skip across 5 files, including the 12 client cases |
| Existing native Windows live-progress test | Existing coverage | 1 passed; elapsed time advances while the orchestrator blocks |
| Real Chrome + native PowerShell + actual served page | Delayed poll leaves an indefinite running page on base | Second poll delayed 3s: ACK 204, updater fixture exit 0, heading Update complete, spinner hidden |
| Real Chrome after lost terminal connection | Running display persists | Update status unavailable, spinner hidden; updater fixture exits after delivery bound |

Commands:

```bash
scripts/run_tests.sh tests/test_desktop_update_windows_ui_delivery.py -q
scripts/run_tests.sh tests/test_desktop_update_windows_progress.py -q
cd apps/desktop
npm run test:desktop:platforms -- scripts/desktop-update-ui.test.mjs electron/update-gate.test.ts electron/update-marker.test.ts electron/update-handoff-marker.test.ts electron/handoff-result.test.ts
```

Local native Vitest execution selected the same `electron` project using an isolated temporary config, because the checkout shared existing test dependencies and lacked an unrelated renderer build plugin. ESLint on the new client test, Ruff on the native test, `git diff --check`, and contributor attribution audit passed. All six changed files are below 2,000 lines. Native browser tests used an isolated, owned headless profile and updater self-test; no live Hermes service was stopped or updated.

Final-head verification additionally passed the combined 73-test Python/native/classifier run and both real-Chrome scenarios after refreshing onto the pinned base. Two separate reviewers approved the final six-file diff.

The review also found that future page-only edits would skip the new JavaScript tests. A separate fix lane added exact-file frontend classification; its regression failed before the change, then all 69 classifier tests passed. Existing PowerShell-only routing stays unchanged. Related classifier PR #65296 changes Rust/frontend prefix handling and does not implement this page exemption.

## Source lineage and credit

This is **Axl Ibiza's** continued Windows installation/update investigation. The GitHub source graph, rather than PR-author counts alone, establishes his prior work: merged [#93353](https://github.com/NousResearch/hermes-agent/pull/93353) carries his non-destructive SQLite repair from #93268; merged [#85170](https://github.com/NousResearch/hermes-agent/pull/85170) credits his npm-closure review finding. Historical #60233 retains his PyYAML/native-lock invariant and is closed, not merged. His #94107 and #100763 retain their separate editable-install and verifier scopes.

**OutThisLife's** merged [#83634](https://github.com/NousResearch/hermes-agent/pull/83634), earlier #75895 quiet-window design, and credited **Teknium** web-shell work supply the existing handoff architecture and visual surface. This patch preserves them and closes terminal-delivery behavior they did not establish for a delayed Windows browser.

## FILE-LIST coordination and remaining boundaries

The open `desktop-update` search was paginated to all 717 returned PRs before writing. Shared-file overlap was identified; it is not represented as zero filename overlap. This change owns terminal delivery, client loss handling, regression tests, and the narrow CI routing required to keep those tests active for page-only edits. It can land independently before the related changes below; their owners retain their source and scope, and they must retain this delivery contract when rebasing:

- **chelsealong #103632:** icon markup in `ui.html`; independent of delivery.
- **astraltrekkin #102373** and **kyssta-exe #103140/#103400:** child pipe/deadline and QuickEdit handling; independent of terminal delivery.
- **fangliquanflq #95719** and **seluvia #97299:** installer ownership and Desktop backend startup gate. These remain separate fixes; this PR does not adopt or replace them.
- Other shared-file lanes include #96340, #93961, #84771, #84025, #89317, #101443, #102464, #97056, and Axl's #93042/#94107/#100763. The new native test uses a new file to avoid their existing test files.

Related reports #102283, #103222, #97394, #97287 and #88252 are not closed by this PR. The logs establish exit 0 and Desktop relaunch during the September 5 run, not a full installation-health check or the historical browser's final DOM/request sequence. Attribution of that field incident to the independently reproduced missed-delivery mechanism remains unconfirmed. This closes the progress-window completion class, not every Windows installation/rollback or genuinely hung-child failure. Interrupted venv retry recovery discovered during this investigation is tracked separately in #103751, with a complete native filesystem reproduction.

