### PR TITLE
fix(agent): alias Perplexity-reserved Responses tools

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -65,14 +65,21 @@ def _merge_extra_headers(kwargs: dict[str, Any], **headers: str) -> None:
 # (incomplete hang / HTTP 400); it goes on the wire under this alias.
 _XAI_CLIENT_WEB_SEARCH_ALIAS = "hermes_web_search"
 
-# OpenCode /v1/responses rejects client tools using these names (HTTP 400
-# "custom function name 'X' is reserved"); xAI reserves ``tool_search`` for
-# Grok's native Tool Search. Aliased as hermes_<name>.
+# Responses providers reject client functions whose names collide with native
+# tools (HTTP 400 "custom function name 'X' is reserved"). Alias them as
+# hermes_<name> and map them back before local dispatch.
 # OpenCode's /v1/responses endpoints (Zen and Go, including custom providers pointing at opencode.ai)
 # reserve certain function names server-side and reject client tools that use them with HTTP 400 ("custom
 # function name 'X' is reserved"). Same treatment as the xAI web_search collision: rename on the wire
 # (hermes_<name>), map back in normalize_response so Hermes dispatch is unaffected. See #85589.
 _OPENCODE_RESERVED_TOOL_NAMES = ("web_search", "search_files")
+_PERPLEXITY_RESERVED_TOOL_NAMES = (
+    "web_search",
+    "search_files",
+    "fetch_url",
+    "people_search",
+    "finance_search",
+)
 _XAI_RESERVED_TOOL_NAMES = ("tool_search",)
 _RESERVED_TOOL_ALIAS_PREFIX = "hermes_"
 
@@ -80,7 +87,7 @@ _RESERVED_TOOL_ALIAS_PREFIX = "hermes_"
 # built a request; real requests carry request-local ``_last_wire_aliases``.
 _LEGACY_ALIAS_FALLBACK = {
     f"{_RESERVED_TOOL_ALIAS_PREFIX}{name}": name
-    for name in (*_OPENCODE_RESERVED_TOOL_NAMES, *_XAI_RESERVED_TOOL_NAMES)
+    for name in (*_OPENCODE_RESERVED_TOOL_NAMES, *_PERPLEXITY_RESERVED_TOOL_NAMES, *_XAI_RESERVED_TOOL_NAMES)
 }
 _LEGACY_ALIAS_FALLBACK[_XAI_CLIENT_WEB_SEARCH_ALIAS] = "web_search"
 
@@ -98,6 +105,16 @@ def _is_opencode_responses_backend(params: dict[str, Any]) -> bool:
         from utils import base_url_hostname
 
         return base_url_hostname(str(params.get("base_url") or "")).lower() == "opencode.ai"
+    except Exception:
+        return False
+
+
+def _is_perplexity_responses_backend(params: dict[str, Any]) -> bool:
+    """True for Perplexity's Responses-compatible Agent API endpoint."""
+    try:
+        from utils import base_url_hostname
+
+        return base_url_hostname(str(params.get("base_url") or "")).lower() == "api.perplexity.ai"
     except Exception:
         return False
 
@@ -178,6 +195,11 @@ def _alias_wire_tools(response_tools: Any, params: dict[str, Any], is_xai_respon
     if response_tools and _is_opencode_responses_backend(params):
         response_tools, _oc_aliases = _alias_reserved_tools(response_tools, _OPENCODE_RESERVED_TOOL_NAMES)
         wire_aliases.update(_oc_aliases)
+    # Perplexity's Agent API reserves the same names as server-side tools.
+    # Keep Hermes's client-side functions available under wire aliases.
+    if response_tools and _is_perplexity_responses_backend(params):
+        response_tools, _pplx_aliases = _alias_reserved_tools(response_tools, _PERPLEXITY_RESERVED_TOOL_NAMES)
+        wire_aliases.update(_pplx_aliases)
     # xAI server-side web search vs Hermes web providers. grok models on xAI's /v1/responses surface have a
     # *native*, server-executed web search. A client-side function literally named ``web_search`` collides
     # with that engine: declared as a plain ``function`` rather than ``{"type": "web_search"}``, the search

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -965,10 +965,9 @@ class TestCodexBuildKwargs:
             assert "reasoning" not in kw, f"{model} must not receive reasoning"
 
 
-class TestOpencodeReservedToolAliases:
-    """OpenCode /v1/responses reserves web_search / search_files as function
-    names (HTTP 400 "custom function name 'X' is reserved", #85589). The
-    transport aliases them on the wire and maps them back on dispatch."""
+class TestResponsesReservedToolAliases:
+    """Responses providers may reserve web_search / search_files as function
+    names. The transport aliases them on the wire and maps them back."""
 
     @pytest.fixture
     def transport(self):
@@ -988,6 +987,12 @@ class TestOpencodeReservedToolAliases:
             "name": "read_file", "description": "Read a file.",
             "parameters": {"type": "object",
                            "properties": {"path": {"type": "string"}}}}},
+    ]
+    _PERPLEXITY_ONLY_TOOLS = [
+        {"type": "function", "function": {
+            "name": name, "description": f"Client {name}.",
+            "parameters": {"type": "object", "properties": {}}}}
+        for name in ("fetch_url", "people_search", "finance_search")
     ]
 
     def _names(self, kw):
@@ -1046,6 +1051,73 @@ class TestOpencodeReservedToolAliases:
         assert "search_files" in names
         assert "web_search" in names
         assert "hermes_search_files" not in names
+
+    def test_perplexity_agent_api_aliases_reserved_names(self, transport, monkeypatch):
+        kw = transport.build_kwargs(
+            model="perplexity/sonar",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=list(self._TOOLS) + list(self._PERPLEXITY_ONLY_TOOLS),
+            provider="custom",
+            base_url="https://api.perplexity.ai/v1",
+        )
+        names = self._names(kw)
+        assert "hermes_search_files" in names
+        assert "hermes_web_search" in names
+        assert "search_files" not in names
+        assert "web_search" not in names
+        assert "hermes_fetch_url" in names
+        assert "hermes_people_search" in names
+        assert "hermes_finance_search" in names
+        assert "fetch_url" not in names
+        assert "people_search" not in names
+        assert "finance_search" not in names
+        assert "read_file" in names
+        assert transport._last_wire_aliases == {
+            "hermes_search_files": "search_files",
+            "hermes_web_search": "web_search",
+            "hermes_fetch_url": "fetch_url",
+            "hermes_people_search": "people_search",
+            "hermes_finance_search": "finance_search",
+        }
+
+        msg = SimpleNamespace(
+            content=None,
+            reasoning=None,
+            tool_calls=[SimpleNamespace(
+                id="call_1", call_id="call_1", response_item_id="fc_1",
+                function=SimpleNamespace(
+                    name="hermes_search_files",
+                    arguments='{"pattern":"README"}',
+                ),
+            )],
+            codex_reasoning_items=None,
+            codex_message_items=None,
+            reasoning_details=None,
+        )
+        monkeypatch.setattr(
+            "agent.codex_responses_adapter._normalize_codex_response",
+            lambda resp, issuer_kind=None: (msg, "tool_calls"),
+        )
+        normalized = transport.normalize_response(SimpleNamespace(output=[], status="completed"))
+        assert [tc.name for tc in normalized.tool_calls] == ["search_files"]
+
+    def test_perplexity_lookalike_host_keeps_original_names(self, transport):
+        for base_url in (
+            "https://sub.api.perplexity.ai/v1",
+            "https://api.perplexity.ai.example.com/v1",
+            "https://example.com/api.perplexity.ai/v1?host=api.perplexity.ai",
+        ):
+            kw = transport.build_kwargs(
+                model="perplexity/sonar",
+                messages=[{"role": "user", "content": "hi"}],
+                tools=list(self._TOOLS),
+                provider="custom",
+                base_url=base_url,
+            )
+            names = self._names(kw)
+            assert "search_files" in names
+            assert "web_search" in names
+            assert "hermes_search_files" not in names
 
     def test_normalize_maps_reserved_aliases_back(self, transport, monkeypatch):
         msg = SimpleNamespace(


### PR DESCRIPTION
## What changed

Perplexity's Responses-compatible Agent API reserves these custom function
names: `web_search`, `search_files`, `fetch_url`, `people_search`, and
`finance_search`. Hermes currently exposes `web_search` and `search_files`, and
deferred/plugin tool catalogs may expose the others, so Perplexity can reject
the request with HTTP 400 before the model runs.

This change:

- detects the exact `api.perplexity.ai` endpoint host;
- reuses the existing Responses transport's reserved-name alias mechanism;
- sends conflicting functions under the existing `hermes_` wire prefix; and
- preserves the request-local reverse mapping so Hermes still dispatches
  each original function name internally.

Other endpoints and non-conflicting tools are unchanged. Explicit negative cases
prevent enabling Perplexity behavior for a Perplexity subdomain, a hostname
suffix lookalike, or a path/query that merely mentions `api.perplexity.ai`.
The positive test also proves the request-local alias map reverses an aliased
Perplexity tool call back to `search_files` before Hermes dispatch.

## Why

Without the aliasing, a valid Perplexity Agent API custom-provider configuration
cannot use Hermes's normal file/web tool schema. The request fails during tool
validation, before inference or tool dispatch.

The Responses transport already solves the same wire-name collision for
OpenCode and xAI. Extending that mechanism keeps the alias provider-scoped and
avoids renaming Hermes's internal tools.

## Relationship to existing work

Related: #81308 adds a Perplexity Chat Completions provider and repairs strict
JSON tool schemas. This change is separate: it targets the Responses-compatible
Agent API at `/v1` and fixes reserved custom-function names, not JSON schema
shape.

Named custom-provider/model normalization is also outside this focused change;
#62908 addresses named custom-provider usability.

## How to test

```bash
scripts/run_tests.sh tests/agent/transports/test_codex_transport.py
scripts/run_tests.sh tests/agent/transports/
```

Verified on Fedora Linux x86_64, Python 3.11:

- `126 passed` in `test_codex_transport.py`
- `367 passed` in `tests/agent/transports/`
- `git diff --check` passes
- live Perplexity Agent API smoke test accepted the full file tool schema,
  invoked Hermes's real `search_files` tool, and returned the expected response
- direct validation probes confirmed HTTP 400 reserved-name errors for
  `web_search`, `search_files`, `fetch_url`, `people_search`, and
  `finance_search`; control functions `sandbox` and `read_file` were accepted

No credentials, logging behavior, dependencies, or persistent configuration are
changed by this patch.
