### PR TITLE
fix: make clarify reply claims atomic

### DIFF
--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -353,11 +353,9 @@ class GatewayInboundMixin:
             # Selection-shaped but invalid (out-of-range number, bad comma-list): keep the clarify
             # armed for retry — don't cancel, don't treat as an unrelated follow-up.
             return _retain("invalid selection attempt")
-        if _text_outcome == _clarify_mod.TEXT_REJECTED_PROSE:
-            # Native-choice prompts reject unmatched prose so it continues through normal busy
-            # routing. Release this clarify first: redirect() degrades to steer() while tools
-            # execute, and that steer cannot drain until the clarify tool returns.
-            _clarify_mod.resolve_gateway_clarify(_pending_clarify.clarify_id, "")
+        # TEXT_REJECTED_PROSE falls through normal busy routing. The atomic
+        # text attempt already released the exact entry it classified; this
+        # precheck snapshot may be stale after a rapid reply.
         return None
 
     # Reply → choice for a pending slash-confirm prompt; the command spelling wins over the

--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -52,6 +52,51 @@ class TestClarifyPrimitive:
         assert cm.resolve_gateway_clarify("id-race", "") is False
         assert entry.response == "A"
 
+    def test_resolved_head_is_skipped_before_waiter_cleanup(self):
+        from tools import clarify_gateway as cm
+
+        cm.register("answered", "same-session", "First?", ["A"])
+        next_entry = cm.register("next", "same-session", "Second?", ["B"])
+        assert cm.resolve_gateway_clarify("answered", "A")
+        assert cm.get_pending_for_session(
+            "same-session", include_choice_prompts=True
+        ) is next_entry
+        assert cm.has_pending("same-session")
+
+    def test_concurrent_text_replies_claim_distinct_fifo_entries(self, monkeypatch):
+        from tools import clarify_gateway as cm
+
+        first = cm.register("first", "same-session", "First?", ["A"])
+        second = cm.register("second", "same-session", "Second?", ["A"])
+        original = cm._coerce_text_response_detailed
+        first_inside = threading.Event()
+        release_first = threading.Event()
+        calls_lock = threading.Lock()
+        calls = 0
+
+        def controlled(*args, **kwargs):
+            nonlocal calls
+            with calls_lock:
+                calls += 1
+                current = calls
+            if current == 1:
+                first_inside.set()
+                assert release_first.wait(timeout=5)
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(cm, "_coerce_text_response_detailed", controlled)
+        with ThreadPoolExecutor(2) as pool:
+            one = pool.submit(cm.attempt_text_response_for_session, "same-session", "A")
+            assert first_inside.wait(timeout=5)
+            two = pool.submit(cm.attempt_text_response_for_session, "same-session", "A")
+            release_first.set()
+            assert [one.result(timeout=5), two.result(timeout=5)] == [
+                cm.TEXT_RESOLVED,
+                cm.TEXT_RESOLVED,
+            ]
+        assert first.response == "A"
+        assert second.response == "A"
+
     def test_open_ended_auto_awaits_text(self):
         """Clarify with no choices is in text-capture mode immediately."""
         from tools import clarify_gateway as cm
@@ -377,12 +422,82 @@ class TestNativeRejectClassification:
         value, reason = cm._coerce_text_response_detailed(entry, "1,99")
         assert value is None
         assert reason == "invalid_selection"
-        assert cm.attempt_text_response_for_session("sk-ms2", "nope,nope") == (
+        assert cm.attempt_text_response_for_session("sk-ms2", "1,99") == (
             cm.TEXT_REJECTED_SELECTION
         )
         pending = cm.get_pending_for_session("sk-ms2", include_choice_prompts=True)
         assert pending is not None
         assert not pending.event.is_set()
+
+    def test_exact_multi_select_label_may_contain_comma(self):
+        import json
+        from tools import clarify_gateway as cm
+
+        entry = cm.register(
+            "comma-label",
+            "comma-label-session",
+            "Pick",
+            ["Alpha, Beta", "Gamma"],
+            multi_select=True,
+        )
+        value, reason = cm._coerce_text_response_detailed(entry, "Alpha, Beta")
+        assert reason is None
+        assert value is not None
+        assert json.loads(value) == ["Alpha, Beta"]
+
+    def test_evidence_based_comma_and_numeric_edge_contract(self):
+        from tools import clarify_gateway as cm
+
+        malformed = ("1,", ",1", "1,,2", "1,99", "²", "9" * 5000)
+        for index, response in enumerate(malformed):
+            session = f"malformed-{index}"
+            entry = cm.register(
+                f"malformed-{index}", session, "Pick", ["A", "B"], multi_select=True
+            )
+            assert cm.attempt_text_response_for_session(session, response) == (
+                cm.TEXT_REJECTED_SELECTION
+            )
+            assert not entry.event.is_set()
+
+        prose = ("nope,nope", "hello, world", "thanks,", "Привет, мир", "   ,   ")
+        for index, response in enumerate(prose):
+            session = f"prose-{index}"
+            entry = cm.register(
+                f"prose-{index}", session, "Where?",
+                ["Send to SOL", "Keep with Enoch"], multi_select=True,
+            )
+            assert cm.attempt_text_response_for_session(session, response) == (
+                cm.TEXT_REJECTED_PROSE
+            )
+            assert entry.event.is_set()
+            assert entry.response == ""
+
+    def test_single_select_numeric_like_edges_remain_armed(self):
+        from tools import clarify_gateway as cm
+
+        for index, response in enumerate(("²", "9" * 5000)):
+            session = f"single-malformed-{index}"
+            entry = cm.register(
+                f"single-malformed-{index}", session, "Pick", ["A", "B"]
+            )
+            assert cm.attempt_text_response_for_session(session, response) == (
+                cm.TEXT_REJECTED_SELECTION
+            )
+            assert not entry.event.is_set()
+
+    def test_rejected_prose_cancels_exact_selected_entry(self):
+        from tools import clarify_gateway as cm
+
+        stale = cm.register("stale", "same-session", "Old?", ["A"])
+        current = cm.register("current", "same-session", "Current?", ["B"])
+        assert cm.resolve_gateway_clarify(stale.clarify_id, "A")
+        assert cm.attempt_text_response_for_session(
+            "same-session", "unrelated follow-up prose"
+        ) == cm.TEXT_REJECTED_PROSE
+        assert stale.response == "A"
+        assert current.event.is_set()
+        assert current.response == ""
+        assert not cm.has_pending("same-session")
 
     def test_multi_select_free_prose_is_rejected_prose(self):
         from tools import clarify_gateway as cm

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -98,16 +98,27 @@ def resolve_gateway_clarify(clarify_id: str, response: str) -> bool:
         return True
 
 
+def _get_pending_for_session_locked(
+    session_key: str, *, include_choice_prompts: bool = False
+) -> Optional[_ClarifyEntry]:
+    """Oldest unresolved matching entry; caller holds ``_lock``."""
+    for cid in _session_index.get(session_key) or []:
+        entry = _entries.get(cid)
+        if entry is not None and not entry.event.is_set() and (
+            include_choice_prompts or entry.awaiting_text
+        ):
+            return entry
+    return None
+
+
 def get_pending_for_session(session_key: str, *, include_choice_prompts: bool = False) -> Optional[_ClarifyEntry]:
     """Oldest pending entry awaiting free text (open-ended, or after "Other");
     ``include_choice_prompts=True`` returns the oldest unresolved entry of any kind (user
     typed at an active choice prompt: resolve it rather than queue a follow-up turn)."""
     with _lock:
-        for cid in _session_index.get(session_key) or []:
-            entry = _entries.get(cid)
-            if entry is not None and (include_choice_prompts or entry.awaiting_text):
-                return entry
-        return None
+        return _get_pending_for_session_locked(
+            session_key, include_choice_prompts=include_choice_prompts
+        )
 
 
 def _match_label(text: str, choices: List[str]) -> Optional[str]:
@@ -124,7 +135,7 @@ def _match_label(text: str, choices: List[str]) -> Optional[str]:
 def _split_tokens(text: str) -> Optional[List[str]]:
     """Comma-separated tokens, or space-separated all-numeric tokens ("1 3"); else None."""
     if "," in text:
-        return [t.strip() for t in text.split(",") if t.strip()]
+        return [t.strip() for t in text.split(",")]
     parts = text.split()
     return parts if len(parts) > 1 and all(p.isdigit() for p in parts) else None
 
@@ -137,21 +148,30 @@ def _is_int(text: str) -> bool:
         return False
 
 
+def _looks_int(text: str) -> bool:
+    """True for parseable integers and digit-like inputs that ``int`` rejects."""
+    stripped = text[1:] if text.startswith("-") else text
+    return bool(stripped) and (stripped.isdigit() or _is_int(text))
+
+
 def _selection_attempt_tokens(text: str, choices: Optional[List[str]] = None) -> Optional[List[str]]:
-    """Tokens when ``text`` looks like a typed selection (bare int, comma list,
-    all-numeric space list); None for free prose so the gateway can release the
-    clarify. Comma-list labels may span up to the longest choice's word count."""
+    """Selection tokens when numeric or exact-label evidence exists; else None."""
     stripped = str(text).strip()
     if not stripped:
         return None
     tokens = _split_tokens(stripped)
     if tokens is None:
-        digits = stripped[1:] if stripped.startswith("-") else stripped
-        return [stripped] if digits.isdigit() or _is_int(stripped) else None
-    if "," not in stripped or not tokens:
+        return [stripped] if _looks_int(stripped) else None
+    if "," not in stripped:
         return tokens or None
-    max_words = max(1, max((len(str(c).split()) for c in choices or []), default=1))
-    return tokens if all(t.isdigit() or len(t.split()) <= max_words for t in tokens) else None
+    nonempty = [token for token in tokens if token]
+    if not nonempty:
+        return None
+    evidence = any(
+        _looks_int(token) or _match_label(token, choices or []) is not None
+        for token in nonempty
+    )
+    return tokens if evidence else None
 
 
 def _coerce_text_response(entry: _ClarifyEntry, response: str) -> Optional[str]:
@@ -173,9 +193,11 @@ def _coerce_text_response_detailed(entry: _ClarifyEntry, response: str) -> tuple
         coerced = _coerce_multi_select_text(entry, text)
         selection_shaped = _selection_attempt_tokens(text, entry.choices) is not None
     else:
-        # Out-of-range / non-canonical integer is a failed selection, not prose.
-        selection_shaped = _is_int(text)
-        idx = int(text) - 1 if selection_shaped else -1
+        selection_shaped = _looks_int(text)
+        try:
+            idx = int(text) - 1
+        except ValueError:
+            idx = -1
         coerced = entry.choices[idx] if 0 <= idx < len(entry.choices) else _match_label(text, entry.choices)
     if coerced is not None:
         return coerced, None
@@ -190,10 +212,18 @@ def _coerce_multi_select_text(entry: _ClarifyEntry, text: str) -> Optional[str]:
     choices, selected = entry.choices or [], []
     if not text:
         return None
+    whole_label = _match_label(text, choices)
+    if whole_label is not None:
+        return json.dumps([whole_label], ensure_ascii=False)
     tokens = _split_tokens(text)
     for token in [text] if tokens is None else tokens:
-        if token.isdigit():
-            idx = int(token) - 1
+        if not token:
+            return None
+        if _looks_int(token):
+            try:
+                idx = int(token) - 1
+            except ValueError:
+                return None
             label = str(choices[idx]).strip() if 0 <= idx < len(choices) else None
         else:
             label = _match_label(token, choices)
@@ -205,16 +235,22 @@ def _coerce_multi_select_text(entry: _ClarifyEntry, text: str) -> Optional[str]:
 
 
 def attempt_text_response_for_session(session_key: str, response: str) -> str:
-    """Try to resolve the oldest pending clarify from typed text; returns a TEXT_* outcome."""
-    entry = get_pending_for_session(session_key, include_choice_prompts=True)
-    if entry is None:
-        return TEXT_NO_PENDING
-    coerced, reason = _coerce_text_response_detailed(entry, response)
-    if coerced is None:
-        return TEXT_REJECTED_SELECTION if reason == "invalid_selection" else TEXT_REJECTED_PROSE
-    if resolve_gateway_clarify(entry.clarify_id, coerced):
-        return TEXT_RESOLVED
-    return TEXT_NO_PENDING  # lost a race with a button/callback resolution — no work left
+    """Atomically classify and resolve the oldest pending clarify from typed text."""
+    with _lock:
+        entry = _get_pending_for_session_locked(session_key, include_choice_prompts=True)
+        if entry is None:
+            return TEXT_NO_PENDING
+        coerced, reason = _coerce_text_response_detailed(entry, response)
+        if coerced is None:
+            if reason == "invalid_selection":
+                return TEXT_REJECTED_SELECTION
+            resolve_gateway_clarify(entry.clarify_id, "")
+            return TEXT_REJECTED_PROSE
+        return (
+            TEXT_RESOLVED
+            if resolve_gateway_clarify(entry.clarify_id, coerced)
+            else TEXT_NO_PENDING
+        )
 
 
 def resolve_text_response_for_session(session_key: str, response: str) -> bool:
@@ -232,9 +268,13 @@ def mark_awaiting_text(clarify_id: str) -> bool:
 
 
 def has_pending(session_key: str) -> bool:
-    """True when this session has at least one pending clarify entry."""
+    """True when this session has at least one unresolved clarify entry."""
     with _lock:
-        return any(_entries.get(cid) is not None for cid in _session_index.get(session_key) or [])
+        return any(
+            entry is not None and not entry.event.is_set()
+            for cid in _session_index.get(session_key) or []
+            if (entry := _entries.get(cid)) is not None
+        )
 
 
 def clear_session(session_key: str) -> int:


### PR DESCRIPTION
## Summary

- make typed clarify reply selection, classification, and resolution one atomic FIFO claim
- skip already-resolved entries before waiter cleanup and cancel the exact prose-classified entry
- harden single/multi-select parsing for Unicode and oversized numbers, malformed comma segments, comma-containing labels, and ordinary comma prose
- remove stale gateway-side cancellation based on a precheck snapshot

## Tests

- `python -m pytest -q tests/tools/test_clarify_gateway.py tests/tools/test_clarify_tool.py tests/gateway/test_telegram_clarify_buttons.py tests/gateway/test_slack_clarify_buttons.py tests/gateway/test_discord_clarify_buttons.py tests/gateway/test_clarify_active_session_bypass.py tests/gateway/test_clarify_thread_followup_not_swallowed.py tests/gateway/test_clarify_send_timeout_ambiguity.py tests/gateway/test_clarify_progress_leak.py -o 'addopts='` (118 passed)
- affected suite repeated 10 times before final exact-label regression
- Ruff, `py_compile`, and `git diff --check`
- independent bounded concurrency and parser reviews
