### PR TITLE
fix(mcp): keep idle stdio servers connected

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1449,10 +1449,12 @@ platform_toolsets:
 # Optional per-server settings:
 #   timeout: tool call timeout in seconds (default: 120)
 #   connect_timeout: initial connection timeout (default: 60)
-#   keepalive_interval: liveness ping cadence in seconds (default: 180).
-#     Lower it below the server's session TTL for servers that expire idle
-#     sessions quickly (e.g. Unreal Engine editor MCP, ~15s), otherwise idle
-#     tool calls hit an expired session and pay a slow reconnect. Floored at 5s.
+#   keepalive_interval: liveness ping cadence in seconds (floored at 5s).
+#     HTTP servers default to 180s; lower it below the server's session TTL for
+#     servers that expire idle sessions quickly (e.g. Unreal Engine editor MCP,
+#     ~15s), otherwise idle tool calls hit an expired session and pay a slow
+#     reconnect. Stdio servers disable keepalive by default; set this explicitly
+#     to opt a stdio server in.
 #
 # mcp_servers:
 #   time:

--- a/tests/tools/test_mcp_capability_gating.py
+++ b/tests/tools/test_mcp_capability_gating.py
@@ -110,6 +110,7 @@ class TestKeepaliveProbe:
 
     async def test_keepalive_uses_ping_for_prompt_only_server(self):
         task = MCPServerTask("test")
+        task._config = {"url": "https://example.test/mcp"}
         task.initialize_result = _caps(prompts=SimpleNamespace())
         task.session = SimpleNamespace(
             list_tools=AsyncMock(),
@@ -126,6 +127,7 @@ class TestKeepaliveProbe:
     async def test_keepalive_uses_ping_legacy_fallback(self):
         """No captured capabilities → still pings (no spurious list_tools)."""
         task = MCPServerTask("test")
+        task._config = {"url": "https://example.test/mcp"}
         assert task.initialize_result is None
         task.session = SimpleNamespace(
             list_tools=AsyncMock(),
@@ -148,7 +150,7 @@ class TestKeepaliveInterval:
     async def _captured_interval(self, config):
         """Run one keepalive cycle and capture the ``asyncio.wait`` timeout."""
         task = MCPServerTask("test")
-        task._config = config
+        task._config = {"url": "https://example.test/mcp", **config}
         task.session = SimpleNamespace(send_ping=AsyncMock())
         captured = {}
         real_wait = asyncio.wait
@@ -183,6 +185,33 @@ class TestKeepaliveInterval:
             await self._captured_interval({"keepalive_interval": 0.1})
             == _MIN_KEEPALIVE_INTERVAL
         )
+
+    @pytest.mark.asyncio
+    async def test_default_stdio_connection_waits_without_keepalive(self):
+        """A healthy local pipe must not be probed solely because it is idle."""
+        task = MCPServerTask("test")
+        task._config = {"command": "example-mcp"}
+        task.session = SimpleNamespace(send_ping=AsyncMock())
+        captured = {}
+        real_wait = asyncio.wait
+
+        async def fake_wait(tasks, timeout=None, return_when=None):
+            captured["timeout"] = timeout
+            task._shutdown_event.set()
+            return await real_wait(
+                tasks, timeout=0.5, return_when=return_when or asyncio.FIRST_COMPLETED
+            )
+
+        import tools.mcp_tool as mcp_mod
+        orig = mcp_mod.asyncio.wait
+        mcp_mod.asyncio.wait = fake_wait
+        try:
+            assert await task._wait_for_lifecycle_event() == "shutdown"
+        finally:
+            mcp_mod.asyncio.wait = orig
+
+        assert captured["timeout"] is None
+        task.session.send_ping.assert_not_called()
 
 
 def _mcp_error(code, message="boom"):

--- a/tests/tools/test_mcp_capability_gating.py
+++ b/tests/tools/test_mcp_capability_gating.py
@@ -213,6 +213,31 @@ class TestKeepaliveInterval:
         assert captured["timeout"] is None
         task.session.send_ping.assert_not_called()
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("limit_attr", "start_attr", "reason"),
+        [
+            ("_idle_timeout_seconds", "_last_tool_call_at", "idle_timeout_seconds"),
+            ("_max_lifetime_seconds", "_lifecycle_started_at", "max_lifetime_seconds"),
+        ],
+    )
+    async def test_stdio_recycle_wakes_after_active_rpc(self, limit_attr, start_attr, reason):
+        """Lock release must expose an elapsed recycle deadline without sending a ping."""
+        task = MCPServerTask("test")
+        task._config = {"command": "example-mcp"}
+        session = task.session = SimpleNamespace(send_ping=AsyncMock())
+        setattr(task, limit_attr, 0.01)
+        setattr(task, start_attr, task._lifecycle_started_at - 1.0)
+
+        async with task._rpc_lock:
+            lifecycle = asyncio.create_task(task._wait_for_lifecycle_event())
+            await asyncio.sleep(0)
+            assert not lifecycle.done()
+
+        assert await asyncio.wait_for(lifecycle, timeout=2.0) == "recycle"
+        assert task._recycled_reason == reason
+        session.send_ping.assert_not_called()
+
 
 def _mcp_error(code, message="boom"):
     """Build a real MCPError carrying a JSON-RPC error code.

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -240,8 +240,9 @@ _PARKED_RETRY_INTERVAL = 300
 # Bounded wait for a respawned stdio child when a call finds it dead (gateway restarts kill
 # every MCP child); bounded so a broken server still parks via run()'s rapid-drop budget.
 _STDIO_RESPAWN_WAIT_SEC = 15.0
-# The client MUST ping faster than the server's idle-session TTL (short-TTL servers need a
-# smaller configured ``keepalive_interval``); the floor stops a tiny interval busy-looping.
+# Remote clients MUST ping faster than the server's idle-session TTL (short-TTL servers need a
+# smaller configured ``keepalive_interval``); stdio only opts in explicitly because local pipes
+# have no remote session TTL. The floor stops a tiny interval busy-looping.
 _DEFAULT_KEEPALIVE_INTERVAL, _MIN_KEEPALIVE_INTERVAL = 180, 5
 # One bounded cancellation cycle at final shutdown so resistant tasks cannot hang exit.
 _MCP_LOOP_DRAIN_TIMEOUT = 3.0

--- a/tools/mcp_tool_server_run.py
+++ b/tools/mcp_tool_server_run.py
@@ -53,17 +53,20 @@ class MCPServerRunMixin:
     async def _wait_for_lifecycle_event(self) -> str:
         """Serve until a lifecycle event: ``"shutdown"`` (exits run), ``"reconnect"`` (session torn
         down, transport re-entered; event cleared first) or ``"recycle"`` (stdio idle/lifetime
-        limit; restarts lazily on next call). Shutdown wins a tie. A keepalive (``ping``,
-        list_tools fallback) runs every ``keepalive_interval`` (must stay below the server's
-        session TTL); a failure triggers a reconnect.
+        limit; restarts lazily on next call). Shutdown wins a tie. Remote transports run a
+        keepalive (``ping``, list_tools fallback) every ``keepalive_interval`` (which must stay
+        below the server's session TTL); stdio does so only when explicitly configured. A
+        keepalive failure triggers a reconnect.
 
         Periodically sends a lightweight keepalive (``ping``, with a ``list_tools`` fallback for servers
         that don't implement the optional ping utility — see :meth:`_keepalive_probe`) to prevent
         TCP/session state from going stale during idle periods (#17003).
         """
-        keepalive_interval = max(
-            _core._MIN_KEEPALIVE_INTERVAL,
-            float(self._config.get("keepalive_interval", _core._DEFAULT_KEEPALIVE_INTERVAL)))
+        keepalive_interval = None
+        if self._is_http() or "keepalive_interval" in self._config:
+            keepalive_interval = max(
+                _core._MIN_KEEPALIVE_INTERVAL,
+                float(self._config.get("keepalive_interval", _core._DEFAULT_KEEPALIVE_INTERVAL)))
         shutdown_task, reconnect_task = self._event_waiters()
         try:
             while True:
@@ -72,13 +75,16 @@ class MCPServerRunMixin:
                 timeout = keepalive_interval
                 recycle_deadline = self._next_stdio_recycle_deadline()
                 if recycle_deadline is not None:
-                    timeout = max(0.0, min(timeout, recycle_deadline - time.monotonic()))
+                    recycle_timeout = max(0.0, recycle_deadline - time.monotonic())
+                    timeout = recycle_timeout if timeout is None else min(timeout, recycle_timeout)
                 done, _pending = await asyncio.wait(
                     {shutdown_task, reconnect_task}, timeout=timeout, return_when=asyncio.FIRST_COMPLETED)
                 if done:
                     break
                 if self._recycle_if_due():
                     return "recycle"
+                if keepalive_interval is None:
+                    continue
                 # Timeout: probe for a stale session — NEVER while an RPC is in flight (a
                 # concurrent ping can wedge the stdio stream; a busy server is alive anyway).
                 # Timeout — no lifecycle event fired. See #48069.

--- a/tools/mcp_tool_server_run.py
+++ b/tools/mcp_tool_server_run.py
@@ -50,6 +50,11 @@ class MCPServerRunMixin:
         self._mark_stdio_recycled(recycle_reason)
         return True
 
+    async def _wait_for_rpc_idle(self) -> None:
+        """Wake the lifecycle loop when the active RPC releases its lock."""
+        async with self._rpc_lock:
+            pass
+
     async def _wait_for_lifecycle_event(self) -> str:
         """Serve until a lifecycle event: ``"shutdown"`` (exits run), ``"reconnect"`` (session torn
         down, transport re-entered; event cleared first) or ``"recycle"`` (stdio idle/lifetime
@@ -68,6 +73,7 @@ class MCPServerRunMixin:
                 _core._MIN_KEEPALIVE_INTERVAL,
                 float(self._config.get("keepalive_interval", _core._DEFAULT_KEEPALIVE_INTERVAL)))
         shutdown_task, reconnect_task = self._event_waiters()
+        rpc_idle_task = None
         try:
             while True:
                 if self._recycle_if_due():
@@ -77,10 +83,23 @@ class MCPServerRunMixin:
                 if recycle_deadline is not None:
                     recycle_timeout = max(0.0, recycle_deadline - time.monotonic())
                     timeout = recycle_timeout if timeout is None else min(timeout, recycle_timeout)
+                elif (not self._is_http() and self._rpc_lock.locked()
+                      and (self._idle_timeout_seconds is not None
+                           or self._max_lifetime_seconds is not None)):
+                    # Recycle deadlines are intentionally hidden while an RPC is active. Without
+                    # a default stdio keepalive timeout, lock release must wake this loop so the
+                    # now-visible deadline is evaluated instead of waiting forever.
+                    rpc_idle_task = rpc_idle_task or asyncio.ensure_future(self._wait_for_rpc_idle())
+                waiters = {shutdown_task, reconnect_task}
+                if rpc_idle_task is not None:
+                    waiters.add(rpc_idle_task)
                 done, _pending = await asyncio.wait(
-                    {shutdown_task, reconnect_task}, timeout=timeout, return_when=asyncio.FIRST_COMPLETED)
-                if done:
+                    waiters, timeout=timeout, return_when=asyncio.FIRST_COMPLETED)
+                if shutdown_task in done or reconnect_task in done:
                     break
+                if rpc_idle_task in done:
+                    rpc_idle_task = None
+                    continue
                 if self._recycle_if_due():
                     return "recycle"
                 if keepalive_interval is None:
@@ -105,7 +124,10 @@ class MCPServerRunMixin:
                     # Clear the rapid-drop budget (#62212).
                     self._mark_session_proven()
         finally:
-            await self._cancel_waiters(shutdown_task, reconnect_task)
+            waiters = [shutdown_task, reconnect_task]
+            if rpc_idle_task is not None:
+                waiters.append(rpc_idle_task)
+            await self._cancel_waiters(*waiters)
         if self._shutdown_event.is_set():
             self._fail_inflight_calls("shutdown")
             return "shutdown"

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -60,7 +60,7 @@ mcp_servers:
 | `supports_parallel_tool_calls` | bool | both | Allow tools from this server to run concurrently |
 | `skip_preflight` | bool | HTTP | Bypass the fail-fast content-type probe for valid Streamable HTTP endpoints whose HEAD/GET answers a non-MCP content type (default: `false`) |
 | `transport` | string | HTTP | Set to `sse` to use the SSE transport instead of Streamable HTTP |
-| `keepalive_interval` | number | both | Liveness ping cadence in seconds (default: `180`, floored at 5s). Set below the server's session TTL for servers that GC idle sessions quickly |
+| `keepalive_interval` | number | both | Liveness ping cadence in seconds (floored at 5s). HTTP defaults to `180`; set it below the server's session TTL when the server GC's idle sessions quickly. Stdio disables keepalive when omitted; set a value to opt in explicitly |
 | `idle_timeout_seconds` | number | stdio | Optional stdio server recycle after idle time (`0` disables). May also live under a `lifecycle:` mapping |
 | `max_lifetime_seconds` | number | stdio | Optional stdio server recycle after age (`0` disables). May also live under a `lifecycle:` mapping |
 | `tools` | mapping | both | Filtering and utility-tool policy |


### PR DESCRIPTION
## What does this PR do?

Keeps healthy stdio MCP servers connected while they are idle. Hermes previously ran the HTTP session keepalive against every transport, so a slow or unsupported control request on a local stdio pipe could tear down a working server and eventually park it, removing its tools for the rest of the session.

### Symptom

A stdio MCP server connects and registers its tools successfully, then Hermes initiates an unsolicited reconnect after an idle interval. Repeated transport failures can park the server and make its tools unavailable.

### Impact

Affected stdio MCP tools can disappear from an otherwise healthy session after the initial connection succeeded.

### Bug Cause

**Trigger:** `tools/mcp_tool_server_run.py:53` / `_wait_for_lifecycle_event()` after the default keepalive interval elapses.

**Causal chain:**
1. A healthy stdio MCP server remains idle after startup.
2. The lifecycle loop applies the HTTP/SSE session-TTL keepalive to stdio too and sends `ping` or `tools/list` over the local pipe.
3. A failed control request triggers transport rebuilding; repeated failures park the server and deregister its tools.

**Why it is wrong:** Local stdio pipes do not have the remote session TTL that the keepalive was introduced to refresh, so initiating protocol traffic solely because the pipe is idle adds a failure path without preserving a session.

**Working sibling / contrast:** HTTP and SSE servers still receive the default keepalive because their remote sessions can expire. A stdio server can still opt in explicitly with `keepalive_interval` when its implementation requires it.

**Ruled out:** Initial connection failure and duplicate external server processes do not explain the transition because the reported server had already completed discovery and registered its tools. The original keepalive change was specifically introduced for short-TTL HTTP sessions, but its transport guard was missing.

### Fix

Default the keepalive timer only for HTTP/SSE transports. Stdio lifecycle waits now remain event-driven unless `keepalive_interval` is explicitly configured, while idle/lifetime recycling deadlines and real-failure parked self-probes remain unchanged.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool_server_run.py` - restrict default keepalive probes to remote transports while preserving explicit stdio opt-in and recycle deadlines.
- `tools/mcp_tool.py` - document the transport-specific default.
- `tests/tools/test_mcp_capability_gating.py` - verify default stdio waits do not probe and existing remote keepalive behavior remains intact.

## How to Test

1. Configure a stdio MCP server without `keepalive_interval`, connect, and leave the session idle beyond the default keepalive interval; no control probe or reconnect should occur.
2. Configure an HTTP MCP server or explicitly set `keepalive_interval` for stdio; keepalive probes should continue at the configured cadence.
3. Run:

```bash
scripts/run_tests.sh tests/tools/test_mcp_capability_gating.py tests/tools/test_mcp_failure_classification.py tests/tools/test_mcp_stability.py tests/tools/test_mcp_initial_connect_shutdown.py
scripts/run_tests.sh tests/tools/test_mcp_parked_self_probe.py tests/tools/test_mcp_reconnect_signal.py tests/tools/test_mcp_reconnect_retry_reset.py tests/tools/test_mcp_stdio_fastfail_reconnect.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - docstrings updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - automated lifecycle tests cover the transport-specific behavior.
