### PR TITLE
fix: split iMessage kanban notification routing

### DIFF
--- a/gateway/kanban_watchers_notifier.py
+++ b/gateway/kanban_watchers_notifier.py
@@ -439,8 +439,8 @@ class _KanbanNotification:
         self.synth = synth + "\n\n" + t("gateway.kanban.wake.guidance")
 
     def _log_woke(self) -> None:
-        logger.info("kanban notifier: woke agent for %s on %s/%s profile=%s events=%s",
-                    self.task_id, self.platform_str, self.sub["chat_id"], self.sub_profile or "default", self.wake_kinds)
+        logger.info("kanban notifier: woke agent for %s on %s profile=%s events=%s",
+                    self.task_id, self.platform_str, self.sub_profile or "default", self.wake_kinds)
 
     async def wake(self) -> None:
         """Wake the creator session (raises on failure): push adapters get a full SessionSource, non-push a raw self-post."""
@@ -486,8 +486,8 @@ class _KanbanNotification:
         # "no exception == delivered" contract.
         if getattr(_send_res, "success", True) is False:
             raise RuntimeError(f"adapter send() reported failure: {getattr(_send_res, 'error', None) or 'unknown error'}")
-        logger.debug("kanban notifier: delivered %s event for %s to %s/%s on board %s",
-                     ev.kind, self.task_id, self.platform_str, sub["chat_id"], self.board_slug)
+        logger.debug("kanban notifier: delivered %s event for %s to %s on board %s",
+                     ev.kind, self.task_id, self.platform_str, self.board_slug)
         # Upload artifact paths from the completion payload / legacy result as
         # native files. Only on ``completed`` so retries never spam attachments.
         if ev.kind == "completed":

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -384,22 +384,30 @@ class GatewaySlashCommandsMixin(
         if not (platform_str and chat_id):
             return False
 
+        source_target = dict(
+            platform=platform_str, chat_id=chat_id, chat_type=chat_type,
+            thread_id=_field("thread_id"), user_id=_field("user_id"),
+            # Also persist the stable alt id (Signal UUID, Feishu union_id): build_session_key
+            # keys the participant on ``user_id_alt or user_id``, so a replayed wake rebuilds
+            # the same session key only when the alt id survives the round-trip.
+            user_id_alt=_field("user_id_alt"),
+            notifier_profile=(getattr(self, "_kanban_notifier_profile", None)
+                              or getattr(self, "_active_profile_name", lambda: "default")()),
+            # Default chat-origin behavior is still passive message + active wake;
+            # kanban_notify_policy narrows iMessage-like sources to wake-only only
+            # when it can add the paired private Telegram raw-notify route.
+            delivery_mode="notify+wake", delivery_metadata=delivery_metadata,
+        )
+
         def _sub():
             from hermes_cli import kanban_db as _kb
             from hermes_cli import kanban_db_connect as _kbc
             from hermes_cli import kanban_db_notify as _kbn
+            from hermes_cli.kanban_notify_policy import kanban_auto_subscribe_targets
             conn = _kbc.connect(board=requested_board)
             try:
-                _kbn.add_notify_sub(
-                    conn, task_id=task_id, platform=platform_str, chat_id=chat_id, chat_type=chat_type,
-                    thread_id=_field("thread_id"), user_id=_field("user_id"),
-                    # Also persist the stable alt id (Signal UUID, Feishu union_id): build_session_key
-                    # keys the participant on ``user_id_alt or user_id``, so a replayed wake rebuilds
-                    # the same session key only when the alt id survives the round-trip.
-                    user_id_alt=_field("user_id_alt"),
-                    notifier_profile=getattr(self, "_kanban_notifier_profile", None) or self._active_profile_name(),
-                    # Subscribing from chat: deliver the passive message and wake the destination agent.
-                    delivery_mode="notify+wake", delivery_metadata=delivery_metadata)
+                for target in kanban_auto_subscribe_targets(source_target):
+                    _kbn.add_notify_sub(conn, task_id=task_id, **target)
             finally:
                 conn.close()
         await asyncio.to_thread(_sub)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -407,7 +407,7 @@ class GatewaySlashCommandsMixin(
             conn = _kbc.connect(board=requested_board)
             try:
                 for target in kanban_auto_subscribe_targets(source_target):
-                    _kbn.add_notify_sub(conn, task_id=task_id, **target)
+                    _kbn.add_auto_notify_sub(conn, task_id=task_id, **target)
             finally:
                 conn.close()
         await asyncio.to_thread(_sub)

--- a/hermes_cli/kanban_db_notify.py
+++ b/hermes_cli/kanban_db_notify.py
@@ -129,6 +129,42 @@ def add_notify_sub(
             )
 
 
+def notify_sub_exists(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+) -> bool:
+    """True when the exact subscription routing key already exists."""
+    return conn.execute(
+        "SELECT 1 FROM kanban_notify_subs " + _SUB_KEY_WHERE + " LIMIT 1",
+        _sub_key(task_id, platform, chat_id, thread_id),
+    ).fetchone() is not None
+
+
+def add_auto_notify_sub(conn: sqlite3.Connection, **kwargs: Any) -> bool:
+    """Auto-subscribe without mutating an existing explicit subscription.
+
+    ``add_notify_sub`` is deliberately last-write-wins for the explicit
+    ``notify-subscribe`` CLI. Auto-subscribe is weaker: if a row already exists
+    for the same task/platform/chat/thread (explicit, inherited, or an earlier
+    idempotent create), leave every stored field untouched and report that no
+    new row was inserted.
+    """
+    if notify_sub_exists(
+        conn,
+        task_id=kwargs["task_id"],
+        platform=kwargs["platform"],
+        chat_id=kwargs["chat_id"],
+        thread_id=kwargs.get("thread_id"),
+    ):
+        return False
+    add_notify_sub(conn, **kwargs)
+    return True
+
+
 def _notify_profile_filter(
     notifier_profiles: Optional[Iterable[str]],
     *,

--- a/hermes_cli/kanban_notify_policy.py
+++ b/hermes_cli/kanban_notify_policy.py
@@ -1,0 +1,114 @@
+"""Kanban notification auto-subscribe routing policies.
+
+Auto-subscribe call sites start from a source-session subscription target. Most
+platforms keep the historical single ``notify+wake`` row. iMessage-like sources
+(Photon and BlueBubbles) are the exception: raw terminal status pings are noisy
+there, so when a private Telegram home channel is configured we split the route
+into source wake-only plus Telegram passive-notify.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterable, Mapping, Optional
+
+logger = logging.getLogger(__name__)
+
+IMESSAGE_KANBAN_SOURCE_PLATFORMS = frozenset({"photon", "bluebubbles"})
+_RAW_NOTIFY_HOME_PLATFORM = "telegram"
+
+
+def _clean_str(value: Any) -> Optional[str]:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _routing_key(target: Mapping[str, Any]) -> tuple[str, str, str]:
+    return (
+        str(target.get("platform") or "").lower(),
+        str(target.get("chat_id") or ""),
+        str(target.get("thread_id") or ""),
+    )
+
+
+def _dedupe_targets(targets: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for target in targets:
+        key = _routing_key(target)
+        if key in seen or not key[0] or not key[1]:
+            continue
+        seen.add(key)
+        out.append(target)
+    return out
+
+
+def _telegram_dm_metadata(thread_id: Optional[str]) -> Optional[dict[str, Any]]:
+    metadata: dict[str, Any] = {"chat_type": "dm"}
+    if thread_id:
+        metadata["thread_id"] = thread_id
+        # Telegram DM topic mode needs the same placement metadata used by
+        # gateway-origin replies so passive pings do not fall into the root lobby.
+        metadata["telegram_dm_topic_reply_fallback"] = True
+        if thread_id != "1":
+            metadata["direct_messages_topic_id"] = thread_id
+    return metadata
+
+
+def _telegram_home_notify_target(notifier_profile: Optional[str]) -> Optional[dict[str, Any]]:
+    """Passive raw-notify target for the configured Telegram home channel.
+
+    Returns None when Telegram has no configured home channel. The caller then
+    keeps the historical source ``notify+wake`` route so terminal notifications
+    are not silently dropped on installs without Telegram.
+    """
+    try:
+        from gateway.config import Platform, load_gateway_config
+
+        home = load_gateway_config().get_home_channel(Platform(_RAW_NOTIFY_HOME_PLATFORM))
+    except Exception:
+        logger.debug("kanban notify policy: Telegram home lookup failed", exc_info=True)
+        return None
+    if home is None or not _clean_str(getattr(home, "chat_id", "")):
+        return None
+    thread_id = _clean_str(getattr(home, "thread_id", None))
+    target: dict[str, Any] = {
+        "platform": _RAW_NOTIFY_HOME_PLATFORM,
+        "chat_id": str(home.chat_id),
+        "chat_type": "dm",
+        "thread_id": thread_id,
+        "user_id": _clean_str(getattr(home, "user_id", None)),
+        "notifier_profile": notifier_profile,
+        "delivery_mode": "notify",
+        "delivery_metadata": _telegram_dm_metadata(thread_id),
+    }
+    return {key: value for key, value in target.items() if value is not None}
+
+
+def kanban_auto_subscribe_targets(source_target: Optional[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Return ``add_notify_sub`` kwargs for a new task auto-subscription.
+
+    ``source_target`` is the historical single route back to the creating
+    session. For Photon/BlueBubbles/iMessage-like sources, split supported
+    installs into two rows:
+
+    * source platform: ``delivery_mode='wake'`` (Molly can narrate there)
+    * Telegram home: ``delivery_mode='notify'`` (raw terminal events only)
+
+    Explicit ``hermes kanban notify-subscribe`` rows do not call this helper, so
+    operator-chosen subscriptions remain last-write-wins and untouched.
+    """
+    if not source_target:
+        return []
+    source = dict(source_target)
+    platform = str(source.get("platform") or "").lower()
+    if platform not in IMESSAGE_KANBAN_SOURCE_PLATFORMS:
+        return _dedupe_targets([source])
+
+    telegram_target = _telegram_home_notify_target(source.get("notifier_profile"))
+    if telegram_target is None:
+        return _dedupe_targets([source])
+
+    wake_source = dict(source)
+    wake_source["delivery_mode"] = "wake"
+    return _dedupe_targets([wake_source, telegram_target])

--- a/tests/gateway/test_kanban_imessage_notification_policy.py
+++ b/tests/gateway/test_kanban_imessage_notification_policy.py
@@ -1,0 +1,156 @@
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+from gateway.slash_commands import GatewaySlashCommandsMixin
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban_db_notify as kbn
+
+
+@pytest.fixture
+def kanban_home_with_telegram_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    for env_name in (
+        "TELEGRAM_HOME_CHANNEL",
+        "TELEGRAM_HOME_CHANNEL_THREAD_ID",
+        "TELEGRAM_CRON_THREAD_ID",
+    ):
+        monkeypatch.delenv(env_name, raising=False)
+    (home / "config.yaml").write_text(
+        """
+platforms:
+  telegram:
+    enabled: true
+    home_channel:
+      platform: telegram
+      chat_id: tg-private-home
+      name: Private Telegram
+      thread_id: "42"
+      user_id: tg-private-user
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    kb.init_db()
+    return home
+
+
+def _sub_by_platform(subs, platform):
+    matches = [sub for sub in subs if sub["platform"] == platform]
+    assert len(matches) == 1
+    return matches[0]
+
+
+class _KanbanSlashRunner(GatewaySlashCommandsMixin):
+    def _reply_anchor_for_event(self, event):
+        return None
+
+    def _thread_metadata_for_source(self, source, anchor):
+        metadata = {}
+        if source.thread_id:
+            metadata["thread_id"] = str(source.thread_id)
+        if source.chat_type:
+            metadata["chat_type"] = str(source.chat_type)
+        return metadata
+
+    def _active_profile_name(self):
+        return "molly"
+
+
+@pytest.mark.asyncio
+async def test_gateway_kanban_create_from_imessage_splits_wake_and_raw_notify(
+    kanban_home_with_telegram_home,
+):
+    """/kanban create from iMessage makes Photon/BlueBubbles wake-only and routes raw pings to Telegram."""
+    source = SessionSource(
+        platform=Platform.BLUEBUBBLES,
+        chat_id="imessage-chat",
+        chat_type="dm",
+        user_id="imessage-user",
+        thread_id="imessage-thread",
+    )
+    event = MessageEvent(
+        text="/kanban create 'policy routed task' --assignee stark",
+        source=source,
+    )
+
+    output = await _KanbanSlashRunner()._handle_kanban_command(event)
+    match = re.search(r"Created\s+(t_[0-9a-f]+)\b", output)
+    assert match, output
+    task_id = match.group(1)
+
+    with kbc.connect_closing() as conn:
+        subs = kbn.list_notify_subs(conn, task_id)
+
+    assert len(subs) == 2
+    source_sub = _sub_by_platform(subs, "bluebubbles")
+    assert source_sub["chat_id"] == "imessage-chat"
+    assert source_sub["thread_id"] == "imessage-thread"
+    assert source_sub["user_id"] == "imessage-user"
+    assert source_sub["notifier_profile"] == "molly"
+    assert source_sub["delivery_mode"] == "wake"
+
+    raw_sub = _sub_by_platform(subs, "telegram")
+    assert raw_sub["chat_id"] == "tg-private-home"
+    assert raw_sub["thread_id"] == "42"
+    assert raw_sub["user_id"] == "tg-private-user"
+    assert raw_sub["notifier_profile"] == "molly"
+    assert raw_sub["delivery_mode"] == "notify"
+    assert raw_sub["delivery_metadata"]["telegram_dm_topic_reply_fallback"] is True
+
+
+def test_kanban_create_tool_from_photon_splits_and_children_inherit_readback(
+    kanban_home_with_telegram_home,
+):
+    """kanban_create auto-subscribe applies the same policy and child tasks inherit both rows."""
+    from gateway.session_context import clear_session_vars, set_session_vars
+    from tools.kanban_tools import _handle_create
+
+    tokens = set_session_vars(
+        platform="photon",
+        chat_id="photon-chat",
+        chat_type="dm",
+        thread_id="photon-thread",
+        user_id="photon-user",
+        profile="molly",
+    )
+    try:
+        result = json.loads(_handle_create({"title": "tool policy root", "assignee": "stark"}))
+        assert result["ok"] is True
+        assert result["subscribed"] is True
+        root = result["task_id"]
+        with kbc.connect_closing() as conn:
+            child = kb.create_task(
+                conn,
+                title="tool policy child",
+                assignee="reviewer",
+                parents=[root],
+            )
+            root_subs = kbn.list_notify_subs(conn, root)
+            child_subs = kbn.list_notify_subs(conn, child)
+    finally:
+        clear_session_vars(tokens)
+
+    assert len(root_subs) == 2
+    assert _sub_by_platform(root_subs, "photon")["delivery_mode"] == "wake"
+    assert _sub_by_platform(root_subs, "telegram")["delivery_mode"] == "notify"
+
+    assert len(child_subs) == 2
+    child_source = _sub_by_platform(child_subs, "photon")
+    child_raw = _sub_by_platform(child_subs, "telegram")
+    assert child_source["chat_id"] == "photon-chat"
+    assert child_source["thread_id"] == "photon-thread"
+    assert child_source["delivery_mode"] == "wake"
+    assert child_raw["chat_id"] == "tg-private-home"
+    assert child_raw["thread_id"] == "42"
+    assert child_raw["delivery_mode"] == "notify"

--- a/tests/gateway/test_kanban_imessage_notification_policy.py
+++ b/tests/gateway/test_kanban_imessage_notification_policy.py
@@ -154,3 +154,47 @@ def test_kanban_create_tool_from_photon_splits_and_children_inherit_readback(
     assert child_raw["chat_id"] == "tg-private-home"
     assert child_raw["thread_id"] == "42"
     assert child_raw["delivery_mode"] == "notify"
+
+
+def test_auto_subscribe_preserves_existing_explicit_source_subscription(
+    kanban_home_with_telegram_home,
+):
+    """Auto-subscribe may add the raw Telegram pair, but must not rewrite an existing source row."""
+    from gateway.session_context import clear_session_vars, set_session_vars
+    from tools.kanban_tools import _maybe_auto_subscribe
+
+    tokens = set_session_vars(
+        platform="photon",
+        chat_id="photon-chat",
+        chat_type="dm",
+        thread_id="photon-thread",
+        user_id="photon-user",
+        profile="molly",
+    )
+    try:
+        with kbc.connect_closing() as conn:
+            task_id = kb.create_task(conn, title="explicit source preserved", assignee="stark")
+            kbn.add_notify_sub(
+                conn,
+                task_id=task_id,
+                platform="photon",
+                chat_id="photon-chat",
+                chat_type="dm",
+                thread_id="photon-thread",
+                user_id="explicit-user",
+                notifier_profile="operator",
+                delivery_mode="notify+wake",
+                delivery_metadata={"explicit": "kept"},
+            )
+            assert _maybe_auto_subscribe(conn, task_id) is True
+            subs = kbn.list_notify_subs(conn, task_id)
+    finally:
+        clear_session_vars(tokens)
+
+    assert len(subs) == 2
+    source_sub = _sub_by_platform(subs, "photon")
+    assert source_sub["delivery_mode"] == "notify+wake"
+    assert source_sub["user_id"] == "explicit-user"
+    assert source_sub["notifier_profile"] == "operator"
+    assert source_sub["delivery_metadata"] == {"explicit": "kept"}
+    assert _sub_by_platform(subs, "telegram")["delivery_mode"] == "notify"

--- a/tests/gateway/test_kanban_imessage_notification_policy.py
+++ b/tests/gateway/test_kanban_imessage_notification_policy.py
@@ -1,4 +1,6 @@
+import asyncio
 import json
+import logging
 import re
 from pathlib import Path
 
@@ -6,6 +8,7 @@ import pytest
 
 from gateway.config import Platform
 from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
 from gateway.session import SessionSource
 from gateway.slash_commands import GatewaySlashCommandsMixin
 from hermes_cli import kanban_db as kb
@@ -65,6 +68,43 @@ class _KanbanSlashRunner(GatewaySlashCommandsMixin):
 
     def _active_profile_name(self):
         return "molly"
+
+
+class _RecordingAdapter:
+    def __init__(self):
+        self.sent = []
+        self.handled = []
+
+    async def send(self, chat_id, text, metadata=None):
+        self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+
+    async def handle_message(self, event):
+        self.handled.append(event)
+
+
+async def _run_one_notifier_tick(monkeypatch, runner):
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay):
+        if delay == 5:
+            return None
+        runner._running = False
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    await runner._kanban_notifier_watcher(interval=1)
+
+
+def _make_notifier_runner(adapters):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = adapters
+    runner._profile_adapters = {}
+    runner._primary_profile_name = "molly"
+    runner._active_profile_name = lambda: "molly"
+    runner._kanban_sub_fail_counts = {}
+    runner._kanban_dispatcher_lock_handle = object()
+    return runner
 
 
 @pytest.mark.asyncio
@@ -198,3 +238,51 @@ def test_auto_subscribe_preserves_existing_explicit_source_subscription(
     assert source_sub["notifier_profile"] == "operator"
     assert source_sub["delivery_metadata"] == {"explicit": "kept"}
     assert _sub_by_platform(subs, "telegram")["delivery_mode"] == "notify"
+
+
+@pytest.mark.asyncio
+async def test_imessage_policy_delivery_logs_omit_recipient_identifiers(
+    kanban_home_with_telegram_home,
+    monkeypatch,
+    caplog,
+):
+    """New iMessage split route delivers to both targets without logging their recipient IDs."""
+    source = SessionSource(
+        platform=Platform.BLUEBUBBLES,
+        chat_id="synthetic-imessage-recipient",
+        chat_type="dm",
+        user_id="synthetic-imessage-user",
+        thread_id="synthetic-imessage-thread",
+    )
+    event = MessageEvent(
+        text="/kanban create 'policy log redaction task' --assignee stark",
+        source=source,
+    )
+
+    output = await _KanbanSlashRunner()._handle_kanban_command(event)
+    match = re.search(r"Created\s+(t_[0-9a-f]+)\b", output)
+    assert match, output
+    task_id = match.group(1)
+    with kbc.connect_closing() as conn:
+        kb.complete_task(conn, task_id, summary="done")
+
+    telegram = _RecordingAdapter()
+    bluebubbles = _RecordingAdapter()
+    runner = _make_notifier_runner({
+        Platform.TELEGRAM: telegram,
+        Platform.BLUEBUBBLES: bluebubbles,
+    })
+
+    with caplog.at_level(logging.DEBUG, logger="gateway.run"):
+        await _run_one_notifier_tick(monkeypatch, runner)
+
+    assert [delivery["chat_id"] for delivery in telegram.sent] == ["tg-private-home"]
+    assert len(bluebubbles.handled) == 1
+    assert bluebubbles.handled[0].source.chat_id == "synthetic-imessage-recipient"
+
+    log_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert "synthetic-imessage-recipient" not in log_text
+    assert "tg-private-home" not in log_text
+    assert "delivered completed event for " in log_text
+    assert f"delivered completed event for {task_id} to telegram on board default" in log_text
+    assert f"woke agent for {task_id} on bluebubbles profile=molly" in log_text

--- a/tests/gateway/test_kanban_notifier_wake_only_ordering.py
+++ b/tests/gateway/test_kanban_notifier_wake_only_ordering.py
@@ -54,29 +54,29 @@ async def _run_one_notifier_tick(monkeypatch, runner):
     await runner._kanban_notifier_watcher(interval=1)
 
 
-def _make_runner(adapter):
+def _make_runner(adapter, *, platform=Platform.TELEGRAM):
     runner = GatewayRunner.__new__(GatewayRunner)
     runner._running = True
-    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.adapters = {platform: adapter}
     runner._kanban_sub_fail_counts = {}
     runner._kanban_dispatcher_lock_handle = object()
     return runner
 
 
-def _make_completed_task(delivery_mode):
+def _make_completed_task(delivery_mode, *, platform="telegram", chat_id="chat-1"):
     conn = kbc.connect()
     try:
         tid = kb.create_task(
             conn,
             title="wake ordering task",
             assignee="worker",
-            session_id="agent:main:telegram:dm:chat-1",
+            session_id=f"agent:main:{platform}:dm:{chat_id}",
         )
         kbn.add_notify_sub(
             conn,
             task_id=tid,
-            platform="telegram",
-            chat_id="chat-1",
+            platform=platform,
+            chat_id=chat_id,
             chat_type="dm",
             delivery_mode=delivery_mode,
         )
@@ -125,6 +125,42 @@ def test_wake_only_success_advances_cursor_single_wake(tmp_path, monkeypatch):
         "cursor must advance after a successful wake-only delivery"
     )
     assert runner._kanban_sub_fail_counts == {}
+
+
+def test_wake_only_log_omits_source_recipient_id(tmp_path, monkeypatch, caplog):
+    """Wake logs keep task/platform diagnostics without printing the source chat id."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "wake-log.db"))
+    kb.init_db()
+    source_chat_id = "synthetic-imessage-chat-id"
+    tid = _make_completed_task("wake", platform="bluebubbles", chat_id=source_chat_id)
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter, platform=Platform.BLUEBUBBLES)
+    with caplog.at_level("INFO", logger="gateway.run"):
+        asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert tid in messages
+    assert "bluebubbles" in messages
+    assert source_chat_id not in messages
+
+
+def test_passive_notify_log_omits_telegram_recipient_id(tmp_path, monkeypatch, caplog):
+    """Passive raw-notify logs keep task/platform diagnostics without printing the Telegram chat id."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "notify-log.db"))
+    kb.init_db()
+    private_chat_id = "synthetic-private-telegram-chat-id"
+    tid = _make_completed_task("notify", chat_id=private_chat_id)
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    with caplog.at_level("DEBUG", logger="gateway.run"):
+        asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert tid in messages
+    assert "telegram" in messages
+    assert private_chat_id not in messages
 
 
 def test_wake_only_failure_rewinds_and_redelivers(tmp_path, monkeypatch):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -892,6 +892,14 @@ def _resolve_notify_target() -> Optional[dict[str, Any]]:
         delivery_metadata=delivery_metadata or None)
 
 
+def _resolve_notify_targets() -> list[dict[str, Any]]:
+    target = _resolve_notify_target()
+    if target is None:
+        return []
+    from hermes_cli.kanban_notify_policy import kanban_auto_subscribe_targets
+    return kanban_auto_subscribe_targets(target)
+
+
 def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
     """Subscribe the calling session to completion/block events; True iff a row was
     written (surfaced as ``subscribed`` so an orchestrator can fall back to explicit
@@ -902,19 +910,19 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
             return False
     except Exception:
         pass  # unreadable config keeps the user-friendly default (True)
-    target = None
+    targets: list[dict[str, Any]] = []
     try:
-        target = _resolve_notify_target()
-        if target is None:
+        targets = _resolve_notify_targets()
+        if not targets:
             return False  # CLI / cron / test — no persistent channel
         from hermes_cli import kanban_db as _kb
         from hermes_cli import kanban_db_notify as _kbn
-        _kbn.add_notify_sub(conn, task_id=task_id, **target)
+        for target in targets:
+            _kbn.add_notify_sub(conn, task_id=task_id, **target)
         return True
     except Exception as _exc:
         logger.warning(
-            "_maybe_auto_subscribe failed: %r (platform=%r key_set=%r)",
-            _exc, target["platform"] if target else "", bool(target and target["chat_id"]))
+            "_maybe_auto_subscribe failed: %r (targets=%d)", _exc, len(targets))
         return False
 
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -918,7 +918,7 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
         from hermes_cli import kanban_db as _kb
         from hermes_cli import kanban_db_notify as _kbn
         for target in targets:
-            _kbn.add_notify_sub(conn, task_id=task_id, **target)
+            _kbn.add_auto_notify_sub(conn, task_id=task_id, **target)
         return True
     except Exception as _exc:
         logger.warning(


### PR DESCRIPTION
Summary
- Adds a shared Kanban auto-subscribe routing policy for iMessage-like sources (Photon and BlueBubbles): source subscription for wake delivery plus Telegram home subscription for passive raw notify delivery.
- Keeps non-iMessage auto-subscribe behavior on the historical single notify+wake row.
- Preserves existing explicit notification subscriptions instead of rewriting duplicate rows during auto-subscribe.
- Scrubs recipient/chat identifiers from the existing Kanban notifier wake and passive-send success logs while preserving non-sensitive task/platform/profile/board diagnostics.

Test Plan
- scripts/run_tests.sh tests/gateway/test_kanban_imessage_notification_policy.py tests/gateway/test_kanban_notifier_wake_only_ordering.py tests/gateway/test_kanban_notifier.py tests/hermes_cli/test_kanban_notify.py
- .venv/bin/ruff check gateway/kanban_watchers_notifier.py hermes_cli/kanban_notify_policy.py hermes_cli/kanban_db_notify.py gateway/slash_commands.py tools/kanban_tools.py tests/gateway/test_kanban_imessage_notification_policy.py tests/gateway/test_kanban_notifier_wake_only_ordering.py

Operational boundaries
- No gateway restart.
- No live apply.
- No test messages sent.
