### PR TITLE
fix(gateway): serialize respawn ledger updates

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import Any, Callable, NamedTuple, Optional
 
 from hermes_constants import _get_platform_default_hermes_home, get_hermes_home
-from utils import atomic_json_write
+from utils import atomic_json_write, atomic_write_text
 
 if sys.platform == "win32":
     import msvcrt
@@ -42,6 +42,7 @@ _GATEWAY_RUNNING_PID_CACHE_TTL_SECONDS = 1.0
 _gateway_running_pid_cache_lock = threading.Lock()
 # key: (pid_path, cleanup_stale, include_runtime_status) -> (cached_at, file signature, pid)
 _gateway_running_pid_cache: dict[tuple[str, bool, bool], tuple[float, tuple, Optional[int]]] = {}
+_gateway_starts_thread_lock = threading.Lock()
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +55,36 @@ class StormInfo(NamedTuple):
     backoff_s: float
 
 
+@contextlib.contextmanager
+def _gateway_starts_file_lock(path: Path):
+    """Serialize the start-ledger transaction across threads and processes."""
+    lock_path = path.with_name(".gateway-starts.lock")
+    handle = open(lock_path, "a+b")
+    windows = _IS_WINDOWS
+    try:
+        # Windows byte-range locks can reject a same-process contender instead
+        # of waiting, so serialize local threads before taking the OS lock.
+        with _gateway_starts_thread_lock:
+            if windows:
+                if os.fstat(handle.fileno()).st_size == 0:
+                    handle.write(b"\0")
+                    handle.flush()
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+            else:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                if windows:
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    finally:
+        handle.close()
+
+
 def record_start_and_check_storm(
     max_starts: int = 5, window_s: float = 120.0, *, backoff_cap_s: float = 300.0
 ) -> Optional[StormInfo]:
@@ -62,19 +93,18 @@ def record_start_and_check_storm(
     try:
         path = get_hermes_home() / "gateway-starts.log"
         path.parent.mkdir(parents=True, exist_ok=True)
-        now = datetime.now(timezone.utc).timestamp()
-        existing: list[float] = []
-        if path.exists():
-            for line in path.read_text(encoding="utf-8").splitlines():
-                with contextlib.suppress(ValueError):
-                    existing.append(float(line))
-        existing.append(now)
-        recent = [ts for ts in existing if now - ts <= window_s]
-        # Ring-buffer the persisted file so it stays bounded.
-        to_write = existing[-max(max_starts * 4, 40):]
-        tmp = path.with_suffix(".tmp")
-        tmp.write_text("\n".join(repr(ts) for ts in to_write) + "\n", encoding="utf-8")
-        os.replace(tmp, path)
+        with _gateway_starts_file_lock(path):
+            now = datetime.now(timezone.utc).timestamp()
+            existing: list[float] = []
+            if path.exists():
+                for line in path.read_text(encoding="utf-8").splitlines():
+                    with contextlib.suppress(ValueError):
+                        existing.append(float(line))
+            existing.append(now)
+            recent = [ts for ts in existing if now - ts <= window_s]
+            # Ring-buffer the persisted file so it stays bounded.
+            to_write = existing[-max(max_starts * 4, 40):]
+            atomic_write_text(path, "\n".join(repr(ts) for ts in to_write) + "\n")
         if len(recent) <= max_starts:
             return None
         backoff = min(backoff_cap_s, 5.0 * (2 ** min(len(recent) - max_starts, 6)))

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sys
+import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -1159,6 +1160,53 @@ class TestRespawnStormBreaker:
                 max_starts=5, window_s=120.0
             )
             assert result is None
+
+    def test_concurrent_starts_preserve_every_record(self, tmp_path, monkeypatch):
+        """The ledger update is one transaction, not three individually safe file operations."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        ledger = tmp_path / "gateway-starts.log"
+        ledger.write_text("1.0\n", encoding="utf-8")
+        first_read = threading.Event()
+        release_first = threading.Event()
+        read_lock = threading.Lock()
+        original_read_text = Path.read_text
+        gated = False
+
+        def pause_first_ledger_reader(path, *args, **kwargs):
+            nonlocal gated
+            body = original_read_text(path, *args, **kwargs)
+            if path == ledger:
+                with read_lock:
+                    is_first = not gated
+                    gated = True
+                if is_first:
+                    first_read.set()
+                    assert release_first.wait(2), "second start never entered the race window"
+            return body
+
+        monkeypatch.setattr(Path, "read_text", pause_first_ledger_reader)
+        results = []
+        first = threading.Thread(
+            target=lambda: results.append(status.record_start_and_check_storm(100, 10**12))
+        )
+        second = threading.Thread(
+            target=lambda: results.append(status.record_start_and_check_storm(100, 10**12))
+        )
+
+        first.start()
+        assert first_read.wait(2), "first start never read the ledger"
+        second.start()
+        # Without a transaction lock the second call reads the same snapshot
+        # and commits it while the first is paused, dropping one of the starts.
+        second.join(0.1)
+        release_first.set()
+        first.join(2)
+        second.join(2)
+
+        assert not first.is_alive() and not second.is_alive()
+        assert results == [None, None]
+        records = [line for line in ledger.read_text(encoding="utf-8").splitlines() if line]
+        assert len(records) == 3, records
 
 
 class TestLaunchdPlistRespawnGovernance:


### PR DESCRIPTION
## What does this PR do?

Serializes the complete `gateway-starts.log` read/append/trim/write transaction across threads and processes. Atomic replacement alone prevented partial files but still allowed two concurrent launchers to read the same predecessor and overwrite one another, undercounting the starts used by the respawn-storm breaker.

The lock is scoped to the ledger, released automatically when a process exits, and implemented with `flock` on POSIX and a byte-range lock plus same-process thread serialization on Windows. The final write uses the repository's unique-temp atomic text writer.

## Related Issue

Fixes #103761

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/status.py`: lock the entire respawn-ledger transaction across threads and processes; replace the shared scratch filename with the standard unique-temp atomic writer.
- `tests/gateway/test_status.py`: add a deterministic race test that pauses one reader and verifies both concurrent starts remain in the ledger.

## How to Test

1. Run `python -m pytest tests/gateway/test_status.py -q -k RespawnStormBreaker`.
2. Run `python -m ruff check gateway/status.py tests/gateway/test_status.py`.
3. Run `git diff --check origin/main...HEAD`.

Results on Windows 11 / Python 3.13:

- Respawn-storm tests: 2 passed.
- Ruff: passed.
- Diff check: passed.
- Full `tests/gateway/test_status.py`: 75 passed; 2 unrelated platform-assumption failures (`sleep` executable missing and a POSIX `ps` fallback expectation on Windows).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing Issues and PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Python 3.13

### Documentation & Housekeeping

- [x] Documentation update — N/A; no user-facing interface or configuration changed
- [x] `cli-config.yaml.example` update — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A
- [x] Cross-platform impact considered: POSIX `flock`; Windows byte-range lock with local thread serialization
- [x] Tool descriptions/schemas update — N/A

## Screenshots / Logs

Not applicable; this is a concurrency fix in gateway lifecycle bookkeeping. The regression test deterministically exercises the lost-update interleaving.