### PR TITLE
fix(switch_model): prune fallback chain by endpoint identity, not provider string

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2058,20 +2058,50 @@ def _build_primary_runtime_snapshot(agent, api_mode) -> Dict[str, Any]:
     return rt
 
 
-def _finish_switch(agent, new_provider, old_norm, new_norm) -> None:
+def _finish_switch(
+    agent, new_provider, old_norm, new_norm, *,
+    old_provider: str = "", old_model: str = "", old_base_url: str = "",
+    new_model: str = "", new_base_url: str = "",
+) -> None:
     """Post-switch bookkeeping: fallback reset/prune, request_overrides, billing route."""
     agent._fallback_activated = False
     agent._provider_fallback_active = False
     agent._provider_fallback_route = None
     agent._fallback_index = 0
-    # On a deliberate provider swap, prune fallback entries targeting the OLD or NEW primary;
-    # otherwise a failed turn silently re-activates the provider the user just rejected.
+    # On a deliberate provider swap, prune fallback entries resolving to the OLD or NEW
+    # primary's ENDPOINT; otherwise a failed turn silently re-activates the backend the user
+    # just rejected. Identity semantics live in agent.backend_identity (same_endpoint):
+    # bare `custom` is a category, not a deployment — custom:antigravity and a local
+    # custom proxy at 127.0.0.1:8001 are different backends and must survive a switch away
+    # from the former. Raw provider-string equality (#103788) wiped every bare-custom entry
+    # whenever the old/new primary label was `custom`.
     fallback_chain = list(getattr(agent, "_fallback_chain", []) or [])
     if old_norm and new_norm and old_norm != new_norm:
+        from agent.backend_identity import BackendIdentity, FailureScope, should_skip_candidate
+        old_ident = BackendIdentity.build(
+            provider=old_provider or old_norm, model=old_model, base_url=old_base_url)
+        new_ident = BackendIdentity.build(
+            provider=new_provider or new_norm, model=new_model, base_url=new_base_url)
+        pruned = len(fallback_chain)
         fallback_chain = [
             entry for entry in fallback_chain
-            if (entry.get("provider") or "").strip().lower() not in {old_norm, new_norm}
+            if not (
+                should_skip_candidate(BackendIdentity.build(
+                    provider=entry.get("provider"), model=entry.get("model"),
+                    base_url=entry.get("base_url") or ""), old_ident, FailureScope.ENDPOINT)
+                or should_skip_candidate(BackendIdentity.build(
+                    provider=entry.get("provider"), model=entry.get("model"),
+                    base_url=entry.get("base_url") or ""), new_ident, FailureScope.ENDPOINT)
+            )
         ]
+        pruned -= len(fallback_chain)
+        if pruned:
+            logger.info(
+                "switch_model: pruned %d fallback entr%s resolving to the old/new primary endpoint "
+                "(%s -> %s); %d remain",
+                pruned, "y" if pruned == 1 else "ies",
+                old_ident.provider or "?", new_ident.provider or "?", len(fallback_chain),
+            )
     agent._fallback_chain = fallback_chain
     agent._fallback_model = fallback_chain[0] if fallback_chain else None
     # Apply the switched-to provider's request_overrides (custom_providers extra_body).
@@ -2106,6 +2136,7 @@ def switch_model(
     snapshot and re-raises (callers catch)."""
     old_model = agent.model
     old_provider = agent.provider
+    old_base_url = str(getattr(agent, "base_url", "") or "")
     # ── Reload credential pool for the new provider (issue #52727) ── Without this,
     # ``recover_with_credential_pool`` sees a ``pool.provider != agent.provider`` mismatch and
     # short-circuits, leaving the new provider with no rotation/recovery on 401/429 and burning the original
@@ -2156,7 +2187,11 @@ def switch_model(
     from agent.chat_completion_helpers import _reset_stale_streak
     _reset_stale_streak(agent)
     agent._primary_runtime = _build_primary_runtime_snapshot(agent, api_mode)
-    _finish_switch(agent, new_provider, old_norm, new_norm)
+    _finish_switch(
+        agent, new_provider, old_norm, new_norm,
+        old_provider=old_provider, old_model=old_model, old_base_url=old_base_url,
+        new_model=new_model, new_base_url=str(base_url or ""),
+    )
     logger.info(
         "Model switched in-place: %s (%s) -> %s (%s)",
         old_model, old_provider, new_model, new_provider,

--- a/tests/agent/test_switch_model_fallback_prune_103788.py
+++ b/tests/agent/test_switch_model_fallback_prune_103788.py
@@ -1,0 +1,119 @@
+"""Regression tests for #103788: switch_model()'s fallback prune must drop
+entries by backend ENDPOINT identity, not raw provider-string equality.
+
+Bare `custom` is a category, not a deployment — `custom:antigravity` and a
+local custom proxy at 127.0.0.1:8001 are different backends. The old prune
+compared ``entry.provider in {old_norm, new_norm}`` verbatim, so any switch
+whose old or new provider label was bare ``custom`` wiped every bare-custom
+fallback entry (chain emptied -> eager-failover never entered -> a 429 on the
+new primary retried to failure instead of falling back). The prune now reuses
+agent.backend_identity.same_endpoint (FailureScope.ENDPOINT): explicit
+base_urls decide; a shared provider label only implies the same endpoint when
+URLs are absent.
+"""
+
+import agent.agent_runtime_helpers as arh
+
+
+class _Agent:
+    pass
+
+
+def _run_finish_switch(*, chain, old_provider, old_base_url, old_model,
+                       new_provider, new_base_url, new_model):
+    """Drive _finish_switch on a bare agent with the given pre-switch identity.
+
+    Falls back to the legacy 4-arg signature on unfixed main (the RED run) so
+    the test demonstrates the behavioral bug (chain emptied), not a TypeError.
+    """
+    a = _Agent()
+    a._fallback_activated = True
+    a._provider_fallback_active = True
+    a._provider_fallback_route = ("old-model", old_provider)
+    a._fallback_index = 1
+    a._fallback_chain = [dict(e) for e in chain]
+    try:
+        arh._finish_switch(
+            a, new_provider,
+            (old_provider or "").strip().lower(), (new_provider or "").strip().lower(),
+            old_provider=old_provider, old_model=old_model, old_base_url=old_base_url,
+            new_model=new_model, new_base_url=new_base_url,
+        )
+    except TypeError:
+        # Pre-fix signature: _finish_switch(agent, new_provider, old_norm, new_norm)
+        arh._finish_switch(
+            a, new_provider,
+            (old_provider or "").strip().lower(), (new_provider or "").strip().lower(),
+        )
+    return a
+
+
+def test_bare_custom_chain_survives_custom_to_named_custom_switch():
+    """#103788 repro: 4 local bare-custom fallback entries must survive a
+    switch from a bare-custom primary (antigravity host) to custom:antigravity."""
+    chain = [
+        {"provider": "custom", "model": "hy4-preview", "base_url": "http://127.0.0.1:8001/v1"},
+        {"provider": "custom", "model": "hy4-preview", "base_url": "http://127.0.0.1:8002/v1"},
+        {"provider": "custom", "model": "glm-5.3-flash", "base_url": "http://127.0.0.1:8001/v1"},
+        {"provider": "custom", "model": "glm-5.3-flash", "base_url": "http://127.0.0.1:8002/v1"},
+    ]
+    a = _run_finish_switch(
+        chain=chain,
+        old_provider="custom", old_base_url="http://antigravity-host/v1",
+        old_model="gemini-3.8-flash-high",
+        new_provider="custom:antigravity", new_base_url="http://antigravity-host/v1",
+        new_model="claude-opus-4.6",
+    )
+    assert len(a._fallback_chain) == 4, (
+        "bare-custom entries at different endpoints must survive the prune; "
+        f"got {len(a._fallback_chain)}"
+    )
+    assert a._fallback_model == chain[0]
+
+
+def test_entry_at_old_primary_endpoint_is_pruned():
+    """The prune still works for its original purpose: an entry resolving to the
+    old primary's endpoint (same explicit base_url) is dropped on switch-away."""
+    old_url = "http://antigravity-host/v1"
+    chain = [
+        {"provider": "custom", "model": "gemini-3.8-flash-high", "base_url": old_url},
+        {"provider": "custom", "model": "hy4-preview", "base_url": "http://127.0.0.1:8001/v1"},
+    ]
+    a = _run_finish_switch(
+        chain=chain,
+        old_provider="custom", old_base_url=old_url, old_model="gemini-3.8-flash-high",
+        new_provider="custom:codebuddy", new_base_url="http://codebuddy-host/v1",
+        new_model="claude-opus-4.6",
+    )
+    assert len(a._fallback_chain) == 1
+    assert a._fallback_chain[0]["base_url"] == "http://127.0.0.1:8001/v1"
+
+
+def test_named_provider_entries_pruned_by_label_when_url_absent():
+    """Named providers without explicit URLs still prune by provider label
+    (shared label = shared default endpoint) — deepseek chain entry must not
+    survive a deliberate switch away from deepseek."""
+    chain = [
+        {"provider": "deepseek", "model": "deepseek-v4-flash"},
+        {"provider": "anthropic", "model": "claude-sonnet-4.6"},
+    ]
+    a = _run_finish_switch(
+        chain=chain,
+        old_provider="deepseek", old_base_url="", old_model="deepseek-v4-flash",
+        new_provider="openai", new_base_url="", new_model="gpt-5.2",
+    )
+    assert [e["provider"] for e in a._fallback_chain] == ["anthropic"]
+
+
+def test_same_provider_switch_does_not_prune():
+    """old_norm == new_norm (e.g. credential refresh re-selects the same
+    provider): the prune is skipped entirely — unchanged behavior."""
+    chain = [{"provider": "custom", "model": "hy4-preview", "base_url": "http://127.0.0.1:8001/v1"}]
+    a = _run_finish_switch(
+        chain=chain,
+        old_provider="custom", old_base_url="http://antigravity-host/v1",
+        old_model="gemini-3.8-flash-high",
+        new_provider="custom", new_base_url="http://antigravity-host/v1",
+        new_model="gemini-3.8-flash-high",
+    )
+    assert len(a._fallback_chain) == 1


### PR DESCRIPTION
Fixes #103788.

**What.** `switch_model()`'s post-switch prune dropped any fallback entry whose provider string matched the old/new primary verbatim (`entry.provider in {old_norm, new_norm}`). Bare `custom` is a category, not a deployment. With `agent.provider` legitimately bare `custom` (custom: providers resolve to that label at runtime), a switch away from it wiped **every** bare-custom fallback entry — the chain came back empty, the eager-failover guard `_fallback_index < len(_fallback_chain)` (0 < 0) never entered, and a 429 on the new primary retried to failure instead of falling back (observed in the report: ~30 min of retry-then-fail cycles, zero `switching to fallback` logs).

**Fix.** Reuse the repo's owned identity semantics (`agent/backend_identity.py`, `should_skip_candidate` with `FailureScope.ENDPOINT` = `same_endpoint`) instead of raw string equality: an entry is pruned only when it resolves to the old or new primary's **endpoint**.
- Explicit `base_url` decides (a local custom proxy at 127.0.0.1:8001 is not `custom:antigravity`, so it survives).
- A shared provider label implies the same endpoint only when URLs are absent — named providers keep today's provider-level prune behavior.
- `old_model`/`old_base_url` are captured before the runtime swap and passed through `_finish_switch`; `new_base_url` comes from the resolved destination.

Also logs an INFO line when a prune removes entries (silent failover loss was the hard-to-diagnose part of this bug).

**Verification.**
- Regression tests added: `tests/agent/test_switch_model_fallback_prune_103788.py` (4 tests). RED on unfixed main (`test_bare_custom_chain_survives...` — chain emptied to 0); GREEN with the fix (4 passed).
- Neighboring suites green: `test_switch_model_request_overrides.py`, `test_model_command_custom_providers.py`, `test_25107_stale_base_url_api_mode.py`, `test_fallback_chain_reload.py`, `test_model_switch_persistence.py` — 17 passed.

**Real-usage grounding.** We run Hermes daily with `custom:` provider routes (bare `custom` label + fallback chain of distinct custom endpoints); the emptied-chain failure mode matches the report exactly.