### PR TITLE
fix(desktop): retry transient remote gateway dials after renderer reload

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -1,3 +1,4 @@
+import { GatewayReauthRequiredError } from '@hermes/shared'
 import { act, cleanup, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -174,13 +175,15 @@ class FakeWebSocket {
 }
 
 const primaryConn = {
-  authMode: 'token' as const,
+  authMode: 'token' as 'oauth' | 'token',
   baseUrl: 'https://vps.example.com',
   connectionId: 'primary-vps',
   profile: 'default',
   token: 't',
   wsUrl: 'wss://vps.example.com/api/ws?token=t'
 }
+
+const remotePrimaryConn = { ...primaryConn, mode: 'remote' as const }
 
 const coderConn = {
   authMode: 'token' as const,
@@ -1624,6 +1627,209 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect(desktop.getConnection.mock.calls.length).toBeGreaterThan(1)
     expect($gatewayState.get()).toBe('open')
     expect($desktopBoot.get().error).toBeNull()
+  })
+
+  it('RETRY CONTRACT: a resolved remote whose first renderer gateway dial fails retries even when main still reports stale non-retryable ready progress', async () => {
+    // Renderer reload against a saved direct remote: Electron has already
+    // reported a successful backend.ready snapshot, so that stale progress
+    // cannot classify the renderer-owned WebSocket dial which follows it.
+    const desktop = fakeDesktop()
+    desktop.getConnection = vi.fn(async () => remotePrimaryConn)
+    desktop.getBootProgress = vi.fn(async () => ({
+      error: null,
+      fakeMode: false,
+      message: 'Hermes is ready',
+      phase: 'backend.ready',
+      progress: 100,
+      retryable: false,
+      running: true,
+      timestamp: 1
+    }))
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+    FakeWebSocket.mode = 'fail'
+
+    render(<Harness />)
+    await flushAsync()
+
+    // getConnection resolved the saved REMOTE descriptor; only its first
+    // renderer-owned gateway.connect() failed.
+    expect(desktop.getConnection).toHaveBeenCalledTimes(1)
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    expect($desktopBoot.get().error).toBeNull()
+
+    // The same endpoint becomes reachable before the bounded retry fires.
+    FakeWebSocket.mode = 'open'
+    await advanceBackoff()
+
+    expect(desktop.getConnection).toHaveBeenCalledTimes(2)
+    expect($gatewayState.get()).toBe('open')
+    expect($desktopBoot.get().error).toBeNull()
+  })
+
+  it('RETRY CONTRACT: a local descriptor never enters the renderer-side remote retry branch', async () => {
+    const desktop = fakeDesktop()
+    desktop.getConnection.mockImplementation(async () => ({ ...remotePrimaryConn, mode: 'local' as const }) as never)
+    desktop.getBootProgress = vi.fn(async () => ({
+      error: 'contradictory main snapshot',
+      fakeMode: false,
+      message: 'Desktop boot failed',
+      phase: 'backend.error',
+      progress: 24,
+      retryable: true,
+      running: false,
+      timestamp: 1
+    }))
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+    FakeWebSocket.mode = 'fail'
+
+    render(<Harness />)
+    await flushAsync()
+
+    expect($desktopBoot.get().error).toBeTruthy()
+    expect(desktop.getConnection).toHaveBeenCalledTimes(1)
+    await advanceBackoff()
+    expect(desktop.getConnection).toHaveBeenCalledTimes(1)
+  })
+
+  it('RETRY CONTRACT: a confirmed remote reauth rejection remains terminal despite contradictory retryable progress', async () => {
+    const desktop = fakeDesktop()
+    desktop.getConnection = vi.fn(async () => ({ ...remotePrimaryConn, authMode: 'oauth' as const }))
+    desktop.getGatewayWsUrl = vi.fn(async () => {
+      throw new GatewayReauthRequiredError('Sign in again')
+    })
+    desktop.getBootProgress = vi.fn(async () => ({
+      error: 'contradictory main snapshot',
+      fakeMode: false,
+      message: 'Desktop boot failed',
+      phase: 'backend.error',
+      progress: 24,
+      retryable: true,
+      running: false,
+      timestamp: 1
+    }))
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+
+    expect($desktopBoot.get().error).toBeTruthy()
+    expect(desktop.getConnection).toHaveBeenCalledTimes(1)
+    expect(FakeWebSocket.instances).toHaveLength(0)
+    await advanceBackoff()
+    expect(desktop.getConnection).toHaveBeenCalledTimes(1)
+  })
+
+  it('RETRY CONTRACT: invalid remote WebSocket URLs remain terminal despite contradictory retryable progress', async () => {
+    const desktop = fakeDesktop()
+    desktop.getConnection = vi.fn(async () => ({ ...remotePrimaryConn, wsUrl: 'not a WebSocket URL' }))
+    desktop.getGatewayWsUrl = vi.fn(async () => 'not a WebSocket URL')
+    desktop.getBootProgress = vi.fn(async () => ({
+      error: 'contradictory main snapshot',
+      fakeMode: false,
+      message: 'Desktop boot failed',
+      phase: 'backend.error',
+      progress: 24,
+      retryable: true,
+      running: false,
+      timestamp: 1
+    }))
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+    FakeWebSocket.mode = 'fail'
+
+    render(<Harness />)
+    await flushAsync()
+
+    expect($desktopBoot.get().error).toBeTruthy()
+    expect(desktop.getConnection).toHaveBeenCalledTimes(1)
+    await advanceBackoff()
+    expect(desktop.getConnection).toHaveBeenCalledTimes(1)
+  })
+
+  it('RETRY CONTRACT: missing OAuth ticket capability remains terminal despite contradictory retryable progress', async () => {
+    const desktop = fakeDesktop()
+    desktop.getConnection = vi.fn(async () => ({ ...remotePrimaryConn, authMode: 'oauth' as const }))
+    Reflect.deleteProperty(desktop, 'getGatewayWsUrl')
+    desktop.getBootProgress = vi.fn(async () => ({
+      error: 'contradictory main snapshot',
+      fakeMode: false,
+      message: 'Desktop boot failed',
+      phase: 'backend.error',
+      progress: 24,
+      retryable: true,
+      running: false,
+      timestamp: 1
+    }))
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+
+    expect($desktopBoot.get().error).toMatch(/cannot refresh OAuth WebSocket tickets/i)
+    expect(desktop.getConnection).toHaveBeenCalledTimes(1)
+    expect(FakeWebSocket.instances).toHaveLength(0)
+    await advanceBackoff()
+    expect(desktop.getConnection).toHaveBeenCalledTimes(1)
+  })
+
+  it('RETRY CONTRACT: a post-connect failure stays terminal even when its socket closes before boot catches it', async () => {
+    const desktop = fakeDesktop()
+    desktop.getConnection = vi.fn(async () => remotePrimaryConn)
+    desktop.getBootProgress = vi.fn(async () => ({
+      error: 'contradictory main snapshot',
+      fakeMode: false,
+      message: 'Desktop boot failed',
+      phase: 'backend.error',
+      progress: 24,
+      retryable: true,
+      running: false,
+      timestamp: 1
+    }))
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    const refreshHermesConfig = vi.fn(async () => {
+      FakeWebSocket.instances[0]?.drop()
+      throw new Error('post-connect initialization failed')
+    })
+
+    render(<Harness refreshHermesConfig={refreshHermesConfig} />)
+    await flushAsync()
+
+    expect(refreshHermesConfig).toHaveBeenCalledTimes(1)
+    expect($desktopBoot.get().error).toBeTruthy()
+    expect(desktop.getConnection).toHaveBeenCalledTimes(1)
+    await advanceBackoff()
+    expect(desktop.getConnection).toHaveBeenCalledTimes(1)
+  })
+
+  it('RETRY CONTRACT: a persistent renderer-side remote dial outage consumes the existing five-attempt bound', async () => {
+    const desktop = fakeDesktop()
+    desktop.getConnection = vi.fn(async () => remotePrimaryConn)
+    desktop.getBootProgress = vi.fn(async () => ({
+      error: null,
+      fakeMode: false,
+      message: 'Hermes is ready',
+      phase: 'backend.ready',
+      progress: 100,
+      retryable: false,
+      running: true,
+      timestamp: 1
+    }))
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+    FakeWebSocket.mode = 'fail'
+
+    render(<Harness />)
+    await flushAsync()
+
+    for (let i = 0; i < 7; i += 1) {
+      await advanceBackoff()
+    }
+
+    expect(desktop.getConnection).toHaveBeenCalledTimes(6)
+    expect(FakeWebSocket.instances).toHaveLength(6)
+    expect($desktopBoot.get().error).toBeTruthy()
+    await advanceBackoff()
+    expect(desktop.getConnection).toHaveBeenCalledTimes(6)
+    expect(FakeWebSocket.instances).toHaveLength(6)
   })
 
   it('FIX #82679: boot retries are BOUNDED — a persistently dead remote ends in the recovery overlay, not a spinner', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -108,15 +108,14 @@ const RECONNECT_ESCALATE_AFTER_MS = 300_000
 // only a STREAK of unanswered pings rebuilds the transport.
 const GATEWAY_LIVENESS_PROBE_TIMEOUT_MS = 5_000
 
-// Bounded self-heal for a failed REMOTE boot (#82679): when the primary boot
-// fails on a transient remote fault (dropped SSH/HTTP registered connection,
-// mint timeout — main tags those `retryable` on the boot progress), the
-// renderer re-attempts the whole boot with the same full-jitter backoff the
-// post-boot reconnect loop uses, up to this many attempts. Retries are
-// bounded and end in the real recovery affordance (the boot-failure overlay
-// with Retry / Settings), never an infinite spinner. Local failures and
-// confirmed reauth rejections never enter this loop — a missing capability
-// differs from a transient failure.
+// Bounded self-heal for a failed REMOTE boot (#82679): main classifies faults
+// before a descriptor exists; the renderer also classifies a valid remote
+// WebSocket dial that fails before becoming usable. The renderer re-attempts
+// the whole boot with the same full-jitter backoff the post-boot reconnect loop
+// uses, up to this many attempts. Retries are bounded and end in the real
+// recovery affordance (the boot-failure overlay with Retry / Settings), never
+// an infinite spinner. Local failures, mint/capability failures, and confirmed
+// reauth rejections never enter this loop.
 const BOOT_RETRY_MAX_ATTEMPTS = 5
 // Base delay for boot retries. Deliberately slower than the socket reconnect
 // loop's 300ms: each attempt may rebuild an SSH master + remote dashboard.
@@ -138,6 +137,16 @@ export function primaryRuntimeConnectionId(connection: Pick<HermesConnection, 'c
   }
 
   return connection.mode === 'local' ? 'local' : null
+}
+
+function isGatewayWebSocketUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+
+    return url.protocol === 'ws:' || url.protocol === 'wss:'
+  } catch {
+    return false
+  }
 }
 
 interface GatewayBootOptions {
@@ -1017,6 +1026,14 @@ export function useGatewayBoot({
     })
 
     async function boot() {
+      // These are historical facts for one boot attempt, not a late read of
+      // gateway.connectionState. A socket can close after a successful dial;
+      // later initialization errors must not be reclassified as boot dials.
+      let connectionDescriptorResolved = false
+      let resolvedRemoteConnection = false
+      let remoteGatewayConnectAttempted = false
+      let gatewayConnectSucceeded = false
+
       try {
         // A profile-pinned helper window (the HUD) dials its target profile's
         // backend directly — ensureBackend spawns/reuses it from the pool.
@@ -1034,6 +1051,9 @@ export function useGatewayBoot({
         if (cancelled) {
           return
         }
+
+        connectionDescriptorResolved = true
+        resolvedRemoteConnection = conn.mode === 'remote'
 
         setDesktopBootStep({
           phase: 'renderer.gateway.connect',
@@ -1059,17 +1079,23 @@ export function useGatewayBoot({
         // Mint a fresh WS URL right before connecting. For OAuth gateways the
         // ticket is single-use with a short TTL, so the ticket baked into
         // conn.wsUrl is stale; resolveGatewayWsUrl() re-mints it rather than
-        // connecting with a dead ticket. Auth rejection asks for sign-in;
-        // connectivity failures remain retryable. Bounded like the reconnect
-        // path (#93454) so a wedged mint fails into boot retry instead of
-        // hanging "Starting Hermes…" forever.
+        // connecting with a dead ticket. Auth rejection asks for sign-in; the
+        // Electron mint path has its own bounded transport retries. This await
+        // is bounded like the reconnect path (#93454) so a wedged mint reaches
+        // the recovery affordance instead of hanging "Starting Hermes…".
         const wsUrl = await withTimeout(
           resolveGatewayWsUrl(desktop, conn),
           RECONNECT_ATTEMPT_TIMEOUT_MS,
           'Timed out minting the gateway WebSocket URL'
         )
 
+        // The complementary retry classification is deliberately narrower
+        // than every remote pre-open error: only a valid WebSocket dial after
+        // a resolved remote descriptor is transient here. URL and capability
+        // failures stay terminal at their own boundaries.
+        remoteGatewayConnectAttempted = resolvedRemoteConnection && isGatewayWebSocketUrl(wsUrl)
         await gateway.connect(wsUrl)
+        gatewayConnectSucceeded = true
 
         if (cancelled) {
           return
@@ -1116,15 +1142,25 @@ export function useGatewayBoot({
         if (!cancelled) {
           const message = err instanceof Error ? err.message : String(err)
 
-          // Transient remote failure (dropped SSH/HTTP registered connection,
-          // mint timeout): self-heal with bounded, jittered retries instead of
-          // parking on "Desktop boot failed" until the user re-enters the same
-          // connection details (#82679). Main already cleared the failed cached
-          // descriptor, so the next getConnection() rebuilds the connection —
-          // exactly what manual re-entry forced. Exhausted retries, local
-          // failures, and confirmed reauth rejections end in the real recovery
-          // affordance (the boot-failure overlay), never an infinite spinner.
-          if (bootRetryAttempt < BOOT_RETRY_MAX_ATTEMPTS && (await bootFailureIsRetryable()) && !cancelled) {
+          // Preserve the main-process classification for failures before a
+          // descriptor is available. Once this renderer has a descriptor, the
+          // only complementary retry is a transient, valid remote WebSocket
+          // dial which never became usable. A confirmed reauth rejection,
+          // invalid URL/capability failure, local descriptor, and anything
+          // after a successful dial retain the terminal recovery surface.
+          const retryableBeforeDescriptor = !connectionDescriptorResolved && (await bootFailureIsRetryable())
+
+          const retryableRemoteGatewayDial =
+            resolvedRemoteConnection &&
+            remoteGatewayConnectAttempted &&
+            !gatewayConnectSucceeded &&
+            !isGatewayReauthRequired(err)
+
+          if (
+            bootRetryAttempt < BOOT_RETRY_MAX_ATTEMPTS &&
+            (retryableBeforeDescriptor || retryableRemoteGatewayDial) &&
+            !cancelled
+          ) {
             const delay = reconnectBackoffDelayMs(bootRetryAttempt, { baseDelayMs: BOOT_RETRY_BASE_DELAY_MS })
             bootRetryAttempt += 1
             resumeDesktopBootForRetry(translateNow('boot.steps.retryingRemoteBackend'))


### PR DESCRIPTION
## Summary

A saved direct-remote Desktop can reload its renderer while the remote gateway is unavailable. Electron main then returns its cached remote descriptor, but the renderer-owned WebSocket dial fails. Because main still exposes the earlier successful `backend.ready` snapshot with `retryable: false`, the renderer treats the failure as terminal and never reconnects after the same endpoint returns.

This change extends the existing bounded boot-retry contract from #82679 only for that demonstrated renderer-side boundary.

## Strict scope

- Preserves main's existing pre-descriptor `retryable` classification.
- Adds retry eligibility only after a `remote` descriptor and a valid `ws:`/`wss:` dial that never became usable.
- Reuses the existing one-initial-plus-five retry budget.
- Keeps local descriptors, invalid WebSocket URLs, missing OAuth capability, confirmed reauthentication, and post-connect initialization failures terminal.
- Does not touch local runtime discovery or `resolveHermesBackend()`.

This is a demonstrated recovery sub-path related to #103786. It does **not** establish or fix the original AppHangB1 cause or the reported unread server socket, so this PR uses `Refs`, not `Closes`.

## Evidence frame

- Current integration base: `966637323e6f90864e069dbc12755934c2c86387`
- Current head: `b650c410167fee33516f24fa21afb505fb9ad685`
- Platform: Windows Desktop with a valid saved direct remote
- Runtime path: production Electron → renderer boot → Electron IPC → real `hermes serve` → browser WebSocket; inference alone is mocked

### RED on base

Reloading the renderer during a transient gateway outage, while preserving the Electron main PID, leaves the app in the boot-failure overlay after the gateway is restored. Before and after reload, `getBootProgress()` returns the same stale snapshot: `backend.ready`, `retryable:false`, identical timestamp. The restored server receives no new WebSocket and no RPC.

The result reproduced with GPU enabled twice and with GPU disabled once. GPU is not causal.

### Prior real-path GREEN on `8cfc50f1eae36a7cfacc31391f0867d9377de767`

| Control | Result | Same main PID | Fresh WS + RPC | Main max timer gap | Renderer max timer gap |
|---|---:|---:|---:|---:|---:|
| GPU disabled | PASS | yes | yes | 44.90 ms | 470.60 ms |
| GPU enabled | PASS | yes | yes | 42.38 ms | 525.50 ms |

Recovery completed in 2237 ms and 2989 ms respectively. Both restored servers accepted a new WebSocket and completed a real composer → gateway → inference response.

The branch was subsequently rebased cleanly onto current `main@966637323e6f`. The current head preserves the bounded recovery change and has been revalidated with the focused hook suite, typecheck, targeted lint, and a production build; the real Windows scenario above was not rerun after this mechanical rebase.

## Tests

- Untouched base hook suite: `42 passed`
- Current-head hook suite: `50 passed`
- Current-head TypeScript typecheck: PASS
- Current-head focused ESLint: PASS
- Current-head production build and `git diff --check`: PASS
- Independent adversarial review: PASS; no P0/P1
- Hosted CI on the refreshed head: PASS, including `All required checks pass`, JS/TS, Nix, OSV, and both Docker architectures

This PR is ready for review as a bounded recovery fix related to #103786; it does not claim to close the original AppHangB1 report.

## Ownership / interlocks

- #85048 / #85182 own automatic reload after `render-process-gone: reason=killed`; this PR does not duplicate that lifecycle action.
- #98486 / #98600 own late local-backend overlay recovery.
- #103683 changes private-CA `wss://` transport placement and remains a merge-order/test interlock.
- #93454 and #82679 provide the existing bounded reconnect/retry behavior this change preserves and extends.

Refs #103786