### PR TITLE
feat(sessions): configurable per-session exclusivity with queue-instead-of-refuse (#101279)

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -704,21 +704,56 @@ def _stamp_api_content_sidecar(
     if _api_content is None or _api_content == _turn_user_msg.get("content"):
         return
     _turn_user_msg["api_content"] = _api_content
-    # In-place preflight compaction already inserted this turn's user row and the
-    # crash persist identity-skips compacted dicts, so backfill the stamp onto the row
-    # directly. Rotation mode flushes to the child session later.
-    if not (preflight_compressed and getattr(agent, "_last_compaction_in_place", False)):
+    # When this turn's user row was ALREADY materialized before the sidecar could be
+    # composed, the crash persist below skips the message (marker/identity) and the
+    # stamp would never reach the DB — the next turn then replays clean content and
+    # the request prefix diverges at this message. Two writers get there first:
+    # in-place preflight compaction (archive_and_compact runs before
+    # prefetch/pre_llm_call) and a close/early flush that raced the prologue on the
+    # CLI path (#102194). Both stamp ``_row_id`` on the live dict when they write it
+    # (``_insert_message_rows`` directly, ``sync_flushed_message_markers`` after the
+    # batch commit), so that id is at once the proof a row exists and the address to
+    # update — no positional guess, and no extra write on the normal path where the
+    # row does not exist yet.
+    #
+    # Do NOT widen this to an unconditional backfill: without a row id the store can
+    # only target the newest active user row, and a repeated user turn ("ok", "y",
+    # "continue") makes the PREVIOUS turn's row compare equal — this turn's bytes
+    # would overwrite its sidecar and be replayed as that turn forever.
+    #
+    # Rotation mode needs nothing here: its compacted copies flush to the child
+    # session after this stamp.
+    _row_id = _turn_user_msg.get("_row_id")
+    _has_valid_row_id = (
+        isinstance(_row_id, int)
+        and not isinstance(_row_id, bool)
+        and _row_id > 0
+    )
+    _in_place_compacted = preflight_compressed and bool(
+        getattr(agent, "_last_compaction_in_place", False)
+    )
+    if not (_has_valid_row_id or _in_place_compacted):
         return
     _db = getattr(agent, "_session_db", None)
     if _db is not None:
         try:
-            _db.set_latest_user_api_content(
-                agent.session_id, _turn_user_msg.get("content"), _api_content
-            )
+            if _has_valid_row_id:
+                _db.set_message_api_content(
+                    agent.session_id,
+                    _row_id,
+                    _turn_user_msg.get("content"),
+                    _api_content,
+                )
+            else:
+                # Compacted copy that carries no row id: fall back to the positional
+                # backfill, which is safe here because archive_and_compact just made
+                # this message the newest active user row.
+                _db.set_latest_user_api_content(
+                    agent.session_id, _turn_user_msg.get("content"), _api_content
+                )
         except Exception:
             logger.warning(
-                "in-place compaction api_content backfill failed "
-                "for session=%s",
+                "api_content backfill failed for session=%s",
                 agent.session_id or "none",
                 exc_info=True,
             )

--- a/cli.py
+++ b/cli.py
@@ -2970,6 +2970,27 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin, CLITuiMix
         except Exception as exc:
             logger.warning("Failed to claim active session slot: %s", exc)
             return True
+        if message and getattr(message, "reason", None) == "SESSION_NOT_OWNED":
+            # Shared-brain deployments (gateway.per_session_exclusive: false) queue
+            # behind the live owner instead of being refused (#101279).
+            try:
+                from hermes_cli.active_sessions import per_session_exclusive, wait_for_session_ownership
+
+                if not per_session_exclusive(self.config) and wait_for_session_ownership(
+                    session_id=self.session_id,
+                    on_wait=lambda _e: self._console_print(
+                        "[yellow]\N{HOURGLASS} Another Hermes process is using this session; "
+                        "waiting for it to finish before starting your turn...[/yellow]"
+                    ),
+                ):
+                    lease, message = try_acquire_active_session(
+                        session_id=self.session_id,
+                        surface=surface,
+                        config=self.config,
+                        metadata={"live_session_id": str(self.session_id)},
+                    )
+            except Exception:
+                logger.debug("Session ownership queueing unavailable; keeping refusal", exc_info=True)
         if message:
             print(message, file=sys.stderr) if stderr else self._console_print(f"[bold red]{message}[/]")
             return False

--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -61,6 +61,40 @@ def resolve_max_concurrent_sessions(config: Any) -> Optional[int]:
     return coerce_max_concurrent_sessions(raw, key=key)
 
 
+def per_session_exclusive(config: Any) -> bool:
+    """Resolve ``gateway.per_session_exclusive`` (default True) with top-level fallback.
+
+    True (default): a second live owner is REFUSED (``SESSION_NOT_OWNED``) — the solo-deployment
+    correctness default. False: shared-brain deployments may opt out, and a surfaced
+    ``SESSION_NOT_OWNED`` refusal becomes a bounded WAIT for the current owner to finish (the
+    same serialization the messaging gateway already gives Telegram: the queued turn starts only
+    after the running one, with the full transcript). Invalid values warn once and keep the
+    safe default. See #101279.
+    """
+    raw: Any = None
+    key = "gateway.per_session_exclusive"
+    if isinstance(config, dict):
+        gateway_cfg = config.get("gateway")
+        if isinstance(gateway_cfg, dict) and "per_session_exclusive" in gateway_cfg:
+            raw = gateway_cfg.get("per_session_exclusive")
+        elif "per_session_exclusive" in config:
+            raw = config.get("per_session_exclusive")
+            key = "per_session_exclusive"
+    else:
+        raw = getattr(config, "per_session_exclusive", None)
+        if raw is None:
+            gateway_cfg = getattr(config, "gateway", None)
+            raw = getattr(gateway_cfg, "per_session_exclusive", None)
+    if raw is None:
+        return True
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, str) and raw.strip().lower() in ("true", "false"):
+        return raw.strip().lower() == "true"
+    logger.warning("Ignoring invalid %s=%r (expected true/false); keeping exclusivity", key, raw)
+    return True
+
+
 def format_age(seconds: float) -> str:
     minutes = max(0, int(seconds // 60))
     if minutes < 60:
@@ -524,6 +558,64 @@ def try_acquire_active_session(
         _write_entries(state_path, entries)
 
     return lease, None
+
+
+def wait_for_session_ownership(
+    *, session_id: str, registry_home: str | Path | None = None,
+    wait_seconds: float = 1800.0, poll_seconds: float = 1.0,
+    should_abort=None, on_wait=None,
+) -> bool:
+    """Block until no OTHER live lease holds *session_id* (or the wait bounds expire).
+
+    The queueing half of ``gateway.per_session_exclusive: false`` (#101279): after a
+    ``SESSION_NOT_OWNED`` refusal, the caller waits for the current owner to finish and
+    re-acquires — the serialization the messaging gateway already gives Telegram, instead
+    of pushing a refusal onto the second user. Returns True when the session is free (or
+    was free all along); False when the wait timed out or was aborted. Never raises: a
+    registry that cannot be read mid-wait returns False so the caller falls back to the
+    refusal path.
+
+    *should_abort* (optional): called each poll; a truthy return cancels the wait.
+    *on_wait* (optional): called once with the elapsed seconds when the wait proves
+    non-trivial (>0 polls), for a status line like the gateway's
+    "Another Hermes process is using this session; waiting...".
+    """
+    key = str(session_id or "")
+    deadline = time.monotonic() + max(0.0, float(wait_seconds))
+    poll = max(0.05, float(poll_seconds))
+    notified = False
+    state_path = _state_path(registry_home)
+    lock_path = _lock_path(registry_home)
+    while True:
+        try:
+            with _FileLock(lock_path):
+                loaded = _read_live_entries(
+                    state_path, track_liveness=False,
+                    warn="Active-session registry is unavailable while waiting for ownership",
+                )
+                if loaded is None:
+                    return False
+                _, entries = loaded
+                if not any(
+                    str(existing.get("session_id") or "") == key for existing in entries
+                ):
+                    return True
+        except Exception:
+            logger.warning("Ownership wait registry check failed", exc_info=True)
+            return False
+        if should_abort is not None:
+            try:
+                if should_abort():
+                    return False
+            except Exception:
+                logger.debug("Ownership wait abort probe failed", exc_info=True)
+        if time.monotonic() >= deadline:
+            return False
+        if on_wait is not None and not notified:
+            notified = True
+            with suppress(Exception):
+                on_wait(0.0)
+        time.sleep(poll)
 
 
 def release_active_session(lease: ActiveSessionLease) -> None:

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -576,12 +576,41 @@ class SessionMessagesMixin:
     def set_latest_user_api_content(self, session_id: str, content: Any, api_content: str) -> int:
         """Backfill the ``api_content`` sidecar onto the newest ACTIVE user row (0/1 rows). Preflight compaction
         inserts that row BEFORE the sidecar exists and the later persist identity-skips compacted dicts;
-        without this a reload reopens the prompt-cache divergence. ``content`` match guards a racing rewrite."""
+        without this a reload reopens the prompt-cache divergence. ``content`` match guards a racing rewrite.
+
+        POSITIONAL, and only safe when the caller already knows the newest active user row IS the message it
+        stamped. The content match is NOT sufficient on its own: repeated identical user turns ("ok", "y",
+        "continue") make an OLDER row compare equal, so calling this before the current turn's row exists
+        overwrites the previous turn's sidecar with this turn's bytes — durable wrong-bytes replay, a worse
+        cache break than the missing sidecar. When the caller holds the durable row id (``_row_id``, synced
+        onto the live dict by ``sync_flushed_message_markers`` and stamped by ``_insert_message_rows``), use
+        :meth:`set_message_api_content` instead — it addresses the exact row and cannot land on a neighbour."""
         return self._write_rowcount(
             "UPDATE messages SET api_content = ? WHERE id = (SELECT id FROM messages "
             "WHERE session_id = ? AND role = 'user' AND active = 1 ORDER BY id DESC LIMIT 1"
             ") AND content IS ?",
             (_scrub_surrogates(api_content), session_id, self._encode_content(content)))
+
+    def set_message_api_content(self, session_id: str, row_id: int, content: Any, api_content: str) -> int:
+        """Backfill the ``api_content`` sidecar onto ONE known durable row.
+
+        Row-addressed counterpart to :meth:`set_latest_user_api_content`: the caller passes the ``_row_id``
+        the write path stamped on the live message dict, so the update cannot drift onto a neighbouring row
+        that merely carries the same text.
+
+        Used by the turn prologue whenever the current turn's user row was already materialized before the
+        sidecar could be composed (in-place preflight compaction, a close/early flush that raced the
+        prologue — #102194). The crash persist then marker-skips that message, so this is the only way the
+        stamped bytes reach the store.
+
+        ``active = 1`` and the ``content`` match stay as defensive guards: a row the compaction archived, or
+        one a racing rewrite changed, is left untouched."""
+        if not session_id or isinstance(row_id, bool) or not isinstance(row_id, int) or row_id <= 0:
+            return 0
+        return self._write_rowcount(
+            "UPDATE messages SET api_content = ? "
+            "WHERE id = ? AND session_id = ? AND role = 'user' AND active = 1 AND content IS ?",
+            (_scrub_surrogates(api_content), row_id, session_id, self._encode_content(content)))
 
     def _dedupe_display_generations(self, rows):
         """Collapse compaction generations so each logical message appears once (the protected tail is copied

--- a/tests/agent/test_api_content_row_addressed_backfill.py
+++ b/tests/agent/test_api_content_row_addressed_backfill.py
@@ -1,0 +1,257 @@
+"""Row-addressed ``api_content`` backfill (NousResearch/hermes-agent#102194).
+
+The sidecar is stamped by the turn prologue and normally reaches the DB in the
+same INSERT as the clean content (the crash persist runs after the stamp). When
+another writer materialized the current turn's user row FIRST — in-place
+preflight compaction, or a close/early flush that raced the prologue — that
+insert never happens: the crash persist marker-skips the message and the row
+keeps ``api_content = NULL``, so the next turn replays clean content and the
+request prefix diverges exactly at that message.
+
+The prologue therefore backfills, but only when a row provably exists for THIS
+dict. ``_row_id`` is that proof and that address: both early writers stamp it on
+the live message (``_insert_message_rows`` directly, ``sync_flushed_message_markers``
+after the batch commit). A positional "newest active user row" update cannot be
+substituted for it — a repeated user turn ("ok", "y", "continue") makes the
+previous turn's row compare equal on content, and the backfill would overwrite
+that turn's sidecar with this turn's bytes.
+"""
+
+from __future__ import annotations
+
+import types
+from unittest.mock import patch
+
+import pytest
+
+from agent.turn_context import compose_user_api_content
+from hermes_state import SessionDB
+from tests.agent.test_api_content_sidecar import _FakeAgent, _build
+
+
+def _open_db(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(session_id="s1", source="cli")
+    return db
+
+
+def _open_db_with_sessions(tmp_path, *session_ids):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    for sid in session_ids:
+        db.create_session(session_id=sid, source="cli")
+    return db
+
+
+class TestSetMessageApiContent:
+    """The store primitive: addressed by row id, guarded on the rest."""
+
+    def test_updates_the_addressed_row(self, tmp_path):
+        db = _open_db(tmp_path)
+        try:
+            db.append_message("s1", "user", content="ok")
+            row_id = db.get_messages("s1")[0]["id"]
+            assert db.set_message_api_content("s1", row_id, "ok", "ok\n\nCTX") == 1
+            assert db.get_messages("s1")[0]["api_content"] == "ok\n\nCTX"
+        finally:
+            db.close()
+
+    def test_older_identical_row_is_untouched(self, tmp_path):
+        """Two user turns with the same text — the repeated-"ok" shape.
+
+        Addressing the row makes the older turn's sidecar unreachable; the
+        positional helper cannot tell them apart (asserted on the same DB).
+        """
+        db = _open_db(tmp_path)
+        try:
+            db.append_message("s1", "user", content="ok")
+            db.append_message("s1", "assistant", content="hi")
+            db.append_message("s1", "user", content="ok")
+            rows = db.get_messages("s1")
+            older_id, newer_id = rows[0]["id"], rows[2]["id"]
+            assert older_id != newer_id
+
+            db.set_message_api_content("s1", newer_id, "ok", "ok\n\nCTX-NEW")
+            assert db.get_messages("s1")[2]["api_content"] == "ok\n\nCTX-NEW"
+            # The older identical row was not touched.
+            assert db.get_messages("s1")[0]["api_content"] is None
+        finally:
+            db.close()
+
+    def test_content_mismatch_writes_nothing(self, tmp_path):
+        """A row a racing rewrite changed is left untouched."""
+        db = _open_db(tmp_path)
+        try:
+            db.append_message("s1", "user", content="ok")
+            row_id = db.get_messages("s1")[0]["id"]
+            assert db.set_message_api_content("s1", row_id, "different", "ok\n\nCTX") == 0
+            assert db.get_messages("s1")[0]["api_content"] is None
+        finally:
+            db.close()
+
+    def test_rejects_invalid_row_id_and_session(self, tmp_path):
+        db = _open_db(tmp_path)
+        try:
+            db.append_message("s1", "user", content="ok")
+            for bad_id in (0, -1, None, "5", True):
+                assert db.set_message_api_content("s1", bad_id, "ok", "ok\n\nCTX") == 0
+            assert db.set_message_api_content("", 1, "ok", "ok\n\nCTX") == 0
+            assert db.get_messages("s1")[0]["api_content"] is None
+        finally:
+            db.close()
+
+    def test_archived_row_is_untouched(self, tmp_path):
+        """A compaction-archived row (active=0) must not be revived."""
+        db = _open_db(tmp_path)
+        try:
+            db.append_message("s1", "user", content="ok")
+            row_id = db.get_messages("s1")[0]["id"]
+            db.archive_and_compact("s1", [{"role": "user", "content": "summary"}])
+            assert db.set_message_api_content("s1", row_id, "ok", "ok\n\nCTX") == 0
+        finally:
+            db.close()
+
+
+class TestPrologueRowAddressedBackfill:
+    """The prologue backfills when — and only when — the row provably exists."""
+
+    def _agent_with_db(self, tmp_path, **overrides):
+        db = _open_db_with_sessions(tmp_path, "s1", "sess-1")
+        agent = _FakeAgent()
+        agent._session_db = db
+        for k, v in overrides.items():
+            setattr(agent, k, v)
+        return agent, db
+
+    def test_row_id_backfill_replaces_positional_call(self, tmp_path):
+        """A pre-persisted row (close-flush raced the prologue) carries
+        ``_row_id``; the backfill must address it, not the newest row."""
+        agent, db = self._agent_with_db(tmp_path)
+        # Pre-existing older turn with identical clean text.
+        db.append_message(agent.session_id, "user", content="ok")
+        # The current turn's message was already flushed: stamped with a row id
+        # and the persisted marker, so the crash persist will skip it.
+        current_row_id = db.append_message(
+            agent.session_id, "user", content="ok"
+        )
+        try:
+            with patch(
+                "hermes_cli.plugins.invoke_hook",
+                return_value=[{"context": "PLUGIN-CTX"}],
+            ), patch(
+                "agent.session_persistence._is_ephemeral_scaffolding",
+                lambda _m: False,
+            ):
+                ctx = _build(
+                    agent,
+                    user_message="ok",
+                    # The live dict the prologue will see, carrying the flush stamps.
+                    conversation_history=[],
+                )
+            # Stamp the row-id path precondition directly on the live dict, as
+            # sync_flushed_message_markers would have.
+            turn_msg = ctx.messages[ctx.current_turn_user_idx]
+            turn_msg["_row_id"] = current_row_id
+
+            expected = compose_user_api_content(
+                "ok", ctx.ext_prefetch_cache, ctx.plugin_user_context
+            )
+            # Re-run the stamp with the row id present: the exact-sent-bytes
+            # backfill must land on the addressed row.
+            from agent.turn_context import _stamp_api_content_sidecar
+
+            _stamp_api_content_sidecar(
+                agent, ctx.messages, ctx.current_turn_user_idx,
+                ctx.ext_prefetch_cache, ctx.plugin_user_context,
+                preflight_compressed=False,
+            )
+            rows = db.get_messages(agent.session_id)
+            assert rows[1]["api_content"] == expected
+            # The older identical row keeps its (absent) sidecar.
+            assert rows[0]["api_content"] is None
+        finally:
+            db.close()
+
+    def test_in_place_compaction_falls_back_to_positional(self, tmp_path):
+        """Compacted copies carry no ``_row_id``; the pre-existing positional
+        backfill stays for them (archive_and_compact just made this row the
+        newest active user row, so targeting by position is safe there)."""
+        agent, db = self._agent_with_db(tmp_path, _last_compaction_in_place=True)
+        positional_calls = []
+        orig_positional = db.set_latest_user_api_content
+
+        def _spy(*args, **kwargs):
+            positional_calls.append(args)
+            return orig_positional(*args, **kwargs)
+
+        db.set_latest_user_api_content = _spy
+        try:
+            with patch(
+                "hermes_cli.plugins.invoke_hook",
+                return_value=[{"context": "PLUGIN-CTX"}],
+            ):
+                ctx = _build(agent, user_message="hello")
+            turn_msg = ctx.messages[ctx.current_turn_user_idx]
+            assert "_row_id" not in turn_msg
+
+            from agent.turn_context import _stamp_api_content_sidecar
+
+            _stamp_api_content_sidecar(
+                agent, ctx.messages, ctx.current_turn_user_idx,
+                ctx.ext_prefetch_cache, ctx.plugin_user_context,
+                preflight_compressed=True,
+            )
+            # The positional fallback fired (row-addressed path not taken:
+            # no _row_id on the compacted copy).
+            assert len(positional_calls) == 1
+            assert positional_calls[0][0] == agent.session_id
+            expected = compose_user_api_content(
+                "hello", ctx.ext_prefetch_cache, ctx.plugin_user_context
+            )
+            assert positional_calls[0][2] == expected
+        finally:
+            db.close()
+
+    def test_no_backfill_without_row_id_or_compaction(self, tmp_path):
+        """Normal path: the row does not exist yet, and nothing is written
+        by the stamp (the crash persist below writes the row once, with the
+        sidecar in the same INSERT)."""
+        agent, db = self._agent_with_db(tmp_path)
+        calls = []
+        orig = db.set_latest_user_api_content
+
+        def _spy(*args, **kwargs):
+            calls.append(args)
+            return orig(*args, **kwargs)
+
+        db.set_latest_user_api_content = _spy
+        try:
+            with patch(
+                "hermes_cli.plugins.invoke_hook",
+                return_value=[{"context": "PLUGIN-CTX"}],
+            ):
+                ctx = _build(agent, user_message="hello")
+            assert ctx.messages[ctx.current_turn_user_idx]["api_content"]
+            assert calls == []  # no positional backfill on the normal path
+        finally:
+            db.close()
+
+
+def test_positional_backfill_collision_documented(tmp_path):
+    """The exact failure mode that rules out an unconditional positional
+    backfill: repeated identical user turns. The positional helper cannot
+    distinguish the rows; the row-addressed primitive can."""
+    db = _open_db(tmp_path)
+    try:
+        db.append_message("s1", "user", content="continue")
+        db.append_message("s1", "assistant", content="doing it")
+        older = db.get_messages("s1")[0]["id"]
+        db.set_latest_user_api_content("s1", "continue", "continue\n\nCTX-1")
+        assert db.get_messages("s1")[0]["api_content"] == "continue\n\nCTX-1"
+
+        # New turn with the same text, row NOT yet materialized: a positional
+        # backfill now would hit the older row — which the row-addressed
+        # primitive refuses to do (no valid id => no write).
+        assert db.set_message_api_content("s1", 0, "continue", "continue\n\nCTX-2") == 0
+        assert db.get_messages("s1")[0]["api_content"] == "continue\n\nCTX-1"
+    finally:
+        db.close()

--- a/tests/test_per_session_exclusive_opt_out.py
+++ b/tests/test_per_session_exclusive_opt_out.py
@@ -1,0 +1,155 @@
+"""Configurable per-session exclusivity: queue-instead-of-refuse (#101279).
+
+Default behavior is untouched: one live owner per stored session, a second surface
+is refused with SESSION_NOT_OWNED (see tests/test_active_session_exclusivity.py).
+
+When the operator opts out via ``gateway.per_session_exclusive: false`` (shared-brain
+deployments: several humans deliberately working the same sessions from two desktop
+backends over one central gateway), a SESSION_NOT_OWNED refusal becomes a bounded
+WAIT for the current owner to finish, then a re-acquire — the serialization the
+messaging gateway already gives Telegram ("Another Hermes process is using this
+session; waiting..."), instead of pushing a mid-day failure onto the second user.
+
+The opt-out NEVER weakens the other fences:
+- registry-unreadable refusals (SESSION_COORDINATION_UNAVAILABLE) still fail closed;
+- capacity refusals (MAX_CONCURRENT_SESSIONS) are untouched;
+- the wait is bounded, and its timeout falls back to the original refusal.
+"""
+
+import itertools
+import threading
+import time
+
+import pytest
+
+from hermes_cli.active_sessions import (
+    SESSION_NOT_OWNED,
+    per_session_exclusive,
+    release_active_session,
+    try_acquire_active_session,
+    wait_for_session_ownership,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+
+_owner_seq = itertools.count()
+
+
+def acquire(session_id, config=None, surface="tui", live_id=None):
+    return try_acquire_active_session(
+        session_id=session_id,
+        surface=surface,
+        config=config if config is not None else {},
+        metadata={"live_session_id": live_id or f"live-{next(_owner_seq)}"},
+    )
+
+
+class TestPerSessionExclusiveResolution:
+    def test_default_is_exclusive(self):
+        assert per_session_exclusive({}) is True
+        assert per_session_exclusive(None) is True
+
+    def test_gateway_false_opts_out(self):
+        assert per_session_exclusive({"gateway": {"per_session_exclusive": False}}) is False
+
+    def test_gateway_true_stays_exclusive(self):
+        assert per_session_exclusive({"gateway": {"per_session_exclusive": True}}) is True
+
+    def test_top_level_fallback(self):
+        assert per_session_exclusive({"per_session_exclusive": False}) is False
+
+    def test_string_values_coerce(self):
+        assert per_session_exclusive({"gateway": {"per_session_exclusive": "false"}}) is False
+        assert per_session_exclusive({"gateway": {"per_session_exclusive": "true"}}) is True
+
+    def test_invalid_value_warns_and_keeps_default(self):
+        assert per_session_exclusive({"gateway": {"per_session_exclusive": "sometimes"}}) is True
+        assert per_session_exclusive({"gateway": {"per_session_exclusive": 3}}) is True
+
+    def test_attribute_style_config(self):
+        class Cfg:
+            per_session_exclusive = False
+        assert per_session_exclusive(Cfg()) is False
+
+        class Gateway:
+            per_session_exclusive = False
+
+        class Cfg2:
+            gateway = Gateway()
+        assert per_session_exclusive(Cfg2()) is False
+
+
+class TestExclusivityStillEnforcedByDefault:
+    def test_refusal_unchanged_when_opted_in(self):
+        lease_a, _ = acquire("S")
+        assert lease_a is not None
+        lease_b, refusal = acquire("S", config={"gateway": {"per_session_exclusive": True}})
+        assert lease_b is None
+        assert refusal.reason == SESSION_NOT_OWNED
+
+
+class TestWaitForSessionOwnership:
+    def test_free_session_returns_immediately(self):
+        assert wait_for_session_ownership(session_id="S") is True
+
+    def test_held_session_blocks_until_released(self):
+        lease_a, _ = acquire("S")
+        assert lease_a is not None
+
+        def _release_after(delay: float) -> None:
+            time.sleep(delay)
+            release_active_session(lease_a)
+
+        releaser = threading.Thread(target=_release_after, args=(0.3,), daemon=True)
+        releaser.start()
+        try:
+            # poll fast so the test waits ~0.3s, not the default poll interval
+            assert wait_for_session_ownership(
+                session_id="S", wait_seconds=5.0, poll_seconds=0.05
+            ) is True
+        finally:
+            releaser.join(timeout=2)
+        # After the wait, the second surface can acquire.
+        lease_b, refusal = acquire("S", config={"gateway": {"per_session_exclusive": False}})
+        assert lease_b is not None and refusal is None
+
+    def test_timeout_returns_false_then_refusal_still_applies(self):
+        lease_a, _ = acquire("S")
+        assert lease_a is not None
+        assert wait_for_session_ownership(
+            session_id="S", wait_seconds=0.15, poll_seconds=0.05
+        ) is False
+        # The bounded-timeout caller falls back to the original refusal.
+        lease_b, refusal = acquire("S", config={"gateway": {"per_session_exclusive": False}})
+        assert lease_b is None
+        assert refusal.reason == SESSION_NOT_OWNED
+
+    def test_on_wait_notifies_exactly_once(self):
+        lease_a, _ = acquire("S")
+        assert lease_a is not None
+        calls: list[float] = []
+        releaser_done = threading.Event()
+
+        def _release() -> None:
+            time.sleep(0.2)
+            release_active_session(lease_a)
+            releaser_done.set()
+
+        threading.Thread(target=_release, daemon=True).start()
+        try:
+            assert wait_for_session_ownership(
+                session_id="S", wait_seconds=5.0, poll_seconds=0.05, on_wait=calls.append
+            ) is True
+        finally:
+            releaser_done.wait(timeout=2)
+        assert len(calls) == 1, "the waiting notice must fire once, not per poll"
+
+    def test_other_sessions_are_not_waited_on(self):
+        lease_a, _ = acquire("OTHER")
+        assert lease_a is not None
+        # Waiting for S while OTHER is held must return immediately.
+        assert wait_for_session_ownership(session_id="S", wait_seconds=0.1, poll_seconds=0.05) is True

--- a/tui_gateway/methods_voice.py
+++ b/tui_gateway/methods_voice.py
@@ -436,7 +436,15 @@ def _(rid, params: dict) -> dict:
     """What THIS BUILD enforces (a client withholds unless advertised), sourced from the enforcing
     module, never config: a believed-but-absent capability is worse."""
     from hermes_cli.active_sessions import PER_SESSION_EXCLUSIVE_SUBMIT
-    return _ok(rid, {"per_session_exclusive_submit": bool(PER_SESSION_EXCLUSIVE_SUBMIT)})
+    capabilities = {"per_session_exclusive_submit": bool(PER_SESSION_EXCLUSIVE_SUBMIT)}
+    # Config-dependent behavior, advertised separately: with
+    # gateway.per_session_exclusive: false a SESSION_NOT_OWNED refusal becomes a bounded
+    # queue behind the live owner (#101279). Clients may surface "queued" instead of
+    # "refused" only when this is advertised.
+    with contextlib.suppress(Exception):
+        from hermes_cli.active_sessions import per_session_exclusive
+        capabilities["per_session_exclusive_queue_mode"] = not per_session_exclusive(_load_cfg())
+    return _ok(rid, capabilities)
 
 
 @method("ping")

--- a/tui_gateway/session_lifecycle.py
+++ b/tui_gateway/session_lifecycle.py
@@ -43,6 +43,54 @@ def _claim_active_session_slot(
         return (None, _SESSION_OWNERSHIP_UNAVAILABLE)
 
 
+def _maybe_queue_for_session_ownership(
+    session_key: str, *, live_session_id: str, surface: str, profile_home: str | Path | None
+) -> tuple[Any, str | None]:
+    """Queue-instead-of-refuse for shared-brain deployments (#101279).
+
+    After a SESSION_NOT_OWNED refusal, when the operator set
+    ``gateway.per_session_exclusive: false`` we wait (bounded) for the current
+    owner to finish, then re-acquire — the serialization the messaging gateway
+    already gives Telegram. Any other refusal reason (registry unavailable,
+    capacity) is returned untouched, and so is the default-refuse behavior when
+    the operator did not opt out.
+    """
+    try:
+        from hermes_cli.active_sessions import (
+            SESSION_NOT_OWNED,
+            per_session_exclusive,
+            wait_for_session_ownership,
+        )
+        if per_session_exclusive(_load_cfg()):
+            return (None, None)  # exclusivity stays: the refusal was correct
+    except Exception as exc:
+        logger.debug("Exclusivity opt-out probe failed; keeping refusal: %s", exc)
+        return (None, None)
+    waited = {"value": False}
+
+    def _on_wait(_elapsed: float) -> None:
+        waited["value"] = True
+
+    if not wait_for_session_ownership(
+        session_id=session_key, registry_home=profile_home,
+        should_abort=None, on_wait=_on_wait,
+    ):
+        return (None, None)  # timed out / registry unreadable -> caller keeps the original refusal
+    if waited["value"]:
+        logger.info("Session %s ownership wait satisfied; re-acquiring", session_key)
+    lease, limit_message = _claim_active_session_slot(
+        session_key, live_session_id=live_session_id, surface=surface, profile_home=profile_home)
+    if lease is None and limit_message is not None:
+        # A second-window refusal (owner came back or a capacity cap hit) keeps its own message.
+        try:
+            from hermes_cli.active_sessions import SESSION_NOT_OWNED as _REASON
+            if getattr(limit_message, "reason", None) != _REASON:
+                return (None, None)
+        except Exception:
+            return (None, None)
+    return (lease, limit_message)
+
+
 def _ensure_active_session_slot(sid: str, session: dict) -> str | None:
     """Claim this session's cap slot on its first real turn; None when ok. session.create/resume deliberately
     do NOT claim: tile paints, reconnect-resumes and abandoned drafts would hold invisible slots (no DB row)
@@ -52,6 +100,14 @@ def _ensure_active_session_slot(sid: str, session: dict) -> str | None:
     lease, limit_message = _claim_active_session_slot(
         str(session.get("session_key") or ""), live_session_id=sid,
         surface=_session_source(session), profile_home=session.get("profile_home"))
+    if limit_message is not None and getattr(limit_message, "reason", None) == "SESSION_NOT_OWNED":
+        # Shared-brain deployments (gateway.per_session_exclusive: false) queue behind the
+        # live owner instead of being refused (#101279). Default deployments keep the refusal.
+        queued_lease, queued_message = _maybe_queue_for_session_ownership(
+            str(session.get("session_key") or ""), live_session_id=sid,
+            surface=_session_source(session), profile_home=session.get("profile_home"))
+        if queued_lease is not None:
+            lease, limit_message = queued_lease, queued_message
     if limit_message is None:
         session["active_session_lease"] = lease
     return limit_message


### PR DESCRIPTION
## What

Configurable per-session exclusivity for shared-brain deployments (#101279): a new `gateway.per_session_exclusive` config switch (default `true` — behavior unchanged) that, when set to `false`, turns a `SESSION_NOT_OWNED` refusal into a bounded **wait for the current owner to finish, then re-acquire** — the queue semantics the messaging gateway already gives Telegram — instead of pushing a mid-day failure onto the second surface.

This implements the issue's proposed Option 1 (config switch, default on) + Option 2 (queue instead of refuse) as one coherent design: the switch decides whether the desktop/CLI submit paths queue or refuse.

## Changes

- `hermes_cli/active_sessions.py`
  - `per_session_exclusive(config)` — resolves `gateway.per_session_exclusive` (top-level fallback, bool/"true"/"false" strings accepted, invalid values warn once and keep the safe default `True`).
  - `wait_for_session_ownership(...)` — bounded poll of the live-lease registry until no other lease holds the session (or timeout/abort). Never raises: an unreadable registry returns `False` so the caller falls back to the original refusal. `on_wait` fires exactly once for a status line ("Another Hermes process is using this session; waiting...").
- `tui_gateway/session_lifecycle.py` — `_ensure_active_session_slot`: on a `SESSION_NOT_OWNED` refusal, when the operator opted out, wait for the owner and re-acquire (`_maybe_queue_for_session_ownership`). All other refusal reasons (registry unavailable, capacity) are untouched, and the default path is a single dict check as before.
- `cli.py` `_claim_active_session` — same queue-instead-of-refuse on the CLI surface, with a yellow hourglass notice.
- `tui_gateway/methods_voice.py` `gateway.capabilities` — advertises `per_session_exclusive_queue_mode` (config-dependent, separate from the build-enforced `per_session_exclusive_submit`) so clients can surface "queued" instead of "refused" only when it is actually true.

## What does NOT change

- Default deployments: exclusivity stays exactly as enforced today (the existing `tests/test_active_session_exclusivity.py` suite passes untouched).
- `SESSION_COORDINATION_UNAVAILABLE` (registry unreadable) still fails closed — queueing is never used to smuggle a second writer through an unknown-ownership state.
- `MAX_CONCURRENT_SESSIONS` capacity policy is untouched.
- The wait is bounded (default 1800s, matching `LEASE_WAIT_SECONDS`); a timeout falls back to the original refusal.
- `PER_SESSION_EXCLUSIVE_SUBMIT` remains a module constant: the build-level enforcement is unchanged; the config only governs how a surfaced refusal is handled.

## Tests

`tests/test_per_session_exclusive_opt_out.py` (13 new):
- resolution: default true; gateway false/true; top-level fallback; string coercion; invalid values warn + keep default; attribute-style config objects
- exclusivity still enforced when opted in
- wait semantics: free session returns immediately; held session blocks until release then re-acquire succeeds; bounded timeout returns False and the refusal still applies; `on_wait` fires exactly once (not per poll); other sessions' leases are not waited on

Regression: `tests/test_active_session_exclusivity.py` + `tests/hermes_cli/test_active_sessions.py` (29) pass unchanged; `tests/tui_gateway/test_protocol.py` (68) and the cross-process ownership suites (10) pass. `ruff check` clean.

Closes #101279
