### PR TITLE
fix(models): scope in-memory catalog records by profile path

### DIFF
--- a/hermes_cli/model_catalog.py
+++ b/hermes_cli/model_catalog.py
@@ -15,7 +15,7 @@ import time
 import urllib.error
 import urllib.request
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 from hermes_cli import __version__ as _HERMES_VERSION
 from utils import atomic_replace
@@ -37,9 +37,15 @@ SUPPORTED_SCHEMA_VERSION = 1
 
 _HERMES_USER_AGENT = f"hermes-cli/{_HERMES_VERSION}"
 
-# In-process cache, invalidated against the disk file's mtime and TTL.
-_catalog_cache: dict[str, Any] | None = None
-_catalog_cache_source_mtime: float = 0.0
+
+class _CatalogCache(NamedTuple):
+    path: Path
+    mtime: float
+    data: dict[str, Any]
+
+
+# Publish identity and data together: one process can serve several profile homes.
+_catalog_cache: _CatalogCache | None = None
 
 
 def _load_catalog_config() -> dict[str, Any]:
@@ -193,8 +199,8 @@ def _spawn_catalog_swr_refresh(url: str) -> None:
 
 
 def _remember(data: dict[str, Any], mtime: float) -> dict[str, Any]:
-    global _catalog_cache, _catalog_cache_source_mtime
-    _catalog_cache, _catalog_cache_source_mtime = data, mtime
+    global _catalog_cache
+    _catalog_cache = _CatalogCache(_cache_path(), mtime, data)
     return data
 
 
@@ -210,8 +216,9 @@ def get_catalog(*, force_refresh: bool = False) -> dict[str, Any]:
     disk_fresh = disk_data is not None and (now - disk_mtime) < ttl_seconds
 
     if not force_refresh and disk_data is not None:
-        if disk_fresh and _catalog_cache is not None and disk_mtime == _catalog_cache_source_mtime:
-            return _catalog_cache
+        cached = _catalog_cache
+        if disk_fresh and cached is not None and cached.path == _cache_path() and cached.mtime == disk_mtime:
+            return cached.data
         if not disk_fresh:
             # Stale-while-revalidate: serve the expired disk copy now and refresh off-thread so the
             # /model picker (which calls this on every open) never blocks on the manifest fetch.
@@ -303,7 +310,9 @@ def _default_model_from_block(block: dict[str, Any] | None) -> str | None:
 def get_default_model_from_cache(provider: str) -> str | None:
     """The manifest's labeled default for ``provider`` (the model Hermes silently lands on when the
     user never picked one) — in-process then disk cache only, never a fetch."""
-    found = _default_model_from_block(_block_of(_catalog_cache, provider)) if _catalog_cache is not None else None
+    cached = _catalog_cache
+    found = (_default_model_from_block(_block_of(cached.data, provider))
+             if cached is not None and cached.path == _cache_path() else None)
     if found:
         return found
     disk_data, _mtime = _read_disk_cache()
@@ -331,6 +340,5 @@ def seed_cache_from_checkout(project_root: "Path | str") -> bool:
 
 def reset_cache() -> None:
     """Clear the in-process cache. Used by tests and ``hermes model --refresh``."""
-    global _catalog_cache, _catalog_cache_source_mtime
+    global _catalog_cache
     _catalog_cache = None
-    _catalog_cache_source_mtime = 0.0

--- a/tests/hermes_cli/test_model_cache_swr.py
+++ b/tests/hermes_cli/test_model_cache_swr.py
@@ -153,8 +153,7 @@ class TestCatalogSWR:
         import hermes_cli.model_catalog as mc
 
         manifest = {"version": 1, "providers": {"nous": {"models": [{"id": "hermes-4"}]}}}
-        monkeypatch.setattr(mc, "_catalog_cache", None)
-        monkeypatch.setattr(mc, "_catalog_cache_source_mtime", 0.0)
+        mc.reset_cache()
         with patch.object(mc, "_load_catalog_config", return_value={
                  "enabled": True, "ttl_hours": 1.0, "url": "https://example/cat.json",
                  "providers": {}}), \
@@ -170,8 +169,7 @@ class TestCatalogSWR:
         import hermes_cli.model_catalog as mc
 
         manifest = {"version": 1, "providers": {}}
-        monkeypatch.setattr(mc, "_catalog_cache", None)
-        monkeypatch.setattr(mc, "_catalog_cache_source_mtime", 0.0)
+        mc.reset_cache()
         with patch.object(mc, "_load_catalog_config", return_value={
                  "enabled": True, "ttl_hours": 1.0, "url": "https://example/cat.json",
                  "providers": {}}), \

--- a/tests/hermes_cli/test_model_catalog_profile_identity.py
+++ b/tests/hermes_cli/test_model_catalog_profile_identity.py
@@ -1,0 +1,56 @@
+"""A warm manifest must not supply another profile's catalog or silent default."""
+
+import json
+import os
+import time
+
+import pytest
+
+from hermes_cli import model_catalog, models
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+@pytest.fixture
+def profile_catalogs(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    model_catalog.reset_cache()
+    catalogs = []
+    timestamp = time.time()
+    for name in ("first", "second"):
+        home = tmp_path / "profiles" / name
+        path = home / "cache" / "model_catalog.json"
+        path.parent.mkdir(parents=True)
+        manifest = {"version": 1, "providers": {"nous": {"models": [
+            {"id": f"{name}-model", "default": True}
+        ]}}}
+        path.write_text(json.dumps(manifest), encoding="utf-8")
+        # Copied/seeded caches can share timestamps; identity must include the path.
+        os.utime(path, (timestamp, timestamp))
+        catalogs.append((home, manifest))
+    yield catalogs
+    model_catalog.reset_cache()
+
+
+def test_silent_default_uses_current_profile_after_another_profile_warms_cache(profile_catalogs):
+    first, second = profile_catalogs
+    token = set_hermes_home_override(first[0])
+    try:
+        assert model_catalog.get_catalog() == first[1]
+    finally:
+        reset_hermes_home_override(token)
+    token = set_hermes_home_override(second[0])
+    try:
+        assert models.pick_silent_default_model(
+            ["first-model", "second-model"], provider="nous"
+        ) == "second-model"
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_equal_timestamps_do_not_alias_profile_catalogs(profile_catalogs):
+    for home, manifest in [*profile_catalogs, profile_catalogs[0]]:
+        token = set_hermes_home_override(home)
+        try:
+            assert model_catalog.get_catalog() == manifest
+        finally:
+            reset_hermes_home_override(token)


### PR DESCRIPTION
## What does this PR do?

Prevents a warm in-process model manifest from supplying another profile's catalog or silent default. The old cache retained only data and mtime; its default-model reader did not verify the source at all, while `get_catalog()` treated equal file mtimes as equal identity.

## Related Issue

Fixes #103782

Related but independent of #103779: that PR preserves ContextVars across background refresh threads. This PR fixes synchronous reuse of a **warm in-memory record**, without a background fetch. Both branches are based directly on the same main; `git merge-tree --write-tree` reports a clean merge of the two heads.

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- Store source path, mtime, and manifest in one private cache record, published in a single assignment.
- Require the current cache path to match before either `get_catalog` or `get_default_model_from_cache` reuses that record.
- Read a local snapshot of the record so its identity and contents stay paired.
- Keep the cache-only default fallback, disk format, TTL, single-entry memory bound, and network behavior unchanged.
- Add two invariant tests with real temporary profile files: recommended silent-default selection after another profile warmed the cache, and alternating different manifests with identical mtimes.
- Existing SWR tests reset cache through `reset_cache()` instead of mutating the removed private mtime global; their behavior assertions are unchanged.

## Before / After

Before, both new tests fail on main: profile B selects profile A's model, and equal-mtime files alias to A's manifest. After the fix both pass, including the return switch to A.

## How to Test

```sh
scripts/run_tests.sh tests/hermes_cli/test_model_catalog_profile_identity.py tests/hermes_cli/test_model_catalog.py tests/hermes_cli/test_model_cache_swr.py tests/test_empty_model_fallback.py -q
```

Native Windows / Python 3.13: **45 passed, 0 failed**. New tests on unmodified main `9dd6634c56`: **2 failed**. Ruff over the changed files and `git diff --check`: passed. No live model account is required.

## Compatibility and risks

Only a private in-memory representation changes; repository callers do not consume that representation. Existing files need no migration. Explicitly configured models, model lists, default-label policy, and prompt caching are unchanged. No unbounded per-profile cache is introduced.

## Checklist

- [x] Read contributing guide; conventional single-purpose commit
- [x] Searched existing issues/PRs; checked #64771 and #76076 for intent/overlap
- [x] Added regression tests proven red on current main
- [x] Tested on native Windows; cross-platform pathlib operations only
- [ ] Full repository suite passed locally (not run)
- [x] Config/schema/architecture/documentation changes: not applicable