### PR TITLE
feat(optional-skills): add wavespeed — hosted image/video/audio/3D generation

### DIFF
--- a/optional-skills/creative/wavespeed/SKILL.md
+++ b/optional-skills/creative/wavespeed/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: wavespeed
+description: "Generate and edit images, video, audio and 3D via WaveSpeed."
+version: 1.0.0
+author: Zeyi Cheng (chengzeyi), WaveSpeedAI
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [image-generation, video-generation, text-to-image, image-to-video, text-to-video, text-to-speech, upscale, 3d-generation, wavespeed, seedream, seedance, minimax, wan, veo, creative]
+    category: creative
+    homepage: https://github.com/WaveSpeedAI/agent-skills
+    related_skills: [comfyui]
+prerequisites:
+  commands: [wavespeed]
+required_environment_variables:
+  - name: WAVESPEED_API_KEY
+    prompt: WaveSpeed API key (starts with wsk_)
+    help: "Get one at https://wavespeed.ai/accesskey. Not needed if the user has already run `wavespeed login`, which stores the key locally."
+    required_for: "running models when no stored login exists"
+    optional: true
+---
+
+# WaveSpeed Skill
+
+Run hosted generative-media models on the WaveSpeed platform through the open-source `wavespeed` CLI: text-to-image, image editing, text-to-video, image-to-video, video editing, upscaling, face swap, text-to-speech, and 3D. Every model is one `wavespeed run <model-id>` call with explicit inputs; this skill covers finding the right model, reading its schema, quoting the price, and running it. It does not run models locally and does not cover ComfyUI workflows (see `comfyui`).
+
+## When to Use
+
+- The user wants an image, video, audio clip, or 3D asset created or edited: hero images, product photo edits, short clips from a still, voiceovers, upscales, watermark cleanup on their own media.
+- The user names a hosted model (Seedream, Seedance, MiniMax H3, Wan, Veo, Kling, Nano Banana, MiniMax Speech) or asks which model to use for a media task.
+- The user asks what a generation would cost before spending credits.
+
+Do not use it for local diffusion pipelines or for media the user has no right to edit (see Pitfalls).
+
+## Prerequisites
+
+- Node.js 18+ and the CLI: `npm install -g @wavespeed/cli`. Run `scripts/check_setup.py` via `terminal` to confirm the binary is on PATH and the account is signed in.
+- Auth, one of: `wavespeed login` (opens https://wavespeed.ai/accesskey and stores the key), or `WAVESPEED_API_KEY` in the environment. Never ask the user to paste a key into the chat; if `wavespeed status` reports signed out, ask them to run `wavespeed login`.
+- Generations spend account credits; `wavespeed balance` shows the remaining amount.
+
+## How to Run
+
+All commands go through `terminal`. Always pass `--json` so the result is machine-readable.
+
+```bash
+# 1. Find a model on the live catalog
+wavespeed models "seedream"
+wavespeed models --type image-to-video --popular
+
+# 2. Read its input schema (fields, enums, defaults)
+wavespeed run bytedance/seedream-v5.0-pro -h
+
+# 3. Quote, then run
+wavespeed price bytedance/seedream-v5.0-pro -p "a cyberpunk skyline at golden hour" -i resolution=2k
+wavespeed run bytedance/seedream-v5.0-pro \
+  -p "a cyberpunk skyline at golden hour" \
+  -i aspect_ratio="16:9" -i resolution="2k" --json
+```
+
+`run --json` prints `{ id, model, prompt, outputs: [url, ...], saved: [path, ...], elapsed_ms, raw }`. Report `outputs[0]` to the user; add `--download "./out/{index}.{ext}"` when they want the file on disk.
+
+Local files: prefix the path with `@` and the CLI uploads it and substitutes the hosted URL.
+
+```bash
+wavespeed run bytedance/seedream-v5.0-pro/edit \
+  -p "replace the background with a sunlit kitchen" \
+  -i images='["@./input.jpg"]' --json
+
+wavespeed run wavespeed-ai/minimax-h3/image-to-video \
+  -p "subtle parallax, gentle wind" -i image=@./hero.jpg -i duration=5 --json
+```
+
+## Quick Reference
+
+| Task | Start with | Notes |
+|---|---|---|
+| Text to image | `bytedance/seedream-v5.0-pro` | `aspect_ratio`, `resolution` 1k/2k/4k |
+| Image edit | `bytedance/seedream-v5.0-pro/edit` | `images` is a JSON array of URLs or `@paths` |
+| Text/image to video | `wavespeed-ai/minimax-h3/text-to-video`, `.../image-to-video` | open-weights, cheap, native audio; `duration` 3-15 |
+| Highest-quality video | `bytedance/seedance-2.5/*` | same field names, up to 4k |
+| Video edit / extend | `wavespeed-ai/minimax-h3/video-edit`, `.../video-extend` | `video` is required |
+| Text to speech | `minimax/speech-2.6-turbo` | `text`, `voice_id` |
+| Upscale | `wavespeed-ai/image-upscaler`, `wavespeed-ai/ultimate-video-upscaler` | target resolution field |
+
+Other useful commands: `wavespeed show <id>` (recover a run by id), `wavespeed upload <file>` (hosted URL only), `wavespeed usage` and `wavespeed billings` (spend), `wavespeed models --type text-to-3d`.
+
+Per-model detail (all parameters, pricing tiers, prompt tips) for Seedream, Seedance, Veo 3.1, Wan, Nano Banana, MiniMax Speech and the upscalers lives in `references/models.md`.
+
+## Procedure
+
+1. Confirm setup with `scripts/check_setup.py`; stop and ask for `wavespeed login` if it reports signed out.
+2. Pick the model. Search the catalog with `wavespeed models`; never invent a model id. Use the Quick Reference defaults unless the user names a model.
+3. Read the schema with `wavespeed run <model> -h` and map the user's request onto the documented fields only.
+4. Quote with `wavespeed price` when the run is a video, a 4k image, or the user asked about cost; state the number before running.
+5. Run with `--json`, keep the returned `id`, and give the user `outputs[0]` (or the `saved` path when `--download` was used).
+6. If the run fails, read the `raw` error in the JSON; schema mistakes and unsupported values are the usual causes. Fix the inputs and retry once.
+
+## Pitfalls
+
+- Bare local paths are passed through untouched and rejected by the model. Only `@`-prefixed values upload.
+- Field names are per model; `-h` is the source of truth. A field that works on one model may not exist on another.
+- Video runs take 30 seconds to several minutes; the CLI waits, so do not spawn a second run for the same request.
+- Face swap and watermark removal act on other people's likeness or marks. Only proceed when the user owns the media or has consent and rights, never for impersonation or stripping third-party attribution.
+- The CLI never rewrites prompts. If the user wants prompt help, write the prompt yourself before running.
+
+## Verification
+
+- `wavespeed status` shows the signed-in account and `wavespeed balance` a non-zero credit.
+- A successful run returns JSON with a non-empty `outputs` array and an `id` that `wavespeed show <id>` can reload.
+- Open the output URL (or the downloaded file) to confirm the asset matches the request before reporting done.

--- a/optional-skills/creative/wavespeed/references/models.md
+++ b/optional-skills/creative/wavespeed/references/models.md
@@ -1,0 +1,575 @@
+# WaveSpeed model reference
+
+Per-model inputs, pricing and prompt tips, condensed from the WaveSpeedAI per-model skills (https://github.com/WaveSpeedAI/agent-skills). Field names are the ones `wavespeed run <model> -h` prints; prices are list prices at the time of writing and `wavespeed price` is authoritative.
+
+## Seedream V4.5 Image Generation/Editing
+
+**Model ID:** `bytedance/seedream-v4.5`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `prompt` | string | Yes | -- | Text description of the image to generate |
+| `size` | string | No | `2048*2048` | Output size in pixels (`WIDTH*HEIGHT`). Each dimension: 1024-4096. |
+
+**Model ID:** `bytedance/seedream-v4.5/edit`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `images` | string[] | Yes | `[]` | URLs of input images to edit (1-10 images). Must be publicly accessible. |
+| `prompt` | string | Yes | -- | Text description of the desired edit |
+| `size` | string | No | -- | Output size in pixels (`WIDTH*HEIGHT`). Each dimension: 1024-4096. |
+
+### Pricing
+
+$0.04 per image (both generation and editing).
+
+### Tips
+
+- Seedream V4.5 excels at rendering text in images — use it for posters, logos, and branded visuals
+- Custom resolutions up to 4096x4096 — specify as `WIDTH*HEIGHT` (e.g., `2048*3072` for portrait posters)
+- For image editing, the model preserves facial features, lighting, and color tone from inputs
+
+## Nano Banana Pro Image Generation/Editing
+
+**Model ID:** `google/nano-banana-pro/text-to-image`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `prompt` | string | Yes | -- | Text description of the image to generate |
+| `aspect_ratio` | string | No | -- | Output aspect ratio. One of: `1:1`, `3:2`, `2:3`, `3:4`, `4:3`, `4:5`, `5:4`, `9:16`, `16:9`, `21:9` |
+| `resolution` | string | No | `1k` | Image resolution. One of: `1k`, `2k`, `4k` |
+| `output_format` | string | No | `png` | Output format. One of: `png`, `jpeg` |
+
+**Model ID:** `google/nano-banana-pro/edit`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `images` | string[] | Yes | `[]` | URLs of input images to edit (1-14 images) |
+| `prompt` | string | Yes | -- | Text description of the desired edit |
+| `aspect_ratio` | string | No | -- | Output aspect ratio. One of: `1:1`, `3:2`, `2:3`, `3:4`, `4:3`, `4:5`, `5:4`, `9:16`, `16:9`, `21:9` |
+| `resolution` | string | No | `1k` | Image resolution. One of: `1k`, `2k`, `4k` |
+| `output_format` | string | No | `png` | Output format. One of: `png`, `jpeg` |
+
+### Aspect Ratio Options
+
+| Aspect Ratio | Use Case |
+|-------------|----------|
+| `1:1` | Square — social media posts, profile pictures |
+| `3:2` | Landscape — standard photography |
+| `2:3` | Portrait — standard photography |
+| `3:4` | Portrait — social media, product images |
+| `4:3` | Landscape — presentations, web content |
+| `4:5` | Portrait — Instagram posts |
+| `5:4` | Landscape — print, web banners |
+| `9:16` | Vertical — mobile wallpapers, stories |
+| `16:9` | Widescreen — desktop wallpapers, video thumbnails |
+| `21:9` | Ultra-wide — cinematic, panoramic |
+
+### Resolution and Pricing
+
+| Resolution | Cost |
+|------------|------|
+| 1k | $0.14 per image |
+| 2k | $0.14 per image |
+| 4k | $0.24 per image |
+
+### Prompt Tips
+
+- Be specific and descriptive: "A red vintage Porsche 911 on a winding mountain road at golden hour" vs "a car"
+- Include style keywords: "digital art", "oil painting", "photorealistic", "watercolor", "cinematic"
+- For edits, clearly describe the desired change: "Replace the sky with a dramatic sunset"
+- For multi-image edits, reference images by position: "Apply the style from the second image to the first image"
+- Leverage multilingual text rendering: the model supports on-image text with automatic translation
+- Use camera-style control language: "shallow depth of field", "wide angle", "top-down view"
+
+## Nano Banana 2 Image Generation/Editing
+
+**Model ID:** `google/nano-banana-2/text-to-image`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `prompt` | string | Yes | -- | Text description of the image to generate |
+| `aspect_ratio` | string | No | -- | Output aspect ratio. One of: `1:1`, `3:2`, `2:3`, `3:4`, `4:3`, `4:5`, `5:4`, `9:16`, `16:9`, `21:9`, `1:4`, `4:1`, `1:8`, `8:1` |
+| `resolution` | string | No | `1k` | Image resolution. One of: `1k`, `2k`, `4k` |
+| `output_format` | string | No | `png` | Output format. One of: `png`, `jpeg` |
+
+**Model ID:** `google/nano-banana-2/edit`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `images` | string[] | Yes | `[]` | URLs of input images to edit (1-14 images) |
+| `prompt` | string | Yes | -- | Text description of the desired edit |
+| `aspect_ratio` | string | No | -- | Output aspect ratio. One of: `1:1`, `3:2`, `2:3`, `3:4`, `4:3`, `4:5`, `5:4`, `9:16`, `16:9`, `21:9`, `1:4`, `4:1`, `1:8`, `8:1` |
+| `resolution` | string | No | `1k` | Image resolution. One of: `1k`, `2k`, `4k` |
+| `output_format` | string | No | `png` | Output format. One of: `png`, `jpeg` |
+
+### Aspect Ratio Options
+
+| Aspect Ratio | Use Case |
+|-------------|----------|
+| `1:1` | Square — social media posts, profile pictures |
+| `3:2` | Landscape — standard photography |
+| `2:3` | Portrait — standard photography |
+| `3:4` | Portrait — social media, product images |
+| `4:3` | Landscape — presentations, web content |
+| `4:5` | Portrait — Instagram posts |
+| `5:4` | Landscape — print, web banners |
+| `9:16` | Vertical — mobile wallpapers, stories |
+| `16:9` | Widescreen — desktop wallpapers, video thumbnails |
+| `21:9` | Ultra-wide — cinematic, panoramic |
+| `1:4` | Ultra-tall — vertical banners, tall infographics |
+| `4:1` | Ultra-wide — horizontal banners, letterbox |
+| `1:8` | Extreme vertical — scrolling banners, tower ads |
+| `8:1` | Extreme horizontal — panoramic strips, timelines |
+
+### Resolution and Pricing
+
+| Resolution | Cost |
+|------------|------|
+| 1k | $0.08 per image |
+| 2k | $0.12 per image |
+| 4k | $0.16 per image |
+
+### Prompt Tips
+
+- Be specific and descriptive: "A red vintage Porsche 911 on a winding mountain road at golden hour" vs "a car"
+- Include style keywords: "digital art", "oil painting", "photorealistic", "watercolor", "cinematic"
+- For edits, clearly describe the desired change: "Replace the sky with a dramatic sunset"
+- For multi-image edits, reference images by position: "Apply the style from the second image to the first image"
+- Leverage multilingual text rendering: the model supports on-image text with automatic translation
+- Use camera-style control language: "shallow depth of field", "wide angle", "top-down view"
+
+## Seedance V1.5 Pro Video Generation
+
+**Model ID:** `bytedance/seedance-v1.5-pro/text-to-video`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `prompt` | string | Yes | -- | Text description of the scene, style, actions, camera motion, and mood |
+| `aspect_ratio` | string | No | `16:9` | Aspect ratio. One of: `21:9`, `16:9`, `4:3`, `1:1`, `3:4`, `9:16` |
+| `duration` | integer | No | `5` | Video duration in seconds. Range: 4-12. Use `-1` for smart duration (model selects). |
+| `resolution` | string | No | `720p` | Video resolution. One of: `480p`, `720p`, `1080p` |
+| `generate_audio` | boolean | No | `true` | Generate accompanying audio |
+| `camera_fixed` | boolean | No | `false` | Keep camera fixed (true) or allow prompt-driven camera motion (false) |
+| `seed` | integer | No | `-1` | Random seed (-1 for random). Range: -1 to 2147483647 |
+
+**Model ID:** `bytedance/seedance-v1.5-pro/image-to-video`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `image` | string | Yes | -- | URL of the source image to animate |
+| `prompt` | string | Yes | -- | Text description of the desired motion/animation |
+| `last_image` | string | No | -- | URL of an optional end-frame reference image |
+| `aspect_ratio` | string | No | -- | Aspect ratio. One of: `21:9`, `16:9`, `4:3`, `1:1`, `3:4`, `9:16` |
+| `duration` | integer | No | `5` | Video duration in seconds. Range: 4-12 |
+| `resolution` | string | No | `720p` | Video resolution. One of: `480p`, `720p`, `1080p` |
+| `generate_audio` | boolean | No | `true` | Generate accompanying audio |
+| `camera_fixed` | boolean | No | `false` | Keep camera fixed (true) or allow prompt-driven camera motion (false) |
+| `seed` | integer | No | `-1` | Random seed (-1 for random). Range: -1 to 2147483647 |
+
+### Pricing
+
+| Resolution | Duration | Audio | Cost |
+|------------|----------|-------|------|
+| 480p | 5s | No | $0.06 |
+| 480p | 5s | Yes | $0.12 |
+| 720p | 5s | No | $0.13 |
+| 720p | 5s | Yes | $0.26 |
+| 480p | 10s | Yes | $0.24 |
+| 720p | 10s | Yes | $0.52 |
+
+### Prompt Tips
+
+- Describe scene, style, subject actions, camera motion, and mood in your prompt
+- Use `camera_fixed: true` for stable tripod-style shots
+- Use `camera_fixed: false` and describe camera motion: "slow pan left", "tracking shot", "zoom in"
+- Set `generate_audio: false` when you plan to add your own audio track
+- Use smart duration (`duration: -1`) to let the model choose the best length for text-to-video
+
+## Veo 3.1 Fast Video Generation
+
+**Model ID:** `google/veo3.1-fast/text-to-video`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `prompt` | string | Yes | -- | Text description of the video to generate |
+| `aspect_ratio` | string | No | `16:9` | Aspect ratio. One of: `16:9`, `9:16` |
+| `duration` | integer | No | `8` | Duration in seconds. One of: `4`, `6`, `8` |
+| `resolution` | string | No | `1080p` | Video resolution. One of: `720p`, `1080p`, `4k` |
+| `generate_audio` | boolean | No | `true` | Generate accompanying audio |
+| `negative_prompt` | string | No | -- | Text describing unwanted elements |
+| `seed` | integer | No | -- | Random seed for reproducibility. Range: -1 to 2147483647 |
+
+**Model ID:** `google/veo3.1-fast/image-to-video`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `image` | string | Yes | -- | URL of the source image (clear, high-quality still image) |
+| `prompt` | string | Yes | -- | Text description of the desired motion/animation |
+| `last_image` | string | No | -- | URL of an end-frame reference image |
+| `aspect_ratio` | string | No | `16:9` | Aspect ratio. One of: `16:9`, `9:16` |
+| `duration` | integer | No | `8` | Duration in seconds. One of: `4`, `6`, `8` |
+| `resolution` | string | No | `1080p` | Video resolution. One of: `720p`, `1080p`, `4k` |
+| `generate_audio` | boolean | No | `true` | Generate accompanying audio |
+| `negative_prompt` | string | No | -- | Text describing unwanted elements |
+| `seed` | integer | No | -- | Random seed for reproducibility. Range: -1 to 2147483647 |
+
+**Model ID:** `google/veo3.1-fast/video-extend`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `video` | string | Yes | -- | URL of the Veo-generated video to extend. Max 141 seconds. |
+| `prompt` | string | No | -- | Text guidance for the extension |
+| `resolution` | string | No | `1080p` | Video resolution. One of: `720p`, `1080p` |
+| `negative_prompt` | string | No | -- | Text describing unwanted elements |
+| `seed` | integer | No | -- | Random seed for reproducibility. Range: -1 to 2147483647 |
+
+### Constraints
+
+- Input video **must be Veo-generated** (will not work with arbitrary videos)
+- Each run adds **+7 seconds** to the video
+- Maximum **20 extensions** in a chain
+- Maximum final video length: **148 seconds**
+- Output is a single MP4 (original + extension appended)
+- Aspect ratio and resolution are inherited from the input video
+
+### Pricing
+
+### Prompt Tips
+
+- Be specific about scene, style, subject actions, camera motion, and mood
+- Use `negative_prompt` to avoid artifacts: "blurry, low quality, distorted"
+- For image-to-video, use a clear, high-quality still image as input
+- For video extend, describe what should happen next in the scene
+- Video extend chains enable building longer narratives — up to 148 seconds total
+
+## Wan 2.6 Video Generation
+
+**Model ID:** `alibaba/wan-2.6/text-to-video`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `prompt` | string | Yes | -- | Text description of the video to generate |
+| `negative_prompt` | string | No | -- | Text description of what to avoid in the video |
+| `audio` | string | No | -- | Audio URL to guide generation |
+| `size` | string | No | `1280*720` | Output size in pixels. One of: `1280*720`, `720*1280`, `1920*1080`, `1080*1920` |
+| `duration` | integer | No | `5` | Video duration in seconds. One of: `5`, `10`, `15` |
+| `shot_type` | string | No | `single` | Shot type. One of: `single`, `multi` |
+| `enable_prompt_expansion` | boolean | No | `false` | Enable prompt optimizer for enhanced prompts |
+| `seed` | integer | No | `-1` | Random seed (-1 for random). Range: -1 to 2147483647 |
+
+**Model ID:** `alibaba/wan-2.6/image-to-video`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `image` | string | Yes | -- | URL of the source image to animate |
+| `prompt` | string | Yes | -- | Text description of the desired motion/animation |
+| `negative_prompt` | string | No | -- | Text description of what to avoid in the video |
+| `audio` | string | No | -- | Audio URL to guide generation |
+| `resolution` | string | No | `720p` | Output resolution. One of: `720p`, `1080p` |
+| `duration` | integer | No | `5` | Video duration in seconds. One of: `5`, `10`, `15` |
+| `shot_type` | string | No | `single` | Shot type. One of: `single`, `multi` |
+| `enable_prompt_expansion` | boolean | No | `false` | Enable prompt optimizer for enhanced prompts |
+| `seed` | integer | No | `-1` | Random seed (-1 for random). Range: -1 to 2147483647 |
+
+### Resolution Options (Image-to-Video)
+
+| Resolution | Use Case |
+|------------|----------|
+| `720p` | Standard quality, faster generation |
+| `1080p` | Full HD, higher quality |
+
+### Pricing
+
+| Resolution | 5 seconds | 10 seconds | 15 seconds |
+|------------|-----------|------------|------------|
+| 720p | $0.50 | $1.00 | $1.50 |
+| 1080p | $0.75 | $1.50 | $2.25 |
+
+### Prompt Tips
+
+- Be specific about motion and action: "A bird takes flight from a branch" vs "a bird"
+- Include camera movement: "slow pan left", "zoom in", "tracking shot"
+- Describe temporal progression: "transitioning from day to night", "flowers slowly blooming"
+- Use `negative_prompt` to avoid artifacts: "blurry, low quality, distorted, static"
+- Enable `enable_prompt_expansion` for automatic prompt enhancement
+- For `multi` shot type, describe distinct scenes for more dynamic videos
+
+## Wan 2.2 Animate
+
+**Model ID:** `wavespeed-ai/wan-2.2/animate`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `image` | string | Yes | -- | URL of the character image to animate |
+| `video` | string | Yes | -- | URL of the driving video providing motion reference |
+| `prompt` | string | No | -- | Text prompt for additional guidance |
+| `mode` | string | No | `animate` | Operation mode. `animate`: image character moves like video subject. `replace`: video subject is swapped with image character. |
+| `resolution` | string | No | `480p` | Output resolution. One of: `480p`, `720p` |
+| `seed` | integer | No | `-1` | Random seed (-1 for random). Range: -1 to 2147483647 |
+
+### Pricing
+
+| Resolution | Cost per 5 seconds |
+|------------|--------------------|
+| 480p | $0.20 |
+| 720p | $0.40 |
+
+Output duration is 5-120 seconds. Minimum charge is 5 seconds. Per-second rate: $0.04/s (480p), $0.08/s (720p).
+
+### Tips
+
+- Match composition and pose between the input image and driving video for best results
+- Use the same or similar aspect ratio between image and video
+- Avoid heavy occlusion by hands, microphones, or props in the input media
+- Start with `480p` for prototyping, then move to `720p` for production quality
+- **Animate mode**: best when you want the image character to perform the motions from the video
+- **Replace mode**: best when you want to keep the video's scene and motion but swap in a different character
+
+## InfiniteTalk
+
+**Model ID:** `wavespeed-ai/infinitetalk`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `image` | string | Yes | -- | URL of the portrait image to animate |
+| `audio` | string | Yes | -- | URL of the audio to drive the animation |
+| `mask_image` | string | No | -- | URL of a mask image to specify which person to animate. **Warning:** The mask should only cover the regions to animate — do not upload the full image as `mask_image`, or the result may render as fully black. |
+| `prompt` | string | No | -- | Text prompt for additional guidance. Keep it short; English recommended to avoid noisy results. |
+| `resolution` | string | No | `480p` | Output resolution. One of: `480p`, `720p` |
+| `seed` | integer | No | `-1` | Random seed (-1 for random). Range: -1 to 2147483647 |
+
+### Resolution and Pricing
+
+| Resolution | Cost per 5 seconds | Rate per second | Max length |
+|------------|--------------------|-----------------| -----------|
+| 480p | $0.15 | $0.03/s | 10 minutes |
+| 720p | $0.30 | $0.06/s | 10 minutes |
+
+Minimum charge is 5 seconds. Video length is determined by the audio duration (up to 10 minutes).
+
+### Tips
+
+- Use a clear, front-facing portrait for best results
+- Audio quality matters — use clean speech recordings with minimal background noise
+- Keep prompts short and in English to avoid noisy or unexpected results
+- For group photos, always provide a `mask_image` to target the correct face
+- 480p is faster to generate; use 720p when higher quality is needed
+- Processing time is approximately 10-30 seconds of wall time per 1 second of video
+
+## MiniMax Speech 2.6 Turbo
+
+**Model ID:** `minimax/speech-2.6-turbo`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `text` | string | Yes | -- | Text to convert to speech. Max 10,000 characters. Use `<#x#>` between words to insert pauses (0.01-99.99 seconds). |
+| `voice_id` | string | Yes | -- | Voice preset ID. See [Voice IDs](#voice-ids) below. |
+| `speed` | number | No | `1` | Speech speed. Range: 0.50-2.00 |
+| `volume` | number | No | `1` | Speech volume. Range: 0.10-10.00 |
+| `pitch` | number | No | `0` | Speech pitch. Range: -12 to 12 |
+| `emotion` | string | No | `happy` | Emotional tone. One of: `happy`, `sad`, `angry`, `fearful`, `disgusted`, `surprised`, `neutral` |
+| `english_normalization` | boolean | No | `false` | Improve English number reading normalization |
+| `sample_rate` | integer | No | -- | Sample rate in Hz. One of: `8000`, `16000`, `22050`, `24000`, `32000`, `44100` |
+| `bitrate` | integer | No | -- | Bitrate in bps. One of: `32000`, `64000`, `128000`, `256000` |
+| `channel` | string | No | -- | Audio channels. `1` (mono) or `2` (stereo) |
+| `format` | string | No | -- | Output format. One of: `mp3`, `wav`, `pcm`, `flac` |
+| `language_boost` | string | No | -- | Enhance recognition for a specific language. See [Supported Languages](#supported-languages). |
+
+### Voice IDs
+
+### English Voices (Popular)
+
+| Voice ID | Description |
+|----------|-------------|
+| `English_CalmWoman` | Calm female voice |
+| `English_Trustworth_Man` | Trustworthy male voice |
+| `English_expressive_narrator` | Expressive narrator |
+| `English_radiant_girl` | Radiant girl voice |
+| `English_magnetic_voiced_man` | Magnetic male voice |
+| `English_CaptivatingStoryteller` | Storyteller voice |
+| `English_Upbeat_Woman` | Upbeat female voice |
+| `English_GentleTeacher` | Gentle teacher voice |
+| `English_PlayfulGirl` | Playful girl voice |
+| `English_ManWithDeepVoice` | Deep male voice |
+| `English_ConfidentWoman` | Confident female voice |
+| `English_Comedian` | Comedic voice |
+| `English_SereneWoman` | Serene female voice |
+| `English_WiseScholar` | Scholarly voice |
+| `English_Cute_Girl` | Cute girl voice |
+| `English_Sharp_Commentator` | Sharp commentator |
+| `English_Lucky_Robot` | Robot voice |
+
+### General Voices
+
+`Wise_Woman`, `Friendly_Person`, `Inspirational_girl`, `Deep_Voice_Man`, `Calm_Woman`, `Casual_Guy`, `Lively_Girl`, `Patient_Man`, `Young_Knight`, `Determined_Man`, `Lovely_Girl`, `Decent_Boy`, `Imposing_Manner`, `Elegant_Man`, `Abbess`, `Sweet_Girl_2`, `Exuberant_Girl`
+
+### Special Voices
+
+`whisper_man`, `whisper_woman_1`, `angry_pirate_1`, `massive_kind_troll`, `movie_trailer_deep`, `peace_and_ease`
+
+### Pricing
+
+$0.06 per 1,000 characters.
+
+## Image Upscaler
+
+**Model ID:** `wavespeed-ai/image-upscaler`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `image` | string | Yes | -- | URL of the image to upscale |
+| `target_resolution` | string | No | `4k` | Target resolution. One of: `2k`, `4k`, `8k` |
+| `output_format` | string | No | `jpeg` | Output format. One of: `jpeg`, `png`, `webp` |
+
+### Pricing
+
+$0.01 per image (all resolutions).
+
+## Ultimate Video Upscaler
+
+**Model ID:** `wavespeed-ai/ultimate-video-upscaler`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `video` | string | Yes | -- | URL of the video to upscale. Must be publicly accessible. |
+| `target_resolution` | string | No | `1080p` | Target resolution. One of: `720p`, `1080p`, `2k`, `4k` |
+
+### Pricing
+
+| Target Resolution | Cost per 5 seconds |
+|-------------------|--------------------|
+| 720p | $0.10 |
+| 1080p | $0.15 |
+| 2K | $0.25 |
+| 4K | $0.40 |
+
+Minimum charge is 5 seconds. Videos up to 10 minutes supported. Processing time is approximately 10-30 seconds per 1 second of video.
+
+## Face Swapper
+
+**Model ID:** `wavespeed-ai/image-face-swap`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `image` | string | Yes | -- | URL of the image containing the face to replace |
+| `face_image` | string | Yes | -- | URL of the reference face image to swap in |
+| `target_index` | integer | No | `0` | Which face to replace (0 = largest face, 1-10 for others) |
+| `output_format` | string | No | `jpeg` | Output format. One of: `jpeg`, `png`, `webp` |
+
+**Model ID:** `wavespeed-ai/video-face-swap`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `video` | string | Yes | -- | URL of the video containing the face to replace. Must be publicly accessible. Max 10 minutes. |
+| `face_image` | string | Yes | -- | URL of the reference face image to swap in |
+| `target_index` | integer | No | `0` | Which face to replace (0 = largest face, 1-10 for others) |
+
+### Pricing
+
+| Operation | Cost |
+|-----------|------|
+| Image face swap | $0.01 per image |
+| Video face swap | $0.01 per second (minimum $0.05 / 5 seconds) |
+
+Video face swap supports videos up to 10 minutes.
+
+### Tips
+
+- Use clear, front-facing portraits for the reference face for best results
+- Consistent lighting between the target and reference face improves quality
+- Anime or illustrated characters may produce lower quality output
+- Use `target_index` to select specific faces when multiple people are present (0 = largest face)
+
+### Responsible use
+
+Face swapping manipulates a real person's likeness. Before calling either endpoint, confirm all of the following with the user. If any answer is no or unclear, do not run the model and explain why.
+
+- **Consent**: the person whose face is being inserted, and any identifiable person in the target media, has agreed to this use. Do not use the face of a public figure, a colleague, an ex-partner, or anyone else without their explicit consent.
+- **Rights to the media**: the user owns the target image or video or has permission from the owner to edit it.
+- **No impersonation or deception**: the output will not be presented as a real, unedited recording, used for fraud, identity verification bypass, harassment, defamation, political manipulation, or to put words or actions on someone they did not say or do.
+- **No sexual or intimate content**: never swap a face onto sexual, nude, or intimate material, regardless of consent claims.
+- **No minors**: do not process images or videos of children.
+- **Disclosure**: when the result will be shared, recommend labeling it as AI-edited.
+
+WaveSpeed's [Terms of Service](https://wavespeed.ai/static/terms) prohibit non-consensual and deceptive likeness edits; requests that violate them are refused and accounts may be suspended.
+
+## Watermark Remover
+
+**Model ID:** `wavespeed-ai/image-watermark-remover`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `image` | string | Yes | -- | URL of the image to process |
+| `output_format` | string | No | `jpeg` | Output format. One of: `jpeg`, `png`, `webp` |
+
+**Model ID:** `wavespeed-ai/video-watermark-remover`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `video` | string | Yes | -- | URL of the video to process. Must be publicly accessible. Max 10 minutes. |
+
+### Pricing
+
+| Operation | Cost |
+|-----------|------|
+| Image watermark removal | $0.012 per image |
+| Video watermark removal | $0.01 per second (minimum $0.05 / 5 seconds) |
+
+Video watermark removal supports videos up to 10 minutes. Processing time is approximately 5-20 seconds per 1 second of video.
+
+### Responsible use
+
+Watermarks and overlays are usually there to assert ownership or attribution. Before calling either endpoint, confirm the following with the user. If the answer is no or unclear, do not run the model and explain why.
+
+- **Ownership or license**: the user created the media, holds the rights to it, or has a license that permits removing the mark (for example, a purchased stock asset whose license allows clean use, or their own export from a tool that stamps a logo).
+- **Not someone else's mark**: do not remove a watermark, logo, credit, or copyright notice placed by a third party to identify their work. Stock-site preview watermarks, photographer credits, broadcaster logos, and platform attribution marks are all out of scope.
+- **No misrepresentation**: the result will not be passed off as original, unlicensed, or unedited work, and will not be used to evade licensing fees or attribution requirements.
+- **Legitimate overlays only**: typical valid uses are removing captions or subtitles the user added, cleaning timestamps from their own camera footage, or restoring an area under a logo they own.
+
+WaveSpeed's [Terms of Service](https://wavespeed.ai/static/terms) prohibit using the service to infringe intellectual property; requests that violate them are refused and accounts may be suspended.
+

--- a/optional-skills/creative/wavespeed/scripts/check_setup.py
+++ b/optional-skills/creative/wavespeed/scripts/check_setup.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Confirm the wavespeed CLI is installed and signed in.
+
+Prints one JSON object on stdout:
+  {"cli": "0.4.8" | null, "signed_in": true | false | null, "hint": "..."}
+
+Exit codes: 0 ready, 1 CLI missing, 2 CLI present but not signed in.
+No network calls beyond what `wavespeed status` itself does; safe to run in tests
+with a stubbed binary. Cross-platform (stdlib only).
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+INSTALL_HINT = "Install with: npm install -g @wavespeed/cli"
+LOGIN_HINT = "Ask the user to run: wavespeed login  (or set WAVESPEED_API_KEY)"
+
+
+def _run(args: list[str]) -> tuple[int, str]:
+    try:
+        proc = subprocess.run(args, capture_output=True, text=True, timeout=30, check=False)
+    except (OSError, subprocess.SubprocessError) as exc:  # pragma: no cover - defensive
+        return 1, str(exc)
+    return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
+
+
+def check(binary: str = "wavespeed") -> dict:
+    path = shutil.which(binary)
+    if not path:
+        return {"cli": None, "signed_in": None, "hint": INSTALL_HINT}
+
+    code, out = _run([path, "--version"])
+    version = out.strip().splitlines()[0] if code == 0 and out.strip() else None
+
+    if os.environ.get("WAVESPEED_API_KEY"):
+        return {"cli": version, "signed_in": True, "hint": "WAVESPEED_API_KEY is set"}
+
+    code, out = _run([path, "status"])
+    lowered = out.lower()
+    signed_in = code == 0 and "not" not in lowered.split("signed")[0][-8:] and "signed out" not in lowered
+    return {
+        "cli": version,
+        "signed_in": signed_in,
+        "hint": "ready" if signed_in else LOGIN_HINT,
+    }
+
+
+def main() -> int:
+    result = check()
+    print(json.dumps(result))
+    if result["cli"] is None:
+        return 1
+    if not result["signed_in"]:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/skills/test_wavespeed_skill.py
+++ b/tests/skills/test_wavespeed_skill.py
@@ -1,0 +1,146 @@
+"""Invariant tests for the optional wavespeed skill.
+
+Covers optional-skills/creative/wavespeed. Asserts contracts (frontmatter
+hardline, the setup checker's exit codes with a stubbed binary), not
+snapshots of skill prose. No network.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent.parent
+SKILL_DIR = REPO / "optional-skills" / "creative" / "wavespeed"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+CHECK_SETUP = SKILL_DIR / "scripts" / "check_setup.py"
+
+
+def _frontmatter() -> dict:
+    text = SKILL_MD.read_text(encoding="utf-8")
+    assert text.startswith("---\n")
+    end = text.index("\n---", 4)
+    return yaml.safe_load(text[4:end])
+
+
+def _load_check_setup():
+    spec = importlib.util.spec_from_file_location("check_setup", CHECK_SETUP)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _stub_wavespeed(tmp_path: Path, status_stdout: str, status_rc: int = 0) -> Path:
+    """Write a fake `wavespeed` binary that answers --version and status."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    if os.name == "nt":  # pragma: no cover - exercised on Windows CI only
+        script = bindir / "wavespeed.cmd"
+        script.write_text(
+            "@echo off\r\n"
+            'if "%1"=="--version" (echo 0.4.8 & exit /b 0)\r\n'
+            f'if "%1"=="status" (echo {status_stdout} & exit /b {status_rc})\r\n'
+            "exit /b 1\r\n",
+            encoding="utf-8",
+        )
+    else:
+        script = bindir / "wavespeed"
+        script.write_text(
+            "#!/bin/sh\n"
+            'if [ "$1" = "--version" ]; then echo 0.4.8; exit 0; fi\n'
+            f'if [ "$1" = "status" ]; then echo "{status_stdout}"; exit {status_rc}; fi\n'
+            "exit 1\n",
+            encoding="utf-8",
+        )
+        script.chmod(script.stat().st_mode | stat.S_IXUSR)
+    return bindir
+
+
+# --- frontmatter contracts ---------------------------------------------------
+
+
+def test_frontmatter_hardline():
+    fm = _frontmatter()
+    assert fm["name"] == "wavespeed" == SKILL_DIR.name
+    assert len(fm["description"]) <= 60 and fm["description"].endswith(".")
+    assert fm["license"] == "MIT"
+    assert set(fm["platforms"]) == {"linux", "macos", "windows"}
+    assert fm["metadata"]["hermes"]["category"] == "creative"
+    assert "wavespeed" in fm["prerequisites"]["commands"]
+
+
+def test_api_key_is_optional_and_never_requested_in_chat():
+    fm = _frontmatter()
+    env = {e["name"]: e for e in fm["required_environment_variables"]}
+    assert env["WAVESPEED_API_KEY"]["optional"] is True
+    body = SKILL_MD.read_text(encoding="utf-8").lower()
+    assert "never ask the user to paste a key" in body
+
+
+def test_referenced_files_exist():
+    body = SKILL_MD.read_text(encoding="utf-8")
+    for rel in ("scripts/check_setup.py", "references/models.md"):
+        assert rel in body
+        assert (SKILL_DIR / rel).is_file(), rel
+
+
+# --- scripts/check_setup.py --------------------------------------------------
+
+
+def test_check_setup_reports_missing_cli(tmp_path, monkeypatch):
+    monkeypatch.setenv("PATH", str(tmp_path))  # nothing on PATH
+    monkeypatch.delenv("WAVESPEED_API_KEY", raising=False)
+    mod = _load_check_setup()
+    result = mod.check()
+    assert result == {"cli": None, "signed_in": None, "hint": mod.INSTALL_HINT}
+
+
+def test_check_setup_signed_out(tmp_path, monkeypatch):
+    bindir = _stub_wavespeed(tmp_path, "Not signed in", status_rc=1)
+    monkeypatch.setenv("PATH", str(bindir))
+    monkeypatch.delenv("WAVESPEED_API_KEY", raising=False)
+    mod = _load_check_setup()
+    result = mod.check()
+    assert result["cli"] == "0.4.8"
+    assert result["signed_in"] is False
+    assert result["hint"] == mod.LOGIN_HINT
+
+
+def test_check_setup_signed_in(tmp_path, monkeypatch):
+    bindir = _stub_wavespeed(tmp_path, "Signed in as user@example.com")
+    monkeypatch.setenv("PATH", str(bindir))
+    monkeypatch.delenv("WAVESPEED_API_KEY", raising=False)
+    mod = _load_check_setup()
+    result = mod.check()
+    assert result["signed_in"] is True and result["hint"] == "ready"
+
+
+def test_check_setup_env_key_short_circuits_status(tmp_path, monkeypatch):
+    bindir = _stub_wavespeed(tmp_path, "Not signed in", status_rc=1)
+    monkeypatch.setenv("PATH", str(bindir))
+    monkeypatch.setenv("WAVESPEED_API_KEY", "wsk_test")
+    mod = _load_check_setup()
+    assert mod.check()["signed_in"] is True
+
+
+@pytest.mark.skipif(os.name == "nt", reason="exit-code contract exercised via the POSIX stub")
+def test_check_setup_exit_codes(tmp_path, monkeypatch):
+    env = dict(os.environ, PATH=str(tmp_path))
+    env.pop("WAVESPEED_API_KEY", None)
+    proc = subprocess.run([sys.executable, str(CHECK_SETUP)], capture_output=True, text=True, env=env, check=False)
+    assert proc.returncode == 1
+    assert json.loads(proc.stdout)["cli"] is None
+
+    bindir = _stub_wavespeed(tmp_path, "Not signed in", status_rc=1)
+    env["PATH"] = str(bindir)
+    proc = subprocess.run([sys.executable, str(CHECK_SETUP)], capture_output=True, text=True, env=env, check=False)
+    assert proc.returncode == 2


### PR DESCRIPTION
## What does this PR do?

Adds an optional creative skill for the WaveSpeed platform (hosted generative-media models: Seedream, Seedance, MiniMax H3, Wan, Veo, Kling, Nano Banana, MiniMax Speech, upscalers, and more) through the open-source `wavespeed` CLI. It gives Hermes a guided path for "make a hero image", "animate this photo into a clip", "upscale these thumbnails", "voice this paragraph": find a model on the live catalog, read its input schema, quote the price, run with `--json`, upload local files with the `@path` marker. Placed in `optional-skills/` per the contributing guide (paid service, API key), next to `comfyui` and `audiocraft`.

## Related Issue

None.

## Type of Change

- [x] 🎯 New skill (bundled or hub)

## Changes Made

- `optional-skills/creative/wavespeed/SKILL.md` — frontmatter per the hardline (60-char description, platforms, `metadata.hermes`, `prerequisites.commands`, optional `WAVESPEED_API_KEY` with `wavespeed login` as the primary auth), sections in the modern order.
- `optional-skills/creative/wavespeed/scripts/check_setup.py` — stdlib, cross-platform: reports CLI version and signed-in state as JSON, exit codes 0/1/2.
- `optional-skills/creative/wavespeed/references/models.md` — per-model parameters, pricing, prompt tips for 13 models, kept out of SKILL.md to stay under the size line.
- `tests/skills/test_wavespeed_skill.py` — frontmatter contracts and the setup checker with a stubbed `wavespeed` binary; no network.

## How to Test

1. `pytest tests/skills/test_authoring_standards.py tests/skills/test_wavespeed_skill.py -k wavespeed -q` — 14 passed.
2. `npm install -g @wavespeed/cli && wavespeed login`, then `hermes skills install official/creative/wavespeed`.
3. `hermes --toolsets skills -q "Use the wavespeed skill to generate a 16:9 image of a lighthouse at dawn"` — the agent runs `wavespeed models`, then `wavespeed run <model> -p ... --json`, and returns the output URL.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the skills test files above; the full `pytest tests/ -q` needs the complete tree and was not run on my sparse checkout
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (Linux); the checker is stdlib-only and its Windows branch is covered by the stub

### Documentation & Housekeeping

- [x] Documentation — N/A (self-contained skill)
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered: `platforms: [linux, macos, windows]`, no POSIX-only primitives
- [x] Tool descriptions/schemas — N/A

## For New Skills

- [x] Optional, not bundled: paid service with an API key, per the contributing guide
- [x] SKILL.md follows the standard format
- [x] No external dependencies beyond the `wavespeed` CLI it documents (installed via npm; `check_setup.py` is stdlib)
- [x] Tested end-to-end with the CLI; the skill text was drafted with an AI assistant and reviewed line by line by me (I maintain the CLI)