### PR TITLE
fix(provider): keep custom body fields in Desktop and auxiliary calls

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -260,9 +260,12 @@ def _custom_provider_extra_body_for_agent(
     *, provider: str, model: str, base_url: str, custom_providers: List[Dict[str, Any]]
 ) -> Optional[Dict[str, Any]]:
     provider_norm = (provider or "").strip().lower()
-    if provider_norm != "custom" and not provider_norm.startswith("custom:"):
-        return None
-    provider_key_filter = provider_norm.partition(":")[2].strip()
+    if provider_norm.startswith("custom:"):
+        provider_key_filter = provider_norm.partition(":")[2].strip()
+    elif provider_norm in {"", "auto", "custom"}:
+        provider_key_filter = ""
+    else:
+        provider_key_filter = provider_norm
     target_url = _normalized_custom_base_url(base_url)
     if not target_url:
         return None
@@ -282,7 +285,11 @@ def _custom_provider_extra_body_for_agent(
         extra_body = entry.get("extra_body")
         if not isinstance(extra_body, dict) or not extra_body:
             continue
-        if str(entry.get("model", "") or "").strip():
+        if not str(model or "").strip():
+            return dict(extra_body)
+        models = entry.get("models")
+        has_catalog = isinstance(models, (dict, list, tuple)) and bool(models)
+        if str(entry.get("model", "") or "").strip() or has_catalog:
             if _custom_provider_model_matches(model, entry):
                 return dict(extra_body)
         elif fallback is None:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5924,6 +5924,24 @@ def _merge_aux_extra_body(
     return merged_extra
 
 
+def _custom_provider_extra_body_for_aux(
+    provider: str, model: str, base_url: str,
+) -> Optional[Dict[str, Any]]:
+    """Resolve route-scoped provider body fields without carrying them across fallback routes."""
+    try:
+        from agent.agent_init import _custom_provider_extra_body_for_agent
+        from hermes_cli.config import get_compatible_custom_providers, load_config_readonly
+
+        config = load_config_readonly()
+        return _custom_provider_extra_body_for_agent(
+            provider=provider, model=model, base_url=base_url,
+            custom_providers=get_compatible_custom_providers(config),
+        )
+    except Exception:
+        logger.debug("aux custom-provider extra_body resolution failed", exc_info=True)
+        return None
+
+
 def _build_call_kwargs(
     provider: str, model: str, messages: list, temperature: Optional[float] = None,
     max_tokens: Optional[int] = None, tools: Optional[list] = None, timeout: float = 30.0,
@@ -5949,6 +5967,11 @@ def _build_call_kwargs(
         kwargs.update(auxiliary_max_tokens_param(max_tokens, model=model))  # picks max_completion_tokens where needed
     if tools:
         kwargs["tools"] = _dedupe_tool_names(tools, provider, model)
+    if inherited_extra := _custom_provider_extra_body_for_aux(
+        provider, model, effective_base,
+    ):
+        inherited_extra.update(extra_body or {})
+        extra_body = inherited_extra
     # Provider profiles are the source of truth for reasoning wire shapes (top-level, nested body,
     # or extra_body.reasoning); providers without a reasoning-aware profile keep the generic
     # ``extra_body.reasoning`` fallback.

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2510,6 +2510,34 @@ class TestAuxiliaryTaskExtraBody:
         kwargs = client.chat.completions.create.call_args.kwargs
         assert kwargs["extra_body"]["enable_thinking"] is True
 
+    def test_sync_call_inherits_matching_provider_extra_body(self):
+        client = MagicMock()
+        client.base_url = "https://proxy.example/v1"
+        response = MagicMock()
+        client.chat.completions.create.return_value = response
+        config = {
+            "auxiliary": {"approval": {"extra_body": {"shared": "task"}}},
+            "custom_providers": [{
+                "name": "proxy", "base_url": "https://proxy.example/v1",
+                "model": "proxy-model",
+                "extra_body": {"user": "proxy-user", "shared": "provider"},
+            }],
+        }
+
+        with patch("hermes_cli.config.load_config", return_value=config), \
+             patch("hermes_cli.config.load_config_readonly", return_value=config), \
+             patch("agent.auxiliary_client._get_cached_client", return_value=(client, "proxy-model")):
+            result = call_llm(
+                task="approval", provider="custom:proxy", model="proxy-model",
+                base_url="https://proxy.example/v1", api_key="test-key",
+                messages=[{"role": "user", "content": "approve?"}],
+            )
+
+        assert result is response
+        assert client.chat.completions.create.call_args.kwargs["extra_body"] == {
+            "user": "proxy-user", "shared": "task",
+        }
+
 
 
 

--- a/tests/agent/test_custom_provider_extra_body_matching.py
+++ b/tests/agent/test_custom_provider_extra_body_matching.py
@@ -53,7 +53,7 @@ class TestExtraBodyResolution:
         assert got == {"service_tier": "flex"}
 
     def test_non_catalog_model_gets_no_override(self):
-        entry = _entry(model="gpt-5.5", models={"gpt-5.5": {}})
+        entry = _entry(models={"gpt-5.5": {}})
         got = _custom_provider_extra_body_for_agent(
             provider="custom", model="gpt-4o",
             base_url=BASE, custom_providers=[entry],
@@ -67,3 +67,17 @@ class TestExtraBodyResolution:
             base_url=BASE, custom_providers=[entry],
         )
         assert got is None
+
+    def test_unresolved_provider_and_model_match_by_url(self):
+        got = _custom_provider_extra_body_for_agent(
+            provider="", model="", base_url=BASE,
+            custom_providers=[_entry(model="gpt-5.6-terra")],
+        )
+        assert got == {"service_tier": "flex"}
+
+    def test_unprefixed_provider_name_matches_entry_identity(self):
+        got = _custom_provider_extra_body_for_agent(
+            provider="openai", model="gpt-5.6-terra", base_url=BASE,
+            custom_providers=[_entry(model="gpt-5.6-terra")],
+        )
+        assert got == {"service_tier": "flex"}

--- a/tests/tui_gateway/test_custom_provider_session_persistence.py
+++ b/tests/tui_gateway/test_custom_provider_session_persistence.py
@@ -171,6 +171,22 @@ class TestResumeRoundTrip:
         assert kwargs["base_url"] == MIMO_URL
         assert kwargs["api_key"] == MIMO_KEY
 
+    def test_make_agent_forwards_runtime_request_overrides(self, monkeypatch):
+        config = {
+            "model": {"default": "mimo-v2.5-pro", "provider": "custom:mimo-v2.5-pro"},
+            "custom_providers": [{
+                **LEGACY_LIST_CONFIG["custom_providers"][0],
+                "model": "mimo-v2.5-pro",
+                "extra_body": {"user": "proxy-user"},
+            }],
+        }
+
+        kwargs = _make_agent_with_override(
+            "mimo-v2.5-pro", monkeypatch, config, model_cfg=config["model"]
+        )
+
+        assert kwargs["request_overrides"] == {"extra_body": {"user": "proxy-user"}}
+
 
 # --- Regression: bare "custom" WITHOUT a base_url (GH #44022 / #47714) ------
 #

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2296,6 +2296,7 @@ def _make_agent(
         checkpoints_enabled=is_truthy_value(os.environ.get("HERMES_TUI_CHECKPOINTS")),
         pass_session_id=is_truthy_value(os.environ.get("HERMES_TUI_PASS_SESSION_ID")),
         skip_context_files=ignore_rules, skip_memory=ignore_rules, fallback_model=_load_fallback_model(),
+        request_overrides=runtime.get("request_overrides"),
         **_agent_cbs(sid))
     if context_cwd_is_launch_artifact is None:
         with _sessions_lock:


### PR DESCRIPTION
## What does this PR do?

Custom OpenAI-compatible providers can require fields in `extra_body`, but Desktop/TUI agent construction and auxiliary LLM calls dropped those fields while the CLI preserved them. This change forwards resolved request overrides into Desktop/TUI agents and derives provider-level body fields for each auxiliary destination without leaking them across unrelated provider routes.

### Symptom

A custom provider that requires a JSON body field such as `user` works through `hermes chat`, while the same profile can receive HTTP 400 responses through Desktop/TUI or smart approval because the field is absent.

### Impact

Desktop/TUI users and auxiliary tasks cannot use otherwise valid custom providers whose proxies require provider-level request body fields.

### Bug Cause

**Trigger:** `tui_gateway/server.py:2259` / `_make_agent`, `agent/agent_init.py:259` / `_custom_provider_extra_body_for_agent`, and `agent/auxiliary_client.py:5927` / `_build_call_kwargs`

**Causal chain:**
1. Runtime provider resolution returns custom-provider `request_overrides` containing `extra_body`.
2. Desktop/TUI does not pass those overrides to `AIAgent`; unresolved or unprefixed provider identities also fail the init-time matcher, and auxiliary request assembly never consults provider-level fields.
3. The OpenAI-compatible endpoint receives a request without its required field and rejects it.

**Why it is wrong:** The same resolved provider configuration produces different request bodies depending on the entry surface and side-call path.

**Working sibling / contrast:** CLI and cron already pass `runtime["request_overrides"]` into `AIAgent`.

**Ruled out:** The OpenAI SDK is not stripping the field; the working CLI path sends it when `extra_body` reaches request construction.

### Fix

- Forward resolved `request_overrides` when Desktop/TUI constructs `AIAgent`.
- Match custom-provider fields by normalized endpoint plus provider identity, while allowing URL-only matching for unresolved, `auto`, and bare `custom` routes and retaining model catalog isolation when a model is known.
- Resolve inherited fields inside per-destination auxiliary kwargs construction so task/caller values win and fallback providers cannot inherit fields from the source route.

## Related Issue

Closes #103738

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` - forwards runtime request overrides to Desktop/TUI agents.
- `agent/agent_init.py` - safely matches provider-level body fields for unresolved and named routes.
- `agent/auxiliary_client.py` - inherits matching body fields per auxiliary destination.
- `tests/agent/` and `tests/tui_gateway/` - cover matching, forwarding, precedence, and auxiliary propagation.

## How to Test

1. Configure a custom OpenAI-compatible provider with a required `extra_body.user` field.
2. Send a Desktop/TUI message and trigger an auxiliary approval request; both requests should include the field.
3. Run the focused automated suites:

```bash
scripts/run_tests.sh tests/agent/test_custom_provider_extra_body_matching.py tests/tui_gateway/test_custom_provider_session_persistence.py tests/agent/test_auxiliary_client.py
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repo test entry on relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update is N/A
- [x] `cli-config.yaml.example` update is N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no workflow changed
- [x] I've considered cross-platform impact; the request routing behavior is platform-independent
- [x] Tool descriptions and schemas are N/A because no tool contract changed
