### PR TITLE
feat(cli): write --usage-file after chat -q and oneshot

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1130,6 +1130,9 @@ def _notify_single_query_session_finalize(cli, *, reason: str = "shutdown") -> N
 def _finalize_single_query(cli) -> None:
     """Close one-shot CLI resources before releasing the active session lease."""
     try:
+        from hermes_cli.usage_report import write_usage_file_from_cli
+
+        write_usage_file_from_cli(cli)
         _notify_single_query_session_finalize(cli)
         _run_cleanup(notify_session_finalize=False)
     finally:
@@ -15004,6 +15007,7 @@ def main(
     pass_session_id: bool = False,
     ignore_user_config: bool = False,
     ignore_rules: bool = False,
+    usage_file: str = None,
 ):
     """
     Hermes Agent CLI - Interactive AI Assistant
@@ -15140,6 +15144,7 @@ def main(
         pass_session_id=pass_session_id,
         ignore_rules=ignore_rules,
     )
+    cli.usage_file = usage_file
 
     if parsed_skills:
         skills_prompt, loaded_skills, missing_skills = build_preloaded_skills_prompt(

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -111,6 +111,17 @@ def build_top_level_parser():
             "auto-bypassed. Intended for scripts / pipes."
         ),
     )
+    parser.add_argument(
+        "--usage-file",
+        metavar="PATH",
+        default=None,
+        help=(
+            "After -z/--oneshot or `hermes chat -q`, write a JSON usage "
+            "report (estimated cost, token counts, model, api_calls) to PATH. "
+            "The report is written even when the run fails, so pipelines "
+            "can always account for spend."
+        ),
+    )
     # --model / --provider are accepted at the top level so they can pair
     # with -z without needing the `chat` subcommand.  If neither -z nor a
     # subcommand consumes them, they fall through harmlessly as None.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2388,6 +2388,7 @@ def cmd_chat(args):
         "ignore_rules": getattr(args, "ignore_rules", False) or getattr(args, "safe_mode", False),
         "ignore_user_config": getattr(args, "ignore_user_config", False) or getattr(args, "safe_mode", False),
         "compact": getattr(args, "compact", False),
+        "usage_file": getattr(args, "usage_file", None),
     }
     # Filter out None values
     kwargs = {k: v for k, v in kwargs.items() if v is not None}
@@ -11570,6 +11571,7 @@ _TOP_LEVEL_VALUE_FLAGS = frozenset(
         "-t", "--toolsets",
         "-r", "--resume",
         "-s", "--skills",
+        "--usage-file",
         # ``-c / --continue`` is nargs='?' (optional value). Treat it as
         # value-taking: if the next token is a subcommand-looking word
         # the user almost certainly meant it as the session name, and
@@ -11793,6 +11795,7 @@ def _try_termux_fast_cli_launch() -> bool:
                 model=getattr(args, "model", None),
                 provider=getattr(args, "provider", None),
                 toolsets=getattr(args, "toolsets", None),
+                usage_file=getattr(args, "usage_file", None),
             )
         )
 
@@ -13177,6 +13180,7 @@ def main():
                 model=getattr(args, "model", None),
                 provider=getattr(args, "provider", None),
                 toolsets=getattr(args, "toolsets", None),
+                usage_file=getattr(args, "usage_file", None),
             )
         )
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -28,6 +28,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from typing import Optional
 
 from hermes_cli.fallback_config import get_fallback_chain
+from hermes_cli.usage_report import result_from_agent, write_usage_file
 
 
 def _normalize_toolsets(toolsets: object = None) -> list[str] | None:
@@ -127,6 +128,7 @@ def run_oneshot(
     model: Optional[str] = None,
     provider: Optional[str] = None,
     toolsets: object = None,
+    usage_file: Optional[str] = None,
 ) -> int:
     """Execute a single prompt and print only the final content block.
 
@@ -137,6 +139,8 @@ def run_oneshot(
         provider: Optional provider override. Falls back to config.yaml's
             model.provider, then "auto".
         toolsets: Optional comma-separated string or iterable of toolsets.
+        usage_file: Optional path; when set, a JSON usage report is written
+            after the run, even when the run fails.
 
     Returns the exit code.  Caller should sys.exit() with the return.
     """
@@ -178,11 +182,12 @@ def run_oneshot(
     devnull = open(os.devnull, "w", encoding="utf-8")
 
     response: Optional[str] = None
+    result: dict = {}
     failure: BaseException | None = None
     try:
         with redirect_stdout(devnull), redirect_stderr(devnull):
             try:
-                response = _run_agent(
+                response, result = _run_agent(
                     prompt,
                     model=model,
                     provider=provider,
@@ -208,15 +213,20 @@ def run_oneshot(
         # Re-raise control-flow exceptions so the parent handles them as usual
         # (Ctrl-C / explicit sys.exit() inside the agent).
         if isinstance(failure, (KeyboardInterrupt, SystemExit)):
+            write_usage_file(usage_file, result, failure=repr(failure))
             raise failure
+        write_usage_file(usage_file, result, failure=str(failure))
         real_stderr.write(f"hermes -z: agent failed: {failure}\n")
         real_stderr.flush()
         return 1
 
     if not (response or "").strip():
+        write_usage_file(usage_file, result, failure="no final response")
         real_stderr.write("hermes -z: no final response was produced; treating the run as failed.\n")
         real_stderr.flush()
         return 1
+
+    write_usage_file(usage_file, result)
 
     assert response is not None  # narrowed by the empty-response guard above
     real_stdout.write(response)
@@ -248,9 +258,9 @@ def _run_agent(
     provider: Optional[str] = None,
     toolsets: object = None,
     use_config_toolsets: bool = True,
-) -> str:
+) -> tuple[str, dict]:
     """Build an AIAgent exactly like a normal CLI chat turn would, then
-    run a single conversation.  Returns the final response string."""
+    run a single conversation.  Returns ``(final_response, usage_result)``."""
     # Imports are local so they don't run when hermes is invoked for
     # other commands (keeps top-level CLI startup cheap).
     from hermes_cli.config import load_config
@@ -364,7 +374,8 @@ def _run_agent(
     agent.stream_delta_callback = None
     agent.tool_gen_callback = None
 
-    return agent.chat(prompt) or ""
+    response = agent.chat(prompt) or ""
+    return response, result_from_agent(agent)
 
 
 def _oneshot_clarify_callback(question: str, choices=None) -> str:

--- a/hermes_cli/usage_report.py
+++ b/hermes_cli/usage_report.py
@@ -1,0 +1,164 @@
+"""JSON usage report for ``hermes -z --usage-file`` and ``hermes chat -q --usage-file``.
+
+Pipelines (Paperclip included) need a machine-readable spend record after a
+non-interactive run. Oneshot and chat ``-q`` write the same shape.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Optional
+
+
+def write_usage_file(
+    path: Optional[str], result: dict, failure: Optional[str] = None
+) -> None:
+    """Best-effort JSON usage report.
+
+    Written even on failure so callers can always account for spend. Never
+    raises: a broken usage write must not mask the run's own outcome.
+    """
+    if not path:
+        return
+    try:
+        report = {
+            "estimated_cost_usd": result.get("estimated_cost_usd"),
+            "actual_cost_usd": result.get("actual_cost_usd"),
+            "cost_status": result.get("cost_status"),
+            "cost_source": result.get("cost_source"),
+            "input_tokens": result.get("input_tokens"),
+            "output_tokens": result.get("output_tokens"),
+            "cache_read_tokens": result.get("cache_read_tokens"),
+            "cache_write_tokens": result.get("cache_write_tokens"),
+            "reasoning_tokens": result.get("reasoning_tokens"),
+            "total_tokens": result.get("total_tokens"),
+            "api_calls": result.get("api_calls"),
+            "model": result.get("model"),
+            "provider": result.get("provider"),
+            "session_id": result.get("session_id"),
+            "completed": result.get("completed"),
+            "failed": bool(result.get("failed")) or failure is not None,
+            "service_tier": result.get("service_tier"),
+        }
+        if failure is not None:
+            report["failure"] = failure
+        out = Path(path).expanduser()
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    except Exception:
+        pass
+
+
+def _first_number(*values: Any) -> float | None:
+    for value in values:
+        if value is None or value == "":
+            continue
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            continue
+        if number == number:
+            return number
+    return None
+
+
+def result_from_agent(
+    agent: Any,
+    session: Optional[dict] = None,
+    *,
+    failed: bool = False,
+    session_id: Optional[str] = None,
+) -> dict:
+    """Collect spend fields from a live agent, falling back to a session row."""
+    session = session or {}
+    sid = (
+        session_id
+        or (getattr(agent, "session_id", None) if agent is not None else None)
+        or session.get("id")
+    )
+    return {
+        "estimated_cost_usd": _first_number(
+            getattr(agent, "session_estimated_cost_usd", None) if agent is not None else None,
+            session.get("estimated_cost_usd"),
+        ),
+        "actual_cost_usd": _first_number(session.get("actual_cost_usd")),
+        "cost_status": (
+            getattr(agent, "session_cost_status", None) if agent is not None else None
+        )
+        or session.get("cost_status"),
+        "cost_source": (
+            getattr(agent, "session_cost_source", None) if agent is not None else None
+        )
+        or session.get("cost_source"),
+        "input_tokens": _first_number(
+            getattr(agent, "session_input_tokens", None) if agent is not None else None,
+            session.get("input_tokens"),
+        ),
+        "output_tokens": _first_number(
+            getattr(agent, "session_output_tokens", None) if agent is not None else None,
+            session.get("output_tokens"),
+        ),
+        "cache_read_tokens": _first_number(
+            getattr(agent, "session_cache_read_tokens", None) if agent is not None else None,
+            session.get("cache_read_tokens"),
+        ),
+        "cache_write_tokens": _first_number(
+            getattr(agent, "session_cache_write_tokens", None) if agent is not None else None,
+            session.get("cache_write_tokens"),
+        ),
+        "reasoning_tokens": _first_number(
+            getattr(agent, "session_reasoning_tokens", None) if agent is not None else None,
+            session.get("reasoning_tokens"),
+        ),
+        "total_tokens": _first_number(
+            getattr(agent, "session_total_tokens", None) if agent is not None else None,
+            session.get("total_tokens"),
+        ),
+        "api_calls": _first_number(
+            getattr(agent, "api_call_count", None) if agent is not None else None,
+            session.get("api_call_count"),
+        ),
+        "model": (getattr(agent, "model", None) if agent is not None else None)
+        or session.get("model"),
+        "provider": (getattr(agent, "provider", None) if agent is not None else None)
+        or session.get("provider"),
+        "session_id": sid,
+        "completed": True,
+        "failed": failed,
+        "service_tier": (
+            ((getattr(agent, "request_overrides", None) or {}).get("extra_body") or {}).get(
+                "service_tier"
+            )
+            if agent is not None
+            else None
+        ),
+    }
+
+
+def result_from_cli(cli: Any, *, failed: bool = False) -> dict:
+    agent = getattr(cli, "agent", None)
+    session: dict = {}
+    session_id = getattr(cli, "session_id", None) or getattr(agent, "session_id", None)
+    db = getattr(cli, "_session_db", None)
+    if db is not None and session_id:
+        try:
+            session = db.get_session(session_id) or {}
+        except Exception:
+            session = {}
+    return result_from_agent(agent, session, failed=failed, session_id=session_id)
+
+
+def write_usage_file_from_cli(cli: Any, *, failure: Optional[str] = None) -> None:
+    """Write ``cli.usage_file`` if the flag was set. Never raises."""
+    try:
+        path = getattr(cli, "usage_file", None)
+        if not path:
+            return
+        write_usage_file(
+            path,
+            result_from_cli(cli, failed=failure is not None),
+            failure=failure,
+        )
+    except Exception:
+        pass

--- a/tests/hermes_cli/test_chat_usage_file.py
+++ b/tests/hermes_cli/test_chat_usage_file.py
@@ -1,0 +1,130 @@
+"""Tests for hermes chat -q --usage-file."""
+
+import json
+from types import SimpleNamespace
+
+from hermes_cli.usage_report import (
+    result_from_cli,
+    write_usage_file,
+    write_usage_file_from_cli,
+)
+
+
+def test_result_from_cli_prefers_agent_then_session():
+    agent = SimpleNamespace(
+        session_id="sess-agent",
+        session_estimated_cost_usd=1.25,
+        session_cost_status="estimated",
+        session_cost_source="provider_models_api",
+        session_input_tokens=100,
+        session_output_tokens=20,
+        session_cache_read_tokens=0,
+        session_cache_write_tokens=0,
+        session_reasoning_tokens=5,
+        session_total_tokens=125,
+        api_call_count=3,
+        model="moonshotai/kimi-k3",
+        provider="openrouter",
+        request_overrides={},
+    )
+    db = SimpleNamespace(
+        get_session=lambda _sid: {
+            "id": "sess-agent",
+            "estimated_cost_usd": 9.99,
+            "actual_cost_usd": 0.0,
+            "input_tokens": 1,
+        }
+    )
+    cli = SimpleNamespace(agent=agent, session_id="sess-agent", _session_db=db, usage_file=None)
+    report = result_from_cli(cli)
+    assert report["estimated_cost_usd"] == 1.25
+    assert report["actual_cost_usd"] == 0.0
+    assert report["input_tokens"] == 100
+    assert report["session_id"] == "sess-agent"
+    assert report["model"] == "moonshotai/kimi-k3"
+
+
+def test_result_from_cli_falls_back_to_session_when_agent_empty():
+    db = SimpleNamespace(
+        get_session=lambda _sid: {
+            "id": "sess-db",
+            "estimated_cost_usd": 4.5,
+            "actual_cost_usd": None,
+            "input_tokens": 80,
+            "output_tokens": 10,
+            "model": "deepseek/deepseek-v4-pro",
+        }
+    )
+    cli = SimpleNamespace(
+        agent=None,
+        session_id="sess-db",
+        _session_db=db,
+        usage_file=None,
+    )
+    report = result_from_cli(cli)
+    assert report["estimated_cost_usd"] == 4.5
+    assert report["input_tokens"] == 80
+    assert report["model"] == "deepseek/deepseek-v4-pro"
+
+
+def test_write_usage_file_includes_actual_cost(tmp_path):
+    path = tmp_path / "usage.json"
+    write_usage_file(
+        str(path),
+        {
+            "estimated_cost_usd": 1.5,
+            "actual_cost_usd": 1.4,
+            "input_tokens": 10,
+            "output_tokens": 2,
+            "model": "x",
+            "provider": "openrouter",
+            "session_id": "abc",
+            "completed": True,
+            "failed": False,
+        },
+    )
+    report = json.loads(path.read_text())
+    assert report["estimated_cost_usd"] == 1.5
+    assert report["actual_cost_usd"] == 1.4
+    assert report["session_id"] == "abc"
+
+
+def test_write_usage_file_from_cli_noop_without_flag(tmp_path):
+    cli = SimpleNamespace(
+        usage_file=None,
+        agent=SimpleNamespace(session_estimated_cost_usd=1.0, session_id="s"),
+        session_id="s",
+        _session_db=None,
+    )
+    write_usage_file_from_cli(cli)
+    assert not (tmp_path / "usage.json").exists()
+
+
+def test_write_usage_file_from_cli_writes_when_flag_set(tmp_path):
+    path = tmp_path / "nested" / "usage.json"
+    agent = SimpleNamespace(
+        session_id="sess-1",
+        session_estimated_cost_usd=0.42,
+        session_cost_status="estimated",
+        session_cost_source="provider_models_api",
+        session_input_tokens=50,
+        session_output_tokens=8,
+        session_cache_read_tokens=0,
+        session_cache_write_tokens=0,
+        session_reasoning_tokens=0,
+        session_total_tokens=58,
+        api_call_count=1,
+        model="moonshotai/kimi-k3",
+        provider="openrouter",
+        request_overrides={},
+    )
+    cli = SimpleNamespace(
+        usage_file=str(path),
+        agent=agent,
+        session_id="sess-1",
+        _session_db=None,
+    )
+    write_usage_file_from_cli(cli)
+    report = json.loads(path.read_text())
+    assert report["estimated_cost_usd"] == 0.42
+    assert report["failed"] is False

--- a/tests/hermes_cli/test_oneshot_usage_file.py
+++ b/tests/hermes_cli/test_oneshot_usage_file.py
@@ -1,0 +1,66 @@
+"""Tests for hermes -z --usage-file (per-run JSON usage report)."""
+
+import json
+
+from hermes_cli.usage_report import write_usage_file
+
+
+def _result(**overrides):
+    base = {
+        "estimated_cost_usd": 0.1234,
+        "cost_status": "estimated",
+        "cost_source": "pricing-table",
+        "input_tokens": 1000,
+        "output_tokens": 200,
+        "cache_read_tokens": 800,
+        "cache_write_tokens": 0,
+        "reasoning_tokens": 50,
+        "total_tokens": 1250,
+        "api_calls": 3,
+        "model": "openai/gpt-5.5",
+        "provider": "openrouter",
+        "session_id": "abc123",
+        "completed": True,
+        "failed": False,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestWriteUsageFile:
+    def test_writes_report_with_cost_and_tokens(self, tmp_path):
+        path = tmp_path / "usage.json"
+        write_usage_file(str(path), _result())
+        report = json.loads(path.read_text())
+        assert report["estimated_cost_usd"] == 0.1234
+        assert report["input_tokens"] == 1000
+        assert report["output_tokens"] == 200
+        assert report["model"] == "openai/gpt-5.5"
+        assert report["api_calls"] == 3
+        assert report["failed"] is False
+        assert "failure" not in report
+
+    def test_none_path_is_noop(self, tmp_path):
+        write_usage_file(None, _result())
+        assert not (tmp_path / "usage.json").exists()
+
+    def test_failure_marks_failed_and_records_message(self, tmp_path):
+        path = tmp_path / "usage.json"
+        write_usage_file(str(path), {}, failure="boom")
+        report = json.loads(path.read_text())
+        assert report["failed"] is True
+        assert report["failure"] == "boom"
+        assert report["estimated_cost_usd"] is None
+
+    def test_creates_parent_directories(self, tmp_path):
+        path = tmp_path / "nested" / "dir" / "usage.json"
+        write_usage_file(str(path), _result())
+        assert json.loads(path.read_text())["total_tokens"] == 1250
+
+    def test_unwritable_path_never_raises(self):
+        write_usage_file("/proc/definitely/not/writable/usage.json", _result())
+
+    def test_result_failed_flag_carries_through(self, tmp_path):
+        path = tmp_path / "usage.json"
+        write_usage_file(str(path), _result(failed=True))
+        assert json.loads(path.read_text())["failed"] is True


### PR DESCRIPTION
## Summary
- `--usage-file` was oneshot-only on some trees, and missing entirely on current main. Paperclip (and any other `hermes chat -q` pipeline) never received a machine-readable spend record.
- This adds a shared `hermes_cli/usage_report.py` writer, wires it into `hermes -z` and `hermes chat -q` (including the quiet `sys.exit` path via `_finalize_single_query`), and keeps the write best-effort so a broken report cannot mask the run.

## Test plan
- [x] `pytest tests/hermes_cli/test_chat_usage_file.py tests/hermes_cli/test_oneshot_usage_file.py` (11 passed)
- [ ] `hermes chat -q "ping" --usage-file /tmp/usage.json` writes `estimated_cost_usd` / token fields
- [ ] `hermes -z "ping" --usage-file /tmp/z.json` still writes the same shape, including on failure