### PR TITLE
fix(gateway): ledger-bracket the queued-lane final send

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1536,6 +1536,13 @@ class MessageEvent:
     source: SessionSource = None
     raw_message: Any = None
     message_id: Optional[str] = None
+    # Delivery-ledger identity for the final send, when it differs from ``message_id``. A queued
+    # (/queue) chain answers the LAST message of the chain, so its final send has to be ledgered
+    # under that message's id. Keyed on the opening event's id instead, two chained turns carrying
+    # the same text collide on one obligation id and the earlier turn's row is overwritten (a
+    # refused first reply then reads as delivered). Reply routing is unaffected: the reply anchor
+    # still comes from this event.
+    ledger_message_id: Optional[str] = None
     # Platform update id (Telegram ``update_id``): ``/restart`` records it so the new gateway
     # advances past it even if PTB's shutdown ACK times out.
     platform_update_id: Optional[int] = None
@@ -3731,8 +3738,13 @@ class BasePlatformAdapter(ABC):
             if not await asyncio.to_thread(ledger_enabled):
                 return None
             source = event.source
+            # ``ledger_message_id`` wins when set: a queued chain's final answers the last message
+            # of the chain, not the event that opened it (see ``MessageEvent.ledger_message_id``).
+            _ledger_id = getattr(event, "ledger_message_id", None)
+            if _ledger_id is None:
+                _ledger_id = getattr(event, "message_id", "")
             obligation_id = compute_obligation_id(
-                session_key, str(getattr(event, "message_id", "") or ""), text_content)
+                session_key, str(_ledger_id or ""), text_content)
             await asyncio.to_thread(
                 record_obligation, obligation_id=obligation_id, session_key=session_key,
                 platform=str(getattr(source.platform, "value", source.platform)),

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, cast
 
 from gateway.config import Platform, _BUILTIN_PLATFORM_VALUES
-from gateway.platforms.base import MessageEvent, MessageType
+from gateway.platforms.base import MessageEvent, MessageType, _mark_notify_metadata
 from gateway.session import SessionEntry, SessionSource
 from gateway.run_shutdown import _log_suppressed, _notice_target_key, _send_error, _send_failed
 
@@ -303,8 +303,12 @@ class GatewayNotificationsMixin:
         self, response: str, source: SessionSource, adapter,
         metadata: Optional[Dict[str, Any]] = None, event_message_id: Optional[str] = None,
         text_already_delivered: bool = False, deliver_media: bool = True, stream_consumer=None,
+        session_key: Optional[str] = None,
     ) -> None:
-        """Deliver a queued response using the normal text+attachment split."""
+        """Deliver a queued response using the normal text+attachment split.
+
+        ``session_key`` lets the text send record a delivery-ledger obligation like the normal final
+        send does (see ``_send_queued_final_text``); without it the send stays unledgered."""
         from gateway.run import _strip_response_attachments_for_direct_send
         if not text_already_delivered:
             text_content = _strip_response_attachments_for_direct_send(response, adapter)
@@ -331,7 +335,8 @@ class GatewayNotificationsMixin:
                     except Exception as _qe:
                         logger.debug("Queued-lane reconcile edit failed (%s); falling back to send.", _qe)
                 if not _reconciled:
-                    await adapter.send(source.chat_id, text_content, metadata=metadata)
+                    await self._send_queued_final_text(
+                        adapter, source, text_content, metadata, event_message_id, session_key)
         # Failed turns deliver their (normalized failure) text but must not upload attachments as if
         # they succeeded — mirrors the ``not agent_result.get("failed")`` completed-turn guard.
         if not deliver_media:
@@ -340,6 +345,38 @@ class GatewayNotificationsMixin:
             response, MessageEvent(text="", source=source, message_id=event_message_id), adapter,
             thread_metadata=metadata,
         )
+
+    async def _send_queued_final_text(
+        self, adapter, source: SessionSource, text_content: str, metadata: Optional[Dict[str, Any]],
+        event_message_id: Optional[str], session_key: Optional[str],
+    ):
+        """Send a queued-lane final through the adapter's ledger-bracketed final send.
+
+        This lane used to call ``adapter.send`` bare and discard the result. A final refused here
+        (flood control, a transport that just died) was gone for good: no delivery-ledger row was ever
+        written, so neither the boot sweep nor the runtime redelivery could see it, and the queued
+        follow-up ran as if the answer had landed. The normal final send records the obligation before
+        the send and finalizes it from the result; this routes the queued lane through that same method
+        so both lanes recover the same way. The event carries the inbound message id, so the obligation
+        id matches the one the normal lane would compute for the same turn (idempotent re-record), and
+        the reply is marked notify-worthy like every other user-visible final. Adapters without the
+        base contract (relay doubles, third-party plugins) and sends without a session key keep the
+        plain send. Returns the SendResult, or None when the adapter's send returned nothing
+        (queued-final-ledger)."""
+        bracketed = getattr(adapter, "_send_final_text", None)
+        if session_key and callable(bracketed):
+            results: list = []
+            await bracketed(
+                MessageEvent(text="", source=source, message_id=event_message_id), session_key,
+                text_content, _mark_notify_metadata(metadata), False, 0, results.append)
+            result = results[-1] if results else None
+        else:
+            result = await adapter.send(source.chat_id, text_content, metadata=metadata)
+        if not getattr(result, "success", False):
+            logger.warning(
+                "Queued-lane final send to %s failed: %s", getattr(source, "chat_id", "?"),
+                getattr(result, "error", None) or "no result")
+        return result
 
     def _schedule_update_notification_watch(self) -> None:
         """Ensure a background task is watching for update completion."""

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -303,12 +303,14 @@ class GatewayNotificationsMixin:
         self, response: str, source: SessionSource, adapter,
         metadata: Optional[Dict[str, Any]] = None, event_message_id: Optional[str] = None,
         text_already_delivered: bool = False, deliver_media: bool = True, stream_consumer=None,
-        session_key: Optional[str] = None,
+        session_key: Optional[str] = None, inbound_message_id: Optional[str] = None,
     ) -> None:
         """Deliver a queued response using the normal text+attachment split.
 
         ``session_key`` lets the text send record a delivery-ledger obligation like the normal final
-        send does (see ``_send_queued_final_text``); without it the send stays unledgered."""
+        send does, keyed on ``inbound_message_id`` (the raw inbound id, distinct from the
+        ``event_message_id`` reply anchor); see ``_send_queued_final_text``. Without a key the send
+        stays unledgered."""
         from gateway.run import _strip_response_attachments_for_direct_send
         if not text_already_delivered:
             text_content = _strip_response_attachments_for_direct_send(response, adapter)
@@ -336,7 +338,8 @@ class GatewayNotificationsMixin:
                         logger.debug("Queued-lane reconcile edit failed (%s); falling back to send.", _qe)
                 if not _reconciled:
                     await self._send_queued_final_text(
-                        adapter, source, text_content, metadata, event_message_id, session_key)
+                        adapter, source, text_content, metadata, event_message_id, session_key,
+                        inbound_message_id)
         # Failed turns deliver their (normalized failure) text but must not upload attachments as if
         # they succeeded — mirrors the ``not agent_result.get("failed")`` completed-turn guard.
         if not deliver_media:
@@ -349,27 +352,34 @@ class GatewayNotificationsMixin:
     async def _send_queued_final_text(
         self, adapter, source: SessionSource, text_content: str, metadata: Optional[Dict[str, Any]],
         event_message_id: Optional[str], session_key: Optional[str],
+        inbound_message_id: Optional[str] = None,
     ):
-        """Send a queued-lane final through the adapter's ledger-bracketed final send.
+        """Send a queued-lane final under the delivery-ledger bracket the normal final send uses.
 
-        This lane used to call ``adapter.send`` bare and discard the result. A final refused here
-        (flood control, a transport that just died) was gone for good: no delivery-ledger row was ever
-        written, so neither the boot sweep nor the runtime redelivery could see it, and the queued
-        follow-up ran as if the answer had landed. The normal final send records the obligation before
-        the send and finalizes it from the result; this routes the queued lane through that same method
-        so both lanes recover the same way. The event carries the inbound message id, so the obligation
-        id matches the one the normal lane would compute for the same turn (idempotent re-record), and
-        the reply is marked notify-worthy like every other user-visible final. Adapters without the
-        base contract (relay doubles, third-party plugins) and sends without a session key keep the
-        plain send. Returns the SendResult, or None when the adapter's send returned nothing
-        (queued-final-ledger)."""
-        bracketed = getattr(adapter, "_send_final_text", None)
-        if session_key and callable(bracketed):
-            results: list = []
-            await bracketed(
-                MessageEvent(text="", source=source, message_id=event_message_id), session_key,
-                text_content, _mark_notify_metadata(metadata), False, 0, results.append)
-            result = results[-1] if results else None
+        This lane used to call ``adapter.send`` bare and discard the result, so a final refused here
+        (flood control, a transport that had just died) left no ledger row and was gone for good.
+        Now the obligation is recorded before the send and finalized from the result, the same
+        record / send-with-retry / finalize sequence as ``_send_final_text``, so both lanes recover
+        the same way. The ledger id is keyed on the raw inbound message id, as the normal lane's is;
+        ``event_message_id`` is only the reply anchor, which is None wherever replies are not used
+        (Telegram forum topics, Slack reaction handoffs) and so cannot identify the turn. Adapters
+        without the base contract and sends without a session key keep the plain send. Returns the
+        SendResult, or None when the adapter's send returned nothing."""
+        record = getattr(adapter, "_record_delivery_obligation", None)
+        finalize = getattr(adapter, "_finalize_delivery_obligation", None)
+        transport_for = getattr(adapter, "_final_delivery_adapter", None)
+        if session_key and callable(record) and callable(finalize) and callable(transport_for):
+            delivery_adapter = transport_for(source)
+            ledger_message_id = (
+                inbound_message_id if inbound_message_id is not None else event_message_id)
+            ledger_event = MessageEvent(text="", source=source, message_id=ledger_message_id)
+            obligation_id = await record(
+                ledger_event, session_key, text_content, delivery_adapter, False)
+            result = await delivery_adapter._send_with_retry(
+                chat_id=source.chat_id, content=text_content, reply_to=event_message_id,
+                metadata=_mark_notify_metadata(metadata))
+            if obligation_id is not None:
+                await finalize(obligation_id, result, ledger_event, delivery_adapter)
         else:
             result = await adapter.send(source.chat_id, text_content, metadata=metadata)
         if not getattr(result, "success", False):

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -3396,8 +3396,9 @@ class GatewayTurnMixin:
                     metadata=turn_ctx._status_thread_metadata, event_message_id=turn_ctx.event_message_id,
                     text_already_delivered=_already_streamed,
                     deliver_media=not _delivery_result.get("failed"), stream_consumer=_sc,
-                    # The text send records a delivery-ledger obligation under this key (queued-final-ledger).
-                    session_key=session_key,
+                    # The text send records a delivery-ledger obligation under this key, keyed on
+                    # the raw inbound id (the anchor above is only the reply target).
+                    session_key=session_key, inbound_message_id=turn_ctx.inbound_message_id,
                 )
             except Exception as e:
                 logger.warning("Failed to send first response before queued message: %s", e)

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -3452,6 +3452,10 @@ class GatewayTurnMixin:
         next_source, next_message, next_session_key = source, pending, session_key
         # message_type is carried into the recursive call so queued voice turns can stream TTS.
         next_message_id = next_channel_prompt = next_message_type = None
+        # The raw inbound id keys the delivery-ledger obligation for the follow-up's own final send,
+        # distinct from the reply anchor above (None in forum topics). Carry it or two chained
+        # topic turns with the same text would collide on one obligation id (queued-final-ledger).
+        next_inbound_id = None
         # See #60671.
         if pending_event is not None:
             next_source = getattr(pending_event, "source", None) or source
@@ -3476,6 +3480,7 @@ class GatewayTurnMixin:
             if next_message is None:
                 return result
             next_message_id = self._reply_anchor_for_event(pending_event)
+            next_inbound_id = str(pending_event.message_id) if getattr(pending_event, "message_id", None) else None
             next_channel_prompt = getattr(pending_event, "channel_prompt", None)
             next_message_type = getattr(pending_event, "message_type", None)
 
@@ -3511,8 +3516,8 @@ class GatewayTurnMixin:
             message=next_message, context_prompt=turn_ctx.context_prompt, history=updated_history,
             source=next_source, session_id=session_id, session_key=next_session_key,
             run_generation=run_generation, _interrupt_depth=_interrupt_depth + 1,
-            event_message_id=next_message_id, channel_prompt=next_channel_prompt,
-            message_type=next_message_type,
+            event_message_id=next_message_id, inbound_message_id=next_inbound_id,
+            channel_prompt=next_channel_prompt, message_type=next_message_type,
         )
         return _preserve_queued_followup_history_offset(result, followup_result)
 

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1983,6 +1983,15 @@ class GatewayTurnMixin:
             )
             _turn_seconds = time.monotonic() - _turn_started_monotonic
 
+            # A queued (/queue) chain answered the LAST message of the chain, so the outer final
+            # send (bracketed by the adapter against this event) must be ledgered under that
+            # message's id or it collides with an earlier turn's row carrying the same text. Reply
+            # routing is untouched: the anchor still comes from this event.
+            if isinstance(agent_result, dict):
+                _terminal_inbound = agent_result.get("queued_terminal_inbound_id")
+                if _terminal_inbound:
+                    event.ledger_message_id = str(_terminal_inbound)
+
             await self._hmwa_stop_typing_for_turn(event, source)
 
             if not self._is_session_run_current(_quick_key, run_generation):
@@ -3519,7 +3528,16 @@ class GatewayTurnMixin:
             event_message_id=next_message_id, inbound_message_id=next_inbound_id,
             channel_prompt=next_channel_prompt, message_type=next_message_type,
         )
-        return _preserve_queued_followup_history_offset(result, followup_result)
+        merged = _preserve_queued_followup_history_offset(result, followup_result)
+        # The TERMINAL turn of the chain owns the ledger identity for the outer final send, which
+        # the adapter brackets against the event that OPENED the chain. Without this the terminal
+        # reply is recorded under the first message's id, so a first reply that was refused (flood
+        # control) has its outstanding row replaced and marked delivered by an identical-text
+        # terminal reply, and is never redelivered. A deeper recursion has already set its own id,
+        # so only fill the key while it is still absent: the innermost turn wins.
+        if isinstance(merged, dict) and "queued_terminal_inbound_id" not in merged:
+            merged = {**merged, "queued_terminal_inbound_id": next_inbound_id}
+        return merged
 
     async def _run_agent_cleanup_turn_tasks(
         self, turn_ctx: TurnContext, *, progress_task: Any, log_task: Any, interrupt_monitor: "asyncio.Task",

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -3396,6 +3396,8 @@ class GatewayTurnMixin:
                     metadata=turn_ctx._status_thread_metadata, event_message_id=turn_ctx.event_message_id,
                     text_already_delivered=_already_streamed,
                     deliver_media=not _delivery_result.get("failed"), stream_consumer=_sc,
+                    # The text send records a delivery-ledger obligation under this key (queued-final-ledger).
+                    session_key=session_key,
                 )
             except Exception as e:
                 logger.warning("Failed to send first response before queued message: %s", e)

--- a/tests/gateway/test_queued_final_ledger.py
+++ b/tests/gateway/test_queued_final_ledger.py
@@ -1,0 +1,255 @@
+"""A queued-lane final is ledger-bracketed like the normal final send.
+
+When a follow-up is queued behind a turn (a message typed while the agent worked, a
+subagent batch reporting back), the first response is delivered by the queued lane in
+``run_turn.py`` before the follow-up runs. That lane called ``adapter.send`` bare and
+discarded the result: no delivery-ledger row was recorded, so a final refused there
+(flood control, a transport that had just died) was lost for good. Neither the boot
+sweep nor the runtime redelivery could see it, and the follow-up ran as if the answer
+had landed. On 5 Sep 2026 two long replies were lost this way within an hour, both
+refused by Telegram flood control while a delegation batch arrived the same second.
+
+Now the queued lane routes its text send through the adapter's ``_send_final_text``,
+the same ledger-bracketed method the normal lane uses: the obligation is recorded
+before the send under the id the normal lane would compute for the same turn, the
+result finalizes it, and the reply is marked notify-worthy like every other final.
+The reconcile-by-edit path is unchanged. Adapters without the base contract and
+sends without a session key keep the plain send.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway import delivery_ledger as dl
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+SESSION_KEY = "agent:main:telegram:dm:5230977008"
+CHAT = "5230977008"
+INBOUND_ID = "5301"
+TEXT = "**Yes.** I would make room for one island trip and one Balkan trip."
+
+
+@pytest.fixture(autouse=True)
+def _fresh_db(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(dl, "_db_path", lambda: home / "state.db")
+    monkeypatch.setattr(dl, "_owner_stamp", lambda: (os.getpid(), 202))
+    monkeypatch.setattr(dl, "ledger_enabled", lambda config=None: True)
+    yield
+
+
+def _rows():
+    with dl._connect() as conn:
+        cur = conn.execute(
+            "SELECT obligation_id, session_key, state, attempts, last_error, content, chat_id, platform"
+            " FROM delivery_obligations")
+        return [dict(zip(("obligation_id", "session_key", "state", "attempts", "last_error", "content",
+                          "chat_id", "platform"), r)) for r in cur.fetchall()]
+
+
+def _source():
+    return SimpleNamespace(platform=Platform.TELEGRAM, chat_id=CHAT, thread_id=None, chat_type="dm")
+
+
+def _telegram_adapter(send_result=None):
+    """A real Telegram adapter (the base contract) whose transport send is a mock."""
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token", extra={}))
+    runner = MagicMock()
+    runner._adapter_for_source = MagicMock(return_value=adapter)
+    runner._schedule_flood_redelivery = MagicMock(return_value=187.0)
+    adapter.gateway_runner = runner
+    adapter.send = AsyncMock(return_value=send_result or SendResult(success=True, message_id="900"))
+    adapter.edit_message = AsyncMock(return_value=SendResult(success=False, error="message to edit not found"))
+    return adapter
+
+
+def _plain_adapter():
+    """A relay-style double without the base contract: only ``send`` and the media helpers."""
+    return SimpleNamespace(
+        name="relay", extract_media=BasePlatformAdapter.extract_media,
+        send=AsyncMock(return_value=SendResult(success=True, message_id="p1")))
+
+
+def _runner():
+    from gateway.run import GatewayRunner
+
+    return object.__new__(GatewayRunner)
+
+
+async def _deliver(adapter, *, session_key=SESSION_KEY, stream_consumer=None, metadata=None, text=TEXT):
+    from gateway.run import GatewayRunner
+
+    await GatewayRunner._deliver_queued_first_response(
+        _runner(), text, source=_source(), adapter=adapter, metadata=metadata, event_message_id=INBOUND_ID,
+        text_already_delivered=False, deliver_media=False, stream_consumer=stream_consumer,
+        session_key=session_key)
+
+
+# ---------------------------------------------------------------------------
+# The bracket: record before the send, finalize from the result.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_a_delivered_queued_final_is_recorded_and_marked_delivered():
+    adapter = _telegram_adapter()
+
+    await _deliver(adapter)
+
+    rows = _rows()
+    assert len(rows) == 1
+    assert rows[0]["state"] == "delivered"
+    assert rows[0]["session_key"] == SESSION_KEY
+    assert rows[0]["content"] == TEXT
+    assert (rows[0]["platform"], rows[0]["chat_id"]) == ("telegram", CHAT)
+    adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_the_obligation_id_is_the_one_the_normal_lane_would_use():
+    """Same turn, same text: re-recording from either lane is idempotent, never a second row."""
+    adapter = _telegram_adapter()
+
+    await _deliver(adapter)
+
+    assert _rows()[0]["obligation_id"] == dl.compute_obligation_id(SESSION_KEY, INBOUND_ID, TEXT)
+
+
+@pytest.mark.asyncio
+async def test_a_flood_refused_queued_final_stays_in_the_ledger_as_failed(caplog):
+    """The row survives the refusal, so the sweeps (and a flood timer, where present) can redeliver."""
+    adapter = _telegram_adapter(SendResult(success=False, error="flood_control:185.0"))
+
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        await _deliver(adapter)
+
+    rows = _rows()
+    assert len(rows) == 1
+    assert rows[0]["state"] == "failed"
+    assert rows[0]["last_error"] == "flood_control:185.0"
+    assert any("Queued-lane final send" in r.getMessage() and "flood_control:185.0" in r.getMessage()
+               for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_any_other_refusal_is_recorded_as_failed_too():
+    adapter = _telegram_adapter(SendResult(success=False, error="Forbidden: bot was blocked by the user"))
+
+    await _deliver(adapter)
+
+    assert _rows()[0]["state"] == "failed"
+    assert "blocked" in _rows()[0]["last_error"]
+
+
+@pytest.mark.asyncio
+async def test_the_queued_final_is_sent_like_the_normal_final():
+    """Reply anchor on the inbound message and a notify-worthy copy of the thread metadata."""
+    adapter = _telegram_adapter()
+    metadata = {"thread_id": "topic-7"}
+
+    await _deliver(adapter, metadata=metadata)
+
+    kwargs = adapter.send.await_args.kwargs
+    assert kwargs["chat_id"] == CHAT
+    assert kwargs["content"] == TEXT
+    assert kwargs["reply_to"] == INBOUND_ID
+    assert kwargs["metadata"]["notify"] is True
+    assert kwargs["metadata"]["thread_id"] == "topic-7"
+    assert metadata == {"thread_id": "topic-7"}  # the caller's dict is cloned, not mutated
+
+
+# ---------------------------------------------------------------------------
+# What is unchanged: reconcile-by-edit, plain adapters, no session key.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_reconcile_by_edit_records_no_obligation():
+    adapter = _telegram_adapter()
+    adapter.edit_message = AsyncMock(return_value=SendResult(success=True, message_id="sealed-9"))
+    sc = SimpleNamespace(message_id="sealed-9", _turn_split_delivery=False)
+
+    await _deliver(adapter, stream_consumer=sc)
+
+    adapter.edit_message.assert_awaited_once()
+    adapter.send.assert_not_awaited()
+    assert _rows() == []
+
+
+@pytest.mark.asyncio
+async def test_a_failed_reconcile_edit_falls_through_to_the_bracketed_send():
+    adapter = _telegram_adapter()  # edit_message fails by default
+    sc = SimpleNamespace(message_id="sealed-9", _turn_split_delivery=False)
+
+    await _deliver(adapter, stream_consumer=sc)
+
+    adapter.send.assert_awaited_once()
+    assert _rows()[0]["state"] == "delivered"
+
+
+@pytest.mark.asyncio
+async def test_an_adapter_without_the_base_contract_keeps_the_plain_send():
+    adapter = _plain_adapter()
+
+    await _deliver(adapter, metadata={"thread_id": "t"})
+
+    adapter.send.assert_awaited_once_with(CHAT, TEXT, metadata={"thread_id": "t"})
+    assert _rows() == []
+
+
+@pytest.mark.asyncio
+async def test_without_a_session_key_the_plain_send_is_kept():
+    """No key, no ledger row possible: the send still happens, unbracketed, as before."""
+    adapter = _telegram_adapter()
+
+    await _deliver(adapter, session_key=None, metadata={"thread_id": "t"})
+
+    adapter.send.assert_awaited_once_with(CHAT, TEXT, metadata={"thread_id": "t"})
+    assert _rows() == []
+
+
+@pytest.mark.asyncio
+async def test_a_plain_send_failure_is_still_logged(caplog):
+    adapter = _plain_adapter()
+    adapter.send = AsyncMock(return_value=SendResult(success=False, error="flood_control:30.0"))
+
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        await _deliver(adapter)
+
+    assert any("Queued-lane final send" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# The call site hands the session key over.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_the_queued_lane_receives_the_session_key_from_the_turn():
+    from gateway.run import GatewayRunner
+
+    runner = _runner()
+    runner._run_agent_stream_confirmed_final_delivery = MagicMock(return_value=False)
+    runner._is_intentional_silence = MagicMock(return_value=False)
+    runner._pop_post_delivery_callback = MagicMock(return_value=None)
+    runner._deliver_queued_first_response = AsyncMock()
+    turn_ctx = SimpleNamespace(
+        session_key=SESSION_KEY, stream_consumer_holder=[None], source=_source(),
+        _status_thread_metadata={"thread_id": None}, event_message_id=INBOUND_ID, run_generation=3)
+    adapter = _telegram_adapter()
+
+    await GatewayRunner._run_agent_deliver_first_response(
+        runner, turn_ctx, adapter, {"final_response": TEXT}, {}, None)
+
+    runner._deliver_queued_first_response.assert_awaited_once()
+    kwargs = runner._deliver_queued_first_response.await_args.kwargs
+    assert kwargs["session_key"] == SESSION_KEY
+    assert kwargs["event_message_id"] == INBOUND_ID
+    assert kwargs["text_already_delivered"] is False

--- a/tests/gateway/test_queued_final_ledger.py
+++ b/tests/gateway/test_queued_final_ledger.py
@@ -302,3 +302,37 @@ async def test_the_queued_lane_receives_the_session_key_and_inbound_id_from_the_
     assert kwargs["inbound_message_id"] == INBOUND_ID
     assert kwargs["event_message_id"] is None
     assert kwargs["text_already_delivered"] is False
+
+
+@pytest.mark.asyncio
+async def test_a_chained_queued_turn_carries_its_own_inbound_id():
+    """A queued follow-up that itself queues another follow-up (recursive _run_agent) must pass the
+    inbound id on, or the chained turn's own queued final would key on None in a forum topic and
+    collide with a sibling. The recursive call carries pending_event's raw message id."""
+    from gateway.run import GatewayRunner
+
+    runner = _runner()
+    runner._MAX_INTERRUPT_DEPTH = 8
+    runner._run_agent = AsyncMock(return_value={"final_response": "done", "messages": []})
+    runner._run_agent_deliver_first_response = AsyncMock()
+    runner._is_goal_continuation_event = MagicMock(return_value=False)
+    runner._session_key_for_source = MagicMock(return_value=TOPIC_SESSION_KEY)
+    runner._prepare_profile_scoped_inbound_message_text = AsyncMock(return_value="the follow-up")
+    runner._reply_anchor_for_event = MagicMock(return_value=None)   # forum topic: no anchor
+    runner._adapter_for_source = MagicMock(return_value=None)
+    runner._refresh_agent_cache_message_count = AsyncMock()
+    topic = _source(chat_id="-1001", thread_id="7", chat_type="supergroup")
+    turn_ctx = SimpleNamespace(
+        source=topic, session_id="sid", session_key=TOPIC_SESSION_KEY, run_generation=1,
+        _interrupt_depth=0, history=[], _status_thread_metadata={"thread_id": "7"},
+        context_prompt=None, result_holder=[None])
+    pending_event = SimpleNamespace(
+        source=topic, message_id="6002", channel_prompt=None, message_type=None)
+
+    await GatewayRunner._run_agent_queued_followup(
+        runner, turn_ctx, adapter=None, pending="hi again", pending_event=pending_event,
+        response="resp", result={"interrupted": True, "messages": []}, stream_task=None)
+
+    runner._run_agent.assert_awaited_once()
+    assert runner._run_agent.await_args.kwargs["inbound_message_id"] == "6002"
+    assert runner._run_agent.await_args.kwargs["event_message_id"] is None

--- a/tests/gateway/test_queued_final_ledger.py
+++ b/tests/gateway/test_queued_final_ledger.py
@@ -9,12 +9,14 @@ sweep nor the runtime redelivery could see it, and the follow-up ran as if the a
 had landed. On 5 Sep 2026 two long replies were lost this way within an hour, both
 refused by Telegram flood control while a delegation batch arrived the same second.
 
-Now the queued lane routes its text send through the adapter's ``_send_final_text``,
-the same ledger-bracketed method the normal lane uses: the obligation is recorded
-before the send under the id the normal lane would compute for the same turn, the
-result finalizes it, and the reply is marked notify-worthy like every other final.
-The reconcile-by-edit path is unchanged. Adapters without the base contract and
-sends without a session key keep the plain send.
+Now the queued lane runs the same bracket as the normal lane: the obligation is
+recorded before the send, the send goes through the adapter's retrying transport, and
+the result finalizes the row. The obligation id is keyed on the raw inbound message id
+exactly as the normal lane keys it; the reply anchor is only the reply target and is
+None wherever replies are not used (Telegram forum topics), so it cannot identify the
+turn. The reply is marked notify-worthy like every other final. The reconcile-by-edit
+path is unchanged. Adapters without the base contract and sends without a session key
+keep the plain send.
 """
 
 from __future__ import annotations
@@ -31,6 +33,7 @@ from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter, SendResult
 
 SESSION_KEY = "agent:main:telegram:dm:5230977008"
+TOPIC_SESSION_KEY = "agent:main:telegram:group:-1001:topic:7"
 CHAT = "5230977008"
 INBOUND_ID = "5301"
 TEXT = "**Yes.** I would make room for one island trip and one Balkan trip."
@@ -46,17 +49,19 @@ def _fresh_db(tmp_path, monkeypatch):
     yield
 
 
+_COLUMNS = ("obligation_id", "session_key", "state", "attempts", "last_error", "content", "chat_id",
+            "platform")
+
+
 def _rows():
     with dl._connect() as conn:
-        cur = conn.execute(
-            "SELECT obligation_id, session_key, state, attempts, last_error, content, chat_id, platform"
-            " FROM delivery_obligations")
-        return [dict(zip(("obligation_id", "session_key", "state", "attempts", "last_error", "content",
-                          "chat_id", "platform"), r)) for r in cur.fetchall()]
+        cur = conn.execute(f"SELECT {', '.join(_COLUMNS)} FROM delivery_obligations")
+        return [dict(zip(_COLUMNS, r)) for r in cur.fetchall()]
 
 
-def _source():
-    return SimpleNamespace(platform=Platform.TELEGRAM, chat_id=CHAT, thread_id=None, chat_type="dm")
+def _source(*, chat_id=CHAT, thread_id=None, chat_type="dm"):
+    return SimpleNamespace(platform=Platform.TELEGRAM, chat_id=chat_id, thread_id=thread_id,
+                           chat_type=chat_type)
 
 
 def _telegram_adapter(send_result=None):
@@ -69,7 +74,8 @@ def _telegram_adapter(send_result=None):
     runner._schedule_flood_redelivery = MagicMock(return_value=187.0)
     adapter.gateway_runner = runner
     adapter.send = AsyncMock(return_value=send_result or SendResult(success=True, message_id="900"))
-    adapter.edit_message = AsyncMock(return_value=SendResult(success=False, error="message to edit not found"))
+    adapter.edit_message = AsyncMock(
+        return_value=SendResult(success=False, error="message to edit not found"))
     return adapter
 
 
@@ -86,13 +92,14 @@ def _runner():
     return object.__new__(GatewayRunner)
 
 
-async def _deliver(adapter, *, session_key=SESSION_KEY, stream_consumer=None, metadata=None, text=TEXT):
+async def _deliver(adapter, *, session_key=SESSION_KEY, stream_consumer=None, metadata=None,
+                   text=TEXT, source=None, anchor=INBOUND_ID, inbound_id=INBOUND_ID):
     from gateway.run import GatewayRunner
 
     await GatewayRunner._deliver_queued_first_response(
-        _runner(), text, source=_source(), adapter=adapter, metadata=metadata, event_message_id=INBOUND_ID,
-        text_already_delivered=False, deliver_media=False, stream_consumer=stream_consumer,
-        session_key=session_key)
+        _runner(), text, source=source or _source(), adapter=adapter, metadata=metadata,
+        event_message_id=anchor, text_already_delivered=False, deliver_media=False,
+        stream_consumer=stream_consumer, session_key=session_key, inbound_message_id=inbound_id)
 
 
 # ---------------------------------------------------------------------------
@@ -115,6 +122,23 @@ async def test_a_delivered_queued_final_is_recorded_and_marked_delivered():
 
 
 @pytest.mark.asyncio
+async def test_the_row_is_already_attempting_while_the_send_is_in_flight():
+    """Record BEFORE the send: a crash mid-send must leave a row the next boot can redeliver."""
+    adapter = _telegram_adapter()
+    seen: list = []
+
+    async def _send(**kwargs):
+        seen.append([(r["state"], r["content"]) for r in _rows()])
+        return SendResult(success=True, message_id="900")
+
+    adapter.send = AsyncMock(side_effect=_send)
+
+    await _deliver(adapter)
+
+    assert seen == [[("attempting", TEXT)]]
+
+
+@pytest.mark.asyncio
 async def test_the_obligation_id_is_the_one_the_normal_lane_would_use():
     """Same turn, same text: re-recording from either lane is idempotent, never a second row."""
     adapter = _telegram_adapter()
@@ -125,8 +149,28 @@ async def test_the_obligation_id_is_the_one_the_normal_lane_would_use():
 
 
 @pytest.mark.asyncio
+async def test_forum_topic_turns_are_identified_by_their_inbound_id_not_the_reply_anchor():
+    """Telegram forum topics route by topic metadata and never reply, so the anchor is None for
+    every message in the topic. Two turns answering with the same text must still get two rows,
+    or the second would overwrite the first's outstanding obligation and retry state."""
+    adapter = _telegram_adapter()
+    topic = _source(chat_id="-1001", thread_id="7", chat_type="supergroup")
+
+    await _deliver(adapter, session_key=TOPIC_SESSION_KEY, source=topic, anchor=None,
+                   inbound_id="5301")
+    await _deliver(adapter, session_key=TOPIC_SESSION_KEY, source=topic, anchor=None,
+                   inbound_id="5302")
+
+    ids = sorted(r["obligation_id"] for r in _rows())
+    assert ids == sorted([dl.compute_obligation_id(TOPIC_SESSION_KEY, "5301", TEXT),
+                          dl.compute_obligation_id(TOPIC_SESSION_KEY, "5302", TEXT)])
+    assert [c.kwargs["reply_to"] for c in adapter.send.await_args_list] == [None, None]
+
+
+@pytest.mark.asyncio
 async def test_a_flood_refused_queued_final_stays_in_the_ledger_as_failed(caplog):
-    """The row survives the refusal, so the sweeps (and a flood timer, where present) can redeliver."""
+    """The row survives the refusal, so the sweeps (and a flood timer, where present) can redeliver
+    it."""
     adapter = _telegram_adapter(SendResult(success=False, error="flood_control:185.0"))
 
     with caplog.at_level(logging.WARNING, logger="gateway.run"):
@@ -136,13 +180,14 @@ async def test_a_flood_refused_queued_final_stays_in_the_ledger_as_failed(caplog
     assert len(rows) == 1
     assert rows[0]["state"] == "failed"
     assert rows[0]["last_error"] == "flood_control:185.0"
-    assert any("Queued-lane final send" in r.getMessage() and "flood_control:185.0" in r.getMessage()
-               for r in caplog.records)
+    assert any("Queued-lane final send" in r.getMessage()
+               and "flood_control:185.0" in r.getMessage() for r in caplog.records)
 
 
 @pytest.mark.asyncio
 async def test_any_other_refusal_is_recorded_as_failed_too():
-    adapter = _telegram_adapter(SendResult(success=False, error="Forbidden: bot was blocked by the user"))
+    adapter = _telegram_adapter(
+        SendResult(success=False, error="Forbidden: bot was blocked by the user"))
 
     await _deliver(adapter)
 
@@ -228,11 +273,11 @@ async def test_a_plain_send_failure_is_still_logged(caplog):
 
 
 # ---------------------------------------------------------------------------
-# The call site hands the session key over.
+# The call site hands the session key and the raw inbound id over.
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_the_queued_lane_receives_the_session_key_from_the_turn():
+async def test_the_queued_lane_receives_the_session_key_and_inbound_id_from_the_turn():
     from gateway.run import GatewayRunner
 
     runner = _runner()
@@ -240,9 +285,12 @@ async def test_the_queued_lane_receives_the_session_key_from_the_turn():
     runner._is_intentional_silence = MagicMock(return_value=False)
     runner._pop_post_delivery_callback = MagicMock(return_value=None)
     runner._deliver_queued_first_response = AsyncMock()
+    # A forum-topic turn: no reply anchor, but a raw inbound id the ledger must be keyed on.
     turn_ctx = SimpleNamespace(
-        session_key=SESSION_KEY, stream_consumer_holder=[None], source=_source(),
-        _status_thread_metadata={"thread_id": None}, event_message_id=INBOUND_ID, run_generation=3)
+        session_key=TOPIC_SESSION_KEY, stream_consumer_holder=[None],
+        source=_source(chat_id="-1001", thread_id="7", chat_type="supergroup"),
+        _status_thread_metadata={"thread_id": "7"}, event_message_id=None,
+        inbound_message_id=INBOUND_ID, run_generation=3)
     adapter = _telegram_adapter()
 
     await GatewayRunner._run_agent_deliver_first_response(
@@ -250,6 +298,7 @@ async def test_the_queued_lane_receives_the_session_key_from_the_turn():
 
     runner._deliver_queued_first_response.assert_awaited_once()
     kwargs = runner._deliver_queued_first_response.await_args.kwargs
-    assert kwargs["session_key"] == SESSION_KEY
-    assert kwargs["event_message_id"] == INBOUND_ID
+    assert kwargs["session_key"] == TOPIC_SESSION_KEY
+    assert kwargs["inbound_message_id"] == INBOUND_ID
+    assert kwargs["event_message_id"] is None
     assert kwargs["text_already_delivered"] is False

--- a/tests/gateway/test_queued_final_ledger.py
+++ b/tests/gateway/test_queued_final_ledger.py
@@ -336,3 +336,112 @@ async def test_a_chained_queued_turn_carries_its_own_inbound_id():
     runner._run_agent.assert_awaited_once()
     assert runner._run_agent.await_args.kwargs["inbound_message_id"] == "6002"
     assert runner._run_agent.await_args.kwargs["event_message_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# A chain's terminal reply must not overwrite an earlier turn's row.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_the_terminal_turn_of_a_chain_is_ledgered_under_its_own_inbound_id():
+    """Two turns of one queued chain answering with the SAME text must keep two ledger rows.
+
+    The outer final send is bracketed by the adapter against the event that OPENED the chain. Keyed
+    on that event's id, a terminal reply carrying the same text as an earlier refused reply computes
+    the earlier row's obligation id, replaces its outstanding row and marks it delivered, so the
+    refused reply is never redelivered. ``MessageEvent.ledger_message_id`` carries the terminal
+    turn's own inbound id so the rows stay distinct. ``_send_with_retry`` is stubbed here because
+    the retry ladder is covered elsewhere and this pins the ledger identity only.
+    """
+    from gateway.platforms.base import MessageEvent
+
+    same_text = "Done."
+    adapter = _telegram_adapter()
+    # Turn A (inbound 101): its queued final is refused by flood control and stays outstanding.
+    adapter._send_with_retry = AsyncMock(
+        return_value=SendResult(success=False, error="flood_control:30.0"))
+    await _deliver(adapter, text=same_text, anchor="101", inbound_id="101")
+
+    first = _rows()
+    assert len(first) == 1
+    assert first[0]["state"] == "failed"
+    turn_a_id = first[0]["obligation_id"]
+
+    # Turn B is the chain's TERMINAL turn (inbound 102). The adapter still holds turn A's event, so
+    # only the ledger override distinguishes the row.
+    adapter._send_with_retry = AsyncMock(return_value=SendResult(success=True, message_id="901"))
+    event = MessageEvent(text="hi again", source=_source(), message_id="101",
+                         ledger_message_id="102")
+    await adapter._send_final_text(event, SESSION_KEY, same_text, {}, False, 0, lambda _r: None)
+
+    rows = {r["obligation_id"]: r for r in _rows()}
+    assert len(rows) == 2, "the terminal reply reused the earlier turn's obligation id"
+    assert rows[turn_a_id]["state"] == "failed", \
+        "turn A's refused reply was overwritten and would never be redelivered"
+    assert rows[dl.compute_obligation_id(SESSION_KEY, "102", same_text)]["state"] == "delivered"
+
+
+@pytest.mark.asyncio
+async def test_an_unchained_turn_still_keys_on_its_own_event_id():
+    """No override means no behaviour change: the event's own id keys the row, as before."""
+    from gateway.platforms.base import MessageEvent
+
+    adapter = _telegram_adapter()
+    adapter._send_with_retry = AsyncMock(return_value=SendResult(success=True, message_id="902"))
+    event = MessageEvent(text="hi", source=_source(), message_id=INBOUND_ID)
+
+    assert event.ledger_message_id is None
+    await adapter._send_final_text(event, SESSION_KEY, TEXT, {}, False, 0, lambda _r: None)
+
+    assert _rows()[0]["obligation_id"] == dl.compute_obligation_id(SESSION_KEY, INBOUND_ID, TEXT)
+
+
+def _chain_runner_and_ctx(followup_return):
+    """A runner whose recursive ``_run_agent`` returns ``followup_return``, plus a topic turn."""
+    from gateway.run import GatewayRunner
+
+    runner = _runner()
+    runner._MAX_INTERRUPT_DEPTH = 8
+    runner._run_agent = AsyncMock(return_value=followup_return)
+    runner._run_agent_deliver_first_response = AsyncMock()
+    runner._is_goal_continuation_event = MagicMock(return_value=False)
+    runner._session_key_for_source = MagicMock(return_value=TOPIC_SESSION_KEY)
+    runner._prepare_profile_scoped_inbound_message_text = AsyncMock(return_value="the follow-up")
+    runner._reply_anchor_for_event = MagicMock(return_value=None)
+    runner._adapter_for_source = MagicMock(return_value=None)
+    runner._refresh_agent_cache_message_count = AsyncMock()
+    topic = _source(chat_id="-1001", thread_id="7", chat_type="supergroup")
+    turn_ctx = SimpleNamespace(
+        source=topic, session_id="sid", session_key=TOPIC_SESSION_KEY, run_generation=1,
+        _interrupt_depth=0, history=[], _status_thread_metadata={"thread_id": "7"},
+        context_prompt=None, result_holder=[None])
+    pending_event = SimpleNamespace(
+        source=topic, message_id="6002", channel_prompt=None, message_type=None)
+    return GatewayRunner, runner, turn_ctx, pending_event
+
+
+@pytest.mark.asyncio
+async def test_the_chain_returns_the_terminal_inbound_id_to_the_outer_bracket():
+    """The outer handler needs the terminal turn's id to ledger the final send under it."""
+    GatewayRunner, runner, turn_ctx, pending_event = _chain_runner_and_ctx(
+        {"final_response": "done", "messages": []})
+
+    merged = await GatewayRunner._run_agent_queued_followup(
+        runner, turn_ctx, adapter=None, pending="hi again", pending_event=pending_event,
+        response="resp", result={"interrupted": True, "messages": []}, stream_task=None)
+
+    assert merged["queued_terminal_inbound_id"] == "6002"
+
+
+@pytest.mark.asyncio
+async def test_a_deeper_chain_keeps_the_innermost_inbound_id():
+    """Chained follow-ups nest, and the LAST message answered owns the ledger identity, so an id
+    already set by a deeper recursion must not be overwritten on the way out."""
+    GatewayRunner, runner, turn_ctx, pending_event = _chain_runner_and_ctx(
+        {"final_response": "done", "messages": [], "queued_terminal_inbound_id": "6003"})
+
+    merged = await GatewayRunner._run_agent_queued_followup(
+        runner, turn_ctx, adapter=None, pending="hi again", pending_event=pending_event,
+        response="resp", result={"interrupted": True, "messages": []}, stream_task=None)
+
+    assert merged["queued_terminal_inbound_id"] == "6003"

--- a/tests/gateway/test_queued_native_image_session_key.py
+++ b/tests/gateway/test_queued_native_image_session_key.py
@@ -56,7 +56,9 @@ class CaptureQueuedNativeImageAgent:
         self.tools = []
         self.tool_progress_callback = kwargs.get("tool_progress_callback")
 
-    def run_conversation(self, message, conversation_history=None, task_id=None):
+    def run_conversation(self, message, conversation_history=None, task_id=None, **kwargs):
+        # The real AIAgent.run_conversation accepts the persist_* kwargs the gateway adds for a
+        # message with a raw inbound id (queued follow-ups now carry theirs); tolerate them.
         type(self).calls.append(message)
         return {
             "final_response": f"done-{len(type(self).calls)}",


### PR DESCRIPTION
## What does this PR do?

When a follow-up is queued behind a turn (a message the user typed while the agent was working, or a subagent batch reporting back), `_run_agent_deliver_first_response` delivers the first response through `_deliver_queued_first_response` before the follow-up runs. That lane called `adapter.send` bare and discarded the result. No delivery-ledger obligation was recorded, so a final refused there was lost for good: the boot sweep and the runtime redelivery only see ledger rows, and the follow-up ran as if the answer had landed.

This is not theoretical. On 5 Sep 2026 a Telegram gateway lost two long replies within an hour, both refused by flood control (`flood_control:200` and `flood_control:210`) at the exact moment a delegation batch arrived as a queued follow-up. The normal lane would have recorded them and the ledger would have redelivered them; the queued lane dropped them silently. The only trace was `Queued follow-up for session ...: final stream delivery not confirmed; sending first response before continuing.` followed by the adapter's flood warning.

The obligation is keyed on the raw inbound message id, as the normal lane keys it, carried both into the first queued delivery and into any chained (recursive) queued turn, so two follow-ups in one Telegram forum topic (where there is no reply anchor) that answer with the same text get distinct ledger rows instead of colliding.

The fix runs the queued lane's text send under the same delivery-ledger bracket as the normal final send, using the adapter's own methods in the same order (`_record_delivery_obligation`, `_send_with_retry`, `_finalize_delivery_obligation`):

- the obligation is recorded before the send, keyed on the raw inbound message id exactly as the normal lane keys it (session key, inbound id, text). The reply anchor is deliberately not used for identity: it is None wherever replies are not used (Telegram forum topics, Slack reaction handoffs), so two turns in one topic answering with the same text would otherwise share an obligation id and the second `INSERT OR REPLACE` would overwrite the first's outstanding row;
- the result finalizes the row (`delivered`, or `failed` with the adapter's error), so the existing sweeps can redeliver it after a restart or reconnect, and the flood-aware runtime retry of #103669 can pick it up too;
- the send carries the turn's reply anchor and a notify-marked copy of the thread metadata, like every other user-visible final;
- a failed send is logged at WARNING instead of vanishing.

Unchanged: the reconcile-by-edit path (a stream-sealed message is still edited in place, with no ledger row; that path is not touched here), adapters without the base contract (relay doubles, third-party plugins keep the plain send), and sends without a session key.

## Related Issue

No issue filed; the diagnosis is in the description above (gateway log, 5 Sep 2026, 08:01 and 08:58 UTC).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run_notifications.py`: `_deliver_queued_first_response` takes optional `session_key` and `inbound_message_id`; the bare `adapter.send` is replaced by the new `_send_queued_final_text`, which records the obligation under the raw inbound id, sends through the delivery adapter's `_send_with_retry` with the reply anchor and a notify-marked copy of the thread metadata, finalizes from the result, falls back to the plain send when the adapter lacks the base contract or no session key is available, and logs a failed result.
- `gateway/run_turn.py`: `_run_agent_deliver_first_response` passes the turn's session key and raw inbound message id to the queued lane, alongside the reply anchor it already passed.
- `tests/gateway/test_queued_final_ledger.py` (new, 13 tests): the row is recorded and marked delivered; the row is already `attempting` while the transport send is in flight; the obligation id matches the normal lane; two forum-topic turns with the same text and no reply anchor get distinct rows and unanchored sends; a flood refusal and any other refusal leave a `failed` row and a warning; the send is reply-anchored and notify-marked without mutating the caller's metadata; reconcile-by-edit records nothing; a failed reconcile edit falls through to the bracketed send; plain adapters and key-less sends keep the bare send; the call site hands the session key and inbound id over. Each guard was checked by mutation (disabling the record, moving it after the send, keying on the anchor, dropping the notify mark, dropping the key or the inbound id at the call site, dropping the warning each fail at least one test).

## How to Test

1. `pytest tests/gateway/test_queued_final_ledger.py tests/gateway/test_stream_final_contract.py tests/gateway/test_tts_media_routing.py -q` (31 passed). The last two are the existing queued-lane tests; their relay-style adapter doubles keep the plain send.
2. `pytest tests/gateway -q` on this branch reports the same result as a clean checkout of `main` in my environment (the API server, webhook, WhatsApp Cloud and Mattermost modules need optional dependencies or network and fail or fail to collect identically on both), so none of those come from this change. The scope actually verified by this PR is item 1.
3. Live reproduction on a Telegram gateway: ask a question that produces a long streamed answer while a background delegation is running, so its batch result arrives as a queued follow-up, and make the final send fail (rate limit, or temporarily block the bot API host). Before: the log shows `Queued follow-up ... sending first response before continuing` and the answer never arrives, with no ledger row. After: the row exists in `delivery_obligations` as `failed` with the adapter's error and is redelivered by the next sweep (or by the flood timer of #103669); `Queued-lane final send to <chat> failed: <error>` is logged at WARNING.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected gateway suites and all tests pass (see How to Test for the full-suite baseline)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (tests) and Ubuntu 22.04 (live Telegram gateway, the box the incident came from)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
