### PR TITLE
fix(agent): prevent 90s timeouts for GPT-5.6 reasoning

### DIFF
--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -23,6 +23,8 @@ _REASONING_STALE_TIMEOUT_FLOORS: dict[int, tuple[str, ...]] = {
         "deepseek-r1", "deepseek-reasoner", "deepseek-v4-flash", "deepseek-v4-pro",
         # OpenAI o-series: each variant enumerated so bare ``o1`` cannot over-match ``olmo-1``.
         "o1", "o1-mini", "o1-pro", "o1-preview", "o3", "o3-pro",
+        # GPT-5.6 named reasoning variants (for example, -sol and -terra).
+        "gpt-5.6",
         # Mythos-class named models (claude-fable-5): 1M ctx + 128K output, a heavier thinking
         # phase than the numbered line — otherwise the stale detector trips the circuit breaker.
         "claude-fable",

--- a/tests/agent/test_reasoning_stale_timeout_floor.py
+++ b/tests/agent/test_reasoning_stale_timeout_floor.py
@@ -70,6 +70,9 @@ import pytest
     ("openai/o3-pro", 600.0),
     ("openai/o3-mini", 300.0),
     ("openai/o4-mini", 300.0),
+    # GPT-5.6 reasoning family; vendor prefixes and named variants inherit.
+    ("openai/gpt-5.6-sol", 600.0),
+    ("gpt-5.6-terra", 600.0),
     # Anthropic Claude 4.x thinking variants.
     ("anthropic/claude-opus-4-6", 240.0),
     ("anthropic/claude-opus-4-20250514", 240.0),
@@ -157,6 +160,29 @@ def test_non_reasoning_model_keeps_default(monkeypatch, tmp_path):
     base, implicit = agent._resolved_api_call_stale_timeout_base()
     assert base == 90.0
     assert implicit is True
+
+
+def test_gpt_5_6_floor_reaches_non_stream_and_stream_resolvers(monkeypatch, tmp_path):
+    """Small GPT-5.6 requests get the reasoning floor on both request paths."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
+    _write_config(tmp_path, "")
+
+    import run_agent
+    from agent.chat_completion_helpers import _cloud_stale_timeout
+    from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+
+    monkeypatch.setattr(run_agent, "get_provider_stale_timeout", lambda *a, **k: None)
+    agent = _make_agent(tmp_path, model="gpt-5.6-sol")
+
+    assert agent._resolved_api_call_stale_timeout_base() == (600.0, False)
+    assert _cloud_stale_timeout(180.0, {"model": "gpt-5.6-sol", "input": "small"}) == 600.0
+    assert get_reasoning_stale_timeout_floor("vendor/my-gpt-5.6-sol") is None
+    assert get_reasoning_stale_timeout_floor("gpt-5.60-sol") is None
+
+    monkeypatch.setattr(run_agent, "get_provider_stale_timeout", lambda *a, **k: 900.0)
+    assert agent._resolved_api_call_stale_timeout_base() == (900.0, False)
+    assert _cloud_stale_timeout(900.0, {"model": "gpt-5.6-sol", "input": "small"}) == 900.0
 
 
 # ── stream-side mirror (the real builder lives in a worker thread) ────────


### PR DESCRIPTION
## What does this PR do?

GPT-5.6 reasoning requests can be aborted by Hermes after 90 seconds when the request context is below the separate Codex context-size floor. This change classifies the GPT-5.6 family in the existing deep-reasoning timeout table, giving variants such as `gpt-5.6-sol` and `gpt-5.6-terra` a 600-second stale-timeout floor while preserving explicit timeout overrides and ordinary chat-model defaults.

### Symptom

An `openai-codex` request using `gpt-5.6-sol` with high reasoning effort can fail with `Non-streaming API call timed out after 90s` during a long reasoning phase.

### Impact

Affected GPT-5.6 reasoning sessions can lose an otherwise healthy in-flight model response and require the user to retry or configure a manual timeout override.

### Bug Cause

**Trigger:** `agent/reasoning_timeouts.py:18` / `_REASONING_STALE_TIMEOUT_FLOORS` omits the GPT-5.6 family.

**Causal chain:**
1. A GPT-5.6 reasoning request with fewer than 10,000 estimated input tokens enters a long pre-response reasoning phase.
2. The separate Codex context-size floor does not engage, and the reasoning-model matcher returns no floor for `gpt-5.6-sol`.
3. The non-stream request path keeps the generic 90-second default and aborts the call.

**Why it is wrong:** GPT-5.6 named variants are reasoning models, but they are missing from the allowlist already used by both stream and non-stream stale-timeout resolvers.

**Working sibling / contrast:** OpenAI o-series reasoning models already receive the 600-second floor through the same matcher and resolver paths.

**Ruled out:** The Codex event-idle and no-byte TTFB watchdogs are separate mechanisms. The reported sub-10k requests never receive the context-size floor, while a model-scoped `stale_timeout_seconds: 900` override prevents the local 90-second termination.

### Fix

Add the start-anchored `gpt-5.6` family slug to the existing 600-second reasoning floor and cover named variants, non-stream resolution, stream resolution, explicit override precedence, and near-match exclusions.

## Related Issue

Closes #103802

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/reasoning_timeouts.py` - classify GPT-5.6 named reasoning variants for the existing deep-reasoning stale-timeout floor.
- `tests/agent/test_reasoning_stale_timeout_floor.py` - verify matcher boundaries and both timeout resolution paths.

## How to Test

1. Run the focused reasoning and non-stream timeout tests.
2. Confirm the GPT-5.6 matcher and resolver assertions pass while unrelated names remain unmatched.

```bash
scripts/run_tests.sh tests/agent/test_reasoning_stale_timeout_floor.py tests/agent/test_non_stream_stale_timeout.py -q
```

Result: 46 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry point on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation and docstrings are unchanged or updated as needed
- [x] No configuration keys were added or changed
- [x] No architecture or workflow documentation changes are required
- [x] Cross-platform impact was considered; the matcher and timeout resolution are platform-independent
- [x] No tool descriptions or schemas were changed

## Screenshots / Logs

Not applicable. The focused automated suite reports 46 passed.
