### PR TITLE
fix(logging): route records to the default home when a profile is deleted

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -383,6 +383,17 @@ class _ProfileRoutingFileHandler(logging.Handler):
             candidate = Path(raw_home).expanduser().resolve()
         except (TypeError, ValueError, OSError):
             candidate = self._default_home
+        if (
+            candidate != self._default_home
+            and candidate in self._profile_homes
+            and not candidate.is_dir()
+        ):
+            # The profile was deleted underneath this long-lived process — the
+            # startup ``_profile_homes`` snapshot is static, so its handler would
+            # retry (and stderr-spam) the vanished logs/ path on every record
+            # (#103777). Fall back to the default home; mirrors the cron
+            # scheduler's ``_existing_profile_homes()`` is_dir() filter.
+            return self._default_home
         return candidate if candidate in self._profile_homes else self._default_home
 
     def _handler_for_home(self, home: Path) -> _ManagedRotatingFileHandler:

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -142,8 +142,62 @@ class TestSetupLogging:
             hermes_home / "logs" / "agent.log"
         ).read_text()
 
+    def test_profile_routing_falls_back_when_profile_home_deleted(
+        self, hermes_home, tmp_path, capsys
+    ):
+        """A profile deleted underneath a long-lived dashboard must not loop.
 
+        ``_profile_homes`` is a startup snapshot, so a ``hermes profile delete``
+        leaves the routing set naming a home whose directory no longer exists.
+        Records for that home must fall back to the default home instead of
+        retrying (and stderr-spamming) the vanished logs/ path on every record
+        (#103777).
+        """
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 
+        profile_home = tmp_path / "profile-deleted"
+        profile_home.mkdir()
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+        assert hermes_logging.enable_profile_log_routing(
+            [hermes_home, profile_home]
+        ) is True
+
+        logger = logging.getLogger("cron.scheduler.profile-routing-deleted-test")
+        # The default home's agent.log must exist before the fallback assertion
+        # can mean anything (lazy-opening handlers may not have created it yet).
+        logger.info("routing fallback default-home probe record")
+        hermes_logging.flush_log_queue()
+        default_log = hermes_home / "logs" / "agent.log"
+        assert "default-home probe record" in default_log.read_text()
+
+        token = set_hermes_home_override(profile_home)
+        try:
+            logger.info("profile-routed record before deletion")
+        finally:
+            reset_hermes_home_override(token)
+        hermes_logging.flush_log_queue()
+        assert "record before deletion" in (
+            profile_home / "logs" / "agent.log"
+        ).read_text()
+
+        # `hermes profile delete` removes the home while the dashboard process
+        # (and its static routing snapshot) keeps running.
+        import shutil
+
+        shutil.rmtree(profile_home)
+
+        token = set_hermes_home_override(profile_home)
+        try:
+            logger.info("profile-routed record after deletion")
+        finally:
+            reset_hermes_home_override(token)
+        hermes_logging.flush_log_queue()
+
+        assert "record after deletion" in default_log.read_text()
+        # The deleted profile's directory must not be resurrected on disk.
+        assert not profile_home.exists()
+        # No "--- Logging error ---" FileNotFoundError loop on stderr.
+        assert "FileNotFoundError" not in capsys.readouterr().err
 
     def test_explicit_params_override_config(self, hermes_home):
         """Explicit function params take precedence over config.yaml."""


### PR DESCRIPTION
## What does this PR do?

Long-lived multiplex processes (e.g. the dashboard's embedded cron ticker) swap their static file handlers for `_ProfileRoutingFileHandler`, which keeps a snapshot of the served profile homes taken at startup. When `hermes profile delete` removes a home while the process keeps running, that snapshot still names the deleted home: every record with `hermes_home` pointing at it stats the vanished `logs/agent.log`, closes the stale stream, fails to reopen with `FileNotFoundError`, and routes the error to stderr — a repeating `--- Logging error ---` loop on every logging tick (#103777).

This PR makes `_home_for_record` fall back to the default home when a routed home's directory no longer exists, mirroring the cron scheduler's existing `_existing_profile_homes()` `is_dir()` filter. The deleted profile's directory is never resurrected on disk, and its records keep flowing to the default home instead of being dropped with stderr noise.

## Related Issue

Fixes #103777

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_logging.py` — `_ProfileRoutingFileHandler._home_for_record`: when the resolved record home is in the routing set but its directory no longer exists, return the default home instead (one `is_dir()` stat per routed record, same order as the per-record stat the managed rotating handler already does).
- `tests/test_hermes_logging.py` — new regression test `test_profile_routing_falls_back_when_profile_home_deleted`: routes a record to a profile home, deletes the home (as `hermes profile delete` does), then asserts the next record lands in the default home's `agent.log`, the deleted directory is not resurrected, and no `FileNotFoundError` reaches stderr.

## How to Test

1. `pytest tests/test_hermes_logging.py -q` — Observed result: 28 passed, 3 skipped (platform skips pre-existing on main).
2. `pytest tests/test_hermes_logging.py -k falls_back_when_profile_home_deleted -q` — Observed result on unpatched main: FAILED, with the issue's exact failure signature (`hermes_logging.py` `_ManagedRotatingFileHandler.emit` → `super().emit(record)` → `--- Logging error --- FileNotFoundError` for `profiles/<deleted>/logs/agent.log`, Message: `'profile-routed record after deletion'`); with this patch: passed.
3. `pytest tests/cron/test_cron_multiplex_desktop_ticker_scope.py -q` — Observed result: 3 passed (routing consumer unaffected).
4. `ruff check hermes_logging.py tests/test_hermes_logging.py` — All checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin arm64), Python 3.11.15

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A