### PR TITLE
fix(installer): keep original venv recoverable across retries

### DIFF
--- a/.github/workflows/installer-tests.yml
+++ b/.github/workflows/installer-tests.yml
@@ -44,3 +44,11 @@ jobs:
       - name: System Node and npm compatibility (Windows PowerShell 5.1)
         shell: powershell
         run: powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-node-compatibility.ps1
+
+      - name: Interrupted venv transaction recovery (pwsh 7)
+        shell: pwsh
+        run: pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-venv-retry-transaction.ps1
+
+      - name: Interrupted venv transaction recovery (Windows PowerShell 5.1)
+        shell: powershell
+        run: powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-venv-retry-transaction.ps1

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2579,6 +2579,19 @@ function Install-Venv {
     $venvBackupName = $null
     $venvParked = $false
     try {
+    # A previous venv stage may have finished (or been interrupted after
+    # parking the old tree) without reaching dependency validation. Restore
+    # that transaction's original generation before beginning another recreate
+    # so a retry cannot promote the unverified replacement to rollback source.
+    $pendingVenvBackup = Get-PendingVenvBackup
+    if ($pendingVenvBackup) {
+        Write-Warn "Reconciling unfinished venv transaction before retrying"
+        Restore-VenvBackup
+        if (Get-PendingVenvBackup) {
+            throw "Could not restore the original venv from $pendingVenvBackup; retry aborted during transaction recovery."
+        }
+    }
+
     if (Test-Path -LiteralPath "venv") {
         $venvHadExistingVenv = $true
         Write-Info "Virtual environment already exists, recreating..."
@@ -2672,11 +2685,17 @@ function Install-Venv {
         # interpreter and no rollback source. Abort with the previous install
         # intact so the user can close holders and retry.
         $venvBackupName = "venv.stale.{0}-{1}" -f (Get-Date -Format "yyyyMMddHHmmss"), ([Guid]::NewGuid().ToString("N"))
+        # Publish intent before the atomic rename. If this process is killed
+        # after publication but before the rename, Get-PendingVenvBackup drops
+        # the marker because its target does not exist. If it is killed after
+        # the rename, the next attempt can restore this original generation.
+        Set-Content -LiteralPath (Join-Path $InstallDir "venv.pending-backup") -Value $venvBackupName -Encoding ascii
         try {
             Rename-Item -LiteralPath "venv" -NewName $venvBackupName -ErrorAction Stop
             $venvParked = $true
         } catch {
             $renameErr = $_.Exception.Message
+            Remove-Item -LiteralPath (Join-Path $InstallDir "venv.pending-backup") -Force -ErrorAction SilentlyContinue
             throw (
                 "Could not move the existing venv aside ($renameErr). " +
                 "A process still has the install directory open (often a non-Hermes " +
@@ -2732,10 +2751,9 @@ function Install-Venv {
     # committed after Install-Dependencies' baseline-import gate passes -- the
     # bootstrap runs the stages as separate processes, and every dependency
     # tier (or the import validation) can still fail after this stage
-    # succeeds. Record the parked backup so the dependency stage can restore
-    # it on failure and commit its cleanup only after validation (#83149).
+    # succeeds. The marker was published before parking the original so an
+    # interruption cannot strand the only rollback source without a pointer.
     if ($venvParked) {
-        Set-Content -LiteralPath (Join-Path $InstallDir "venv.pending-backup") -Value $venvBackupName -Encoding ascii
         Write-Info "Previous venv parked at $venvBackupName until the dependency install is verified"
     }
 
@@ -2768,6 +2786,7 @@ function Install-Venv {
                     Write-Warn "Failed replacement parked at $failedVenvName"
                 }
                 Rename-Item -LiteralPath $venvBackupName -NewName "venv" -ErrorAction Stop
+                Remove-Item -LiteralPath (Join-Path $InstallDir "venv.pending-backup") -Force -ErrorAction SilentlyContinue
                 Write-Warn "Restored previous virtual environment after failed recreate"
             } catch {
                 $rollbackError = $_.Exception.Message

--- a/scripts/tests/test-install-ps1-venv-retry-transaction.ps1
+++ b/scripts/tests/test-install-ps1-venv-retry-transaction.ps1
@@ -1,0 +1,217 @@
+# Behavioral fault-injection tests for interrupted venv transactions.
+#
+# The test lifts the shipped functions from install.ps1's PowerShell AST and
+# executes their real marker, directory-rename, stale-sweep, and rollback logic
+# against isolated temporary trees. Only process discovery, task control, uv,
+# and sleeps are synthetic.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path))
+$installScript = Join-Path $repoRoot 'scripts\install.ps1'
+$tokens = $null
+$parseErrors = $null
+$ast = [Management.Automation.Language.Parser]::ParseFile(
+    $installScript, [ref]$tokens, [ref]$parseErrors)
+if ($parseErrors.Count -gt 0) { throw 'Installer parse failed' }
+
+$functionNames = @(
+    'Install-Venv',
+    'Get-PendingVenvBackup',
+    'Restore-VenvBackup',
+    'Complete-VenvTransaction'
+)
+foreach ($name in $functionNames) {
+    $matches = @($ast.FindAll({
+        param($node)
+        $node -is [Management.Automation.Language.FunctionDefinitionAst] -and
+            $node.Name -eq $name
+    }, $true))
+    if ($matches.Count -ne 1) { throw "Expected one complete function: $name" }
+    Invoke-Expression $matches[0].Extent.Text
+}
+
+$testRoot = Join-Path $env:TEMP ("hermes-venv-retry-test-" + [Guid]::NewGuid().ToString('N'))
+$NoVenv = $false
+$script:UvCmd = 'synthetic-uv-never-executed.exe'
+$script:Failures = 0
+$script:FailNextVenvRename = $false
+$script:FakeVenvExitCode = 0
+
+function Write-Info { param([string]$Message) }
+function Write-Warn { param([string]$Message) }
+function Write-Success { param([string]$Message) }
+function Resolve-AvailablePythonVersion {
+    [pscustomobject]@{ Path = 'synthetic-python'; Version = '3.11' }
+}
+function schtasks { $global:LASTEXITCODE = 0 }
+function taskkill { $global:LASTEXITCODE = 0 }
+function Get-CimInstance { @() }
+function Start-Sleep { }
+function Rename-Item {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$LiteralPath,
+        [Parameter(Mandatory = $true)][string]$NewName
+    )
+    if ($script:FailNextVenvRename -and (Split-Path -Leaf $LiteralPath) -eq 'venv') {
+        $script:FailNextVenvRename = $false
+        throw 'synthetic rename interruption'
+    }
+    Microsoft.PowerShell.Management\Rename-Item -LiteralPath $LiteralPath -NewName $NewName -ErrorAction Stop
+}
+function New-Object {
+    param([string]$TypeName)
+    if ($TypeName -eq 'System.Diagnostics.ProcessStartInfo') {
+        return [pscustomobject]@{
+            FileName = ''
+            Arguments = ''
+            WorkingDirectory = ''
+            UseShellExecute = $false
+            CreateNoWindow = $false
+            RedirectStandardOutput = $false
+            RedirectStandardError = $false
+        }
+    }
+    if ($TypeName -ne 'System.Diagnostics.Process') {
+        throw "Unexpected object type $TypeName"
+    }
+    $reader = [pscustomobject]@{}
+    $reader | Add-Member ScriptMethod ReadToEndAsync {
+        [pscustomobject]@{ Result = '' }
+    }
+    $process = [pscustomobject]@{
+        StartInfo = $null
+        StandardOutput = $reader
+        StandardError = $reader
+        ExitCode = $script:FakeVenvExitCode
+    }
+    $process | Add-Member ScriptMethod Start {
+        $scriptsDir = Join-Path $this.StartInfo.WorkingDirectory 'venv\Scripts'
+        [IO.Directory]::CreateDirectory($scriptsDir) | Out-Null
+        [IO.File]::WriteAllText(
+            (Join-Path $scriptsDir 'python.exe'),
+            'synthetic interpreter placeholder')
+        [IO.File]::WriteAllText(
+            (Join-Path $this.StartInfo.WorkingDirectory 'venv\generation.txt'),
+            'PARTIAL_NEW_ENV_WITHOUT_DEPENDENCIES')
+        return $true
+    }
+    $process | Add-Member ScriptMethod WaitForExit { }
+    $process | Add-Member ScriptMethod Dispose { }
+    return $process
+}
+
+function Assert-Equal {
+    param($Expected, $Actual, [Parameter(Mandatory = $true)][string]$Label)
+    if ($Expected -ceq $Actual) {
+        Write-Host "PASS: $Label"
+    } else {
+        Write-Host "FAIL: $Label"
+        Write-Host "  expected: [$Expected]"
+        Write-Host "  actual:   [$Actual]"
+        $script:Failures++
+    }
+}
+
+function New-TestCase {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [switch]$SeedLiveVenv
+    )
+    $caseDir = Join-Path $testRoot $Name
+    [IO.Directory]::CreateDirectory($caseDir) | Out-Null
+    if ($SeedLiveVenv) {
+        $venv = Join-Path $caseDir 'venv'
+        [IO.Directory]::CreateDirectory($venv) | Out-Null
+        [IO.File]::WriteAllText(
+            (Join-Path $venv 'generation.txt'), 'ORIGINAL_WORKING_ENV')
+    }
+    return $caseDir
+}
+
+function Read-LiveGeneration {
+    return [IO.File]::ReadAllText((Join-Path $script:InstallDir 'venv\generation.txt'))
+}
+
+try {
+    Write-Host '-- first-attempt venv failure --'
+    $script:InstallDir = New-TestCase -Name 'first-failure' -SeedLiveVenv
+    $script:FakeVenvExitCode = 1
+    try {
+        Install-Venv
+        $script:Failures++
+        Write-Host 'FAIL: uv failure aborts the first venv stage'
+    } catch {
+        Assert-Equal $true ($_.Exception.Message -like '*uv venv exited with 1*') 'uv failure aborts the first venv stage'
+    } finally {
+        $script:FakeVenvExitCode = 0
+    }
+    Assert-Equal 'ORIGINAL_WORKING_ENV' (Read-LiveGeneration) 'first-attempt failure restores the original generation'
+    Assert-Equal $false (Test-Path -LiteralPath (Join-Path $script:InstallDir 'venv.pending-backup')) 'first-attempt rollback clears the pending marker'
+
+    Write-Host ''
+    Write-Host '-- retry before dependency validation --'
+    $script:InstallDir = New-TestCase -Name 'retry' -SeedLiveVenv
+    Install-Venv
+    $firstBackup = Get-PendingVenvBackup
+    Assert-Equal $true ([bool]$firstBackup) 'the first venv stage publishes a rollback marker'
+    Assert-Equal $true (Test-Path -LiteralPath (Join-Path $script:InstallDir "$firstBackup\generation.txt")) 'the first stage preserves the original generation'
+
+    Install-Venv
+    $retryBackup = Get-PendingVenvBackup
+    Assert-Equal $true ([bool]$retryBackup) 'the retry keeps a rollback marker'
+    Assert-Equal $true (Test-Path -LiteralPath (Join-Path $script:InstallDir "$retryBackup\generation.txt")) 'the retry keeps the original rollback generation'
+    Assert-Equal 'ORIGINAL_WORKING_ENV' ([IO.File]::ReadAllText((Join-Path $script:InstallDir "$retryBackup\generation.txt"))) 'the retry marker still names the original generation'
+    Restore-VenvBackup
+    Assert-Equal 'ORIGINAL_WORKING_ENV' (Read-LiveGeneration) 'dependency failure after retry restores the original generation'
+
+    Write-Host ''
+    Write-Host '-- interruption before the original rename --'
+    $script:InstallDir = New-TestCase -Name 'before-rename' -SeedLiveVenv
+    $orphanMarkerName = 'venv.stale.pre-rename'
+    Set-Content -LiteralPath (Join-Path $script:InstallDir 'venv.pending-backup') -Value $orphanMarkerName -Encoding ascii
+    Install-Venv
+    Restore-VenvBackup
+    Assert-Equal 'ORIGINAL_WORKING_ENV' (Read-LiveGeneration) 'a marker published before a missing rename does not replace the live original'
+
+    Write-Host ''
+    Write-Host '-- rename failure after marker publication --'
+    $script:InstallDir = New-TestCase -Name 'rename-failure' -SeedLiveVenv
+    $script:FailNextVenvRename = $true
+    try {
+        Install-Venv
+        $script:Failures++
+        Write-Host 'FAIL: the rename failure aborts the venv stage'
+    } catch {
+        Assert-Equal $true ($_.Exception.Message -like '*previous install was left intact*') 'the rename failure aborts the venv stage'
+    }
+    Assert-Equal 'ORIGINAL_WORKING_ENV' (Read-LiveGeneration) 'rename failure leaves the live original intact'
+    Assert-Equal $false (Test-Path -LiteralPath (Join-Path $script:InstallDir 'venv.pending-backup')) 'rename failure clears its unpublished rollback marker'
+
+    Write-Host ''
+    Write-Host '-- interruption after the original rename --'
+    $script:InstallDir = New-TestCase -Name 'after-rename'
+    $parkedOriginal = 'venv.stale.after-rename'
+    $parkedPath = Join-Path $script:InstallDir $parkedOriginal
+    [IO.Directory]::CreateDirectory($parkedPath) | Out-Null
+    [IO.File]::WriteAllText((Join-Path $parkedPath 'generation.txt'), 'ORIGINAL_WORKING_ENV')
+    Set-Content -LiteralPath (Join-Path $script:InstallDir 'venv.pending-backup') -Value $parkedOriginal -Encoding ascii
+    Install-Venv
+    Restore-VenvBackup
+    Assert-Equal 'ORIGINAL_WORKING_ENV' (Read-LiveGeneration) 'a retry after rename-before-create restores the original generation'
+} finally {
+    if (Test-Path -LiteralPath $testRoot) {
+        Microsoft.PowerShell.Management\Remove-Item -LiteralPath $testRoot -Recurse -Force
+    }
+}
+
+if ($script:Failures -gt 0) {
+    Write-Host ''
+    Write-Host "$script:Failures assertion(s) failed"
+    exit 1
+}
+
+Write-Host ''
+Write-Host 'all assertions passed'


### PR DESCRIPTION
## What does this PR do?

A Windows installer retry no longer discards the original verified virtual environment before replacement dependencies pass. The retry first reconciles any unfinished venv transaction, then publishes the rollback marker before moving the original directory so interruption on either side of the rename remains recoverable.

### Symptom

Running the venv stage twice before the dependency stage completes causes a later dependency rollback to restore the first unverified replacement instead of the original working environment.

### Impact

A failed Windows update can report that the previous virtual environment was restored while leaving Hermes without its previously installed dependencies.

### Bug Cause

**Trigger:** `scripts/install.ps1:2738` / `Install-Venv` recreates a venv while `venv.pending-backup` already names an unfinished transaction.

**Causal chain:**
1. The first venv stage parks the original working generation and records it as the pending backup.
2. A retry parks the unverified replacement, overwrites the marker, and sweeps the original parked generation.
3. Dependency rollback restores the unverified replacement, so the original working environment is lost.

**Why it is wrong:** The marker tracked the most recent recreate attempt rather than the original verified generation for the still-open transaction. It was also published after the original rename, leaving an interruption window with no durable pointer.

**Working sibling / contrast:** A single uninterrupted venv attempt already retains its backup through dependency validation; this change preserves that contract across retries and stage-host interruption.

**Ruled out:** Desktop progress delivery and cross-entry update serialization do not own this filesystem transaction. The native reproduction exercises the production marker, rename, sweep, and rollback functions directly.

### Fix

Before recreating a venv, `Install-Venv` restores any pending transaction's original generation and aborts if reconciliation cannot complete. New transactions publish the marker before the atomic rename, clear it on a synchronous rename failure or successful immediate rollback, and retain it until dependency validation commits. A native PowerShell fault-injection test covers first-attempt rollback, retry-before-dependencies, and interruptions before, during, and after the rename; the Windows installer workflow runs it under PowerShell 5.1 and PowerShell 7.

## Related Issue

Closes #103751

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/install.ps1` - reconcile unfinished venv transactions and publish rollback intent before renaming.
- `scripts/tests/test-install-ps1-venv-retry-transaction.ps1` - execute native filesystem retry and interruption scenarios against production functions.
- `.github/workflows/installer-tests.yml` - run the new behavioral test under both supported PowerShell hosts.

## How to Test

1. On Windows, run `powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-venv-retry-transaction.ps1`.
2. Confirm all first-attempt, retry, marker, rename-failure, and post-rename recovery assertions pass.
3. Run `scripts/run_tests.sh tests/test_install_ps1_venv_transaction_boundary.py tests/test_install_ps1_venv_rename_abort.py tests/test_install_ps1_venv_recreate_safety.py`.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix.
- [x] I've run the relevant repository tests and all completed tests pass.
- [x] I've added tests for my changes.
- [x] I've tested on my platform: Windows 11 with Windows PowerShell 5.1.

### Documentation & Housekeeping

- [x] Relevant documentation remains accurate; no user-facing command changed.
- [x] N/A - no config keys changed.
- [x] N/A - no architecture or contributor workflow changed.
- [x] Cross-platform impact considered: the changed installer path is Windows-specific and is tested on native Windows.
- [x] N/A - no tool descriptions or schemas changed.

## Screenshots / Logs

The native test reports 14 passing assertions, and the four adjacent Python files report 16 passing tests. Before the production fix, the retry and post-rename recovery scenarios restored `PARTIAL_NEW_ENV_WITHOUT_DEPENDENCIES` instead of `ORIGINAL_WORKING_ENV`.
