### PR TITLE
fix(runtime): keep local model memory caps across restarts

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2296,7 +2296,7 @@ DEFAULT_CONFIG = {
         "region": "global",
     },
     # Managed llama.cpp runtime (docs: user-guide/local-models): official binaries, one supervised
-    # llama-server in router mode. No context/VRAM knobs by design.
+    # llama-server in router mode.
     "local_runtime": {
         # Off = detection-only (Hermes still finds an external llama-server you run).
         "enabled": False,
@@ -2309,6 +2309,9 @@ DEFAULT_CONFIG = {
         "port": 0,  # Port for the managed server. 0 = pick a free port at spawn.
         # Extra ports detection probes for an external llama-server (besides 8080).
         "detect_ports": [],
+        # Optional per-model upper bounds for ctx-size, batch-size, and ubatch-size. Regenerated
+        # presets reapply these after the hardware policy chooses its launch posture.
+        "launch_overrides": {},
     },
     "_config_version": 40,  # Config schema version - bump this when adding new required fields
 }

--- a/hermes_cli/local_runtime/bootstrap.py
+++ b/hermes_cli/local_runtime/bootstrap.py
@@ -141,7 +141,8 @@ def refresh_local_runtime() -> bool:
         return False
 
 
-def _generate_presets(mdir: Path, preset_path: Path) -> Path | None:
+def _generate_presets(mdir: Path, preset_path: Path, *,
+                      launch_overrides: dict[str, dict] | None = None) -> Path | None:
     """Write the launch-policy INI for every staged model; returns the path to hand the router.
 
     Priced against CAPACITY, not live free VRAM: this runs while the outgoing server instance may
@@ -156,7 +157,9 @@ def _generate_presets(mdir: Path, preset_path: Path) -> Path | None:
     from hermes_cli.local_runtime.presets import generate_presets
 
     try:
-        for entry in generate_presets(mdir, probe_budget(planning=True), preset_path):
+        for entry in generate_presets(
+                mdir, probe_budget(planning=True), preset_path,
+                launch_overrides=launch_overrides):
             if entry.refusal:
                 logger.warning("model refused by physics check: %s", entry.refusal)
         return preset_path
@@ -232,7 +235,10 @@ def ensure_local_runtime(config: dict, force: bool = False) -> "object | None":
 
         mdir = models_dir()
         mdir.mkdir(parents=True, exist_ok=True)
-        preset_path = _generate_presets(mdir, runtimes_root() / "presets.ini")
+        preset_path = _generate_presets(
+            mdir, runtimes_root() / "presets.ini",
+            launch_overrides=section.get("launch_overrides"),
+        )
 
         sup = LlamaServerSupervisor(install_dir, mdir, preset_path=preset_path,
                                     models_max=int(section.get("models_max", 4)),

--- a/hermes_cli/local_runtime/growth.py
+++ b/hermes_cli/local_runtime/growth.py
@@ -7,6 +7,7 @@ other-process supervisors keep their own policies.
 from __future__ import annotations
 
 from contextlib import suppress
+from dataclasses import replace
 import json
 import logging
 
@@ -107,11 +108,14 @@ def maybe_grow_window(model_id: str, *, base_url: str, session_tokens: int,
     except Exception:  # noqa: BLE001
         server_idle = False
 
+    decision_profile = (
+        replace(profile, n_ctx_train=context_cap) if context_cap is not None else profile
+    )
     decision = growth_decision(
         # Capacity budget, not live-free: growth executes via a server bounce, so the grown
         # instance loads onto a freed card. Live-free is distorted by the very model being grown
         # — it reads its own residency as unavailable and vetoes rungs that fit.
-        profile, probe_budget(planning=True),
+        decision_profile, probe_budget(planning=True),
         current_window=current_window,
         session_tokens=session_tokens,
         measured_decode_tok_s=measured_decode_tok_s,

--- a/hermes_cli/local_runtime/growth.py
+++ b/hermes_cli/local_runtime/growth.py
@@ -75,6 +75,7 @@ def maybe_grow_window(model_id: str, *, base_url: str, session_tokens: int,
     from hermes_cli.local_runtime.estimator import profile_from_gguf
     from hermes_cli.local_runtime.gguf import read_gguf_header
     from hermes_cli.local_runtime.hardware import probe_budget
+    from hermes_cli.local_runtime.presets import effective_ctx_cap
 
     sup = get_supervisor()
     if sup is None or not is_managed_endpoint(base_url):
@@ -88,6 +89,17 @@ def maybe_grow_window(model_id: str, *, base_url: str, session_tokens: int,
         profile = profile_from_gguf(read_gguf_header(gguf))
     except (ValueError, OSError) as exc:
         logger.debug("growth skip %s: unreadable gguf (%s)", model_id, exc)
+        return None
+
+    from hermes_cli.config import load_config
+
+    config = load_config()
+    launch_overrides = ((config.get("local_runtime") or {}).get("launch_overrides")
+                        if isinstance(config, dict) else None)
+    context_cap = effective_ctx_cap(
+        launch_overrides, model_id, profile.n_ctx_train or current_window)
+    if context_cap is not None and current_window >= context_cap:
+        logger.debug("growth %s: configured context cap reached (%s)", model_id, context_cap)
         return None
 
     try:
@@ -113,11 +125,14 @@ def maybe_grow_window(model_id: str, *, base_url: str, session_tokens: int,
         logger.debug("growth %s: %s (%s)", model_id, decision.action, decision.reason)
         return None
 
+    next_window = min(decision.next_window, context_cap) if context_cap is not None else decision.next_window
+    if next_window <= current_window:
+        return None
     logger.info("context growth %s: %s", model_id, decision.reason)
-    save_window_override(model_id, decision.next_window)
+    save_window_override(model_id, next_window)
     if not refresh_local_runtime():
         # The override still lands at the next boot; report no growth NOW so the caller
         # compresses instead of overflowing a stale window.
         logger.warning("growth %s: server refresh failed; compression proceeds", model_id)
         return None
-    return decision.next_window
+    return next_window

--- a/hermes_cli/local_runtime/presets.py
+++ b/hermes_cli/local_runtime/presets.py
@@ -65,13 +65,30 @@ def _override_int(overrides: dict, key: str, model_id: str) -> int | None:
     return parsed
 
 
+def effective_ctx_cap(launch_overrides: object, model_id: str,
+                      native_window: int) -> int | None:
+    """Validated per-model context cap, normalized to Hermes' floor and model native limit."""
+    if not isinstance(launch_overrides, dict):
+        if launch_overrides is not None:
+            logger.warning("ignoring invalid local_runtime.launch_overrides=%r", launch_overrides)
+        return None
+    model_overrides = launch_overrides.get(model_id) or {}
+    if not isinstance(model_overrides, dict):
+        logger.warning("ignoring invalid local_runtime.launch_overrides.%s=%r",
+                       model_id, model_overrides)
+        return None
+    configured = _override_int(model_overrides, "ctx-size", model_id)
+    if configured is None:
+        return None
+    return max(min(FLOOR, native_window), min(configured, native_window))
+
+
 def _cap_window(profile: ModelProfile, budget: HardwareBudget, decision: WindowDecision,
                 configured: int | None) -> WindowDecision:
     """Apply a configured upper bound without weakening the 64K/native safety floor."""
     if configured is None:
         return decision
-    native = profile.n_ctx_train or decision.window
-    capped = max(min(FLOOR, native), min(configured, native, decision.window))
+    capped = min(configured, decision.window)
     if capped == decision.window:
         return decision
     kv = ctx_bytes(profile, capped)
@@ -167,7 +184,7 @@ def _preset_for(gguf: Path, budget: HardwareBudget, mtp_capable: set[str],
         logger.warning("preset skip %s: %s", gguf.name, exc)
         return None
     entry = entry_for_model(model_id)
-    model_overrides = (launch_overrides or {}).get(model_id) or {}
+    model_overrides = launch_overrides.get(model_id) or {} if isinstance(launch_overrides, dict) else {}
     if not isinstance(model_overrides, dict):
         logger.warning("ignoring invalid local_runtime.launch_overrides.%s=%r",
                        model_id, model_overrides)
@@ -194,7 +211,7 @@ def _preset_for(gguf: Path, budget: HardwareBudget, mtp_capable: set[str],
     decision = _restore_grown_window(model_id, profile, budget, decision, overhead)
     decision = _cap_window(
         profile, budget, decision,
-        _override_int(model_overrides, "ctx-size", model_id),
+        effective_ctx_cap(launch_overrides, model_id, profile.n_ctx_train or decision.window),
     )
 
     # The policy launch flags match the pricing above (same entry/is_mtp/posture). User caps may

--- a/hermes_cli/local_runtime/presets.py
+++ b/hermes_cli/local_runtime/presets.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 
 from hermes_cli.local_runtime.context_policy import (
-    RUNTIME_OVERHEAD_BYTES, WindowDecision, initial_window, launch_args, ub_logits_bytes)
+    FLOOR, RUNTIME_OVERHEAD_BYTES, WindowDecision, initial_window, launch_args, ub_logits_bytes)
 from hermes_cli.local_runtime.estimator import (
     HardwareBudget, ModelProfile, PhysicsRefusal, ctx_bytes, profile_from_gguf)
 from hermes_cli.local_runtime.gguf import model_id_from_stem, read_gguf_header
@@ -44,6 +44,61 @@ def _args_to_keys(args: list[str]) -> dict[str, str]:
         keys[key] = args[i + 1]
         i += 2
     return keys
+
+
+def _override_int(overrides: dict, key: str, model_id: str) -> int | None:
+    value = overrides.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        logger.warning("ignoring invalid local_runtime.launch_overrides.%s.%s=%r",
+                       model_id, key, value)
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = 0
+    if parsed <= 0:
+        logger.warning("ignoring invalid local_runtime.launch_overrides.%s.%s=%r",
+                       model_id, key, value)
+        return None
+    return parsed
+
+
+def _cap_window(profile: ModelProfile, budget: HardwareBudget, decision: WindowDecision,
+                configured: int | None) -> WindowDecision:
+    """Apply a configured upper bound without weakening the 64K/native safety floor."""
+    if configured is None:
+        return decision
+    native = profile.n_ctx_train or decision.window
+    capped = max(min(FLOOR, native), min(configured, native, decision.window))
+    if capped == decision.window:
+        return decision
+    kv = ctx_bytes(profile, capped)
+    return WindowDecision(
+        window=capped,
+        spill_bytes=max(0, profile.weights_bytes + kv - budget.usable_vram_bytes),
+        kv_on_gpu=kv <= budget.usable_vram_bytes,
+        reasons=[*decision.reasons, f"configured ctx-size cap ({capped // 1024}K)"],
+    )
+
+
+def _apply_batch_caps(keys: dict[str, str], overrides: dict, model_id: str, *,
+                      mtp_capable: bool, mtp_prefill: bool) -> None:
+    """Cap policy/default batch values; keep ubatch no larger than batch."""
+    default_batch = 4096 if mtp_capable and mtp_prefill else 2048
+    default_ubatch = 2048 if (not mtp_capable or mtp_prefill) else 512
+    batch = int(keys.get("batch-size", default_batch))
+    ubatch = int(keys.get("ubatch-size", default_ubatch))
+    batch_cap = _override_int(overrides, "batch-size", model_id)
+    ubatch_cap = _override_int(overrides, "ubatch-size", model_id)
+    effective_batch = min(batch, batch_cap) if batch_cap is not None else batch
+    effective_ubatch = min(ubatch, ubatch_cap) if ubatch_cap is not None else ubatch
+    effective_ubatch = min(effective_ubatch, effective_batch)
+    if effective_batch != batch:
+        keys["batch-size"] = str(effective_batch)
+    if effective_ubatch != ubatch:
+        keys["ubatch-size"] = str(effective_ubatch)
 
 
 def _asset_path(asset) -> "Path | None":
@@ -99,8 +154,8 @@ def _restore_grown_window(model_id: str, profile: ModelProfile, budget: Hardware
     return decision
 
 
-def _preset_for(gguf: Path, budget: HardwareBudget,
-                mtp_capable: set[str]) -> PresetEntry | None:
+def _preset_for(gguf: Path, budget: HardwareBudget, mtp_capable: set[str],
+                launch_overrides: dict[str, dict] | None = None) -> PresetEntry | None:
     """The launch decision for one staged model, or None when its header is unreadable."""
     from hermes_cli.local_runtime.catalog import entry_for_model
 
@@ -112,6 +167,11 @@ def _preset_for(gguf: Path, budget: HardwareBudget,
         logger.warning("preset skip %s: %s", gguf.name, exc)
         return None
     entry = entry_for_model(model_id)
+    model_overrides = (launch_overrides or {}).get(model_id) or {}
+    if not isinstance(model_overrides, dict):
+        logger.warning("ignoring invalid local_runtime.launch_overrides.%s=%r",
+                       model_id, model_overrides)
+        model_overrides = {}
     is_mtp = entry.mtp if entry is not None else model_id in mtp_capable
     if is_mtp and profile.kv_scale == 1.0:
         # Header-derived profiles don't know about MTP's draft context; apply the calibrated KV
@@ -132,11 +192,18 @@ def _preset_for(gguf: Path, budget: HardwareBudget,
     if isinstance(decision, PhysicsRefusal):
         return PresetEntry(model_id=model_id, window=0, spilled=False, refusal=decision.message)
     decision = _restore_grown_window(model_id, profile, budget, decision, overhead)
+    decision = _cap_window(
+        profile, budget, decision,
+        _override_int(model_overrides, "ctx-size", model_id),
+    )
 
-    # The launch flags MUST match the pricing above (same entry/is_mtp/posture).
+    # The policy launch flags match the pricing above (same entry/is_mtp/posture). User caps may
+    # lower batch allocation afterward, which only makes the fit estimate more conservative.
     keys = _args_to_keys(launch_args(
         profile, decision, mtp_capable=is_mtp, uma=budget.uma, mtp_prefill=mtp_prefill,
         mtp_draft_depth=entry.mtp_draft_depth if entry is not None else 3))
+    _apply_batch_caps(keys, model_overrides, model_id,
+                      mtp_capable=is_mtp, mtp_prefill=mtp_prefill)
     if entry is not None and is_mtp:
         # Integrated-MTP targets sample on the backend, and so does the draft (pairing validated
         # against the vendor's published llama.cpp recipes).
@@ -165,15 +232,20 @@ def _preset_for(gguf: Path, budget: HardwareBudget,
 
 
 def generate_presets(models_dir: Path, budget: HardwareBudget, preset_path: Path,
-                     mtp_capable: set[str] | None = None) -> list[PresetEntry]:
+                     mtp_capable: set[str] | None = None,
+                     launch_overrides: dict[str, dict] | None = None) -> list[PresetEntry]:
     """Walk the staged models, run the launch decision per model, and write one INI. Refused
     models get no section (the picker surfaces the refusal from the returned entries)."""
     from hermes_cli.local_runtime.bootstrap import staged_in
 
+    if launch_overrides is not None and not isinstance(launch_overrides, dict):
+        logger.warning("ignoring invalid local_runtime.launch_overrides=%r", launch_overrides)
+        launch_overrides = None
     entries: list[PresetEntry] = []
     sections: list[str] = []
     for gguf in staged_in(models_dir, require_complete=False):
-        entry = _preset_for(gguf, budget, mtp_capable or set())
+        entry = _preset_for(
+            gguf, budget, mtp_capable or set(), launch_overrides=launch_overrides)
         if entry is None:
             continue
         entries.append(entry)

--- a/hermes_cli/local_runtime/presets.py
+++ b/hermes_cli/local_runtime/presets.py
@@ -80,7 +80,12 @@ def effective_ctx_cap(launch_overrides: object, model_id: str,
     configured = _override_int(model_overrides, "ctx-size", model_id)
     if configured is None:
         return None
-    return max(min(FLOOR, native_window), min(configured, native_window))
+    minimum = min(FLOOR, native_window)
+    if configured < minimum:
+        logger.warning(
+            "local_runtime.launch_overrides.%s.ctx-size=%s raised to minimum %s",
+            model_id, configured, minimum)
+    return max(minimum, min(configured, native_window))
 
 
 def _cap_window(profile: ModelProfile, budget: HardwareBudget, decision: WindowDecision,

--- a/tests/hermes_cli/test_boot_preset_staleness.py
+++ b/tests/hermes_cli/test_boot_preset_staleness.py
@@ -124,3 +124,42 @@ def test_refresh_no_server_anywhere_is_a_noop(hermes_home, monkeypatch):
     monkeypatch.setattr(
         "hermes_cli.local_runtime.endpoint._state_endpoint", lambda: None)
     assert boot.refresh_local_runtime() is False
+
+
+def test_bootstrap_forwards_launch_overrides_to_preset_generation(tmp_path, monkeypatch):
+    import hermes_cli.local_runtime.bootstrap as boot
+
+    captured = {}
+    monkeypatch.setattr(boot, "_SUPERVISOR", None)
+    monkeypatch.setattr(boot, "staged_models", lambda: [tmp_path / "model.gguf"])
+    monkeypatch.setattr(boot, "models_dir", lambda: tmp_path / "models")
+    monkeypatch.setattr(boot, "runtimes_root", lambda: tmp_path / "runtimes")
+    monkeypatch.setattr(boot, "_generate_presets",
+                        lambda *args, **kwargs: captured.update(kwargs) or tmp_path / "presets.ini")
+    monkeypatch.setattr(boot, "_start_idle_sweeper", lambda sup: None)
+    monkeypatch.setattr("hermes_cli.local_runtime.endpoint._state_endpoint", lambda: None)
+    monkeypatch.setattr("hermes_cli.local_runtime.binaries.installed_tags", lambda: ["b10679"])
+    monkeypatch.setattr("hermes_cli.local_runtime.binaries.ensure_runtime_installed",
+                        lambda *args: tmp_path / "runtime")
+
+    class _Supervisor:
+        base_url = "http://127.0.0.1:1234/v1"
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            pass
+
+    overrides = {"model-a": {"ctx-size": 65536, "ubatch-size": 512}}
+
+    monkeypatch.setattr("hermes_cli.local_runtime.supervisor.LlamaServerSupervisor", _Supervisor)
+    result = boot.ensure_local_runtime({
+        "local_runtime": {
+            "enabled": True, "tag": "b10679", "backend": "cpu",
+            "launch_overrides": overrides,
+        },
+    })
+
+    assert result is not None
+    assert captured["launch_overrides"] is overrides

--- a/tests/hermes_cli/test_local_growth.py
+++ b/tests/hermes_cli/test_local_growth.py
@@ -57,7 +57,7 @@ def test_growth_declines_foreign_endpoints(hermes_home):
     assert grown is None
 
 
-def _patch_managed_growth(monkeypatch, tmp_path, *, cap, next_window):
+def _patch_managed_growth(monkeypatch, tmp_path, *, cap, next_window, budget=None):
     import hermes_cli.local_runtime.bootstrap as boot
     import hermes_cli.local_runtime.context_policy as policy
     import hermes_cli.local_runtime.growth as growth
@@ -76,13 +76,14 @@ def _patch_managed_growth(monkeypatch, tmp_path, *, cap, next_window):
     monkeypatch.setattr(growth, "is_managed_endpoint", lambda base_url: True)
     monkeypatch.setattr("hermes_cli.local_runtime.gguf.read_gguf_header", lambda path: object())
     monkeypatch.setattr("hermes_cli.local_runtime.estimator.profile_from_gguf", lambda header: profile)
-    monkeypatch.setattr(hardware, "probe_budget", lambda planning: object())
+    monkeypatch.setattr(hardware, "probe_budget", lambda planning: budget or object())
     monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
         "local_runtime": {"launch_overrides": {"model-a": {"ctx-size": cap}}},
     })
-    monkeypatch.setattr(policy, "growth_decision", lambda *args, **kwargs: type("Decision", (), {
-        "action": "grow", "next_window": next_window, "reason": "test growth",
-    })())
+    if next_window is not None:
+        monkeypatch.setattr(policy, "growth_decision", lambda *args, **kwargs: type("Decision", (), {
+            "action": "grow", "next_window": next_window, "reason": "test growth",
+        })())
     return growth
 
 
@@ -114,6 +115,37 @@ def test_growth_clamps_next_rung_to_configured_context_cap(hermes_home, tmp_path
 
     assert result == 81920
     assert writes == [("model-a", 81920)]
+
+
+def test_growth_prices_configured_cap_instead_of_larger_native_rung(
+        hermes_home, tmp_path, monkeypatch):
+    from hermes_cli.local_runtime.estimator import HardwareBudget, ctx_bytes
+
+    cap = 81920
+    profile = _tiny_profile("model-a")
+    capped_bytes = profile.weights_bytes + ctx_bytes(profile, cap)
+    native_rung_bytes = profile.weights_bytes + ctx_bytes(profile, 98304)
+    assert capped_bytes < native_rung_bytes
+    budget = HardwareBudget(
+        usable_vram_bytes=capped_bytes,
+        total_device_bytes=capped_bytes,
+        ram_available_bytes=0,
+    )
+    growth = _patch_managed_growth(
+        monkeypatch, tmp_path, cap=cap, next_window=None, budget=budget)
+    writes = []
+    refreshes = []
+    monkeypatch.setattr(growth, "save_window_override", lambda *args: writes.append(args))
+    monkeypatch.setattr("hermes_cli.local_runtime.bootstrap.refresh_local_runtime",
+                        lambda: refreshes.append(True) or True)
+
+    result = growth.maybe_grow_window(
+        "model-a", base_url="http://127.0.0.1:8080/v1",
+        session_tokens=60_000, current_window=65536)
+
+    assert result == cap
+    assert writes == [("model-a", cap)]
+    assert refreshes == [True]
 
 
 def test_occupancy_confirmed_skips_gate_one():

--- a/tests/hermes_cli/test_local_growth.py
+++ b/tests/hermes_cli/test_local_growth.py
@@ -57,6 +57,65 @@ def test_growth_declines_foreign_endpoints(hermes_home):
     assert grown is None
 
 
+def _patch_managed_growth(monkeypatch, tmp_path, *, cap, next_window):
+    import hermes_cli.local_runtime.bootstrap as boot
+    import hermes_cli.local_runtime.context_policy as policy
+    import hermes_cli.local_runtime.growth as growth
+    import hermes_cli.local_runtime.hardware as hardware
+
+    class _Supervisor:
+        def is_idle(self, model_id):
+            return True
+
+    gguf = tmp_path / "model-a.gguf"
+    gguf.write_bytes(b"GGUF")
+    profile = _tiny_profile("model-a")
+    monkeypatch.setattr(boot, "get_supervisor", lambda: _Supervisor())
+    monkeypatch.setattr(boot, "staged_models", lambda: [gguf])
+    monkeypatch.setattr(boot, "refresh_local_runtime", lambda: True)
+    monkeypatch.setattr(growth, "is_managed_endpoint", lambda base_url: True)
+    monkeypatch.setattr("hermes_cli.local_runtime.gguf.read_gguf_header", lambda path: object())
+    monkeypatch.setattr("hermes_cli.local_runtime.estimator.profile_from_gguf", lambda header: profile)
+    monkeypatch.setattr(hardware, "probe_budget", lambda planning: object())
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+        "local_runtime": {"launch_overrides": {"model-a": {"ctx-size": cap}}},
+    })
+    monkeypatch.setattr(policy, "growth_decision", lambda *args, **kwargs: type("Decision", (), {
+        "action": "grow", "next_window": next_window, "reason": "test growth",
+    })())
+    return growth
+
+
+def test_growth_stops_at_configured_context_cap(hermes_home, tmp_path, monkeypatch):
+    growth = _patch_managed_growth(monkeypatch, tmp_path, cap=65536, next_window=98304)
+    writes = []
+    refreshes = []
+    monkeypatch.setattr(growth, "save_window_override", lambda *args: writes.append(args))
+    monkeypatch.setattr("hermes_cli.local_runtime.bootstrap.refresh_local_runtime",
+                        lambda: refreshes.append(True) or True)
+
+    result = growth.maybe_grow_window(
+        "model-a", base_url="http://127.0.0.1:8080/v1",
+        session_tokens=60_000, current_window=65536)
+
+    assert result is None
+    assert writes == []
+    assert refreshes == []
+
+
+def test_growth_clamps_next_rung_to_configured_context_cap(hermes_home, tmp_path, monkeypatch):
+    growth = _patch_managed_growth(monkeypatch, tmp_path, cap=81920, next_window=98304)
+    writes = []
+    monkeypatch.setattr(growth, "save_window_override", lambda *args: writes.append(args))
+
+    result = growth.maybe_grow_window(
+        "model-a", base_url="http://127.0.0.1:8080/v1",
+        session_tokens=60_000, current_window=65536)
+
+    assert result == 81920
+    assert writes == [("model-a", 81920)]
+
+
 def test_occupancy_confirmed_skips_gate_one():
     """The agent's compression gate IS the occupancy signal: when it fired,
     growth must not re-derive its own edge and hold. Decision-table check

--- a/tests/hermes_cli/test_local_growth.py
+++ b/tests/hermes_cli/test_local_growth.py
@@ -198,6 +198,38 @@ def test_preset_ignores_override_below_launch_window(hermes_home, tmp_path, monk
     assert entry.window == 131072
 
 
+def test_launch_overrides_survive_preset_regeneration(hermes_home, tmp_path, monkeypatch):
+    """User launch limits are reapplied after every generated-policy rewrite."""
+    import configparser
+
+    import hermes_cli.local_runtime.presets as presets_mod
+    from hermes_cli.local_runtime.estimator import HardwareBudget
+
+    mdir = tmp_path / "models"
+    _stage_fake_gguf(mdir, "tiny-dense")
+    monkeypatch.setattr(presets_mod, "read_gguf_header", lambda p: _header_stub())
+    monkeypatch.setattr(presets_mod, "profile_from_gguf",
+                        lambda h: _tiny_profile("tiny-dense"))
+    gib = 1 << 30
+    budget = HardwareBudget(usable_vram_bytes=24 * gib,
+                            total_device_bytes=24 * gib,
+                            ram_available_bytes=64 * gib)
+    overrides = {
+        "tiny-dense": {"ctx-size": 65536, "batch-size": 512, "ubatch-size": 512},
+    }
+    preset = tmp_path / "presets.ini"
+
+    for _ in range(2):
+        entry = presets_mod.generate_presets(
+            mdir, budget, preset, launch_overrides=overrides)[0]
+        ini = configparser.ConfigParser()
+        ini.read(preset)
+        assert entry.window == 65536
+        assert ini["tiny-dense"]["ctx-size"] == "65536"
+        assert ini["tiny-dense"]["batch-size"] == "512"
+        assert ini["tiny-dense"]["ubatch-size"] == "512"
+
+
 def test_preset_restores_grown_window_midladder(hermes_home, tmp_path, monkeypatch):
     """The real growth shape: launch at a lower rung, override to a middle
     rung -> the preset window follows the override."""

--- a/tests/hermes_cli/test_local_growth.py
+++ b/tests/hermes_cli/test_local_growth.py
@@ -321,6 +321,21 @@ def test_launch_overrides_survive_preset_regeneration(hermes_home, tmp_path, mon
         assert ini["tiny-dense"]["ubatch-size"] == "512"
 
 
+def test_context_cap_below_floor_warns_and_uses_floor(caplog):
+    from hermes_cli.local_runtime.context_policy import FLOOR
+    from hermes_cli.local_runtime.presets import effective_ctx_cap
+
+    configured = FLOOR // 2
+    cap = effective_ctx_cap(
+        {"model-a": {"ctx-size": configured}}, "model-a", native_window=FLOOR * 2)
+
+    assert cap == FLOOR
+    assert (
+        f"local_runtime.launch_overrides.model-a.ctx-size={configured} "
+        f"raised to minimum {FLOOR}"
+    ) in caplog.text
+
+
 def test_preset_restores_grown_window_midladder(hermes_home, tmp_path, monkeypatch):
     """The real growth shape: launch at a lower rung, override to a middle
     rung -> the preset window follows the override."""

--- a/tests/hermes_cli/test_local_runtime.py
+++ b/tests/hermes_cli/test_local_runtime.py
@@ -749,13 +749,13 @@ def test_runtime_provider_seam_explicit_base_url_wins(tmp_path, monkeypatch):
 
 
 def test_local_runtime_config_defaults_shape():
-    """Contract: the section exists, is off by default, and carries no
-    context/VRAM knobs (design: constants, not knobs)."""
+    """The runtime is off by default; hardware policy stays free of global tuning knobs."""
     from hermes_cli.config_defaults import DEFAULT_CONFIG
 
     cfg = DEFAULT_CONFIG["local_runtime"]
     assert cfg["enabled"] is False
     assert isinstance(cfg["tag"], str) and cfg["tag"].startswith("b")
+    assert cfg["launch_overrides"] == {}
     forbidden = [k for k in cfg if "context" in k or "ctx" in k or "vram" in k or "kv" in k]
     assert forbidden == [], f"policy constants leaked into config: {forbidden}"
 

--- a/website/docs/user-guide/local-models.md
+++ b/website/docs/user-guide/local-models.md
@@ -114,7 +114,17 @@ local_runtime:
   backend: auto      # auto | cuda | metal | vulkan | hip | cpu
   tag: b10362        # pinned llama.cpp release; Hermes updates it with
                      # each release after re-validation
+  launch_overrides:  # optional per-model upper bounds, reapplied on boot
+    qwen3.6-35b-a3b:
+      ctx-size: 131072
+      batch-size: 512
+      ubatch-size: 512
 ```
+
+Use the model ID shown by the Local Models pane as the mapping key. Overrides
+only lower the context policy's chosen values; they cannot raise a launch past
+the policy's hardware fit or lower context below Hermes' 64K minimum. Restart
+the managed runtime after changing them.
 
 Models and runtime builds live under the Hermes home directory
 (`models/` and `runtimes/llamacpp/`). Selecting a local model as your

--- a/website/docs/user-guide/local-models.md
+++ b/website/docs/user-guide/local-models.md
@@ -52,8 +52,9 @@ what a hardware upgrade would unlock.
 
 ## How memory management works
 
-Local models live or die by memory placement, so Hermes manages it
-end-to-end and exposes no knobs:
+Local models live or die by memory placement, so Hermes manages the
+hardware policy end-to-end without global tuning knobs. Optional per-model
+upper bounds are available for memory-constrained systems:
 
 - **Models start at a context window that fully fits your GPU** and grow
   toward their native maximum as your conversation needs more room. You


### PR DESCRIPTION
## What does this PR do?

Managed local-runtime boots regenerated `presets.ini` exclusively from the hardware context policy, so users could not persist a smaller context window or microbatch. On the reported 24 GB Apple Silicon system, the selected 221184-token / 2048-microbatch posture consumed 22.2 GB resident memory and drove 8.6 GB of swap; manually lowering it was overwritten on the next boot. This change adds safe per-model launch caps that are reapplied on every preset generation.

### Symptom

Editing `presets.ini` can lower `ctx-size`, `batch-size`, and `ubatch-size`, but the next managed-runtime boot overwrites those values with policy output.

### Impact

Users on memory-constrained and unified-memory systems cannot retain a measured stable launch posture. The reported system recovered roughly 6-8 GB of memory and reduced swap from 8.6 GB to 2.9 GB with lower values, without reducing measured decode throughput.

### Bug Cause

**Trigger:** `hermes_cli/local_runtime/bootstrap.py:238` / `ensure_local_runtime`

**Causal chain:**
1. A user restarts the managed runtime after manually lowering model launch values.
2. `ensure_local_runtime` calls `_generate_presets` without any user launch constraints, and `generate_presets` rewrites every model section from policy output alone.
3. The router receives the larger regenerated context and microbatch values, discarding the user's stable configuration.

**Why it is wrong:** The generated INI is the sole router-side launch-policy carrier, but the runtime configuration had no path into per-model preset generation.

**Working sibling / contrast:** Manually managed OpenAI-compatible local servers retain user-supplied launch arguments because Hermes does not regenerate their configuration.

**Ruled out:** The growth override is not a solution because it is intentionally monotonic and only restores a larger window; it never lowers the initial launch posture.

### Fix

Add `local_runtime.launch_overrides.<model-id>` caps for `ctx-size`, `batch-size`, and `ubatch-size`, pass them through bootstrap, and apply them after policy and growth decisions. Caps can only lower policy/default values, context retains Hermes' 64K minimum, and microbatch is constrained not to exceed batch size. Invalid per-model values are ignored without breaking preset generation. Document the persistent configuration and verify that it survives repeated regeneration.

## Related Issue

Closes #103820

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/local_runtime/bootstrap.py` - forward persistent per-model launch caps into preset generation.
- `hermes_cli/local_runtime/presets.py` - apply safe context, batch, and microbatch caps after policy selection.
- `hermes_cli/config_defaults.py` - add the empty `launch_overrides` configuration mapping.
- `website/docs/user-guide/local-models.md` - document per-model launch caps and restart behavior.
- `tests/hermes_cli/` - cover bootstrap propagation and repeated preset regeneration.

## How to Test

1. Configure a staged model under `local_runtime.launch_overrides` with lower context, batch, and microbatch values.
2. Generate the model presets twice and verify both generated sections retain those caps.
3. Run the focused runtime suite:

```bash
scripts/run_tests.sh tests/hermes_cli/test_local_growth.py tests/hermes_cli/test_boot_preset_staleness.py tests/hermes_cli/test_local_runtime.py
```

Result: 70 tests passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repo's test entry on relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` is N/A because it does not enumerate `local_runtime`
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because architecture and workflows are unchanged
- [x] I've considered cross-platform impact; the caps are platform-independent and specifically support UMA tuning
- [x] Tool descriptions and schemas are N/A because no model tool changed

## Screenshots / Logs

N/A - automated preset read-back verifies the generated router configuration.
