### PR TITLE
fix(process_registry): drop OOMPolicy=kill from systemd scope units

### DIFF
--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -126,12 +126,16 @@ def _worker_memory_max_bytes() -> int:
 
 def _systemd_scope_argv(binary: str, unit_name: str, *argv: str) -> List[str]:
     """``systemd-run --user --scope`` argv shared by the probe and real spawns.
-    ``--collect`` self-cleans the scope after exit; ``--unit`` names it for systemctl."""
+    ``--collect`` self-cleans the scope after exit; ``--unit`` names it for systemctl.
+    NOTE: OOMPolicy=kill is intentionally OMITTED — systemd <250 rejects it on scope
+    units ("Unknown assignment: OOMPolicy=kill"), which makes the availability probe
+    fail and kills restart-safe cron dispatch on Ubuntu 20.04 (systemd 245). MemoryMax
+    + MemoryAccounting still bound the worker cgroup; the kernel OOM killer applies.
+    """
     return [
         binary, "--user", "--scope", "--quiet", "--unit", unit_name, "--collect",
         "--property", "MemoryAccounting=yes",
         "--property", f"MemoryMax={_worker_memory_max_bytes()}",
-        "--property", "OOMPolicy=kill",
         "--", *argv,
     ]
 


### PR DESCRIPTION
## Problem
On Ubuntu 20.04 (systemd 245), cron jobs silently never run. The availability probe for restart-safe dispatch fails with:

```
Unknown assignment: OOMPolicy=kill
systemd-run --user --scope is unavailable
```

systemd <250 rejects `OOMPolicy=kill` on `--scope` units.

## Fix
Remove `OOMPolicy=kill` from `_systemd_scope_argv`. `MemoryMax` + `MemoryAccounting` still bound the worker cgroup, and the kernel OOM killer still applies — no memory-limit regression.

## Verification
- systemd 245 (Ubuntu 20.04): scope spawn + probe now succeed; cron jobs dispatch.
- Coverage: single code path shared by probe and real spawns.