### PR TITLE
fix(gateway): scope multiplex busy-session handler to its owning profile

### DIFF
--- a/gateway/run_adapters.py
+++ b/gateway/run_adapters.py
@@ -1304,10 +1304,15 @@ class GatewayAdapterLifecycleMixin:
         return _handler
 
     def _make_profile_busy_session_handler(self, profile_name: str):
-        """Stamp an owning adapter's profile before resolving busy policy."""
+        """Stamp an owning adapter's profile, then resolve busy policy under the profile scope
+        (auth runs against the profile's own allowlist, same as the cold-path message handler)."""
+        from gateway.run import _async_profile_runtime_scope
+        profile_home = self._profile_home_or_none(profile_name)
+
         async def _handler(event, _session_key):
             self._stamp_event_profile(event, profile_name)
-            return await self._handle_active_session_busy_message(event, self._session_key_for_source(event.source))
+            async with self._scope_or_null(_async_profile_runtime_scope, profile_home):
+                return await self._handle_active_session_busy_message(event, self._session_key_for_source(event.source))
 
         return _handler
 

--- a/gateway/run_adapters.py
+++ b/gateway/run_adapters.py
@@ -1308,6 +1308,11 @@ class GatewayAdapterLifecycleMixin:
         (auth runs against the profile's own allowlist, same as the cold-path message handler)."""
         from gateway.run import _async_profile_runtime_scope
         profile_home = self._profile_home_or_none(profile_name)
+        if profile_home is None:
+            logger.debug(
+                "No profile home for %s; busy-session handler runs unscoped (env-authorized).",
+                profile_name,
+            )
 
         async def _handler(event, _session_key):
             self._stamp_event_profile(event, profile_name)

--- a/tests/gateway/test_busy_session_profile_scope.py
+++ b/tests/gateway/test_busy_session_profile_scope.py
@@ -1,0 +1,88 @@
+"""Regression for #103717: a secondary multiplex profile's busy-session
+follow-ups must authorize against THAT profile's allowlist, not whatever
+``os.environ`` happens to hold (the primary profile's first-writer-bridged
+value under multiplex).
+
+``_make_profile_message_handler`` (the cold path) wraps ``_handle_message``
+in ``_async_profile_runtime_scope`` before authorization runs. Until this
+fix, ``_make_profile_busy_session_handler`` (the busy path) stamped
+``source.profile`` but never entered that scope, so ``_is_user_authorized``
+fell through to ``os.environ`` and read the wrong profile's
+``FEISHU_ALLOWED_USERS``.
+"""
+from pathlib import Path
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.pairing import PairingStore
+from gateway.session import SessionSource
+
+
+@pytest.fixture
+def mux_home(tmp_path, monkeypatch):
+    from agent import secret_scope
+
+    home = tmp_path / "hh"
+    (home / "profiles" / "secondary").mkdir(parents=True)
+    (home / ".env").write_text("FEISHU_ALLOWED_USERS=primary-user\n")
+    (home / "profiles" / "secondary" / ".env").write_text(
+        "FEISHU_ALLOWED_USERS=secondary-user\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for key in ("FEISHU_ALLOWED_USERS", "GATEWAY_ALLOW_ALL_USERS", "GATEWAY_ALLOWED_USERS"):
+        monkeypatch.delenv(key, raising=False)
+    prev = secret_scope.is_multiplex_active()
+    secret_scope.set_multiplex_active(True)
+    yield home
+    secret_scope.set_multiplex_active(prev)
+
+
+def _runner(home):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner.config.platforms = {Platform.FEISHU: PlatformConfig(enabled=True, extra={})}
+    runner.pairing_store = PairingStore(profile="default")
+    runner.pairing_stores = {"default": runner.pairing_store}
+    runner._profile_adapters = {"secondary": {}}
+    runner.adapters = {}
+    return runner
+
+
+def _feishu_event(user_id):
+    from gateway.platforms.base import MessageEvent, MessageType
+
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        user_id=user_id,
+        user_name=user_id,
+        chat_id="oc_dm",
+        chat_type="dm",
+        profile=None,
+    )
+    return MessageEvent(text="follow-up", message_type=MessageType.TEXT, source=source, message_id="m1")
+
+
+@pytest.mark.asyncio
+async def test_busy_handler_authorizes_against_secondary_profile_allowlist(mux_home):
+    """Secondary profile owner's follow-up while their session is busy must be
+    authorized against the SECONDARY profile's own allowlist."""
+    runner = _runner(mux_home)
+
+    # Isolate exactly the authorization decision the busy path gates on
+    # (see gateway/run_busy.py::_handle_active_session_busy_message's first
+    # check) without pulling in queueing/steer machinery unrelated to the bug.
+    async def _stub_busy_message(event, session_key):
+        return runner._is_user_authorized(event.source)
+
+    runner._handle_active_session_busy_message = _stub_busy_message
+
+    handler = runner._make_profile_busy_session_handler("secondary")
+
+    authorized_event = _feishu_event("secondary-user")
+    assert await handler(authorized_event, "sk") is True
+
+    intruder_event = _feishu_event("primary-user")
+    assert await handler(intruder_event, "sk") is False

--- a/tests/gateway/test_busy_session_profile_scope.py
+++ b/tests/gateway/test_busy_session_profile_scope.py
@@ -86,3 +86,15 @@ async def test_busy_handler_authorizes_against_secondary_profile_allowlist(mux_h
 
     intruder_event = _feishu_event("primary-user")
     assert await handler(intruder_event, "sk") is False
+
+
+def test_busy_handler_logs_when_profile_home_unresolved(mux_home, monkeypatch, caplog):
+    """An unresolvable profile falls back to an unscoped (env-authorized) handler;
+    that degradation must be logged, not silent."""
+    runner = _runner(mux_home)
+    monkeypatch.setattr(runner, "_profile_home_or_none", lambda profile_name: None)
+
+    with caplog.at_level("DEBUG", logger="gateway.run"):
+        runner._make_profile_busy_session_handler("secondary")
+
+    assert "No profile home for secondary" in caplog.text


### PR DESCRIPTION
## What does this PR do?

Fixes #103717. Under `gateway.multiplex_profiles`, a secondary profile's
follow-up messages sent while their own session is already processing
(the "busy" path) were dropped as unauthorized, because the busy-session
handler resolved authorization against the **wrong** profile's allowlist.

## Root cause

`GatewayAdapterLifecycleMixin._make_profile_busy_session_handler`
(`gateway/run_adapters.py`) stamped `event.source.profile` but never
entered the profile's runtime scope before delegating to
`_handle_active_session_busy_message`. That handler's first gate calls
`self._is_user_authorized(event.source)`, which (via
`gateway/authz_mixin.py::_platform_gate_env`) reads the per-profile
secret scope **when one is installed**, else falls back to
`os.environ` — which under multiplex holds the primary profile's
first-writer-bridged `<PLATFORM>_ALLOWED_USERS`. A secondary profile's
own user was therefore checked against the *primary* profile's
allowlist and rejected.

The cold path (`_make_profile_message_handler`) already wraps
`_handle_message` in `_async_profile_runtime_scope` before
authorization runs — the busy path was the one sibling call site that
was missed.

## Fix

Wrap the busy handler's delegation to `_handle_active_session_busy_message`
in `_async_profile_runtime_scope` (falling back to a null scope when the
profile's home directory can't be resolved), mirroring
`_make_profile_message_handler` exactly:

```python
def _make_profile_busy_session_handler(self, profile_name: str):
    from gateway.run import _async_profile_runtime_scope
    profile_home = self._profile_home_or_none(profile_name)

    async def _handler(event, _session_key):
        self._stamp_event_profile(event, profile_name)
        async with self._scope_or_null(_async_profile_runtime_scope, profile_home):
            return await self._handle_active_session_busy_message(
                event, self._session_key_for_source(event.source))

    return _handler
```

## Test plan

Added `tests/gateway/test_busy_session_profile_scope.py`, which builds a
real `GatewayRunner` against a temp `HERMES_HOME` with two profiles —
`FEISHU_ALLOWED_USERS=primary-user` at the root, `FEISHU_ALLOWED_USERS=secondary-user`
under `profiles/secondary/.env` — and drives the real, unmocked
`_is_user_authorized` through `_make_profile_busy_session_handler("secondary")`.

- **Fails without the fix**: reverted only `gateway/run_adapters.py`
  (`git checkout HEAD~1 -- gateway/run_adapters.py`, then reapplied) and
  reran the new test — the secondary profile's own user was rejected:
  ```
  FAILED tests/gateway/test_busy_session_profile_scope.py::test_busy_handler_authorizes_against_secondary_profile_allowlist - assert False is True
  1 failed in 0.80s
  ```
- **Passes with the fix**:
  ```
  $ python3 -m pytest tests/gateway/test_busy_session_profile_scope.py -q
  1 passed in 0.73s
  ```
- **No regressions**: ran the full `tests/gateway/` suite before and after
  the change (with `aiohttp` installed to enable the Slack/WeCom plugin
  tests). One pre-existing, unrelated failure
  (`test_wecom_callback.py`, `ET.fromstring` on a `None` module — an
  environment/optional-dependency gap, not multiplex-related) reproduces
  identically on unmodified `gateway/run_adapters.py`; everything else,
  including `test_busy_session_auth_bypass.py`,
  `test_multiplex_adapter_registry.py`, `test_multiplex_profile_authz.py`,
  and `test_multiplex_interactive_auth.py`, passes.
- `ruff check gateway/run_adapters.py tests/gateway/test_busy_session_profile_scope.py` — all checks passed.

## Notes

- `_handle_active_session_busy_message` is also reachable via the
  default (non-profile) handler path, which is untouched — primary
  profile behavior is unchanged.
- This PR only touches `gateway/run_adapters.py` and adds one test file;
  no dependency, lockfile, or CI changes.

---
AI-assistance disclosure: this patch was authored end-to-end by an AI coding agent (Claude), including root-cause tracing, the fix, the regression test, and this PR description.
