### PR TITLE
fix(update): the fleet probe credits a restarted gateway no bookkeeping list names (#103679)

### DIFF
--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -1273,6 +1273,9 @@ def _verify_fleet_after_update(restart, *, _pre_update_plan, _windows_gateway_re
                     if _stale_serve_rows is not None
                     else None
                 ),
+                # The matrix printed just above is the strongest evidence available: it outranks
+                # unit-name matching for a gateway no restart list happens to name. See #103679.
+                fleet_rows=_fleet_snapshot,
             )
             if report_unaccounted_runtimes(_runtime_outcomes):
                 restart.incomplete = True

--- a/hermes_cli/update_inventory.py
+++ b/hermes_cli/update_inventory.py
@@ -297,10 +297,41 @@ def _gateway_named_in(r: RuntimeRecord, names: set) -> bool:
     )
 
 
+def _fleet_proves_gateway_replaced(r: RuntimeRecord, fleet_rows) -> bool:
+    """Did the post-restart fleet probe positively observe *r*'s replacement?
+
+    Name matching answers "did some bookkeeping list mention this runtime"; the fleet probe
+    answers the question the tripwire actually exists to ask — "is anything still serving
+    pre-update modules". A row for the same profile in state ``current`` (its stamped
+    ``code_sha`` equals the fresh checkout's HEAD) whose pid differs from the planned
+    pre-update pid is direct proof the old process is gone and its successor is on the new
+    code, whatever the restart phase happened to call the unit. See #103679.
+
+    Deliberately strict, so the blind-spot tripwire stays fail-closed:
+    ``stale``/``down``/``unknown`` rows prove nothing (``unknown`` means the live gateway
+    never stamped an identity, i.e. it predates the stamp and IS old code), a missing pid on
+    either side proves nothing, and an equal pid means the very process the plan inventoried
+    is still the one answering — never restarted.
+    """
+    if r.pid is None:
+        return False
+    for row in fleet_rows or ():
+        if not isinstance(row, dict) or row.get("profile") != r.profile:
+            continue
+        if row.get("state") != "current":
+            continue
+        try:
+            if int(row.get("pid")) != int(r.pid):
+                return True
+        except (TypeError, ValueError):
+            continue
+    return False
+
+
 def match_runtime_outcomes(
     plan: "UpdatePlan", *, restarted_services: list, relaunched_profiles: list,
     externally_supervised_profiles: list, killed_pids: set, failed_units: list,
-    stale_serve_pids: "set | None" = None,
+    stale_serve_pids: "set | None" = None, fleet_rows: "list | None" = None,
 ) -> list[dict[str, Any]]:
     """Reconcile the plan's runtimes against what the restart phase DID.
 
@@ -315,6 +346,12 @@ def match_runtime_outcomes(
     See #91277.
     They never borrow the gateway's outcome: ``relaunched_profiles`` and ``hermes-gateway*`` name a
     different process that shares the profile, nothing more. See #100479.
+
+    ``fleet_rows`` (the post-restart fleet version matrix) is the evidence fallback for a gateway no
+    bookkeeping list names: restart bookkeeping is recorded in each platform branch's OWN vocabulary
+    (systemd unit, launchd label, SCM service name), so a spelling this module does not know turns a
+    verified-healthy restart into ``unaccounted`` and fails the whole update closed. A ``current`` row
+    on a different pid outranks any name check. See #103679.
     """
     outcomes: list[dict[str, Any]] = []
     try:
@@ -342,7 +379,12 @@ def match_runtime_outcomes(
                 return "stopped"
             if _gateway_named_in(r, failed_set):
                 return "failed"
-            return "restarted" if _gateway_named_in(r, restarted_set) else "unaccounted"
+            if _gateway_named_in(r, restarted_set):
+                return "restarted"
+            # No bookkeeping list names it. Before declaring a silent miss, ask the probe that just
+            # ran: a live gateway for this profile on the fresh checkout's sha, under a pid that is
+            # not the one the plan inventoried, is a verified replacement. See #103679.
+            return "restarted" if _fleet_proves_gateway_replaced(r, fleet_rows) else "unaccounted"
 
         for r in plan.runtimes:
             if isinstance(r, RuntimeRecord):

--- a/tests/hermes_cli/test_restart_plan_reconciliation.py
+++ b/tests/hermes_cli/test_restart_plan_reconciliation.py
@@ -298,3 +298,78 @@ def test_mixed_fleet_only_the_missed_one_escalates(capsys):
     assert "ghost" in missed_block
     assert "[default]" not in missed_block
     assert "[work]" not in missed_block
+
+
+def _row(profile: str, pid: int, state: str = "current", sha: str = "abc123") -> dict:
+    """A `collect_fleet_versions` row shape."""
+    return {"profile": profile, "pid": pid, "code_sha": sha, "code_version": "1.0", "state": state}
+
+
+def test_fleet_row_on_a_new_pid_credits_a_gateway_no_bookkeeping_names():
+    """#103679: restart bookkeeping is recorded in each platform's OWN vocabulary
+    (launchd label ``ai.hermes.gateway``, an SCM service name, ...). A spelling this
+    module does not know made a verified-healthy restart ``unaccounted`` and failed the
+    whole update closed — right after the matrix printed the new pid as up to date.
+    The probe outranks the name check."""
+    plan = _plan(_rt("default", 400, supervisor="launchd"))
+    outcomes = match_runtime_outcomes(
+        plan, restarted_services=["some.label.this.module.never.heard.of"],
+        relaunched_profiles=[], externally_supervised_profiles=[], killed_pids=set(),
+        failed_units=[], fleet_rows=[_row("default", 981)],
+    )
+    assert outcomes[0]["outcome"] == "restarted"
+    assert report_unaccounted_runtimes(outcomes) is False
+
+
+def test_fleet_evidence_needs_a_current_row_on_a_different_pid():
+    """Fail-closed boundaries: the same pid is the SAME process (never restarted), and a
+    stale/down/unknown row is not proof of anything."""
+    def _outcome(rows, pid=400):
+        return match_runtime_outcomes(
+            _plan(_rt("default", pid, supervisor="launchd")), restarted_services=[],
+            relaunched_profiles=[], externally_supervised_profiles=[], killed_pids=set(),
+            failed_units=[], fleet_rows=rows,
+        )[0]["outcome"]
+
+    # Same pid: the process the plan inventoried is still the one answering.
+    assert _outcome([_row("default", 400)]) == "unaccounted"
+    # Not provably on the new code.
+    assert _outcome([_row("default", 981, state="stale")]) == "unaccounted"
+    assert _outcome([_row("default", 981, state="down")]) == "unaccounted"
+    assert _outcome([_row("default", 981, state="unknown")]) == "unaccounted"
+    # Another profile's row never credits this one.
+    assert _outcome([_row("work", 981)]) == "unaccounted"
+    # No probe at all keeps today's behavior.
+    assert _outcome(None) == "unaccounted"
+    assert _outcome([]) == "unaccounted"
+    # Junk rows are ignored, not crashed on.
+    assert _outcome(["nonsense", {"profile": "default"}, {"profile": "default", "pid": None, "state": "current"}]) == "unaccounted"
+
+
+def test_fleet_evidence_never_overrides_a_failed_unit_or_credits_serve():
+    """The override applies ONLY where the row would have been ``unaccounted``: a unit the
+    restart phase reported as failed stays ``failed``, and a serve/dashboard is reconciled
+    in its own vocabulary (#100479) — the gateway fleet probe says nothing about it."""
+    failed = match_runtime_outcomes(
+        _plan(_rt("default", 400, supervisor="systemd")), restarted_services=[],
+        relaunched_profiles=[], externally_supervised_profiles=[], killed_pids=set(),
+        failed_units=["hermes-gateway.service"], fleet_rows=[_row("default", 981)],
+    )
+    assert failed[0]["outcome"] == "failed"
+
+    mixed = match_runtime_outcomes(
+        _plan(_rt("default", 400, supervisor="launchd"), _serve("default", 900)),
+        restarted_services=[], relaunched_profiles=[], externally_supervised_profiles=[],
+        killed_pids=set(), failed_units=[], fleet_rows=[_row("default", 981)],
+    )
+    assert {o["pid"]: o["outcome"] for o in mixed} == {400: "restarted", 900: "unaccounted"}
+
+
+def test_fleet_evidence_does_not_resurrect_a_deliberately_stopped_gateway():
+    """A gateway the restart phase stopped stays ``stopped``; killed wins over the probe."""
+    outcomes = match_runtime_outcomes(
+        _plan(_rt("default", 400, supervisor="manual")), restarted_services=[],
+        relaunched_profiles=[], externally_supervised_profiles=[], killed_pids={400},
+        failed_units=[], fleet_rows=[_row("default", 981)],
+    )
+    assert outcomes[0]["outcome"] == "stopped"


### PR DESCRIPTION
## What does this PR do?

Plan-vs-execution reconciliation decides whether a planned gateway was actually restarted **by matching names**. But restart bookkeeping is recorded in each platform branch's *own* vocabulary — a systemd unit (`hermes-gateway`), a launchd label (`ai.hermes.gateway`), a Windows SCM service name. Any spelling `update_inventory` does not know turns a verified-healthy restart into `outcome=unaccounted`, which escalates exactly like a STALE fleet row: receipt `partial`, **exit 1**, `fleet_restart_pending` left behind.

On macOS this fired on **every** healthy default-profile update. The absurd part is visible in the reporter's own log — the fleet matrix and the tripwire disagree about the same gateway, three lines apart:

```
  ✓ Restarted ai.hermes.gateway
Fleet version check:
  ✓ default (pid 4285) @ 9dd6634c — up to date      <-- live probe: replaced, on new code

  ⚠ Planned runtimes the restart phase never touched:
    ✗ gateway [default] pid 33342 — planned mechanism: launchd   <-- name check: never touched
```

The fleet version matrix is computed a few lines *earlier in the same function* and is strictly stronger evidence than a name. A live gateway for the profile, stamped with the fresh checkout's sha, under a pid that is **not** the one the plan inventoried, is direct proof the pre-update process is gone and its successor is on the new code. This PR passes those rows into `match_runtime_outcomes` and consults them **only** where the row would otherwise have been `unaccounted`.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[🩸 Planned Gateway Runtime<br/>profile=default pid=33342] --> B{🔥 Named In Restart Bookkeeping?}
    B -->|Yes| R[⚔️ restarted]
    B -->|No — unknown platform spelling| C{🕯️ Fleet Probe Evidence}
    C -->|current row AND pid != planned pid| R
    C -->|stale / down / unknown / same pid / no probe| U[💀 unaccounted → exit 1]
    R --> S[🗝️ Receipt success · exit 0 · pending marker cleared]
    style C fill:#1a0308,stroke:#ff0038
    style U fill:#2a0206,stroke:#ff0038
```

## Related Issue

Fixes #103679

## Relationship to #103680 (not a duplicate, not a supersede)

#103680 fixes the **name-vocabulary** half: it teaches the matcher the launchd spelling `ai.hermes.gateway`. That is correct and this PR does not touch `_gateway_named_in` or its matcher — those changes stay theirs.

This PR fixes the **evidence** half, one layer below: the tripwire had no way to consult the live probe that had *already answered the question*, so any future or platform-specific unit spelling the matcher does not enumerate reproduces the identical false exit 1. Both changes compose — verified with `git merge-tree`, they merge cleanly in either order, no conflict in source or tests.

Neither `hermes_cli/update_cmd.py` (#98612) nor the receipt/marker discharge path (#103414) is touched.

## Changes Made

- `hermes_cli/update_inventory.py` — new `_fleet_proves_gateway_replaced()`; `match_runtime_outcomes()` takes an optional `fleet_rows=` and uses it as the evidence fallback for a gateway no bookkeeping list names.
- `hermes_cli/update_cmd_fleet.py` — `_verify_fleet_after_update` passes the `_fleet_snapshot` it already computed into reconciliation.
- `tests/hermes_cli/test_restart_plan_reconciliation.py` — the crediting case plus every fail-closed boundary.

## Why this stays fail-closed

The blind-spot tripwire (#91277) exists to catch a platform branch that silently skipped a target, and it keeps doing so. The override is deliberately narrow:

| Situation | Outcome | Why |
|---|---|---|
| `current` row, pid ≠ planned pid | `restarted` | verified replacement on the fresh sha |
| `current` row, pid **==** planned pid | `unaccounted` | the inventoried process is still the one answering |
| `stale` / `down` row | `unaccounted` | already escalated by the matrix itself |
| `unknown` row | `unaccounted` | no identity stamp ⇒ the live gateway *is* pre-stamp code |
| row for another profile | `unaccounted` | never cross-credits |
| no probe / empty rows / junk rows | `unaccounted` | identical to today's behaviour |
| unit reported in `failed_units` | `failed` | evidence never overrides a reported failure |
| pid in `killed_pids` | `stopped` | a deliberate stop is not a restart |
| serve / dashboard runtime | untouched | reconciled by incarnation (#100479); the gateway probe says nothing about them |

## How to Test

1. Replay the production receipt from the issue thread:

```python
plan.runtimes = [RuntimeRecord(kind="gateway", profile="default", pid=33342, supervisor="launchd", ...)]
match_runtime_outcomes(plan, restarted_services=["some.label.this.module.never.heard.of"],
                       relaunched_profiles=[], externally_supervised_profiles=[], killed_pids=set(),
                       failed_units=[],
                       fleet_rows=[{"profile": "default", "pid": 4285, "code_sha": "<HEAD>", "state": "current"}])
# before: unaccounted (exit 1)   after: restarted (exit 0)
```

2. `pytest tests/hermes_cli/test_restart_plan_reconciliation.py`
3. Regression sweep: `pytest tests/hermes_cli/test_restart_plan_reconciliation.py tests/hermes_cli/test_update_restart_recovery.py tests/hermes_cli/test_update_fleet_restart_pending.py tests/hermes_cli/test_update_fleet_check_fail_closed.py tests/hermes_cli/test_update_desktop_stale_warning.py` → **74 passed**.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate — #103680 (name vocabulary), #98612 (catch-up skip) and #103414 (receipt discharge) each own a different layer; none touches `match_runtime_outcomes`
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (`tests/hermes_cli/test_cmd_update.py` has 9 pre-existing failures here from a local npm/node mismatch — identical on a clean `origin/main` checkout, unrelated to this change)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (behaviour documented in the touched docstrings)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — the fix is platform-agnostic by construction: it removes the dependence on any one platform's unit-name spelling. `fleet_rows` defaults to `None`, so any caller that does not pass a probe result keeps today's exact behaviour.
- [x] I've updated tool descriptions/schemas — N/A
