### PR TITLE
build(installer): preserve standalone delivery while enforcing source ownership

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -36,6 +36,6 @@ docker/entrypoint.sh text eol=lf
 # The standalone Windows installer is assembled from these canonical LF inputs.
 # Keep the readable distribution artifact at the URL used by existing clients.
 scripts/install.ps1 text eol=lf linguist-generated=true
-# Verbatim source includes inherited trailing spaces; exact assembly, not a
+# Verbatim source includes inherited trailing spaces and blank lines; assembly, not a
 # whitespace rewrite, preserves the distributed installer's original bytes.
-scripts/windows-installer/source/** text eol=lf whitespace=-blank-at-eol
+scripts/windows-installer/source/** text eol=lf whitespace=-blank-at-eol,-blank-at-eof

--- a/.gitattributes
+++ b/.gitattributes
@@ -32,3 +32,8 @@ docker/entrypoint.sh text eol=lf
 *.html  text eol=lf
 *.svg   text eol=lf
 *.ps1   text eol=crlf
+
+# The standalone Windows installer is assembled from these canonical LF inputs.
+# Keep the readable distribution artifact at the URL used by existing clients.
+scripts/install.ps1 text eol=lf linguist-generated=true
+scripts/windows-installer/source/** text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -36,4 +36,6 @@ docker/entrypoint.sh text eol=lf
 # The standalone Windows installer is assembled from these canonical LF inputs.
 # Keep the readable distribution artifact at the URL used by existing clients.
 scripts/install.ps1 text eol=lf linguist-generated=true
-scripts/windows-installer/source/** text eol=lf
+# Verbatim source includes inherited trailing spaces; exact assembly, not a
+# whitespace rewrite, preserves the distributed installer's original bytes.
+scripts/windows-installer/source/** text eol=lf whitespace=-blank-at-eol

--- a/.github/workflows/installer-tests.yml
+++ b/.github/workflows/installer-tests.yml
@@ -44,3 +44,11 @@ jobs:
       - name: System Node and npm compatibility (Windows PowerShell 5.1)
         shell: powershell
         run: powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-node-compatibility.ps1
+
+      - name: Interrupted venv transaction recovery (pwsh 7)
+        shell: pwsh
+        run: pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-venv-retry-transaction.ps1
+
+      - name: Interrupted venv transaction recovery (Windows PowerShell 5.1)
+        shell: powershell
+        run: powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-venv-retry-transaction.ps1

--- a/.github/workflows/installer-tests.yml
+++ b/.github/workflows/installer-tests.yml
@@ -24,6 +24,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Verify standalone installer source and generated output
+        env:
+          INSTALLER_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before }}
+          INSTALLER_HEAD_REF: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: python scripts/build_windows_installer.py --check --base-ref "$env:INSTALLER_BASE_REF" --head-ref "$env:INSTALLER_HEAD_REF"
 
       # Windows PowerShell 5.1 as well as pwsh 7: install.ps1 is delivered via
       # `irm | iex` into whatever shell the user already has, and 5.1 is what

--- a/apps/desktop/src/app/messaging/index.test.tsx
+++ b/apps/desktop/src/app/messaging/index.test.tsx
@@ -75,7 +75,6 @@ afterEach(() => {
 })
 
 async function renderMessaging() {
-  const { MessagingView } = await import('./index')
   let result: ReturnType<typeof render>
   await act(async () => {
     result = render(
@@ -88,10 +87,14 @@ async function renderMessaging() {
   return result!
 }
 
+// Load stable modules during collection, after mock fixtures are initialized.
+// Cold transforms must not consume a behavioral test or hook deadline.
+const { MessagingView } = await import('./index')
+const { $settingsScopeOverride } = await import('@/store/settings-scope')
+const { $changeEventsAvailable, $pairingChangeTick, $platformsChangeTick } = await import('@/store/live-sync')
+
 describe('MessagingView profile scope', () => {
   it('follows the active profile instead of targeting primary when there is no override', async () => {
-    const { $settingsScopeOverride } = await import('@/store/settings-scope')
-
     $settingsScopeOverride.set(null)
     getMessagingPlatforms.mockResolvedValue({ platforms: [platform()] })
 
@@ -204,7 +207,6 @@ describe('MessagingView pairing', () => {
     // connect/disconnect health via gateway_state.json, which a new pairing
     // request never moves. Riding it would leave someone invisible in the
     // pending list until an unrelated reconnect happened to fire.
-    const { $changeEventsAvailable, $pairingChangeTick, $platformsChangeTick } = await import('@/store/live-sync')
 
     getMessagingPlatforms.mockResolvedValue({ platforms: [platform()] })
     getPairing.mockResolvedValue({ approved: [], pending: [] })

--- a/apps/desktop/src/app/settings/config-settings.test.tsx
+++ b/apps/desktop/src/app/settings/config-settings.test.tsx
@@ -48,7 +48,6 @@ afterEach(() => {
 })
 
 async function renderConfigSettings() {
-  const { ConfigSettings } = await import('./config-settings')
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   const importInputRef = createRef<HTMLInputElement>()
 
@@ -62,6 +61,10 @@ async function renderConfigSettings() {
 
   return { importInputRef }
 }
+
+// Load stable modules during collection, after mock fixtures are initialized.
+// Cold transforms must not consume a behavioral test or hook deadline.
+const { ConfigSettings } = await import('./config-settings')
 
 describe('ConfigSettings autosave', () => {
   it('sends a later revert instead of diffing it away against the stale page-load baseline', async () => {

--- a/apps/desktop/src/app/settings/fallback-models-field.test.tsx
+++ b/apps/desktop/src/app/settings/fallback-models-field.test.tsx
@@ -31,7 +31,6 @@ afterEach(() => {
 })
 
 async function renderField(value: unknown, onChange = vi.fn()) {
-  const { FallbackModelsField } = await import('./fallback-models-field')
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
   render(
@@ -44,7 +43,6 @@ async function renderField(value: unknown, onChange = vi.fn()) {
 }
 
 async function renderFieldWithRerender(value: unknown, onChange = vi.fn()) {
-  const { FallbackModelsField } = await import('./fallback-models-field')
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
   const view = render(
@@ -65,6 +63,10 @@ const CHAIN = [
   { provider: 'copilot', model: 'gpt-5-mini' },
   { provider: 'openai-codex', model: 'gpt-5.4-mini' }
 ]
+
+// Load stable modules during collection, after mock fixtures are initialized.
+// Cold transforms must not consume a behavioral test or hook deadline.
+const { FallbackModelsField } = await import('./fallback-models-field')
 
 describe('FallbackModelsField', () => {
   it('renders each {provider, model} entry as its own row (never "[object Object]")', async () => {

--- a/apps/desktop/src/app/settings/gateway-settings.test.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.test.tsx
@@ -1,6 +1,8 @@
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { GatewaySettings } from './gateway-settings'
+
 const getConnectionConfig = vi.fn()
 const saveConnectionConfig = vi.fn()
 
@@ -37,8 +39,6 @@ afterEach(() => {
 
 describe('GatewaySettings', () => {
   it('loads the machine-level connection config (no profile scoping)', async () => {
-    const { GatewaySettings } = await import('./gateway-settings')
-
     render(<GatewaySettings />)
     expect(await screen.findByText('Local gateway')).toBeTruthy()
     expect(

--- a/apps/desktop/src/app/settings/keys-settings.test.tsx
+++ b/apps/desktop/src/app/settings/keys-settings.test.tsx
@@ -32,8 +32,6 @@ afterEach(() => {
 })
 
 async function renderKeysSettings(view: 'settings' | 'tools', route = '/settings') {
-  const { KeysSettings } = await import('./keys-settings')
-
   await act(async () => {
     render(
       <MemoryRouter initialEntries={[route]}>
@@ -52,6 +50,10 @@ function DeepLinkButton({ target }: { target: string }) {
     </button>
   )
 }
+
+// Load stable modules during collection, after mock fixtures are initialized.
+// Cold transforms must not consume a behavioral test or hook deadline.
+const { KeysSettings } = await import('./keys-settings')
 
 describe('KeysSettings', () => {
   it('fetches env vars for the active profile (undefined, never null) when unscoped', async () => {
@@ -107,8 +109,6 @@ describe('KeysSettings', () => {
       BRAVE_SEARCH_API_KEY: envVar('tool', { description: 'Search the web with Brave.' }),
       FIRECRAWL_API_KEY: envVar('tool', { description: 'Crawl and extract websites.' })
     })
-
-    const { KeysSettings } = await import('./keys-settings')
 
     render(
       <MemoryRouter initialEntries={['/settings?tab=keys']}>

--- a/apps/desktop/src/app/settings/memory/provider-config-modal.test.tsx
+++ b/apps/desktop/src/app/settings/memory/provider-config-modal.test.tsx
@@ -66,7 +66,6 @@ afterEach(() => {
 })
 
 async function renderModal(open = true) {
-  const { ProviderConfigModal } = await import('./provider-config-modal')
   const onOpenChange = vi.fn()
   const onSaved = vi.fn().mockResolvedValue(undefined)
 
@@ -82,6 +81,10 @@ async function renderModal(open = true) {
 
   return { ...result, onOpenChange, onSaved }
 }
+
+// Load stable modules during collection, after mock fixtures are initialized.
+// Cold transforms must not consume a behavioral test or hook deadline.
+const { ProviderConfigModal } = await import('./provider-config-modal')
 
 describe('ProviderConfigModal', () => {
   it('renders every field grouped, including inline ones, with kind-specific controls', async () => {

--- a/apps/desktop/src/app/settings/memory/provider-config-panel.test.tsx
+++ b/apps/desktop/src/app/settings/memory/provider-config-panel.test.tsx
@@ -109,10 +109,12 @@ afterEach(() => {
 })
 
 async function renderPanel(provider = 'honcho') {
-  const { ProviderConfigPanel } = await import('./provider-config-panel')
-
   return render(<ProviderConfigPanel provider={provider} />)
 }
+
+// Load stable modules during collection, after mock fixtures are initialized.
+// Cold transforms must not consume a behavioral test or hook deadline.
+const { ProviderConfigPanel } = await import('./provider-config-panel')
 
 describe('ProviderConfigPanel', () => {
   it('renders the declared inline fields generically', async () => {

--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -87,7 +87,6 @@ afterEach(() => {
 })
 
 async function renderModelSettings(scopeProfile?: string) {
-  const { ModelSettings } = await import('./model-settings')
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
   return render(
@@ -100,6 +99,10 @@ async function renderModelSettings(scopeProfile?: string) {
     </MemoryRouter>
   )
 }
+
+// Load stable modules during collection, after mock fixtures are initialized.
+// Cold transforms must not consume a behavioral test or hook deadline.
+const { ModelSettings } = await import('./model-settings')
 
 describe('ModelSettings profile scope', () => {
   // #90549: the API helpers treat `null` as "deliberately target the

--- a/apps/desktop/src/app/settings/providers-settings.test.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.test.tsx
@@ -78,7 +78,6 @@ afterEach(() => {
 // Removal goes through confirm() from @/store/confirm, so the host has to be
 // mounted for the prompt to render — same as in the real app shell.
 async function renderProvidersSettings() {
-  const { ProvidersSettings } = await import('./providers-settings')
   let result: ReturnType<typeof render>
   await act(async () => {
     result = render(
@@ -91,6 +90,10 @@ async function renderProvidersSettings() {
 
   return result!
 }
+
+// Load stable modules during collection, after mock fixtures are initialized.
+// Cold transforms must not consume a behavioral test or hook deadline.
+const { ProvidersSettings } = await import('./providers-settings')
 
 describe('ProvidersSettings', () => {
   it('disconnects a connected provider account and refreshes the accounts list', async () => {
@@ -172,7 +175,6 @@ describe('ProvidersSettings', () => {
     })
     listOAuthProviders.mockResolvedValue({ providers: [] })
 
-    const { ProvidersSettings } = await import('./providers-settings')
     await act(async () => {
       render(<ProvidersSettings onClose={vi.fn()} onViewChange={vi.fn()} view="keys" />)
     })
@@ -191,7 +193,6 @@ describe('ProvidersSettings', () => {
     })
     listOAuthProviders.mockResolvedValue({ providers: [] })
 
-    const { ProvidersSettings } = await import('./providers-settings')
     render(<ProvidersSettings onClose={vi.fn()} onViewChange={vi.fn()} view="keys" />)
 
     // Equal priority → alphabetical tiebreak: Acme, Middle, Zebra.
@@ -224,7 +225,6 @@ describe('ProvidersSettings', () => {
     getEnvVars.mockResolvedValue({})
     listOAuthProviders.mockResolvedValue({ providers: [] })
 
-    const { ProvidersSettings } = await import('./providers-settings')
     render(<ProvidersSettings onClose={vi.fn()} onViewChange={vi.fn()} view="keys" />)
 
     const row = await screen.findByText('Local / custom endpoint')

--- a/apps/desktop/src/app/settings/terminal-backend-panel.test.tsx
+++ b/apps/desktop/src/app/settings/terminal-backend-panel.test.tsx
@@ -59,9 +59,12 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
+// Load stable modules during collection, after mock fixtures are initialized.
+// Cold transforms must not consume a behavioral test or hook deadline.
+const { TerminalBackendPanel } = await import('./terminal-backend-panel')
+
 describe('TerminalBackendPanel', () => {
   it('lists backends with status pills from the backends endpoint', async () => {
-    const { TerminalBackendPanel } = await import('./terminal-backend-panel')
     render(<TerminalBackendPanel onConfiguredChange={vi.fn()} />)
 
     expect(await screen.findByText('Local')).toBeTruthy()
@@ -74,14 +77,12 @@ describe('TerminalBackendPanel', () => {
   })
 
   it('shows setup guidance detail for a needs_setup backend', async () => {
-    const { TerminalBackendPanel } = await import('./terminal-backend-panel')
     render(<TerminalBackendPanel onConfiguredChange={vi.fn()} />)
 
     expect(await screen.findByText(/Docker daemon not reachable/)).toBeTruthy()
   })
 
   it('marks the active backend with an In use pill', async () => {
-    const { TerminalBackendPanel } = await import('./terminal-backend-panel')
     render(<TerminalBackendPanel onConfiguredChange={vi.fn()} />)
 
     const local = await screen.findByRole('button', { name: /Local/ })
@@ -91,7 +92,6 @@ describe('TerminalBackendPanel', () => {
 
   it('selects a backend when clicked and reports the change', async () => {
     const onConfiguredChange = vi.fn()
-    const { TerminalBackendPanel } = await import('./terminal-backend-panel')
     render(<TerminalBackendPanel onConfiguredChange={onConfiguredChange} />)
 
     fireEvent.click(await screen.findByRole('button', { name: /SSH/ }))
@@ -105,7 +105,6 @@ describe('TerminalBackendPanel', () => {
 
   it('allows selecting a needs_setup backend (guidance instead of blocking)', async () => {
     selectTerminalBackend.mockResolvedValue({ ok: true, backend: 'docker' })
-    const { TerminalBackendPanel } = await import('./terminal-backend-panel')
     render(<TerminalBackendPanel onConfiguredChange={vi.fn()} />)
 
     fireEvent.click(await screen.findByRole('button', { name: /Docker/ }))
@@ -116,7 +115,6 @@ describe('TerminalBackendPanel', () => {
   })
 
   it('does not re-select the already active backend', async () => {
-    const { TerminalBackendPanel } = await import('./terminal-backend-panel')
     render(<TerminalBackendPanel onConfiguredChange={vi.fn()} />)
 
     fireEvent.click(await screen.findByRole('button', { name: /Local/ }))

--- a/apps/desktop/src/app/settings/toolset-config-panel.test.tsx
+++ b/apps/desktop/src/app/settings/toolset-config-panel.test.tsx
@@ -157,6 +157,11 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
+// Load stable modules during collection, after mock fixtures are initialized.
+// Cold transforms must not consume a behavioral test or hook deadline.
+const { ToolsetConfigPanel } = await import('./toolset-config-panel')
+const { notify } = await import('@/store/notifications')
+
 describe('ToolsetConfigPanel', () => {
   it('renders inline voice/model fields for a TTS provider row carrying tts_provider', async () => {
     // The Capabilities gap: provider rows only showed API keys — voice/model
@@ -183,7 +188,6 @@ describe('ToolsetConfigPanel', () => {
       })
     )
 
-    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
     expect(await screen.findByText('OpenAI TTS Model')).toBeTruthy()
@@ -199,7 +203,6 @@ describe('ToolsetConfigPanel', () => {
   })
 
   it('renders no inline voice fields for rows without tts_provider (older backend)', async () => {
-    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
     await screen.findByText('Microsoft Edge TTS')
@@ -208,7 +211,6 @@ describe('ToolsetConfigPanel', () => {
   })
 
   it('lists providers from the config endpoint', async () => {
-    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
     expect(await screen.findByText('Microsoft Edge TTS')).toBeTruthy()
@@ -217,7 +219,6 @@ describe('ToolsetConfigPanel', () => {
   })
 
   it('expands a provider on row click and activates it via the explicit button', async () => {
-    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
     // Row click only expands — browsing details must not rewrite config.
@@ -240,7 +241,6 @@ describe('ToolsetConfigPanel', () => {
         })
     )
 
-    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
     // Edge auto-expands (first configured provider); activate it explicitly.
@@ -292,7 +292,6 @@ describe('ToolsetConfigPanel', () => {
       default: 'z-image-turbo'
     })
 
-    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="image_gen" />)
 
     // Both catalog rows render with their picker metadata.
@@ -306,7 +305,6 @@ describe('ToolsetConfigPanel', () => {
   })
 
   it('does not fetch model catalogs for toolsets without them', async () => {
-    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
     await screen.findByText('Microsoft Edge TTS')
@@ -314,7 +312,6 @@ describe('ToolsetConfigPanel', () => {
   })
 
   it('saves an API key for a provider env var', async () => {
-    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
     // Select the keyed provider so its env vars render.
@@ -373,7 +370,6 @@ describe('ToolsetConfigPanel', () => {
       })
     )
 
-    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
     // The active provider's env-var field only renders when it's the expanded
@@ -420,7 +416,6 @@ describe('ToolsetConfigPanel', () => {
         running: false
       })
 
-    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="browser" />)
 
     fireEvent.click(await screen.findByRole('button', { name: /Run setup/ }))
@@ -454,7 +449,6 @@ describe('ToolsetConfigPanel', () => {
     // Spawn failed server-side — must NOT proceed to poll a non-existent action.
     runToolsetPostSetup.mockResolvedValue({ ok: false, pid: 0, name: 'tools-post-setup' })
 
-    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="browser" />)
 
     fireEvent.click(await screen.findByRole('button', { name: /Run setup/ }))
@@ -493,7 +487,6 @@ describe('ToolsetConfigPanel', () => {
       running: false
     })
 
-    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="browser" />)
 
     fireEvent.click(await screen.findByRole('button', { name: /Run setup/ }))
@@ -531,7 +524,6 @@ describe('ToolsetConfigPanel', () => {
       })
     )
 
-    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="browser" />)
 
     // Installed confirmation replaces the contradictory install prompt…
@@ -585,7 +577,6 @@ describe('ToolsetConfigPanel', () => {
         })
       )
 
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
       await screen.findByText('Microsoft Edge TTS')
@@ -623,7 +614,6 @@ describe('ToolsetConfigPanel', () => {
         })
       )
 
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
       await screen.findByText('ElevenLabs')
@@ -637,7 +627,6 @@ describe('ToolsetConfigPanel', () => {
       // Older backend (no `status` field): keyless rows keep the legacy
       // Ready pill, keyed-and-unset rows keep no pill. Narrow compat path —
       // desktop and backend update on separate clocks.
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
       await screen.findByText('Microsoft Edge TTS')
@@ -674,7 +663,6 @@ describe('ToolsetConfigPanel', () => {
         })
       )
 
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
       expect(await screen.findByText('ELEVENLABS_API_KEY')).toBeTruthy()
@@ -717,7 +705,6 @@ describe('ToolsetConfigPanel', () => {
         })
       )
 
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="browser" />)
 
       await screen.findByText('Local Browser')
@@ -754,7 +741,6 @@ describe('ToolsetConfigPanel', () => {
         running: false
       })
 
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="browser" />)
 
       fireEvent.click(await screen.findByRole('button', { name: /Re-run setup/ }))
@@ -782,7 +768,6 @@ describe('ToolsetConfigPanel', () => {
         })
       )
 
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="browser" />)
 
       await screen.findByText('Local Browser')
@@ -819,7 +804,6 @@ describe('ToolsetConfigPanel', () => {
       // so the managed row silently never activated. The endpoint now
       // reports needs_nous_auth and the panel must surface a sign-in action
       // instead of the misleading "provider selected" success toast.
-      const { notify } = await import('@/store/notifications')
 
       getToolsetConfig.mockResolvedValue(nousBrowserConfig())
       selectToolsetProvider.mockResolvedValue({
@@ -830,7 +814,6 @@ describe('ToolsetConfigPanel', () => {
         feature: 'browser'
       })
 
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="browser" />)
 
       // The single Nous row auto-expands; activate via the explicit button.
@@ -853,8 +836,6 @@ describe('ToolsetConfigPanel', () => {
     })
 
     it('drives the existing Nous OAuth device-code flow from the sign-in action and refetches', async () => {
-      const { notify } = await import('@/store/notifications')
-
       getToolsetConfig.mockResolvedValue(nousBrowserConfig())
       selectToolsetProvider.mockResolvedValue({
         ok: true,
@@ -875,7 +856,6 @@ describe('ToolsetConfigPanel', () => {
       const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
 
       try {
-        const { ToolsetConfigPanel } = await import('./toolset-config-panel')
         render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="browser" />)
 
         await screen.findByRole('button', { name: /Nous Subscription/ })
@@ -909,8 +889,6 @@ describe('ToolsetConfigPanel', () => {
     }, 20000)
 
     it('shows the plain success toast when the managed row is already entitled', async () => {
-      const { notify } = await import('@/store/notifications')
-
       getToolsetConfig.mockResolvedValue(nousBrowserConfig())
       selectToolsetProvider.mockResolvedValue({
         ok: true,
@@ -918,7 +896,6 @@ describe('ToolsetConfigPanel', () => {
         provider: 'Nous Subscription (Browser Use cloud)'
       })
 
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="browser" />)
 
       await screen.findByRole('button', { name: /Nous Subscription/ })
@@ -957,7 +934,6 @@ describe('ToolsetConfigPanel', () => {
         })
       )
 
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
       const trigger = await screen.findByRole('button', { name: /^Actions$/ })
@@ -970,7 +946,6 @@ describe('ToolsetConfigPanel', () => {
     it('hides "Manage in API Keys" while the key is unset', async () => {
       // Default config(): ElevenLabs key is not set. An unset key is managed
       // right here via Set — no point bouncing the user to another page.
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
       // Expand the keyed provider so its env row renders. Wait for the
@@ -1029,7 +1004,6 @@ describe('ToolsetConfigPanel', () => {
     it('shows the resolved per-capability backends as badges', async () => {
       getToolsetConfig.mockResolvedValue(webConfig())
 
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="web" />)
 
       expect(await screen.findByText('Search: searxng')).toBeTruthy()
@@ -1043,7 +1017,6 @@ describe('ToolsetConfigPanel', () => {
       getToolsetConfig.mockResolvedValue(webConfig())
       selectToolsetProvider.mockResolvedValue({ ok: true, name: 'web', provider: 'SearXNG', capability: 'search' })
 
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="web" />)
 
       // Active/expanded provider is search-only SearXNG.
@@ -1062,7 +1035,6 @@ describe('ToolsetConfigPanel', () => {
     })
 
     it('does not render capability chrome for non-web toolsets', async () => {
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
       await screen.findByText('Microsoft Edge TTS')

--- a/apps/desktop/src/app/skills/index.test.tsx
+++ b/apps/desktop/src/app/skills/index.test.tsx
@@ -76,7 +76,6 @@ function toolset(overrides: Record<string, unknown> = {}) {
 }
 
 async function renderSkills() {
-  const { SkillsView } = await import('./index')
   let result: ReturnType<typeof render>
   await act(async () => {
     result = render(
@@ -116,12 +115,14 @@ afterEach(() => {
   queryClient.clear()
 })
 
-// SkillsView is a heavy module: the first test pays the whole dynamic-import
-// cost, and the file legitimately runs ~14s on CI runners — right against the
-// global 15s per-test budget, so slow runners cascade-fail all 11 tests
-// (2× in a row on PR #93612, plus a main run the same hour). Give this file
-// headroom; the tests are not slow individually.
-describe('SkillsView toolset management', { timeout: 60_000 }, () => {
+// Load stable modules during collection, after mock fixtures are initialized.
+// Cold transforms must not consume a behavioral test or hook deadline.
+const { SkillsView } = await import('./index')
+const { notify } = await import('@/store/notifications')
+const { EmbeddedHubPicker } = await import('./embedded-hub-picker')
+const { installHubSkill } = await import('@/store/hub-actions')
+
+describe('SkillsView toolset management', () => {
   it('renders a switch for each toolset and toggles it off', async () => {
     await renderSkills()
 
@@ -173,7 +174,6 @@ describe('SkillsView toolset management', { timeout: 60_000 }, () => {
       ]
     })
 
-    const { SkillsView } = await import('./index')
     await act(async () => {
       render(
         <QueryClientProvider client={queryClient}>
@@ -219,7 +219,6 @@ describe('SkillsView toolset management', { timeout: 60_000 }, () => {
       }
     ])
 
-    const { SkillsView } = await import('./index')
     await act(async () => {
       render(
         <QueryClientProvider client={queryClient}>
@@ -263,7 +262,6 @@ describe('SkillsView toolset management', { timeout: 60_000 }, () => {
       }
     ])
 
-    const { SkillsView } = await import('./index')
     await act(async () => {
       render(
         <QueryClientProvider client={queryClient}>
@@ -284,9 +282,6 @@ describe('SkillsView toolset management', { timeout: 60_000 }, () => {
   })
 
   it('hub picker refuses to reinstall an already-installed skill', async () => {
-    const { notify } = await import('@/store/notifications')
-    const { EmbeddedHubPicker } = await import('./embedded-hub-picker')
-
     render(<EmbeddedHubPicker installedNames={new Set(['web-research'])} profile={null} />)
 
     // The picker is expanded by default — the hub iframe is live on mount.
@@ -319,7 +314,6 @@ describe('SkillsView toolset management', { timeout: 60_000 }, () => {
 
     // Embedded mode drives tabs through local state (the route hooks are
     // mocked here), starting on Skills: the picker mounts with the tab.
-    const { SkillsView } = await import('./index')
     await act(async () => {
       render(
         <QueryClientProvider client={queryClient}>
@@ -378,7 +372,6 @@ describe('SkillsView toolset management', { timeout: 60_000 }, () => {
     // the live surface pointed at ITS backend — the reads must carry the
     // (connection, profile) pin, not a bare profile name that would resolve
     // against the ACTIVE gateway (the wrong-machine bug).
-    const { SkillsView } = await import('./index')
     await act(async () => {
       render(
         <QueryClientProvider client={queryClient}>
@@ -451,7 +444,6 @@ describe('SkillsView toolset management', { timeout: 60_000 }, () => {
     // carries an Install button (no toggle until installed) that routes
     // through the standard hub action pipeline scoped to the Capabilities
     // profile. Already-installed catalog entries are filtered out.
-    const { installHubSkill } = await import('@/store/hub-actions')
 
     getSkills.mockResolvedValue([
       {
@@ -492,7 +484,6 @@ describe('SkillsView toolset management', { timeout: 60_000 }, () => {
       ]
     })
 
-    const { SkillsView } = await import('./index')
     await act(async () => {
       render(
         <QueryClientProvider client={queryClient}>

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tool-panel-close.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tool-panel-close.test.tsx
@@ -71,6 +71,10 @@ const zoneAt = (index: number) => {
 
 const tabEl = (paneId: string) => document.querySelector<HTMLElement>(`[data-tree-tab="${paneId}"]`)
 
+// Load stable modules during collection, after mock fixtures are initialized.
+// Cold transforms must not consume a behavioral test or hook deadline.
+const { closeActiveTab } = await import('@/app/chat/close-tab')
+
 describe('right-clicking a tool panel tab', () => {
   it('offers Close when logs is STACKED with the terminal', async () => {
     declareDefaultTree(
@@ -121,7 +125,6 @@ describe('right-clicking a tool panel tab', () => {
 
 describe('⌘W over a focused tool panel', () => {
   it('closes the logs tab and the toggle brings it back', async () => {
-    const { closeActiveTab } = await import('@/app/chat/close-tab')
     const { allPaneIds } = await import('../model')
     const { revealTreePane, setPaneCollapsed } = await import('../store')
 

--- a/apps/desktop/src/pairing-scope.test.ts
+++ b/apps/desktop/src/pairing-scope.test.ts
@@ -10,11 +10,14 @@ const api = vi.fn().mockResolvedValue({ ok: true })
 
 vi.stubGlobal('window', { hermesDesktop: { api } })
 
+// Load stable modules during collection, after mock fixtures are initialized.
+// Cold transforms must not consume a behavioral test or hook deadline.
+const mod = await import('@/hermes')
+
 describe('pairing requests carry the active profile', () => {
   beforeEach(() => api.mockClear())
 
   it('scopes approve and revoke by body, and the listing by query', async () => {
-    const mod = await import('@/hermes')
     mod.setApiRequestProfile('work')
 
     await mod.approvePairing('telegram', 'a'.repeat(16))
@@ -29,7 +32,6 @@ describe('pairing requests carry the active profile', () => {
   })
 
   it('omits the profile entirely for single-profile users', async () => {
-    const mod = await import('@/hermes')
     mod.setApiRequestProfile(null)
 
     await mod.approvePairing('telegram', 'a'.repeat(16))

--- a/apps/desktop/src/plugins/hermes-bots/data.cached-roster.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/data.cached-roster.test.ts
@@ -48,10 +48,12 @@ beforeEach(() => {
   connection.id = 'local'
 })
 
+// Load stable modules during collection, after mock fixtures are initialized.
+// Cold transforms must not consume a behavioral test or hook deadline.
+const { cachedUnionRoster } = await import('./data')
+
 describe('cachedUnionRoster', () => {
   it('reads the entry useRoster wrote under the connection-suffixed key', async () => {
-    const { cachedUnionRoster } = await import('./data')
-
     seed(['hermes-bots', 'roster', 'local'], { profiles: [{ name: 'default' }] })
 
     expect(cachedUnionRoster()?.profiles).toHaveLength(1)
@@ -61,8 +63,6 @@ describe('cachedUnionRoster', () => {
   })
 
   it('falls back to another connection’s entry when the window has moved', async () => {
-    const { cachedUnionRoster } = await import('./data')
-
     seed(['hermes-bots', 'roster', 'vera'], { profiles: [{ connectionId: 'vera', name: 'default' }] })
     connection.id = 'local'
 
@@ -70,8 +70,6 @@ describe('cachedUnionRoster', () => {
   })
 
   it('prefers the freshest snapshot among several cached connections', async () => {
-    const { cachedUnionRoster } = await import('./data')
-
     seed(['hermes-bots', 'roster', 'old'], { fetchedAt: 1_000, profiles: [{ name: 'stale' }] })
     seed(['hermes-bots', 'roster', 'new'], { fetchedAt: 9_000, profiles: [{ name: 'fresh' }] })
     connection.id = 'neither'
@@ -80,8 +78,6 @@ describe('cachedUnionRoster', () => {
   })
 
   it('reports nothing rather than throwing on a cold cache', async () => {
-    const { cachedUnionRoster } = await import('./data')
-
     expect(cachedUnionRoster()).toBeNull()
   })
 })

--- a/apps/desktop/src/store/session-unread-tile.test.ts
+++ b/apps/desktop/src/store/session-unread-tile.test.ts
@@ -1,16 +1,18 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
 // The completed-unread dot is keyed on the FOCUSED session, not the selected
 // one. A tile is never $selectedStoredSessionId, so keying either half on the
 // selection left a tiled session's dot green with no way to clear it.
 
 describe('completed-unread dot follows the focused session', () => {
-  beforeEach(() => {
-    vi.resetModules()
-  })
+  const disposers: (() => void)[] = []
 
   afterEach(() => {
-    vi.resetModules()
+    // Undo the registrations and store writes this file makes, so the next
+    // test starts clean without paying to rebuild the module graph.
+    while (disposers.length > 0) {
+      disposers.pop()?.()
+    }
   })
 
   async function setup() {
@@ -21,14 +23,23 @@ describe('completed-unread dot follows the focused session', () => {
     const session = await import('./session')
     const states = await import('./session-states')
 
+    // `declareDefaultTree` only seeds `$layoutTree` when it is empty, so the
+    // layout has to be cleared here or the second test would adopt the first
+    // test's tree instead of the one it declares.
+    tree.$layoutTree.set(null)
+    tree.$activeTreeGroup.set(null)
+
     for (const id of ['workspace', 'session-tile:tiled']) {
-      registry.register({
-        area: 'panes',
-        data: id === 'workspace' ? { placement: 'main', uncloseable: true } : { placement: 'main' },
-        id,
-        render: () => null,
-        title: id
-      })
+      disposers.push(
+        registry.register({
+          area: 'panes',
+          data:
+            id === 'workspace' ? { placement: 'main', uncloseable: true } : { placement: 'main' },
+          id,
+          render: () => null,
+          title: id
+        })
+      )
     }
 
     // The workspace holds the primary chat, a second zone holds the tile.

--- a/apps/desktop/src/store/session-unread-tile.test.ts
+++ b/apps/desktop/src/store/session-unread-tile.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, describe, expect, it } from 'vitest'
 
+import * as model from '@/components/pane-shell/tree/model'
+import * as tree from '@/components/pane-shell/tree/store'
+import { registry } from '@/contrib/registry'
+import { createClientSessionState } from '@/lib/chat-runtime'
+
+import * as session from './session'
+import * as states from './session-states'
+
 // The completed-unread dot is keyed on the FOCUSED session, not the selected
 // one. A tile is never $selectedStoredSessionId, so keying either half on the
 // selection left a tiled session's dot green with no way to clear it.
@@ -15,14 +23,7 @@ describe('completed-unread dot follows the focused session', () => {
     }
   })
 
-  async function setup() {
-    const tree = await import('@/components/pane-shell/tree/store')
-    const model = await import('@/components/pane-shell/tree/model')
-    const { registry } = await import('@/contrib/registry')
-    const { createClientSessionState } = await import('@/lib/chat-runtime')
-    const session = await import('./session')
-    const states = await import('./session-states')
-
+  function setup() {
     // `declareDefaultTree` only seeds `$layoutTree` when it is empty, so the
     // layout has to be cleared here or the second test would adopt the first
     // test's tree instead of the one it declares.
@@ -33,8 +34,7 @@ describe('completed-unread dot follows the focused session', () => {
       disposers.push(
         registry.register({
           area: 'panes',
-          data:
-            id === 'workspace' ? { placement: 'main', uncloseable: true } : { placement: 'main' },
+          data: id === 'workspace' ? { placement: 'main', uncloseable: true } : { placement: 'main' },
           id,
           render: () => null,
           title: id
@@ -62,8 +62,8 @@ describe('completed-unread dot follows the focused session', () => {
     return { finishTurn, session, tree }
   }
 
-  it('clears the dot when an already-open tile is fronted', async () => {
-    const { finishTurn, session, tree } = await setup()
+  it('clears the dot when an already-open tile is fronted', () => {
+    const { finishTurn, session, tree } = setup()
 
     tree.noteActiveTreeGroup('grp-main')
     finishTurn('tiled')
@@ -75,8 +75,8 @@ describe('completed-unread dot follows the focused session', () => {
     expect(session.$unreadFinishedSessionIds.get()).toEqual([])
   })
 
-  it('never marks a tile that finishes while it is the focused one', async () => {
-    const { finishTurn, session, tree } = await setup()
+  it('never marks a tile that finishes while it is the focused one', () => {
+    const { finishTurn, session, tree } = setup()
 
     tree.noteActiveTreeGroup('grp-tile')
     finishTurn('tiled')
@@ -84,8 +84,8 @@ describe('completed-unread dot follows the focused session', () => {
     expect(session.$unreadFinishedSessionIds.get()).toEqual([])
   })
 
-  it('marks the primary session when a tile has focus', async () => {
-    const { finishTurn, session, tree } = await setup()
+  it('marks the primary session when a tile has focus', () => {
+    const { finishTurn, session, tree } = setup()
 
     tree.noteActiveTreeGroup('grp-tile')
     finishTurn('primary')

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -78,6 +78,10 @@ import {
 
 const session = (over: Partial<SessionInfo>): SessionInfo => makeSessionInfo({ id: 'live', ...over })
 
+// Load stable modules during collection, after mock fixtures are initialized.
+// Cold transforms must not consume a behavioral test or hook deadline.
+const { openSession } = await import('@/app/open-session')
+
 describe('composer model persistence scope', () => {
   const local = { baseUrl: '', connectionId: 'local', mode: 'local' } as never
 
@@ -1201,7 +1205,6 @@ describe('unread finished sessions', () => {
 
     // A no-op navigate — openSession with 'in-place' against the already
     // selected session hits focusOpenSession and returns without loading.
-    const { openSession } = await import('@/app/open-session')
     openSession('s1', () => {}, 'in-place')
 
     expect($unreadFinishedSessionIds.get()).toEqual([])

--- a/scripts/build_windows_installer.py
+++ b/scripts/build_windows_installer.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Assemble the standalone Windows installer without changing its script scope."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import stat
+import sys
+import subprocess
+import tempfile
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+AUTHORING_ROOT = REPO_ROOT / "scripts" / "windows-installer"
+OUTPUT = REPO_ROOT / "scripts" / "install.ps1"
+LINE_LIMIT = 2000
+INCLUDE = re.compile(r"# @include ([A-Za-z0-9][A-Za-z0-9._/-]*\.ps1)\n\Z")
+WINDOWS_DEVICE = re.compile(r"(?:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(?:\.|$)", re.I)
+
+
+class AssemblyError(ValueError):
+    """The source graph cannot produce an unambiguous standalone artifact."""
+
+
+def verify_history(base_ref: str, head_ref: str = "HEAD", repo_root: Path = REPO_ROOT) -> None:
+    """Keep source debt monotonic across every manifest commit in a PR stack."""
+    def git(*args: str) -> bytes:
+        result = subprocess.run(["git", *args], cwd=repo_root, capture_output=True)
+        if result.returncode:
+            raise AssemblyError(f"cannot verify installer history: {result.stderr.decode(errors='replace').strip()}")
+        return result.stdout
+
+    base = git("rev-parse", "--verify", "--end-of-options", f"{base_ref}^{{commit}}").decode().strip()
+    head = git("rev-parse", "--verify", "--end-of-options", f"{head_ref}^{{commit}}").decode().strip()
+    git("merge-base", "--is-ancestor", base, head)
+    path = "scripts/windows-installer/manifest.json"
+    revisions = git("log", "--reverse", "--format=%H", f"{base}..{head}", "--", path).decode().splitlines()
+    for revision in revisions:
+        current = json.loads(git("show", f"{revision}:{path}"), object_pairs_hook=_object)
+        parent = git("rev-parse", f"{revision}^").decode().strip()
+        previous_path = git("ls-tree", "--name-only", parent, "--", path).strip()
+        ceilings = current["kill_track"]
+        if not previous_path:
+            original = git("show", f"{parent}:scripts/install.ps1")
+            source = git("show", f"{revision}:scripts/windows-installer/source/install.ps1")
+            if source != original or ceilings != {"install.ps1": original.count(b"\n")}:
+                raise AssemblyError("initial kill-track source must exactly preserve its parent installer")
+        else:
+            previous = json.loads(git("show", f"{parent}:{path}"), object_pairs_hook=_object)["kill_track"]
+            if any(name not in previous or ceiling > previous[name] for name, ceiling in ceilings.items()):
+                raise AssemblyError(f"kill-track ceilings may only shrink: {revision}")
+
+
+def _is_link(path: Path) -> bool:
+    # Path.is_junction() only exists in Python 3.12+. lstat exposes the Windows
+    # reparse attribute on the supported Python 3.11 baseline too.
+    try:
+        attributes = getattr(path.lstat(), "st_file_attributes", 0)
+    except FileNotFoundError:
+        return False
+    return path.is_symlink() or bool(attributes & stat.FILE_ATTRIBUTE_REPARSE_POINT)
+
+
+def _object(pairs: list[tuple[str, object]]) -> dict:
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise AssemblyError(f"duplicate manifest key: {key}")
+        result[key] = value
+    return result
+
+
+def _name(value: object) -> str:
+    if not isinstance(value, str) or not value:
+        raise AssemblyError("source paths must be nonempty strings")
+    path = PurePosixPath(value)
+    if (
+        path.is_absolute()
+        or "\\" in value
+        or ":" in value
+        or any(part in {"", ".", ".."} for part in value.split("/"))
+        or any(part.endswith(".") or WINDOWS_DEVICE.match(part) for part in value.split("/"))
+        or path.suffix != ".ps1"
+        or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._/-]*", value)
+    ):
+        raise AssemblyError(f"invalid source path: {value!r}")
+    return value
+
+
+def _plain_path(root: Path, name: str) -> Path:
+    candidate = root / name
+    if not candidate.resolve().is_relative_to(root.resolve()):
+        raise AssemblyError(f"source path escapes its root: {name}")
+    parts = PurePosixPath(name).parts
+    for checked in (root, *(root.joinpath(*parts[:i]) for i in range(1, len(parts) + 1))):
+        if _is_link(checked):
+            raise AssemblyError(f"source path contains a link: {name}")
+    if not candidate.is_file():
+        raise AssemblyError(f"source file is missing: {name}")
+    return candidate
+
+
+def _read_source(path: Path) -> str:
+    text = path.read_bytes().decode("utf-8")
+    if text.startswith("\ufeff"):
+        raise AssemblyError(f"source must not contain a UTF-8 BOM: {path.name}")
+    text = text.replace("\r\n", "\n")
+    if "\r" in text or not text.endswith("\n"):
+        raise AssemblyError(f"source requires LF/CRLF lines and a final newline: {path.name}")
+    return text
+
+
+def assemble(authoring_root: Path = AUTHORING_ROOT) -> bytes:
+    """Validate and expand the declared source graph to canonical UTF-8/LF bytes."""
+    manifest = json.loads(
+        (authoring_root / "manifest.json").read_text(encoding="utf-8"),
+        object_pairs_hook=_object,
+    )
+    required = {"version", "entry", "files", "kill_track"}
+    if not isinstance(manifest, dict) or set(manifest) != required:
+        raise AssemblyError(f"manifest requires exactly these fields: {sorted(required)}")
+    if type(manifest["version"]) is not int or manifest["version"] != 1:
+        raise AssemblyError("unsupported manifest version")
+    if not isinstance(manifest["files"], list) or not manifest["files"]:
+        raise AssemblyError("manifest files must be a nonempty ordered list")
+    names = [_name(value) for value in manifest["files"]]
+    if len({name.casefold() for name in names}) != len(names):
+        raise AssemblyError("duplicate or case-colliding manifest source paths")
+    entry = _name(manifest["entry"])
+    if entry not in names:
+        raise AssemblyError("entry must be a declared source file")
+    kill_track = manifest["kill_track"]
+    if not isinstance(kill_track, dict) or not set(kill_track).issubset(names):
+        raise AssemblyError("kill_track must map declared source paths to line ceilings")
+    for name, ceiling in kill_track.items():
+        if type(ceiling) is not int or ceiling <= LINE_LIMIT:
+            raise AssemblyError(f"invalid kill-track ceiling: {name}")
+
+    root = authoring_root / "source"
+    sources = {}
+    for name in names:
+        text = _read_source(_plain_path(root, name))
+        lines = text.count("\n")
+        ceiling = kill_track.get(name, LINE_LIMIT)
+        if lines > ceiling:
+            raise AssemblyError(f"source exceeds its {ceiling}-line ceiling: {name} ({lines})")
+        if name in kill_track and lines <= LINE_LIMIT:
+            raise AssemblyError(f"remove completed source from kill_track: {name}")
+        sources[name] = text
+
+    # Everything in source/ is authored input. No extension-based size exemptions.
+    inventory = set()
+    for path in root.rglob("*"):
+        name = path.relative_to(root).as_posix()
+        if _is_link(path):
+            raise AssemblyError(f"source inventory contains a link: {name}")
+        if path.is_file():
+            inventory.add(name)
+    if inventory != set(names):
+        raise AssemblyError(f"undeclared source files: {sorted(inventory - set(names))}")
+
+    visited: list[str] = []
+    active: list[str] = []
+
+    def expand(name: str) -> str:
+        if name in active:
+            raise AssemblyError(f"source inclusion cycle: {' -> '.join([*active, name])}")
+        if name in visited:
+            raise AssemblyError(f"source included more than once: {name}")
+        if name not in sources:
+            raise AssemblyError(f"include is not declared in manifest: {name}")
+        active.append(name)
+        visited.append(name)
+        output = []
+        for line in sources[name].splitlines(keepends=True):
+            if line.startswith("# @include"):
+                match = INCLUDE.fullmatch(line)
+                if match is None:
+                    raise AssemblyError(f"malformed include directive in {name}: {line.rstrip()!r}")
+                output.append(expand(_name(match[1])))
+            else:
+                output.append(line)
+        active.pop()
+        return "".join(output)
+
+    result = expand(entry)
+    if set(visited) != set(names):
+        raise AssemblyError(f"orphaned declared sources: {sorted(set(names) - set(visited))}")
+    if visited != names:
+        raise AssemblyError("manifest files must follow source inclusion traversal order")
+    return result.encode("utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="fail if the checked-in artifact differs")
+    parser.add_argument("--base-ref", help="verify monotonic source debt since this Git commit")
+    parser.add_argument("--head-ref", default="HEAD", help="PR head for history verification (not its test merge)")
+    args = parser.parse_args(argv)
+    try:
+        if Path(__file__).read_bytes().count(b"\n") > LINE_LIMIT:
+            raise AssemblyError("installer assembler exceeds the authored source line ceiling")
+        data = assemble(AUTHORING_ROOT)
+        if args.base_ref:
+            verify_history(args.base_ref, args.head_ref)
+        if _is_link(OUTPUT):
+            raise AssemblyError("installer output must not be a filesystem link")
+        if args.check:
+            if not OUTPUT.is_file() or OUTPUT.read_bytes() != data:
+                raise AssemblyError("scripts/install.ps1 is stale; run python scripts/build_windows_installer.py")
+        else:
+            temporary = None
+            try:
+                with tempfile.NamedTemporaryFile(dir=OUTPUT.parent, prefix=".install-", suffix=".tmp", delete=False) as stream:
+                    temporary = Path(stream.name)
+                    stream.write(data)
+                os.replace(temporary, OUTPUT)
+            finally:
+                if temporary is not None and temporary.exists():
+                    temporary.unlink()
+        print(f"{'Verified' if args.check else 'Generated'} scripts/install.ps1: {len(data)} bytes, sha256 {hashlib.sha256(data).hexdigest()}")
+        return 0
+    except (AssemblyError, OSError, UnicodeError, json.JSONDecodeError) as exc:
+        print(f"Windows installer assembly failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_windows_installer.py
+++ b/scripts/build_windows_installer.py
@@ -39,21 +39,30 @@ def verify_history(base_ref: str, head_ref: str = "HEAD", repo_root: Path = REPO
     head = git("rev-parse", "--verify", "--end-of-options", f"{head_ref}^{{commit}}").decode().strip()
     base = git("merge-base", base, head).decode().strip()
     path = "scripts/windows-installer/manifest.json"
-    revisions = git("log", "--reverse", "--format=%H", f"{base}..{head}", "--", path).decode().splitlines()
+    # A path-filtered log can omit a merge that restores an older manifest.
+    # Walk the complete DAG and check every parent edge carrying source debt.
+    revisions = git("rev-list", "--reverse", "--topo-order", f"{base}..{head}").decode().splitlines()
     for revision in revisions:
+        parents = git("rev-list", "--parents", "-n", "1", revision).decode().split()[1:]
+        previous = []
+        for parent in parents:
+            if git("ls-tree", "--name-only", parent, "--", path).strip():
+                previous.append(json.loads(git("show", f"{parent}:{path}"), object_pairs_hook=_object)["kill_track"])
+        if not git("ls-tree", "--name-only", revision, "--", path).strip():
+            if previous:
+                raise AssemblyError(f"installer source ownership manifest was removed: {revision}")
+            continue
         current = json.loads(git("show", f"{revision}:{path}"), object_pairs_hook=_object)
-        parent = git("rev-parse", f"{revision}^").decode().strip()
-        previous_path = git("ls-tree", "--name-only", parent, "--", path).strip()
         ceilings = current["kill_track"]
-        if not previous_path:
-            original = git("show", f"{parent}:scripts/install.ps1")
+        if not previous:
+            original = git("show", f"{parents[0]}:scripts/install.ps1")
             source = git("show", f"{revision}:scripts/windows-installer/source/install.ps1")
             if source != original or ceilings != {"install.ps1": original.count(b"\n")}:
                 raise AssemblyError("initial kill-track source must exactly preserve its parent installer")
         else:
-            previous = json.loads(git("show", f"{parent}:{path}"), object_pairs_hook=_object)["kill_track"]
-            if any(name not in previous or ceiling > previous[name] for name, ceiling in ceilings.items()):
-                raise AssemblyError(f"kill-track ceilings may only shrink: {revision}")
+            for prior in previous:
+                if any(name not in prior or ceiling > prior[name] for name, ceiling in ceilings.items()):
+                    raise AssemblyError(f"kill-track ceilings may only shrink on every parent edge: {revision}")
 
 
 def _is_link(path: Path) -> bool:

--- a/scripts/build_windows_installer.py
+++ b/scripts/build_windows_installer.py
@@ -37,7 +37,7 @@ def verify_history(base_ref: str, head_ref: str = "HEAD", repo_root: Path = REPO
 
     base = git("rev-parse", "--verify", "--end-of-options", f"{base_ref}^{{commit}}").decode().strip()
     head = git("rev-parse", "--verify", "--end-of-options", f"{head_ref}^{{commit}}").decode().strip()
-    git("merge-base", "--is-ancestor", base, head)
+    base = git("merge-base", base, head).decode().strip()
     path = "scripts/windows-installer/manifest.json"
     revisions = git("log", "--reverse", "--format=%H", f"{base}..{head}", "--", path).decode().splitlines()
     for revision in revisions:

--- a/scripts/ci/classify_changes.py
+++ b/scripts/ci/classify_changes.py
@@ -113,8 +113,15 @@ _MCP_CATALOG_FILES = {"hermes_cli/mcp_catalog.py"}
 
 # Windows installer + its PowerShell tests. These only run on a Windows runner,
 # so they get their own lane rather than riding along with ``python``.
-_INSTALLER_PATHS = ("scripts/tests/",)
-_INSTALLER_FILES = {"scripts/install.ps1", "scripts/install.cmd"}
+_INSTALLER_PATHS = ("scripts/tests/", "scripts/windows-installer/")
+_INSTALLER_FILES = {
+    ".gitattributes",
+    "scripts/install.ps1", "scripts/install.cmd",
+    "scripts/build_windows_installer.py",
+    "tests/test_windows_installer_assembly.py",
+    "tests/test_windows_installer_delivery.py",
+    "tests/test_windows_installer_history.py",
+}
 
 # Windows desktop-update hand-off (scripts/desktop-update/windows.ps1 + the
 # Electron side that launches it) and the pytest files that spawn it.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2579,6 +2579,19 @@ function Install-Venv {
     $venvBackupName = $null
     $venvParked = $false
     try {
+    # A previous venv stage may have finished (or been interrupted after
+    # parking the old tree) without reaching dependency validation. Restore
+    # that transaction's original generation before beginning another recreate
+    # so a retry cannot promote the unverified replacement to rollback source.
+    $pendingVenvBackup = Get-PendingVenvBackup
+    if ($pendingVenvBackup) {
+        Write-Warn "Reconciling unfinished venv transaction before retrying"
+        Restore-VenvBackup
+        if (Get-PendingVenvBackup) {
+            throw "Could not restore the original venv from $pendingVenvBackup; retry aborted during transaction recovery."
+        }
+    }
+
     if (Test-Path -LiteralPath "venv") {
         $venvHadExistingVenv = $true
         Write-Info "Virtual environment already exists, recreating..."
@@ -2672,11 +2685,17 @@ function Install-Venv {
         # interpreter and no rollback source. Abort with the previous install
         # intact so the user can close holders and retry.
         $venvBackupName = "venv.stale.{0}-{1}" -f (Get-Date -Format "yyyyMMddHHmmss"), ([Guid]::NewGuid().ToString("N"))
+        # Publish intent before the atomic rename. If this process is killed
+        # after publication but before the rename, Get-PendingVenvBackup drops
+        # the marker because its target does not exist. If it is killed after
+        # the rename, the next attempt can restore this original generation.
+        Set-Content -LiteralPath (Join-Path $InstallDir "venv.pending-backup") -Value $venvBackupName -Encoding ascii
         try {
             Rename-Item -LiteralPath "venv" -NewName $venvBackupName -ErrorAction Stop
             $venvParked = $true
         } catch {
             $renameErr = $_.Exception.Message
+            Remove-Item -LiteralPath (Join-Path $InstallDir "venv.pending-backup") -Force -ErrorAction SilentlyContinue
             throw (
                 "Could not move the existing venv aside ($renameErr). " +
                 "A process still has the install directory open (often a non-Hermes " +
@@ -2732,10 +2751,9 @@ function Install-Venv {
     # committed after Install-Dependencies' baseline-import gate passes -- the
     # bootstrap runs the stages as separate processes, and every dependency
     # tier (or the import validation) can still fail after this stage
-    # succeeds. Record the parked backup so the dependency stage can restore
-    # it on failure and commit its cleanup only after validation (#83149).
+    # succeeds. The marker was published before parking the original so an
+    # interruption cannot strand the only rollback source without a pointer.
     if ($venvParked) {
-        Set-Content -LiteralPath (Join-Path $InstallDir "venv.pending-backup") -Value $venvBackupName -Encoding ascii
         Write-Info "Previous venv parked at $venvBackupName until the dependency install is verified"
     }
 
@@ -2768,6 +2786,7 @@ function Install-Venv {
                     Write-Warn "Failed replacement parked at $failedVenvName"
                 }
                 Rename-Item -LiteralPath $venvBackupName -NewName "venv" -ErrorAction Stop
+                Remove-Item -LiteralPath (Join-Path $InstallDir "venv.pending-backup") -Force -ErrorAction SilentlyContinue
                 Write-Warn "Restored previous virtual environment after failed recreate"
             } catch {
                 $rollbackError = $_.Exception.Message

--- a/scripts/tests/test-install-ps1-venv-retry-transaction.ps1
+++ b/scripts/tests/test-install-ps1-venv-retry-transaction.ps1
@@ -1,0 +1,217 @@
+# Behavioral fault-injection tests for interrupted venv transactions.
+#
+# The test lifts the shipped functions from install.ps1's PowerShell AST and
+# executes their real marker, directory-rename, stale-sweep, and rollback logic
+# against isolated temporary trees. Only process discovery, task control, uv,
+# and sleeps are synthetic.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path))
+$installScript = Join-Path $repoRoot 'scripts\install.ps1'
+$tokens = $null
+$parseErrors = $null
+$ast = [Management.Automation.Language.Parser]::ParseFile(
+    $installScript, [ref]$tokens, [ref]$parseErrors)
+if ($parseErrors.Count -gt 0) { throw 'Installer parse failed' }
+
+$functionNames = @(
+    'Install-Venv',
+    'Get-PendingVenvBackup',
+    'Restore-VenvBackup',
+    'Complete-VenvTransaction'
+)
+foreach ($name in $functionNames) {
+    $matches = @($ast.FindAll({
+        param($node)
+        $node -is [Management.Automation.Language.FunctionDefinitionAst] -and
+            $node.Name -eq $name
+    }, $true))
+    if ($matches.Count -ne 1) { throw "Expected one complete function: $name" }
+    Invoke-Expression $matches[0].Extent.Text
+}
+
+$testRoot = Join-Path $env:TEMP ("hermes-venv-retry-test-" + [Guid]::NewGuid().ToString('N'))
+$NoVenv = $false
+$script:UvCmd = 'synthetic-uv-never-executed.exe'
+$script:Failures = 0
+$script:FailNextVenvRename = $false
+$script:FakeVenvExitCode = 0
+
+function Write-Info { param([string]$Message) }
+function Write-Warn { param([string]$Message) }
+function Write-Success { param([string]$Message) }
+function Resolve-AvailablePythonVersion {
+    [pscustomobject]@{ Path = 'synthetic-python'; Version = '3.11' }
+}
+function schtasks { $global:LASTEXITCODE = 0 }
+function taskkill { $global:LASTEXITCODE = 0 }
+function Get-CimInstance { @() }
+function Start-Sleep { }
+function Rename-Item {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$LiteralPath,
+        [Parameter(Mandatory = $true)][string]$NewName
+    )
+    if ($script:FailNextVenvRename -and (Split-Path -Leaf $LiteralPath) -eq 'venv') {
+        $script:FailNextVenvRename = $false
+        throw 'synthetic rename interruption'
+    }
+    Microsoft.PowerShell.Management\Rename-Item -LiteralPath $LiteralPath -NewName $NewName -ErrorAction Stop
+}
+function New-Object {
+    param([string]$TypeName)
+    if ($TypeName -eq 'System.Diagnostics.ProcessStartInfo') {
+        return [pscustomobject]@{
+            FileName = ''
+            Arguments = ''
+            WorkingDirectory = ''
+            UseShellExecute = $false
+            CreateNoWindow = $false
+            RedirectStandardOutput = $false
+            RedirectStandardError = $false
+        }
+    }
+    if ($TypeName -ne 'System.Diagnostics.Process') {
+        throw "Unexpected object type $TypeName"
+    }
+    $reader = [pscustomobject]@{}
+    $reader | Add-Member ScriptMethod ReadToEndAsync {
+        [pscustomobject]@{ Result = '' }
+    }
+    $process = [pscustomobject]@{
+        StartInfo = $null
+        StandardOutput = $reader
+        StandardError = $reader
+        ExitCode = $script:FakeVenvExitCode
+    }
+    $process | Add-Member ScriptMethod Start {
+        $scriptsDir = Join-Path $this.StartInfo.WorkingDirectory 'venv\Scripts'
+        [IO.Directory]::CreateDirectory($scriptsDir) | Out-Null
+        [IO.File]::WriteAllText(
+            (Join-Path $scriptsDir 'python.exe'),
+            'synthetic interpreter placeholder')
+        [IO.File]::WriteAllText(
+            (Join-Path $this.StartInfo.WorkingDirectory 'venv\generation.txt'),
+            'PARTIAL_NEW_ENV_WITHOUT_DEPENDENCIES')
+        return $true
+    }
+    $process | Add-Member ScriptMethod WaitForExit { }
+    $process | Add-Member ScriptMethod Dispose { }
+    return $process
+}
+
+function Assert-Equal {
+    param($Expected, $Actual, [Parameter(Mandatory = $true)][string]$Label)
+    if ($Expected -ceq $Actual) {
+        Write-Host "PASS: $Label"
+    } else {
+        Write-Host "FAIL: $Label"
+        Write-Host "  expected: [$Expected]"
+        Write-Host "  actual:   [$Actual]"
+        $script:Failures++
+    }
+}
+
+function New-TestCase {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [switch]$SeedLiveVenv
+    )
+    $caseDir = Join-Path $testRoot $Name
+    [IO.Directory]::CreateDirectory($caseDir) | Out-Null
+    if ($SeedLiveVenv) {
+        $venv = Join-Path $caseDir 'venv'
+        [IO.Directory]::CreateDirectory($venv) | Out-Null
+        [IO.File]::WriteAllText(
+            (Join-Path $venv 'generation.txt'), 'ORIGINAL_WORKING_ENV')
+    }
+    return $caseDir
+}
+
+function Read-LiveGeneration {
+    return [IO.File]::ReadAllText((Join-Path $script:InstallDir 'venv\generation.txt'))
+}
+
+try {
+    Write-Host '-- first-attempt venv failure --'
+    $script:InstallDir = New-TestCase -Name 'first-failure' -SeedLiveVenv
+    $script:FakeVenvExitCode = 1
+    try {
+        Install-Venv
+        $script:Failures++
+        Write-Host 'FAIL: uv failure aborts the first venv stage'
+    } catch {
+        Assert-Equal $true ($_.Exception.Message -like '*uv venv exited with 1*') 'uv failure aborts the first venv stage'
+    } finally {
+        $script:FakeVenvExitCode = 0
+    }
+    Assert-Equal 'ORIGINAL_WORKING_ENV' (Read-LiveGeneration) 'first-attempt failure restores the original generation'
+    Assert-Equal $false (Test-Path -LiteralPath (Join-Path $script:InstallDir 'venv.pending-backup')) 'first-attempt rollback clears the pending marker'
+
+    Write-Host ''
+    Write-Host '-- retry before dependency validation --'
+    $script:InstallDir = New-TestCase -Name 'retry' -SeedLiveVenv
+    Install-Venv
+    $firstBackup = Get-PendingVenvBackup
+    Assert-Equal $true ([bool]$firstBackup) 'the first venv stage publishes a rollback marker'
+    Assert-Equal $true (Test-Path -LiteralPath (Join-Path $script:InstallDir "$firstBackup\generation.txt")) 'the first stage preserves the original generation'
+
+    Install-Venv
+    $retryBackup = Get-PendingVenvBackup
+    Assert-Equal $true ([bool]$retryBackup) 'the retry keeps a rollback marker'
+    Assert-Equal $true (Test-Path -LiteralPath (Join-Path $script:InstallDir "$retryBackup\generation.txt")) 'the retry keeps the original rollback generation'
+    Assert-Equal 'ORIGINAL_WORKING_ENV' ([IO.File]::ReadAllText((Join-Path $script:InstallDir "$retryBackup\generation.txt"))) 'the retry marker still names the original generation'
+    Restore-VenvBackup
+    Assert-Equal 'ORIGINAL_WORKING_ENV' (Read-LiveGeneration) 'dependency failure after retry restores the original generation'
+
+    Write-Host ''
+    Write-Host '-- interruption before the original rename --'
+    $script:InstallDir = New-TestCase -Name 'before-rename' -SeedLiveVenv
+    $orphanMarkerName = 'venv.stale.pre-rename'
+    Set-Content -LiteralPath (Join-Path $script:InstallDir 'venv.pending-backup') -Value $orphanMarkerName -Encoding ascii
+    Install-Venv
+    Restore-VenvBackup
+    Assert-Equal 'ORIGINAL_WORKING_ENV' (Read-LiveGeneration) 'a marker published before a missing rename does not replace the live original'
+
+    Write-Host ''
+    Write-Host '-- rename failure after marker publication --'
+    $script:InstallDir = New-TestCase -Name 'rename-failure' -SeedLiveVenv
+    $script:FailNextVenvRename = $true
+    try {
+        Install-Venv
+        $script:Failures++
+        Write-Host 'FAIL: the rename failure aborts the venv stage'
+    } catch {
+        Assert-Equal $true ($_.Exception.Message -like '*previous install was left intact*') 'the rename failure aborts the venv stage'
+    }
+    Assert-Equal 'ORIGINAL_WORKING_ENV' (Read-LiveGeneration) 'rename failure leaves the live original intact'
+    Assert-Equal $false (Test-Path -LiteralPath (Join-Path $script:InstallDir 'venv.pending-backup')) 'rename failure clears its unpublished rollback marker'
+
+    Write-Host ''
+    Write-Host '-- interruption after the original rename --'
+    $script:InstallDir = New-TestCase -Name 'after-rename'
+    $parkedOriginal = 'venv.stale.after-rename'
+    $parkedPath = Join-Path $script:InstallDir $parkedOriginal
+    [IO.Directory]::CreateDirectory($parkedPath) | Out-Null
+    [IO.File]::WriteAllText((Join-Path $parkedPath 'generation.txt'), 'ORIGINAL_WORKING_ENV')
+    Set-Content -LiteralPath (Join-Path $script:InstallDir 'venv.pending-backup') -Value $parkedOriginal -Encoding ascii
+    Install-Venv
+    Restore-VenvBackup
+    Assert-Equal 'ORIGINAL_WORKING_ENV' (Read-LiveGeneration) 'a retry after rename-before-create restores the original generation'
+} finally {
+    if (Test-Path -LiteralPath $testRoot) {
+        Microsoft.PowerShell.Management\Remove-Item -LiteralPath $testRoot -Recurse -Force
+    }
+}
+
+if ($script:Failures -gt 0) {
+    Write-Host ''
+    Write-Host "$script:Failures assertion(s) failed"
+    exit 1
+}
+
+Write-Host ''
+Write-Host 'all assertions passed'

--- a/scripts/windows-installer/README.md
+++ b/scripts/windows-installer/README.md
@@ -1,0 +1,86 @@
+# Windows installer authoring
+
+`scripts/install.ps1` is the generated, standalone distribution artifact. Its
+path and one-file format are compatibility contracts: released desktop and
+bootstrap binaries download that exact raw GitHub path and cache only that file.
+The Python updater also copies it into old bootstrap caches. Keep these consumers
+working by editing the sources here and regenerating the artifact:
+
+```console
+python scripts/build_windows_installer.py
+python scripts/build_windows_installer.py --check
+```
+
+The assembler uses only Python's standard library. It emits UTF-8 without a BOM,
+with LF line endings, on every host. The existing GUI cache writers retain their
+own BOM handling for Windows PowerShell 5.1. Source CRLF is normalized to LF; bare
+CR, missing final newlines, and source BOMs are rejected. `--check` compares exact
+artifact bytes and does not write files.
+
+## Source graph
+
+`manifest.json` names the entry source and every file in `source/`, in depth-first
+inclusion order. Source files are literal PowerShell text. A directive on its own
+line inserts another source file's text at build time:
+
+```powershell
+# @include repository.ps1
+```
+
+Include paths are relative to `source/`, including in nested fragments. No
+directory traversal, absolute paths, links, duplicate inclusion, cycles, missing
+files, unlisted files, orphaned files, or case-colliding manifest paths are allowed.
+The reserved `# @include` prefix must appear only as an assembly directive, never
+as literal data in a PowerShell here-string.
+
+Assembly performs no runtime module import, scriptblock wrapping, encoding,
+compression, or minification. It preserves the original parameter block,
+initialization order, function bodies, script scope, stage protocol, entry-point
+dispatch, and invocation path. No authored file is loaded from the network or
+dot-sourced by the generated installer.
+
+## Extracting one coherent shard
+
+1. Move a contiguous, complete source region verbatim into a topical file in
+   `source/`. Preserve all bytes after LF normalization, including comments and
+   blank lines; do not split a function or a PowerShell here-string.
+2. Replace that exact region with one include directive. Update `files` to match
+   depth-first traversal of the resulting inclusion graph.
+3. Lower any affected kill-track ceiling to the residual's current physical line
+   count, including its include directives. Remove a kill-track entry once that
+   source is at or below 2,000 lines.
+4. Regenerate and prove the distribution artifact is byte-identical to the
+   preceding extraction's artifact. Run the installer behavior checks in both
+   Windows PowerShell 5.1 and PowerShell 7.
+
+One coherent extraction belongs in one PR. Behavior changes belong in later PRs
+that edit the appropriate authored shard and regenerate the artifact.
+
+## Source size and the temporary residual
+
+The assembly mechanism initially preserves the existing 5,082-line authored
+installer in `source/install.ps1`. It remains explicitly listed in `kill_track`;
+introducing a generator alone does not complete its sharding. Its ceiling must
+decrease with each extraction, and the kill track must be empty when the source
+sharding finishes. Every other authored source has a 2,000-line ceiling.
+
+The distribution artifact is a build output only while exact regeneration passes.
+Do not create a blanket PowerShell exemption or use this mechanism to hide an
+oversized authored input. CI must run the generation check on source, manifest,
+assembler, and artifact changes, and must reject increases to kill-track ceilings.
+The assembler validates the current graph. CI also passes `--base-ref` and
+`--head-ref` to check every manifest-changing commit in the PR, including a
+stack of extractions. The first manifest must preserve its parent installer's
+source bytes and exact line ceiling; later ceilings may only decrease or be
+removed. Removed allowances cannot be reintroduced. CI checks the real PR head
+for this history contract and the test-merge checkout for artifact regeneration.
+
+The initial source is taken from Git blob
+`e67300b455a1c7d67bc71a94e9a08b04b67f3425:scripts/install.ps1`:
+246,939 bytes, SHA-256
+`55b3d76e62abba5cecc16d17a65d799aaa6490e3dc88640fdcae282c4db5fd9f`.
+Assembly metadata lives here, so the generated script needs no header changes.
+
+The extraction base includes fangliquanflq's original-generation retry recovery in [PR #103771](https://github.com/NousResearch/hermes-agent/pull/103771), following Axl Ibiza's investigation and reproduction in [issue #103751](https://github.com/NousResearch/hermes-agent/issues/103751). This assembly mechanism preserves that implementation verbatim.
+
+This source decomposition follows Axl Ibiza's graph-gated extraction work tracked in [#79922](https://github.com/NousResearch/hermes-agent/issues/79922) and [#78647](https://github.com/NousResearch/hermes-agent/issues/78647). Individual source moves preserve prior contributor code; they do not transfer its authorship.

--- a/scripts/windows-installer/manifest.json
+++ b/scripts/windows-installer/manifest.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "entry": "install.ps1",
+  "files": [
+    "install.ps1"
+  ],
+  "kill_track": {
+    "install.ps1": 5082
+  }
+}

--- a/scripts/windows-installer/source/install.ps1
+++ b/scripts/windows-installer/source/install.ps1
@@ -1,0 +1,5082 @@
+# ============================================================================
+# Hermes Agent Installer for Windows
+# ============================================================================
+# Installation script for Windows (PowerShell).
+# Uses uv for fast Python provisioning and package management.
+#
+# Usage:
+#   iex (irm https://hermes-agent.nousresearch.com/install.ps1)
+#
+# Or download and run with options:
+#   .\install.ps1 -NoVenv -SkipSetup
+#
+# ============================================================================
+
+param(
+    [switch]$NoVenv,
+    [switch]$SkipSetup,
+    [switch]$SkipComputerUse,
+    [string]$Branch = "main",
+    # -Commit and -Tag are higher-precedence variants of -Branch for users
+    # who need reproducible installs (desktop installer pinning, CI, release
+    # bundles).  When set, the repository stage clones $Branch (faster than
+    # cloning the full default-branch history) and then `git checkout`s the
+    # exact ref.  Precedence: Commit > Tag > Branch.
+    [string]$Commit = "",
+    # Apply -Commit even when it would roll an existing install BACKWARDS.
+    # Without this the repository stage skips a pin that is already an ancestor
+    # of HEAD, so a stale baked-in BUILD_PIN_COMMIT can't downgrade a current
+    # checkout. Reproducible/CI installs that genuinely want an older SHA on an
+    # existing tree pass -ForceCommit.
+    [switch]$ForceCommit,
+    [string]$Tag = "",
+    [string]$HermesHome = $(if ($env:HERMES_HOME) { $env:HERMES_HOME } else { "$env:LOCALAPPDATA\hermes" }),
+    [string]$InstallDir = $(if ($env:HERMES_HOME) { "$env:HERMES_HOME\hermes-agent" } else { "$env:LOCALAPPDATA\hermes\hermes-agent" }),
+
+    # --- Stage protocol (additive; default invocation behaves as before) ----
+    # See the "Stage protocol" section near the bottom of the file for the
+    # full contract.  Intended for programmatic drivers (the desktop GUI's
+    # onboarding wizard, CI, future install.sh parity, etc.).  CLI users
+    # running the canonical `irm | iex` one-liner never touch these flags.
+    [switch]$Manifest,
+    [string]$Stage,
+    [switch]$ProtocolVersion,
+    [switch]$NonInteractive,
+    [switch]$Json,
+
+    # Print the paths this install would use, as JSON, and exit without
+    # touching anything. The first question on any "installer says a path
+    # doesn't exist" report is which paths it actually resolved -- especially
+    # on profiles Windows exposes through an 8.3 alias, where what the user
+    # sees in Explorer and what the installer receives differ.
+    #
+    #   powershell -File install.ps1 -ShowResolvedPaths
+    [switch]$ShowResolvedPaths,
+
+    # --- Ensure mode (dep_ensure.py entry point) ---
+    [string]$Ensure = "",
+    [switch]$PostInstall,
+
+    # --- Desktop GUI build (opt-in) ---
+    # When set, install.ps1 includes Stage-Desktop in the manifest and
+    # builds apps/desktop into a launchable Hermes.exe.
+    #
+    # Why opt-in:
+    #   * Hermes-Setup.exe (the signed Tauri bootstrap installer) passes
+    #     -IncludeDesktop so a user who installed via the GUI ends up
+    #     with a launchable desktop binary.
+    #   * The Electron desktop's own bootstrap-runner.ts runs install.ps1
+    #     from inside an already-launched Hermes.exe; if THAT recursively
+    #     built apps/desktop it would try to overwrite the live Hermes.exe
+    #     on disk and fail. The recursive path omits the flag.
+    #   * The canonical CLI one-liner (irm | iex) omits the flag too;
+    #     terminal users don't need a desktop binary built for them, and
+    #     `hermes desktop` already builds on demand.
+    [switch]$IncludeDesktop
+)
+
+$ErrorActionPreference = "Stop"
+
+# Suppress Invoke-WebRequest's per-chunk progress bar.  Windows PowerShell
+# 5.1's progress UI repaints synchronously on every received byte, which
+# pegs CPU on a single core and throttles downloads by 10-100x (a 57MB
+# PortableGit grab can take 5 minutes with progress on vs 20 seconds
+# with progress off, on the same network).  Every IWR call in this
+# script is fire-and-forget so we never need to see the bar.  Restored
+# automatically when the script exits.
+$ProgressPreference = "SilentlyContinue"
+
+# Force the console to UTF-8 so non-ASCII output from native commands
+# (e.g. playwright's box-drawing progress bars and download banners,
+# git's bullet glyphs, npm's check marks) renders correctly instead of
+# as IBM437/Windows-1252 mojibake (sequences like 0xE2 0x95 0x94 box-
+# drawing chars decoded under the legacy DOS codepage).  This is a
+# DISPLAY-only fix; the underlying bytes are already correct.  We do
+# NOT change the file's own encoding (it remains pure ASCII for PS 5.1
+# parser compatibility; see comments at the top of the entry-point
+# dispatch).  This affects only what the user sees in their terminal
+# during this install run, and reverts automatically when the script
+# exits and the host's console encoding is restored.
+try {
+    [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
+} catch {
+    # Some constrained PowerShell hosts disallow encoding mutation.
+    # Mojibake on output is then cosmetic-only, install still works.
+}
+
+# ============================================================================
+# 8.3 short-path normalization
+# ============================================================================
+# Windows generates an 8.3 short alias for a user-profile folder whose name
+# contains a space ("First Last" -> FIRST~1.LAS), a dot ("Stone.ZEN8" ->
+# STONE~1.ZEN), or an accented character ("Ruben" spelled with an acute e ->
+# RUBN~1). It can then expose %TEMP%, %TMP%, %LOCALAPPDATA%, %APPDATA% and
+# %USERPROFILE% -- plus everything derived from them, including the default
+# HERMES_HOME and InstallDir -- in that short form:
+#   C:\Users\FIRST~1.LAS\AppData\Local\Temp
+#
+# PowerShell's FileSystem provider mishandles the aliased component when such a
+# path reaches a provider cmdlet (`Tee-Object -FilePath`, `Out-File`,
+# `New-Item`, `Test-Path`), throwing "An object at the specified path
+# C:\Users\FIRST~1.LAS does not exist" -- localized on non-English hosts.
+# Every Node/Electron stage streams its build log to %TEMP% via Tee-Object and
+# the desktop stage probes the binary it produced under the profile-derived
+# InstallDir, so the bootstrap aborts even though the artifact built fine.
+# The Python/uv stages, which never hand a %TEMP% path to a provider cmdlet,
+# sail through -- which is why the failure looks Node-specific.
+#
+# Expanding every profile-rooted path back to long form once, up front, lets
+# every downstream cmdlet and child process see something the provider can
+# resolve. Three resolvers, tried in order, because no single one covers every
+# host:
+#
+#   1. kernel32!GetLongPathNameW -- expands any 8.3 component regardless of
+#      locale, including the accented-username aliases the COM resolver misses.
+#   2. Scripting.FileSystemObject -- fallback for hosts where P/Invoke is
+#      blocked.
+#   3. Profile-root substitution -- when the volume has 8.3 generation disabled
+#      or the alias is stale, neither resolver can expand the name because it
+#      no longer maps to anything on disk. The aliased component is always the
+#      profile folder itself (everything below it was created long), so swap in
+#      a profile root we can prove is long and reattach the tail.
+#
+# All three degrade to returning the input untouched, so a host where none of
+# them apply -- including non-Windows -- behaves exactly as it did before.
+
+$script:LongProfileRoot = $null
+
+function Write-PathDiag {
+    # Diagnostics for this block go to stderr, never stdout: the stage protocol
+    # hands drivers a single line of JSON on stdout and a stray note would break
+    # anything parsing it.
+    #
+    # Suppressed entirely under -ShowResolvedPaths, which is a machine-readable
+    # query: Windows PowerShell 5.1 wraps any native-command stderr in a
+    # NativeCommandError and folds it back into the caller's own stream, so a
+    # child writing here at all is enough to corrupt a 5.1 caller's capture.
+    # The JSON already carries everything these lines say.
+    #
+    # [Console]::Error.WriteLine specifically -- verified reaching a caller on a
+    # windows-latest runner. $host.UI.WriteErrorLine was tried and silently
+    # produced nothing there under a non-interactive host.
+    param([string]$Message)
+    if ($ShowResolvedPaths) { return }
+    [Console]::Error.WriteLine("[hermes] $Message")
+}
+
+function Get-LongProfileRoot {
+    # The user's profile directory in long form, or '' when every source we
+    # can reach is itself aliased. Cached: this runs per env var.
+    if ($null -ne $script:LongProfileRoot) { return $script:LongProfileRoot }
+    $script:LongProfileRoot = ''
+
+    # %USERPROFILE% first: it is what the rest of the install derives from, and
+    # on a host handing us aliased paths the .NET known-folder lookup tends to
+    # be aliased in exactly the same way. Then the HOMEDRIVE/HOMEPATH pair, then
+    # the profile's parent (C:\Users never carries an alias) plus %USERNAME%,
+    # which stays the long account name even when every path is short.
+    $envProfile = [Environment]::GetEnvironmentVariable('USERPROFILE')
+    $shellProfile = [Environment]::GetFolderPath('UserProfile')
+    $candidates = @($envProfile, $shellProfile, "$env:HOMEDRIVE$env:HOMEPATH")
+    foreach ($anchor in @($envProfile, $shellProfile)) {
+        if ($anchor -and $env:USERNAME) {
+            $parent = Split-Path -Parent $anchor.TrimEnd('\', '/')
+            if ($parent) { $candidates += (Join-Path $parent $env:USERNAME) }
+        }
+    }
+
+    foreach ($candidate in $candidates) {
+        if ([string]::IsNullOrWhiteSpace($candidate)) { continue }
+        # Trailing separators make Split-Path -Parent return the directory
+        # itself, which would silently break the ancestry check downstream.
+        $candidate = $candidate.TrimEnd('\', '/')
+        if (-not $candidate) { continue }
+        if ($candidate -match '~\d') { continue }
+        try {
+            if (Test-Path -LiteralPath $candidate -PathType Container) {
+                $script:LongProfileRoot = $candidate
+                break
+            }
+        } catch {
+            # Unreadable candidate (denied, malformed): try the next one.
+        }
+    }
+
+    # Say which root we landed on. When someone reports "still broken" this is
+    # the first thing worth knowing, and it costs one line on the rare path
+    # where an alias actually showed up.
+    if ($script:LongProfileRoot) {
+        Write-PathDiag "long profile root: $script:LongProfileRoot"
+    } else {
+        Write-PathDiag "no long profile root found; 8.3 paths left as-is (tried: $($candidates -join ', '))"
+    }
+    return $script:LongProfileRoot
+}
+
+function Expand-ShortProfileRoot {
+    # Rebuild $Path onto a known-long profile root when its aliased component
+    # is the profile folder. Returns $Path unchanged when it isn't, so a custom
+    # TEMP on another volume (D:\SHORT~1\Temp) is never rewritten.
+    param([string]$Path)
+
+    $longRoot = Get-LongProfileRoot
+    if (-not $longRoot) { return $Path }
+    $longRootParent = Split-Path -Parent $longRoot
+    if (-not $longRootParent) { return $Path }
+
+    $node = $Path
+    $tail = ''
+    while ($node -and ($node -match '~\d')) {
+        $leaf = Split-Path -Leaf $node
+        $parent = Split-Path -Parent $node
+        if (-not $parent) { return $Path }
+        if ($leaf -match '~\d') {
+            # Candidate profile folder. Only substitute when it sits in the
+            # same directory as the real profile (both C:\Users).
+            if ($parent -ne $longRootParent) { return $Path }
+            if ($tail) { return (Join-Path $longRoot $tail) }
+            return $longRoot
+        }
+        $tail = if ($tail) { Join-Path $leaf $tail } else { $leaf }
+        $node = $parent
+    }
+    return $Path
+}
+
+function ConvertTo-LongPath {
+    param([string]$Path)
+    if ([string]::IsNullOrWhiteSpace($Path)) { return $Path }
+    # Only 8.3 short names carry a tilde+digit ("~1"); skip every resolver for
+    # ordinary long paths, which is the overwhelmingly common case.
+    if ($Path -notmatch '~\d') {
+        $script:LastResolver = 'skipped-long-path'
+        return $Path
+    }
+
+    # 1. kernel32. Compiled on first use only, so a normal profile never pays
+    #    the Add-Type cost (this file is re-entered once per install stage).
+    try {
+        if (-not ([System.Management.Automation.PSTypeName]'HermesInstall.LongPath').Type) {
+            Add-Type -Namespace 'HermesInstall' -Name 'LongPath' -MemberDefinition @'
+[DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+public static extern int GetLongPathNameW(string lpszShortPath, System.Text.StringBuilder lpszLongPath, int cchBuffer);
+'@
+        }
+        $buffer = New-Object System.Text.StringBuilder 4096
+        $length = [HermesInstall.LongPath]::GetLongPathNameW($Path, $buffer, $buffer.Capacity)
+        if ($length -gt $buffer.Capacity) {
+            $buffer = New-Object System.Text.StringBuilder $length
+            $length = [HermesInstall.LongPath]::GetLongPathNameW($Path, $buffer, $buffer.Capacity)
+        }
+        if ($length -gt 0) {
+            $expanded = $buffer.ToString()
+            if ($expanded -and $expanded -notmatch '~\d') {
+                $script:LastResolver = 'kernel32'
+                return $expanded
+            }
+        }
+    } catch {
+        # Not Windows, or P/Invoke denied by policy: try the next resolver.
+    }
+
+    # 2. COM. Validate the result the same way the kernel32 branch does: this
+    # resolver can report success and still hand back a path that carries the
+    # alias (observed on a windows-latest runner, where it "resolved"
+    # C:\Users\FIRST~1.LAS\... to itself). Accepting that silently is what let a
+    # short path reach the provider cmdlets in the first place, so an
+    # unexpanded result counts as failure and falls through.
+    try {
+        $fso = New-Object -ComObject Scripting.FileSystemObject
+        $resolved = $null
+        if ($fso.FolderExists($Path))   { $resolved = $fso.GetFolder($Path).Path }
+        elseif ($fso.FileExists($Path)) { $resolved = $fso.GetFile($Path).Path }
+        if ($resolved -and $resolved -notmatch '~\d') {
+            $script:LastResolver = 'com'
+            return $resolved
+        }
+    } catch {
+        # COM unavailable / locked-down host: try the next resolver.
+    }
+
+    # 3. The alias resolves to nothing. Rebuild from a long profile root.
+    $rebuilt = Expand-ShortProfileRoot $Path
+    $script:LastResolver = if ($rebuilt -ne $Path) { 'profile-root' } else { 'none' }
+    return $rebuilt
+}
+
+function Set-LongProfileEnvVars {
+    # Normalize every profile-rooted variable the install reads, not just
+    # %TEMP%: the desktop stage derives InstallDir from %LOCALAPPDATA%, and a
+    # short root there fails the post-build probe after a successful build.
+    # Returns $true when anything was rewritten.
+    $rewrote = $false
+    $script:NormalizedPathRewrites = @{}
+    foreach ($name in @('TEMP', 'TMP', 'LOCALAPPDATA', 'APPDATA', 'USERPROFILE')) {
+        $current = [Environment]::GetEnvironmentVariable($name)
+        if (-not $current) { continue }
+        $expanded = ConvertTo-LongPath $current
+        if ($expanded -and $expanded -ne $current) {
+            Set-Item -Path "Env:$name" -Value $expanded
+            $rewrote = $true
+            $script:NormalizedPathRewrites[$name] = $expanded
+            # Rewriting a profile path is rare and corrective; say so. Every
+            # report of this bug class arrived as a bare "does not exist" with
+            # no hint that a short alias was involved. stderr, so the stage
+            # protocol's stdout JSON stays parseable.
+            Write-PathDiag "expanded 8.3 short path in %$name%: $current -> $expanded"
+        }
+    }
+    return $rewrote
+}
+
+# ConvertTo-LongPath only assigns $script:LastResolver when a ~\d short path
+# actually needs expansion, so an ordinary long profile leaves it unset -- and
+# the ResolvedPathReport below reads it unconditionally, which is fatal under
+# Set-StrictMode before any stage starts. 'none' is the resolver's own value
+# for "nothing ran".
+$script:LastResolver = 'none'
+$script:NormalizedProfilePaths = Set-LongProfileEnvVars
+
+# Re-derive the install paths now that the env vars behind their defaults are
+# long. An explicitly passed -HermesHome / -InstallDir is normalized in place
+# rather than replaced, so a caller's choice is never overwritten by a default.
+# $PSBoundParameters is only meaningful at script scope, so this stays inline.
+if ($PSBoundParameters.ContainsKey('HermesHome')) {
+    $HermesHome = ConvertTo-LongPath $HermesHome
+} else {
+    $HermesHome = ConvertTo-LongPath $(
+        if ($env:HERMES_HOME) { $env:HERMES_HOME } else { "$env:LOCALAPPDATA\hermes" }
+    )
+}
+if ($PSBoundParameters.ContainsKey('InstallDir')) {
+    $InstallDir = ConvertTo-LongPath $InstallDir
+} else {
+    $InstallDir = ConvertTo-LongPath $(
+        if ($env:HERMES_HOME) { "$env:HERMES_HOME\hermes-agent" } else { "$env:LOCALAPPDATA\hermes\hermes-agent" }
+    )
+}
+if ($script:NormalizedProfilePaths) {
+    # Which paths the install actually settled on. Absent from every report of
+    # this bug class, and the whole question once a short alias is in play.
+    Write-PathDiag "resolved install paths: HermesHome=$HermesHome InstallDir=$InstallDir"
+}
+
+# Captured here, where the values are final, and emitted from the entry-point
+# dispatch at the bottom (alongside -ProtocolVersion / -Manifest) so
+# -ShowResolvedPaths exits before any stage runs.
+#
+# The report goes to STDOUT as JSON: on Windows a child's stderr does not
+# reliably reach a parent process -- three separate capture mechanisms each came
+# back empty on a windows-latest runner while stdout arrived intact -- and the
+# first question on any "installer says a path doesn't exist" report is which
+# paths it actually resolved.
+$script:ResolvedPathReport = @{
+    long_profile_root = (Get-LongProfileRoot)
+    normalized        = $script:NormalizedPathRewrites
+    resolver          = $script:LastResolver
+    temp              = $env:TEMP
+    hermes_home       = $HermesHome
+    install_dir       = $InstallDir
+}
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+$RepoUrlSsh = "git@github.com:NousResearch/hermes-agent.git"
+$RepoUrlHttps = "https://github.com/NousResearch/hermes-agent.git"
+$PythonVersion = "3.11"
+# Minor versions the installer accepts when the requested $PythonVersion isn't
+# available, in preference order. Only checkout-private uv-managed interpreters
+# are eligible. Single source of truth shared by Test-Python's fallback and
+# Resolve-AvailablePythonVersion.
+$PythonFallbackVersions = @("3.12", "3.13", "3.10")
+$PythonFindTimeoutMs = 30000
+$NodeVersion = "22"
+# The npm range the root package.json pins in `engines.npm`.  A constant rather
+# than a manifest read like the POSIX side does: Test-Node runs BEFORE the repo
+# is cloned, so there is usually no package.json on disk yet (and none at all
+# when install.ps1 is piped straight from the web). Keep this fallback in sync
+# with package.json; Get-NpmRange prefers the manifest once a checkout exists.
+$NpmRange = "<11.10.0 || >=11.17.0"
+
+# Stage-protocol version.  Bumped only for genuinely breaking changes to the
+# manifest schema, stage-name set semantics, or stdout JSON shape.  Adding a
+# new stage does NOT bump this -- drivers iterate the manifest dynamically.
+$InstallStageProtocolVersion = 1
+
+# ============================================================================
+# Helper functions
+
+# Return the real OS processor architecture as a lowercase string suitable for
+# Node.js / electron download URL slugs: "arm64", "x64", or "x86".
+#
+# Why not just trust [Environment]::Is64BitOperatingSystem or
+# [RuntimeInformation]::OSArchitecture?  On Windows on ARM, when this script
+# is invoked from Windows PowerShell 5.1 (the default `powershell.exe`) or
+# any x64 PowerShell host, the process runs under Prism x64 emulation and
+# BOTH of those APIs report `X64` -- they describe the emulated view, not
+# the real OS.  We've seen this concretely on Snapdragon X1 hardware: an
+# ARM64-based Surface Laptop returns OSArchitecture=X64 from an emulated
+# PowerShell session.
+#
+# Win32_Processor.Architecture is invariant to emulation.  Values:
+#   0=x86, 5=ARM, 9=AMD64/x64, 12=ARM64.  We fall back to
+#   PROCESSOR_ARCHITEW6432 (set on WoW64 with the real OS arch) and then
+#   PROCESSOR_ARCHITECTURE so we still produce a sensible answer if CIM
+#   isn't available (locked-down WMI, container, etc.).
+function Get-WindowsArch {
+    try {
+        $proc = Get-CimInstance -ClassName Win32_Processor -ErrorAction Stop |
+            Select-Object -First 1
+        switch ([int]$proc.Architecture) {
+            12 { return "arm64" }
+            9  { return "x64" }
+            0  { return "x86" }
+            5  { return "arm" }
+        }
+    } catch {
+        # CIM unavailable -- fall through to env-var path
+    }
+
+    $envArch = if ($env:PROCESSOR_ARCHITEW6432) {
+        $env:PROCESSOR_ARCHITEW6432
+    } else {
+        $env:PROCESSOR_ARCHITECTURE
+    }
+    switch ($envArch) {
+        "ARM64" { return "arm64" }
+        "AMD64" { return "x64" }
+        "x86"   { return "x86" }
+        default {
+            # Last-resort: respect 64-bitness so we don't ship a 32-bit
+            # toolchain to anyone.
+            if ([Environment]::Is64BitOperatingSystem) { return "x64" } else { return "x86" }
+        }
+    }
+}
+
+# ============================================================================
+
+function Write-Banner {
+    Write-Host ""
+    Write-Host "+---------------------------------------------------------+" -ForegroundColor Magenta
+    Write-Host "|             * Hermes Agent Installer                    |" -ForegroundColor Magenta
+    Write-Host "+---------------------------------------------------------+" -ForegroundColor Magenta
+    Write-Host "|  An open source AI agent by Nous Research.              |" -ForegroundColor Magenta
+    Write-Host "+---------------------------------------------------------+" -ForegroundColor Magenta
+    Write-Host ""
+}
+
+function Write-Info {
+    param([string]$Message)
+    Write-Host "-> $Message" -ForegroundColor Cyan
+}
+
+function Write-Success {
+    param([string]$Message)
+    Write-Host "[OK] $Message" -ForegroundColor Green
+}
+
+function Write-Warn {
+    param([string]$Message)
+    Write-Host "[!] $Message" -ForegroundColor Yellow
+}
+
+function Write-Err {
+    param([string]$Message)
+    Write-Host "[X] $Message" -ForegroundColor Red
+}
+
+function Invoke-NativeWithRelaxedErrorAction {
+    param([scriptblock]$Script)
+
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        & $Script
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+}
+function Discard-LockfileChurn {
+    param([string]$Repo = $InstallDir)
+
+    if (-not $Repo -or -not (Test-Path (Join-Path $Repo ".git"))) { return }
+
+    try {
+        $diff = & git -c windows.appendAtomically=false -C $Repo diff --name-only 2>$null
+        if ($LASTEXITCODE -ne 0 -or -not $diff) { return }
+
+        $dirtyPackageDirs = [System.Collections.Generic.HashSet[string]]::new(
+            [System.StringComparer]::OrdinalIgnoreCase
+        )
+        foreach ($path in $diff) {
+            if ($path -like "*package.json") {
+                $null = $dirtyPackageDirs.Add((Split-Path $path -Parent))
+            }
+        }
+
+        $dirtyLocks = [System.Collections.Generic.List[string]]::new()
+        foreach ($path in $diff) {
+            if ($path -notlike "*package-lock.json") { continue }
+            $lockDir = Split-Path $path -Parent
+            if ($dirtyPackageDirs.Contains($lockDir)) { continue }
+            $dirtyLocks.Add($path)
+        }
+
+        if ($dirtyLocks.Count -eq 0) { return }
+        & git -c windows.appendAtomically=false -C $Repo checkout -- @($dirtyLocks) 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Info "Discarded npm lockfile churn ($($dirtyLocks.Count) file(s))"
+        }
+    } catch {
+        # Best-effort only; never let cleanup block the installer update path.
+    }
+}
+# Inspect npm output for a TLS-trust failure and, if found, print actionable
+# remediation. npm/Node surface corporate MITM proxies and missing root CAs as
+# "unable to get local issuer certificate" / "self-signed certificate in
+# certificate chain" / UNABLE_TO_GET_ISSUER_CERT_LOCALLY -- most commonly while
+# Electron's install.js postinstall downloads the Electron binary. The reporter
+# usually misreads this as an admin-rights or generic install failure (see
+# issue #38016), so detect it once here and route every npm stage through this
+# hint. Returns $true when a cert error was detected (caller may adjust its own
+# messaging), $false otherwise.
+function Show-NpmCertHint {
+    param([string]$NpmOutput)
+    if (-not $NpmOutput) { return $false }
+    $isCertError = $NpmOutput -match "unable to get local issuer certificate" `
+        -or $NpmOutput -match "self.signed certificate" `
+        -or $NpmOutput -match "UNABLE_TO_GET_ISSUER_CERT_LOCALLY" `
+        -or $NpmOutput -match "SELF_SIGNED_CERT_IN_CHAIN" `
+        -or $NpmOutput -match "CERT_HAS_EXPIRED"
+    if (-not $isCertError) { return $false }
+    Write-Warn "This looks like a TLS certificate-trust failure, not a permissions problem."
+    Write-Info "  A corporate proxy or antivirus is likely intercepting HTTPS and presenting a"
+    Write-Info "  certificate Node.js doesn't trust. To fix, point Node at your org's root CA:"
+    Write-Info "    1. Get the corporate root CA as a .pem/.crt from your IT team."
+    Write-Info "    2. setx NODE_EXTRA_CA_CERTS `"C:\path\to\corp-ca.pem`""
+    Write-Info "    3. Open a NEW terminal (so the env var takes effect) and re-run the installer."
+    Write-Info "  Quick (less secure) alternative -- disable TLS verification just for the install:"
+    Write-Info "    npm config set strict-ssl false   (re-enable afterwards: npm config set strict-ssl true)"
+    return $true
+}
+
+function Write-NpmDebugLogTail {
+    # On failure npm prints only a terse summary to stdout/stderr; the real
+    # evidence (postinstall script stderr like Electron's install.js, network
+    # traces, EBUSY retries) lives in npm's own debug log under
+    # <npm-cache>\_logs\<timestamp>-debug-0.log. The bootstrap installer's
+    # streaming sink only captures what WE emit, so on any npm failure this
+    # helper locates that debug log and replays its tail into our output
+    # stream -- making the bootstrap log a self-contained diagnosis instead
+    # of "exit 1, details in a file on a VM nobody can reach".
+    param(
+        [string]$NpmOutput,
+        [int]$TailLines = 200
+    )
+    $logPath = $null
+    # Preferred: npm names the exact file in its failure summary.
+    if ($NpmOutput -and $NpmOutput -match "A complete log of this run can be found in:\s*(?<path>[^\r\n]+)") {
+        $candidate = $Matches['path'].Trim()
+        if (Test-Path -LiteralPath $candidate) { $logPath = $candidate }
+    }
+    # Fallback (covers --silent runs, truncated output): newest debug log in
+    # npm's cache _logs directory.
+    if (-not $logPath) {
+        try {
+            $npm = Resolve-NpmCmd
+            if ($npm) {
+                $prevEAPLocal = $ErrorActionPreference
+                $ErrorActionPreference = "Continue"
+                $cacheDir = (& $npm config get cache 2>$null | Select-Object -Last 1)
+                $ErrorActionPreference = $prevEAPLocal
+                if ($cacheDir) {
+                    $logsDir = Join-Path ("$cacheDir").Trim() "_logs"
+                    if (Test-Path -LiteralPath $logsDir) {
+                        $newest = Get-ChildItem -LiteralPath $logsDir -Filter "*-debug-*.log" -ErrorAction SilentlyContinue |
+                            Sort-Object LastWriteTime -Descending | Select-Object -First 1
+                        if ($newest) { $logPath = $newest.FullName }
+                    }
+                }
+            }
+        } catch { }
+    }
+    if (-not $logPath) {
+        Write-Warn "npm debug log could not be located -- no further npm detail available"
+        return
+    }
+    $tail = $null
+    try {
+        $tail = Get-Content -LiteralPath $logPath -Tail $TailLines -ErrorAction Stop
+    } catch {
+        Write-Warn "Could not read npm debug log ${logPath}: $($_.Exception.Message)"
+        return
+    }
+    Write-Warn "---- npm debug log: last $TailLines lines of $logPath ----"
+    foreach ($line in $tail) { Write-Host "    $line" -ForegroundColor DarkGray }
+    Write-Warn "---- end npm debug log ----"
+}
+
+# --- Ensure-mode helpers ---
+
+function Resolve-NpmCmd {
+    $npmCmd = Get-Command npm -ErrorAction SilentlyContinue
+    if (-not $npmCmd) { return $null }
+    $npmExe = $npmCmd.Source
+    if ($npmExe -like "*.ps1") {
+        $npmCmdSibling = Join-Path (Split-Path $npmExe -Parent) "npm.cmd"
+        if (Test-Path $npmCmdSibling) { return $npmCmdSibling }
+    }
+    return $npmExe
+}
+
+function Find-SystemBrowser {
+    # Honor ONLY an explicit, user-set AGENT_BROWSER_EXECUTABLE_PATH override.
+    #
+    # We no longer scan well-known install locations for a system browser.
+    # Auto-detection silently bound the install to an arbitrary binary instead
+    # of the bundled Playwright Chromium, which made the browser tool behave
+    # differently across hosts (and, on Linux, picked up a sandboxed Snap
+    # Chromium that hangs every browser_navigate). Every install now uses the
+    # bundled Chromium unless the user explicitly points elsewhere.
+    $override = $env:AGENT_BROWSER_EXECUTABLE_PATH
+    if ([string]::IsNullOrWhiteSpace($override)) { return $null }
+    if (Test-Path $override) { return $override }
+    return $null
+}
+
+function Write-BrowserEnv {
+    param([string]$BrowserPath)
+    if (-not (Test-Path $HermesHome)) {
+        New-Item -ItemType Directory -Force -Path $HermesHome | Out-Null
+    }
+    $envFile = Join-Path $HermesHome ".env"
+    if (-not (Test-Path $envFile)) {
+        Set-Content -Path $envFile -Value "AGENT_BROWSER_EXECUTABLE_PATH=$BrowserPath" -Encoding UTF8
+        return
+    }
+    $content = Get-Content $envFile -Raw -ErrorAction SilentlyContinue
+    if ($content -and $content -match "AGENT_BROWSER_EXECUTABLE_PATH=") { return }
+    Add-Content -Path $envFile -Value "AGENT_BROWSER_EXECUTABLE_PATH=$BrowserPath" -Encoding UTF8
+}
+
+function Install-AgentBrowser {
+    $npm = Resolve-NpmCmd
+    if (-not $npm) {
+        Write-Err "npm not found -- install Node.js first"
+        throw "npm not found"
+    }
+
+    # agent-browser itself is intentionally NOT installed here (#43564 /
+    # PR #44772 review): it resolves lazily via `npx agent-browser` instead,
+    # which every consumer (tools/browser_tool.py, `hermes update`'s npx
+    # cache warm) already goes through. Eagerly npm-installing a second,
+    # separately version-pinned copy here -- only reachable via this
+    # explicit -Ensure browser fallback in the first place -- was redundant
+    # complexity and an extra credential/supply-chain surface for a path
+    # npx already covers.
+    Write-Info "Installing camofox browser server..."
+    $prefixDir = Join-Path $HermesHome "node"
+    if (-not (Test-Path $prefixDir)) {
+        New-Item -ItemType Directory -Path $prefixDir -Force | Out-Null
+    }
+    $npmLog = [System.IO.Path]::GetTempFileName()
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    & $npm install -g --prefix $prefixDir --silent --ignore-scripts "@askjo/camofox-browser@^1.5.2" 2>&1 | Tee-Object -FilePath $npmLog | Out-Null
+    $npmExit = $LASTEXITCODE
+    $ErrorActionPreference = $prevEAP
+    if ($npmExit -ne 0) {
+        $npmDetail = Get-Content $npmLog -Raw -ErrorAction SilentlyContinue
+        Remove-Item $npmLog -Force -ErrorAction SilentlyContinue
+        Write-Err "npm install -g failed (exit $npmExit): $npmDetail"
+        Show-NpmCertHint $npmDetail | Out-Null
+        # This install runs with --silent, so $npmDetail is often near-empty;
+        # npm's debug log is the only place the real error survives.
+        Write-NpmDebugLogTail -NpmOutput $npmDetail
+        throw "npm install failed"
+    }
+    Remove-Item $npmLog -Force -ErrorAction SilentlyContinue
+
+    $sysBrowser = Find-SystemBrowser
+    if ($sysBrowser) {
+        Write-BrowserEnv -BrowserPath $sysBrowser
+        Write-Info "Explicit browser override set -- Chromium download will be skipped when agent-browser installs on demand"
+    }
+    Write-Success "Agent-browser ready"
+}
+
+# ============================================================================
+# Dependency checks
+# ============================================================================
+
+# Resolve the PowerShell host executable used to spawn child PowerShell
+# processes (the astral uv installer below).  We must NOT hardcode the bare
+# name `powershell`: it names *Windows PowerShell* and only resolves when its
+# System32 directory is on PATH.  When install.ps1 is run under PowerShell 7+
+# (`pwsh`) -- or any session where `powershell` isn't on PATH -- a bare
+# `powershell` spawn dies with "The term 'powershell' is not recognized",
+# aborting uv installation (field report: Windows install stuck, uv install
+# failed with exactly that message).  Prefer the absolute path of the host we
+# are already running in (PATH-independent), then fall back to whichever of
+# powershell/pwsh is resolvable, and only then to the bare name.
+function Get-PowerShellHostExe {
+    try {
+        $hostExe = (Get-Process -Id $PID).Path
+        if ($hostExe -and (Test-Path $hostExe)) {
+            $leaf = Split-Path $hostExe -Leaf
+            # Only trust the current host when it is a real PowerShell CLI
+            # (not e.g. powershell_ise.exe or an embedded host that can't take
+            # `-ExecutionPolicy`/`-Command`).
+            if ($leaf -match '^(?i:powershell|pwsh)\.exe$') { return $hostExe }
+        }
+    } catch { }
+    foreach ($candidate in @("powershell", "pwsh")) {
+        $cmd = Get-Command $candidate -CommandType Application -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+        if ($cmd -and $cmd.Source) { return $cmd.Source }
+    }
+    # Last-ditch: hand back the bare name so the spawn surfaces its own error.
+    return "powershell"
+}
+
+function Install-Uv {
+    # Hermes owns its own uv at $HermesHome\bin\uv.exe.  Always install there --
+    # no PATH probing, no conda guards, no multi-location resolution chains.
+    # The runtime update path (hermes_cli/managed_uv.py) looks in the same
+    # place, so install.ps1 and `hermes update` stay in sync.
+    $managedUv = Join-Path $HermesHome "bin\uv.exe"
+
+    if (Test-Path $managedUv) {
+        $script:UvCmd = $managedUv
+        $version = & $managedUv --version
+        Write-Success "Managed uv found ($version)"
+        return $true
+    }
+
+    Write-Info "Installing managed uv into $HermesHome\bin ..."
+    New-Item -ItemType Directory -Path (Join-Path $HermesHome "bin") -Force | Out-Null
+
+    # UV_INSTALL_DIR tells the astral installer to place the binary
+    # directly into $HermesHome\bin instead of ~/.local/bin.
+    $prevEAP = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        $env:UV_INSTALL_DIR = Join-Path $HermesHome "bin"
+        # Spawn via the resolved host exe (see Get-PowerShellHostExe) rather
+        # than a bare `powershell`, which isn't guaranteed to be on PATH under
+        # PowerShell 7 / pwsh-only setups.
+        $psHostExe = Get-PowerShellHostExe
+
+        # Rungs 1 + 2: run the uv installer -- astral.sh first, then the
+        # byte-identical copy published on GitHub releases.  Corporate
+        # proxies and AV products frequently block astral.sh while
+        # github.com is reachable (issue #69216), so a second source turns
+        # a hard failure into a working install.  Capture the installer
+        # output (Tee-Object) instead of discarding it: when every source
+        # fails, the real error (download blocked, AV quarantine,
+        # permissions) must reach the user instead of only the generic
+        # "installed but not found" message.
+        $installerOutput = @()
+        $astralOut = @()
+        & $psHostExe -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex" 2>&1 | Tee-Object -Variable astralOut | Out-Null
+        $installerOutput += "--- uv installer source: astral.sh ---"
+        $installerOutput += @($astralOut | ForEach-Object { "$_" })
+        if (Test-Path $managedUv) {
+            Write-Info "uv installer succeeded via astral.sh"
+        } else {
+            Write-Info "astral.sh uv installer did not produce $managedUv; trying GitHub releases mirror ..."
+            $ghOut = @()
+            & $psHostExe -ExecutionPolicy ByPass -c "irm https://github.com/astral-sh/uv/releases/latest/download/uv-installer.ps1 | iex" 2>&1 | Tee-Object -Variable ghOut | Out-Null
+            $installerOutput += "--- uv installer source: GitHub releases ---"
+            $installerOutput += @($ghOut | ForEach-Object { "$_" })
+            if (Test-Path $managedUv) {
+                Write-Info "uv installer succeeded via GitHub releases"
+            }
+        }
+
+        # Rung 3: salvage an existing uv.exe.  When the installer cannot run
+        # at all (network fully blocked) but a working uv already exists --
+        # on PATH, or at ~/.local/bin (the astral default location when
+        # UV_INSTALL_DIR was ignored by an older installer) -- copy it into
+        # the managed location so the managed-first invariant holds
+        # (hermes_cli/managed_uv.py looks only at $HermesHome\bin\uv.exe).
+        if (-not (Test-Path $managedUv)) {
+            $existingUv = $null
+            $uvOnPath = Get-Command uv -CommandType Application -ErrorAction SilentlyContinue |
+                Select-Object -First 1
+            if ($uvOnPath -and $uvOnPath.Source -and (Test-Path $uvOnPath.Source)) {
+                $existingUv = $uvOnPath.Source
+            }
+            if (-not $existingUv) {
+                $defaultUv = Join-Path $env:USERPROFILE ".local\bin\uv.exe"
+                if (Test-Path $defaultUv) { $existingUv = $defaultUv }
+            }
+            if ($existingUv) {
+                Write-Info "Salvaging existing uv from $existingUv"
+                try {
+                    Copy-Item $existingUv $managedUv -Force
+                    # Verify the salvaged binary actually runs before
+                    # trusting it as the managed uv.
+                    $null = & $managedUv --version
+                } catch {
+                    Write-Info "Existing uv at $existingUv could not be salvaged: $_"
+                    Remove-Item $managedUv -Force -ErrorAction SilentlyContinue
+                }
+            }
+        }
+
+        $ErrorActionPreference = $prevEAP
+
+        if (Test-Path $managedUv) {
+            $script:UvCmd = $managedUv
+            $version = & $managedUv --version
+            Write-Success "Managed uv installed ($version)"
+            return $true
+        }
+
+        Write-Err "uv installed but not found at $managedUv"
+        if ($installerOutput.Count -gt 0) {
+            Write-Info "uv installer output (last 15 lines):"
+            $installerOutput | Select-Object -Last 15 | ForEach-Object { Write-Info "  $_" }
+        }
+        Write-Info "Install manually: https://docs.astral.sh/uv/getting-started/installation/"
+        return $false
+    } catch {
+        if ($prevEAP) { $ErrorActionPreference = $prevEAP }
+        Write-Err "Failed to install uv: $_"
+        Write-Info "Install manually: https://docs.astral.sh/uv/getting-started/installation/"
+        return $false
+    }
+}
+
+# Refresh $env:Path from the User + Machine registry hives.  Stage drivers
+# invoke each stage in a fresh powershell process, but those processes
+# inherit env from the parent driver shell, NOT from the registry.  When
+# an earlier stage (Stage-Git, Stage-Node, ...) installs a binary and
+# pushes its directory into User PATH, the next child process's $env:Path
+# is stale and the binary appears missing.  This helper re-reads PATH
+# from the registry so every Invoke-Stage starts from a fresh, up-to-date
+# PATH view.  Cheap (registry reads, no I/O elsewhere) and idempotent.
+function Sync-EnvPath {
+    $env:Path = [Environment]::GetEnvironmentVariable("Path", "User") + ";" + [Environment]::GetEnvironmentVariable("Path", "Machine")
+}
+
+# npm lifecycle scripts on Windows spawn ``cmd.exe /d /s /c node <script>``.
+# PowerShell can resolve ``node`` via Get-Command while the child cmd process
+# still sees a PATH without node.exe's directory (nvm4w shims, App Paths
+# aliases, stale cross-process PATH).  Prepend the resolved node.exe parent
+# directory so postinstall hooks (electron-winstaller, native modules, etc.)
+# can find ``node``.  Regression for #48130.
+function Ensure-NodeExeOnPath {
+    $nodeCmd = Get-Command node -ErrorAction SilentlyContinue
+    if (-not $nodeCmd) { return $false }
+
+    $nodeExeDir = Split-Path $nodeCmd.Source -Parent
+    if (-not $nodeExeDir) { return $false }
+
+    $pathParts = $env:Path -split ";"
+    if ($pathParts -notcontains $nodeExeDir) {
+        $env:Path = "$nodeExeDir;$env:Path"
+    }
+    return $true
+}
+
+# Put the Hermes-managed Node dir at the FRONT of the persisted User PATH.
+#
+# Appending is not enough: it leaves a pre-existing system Node ahead of the
+# bundled one in every new shell, so anything launched without a curated
+# environment (a standalone hermes-setup.exe run, a user typing `npm`) silently
+# resolves the wrong Node.  Bundled must win.
+#
+# Move-to-front rather than add-if-missing, because installs made by an older
+# install.ps1 already have this dir in User PATH -- at the tail.  An
+# add-if-missing check sees it present and leaves the broken ordering in place
+# forever, so the very users the ordering bug hurt would never be repaired.
+#
+# Unrelated entries keep their relative order, including empty segments (a
+# trailing ';' is legal and common in a real User PATH; Install-Git's splitting
+# preserves them too, so this must not quietly rewrite them).  Duplicate
+# occurrences of the managed dir collapse into the single leading entry.
+# PowerShell's -ne is case-insensitive for strings, which is the right
+# comparison on Windows.  Persists only when the resulting string differs, so
+# an already-correct PATH costs one registry read and no write.
+function Set-ManagedNodeFirstOnUserPath {
+    param([string]$NodeDir)
+
+    if (-not $NodeDir) { return }
+
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    $items = if ($userPath) { @($userPath -split ";") } else { @() }
+
+    $rest = @($items | Where-Object { $_ -ne $NodeDir })
+    $updated = (@($NodeDir) + $rest) -join ";"
+
+    if ($updated -ne $userPath) {
+        [Environment]::SetEnvironmentVariable("Path", $updated, "User")
+    }
+}
+
+# The npm range to install into the managed Node tree.  Prefers the checkout's
+# root package.json so the installer and the manifest cannot drift; falls back
+# to the $NpmRange constant, which is the common case here because Test-Node
+# runs before the repo is cloned.
+function Get-NpmRange {
+    $manifest = Join-Path $InstallDir "package.json"
+    if (Test-Path $manifest) {
+        try {
+            $engines = (Get-Content $manifest -Raw | ConvertFrom-Json).engines
+            if ($engines -and $engines.npm) { return [string]$engines.npm }
+        } catch { }
+    }
+    return $NpmRange
+}
+
+# Convert the numeric core of an npm version or range operand into a stable
+# three-component System.Version. npm reports semantic versions, but the
+# installer only needs the numeric core for the comparator ranges authored in
+# package.json (for example, <11.10.0 || >=11.17.0).
+function ConvertTo-NpmVersion {
+    param([string]$Version)
+
+    if (-not $Version) { return $null }
+
+    $core = ($Version.Trim() -replace '^v', '' -replace '-.*$', '')
+    $parts = @($core -split '\.')
+    if ($parts.Count -lt 1 -or $parts.Count -gt 3) { return $null }
+    foreach ($part in $parts) {
+        if ($part -notmatch '^\d+$') { return $null }
+    }
+    while ($parts.Count -lt 3) { $parts += '0' }
+
+    try {
+        return [version]($parts -join '.')
+    } catch {
+        return $null
+    }
+}
+
+# Evaluate the comparator-only npm ranges used by the root manifest and the
+# pre-clone fallback. Alternatives are separated with || and each alternative
+# may contain one or more whitespace-separated <, <=, >, or >= comparators.
+# Unknown range syntax fails closed so an incompatible system npm cannot reach
+# npm ci and fail later with EBADENGINE.
+function Test-NpmVersionOk {
+    param(
+        [string]$Version,
+        [string]$Range = (Get-NpmRange)
+    )
+
+    $actual = ConvertTo-NpmVersion $Version
+    if (-not $actual -or -not $Range) { return $false }
+
+    foreach ($alternative in @($Range -split '\s*\|\|\s*')) {
+        $clause = $alternative.Trim()
+        if (-not $clause) { continue }
+
+        $comparators = [regex]::Matches(
+            $clause,
+            '(?:^|\s)(<=|>=|<|>)\s*(\d+(?:\.\d+){0,2})(?=\s|$)'
+        )
+        if ($comparators.Count -eq 0) { continue }
+
+        $remainder = [regex]::Replace(
+            $clause,
+            '(?:^|\s)(?:<=|>=|<|>)\s*\d+(?:\.\d+){0,2}(?=\s|$)',
+            ''
+        ).Trim()
+        if ($remainder) { continue }
+
+        $matchesClause = $true
+        foreach ($comparator in $comparators) {
+            $target = ConvertTo-NpmVersion $comparator.Groups[2].Value
+            if (-not $target) {
+                $matchesClause = $false
+                break
+            }
+
+            $matchesComparator = switch ($comparator.Groups[1].Value) {
+                '<'  { $actual -lt $target }
+                '<=' { $actual -le $target }
+                '>'  { $actual -gt $target }
+                '>=' { $actual -ge $target }
+                default { $false }
+            }
+            if (-not $matchesComparator) {
+                $matchesClause = $false
+                break
+            }
+        }
+
+        if ($matchesClause) { return $true }
+    }
+
+    return $false
+}
+
+# Upgrade the Hermes-managed Node tree's bundled npm into $NpmRange when
+# needed. Managed Node trees survive updates, so their bundled npm can drift
+# outside a newer root package.json engine range. The repo .npmrc sets
+# `engine-strict=true`, making that mismatch fatal at the first `npm ci`.
+# Provision the right npm here instead of reacting to EBADENGINE later.
+#
+# Three details are load-bearing, mirroring _nb_ensure_bundled_npm_range in
+# scripts/lib/node-bootstrap.sh and upgrade_managed_npm in
+# hermes_cli/npm_engine.py:
+#   - a temp cwd, so the checkout's own .npmrc (engine-strict,
+#     min-release-age) does not gate the very upgrade meant to satisfy it;
+#   - npm_config_min_release_age=0, which also neutralises a user ~/.npmrc;
+#   - an explicit --prefix at the managed tree, so the upgrade rewrites the
+#     tree's own npm rather than installing a second copy elsewhere.
+#
+# Best-effort: a failure leaves a working Node with an old npm, which beats no
+# Node at all, and npm_engine.py still covers the EBADENGINE that follows.
+function Update-ManagedNpm {
+    param([string]$NodeDir)
+
+    $npmCmd = Join-Path $NodeDir "npm.cmd"
+    if (-not (Test-Path $npmCmd)) { return $false }
+
+    $range = Get-NpmRange
+
+    # Skip the network round-trip when the bundled npm already satisfies the
+    # same range used by the system-Node acceptance gate.
+    try {
+        $have = (& $npmCmd --version 2>$null | Select-Object -First 1)
+        if ($have -and (Test-NpmVersionOk $have $range)) { return $true }
+    } catch { }
+
+    # In-app updates run while the desktop app's Node processes are alive.
+    # The managed npm lives inside the very tree they execute from, so an
+    # in-place upgrade would hit WinError 5 (Access denied) on npm.cmd
+    # (#80926).  Defer; the next update with the app closed retries.
+    if (Test-ManagedNodeInUse $NodeDir) {
+        Write-Warn "Hermes-managed Node.js is in use by a running app; skipping the bundled npm upgrade (applies on a later update with the app closed)."
+        return $false
+    }
+
+    Write-Info "Upgrading bundled npm to satisfy $range ..."
+
+    $tmpCwd = Join-Path $env:TEMP ("hermes-npm-upgrade-" + [Guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Force -Path $tmpCwd | Out-Null
+    $prevAge = $env:npm_config_min_release_age
+    $prevCI = $env:CI
+    $prevEAP = $ErrorActionPreference
+    Push-Location $tmpCwd
+    try {
+        $env:npm_config_min_release_age = "0"
+        $env:CI = "1"
+        # Relax EAP=Stop so npm's stderr lines don't get wrapped as
+        # ErrorRecords and short-circuit before $LASTEXITCODE is checked.
+        # Same pattern as Install-Uv.
+        $ErrorActionPreference = "Continue"
+        & $npmCmd install --global --prefix $NodeDir "npm@$range" `
+            --no-fund --no-audit --progress=false 2>&1 | Out-Null
+        $exit = $LASTEXITCODE
+    } catch {
+        $exit = 1
+    } finally {
+        $ErrorActionPreference = $prevEAP
+        Pop-Location
+        $env:npm_config_min_release_age = $prevAge
+        $env:CI = $prevCI
+        Remove-Item -Recurse -Force $tmpCwd -ErrorAction SilentlyContinue
+    }
+
+    if ($exit -ne 0) {
+        Write-Warn "Could not upgrade bundled npm to $range -- ``npm ci`` may fail with EBADENGINE."
+        Write-Info  "Fix manually: npm install -g --prefix `"$NodeDir`" npm@`"$range`""
+        return $false
+    }
+
+    Write-Success "npm $(& $npmCmd --version 2>$null) installed"
+    return $true
+}
+
+function Test-ManagedNodeInUse {
+    param([string]$NodeDir)
+    # Windows locks files that running processes execute from.  During an
+    # in-app update the desktop app's Node processes may hold the managed
+    # tree open, and rewriting it then fails with WinError 5 (Access denied)
+    # on npm.cmd (#80926).  Cheap pre-check used to skip destructive steps;
+    # the rename/move itself remains the authoritative guard.
+    #
+    # Check the executable path AND the command line: a cmd.exe wrapper
+    # running npm.cmd from the tree reports its own exe (cmd.exe lives in
+    # System32) while the tree path appears only in the command line.
+    # Win32_Process.CommandLine is available on Windows PowerShell 5.1 and
+    # 7+ (the Get-Process .CommandLine ETS property is 7.4+ only), and a
+    # single CIM query beats a per-process property access loop.
+    return @(
+        Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
+            Where-Object {
+                ($_.ExecutablePath -like "$NodeDir\*") -or
+                ($_.CommandLine -like "*$NodeDir*")
+            }
+    ).Count -gt 0
+}
+
+# Re-discover uv without re-installing it.  Cross-process stage drivers
+# (the desktop GUI's onboarding wizard, CI step-runners) invoke each stage
+# in a fresh powershell process, so $script:UvCmd set by Install-Uv in a
+# prior process is not visible here.  Later stages (Test-Python,
+# Install-Venv, Install-Dependencies, Install-PlatformSdks) call this
+# at the top to populate $script:UvCmd from the managed location.
+# Throws if uv is not findable -- the caller's stage then surfaces a
+# clean error via the stage-driver's try/catch.
+function Resolve-UvCmd {
+    # Already resolved (default invocation path: Install-Uv ran earlier
+    # in the same process and set $script:UvCmd).
+    if ($script:UvCmd) {
+        if ($script:UvCmd -eq "uv") {
+            # "uv" on PATH -- verify it's still resolvable (PATH could have
+            # changed mid-session; cheap to recheck).
+            if (Get-Command uv -ErrorAction SilentlyContinue) { return }
+        } elseif (Test-Path $script:UvCmd) {
+            return
+        }
+        # Stale; fall through to re-discover.
+    }
+
+    # Check the managed location first -- this is where Install-Uv puts it.
+    $managedUv = Join-Path $HermesHome "bin\uv.exe"
+    if (Test-Path $managedUv) {
+        $script:UvCmd = $managedUv
+        return
+    }
+
+    # Fall back to PATH (covers edge cases where the installer ran in a
+    # sibling process and HERMES_HOME wasn't propagated).
+    if (Get-Command uv -ErrorAction SilentlyContinue) {
+        $script:UvCmd = "uv"
+        return
+    }
+
+    # Refresh PATH from registry in case the current process started before
+    # Install-Uv updated User PATH.
+    $env:Path = [Environment]::GetEnvironmentVariable("Path", "User") + ";" + [Environment]::GetEnvironmentVariable("Path", "Machine")
+    if (Get-Command uv -ErrorAction SilentlyContinue) {
+        $script:UvCmd = "uv"
+        return
+    }
+
+    throw "uv is not installed. Run install.ps1 -Stage uv first."
+}
+
+function Initialize-ManagedPythonEnvironment {
+    # Python used by Hermes belongs to the checkout, never to another
+    # application or a user-level uv configuration. Keep this aligned with
+    # hermes_cli.managed_uv.managed_python_env(), which owns the update path.
+    foreach ($name in @(
+        "CONDA_DEFAULT_ENV", "CONDA_PREFIX", "UV_PROJECT_ENVIRONMENT",
+        "UV_NO_MANAGED_PYTHON", "UV_PYTHON", "UV_PYTHON_DOWNLOADS",
+        "UV_SYSTEM_PYTHON", "VIRTUAL_ENV", "PYTHONHOME", "PYTHONPATH"
+    )) {
+        Remove-Item -Path "Env:$name" -ErrorAction SilentlyContinue
+    }
+
+    $managedRoot = Join-Path $InstallDir ".hermes-runtime\python"
+    New-Item -ItemType Directory -Force -Path $managedRoot | Out-Null
+    $env:UV_MANAGED_PYTHON = "1"
+    $env:UV_NO_CONFIG = "1"
+    $env:UV_PYTHON_INSTALL_BIN = "0"
+    $env:UV_PYTHON_INSTALL_DIR = $managedRoot
+    $env:UV_PYTHON_INSTALL_REGISTRY = "0"
+    return [System.IO.Path]::GetFullPath($managedRoot)
+}
+
+function Resolve-AvailablePythonVersion {
+    # Return the path and minor version of the first Hermes-managed interpreter
+    # uv can find, preferring the requested version and then fallback minors.
+    # System and application-owned interpreters are deliberately ineligible.
+    #
+    # Under Hermes-Setup.exe each stage runs in a fresh powershell.exe. The
+    # venv stage therefore re-resolves both version and provenance rather than
+    # relying on state selected by the earlier Python stage (#50769).
+    [string]$managedRoot = Initialize-ManagedPythonEnvironment
+    $managedPrefix = $managedRoot.TrimEnd('\') + '\'
+    $candidates = @($PythonVersion) + $PythonFallbackVersions
+    $seen = @{}
+    foreach ($ver in $candidates) {
+        if (-not $ver -or $seen.ContainsKey($ver)) { continue }
+        $seen[$ver] = $true
+        $process = $null
+        try {
+            # PowerShell 5.1 can lose a nested native command's stdout when
+            # this installer itself is redirected by the desktop bootstrapper.
+            # Capture uv directly through ProcessStartInfo instead of relying
+            # on the native-command pipeline for the interpreter path.
+            $process = New-Object System.Diagnostics.Process
+            $startInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $startInfo.FileName = $UvCmd
+            $startInfo.Arguments = "python find $ver --managed-python --no-config"
+            $startInfo.UseShellExecute = $false
+            $startInfo.CreateNoWindow = $true
+            $startInfo.RedirectStandardOutput = $true
+            $startInfo.RedirectStandardError = $true
+            $process.StartInfo = $startInfo
+            if (-not $process.Start()) { continue }
+            $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+            $stderrTask = $process.StandardError.ReadToEndAsync()
+            if (-not $process.WaitForExit($PythonFindTimeoutMs)) {
+                try { $process.Kill() } catch { }
+                $process.WaitForExit()
+                throw "uv python find $ver timed out after $PythonFindTimeoutMs ms"
+            }
+            $stdout = $stdoutTask.Result
+            $stderrTask.Result | Out-Null
+            if ($process.ExitCode -ne 0) { continue }
+            [string]$foundPath = ($stdout.Trim() -split "`r?`n") | Select-Object -Last 1
+            if ($foundPath) {
+                $absolute = [System.IO.Path]::GetFullPath($foundPath)
+                if ($absolute.StartsWith($managedPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+                    return [PSCustomObject]@{
+                        Path = $absolute
+                        Version = $ver
+                    }
+                }
+            }
+        } catch {
+            throw "Failed to resolve Hermes-managed Python $ver`: $_"
+        } finally {
+            if ($process) { $process.Dispose() }
+        }
+    }
+    return $null
+}
+
+function Test-Python {
+    Initialize-ManagedPythonEnvironment | Out-Null
+    Write-Info "Checking Python $PythonVersion..."
+
+    # Only a checkout-private uv-managed interpreter satisfies this stage.
+    try {
+        $resolvedPython = Resolve-AvailablePythonVersion
+        if ($resolvedPython) {
+            $ver = & $resolvedPython.Path --version 2>$null
+            Write-Success "Python found: $ver"
+            return $true
+        }
+    } catch { }
+    
+    # Python not found -- use uv to install it (no admin needed!)
+    Write-Info "Python $PythonVersion not found, installing via uv..."
+    # Capture EAP outside the try block so the catch's restore call always
+    # has a meaningful value (see Install-Uv for the full rationale).
+    $prevEAP = $ErrorActionPreference
+    try {
+        # Temporarily relax ErrorActionPreference: uv writes download progress
+        # ("Downloading cpython-3.11.15-windows-x86_64-none (24.5MiB)") to
+        # stderr.  With $ErrorActionPreference = "Stop" (set at the top of this
+        # script) PowerShell wraps stderr lines from native commands as
+        # ErrorRecord objects when captured via 2>&1, then throws a terminating
+        # exception on the first one -- even though uv exits 0 and Python was
+        # installed successfully.  Verify success via `uv python find`
+        # afterwards, which is the reliable signal regardless of exit-code
+        # semantics or stderr noise.  This fix was previously landed as
+        # commit ec1714e71 and then lost in a release squash; reapplied here.
+        $ErrorActionPreference = "Continue"
+        $uvOutput = & $UvCmd python install $PythonVersion --no-bin --no-registry --no-config 2>&1
+        $uvExitCode = $LASTEXITCODE
+        $ErrorActionPreference = $prevEAP
+
+        # Check if Python is now available (more reliable than exit code
+        # since uv may return non-zero due to "already installed" etc.)
+        $resolvedPython = Resolve-AvailablePythonVersion
+        if ($resolvedPython) {
+            $ver = & $resolvedPython.Path --version 2>$null
+            Write-Success "Python installed: $ver"
+            return $true
+        }
+
+        # uv ran but Python still not findable -- show what happened
+        if ($uvExitCode -ne 0) {
+            Write-Warn "uv python install output:"
+            Write-Host $uvOutput -ForegroundColor DarkGray
+        }
+    } catch {
+        # Restore EAP in case the try block threw before the assignment
+        if ($prevEAP) { $ErrorActionPreference = $prevEAP }
+        Write-Warn "uv python install error: $_"
+    }
+
+    # Preserve the established minor-version fallback contract, but provision
+    # every fallback into the same private store instead of borrowing a system
+    # interpreter. This path is reached only when the preferred install failed.
+    foreach ($fallbackVer in $PythonFallbackVersions) {
+        try {
+            Write-Info "Trying managed Python fallback $fallbackVer..."
+            $previousFallbackEAP = $ErrorActionPreference
+            $ErrorActionPreference = "Continue"
+            & $UvCmd python install $fallbackVer --no-bin --no-registry --no-config 2>&1 | Out-Null
+            $ErrorActionPreference = $previousFallbackEAP
+            $resolvedPython = Resolve-AvailablePythonVersion
+            if ($resolvedPython) {
+                $ver = & $resolvedPython.Path --version 2>$null
+                Write-Success "Python fallback installed: $ver"
+                return $true
+            }
+        } catch {
+            if ($previousFallbackEAP) { $ErrorActionPreference = $previousFallbackEAP }
+        }
+    }
+
+    Write-Err "Failed to install Python $PythonVersion"
+    Write-Info "Check network access to uv's managed Python downloads, then retry."
+    return $false
+}
+
+$script:GitInstallFailureReason = $null
+$script:GitBashPath = $null
+$script:GitBashProbeOutput = $null
+
+function Test-GitBashCompatibility {
+    <#
+    .SYNOPSIS
+    Verify that Git Bash can launch external MSYS programs, not just evaluate
+    shell builtins. Mandatory ASLR can allow bash.exe itself to start while
+    every child linked to msys-2.0.dll fails during fork/spawn.
+    #>
+    param([Parameter(Mandatory = $true)][string]$BashPath)
+
+    $script:GitBashProbeOutput = $null
+    if (-not (Test-Path -LiteralPath $BashPath)) {
+        $script:GitBashProbeOutput = "bash.exe was not found at $BashPath"
+        return $false
+    }
+
+    $process = New-Object System.Diagnostics.Process
+    try {
+        $startInfo = New-Object System.Diagnostics.ProcessStartInfo
+        $startInfo.FileName = $BashPath
+        $startInfo.Arguments = '--noprofile --norc -c "/usr/bin/true; /usr/bin/cat --version >/dev/null"'
+        $startInfo.UseShellExecute = $false
+        $startInfo.CreateNoWindow = $true
+        $startInfo.RedirectStandardOutput = $true
+        $startInfo.RedirectStandardError = $true
+        $process.StartInfo = $startInfo
+
+        if (-not $process.Start()) {
+            $script:GitBashProbeOutput = "bash.exe did not start"
+            return $false
+        }
+        if (-not $process.WaitForExit(15000)) {
+            try { $process.Kill() } catch { }
+            $script:GitBashProbeOutput = "Git Bash compatibility probe timed out"
+            return $false
+        }
+
+        $stdout = $process.StandardOutput.ReadToEnd()
+        $stderr = $process.StandardError.ReadToEnd()
+        $script:GitBashProbeOutput = ("$stdout`n$stderr").Trim()
+        return ($process.ExitCode -eq 0)
+    } catch {
+        $script:GitBashProbeOutput = $_.Exception.Message
+        return $false
+    } finally {
+        $process.Dispose()
+    }
+}
+
+function Test-MandatoryAslrEnabled {
+    <# Return true only when Windows reports system-wide ForceRelocateImages=ON. #>
+    try {
+        $cmd = Get-Command Get-ProcessMitigation -ErrorAction SilentlyContinue
+        if (-not $cmd) { return $false }
+        $mitigations = & $cmd -System
+        $value = $mitigations.Aslr.ForceRelocateImages
+        return ($null -ne $value -and $value.ToString().ToUpperInvariant() -eq "ON")
+    } catch {
+        return $false
+    }
+}
+
+function Get-GitRootFromBashPath {
+    param([Parameter(Mandatory = $true)][string]$BashPath)
+
+    $binDir = Split-Path -Path $BashPath -Parent
+    if ((Split-Path -Path $binDir -Leaf) -ine "bin") {
+        return (Split-Path -Path $binDir -Parent)
+    }
+
+    $parent = Split-Path -Path $binDir -Parent
+    if ((Split-Path -Path $parent -Leaf) -ieq "usr") {
+        return (Split-Path -Path $parent -Parent)
+    }
+    return $parent
+}
+
+function New-GitBashAslrFailureReason {
+    param([Parameter(Mandatory = $true)][string]$BashPath)
+
+    $gitRoot = Get-GitRootFromBashPath -BashPath $BashPath
+    $escapedRoot = $gitRoot -replace "'", "''"
+    return @(
+        "Git Bash at $BashPath cannot launch required MSYS child processes because Windows Mandatory ASLR (ForceRelocateImages) is enabled system-wide. Reinstalling Git will not change this policy."
+        "Open PowerShell as Administrator and run:"
+        "`$gitRoot = '$escapedRoot'"
+        'Get-Item "$gitRoot\bin\bash.exe", "$gitRoot\usr\bin\*.exe" -ErrorAction SilentlyContinue | ForEach-Object { Set-ProcessMitigation -Name $_.FullName -Disable ForceRelocateImages }'
+        "Then rerun Hermes setup. If the override is blocked or later re-applied, ask your Windows administrator to allow this per-program exception."
+    ) -join [Environment]::NewLine
+}
+
+function Install-Git {
+    <#
+    .SYNOPSIS
+    Ensure Git (and Git Bash) are installed.  Git for Windows bundles bash.exe
+    which Hermes uses to run shell commands.
+
+    Priority order (deliberately simple -- no winget, no registry, no system
+    package manager):
+      1. Existing ``git`` on PATH -- use it as-is (the common fast path).
+      2. Download **PortableGit** from the official git-for-windows GitHub
+         release (self-extracting 7z.exe) and unpack it to
+         ``%LOCALAPPDATA%\hermes\git`` -- never touches system Git, never
+         requires admin, works even on locked-down machines and machines
+         with a broken system Git install.
+
+    **Why PortableGit, not MinGit:**  MinGit is the minimal-automation
+    distribution and ships ONLY ``git.exe`` -- no bash, no POSIX utilities.
+    Hermes needs ``bash.exe`` to run shell commands.  PortableGit is the
+    full Git for Windows distribution without the installer UI; it ships
+    ``git.exe`` + ``bash.exe`` + ``sh``, ``awk``, ``sed``, ``grep``, ``curl``,
+    ``ssh``, etc. in ``usr\bin\``.
+
+    We deliberately skip winget because it fails badly when the system Git
+    install is in a half-installed state (partially registered, or uninstall-
+    blocked).  Owning the Hermes copy of Git ourselves is predictable and
+    recoverable: if it ever breaks, ``Remove-Item %LOCALAPPDATA%\hermes\git``
+    and re-running this installer fully recovers.
+
+    After install we locate ``bash.exe`` and persist the path in
+    ``HERMES_GIT_BASH_PATH`` (User scope) so Hermes can find it in a fresh
+    shell without a second PATH refresh.
+    #>
+    $script:GitInstallFailureReason = $null
+    Write-Info "Checking Git..."
+
+    if (Get-Command git -ErrorAction SilentlyContinue) {
+        $version = git --version
+        Write-Success "Git found ($version)"
+        Set-GitBashEnvVar
+        if ($script:GitBashPath -and (Test-GitBashCompatibility -BashPath $script:GitBashPath)) {
+            Write-Success "Git Bash can launch MSYS programs"
+            return $true
+        }
+
+        if ($script:GitBashPath -and (Test-MandatoryAslrEnabled)) {
+            $script:GitInstallFailureReason = New-GitBashAslrFailureReason -BashPath $script:GitBashPath
+            Write-Err $script:GitInstallFailureReason
+            return $false
+        }
+
+        if ($script:GitBashPath) {
+            $probeDetail = if ($script:GitBashProbeOutput) { ": $script:GitBashProbeOutput" } else { "" }
+            Write-Warn "System Git Bash could not launch required MSYS programs$probeDetail"
+        } else {
+            Write-Warn "Git is on PATH, but its Git Bash installation could not be located."
+        }
+        Write-Info "Trying a Hermes-managed PortableGit install instead..."
+    }
+
+    # Download PortableGit into $HermesHome\git.  Always works as long as
+    # we can reach github.com -- no admin, no winget, no reliance on the
+    # user's possibly-broken system Git install.
+    Write-Info "Git not found -- downloading PortableGit to $HermesHome\git\ ..."
+    Write-Info "(no admin rights required; isolated from any system Git install)"
+
+    try {
+        $arch = Get-WindowsArch
+        if ($arch -eq 'arm64') {
+            $assetTag = 'arm64'
+            $downloadIsZip = $false
+        } elseif ($arch -eq 'x64') {
+            $assetTag = '64-bit'
+            $downloadIsZip = $false
+        } else {
+            # PortableGit does not ship 32-bit / arm builds -- fall back to MinGit
+            # 32-bit with a warning that bash-based features will be unavailable.
+            $assetTag = '32-bit-mingit'
+            $downloadIsZip = $true
+        }
+
+        # Pinned git-for-windows release. We deliberately do NOT hit
+        # api.github.com/repos/.../releases/latest here: that endpoint
+        # is rate-limited to 60 requests/hour/IP for unauthenticated
+        # callers, and users behind CGNAT / corporate NAT / dorm WiFi
+        # routinely hit the limit, breaking the installer.
+        # Static github.com/.../releases/download/<tag>/<asset> URLs
+        # are not subject to the API rate limit.
+        $gitTag    = "v2.54.0.windows.1"
+        $gitVer    = "2.54.0"
+        $gitVerTag = "$gitVer.windows.1"
+
+        if ($arch -eq "32-bit-mingit") {
+            Write-Warn "32-bit Windows detected -- PortableGit is 64-bit only.  Installing MinGit 32-bit as a last resort; bash-dependent Hermes features (terminal tool, agent-browser) will not work on this machine."
+            $assetName    = "MinGit-$gitVer-32-bit.zip"
+            $downloadIsZip = $true
+        } elseif ($arch -eq "arm64") {
+            $assetName    = "PortableGit-$gitVer-arm64.7z.exe"
+            $downloadIsZip = $false
+        } else {
+            $assetName    = "PortableGit-$gitVer-64-bit.7z.exe"
+            $downloadIsZip = $false
+        }
+
+        $downloadUrl = "https://github.com/git-for-windows/git/releases/download/$gitTag/$assetName"
+        $downloadExt = if ($downloadIsZip) { "zip" } else { "7z.exe" }
+        $tmpFile = "$env:TEMP\$assetName"
+        $gitDir = "$HermesHome\git"
+
+        Write-Info "Downloading $assetName (Git for Windows $gitVerTag)..."
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $tmpFile -UseBasicParsing
+
+        if (Test-Path $gitDir) {
+            Write-Info "Removing previous Git install at $gitDir ..."
+            Remove-Item -Recurse -Force $gitDir
+        }
+        New-Item -ItemType Directory -Path $gitDir -Force | Out-Null
+
+        if ($downloadIsZip) {
+            Expand-Archive -Path $tmpFile -DestinationPath $gitDir -Force
+        } else {
+            # PortableGit is a self-extracting 7z archive.  Invoke it with
+            # `-o<target> -y` (silent) to extract to $gitDir.  No 7z install
+            # required; it's fully self-contained.
+            Write-Info "Extracting PortableGit to $gitDir ..."
+            $extractProc = Start-Process -FilePath $tmpFile `
+                -ArgumentList "-o`"$gitDir`"", "-y" `
+                -NoNewWindow -Wait -PassThru
+            if ($extractProc.ExitCode -ne 0) {
+                throw "PortableGit extraction failed (exit code $($extractProc.ExitCode))"
+            }
+        }
+        Remove-Item -Force $tmpFile -ErrorAction SilentlyContinue
+
+        # PortableGit layout: cmd\git.exe + bin\bash.exe + usr\bin\ (coreutils)
+        # MinGit layout:      cmd\git.exe + usr\bin\bash.exe (if present)
+        $gitExe = "$gitDir\cmd\git.exe"
+        if (-not (Test-Path $gitExe)) {
+            throw "Git extraction did not produce git.exe at $gitExe"
+        }
+
+        # Add to session PATH so the rest of this install run can use git.
+        $env:Path = "$gitDir\cmd;$env:Path"
+
+        # Persist to User PATH so fresh shells see it.  PortableGit needs
+        # cmd\ (for git.exe), bin\ (for bash.exe + core tools), and
+        # usr\bin\ (for perl, ssh, curl, and other POSIX coreutils).
+        $newPathEntries = @(
+            "$gitDir\cmd",
+            "$gitDir\bin",
+            "$gitDir\usr\bin"
+        )
+        $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+        $userPathItems = if ($userPath) { $userPath -split ";" } else { @() }
+        $changed = $false
+        foreach ($entry in $newPathEntries) {
+            if ($userPathItems -notcontains $entry) {
+                $userPathItems += $entry
+                $changed = $true
+            }
+        }
+        if ($changed) {
+            [Environment]::SetEnvironmentVariable("Path", ($userPathItems -join ";"), "User")
+        }
+
+        $version = & $gitExe --version
+        Write-Success "Git $version installed to $gitDir (portable, user-scoped)"
+        Set-GitBashEnvVar
+        if (-not $script:GitBashPath) {
+            throw "PortableGit extraction did not produce a usable bash.exe"
+        }
+        if (-not (Test-GitBashCompatibility -BashPath $script:GitBashPath)) {
+            if (Test-MandatoryAslrEnabled) {
+                $script:GitInstallFailureReason = New-GitBashAslrFailureReason -BashPath $script:GitBashPath
+            } else {
+                $probeDetail = if ($script:GitBashProbeOutput) { " Probe output: $script:GitBashProbeOutput" } else { "" }
+                $script:GitInstallFailureReason = "Git Bash at $script:GitBashPath exists but cannot launch required MSYS programs.$probeDetail"
+            }
+            throw $script:GitInstallFailureReason
+        }
+        Write-Success "Git Bash can launch MSYS programs"
+        return $true
+    } catch {
+        if ($script:GitInstallFailureReason) {
+            Write-Err $script:GitInstallFailureReason
+            return $false
+        }
+        Write-Err "Could not install portable Git: $_"
+        Write-Info ""
+        Write-Info "Fallback: install Git manually from https://git-scm.com/download/win"
+        Write-Info "then re-run this installer.  Hermes needs Git Bash on Windows to run"
+        Write-Info "shell commands (same as Claude Code and other coding agents)."
+        return $false
+    }
+}
+
+function Set-GitBashEnvVar {
+    <#
+    .SYNOPSIS
+    Locate ``bash.exe`` from an already-installed Git and persist the path in
+    ``HERMES_GIT_BASH_PATH`` (User env scope) so Hermes can find it even before
+    PATH propagation completes in a newly-spawned shell.
+    #>
+    $script:GitBashPath = $null
+    $candidates = @()
+
+    # Our own portable Git install is ALWAYS checked first, so a broken
+    # system Git doesn't hijack us.  If the user had a working system Git
+    # we'd have returned early from Install-Git's fast path and never called
+    # this with a system-Git-only installation anyway.
+    #
+    # Layouts:
+    #   PortableGit (our default): $HermesHome\git\bin\bash.exe
+    #   MinGit (32-bit fallback):  $HermesHome\git\usr\bin\bash.exe
+    $candidates += "$HermesHome\git\bin\bash.exe"       # PortableGit layout (primary)
+    $candidates += "$HermesHome\git\usr\bin\bash.exe"   # MinGit / PortableGit usr\bin fallback
+
+    # git.exe on PATH can tell us where the install root is
+    $gitCmd = Get-Command git -ErrorAction SilentlyContinue
+    if ($gitCmd) {
+        $gitExe = $gitCmd.Source
+        # Git for Windows (full installer): <root>\cmd\git.exe + <root>\bin\bash.exe
+        # MinGit:                           <root>\cmd\git.exe + <root>\usr\bin\bash.exe
+        $gitRoot = Split-Path (Split-Path $gitExe -Parent) -Parent
+        $candidates += "$gitRoot\bin\bash.exe"
+        $candidates += "$gitRoot\usr\bin\bash.exe"
+    }
+
+    # Standard system install locations as a final fallback.  Note:
+    # ProgramFiles(x86) can't be referenced via ${env:...} string interpolation
+    # because of the parens -- use [Environment]::GetEnvironmentVariable().
+    $candidates += "${env:ProgramFiles}\Git\bin\bash.exe"
+    $pf86 = [Environment]::GetEnvironmentVariable("ProgramFiles(x86)")
+    if ($pf86) { $candidates += "$pf86\Git\bin\bash.exe" }
+    $candidates += "${env:LocalAppData}\Programs\Git\bin\bash.exe"
+
+    foreach ($candidate in $candidates) {
+        if ($candidate -and (Test-Path $candidate)) {
+            [Environment]::SetEnvironmentVariable("HERMES_GIT_BASH_PATH", $candidate, "User")
+            $env:HERMES_GIT_BASH_PATH = $candidate
+            $script:GitBashPath = $candidate
+            Write-Info "Set HERMES_GIT_BASH_PATH=$candidate"
+            return
+        }
+    }
+
+    Write-Warn "Could not locate bash.exe -- Hermes may not find Git Bash."
+    Write-Info "If needed, set HERMES_GIT_BASH_PATH manually to your bash.exe path."
+}
+
+# The dependency tree supports Node 22.22+, 24.11+, and 26+. nanoid 6 excludes
+# Node 23 and 25 while its >=26 arm accepts later releases, and @babel/* 8.x
+# requires ^22.18.0 || >=24.11.0 -- so accepting 23/25 or an early Node 24
+# only defers the failure to `npm ci` under engine-strict. Keep this in sync
+# with the root package.json.
+function Test-NodeVersionOk {
+    param([string]$Version)
+    if ($Version -match '-') { return $false }
+    try {
+        $v = [version]($Version -replace '^v', '')
+    } catch {
+        return $false
+    }
+    if ($v.Major -eq 22) { return ($v.Minor -ge 22) }
+    if ($v.Major -eq 24) { return ($v.Minor -ge 11) }
+    return ($v.Major -ge 26)
+}
+
+# Accept a system Node only when its companion npm also satisfies the same
+# range used to provision the Hermes-managed tree. Keeping this probe separate
+# lets the initial PATH check and the post-winget check share one authority.
+function Test-SystemNodeReady {
+    if (-not (Get-Command node -ErrorAction SilentlyContinue)) { return $false }
+
+    $version = node --version
+    if (Test-NodeVersionOk $version) {
+        Ensure-NodeExeOnPath | Out-Null
+    } else {
+        Write-Warn "Node.js $version is unsupported (Hermes requires Node 22.22+, 24.11+, or 26+)"
+        return $false
+    }
+
+    $npmRange = Get-NpmRange
+    $npmCmd = Get-Command npm.cmd -ErrorAction SilentlyContinue
+    if (-not $npmCmd) {
+        $npmCmd = Get-Command npm -ErrorAction SilentlyContinue
+    }
+
+    $npmVersion = $null
+    if ($npmCmd) {
+        try {
+            $npmVersion = (& $npmCmd --version 2>$null | Select-Object -First 1)
+        } catch { }
+    }
+
+    if ($npmVersion -and (Test-NpmVersionOk $npmVersion $npmRange)) {
+        Write-Success "Node.js $version with npm $npmVersion found"
+        return $true
+    }
+
+    if ($npmVersion) {
+        Write-Warn "Node.js $version uses npm $npmVersion, which does not satisfy Hermes requirement $npmRange"
+    } else {
+        Write-Warn "Node.js $version was found, but npm is missing or could not report its version"
+    }
+    return $false
+}
+
+function Test-Node {
+    Write-Info "Checking Node.js (for browser tools)..."
+
+    if (Test-SystemNodeReady) {
+        $script:HasNode = $true
+        return $true
+    }
+
+    Write-Info "Using a Hermes-managed Node.js installation instead..."
+
+    # Prefer a Hermes-managed Node from a previous run over a too-old system one.
+    $managedNode = "$HermesHome\node\node.exe"
+    if ((Test-Path $managedNode) -and (Test-NodeVersionOk (& $managedNode --version))) {
+        $version = & $managedNode --version
+        $env:Path = "$HermesHome\node;$env:Path"
+        Set-ManagedNodeFirstOnUserPath "$HermesHome\node"
+        Write-Success "Node.js $version found (Hermes-managed)"
+        # A tree from an older install still has that Node major's bundled
+        # npm, which is below the current engines.npm floor. No-ops when the
+        # npm is already in range, so reruns cost one --version probe.
+        Update-ManagedNpm "$HermesHome\node" | Out-Null
+        $script:HasNode = $true
+        return $true
+    }
+
+    Write-Info "Installing Hermes-managed Node.js $NodeVersion LTS..."
+
+    # Try the portable-zip path FIRST -- no UAC, no admin, no winget MSI.
+    # winget install OpenJS.NodeJS.LTS triggers a system-wide MSI install
+    # which prompts UAC (the dialog often appears minimized in the taskbar
+    # and the install silently waits for consent, looking like a hang).
+    # The portable zip path drops node.exe + npm into $HermesHome\node\
+    # which is user-scoped and identical to how Install-Git handles
+    # PortableGit.  Same UX guarantee: works on locked-down enterprise
+    # machines with no admin rights.
+    Write-Info "Downloading portable Node.js $NodeVersion to $HermesHome\node\ ..."
+    Write-Info "(no admin rights required; isolated from any system Node install)"
+    try {
+        $arch = Get-WindowsArch
+        $indexUrl = "https://nodejs.org/dist/latest-v${NodeVersion}.x/"
+        $indexPage = Invoke-WebRequest -Uri $indexUrl -UseBasicParsing
+        $zipName = ($indexPage.Content | Select-String -Pattern "node-v${NodeVersion}\.\d+\.\d+-win-${arch}\.zip" -AllMatches).Matches[0].Value
+
+        if ($zipName) {
+            $downloadUrl = "${indexUrl}${zipName}"
+            $tmpZip = "$env:TEMP\$zipName"
+            $tmpDir = "$env:TEMP\hermes-node-extract"
+
+            Invoke-WebRequest -Uri $downloadUrl -OutFile $tmpZip -UseBasicParsing
+            if (Test-Path $tmpDir) { Remove-Item -Recurse -Force $tmpDir }
+            Expand-Archive -Path $tmpZip -DestinationPath $tmpDir -Force
+
+            $extractedDir = Get-ChildItem $tmpDir -Directory | Select-Object -First 1
+            if ($extractedDir) {
+                # Rename-swap instead of delete-then-move: the live tree is
+                # never removed before its replacement is fully extracted.
+                # Windows permits renaming a tree with running executables,
+                # but if a process holds it without FILE_SHARE_DELETE the
+                # rename fails with WinError 5 -- that refusal means the tree
+                # is in use, so defer instead of forcing the write (#80926).
+                # Best-effort sweep of staging/backup litter from interrupted
+                # runs; locked files simply stay for the next attempt.  Only
+                # dirs older than 10 minutes are removed so a concurrent
+                # heal's in-flight swap is never disturbed.
+                Get-ChildItem "$HermesHome" -Directory -Filter "node.old-*" -ErrorAction SilentlyContinue |
+                    Where-Object { $_.LastWriteTime -lt (Get-Date).AddMinutes(-10) } |
+                    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+                Get-ChildItem "$HermesHome" -Directory -Filter "node.new-*" -ErrorAction SilentlyContinue |
+                    Where-Object { $_.LastWriteTime -lt (Get-Date).AddMinutes(-10) } |
+                    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+                $stamp = [Guid]::NewGuid().ToString("N")
+                $staged = "$HermesHome\node.new-$stamp"
+                $backup = "$HermesHome\node.old-$stamp"
+                # Stage to a sibling directory so the final swap is a
+                # same-volume rename (atomic), not a cross-volume Move-Item
+                # (copy+delete, non-atomic -- a partial copy would leave a
+                # broken tree).  Move from $env:TEMP here, rename below.
+                try {
+                    Move-Item $extractedDir.FullName $staged -ErrorAction Stop
+                } catch {
+                    Write-Warn "Failed to stage the new Node.js tree; aborting the Node upgrade."
+                    Remove-Item -Recurse -Force $tmpDir -ErrorAction SilentlyContinue
+                    Remove-Item -Force $tmpZip -ErrorAction SilentlyContinue
+                    return $false
+                }
+                if (Test-Path "$HermesHome\node") {
+                    try {
+                        Rename-Item "$HermesHome\node" $backup -ErrorAction Stop
+                    } catch {
+                        Write-Warn "Hermes-managed Node.js is in use by a running app; deferring its upgrade. Close the app and re-run the update."
+                        Remove-Item -Recurse -Force $staged -ErrorAction SilentlyContinue
+                        Remove-Item -Recurse -Force $tmpDir -ErrorAction SilentlyContinue
+                        Remove-Item -Force $tmpZip -ErrorAction SilentlyContinue
+                        return $false
+                    }
+                    # A rename preserves LastWriteTime, so a backup renamed
+                    # from a long-lived tree would instantly look older than
+                    # the litter-sweep cutoff to a concurrent heal.  Touch it
+                    # (best-effort) so the in-flight backup is never swept.
+                    try {
+                        (Get-Item $backup).LastWriteTime = Get-Date
+                    } catch { }
+                    try {
+                        Rename-Item $staged "$HermesHome\node" -ErrorAction Stop
+                    } catch {
+                        # Restore the live tree before bailing.  The swap is a
+                        # same-volume rename, so a failure leaves no partial
+                        # target to clear.
+                        Rename-Item $backup "$HermesHome\node" -ErrorAction SilentlyContinue
+                        Remove-Item -Recurse -Force $staged -ErrorAction SilentlyContinue
+                        Remove-Item -Recurse -Force $tmpDir -ErrorAction SilentlyContinue
+                        Remove-Item -Force $tmpZip -ErrorAction SilentlyContinue
+                        return $false
+                    }
+                    Remove-Item -Recurse -Force $backup -ErrorAction SilentlyContinue
+                } else {
+                    try {
+                        Rename-Item $staged "$HermesHome\node" -ErrorAction Stop
+                    } catch {
+                        Remove-Item -Recurse -Force $staged -ErrorAction SilentlyContinue
+                        Remove-Item -Recurse -Force $tmpDir -ErrorAction SilentlyContinue
+                        Remove-Item -Force $tmpZip -ErrorAction SilentlyContinue
+                        return $false
+                    }
+                }
+
+                # Session PATH so the rest of this run sees node/npm.
+                $env:Path = "$HermesHome\node;$env:Path"
+
+                # Persist to User PATH so fresh shells (and future stages
+                # in cross-process driver mode) see it.  Matches the
+                # pattern Install-Git uses for PortableGit.  See
+                # Set-ManagedNodeFirstOnUserPath for why this is a
+                # move-to-front and not an add-if-missing.
+                Set-ManagedNodeFirstOnUserPath "$HermesHome\node"
+
+                $version = & "$HermesHome\node\node.exe" --version
+                Write-Success "Node.js $version installed to $HermesHome\node\ (portable, user-scoped)"
+                # The zip's bundled npm is below the repo's engines.npm floor.
+                Update-ManagedNpm "$HermesHome\node" | Out-Null
+                $script:HasNode = $true
+
+                Remove-Item -Force $tmpZip -ErrorAction SilentlyContinue
+                Remove-Item -Recurse -Force $tmpDir -ErrorAction SilentlyContinue
+                return $true
+            }
+        }
+    } catch {
+        Write-Warn "Portable Node.js download failed: $_"
+    }
+
+    # Fallback: try winget (used to be primary, demoted because the MSI
+    # install triggers a UAC prompt that frequently appears minimized in
+    # the taskbar -- looks like a hang to users on stock Windows).
+    # Kept for environments where the portable download fails (proxy,
+    # locked firewall, etc.) but the user is willing to consent to UAC.
+    if (Get-Command winget -ErrorAction SilentlyContinue) {
+        Write-Info "Falling back to winget (may prompt UAC -- check your taskbar for a flashing icon)..."
+        # Capture EAP outside the try block so the catch's restore call always
+        # has a meaningful value (see Install-Uv for the full rationale).
+        $prevEAP = $ErrorActionPreference
+        try {
+            # Relax EAP=Stop so stderr lines from winget don't get wrapped
+            # as ErrorRecords and short-circuit the 2>&1 pipe before we can
+            # check the post-condition.  See the long comment in Install-Uv
+            # for the same pattern.
+            $ErrorActionPreference = "Continue"
+            # On ARM64, force winget to fetch the ARM64 installer.  Without
+            # the explicit override, winget on WoW64 sometimes still resolves
+            # to x64 manifests, leaving us with an emulated Node toolchain
+            # even after a "successful" install.  The OpenJS manifest does
+            # publish an arm64 installer, so this is safe.
+            $wingetArgs = @(
+                'install','OpenJS.NodeJS','--silent',
+                '--accept-package-agreements','--accept-source-agreements'
+            )
+            if ((Get-WindowsArch) -eq 'arm64') {
+                $wingetArgs += @('--architecture','arm64')
+            }
+            winget @wingetArgs 2>&1 | Out-Null
+            $ErrorActionPreference = $prevEAP
+            # Refresh PATH
+            $env:Path = [Environment]::GetEnvironmentVariable("Path", "User") + ";" + [Environment]::GetEnvironmentVariable("Path", "Machine")
+            if (Test-SystemNodeReady) {
+                $script:HasNode = $true
+                return $true
+            }
+        } catch {
+            if ($prevEAP) { $ErrorActionPreference = $prevEAP }
+        }
+    }
+
+
+    Write-Info "Install manually: https://nodejs.org/en/download/"
+    $script:HasNode = $false
+    return $true
+}
+
+function Update-ProcessPathForPackages {
+    # Make freshly-installed shims (rg.exe, ffmpeg.exe) visible to Get-Command in
+    # THIS process without spawning a new shell, by folding the persisted
+    # User+Machine hives plus winget's alias-shim directory into $env:Path.
+    # Called after every package-manager attempt (winget/choco/scoop): previously
+    # PATH was only refreshed inside the winget branch, so a successful
+    # choco/scoop fallback -- or any install on a box without winget -- could be
+    # misreported as "not installed".
+    #
+    # MERGE rather than overwrite: start from the existing process PATH so any
+    # process-only entries added earlier in this installer run survive, then
+    # APPEND hive/winget-Links entries not already present (case-insensitive,
+    # order-preserving dedupe). A wholesale replace would silently drop those
+    # process-only entries.
+    $candidates = @()
+    $candidates += $env:Path
+    $candidates += [Environment]::GetEnvironmentVariable("Path", "User")
+    $candidates += [Environment]::GetEnvironmentVariable("Path", "Machine")
+    $wingetLinks = Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links"
+    if (Test-Path $wingetLinks) {
+        $candidates += $wingetLinks
+    }
+    $seen = New-Object System.Collections.Generic.HashSet[string] ([StringComparer]::OrdinalIgnoreCase)
+    $ordered = New-Object System.Collections.Generic.List[string]
+    foreach ($chunk in $candidates) {
+        if ([string]::IsNullOrEmpty($chunk)) { continue }
+        foreach ($entry in $chunk.Split(';')) {
+            $trimmed = $entry.Trim()
+            if ($trimmed -and $seen.Add($trimmed)) {
+                $ordered.Add($trimmed)
+            }
+        }
+    }
+    $env:Path = [string]::Join(';', $ordered)
+}
+
+function Install-SystemPackages {
+    $script:HasRipgrep = $false
+    $script:HasFfmpeg = $false
+    $needRipgrep = $false
+    $needFfmpeg = $false
+
+    Write-Info "Checking ripgrep (fast file search)..."
+    if (Get-Command rg -ErrorAction SilentlyContinue) {
+        $version = rg --version | Select-Object -First 1
+        Write-Success "$version found"
+        $script:HasRipgrep = $true
+    } else {
+        $needRipgrep = $true
+    }
+
+    Write-Info "Checking ffmpeg (TTS voice messages)..."
+    if (Get-Command ffmpeg -ErrorAction SilentlyContinue) {
+        Write-Success "ffmpeg found"
+        $script:HasFfmpeg = $true
+    } else {
+        $needFfmpeg = $true
+    }
+
+    if (-not $needRipgrep -and -not $needFfmpeg) { return }
+
+    # Build description and package lists for each package manager
+    $descParts = @()
+    $wingetPkgs = @()
+    $chocoPkgs = @()
+    $scoopPkgs = @()
+
+    if ($needRipgrep) {
+        $descParts += "ripgrep for faster file search"
+        $wingetPkgs += "BurntSushi.ripgrep.MSVC"
+        $chocoPkgs += "ripgrep"
+        $scoopPkgs += "ripgrep"
+    }
+    if ($needFfmpeg) {
+        $descParts += "ffmpeg for TTS voice messages"
+        $wingetPkgs += "Gyan.FFmpeg"
+        $chocoPkgs += "ffmpeg"
+        $scoopPkgs += "ffmpeg"
+    }
+
+    $description = $descParts -join " and "
+    $hasWinget = Get-Command winget -ErrorAction SilentlyContinue
+    $hasChoco = Get-Command choco -ErrorAction SilentlyContinue
+    $hasScoop = Get-Command scoop -ErrorAction SilentlyContinue
+
+    # Try winget first (most common on modern Windows)
+    if ($hasWinget) {
+        Write-Info "Installing $description via winget..."
+        # Per-package log paths -- key the lookup by package id so we can
+        # decide AFTER the post-install Get-Command check whether to keep
+        # the log (still missing -> keep as breadcrumb) or delete it (now
+        # present -> happy path, no clutter).
+        $pkgLogs = @{}
+        foreach ($pkg in $wingetPkgs) {
+            $log = "$env:TEMP\hermes-winget-$($pkg -replace '[^A-Za-z0-9]','_')-$(Get-Random).log"
+            $pkgLogs[$pkg] = $log
+            # --source winget pins us to the github-backed source.  Without this,
+            # a broken msstore source (cert validation failures like 0x8a15005e
+            # are common on Windows-on-ARM and some corporate networks) makes
+            # winget bail with "please specify --source" *before* attempting any
+            # install -- and it exits 0, so the surrounding try/catch never fires.
+            # We don't ship anything from msstore, so pinning is safe.
+            try {
+                $output = winget install --exact --id $pkg --source winget --silent `
+                    --accept-package-agreements --accept-source-agreements 2>&1
+                $code = $LASTEXITCODE
+                $output | Out-File -FilePath $log -Encoding utf8
+                "winget exit: $code" | Out-File -FilePath $log -Encoding utf8 -Append
+                # 0x8A15002B (-1978335189) = APPINSTALLER_CLI_ERROR_UPDATE_NOT_APPLICABLE.
+                # winget treats `install` on a package it already has registered as
+                # an *upgrade*, finds no newer version, and bails with this code --
+                # even when the binary is gone from disk/PATH (stale registration,
+                # files removed outside winget, or a missing alias shim). We KNOW the
+                # command was missing (that's why we're here), so a plain install
+                # dead-ends forever. Force a reinstall to repair the registration so
+                # the shim reappears.
+                if ($code -eq -1978335189) {
+                    "-> already-installed/no-upgrade; retrying with --force" | Out-File -FilePath $log -Encoding utf8 -Append
+                    $output = winget install --exact --id $pkg --source winget --silent --force `
+                        --accept-package-agreements --accept-source-agreements 2>&1
+                    $output | Out-File -FilePath $log -Encoding utf8 -Append
+                    "winget exit (force): $LASTEXITCODE" | Out-File -FilePath $log -Encoding utf8 -Append
+                }
+            } catch {
+                $_ | Out-File -FilePath $log -Encoding utf8 -Append
+                "winget exit: <exception>" | Out-File -FilePath $log -Encoding utf8 -Append
+            }
+        }
+        # Refresh PATH so packages winget exposed via "command line aliases" in
+        # %LOCALAPPDATA%\Microsoft\WinGet\Links (added to PATH only in
+        # newly-spawned shells, not this process) are visible to Get-Command below.
+        Update-ProcessPathForPackages
+        if ($needRipgrep -and (Get-Command rg -ErrorAction SilentlyContinue)) {
+            Write-Success "ripgrep installed"
+            $script:HasRipgrep = $true
+            $needRipgrep = $false
+            Remove-Item -Path $pkgLogs["BurntSushi.ripgrep.MSVC"] -ErrorAction SilentlyContinue
+        } elseif ($pkgLogs.ContainsKey("BurntSushi.ripgrep.MSVC")) {
+            Write-Warn "winget could not install ripgrep; details: $($pkgLogs['BurntSushi.ripgrep.MSVC'])"
+        }
+        if ($needFfmpeg -and (Get-Command ffmpeg -ErrorAction SilentlyContinue)) {
+            Write-Success "ffmpeg installed"
+            $script:HasFfmpeg = $true
+            $needFfmpeg = $false
+            Remove-Item -Path $pkgLogs["Gyan.FFmpeg"] -ErrorAction SilentlyContinue
+        } elseif ($pkgLogs.ContainsKey("Gyan.FFmpeg")) {
+            Write-Warn "winget could not install ffmpeg; details: $($pkgLogs['Gyan.FFmpeg'])"
+        }
+        if (-not $needRipgrep -and -not $needFfmpeg) { return }
+    }
+
+    # Fallback: choco
+    if ($hasChoco -and ($needRipgrep -or $needFfmpeg)) {
+        Write-Info "Trying Chocolatey..."
+        foreach ($pkg in $chocoPkgs) {
+            try { choco install $pkg -y 2>&1 | Out-Null } catch { }
+        }
+        Update-ProcessPathForPackages
+        if ($needRipgrep -and (Get-Command rg -ErrorAction SilentlyContinue)) {
+            Write-Success "ripgrep installed via chocolatey"
+            $script:HasRipgrep = $true
+            $needRipgrep = $false
+        }
+        if ($needFfmpeg -and (Get-Command ffmpeg -ErrorAction SilentlyContinue)) {
+            Write-Success "ffmpeg installed via chocolatey"
+            $script:HasFfmpeg = $true
+            $needFfmpeg = $false
+        }
+    }
+
+    # Fallback: scoop
+    if ($hasScoop -and ($needRipgrep -or $needFfmpeg)) {
+        Write-Info "Trying Scoop..."
+        foreach ($pkg in $scoopPkgs) {
+            try { scoop install $pkg 2>&1 | Out-Null } catch { }
+        }
+        Update-ProcessPathForPackages
+        if ($needRipgrep -and (Get-Command rg -ErrorAction SilentlyContinue)) {
+            Write-Success "ripgrep installed via scoop"
+            $script:HasRipgrep = $true
+            $needRipgrep = $false
+        }
+        if ($needFfmpeg -and (Get-Command ffmpeg -ErrorAction SilentlyContinue)) {
+            Write-Success "ffmpeg installed via scoop"
+            $script:HasFfmpeg = $true
+            $needFfmpeg = $false
+        }
+    }
+
+    # Show manual instructions for anything still missing
+    if ($needRipgrep) {
+        Write-Warn "ripgrep not installed (file search will use findstr fallback)"
+        Write-Info "  winget install BurntSushi.ripgrep.MSVC"
+    }
+    if ($needFfmpeg) {
+        Write-Warn "ffmpeg not installed (TTS voice messages will be limited)"
+        Write-Info "  winget install Gyan.FFmpeg"
+    }
+}
+
+# ============================================================================
+# Installation
+# ============================================================================
+
+function Install-Repository {
+    Write-Info "Installing to $InstallDir..."
+
+    $didUpdate = $false
+
+    if (Test-Path $InstallDir) {
+        # Test-Path "$InstallDir\.git" returns True when .git is a file OR a
+        # directory OR a symlink OR a submodule-style gitfile -- and also when
+        # it's a broken stub left over from a failed previous install (e.g.
+        # a partial Remove-Item that couldn't delete a locked index.lock).
+        # Validate the repo properly by asking git itself.  Three checks
+        # belt-and-braces: rev-parse (work tree), git status, and a resolvable
+        # HEAD (an initial commit).  If any fails the repo is broken and we
+        # fall through to a fresh clone.
+        $repoValid = $false
+        if (Test-Path "$InstallDir\.git") {
+            Push-Location $InstallDir
+            try {
+                # Reset $LASTEXITCODE before the probe so we don't pick up
+                # a stale 0 from an earlier git call in this session.
+                $global:LASTEXITCODE = 0
+                $revParseOut = & git -c windows.appendAtomically=false rev-parse --is-inside-work-tree 2>&1
+                $revParseOk = ($LASTEXITCODE -eq 0) -and ($revParseOut -match "true")
+
+                $global:LASTEXITCODE = 0
+                $null = & git -c windows.appendAtomically=false status --short 2>&1
+                $statusOk = ($LASTEXITCODE -eq 0)
+
+                # An interrupted previous clone leaves a repo with NO initial
+                # commit. rev-parse/status still succeed there, but the update
+                # path's `git stash` (and later `git checkout`) abort with
+                # "You do not have the initial commit yet" and fail the install
+                # (#40998). Require a resolvable HEAD so such partial checkouts
+                # are treated as broken and re-cloned fresh below.
+                $global:LASTEXITCODE = 0
+                $null = & git -c windows.appendAtomically=false rev-parse --verify HEAD 2>&1
+                $hasCommit = ($LASTEXITCODE -eq 0)
+
+                if ($revParseOk -and $statusOk -and $hasCommit) {
+                    $repoValid = $true
+                }
+            } catch {}
+            Pop-Location
+        }
+
+        if ($repoValid) {
+            Write-Info "Existing installation found, updating..."
+            Push-Location $InstallDir
+            # Wrap the entire fetch+checkout block in EAP=Continue so git's
+            # routine stderr output (e.g. 'From <url>' info lines emitted by
+            # `git fetch`) doesn't terminate the script under the global
+            # EAP=Stop.  We rely on $LASTEXITCODE for actual failures.
+            $prevEAP = $ErrorActionPreference
+            $ErrorActionPreference = "Continue"
+            $autostashRef = ""
+            try {
+                # This is a MANAGED checkout, not a repo the user edits. Git for
+                # Windows defaults to core.autocrlf=true, which renormalizes the
+                # repo's LF-only text files to CRLF in the working tree -- so
+                # tracked files (.envrc, AGENTS.md, agent/*.py, workflows, ...)
+                # show as locally modified even though nobody touched them. A
+                # bare `git checkout` then aborts with "Your local changes would
+                # be overwritten by checkout", which is exactly the failure GUI
+                # users hit on update. Pin autocrlf=false so the dirt is never
+                # created in the first place.
+                git -c windows.appendAtomically=false config core.autocrlf false 2>$null
+                Discard-LockfileChurn $InstallDir
+                # Preserve any real local changes before the checkout instead of
+                # discarding them with `reset --hard HEAD`. The old hard reset
+                # silently destroyed agent-edited source on managed clones (the
+                # #38542 data-loss class). Stash + restore mirrors install.sh:
+                # nothing is lost, and a failed restore leaves the work in a
+                # git stash for manual recovery. Untracked files are included so
+                # agent-created dirs (e.g. tinker-atropos/) survive too.
+                $statusOut = git -c windows.appendAtomically=false status --porcelain 2>$null
+                if (-not [string]::IsNullOrWhiteSpace(($statusOut -join "`n"))) {
+                    # A previously interrupted update can leave the index with
+                    # unmerged entries. In that state `git stash` aborts with
+                    # "could not write index" and the following `git checkout`
+                    # aborts with "you need to resolve your current index first"
+                    # -- the GUI "git checkout main failed (exit 1)" install
+                    # failure. Clear the conflict markers with `git reset` first:
+                    # working-tree changes are kept (and stashed just below); only
+                    # the index conflict state is dropped. Mirrors the `hermes
+                    # update` path (#4735).
+                    $unmergedOut = git -c windows.appendAtomically=false ls-files --unmerged 2>$null
+                    if (-not [string]::IsNullOrWhiteSpace(($unmergedOut -join "`n"))) {
+                        Write-Info "Clearing unmerged index entries from a previous conflict..."
+                        git -c windows.appendAtomically=false reset -q 2>$null
+                    }
+                    $stashName = "hermes-install-autostash-" + (Get-Date -Format "yyyyMMdd-HHmmss")
+                    Write-Info "Local changes detected, stashing before update..."
+                    git -c windows.appendAtomically=false stash push --include-untracked -m "$stashName"
+                    if ($LASTEXITCODE -eq 0) { $autostashRef = "stash@{0}" }
+                }
+                git -c windows.appendAtomically=false fetch origin $Branch
+                if ($LASTEXITCODE -ne 0) { throw "git fetch failed (exit $LASTEXITCODE)" }
+                # Precedence: Commit > Tag > Branch.  Commit and Tag check
+                # out as detached HEAD intentionally -- they're meant to be
+                # reproducible pins, not branches the user pulls into.
+                if ($Commit) {
+                    # Make sure we have the commit locally (a tag-less commit
+                    # SHA isn't always reachable from any one branch fetch).
+                    git -c windows.appendAtomically=false fetch origin $Commit
+                    # A commit pin must never move an existing install
+                    # BACKWARDS. hermes-setup.exe bakes its build-time commit
+                    # into the binary (BUILD_PIN_COMMIT) and passes it as
+                    # -Commit on every install-mode run -- including the retry
+                    # the desktop's "Update didn't finish" screen kicks off. An
+                    # installer built months ago would otherwise rewind a
+                    # current checkout to its build commit, leaving ancient
+                    # code against a current venv (npm workspaces and Python
+                    # deps that no longer match: the #74xxx report). Skip the
+                    # pin when the target is already an ancestor of HEAD; a
+                    # fresh clone has no such ancestry and pins normally.
+                    $skipRollback = $false
+                    if (-not $ForceCommit) {
+                        git -c windows.appendAtomically=false merge-base --is-ancestor $Commit HEAD 2>$null
+                        $isAncestor = ($LASTEXITCODE -eq 0)
+                        $pinnedSha = (& git -c windows.appendAtomically=false rev-parse "$Commit^{commit}" 2>$null)
+                        $headSha = (& git -c windows.appendAtomically=false rev-parse HEAD 2>$null)
+                        $skipRollback = $isAncestor -and ($pinnedSha -ne $headSha)
+                    }
+                    if ($skipRollback) {
+                        Write-Warn "Ignoring -Commit $Commit`: the checkout is already newer."
+                        Write-Warn "Pinning to it would roll this install back. Pass -ForceCommit to override."
+                    } else {
+                        git -c windows.appendAtomically=false checkout --detach $Commit
+                        if ($LASTEXITCODE -ne 0) { throw "git checkout $Commit failed (exit $LASTEXITCODE)" }
+                    }
+                } elseif ($Tag) {
+                    git -c windows.appendAtomically=false fetch origin "refs/tags/${Tag}:refs/tags/${Tag}"
+                    git -c windows.appendAtomically=false checkout --detach "refs/tags/$Tag"
+                    if ($LASTEXITCODE -ne 0) { throw "git checkout tag $Tag failed (exit $LASTEXITCODE)" }
+                } else {
+                    git -c windows.appendAtomically=false checkout $Branch
+                    if ($LASTEXITCODE -ne 0) { throw "git checkout $Branch failed (exit $LASTEXITCODE)" }
+                    # Managed installs should follow origin/$Branch exactly. If
+                    # the checkout has diverged (or has local-only commits),
+                    # ff-only pull cannot succeed -- mirror ``hermes update`` and
+                    # reset to the fetched remote so bootstrap/install can recover.
+                    git -c windows.appendAtomically=false pull --ff-only origin $Branch
+                    if ($LASTEXITCODE -ne 0) {
+                        Write-Warn "Fast-forward not possible; resetting managed install to origin/$Branch..."
+                        git -c windows.appendAtomically=false reset --hard "origin/$Branch"
+                        if ($LASTEXITCODE -ne 0) { throw "git reset --hard origin/$Branch failed (exit $LASTEXITCODE)" }
+                    }
+                }
+
+                if ($autostashRef) {
+                    # Default to restoring so work is never silently dropped.
+                    # Only prompt when we're certain a human can answer: an
+                    # interactive session AND a real, non-redirected console on
+                    # both stdin and stdout. The desktop "Update" button and
+                    # bootstrap run the installer without a usable console -- in
+                    # those cases Read-Host would hang or return empty, so we
+                    # skip the prompt and just restore (the safe default).
+                    $restoreNow = $true
+                    $hasConsole = $false
+                    try {
+                        $hasConsole = (
+                            [Environment]::UserInteractive `
+                            -and (-not [Console]::IsInputRedirected) `
+                            -and (-not [Console]::IsOutputRedirected) `
+                            -and ($Host.Name -eq "ConsoleHost")
+                        )
+                    } catch { $hasConsole = $false }
+                    if ($hasConsole) {
+                        Write-Warn "Local changes were stashed before updating."
+                        Write-Warn "Restoring them may reapply local customizations onto the updated codebase."
+                        $restoreAnswer = Read-Host "Restore local changes now? [Y/n]"
+                        if ($restoreAnswer -match '^(n|no)$') { $restoreNow = $false }
+                    }
+
+                    if ($restoreNow) {
+                        Write-Info "Restoring local changes..."
+                        $restoreOutput = @(git -c windows.appendAtomically=false stash apply $autostashRef 2>&1)
+                        $restoreExit = $LASTEXITCODE
+                        $conflictedFiles = @(
+                            git -c windows.appendAtomically=false diff --name-only --diff-filter=U 2>$null
+                        ) | Where-Object { $_ -and $_.ToString().Trim() }
+                        if (($restoreExit -eq 0) -and ($conflictedFiles.Count -eq 0)) {
+                            git -c windows.appendAtomically=false stash drop $autostashRef 2>$null
+                            Write-Warn "Local changes were restored on top of the updated codebase."
+                            Write-Warn "Review git diff / git status if Hermes behaves unexpectedly."
+                        } else {
+                            Write-Err "Update pulled new code, but restoring local changes hit conflicts."
+                            foreach ($line in $restoreOutput) {
+                                if ($line -and $line.ToString().Trim()) {
+                                    Write-Host $line
+                                }
+                            }
+                            if ($conflictedFiles.Count -gt 0) {
+                                Write-Host ""
+                                Write-Host "Conflicted files:"
+                                foreach ($file in $conflictedFiles) {
+                                    Write-Host "  - $file"
+                                }
+                            }
+                            Write-Host ""
+                            Write-Info "Your stashed changes are preserved -- nothing is lost."
+                            Write-Info "  Stash ref: $autostashRef"
+                            git -c windows.appendAtomically=false reset --hard HEAD 2>$null | Out-Null
+                            Write-Info "Working tree reset to clean state."
+                            Write-Info "Restore your changes later with: git stash apply $autostashRef"
+                        }
+                    } else {
+                        Write-Info "Skipped restoring local changes."
+                        Write-Info "Your changes are still preserved in git stash."
+                        Write-Info "Restore manually with: git stash apply $autostashRef"
+                    }
+                    $autostashRef = ""
+                }
+            } finally {
+                if ($autostashRef) {
+                    # We stashed but never reached the restore block (a fetch/
+                    # checkout/pull failure threw). Leave the stash in place and
+                    # tell the user how to recover it -- never silently drop it.
+                    Write-Warn "Update did not complete. Your local changes are preserved in git stash."
+                    Write-Info "Restore manually with: git stash apply $autostashRef"
+                }
+                $ErrorActionPreference = $prevEAP
+                Pop-Location
+            }
+            $didUpdate = $true
+        } else {
+            # Directory exists but isn't a usable git repo -- e.g. an
+            # interrupted clone with no initial commit (#40998), or a leftover
+            # ``.git`` stub from a partial uninstall that used to lock the
+            # installer into the "update" branch forever. Move it aside rather
+            # than deleting it -- never destroy a directory the user might still
+            # want -- and fall through to a fresh clone.
+            $backupDir = "$InstallDir.broken-" + (Get-Date -Format "yyyyMMdd-HHmmss")
+            Write-Warn "Existing directory at $InstallDir is not a valid git repo."
+            Write-Warn "Moving it aside to $backupDir before re-cloning."
+            try {
+                Move-Item -LiteralPath $InstallDir -Destination $backupDir -ErrorAction Stop
+            } catch {
+                Write-Err "Could not move $InstallDir aside : $_"
+                Write-Info "Close any programs that might be using files in $InstallDir (editors,"
+                Write-Info "terminals, running hermes processes) and try again."
+                throw
+            }
+        }
+    }
+
+    if (-not $didUpdate) {
+        $cloneSuccess = $false
+
+        # Fix Windows git "copy-fd: write returned: Invalid argument" error.
+        # Git for Windows can fail on atomic file operations (hook templates,
+        # config lock files) due to antivirus, OneDrive, or NTFS filter drivers.
+        # The -c flag injects config before any file I/O occurs.
+        Write-Info "Configuring git for Windows compatibility..."
+        $env:GIT_CONFIG_COUNT = "1"
+        $env:GIT_CONFIG_KEY_0 = "windows.appendAtomically"
+        $env:GIT_CONFIG_VALUE_0 = "false"
+        git config --global windows.appendAtomically false 2>$null
+
+        # Try SSH first, then HTTPS, with -c flag for atomic write fix
+        Write-Info "Trying SSH clone..."
+        $env:GIT_SSH_COMMAND = "ssh -o BatchMode=yes -o ConnectTimeout=5"
+        try {
+            Invoke-NativeWithRelaxedErrorAction { git -c windows.appendAtomically=false clone --depth 1 --branch $Branch $RepoUrlSsh $InstallDir }
+            if ($LASTEXITCODE -eq 0) { $cloneSuccess = $true }
+        } catch { }
+        $env:GIT_SSH_COMMAND = $null
+
+        if (-not $cloneSuccess) {
+            if (Test-Path $InstallDir) { Remove-Item -Recurse -Force $InstallDir -ErrorAction SilentlyContinue }
+            Write-Info "SSH failed, trying HTTPS..."
+            try {
+                Invoke-NativeWithRelaxedErrorAction { git -c windows.appendAtomically=false clone --depth 1 --branch $Branch $RepoUrlHttps $InstallDir }
+                if ($LASTEXITCODE -eq 0) { $cloneSuccess = $true }
+            } catch { }
+        }
+
+        # Fallback: download ZIP archive (bypasses git file I/O issues entirely)
+        if (-not $cloneSuccess) {
+            if (Test-Path $InstallDir) { Remove-Item -Recurse -Force $InstallDir -ErrorAction SilentlyContinue }
+            Write-Warn "Git clone failed -- downloading ZIP archive instead..."
+            try {
+                # Pick the ZIP URL for the most-specific ref the caller asked
+                # for.  GitHub supports archive URLs for commits, tags, and
+                # branches; we honour Commit > Tag > Branch.
+                if ($Commit) {
+                    $zipUrl = "https://github.com/NousResearch/hermes-agent/archive/$Commit.zip"
+                    $zipLabel = $Commit
+                } elseif ($Tag) {
+                    $zipUrl = "https://github.com/NousResearch/hermes-agent/archive/refs/tags/$Tag.zip"
+                    $zipLabel = $Tag
+                } else {
+                    $zipUrl = "https://github.com/NousResearch/hermes-agent/archive/refs/heads/$Branch.zip"
+                    $zipLabel = $Branch
+                }
+                $zipPath = "$env:TEMP\hermes-agent-$zipLabel.zip"
+                $extractPath = "$env:TEMP\hermes-agent-extract"
+
+                Invoke-WebRequest -Uri $zipUrl -OutFile $zipPath -UseBasicParsing
+                if (Test-Path $extractPath) { Remove-Item -Recurse -Force $extractPath }
+                Expand-Archive -Path $zipPath -DestinationPath $extractPath -Force
+
+                # GitHub ZIPs extract to repo-branch/ subdirectory
+                $extractedDir = Get-ChildItem $extractPath -Directory | Select-Object -First 1
+                if ($extractedDir) {
+                    New-Item -ItemType Directory -Force -Path (Split-Path $InstallDir) -ErrorAction SilentlyContinue | Out-Null
+                    Move-Item $extractedDir.FullName $InstallDir -Force
+                    Write-Success "Downloaded and extracted"
+
+                    # Initialize git repo so updates work later. A bare
+                    # `git init` leaves NO HEAD -- desktop's write-build-stamp
+                    # then hard-fails with "could not determine git commit"
+                    # (#50823 / #61657). Fetch the requested ref and force-check
+                    # it out (-f) so untracked ZIP files cannot block checkout.
+                    Push-Location $InstallDir
+                    git -c windows.appendAtomically=false init 2>$null
+                    git -c windows.appendAtomically=false config windows.appendAtomically false 2>$null
+                    # Pin autocrlf=false BEFORE the checkout below. Git for Windows
+                    # defaults to core.autocrlf=true, which would renormalize the
+                    # repo's LF text files to CRLF in the working tree during
+                    # `checkout -f FETCH_HEAD` -- leaving this freshly-created
+                    # managed checkout dirty vs HEAD and aborting the next
+                    # `hermes update` (see the notes at the shared clone-path
+                    # config below and install.ps1:1461-1469). The later pin on
+                    # the shared path is idempotent and still covers git clones.
+                    git -c windows.appendAtomically=false config core.autocrlf false 2>$null
+                    git remote add origin $RepoUrlHttps 2>$null
+                    $fetchRef = if ($Commit) { $Commit } elseif ($Tag) { "refs/tags/$Tag" } else { $Branch }
+                    Write-Info "Fetching $fetchRef so the ZIP checkout has a resolvable HEAD..."
+                    $prevZipEAP = $ErrorActionPreference
+                    $ErrorActionPreference = "Continue"
+                    try {
+                        git -c windows.appendAtomically=false fetch --depth 1 origin $fetchRef 2>&1 | Out-Null
+                        if ($LASTEXITCODE -eq 0) {
+                            if ($Commit -or $Tag) {
+                                git -c windows.appendAtomically=false checkout -f --detach FETCH_HEAD 2>&1 | Out-Null
+                            } else {
+                                git -c windows.appendAtomically=false checkout -f -B $Branch FETCH_HEAD 2>&1 | Out-Null
+                            }
+                            if ($LASTEXITCODE -eq 0) {
+                                Write-Success "ZIP checkout pinned to $fetchRef"
+                            } else {
+                                # Checkout blocked, but FETCH_HEAD still has a SHA we can stamp with.
+                                $fetchSha = & git -c windows.appendAtomically=false rev-parse FETCH_HEAD 2>$null
+                                if ($LASTEXITCODE -eq 0 -and $fetchSha) {
+                                    if (-not $env:GITHUB_SHA) { $env:GITHUB_SHA = ("$fetchSha").Trim() }
+                                    Write-Warn "ZIP checkout failed; seeded GITHUB_SHA from FETCH_HEAD for desktop stamp"
+                                } else {
+                                    Write-Warn "ZIP extract succeeded but git checkout failed -- desktop build may need `$env:GITHUB_SHA"
+                                }
+                            }
+                        } else {
+                            Write-Warn "ZIP extract succeeded but git fetch of $fetchRef failed -- desktop build may need `$env:GITHUB_SHA"
+                        }
+                    } finally {
+                        $ErrorActionPreference = $prevZipEAP
+                    }
+                    Pop-Location
+                    Write-Success "Git repo initialized for future updates"
+
+                    $cloneSuccess = $true
+                }
+
+                # Cleanup temp files
+                Remove-Item -Force $zipPath -ErrorAction SilentlyContinue
+                Remove-Item -Recurse -Force $extractPath -ErrorAction SilentlyContinue
+            } catch {
+                Write-Err "ZIP download also failed: $_"
+            }
+        }
+
+        if (-not $cloneSuccess) {
+            throw "Failed to download repository (tried git clone SSH, HTTPS, and ZIP)"
+        }
+    }
+
+    # Set per-repo config (harmless if it fails)
+    Push-Location $InstallDir
+    git -c windows.appendAtomically=false config windows.appendAtomically false 2>$null
+    # Pin autocrlf=false on the managed clone so git never renormalizes the
+    # repo's LF text files to CRLF in the working tree. Without this, the very
+    # next `hermes update` checkout aborts on a "dirty" tree the user never
+    # touched (see the update path above).
+    git -c windows.appendAtomically=false config core.autocrlf false 2>$null
+
+    # Post-clone pin: when a clone (or ZIP-fallback init) just landed us on
+    # $Branch's tip, honour the higher-precedence $Commit / $Tag by checking
+    # the exact ref out as a detached HEAD.  Skipped for the in-place update
+    # path (above) since that already routed via the same precedence.
+    if (-not $didUpdate) {
+        # Same EAP=Continue wrap as the update path -- git fetch's 'From <url>'
+        # info line goes to stderr and would terminate the script under the
+        # global EAP=Stop otherwise.  We check $LASTEXITCODE for real errors.
+        $prevEAP = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
+        try {
+            if ($Commit) {
+                Write-Info "Pinning to commit $Commit..."
+                git -c windows.appendAtomically=false fetch origin $Commit
+                git -c windows.appendAtomically=false checkout --detach $Commit
+                if ($LASTEXITCODE -ne 0) {
+                    throw "git checkout $Commit failed (exit $LASTEXITCODE)"
+                }
+            } elseif ($Tag) {
+                Write-Info "Pinning to tag $Tag..."
+                git -c windows.appendAtomically=false fetch origin "refs/tags/${Tag}:refs/tags/${Tag}"
+                git -c windows.appendAtomically=false checkout --detach "refs/tags/$Tag"
+                if ($LASTEXITCODE -ne 0) {
+                    throw "git checkout tag $Tag failed (exit $LASTEXITCODE)"
+                }
+            }
+        } finally {
+            $ErrorActionPreference = $prevEAP
+        }
+    }
+
+    Write-Success "Repository ready"
+}
+
+function Install-Venv {
+    if ($NoVenv) {
+        Write-Info "Skipping virtual environment (-NoVenv)"
+        return
+    }
+
+    # Re-resolve the interpreter before creating the venv.  Under Hermes-Setup.exe
+    # each stage runs in its own powershell.exe, so the fallback the `python`
+    # stage picked (e.g. 3.12 when 3.11 is absent) did NOT propagate into this
+    # fresh process -- $PythonVersion is back at its "3.11" default.  Trusting it
+    # here made `uv venv venv --python 3.11` fail with exit 2 on machines without
+    # 3.11 even though the `python` stage reported success (issue #50769).
+    $resolvedPython = Resolve-AvailablePythonVersion
+    if (-not $resolvedPython) {
+        throw "Hermes-managed Python is unavailable. Run install.ps1 -Stage python first."
+    }
+
+    Write-Info "Creating virtual environment with Python $($resolvedPython.Version)..."
+    
+    Push-Location $InstallDir
+
+    # Tasks we disabled below and must re-enable no matter how this stage
+    # exits. Populated only with tasks that were ENABLED before we touched
+    # them, so a task the user deliberately disabled is never re-armed.
+    $gatewayTasksDisabled = @()
+    $venvHadExistingVenv = $false
+    $venvBackupName = $null
+    $venvParked = $false
+    try {
+    # A previous venv stage may have finished (or been interrupted after
+    # parking the old tree) without reaching dependency validation. Restore
+    # that transaction's original generation before beginning another recreate
+    # so a retry cannot promote the unverified replacement to rollback source.
+    $pendingVenvBackup = Get-PendingVenvBackup
+    if ($pendingVenvBackup) {
+        Write-Warn "Reconciling unfinished venv transaction before retrying"
+        Restore-VenvBackup
+        if (Get-PendingVenvBackup) {
+            throw "Could not restore the original venv from $pendingVenvBackup; retry aborted during transaction recovery."
+        }
+    }
+
+    if (Test-Path -LiteralPath "venv") {
+        $venvHadExistingVenv = $true
+        Write-Info "Virtual environment already exists, recreating..."
+        # On Windows, native Python extensions (e.g. _bcrypt.pyd, tornado's
+        # speedups.pyd) are loaded as DLLs by any running hermes process.
+        # Windows denies deletion of loaded DLLs, so every process running out
+        # of this venv must be stopped before retiring it. This keeps cleanup
+        # from accumulating locked stale trees and avoids carrying a live
+        # gateway into the replacement venv.
+        if ($env:OS -eq "Windows_NT") {
+            $myPid = $PID
+            Write-Info "Stopping any running hermes processes before recreating venv..."
+            # Disarm the respawner FIRST: the gateway autostart Scheduled Task
+            # relaunches a killed gateway within seconds, and losing that race
+            # re-locks the venv's .pyd files between our kill sweep and
+            # venv parking/cleanup (the July 2026 _brotlicffi.pyd incident). schtasks
+            # /End stops a running task instance; /Change /DISABLE stops it
+            # from re-firing mid-install. (The Startup-folder .vbs fallback is
+            # NOT touched: it only fires at logon, so it cannot respawn a
+            # gateway mid-install.) Re-enabled in the finally below -- including
+            # on failure -- but only for tasks that were enabled to begin with.
+            # Best-effort: a missing task just errors quietly.
+            try {
+                schtasks /Query /FO CSV 2>$null | ConvertFrom-Csv | Where-Object { $_.TaskName -like '*Hermes_Gateway*' } | ForEach-Object {
+                    $tn = $_.TaskName
+                    if ($_.Status -eq 'Disabled') {
+                        Write-Info "  gateway autostart task $tn is already disabled; leaving it that way"
+                        return
+                    }
+                    schtasks /End /TN $tn 2>$null | Out-Null
+                    schtasks /Change /TN $tn /DISABLE 2>$null | Out-Null
+                    $gatewayTasksDisabled += $tn
+                    Write-Info "  disabled gateway autostart task $tn for the duration of the install"
+                }
+            } catch {
+                Write-Warn "Could not enumerate gateway scheduled tasks: $($_.Exception.Message)"
+            }
+            # The launcher CLI (hermes.exe) plus its child tree.
+            & taskkill /F /T /IM hermes.exe /FI "PID ne $myPid" 2>$null | Out-Null
+            # taskkill /IM hermes.exe is NOT enough: the gateway/agent that a
+            # scheduled task or watchdog autostarts runs as
+            # `pythonw.exe -m hermes_cli.main gateway run` straight out of
+            # venv\Scripts\, so its image name is python/pythonw, not hermes.exe.
+            # That process holds the venv's .pyd files open and re-triggers the
+            # access-denied failure. Select only roots whose executable lives
+            # under this venv, then stop each root's whole process tree. Some
+            # Hermes children re-exec through .hermes-runtime, so killing only
+            # the selected venv process can leave its child holding the install
+            # open. The path-prefix check still keeps unrelated Python processes
+            # outside this venv untouched.
+            #
+            # The gateway autostart task registers with /RL LIMITED as the current
+            # user (see hermes_cli/gateway_windows.py), so the installer always
+            # runs at equal-or-higher integrity and can read its executable path.
+            # Get-CimInstance is used over Get-Process because it returns a null
+            # ExecutablePath for a process it cannot inspect (a different session)
+            # instead of throwing, so an unreadable process is skipped rather than
+            # aborting the whole sweep.
+            #
+            # The sweep is a bounded LOOP, not single-shot: supervised processes
+            # (the Desktop app's backend, a watchdog-managed gateway) respawn in
+            # the window between one kill pass and venv parking. Each pass re-
+            # enumerates; three consecutive clean passes (or the attempt cap)
+            # ends the loop.
+            $venvPrefix = [System.IO.Path]::GetFullPath((Join-Path $InstallDir "venv")).TrimEnd('\') + '\'
+            $cleanPasses = 0
+            for ($sweep = 0; $sweep -lt 10 -and $cleanPasses -lt 3; $sweep++) {
+                $found = 0
+                try {
+                    Get-CimInstance Win32_Process -ErrorAction Stop |
+                        Where-Object { $_.ProcessId -ne $myPid -and $_.ExecutablePath -and $_.ExecutablePath.StartsWith($venvPrefix, [System.StringComparison]::OrdinalIgnoreCase) } |
+                        ForEach-Object {
+                            $found++
+                            $treePid = [string]$_.ProcessId
+                            Write-Info "  stopping process tree at PID $treePid ($($_.Name)) running from venv"
+                            & taskkill /F /T /PID $treePid 2>$null | Out-Null
+                        }
+                } catch {
+                    Write-Warn "Could not enumerate venv processes: $($_.Exception.Message)"
+                    break
+                }
+                if ($found -eq 0) { $cleanPasses++ } else { $cleanPasses = 0 }
+                Start-Sleep -Milliseconds 400
+            }
+        }
+        # Move the old venv aside before creating its replacement. A directory
+        # rename is atomic on the same volume and does not require deleting
+        # files mapped as DLLs. NEVER fall back to deleting the live venv
+        # (#83149): Remove-Item -Recurse can delete most of site-packages and
+        # then fail on one locked .pyd, leaving a gutted venv with no usable
+        # interpreter and no rollback source. Abort with the previous install
+        # intact so the user can close holders and retry.
+        $venvBackupName = "venv.stale.{0}-{1}" -f (Get-Date -Format "yyyyMMddHHmmss"), ([Guid]::NewGuid().ToString("N"))
+        # Publish intent before the atomic rename. If this process is killed
+        # after publication but before the rename, Get-PendingVenvBackup drops
+        # the marker because its target does not exist. If it is killed after
+        # the rename, the next attempt can restore this original generation.
+        Set-Content -LiteralPath (Join-Path $InstallDir "venv.pending-backup") -Value $venvBackupName -Encoding ascii
+        try {
+            Rename-Item -LiteralPath "venv" -NewName $venvBackupName -ErrorAction Stop
+            $venvParked = $true
+        } catch {
+            $renameErr = $_.Exception.Message
+            Remove-Item -LiteralPath (Join-Path $InstallDir "venv.pending-backup") -Force -ErrorAction SilentlyContinue
+            throw (
+                "Could not move the existing venv aside ($renameErr). " +
+                "A process still has the install directory open (often a non-Hermes " +
+                "python.exe that resolved into this venv via PATH). Close those " +
+                "processes and retry - the previous install was left intact."
+            )
+        }
+    }
+    
+    # Pass the already-validated private interpreter path and prohibit uv from
+    # resolving or downloading a different Python during venv creation. Use
+    # ProcessStartInfo because the desktop bootstrapper redirects this script;
+    # Windows PowerShell 5.1 can otherwise lose nested native output/exit state.
+    $venvProcess = New-Object System.Diagnostics.Process
+    try {
+        $venvStartInfo = New-Object System.Diagnostics.ProcessStartInfo
+        $venvStartInfo.FileName = $UvCmd
+        $venvStartInfo.Arguments = "venv venv --python `"$($resolvedPython.Path)`" --managed-python --no-python-downloads --no-config"
+        $venvStartInfo.WorkingDirectory = $InstallDir
+        $venvStartInfo.UseShellExecute = $false
+        $venvStartInfo.CreateNoWindow = $true
+        $venvStartInfo.RedirectStandardOutput = $true
+        $venvStartInfo.RedirectStandardError = $true
+        $venvProcess.StartInfo = $venvStartInfo
+        if (-not $venvProcess.Start()) {
+            throw "Failed to start uv while creating the virtual environment"
+        }
+        $venvStdoutTask = $venvProcess.StandardOutput.ReadToEndAsync()
+        $venvStderrTask = $venvProcess.StandardError.ReadToEndAsync()
+        $venvProcess.WaitForExit()
+        $venvStdout = $venvStdoutTask.Result
+        $venvStderr = $venvStderrTask.Result
+        $venvExitCode = $venvProcess.ExitCode
+        if ($venvStdout) { Write-Host $venvStdout.TrimEnd() }
+        if ($venvStderr) { Write-Host $venvStderr.TrimEnd() }
+    } finally {
+        $venvProcess.Dispose()
+    }
+    # Fail fast so the stage cannot report ok=true when uv failed.
+    if ($venvExitCode -ne 0) {
+        throw "Failed to create virtual environment (uv venv exited with $venvExitCode)"
+    }
+
+    # uv can return success without leaving the interpreter expected by the
+    # installer (for example after an interrupted filesystem operation). Treat
+    # that as a failed transaction so the previous venv can be restored.
+    $venvPythonExe = Join-Path $InstallDir "venv\Scripts\python.exe"
+    if (-not (Test-Path -LiteralPath $venvPythonExe -PathType Leaf)) {
+        throw "uv reported success but venv interpreter is missing at $venvPythonExe"
+    }
+
+    # The replacement has a working interpreter, but the transaction is only
+    # committed after Install-Dependencies' baseline-import gate passes -- the
+    # bootstrap runs the stages as separate processes, and every dependency
+    # tier (or the import validation) can still fail after this stage
+    # succeeds. The marker was published before parking the original so an
+    # interruption cannot strand the only rollback source without a pointer.
+    if ($venvParked) {
+        Write-Info "Previous venv parked at $venvBackupName until the dependency install is verified"
+    }
+
+    # Clean up parked venvs from previous installs whose handles have since
+    # been released. Best-effort -- a still-held tree just stays for next time.
+    # The backup parked THIS run is excluded: it is the rollback source until
+    # Install-Dependencies commits the transaction.
+    Get-ChildItem -Directory -Filter "venv.stale.*" -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -ne $venvBackupName } | ForEach-Object {
+            Remove-Item -Recurse -Force $_.FullName -ErrorAction SilentlyContinue
+        }
+
+    # Neutralize any inherited UV_PYTHON (e.g. $env:UV_PYTHON = "3.14" left in
+    # the user's shell). uv honours UV_PYTHON over an existing venv for the
+    # later `uv sync` / `uv pip install` tiers, so without this it would
+    # silently delete this 3.11 venv and recreate it at the inherited version
+    # -- building Rust transitives that have no wheel for that version from
+    # source via maturin, which fails. Pinning UV_PYTHON to the interpreter we
+    # just created forces every subsequent uv command onto it.
+    $env:UV_PYTHON = $venvPythonExe
+    } catch {
+        $originalError = $_
+        $rollbackError = $null
+
+        if ($venvParked -and $venvBackupName -and (Test-Path -LiteralPath $venvBackupName)) {
+            try {
+                if (Test-Path -LiteralPath "venv") {
+                    $failedVenvName = "venv.failed.{0}-{1}" -f (Get-Date -Format "yyyyMMddHHmmss"), ([Guid]::NewGuid().ToString("N"))
+                    Rename-Item -LiteralPath "venv" -NewName $failedVenvName -ErrorAction Stop
+                    Write-Warn "Failed replacement parked at $failedVenvName"
+                }
+                Rename-Item -LiteralPath $venvBackupName -NewName "venv" -ErrorAction Stop
+                Remove-Item -LiteralPath (Join-Path $InstallDir "venv.pending-backup") -Force -ErrorAction SilentlyContinue
+                Write-Warn "Restored previous virtual environment after failed recreate"
+            } catch {
+                $rollbackError = $_.Exception.Message
+            }
+
+            if ($rollbackError) {
+                throw "Virtual environment recreate failed: $($originalError.Exception.Message). Rollback failed: $rollbackError. Previous venv remains at $venvBackupName."
+            }
+        } elseif (-not $venvHadExistingVenv -and (Test-Path -LiteralPath "venv")) {
+            # Preserve a partial first install too. This branch must not touch a
+            # pre-existing venv whose move-aside failed above.
+            try {
+                $failedVenvName = "venv.failed.{0}-{1}" -f (Get-Date -Format "yyyyMMddHHmmss"), ([Guid]::NewGuid().ToString("N"))
+                Rename-Item -LiteralPath "venv" -NewName $failedVenvName -ErrorAction Stop
+                Write-Warn "Partial virtual environment parked at $failedVenvName"
+            } catch {
+                $rollbackError = $_.Exception.Message
+            }
+            if ($rollbackError) {
+                throw "Virtual environment creation failed: $($originalError.Exception.Message). Could not park partial venv: $rollbackError"
+            }
+        }
+
+        throw $originalError
+    } finally {
+        Pop-Location
+        # Re-arm the gateway autostart tasks disabled during the venv teardown
+        # -- in a finally so a failed teardown/creation can never strand the
+        # user's gateway autostart in the disabled state. Same function scope,
+        # so the list survives even under the stage-per-process bootstrap.
+        # Deliberately NOT started here -- dependencies aren't installed yet;
+        # the task fires normally on next logon and `hermes update` / the
+        # gateway resume path handles the immediate restart.
+        if ($gatewayTasksDisabled -and $gatewayTasksDisabled.Count -gt 0) {
+            foreach ($tn in $gatewayTasksDisabled) {
+                schtasks /Change /TN $tn /ENABLE 2>$null | Out-Null
+            }
+            Write-Info "Re-enabled gateway autostart task(s): $($gatewayTasksDisabled -join ', ')"
+        }
+    }
+
+    Write-Success "Virtual environment ready (Python $($resolvedPython.Version))"
+}
+
+function Get-PendingVenvBackup {
+    # Rollback source recorded by Install-Venv (#83149). Returns the parked
+    # directory name, or $null when there is nothing to roll back to. A marker
+    # pointing at a directory that no longer exists is stale -- drop it.
+    $markerPath = Join-Path $InstallDir "venv.pending-backup"
+    if (-not (Test-Path -LiteralPath $markerPath -PathType Leaf)) { return $null }
+    $name = (Get-Content -LiteralPath $markerPath -ErrorAction SilentlyContinue | Select-Object -First 1)
+    if ($name) { $name = $name.Trim() }
+    if (-not $name -or -not (Test-Path -LiteralPath (Join-Path $InstallDir $name))) {
+        Remove-Item -LiteralPath $markerPath -Force -ErrorAction SilentlyContinue
+        return $null
+    }
+    return $name
+}
+
+function Complete-VenvTransaction {
+    # Commit: dependency install + baseline imports passed, so the previous
+    # venv is no longer needed as a rollback source. Best-effort delete; a
+    # tree still held open just stays parked for the next install's sweep.
+    $backupName = Get-PendingVenvBackup
+    if (-not $backupName) { return }
+    $backupPath = Join-Path $InstallDir $backupName
+    Remove-Item -LiteralPath $backupPath -Recurse -Force -ErrorAction SilentlyContinue
+    if (Test-Path -LiteralPath $backupPath) {
+        Write-Warn "Old venv parked at $backupName (a process still holds files in it); it will be cleaned up on the next install"
+    }
+    Remove-Item -LiteralPath (Join-Path $InstallDir "venv.pending-backup") -Force -ErrorAction SilentlyContinue
+}
+
+function Restore-VenvBackup {
+    # Rollback: the dependency stage failed after Install-Venv replaced the
+    # venv. Park the unusable replacement and restore the previous working
+    # venv so Hermes (and the venv-blocker probe) stay usable (#83149).
+    $backupName = Get-PendingVenvBackup
+    if (-not $backupName) { return }
+    try {
+        if (Test-Path -LiteralPath (Join-Path $InstallDir "venv")) {
+            $failedVenvName = "venv.failed.{0}-{1}" -f (Get-Date -Format "yyyyMMddHHmmss"), ([Guid]::NewGuid().ToString("N"))
+            Rename-Item -LiteralPath (Join-Path $InstallDir "venv") -NewName $failedVenvName -ErrorAction Stop
+            Write-Warn "Failed replacement parked at $failedVenvName"
+        }
+        Rename-Item -LiteralPath (Join-Path $InstallDir $backupName) -NewName "venv" -ErrorAction Stop
+        Remove-Item -LiteralPath (Join-Path $InstallDir "venv.pending-backup") -Force -ErrorAction SilentlyContinue
+        Write-Warn "Restored previous virtual environment after failed dependency install"
+    } catch {
+        Write-Warn "Could not restore previous venv (still parked at $backupName): $($_.Exception.Message)"
+    }
+}
+
+function Install-Dependencies {
+    Write-Info "Installing dependencies..."
+    
+    Push-Location $InstallDir
+    
+    if (-not $NoVenv) {
+        # Tell uv to install into our venv (no activation needed)
+        $env:VIRTUAL_ENV = "$InstallDir\venv"
+    }
+
+    # Re-pin UV_PYTHON to the venv interpreter. Install-Venv already does this,
+    # but the bootstrap runs install stages (venv, python-deps) as separate
+    # processes, so the env var set in Install-Venv does NOT survive into a
+    # separate python-deps invocation. Re-deriving it here covers that path.
+    # Without it, an inherited $env:UV_PYTHON = "3.14" makes the uv sync/pip
+    # tiers below recreate the venv at 3.14 and fail the maturin source build
+    # (no cp314 wheels yet).
+    if (-not $NoVenv) {
+        $venvPythonExe = Join-Path $InstallDir "venv\Scripts\python.exe"
+        if (Test-Path $venvPythonExe) {
+            $env:UV_PYTHON = $venvPythonExe
+        }
+    }
+
+    # Hash-verified install (Tier 0) -- when uv.lock is present, prefer
+    # `uv sync --locked`. The lockfile records SHA256 hashes for every
+    # transitive dependency, so a compromised transitive (different hash
+    # than what we shipped) is REJECTED by the resolver. This is the
+    # *only* path that protects against the "direct dep is fine, but the
+    # dep's dep got worm-poisoned overnight" failure mode. The
+    # `uv pip install` tiers below re-resolve transitives fresh from PyPI
+    # without any hash verification -- they exist to keep installs working
+    # when the lockfile is stale, missing, or out-of-sync with the
+    # current extras spec, NOT because they're equivalent in posture.
+    #
+    # Everything through the baseline-import gate runs inside the venv
+    # transaction opened by Install-Venv (#83149): on any failure the parked
+    # previous venv is restored before the error propagates, and the parked
+    # tree is deleted only after the imports prove the replacement usable.
+    try {
+    if (Test-Path "uv.lock") {
+        Write-Info "Trying tier: hash-verified (uv.lock) ..."
+        # Critical flag choice: `--extra all`, NOT `--all-extras`.
+        #   --all-extras = every [project.optional-dependencies] key,
+        #                  bypassing the curated [all] extra. On Windows
+        #                  that means [matrix] -> python-olm (no wheel,
+        #                  needs `make` to build from sdist) and the
+        #                  install fails.
+        #   --extra all  = just the [all] extra's contents (curated).
+        #
+        # UV_PROJECT_ENVIRONMENT pins the sync target to our venv\.
+        # Without it, modern uv (>=0.5) ignores VIRTUAL_ENV for `sync`
+        # and creates a sibling .venv\ inside the repo -- leaving venv\
+        # empty and producing the broken state where `hermes.exe` exists
+        # in the wrong directory and imports fail with ModuleNotFoundError.
+        # (Mirrors the same flag in scripts/install.sh::install_deps.)
+        $env:UV_PROJECT_ENVIRONMENT = "$InstallDir\venv"
+        Invoke-NativeWithRelaxedErrorAction { & $UvCmd sync --extra all --locked }
+        if ($LASTEXITCODE -eq 0) {
+            Write-Success "Main package installed (hash-verified via uv.lock)"
+            $script:InstalledTier = "hash-verified (uv.lock)"
+            # Skip the rest of the tiered cascade -- we already have a
+            # complete, hash-verified install.
+            $skipPipFallback = $true
+        } else {
+            Write-Warn "uv.lock sync failed (lockfile may be stale), falling back to PyPI resolve..."
+            $skipPipFallback = $false
+        }
+    } else {
+        Write-Info "uv.lock not found -- falling back to PyPI resolve (no hash verification)"
+        $skipPipFallback = $false
+    }
+
+    # Install main package.  Tiered fallback so a single flaky transitive
+    # doesn't silently drop everything.  Each tier's stdout/stderr is
+    # preserved -- no Out-Null swallowing -- so the user can see what failed.
+    #
+    # Tier 1: [all] -- the curated extra in pyproject.toml.
+    # Tier 2: [all] minus the currently-broken extras list ($brokenExtras).
+    #         Edit $brokenExtras below when something on PyPI breaks; this
+    #         lets users keep the rest of [all] when one transitive is
+    #         unavailable. The list of [all]'s contents is parsed from
+    #         pyproject.toml at runtime -- there is NO hand-mirrored copy
+    #         to drift out of sync.
+    # Tier 3: bare `.` -- last-resort so at least the core CLI launches.
+
+    # Currently-broken extras. Edit this list when an upstream package
+    # gets quarantined / yanked / breaks resolution. Empty means everything
+    # in [all] should be installable; populate with the names of extras
+    # whose deps are temporarily unavailable.
+    $brokenExtras = @()
+
+    # Parse [project.optional-dependencies].all from pyproject.toml.
+    # tomllib is stdlib on Python 3.11+ which the bootstrap guarantees.
+    $pythonExeForParse = if (-not $NoVenv) { "$InstallDir\venv\Scripts\python.exe" } else { (& $UvCmd python find $PythonVersion) }
+    $allExtras = @()
+    if (Test-Path $pythonExeForParse) {
+        $parsed = & $pythonExeForParse -c @"
+import re, sys, tomllib
+try:
+    with open('pyproject.toml', 'rb') as fh:
+        data = tomllib.load(fh)
+    specs = data['project']['optional-dependencies']['all']
+    out = []
+    for s in specs:
+        m = re.search(r'hermes-agent\[([\w-]+)\]', s)
+        if m: out.append(m.group(1))
+    print(','.join(out))
+except Exception:
+    sys.exit(1)
+"@ 2>$null
+        if ($LASTEXITCODE -eq 0 -and $parsed) {
+            $allExtras = $parsed.Trim().Split(',')
+        }
+    }
+    if (-not $allExtras -or $allExtras.Count -eq 0) {
+        Write-Warn "Could not parse [all] from pyproject.toml; Tier 2 will be a no-op."
+        $safeAll = "all"
+    } else {
+        $safeAll = ($allExtras | Where-Object { $brokenExtras -notcontains $_ }) -join ","
+    }
+    $brokenLabel = if ($brokenExtras) { ($brokenExtras -join ", ") } else { "none" }
+
+    $installTiers = @(
+        @{ Name = "all"; Spec = ".[all]" },
+        @{ Name = "all minus known-broken ($brokenLabel)"; Spec = ".[$safeAll]" },
+        @{ Name = "core only (no extras)"; Spec = "." }
+    )
+    $installed = $skipPipFallback
+    if (-not $skipPipFallback) {
+        foreach ($tier in $installTiers) {
+        Write-Info "Trying tier: $($tier.Name) ..."
+        Invoke-NativeWithRelaxedErrorAction { & $UvCmd pip install -e $tier.Spec }
+        if ($LASTEXITCODE -eq 0) {
+            Write-Success "Main package installed ($($tier.Name))"
+            $script:InstalledTier = $tier.Name
+            $installed = $true
+            break
+        }
+        Write-Warn "Tier '$($tier.Name)' failed (exit $LASTEXITCODE). Trying next tier..."
+        }
+    }
+    if (-not $installed) {
+        throw "Failed to install hermes-agent package even with no extras. Inspect the uv pip install output above."
+    }
+
+    # Baseline-import gate. Even if a tier reported success above, the
+    # actual deps may have landed somewhere other than $InstallDir\venv\
+    # (e.g. uv 0.5+ syncing into a sibling .venv\ when UV_PROJECT_ENVIRONMENT
+    # isn't set, leaving venv\ empty and hermes.exe broken with
+    # `ModuleNotFoundError: No module named 'dotenv'` on first run).
+    # We probe via the venv's own python so a misdirected sync is caught
+    # here, not 30 seconds later when the user runs `hermes`.
+    if (-not $NoVenv) {
+        $venvPython = "$InstallDir\venv\Scripts\python.exe"
+        if (-not (Test-Path $venvPython)) {
+            throw "Install reported success but $venvPython does not exist. The dependency sync likely landed in a sibling .venv\ directory. Re-run the installer; if it persists, close Hermes processes and preserve existing venv directories before retrying. Do not delete venv in place."
+        }
+        # Relax EAP=Stop while running the import probe.  Python writes
+        # deprecation warnings and import-system info to stderr; under
+        # EAP=Stop the 2>&1 merge wraps those as ErrorRecord objects and
+        # throws even when the imports succeed.  $LASTEXITCODE is the
+        # reliable signal (it's 0 iff the python invocation exited 0,
+        # regardless of what was written to stderr).
+        $prevEAP = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
+        & $venvPython -c "import dotenv, openai, rich, prompt_toolkit" 2>&1 | Out-Null
+        $importExitCode = $LASTEXITCODE
+        $ErrorActionPreference = $prevEAP
+        if ($importExitCode -ne 0) {
+            $sibling = "$InstallDir\.venv"
+            $hint = if (Test-Path $sibling) {
+                "Detected sibling .venv\ at $sibling -- uv synced there instead of venv\. Close Hermes processes, preserve the existing venv, and rerun the installer so the transactional recovery path can move directories safely."
+            } else {
+                "Recover with: cd '$InstallDir'; `$env:UV_PROJECT_ENVIRONMENT='$InstallDir\venv'; uv sync --extra all --locked"
+            }
+            throw "Baseline imports failed in $InstallDir\venv (dotenv/openai/rich/prompt_toolkit). The install completed but dependencies are not in the venv. $hint"
+        }
+        Write-Success "Baseline imports verified in venv"
+    }
+
+    # Commit the venv transaction: the dependency install completed and the
+    # baseline imports passed, so the previous venv is no longer needed as a
+    # rollback source (#83149).
+    Complete-VenvTransaction
+    } catch {
+        # Dependency install or import validation failed: restore the previous
+        # working venv (parked by Install-Venv) before surfacing the error, so
+        # a failed update leaves Hermes and its blocker probe usable.
+        Restore-VenvBackup
+        Pop-Location
+        throw
+    }
+
+    if (-not $NoVenv) {
+        # uv on Windows can register hermes.exe in dist-info/RECORD but fail to
+        # materialise the .exe (file lock during self-update, distlib edge case).
+        # Catch it here so a fresh install/update does not finish with a broken
+        # `hermes` command while hermes-agent.exe / hermes-acp.exe exist
+        $scriptsDir = Join-Path $InstallDir "venv\Scripts"
+        $pythonExe = Join-Path $scriptsDir "python.exe"
+        if ((Test-Path $scriptsDir) -and (Test-Path $pythonExe)) {
+            $scriptNames = & $pythonExe -c @"
+import tomllib
+with open('pyproject.toml', 'rb') as fh:
+    scripts = tomllib.load(fh).get('project', {}).get('scripts', {}) or {}
+print(','.join(scripts))
+"@ 2>$null
+            if ($LASTEXITCODE -eq 0 -and $scriptNames) {
+                $expected = @($scriptNames.Trim().Split(',') | Where-Object { $_ })
+                $missing = @()
+                foreach ($name in $expected) {
+                    $exe = Join-Path $scriptsDir "$name.exe"
+                    if (-not (Test-Path $exe)) { $missing += "$name.exe" }
+                }
+                if ($missing.Count -gt 0) {
+                    Write-Warn "Console entry point(s) missing: $($missing -join ', ')"
+                    Write-Info "Reinstalling entry points..."
+                    $env:UV_PROJECT_ENVIRONMENT = "$InstallDir\venv"
+                    Invoke-NativeWithRelaxedErrorAction { & $UvCmd pip install --reinstall -e . }
+                    $stillMissing = @()
+                    foreach ($name in $expected) {
+                        $exe = Join-Path $scriptsDir "$name.exe"
+                        if (-not (Test-Path $exe)) { $stillMissing += "$name.exe" }
+                    }
+                    if ($stillMissing.Count -gt 0) {
+                        Write-Warn "Entry points still missing after repair: $($stillMissing -join ', ')"
+                        Write-Info "Workaround: `"$pythonExe`" -m hermes_cli.main <command>"
+                    } else {
+                        Write-Success "Console entry points restored"
+                    }
+                }
+            }
+        }
+    }
+
+    # Verify the dashboard deps specifically -- they're the most common thing
+    # users hit and lazy-import errors from `hermes dashboard` are confusing.
+    # If tier 1 failed (the common case), [web] was still picked up by tiers
+    # 2-3; only tier 4 leaves you without it.
+    $pythonExe = if (-not $NoVenv) { "$InstallDir\venv\Scripts\python.exe" } else { (& $UvCmd python find $PythonVersion) }
+    if (Test-Path $pythonExe) {
+        $webOk = $false
+        $webServerSyntaxOk = $false
+        # Relax EAP=Stop while running the import probe; see the matching
+        # comment on the baseline-imports check above.  Python writes
+        # deprecation warnings to stderr and we don't want those wrapped
+        # as ErrorRecords that silently force the "not importable" path
+        # even when fastapi/uvicorn are actually installed.
+        $prevEAP = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
+        try {
+            & $pythonExe -c "import fastapi, uvicorn" 2>&1 | Out-Null
+            if ($LASTEXITCODE -eq 0) { $webOk = $true }
+        } catch { }
+        try {
+            & $pythonExe -m py_compile "$InstallDir\hermes_cli\web_server.py" 2>&1 | Out-Null
+            if ($LASTEXITCODE -eq 0) { $webServerSyntaxOk = $true }
+        } catch { }
+        $ErrorActionPreference = $prevEAP
+        if (-not $webOk) {
+            Write-Warn "fastapi/uvicorn not importable -- `hermes dashboard` will not work."
+            Write-Info "Attempting targeted install of [web] extra as last resort..."
+            & $UvCmd pip install -e ".[web]"
+            if ($LASTEXITCODE -eq 0) {
+                Write-Success "[web] extra installed; `hermes dashboard` should now work."
+            } else {
+                Write-Warn "Could not install [web] extra. Run manually: uv pip install --python `"$pythonExe`" `"fastapi>=0.104,<1`" `"uvicorn[standard]>=0.24,<1`""
+            }
+        }
+        if (-not $webServerSyntaxOk) {
+            throw "dashboard backend source failed syntax check: hermes_cli/web_server.py"
+        }
+    }
+    
+    Pop-Location
+    
+    Write-Success "All dependencies installed"
+}
+
+function Install-HermesCommandLaunchers {
+    param(
+        [Parameter(Mandatory=$true)] [string]$Root,
+        [Parameter(Mandatory=$true)] [string]$Destination
+    )
+
+    # Expose ONLY the hermes launchers on PATH -- never the whole
+    # venv\Scripts directory, which contains python.exe / pip.exe and
+    # silently hijacks the `python` command in every terminal (#83797).
+    # Requiring hermes.exe before creating the destination keeps the PATH
+    # stage from reporting success with an unusable command (PR #92092).
+    $scriptsDir = Join-Path $Root "venv\Scripts"
+    $requiredSource = Join-Path $scriptsDir "hermes.exe"
+    if (-not (Test-Path -LiteralPath $requiredSource -PathType Leaf)) {
+        throw "Cannot set up the hermes command: required launcher not found: $requiredSource"
+    }
+
+    New-Item -ItemType Directory -Force -Path $Destination | Out-Null
+
+    # Launcher form depends on the venv (keep in lockstep with
+    # hermes_cli/_install_repair.py): a normal venv's exe trampoline
+    # embeds an absolute interpreter path and survives copying; a
+    # relocatable venv's trampoline (managed_uv rebuilds use
+    # --relocatable) resolves relative to its own location, and a copy
+    # dies with 'uv trampoline failed to canonicalize script path' --
+    # those get a .cmd delegator invoking the in-venv exe instead.
+    $pyvenvCfg = Join-Path $Root "venv\pyvenv.cfg"
+    $venvRelocatable = $false
+    if (Test-Path -LiteralPath $pyvenvCfg) {
+        $venvRelocatable = [bool](Select-String -Path $pyvenvCfg -Pattern '^\s*relocatable\s*=\s*true\s*$' -Quiet)
+    }
+    foreach ($launcher in @("hermes", "hermes-acp")) {
+        $src = Join-Path $scriptsDir "$launcher.exe"
+        if (-not (Test-Path -LiteralPath $src -PathType Leaf)) { continue }
+        if ($venvRelocatable) {
+            Remove-Item (Join-Path $Destination "$launcher.exe") -Force -ErrorAction SilentlyContinue
+            Set-Content -Path (Join-Path $Destination "$launcher.cmd") -Value "@echo off`r`n`"$src`" %*" -Encoding Ascii
+        } else {
+            Remove-Item (Join-Path $Destination "$launcher.cmd") -Force -ErrorAction SilentlyContinue
+            Copy-Item -Force -LiteralPath $src -Destination (Join-Path $Destination "$launcher.exe")
+        }
+    }
+
+    # Verify either staged form before the caller mutates PATH.
+    $requiredExe = Join-Path $Destination "hermes.exe"
+    $requiredCmd = Join-Path $Destination "hermes.cmd"
+    if (-not ((Test-Path -LiteralPath $requiredExe -PathType Leaf) -or
+              (Test-Path -LiteralPath $requiredCmd -PathType Leaf))) {
+        throw "Cannot set up the hermes command: launcher was not installed: $requiredExe"
+    }
+    return $Destination
+}
+
+function Set-PathVariable {
+    Write-Info "Setting up hermes command..."
+    
+    if ($NoVenv) {
+        $hermesBin = "$InstallDir"
+    } else {
+        # $HermesHome\bin is the managed binary dir (shared with the managed
+        # uv), OUTSIDE the git checkout: `hermes update`'s autostash
+        # (git stash push --include-untracked) deletes untracked files from
+        # the working tree, which silently removed the launchers an earlier
+        # installer staged under hermes-agent\bin. No git operation can ever
+        # touch this dir. Staging and verification live in
+        # Install-HermesCommandLaunchers, which throws BEFORE any PATH
+        # mutation when the launchers cannot be staged.
+        $hermesBin = "$HermesHome\bin"
+        Install-HermesCommandLaunchers -Root $InstallDir -Destination $hermesBin | Out-Null
+    }
+    
+    $currentPath = [Environment]::GetEnvironmentVariable("Path", "User")
+
+    # Migrate older layouts off the user PATH:
+    #   venv\Scripts     -- shadowed the user's python (#83797)
+    #   hermes-agent\bin -- lived inside the git checkout, where the update
+    #                       autostash could sweep the launchers off disk
+    # The hermes-agent\bin FILES are left in place on purpose: editor/ACP
+    # configs that captured absolute launcher paths keep working, and the
+    # dir is git-ignored so it cannot dirty the checkout.
+    if (-not $NoVenv) {
+        $legacyEntries = @("$InstallDir\venv\Scripts", "$InstallDir\bin")
+        $items = @(($currentPath -split ';') | Where-Object { $_ })
+        $cleaned = @($items | Where-Object { $legacyEntries -notcontains $_ })
+        if ($cleaned.Count -ne $items.Count) {
+            $currentPath = $cleaned -join ";"
+            [Environment]::SetEnvironmentVariable("Path", $currentPath, "User")
+            Write-Info "Removed legacy launcher entries from user PATH (kept hermes via $hermesBin)"
+        }
+    }
+    
+    if ($currentPath -notlike "*$hermesBin*") {
+        [Environment]::SetEnvironmentVariable(
+            "Path",
+            "$hermesBin;$currentPath",
+            "User"
+        )
+        Write-Success "Added to user PATH: $hermesBin"
+    } else {
+        Write-Info "PATH already configured"
+    }
+    
+    # Set HERMES_HOME so the Python code finds config/data in the right place.
+    # Only needed on Windows where we install to %LOCALAPPDATA%\hermes instead
+    # of the Unix default ~/.hermes
+    $currentHermesHome = [Environment]::GetEnvironmentVariable("HERMES_HOME", "User")
+    if (-not $currentHermesHome -or $currentHermesHome -ne $HermesHome) {
+        [Environment]::SetEnvironmentVariable("HERMES_HOME", $HermesHome, "User")
+        Write-Success "Set HERMES_HOME=$HermesHome"
+    }
+    $env:HERMES_HOME = $HermesHome
+    
+    # Update current session
+    $env:Path = "$hermesBin;$env:Path"
+    
+    Write-Success "hermes command ready"
+}
+
+function Write-BootstrapMarker {
+    # Writes $InstallDir\.hermes-bootstrap-complete which tells the Hermes
+    # desktop app (apps/desktop/electron/main.ts) "install.ps1 ran
+    # successfully -- DON'T trigger the legacy first-launch bootstrap
+    # runner."
+    #
+    # Schema mirrors what main.ts's writeBootstrapMarker() / isBootstrap
+    # Complete() expect. Keep this in lockstep when either side changes:
+    #   apps/desktop/electron/main.ts lines 1199-1222
+    #   BOOTSTRAP_MARKER_SCHEMA_VERSION = 1 (line 187)
+    #
+    # Pinned commit/branch come from -Commit + -Branch flags (passed by
+    # Hermes-Setup.exe) or fall back to whatever git resolves in the
+    # checkout. The desktop validates schemaVersion + pinnedCommit
+    # length but doesn't enforce that HEAD matches the pin (users
+    # update via `hermes update` which moves HEAD legitimately).
+    if (-not (Test-Path $InstallDir)) {
+        Write-Warn "Skipping bootstrap marker: $InstallDir doesn't exist"
+        return
+    }
+
+    # Resolve the pinned commit: explicit -Commit wins, otherwise read
+    # the checkout's HEAD via git. If git can't run, leave commit empty
+    # and the marker will fail desktop validation (pinnedCommit.length
+    # >= 7) -- better to be invalid than wrong.
+    $pinnedCommit = $Commit
+    if (-not $pinnedCommit) {
+        # PS 5.1 doesn't support the ?. null-conditional operator, so
+        # check Get-Command's result explicitly before reading .Source.
+        $gitCmd = Get-Command git -ErrorAction SilentlyContinue
+        $gitExe = if ($gitCmd) { $gitCmd.Source } else { $null }
+        if ($gitExe) {
+            Push-Location $InstallDir
+            try {
+                $resolved = & $gitExe rev-parse HEAD 2>$null
+                if ($LASTEXITCODE -eq 0 -and $resolved) {
+                    $pinnedCommit = $resolved.Trim()
+                }
+            } catch {
+                # Ignore -- pinnedCommit stays empty, marker stays invalid,
+                # desktop falls through to its legacy bootstrap path.
+            } finally {
+                Pop-Location
+            }
+        }
+    }
+
+    $pinnedBranch = $Branch
+    if (-not $pinnedBranch) {
+        $pinnedBranch = "main"  # install.ps1's own default for -Branch
+    }
+
+    $markerPath = Join-Path $InstallDir ".hermes-bootstrap-complete"
+    $marker = [ordered]@{
+        schemaVersion = 1
+        pinnedCommit  = $pinnedCommit
+        pinnedBranch  = $pinnedBranch
+        completedAt   = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+        # desktopVersion field intentionally omitted -- only the desktop
+        # app knows its own version, and the marker validator doesn't
+        # require it. The desktop fills it in if/when it writes its
+        # own marker (e.g. after a future in-app upgrade).
+    }
+    $json = $marker | ConvertTo-Json -Compress:$false
+
+    # Write WITHOUT a UTF-8 BOM. PowerShell 5.1's `Set-Content -Encoding UTF8`
+    # always emits a BOM, and Node's plain JSON.parse rejects the BOM as an
+    # unexpected character -- so a BOM'd marker would silently fail the
+    # desktop's readJson(), make isBootstrapComplete() return null, and the
+    # desktop would re-run the legacy bootstrap runner anyway. Defeats the
+    # whole point. Use the .NET API directly for BOM-less UTF-8.
+    $utf8NoBom = New-Object System.Text.UTF8Encoding $false
+    [System.IO.File]::WriteAllText($markerPath, $json, $utf8NoBom)
+
+    Write-Success "Bootstrap marker written: $markerPath"
+}
+
+function Copy-ConfigTemplates {
+    Write-Info "Setting up configuration files..."
+    
+    # Create the HERMES_HOME directory structure ($HermesHome, default %LOCALAPPDATA%\hermes)
+    New-Item -ItemType Directory -Force -Path "$HermesHome\cron" | Out-Null
+    New-Item -ItemType Directory -Force -Path "$HermesHome\sessions" | Out-Null
+    New-Item -ItemType Directory -Force -Path "$HermesHome\logs" | Out-Null
+    New-Item -ItemType Directory -Force -Path "$HermesHome\pairing" | Out-Null
+    New-Item -ItemType Directory -Force -Path "$HermesHome\hooks" | Out-Null
+    New-Item -ItemType Directory -Force -Path "$HermesHome\image_cache" | Out-Null
+    New-Item -ItemType Directory -Force -Path "$HermesHome\audio_cache" | Out-Null
+    New-Item -ItemType Directory -Force -Path "$HermesHome\memories" | Out-Null
+    New-Item -ItemType Directory -Force -Path "$HermesHome\skills" | Out-Null
+
+    
+    # Create .env
+    $envPath = "$HermesHome\.env"
+    if (-not (Test-Path $envPath)) {
+        $examplePath = "$InstallDir\.env.example"
+        if (Test-Path $examplePath) {
+            Copy-Item $examplePath $envPath
+            Write-Success "Created $envPath from template"
+        } else {
+            New-Item -ItemType File -Force -Path $envPath | Out-Null
+            Write-Success "Created $envPath"
+        }
+    } else {
+        Write-Info "$envPath already exists, keeping it"
+    }
+    
+    # Create config.yaml
+    $configPath = "$HermesHome\config.yaml"
+    if (-not (Test-Path $configPath)) {
+        $examplePath = "$InstallDir\cli-config.yaml.example"
+        if (Test-Path $examplePath) {
+            Copy-Item $examplePath $configPath
+            Write-Success "Created $configPath from template"
+        }
+    } else {
+        Write-Info "$configPath already exists, keeping it"
+    }
+    
+    # Create SOUL.md if it doesn't exist (global persona file).
+    # IMPORTANT: write without a BOM.  Windows PowerShell 5.1's
+    # ``Set-Content -Encoding UTF8`` writes UTF-8 WITH a byte-order-mark
+    # (the default PS5 behaviour), and Hermes's prompt-injection scanner
+    # flags the BOM as an invisible unicode character and refuses to
+    # load the file.  PS7's ``-Encoding utf8NoBOM`` fixes that but we
+    # don't control which PowerShell version the user has.  Go direct
+    # to .NET with an explicit UTF8Encoding($false) -- BOM-free on every
+    # PowerShell version.
+    $soulPath = "$HermesHome\SOUL.md"
+    if (-not (Test-Path $soulPath)) {
+        # MUST match DEFAULT_SOUL_MD in hermes_cli/default_soul.py. The runtime
+        # upgrades the old comment-only scaffold to this text on next run, so
+        # drift is self-healing, but keep them in sync to avoid first-run churn.
+        $soulContent = @"
+You are Hermes Agent, built by Nous Research. Be direct: match the length of your reply to the weight of the ask -- a one-line question gets a one-line answer, and finished work gets a short report of what changed, what's verified, and what's left, never a replay of the process. No filler ("Great question," "I'd be happy to"), no restating the request back, no re-summarizing what you already said, no narrating tool calls the user can see. Plain claims over adjectives; when unsure, say so plainly. Agree because it's right, not because the user said it. Depth is earned -- give it when the user asks for detail, teaches, or the stakes demand it, not by default.
+"@
+        $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+        [System.IO.File]::WriteAllText($soulPath, $soulContent, $utf8NoBom)
+        Write-Success "Created $soulPath (edit to customize personality)"
+    }
+    
+    Write-Success "Configuration directory ready: $HermesHome"
+    
+    # Seed bundled skills into $HermesHome\skills (manifest-based, one-time per skill)
+    Write-Info "Syncing bundled skills to $HermesHome\skills ..."
+    $pythonExe = "$InstallDir\venv\Scripts\python.exe"
+    if (Test-Path $pythonExe) {
+        try {
+            # Force the child python.exe to emit UTF-8 on its stdout/stderr.
+            # On non-UTF-8 Windows locales (CP936/GBK zh-CN) Python defaults
+            # its stream encoding to the active codepage and crashes on glyphs
+            # like the checkmark (U+2713) that the codepage can't encode; the
+            # resulting non-UTF-8 bytes break this script's JSON result frame on
+            # stdout and abort the config-templates stage. Scope to this call
+            # only. (Comment kept ASCII per this file's PS 5.1 contract above.)
+            $prevPythonioencoding = $env:PYTHONIOENCODING
+            $prevPythonutf8 = $env:PYTHONUTF8
+            $env:PYTHONIOENCODING = "utf-8"
+            $env:PYTHONUTF8 = "1"
+            try {
+                & $pythonExe "$InstallDir\tools\skills_sync.py" 2>$null
+            } finally {
+                $env:PYTHONIOENCODING = $prevPythonioencoding
+                $env:PYTHONUTF8 = $prevPythonutf8
+            }
+            Write-Success "Skills synced to $HermesHome\skills"
+        } catch {
+            # Fallback: simple directory copy
+            $bundledSkills = "$InstallDir\skills"
+            $userSkills = "$HermesHome\skills"
+            if ((Test-Path $bundledSkills) -and -not (Get-ChildItem $userSkills -Exclude '.bundled_manifest' -ErrorAction SilentlyContinue)) {
+                Copy-Item -Path "$bundledSkills\*" -Destination $userSkills -Recurse -Force -ErrorAction SilentlyContinue
+                Write-Success "Skills copied to $HermesHome\skills"
+            }
+        }
+    }
+}
+
+function Install-NodeDeps {
+    if (-not $HasNode) {
+        # Cross-process driver mode (Hermes-Setup.exe runs each -Stage NAME
+        # in a fresh powershell.exe) means $script:HasNode set by Stage-Node
+        # in the previous process isn't visible here. Re-probe rather than
+        # trust the stale global -- Stage-Node already ran successfully or
+        # the bootstrap would've aborted, so npm is reachable.
+        if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+            Write-Info "Skipping Node.js dependencies (Node not installed)"
+            return
+        }
+    }
+
+    # npm lifecycle scripts need node.exe on the PATH visible to child
+    # cmd.exe processes.  Stage-Node may have run in a prior process, so
+    # re-apply here before any npm install (regression #48130).
+    Ensure-NodeExeOnPath | Out-Null
+
+    # Resolve npm explicitly to npm.cmd, NOT npm.ps1.  Node.js on Windows
+    # ships BOTH npm.cmd (a batch shim) and npm.ps1 (a PowerShell shim).
+    # Get-Command's default ordering picks whichever comes first in PATHEXT,
+    # and on many systems that's .ps1 -- but .ps1 requires scripts to be
+    # enabled in PowerShell's execution policy, which most Windows users
+    # don't have (the Restricted / RemoteSigned default blocks unsigned
+    # .ps1 files).  .cmd has no such restriction and works on every box.
+    #
+    # Strategy: look next to the npm shim we found and prefer npm.cmd if
+    # it exists in the same directory.  Fall back to whatever Get-Command
+    # returned if we can't find a .cmd sibling.
+    $npmCmd = Get-Command npm -ErrorAction SilentlyContinue
+    if (-not $npmCmd) {
+        Write-Warn "npm not found on PATH -- skipping Node.js dependencies."
+        Write-Info "Open a new PowerShell window and re-run 'hermes setup tools' later."
+        return
+    }
+    $npmExe = $npmCmd.Source
+    if ($npmExe -like "*.ps1") {
+        $npmCmdSibling = Join-Path (Split-Path $npmExe -Parent) "npm.cmd"
+        if (Test-Path $npmCmdSibling) {
+            Write-Info "Using npm.cmd (PowerShell execution policy blocks npm.ps1)"
+            $npmExe = $npmCmdSibling
+        } else {
+            Write-Warn "Only npm.ps1 available -- install may fail if script execution is disabled."
+            Write-Info "  If it fails, either enable PS script execution or install Node via winget."
+        }
+    }
+
+    # Wall-clock ceiling for each npm / Playwright invocation in this stage.
+    # scripts/install.sh has time-boxed the same work with
+    # ``run_with_timeout "$NODE_DEPS_TIMEOUT"`` (600s default) since #39219;
+    # Windows never got the guard, so a stalled registry fetch or a wedged
+    # Chromium extraction (#76222, #84614) froze the installer forever -- one
+    # user left it running 12+ hours overnight.  Same env override as bash
+    # for very slow links.
+    $nodeDepsTimeoutSec = 600
+    if ($env:NODE_DEPS_TIMEOUT -match '^\d+$') {
+        $nodeDepsTimeoutSec = [int]$env:NODE_DEPS_TIMEOUT
+    }
+
+    # Helper: run a native command with a hard wall-clock timeout while
+    # still streaming its output live.  Returns the exit code, or 124 on
+    # timeout (the same convention as coreutils ``timeout`` and bash's
+    # run_with_timeout).
+    #
+    # Launcher notes: ``Start-Process -FilePath npm.cmd`` fails with
+    # ``%1 is not a valid Win32 application`` on some PowerShell versions
+    # because Start-Process bypasses cmd.exe / PATHEXT and expects a real
+    # PE file -- so route through cmd.exe, which IS a real PE, honours .cmd
+    # batch shims, and performs the stdout+stderr merge into the log file
+    # natively.  The parent then tails the log into the console each poll
+    # tick, preserving the live progress that makes a 3-minute download
+    # distinguishable from a hang (the whole reason _Run-NpmInstall streams
+    # output in the first place).  ``Wait-Job -Timeout`` was rejected: jobs
+    # swallow live output, and Stop-Job leaves the npm child running.
+    # taskkill /T kills the real process tree.  Works on Windows PowerShell
+    # 5.1 -- no pwsh-only primitives.
+    function _Invoke-NativeWithTimeout(
+        [string]$exePath, [string]$argLine, [string]$workDir,
+        [string]$logPath, [int]$timeoutSec
+    ) {
+        $cmdLine = "/d /s /c "" ""$exePath"" $argLine > ""$logPath"" 2>&1 """
+        $proc = Start-Process -FilePath $env:ComSpec -ArgumentList $cmdLine `
+            -WorkingDirectory $workDir -NoNewWindow -PassThru
+        $deadline = [DateTime]::UtcNow.AddSeconds($timeoutSec)
+        $shown = 0
+        function _Drain-NewLines([string]$path, [ref]$count) {
+            $lines = @(Get-Content $path -ErrorAction SilentlyContinue)
+            if ($lines.Count -gt $count.Value) {
+                $lines[$count.Value..($lines.Count - 1)] | ForEach-Object {
+                    Write-Host "    $_" -ForegroundColor DarkGray
+                }
+                $count.Value = $lines.Count
+            }
+        }
+        while (-not $proc.HasExited) {
+            if ([DateTime]::UtcNow -gt $deadline) {
+                & taskkill /T /F /PID $proc.Id 2>&1 | Out-Null
+                return 124
+            }
+            Start-Sleep -Milliseconds 750
+            _Drain-NewLines $logPath ([ref]$shown)
+        }
+        _Drain-NewLines $logPath ([ref]$shown)
+        return $proc.ExitCode
+    }
+
+    # Helper: run "npm install" in a given directory and surface the real
+    # error when it fails.  Returns $true on success.
+    function _Run-NpmInstall([string]$label, [string]$installDir, [string]$logPath, [string]$npmPath) {
+        Push-Location $installDir
+        # Capture EAP outside the try block so the catch's restore call always
+        # has a meaningful value (see Install-Uv for the full rationale).
+        $prevEAP = $ErrorActionPreference
+        try {
+            # The helper streams npm's output to BOTH the console and the log
+            # file, so the user watches real progress instead of a frozen
+            # "Installing..." line (on a fresh VM the install is 1-3 minutes;
+            # total silence is indistinguishable from a hang) -- and the
+            # wall-clock ceiling turns a genuinely stalled install (#76222
+            # class) into a diagnosable failure instead of an overnight freeze.
+            #
+            # Relax EAP around the invocation: with EAP=Stop (set at the top
+            # of this script), PowerShell can wrap stray stderr from the
+            # launcher plumbing as ErrorRecord objects and throw even though
+            # npm exited 0.  This is the same issue Test-Python and Install-Uv
+            # work around for uv's stderr-emitting installer.  Check success
+            # via the returned exit code, which is reliable regardless of
+            # stderr noise.
+            $ErrorActionPreference = "Continue"
+            $code = _Invoke-NativeWithTimeout $npmPath "install --silent" `
+                $installDir $logPath $nodeDepsTimeoutSec
+            $ErrorActionPreference = $prevEAP
+            if ($code -eq 0) {
+                Write-Success "$label dependencies installed"
+                Remove-Item -Force $logPath -ErrorAction SilentlyContinue
+                return $true
+            }
+            if ($code -eq 124) {
+                Write-Warn "$label npm install timed out after $([math]::Round($nodeDepsTimeoutSec / 60)) minutes -- a stalled download, wedged extraction, or file lock is the usual cause."
+                Write-Info "  Re-run the installer to retry (completed stages are skipped)."
+                Write-Info "  Slow connection? Raise the ceiling: set NODE_DEPS_TIMEOUT to seconds (default 600)."
+            } else {
+                Write-Warn "$label npm install failed -- exit code $code"
+            }
+            if (Test-Path $logPath) {
+                $errText = (Get-Content $logPath -Raw -ErrorAction SilentlyContinue)
+                if ($errText) {
+                    $snippet = if ($errText.Length -gt 1200) { $errText.Substring(0, 1200) + "..." } else { $errText }
+                    Write-Info "  npm output:"
+                    foreach ($line in $snippet -split "`n") {
+                        Write-Host "    $line" -ForegroundColor DarkGray
+                    }
+                    Write-Info "  Full log: $logPath"
+                    Show-NpmCertHint $errText | Out-Null
+                    Write-NpmDebugLogTail -NpmOutput $errText
+                }
+            }
+            Write-Info "Run manually later: cd `"$installDir`"; npm install"
+            return $false
+        } catch {
+            if ($prevEAP) { $ErrorActionPreference = $prevEAP }
+            Write-Warn "$label npm install could not be launched: $_"
+            return $false
+        } finally {
+            Pop-Location
+        }
+    }
+
+    # Browser tools
+    if (Test-Path "$InstallDir\package.json") {
+        Write-Info "Installing Node.js dependencies (browser tools)..."
+        $browserLog = "$env:TEMP\hermes-npm-browser-$(Get-Random).log"
+        $browserNpmOk = _Run-NpmInstall "Browser tools" $InstallDir $browserLog $npmExe
+
+        # Install Playwright Chromium (mirrors scripts/install.sh behaviour for
+        # Linux).  Without this, tools/browser_tool.py::check_browser_requirements
+        # returns False (no Chromium under %LOCALAPPDATA%\ms-playwright), and the
+        # browser_* tools are silently filtered out of the agent's tool schema.
+        # System Chrome at "C:\Program Files\Google\Chrome\..." is NOT used by
+        # agent-browser -- it expects a Playwright-managed Chromium.
+        if ($browserNpmOk) {
+            Write-Info "Installing browser engine (Playwright Chromium)..."
+            # npx lives next to npm in the same bin dir.  Prefer .cmd to dodge
+            # the same execution-policy gotcha that affects npm.ps1 (see above).
+            $npmDir = Split-Path $npmExe -Parent
+            $npxExe = $null
+            foreach ($cand in @("npx.cmd", "npx.exe", "npx")) {
+                $try = Join-Path $npmDir $cand
+                if (Test-Path $try) { $npxExe = $try; break }
+            }
+            if (-not $npxExe) {
+                $npxCmd = Get-Command npx -ErrorAction SilentlyContinue
+                if ($npxCmd) { $npxExe = $npxCmd.Source }
+            }
+            if (-not $npxExe) {
+                Write-Warn "npx not found -- cannot install Playwright Chromium."
+                Write-Info "Run manually later: cd `"$InstallDir`"; npx playwright install chromium"
+            } else {
+                $pwLog = "$env:TEMP\hermes-playwright-install-$(Get-Random).log"
+                Push-Location $InstallDir
+                # Capture EAP outside the try block so the catch's restore call
+                # always has a meaningful value (see Install-Uv for the full
+                # rationale).
+                $prevEAP = $ErrorActionPreference
+                try {
+                    # Playwright Chromium is ~170MB compressed and the
+                    # download regularly takes 3-10 minutes on a fresh
+                    # VM.  Tee the output to console + log so the user
+                    # sees download progress in real time instead of
+                    # staring at a silent prompt that looks hung.  See
+                    # _Run-NpmInstall above for the same pattern and
+                    # the rationale behind 2>&1 before the pipe.
+                    Write-Info "(this can take several minutes -- streaming progress below)"
+                    # --yes auto-accepts npx's "Need to install playwright@X.Y.Z"
+                    # confirmation prompt.  Without it, npx 7+ blocks on stdin
+                    # waiting for a y/N answer that never comes when this is
+                    # invoked through a pipeline (Tee-Object disconnects stdin
+                    # from the user's TTY), and the install hangs indefinitely
+                    # after printing "Need to install the following packages:
+                    # playwright@X.Y.Z".
+                    #
+                    # Relax EAP around the playwright invocation: playwright
+                    # emits a "Chromium downloaded to ..." success banner to
+                    # stderr after a successful install.  The launcher merges
+                    # stderr into the log natively, but keep EAP relaxed so
+                    # stray plumbing stderr can't fire the catch block with a
+                    # mangled banner even though the install succeeded.  Check
+                    # the returned exit code instead, which is the reliable
+                    # signal.
+                    #
+                    # The wall-clock ceiling is the #76222 / #84614 fix: the
+                    # Chromium download reaches 100% and the extraction wedges
+                    # (or the registry fetch stalls), and without a bound the
+                    # installer sits on this line forever.  bash has carried
+                    # the same 600s guard via run_playwright_install since
+                    # #39219.
+                    $ErrorActionPreference = "Continue"
+                    $pwCode = _Invoke-NativeWithTimeout $npxExe "--yes playwright install chromium" `
+                        $InstallDir $pwLog $nodeDepsTimeoutSec
+                    $ErrorActionPreference = $prevEAP
+                    if ($pwCode -eq 0) {
+                        Write-Success "Playwright Chromium installed (browser tools ready)"
+                        Remove-Item -Force $pwLog -ErrorAction SilentlyContinue
+                    } elseif ($pwCode -eq 124) {
+                        Write-Warn "Playwright Chromium install timed out after $([math]::Round($nodeDepsTimeoutSec / 60)) minutes."
+                        Write-Warn "This usually means a stalled download or a wedged archive extraction (a locked previous browser version can also cause it)."
+                        Write-Warn "Browser tools will not work until Chromium is installed."
+                        if (Test-Path $pwLog) { Write-Info "  Partial log: $pwLog" }
+                        Write-Info "Run manually later: cd `"$InstallDir`"; npx playwright install chromium"
+                    } else {
+                        Write-Warn "Playwright Chromium install failed -- exit code $pwCode"
+                        Write-Warn "Browser tools will not work until Chromium is installed."
+                        if (Test-Path $pwLog) {
+                            $pwErr = Get-Content $pwLog -Raw -ErrorAction SilentlyContinue
+                            if ($pwErr) {
+                                $snippet = if ($pwErr.Length -gt 1200) { $pwErr.Substring(0, 1200) + "..." } else { $pwErr }
+                                Write-Info "  playwright output:"
+                                foreach ($line in $snippet -split "`n") {
+                                    Write-Host "    $line" -ForegroundColor DarkGray
+                                }
+                                Write-Info "  Full log: $pwLog"
+                            }
+                        }
+                        Write-Info "Run manually later: cd `"$InstallDir`"; npx playwright install chromium"
+                    }
+                } catch {
+                    if ($prevEAP) { $ErrorActionPreference = $prevEAP }
+                    Write-Warn "Playwright Chromium install could not be launched: $_"
+                    Write-Info "Run manually later: cd `"$InstallDir`"; npx playwright install chromium"
+                } finally {
+                    Pop-Location
+                }
+            }
+        }
+    }
+
+    # TUI
+    $tuiDir = "$InstallDir\ui-tui"
+    if (Test-Path "$tuiDir\package.json") {
+        Write-Info "Installing TUI dependencies..."
+        $tuiLog = "$env:TEMP\hermes-npm-tui-$(Get-Random).log"
+        [void](_Run-NpmInstall "TUI" $tuiDir $tuiLog $npmExe)
+    }
+
+    Install-BrowserUseCli
+    Install-CuaDriver
+}
+
+# The Browser Use CLI is the default browser backend when it is runnable
+# (tools/browser_use_cli.py). Provision it at install time so fresh installs
+# don't silently fall back to the built-in browser tools. Best-effort: any
+# failure is non-fatal (browser_exec can still run via uvx, and `hermes tools`
+# can install it later).
+function Install-BrowserUseCli {
+    if (-not $script:UvCmd) { Resolve-UvCmd }
+    if (-not $script:UvCmd) {
+        Write-Info "Skipping Browser Use CLI install (uv unavailable)"
+        return
+    }
+    $managedBin = Join-Path $HermesHome "bin"
+    $managedBu = Join-Path $managedBin "browser-use.exe"
+    # MANAGED-FIRST: only Hermes' managed copy short-circuits. A browser-use
+    # on the user's PATH is a side install -- resolution prefers the managed
+    # copy, so it must be provisioned regardless.
+    if (Test-Path $managedBu) {
+        Write-Success "Browser Use CLI already installed"
+        return
+    }
+
+    Write-Info "Installing Browser Use CLI (default browser backend)..."
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        # UV_TOOL_BIN_DIR keeps the binary inside Hermes' managed bin dir,
+        # where the browser tool resolves it -- no reliance on the user PATH.
+        $env:UV_TOOL_BIN_DIR = $managedBin
+        $env:UV_NO_CONFIG = "1"
+        & $script:UvCmd tool install browser-use 2>&1 | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Success "Browser Use CLI installed"
+        } else {
+            Write-Warn "Browser Use CLI install failed (exit $LASTEXITCODE) -- browser automation falls back to built-in tools."
+            Write-Info "Install later with: uv tool install browser-use  (or via 'hermes tools')"
+        }
+    } catch {
+        Write-Warn "Browser Use CLI install failed: $_"
+    } finally {
+        $ErrorActionPreference = $prevEAP
+        Remove-Item Env:\UV_TOOL_BIN_DIR -ErrorAction SilentlyContinue
+        Remove-Item Env:\UV_NO_CONFIG -ErrorAction SilentlyContinue
+    }
+}
+
+function Test-CuaDriverRuntimeContract {
+    param([Parameter(Mandatory = $true)][string]$DriverPath)
+
+    try {
+        $versionOutput = (& $DriverPath --version 2>$null | Out-String).Trim()
+        if ($LASTEXITCODE -ne 0) {
+            return $false
+        }
+        $versionMatch = [regex]::Match($versionOutput, '(\d+\.\d+\.\d+)')
+        if (-not $versionMatch.Success) {
+            return $false
+        }
+        if ([version]($versionMatch.Groups[1].Value) -lt [version]'0.20.0') {
+            return $false
+        }
+
+        $manifestOutput = (& $DriverPath manifest 2>$null | Out-String).Trim()
+        if ($LASTEXITCODE -ne 0 -or -not $manifestOutput) {
+            return $false
+        }
+        $manifest = $manifestOutput | ConvertFrom-Json
+        if (-not $manifest.mcp_invocation.args) {
+            return $false
+        }
+
+        $required = @{
+            mcp = @('--socket', '--grant')
+            serve = @(
+                '--socket', '--permission-mode', '--capability-manifest',
+                '--approve-capability-manifest', '--embedded'
+            )
+            stop = @('--socket')
+        }
+        foreach ($commandName in $required.Keys) {
+            $command = $manifest.subcommands | Where-Object { $_.name -eq $commandName }
+            if (-not $command) {
+                return $false
+            }
+            $argNames = @($command.args | ForEach-Object { $_.name })
+            foreach ($requiredArg in $required[$commandName]) {
+                if ($requiredArg -notin $argNames) {
+                    return $false
+                }
+            }
+        }
+        return $true
+    } catch {
+        return $false
+    }
+}
+
+# cua-driver powers the computer_use toolset (background desktop control).
+# Provision it at install time so enabling the tool later -- via `hermes
+# tools`, the dashboard, or the desktop app -- is a config flip, not a
+# surprise multi-minute binary fetch. Best-effort and non-fatal: the enable
+# paths still lazy-install via install_cua_driver() (hermes_cli/tools_config)
+# when this step was skipped or failed.
+function Install-CuaDriver {
+    if ($SkipComputerUse) {
+        Write-Info "Skipping Computer Use (cua-driver) install (-SkipComputerUse)"
+        return
+    }
+    $existingCuaDriver = Get-Command cua-driver -ErrorAction SilentlyContinue
+    if ($existingCuaDriver) {
+        if (Test-CuaDriverRuntimeContract -DriverPath $existingCuaDriver.Source) {
+            Write-Success "Computer Use driver (cua-driver) already installed and compatible"
+            return
+        }
+        Write-Warn "Existing cua-driver is old or incomplete; repairing it"
+    }
+
+    Write-Info "Installing Computer Use driver (cua-driver)..."
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        # Same upstream installer `hermes computer-use install` runs. Bounded
+        # via a background job: the upstream installer serializes with its own
+        # lock (600s stale window), so the ceiling sits above that -- matching
+        # Hermes' _CUA_INSTALLER_TIMEOUT (660s).
+        $job = Start-Job -ScriptBlock {
+            Invoke-RestMethod -UseBasicParsing "https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.ps1" | Invoke-Expression
+        }
+        if (Wait-Job $job -Timeout 660) {
+            Receive-Job $job -ErrorAction SilentlyContinue | Out-Null
+            Remove-Job $job -Force -ErrorAction SilentlyContinue
+            $installedCuaDriver = Get-Command cua-driver -ErrorAction SilentlyContinue
+            if ($installedCuaDriver -and (Test-CuaDriverRuntimeContract -DriverPath $installedCuaDriver.Source)) {
+                Write-Success "Computer Use driver installed (enable via 'hermes tools' -> Computer Use)"
+            } else {
+                Write-Warn "Computer Use driver install did not produce a compatible runtime -- repair it before enabling the tool."
+                Write-Info "Install later with: hermes computer-use install"
+            }
+        } else {
+            Stop-Job $job -ErrorAction SilentlyContinue
+            Remove-Job $job -Force -ErrorAction SilentlyContinue
+            Write-Warn "Computer Use driver install timed out -- it will install on demand when you enable the tool."
+            Write-Info "Install later with: hermes computer-use install"
+        }
+    } catch {
+        Write-Warn "Computer Use driver install failed: $_"
+        Write-Info "Install later with: hermes computer-use install"
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+}
+
+# Clear the cached Electron download + any half-written unpacked output so the
+# next `npm run pack` re-downloads and re-stages from scratch. A corrupt zip in
+# the per-user Electron download cache - most often a partial download resumed
+# into the same file, leaving concatenated junk - makes electron-builder's
+# `app-builder unpack-electron` extract a tree MISSING the electron binary, so
+# the final `electron` -> `Hermes` rename dies with ENOENT and every re-run
+# repeats the broken extraction forever.
+#
+# We deliberately do not validate the zip ourselves: the common
+# prepended/concatenated-junk corruption slips past naive checks, so a
+# self-rolled gate would skip the real-world case. We unconditionally drop the
+# cached electron-*.zip (loose copy and any @electron/get hash-subdir copy) plus
+# the stale unpacked dir, then let the caller retry once - @electron/get
+# re-downloads with its own SHASUM verification, the real source of truth.
+#
+# Returns the removed paths. Best-effort: never throws.
+function Clear-ElectronBuildCache {
+    param([string]$DesktopDir)
+    $removed = @()
+
+    # Per-user Electron download cache dirs, honoring the overrides @electron/get
+    # respects, then the Windows default (%LOCALAPPDATA%\electron\Cache).
+    $cacheDirs = @()
+    if ($env:electron_config_cache) { $cacheDirs += $env:electron_config_cache }
+    if ($env:ELECTRON_CACHE)        { $cacheDirs += $env:ELECTRON_CACHE }
+    if ($env:LOCALAPPDATA)          { $cacheDirs += (Join-Path $env:LOCALAPPDATA 'electron\Cache') }
+    $cacheDirs += (Join-Path $HOME 'AppData\Local\electron\Cache')
+
+    foreach ($dir in $cacheDirs) {
+        if (-not (Test-Path -LiteralPath $dir)) { continue }
+        # Recurse: the bad copy may be the top-level zip OR a copy inside an
+        # @electron/get hash subdir.
+        $removed += @(Get-ChildItem -LiteralPath $dir -Recurse -Filter 'electron-*.zip' -File -ErrorAction SilentlyContinue | ForEach-Object {
+            try { Remove-Item -LiteralPath $_.FullName -Force -ErrorAction Stop; $_.FullName } catch { }
+        })
+    }
+
+    # A half-written unpacked dir from an interrupted prior pack poisons the
+    # rename even after the zip is fixed (win-unpacked / win-arm64-unpacked).
+    $releaseDir = Join-Path $DesktopDir 'release'
+    if (Test-Path -LiteralPath $releaseDir) {
+        $removed += @(Get-ChildItem -LiteralPath $releaseDir -Directory -Filter '*-unpacked' -ErrorAction SilentlyContinue | ForEach-Object {
+            try { Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction Stop; $_.FullName } catch { }
+        })
+    }
+
+    return $removed
+}
+
+# Last-resort Electron mirror after GitHub download fails (#47266).
+$script:DesktopElectronFallbackMirror = "https://npmmirror.com/mirrors/electron/"
+
+# Electron package dir -- workspace-local nest first, then root hoist.
+function Get-ElectronDir {
+    param([string]$InstallDir)
+    $desktopLocal = Join-Path $InstallDir 'apps\desktop\node_modules\electron'
+    if (Test-Path -LiteralPath $desktopLocal) { return $desktopLocal }
+    return (Join-Path $InstallDir 'node_modules\electron')
+}
+
+# True when dist/ holds a usable Electron binary (#38673 / run-electron-builder.mjs).
+function Test-ElectronDist {
+    param([string]$InstallDir)
+    $electronDir = Get-ElectronDir -InstallDir $InstallDir
+    $distExe = Join-Path $electronDir 'dist\electron.exe'
+    return (Test-Path -LiteralPath $distExe)
+}
+
+# Best-effort: run electron/install.js to populate dist/ (optional mirror).
+function Restore-ElectronDist {
+    param([string]$InstallDir, [string]$Mirror)
+    if (Test-ElectronDist -InstallDir $InstallDir) { return $true }
+
+    $electronDir = Get-ElectronDir -InstallDir $InstallDir
+    $distExe = Join-Path $electronDir 'dist\electron.exe'
+    $installer = Join-Path $electronDir 'install.js'
+    if (-not (Test-Path -LiteralPath $installer)) { return $false }
+    $node = Get-Command node -ErrorAction SilentlyContinue
+    if (-not $node) { return $false }
+
+    $distDir = Join-Path $electronDir 'dist'
+    if (Test-Path -LiteralPath $distDir) {
+        Remove-Item -LiteralPath $distDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    Remove-Item -LiteralPath (Join-Path $electronDir 'path.txt') -Force -ErrorAction SilentlyContinue
+
+    $prevMirror = $env:ELECTRON_MIRROR
+    if ($Mirror) { $env:ELECTRON_MIRROR = $Mirror }
+    try {
+        # Out-Host so the downloader's progress shows on the console WITHOUT
+        # leaking into this function's return value (PowerShell returns every
+        # object left on the output stream, so a bare pipe here would make the
+        # boolean below ambiguous).
+        & $node.Source $installer 2>&1 | ForEach-Object { "$_" } | Out-Host
+    } catch {
+    } finally {
+        $env:ELECTRON_MIRROR = $prevMirror
+    }
+    return (Test-Path -LiteralPath $distExe)
+}
+
+function Test-ElectronPkgStagedMissingDist {
+    param([string]$InstallDir)
+    $electronDir = Get-ElectronDir -InstallDir $InstallDir
+    return (
+        (Test-Path -LiteralPath (Join-Path $electronDir 'package.json')) -and
+        (Test-Path -LiteralPath (Join-Path $electronDir 'install.js')) -and
+        (-not (Test-ElectronDist -InstallDir $InstallDir))
+    )
+}
+
+function Try-RestoreElectronDist {
+    param([string]$InstallDir)
+    if (Restore-ElectronDist -InstallDir $InstallDir) { return $true }
+    if ($env:ELECTRON_MIRROR) { return $false }
+    return Restore-ElectronDist -InstallDir $InstallDir -Mirror $script:DesktopElectronFallbackMirror
+}
+
+function Install-DesktopVoiceDeps {
+    # Desktop ships with working voice out of the box: eagerly install the
+    # wake-word + local-STT stacks ([wake] + [voice] extras) instead of
+    # leaving them to lazy first-use install. Policy change (Teknium, July
+    # 2026, #70509 testing): the first ear-click used to trigger a
+    # multi-minute onnxruntime pip install that froze the UI and blew RPC
+    # timeouts. Best-effort -- lazy install remains the fallback for anything
+    # this step fails to fetch.
+    if (-not $script:UvCmd) { Resolve-UvCmd }
+    if (-not $script:UvCmd) {
+        Write-Warn "uv unavailable -- voice/wake deps will lazy-install at first use instead"
+        return
+    }
+    $env:VIRTUAL_ENV = "$InstallDir\venv"
+    Write-Info "Installing voice + wake-word dependencies (onnxruntime, faster-whisper -- 1-3min)..."
+    Push-Location $InstallDir
+    try {
+        Invoke-NativeWithRelaxedErrorAction { & $UvCmd pip install -e ".[wake,voice]" }
+        if ($LASTEXITCODE -eq 0) {
+            Write-Success "Voice + wake-word dependencies installed"
+        } else {
+            Write-Warn "Voice/wake dependency install failed (exit $LASTEXITCODE) -- they will lazy-install at first use"
+        }
+    } finally {
+        Pop-Location
+    }
+}
+
+function Install-Desktop {
+    # Build apps/desktop into a launchable Hermes.exe. Only called from
+    # Stage-Desktop, which is itself only included in the manifest when
+    # -IncludeDesktop was passed to install.ps1.
+    #
+    # The workspace npm install at repo root (done by Install-NodeDeps for
+    # browser tools) does NOT pull apps/desktop's dependencies, because the
+    # browser-tools workspace at $InstallDir\package.json is a separate
+    # workspace from apps/*. We do a full root-level `npm install` here
+    # so the workspace resolves apps/desktop's deps (including Electron
+    # itself, ~150MB), then run `npm run pack` in apps/desktop which
+    # produces the unpacked binary at apps/desktop/release/<os>-unpacked/.
+    #
+    # The Tauri bootstrap installer's launch_hermes_desktop command
+    # resolves apps/desktop/release/win-unpacked/Hermes.exe directly,
+    # so an "unpacked" build (electron-builder --dir) is enough -- we
+    # don't need to produce an NSIS/MSI artifact here.
+
+    # Always re-resolve Node here. Stages run in separate PowerShell processes,
+    # so $script:HasNode from Stage-Node isn't visible; more importantly Test-Node
+    # enforces the supported Node lines and prepends the Hermes-managed Node to
+    # PATH, so the build never runs on an unsupported system Node -- the cause
+    # of the opaque "Build desktop app ... exit code 1" failure (Vite crashes on
+    # old Node).
+    Test-Node | Out-Null
+    if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+        Write-Warn "Skipping desktop build (Node.js / npm not on PATH)"
+        $script:_StageSkippedReason = "Node.js not available"
+        return
+    }
+
+    $desktopDir = "$InstallDir\apps\desktop"
+    if (-not (Test-Path "$desktopDir\package.json")) {
+        Write-Warn "Skipping desktop build (apps/desktop not present in checkout)"
+        $script:_StageSkippedReason = "apps/desktop not present"
+        return
+    }
+
+    $npmCmd = Get-Command npm -ErrorAction SilentlyContinue
+    if (-not $npmCmd) {
+        Write-Warn "Skipping desktop build (npm not on PATH)"
+        $script:_StageSkippedReason = "npm not found"
+        return
+    }
+    $npmExe = $npmCmd.Source
+    if ($npmExe -like "*.ps1") {
+        $sibling = Join-Path (Split-Path $npmExe -Parent) "npm.cmd"
+        if (Test-Path $sibling) { $npmExe = $sibling }
+    }
+
+    # 1. Workspace-level install so apps/desktop's deps (Electron, Vite,
+    # node-pty prebuilds, etc.) actually land in node_modules. This is
+    # the SAME `npm install` Install-NodeDeps does for browser tools,
+    # but at the root rather than the browser-tools workspace, so all
+    # apps/* workspaces resolve.
+    Write-Info "Installing desktop workspace dependencies (this includes Electron ~150MB, takes 1-3min)..."
+    Push-Location $InstallDir
+    $prevEAP = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        # Drop --silent so npm emits its full progress + error trail.
+        # When this fails on a non-dev box (e.g. native-module build
+        # without VS Build Tools, ETARGET on a transitive, etc.), the
+        # actual reason needs to reach the Tauri installer's log; with
+        # --silent it was completely suppressed and the user just saw
+        # "exit 1" with no actionable detail.
+        #
+        # The streaming sink in bootstrap.rs's run_install_script
+        # captures every stdout/stderr line as it's emitted, so we don't
+        # need a side TEMP log file -- the installer's bootstrap log
+        # IS the artifact a support engineer reads.
+        #
+        # Prefer `npm ci`: it wipes node_modules and reinstalls from the
+        # lockfile, always producing a complete tree. Bare `npm install`
+        # can report "up to date" against a stale
+        # node_modules\.package-lock.json marker while node_modules is
+        # actually empty (Windows workspace-hoisting flake), leaving
+        # tsc/typescript unresolved so `npm run pack`'s `tsc -b` dies with
+        # no obvious cause. Fall back to `npm install` only if `npm ci`
+        # fails (lockfile out of sync / very old npm without ci).
+        #
+        # Tee the merged output into $npmOut while still emitting every line
+        # live. We don't need a side log file (the bootstrap streaming sink
+        # is the artifact), but on failure we scan $npmOut for the TLS-trust
+        # signature so corporate-proxy users get the NODE_EXTRA_CA_CERTS hint
+        # instead of an opaque "exit 1" (issue #38016).
+        & $npmExe ci 2>&1 | ForEach-Object { "$_" } | Tee-Object -Variable npmOut
+        $code = $LASTEXITCODE
+        if ($code -ne 0) {
+            Write-Info "  npm ci failed (exit $code) -- retrying with npm install..."
+            & $npmExe install 2>&1 | ForEach-Object { "$_" } | Tee-Object -Variable npmOut
+            $code = $LASTEXITCODE
+        }
+        $ErrorActionPreference = $prevEAP
+        if ($code -ne 0) {
+            if (Test-ElectronPkgStagedMissingDist -InstallDir $InstallDir) {
+                Write-Warn "Desktop dependency install failed with a missing Electron dist; attempting self-heal..."
+                Try-RestoreElectronDist -InstallDir $InstallDir | Out-Null
+            } else {
+                Show-NpmCertHint ($npmOut -join "`n") | Out-Null
+                # Replay npm's own debug log into our stream: the terse
+                # summary above rarely contains the postinstall stderr
+                # (e.g. Electron's install.js) that explains the failure.
+                Write-NpmDebugLogTail -NpmOutput ($npmOut -join "`n")
+                throw "desktop workspace npm install failed (exit $code) -- see lines above for cause"
+            }
+        } else {
+            Write-Success "Desktop workspace dependencies installed"
+        }
+    } catch {
+        if ($prevEAP) { $ErrorActionPreference = $prevEAP }
+        Pop-Location
+        throw
+    }
+    Pop-Location
+
+    # 2. Build apps/desktop. `npm run pack` runs:
+    #      assert-root-install + write-build-stamp + stage-native-deps +
+    #      tsc -b + vite build + electron-builder --dir
+    # The --dir mode produces an unpacked Hermes.exe in
+    # apps/desktop/release/win-unpacked/ without bundling NSIS/MSI;
+    # we don't need a distributable installer artifact, just a
+    # launchable binary the Tauri installer can spawn.
+    #
+    # CSC_IDENTITY_AUTO_DISCOVERY=false tells electron-builder we are
+    # NOT signing the output. Combined with signAndEditExecutable=false in
+    # apps/desktop/package.json's build.win block, electron-builder never
+    # invokes signtool and therefore never fetches/extracts winCodeSign
+    # (whose macOS symlinks crash 7-Zip on non-admin Windows -- a dead end we
+    # are NOT trying to work around). The Hermes icon + product name are
+    # stamped onto Hermes.exe by our own rcedit step (Set-DesktopExeIdentity)
+    # AFTER this build, completely decoupled from electron-builder signing.
+    #
+    # WIN_CSC_LINK and WIN_CSC_KEY_PASSWORD explicitly cleared as
+    # belt-and-suspenders: if the user's environment has them set
+    # for some other tool, electron-builder would still try to sign.
+    Write-Info "Building desktop app (this takes 1-3 minutes)..."
+    $buildLog = "$env:TEMP\hermes-desktop-build-$(Get-Random).log"
+    # Seed GITHUB_SHA for write-build-stamp.mjs. The stamp prefers CI env vars
+    # over `git rev-parse`, so this covers: (1) node can't find git.exe on PATH
+    # even though this PowerShell session can, (2) ZIP/init trees that still
+    # lack a HEAD after a failed post-extract fetch. Without it the desktop
+    # pack dies with "could not determine git commit" (#50823).
+    if (-not $env:GITHUB_SHA) {
+        if ($Commit) {
+            $env:GITHUB_SHA = $Commit
+        } else {
+            Push-Location $InstallDir
+            try {
+                $global:LASTEXITCODE = 0
+                $resolvedSha = & git -c windows.appendAtomically=false rev-parse HEAD 2>$null
+                if ($LASTEXITCODE -ne 0 -or -not $resolvedSha) {
+                    # ZIP path may have FETCH_HEAD after a fetch even when HEAD is unset.
+                    $global:LASTEXITCODE = 0
+                    $resolvedSha = & git -c windows.appendAtomically=false rev-parse FETCH_HEAD 2>$null
+                }
+                if ($LASTEXITCODE -eq 0 -and $resolvedSha) {
+                    $env:GITHUB_SHA = ("$resolvedSha").Trim()
+                }
+            } catch { } finally {
+                Pop-Location
+            }
+        }
+    }
+    if (-not $env:GITHUB_REF_NAME) {
+        $env:GITHUB_REF_NAME = if ($Branch) { $Branch } else { "main" }
+    }
+    if ($env:GITHUB_SHA) {
+        $shaPreview = if ($env:GITHUB_SHA.Length -ge 12) { $env:GITHUB_SHA.Substring(0, 12) } else { $env:GITHUB_SHA }
+        Write-Info "Desktop build stamp: $shaPreview ($($env:GITHUB_REF_NAME))"
+    } else {
+        Write-Warn "Could not resolve a git commit for the desktop stamp -- write-build-stamp will use its non-git fallback"
+    }
+    Push-Location $desktopDir
+    $prevEAP = $ErrorActionPreference
+    $prevCSCAuto = $env:CSC_IDENTITY_AUTO_DISCOVERY
+    $prevWinCscLink = $env:WIN_CSC_LINK
+    $prevWinCscKeyPassword = $env:WIN_CSC_KEY_PASSWORD
+    try {
+        $ErrorActionPreference = "Continue"
+        $env:CSC_IDENTITY_AUTO_DISCOVERY = "false"
+        $env:WIN_CSC_LINK = ""
+        $env:WIN_CSC_KEY_PASSWORD = ""
+        & $npmExe run pack 2>&1 | ForEach-Object { "$_" } | Tee-Object -FilePath $buildLog
+        $code = $LASTEXITCODE
+        if ($code -ne 0) {
+            $purged = @()
+            $restored = $false
+            if (-not (Test-ElectronDist -InstallDir $InstallDir)) {
+                $purged = @(Clear-ElectronBuildCache -DesktopDir $desktopDir)
+                $restored = Restore-ElectronDist -InstallDir $InstallDir
+            }
+            if ($restored) {
+                Write-Warn "Desktop build failed - refreshed the Electron download, retrying once:"
+                foreach ($p in $purged) { Write-Info "  - $p" }
+                & $npmExe run pack 2>&1 | ForEach-Object { "$_" } | Tee-Object -FilePath $buildLog
+                $code = $LASTEXITCODE
+            }
+        }
+        if ($code -ne 0 -and -not $env:ELECTRON_MIRROR) {
+            $mirror = $script:DesktopElectronFallbackMirror
+            Write-Warn "Desktop build still failing - the Electron download from GitHub looks blocked."
+            Write-Warn "Re-downloading Electron via a public mirror ($mirror), then rebuilding:"
+            Write-Info "  (set ELECTRON_MIRROR yourself to use a different/trusted mirror)"
+            if (-not (Test-ElectronDist -InstallDir $InstallDir)) {
+                Restore-ElectronDist -InstallDir $InstallDir -Mirror $mirror | Out-Null
+            }
+            $prevMirror = $env:ELECTRON_MIRROR
+            $env:ELECTRON_MIRROR = $mirror
+            try {
+                & $npmExe run pack 2>&1 | ForEach-Object { "$_" } | Tee-Object -FilePath $buildLog
+                $code = $LASTEXITCODE
+            } finally {
+                $env:ELECTRON_MIRROR = $prevMirror
+            }
+        }
+        $ErrorActionPreference = $prevEAP
+        if ($code -ne 0) {
+            $errText = Get-Content $buildLog -Raw -ErrorAction SilentlyContinue
+            if ($errText) {
+                $snippet = if ($errText.Length -gt 1800) { $errText.Substring(0, 1800) + "..." } else { $errText }
+                Write-Info "  desktop build output:"
+                foreach ($line in $snippet -split "`n") { Write-Host "    $line" -ForegroundColor DarkGray }
+                Write-Info "  Full log: $buildLog"
+            }
+            # `npm run pack` failures (lifecycle script exits) also land in
+            # npm's debug log; replay it so the bootstrap log carries the
+            # full evidence even when $buildLog's tail cuts off the cause.
+            Write-NpmDebugLogTail -NpmOutput $errText
+            throw "apps/desktop build failed (exit $code)"
+        }
+        Write-Success "Desktop app built"
+        Remove-Item -LiteralPath $buildLog -Force -ErrorAction SilentlyContinue
+    } catch {
+        if ($prevEAP) { $ErrorActionPreference = $prevEAP }
+        Pop-Location
+        throw
+    } finally {
+        # Restore env to whatever the caller had -- don't leak our
+        # signing-off override into anything install.ps1 invokes later
+        # (Stage-PlatformSdks, etc.).
+        $env:CSC_IDENTITY_AUTO_DISCOVERY = $prevCSCAuto
+        $env:WIN_CSC_LINK = $prevWinCscLink
+        $env:WIN_CSC_KEY_PASSWORD = $prevWinCscKeyPassword
+    }
+    Pop-Location
+
+    # 3. Sanity-check the produced binary. Probe both arches so this works
+    # on x64 and arm64 build machines.
+    $exeCandidates = @(
+        "$desktopDir\release\win-unpacked\Hermes.exe",
+        "$desktopDir\release\win-arm64-unpacked\Hermes.exe"
+    )
+    $found = $false
+    $desktopExe = $null
+    foreach ($cand in $exeCandidates) {
+        if (Test-Path $cand) {
+            Write-Success "Desktop ready: $cand"
+            $desktopExe = $cand
+            $found = $true
+            break
+        }
+    }
+    if (-not $found) {
+        throw "Desktop build completed but no Hermes.exe was found under $desktopDir\release\*-unpacked\"
+    }
+
+    # 3b. The Hermes icon + identity are stamped onto Hermes.exe by the
+    #     electron-builder `afterPack` hook (apps/desktop/scripts/after-pack.mjs)
+    #     during `npm run pack` above -- for every build, so the installer's
+    #     --update rebuild stays branded too. No separate stamp step needed here.
+    #     electron-builder's own rcedit step stays disabled (signAndEditExecutable
+    #     =false) because enabling it drags in signtool -> winCodeSign -> the
+    #     unfixable symlink crash; the afterPack hook runs rcedit directly.
+
+    # 3c. Grant ALL APPLICATION PACKAGES (S-1-15-2-2) RX on the unpacked app
+    #     directory. Chromium's GPU/renderer sandboxes CHECK-fail with
+    #     0x80000003 when this ACE is missing alongside orphan AppContainer
+    #     SIDs under %LOCALAPPDATA% (electron/electron#51761, hermes-agent#38216).
+    #     Best-effort -- never fail an otherwise-good install over ACL repair.
+    try {
+        $appDir = Split-Path -Parent $desktopExe
+        & icacls $appDir /grant "*S-1-15-2-2:(OI)(CI)(RX)" /T /C /Q | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Success "Granted AppContainer read access on $appDir"
+        } else {
+            Write-Warn "icacls AppContainer grant returned exit $LASTEXITCODE for $appDir"
+        }
+    } catch {
+        Write-Warn "Could not grant AppContainer ACL: $($_.Exception.Message)"
+    }
+
+    # 4. Create Start Menu + Desktop shortcuts pointing DIRECTLY at the packed
+    #    Hermes.exe. We deliberately do NOT point them at `hermes desktop`: that
+    #    command rebuilds (npm install + electron-builder) on every launch,
+    #    which would cost minutes each time. The packed exe is the consumer --
+    #    launching it directly is instant, and updates flow through the
+    #    installer's --update path (which rebuilds once, then relaunches).
+    New-DesktopShortcuts -TargetExe $desktopExe
+}
+
+function New-DesktopShortcuts {
+    param([Parameter(Mandatory = $true)][string]$TargetExe)
+
+    # Best-effort: a shortcut failure must never fail an otherwise-good install.
+    try {
+        $shell = New-Object -ComObject WScript.Shell
+        $workDir = Split-Path -Parent $TargetExe
+
+        # Prefer the standalone icon.ico (shipped beside the exe via
+        # electron-builder extraResources -> resources/icon.ico) over the exe's
+        # embedded resource. An explicit .ico path is more stable across update
+        # cycles: pointing at "$TargetExe,0" makes Windows cache the icon it
+        # extracted from the exe at shortcut-creation time, and that cached
+        # bitmap can persist (showing the OLD/Electron icon) even after the exe
+        # is re-stamped on update. A dedicated .ico sidesteps that extraction.
+        $iconIco = Join-Path $workDir 'resources\icon.ico'
+        if (Test-Path $iconIco) {
+            $iconLocation = "$iconIco,0"
+        } else {
+            $iconLocation = "$TargetExe,0"
+        }
+
+        $targets = @(
+            (Join-Path ([Environment]::GetFolderPath('Programs')) 'Hermes.lnk'),
+            (Join-Path ([Environment]::GetFolderPath('Desktop')) 'Hermes.lnk')
+        )
+
+        foreach ($lnkPath in $targets) {
+            try {
+                $parent = Split-Path -Parent $lnkPath
+                if (-not (Test-Path $parent)) {
+                    New-Item -ItemType Directory -Force -Path $parent | Out-Null
+                }
+                $sc = $shell.CreateShortcut($lnkPath)
+                $sc.TargetPath = $TargetExe
+                $sc.WorkingDirectory = $workDir
+                $sc.IconLocation = $iconLocation
+                $sc.Description = 'Hermes Agent'
+                $sc.Save()
+                Write-Success "Shortcut created: $lnkPath"
+            } catch {
+                Write-Warn "Could not create shortcut $lnkPath : $($_.Exception.Message)"
+            }
+        }
+
+        # Bust the Windows shell icon cache so the desktop/Start-Menu shortcut
+        # repaints with the (possibly newly-stamped) icon instead of a stale
+        # cached bitmap. Critical on the --update path: the exe was re-stamped
+        # with the Hermes icon, but without this the shortcut can keep drawing
+        # the old Electron icon until the user manually refreshes / reboots.
+        # Best-effort and silent -- never fail the install over a cosmetic cache.
+        try {
+            & ie4uinit.exe -show 2>$null
+        } catch {
+            # ie4uinit may be absent/renamed on some SKUs -- ignore.
+        }
+    } catch {
+        Write-Warn "Skipping shortcut creation: $($_.Exception.Message)"
+    }
+}
+
+function Install-PlatformSdks {
+    # Ensure messaging-platform SDKs matching tokens the user added to
+    # ~/.hermes/.env are importable.  Two problems this solves:
+    #
+    # 1. The tiered `uv pip install` cascade above can fall through to a
+    #    lower tier when the first fails (common when RL git deps choke),
+    #    which silently skips some messaging SDKs from [messaging].
+    # 2. `uv` creates the venv without pip.  If a messaging SDK ends up
+    #    missing, the user can't `pip install python-telegram-bot` to
+    #    recover -- pip simply isn't in their venv.
+    #
+    # Strategy: bootstrap pip via `python -m ensurepip` (idempotent), then
+    # for each token set in .env, verify the matching SDK imports.  If not,
+    # run one targeted `pip install` as last-chance recovery.  Keeps fresh
+    # Windows installs from hitting silent "python-telegram-bot not installed"
+    # at runtime.
+    if ($NoVenv) {
+        Write-Info "Skipping platform-SDK verification (-NoVenv: no venv to bootstrap)"
+        return
+    }
+
+    $pythonExe = "$InstallDir\venv\Scripts\python.exe"
+    if (-not (Test-Path $pythonExe)) {
+        Write-Warn "Skipping platform-SDK verification: $pythonExe not found"
+        return
+    }
+
+    $envPath = "$HermesHome\.env"
+    if (-not (Test-Path $envPath)) { return }
+    $envLines = Get-Content $envPath -ErrorAction SilentlyContinue
+
+    # Map: env var set in .env -> (import name, pip spec matching [messaging] extra).
+    # Specs mirror pyproject.toml to avoid version drift.
+    $sdkMap = @(
+        @{ Var = "TELEGRAM_BOT_TOKEN"; Import = "telegram";  Spec = "python-telegram-bot[webhooks]>=22.6,<23" },
+        @{ Var = "DISCORD_BOT_TOKEN";  Import = "discord";   Spec = "discord.py[voice]>=2.7.1,<3" },
+        @{ Var = "SLACK_BOT_TOKEN";    Import = "slack_sdk"; Spec = "slack-sdk>=3.27.0,<4" },
+        @{ Var = "SLACK_APP_TOKEN";    Import = "slack_bolt";Spec = "slack-bolt>=1.18.0,<2" },
+        @{ Var = "WHATSAPP_ENABLED";   Import = "qrcode";    Spec = "qrcode>=7.0,<8" }
+    )
+
+    # Which tokens are actually set (not placeholder)?
+    $needed = @()
+    foreach ($sdk in $sdkMap) {
+        $match = $envLines | Where-Object {
+            $_ -match ("^" + [regex]::Escape($sdk.Var) + "=.+") `
+            -and $_ -notmatch "your-token-here" `
+            -and $_ -notmatch "^\s*#"
+        }
+        if ($match) { $needed += $sdk }
+    }
+    if ($needed.Count -eq 0) { return }
+
+    Write-Host ""
+    Write-Info "Verifying platform SDKs for tokens found in $envPath ..."
+
+    # Verify each SDK's import without triggering side-effect imports.
+    # Quirk: PowerShell wraps non-zero-exit native stderr as a
+    # NativeCommandError that prints even with `2>$null` / `*> $null`
+    # unless we set $ErrorActionPreference to SilentlyContinue for the
+    # span.  Save + restore rather than nuking globally.
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = "SilentlyContinue"
+    try {
+        $missing = @()
+        foreach ($sdk in $needed) {
+            & $pythonExe -c "import $($sdk.Import)" 2>&1 | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                $missing += $sdk
+                Write-Warn "  $($sdk.Import) NOT importable (needed for $($sdk.Var))"
+            } else {
+                Write-Success "  $($sdk.Import) OK"
+            }
+        }
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+    if ($missing.Count -eq 0) { return }
+
+    # Bootstrap pip into the venv if it isn't there.  `uv` creates venvs
+    # without pip; ensurepip is the stdlib-blessed way to add it.
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = "SilentlyContinue"
+    try {
+        & $pythonExe -m pip --version 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Info "Bootstrapping pip into venv (uv doesn't ship pip)..."
+            & $pythonExe -m ensurepip --upgrade 2>&1 | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                Write-Warn "ensurepip failed -- can't auto-install missing SDKs."
+                Write-Info "Manual recovery: $UvCmd pip install `"$($missing[0].Spec)`""
+                return
+            }
+        }
+
+        foreach ($sdk in $missing) {
+            Write-Info "  Installing $($sdk.Spec) ..."
+            & $pythonExe -m pip install $sdk.Spec 2>&1 | ForEach-Object { Write-Host "    $_" }
+            if ($LASTEXITCODE -eq 0) {
+                Write-Success "  Installed $($sdk.Import)"
+            } else {
+                Write-Warn "  Failed to install $($sdk.Spec). Recover manually: $pythonExe -m pip install `"$($sdk.Spec)`""
+            }
+        }
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+}
+
+function Invoke-SetupWizard {
+    if ($SkipSetup) {
+        Write-Info "Skipping setup wizard (-SkipSetup)"
+        return
+    }
+
+    if ($NonInteractive) {
+        # The setup wizard prompts for API keys, model choice, persona, etc.
+        # Non-interactive callers (GUI installer) own that UX themselves; let
+        # them drive it after install.ps1 returns.
+        Write-Info "Skipping setup wizard (non-interactive). Configure via the GUI or 'hermes setup'."
+        return
+    }
+
+    Write-Host ""
+    Write-Info "Starting setup wizard..."
+    Write-Host ""
+
+    Push-Location $InstallDir
+
+    # Run hermes setup using the venv Python directly (no activation needed)
+    if (-not $NoVenv) {
+        & ".\venv\Scripts\python.exe" -m hermes_cli.main setup
+    } else {
+        python -m hermes_cli.main setup
+    }
+
+    Pop-Location
+}
+
+function Start-GatewayIfConfigured {
+    $envPath = "$HermesHome\.env"
+    if (-not (Test-Path $envPath)) { return }
+
+    $hasMessaging = $false
+    $content = Get-Content $envPath -ErrorAction SilentlyContinue
+    foreach ($var in @("TELEGRAM_BOT_TOKEN", "DISCORD_BOT_TOKEN", "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "WHATSAPP_ENABLED")) {
+        $match = $content | Where-Object { $_ -match "^${var}=.+" -and $_ -notmatch "your-token-here" }
+        if ($match) { $hasMessaging = $true; break }
+    }
+
+    if (-not $hasMessaging) { return }
+
+    $hermesCmd = "$InstallDir\venv\Scripts\hermes.exe"
+    if (-not (Test-Path $hermesCmd)) {
+        $hermesCmd = "hermes"
+    }
+
+    # If WhatsApp is enabled but not yet paired, run foreground for QR scan
+    $whatsappEnabled = $content | Where-Object { $_ -match "^WHATSAPP_ENABLED=true" }
+    $whatsappSession = "$HermesHome\whatsapp\session\creds.json"
+    if ($whatsappEnabled -and -not (Test-Path $whatsappSession)) {
+        Write-Host ""
+        Write-Info "WhatsApp is enabled but not yet paired."
+        Write-Info "Running 'hermes whatsapp' to pair via QR code..."
+        Write-Host ""
+        # Non-interactive callers (GUI installer, CI) skip the QR-pair prompt;
+        # WhatsApp pairing requires a human looking at a phone camera, so the
+        # downstream UI is responsible for surfacing this when it makes sense.
+        if (-not $NonInteractive) {
+            $response = Read-Host "Pair WhatsApp now? [Y/n]"
+            if ($response -eq "" -or $response -match "^[Yy]") {
+                try {
+                    & $hermesCmd whatsapp
+                } catch {
+                    # Expected after pairing completes
+                }
+            }
+        } else {
+            Write-Info "Skipping WhatsApp pairing prompt (non-interactive)."
+        }
+    }
+
+    Write-Host ""
+    Write-Info "Messaging platform token detected!"
+    Write-Info "The gateway handles messaging platforms and cron job execution."
+    Write-Host ""
+
+    # In non-interactive mode the gateway lifecycle is the caller's problem
+    # (the GUI manages its own gateway process, CI doesn't want background
+    # services on the build agent, etc.).  Treat it like the user declined.
+    if ($NonInteractive) {
+        Write-Info "Skipping gateway autostart prompt (non-interactive)."
+        Write-Info "Start the gateway later with: hermes gateway"
+        return
+    }
+
+    $response = Read-Host "Would you like to start the gateway now? [Y/n]"
+
+    if ($response -eq "" -or $response -match "^[Yy]") {
+        Write-Info "Starting gateway in background..."
+        try {
+            $logFile = "$HermesHome\logs\gateway.log"
+            Start-Process -FilePath $hermesCmd -ArgumentList "gateway" `
+                -RedirectStandardOutput $logFile `
+                -RedirectStandardError "$HermesHome\logs\gateway-error.log" `
+                -WindowStyle Hidden
+            Write-Success "Gateway started! Your bot is now online."
+            Write-Info "Logs: $logFile"
+            Write-Info "To stop: close the gateway process from Task Manager"
+        } catch {
+            Write-Warn "Failed to start gateway. Run manually: hermes gateway"
+        }
+    } else {
+        Write-Info "Skipped. Start the gateway later with: hermes gateway"
+    }
+}
+
+function Write-Completion {
+    Write-Host ""
+    Write-Host "+---------------------------------------------------------+" -ForegroundColor Green
+    Write-Host "|              [OK] Installation Complete!                |" -ForegroundColor Green
+    Write-Host "+---------------------------------------------------------+" -ForegroundColor Green
+    Write-Host ""
+    
+    # Show file locations
+    Write-Host "* Your files:" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "   Config:    " -NoNewline -ForegroundColor Yellow
+    Write-Host "$HermesHome\config.yaml"
+    Write-Host "   API Keys:  " -NoNewline -ForegroundColor Yellow
+    Write-Host "$HermesHome\.env"
+    Write-Host "   Data:      " -NoNewline -ForegroundColor Yellow
+    Write-Host "$HermesHome\cron\, sessions\, logs\"
+    Write-Host "   Code:      " -NoNewline -ForegroundColor Yellow
+    Write-Host "$HermesHome\hermes-agent\"
+    Write-Host ""
+    
+    Write-Host "---------------------------------------------------------" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "* Commands:" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "   hermes              " -NoNewline -ForegroundColor Green
+    Write-Host "Start chatting"
+    Write-Host "   hermes setup        " -NoNewline -ForegroundColor Green
+    Write-Host "Configure API keys & settings"
+    Write-Host "   hermes config       " -NoNewline -ForegroundColor Green
+    Write-Host "View/edit configuration"
+    Write-Host "   hermes config edit  " -NoNewline -ForegroundColor Green
+    Write-Host "Open config in editor"
+    Write-Host "   hermes gateway      " -NoNewline -ForegroundColor Green
+    Write-Host "Start messaging gateway (Telegram, Discord, etc.)"
+    Write-Host "   hermes update       " -NoNewline -ForegroundColor Green
+    Write-Host "Update to latest version"
+    Write-Host ""
+    
+    Write-Host "---------------------------------------------------------" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "[*] Restart your terminal for PATH changes to take effect" -ForegroundColor Yellow
+    Write-Host ""
+    
+    if (-not $HasNode) {
+        Write-Host "Note: Node.js could not be installed automatically." -ForegroundColor Yellow
+        Write-Host "Browser tools need Node.js. Install manually:" -ForegroundColor Yellow
+        Write-Host "  https://nodejs.org/en/download/" -ForegroundColor Yellow
+        Write-Host ""
+    }
+    
+    if (-not $HasRipgrep) {
+        Write-Host "Note: ripgrep (rg) was not installed. For faster file search:" -ForegroundColor Yellow
+        Write-Host "  winget install BurntSushi.ripgrep.MSVC" -ForegroundColor Yellow
+        Write-Host ""
+    }
+}
+
+# ============================================================================
+# Stage protocol
+# ============================================================================
+#
+# install.ps1 supports a small, stable "stage protocol" that lets programmatic
+# callers (the desktop GUI's onboarding wizard, CI, future install.sh, etc.)
+# drive the install one step at a time and surface progress/errors with their
+# own UI.  CLI users running the canonical `irm | iex` one-liner never
+# encounter this -- default invocation behaves exactly as before.
+#
+# Entry points:
+#
+#   install.ps1                       Interactive install (today's behavior).
+#   install.ps1 -ProtocolVersion      Emit the protocol version integer.
+#   install.ps1 -Manifest             Emit the stage manifest as JSON.
+#   install.ps1 -Stage <name>         Run one stage and emit its result.
+#   install.ps1 -NonInteractive       Disable all Read-Host prompts (also
+#                                     skips the setup wizard and the gateway
+#                                     autostart prompt).  Can be combined
+#                                     with default invocation to do a full
+#                                     non-interactive install.
+#   install.ps1 -Json                 Emit machine-readable JSON instead of
+#                                     the human-readable success banner at
+#                                     the end of a full install.
+#
+# Manifest schema (the JSON returned by -Manifest):
+#
+#   {
+#     "protocol_version": 1,
+#     "stages": [
+#       {
+#         "name": "uv",
+#         "title": "Installing uv package manager",
+#         "category": "prereqs",
+#         "needs_user_input": false
+#       },
+#       ...
+#     ]
+#   }
+#
+# Stage result (the JSON written by -Stage <name>):
+#
+#   {
+#     "stage": "uv",
+#     "ok": true,
+#     "skipped": false,
+#     "reason": null,
+#     "duration_ms": 1234
+#   }
+#
+# Exit codes:
+#
+#   0 -- success (stage ran, or stage was deliberately skipped).
+#   1 -- generic failure; the stage threw.
+#   2 -- unknown stage name passed to -Stage.
+#
+# Adding a stage:
+#
+#   1. Append an entry to $InstallStages below.
+#   2. Make sure the worker function it points at is idempotent and respects
+#      $NonInteractive when it has prompts.  Add it before "configure"
+#      (the wizard) or "gateway" (autostart) if it should run unconditionally;
+#      after those if it's optional post-install glue.
+#   3. Do NOT bump $InstallStageProtocolVersion -- adding stages is additive.
+#      Drivers iterate the manifest dynamically.
+#
+# ============================================================================
+
+# Stage definitions -- the single source of truth.  Each entry maps a stable
+# stage name (the API contract drivers depend on) to the worker function that
+# implements it.  ``Title`` is what UIs show; ``Category`` lets UIs group
+# stages; ``NeedsUserInput`` tells UIs "this stage prompts -- either skip it
+# or arrange to provide answers another way."
+$InstallStages = @(
+    @{ Name = "uv";               Title = "Installing uv package manager";        Category = "prereqs";      NeedsUserInput = $false; Worker = "Stage-Uv" }
+    @{ Name = "git";              Title = "Installing Git";                       Category = "prereqs";      NeedsUserInput = $false; Worker = "Stage-Git" }
+    @{ Name = "node";             Title = "Detecting Node.js";                    Category = "prereqs";      NeedsUserInput = $false; Worker = "Stage-Node" }
+    @{ Name = "system-packages";  Title = "Installing ripgrep and ffmpeg";        Category = "prereqs";      NeedsUserInput = $false; Worker = "Stage-SystemPackages" }
+    @{ Name = "repository";       Title = "Cloning Hermes repository";            Category = "install";      NeedsUserInput = $false; Worker = "Stage-Repository" }
+    # Managed Python lives under $InstallDir\.hermes-runtime, so the checkout
+    # must exist before this stage creates that directory. Otherwise the later
+    # repository stage treats the runtime-only directory as a broken checkout,
+    # parks it, and leaves Stage-Venv with no managed interpreter.
+    @{ Name = "python";           Title = "Verifying Python $PythonVersion";      Category = "prereqs";      NeedsUserInput = $false; Worker = "Stage-Python" }
+    @{ Name = "venv";             Title = "Creating Python virtual environment";  Category = "install";      NeedsUserInput = $false; Worker = "Stage-Venv" }
+    @{ Name = "dependencies";     Title = "Installing Python dependencies";       Category = "install";      NeedsUserInput = $false; Worker = "Stage-Dependencies" }
+    @{ Name = "node-deps";        Title = "Installing Node.js dependencies";      Category = "install";      NeedsUserInput = $false; Worker = "Stage-NodeDeps" }
+)
+if ($IncludeDesktop) {
+    # Insert AFTER node-deps so workspace npm is already installed when
+    # the desktop build runs. Inserted only when explicitly requested
+    # (Hermes-Setup.exe), never via the irm|iex CLI one-liner.
+    $InstallStages += @{ Name = "desktop"; Title = "Building desktop app"; Category = "install"; NeedsUserInput = $false; Worker = "Stage-Desktop" }
+}
+$InstallStages += @(
+    @{ Name = "path";             Title = "Adding Hermes to PATH";                Category = "finalize";     NeedsUserInput = $false; Worker = "Stage-Path" }
+    @{ Name = "config-templates"; Title = "Writing configuration templates";      Category = "finalize";     NeedsUserInput = $false; Worker = "Stage-ConfigTemplates" }
+    @{ Name = "platform-sdks";    Title = "Installing messaging platform SDKs";   Category = "finalize";     NeedsUserInput = $false; Worker = "Stage-PlatformSdks" }
+    @{ Name = "bootstrap-marker"; Title = "Marking install complete";              Category = "finalize";     NeedsUserInput = $false; Worker = "Stage-BootstrapMarker" }
+    # Interactive stages.  In non-interactive mode these become no-ops; the
+    # caller (GUI / CI) handles the equivalent UX themselves.
+    @{ Name = "configure";        Title = "Configuring API keys and models";      Category = "post-install"; NeedsUserInput = $true;  Worker = "Stage-Configure" }
+    @{ Name = "gateway";          Title = "Starting messaging gateway";           Category = "post-install"; NeedsUserInput = $true;  Worker = "Stage-Gateway" }
+)
+
+# Stage workers -- thin wrappers that delegate to the existing Install-* /
+# Test-* / Invoke-* functions while preserving their error semantics.  Kept
+# as a separate layer so the existing functions remain callable directly
+# (helpful for one-off recovery: ``. install.ps1; Install-Venv``).
+#
+# Stages that depend on uv (anything after Stage-Uv) call Resolve-UvCmd
+# first so they work in cross-process driver mode where $script:UvCmd
+# set by Stage-Uv in a sibling powershell process is not visible here.
+# Resolve-UvCmd is a fast no-op when $script:UvCmd is already populated
+# (the default-invocation case where Main runs everything in one
+# process), and throws cleanly if uv truly isn't installed yet.
+function Stage-Uv               { if (-not (Install-Uv))     { throw "uv installation failed" } }
+function Stage-Python           { Resolve-UvCmd; if (-not (Test-Python))    { throw "Python $PythonVersion not available" } }
+function Stage-Git              {
+    if (-not (Install-Git)) {
+        if ($script:GitInstallFailureReason) { throw $script:GitInstallFailureReason }
+        throw "Git not available and auto-install failed -- install from https://git-scm.com/download/win then re-run"
+    }
+}
+# Node is optional (browser tools degrade gracefully without it).  Surface
+# failure to the JSON contract as skipped=true / reason rather than ok=true,
+# so a GUI driver consuming the manifest can distinguish "node ready" from
+# "node missing".  Install flow continues either way -- matches the
+# existing Write-Completion behavior that prints a "Note: Node.js could
+# not be installed" hint instead of aborting.
+function Stage-Node             {
+    if (-not (Test-Node)) {
+        $script:_StageSkippedReason = "Node.js not available; browser tools will be unavailable until node is installed manually from https://nodejs.org/en/download/"
+    }
+}
+function Stage-SystemPackages   { Install-SystemPackages }
+function Stage-Repository       { Install-Repository }
+function Stage-Venv             { Resolve-UvCmd; Install-Venv }
+function Stage-Dependencies     { Resolve-UvCmd; Install-Dependencies }
+function Stage-NodeDeps         { Install-NodeDeps }
+function Stage-Desktop          { Install-DesktopVoiceDeps; Install-Desktop }
+function Stage-Path             { Set-PathVariable }
+function Stage-ConfigTemplates  { Copy-ConfigTemplates }
+function Stage-PlatformSdks     { Resolve-UvCmd; Install-PlatformSdks }
+function Stage-BootstrapMarker  { Write-BootstrapMarker }
+function Stage-Configure        { Invoke-SetupWizard }
+function Stage-Gateway          { Start-GatewayIfConfigured }
+
+function Get-InstallStage {
+    param([string]$Name)
+    foreach ($s in $InstallStages) {
+        if ($s.Name -eq $Name) { return $s }
+    }
+    return $null
+}
+
+function Step-OutOfInstallDir {
+    # Windows refuses to delete a directory any shell is currently cd'd
+    # inside -- and silently leaves orphan files behind, which then wedge
+    # "is this a valid git repo" probes on re-install.  Harmless when the
+    # caller ran the installer from somewhere else.
+    try {
+        $currentResolved = (Get-Location).ProviderPath
+        $installResolved = $null
+        if (Test-Path $InstallDir) {
+            $installResolved = (Resolve-Path $InstallDir -ErrorAction SilentlyContinue).ProviderPath
+        }
+        if ($installResolved -and $currentResolved.ToLower().StartsWith($installResolved.ToLower())) {
+            Write-Info "Stepping out of $InstallDir so Windows can replace files there if needed..."
+            Set-Location $env:USERPROFILE
+        }
+    } catch {}
+}
+
+function Invoke-Stage {
+    param(
+        [Parameter(Mandatory=$true)] [hashtable]$StageDef
+    )
+
+    # Refresh PATH from registry so this stage sees binaries installed by
+    # prior stages, even when each stage runs in its own powershell process.
+    # No-op in cost-relevant cases (default invocation path syncs once per
+    # foreach pass; cross-process drivers get the necessary freshening).
+    Sync-EnvPath
+
+    # Per-stage soft-skip channel.  A worker can populate
+    # $script:_StageSkippedReason to surface "ran, but the thing it was
+    # supposed to set up is not available" as skipped=true in the JSON
+    # frame, without throwing.  Used by Stage-Node so the install flow
+    # doesn't abort when an optional capability is missing while still
+    # being honest in the protocol contract.  Reset before each stage so
+    # a prior stage's reason can never leak into a later stage's frame.
+    $script:_StageSkippedReason = $null
+
+    $start = [DateTime]::UtcNow
+    $result = @{
+        stage        = $StageDef.Name
+        ok           = $false
+        skipped      = $false
+        reason       = $null
+        duration_ms  = 0
+    }
+
+    try {
+        & $StageDef.Worker
+        $result.ok = $true
+        if ($script:_StageSkippedReason) {
+            $result.skipped = $true
+            $result.reason  = $script:_StageSkippedReason
+        }
+    } catch {
+        $result.ok = $false
+        $result.reason = "$_"
+        throw
+    } finally {
+        $result.duration_ms = [int]([DateTime]::UtcNow - $start).TotalMilliseconds
+        if ($Json -or $Stage) {
+            # In stage-driver mode every stage emits a JSON line so the
+            # caller can stream progress.  In default interactive mode we
+            # stay silent here (the worker already wrote human output).
+            $result | ConvertTo-Json -Compress | Write-Output
+            # Tell the entry-point catch that we've already emitted a
+            # frame for this failure (when $result.ok = $false), so it
+            # doesn't double-emit a second JSON object and break the
+            # one-line-per-stage contract the driver protocol promises.
+            if (-not $result.ok) {
+                $script:_StageEmittedErrorFrame = $true
+            }
+        }
+    }
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+
+function Invoke-AllStages {
+    Step-OutOfInstallDir
+    foreach ($s in $InstallStages) {
+        Invoke-Stage -StageDef $s
+    }
+}
+
+function Invoke-EnsureMode {
+    param([string]$Deps)
+    $depList = $Deps -split ","
+    foreach ($dep in $depList) {
+        $dep = $dep.Trim()
+        switch ($dep) {
+            "node" {
+                [void](Test-Node)
+                if (-not $script:HasNode) {
+                    Write-Err "Node.js could not be installed"
+                    exit 1
+                }
+            }
+            "browser" {
+                [void](Test-Node)
+                if ($script:HasNode) {
+                    Install-AgentBrowser
+                } else {
+                    Write-Err "Node.js is required for browser tools but could not be installed"
+                    exit 1
+                }
+            }
+            "ripgrep" {
+                Write-Info "ripgrep: install manually on Windows (scoop install ripgrep)"
+            }
+            "ffmpeg" {
+                Write-Info "ffmpeg: install manually on Windows (scoop install ffmpeg)"
+            }
+            default {
+                Write-Err "Unknown dependency: $dep"
+                exit 1
+            }
+        }
+    }
+}
+
+function Invoke-PostInstallMode {
+    Write-Info "Running post-install setup..."
+    Invoke-EnsureMode -Deps "node,browser"
+    Write-Info "Post-install complete"
+}
+
+function Main {
+    Write-Banner
+    Invoke-AllStages
+    if (-not $Json) {
+        Write-Completion
+    } else {
+        @{ ok = $true; protocol_version = $InstallStageProtocolVersion } | ConvertTo-Json -Compress | Write-Output
+    }
+}
+
+# ----------------------------------------------------------------------------
+# Entry-point dispatch
+# ----------------------------------------------------------------------------
+#
+# All branches funnel through one try/catch so errors don't kill an `irm |
+# iex` PowerShell session, and so failures in stage-driver mode produce a
+# structured JSON error frame instead of a bare exception.
+
+# Dot-sourcing loads the installer's real functions for isolated behavioral
+# tests without running an install. Normal script and `irm | iex` entry points
+# are unchanged.
+if ($MyInvocation.InvocationName -eq ".") {
+    return
+}
+
+try {
+    if ($Ensure -ne "") {
+        if ($PSBoundParameters.ContainsKey("Stage")) {
+            Write-Err "Cannot use -Ensure and -Stage simultaneously"
+            exit 1
+        }
+        Invoke-EnsureMode -Deps $Ensure
+        exit 0
+    }
+    if ($PostInstall) {
+        Invoke-PostInstallMode
+        exit 0
+    }
+
+    if ($ProtocolVersion) {
+        Write-Output $InstallStageProtocolVersion
+        exit 0
+    }
+
+    if ($ShowResolvedPaths) {
+        $script:ResolvedPathReport | ConvertTo-Json -Depth 5 -Compress | Write-Output
+        exit 0
+    }
+
+    if ($Manifest) {
+        $payload = @{
+            protocol_version = $InstallStageProtocolVersion
+            stages = @($InstallStages | ForEach-Object {
+                @{
+                    name             = $_.Name
+                    title            = $_.Title
+                    category         = $_.Category
+                    needs_user_input = $_.NeedsUserInput
+                }
+            })
+        }
+        $payload | ConvertTo-Json -Depth 5 -Compress | Write-Output
+        exit 0
+    }
+
+    # Use PSBoundParameters rather than $Stage truthiness so that an
+    # explicit `-Stage ""` from a misbehaving driver doesn't fall through
+    # to the full-install Main path and silently kick off a destructive
+    # operation.  Empty string is a contract violation; surface it as
+    # unknown-stage exit 2 with a structured JSON frame.
+    if ($PSBoundParameters.ContainsKey("Stage")) {
+        $def = Get-InstallStage -Name $Stage
+        if (-not $def) {
+            $err = @{
+                ok     = $false
+                stage  = $Stage
+                reason = "unknown stage: $Stage. Run install.ps1 -Manifest to list valid stages."
+            }
+            $err | ConvertTo-Json -Compress | Write-Output
+            exit 2
+        }
+        Step-OutOfInstallDir
+        Invoke-Stage -StageDef $def
+        exit 0
+    }
+
+    # Default: full install (today's behavior, plus optional -NonInteractive
+    # and -Json layered on by the params above).
+    Main
+} catch {
+    if ($Json -or $Stage) {
+        # Stage-driver mode: caller wants JSON they can parse.  Emit a
+        # structured error frame and exit non-zero -- BUT only if
+        # Invoke-Stage didn't already emit one for this same failure.
+        # The inner finally emits the authoritative per-stage frame
+        # (with duration_ms + skipped fields); a second emit here
+        # would produce two concatenated JSON objects on stdout and
+        # break drivers that parse one-line-per-invocation.
+        if (-not $script:_StageEmittedErrorFrame) {
+            $err = @{
+                ok     = $false
+                stage  = if ($Stage) { $Stage } else { $null }
+                reason = "$_"
+            }
+            $err | ConvertTo-Json -Compress | Write-Output
+        }
+        exit 1
+    }
+
+    # Interactive mode: keep today's friendly recovery hint.
+    Write-Host ""
+    Write-Err "Installation failed: $_"
+    Write-Host ""
+    Write-Info "If the error is unclear, try downloading and running the script directly:"
+    Write-Host "  Invoke-WebRequest -Uri 'https://hermes-agent.nousresearch.com/install.ps1' -OutFile install.ps1" -ForegroundColor Yellow
+    Write-Host "  .\install.ps1" -ForegroundColor Yellow
+    Write-Host ""
+}

--- a/tests/agent/test_compression_worker_isolation_76354.py
+++ b/tests/agent/test_compression_worker_isolation_76354.py
@@ -66,6 +66,25 @@ def _build_agent_with_db(db: SessionDB, session_id: str, **compressor_kwargs):
     return agent
 
 
+def _timeout_after_worker_started(monkeypatch, started):
+    """Inject the host timeout only after the isolation state actually exists.
+
+    The real pool, worker, fence cancellation and lease cleanup still execute.
+    Deadline arithmetic has separate coverage in test_compress_context_progress_timeout;
+    these tests must not cancel an unscheduled worker before their own barrier.
+    """
+    from agent import conversation_compression as cc
+
+    monkeypatch.setattr(cc, "resolve_context_compression_timeouts", lambda cfg=None: (60, 120))
+
+    def await_started(future, fence, **kwargs):
+        assert started.wait(timeout=30), "compression worker never entered the tested state"
+        assert not future.done()
+        return False, None
+
+    monkeypatch.setattr(cc, "_await_worker_within_budget", await_started)
+
+
 def test_f3_mutating_engine_cannot_touch_live_transcript_after_timeout(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -80,14 +99,9 @@ def test_f3_mutating_engine_cannot_touch_live_transcript_after_timeout(
     agent = _build_agent_with_db(db, session_id)
     agent._cached_system_prompt = "sys"
 
-    # Fast host timeout for the owned wrapper.
-    monkeypatch.setattr(
-        "agent.conversation_compression.resolve_context_compression_timeouts",
-        lambda cfg=None: (0.6, 1.2),
-    )
-
     engine_started = threading.Event()
     release_engine = threading.Event()
+    _timeout_after_worker_started(monkeypatch, engine_started)
     mutated_lists = []
 
     def _mutating_engine(msgs, **_kwargs):
@@ -157,13 +171,9 @@ def test_host_timeout_releases_pool_slot_while_protected_provider_is_still_block
     db.create_session(session_id, source="cli")
     agent = _build_agent_with_db(db, session_id)
     agent._cached_system_prompt = "sys"
-    monkeypatch.setattr(
-        "agent.conversation_compression.resolve_context_compression_timeouts",
-        lambda cfg=None: (0.05, 0.1),
-    )
-
     provider_started = threading.Event()
     release_provider = threading.Event()
+    _timeout_after_worker_started(monkeypatch, provider_started)
 
     def _blocked_provider(_kwargs):
         provider_started.set()
@@ -206,7 +216,7 @@ def test_host_timeout_releases_pool_slot_while_protected_provider_is_still_block
             time.sleep(0.02)
 
 
-def test_f4_five_step_stale_holder_regression(tmp_path: Path) -> None:
+def test_f4_five_step_stale_holder_regression(tmp_path: Path, monkeypatch) -> None:
     """Reviewer's exact 5-step durable-lease regression (#76354 F4).
 
     1. Block the original summary indefinitely.
@@ -233,6 +243,7 @@ def test_f4_five_step_stale_holder_regression(tmp_path: Path) -> None:
 
     summary_started = threading.Event()
     release_summary = threading.Event()
+    _timeout_after_worker_started(monkeypatch, summary_started)
 
     def _blocked_summary(*_args, **_kwargs):
         summary_started.set()
@@ -256,64 +267,67 @@ def test_f4_five_step_stale_holder_regression(tmp_path: Path) -> None:
             messages, "sys", approx_tokens=120_000, commit_fence=fence
         )
 
-    # Step 2: host-owned progress wait times out while summary is blocked.
-    result_msgs, _prompt = run_compress_context_with_progress_timeout(
-        worker=_worker,
-        messages=messages,
-        system_prompt_fallback="fallback",
-        idle_timeout_seconds=0.6,
-        total_ceiling_seconds=1.2,
-    )
-    assert summary_started.wait(timeout=5)
-    assert not release_summary.is_set()  # old worker STILL blocked
-    assert result_msgs is messages
+    try:
+        # Step 2: host-owned progress wait times out while summary is blocked.
+        result_msgs, _prompt = run_compress_context_with_progress_timeout(
+            worker=_worker,
+            messages=messages,
+            system_prompt_fallback="fallback",
+            idle_timeout_seconds=60,
+            total_ceiling_seconds=120,
+        )
+        assert summary_started.wait(timeout=5)
+        assert not release_summary.is_set()  # old worker STILL blocked
+        assert result_msgs is messages
 
-    # Step 3: a NEW compressor acquires the durable lock while the old
-    # summary remains blocked. The host's holder-qualified release freed
-    # the old lease (refresher stopped + row deleted, holder-scoped).
-    new_holder = "pid:new:contender"
-    deadline = time.time() + 5
-    acquired = False
-    while time.time() < deadline:
-        if db.try_acquire_compression_lock(session_id, new_holder, ttl_seconds=60):
-            acquired = True
-            break
-        time.sleep(0.02)
-    assert acquired, (
-        "a new compressor must be able to acquire the durable lock while "
-        "the timed-out worker is still blocked in its summary"
-    )
-    assert not release_summary.is_set()  # provably still step-3 state
-    assert db.get_compression_lock_holder(session_id) == new_holder
+        # Step 3: a NEW compressor acquires the durable lock while the old
+        # summary remains blocked. The host's holder-qualified release freed
+        # the old lease (refresher stopped + row deleted, holder-scoped).
+        new_holder = "pid:new:contender"
+        deadline = time.time() + 5
+        acquired = False
+        while time.time() < deadline:
+            if db.try_acquire_compression_lock(session_id, new_holder, ttl_seconds=60):
+                acquired = True
+                break
+            time.sleep(0.02)
+        assert acquired, (
+            "a new compressor must be able to acquire the durable lock while "
+            "the timed-out worker is still blocked in its summary"
+        )
+        assert not release_summary.is_set()  # provably still step-3 state
+        assert db.get_compression_lock_holder(session_id) == new_holder
 
-    pre_release_rows = db.get_messages_as_conversation(session_id)
+        pre_release_rows = db.get_messages_as_conversation(session_id)
 
-    # Step 4: release the old worker.
-    release_summary.set()
-    # Wait for the late worker to fully unwind (it must NOT touch the lock).
-    deadline = time.time() + 5
-    while time.time() < deadline:
-        if db.get_compression_lock_holder(session_id) != new_holder:
-            break  # would be a failure — checked below
-        if cooldown_cleared:
-            break
-        time.sleep(0.02)
-    time.sleep(0.3)  # settle: give the stale worker every chance to misbehave
+        # Step 4: release the old worker.
+        release_summary.set()
+        # Wait for the late worker to fully unwind (it must NOT touch the lock).
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            if db.get_compression_lock_holder(session_id) != new_holder:
+                break  # would be a failure — checked below
+            if cooldown_cleared:
+                break
+            time.sleep(0.02)
+        time.sleep(0.3)  # settle: give the stale worker every chance to misbehave
 
-    # Step 5a: it cannot clear the cooldown.
-    assert not cooldown_cleared, (
-        "late cancelled worker cleared the compression failure cooldown"
-    )
-    # Step 5b: it cannot release the NEW holder's lease (holder-qualified).
-    assert db.get_compression_lock_holder(session_id) == new_holder, (
-        "late worker released the replacement holder's durable lease (ABA)"
-    )
-    # Step 5c: it cannot publish stale state — transcript unchanged, no
-    # in-place compaction landed, session id did not rotate.
-    post_release_rows = db.get_messages_as_conversation(session_id)
-    assert post_release_rows == pre_release_rows
-    assert agent.session_id == session_id
-    db.release_compression_lock(session_id, new_holder)
+        # Step 5a: it cannot clear the cooldown.
+        assert not cooldown_cleared, (
+            "late cancelled worker cleared the compression failure cooldown"
+        )
+        # Step 5b: it cannot release the NEW holder's lease (holder-qualified).
+        assert db.get_compression_lock_holder(session_id) == new_holder, (
+            "late worker released the replacement holder's durable lease (ABA)"
+        )
+        # Step 5c: it cannot publish stale state — transcript unchanged, no
+        # in-place compaction landed, session id did not rotate.
+        post_release_rows = db.get_messages_as_conversation(session_id)
+        assert post_release_rows == pre_release_rows
+        assert agent.session_id == session_id
+        db.release_compression_lock(session_id, new_holder)
+    finally:
+        release_summary.set()
 
 
 def test_f5_session_contextvar_rebound_after_rotation(

--- a/tests/agent/test_compression_worker_isolation_76354.py
+++ b/tests/agent/test_compression_worker_isolation_76354.py
@@ -106,9 +106,9 @@ def test_f3_mutating_engine_cannot_touch_live_transcript_after_timeout(
 
     def _mutating_engine(msgs, **_kwargs):
         # Legacy/plugin-engine contract: mutate the input list IN PLACE.
-        engine_started.set()
         msgs[:] = [{"role": "assistant", "content": "ENGINE GARBAGE"}]
         mutated_lists.append(msgs)
+        engine_started.set()  # Publish only after the mutation witness exists.
         assert release_engine.wait(timeout=30)
         return msgs
 

--- a/tests/ci/test_classify_changes.py
+++ b/tests/ci/test_classify_changes.py
@@ -140,6 +140,23 @@ CASES = {
     # install.ps1 is a shell script Python never imports, but it's also not
     # provably prose, so python stays on (fail-open) alongside the Windows lane.
     "install.ps1 → installer": (["scripts/install.ps1"], _lanes(python=True, installer=True)),
+    "checkout encoding → installer": ([".gitattributes"], _lanes(python=True, installer=True)),
+    "installer authored module → installer": (
+        ["scripts/windows-installer/source/venv.ps1"],
+        _lanes(python=True, installer=True),
+    ),
+    "installer manifest → installer": (
+        ["scripts/windows-installer/manifest.json"],
+        _lanes(python=True, installer=True),
+    ),
+    "installer assembler → installer": (
+        ["scripts/build_windows_installer.py"],
+        _lanes(python=True, installer=True, scan=True),
+    ),
+    "installer delivery test → installer": (
+        ["tests/test_windows_installer_delivery.py"],
+        _lanes(python=True, python_prod=False, installer=True, scan=True),
+    ),
     "installer test → installer": (
         ["scripts/tests/test-install-ps1-longpath.ps1"],
         _lanes(python=True, installer=True),

--- a/tests/cron/test_misfire_catchup.py
+++ b/tests/cron/test_misfire_catchup.py
@@ -8,7 +8,6 @@ gateway housekeeping, claims and fires those jobs after a grace window.
 """
 
 import threading
-import time
 from datetime import timedelta
 
 import pytest
@@ -148,16 +147,35 @@ class TestFireOverdueJobs:
         """fire_claimed runs off-thread — a slow job must not stall the
         sweep (housekeeping loop) for the length of an agent run."""
 
+        entered = threading.Event()
+        release = threading.Event()
+        returned = threading.Event()
+        result = []
+
         class SlowProvider(RecordingProvider):
             def fire_claimed(self, claimed_job, **kw):
-                time.sleep(3.0)
+                entered.set()
+                assert release.wait(timeout=120)
                 return super().fire_claimed(claimed_job, **kw)
 
         job = create_job(prompt="p", schedule="every 1h")
         _park_in_past(job["id"], minutes=30)
         provider = SlowProvider()
-        start = time.monotonic()
-        assert fire_overdue_jobs(provider) == 1
-        assert time.monotonic() - start < 1.0  # returned before the run
-        assert provider.wait_fired(timeout=10)
+
+        def dispatch():
+            result.append(fire_overdue_jobs(provider))
+            returned.set()
+
+        dispatcher = threading.Thread(target=dispatch)
+        dispatcher.start()
+        try:
+            assert entered.wait(timeout=30)
+            assert returned.wait(timeout=30), "dispatch waited for the blocked job"
+            assert result == [1]
+            assert not provider._done.is_set()
+        finally:
+            release.set()
+            dispatcher.join(timeout=30)
+        assert not dispatcher.is_alive()
+        assert provider.wait_fired(timeout=30)
         assert provider.fired == [job["id"]]

--- a/tests/e2e/test_relay_native_openai_stream.py
+++ b/tests/e2e/test_relay_native_openai_stream.py
@@ -22,8 +22,7 @@ def _sse(*chunk_bodies: bytes) -> bytes:
 def _stream_through_relay(tmp_path, monkeypatch, response_body: bytes, *, finalize_before):
     """Stream ``response_body`` through Relay; Relay's finalizer is forced to complete before
     the consumer thread processes the first chunk matching ``finalize_before(chunk)``.
-    Returns ``(hermes_result, relay_llm_end_event, race_forced)``; ``race_forced`` is False when Relay
-    happened to reach its finalizer only after the consumer took that chunk (see the hook below)."""
+    Returns ``(hermes_result, relay_llm_end_event)``."""
     httpx = pytest.importorskip("httpx")
     nemo_relay = pytest.importorskip("nemo_relay")
     openai = pytest.importorskip("openai")
@@ -57,7 +56,6 @@ def _stream_through_relay(tmp_path, monkeypatch, response_body: bytes, *, finali
     relay_finalizer_started = threading.Event()
     allow_relay_finalizer = threading.Event()
     relay_finalizer_finished = threading.Event()
-    forced = []
     run_relay_finalizer = relay_llm.ManagedLlmStream._relay_finalizer
 
     def run_synchronized_relay_finalizer(managed_stream, attempt):
@@ -73,20 +71,28 @@ def _stream_through_relay(tmp_path, monkeypatch, response_body: bytes, *, finali
     count_chunk = chat_completion_helpers._StreamingCall._count_chunk
 
     def count_chunk_after_relay_finalizes(self, diag, chunk):
-        # Relay's producer is pumped by the consumer thread's own event loop (``ManagedLlmStream.
-        # __next__`` -> ``run_until_complete``), so the finalizer can only START inside a consumer
-        # ``next()``. Whether it has started by the time the final chunk is handed over is a loop
-        # scheduling coin flip. When it has, hold it here so it provably completes before the consumer
-        # touches this chunk (the race under test). When it has not, it cannot run until we return;
-        # waiting for it here is a deadlock, not a slow runner (~1 run in 6 locally, and two
-        # unrelated PRs went red on it the same day). Callers repeat until the race materialized.
+        # Relay's producer is pumped by the consumer thread's OWN event loop (``ManagedLlmStream.
+        # __next__`` -> ``run_until_complete``), so the finalizer can only start while that loop runs.
+        # Blocking the consumer thread here and waiting for it therefore deadlocked whenever the loop
+        # had not reached EOF yet (~1 run in 6). Instead: release the finalizer and PUMP THE STREAM'S
+        # LOOP until it has completed, then hand the chunk to the consumer. That is a real
+        # happens-before (finalizer done -> consumer sees chunk) on every schedule, not a retry lottery.
         if finalize_before(chunk):
-            if relay_finalizer_started.is_set():
-                forced.append(True)
-                allow_relay_finalizer.set()
-                assert relay_finalizer_finished.wait(30), "Relay's finalizer did not finish"
-            else:
-                allow_relay_finalizer.set()  # it will start inside the consumer's next ``next()``
+            import asyncio
+
+            stream = self.managed_stream_holder["stream"]
+            allow_relay_finalizer.set()
+            # A schedule probe may hold the provider generator at this chunk until the consumer has
+            # taken it (adverse consumer-first ordering); release it so the pump below can reach EOF.
+            gate = getattr(stream, "_review_gate", None)
+            if gate is not None:
+                gate.set()
+
+            async def finalizer_done():
+                return await asyncio.to_thread(relay_finalizer_finished.wait, 30)
+
+            assert stream._loop.run_until_complete(finalizer_done()), "Relay's finalizer did not finish"
+            assert relay_finalizer_started.is_set()
         return count_chunk(self, diag, chunk)
 
     monkeypatch.setattr(chat_completion_helpers._StreamingCall, "_count_chunk", count_chunk_after_relay_finalizes)
@@ -111,20 +117,7 @@ def _stream_through_relay(tmp_path, monkeypatch, response_body: bytes, *, finali
     ]
     assert len(llm_end_events) == 1
     assert llm_end_events[0].annotated_response is not None
-    return result, llm_end_events[0], bool(forced)
-
-
-def _stream_until_race_forced(tmp_path, monkeypatch, body, *, finalize_before, attempts=12):
-    """Run the stream until Relay's finalizer was provably forced ahead of the consumer at least once;
-    every run's result is returned so callers assert the invariant on all of them."""
-    runs = []
-    for _ in range(attempts):
-        result, llm_end, race_forced = _stream_through_relay(
-            tmp_path, monkeypatch, body, finalize_before=finalize_before)
-        runs.append((result, llm_end))
-        if race_forced:
-            return runs
-    pytest.fail(f"Relay's finalizer never started before the consumer took the chunk in {attempts} runs")
+    return result, llm_end_events[0]
 
 
 def test_openai_stream_usage_reaches_relay_parent_event(tmp_path, monkeypatch):
@@ -134,14 +127,14 @@ def test_openai_stream_usage_reaches_relay_parent_event(tmp_path, monkeypatch):
         b'"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]',
         b'"choices":[],"usage":{"prompt_tokens":100,"completion_tokens":10,"total_tokens":110}',
     )
-    for result, llm_end in _stream_until_race_forced(
-            tmp_path, monkeypatch, body,
-            finalize_before=lambda chunk: not chunk.choices and getattr(chunk, "usage", None) is not None):
-        assert result.usage is not None
-        assert (result.usage.prompt_tokens, result.usage.completion_tokens, result.usage.total_tokens) == (100, 10, 110)
-        assert llm_end.annotated_response.usage == {
-            "prompt_tokens": 100, "completion_tokens": 10, "total_tokens": 110}
-        assert llm_end.annotated_response.message == "done"
+    result, llm_end = _stream_through_relay(
+        tmp_path, monkeypatch, body,
+        finalize_before=lambda chunk: not chunk.choices and getattr(chunk, "usage", None) is not None)
+    assert result.usage is not None
+    assert (result.usage.prompt_tokens, result.usage.completion_tokens, result.usage.total_tokens) == (100, 10, 110)
+    assert llm_end.annotated_response.usage == {
+        "prompt_tokens": 100, "completion_tokens": 10, "total_tokens": 110}
+    assert llm_end.annotated_response.message == "done"
 
 
 def test_openai_stream_final_tool_call_delta_reaches_relay_parent_event(tmp_path, monkeypatch):
@@ -154,13 +147,13 @@ def test_openai_stream_final_tool_call_delta_reaches_relay_parent_event(tmp_path
         b'"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\"/tmp/x\\"}"}}]},'
         b'"finish_reason":"tool_calls"}]',
     )
-    for result, llm_end in _stream_until_race_forced(
-            tmp_path, monkeypatch, body,
-            finalize_before=lambda chunk: bool(chunk.choices) and chunk.choices[0].finish_reason == "tool_calls"):
-        hermes_call = result.choices[0].message.tool_calls[0]
-        assert (hermes_call.function.name, hermes_call.function.arguments) == ("read_file", '{"path": "/tmp/x"}')
-        assert result.choices[0].finish_reason == "tool_calls"
-        assert llm_end.annotated_response.message is None
-        (relay_call,) = llm_end.annotated_response.tool_calls
-        assert (relay_call["name"], relay_call["arguments"]) == ("read_file", {"path": "/tmp/x"})
-        assert llm_end.annotated_response.finish_reason == "tool_use"
+    result, llm_end = _stream_through_relay(
+        tmp_path, monkeypatch, body,
+        finalize_before=lambda chunk: bool(chunk.choices) and chunk.choices[0].finish_reason == "tool_calls")
+    hermes_call = result.choices[0].message.tool_calls[0]
+    assert (hermes_call.function.name, hermes_call.function.arguments) == ("read_file", '{"path": "/tmp/x"}')
+    assert result.choices[0].finish_reason == "tool_calls"
+    assert llm_end.annotated_response.message is None
+    (relay_call,) = llm_end.annotated_response.tool_calls
+    assert (relay_call["name"], relay_call["arguments"]) == ("read_file", {"path": "/tmp/x"})
+    assert llm_end.annotated_response.finish_reason == "tool_use"

--- a/tests/e2e/test_relay_native_openai_stream.py
+++ b/tests/e2e/test_relay_native_openai_stream.py
@@ -22,7 +22,8 @@ def _sse(*chunk_bodies: bytes) -> bytes:
 def _stream_through_relay(tmp_path, monkeypatch, response_body: bytes, *, finalize_before):
     """Stream ``response_body`` through Relay; Relay's finalizer is forced to complete before
     the consumer thread processes the first chunk matching ``finalize_before(chunk)``.
-    Returns ``(hermes_result, relay_llm_end_event)``."""
+    Returns ``(hermes_result, relay_llm_end_event, race_forced)``; ``race_forced`` is False when Relay
+    happened to reach its finalizer only after the consumer took that chunk (see the hook below)."""
     httpx = pytest.importorskip("httpx")
     nemo_relay = pytest.importorskip("nemo_relay")
     openai = pytest.importorskip("openai")
@@ -56,11 +57,12 @@ def _stream_through_relay(tmp_path, monkeypatch, response_body: bytes, *, finali
     relay_finalizer_started = threading.Event()
     allow_relay_finalizer = threading.Event()
     relay_finalizer_finished = threading.Event()
+    forced = []
     run_relay_finalizer = relay_llm.ManagedLlmStream._relay_finalizer
 
     def run_synchronized_relay_finalizer(managed_stream, attempt):
         relay_finalizer_started.set()
-        assert allow_relay_finalizer.wait(5), "consumer did not release Relay's finalizer"
+        assert allow_relay_finalizer.wait(30), "consumer did not release Relay's finalizer"
         try:
             return run_relay_finalizer(managed_stream, attempt)
         finally:
@@ -71,11 +73,20 @@ def _stream_through_relay(tmp_path, monkeypatch, response_body: bytes, *, finali
     count_chunk = chat_completion_helpers._StreamingCall._count_chunk
 
     def count_chunk_after_relay_finalizes(self, diag, chunk):
-        # ``_count_chunk`` is the first thing the consumer does with every chunk.
+        # Relay's producer is pumped by the consumer thread's own event loop (``ManagedLlmStream.
+        # __next__`` -> ``run_until_complete``), so the finalizer can only START inside a consumer
+        # ``next()``. Whether it has started by the time the final chunk is handed over is a loop
+        # scheduling coin flip. When it has, hold it here so it provably completes before the consumer
+        # touches this chunk (the race under test). When it has not, it cannot run until we return;
+        # waiting for it here is a deadlock, not a slow runner (~1 run in 6 locally, and two
+        # unrelated PRs went red on it the same day). Callers repeat until the race materialized.
         if finalize_before(chunk):
-            assert relay_finalizer_started.wait(5), "Relay's finalizer did not start"
-            allow_relay_finalizer.set()
-            assert relay_finalizer_finished.wait(5), "Relay's finalizer did not finish"
+            if relay_finalizer_started.is_set():
+                forced.append(True)
+                allow_relay_finalizer.set()
+                assert relay_finalizer_finished.wait(30), "Relay's finalizer did not finish"
+            else:
+                allow_relay_finalizer.set()  # it will start inside the consumer's next ``next()``
         return count_chunk(self, diag, chunk)
 
     monkeypatch.setattr(chat_completion_helpers._StreamingCall, "_count_chunk", count_chunk_after_relay_finalizes)
@@ -100,7 +111,20 @@ def _stream_through_relay(tmp_path, monkeypatch, response_body: bytes, *, finali
     ]
     assert len(llm_end_events) == 1
     assert llm_end_events[0].annotated_response is not None
-    return result, llm_end_events[0]
+    return result, llm_end_events[0], bool(forced)
+
+
+def _stream_until_race_forced(tmp_path, monkeypatch, body, *, finalize_before, attempts=12):
+    """Run the stream until Relay's finalizer was provably forced ahead of the consumer at least once;
+    every run's result is returned so callers assert the invariant on all of them."""
+    runs = []
+    for _ in range(attempts):
+        result, llm_end, race_forced = _stream_through_relay(
+            tmp_path, monkeypatch, body, finalize_before=finalize_before)
+        runs.append((result, llm_end))
+        if race_forced:
+            return runs
+    pytest.fail(f"Relay's finalizer never started before the consumer took the chunk in {attempts} runs")
 
 
 def test_openai_stream_usage_reaches_relay_parent_event(tmp_path, monkeypatch):
@@ -110,15 +134,14 @@ def test_openai_stream_usage_reaches_relay_parent_event(tmp_path, monkeypatch):
         b'"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]',
         b'"choices":[],"usage":{"prompt_tokens":100,"completion_tokens":10,"total_tokens":110}',
     )
-    result, llm_end = _stream_through_relay(
-        tmp_path, monkeypatch, body,
-        finalize_before=lambda chunk: not chunk.choices and getattr(chunk, "usage", None) is not None)
-
-    assert result.usage is not None
-    assert (result.usage.prompt_tokens, result.usage.completion_tokens, result.usage.total_tokens) == (100, 10, 110)
-    assert llm_end.annotated_response.usage == {
-        "prompt_tokens": 100, "completion_tokens": 10, "total_tokens": 110}
-    assert llm_end.annotated_response.message == "done"
+    for result, llm_end in _stream_until_race_forced(
+            tmp_path, monkeypatch, body,
+            finalize_before=lambda chunk: not chunk.choices and getattr(chunk, "usage", None) is not None):
+        assert result.usage is not None
+        assert (result.usage.prompt_tokens, result.usage.completion_tokens, result.usage.total_tokens) == (100, 10, 110)
+        assert llm_end.annotated_response.usage == {
+            "prompt_tokens": 100, "completion_tokens": 10, "total_tokens": 110}
+        assert llm_end.annotated_response.message == "done"
 
 
 def test_openai_stream_final_tool_call_delta_reaches_relay_parent_event(tmp_path, monkeypatch):
@@ -131,14 +154,13 @@ def test_openai_stream_final_tool_call_delta_reaches_relay_parent_event(tmp_path
         b'"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\"/tmp/x\\"}"}}]},'
         b'"finish_reason":"tool_calls"}]',
     )
-    result, llm_end = _stream_through_relay(
-        tmp_path, monkeypatch, body,
-        finalize_before=lambda chunk: bool(chunk.choices) and chunk.choices[0].finish_reason == "tool_calls")
-
-    hermes_call = result.choices[0].message.tool_calls[0]
-    assert (hermes_call.function.name, hermes_call.function.arguments) == ("read_file", '{"path": "/tmp/x"}')
-    assert result.choices[0].finish_reason == "tool_calls"
-    assert llm_end.annotated_response.message is None
-    (relay_call,) = llm_end.annotated_response.tool_calls
-    assert (relay_call["name"], relay_call["arguments"]) == ("read_file", {"path": "/tmp/x"})
-    assert llm_end.annotated_response.finish_reason == "tool_use"
+    for result, llm_end in _stream_until_race_forced(
+            tmp_path, monkeypatch, body,
+            finalize_before=lambda chunk: bool(chunk.choices) and chunk.choices[0].finish_reason == "tool_calls"):
+        hermes_call = result.choices[0].message.tool_calls[0]
+        assert (hermes_call.function.name, hermes_call.function.arguments) == ("read_file", '{"path": "/tmp/x"}')
+        assert result.choices[0].finish_reason == "tool_calls"
+        assert llm_end.annotated_response.message is None
+        (relay_call,) = llm_end.annotated_response.tool_calls
+        assert (relay_call["name"], relay_call["arguments"]) == ("read_file", {"path": "/tmp/x"})
+        assert llm_end.annotated_response.finish_reason == "tool_use"

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -619,28 +619,29 @@ async def test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown(monk
         message_id="1",
     )
 
-    result = await runner._handle_message(event)
+    try:
+        result = await runner._handle_message(event)
 
-    assert result == "ok"
-    assert worker_started.is_set()
-    assert runner._run_agent.await_count == 1
-    # Cooldown must be persisted to the state DB (survives restart, #74136),
-    # not stashed in an in-memory dict.
-    assert fake_db.record_compression_failure_cooldown.called
-    _cd_args = fake_db.record_compression_failure_cooldown.call_args[0]
-    assert _cd_args[0] == "sess-timeout"
-    assert _cd_args[1] > time.time()
-    timeout_warnings = [s for s in adapter.sent if "Context compression timed out" in s["content"]]
-    assert len(timeout_warnings) == 1
-    fake_db.archive_and_compact.assert_not_called()
-    assert lease_released.is_set()
-    # Event/state assertions prove the host returned before the detached
-    # worker's event-gated wait completed without a scheduler-sensitive clock
-    # bound: cleanup runs only when that worker actually exits.
-    SlowCompressAgent.last_instance.close.assert_not_called()
-
-    release_worker.set()
-    await asyncio.wait_for(asyncio.to_thread(cleanup_done.wait), timeout=2)
+        assert result == "ok"
+        assert worker_started.is_set()
+        assert runner._run_agent.await_count == 1
+        # Cooldown must be persisted to the state DB (survives restart, #74136),
+        # not stashed in an in-memory dict.
+        assert fake_db.record_compression_failure_cooldown.called
+        _cd_args = fake_db.record_compression_failure_cooldown.call_args[0]
+        assert _cd_args[0] == "sess-timeout"
+        assert _cd_args[1] > time.time()
+        timeout_warnings = [s for s in adapter.sent if "Context compression timed out" in s["content"]]
+        assert len(timeout_warnings) == 1
+        fake_db.archive_and_compact.assert_not_called()
+        assert lease_released.is_set()
+        # Event/state assertions prove the host returned before the detached
+        # worker's event-gated wait completed without a scheduler-sensitive clock
+        # bound: cleanup runs only when that worker actually exits.
+        SlowCompressAgent.last_instance.close.assert_not_called()
+    finally:
+        release_worker.set()
+    assert await asyncio.to_thread(cleanup_done.wait, 30)
 
     # The late worker observed cancellation at the commit fence, so it never
     # mutated the live session after the new turn began. Cleanup still ran once
@@ -786,21 +787,19 @@ async def test_session_hygiene_turn_hold_budget_abandons_streaming_wait(
         message_id="1",
     )
 
-    started = time.monotonic()
-    result = await asyncio.wait_for(runner._handle_message(event), timeout=15)
-    elapsed = time.monotonic() - started
+    try:
+        result = await asyncio.wait_for(runner._handle_message(event), timeout=15)
 
-    # The turn proceeded on the uncompressed transcript well under the 600s
-    # ceiling — the turn-hold budget (~0.3s) abandoned the streaming wait.
-    assert result == "ok"
-    assert elapsed < 5.0, f"turn held for {elapsed:.1f}s despite the turn-hold budget"
-    assert worker_started.is_set()
-    assert runner._run_agent.await_count == 1
-    # The stale commit must be fenced: the late worker never mutates the session.
-    fake_db.archive_and_compact.assert_not_called()
-
-    release_worker.set()
-    await asyncio.wait_for(asyncio.to_thread(cleanup_done.wait), timeout=3)
+        # The turn proceeded on the uncompressed transcript well under the 600s
+        # ceiling — the turn-hold budget (~0.3s) abandoned the streaming wait.
+        assert result == "ok"
+        assert worker_started.is_set()
+        assert runner._run_agent.await_count == 1
+        # The stale commit must be fenced: the late worker never mutates the session.
+        fake_db.archive_and_compact.assert_not_called()
+    finally:
+        release_worker.set()
+    assert await asyncio.to_thread(cleanup_done.wait, 30)
     fake_db.archive_and_compact.assert_not_called()
     StreamingCompressAgent.last_instance.close.assert_called_once()
 
@@ -963,34 +962,33 @@ async def test_session_hygiene_idle_timeout_still_takes_failure_path(
         message_id="1",
     )
 
-    started = time.monotonic()
-    result = await asyncio.wait_for(runner._handle_message(event), timeout=15)
-    elapsed = time.monotonic() - started
+    try:
+        result = await asyncio.wait_for(runner._handle_message(event), timeout=15)
 
-    # The turn proceeded on the uncompressed transcript after the idle
-    # timeout fired (~0.1s).
-    assert result == "ok"
-    assert elapsed < 5.0
-    assert worker_started.is_set()
-    assert runner._run_agent.await_count == 1
+        # The turn proceeded on the uncompressed transcript after the idle
+        # timeout fired (~0.1s).
+        assert result == "ok"
+        assert worker_started.is_set()
+        assert runner._run_agent.await_count == 1
 
-    # Behavior witness: idle timeout MUST send the "no output" message.
-    sent_contents = [m["content"] for m in adapter.sent]
-    assert any(
-        "timed out" in c.lower() and "no output" in c.lower()
-        for c in sent_contents
-    ), f"idle timeout must send 'no output' message, got: {sent_contents}"
+        # Behavior witness: idle timeout MUST send the "no output" message.
+        sent_contents = [m["content"] for m in adapter.sent]
+        assert any(
+            "timed out" in c.lower() and "no output" in c.lower()
+            for c in sent_contents
+        ), f"idle timeout must send 'no output' message, got: {sent_contents}"
 
-    # Behavior witness: idle timeout MUST advance the failure cooldown.
-    # The gateway calls _hygiene_cooldown_for_failure + _record_hygiene_cooldown.
-    # We verify by checking the DB mock was asked to persist.
-    # (The exact call depends on the SessionDB interface; we assert the
-    # gateway attempted to record the failure.)
-    assert fake_db.get_compression_failure_cooldown.called
+        # Behavior witness: idle timeout MUST advance the failure cooldown.
+        # The gateway calls _hygiene_cooldown_for_failure + _record_hygiene_cooldown.
+        # We verify by checking the DB mock was asked to persist.
+        # (The exact call depends on the SessionDB interface; we assert the
+        # gateway attempted to record the failure.)
+        assert fake_db.get_compression_failure_cooldown.called
 
-    # Cleanup: release the stalled worker so it can exit, then verify teardown.
-    release_worker.set()
-    await asyncio.wait_for(asyncio.to_thread(cleanup_done.wait), timeout=3)
+        # Cleanup: release the stalled worker so it can exit, then verify teardown.
+    finally:
+        release_worker.set()
+    assert await asyncio.to_thread(cleanup_done.wait, 30)
     StalledCompressAgent.last_instance.close.assert_called_once()
 
 @pytest.mark.asyncio
@@ -1715,8 +1713,9 @@ async def test_hygiene_does_not_wait_ceiling_after_fence_cancel(
             "Context compression timed out" in s["content"] for s in adapter.sent
         ), "fence-cancel is not a summary-model timeout; no timeout toast"
         release_worker.set()
-        await asyncio.wait_for(asyncio.to_thread(cleanup_done.wait), timeout=2)
+        assert await asyncio.to_thread(cleanup_done.wait, 30)
     finally:
+        release_worker.set()
         db.close()
 
 
@@ -1811,6 +1810,7 @@ async def test_hygiene_unwind_records_cooldown(monkeypatch, tmp_path):
             f"{state!r}"
         )
         release_worker.set()
-        await asyncio.wait_for(asyncio.to_thread(cleanup_done.wait), timeout=2)
+        assert await asyncio.to_thread(cleanup_done.wait, 30)
     finally:
+        release_worker.set()
         db.close()

--- a/tests/hermes_cli/test_relay_shared_metrics.py
+++ b/tests/hermes_cli/test_relay_shared_metrics.py
@@ -148,18 +148,18 @@ def _legacy_dimensions() -> dict[str, str]:
 class _ConcurrentStore(SharedMetricsStore):
     """Exercise transaction integrity without the foreground telemetry time budget."""
 
-    def _connection(self, *, busy_timeout_ms=30_000):
+    def _connection(self, *, busy_timeout_ms=5_000):
         return super()._connection(busy_timeout_ms=busy_timeout_ms)
 
-    def _write(self, *, busy_timeout_ms=30_000):
+    def _write(self, *, busy_timeout_ms=5_000):
         return super()._write(busy_timeout_ms=busy_timeout_ms)
 
 
 def _run_owned_processes(processes):
     """Bound the complete startup/write protocol and always reap our children."""
     started = []
-    # Includes the 30s startup barrier and 30s SQLite contention budget; use
-    # one deadline for the whole group, not an additional budget per child.
+    # Ten writes x 5s, plus the 30s barrier and 5s schema budget, fit within
+    # this shared deadline with headroom. Do not add a budget per child.
     deadline = time.monotonic() + 120
     try:
         for process in processes:

--- a/tests/hermes_cli/test_relay_shared_metrics.py
+++ b/tests/hermes_cli/test_relay_shared_metrics.py
@@ -155,6 +155,31 @@ class _ConcurrentStore(SharedMetricsStore):
         return super()._write(busy_timeout_ms=busy_timeout_ms)
 
 
+def _run_owned_processes(processes):
+    """Bound the complete startup/write protocol and always reap our children."""
+    started = []
+    # Includes the 30s startup barrier and 30s SQLite contention budget; use
+    # one deadline for the whole group, not an additional budget per child.
+    deadline = time.monotonic() + 120
+    try:
+        for process in processes:
+            process.start()
+            started.append(process)
+        for process in started:
+            process.join(timeout=max(0, deadline - time.monotonic()))
+            assert not process.is_alive(), "metrics worker exceeded the protocol budget"
+            assert process.exitcode == 0
+    finally:
+        for process in started:
+            if process.is_alive():
+                process.terminate()
+        cleanup_deadline = time.monotonic() + 10
+        for process in started:
+            process.join(timeout=max(0, cleanup_deadline - time.monotonic()))
+        assert not any(process.is_alive() for process in started)
+
+
+
 def _record_model_calls_in_process(
     database_path: str,
     outbox_directory: str,
@@ -1462,12 +1487,7 @@ def test_cross_process_model_call_updates_are_transactional(tmp_path):
         for _ in range(2)
     ]
 
-    for process in processes:
-        process.start()
-    for process in processes:
-        process.join(timeout=15)
-        assert not process.is_alive()
-        assert process.exitcode == 0
+    _run_owned_processes(processes)
 
     restarted = _ConcurrentStore(database_path, outbox_directory)
     assert restarted.counter_snapshot()[0]["value"] == 20
@@ -1486,12 +1506,7 @@ def test_cross_process_client_active_attempts_record_one_install(tmp_path):
         for _ in range(2)
     ]
 
-    for process in processes:
-        process.start()
-    for process in processes:
-        process.join(timeout=15)
-        assert not process.is_alive()
-        assert process.exitcode == 0
+    _run_owned_processes(processes)
 
     store = _ConcurrentStore(database_path, outbox_directory)
     [active] = store.counter_snapshot()

--- a/tests/hermes_cli/test_relay_shared_metrics.py
+++ b/tests/hermes_cli/test_relay_shared_metrics.py
@@ -145,6 +145,16 @@ def _legacy_dimensions() -> dict[str, str]:
     }
 
 
+class _ConcurrentStore(SharedMetricsStore):
+    """Exercise transaction integrity without the foreground telemetry time budget."""
+
+    def _connection(self, *, busy_timeout_ms=30_000):
+        return super()._connection(busy_timeout_ms=busy_timeout_ms)
+
+    def _write(self, *, busy_timeout_ms=30_000):
+        return super()._write(busy_timeout_ms=busy_timeout_ms)
+
+
 def _record_model_calls_in_process(
     database_path: str,
     outbox_directory: str,
@@ -152,8 +162,8 @@ def _record_model_calls_in_process(
     start_barrier: Any | None = None,
 ) -> None:
     if start_barrier is not None:
-        start_barrier.wait()
-    store = SharedMetricsStore(Path(database_path), Path(outbox_directory))
+        start_barrier.wait(timeout=30)
+    store = _ConcurrentStore(Path(database_path), Path(outbox_directory))
     for _ in range(count):
         store.record_model_call(_dimensions(), _resource())
 
@@ -163,8 +173,8 @@ def _record_client_active_in_process(
     outbox_directory: str,
     start_barrier: Any,
 ) -> None:
-    store = SharedMetricsStore(Path(database_path), Path(outbox_directory))
-    start_barrier.wait()
+    store = _ConcurrentStore(Path(database_path), Path(outbox_directory))
+    start_barrier.wait(timeout=30)
     store.record_client_active(_resource())
 
 
@@ -1368,13 +1378,13 @@ def test_package_export_does_not_chase_concurrent_updates(tmp_path, monkeypatch)
 def test_concurrent_package_builders_commit_one_delta(tmp_path):
     database_path = tmp_path / "metrics.sqlite3"
     outbox_directory = tmp_path / "outbox"
-    store = SharedMetricsStore(database_path, outbox_directory)
+    store = _ConcurrentStore(database_path, outbox_directory)
     store.record_model_call(_dimensions(), _resource())
     ready = threading.Barrier(2)
 
     def export() -> list[Path]:
-        worker_store = SharedMetricsStore(database_path, outbox_directory)
-        ready.wait(timeout=5)
+        worker_store = _ConcurrentStore(database_path, outbox_directory)
+        ready.wait(timeout=30)
         return worker_store.create_and_export_package()
 
     with ThreadPoolExecutor(max_workers=2) as executor:
@@ -1397,13 +1407,13 @@ def test_concurrent_package_builders_commit_one_delta(tmp_path):
 def test_concurrent_due_exports_create_one_daily_package(tmp_path):
     database_path = tmp_path / "metrics.sqlite3"
     outbox_directory = tmp_path / "outbox"
-    store = SharedMetricsStore(database_path, outbox_directory)
+    store = _ConcurrentStore(database_path, outbox_directory)
     store.record_model_call(_dimensions(), _resource())
     ready = threading.Barrier(8)
 
     def export() -> None:
-        worker_store = SharedMetricsStore(database_path, outbox_directory)
-        ready.wait(timeout=5)
+        worker_store = _ConcurrentStore(database_path, outbox_directory)
+        ready.wait(timeout=30)
         worker_store.create_and_export_package_if_due()
 
     with ThreadPoolExecutor(max_workers=8) as executor:
@@ -1423,10 +1433,10 @@ def test_concurrent_due_exports_create_one_daily_package(tmp_path):
 def test_concurrent_model_call_updates_are_transactional(tmp_path):
     database_path = tmp_path / "metrics.sqlite3"
     outbox_directory = tmp_path / "outbox"
-    SharedMetricsStore(database_path, outbox_directory)
+    _ConcurrentStore(database_path, outbox_directory)
 
     def record_calls(count: int) -> None:
-        store = SharedMetricsStore(database_path, outbox_directory)
+        store = _ConcurrentStore(database_path, outbox_directory)
         for _ in range(count):
             store.record_model_call(_dimensions(), _resource())
 
@@ -1435,7 +1445,7 @@ def test_concurrent_model_call_updates_are_transactional(tmp_path):
         for future in futures:
             future.result()
 
-    restarted = SharedMetricsStore(database_path, outbox_directory)
+    restarted = _ConcurrentStore(database_path, outbox_directory)
     assert restarted.counter_snapshot()[0]["value"] == 20
 
 
@@ -1459,7 +1469,7 @@ def test_cross_process_model_call_updates_are_transactional(tmp_path):
         assert not process.is_alive()
         assert process.exitcode == 0
 
-    restarted = SharedMetricsStore(database_path, outbox_directory)
+    restarted = _ConcurrentStore(database_path, outbox_directory)
     assert restarted.counter_snapshot()[0]["value"] == 20
 
 
@@ -1483,11 +1493,26 @@ def test_cross_process_client_active_attempts_record_one_install(tmp_path):
         assert not process.is_alive()
         assert process.exitcode == 0
 
-    store = SharedMetricsStore(database_path, outbox_directory)
+    store = _ConcurrentStore(database_path, outbox_directory)
     [active] = store.counter_snapshot()
     assert active["metric_name"] == CLIENT_ACTIVE_METRIC
     assert active["dimensions"] == {}
     assert active["value"] == 1
+
+
+def test_foreground_store_retains_bounded_contention_policy(tmp_path):
+    store = SharedMetricsStore(tmp_path / "metrics.sqlite3", tmp_path / "outbox")
+    with store._connection() as connection:
+        [budget_ms] = connection.execute("PRAGMA busy_timeout").fetchone()
+    # Concurrent integrity tests override only their connection wait, while the
+    # foreground store still fails promptly instead of holding a live turn.
+    assert 0 < budget_ms < 1000
+    with sqlite3.connect(store.database_path) as blocker:
+        blocker.execute("BEGIN IMMEDIATE")
+        with pytest.raises(sqlite3.OperationalError, match="locked"):
+            store.record_model_call(_dimensions(), _resource())
+        blocker.rollback()
+    assert store.counter_snapshot() == []
 
 
 def test_schema_initialization_waits_for_an_existing_writer(tmp_path):

--- a/tests/test_windows_installer_assembly.py
+++ b/tests/test_windows_installer_assembly.py
@@ -1,0 +1,132 @@
+"""The installer builder has one confined, complete, deterministic source graph."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _authoring(root: Path, contents: dict[str, bytes], *, raw_manifest=None, **updates) -> Path:
+    source = root / "source"
+    source.mkdir(parents=True)
+    for name, content in contents.items():
+        target = source / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+    manifest = {"version": 1, "entry": "install.ps1", "files": list(contents), "kill_track": {}}
+    manifest.update(updates)
+    (root / "manifest.json").write_text(raw_manifest or json.dumps(manifest), encoding="utf-8")
+    return root
+
+
+def _cli(root: Path, *args: str):
+    return subprocess.run(
+        [sys.executable, str(root / "scripts/build_windows_installer.py"), *args],
+        cwd=root, capture_output=True, text=True, timeout=20,
+    )
+
+
+@pytest.mark.parametrize("newline", [b"\n", b"\r\n"], ids=["lf", "windows-crlf"])
+def test_composition_and_cli_check_preserve_the_declared_bytes(tmp_path: Path, newline: bytes):
+    builder = importlib.import_module("scripts.build_windows_installer")
+    scripts = tmp_path / "scripts"
+    inputs = {
+        "install.ps1": b"param([switch]$Manifest)\n# @include topic.ps1\nWrite-Output $Message\n",
+        "topic.ps1": b"$Message = 'fixture'\n# @include nested/helper.ps1\n",
+        "nested/helper.ps1": b"function Get-Fixture { return $Message }\n",
+    }
+    authoring = _authoring(scripts / "windows-installer", {
+        name: content.replace(b"\n", newline) for name, content in inputs.items()
+    })
+    expected = (
+        b"param([switch]$Manifest)\n$Message = 'fixture'\n"
+        b"function Get-Fixture { return $Message }\nWrite-Output $Message\n"
+    )
+    assert builder.assemble(authoring) == expected
+    assert builder.assemble(authoring) == expected
+    # Exercise the real CLI from a separate, relocatable checkout layout.
+    shutil.copyfile(REPO / "scripts/build_windows_installer.py", scripts / "build_windows_installer.py")
+    assert _cli(tmp_path, "--check").returncode != 0
+    generated = _cli(tmp_path)
+    assert generated.returncode == 0, generated.stdout + generated.stderr
+    artifact = scripts / "install.ps1"
+    assert artifact.read_bytes() == expected
+    assert _cli(tmp_path, "--check").returncode == 0
+    artifact.write_bytes(expected + b"# stale local edit\n")
+    assert _cli(tmp_path, "--check").returncode != 0
+    assert artifact.read_bytes().endswith(b"# stale local edit\n"), "check must never rewrite a stale artifact"
+    assert _cli(tmp_path).returncode == 0
+    (authoring / "source/nested/helper.ps1").write_bytes(b"function Get-Fixture { return 'changed' }\n")
+    assert _cli(tmp_path, "--check").returncode != 0
+    assert artifact.read_bytes() == expected
+
+
+@pytest.mark.parametrize("sources,updates,error", [
+    ({"install.ps1": b"# @include topic.ps1\n# @include topic.ps1\n", "topic.ps1": b"# helper\n"}, {}, "more than once"),
+    ({"install.ps1": b"# @include topic.ps1\n", "topic.ps1": b"# @include install.ps1\n"}, {}, "cycle"),
+    ({"install.ps1": b"# @include missing.ps1\n"}, {}, "not declared"),
+    ({"install.ps1": b"# entry\n", "unused.ps1": b"# unused\n"}, {}, "orphan"),
+    ({"install.ps1": b"# entry\n", "hidden.txt": b"# undeclared\n"}, {"files": ["install.ps1"]}, "undeclared"),
+    ({"install.ps1": b"# entry\n"}, {"files": ["install.ps1", "install.ps1"]}, "duplicate"),
+    ({"install.ps1": b"# entry\n"}, {"files": ["install.ps1", "Install.ps1"]}, "case-colliding"),
+    ({"install.ps1": b"# entry\n"}, {"files": ["install.ps1", "../outside.ps1"]}, "invalid source path"),
+    ({"install.ps1": b"# entry\n"}, {"files": ["install.ps1", "/outside.ps1"]}, "invalid source path"),
+    ({"install.ps1": b"# entry\n"}, {"files": ["install.ps1", "nested\\helper.ps1"]}, "invalid source path"),
+    ({"install.ps1": b"# @include topic.ps1 extra\n", "topic.ps1": b"# helper\n"}, {}, "malformed"),
+    ({"install.ps1": b"\xef\xbb\xbf# entry\n"}, {}, "BOM"),
+    ({"install.ps1": b"# entry\r# tail\n"}, {}, "newline"),
+    ({"install.ps1": b"# entry"}, {}, "newline"),
+    ({"install.ps1": b"# line\n" * 2001}, {}, "ceiling"),
+    ({"install.ps1": b"# line\n" * 2002}, {"kill_track": {"install.ps1": 2001}}, "ceiling"),
+    ({"install.ps1": b"# entry\n"}, {"kill_track": {"install.ps1": 2001}}, "completed"),
+    ({"install.ps1": b"# @include topic.ps1\n", "topic.ps1": b"# helper\n"}, {"files": ["topic.ps1", "install.ps1"]}, "traversal order"),
+    ({"install.ps1": b"# entry\n"}, {"raw_manifest": '{"version":1,"version":1,"entry":"install.ps1","files":["install.ps1"],"kill_track":{}}'}, "duplicate manifest key"),
+    ({"install.ps1": b"# entry\n"}, {"raw_manifest": '{"version":1,"entry":"install.ps1","files":["install.ps1"],"kill_track":{"install.ps1":2001,"install.ps1":2002}}'}, "duplicate manifest key"),
+])
+def test_invalid_graph_cannot_publish_an_installer(tmp_path: Path, sources, updates, error):
+    builder = importlib.import_module("scripts.build_windows_installer")
+    authoring = _authoring(tmp_path / "authoring", sources, **updates)
+    with pytest.raises(builder.AssemblyError, match=error):
+        builder.assemble(authoring)
+
+
+@pytest.mark.windows_only
+@pytest.mark.parametrize("site", ["source-root", "nested-source"])
+def test_windows_junctions_cannot_alias_authored_source(tmp_path: Path, site: str):
+    builder = importlib.import_module("scripts.build_windows_installer")
+    if site == "source-root":
+        authoring = _authoring(tmp_path / "authoring", {"install.ps1": b"# fixture\n"})
+        junction = authoring / "source"
+        target = authoring / "actual-source"
+        junction.rename(target)
+    else:
+        authoring = _authoring(tmp_path / "authoring", {
+            "install.ps1": b"# @include actual/topic.ps1\n# @include linked/topic.ps1\n",
+            "actual/topic.ps1": b"# fixture\n",
+        }, files=["install.ps1", "actual/topic.ps1", "linked/topic.ps1"])
+        junction = authoring / "source/linked"
+        target = authoring / "source/actual"
+    powershell = shutil.which("powershell.exe")
+    assert powershell
+    result = subprocess.run(
+        [powershell, "-NoProfile", "-Command",
+         "$ErrorActionPreference = 'Stop'; New-Item -ItemType Junction -Path $env:HERMES_TEST_LINK -Target $env:HERMES_TEST_TARGET | Out-Null"],
+        env={**os.environ, "HERMES_TEST_LINK": str(junction), "HERMES_TEST_TARGET": str(target)},
+        capture_output=True, text=True, timeout=15, creationflags=subprocess.CREATE_NO_WINDOW,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    try:
+        with pytest.raises(builder.AssemblyError, match="link"):
+            builder.assemble(authoring)
+    finally:
+        junction.rmdir()
+    assert target.is_dir()

--- a/tests/test_windows_installer_delivery.py
+++ b/tests/test_windows_installer_delivery.py
@@ -1,0 +1,181 @@
+"""A single generated installer retains its scope across real Windows entry points."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import shutil
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.windows_only
+
+
+@pytest.fixture(params=["powershell.exe", "pwsh.exe"])
+def shell(request):
+    executable = shutil.which(request.param)
+    assert executable, f"Installer delivery must be tested with {request.param} installed"
+    return executable
+
+
+@pytest.fixture
+def delivery(tmp_path: Path):
+    builder = importlib.import_module("scripts.build_windows_installer")
+    cache = tmp_path / "empty-cache"
+    cache.mkdir()
+    artifact = cache / "install.ps1"
+    artifact.write_bytes(builder.assemble())
+    home = tmp_path / "home"
+    home.mkdir()
+    environment = {
+        **os.environ,
+        "HERMES_HOME": str(home),
+        "HERMES_TEST_INSTALLER": str(artifact),
+        "HERMES_TEST_INSTALL_DIR": str(home / "hermes-agent"),
+        "TEMP": str(tmp_path), "TMP": str(tmp_path),
+        "LOCALAPPDATA": str(tmp_path / "localappdata"),
+        "APPDATA": str(tmp_path / "appdata"),
+        "USERPROFILE": str(tmp_path / "profile"),
+        # The clean test runner strips these Windows executable-dispatch vars.
+        "OS": "Windows_NT", "PATHEXT": ".COM;.EXE;.BAT;.CMD",
+    }
+    return artifact, environment
+
+
+def _run(shell: str, delivery, command: str, **environment):
+    artifact, env = delivery
+    result = subprocess.run(
+        [shell, "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", command],
+        cwd=artifact.parent, env={**env, **environment},
+        capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=30,
+        creationflags=subprocess.CREATE_NO_WINDOW,
+    )
+    return result
+
+
+def _json(result):
+    lines = []
+    for line in result.stdout.splitlines():
+        try:
+            lines.append(json.loads(line))
+        except ValueError:
+            continue
+    assert len(lines) == 1, result.stdout + result.stderr
+    return lines[0]
+
+
+def _manifest(shell, delivery, *, desktop=False):
+    command = "& $env:HERMES_TEST_INSTALLER -Manifest"
+    if desktop:
+        command += " -IncludeDesktop"
+    result = _run(shell, delivery, command)
+    assert result.returncode == 0, result.stdout + result.stderr
+    return _json(result)
+
+
+@pytest.mark.parametrize("entry", ["manifest", "desktop", "protocol", "paths", "unknown", "empty", "dot-source"])
+def test_cached_artifact_preserves_public_metadata_and_scope(shell, delivery, entry):
+    artifact, environment = delivery
+    manifest = _manifest(shell, delivery)
+    names = [stage["name"] for stage in manifest["stages"]]
+    desktop_names = [stage["name"] for stage in _manifest(shell, delivery, desktop=True)["stages"]]
+    assert [name for name in desktop_names if name != "desktop"] == names
+    assert desktop_names.count("desktop") == 1
+    commands = {
+        "manifest": "& $env:HERMES_TEST_INSTALLER -Manifest",
+        "desktop": "& $env:HERMES_TEST_INSTALLER -Manifest -IncludeDesktop",
+        "protocol": "& $env:HERMES_TEST_INSTALLER -ProtocolVersion",
+        "paths": "& $env:HERMES_TEST_INSTALLER -ShowResolvedPaths",
+        "unknown": "& $env:HERMES_TEST_INSTALLER -Stage fixture-unknown-stage; exit $LASTEXITCODE",
+        "empty": "& $env:HERMES_TEST_INSTALLER -Stage ''; exit $LASTEXITCODE",
+        "dot-source": """
+. $env:HERMES_TEST_INSTALLER -IncludeDesktop
+$resolved = @($InstallStages | ForEach-Object {
+    $command = Get-Command $_.Worker -CommandType Function -ErrorAction Stop
+    @{ name = $_.Name; worker = $command.Name; file = $command.ScriptBlock.File }
+})
+@{ protocol_version = $InstallStageProtocolVersion; resolved = $resolved } | ConvertTo-Json -Depth 5 -Compress
+""",
+    }
+    result = _run(shell, delivery, commands[entry])
+    assert result.returncode == (2 if entry in {"unknown", "empty"} else 0), result.stdout + result.stderr
+    value = _json(result)
+    checks = {
+        "manifest": lambda: (
+            (value["protocol_version"], [stage["name"] for stage in value["stages"]]),
+            (manifest["protocol_version"], names),
+        ),
+        "desktop": lambda: (
+            (value["protocol_version"], [stage["name"] for stage in value["stages"]]),
+            (manifest["protocol_version"], desktop_names),
+        ),
+        "protocol": lambda: (value, manifest["protocol_version"]),
+        "paths": lambda: (
+            (Path(value["hermes_home"]), Path(value["install_dir"]), Path(value["temp"])),
+            (Path(environment["HERMES_HOME"]), Path(environment["HERMES_TEST_INSTALL_DIR"]), artifact.parent.parent),
+        ),
+        "unknown": lambda: ((value["ok"], value["stage"], "unknown stage" in value["reason"]), (False, "fixture-unknown-stage", True)),
+        "empty": lambda: ((value["ok"], value["stage"], "unknown stage" in value["reason"]), (False, "", True)),
+        "dot-source": lambda: (
+            (value["protocol_version"], [row["name"] for row in value["resolved"]],
+             all(row["worker"] and Path(row["file"]) == artifact for row in value["resolved"])),
+            (manifest["protocol_version"], desktop_names, True),
+        ),
+    }
+    actual, expected = checks[entry]()
+    assert actual == expected
+    assert len(names) == len(set(names))
+    assert list(artifact.parent.iterdir()) == [artifact], "delivery must not fetch or unpack sibling modules"
+    assert not Path(environment["HERMES_TEST_INSTALL_DIR"]).exists(), "metadata entry points must never install"
+
+
+@pytest.mark.parametrize("transport", ["scriptblock", "irm-iex"])
+def test_loopback_delivery_executes_without_a_checkout(shell, delivery, transport):
+    artifact, environment = delivery
+    baseline = _manifest(shell, delivery)
+    payload = artifact.read_bytes()
+    # Exercise the documented irm | iex transport with a metadata-only caller.
+    # The installer body is unchanged; the wrapper binds its public -Manifest flag.
+    if transport == "irm-iex":
+        payload = b"& {\n" + payload + b"\n} -Manifest\n"
+    requests = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            requests.append(self.path)
+            if self.path != "/install.ps1":
+                self.send_error(404)
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *_args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        command = {
+            "scriptblock": "& ([scriptblock]::Create((Invoke-RestMethod -Uri $env:HERMES_TEST_URL))) -Manifest",
+            "irm-iex": "Invoke-RestMethod -Uri $env:HERMES_TEST_URL | Invoke-Expression",
+        }[transport]
+        result = _run(shell, delivery, command, HERMES_TEST_URL=f"http://127.0.0.1:{server.server_port}/install.ps1")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+    assert not thread.is_alive()
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _json(result) == baseline
+    assert requests == ["/install.ps1"]
+    assert list(artifact.parent.iterdir()) == [artifact]
+    assert not Path(environment["HERMES_TEST_INSTALL_DIR"]).exists()

--- a/tests/test_windows_installer_history.py
+++ b/tests/test_windows_installer_history.py
@@ -61,9 +61,11 @@ def _state(repo: Path, ceilings: dict[str, int], sources: dict[str, bytes], buil
     ([INITIAL, EMPTY, INITIAL], True, False),
     ([INITIAL, INCREASE, SHRINK], True, False),
     ([INITIAL], False, False),
+    ([INITIAL, SHRINK, EMPTY], "diverged", True),
 ], ids=[
     "mechanism-shrink-empty", "raised-ceiling", "new-oversized-shard", "dishonest-initial-source",
     "dishonest-initial-ceiling", "reintroduced-after-empty", "intermediate-increase-hidden-at-head", "missing-base-ref",
+    "unrelated-upstream-progress",
 ])
 def test_committed_history_never_increases_installer_source_debt(tmp_path: Path, states, base_exists, accepted):
     builder = importlib.import_module("scripts.build_windows_installer")
@@ -77,6 +79,10 @@ def test_committed_history_never_increases_installer_source_debt(tmp_path: Path,
         _commit(tmp_path, f"Installer source graph revision {index}")
     head = _git(tmp_path, "rev-parse", "HEAD")
     requested_base = base if base_exists else "fixture-missing-base"
+    if base_exists == "diverged":
+        _git(tmp_path, "checkout", "-b", "upstream", base)
+        (tmp_path / "unrelated.txt").write_text("Upstream work outside the installer\n")
+        requested_base = _commit(tmp_path, "Unrelated upstream progress")
     if accepted:
         assert builder.verify_history(requested_base, head, tmp_path) is None
     else:

--- a/tests/test_windows_installer_history.py
+++ b/tests/test_windows_installer_history.py
@@ -89,3 +89,34 @@ def test_committed_history_never_increases_installer_source_debt(tmp_path: Path,
         with pytest.raises(builder.AssemblyError):
             builder.verify_history(requested_base, head, tmp_path)
     assert _git(tmp_path, "status", "--porcelain") == "", "history verification must not mutate its checkout"
+
+
+@pytest.mark.parametrize("retired_first,restore_allowance", [(True, False), (True, True), (False, True)])
+def test_merge_resolution_cannot_restore_an_allowance_from_either_parent(tmp_path: Path, retired_first, restore_allowance):
+    builder = importlib.import_module("scripts.build_windows_installer")
+    _git(tmp_path, "init", "-b", "main")
+    _git(tmp_path, "config", "core.autocrlf", "false")
+    _git(tmp_path, "config", "user.name", "Installer Fixture")
+    _git(tmp_path, "config", "user.email", "fixture@example.invalid")
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts/install.ps1").write_bytes(ORIGINAL)
+    base = _commit(tmp_path, "Original installer")
+    _state(tmp_path, *INITIAL, builder)
+    _commit(tmp_path, "Initial source ownership")
+    _git(tmp_path, "branch", "other")
+    _state(tmp_path, *EMPTY, builder)
+    _commit(tmp_path, "Retire source debt")
+    _git(tmp_path, "checkout", "other")
+    (tmp_path / "unrelated.txt").write_text("Diverged branch\n")
+    _commit(tmp_path, "Unrelated work")
+    if retired_first:
+        _git(tmp_path, "checkout", "main")
+    _git(tmp_path, "merge", "--no-commit", "--no-ff", "other" if retired_first else "main")
+    _state(tmp_path, *(INITIAL if restore_allowance else EMPTY), builder)
+    head = _commit(tmp_path, "Resolve source graph in a real merge")
+    assert len(_git(tmp_path, "rev-list", "--parents", "-n", "1", head).split()) == 3
+    if restore_allowance:
+        with pytest.raises(builder.AssemblyError):
+            builder.verify_history(base, head, tmp_path)
+    else:
+        assert builder.verify_history(base, head, tmp_path) is None

--- a/tests/test_windows_installer_history.py
+++ b/tests/test_windows_installer_history.py
@@ -1,0 +1,85 @@
+"""Committed installer source debt can shrink, but cannot be added or restored."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ORIGINAL = b"# original installer line\n" * 2003
+SMALLER = b"# remaining installer line\n" * 2001
+COMPLETE = b"# extracted entry point\n"
+INITIAL = ({"install.ps1": ORIGINAL.count(b"\n")}, {"install.ps1": ORIGINAL})
+SHRINK = ({"install.ps1": SMALLER.count(b"\n")}, {"install.ps1": SMALLER})
+EMPTY = ({}, {"install.ps1": COMPLETE})
+INCREASE = ({"install.ps1": 2004}, {"install.ps1": ORIGINAL + b"# added debt\n"})
+NEW_SHARD = (
+    {"install.ps1": 2003, "new.ps1": 2001},
+    {"install.ps1": b"# original installer line\n" * 2002 + b"# @include new.ps1\n", "new.ps1": SMALLER},
+)
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-c", "commit.gpgsign=false", "-c", "core.hooksPath=nonexistent-fixture-hooks", *args],
+        cwd=repo, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=15,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    return result.stdout.strip()
+
+
+def _commit(repo: Path, title: str) -> str:
+    _git(repo, "add", "--all")
+    _git(repo, "-c", "user.name=Installer Fixture", "-c", "user.email=fixture@example.invalid", "commit", "-m", title)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _state(repo: Path, ceilings: dict[str, int], sources: dict[str, bytes], builder) -> None:
+    authoring = repo / "scripts/windows-installer"
+    source = authoring / "source"
+    source.mkdir(parents=True, exist_ok=True)
+    for previous in source.glob("*.ps1"):
+        previous.unlink()
+    for name, data in sources.items():
+        (source / name).write_bytes(data)
+    manifest = {"version": 1, "entry": "install.ps1", "files": list(sources), "kill_track": ceilings}
+    (authoring / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    # Each revision passes the local assembly gate. Only committed history can
+    # reject the dishonest or regressive debt declarations below.
+    (repo / "scripts/install.ps1").write_bytes(builder.assemble(authoring))
+
+
+@pytest.mark.parametrize("states,base_exists,accepted", [
+    ([INITIAL, SHRINK, EMPTY], True, True),
+    ([INITIAL, INCREASE], True, False),
+    ([INITIAL, NEW_SHARD], True, False),
+    ([({"install.ps1": 2003}, {"install.ps1": ORIGINAL.replace(b"original", b"altered")})], True, False),
+    ([({"install.ps1": 2004}, {"install.ps1": ORIGINAL})], True, False),
+    ([INITIAL, EMPTY, INITIAL], True, False),
+    ([INITIAL, INCREASE, SHRINK], True, False),
+    ([INITIAL], False, False),
+], ids=[
+    "mechanism-shrink-empty", "raised-ceiling", "new-oversized-shard", "dishonest-initial-source",
+    "dishonest-initial-ceiling", "reintroduced-after-empty", "intermediate-increase-hidden-at-head", "missing-base-ref",
+])
+def test_committed_history_never_increases_installer_source_debt(tmp_path: Path, states, base_exists, accepted):
+    builder = importlib.import_module("scripts.build_windows_installer")
+    _git(tmp_path, "init", "-b", "main")
+    _git(tmp_path, "config", "core.autocrlf", "false")
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts/install.ps1").write_bytes(ORIGINAL)
+    base = _commit(tmp_path, "Original standalone installer")
+    for index, (ceilings, sources) in enumerate(states):
+        _state(tmp_path, ceilings, sources, builder)
+        _commit(tmp_path, f"Installer source graph revision {index}")
+    head = _git(tmp_path, "rev-parse", "HEAD")
+    requested_base = base if base_exists else "fixture-missing-base"
+    if accepted:
+        assert builder.verify_history(requested_base, head, tmp_path) is None
+    else:
+        with pytest.raises(builder.AssemblyError):
+            builder.verify_history(requested_base, head, tmp_path)
+    assert _git(tmp_path, "status", "--porcelain") == "", "history verification must not mutate its checkout"


### PR DESCRIPTION
Existing Desktop/bootstrap releases download and cache only `scripts/install.ps1`. Replacing it with a runtime loader would break pinned downloads, offline caches, and `irm | iex`. This PR introduces bounded-source authoring and deterministic **build-time** assembly while retaining that same readable standalone file and its script scope.

Part of #79922 and #78647. Depends on #103771; the contributor commit is retained with its original authorship. This is the mechanism prerequisite for nine separate verbatim extraction PRs. Its initial **5,082-line residual is explicitly outstanding**; this PR alone does not finish the sharding.

The builder rejects incomplete/ambiguous source graphs, path escapes and filesystem links, orphaned inputs, stale artifacts, and authored line-limit violations. CI verifies every manifest-changing commit from the common merge-base to the actual PR head: the initial source must equal its parent installer; ceilings may only decrease or disappear, and cannot be reintroduced. The test-merge checkout separately verifies generated bytes. Source, manifest, builder, tests, and checkout-encoding changes select installer checks.

Validation:

- Exact artifact identity to `e67300b455a1c7d67bc71a94e9a08b04b67f3425`: 246,939 bytes, SHA-256 `55b3d76e62abba5cecc16d17a65d799aaa6490e3dc88640fdcae282c4db5fd9f`.
- 24 assembly cases; 18 standalone-delivery cases across PowerShell 5.1/7; 12 real Git history cases; 73 classifier cases pass in focused runs.
- Native Node/npm compatibility passes on both hosts. The existing long-path harness passes on 5.1; locally on 7.6.5 it misparses a shell startup warning before its JSON result (10 identical failures on the unchanged prerequisite and this output). The new delivery tests parse and exercise the actual metadata on both hosts. This pre-existing harness boundary is not represented as a passing local check.
- Contributor email audit and `git diff --check` pass. This PR is open and ready for review. Its installer checks passed; the maintainer review-label gate remains unsatisfied. Shared CI fixture repairs are in progress; no merge or release claim.

Credit and coordination: Axl Ibiza's investigation/reproduction is #103751; [fangliquanflq's recovery contribution](https://github.com/NousResearch/hermes-agent/pull/103771) remains the prerequisite. Original rollback history includes [egilewski's #83194](https://github.com/NousResearch/hermes-agent/pull/83194), carried by [#86686](https://github.com/NousResearch/hermes-agent/pull/86686). Source decomposition follows Axl's graph-gated extraction work in #79922/#78647. The Desktop completion repair remains #103749.

This fork stack targets `main` because the author cannot create upstream base branches. GitHub therefore shows prerequisite changes cumulatively. Merge order is explicit; the mechanism's owned range is `e67300b455a1c7d67bc71a94e9a08b04b67f3425..a04c1e2ef4d4a592c567f629ed3613007d608594`. Subsequent extraction PRs provide their exact one-commit review range. Pending installer fixes must target the relevant authored module and regenerate after this stack; direct generated-output edits fail the new gate.


CI follow-up at `bb284bb02d43c42eb31c524cdc5c4f5e6fd2840b`: Shared CI prerequisites preserve Teknium’s original commits from #103507 and anhtahaylove’s original commit from #101478. Axl’s follow-up moves cold UI imports into collection, synchronizes worker-state witnesses before timeout injection, guarantees test worker cleanup, and separates transaction integrity tests from the unchanged production SQLite contention budget. The compression work continues Axl’s earlier investigation in #78202; its existing implementation was inspected before this narrower correction.

The remaining messaging failure came from cold component loading inside a 15-second behavioral deadline; the timed-out helper could continue rendering into later cases. A phase-aware audit classified all 148 Desktop test files containing dynamic imports: 55 already load during collection, 12 use imports only inside mock factories, 53 intentionally isolate modules, 15 receive this fix, and 13 retain verified warm or ordering-dependent imports. The fix loads stable modules during collection after mock fixture initialization, preserving temporal-dead-zone safety and every assertion.

The [latest common test-only delta](https://github.com/andrexibiza/hermes-agent/compare/51eab46c04d4da0c24045abb39cbaf95b2d81997...bb284bb02d43c42eb31c524cdc5c4f5e6fd2840b) changes fifteen test files. All nine extraction deltas remain byte-for-byte identical, and every installer artifact equals its prior PR head. The original #103771 commit remains an ancestor. The 15-file focused suite passes 223 tests at default deadlines. All 519 assertion call ASTs and 267 case/suite titles are unchanged; the prior full UI run passed 7,231 tests. A controlled 17-second messaging-module transform delay reproduces the deadline failure on the preceding tests and passes after collection loading. Two independent reviewers examined this fix. Fresh upstream checks are pending; ready-for-review status does not assert that CI has passed.

The existing `ci-reviewed` gate remains intact. Its sensitive workflow change adds full-history checkout and source/history validation under unchanged `contents: read` permissions. No label or check status has been self-certified.
