### PR TITLE
fix(desktop): preserve profile-only secondary session ownership (#103755)

### DIFF
--- a/apps/desktop/src/store/session-states-runtime-map.test.ts
+++ b/apps/desktop/src/store/session-states-runtime-map.test.ts
@@ -154,10 +154,20 @@ describe('knownOwnerForSession / requestForOwnedSession', () => {
     expect(knownOwnerForSession('stored-live')).toEqual({ connectionId: 'local', profile: 'omar' })
   })
 
-  it('keeps failing closed for untagged or unknown runtimes in multi-profile topology (#97511)', () => {
+  it('routes a profile-only orphan runtime through the bare profile its inbound event proved (#103755)', () => {
     $profiles.set([{ name: 'default' }, { name: 'omar' }] as never)
-    // Untagged events carry no connectionId and record nothing.
-    recordSessionEventScope({ profile: 'omar', session_id: 'rt-untagged' })
+    // A pooled secondary with no registry connection (createSecondary(profile,
+    // null)) emits profile-tagged events with no connectionId. That still
+    // proves the profile even though it can't prove an exact route.
+    recordSessionEventScope({ profile: 'omar', session_id: 'rt-profile-only' })
+
+    expect(knownOwnerForSession('rt-profile-only')).toBe('omar')
+  })
+
+  it('keeps failing closed for genuinely unknown runtimes in multi-profile topology (#97511)', () => {
+    $profiles.set([{ name: 'default' }, { name: 'omar' }] as never)
+    // Fully untagged events (no profile, no connectionId) record nothing.
+    recordSessionEventScope({ session_id: 'rt-untagged' })
 
     expect(knownOwnerForSession('rt-untagged')).toBeUndefined()
     expect(knownOwnerForSession('rt-never-seen')).toBeUndefined()

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -90,16 +90,32 @@ const sessionScopeByRuntimeId = new Map<string, string>()
 // runtime whose event source already proved its owner can still route
 // session-scoped RPCs (approval.respond) when every durable binding
 // (tile / hint / row) is absent — while durable stored identity keeps
-// outranking it (#97511).
-const sessionOwnerByRuntimeId = new Map<string, SessionOwnerRoute>()
+// outranking it (#97511). A profile-only event (a pooled secondary with no
+// registry connection, createSecondary(profile, null)) proves only the bare
+// profile, not an exact route — recorded as that profile name, the same
+// owner shape a connection-tagged row without a connection stamp yields
+// (#103755).
+const sessionOwnerByRuntimeId = new Map<string, SessionOwnerRoute | string>()
 
 export function recordSessionEventScope(event: { connectionId?: string; profile?: string; session_id?: string }): void {
-  if (event.session_id && event.connectionId) {
+  if (!event.session_id) {
+    return
+  }
+
+  if (event.connectionId) {
     sessionScopeByRuntimeId.set(event.session_id, registryBackendScopeKey(event.connectionId, event.profile))
     sessionOwnerByRuntimeId.set(event.session_id, {
       connectionId: event.connectionId,
       profile: String(event.profile ?? '').trim() || 'default'
     })
+
+    return
+  }
+
+  const profile = String(event.profile ?? '').trim()
+
+  if (profile) {
+    sessionOwnerByRuntimeId.set(event.session_id, profile)
   }
 }
 
@@ -989,10 +1005,12 @@ export function openTileGatewayScopes(): Set<string> {
  * Last rung: the owner recorded from the inbound runtime event itself
  * (sessionOwnerByRuntimeId, #97511) — an orphan runtime whose tile/hint/row
  * binding is absent or stale still routes through the exact
- * (connectionId, profile) its events proved, while every durable rung above
- * keeps outranking it, so a stored-id collision never inherits a stale
- * runtime ledger entry. Untagged events record nothing, so unknown owners in
- * multi-profile topology still fail closed.
+ * (connectionId, profile) its events proved, or the bare profile a
+ * profile-only secondary event proved (#103755), while every durable rung
+ * above keeps outranking it, so a stored-id collision never inherits a stale
+ * runtime ledger entry. Fully untagged events (no profile at all) record
+ * nothing, so genuinely unknown owners in multi-profile topology still fail
+ * closed.
  * Returns undefined when no owner is known — the caller fails closed
  * (assertSessionOwnerResolved), never falls to "active".
  */


### PR DESCRIPTION
## What does this PR do?

Fixes the profile-only secondary ownership gap described in #103755:
`recordSessionEventScope` (`apps/desktop/src/store/session-states.ts`) only
recorded a session's owner when an inbound event carried **both**
`session_id` and `connectionId`. A pooled secondary with no registry
connection (`createSecondary(profile, null)` in `store/gateway.ts`)
legitimately emits profile-tagged events with no `connectionId`, so its
runtime was dropped as unowned even though the event proved which profile
held it. When every other ownership rung (tile route / hint / row) was also
absent, `knownOwnerForSession` returned `undefined` and
`approval.respond` (and any other session-scoped RPC) failed closed with
`SessionOwnerResolutionError`, even on a healthy, correctly-routed session.

The fix records the bare profile name as the last-rung owner when
`connectionId` is absent but `profile` is present — the same owner shape a
connection-tagged row without a connection stamp already produces elsewhere
in this ladder (`knownOwnerForSession`'s row rung). Exact
`(connectionId, profile)` routes still take priority whenever a
`connectionId` is present, and events with no profile at all still record
nothing, so genuinely unknown owners in multi-profile topology keep failing
closed exactly as before.

## Related Issue

Fixes #103755

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/store/session-states.ts`: `recordSessionEventScope` now
  records a bare-profile owner (`sessionOwnerByRuntimeId`) for events that
  carry `profile` but no `connectionId`, instead of silently dropping them.
  `sessionScopeByRuntimeId` (the composite scope used by `liveSessionScopes`)
  is untouched — it still only records connection-tagged events, so
  single-source/legacy behavior there is unchanged.
- `apps/desktop/src/store/session-states-runtime-map.test.ts`: replaced the
  test that asserted profile-only events resolve to `undefined` with one
  asserting they resolve to the bare profile, and kept a separate case for
  genuinely untagged (no profile, no connectionId) events still failing
  closed.

## How to Test

1. `cd apps/desktop && npx vitest run src/store/session-states-runtime-map.test.ts`
2. Reproduction (mirrors the issue's regression test): record a profile-only
   event (`{ profile: 'research', session_id: 'rt-secondary' }'`) and confirm
   `knownOwnerForSession('rt-secondary')` now resolves to `'research'`
   instead of `undefined`.

### Test output (after the fix)

```
$ npx vitest run src/store/session-states-runtime-map.test.ts src/store/session-states-scopes.test.ts src/store/session-states.test.ts src/store/session-states-reconnect.test.ts src/store/session-states-foreground-scopes.test.ts src/store/session-states-eviction.test.ts src/store/gateway-connection-scope.test.ts

 Test Files  7 passed (7)
      Tests  136 passed (136)
```

### Proof the new test fails without the fix

Reverted only `session-states.ts` (`git checkout HEAD~1 -- apps/desktop/src/store/session-states.ts`)
and re-ran the new test:

```
FAIL  src/store/session-states-runtime-map.test.ts > knownOwnerForSession / requestForOwnedSession
  > routes a profile-only orphan runtime through the bare profile its inbound event proved (#103755)
AssertionError: expected undefined to be 'omar'
- Expected: "omar"
+ Received: undefined
```

Restored the fix and the suite is green again (see above).

### Other checks

```
$ npx tsc -p . --noEmit          # clean
$ npx eslint src/store/session-states.ts src/store/session-states-runtime-map.test.ts   # clean
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've added tests for my changes
- [ ] I've tested on my platform — tested in Linux CI container only; the
      issue was reported on macOS, but the fix is in pure TypeScript store
      logic with no platform-specific code path.

### Documentation & Housekeeping

- [x] N/A — no docs, config keys, or tool schemas changed.

## Disclosure

This PR was prepared by an AI coding agent (Claude) working autonomously
from the issue text against the current `main` checkout. All test runs and
the failing/passing verification above were executed and observed directly,
not fabricated.
