### PR TITLE
fix(tts): Discord voice replies — Opus routing + strip reasoning from speech

### DIFF
--- a/tests/gateway/test_base_auto_tts_output_format.py
+++ b/tests/gateway/test_base_auto_tts_output_format.py
@@ -78,11 +78,16 @@ def _hold_typing():
 
 
 @pytest.mark.parametrize(
-    "platform", [Platform.DISCORD, Platform.SLACK, "irc", None]
+    "platform", [Platform.SLACK, "irc", None]
 )
 def test_output_path_is_mp3_for_non_opus_platforms(platform):
     path = build_auto_tts_output_path(platform)
     assert path.endswith(".mp3"), path
+
+
+def test_output_path_is_ogg_for_discord():
+    # Discord native voice messages (flags=8192) require Ogg/Opus bytes.
+    assert build_auto_tts_output_path(Platform.DISCORD).endswith(".ogg")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_tts_text_normalize.py
+++ b/tests/tools/test_tts_text_normalize.py
@@ -47,3 +47,13 @@ def test_prepare_spoken_text_polish_edge_cases():
     assert "and/or" in prepare_spoken_text("choose and/or option")
     assert "N/A" in prepare_spoken_text("status N/A here")
     assert "2026/06/02" in prepare_spoken_text("due 2026/06/02 ok")
+
+
+def test_prepare_spoken_text_strips_reasoning_display_blocks():
+    # Gateway reasoning display blocks (show_reasoning) are display-only — never speech.
+    # subtext style (Discord default)
+    assert prepare_spoken_text("-# 💭 Reasoning\n-# think about it\n\nAnswer.") == "Answer."
+    # blockquote style
+    assert prepare_spoken_text("> 💭 **Reasoning:**\n> think\n\nAnswer.") == "Answer."
+    # code-fence style
+    assert prepare_spoken_text("💭 **Reasoning:**\n```\nthink\n```\n\nAnswer.") == "Answer."

--- a/tests/tools/test_tts_text_normalize.py
+++ b/tests/tools/test_tts_text_normalize.py
@@ -57,3 +57,11 @@ def test_prepare_spoken_text_strips_reasoning_display_blocks():
     assert prepare_spoken_text("> 💭 **Reasoning:**\n> think\n\nAnswer.") == "Answer."
     # code-fence style
     assert prepare_spoken_text("💭 **Reasoning:**\n```\nthink\n```\n\nAnswer.") == "Answer."
+
+
+def test_prepare_spoken_text_literal_think_mention_not_swallowed():
+    # A literal "<think>" mention (not a real block) must not eat the rest of the message.
+    assert "Here is the answer" in prepare_spoken_text(
+        "You asked about <think> blocks. Here is the answer.")
+    # Same inside a reasoning display block: it is stripped WITH the reasoning, answer survives.
+    assert prepare_spoken_text("-# 💭 Reasoning\n-# rather than <think> variants\n\nReal answer.") == "Real answer."

--- a/tools/tts_text_normalize.py
+++ b/tools/tts_text_normalize.py
@@ -170,7 +170,11 @@ def smooth_whitespace_for_tts(text: str) -> str:
 # Reasoning blocks: models with ``/reasoning show`` enabled emit ``<think>...</think>`` blocks in the final
 # assistant message. See #34213.
 _THINK_BLOCK_RE = re.compile(r"<think[\s>].*?</think>", flags=re.DOTALL | re.IGNORECASE)
-_THINK_BLOCK_OPEN_RE = re.compile(r"<think[\s>].*\Z", flags=re.DOTALL | re.IGNORECASE)
+# An unterminated <think> block is only a real block when the reasoning starts on the NEXT
+# line ("<think>\nreasoning…"). A LITERAL "<think>" mention mid-sentence (e.g. an answer that
+# talks ABOUT think tags) is followed by a space/word, not a newline — do not treat it as an
+# open block and swallow the rest of the message.
+_THINK_BLOCK_OPEN_RE = re.compile(r"<think[^>\n]*>\s*\n[\s\S]*\Z", flags=re.DOTALL | re.IGNORECASE)
 
 # Gateway reasoning DISPLAY blocks (gateway/run_turn.py `_hmwa_prepend_reasoning`) are prepended
 # to the response when `show_reasoning` is on. Three render styles, all display-only — never speech:
@@ -194,8 +198,8 @@ def strip_nonspoken_blocks(text: str) -> str:
     styles) and the file-mutation verifier footer."""
     if not text:
         return ""
-    for pattern in (_THINK_BLOCK_RE, _THINK_BLOCK_OPEN_RE,
-                    _REASONING_SUBTEXT_RE, _REASONING_BLOCKQUOTE_RE, _REASONING_CODE_RE,
+    for pattern in (_REASONING_SUBTEXT_RE, _REASONING_BLOCKQUOTE_RE, _REASONING_CODE_RE,
+                    _THINK_BLOCK_RE, _THINK_BLOCK_OPEN_RE,
                     _VERIFIER_FOOTER_RE):
         text = pattern.sub(" ", text)
     return text

--- a/tools/tts_text_normalize.py
+++ b/tools/tts_text_normalize.py
@@ -172,16 +172,31 @@ def smooth_whitespace_for_tts(text: str) -> str:
 _THINK_BLOCK_RE = re.compile(r"<think[\s>].*?</think>", flags=re.DOTALL | re.IGNORECASE)
 _THINK_BLOCK_OPEN_RE = re.compile(r"<think[\s>].*\Z", flags=re.DOTALL | re.IGNORECASE)
 
+# Gateway reasoning DISPLAY blocks (gateway/run_turn.py `_hmwa_prepend_reasoning`) are prepended
+# to the response when `show_reasoning` is on. Three render styles, all display-only — never speech:
+#   subtext (Discord default): "-# 💭 Reasoning\n-# <line>…\n\n"
+#   blockquote:                "> 💭 **Reasoning:**\n> <line>…\n\n"
+#   code:                      "💭 **Reasoning:**\n```\n<line>…\n```\n\n"
+_REASONING_SUBTEXT_RE = re.compile(
+    r"^-#\s*💭\s*Reasoning\b[^\n]*\n(?:-#[^\n]*\n)+", re.MULTILINE | re.IGNORECASE)
+_REASONING_BLOCKQUOTE_RE = re.compile(
+    r"^>\s*💭\s*\*\*Reasoning:\*\*[^\n]*\n(?:>\s?[^\n]*\n)+", re.MULTILINE | re.IGNORECASE)
+_REASONING_CODE_RE = re.compile(
+    r"^💭\s*\*\*Reasoning:\*\*[^\n]*\n[ \t]*```[\s\S]*?```[ \t]*(?:\n|$)", re.MULTILINE | re.IGNORECASE)
+
 # run_agent.py's turn-end file-mutation verifier footer (a ``⚠️ File-mutation verifier:``
 # header line plus indented ``•`` bullets) is a UI affordance, not speech.
 _VERIFIER_FOOTER_RE = re.compile(r"^\s*⚠️?\s*File-mutation verifier:.*(?:\n[ \t]+•.*)*", flags=re.MULTILINE)
 
 
 def strip_nonspoken_blocks(text: str) -> str:
-    """Remove ``<think>`` reasoning blocks and the file-mutation verifier footer."""
+    """Remove reasoning/thinking blocks (``<think>`` XML and the gateway's display-block
+    styles) and the file-mutation verifier footer."""
     if not text:
         return ""
-    for pattern in (_THINK_BLOCK_RE, _THINK_BLOCK_OPEN_RE, _VERIFIER_FOOTER_RE):
+    for pattern in (_THINK_BLOCK_RE, _THINK_BLOCK_OPEN_RE,
+                    _REASONING_SUBTEXT_RE, _REASONING_BLOCKQUOTE_RE, _REASONING_CODE_RE,
+                    _VERIFIER_FOOTER_RE):
         text = pattern.sub(" ", text)
     return text
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -156,7 +156,8 @@ def _get_provider(tts_config: Dict[str, Any]) -> str:
 
 
 # Platforms whose native voice-bubble delivery requires Ogg/Opus (MP3 renders broken there).
-OPUS_VOICE_PLATFORMS = frozenset({"telegram", "matrix", "feishu", "whatsapp", "signal"})
+# Discord is included: its native voice-message send (flags=8192) requires Ogg/Opus bytes.
+OPUS_VOICE_PLATFORMS = frozenset({"telegram", "matrix", "feishu", "whatsapp", "signal", "discord"})
 # Built-ins that emit Opus natively when asked for .ogg; the rest need ffmpeg for voice bubbles.
 _NATIVE_OPUS_PROVIDERS = frozenset({"openai", "elevenlabs", "mistral", "gemini"})
 _FFMPEG_OPUS_PROVIDERS = frozenset({"edge", "neutts", "minimax", "xai", "kittentts", "piper"})


### PR DESCRIPTION
## What does this PR do?

Two fixes for Discord voice replies (auto-TTS via `/voice on`), each with a regression test.

**1. Discord native voice messages were silently dropped.** Discord's native voice-message send (`flags=8192`) requires **Ogg/Opus** bytes, but `discord` was missing from `OPUS_VOICE_PLATFORMS`, so `build_auto_tts_output_path(Platform.DISCORD)` returned a `.mp3` path and Edge TTS emitted MP3. The Discord adapter then POSTed those MP3 bytes labeled `audio/ogg` as a native voice message, which Discord silently dropped — voice replies never reached the user. Adding `discord` to `OPUS_VOICE_PLATFORMS` makes the output path `.ogg` and the existing container repair(`_repair_ogg_container`) transcodes MP3 → real Ogg/Opus via ffmpeg.

**2. Reasoning display blocks were read aloud.** With `show_reasoning` on, the gateway prepends a display-only reasoning block (`gateway/run_turn.py::_hmwa_prepend_reasoning`) in one of three render styles — Discord's `-# 💭 Reasoning` subtext, the `> 💭 **Reasoning:**` blockquote, or the `💭 **Reasoning:**` code fence. `strip_nonspoken_blocks` only removed ``, so the reasoning was spoken. Extending it to strip all three styles means only the actual answer is spoken while the reasoning stays visible in the text reply.

## Related Issue

Fixes #  (no existing issue — happy to open one first if the maintainers prefer)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tools/tts_tool.py` — add `discord` to `OPUS_VOICE_PLATFORMS`.
- `tools/tts_text_normalize.py` — strip the three reasoning display-block styles in `strip_nonspoken_blocks`.
- `tests/gateway/test_base_auto_tts_output_format.py` — new `test_output_path_is_ogg_for_discord`; remove Discord from the non-Opus parametrize.
- `tests/tools/test_tts_text_normalize.py` — new `test_prepare_spoken_text_strips_reasoning_display_blocks`.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_tts_text_normalize.py tests/gateway/test_base_auto_tts_output_format.py tests/tools/test_tts_opus_routing.py` → all pass.
2. Manual (Discord): send `/voice on`, then a voice message → the bot now replies with a native voice message.
3. With `show_reasoning: true`, confirm the spoken reply contains only the answer, not the `-# 💭 Reasoning` block.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)

