### PR TITLE
fix(AIS-415): prevent hover prewarm pool oversubscription

### DIFF
--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -223,6 +223,79 @@ describe('prewarmProfileBackend (hover-intent pool spawn)', () => {
 
     expect(openGatewayForProfile).not.toHaveBeenCalledWith('warm-lowered-cap')
   })
+
+  it('counts in-flight spawns against the cap so a hover sweep cannot overshoot (#91545 race)', async () => {
+    // The race: openSecondaryCount() only sees backends whose socket is
+    // already OPEN. During a fast hover sweep the sockets have not opened yet,
+    // so a naive guard reads a stale low count for every prewarm and spawns
+    // past maxBackends — the exact eviction cascade the guard should prevent.
+    // Hold every spawn in flight (socket never opens) and confirm the guard
+    // still stops at the cap. Default cap 3, no open secondaries yet.
+    $poolLimits.set({ idleMs: 600_000, maxBackends: 3 })
+    openSecondaryCount.mockReturnValue(0)
+    // Capture each spawn's resolver so we can drain them at the end and leave
+    // the module-level in-flight set clean for later tests.
+    const resolvers: Array<() => void> = []
+    openGatewayForProfile.mockImplementation(
+      () =>
+        new Promise<undefined>(resolve => {
+          resolvers.push(() => resolve(undefined)) // held until drain
+        })
+    )
+
+    // Sweep across five distinct profiles faster than any socket can open.
+    prewarmProfileBackend('sweep-a')
+    prewarmProfileBackend('sweep-b')
+    prewarmProfileBackend('sweep-c')
+    prewarmProfileBackend('sweep-d')
+    prewarmProfileBackend('sweep-e')
+
+    // Only maxBackends (3) spawns may be launched; the rest are refused while
+    // their predecessors are still in flight.
+    expect(openGatewayForProfile).toHaveBeenCalledTimes(3)
+    const swept = openGatewayForProfile.mock.calls.map(([name]) => name)
+    expect(swept).toEqual(['sweep-a', 'sweep-b', 'sweep-c'])
+    expect(resolvers).toHaveLength(3)
+
+    // Drain the held spawns so the in-flight reservations release and no
+    // promise dangles into the next test.
+    resolvers.forEach(release => release())
+    await new Promise(resolve => setTimeout(resolve, 0))
+  })
+
+  it('frees the in-flight reservation once a spawn settles, letting later prewarms proceed', async () => {
+    $poolLimits.set({ idleMs: 600_000, maxBackends: 3 })
+    openSecondaryCount.mockReturnValue(0)
+    // Two profiles fill 2 of 3 slots and stay open; a third spawn is held in
+    // flight so all three slots are reserved.
+    let resolveHeld: (() => void) | undefined
+    openGatewayForProfile
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockImplementationOnce(
+        () =>
+          new Promise<undefined>(resolve => {
+            resolveHeld = () => resolve(undefined)
+          })
+      )
+      .mockResolvedValue(undefined)
+
+    prewarmProfileBackend('fill-1')
+    prewarmProfileBackend('fill-2')
+    prewarmProfileBackend('fill-3-held')
+    // Flush all microtasks so the two resolved spawns run their
+    // .catch().finally() chain and release their in-flight reservation.
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    // fill-1 and fill-2 have released; fill-3 is still in flight (1 slot used),
+    // so a fourth prewarm has room and proceeds.
+    prewarmProfileBackend('fill-4')
+    expect(openGatewayForProfile).toHaveBeenCalledWith('fill-4')
+
+    // Drain the held spawn so no promise dangles.
+    resolveHeld?.()
+    await new Promise(resolve => setTimeout(resolve, 0))
+  })
 })
 
 describe('refreshProfiles shared rail list (#49289)', () => {

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -412,10 +412,27 @@ const PREWARM_MIN_INTERVAL_MS = 60_000
 
 const prewarmedAt = new Map<string, number>()
 
+// Speculative spawns that have been launched but whose socket has not yet
+// opened. openSecondaryCount() only sees backends whose socket is already
+// open (isOpen), so it is blind to spawns still in flight. A hover sweep
+// across the rail fires prewarms faster (PREWARM_DWELL_MS ~120ms) than the
+// sockets open, so each prewarm saw a stale low count, passed the cap guard,
+// and spawned anyway — overshooting maxBackends and triggering the exact
+// LRU eviction cascade the guard exists to prevent. Counting in-flight
+// reservations against the cap closes that race window.
+const inflightPrewarmKeys = new Set<string>()
+
 export function prewarmProfileBackend(name: string): void {
   const key = normalizeProfileKey(name)
 
   if (key === normalizeProfileKey($activeGatewayProfile.get())) {
+    return
+  }
+
+  // Already have a spawn in flight for this profile: joining it is a no-op
+  // (ensureBackend is idempotent), and re-counting it would double-charge
+  // the cap.
+  if (inflightPrewarmKeys.has(key)) {
     return
   }
 
@@ -430,14 +447,19 @@ export function prewarmProfileBackend(name: string): void {
   // backend. A hover sweep across the rail therefore evicted backends for
   // profiles the user was about to click — prewarming caused the exact churn
   // it exists to prevent. Skip speculative spawns once every pool slot is
-  // occupied by an open socket; the real click still spawns on demand, it
-  // just doesn't get a head start.
-  if (openSecondaryCount() + 1 > $poolLimits.get().maxBackends) {
+  // occupied by an open socket OR reserved by an in-flight prewarm; the real
+  // click still spawns on demand, it just doesn't get a head start.
+  if (openSecondaryCount() + inflightPrewarmKeys.size + 1 > $poolLimits.get().maxBackends) {
     return
   }
 
   prewarmedAt.set(key, now)
-  openGatewayForProfile(key).catch(() => undefined)
+  inflightPrewarmKeys.add(key)
+  openGatewayForProfile(key)
+    .catch(() => undefined)
+    .finally(() => {
+      inflightPrewarmKeys.delete(key)
+    })
 }
 
 let gatewaySwitch: Promise<void> | null = null

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -257,6 +257,7 @@ def test_local_delivery_command_and_ack(tmp_path, monkeypatch):
         "Bot Chat",
         "--create-if-missing",
         "-Q",
+        "--oneshot",
     ]
     # message body rides the temp file, never the command line
     assert "PAYLOAD_SENTINEL_7A91" not in command

--- a/tools/bot_relay.py
+++ b/tools/bot_relay.py
@@ -68,7 +68,7 @@ _HANDLE_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$")
 
 # One turn in a profile's canonical Bot Chat: ``hermes -p <profile> *BOT_CHAT_TURN_ARGS``.
 # ``-c "Bot Chat"`` must match ``bot_mode_probe.BOT_CHAT_TITLE``.
-BOT_CHAT_TURN_ARGS = ("chat", "--in", "~", "-c", "Bot Chat", "--create-if-missing", "-Q")
+BOT_CHAT_TURN_ARGS = ("chat", "--in", "~", "-c", "Bot Chat", "--create-if-missing", "-Q", "--oneshot")
 
 
 def relay_root(root: Path | str) -> Path:


### PR DESCRIPTION
## Summary

- Count in-flight hover prewarm reservations against maxBackends.
- Release each reservation in finally, including rejected spawns.
- Prevent duplicate reservations for the same profile during a concurrent hover sweep.
- Preserve the local --oneshot Bot Chat relay behavior.

This fixes the race where openSecondaryCount() saw only already-open sockets while several prewarm spawns were still pending. A fast profile-rail sweep could exceed the pool cap and trigger LRU eviction, leaving backend-engineer queued until timeout.

## Verification

- npx vitest run src/store/profile.test.ts --reporter=verbose — 22 passed
- scripts/run_tests.sh tests/tools/test_bot_mode_dm.py -q — 42 passed, 1 skipped (Linux Windows-only coverage)
- npm run typecheck — passed
- npx eslint src/store/profile.ts src/store/profile.test.ts — passed
- npm run build — passed; 15,259 modules; assert-dist-built passed
- npm run pack — passed; Electron 40.10.2 Linux x64 unpacked package generated
- Packaged artifact contains resources/app.asar and resources/app.asar.unpacked/dist/electron-main.mjs

Jira: AIS-415