### PR TITLE
skill_view: accept source="local"/"external" to resolve name collisions

### DIFF
--- a/tests/tools/test_skill_view_dedup.py
+++ b/tests/tools/test_skill_view_dedup.py
@@ -4,6 +4,7 @@ import json
 import os
 import time
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -92,3 +93,29 @@ class TestSkillViewDedup:
         # conversation_compression imports this lazily; keep the seam stable.
         from tools.skills_tool import reset_skill_view_dedup as f
         f(None)
+
+    def test_source_switch_does_not_return_stale_stub_from_other_root(self, skills_home, tmp_path):
+        """Regression: a colliding name resolves to a DIFFERENT on-disk file per source, so
+        switching source must never coalesce with the other root's cached "unchanged" view."""
+        external_dir = tmp_path / "external"
+        d = external_dir / "demo-dedup-skill"
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(
+            "---\nname: demo-dedup-skill\ndescription: Demo skill for dedup tests.\n---\n"
+            "# Demo\n\nEXTERNAL VERSION.\n"
+        )
+        with patch("agent.skill_utils.get_external_skills_dirs", return_value=[external_dir]):
+            r1 = json.loads(_skill_view_with_bump(
+                {"name": "demo-dedup-skill", "source": "local"}, task_id="t-svd"))
+            assert r1["success"] is True and "Step one" in r1["content"]
+
+            r2 = json.loads(_skill_view_with_bump(
+                {"name": "demo-dedup-skill", "source": "external"}, task_id="t-svd"))
+            assert r2["success"] is True
+            assert r2.get("dedup") is not True  # must NOT be a stale stub from the local view
+            assert "EXTERNAL VERSION" in r2["content"]
+
+            # Repeating the same source now correctly dedups against itself.
+            r3 = json.loads(_skill_view_with_bump(
+                {"name": "demo-dedup-skill", "source": "external"}, task_id="t-svd"))
+            assert r3.get("dedup") is True

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -906,10 +906,63 @@ class TestSkillViewCollisionDetection:
         assert "Ambiguous skill name 'explore-codebase'" in result["error"]
         assert "matches" in result
         assert len(result["matches"]) == 2
-        # Both paths surfaced
-        assert any("foundations/runtime" in p for p in result["matches"])
-        assert any("external" in p for p in result["matches"])
+        # Both paths surfaced, each tagged with which root it came from
+        assert any("foundations/runtime" in m["path"] and m["source"] == "local" for m in result["matches"])
+        assert any("external" in m["path"] and m["source"] == "external" for m in result["matches"])
         assert "hint" in result
+        # Same relative path in each root would make "pass the full path" impossible advice;
+        # here the local copy is nested and the external one isn't, so that hint still applies.
+        assert "full relative path" in result["hint"]
+
+    def test_identical_relative_path_hints_source_param(self, tmp_path):
+        """When local and external collide on the SAME relative path, "pass the full
+        path" can't disambiguate them — the hint must point at source= instead."""
+        local_dir = tmp_path / "local"
+        external_dir = tmp_path / "external"
+        local_dir.mkdir()
+        external_dir.mkdir()
+
+        _make_skill(local_dir, "local-llm-bench", category="mlops", body="LOCAL VERSION")
+        _make_skill(external_dir, "local-llm-bench", category="mlops", body="EXTERNAL VERSION")
+
+        p1, p2 = self._patch_dirs(local_dir, [external_dir])
+        with p1, p2:
+            raw = skill_view("mlops/local-llm-bench")
+
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert len(result["matches"]) == 2
+        assert {m["source"] for m in result["matches"]} == {"local", "external"}
+        assert 'source="local"' in result["hint"] and 'source="external"' in result["hint"]
+
+    def test_source_local_and_external_each_resolve_the_collision(self, tmp_path):
+        """Once source disambiguates, each call resolves to its own root's content —
+        the actual unblock for the guardrail-halt scenario this guards against."""
+        local_dir = tmp_path / "local"
+        external_dir = tmp_path / "external"
+        local_dir.mkdir()
+        external_dir.mkdir()
+
+        _make_skill(local_dir, "local-llm-bench", category="mlops", body="LOCAL VERSION")
+        _make_skill(external_dir, "local-llm-bench", category="mlops", body="EXTERNAL VERSION")
+
+        p1, p2 = self._patch_dirs(local_dir, [external_dir])
+        with p1, p2:
+            local_result = json.loads(skill_view("mlops/local-llm-bench", source="local"))
+            external_result = json.loads(skill_view("mlops/local-llm-bench", source="external"))
+
+        assert local_result["success"] is True and "LOCAL VERSION" in local_result["content"]
+        assert external_result["success"] is True and "EXTERNAL VERSION" in external_result["content"]
+
+    def test_invalid_source_rejected(self, tmp_path):
+        local_dir = tmp_path / "local"
+        local_dir.mkdir()
+        p1, p2 = self._patch_dirs(local_dir, [])
+        with p1, p2:
+            raw = skill_view("anything", source="bogus")
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "Invalid source" in result["error"]
 
 
     def test_support_markdown_does_not_collide_with_real_skill(self, tmp_path):
@@ -969,3 +1022,7 @@ class TestSkillViewCollisionDetection:
         assert result["success"] is False
         assert "Ambiguous" in result["error"]
         assert len(result["matches"]) == 2
+        # Both candidates are external — source= can't disambiguate two externals,
+        # so this must fall back to the "pass the full path" hint, not source=.
+        assert {m["source"] for m in result["matches"]} == {"external"}
+        assert "full relative path" in result["hint"]

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -964,6 +964,34 @@ class TestSkillViewCollisionDetection:
         assert result["success"] is False
         assert "Invalid source" in result["error"]
 
+    def test_source_external_with_no_external_dirs_configured_gives_clear_error(self, tmp_path):
+        """Regression: filtering all_dirs down to nothing for source="external" must not
+        fall through to the generic "Skills directory does not exist yet" message -- that's
+        about the skills dir never being created, not about a config that has no external_dirs."""
+        local_dir = tmp_path / "local"
+        local_dir.mkdir()
+        _make_skill(local_dir, "solo-skill")
+        p1, p2 = self._patch_dirs(local_dir, [])
+        with p1, p2:
+            raw = skill_view("solo-skill", source="external")
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "external_dirs" in result["error"]
+        assert "does not exist yet" not in result["error"]
+
+    def test_source_local_with_no_local_dirs_gives_clear_error(self, tmp_path):
+        local_dir = tmp_path / "local"  # deliberately not created -> _skills_dir().exists() is False
+        external_dir = tmp_path / "external"
+        external_dir.mkdir()
+        _make_skill(external_dir, "solo-skill")
+        p1, p2 = self._patch_dirs(local_dir, [external_dir])
+        with p1, p2:
+            raw = skill_view("solo-skill", source="local")
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "No local skills directory" in result["error"]
+        assert "does not exist yet" not in result["error"]
+
 
     def test_support_markdown_does_not_collide_with_real_skill(self, tmp_path):
         """Supporting reference docs named <skill>.md are not skills.

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -469,7 +469,10 @@ def _locate_skill(name: str, local_category_name: Optional[str], project_dirs: l
     gate, not-found listing. ``(error_json, skill_dir, skill_md)``; skill_md set iff no error.
     ``local_dirs`` (project dirs + the active skills dir) tags an ambiguous match's ``source`` as
     "local"/"external" and detects the case where two roots collide on the identical relative
-    path — there "pass the full path" is impossible advice, since that path is what collides."""
+    path — there "pass the full path" is impossible advice, since that path is what collides.
+    Known gap: two DIFFERENT project-tier dirs (nested project skill scopes) colliding on the
+    same relative path both tag as "local" — source can't split those apart, same as before
+    this parameter existed; only the local/external split is covered."""
     if not all_dirs:
         return _fail(
             "Skills directory does not exist yet. It will be created on first install."), None, None
@@ -554,6 +557,8 @@ def skill_view(
             return _fail(f"Invalid source '{source}': must be \"local\" or \"external\".")
         local_category_name: str | None = None
         if ":" in name:  # plugin registry; bare names use the flat-tree scan below
+            # A resolvable plugin:skill answers here and returns immediately — source
+            # only affects the flat-tree fall-through below, so it's a no-op for a hit.
             served, local_category_name = _resolve_plugin_skill(name, file_path, task_id, preprocess)
             if served is not None:
                 return served
@@ -565,8 +570,14 @@ def skill_view(
         local_dirs = project_dirs + ([active_skills_dir] if active_skills_dir.exists() else [])
         if source == "local":
             all_dirs = [d for d in all_dirs if d in local_dirs]
+            if not all_dirs:
+                return _fail("No local skills directory is configured.")
         elif source == "external":
             all_dirs = [d for d in all_dirs if d not in local_dirs]
+            if not all_dirs:
+                return _fail(
+                    'No skills.external_dirs are configured — there is nothing to search '
+                    'with source="external".')
         error, skill_dir, skill_md = _locate_skill(
             name, local_category_name, project_dirs, all_dirs, local_dirs)
         if error is not None:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -463,9 +463,13 @@ def _skill_readiness(frontmatter: Dict[str, Any], skill_name: str) -> Tuple[dict
     return fields, extras
 
 
-def _locate_skill(name: str, local_category_name: Optional[str], project_dirs: list, all_dirs):
+def _locate_skill(name: str, local_category_name: Optional[str], project_dirs: list, all_dirs,
+                   local_dirs: Optional[list] = None):
     """Unique on-disk skill for *name*: collision refusal, project-tier precedence, quarantine
-    gate, not-found listing. ``(error_json, skill_dir, skill_md)``; skill_md set iff no error."""
+    gate, not-found listing. ``(error_json, skill_dir, skill_md)``; skill_md set iff no error.
+    ``local_dirs`` (project dirs + the active skills dir) tags an ambiguous match's ``source`` as
+    "local"/"external" and detects the case where two roots collide on the identical relative
+    path — there "pass the full path" is impossible advice, since that path is what collides."""
     if not all_dirs:
         return _fail(
             "Skills directory does not exist yet. It will be created on first install."), None, None
@@ -475,14 +479,31 @@ def _locate_skill(name: str, local_category_name: Optional[str], project_dirs: l
         # ambiguity WITHIN the project tier still refuses.
         candidates = [c for c in candidates if _under_any(c[1], project_dirs)] or candidates
     if len(candidates) > 1:
-        paths = [str(smd) for _, smd in candidates]
-        logger.warning("Skill name collision for '%s': %d candidates — %s", name, len(candidates), "; ".join(paths))
+        local_dirs = local_dirs or []
+
+        def _rel(smd: Path) -> str:
+            for d in all_dirs:
+                if _under_any(smd, [d]):
+                    with suppress(Exception):
+                        return str(smd.relative_to(d))
+            return str(smd)
+
+        matches = [{"path": str(smd), "source": "local" if _under_any(smd, local_dirs) else "external"}
+                   for _, smd in candidates]
+        logger.warning("Skill name collision for '%s': %d candidates — %s", name, len(candidates),
+                        "; ".join(m["path"] for m in matches))
+        if len({_rel(smd) for _, smd in candidates}) == 1 and len({m["source"] for m in matches}) > 1:
+            # Every candidate resolves to the same relative path in a different root — no
+            # alternate path string could ever disambiguate them, only picking a root can.
+            hint = ('Pass source="local" or source="external" to pick a root, or rename one of '
+                    "the colliding skills so each name is unique.")
+        else:
+            hint = ("Pass the full relative path instead of the bare name (e.g., 'category/skill-name'), "
+                    "or rename one of the colliding skills so each name is unique.")
         return _fail(
             f"Ambiguous skill name '{name}': {len(candidates)} skills match across your local skills dir "
-            "and external_dirs. Refusing to guess — load one explicitly by its categorized path.",
-            matches=paths,
-            hint="Pass the full relative path instead of the bare name (e.g., 'category/skill-name'), "
-            "or rename one of the colliding skills so each name is unique."), None, None
+            "and external_dirs. Refusing to guess — load one explicitly.",
+            matches=matches, hint=hint), None, None
     skill_dir, skill_md = candidates[0] if candidates else (None, None)
     # Quarantine gate: a project-tier skill with a dangerous scan verdict must not
     # load even by explicit name (same chokepoint the index and skills_list use).
@@ -517,16 +538,20 @@ def _log_security_warnings(name: str, skill_md: Path, content: str, all_dirs, ac
 
 
 def skill_view(
-    name: str, file_path: str = None, task_id: str = None, preprocess: bool = True) -> str:
+    name: str, file_path: str = None, task_id: str = None, preprocess: bool = True,
+    source: str = None) -> str:
     """View a skill (SKILL.md) or a file within its directory, as JSON. ``name`` is a skill name
     or path ("axolotl", "03-fine-tuning/axolotl"); "plugin:skill" resolves plugin-provided
     skills. ``preprocess`` applies the configured SKILL.md template / inline shell rendering;
-    slash/preload callers render the message themselves."""
+    slash/preload callers render the message themselves. ``source`` ("local"/"external")
+    disambiguates a name that collides across roots — see the "Ambiguous skill name" error."""
     try:
         # Validate before the ':' dispatch so a Windows drive path (C:\skills\foo) can't be
         # reinterpreted as a plugin namespace.
         if lookup_error := _skill_lookup_path_error(name):
             return _fail(lookup_error, hint=_LOOKUP_HINT)
+        if source is not None and source not in ("local", "external"):
+            return _fail(f"Invalid source '{source}': must be \"local\" or \"external\".")
         local_category_name: str | None = None
         if ":" in name:  # plugin registry; bare names use the flat-tree scan below
             served, local_category_name = _resolve_plugin_skill(name, file_path, task_id, preprocess)
@@ -537,8 +562,13 @@ def skill_view(
         if local_category_name and (lookup_error := _skill_lookup_path_error(local_category_name)):
             return _fail(lookup_error, hint=_LOOKUP_HINT)
         project_dirs, all_dirs, active_skills_dir = _skill_search_dirs()
+        local_dirs = project_dirs + ([active_skills_dir] if active_skills_dir.exists() else [])
+        if source == "local":
+            all_dirs = [d for d in all_dirs if d in local_dirs]
+        elif source == "external":
+            all_dirs = [d for d in all_dirs if d not in local_dirs]
         error, skill_dir, skill_md = _locate_skill(
-            name, local_category_name, project_dirs, all_dirs)
+            name, local_category_name, project_dirs, all_dirs, local_dirs)
         if error is not None:
             return error
         try:  # read once — reused for platform check and main content
@@ -626,6 +656,11 @@ SKILL_VIEW_SCHEMA = {
                 "type": "string",
                 "description": "OPTIONAL: Path to a linked file within the skill (e.g., 'references/api.md', 'templates/config.yaml', 'scripts/validate.py'). Omit to get the main SKILL.md content.",
             },
+            "source": {
+                "type": "string",
+                "enum": ["local", "external"],
+                "description": "OPTIONAL: only needed after an \"Ambiguous skill name\" error whose matches span both a local and an external root. 'local' resolves against your local skills dir (and any project skills); 'external' resolves against skills.external_dirs.",
+            },
         },
         "required": ["name"],
     },
@@ -643,13 +678,14 @@ def _skill_view_with_bump(args, **kw):
     session returns a short stub (cache cleared on context compression)."""
     name = args.get("name", "")
     task_id = kw.get("task_id")
-    if (stub := _check_skill_view_dedup(task_id, name, args.get("file_path"))) is not None:
+    source = args.get("source")
+    if (stub := _check_skill_view_dedup(task_id, name, args.get("file_path"), source)) is not None:
         return stub
-    result = skill_view(name, file_path=args.get("file_path"), task_id=task_id)
+    result = skill_view(name, file_path=args.get("file_path"), task_id=task_id, source=source)
     with suppress(Exception):
         parsed = json.loads(result)
         if isinstance(parsed, dict) and parsed.get("success"):
-            _record_skill_view(task_id, name, args.get("file_path"), parsed)
+            _record_skill_view(task_id, name, args.get("file_path"), parsed, source)
             if resolved := parsed.get("name") or name:  # qualified forms return the canonical name
                 from tools.skill_usage import bump_use, bump_view
                 bump_view(str(resolved))

--- a/tools/skills_tool_dedup.py
+++ b/tools/skills_tool_dedup.py
@@ -31,7 +31,7 @@ def _skill_view_fingerprint(payload: dict) -> tuple | None:
         return None
 
 
-def _record_skill_view(task_id, name, file_path, payload: dict) -> None:
+def _record_skill_view(task_id, name, file_path, payload: dict, source=None) -> None:
     """Record a served skill_view so an identical repeat can be deduped."""
     # Never dedup setup-needed views: readiness depends on config/env state that
     # changes without the file changing; the model must see the refreshed status.
@@ -40,7 +40,7 @@ def _record_skill_view(task_id, name, file_path, payload: dict) -> None:
         return
     if (fp := _skill_view_fingerprint(payload)) is None:
         return
-    key = (str(payload.get("name") or name), file_path or "")
+    key = (str(payload.get("name") or name), file_path or "", source or "")
     with _skill_view_tracker_lock:
         cache = _skill_view_tracker.setdefault(str(task_id), {})
         cache[key] = fp
@@ -48,9 +48,11 @@ def _record_skill_view(task_id, name, file_path, payload: dict) -> None:
             del cache[next(iter(cache))]
 
 
-def _check_skill_view_dedup(task_id, name, file_path) -> str | None:
+def _check_skill_view_dedup(task_id, name, file_path, source=None) -> str | None:
     """Dedup stub when this exact skill file was already served to this task and
-    is unchanged on disk; None otherwise."""
+    is unchanged on disk; None otherwise. ``source`` ("local"/"external") must match the
+    recorded view too — a colliding name resolves to a different on-disk file per source, so
+    switching source must never coalesce with the other root's cached view."""
     if not task_id:
         return None
     n = str(name)
@@ -60,8 +62,8 @@ def _check_skill_view_dedup(task_id, name, file_path) -> str | None:
         # Record key is the RESOLVED name; match raw and resolved forms so
         # 'category/skill' and bare-name views coalesce.
         for key, (src, mtime_ns, size) in list(cache.items()):
-            rec_name, rec_fp = key
-            if rec_fp != (file_path or "") or (
+            rec_name, rec_fp, rec_source = key
+            if rec_fp != (file_path or "") or rec_source != (source or "") or (
                     rec_name != n and not n.endswith("/" + rec_name)
                     and not rec_name.endswith("/" + n) and n.split(":")[-1] != rec_name):
                 continue


### PR DESCRIPTION
## Summary

`skill_view()` refuses to guess when a skill name matches more than one
file across search roots (a profile-local skills dir vs
`skills.external_dirs`) — a deliberate anti-shadowing guard. But when
both colliding candidates share the *identical* relative path in their
respective roots, the existing hint ("pass the full relative path
instead of the bare name") is impossible advice: that path is exactly
what collides, so no alternate path string can disambiguate them. There
was previously no way to recover from this specific case at all.

This PR:

- Adds an optional `source: "local" | "external"` parameter to
  `skill_view()` to pick a root explicitly.
- Tags each entry in the ambiguous-match error's `matches` list with
  which root it came from (`{"path": ..., "source": "local"|"external"}`,
  previously a bare path string — a small breaking shape change to that
  field; no in-repo consumer parses it programmatically).
- Only points the hint at `source=` when it can actually help (i.e. the
  colliding candidates span more than one root); otherwise keeps the
  original "pass the full path" advice, since that's still correct when
  two same-name skills are just differently categorized within one root.
- Fixes the repeat-view dedup cache (`skills_tool_dedup.py`), which
  previously keyed only on `(name, file_path)`: switching `source` for a
  diverged colliding skill would otherwise return the *other* root's
  stale "unchanged" stub.
- Gives a clear, specific error (instead of the generic "Skills
  directory does not exist yet") when `source=` filters out every
  search dir — e.g. `source="external"` with no `external_dirs`
  configured.

Known, pre-existing, out-of-scope limitation (documented in a
docstring): two *different* project-tier skill dirs colliding on the
same relative path both tag as `"local"`, so `source=` can't split
those apart — same underlying problem one level deeper, not introduced
or fixed by this change.

Design note: chose a separate `source` parameter over overloading the
existing `namespace:name` colon syntax, since a real plugin literally
named `local` or `external` would collide with that.

## Test plan

- [x] `uv run pytest tests/tools/test_skills_tool.py
      tests/tools/test_skill_view_path_check.py
      tests/tools/test_skill_view_traversal.py
      tests/tools/test_skill_view_dedup.py` — 69 passed, 1 skipped
- [x] New tests cover: `source="local"`/`source="external"` each
      resolving their own root's content, the corrected hint text when
      candidates share an identical path across roots vs. when they
      don't, an invalid `source` value, `source=` filtering out every
      dir (both directions), and the dedup-cache regression (switching
      `source` for a colliding name must not return the other root's
      stale stub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)