### PR TITLE
fix(desktop): keep the ssh session token in the v2 connection registry (#103795)

### DIFF
--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -1054,6 +1054,33 @@ test('token only persists on token-auth remotes; oauth/cloud drop it', () => {
   assert.equal(cloud.token, undefined)
 })
 
+test('an ssh entry keeps its session token through a label rename', () => {
+  // #103795, second half: saveRegistryConnection resolves the surviving
+  // envelope (resolvePersistedRemoteToken keeps the stored one when the
+  // editor sends no new value) and hands it to normalizeConnectionInput —
+  // whose ssh branch used to drop it, so renaming a connection wiped the live
+  // backend's reuse credential and re-armed the reap-and-respawn loop.
+  const stored = {
+    host: 'spark1',
+    id: 'spark',
+    kind: 'ssh' as const,
+    label: 'Spark',
+    port: 2222,
+    token: { enc: 'ssh-session-token' },
+    user: 'tek'
+  }
+
+  const merged = mergeConnectionInput(
+    { id: 'spark', kind: 'ssh', label: 'Spark (office)', token: stored.token },
+    stored
+  )
+
+  const renamed = normalizeConnectionInput(merged, emptyRegistry())
+
+  assert.equal(renamed.label, 'Spark (office)')
+  assert.deepEqual(renamed.token, { enc: 'ssh-session-token' })
+})
+
 // --- mergeConnectionInput (edit inheritance) ---
 
 test('merge preserves fields the editor does not carry (org, ssh extras)', () => {
@@ -1323,6 +1350,46 @@ test('normalizeRegistry falls back to Primary when the last-used source is missi
 
   assert.equal(registry.launchMode, 'last-used')
   assert.equal(registry.lastUsed, 'homelab')
+})
+
+test('normalizeRegistry keeps the persisted ssh session token across a cold read', () => {
+  // #103795: persistSshConnectionToken() writes the adopted per-serve token
+  // onto the ssh entry, but normalization rebuilt the entry from the DIAL
+  // fields alone and dropped it. The token then lived only in the mtime-keyed
+  // in-process cache, so the next launch dialed with an empty reuseToken,
+  // failed remote-lifecycle's `Boolean(reuseToken)` reuse gate, reaped a
+  // healthy owned backend and respawned it on a new port — while the renderer
+  // kept dialing the old token and got 403 forever.
+  const saved = {
+    version: REGISTRY_VERSION,
+    primary: 'spark',
+    connections: [
+      { id: LOCAL_CONNECTION_ID, kind: 'local', label: 'This device' },
+      {
+        id: 'spark',
+        kind: 'ssh',
+        label: 'Spark',
+        host: 'spark1',
+        user: 'tek',
+        port: 2222,
+        token: { enc: 'ssh-session-token' }
+      }
+    ]
+  }
+
+  const registry = normalizeRegistry(saved)
+  const spark = registry.connections.find(connection => connection.id === 'spark')
+
+  assert.deepEqual(spark?.token, { enc: 'ssh-session-token' })
+  assert.equal(spark?.host, 'spark1')
+
+  // Write → read → normalize again: the token must survive every cold read,
+  // not just the first.
+  const reread = normalizeRegistry(JSON.parse(JSON.stringify(registry)))
+
+  assert.deepEqual(reread.connections.find(connection => connection.id === 'spark')?.token, {
+    enc: 'ssh-session-token'
+  })
 })
 
 // --- v1 → v2 migration ---

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -906,7 +906,20 @@ export function normalizeConnectionInput(input: ConnectionInput, registry: Conne
       throw new Error(`A connection to this SSH host already exists ("${sshDupe.label}").`)
     }
 
-    return { id, kind: 'ssh', label, ...sshFields }
+    const entry: RegistryConnection = { id, kind: 'ssh', label, ...sshFields }
+
+    // Carry the adopted session-token envelope across edits. There is no
+    // auth-mode choice to invalidate it (ssh entries always authenticate with
+    // the per-serve token), and saveRegistryConnection already decided which
+    // envelope survives — resolvePersistedRemoteToken keeps the stored one
+    // when the editor sends no new value. Dropping it here made a plain label
+    // rename wipe the live backend's reuse credential and force the same
+    // reap-and-respawn loop as a cold read (#103795).
+    if (input.token !== undefined) {
+      entry.token = input.token
+    }
+
+    return entry
   }
 
   if (kind === 'remote' || kind === 'cloud') {
@@ -1191,6 +1204,20 @@ export function normalizeRegistry(raw: unknown): ConnectionRegistry {
 
         const { mode: _mode, ...sshFields } = ssh
         Object.assign(clean, sshFields)
+
+        // The per-serve session token persistSshConnectionToken() adopted for
+        // this entry. normalizeSshConfig only describes the DIAL (host/user/
+        // port/key/remote paths), so without this line every cold read of
+        // connections.json silently dropped the token — it survived only in
+        // the mtime-keyed in-process cache. The next launch then dialed with
+        // an empty reuseToken, which fails remote-lifecycle's
+        // `Boolean(reuseToken)` reuse gate, so a HEALTHY owned backend was
+        // reaped and respawned on a new port while the renderer kept dialing
+        // the old token — a permanent 403 WS loop (#103795). Mirrors the
+        // remote/cloud branch above.
+        if (entry.token !== undefined) {
+          clean.token = entry.token
+        }
       }
 
       connections.push(clean)


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop SSH "403 WS dial loop" by making the v2 connection registry actually **read back** the SSH session token it already persists.

`persistSshConnectionToken()` (`main.ts`) writes the per-serve session token adopted for an SSH connection onto its registry entry. The registry never read it back:

- `normalizeRegistry()` rebuilds a `kind === 'ssh'` entry from `normalizeSshConfig()` alone, which describes only the **dial** (`host`, `user`, `port`, `keyPath`, `remoteHermesPath`, `remoteProfile`). The sibling `remote`/`cloud` branch preserves `entry.token`; the ssh branch did not.
- `normalizeConnectionInput()` has the same omission, so a plain **label rename** wiped the token too — `saveRegistryConnection()` resolves the surviving envelope with `resolvePersistedRemoteToken()` and passes it in, and the ssh branch dropped it on the floor.

## Root cause chain

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[🔑 persistSshConnectionToken writes token to connections.json] --> B[💾 Token on disk - correct]
    B --> C{🧊 Cold read: normalizeRegistry}
    C -->|remote / cloud branch| D[✅ entry.token preserved]
    C -->|ssh branch| E[❌ Rebuilt from dial fields only - token dropped]
    E --> F[🕳️ reuseToken = empty string]
    F --> G[🚫 reusable gate fails on Boolean reuseToken]
    G --> H[💀 cleanupStale reaps a HEALTHY owned backend]
    H --> I[♻️ Respawn on a new port behind a new tunnel]
    I --> J[📡 Renderer keeps dialing its cached wsUrl token]
    J --> K[⛔ 403 forever - identical token every attempt]
    K --> C
```

The token survived only in the **mtime-keyed in-process cache** (`connectionRegistryCache`), which is why the failure is restart-shaped: it works for the rest of an app run and breaks on the next launch. That matches the report exactly — "restarting the desktop app does not recover", "4 respawns in one evening, ports changing every time", and DevTools showing the *same* `token=` across 1400+ attempts with no re-mint.

It also explains the reporter's direct-on-host probes: the registry token they read was the credential of a backend that had already been reaped and replaced, so `GET /api/sessions` answered 401 and `GET /api/ws?token=` answered 403 while `/api/health` (a `PUBLIC_API_PATHS` route) still answered 200.

This is v2-registry-specific, which is why it tracks the reporter's "Connection: v2 registry SSH entry" note: the legacy v1 `connection.json` store keeps `remote.token` / `profiles[key].token` verbatim, so installs still on v1 never lose it.

## Changes Made

- `apps/desktop/electron/connection-registry.ts`
  - `normalizeRegistry()` ssh branch: carry `entry.token`, mirroring the remote/cloud branch immediately above it.
  - `normalizeConnectionInput()` ssh branch: carry `input.token`. No drop condition is needed — unlike remote entries there is no auth-mode choice on an ssh entry that could invalidate the envelope, and `saveRegistryConnection()` has already decided which envelope survives.
- `apps/desktop/electron/connection-registry.test.ts`: two regression tests.

## How to Test

```bash
# desktop vitest, connection-registry + adjacent suites
npx vitest run apps/desktop/electron/connection-registry.test.ts \
               apps/desktop/electron/connection-config.test.ts \
               apps/desktop/electron/desktop-remote-route.test.ts \
               apps/desktop/electron/backend-dial-claim.test.ts \
               apps/desktop/electron/remote-lifecycle.test.ts
python scripts/check-windows-footguns.py --diff origin/main
```

Results here: **335 passed / 2 skipped** across those five suites (94 in `connection-registry.test.ts`, including the 2 new ones). Reverting only `connection-registry.ts` and re-running fails **exactly** the 2 new tests and nothing else, so they are real regression guards rather than restatements of current behaviour. `tsc --noEmit` clean on both changed files under the electron project's compiler options. No Windows footguns found.

Manual: open a Desktop SSH connection, confirm the backend port in the connection log, fully quit and relaunch the desktop app, and confirm the SAME remote pid/port is reused (previously the backend was killed and respawned on a new port on every launch). Then rename the connection in Settings → Connections and confirm the reuse still holds.

## Not in scope (separate defects found while validating)

Deliberately left alone so this PR stays reviewable and does not collide with existing work:

1. **The SSH spawn path has no credentialed proof of the token it publishes.** `remote-lifecycle.ts` calls `waitForHermes(baseUrl, spawnToken)`, which looks credentialed (`buildReadinessHealthProbe` sets `probeIsCredentialed: true` for `authMode: 'token'`) but probes `/api/health` — a `PUBLIC_API_PATHS` route that answers 200 for any token. The two LOCAL spawn paths (`main.ts:12634`, `main.ts:13098`) both add a `probeGatewayWebSocket()` check for precisely this reason; the SSH paths (POSIX and Windows) are the only spawn paths without one. That asymmetry is what made this bug silent and infinite instead of a single loud error.
2. **`adoptServedDashboardToken()` is inert on a headless `serve`.** Its drift detector reads the SPA index, which a gated headless backend answers with the `web UI disabled` 404, so it always falls back to the spawn token and logs `[boot] could not read served dashboard token` with no other signal.
3. **Renderer never drops a connection object after a WS 403/401**, so a stale `wsUrl?token=` is retried forever. Overlaps the WS work in #103683.

## Related work (checked, no overlap)

- #103732 (`stop named profiles from killing SSH-owned serves`) — Python-side orphan reaper scanning the wrong `desktop-ssh` root. Also produces respawn churn, different layer, different file set.
- #103480 (`pass HERMES_HOME for named-profile SSH serves`) — `buildSpawnCommand` env, wrong `state.db` on Linux named profiles.
- #96914 (`heal SSH-only v1 connection drift into v2 registry`) — touches `connection-registry.ts`, but registers a *missing* ssh entry from v1 drift; it does not read or write `token`. No conflicting hunks.
- #90477 / #91479 / #99022 / #95319 — the connection-lifecycle family the issue lists; none of them touch registry token persistence.

No existing PR references #103795, so nothing is superseded.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Related Issue

Fixes #103795
