### PR TITLE
fix(models): preserve profile context in cache refresh workers

### DIFF
--- a/hermes_cli/model_catalog.py
+++ b/hermes_cli/model_catalog.py
@@ -8,6 +8,7 @@ whose callers fall back to the in-repo lists on ``None``.
 
 from __future__ import annotations
 
+import contextvars
 import json
 import logging
 import threading
@@ -189,7 +190,10 @@ def _spawn_catalog_swr_refresh(url: str) -> None:
             with _catalog_swr_lock:
                 _catalog_swr_inflight = False
 
-    threading.Thread(target=_refresh, daemon=True, name="model-catalog-swr").start()
+    # The picker may be serving a profile scoped by ContextVar, not process HERMES_HOME.
+    context = contextvars.copy_context()
+    threading.Thread(target=lambda: context.run(_refresh),
+                     daemon=True, name="model-catalog-swr").start()
 
 
 def _remember(data: dict[str, Any], mtime: float) -> dict[str, Any]:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -8,6 +8,7 @@ Origin module; cohesive clusters live in siblings and are re-imported here so
 
 from __future__ import annotations
 
+import contextvars
 import copy
 import json
 import logging
@@ -1380,7 +1381,10 @@ def _spawn_swr_refresh(cache_key: str, refresh_fn=None) -> None:
             with _swr_refresh_lock:
                 _swr_refresh_inflight.discard(cache_key)
 
-    threading.Thread(target=_refresh, daemon=True, name=f"model-cache-swr-{cache_key}").start()
+    # Both provider resolution and the cache destination belong to the requesting profile.
+    context = contextvars.copy_context()
+    threading.Thread(target=lambda: context.run(_refresh),
+                     daemon=True, name=f"model-cache-swr-{cache_key}").start()
 
 
 def _provider_models_cache_path() -> Path:

--- a/tests/hermes_cli/test_model_catalog_refresh_scope.py
+++ b/tests/hermes_cli/test_model_catalog_refresh_scope.py
@@ -1,0 +1,96 @@
+"""Background catalog writes must retain the requesting profile's home."""
+
+import json
+import os
+import threading
+import time
+
+from hermes_cli import model_catalog, models
+from hermes_constants import get_hermes_home, reset_hermes_home_override, set_hermes_home_override
+
+
+def test_stale_catalog_refresh_stays_in_requesting_profile(tmp_path, monkeypatch):
+    default_home = tmp_path / "hermes"
+    profile_home = default_home / "profiles" / "worker"
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    monkeypatch.setattr(model_catalog, "_catalog_swr_inflight", False)
+    model_catalog.reset_cache()
+    old = {"version": 1, "providers": {"nous": {"models": [{"id": "old-model"}]}}}
+    fresh = {"version": 1, "providers": {"nous": {"models": [{"id": "new-model"}]}}}
+    paths = [home / "cache" / "model_catalog.json" for home in (default_home, profile_home)]
+    for path in paths:
+        path.parent.mkdir(parents=True)
+        path.write_text(json.dumps(old), encoding="utf-8")
+        os.utime(path, (1, 1))
+    default_before = paths[0].read_bytes()
+    release_fetch = threading.Event()
+    write_finished = threading.Event()
+    write_disk_cache = model_catalog._write_disk_cache
+
+    def fetch(*args):
+        assert release_fetch.wait(5), "caller did not release the refresh"
+        return fresh
+
+    def write(data):
+        try:
+            write_disk_cache(data)
+        finally:
+            write_finished.set()
+
+    # Only replace the HTTP boundary; use a real worker thread and disk I/O.
+    monkeypatch.setattr(model_catalog, "_fetch_manifest_with_fallback", fetch)
+    monkeypatch.setattr(model_catalog, "_write_disk_cache", write)
+    token = set_hermes_home_override(profile_home)
+    try:
+        assert model_catalog.get_catalog() == old
+    finally:
+        reset_hermes_home_override(token)
+        release_fetch.set()
+    assert write_finished.wait(5), "background catalog write did not finish"
+
+    assert json.loads(paths[1].read_text(encoding="utf-8")) == fresh
+    assert paths[0].read_bytes() == default_before
+
+
+def test_provider_refresh_reads_and_writes_in_requesting_profile(tmp_path, monkeypatch):
+    default_home = tmp_path / "hermes"
+    profile_home = default_home / "profiles" / "worker"
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    monkeypatch.setattr(models, "_swr_refresh_inflight", set())
+    provider = "opencode-free"  # Keyless, so the test needs no credentials.
+    row = {"fp": models._credential_fingerprint(provider), "at": time.time() - 7200,
+           "models": ["old-model"]}
+    paths = [home / "provider_models_cache.json" for home in (default_home, profile_home)]
+    for path in paths:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({provider: row}), encoding="utf-8")
+    default_before = paths[0].read_bytes()
+    release_fetch = threading.Event()
+    write_finished = threading.Event()
+    fetch_homes = []
+    save = models._save_provider_models_cache
+
+    def fetch(*args, **kwargs):
+        assert release_fetch.wait(5), "caller did not release the refresh"
+        fetch_homes.append(get_hermes_home())
+        return ["new-model"]
+
+    def write(data):
+        try:
+            save(data)
+        finally:
+            write_finished.set()
+
+    monkeypatch.setattr(models, "provider_model_ids", fetch)
+    monkeypatch.setattr(models, "_save_provider_models_cache", write)
+    token = set_hermes_home_override(profile_home)
+    try:
+        assert models.cached_provider_model_ids(provider) == ["old-model"]
+    finally:
+        reset_hermes_home_override(token)
+        release_fetch.set()
+    assert write_finished.wait(5), "background provider write did not finish"
+
+    assert fetch_homes == [profile_home]
+    assert json.loads(paths[1].read_text(encoding="utf-8"))[provider]["models"] == ["new-model"]
+    assert paths[0].read_bytes() == default_before


### PR DESCRIPTION
## What does this PR do?

Preserves the requesting profile's ContextVars in **both** background model-cache refresh workers. A profile-scoped picker request currently returns stale data as designed, but its bare worker threads later resolve the process default home and write the wrong profile's cache. The provider worker also resolves models outside the requesting home.

## Related Issue

Fixes #103778

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- Capture `contextvars.copy_context()` before scheduling the manifest worker in `hermes_cli/model_catalog.py`.
- Apply the same fix to the provider-list/custom-provider refresh worker in `hermes_cli/models.py`.
- Run each worker inside its captured context. No process environment mutation, new helper, dependency, config key, TTL change, or foreground blocking.
- Add two behavioral tests with real threads and temporary profile files. Only fetch boundaries are replaced; events hold the fetch until the calling scope has ended. The tests assert the requesting cache changes, the default cache remains byte-identical, and provider resolution sees the requesting home.

## Before / After

On clean main `9dd6634c56`, both regression tests fail: the manifest stays stale in the named profile and provider resolution observes the default home. With this patch, both pass. Existing single-profile calls still inherit the same effective home they had before.

## How to Test

Native Windows, Python 3.13, canonical hermetic runner:

```sh
scripts/run_tests.sh tests/hermes_cli/test_model_catalog_refresh_scope.py tests/hermes_cli/test_model_catalog.py tests/hermes_cli/test_model_cache_swr.py tests/hermes_cli/test_models.py -q
```

**113 passed, 0 failed.**

The exact two regression tests were also run in a separate clean-main worktree: **2 failed** before the fix. Ruff over the three changed files and `git diff --check` pass. No live provider account is required and no user profile files are touched by the tests.

## Compatibility and risks

Keeps existing SWR deduplication, timeout, stale-window, and cache formats. Uses the standard context-copying pattern already used by other Hermes background workers. A captured context is exclusive to its worker. Does not claim to redesign process-global cache keys or solve provider-cache concurrent-update issues covered by #92936; this patch addresses thread-context loss.

## Checklist

- [x] Read the contributing guide; conventional isolated commit
- [x] Searched open/closed issues and PRs and inspected original SWR history (#76430)
- [x] Added invariant tests proven red on current main
- [x] Tested on native Windows; no OS-specific API added
- [ ] Full repository suite passed locally (not run)
- [x] Documentation/config/schema/architecture updates: not applicable