### PR TITLE
feat(telegram): opt-in ignore_human_mentions gate (#64388)

### DIFF
--- a/gateway/config_loader.py
+++ b/gateway/config_loader.py
@@ -201,7 +201,7 @@ _SHARED_KEYS: tuple = (
     ("allowed_chats", _TELEGRAM, None),
     ("group_allowed_chats", _TELEGRAM, None),
     ("allowed_topics", _TELEGRAM, None),
-    *_plain("free_response_channels", "mention_patterns", "exclusive_bot_mentions"),
+    *_plain("free_response_channels", "mention_patterns", "exclusive_bot_mentions", "ignore_human_mentions"),
     ("observe_unmentioned_group_messages", _TELEGRAM, None),
     *_plain(
         "dm_policy", "allow_from", "allow_admin_from", "user_allowed_commands",

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5056,6 +5056,18 @@ class TelegramAdapter(BasePlatformAdapter):
             "bots_require_mention", "TELEGRAM_BOTS_REQUIRE_MENTION", "false"
         )
 
+    def _telegram_ignore_human_mentions(self) -> bool:
+        """Return whether group messages that @mention humans (but not this bot) are ignored.
+
+        Opt-in via ``telegram.ignore_human_mentions`` in config.yaml. Defaults to
+        False, preserving the existing respond-by-default behaviour (#64388)."""
+        configured = self.config.extra.get("ignore_human_mentions")
+        if configured is None:
+            return False
+        if isinstance(configured, str):
+            return configured.strip().lower() in {"true", "1", "yes", "on"}
+        return bool(configured)
+
     def _telegram_free_response_chats(self) -> set[str]:
         return self._extra_str_set("free_response_chats", "TELEGRAM_FREE_RESPONSE_CHATS")
 
@@ -5343,6 +5355,46 @@ class TelegramAdapter(BasePlatformAdapter):
         if bot_username:
             return bot_username in self._extract_bot_mention_usernames(message, bot_username)
         return False
+
+    def _message_mentions_human_only(self, message: Message) -> bool:
+        """Return True when the message @mentions human users and does not address this bot.
+
+        Human mentions come from ``mention`` entities whose handle is neither this
+        bot nor another bot (``...bot``), or from ``text_mention`` entities whose
+        target user is not a bot. ``_message_mentions_bot`` already covers this-bot
+        addressing via ``mention``/``text_mention``/``/cmd@botname``, so a message
+        that also addresses the bot returns False here (mixed mentions preserve the
+        direct-address exception)."""
+        # Forwarded messages carry the original sender's entities: a mention inside
+        # forwarded content reflects the original author's addressing, not the
+        # forwarder's, so never treat it as a human-only mention.
+        if getattr(message, "forward_origin", None) is not None or getattr(message, "forward_from", None) is not None:
+            return False
+        if not self._bot:
+            return False
+        bot_username = (self._current_bot_username() or "").lstrip("@").lower()
+        bot_id = getattr(self._bot, "id", None)
+        mentions_human = False
+        for source_text, entities in self._entity_sources(message):
+            for entity in entities:
+                entity_type = self._entity_type(entity)
+                if entity_type == "text_mention":
+                    user = getattr(entity, "user", None)
+                    if user and getattr(user, "id", None) != bot_id and not getattr(user, "is_bot", False):
+                        mentions_human = True
+                    continue
+                if entity_type != "mention":
+                    continue
+                span = self._entity_span(source_text, entity)
+                if span is None:
+                    continue
+                handle = span.strip().lstrip("@").lower()
+                if not handle or handle == bot_username:
+                    continue
+                if re.fullmatch(r"[a-z0-9_]{2,29}bot", handle, re.IGNORECASE):
+                    continue  # another bot, not a human
+                mentions_human = True
+        return mentions_human and not self._message_mentions_bot(message)
 
     def _schedule_bot_identity_recheck(self) -> None:
         """Fire a TTL-guarded identity refresh in the background when routing is about to discard a
@@ -5640,6 +5692,8 @@ class TelegramAdapter(BasePlatformAdapter):
             return False
         if not self._is_group_chat(message):
             return True
+        if self._telegram_ignore_human_mentions() and not self._is_reply_to_bot(message) and self._message_mentions_human_only(message):
+            return False
         thread_id = self._effective_message_thread_id(message)
         if self._topic_gates_pass(thread_id, warn_non_numeric=True) is False:
             return False

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -23,6 +23,7 @@ def _make_adapter(
     guest_mode=None,
     observe_unmentioned_group_messages=None,
     bots_require_mention=None,
+    ignore_human_mentions=None,
     bot_username="hermes_bot",
 ):
     from plugins.platforms.telegram.adapter import TelegramAdapter
@@ -68,6 +69,8 @@ def _make_adapter(
         extra["observe_unmentioned_group_messages"] = observe_unmentioned_group_messages
     if bots_require_mention is not None:
         extra["bots_require_mention"] = bots_require_mention
+    if ignore_human_mentions is not None:
+        extra["ignore_human_mentions"] = ignore_human_mentions
 
     adapter = object.__new__(TelegramAdapter)
     adapter.platform = Platform.TELEGRAM
@@ -154,6 +157,17 @@ def _bot_command_entity(text, command):
     """
     offset = text.index(command)
     return SimpleNamespace(type="bot_command", offset=offset, length=len(command))
+
+
+def _text_mention_entity(text, mention, *, user_id=222, is_bot=False):
+    """Entity Telegram emits when a user without a public username is @mentioned."""
+    offset = text.index(mention)
+    return SimpleNamespace(
+        type="text_mention",
+        offset=offset,
+        length=len(mention),
+        user=SimpleNamespace(id=user_id, is_bot=is_bot),
+    )
 
 
 def test_unmentioned_group_messages_can_be_observed_without_dispatching():
@@ -939,3 +953,69 @@ def test_human_reply_unaffected_by_bots_require_mention():
         gated._should_process_message(_group_message("replying", reply_to_bot=True))
         is True
     )
+
+
+def test_ignore_human_mentions_suppresses_human_mention_in_free_response():
+    adapter = _make_adapter(ignore_human_mentions=True, free_response_chats=["-100"])
+    text = "hi @alice"
+    msg = _group_message(text, entities=[_mention_entity(text, "@alice")])
+    assert adapter._should_process_message(msg) is False
+
+
+def test_ignore_human_mentions_disabled_preserves_respond_by_default():
+    adapter = _make_adapter(free_response_chats=["-100"])
+    text = "hi @alice"
+    msg = _group_message(text, entities=[_mention_entity(text, "@alice")])
+    assert adapter._should_process_message(msg) is True
+
+
+def test_ignore_human_mentions_preserves_direct_bot_mention():
+    adapter = _make_adapter(ignore_human_mentions=True)
+    text = "hi @hermes_bot"
+    msg = _group_message(text, entities=[_mention_entity(text, "@hermes_bot")])
+    assert adapter._should_process_message(msg) is True
+
+
+def test_ignore_human_mentions_preserves_mixed_human_and_bot_mention():
+    adapter = _make_adapter(ignore_human_mentions=True)
+    text = "hi @alice @hermes_bot"
+    msg = _group_message(
+        text, entities=[_mention_entity(text, "@alice"), _mention_entity(text, "@hermes_bot")],
+    )
+    assert adapter._should_process_message(msg) is True
+
+
+def test_ignore_human_mentions_handles_text_mention_entity():
+    adapter = _make_adapter(ignore_human_mentions=True, free_response_chats=["-100"])
+    text = "hi Alice"
+    msg = _group_message(text, entities=[_text_mention_entity(text, "Alice", user_id=222)])
+    assert adapter._should_process_message(msg) is False
+
+
+def test_ignore_human_mentions_preserves_reply_to_bot():
+    adapter = _make_adapter(ignore_human_mentions=True, free_response_chats=["-100"])
+    text = "hi @alice"
+    msg = _group_message(text, entities=[_mention_entity(text, "@alice")], reply_to_bot=True)
+    assert adapter._should_process_message(msg) is True
+
+
+def test_ignore_human_mentions_handles_caption_entities():
+    adapter = _make_adapter(ignore_human_mentions=True, free_response_chats=["-100"])
+    caption = "check @alice"
+    msg = _group_message("", caption=caption, caption_entities=[_mention_entity(caption, "@alice")])
+    assert adapter._should_process_message(msg) is False
+
+
+def test_message_mentions_human_only_ignores_other_bot_handles():
+    adapter = _make_adapter(ignore_human_mentions=True)
+    text = "hi @other_bot"
+    msg = _group_message(text, entities=[_mention_entity(text, "@other_bot")])
+    assert adapter._message_mentions_human_only(msg) is False
+
+
+def test_ignore_human_mentions_preserves_forwarded_messages():
+    adapter = _make_adapter(ignore_human_mentions=True, free_response_chats=["-100"])
+    text = "hi @alice"
+    msg = _group_message(text, entities=[_mention_entity(text, "@alice")])
+    msg.forward_origin = SimpleNamespace(type="user", sender_user=SimpleNamespace(id=333))
+    assert adapter._should_process_message(msg) is True


### PR DESCRIPTION
Supersedes #64456 (closed by `@webtecnica` in favor of this PR).

## What

Adds a `telegram.ignore_human_mentions` config option (default `false`) that silently drops group messages which `@mention` human users — while still responding by default to everything else. This is the middle-ground requested in #64388.

## Why

A group bot today either responds to everything (`require_mention: false`, the default) or only to `@bot` mentions (`require_mention: true`). Neither can express "respond by default, but ignore messages addressed to other people". This fills that gap.

## Scope

Deliberately Telegram-only, matching #64388. Discord and Slack use a different mention model (`<@id>` / role mentions) that is not `MessageEntity`-based, so generalising across adapters would need a cross-platform mention abstraction that is out of scope for this issue.

## Relationship to #64456

This follows up #64456, which implemented the same idea but was left `keep_open` with four review issues. This PR fixes all four:

1. **Gate placement** — #64456 put the filter *after* the free-response / `require_mention: false` acceptance returns, so the reported default-response path was never suppressed. This PR places the guard immediately after the group-chat check, before any acceptance return.
2. **Mixed mentions** — #64456 tracked a single `found_human_mention` flag, misclassifying `@human @bot` as human-only. This PR uses two-flag classification and delegates "does it address the bot" to the existing `_message_mentions_bot` (which already covers `mention` / `text_mention` / `/cmd@botname`).
3. **Config surface** — exposed via `config.yaml` (`telegram.ignore_human_mentions`) through the existing `_SHARED_KEYS` path; no new env var, no `plugin.yaml` change.
4. **Tests** — 9 regression tests covering free-response suppression, respond-by-default when disabled, direct `@bot` preservation, mixed human+bot, `text_mention` entities, reply-to-bot, caption entities, other-bot handle exclusion, and forwarded messages (whose mentions don't reflect the forwarder's intent).

## Notes

- Defaults to `false`, so existing behavior is unchanged.
- Reuses the existing entity-authoritative helpers (`_entity_sources` / `_entity_type` / `_entity_span` / `_message_mentions_bot`) rather than re-parsing entities.

Fixes #64388.

