### PR TITLE
fix(s6): route planned-stop markers to the target profile

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1134,8 +1134,8 @@ def _get_takeover_marker_path(hermes_home: Optional[Path] = None) -> Path:
     return home / _TAKEOVER_MARKER_FILENAME
 
 
-def _get_planned_stop_marker_path() -> Path:
-    return _get_process_hermes_home() / _PLANNED_STOP_MARKER_FILENAME
+def _get_planned_stop_marker_path(hermes_home: Optional[Path] = None) -> Path:
+    return (hermes_home or _get_process_hermes_home()) / _PLANNED_STOP_MARKER_FILENAME
 
 
 def _marker_is_stale(written_at: str, ttl_s: int) -> bool:
@@ -1416,11 +1416,12 @@ def _terminate_verified_owner(
     return None
 
 
-def write_planned_stop_marker(target_pid: int) -> bool:
+def write_planned_stop_marker(target_pid: int, *, target_home: Optional[Path] = None) -> bool:
     """Record that ``target_pid`` is being stopped intentionally: unexpected SIGTERM exits non-zero
     so service managers revive the gateway; the CLI writes this first so a deliberate stop exits
-    cleanly."""
-    return _write_marker(_get_planned_stop_marker_path(), {
+    cleanly. Cross-profile service operations pass the target's home without changing the
+    caller's process environment."""
+    return _write_marker(_get_planned_stop_marker_path(target_home), {
         "target_pid": target_pid, "target_start_time": _get_process_start_time(target_pid),
         "stopper_pid": os.getpid(), "written_at": _utc_now_iso(),
     })

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -549,7 +549,7 @@ class S6ServiceManager:
         if pid is not None:
             try:
                 from gateway.status import write_planned_stop_marker
-                write_planned_stop_marker(pid)
+                write_planned_stop_marker(pid, target_home=_profile_dir_for_gateway_service(name))
             except Exception:
                 pass
         self._run_svc("-d", "stop", name)

--- a/tests/hermes_cli/test_s6_stop_profile_marker.py
+++ b/tests/hermes_cli/test_s6_stop_profile_marker.py
@@ -1,0 +1,45 @@
+"""An s6 stop must reach the selected profile's planned-shutdown reader."""
+
+import os
+import subprocess
+
+import pytest
+
+from gateway import status
+from hermes_cli.service_manager import S6ServiceManager
+
+
+@pytest.mark.parametrize("caller,target", [("default", "worker"), ("worker", "default")])
+def test_stop_marks_target_before_signal_without_overwriting_caller(
+    tmp_path, monkeypatch, caller, target
+):
+    root = tmp_path / "hermes"
+    homes = {"default": root, "worker": root / "profiles" / "worker"}
+    for home in homes.values():
+        home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(homes[caller]))
+    assert status.write_planned_stop_marker(os.getpid() + 1)
+    caller_marker = homes[caller] / ".gateway-planned-stop.json"
+    original = caller_marker.read_bytes()
+    scandir = tmp_path / "services"
+    service = scandir / f"gateway-{target}"
+    service.mkdir(parents=True)
+    commands = []
+
+    def s6_run(command, *args, **kwargs):
+        commands.append(command)
+        if command == "s6-svstat":
+            return subprocess.CompletedProcess([], 0, f"up (pid {os.getpid()}) 10 seconds", "")
+        assert command == "s6-svc"
+        assert args == ("-d", str(service))
+        # Simulate the target receiving SIGTERM, using the real marker reader.
+        with monkeypatch.context() as target_scope:
+            target_scope.setenv("HERMES_HOME", str(homes[target]))
+            assert status.consume_planned_stop_marker_for_self()
+        return subprocess.CompletedProcess([], 0, "", "")
+
+    monkeypatch.setattr("hermes_cli.service_manager._s6_run", s6_run)
+    S6ServiceManager(scandir=scandir).stop(service.name)
+
+    assert commands == ["s6-svstat", "s6-svc"]
+    assert caller_marker.read_bytes() == original


### PR DESCRIPTION
## What does this PR do?

Routes s6 planned-stop markers to the selected gateway profile. `gateway stop --all` invokes one manager from one HERMES_HOME, so using the caller home for every marker leaves other profiles unable to classify the stop as intentional and can overwrite the caller's pending marker.

## Related Issue

Fixes #103772

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- Add an optional keyword-only `target_home` to the existing planned-stop writer; omitted values retain process-home behavior.
- Reuse `_profile_dir_for_gateway_service(name)` in `S6ServiceManager.stop`, just as desired-state persistence already does. No process environment mutation.
- Test both default-to-named and named-to-default stops through the real marker writer and reader with actual temporary files. Replace only the external s6 command boundary; assert the marker can be consumed **before** signal delivery and that the caller's pending marker is unchanged.

## Before / After

Before: both cross-profile regression cases fail because the target reader returns False; the target takes unplanned shutdown/exit-state handling.
After: both cases pass, target recognizes an intentional stop, caller marker survives.

This does not change `s6-svc -d`, desired-state persistence, TTL, or PID/start-time validation. It does not claim to fix the different restart-flag issue #39381 or live-child issue #35882.

## How to Test

Using `scripts/run_tests.sh` on native Windows/Python 3.13:

- `tests/hermes_cli/test_s6_stop_profile_marker.py`: **2 failed on unmodified main**, **2 passed after fix**.
- Above plus `tests/hermes_cli/test_gateway_s6_dispatch.py`: **4 passed**.
- `tests/gateway/test_status.py tests/gateway/test_planned_stop_watcher.py -k 'PlannedStopMarker or watcher'`: **7 passed**.
- `tests/hermes_cli/test_service_manager.py`: **5 passed, 2 failed, 2 skipped**, identically on the patched checkout and a separate clean worktree at `9dd6634c56`. Both failures are existing Linux-only setup operations invoking unavailable `os.chown` on Windows (`test_seed_supervise_skeleton_creates_expected_layout`, `test_s6_log_run_creates_leaf_as_hermes_without_chown`). Left untouched.
- Ruff over all three changed Python files and `git diff --check`: passed.

No live s6 container was used locally; the regression exercises the profile/file contract without sending real signals. Linux CI remains the platform verification for s6-adjacent code.

## Checklist

- [x] Read the contributing guide; conventional single-purpose commit
- [x] Searched existing issues/PRs and relevant history
- [x] Added regression tests proven red on base
- [x] Tested on Windows; platform limitation and baseline failures documented above
- [ ] Full repository test suite passed locally (not run)
- [x] No config, tool schema, dependency, or architecture changes; additional documentation not required

## Compatibility and risks

Existing one-argument callers and marker readers keep process-scoped behavior. Only cross-profile s6 callers opt into an explicit destination. Uses the existing validated profile resolver. No changes to other contributors' branches.