### PR TITLE
fix(agent): strip replayed message_id before it reaches chat-completions wire

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2119,7 +2119,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 # Go, Mistral, Moonshot/Kimi) reject with 422. The transport's convert_messages() drops them
 # in the main loop; the summary path calls chat.completions.create() directly, so mirror it.
 _SUMMARY_FOREIGN_MESSAGE_KEYS = ("reasoning", "finish_reason", "tool_name", "codex_reasoning_items",
-    "codex_message_items", "timestamp", "platform_message_id")
+    "codex_message_items", "timestamp", "platform_message_id", "message_id")
 _EMPTY_SUMMARY_RESPONSE = "I reached the iteration limit and couldn't generate a summary."
 
 

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -34,7 +34,7 @@ _XAI_TOOL_SEARCH_ALIAS = "hermes_tool_search"
 # providers reject with HTTP 400 ("Extra inputs are not permitted").
 _STRIP_MSG_KEYS = (
     "codex_reasoning_items", "codex_message_items", "tool_name", "effect_disposition", "timestamp",
-    "platform_message_id", "api_content", "anthropic_content_blocks", "bedrock_content_blocks",
+    "platform_message_id", "message_id", "api_content", "anthropic_content_blocks", "bedrock_content_blocks",
 )
 _STRIP_TC_KEYS = ("call_id", "response_item_id")
 _HIGH_EFFORTS = {"high", "xhigh", "max", "ultra"}

--- a/tests/agent/test_iteration_summary_message_id_leak.py
+++ b/tests/agent/test_iteration_summary_message_id_leak.py
@@ -1,0 +1,45 @@
+"""Regression test for #103769.
+
+The iteration-summary call hand-builds its wire messages and calls
+``chat.completions.create()`` directly, bypassing ``ChatCompletionsTransport
+.convert_messages()`` — so ``_SUMMARY_FOREIGN_MESSAGE_KEYS`` must mirror the
+transport's strip list. It already stripped ``platform_message_id`` but not
+its session-replay alias ``message_id`` (``_rows_to_conversation`` re-exposes
+the stored platform id under that top-level key for JSONL transcript compat),
+so the alias reached strict Chat Completions providers and 400'd.
+"""
+
+from agent.chat_completion_helpers import _iteration_summary_api_messages
+
+
+class _FakeAgent:
+    provider = "openai"
+    model = "gpt-4o"
+    _cached_system_prompt = ""
+    ephemeral_system_prompt = ""
+    prefill_messages = []
+
+    def _should_sanitize_tool_calls(self):
+        return False
+
+    def _copy_reasoning_content_for_api(self, msg, api_msg):
+        pass
+
+    def _sanitize_api_messages(self, msgs):
+        return msgs
+
+    def _drop_thinking_only_and_merge_users(self, msgs):
+        return msgs
+
+
+def test_iteration_summary_strips_replayed_message_id():
+    agent = _FakeAgent()
+    messages = [
+        {"role": "user", "content": "hi", "message_id": "1545511361084129351"},
+    ]
+    api_messages = _iteration_summary_api_messages(agent, messages)
+    assert "message_id" not in api_messages[0]
+    assert api_messages[0]["content"] == "hi"
+    # Original untouched — recovery dedup via has_platform_message_id still
+    # needs the alias in persisted history.
+    assert messages[0]["message_id"] == "1545511361084129351"

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -140,6 +140,24 @@ class TestChatCompletionsBasic:
         # Original list untouched (deepcopy-on-demand)
         assert msgs[0]["timestamp"] == 1781976577.0
 
+    def test_convert_messages_strips_replayed_message_id(self, transport):
+        """Session replay re-exposes ``platform_message_id`` as a top-level
+        ``message_id`` alias (``_rows_to_conversation``, JSONL transcript
+        compat). That alias is not part of the Chat Completions schema;
+        strict providers (Fireworks-backed OpenCode Go, etc.) reject it with
+        HTTP 400 'Extra inputs are not permitted, field: messages[N].message_id'.
+        Regression test for #103769 (same bug class as #47868's ``timestamp``).
+        """
+        msgs = [
+            {"role": "user", "content": "hi", "message_id": "1545511361084129351"},
+        ]
+        result = transport.convert_messages(msgs)
+        assert "message_id" not in result[0]
+        assert result[0]["content"] == "hi"
+        # Original list untouched (deepcopy-on-demand) — recovery dedup via
+        # has_platform_message_id still needs it in persisted history.
+        assert msgs[0]["message_id"] == "1545511361084129351"
+
     def test_convert_messages_strips_provider_replay_sidecars(self, transport):
         """Native-provider replay channels must not cross a provider boundary.
 


### PR DESCRIPTION
Fixes #103769.

## Problem

Session replay re-exposes the stored platform-side message id as a top-level
`message_id` key on replayed messages (`hermes_state_messages.py`
`_rows_to_conversation`, ~line 808, JSONL transcript compat):

```python
if row["platform_message_id"]:  # platform-side id exposed as ``message_id``
    msg["message_id"] = row["platform_message_id"]
```

`agent/transports/chat_completions.py`'s `_STRIP_MSG_KEYS` already strips
`platform_message_id` before messages reach the wire, but not this replay
alias, so `message_id` leaks into outbound chat-completions payloads. Strict
OpenAI-compatible providers reject the schema-foreign field with HTTP 400:

```
HTTP 400: Error from provider (Console Go): Upstream request failed: [invalid_request_error]
7 request validation errors: Extra inputs are not permitted, field: 'messages[1].message_id',
value: '1545511361084129351'; ...
```

Same bug class as #47868's leaked `timestamp` and #893's leaked
`tool_calls[].call_id`/`response_item_id`.

## Fix

- Add `"message_id"` to `_STRIP_MSG_KEYS` in `agent/transports/chat_completions.py`
  (the main-loop wire sanitizer).
- Add `"message_id"` to `_SUMMARY_FOREIGN_MESSAGE_KEYS` in
  `agent/chat_completion_helpers.py` — the iteration-summary path hand-builds
  its wire messages and calls `chat.completions.create()` directly, bypassing
  `ChatCompletionsTransport.convert_messages()`, so it needs the same strip
  applied separately (this mirror already existed for `platform_message_id`
  and the other keys, just missing this one).

Session state (`agent/session_persistence.py`, `has_platform_message_id`
recovery dedup) is untouched — only the outbound wire copy is stripped.

## Test plan

Added regression tests modeled on the existing `#47868` `timestamp`-strip test:

- `tests/agent/transports/test_chat_completions.py::TestChatCompletionsBasic::test_convert_messages_strips_replayed_message_id`
- `tests/agent/test_iteration_summary_message_id_leak.py::test_iteration_summary_strips_replayed_message_id`

Verified both fail without the fix (`git checkout HEAD~2 -- agent/transports/chat_completions.py agent/chat_completion_helpers.py`, rerun, restore):

```
FAILED tests/agent/transports/test_chat_completions.py::TestChatCompletionsBasic::test_convert_messages_strips_replayed_message_id
AssertionError: assert 'message_id' not in {'role': 'user', 'content': 'hi', 'message_id': '1545511361084129351'}
========================= 1 failed, 58 passed in 1.65s =========================
```

And pass with the fix applied:

```
scripts/run_tests.sh tests/agent/transports/test_chat_completions.py tests/agent/test_iteration_summary_message_id_leak.py tests/agent/test_compressed_summary_metadata.py
=== Summary: 3 files, 69 tests passed, 0 failed (100% complete) in 2.4s (8 workers) ===
```

`ruff check` passes on all changed files.

One unrelated flaky test observed in a broader sweep
(`tests/agent/test_compression_stall_fallback_78981.py::test_stalled_summary_attempts_configured_fallback_chain`,
a timing-sensitive stall/retry test unrelated to this change) — passes cleanly
in isolation and doesn't touch any file this PR modifies.

## AI assistance disclosure

This change was written with AI assistance (Claude).
