### PR TITLE
fix(desktop): preserve trusted secondary session ownership

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -72,6 +72,7 @@ import {
   $sessionTiles,
   $workingSessionIds,
   foregroundSessionScopes,
+  forgetProfileOnlyRuntimeOwners,
   liveSessionScopes,
   openTileGatewayScopes,
   reconcileBusyStatesOnReconnect,
@@ -760,6 +761,7 @@ export function useGatewayBoot({
       // primary thread or a just-created session's owner hold is bound to
       // (#93892).
       foregroundScopes: foregroundSessionScopes,
+      onLocalProfileRetired: forgetProfileOnlyRuntimeOwners,
       onActiveConnectionChanged: publish,
       // Keep $activeGatewayProfile in lockstep with the registry's OWN record
       // of which profile the active socket serves. The registry is the only

--- a/apps/desktop/src/store/gateway-profile-only-owner.integration.test.ts
+++ b/apps/desktop/src/store/gateway-profile-only-owner.integration.test.ts
@@ -1,0 +1,246 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { createElement } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { renderMessageStream } from '@/app/session/hooks/use-message-stream/test-harness'
+import { PendingApprovalFallback } from '@/components/assistant-ui/tool/approval'
+
+// This drives a profile-only secondary's real gateway.ts event callback into
+// the same registry fan-in that useGatewayBoot installs, then dispatches an
+// approval through the normal owner router.  It deliberately leaves every
+// stored/runtime binding rung empty: the inbound socket is the only proof.
+
+const gatewayMocks = vi.hoisted(() => {
+  const instances: Array<{
+    connectionState: string
+    emit: (event: { payload?: Record<string, unknown>; session_id?: string; type: string }) => void
+    request: ReturnType<typeof vi.fn>
+  }> = []
+
+  return { instances }
+})
+
+vi.mock('@/hermes', async importActual => ({
+  ...(await importActual<Record<string, unknown>>()),
+  setApiRequestConnection: vi.fn(),
+  HermesGateway: class {
+    connectionState = 'closed'
+    private eventHandlers = new Set<(event: { payload?: Record<string, unknown>; session_id?: string; type: string }) => void>()
+    request = vi.fn(async (method: string, params: Record<string, unknown>) => ({ method, params }))
+
+    constructor() {
+      gatewayMocks.instances.push(this as never)
+    }
+
+    connect = async (): Promise<void> => {
+      this.connectionState = 'open'
+    }
+
+    close = (): void => {
+      this.connectionState = 'closed'
+    }
+
+    onEvent = (
+      handler: (event: { payload?: Record<string, unknown>; session_id?: string; type: string }) => void
+    ): (() => void) => {
+      this.eventHandlers.add(handler)
+
+      return () => this.eventHandlers.delete(handler)
+    }
+
+    onState = (): (() => void) => () => undefined
+
+    emit = (event: { payload?: Record<string, unknown>; session_id?: string; type: string }): void => {
+      for (const handler of this.eventHandlers) {
+        handler(event)
+      }
+    }
+  }
+}))
+
+const {
+  closeSecondaryGateways,
+  configureGatewayRegistry,
+  ensureGatewayForProfile,
+  retireLocalProfileGateways,
+  setPrimaryGateway
+} = await import('./gateway')
+
+const { $profiles } = await import('./profile')
+
+const { $activeSessionId, _resetSessionOwnerHintsForTests, setSessionOwnerHint, setSessions } = await import('./session')
+const { $gateway } = await import('./gateway')
+const { clearAllPrompts } = await import('./prompts')
+
+const {
+  $sessionStates,
+  $sessionTiles,
+  clearAllSessionStates,
+  forgetProfileOnlyRuntimeOwners,
+  knownOwnerForSession,
+  recordSessionEventScope,
+  requestForOwnedSession
+} = await import('./session-states')
+
+const { isSessionOwnerResolutionError } = await import('./session-owner-resolution')
+
+function installDesktop(): void {
+  ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+    getConnection: vi.fn(async (profile: string) => ({
+      authMode: 'token',
+      mode: 'local',
+      profile,
+      token: 'test-token',
+      wsUrl: `wss://${profile}.invalid/ws`
+    })),
+    notify: vi.fn()
+  }
+}
+
+beforeEach(() => {
+  installDesktop()
+  gatewayMocks.instances.length = 0
+  $profiles.set([{ name: 'default' }, { name: 'research' }] as never)
+  $sessionTiles.set([])
+  setSessions([])
+  clearAllSessionStates()
+  clearAllPrompts()
+  $activeSessionId.set(null)
+  _resetSessionOwnerHintsForTests({ storage: true })
+
+  // This is the exact event fan-in installed by useGatewayBoot: the secondary
+  // producer calls config.onEvent, which records scope before UI dispatch.
+  configureGatewayRegistry({
+    onLocalProfileRetired: forgetProfileOnlyRuntimeOwners,
+    onEvent: event => {
+      recordSessionEventScope(event)
+    }
+  })
+  const primary = { connectionState: 'open', request: vi.fn() }
+  $gateway.set(primary as never)
+  setPrimaryGateway(primary as never, 'default')
+})
+
+afterEach(() => {
+  closeSecondaryGateways()
+  clearAllSessionStates()
+  $sessionTiles.set([])
+  $profiles.set([])
+  setSessions([])
+  _resetSessionOwnerHintsForTests({ storage: true })
+  clearAllPrompts()
+  $activeSessionId.set(null)
+  $gateway.set(null)
+  cleanup()
+  delete (window as { hermesDesktop?: unknown }).hermesDesktop
+})
+
+describe('profile-only secondary approval ownership', () => {
+  it('keeps a profile-only secondary event owner across a focus switch and dispatches approval on that secondary', async () => {
+    await expect(ensureGatewayForProfile('research')).resolves.toBeUndefined()
+    const secondary = gatewayMocks.instances[0]
+
+    expect(secondary).toBeTruthy()
+    // No tile, row, hint, or runtime→stored state mirror is available.
+    expect($sessionTiles.get()).toEqual([])
+    expect($sessionStates.get()).toEqual({})
+
+    secondary.emit({ session_id: 'rt-secondary', type: 'approval.request' })
+    await expect(ensureGatewayForProfile('default')).resolves.toBeUndefined()
+
+    expect(knownOwnerForSession('rt-secondary')).toBe('research')
+
+    const ambient = vi.fn(async () => ({ via: 'ambient' }))
+    await expect(
+      requestForOwnedSession('rt-secondary', ambient as never, 'approval.respond', {
+        choice: 'once',
+        session_id: 'rt-secondary'
+      })
+    ).resolves.toEqual({
+      method: 'approval.respond',
+      params: { choice: 'once', session_id: 'rt-secondary' }
+    })
+
+    expect(secondary.request).toHaveBeenCalledWith('approval.respond', {
+      choice: 'once',
+      session_id: 'rt-secondary'
+    })
+    expect(ambient).not.toHaveBeenCalled()
+  })
+
+  it('continues to fail closed for a profile field not stamped by a secondary socket', async () => {
+    recordSessionEventScope({ profile: 'research', session_id: 'rt-unproven' })
+
+    expect(knownOwnerForSession('rt-unproven')).toBeUndefined()
+    await expect(
+      requestForOwnedSession('rt-unproven', vi.fn() as never, 'approval.respond', { session_id: 'rt-unproven' })
+    ).rejects.toSatisfy(isSessionOwnerResolutionError)
+  })
+
+  it('keeps durable exact ownership ahead of a stamped profile-only runtime fallback', async () => {
+    await expect(ensureGatewayForProfile('research')).resolves.toBeUndefined()
+    gatewayMocks.instances[0].emit({ session_id: 'rt-durable', type: 'approval.request' })
+    setSessionOwnerHint('rt-durable', { connectionId: 'remote-same-name', profile: 'research' })
+
+    expect(knownOwnerForSession('rt-durable')).toEqual({ connectionId: 'remote-same-name', profile: 'research' })
+  })
+
+  it('drops a retired local profile-only event owner so a delayed approval cannot redial it', async () => {
+    const getConnection = (window as unknown as { hermesDesktop: { getConnection: ReturnType<typeof vi.fn> } })
+      .hermesDesktop.getConnection
+
+    await expect(ensureGatewayForProfile('research')).resolves.toBeUndefined()
+    const secondary = gatewayMocks.instances[0]
+
+    secondary.emit({ session_id: 'rt-retired', type: 'approval.request' })
+    expect(knownOwnerForSession('rt-retired')).toBe('research')
+
+    retireLocalProfileGateways('research')
+    getConnection.mockClear()
+
+    await expect(
+      requestForOwnedSession('rt-retired', vi.fn() as never, 'approval.respond', { session_id: 'rt-retired' })
+    ).rejects.toSatisfy(isSessionOwnerResolutionError)
+
+    expect(getConnection).not.toHaveBeenCalled()
+  })
+
+  it('keeps a same-named exact remote runtime owner when the local profile retires', () => {
+    recordSessionEventScope({ connectionId: 'remote-same-name', profile: 'research', session_id: 'rt-remote' })
+
+    retireLocalProfileGateways('research')
+
+    expect(knownOwnerForSession('rt-remote')).toEqual({ connectionId: 'remote-same-name', profile: 'research' })
+  })
+
+  it('fails the mounted approval action closed after local teardown without a redial', async () => {
+    const stream = renderMessageStream('rt-action')
+    const getConnection = (window as unknown as { hermesDesktop: { getConnection: ReturnType<typeof vi.fn> } })
+      .hermesDesktop.getConnection
+
+    configureGatewayRegistry({
+      onLocalProfileRetired: forgetProfileOnlyRuntimeOwners,
+      onEvent: event => {
+        recordSessionEventScope(event)
+        stream.handleEvent(event as never)
+      }
+    })
+    $activeSessionId.set('rt-action')
+    await expect(ensureGatewayForProfile('research')).resolves.toBeUndefined()
+
+    gatewayMocks.instances[0].emit({
+      payload: { command: 'rm -rf /tmp/x', description: 'dangerous command', request_id: 'approval-1' },
+      session_id: 'rt-action',
+      type: 'approval.request'
+    })
+    await waitFor(() => expect(knownOwnerForSession('rt-action')).toBe('research'))
+    retireLocalProfileGateways('research')
+    getConnection.mockClear()
+
+    render(createElement(PendingApprovalFallback))
+    fireEvent.click(await screen.findByRole('button', { name: /Run/ }))
+
+    await waitFor(() => expect(getConnection).not.toHaveBeenCalled())
+    expect(screen.getByRole('button', { name: /Run/ })).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -7,6 +7,7 @@ import { reconnectBackoffDelayMs } from '@/lib/reconnect-backoff'
 import { RECONNECT_ATTEMPT_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
 import { markNativeNotifyBaseline } from '@/store/notify-baseline'
 import { setConnection, setGatewayState } from '@/store/session'
+import { stampSecondaryProfileOwner } from '@/store/session-event-provenance'
 
 // ── Multi-profile gateway routing ──────────────────────────────────────────
 // Concurrent sessions across profiles need concurrent sockets: the renderer's
@@ -41,6 +42,10 @@ interface RegistryConfig {
    * (#89206: the stale-profile split-brain that stranded bot wake-ups).
    */
   onActiveRouteChanged?: (profile: string) => void
+  /** Drop transient profile-pool runtime routes when local profile teardown
+   * permanently retires their owning secondary. Exact registry routes are
+   * deliberately outside this callback: a remote source may share the name. */
+  onLocalProfileRetired?: (profile: string) => void
   /**
    * Scopes a FOREGROUND surface is bound to right now — every mounted
    * session tile's owner and the primary thread's (foregroundSessionScopes in
@@ -715,9 +720,13 @@ function createSecondary(profile: string, connectionId: null | string = null): S
   }
 
   // Events keep carrying the bare profile — session routing is profile-keyed
-  // everywhere. connectionId rides along for surfaces that need the source.
+  // everywhere. A pool secondary with no registry connection has no exact
+  // connection id, so stamp this closure-owned profile before registry fan-in;
+  // the recorder must not promote an arbitrary wire `profile` field instead.
   entry.offEvent = gateway.onEvent(event => {
-    g.config?.onEvent({ ...event, profile, ...(connectionId ? { connectionId } : {}) })
+    const scopedEvent = stampSecondaryProfileOwner({ ...event, ...(connectionId ? { connectionId } : {}) }, profile)
+
+    g.config?.onEvent(scopedEvent)
     releaseTerminalTurnLease(entry.scope, event)
   })
   entry.offState = gateway.onState(state => {
@@ -1775,6 +1784,12 @@ export function retireLocalProfileGateways(profile: string): void {
   const key = normKey(name)
   const scopes = new Set([key, registryBackendScopeKey('local', key)])
   let activeInvalidated = false
+
+  // A profile-only owner is a claim about the legacy local pool, not durable
+  // session identity. Clear it with that pool before a delayed session action
+  // can recreate the deleted/old-name backend. Exact remote owners are
+  // descriptors and remain routable even when they share this profile name.
+  g.config?.onLocalProfileRetired?.(key)
 
   for (const scope of scopes) {
     const entry = g.secondaries.get(scope)

--- a/apps/desktop/src/store/session-event-provenance.ts
+++ b/apps/desktop/src/store/session-event-provenance.ts
@@ -1,0 +1,31 @@
+import type { GatewayEvent } from '@hermes/shared'
+
+// A profile name received over the wire is descriptive, not an ownership
+// claim: primary and arbitrary synthetic events can carry one. The secondary
+// socket closure is the authority for profile-only pool routes, so stamp its
+// outgoing copy with a non-serializable marker before it crosses registry
+// fan-in. JSON-RPC payloads cannot forge a Symbol property.
+const secondaryProfileOwner = Symbol('secondaryProfileOwner')
+
+type SecondaryProfileOwnedEvent = GatewayEvent & {
+  [secondaryProfileOwner]?: string
+}
+
+export function stampSecondaryProfileOwner(event: GatewayEvent, profile: string): GatewayEvent {
+  const scoped = { ...event, profile } as SecondaryProfileOwnedEvent
+
+  Object.defineProperty(scoped, secondaryProfileOwner, {
+    configurable: false,
+    enumerable: false,
+    value: profile,
+    writable: false
+  })
+
+  return scoped
+}
+
+export function secondaryProfileOwnerForEvent(event: GatewayEvent): string | undefined {
+  const profile = (event as SecondaryProfileOwnedEvent)[secondaryProfileOwner]
+
+  return typeof profile === 'string' && profile.trim() ? profile.trim() : undefined
+}

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -16,7 +16,7 @@
  * itself here as the delegate so tile UI stays dependency-light.
  */
 
-import { LOCAL_CONNECTION_ID, registryBackendScopeKey } from '@hermes/shared'
+import { type GatewayEvent, LOCAL_CONNECTION_ID, registryBackendScopeKey } from '@hermes/shared'
 import { atom, computed } from 'nanostores'
 
 import type { ClientSessionState } from '@/app/types'
@@ -56,6 +56,7 @@ import {
   setBusy,
   setSessions
 } from './session'
+import { secondaryProfileOwnerForEvent } from './session-event-provenance'
 import { assertSessionOwnerResolved } from './session-owner-resolution'
 import {
   requestForSessionProfile,
@@ -84,22 +85,53 @@ export const $sessionStates = atom<Record<string, ClientSessionState>>({})
 
 const sessionScopeByRuntimeId = new Map<string, string>()
 
-// Structured twin of the scope ledger: the same inbound events also carry the
-// exact (connectionId, profile) owner, which the composite scope string
-// cannot give back. Consumed as the LAST rung of knownOwnerForSession so a
-// runtime whose event source already proved its owner can still route
-// session-scoped RPCs (approval.respond) when every durable binding
-// (tile / hint / row) is absent — while durable stored identity keeps
-// outranking it (#97511).
-const sessionOwnerByRuntimeId = new Map<string, SessionOwnerRoute>()
+// Structured twin of the scope ledger: inbound events can carry either an
+// exact (connectionId, profile) owner or a producer-proven profile-only pool
+// owner. Consumed as the LAST rung of knownOwnerForSession so a runtime whose
+// event source already proved its owner can still route session-scoped RPCs
+// (approval.respond) when every durable binding (tile / hint / row) is absent
+// — while durable stored identity keeps outranking it (#97511).
+const sessionOwnerByRuntimeId = new Map<string, SessionOwnerScope>()
 
 export function recordSessionEventScope(event: { connectionId?: string; profile?: string; session_id?: string }): void {
-  if (event.session_id && event.connectionId) {
+  if (!event.session_id) {
+    return
+  }
+
+  if (event.connectionId) {
     sessionScopeByRuntimeId.set(event.session_id, registryBackendScopeKey(event.connectionId, event.profile))
     sessionOwnerByRuntimeId.set(event.session_id, {
       connectionId: event.connectionId,
       profile: String(event.profile ?? '').trim() || 'default'
     })
+
+    return
+  }
+
+  // Only gateway.ts's secondary closure can add this non-serializable marker.
+  // A profile field from a primary or arbitrary inbound event is descriptive,
+  // not an owner route, and must keep failing closed in multi-profile installs.
+  const profile = secondaryProfileOwnerForEvent(event as GatewayEvent)
+
+  if (profile) {
+    sessionOwnerByRuntimeId.set(event.session_id, profile)
+  }
+}
+
+/** Forget only profile-pool runtime owners during permanent LOCAL profile
+ * teardown. These string routes came exclusively from the legacy secondary
+ * producer; exact connection descriptors must survive a same-named remote
+ * profile's local delete/rename. */
+export function forgetProfileOnlyRuntimeOwners(profile: string): void {
+  const retired = normalizeProfileKey(profile)
+
+  for (const [runtimeId, owner] of sessionOwnerByRuntimeId) {
+    if (typeof owner === 'string' && normalizeProfileKey(owner) === retired) {
+      sessionOwnerByRuntimeId.delete(runtimeId)
+      // Profile-only events do not populate the composite scope ledger today,
+      // but delete its local counterpart defensively if an older fan-in did.
+      sessionScopeByRuntimeId.delete(runtimeId)
+    }
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes #103755 by preserving profile-only ownership proven by a secondary socket, rather than promoting arbitrary profile-labelled events to owner routes.

- Stamp a renderer-local, non-enumerable Symbol on events at the secondary socket's producer boundary.
- Record that proven bare-profile owner as the final runtime-owner lookup rung; exact connection routes and durable owner precedence remain unchanged.
- Invalidate these transient profile-only owners when local profile deletion/rename retires the pool, preventing a delayed approval from redialing the deleted/old backend. Preserve same-named exact remote owners.
- Add regression coverage through the actual secondary event callback, message-stream approval consumer, and mounted approval action, including retirement/no-redial behavior.

## Relationship to concurrent work

PR #103770 appeared while this candidate was being validated. This is an **alternative implementation**, not an independent unrelated fix; please do not merge both without reconciliation. Thank you to its author for picking up the report.

The substantive differences are explicit producer provenance (unproven profile-only events continue to fail closed) and local-profile retirement cleanup. Our independent review caught a delayed-approval redial path in the initial candidate, so the final change includes lifecycle wiring and a regression. Maintainers are welcome to combine approaches or prefer the smaller one with equivalent invariants.

## Type of Change

- [x] Bug fix

## Changes Made

- `apps/desktop/src/store/session-event-provenance.ts`: internal producer marker and reader.
- `apps/desktop/src/store/gateway.ts`: mark secondary events; notify session state on permanent local profile retirement.
- `apps/desktop/src/store/session-states.ts`: retain proven profile-only runtime owners and invalidate them on local retirement.
- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts`: wire the retirement callback on the production registry path.
- `apps/desktop/src/store/gateway-profile-only-owner.integration.test.ts`: routing, unproven-event rejection, durable precedence, same-named remote preservation, and stale approval lifecycle regressions.

## How to Test

From `apps/desktop`:

```sh
npx vitest run --project ui \
  src/store/gateway-profile-only-owner.integration.test.ts \
  src/store/gateway-connection-lifecycle.test.ts \
  src/store/gateway-connection-scope.test.ts \
  src/store/session-states-runtime-map.test.ts \
  src/store/session-states.test.ts \
  src/store/session-request-router.test.ts \
  src/components/assistant-ui/tool/approval.test.tsx \
  src/app/gateway/hooks/use-gateway-boot.test.tsx
npm run typecheck
npx eslint src/store/gateway.ts src/store/session-states.ts \
  src/store/session-event-provenance.ts \
  src/store/gateway-profile-only-owner.integration.test.ts \
  src/app/gateway/hooks/use-gateway-boot.ts
npm run build
PYTHONDONTWRITEBYTECODE=1 npx playwright test e2e/boot.spec.ts --reporter=list
```

### Observed local results (macOS / Apple Silicon)

- Focused Vitest: **8 files, 205 tests passed**.
- All three desktop TypeScript projects passed.
- ESLint on changed source/tests and `git diff --check` passed.
- Desktop build, including `assert-dist-built`, passed.
- Final rebuilt isolated Electron boot smoke: **5 tests passed**, with a real backend and mock inference. No visual baseline was available; this is not a visual-regression claim.
- Independent review found no remaining code blocker after the retirement correction.

### Red/green evidence

Before the initial fix, the new producer-to-owner regression failed: expected the secondary profile owner, received `undefined` after a foreground profile switch with no durable bindings. Before retirement cleanup, a delayed approval following local profile retirement **resolved/redialed** rather than rejecting. Both paths pass with the final implementation.

### Validation boundaries

This is not a claimed reproduction of the approval failure in a live packaged Electron app. The regression mounts the real message-stream consumer and approval UI with transport fixtures and supplies the registry callbacks used by `useGatewayBoot`. It does not drive actual delete/rename dialogs or prove live reconnect recovery. The separate Electron smoke establishes boot only. The full repository/Python suite was not run; Windows/Linux were not tested locally.

## Checklist

- [x] Read contributing and desktop engineering guidance.
- [x] Conventional commit; focused changes only.
- [x] Searched issues/PRs, including a final pre-submit check; concurrent alternative linked above.
- [x] Regression tests added and observed failing before their respective fixes.
- [x] Tested on macOS / Apple Silicon; limitations stated above.
- [ ] Full repository test suite (not run; focused desktop validation reported instead).
- [x] No config/tool schema/dependency changes; related documentation changes N/A.
- [x] Considered cross-platform impact: renderer TypeScript only, no new OS-specific behavior.

## AI assistance

Prepared with Hermes and Codex assistance, including an independent review pass. Reported test results were executed locally, with final host verification separate from the implementation worker. No private conversations, real session IDs, or profile configuration are included.
