### PR TITLE
fix(agent): keep custom fallbacks available after model switches

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2058,20 +2058,41 @@ def _build_primary_runtime_snapshot(agent, api_mode) -> Dict[str, Any]:
     return rt
 
 
-def _finish_switch(agent, new_provider, old_norm, new_norm) -> None:
+def _finish_switch(agent, old_provider, old_model, old_base_url, new_provider) -> None:
     """Post-switch bookkeeping: fallback reset/prune, request_overrides, billing route."""
     agent._fallback_activated = False
     agent._provider_fallback_active = False
     agent._provider_fallback_route = None
     agent._fallback_index = 0
-    # On a deliberate provider swap, prune fallback entries targeting the OLD or NEW primary;
-    # otherwise a failed turn silently re-activates the provider the user just rejected.
+    # On a deliberate provider swap, prune fallback entries targeting the OLD or NEW deployment;
+    # otherwise a failed turn silently re-activates the primary the user just replaced.
     fallback_chain = list(getattr(agent, "_fallback_chain", []) or [])
+    old_norm = (old_provider or "").strip().lower()
+    new_norm = (new_provider or "").strip().lower()
     if old_norm and new_norm and old_norm != new_norm:
-        fallback_chain = [
-            entry for entry in fallback_chain
-            if (entry.get("provider") or "").strip().lower() not in {old_norm, new_norm}
-        ]
+        from agent.backend_identity import BackendIdentity, should_skip_candidate
+
+        old_identity = BackendIdentity.build(
+            provider=old_provider, model=old_model, base_url=old_base_url
+        )
+        new_identity = BackendIdentity.build(
+            provider=new_provider,
+            model=getattr(agent, "model", ""),
+            base_url=getattr(agent, "base_url", ""),
+        )
+
+        def targets_switched_deployment(entry):
+            candidate = BackendIdentity.build(
+                provider=entry.get("provider"),
+                model=entry.get("model"),
+                base_url=entry.get("base_url"),
+            )
+            return (
+                should_skip_candidate(candidate, old_identity)
+                or should_skip_candidate(candidate, new_identity)
+            )
+
+        fallback_chain = [entry for entry in fallback_chain if not targets_switched_deployment(entry)]
     agent._fallback_chain = fallback_chain
     agent._fallback_model = fallback_chain[0] if fallback_chain else None
     # Apply the switched-to provider's request_overrides (custom_providers extra_body).
@@ -2106,6 +2127,7 @@ def switch_model(
     snapshot and re-raises (callers catch)."""
     old_model = agent.model
     old_provider = agent.provider
+    old_base_url = agent.base_url
     # ── Reload credential pool for the new provider (issue #52727) ── Without this,
     # ``recover_with_credential_pool`` sees a ``pool.provider != agent.provider`` mismatch and
     # short-circuits, leaving the new provider with no rotation/recovery on 401/429 and burning the original
@@ -2156,7 +2178,7 @@ def switch_model(
     from agent.chat_completion_helpers import _reset_stale_streak
     _reset_stale_streak(agent)
     agent._primary_runtime = _build_primary_runtime_snapshot(agent, api_mode)
-    _finish_switch(agent, new_provider, old_norm, new_norm)
+    _finish_switch(agent, old_provider, old_model, old_base_url, new_provider)
     logger.info(
         "Model switched in-place: %s (%s) -> %s (%s)",
         old_model, old_provider, new_model, new_provider,

--- a/tests/run_agent/test_switch_model_fallback_prune.py
+++ b/tests/run_agent/test_switch_model_fallback_prune.py
@@ -12,12 +12,18 @@ from unittest.mock import MagicMock, patch
 from run_agent import AIAgent
 
 
-def _make_agent(chain):
+def _make_agent(
+    chain,
+    *,
+    provider="openrouter",
+    model="x-ai/grok-4",
+    base_url="https://openrouter.ai/api/v1",
+):
     agent = AIAgent.__new__(AIAgent)
 
-    agent.provider = "openrouter"
-    agent.model = "x-ai/grok-4"
-    agent.base_url = "https://openrouter.ai/api/v1"
+    agent.provider = provider
+    agent.model = model
+    agent.base_url = base_url
     agent.api_key = "or-key"
     agent.api_mode = "chat_completions"
     agent.client = MagicMock()
@@ -76,6 +82,51 @@ def test_switch_with_empty_chain_stays_empty():
 
     assert agent._fallback_chain == []
     assert agent._fallback_model is None
+
+
+def test_switch_from_bare_custom_preserves_distinct_custom_fallbacks():
+    survivors = [
+        {
+            "provider": "custom",
+            "model": "hy4-preview",
+            "base_url": "http://127.0.0.1:8001/v1",
+        },
+        {
+            "provider": "custom",
+            "model": "glm-5.3-flash",
+            "base_url": "http://127.0.0.1:8002/v1",
+        },
+    ]
+    chain = [
+        {
+            "provider": "custom",
+            "model": "gemini-3.8-flash-high",
+            "base_url": "http://primary.example/v1",
+        },
+        *survivors,
+        {
+            "provider": "custom",
+            "model": "claude-opus-4.6",
+            "base_url": "http://antigravity.example/v1",
+        },
+    ]
+    agent = _make_agent(
+        chain,
+        provider="custom",
+        model="gemini-3.8-flash-high",
+        base_url="http://primary.example/v1",
+    )
+
+    with patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None):
+        agent.switch_model(
+            new_model="claude-opus-4.6",
+            new_provider="custom:antigravity",
+            api_key="new-key",
+            base_url="http://antigravity.example/v1",
+        )
+
+    assert agent._fallback_chain == survivors
+    assert agent._fallback_model == survivors[0]
 
 
 def test_manual_switch_clears_provider_fallback_provenance():


### PR DESCRIPTION
## What does this PR do?

Model switches no longer erase distinct fallback deployments configured with the bare `custom` provider label. Without this fix, a rate-limited primary can leave the agent retrying for the full backoff budget instead of failing over to a healthy custom endpoint.

### Symptom

Switching from a runtime labeled `custom` to a named custom provider can empty `_fallback_chain`. A later 429 then bypasses eager failover because there are no remaining candidates.

### Impact

Users with bare `custom` fallback entries can lose all configured failover routes after an in-place model switch. The active turn and delegated children that inherit the chain can remain on an exhausted primary.

### Bug Cause

**Trigger:** `agent/agent_runtime_helpers.py:2070` in `_finish_switch()` when the old and new provider labels differ.

**Causal chain:**
1. A live session whose resolved provider is bare `custom` switches to a named custom backend.
2. `_finish_switch()` compares only normalized provider strings and removes every fallback entry labeled `custom`, regardless of its model or endpoint.
3. The next rate limit sees an empty chain and cannot activate a healthy fallback deployment.

**Why it is wrong:** Bare `custom` identifies a provider category, not one concrete backend. Provider-only equality conflates deployments with different models and base URLs.

**Working sibling / contrast:** The failover path already uses `BackendIdentity` and `should_skip_candidate()` to compare provider, model, and endpoint together.

**Ruled out:** Fallback configuration parsing is not responsible; the chain is populated before the switch and is removed specifically by the post-switch prune.

### Fix

Build backend identities for the old primary, new primary, and each fallback candidate. Prune only candidates that resolve to the old or new deployment, while preserving distinct custom models and endpoints.

## Related Issue

Closes #103788

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_runtime_helpers.py` - prune fallback entries using the shared backend identity semantics.
- `tests/run_agent/test_switch_model_fallback_prune.py` - cover bare custom entries across distinct endpoints and exact old/new deployments.

## How to Test

1. Configure multiple bare `custom` fallback entries with distinct models and base URLs.
2. Switch a live agent from bare `custom` to a named custom provider.
3. Confirm distinct fallback deployments remain while entries matching the old and new primaries are removed.

```bash
scripts/run_tests.sh tests/agent/test_backend_identity.py tests/run_agent/test_switch_model_fallback_prune.py
uv run ruff check agent/agent_runtime_helpers.py tests/run_agent/test_switch_model_fallback_prune.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - platform-independent logic
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - covered by the focused regression test.
