### PR TITLE
fix: [Bug]: 'Too big for this machine' tag applied to models that fit easily on unified-memory Macs (Qwen3.8 27B on 128 GB M5 Max) (#102619)

### DIFF
--- a/hermes_cli/local_runtime/hardware.py
+++ b/hermes_cli/local_runtime/hardware.py
@@ -30,9 +30,15 @@ _GIB = 1 << 30
 # reality). Small cards give up window to this; spill mode is their path to big models.
 _MARGIN_FLOOR = 2 << 30
 _MARGIN_FRACTION = 0.09
-# UMA headroom: on unified-memory machines the model shares physical memory with the OS and every
-# app, so budget from RAM minus this fraction.
-_UMA_HEADROOM_FRACTION = 0.20
+# UMA reserve: on unified-memory machines the model shares physical memory with the OS and every
+# app, so budget from the pool minus a reserve — clamp(pool * 10%, 1.5 GiB, 12 GiB). The OS
+# working set is roughly CONSTANT, not proportional to installed memory: a flat 20% held back
+# ~25.6 GiB on a 128 GiB Mac (and 51 GiB on a 256 GiB one) for an OS that needs a fraction of
+# that, refusing models that genuinely fit. The floor keeps small machines honest; the cap stops
+# the reserve growing without bound on big unified boxes.
+_UMA_RESERVE_FRACTION = 0.10
+_UMA_RESERVE_FLOOR = int(1.5 * (1 << 30))
+_UMA_RESERVE_CAP = 12 << 30
 
 # Engine-fallback gates for the unified-pool quirk — BOTH must hold, and no discrete card can
 # meet either: (1) the allocator's pool exceeds the smi report by well past rounding/ECC slack
@@ -244,8 +250,17 @@ def _unified_pool_bytes(smi_total: int, ram_total: int) -> int | None:
     return None
 
 
+def _uma_reserve_bytes(total: int) -> int:
+    """Bytes of a shared pool held back for the OS: clamp(total * 10%, 1.5 GiB, 12 GiB)."""
+    return int(min(_UMA_RESERVE_CAP, max(_UMA_RESERVE_FLOOR, total * _UMA_RESERVE_FRACTION)))
+
+
 def _uma_budget(base: int, total: int) -> HardwareBudget:
-    usable = max(0, int(base * (1 - _UMA_HEADROOM_FRACTION)))
+    """``base`` is what may be claimed now (live-free, or ``total`` when planning); ``total`` is
+    the pool's physical extent. The reserve is sized from ``total`` and subtracted from ``base``,
+    so planning and live differ in available headroom, not in what the OS is owed — sizing the
+    reserve off live-free would shrink it exactly when memory is tightest."""
+    usable = max(0, base - _uma_reserve_bytes(total))
     return HardwareBudget(usable_vram_bytes=usable, total_device_bytes=total,
                           ram_available_bytes=0, uma=True)
 

--- a/tests/hermes_cli/test_unified_pool_quirk.py
+++ b/tests/hermes_cli/test_unified_pool_quirk.py
@@ -29,6 +29,28 @@ def _no_cache(monkeypatch):
     monkeypatch.setattr(hw, "_pool_probe_cache", None)
 
 
+# ── UMA reserve ───────────────────────────────────────────────
+
+
+def test_uma_reserve_is_a_bounded_clamp_sized_from_total():
+    """The OS reserve must be a bounded clamp, not a 20% slice of the pool:
+    a flat fraction refused models that fit on big unified machines (25.6 GiB
+    reserved on a 128 GiB Mac, 51 GiB on a 256 GiB one) while the floor keeps
+    small machines honest."""
+    assert hw._uma_reserve_bytes(8 * GIB) == int(1.5 * GIB)   # floor binds
+    assert hw._uma_reserve_bytes(128 * GIB) == 12 * GIB         # 10% hits the cap
+    assert hw._uma_reserve_bytes(512 * GIB) == 12 * GIB         # cap binds
+    b = hw._uma_budget(128 * GIB, 128 * GIB)
+    assert b.usable_vram_bytes == 128 * GIB - 12 * GIB
+
+
+def test_uma_reserve_never_scales_off_live_free(monkeypatch):
+    """Sizing the reserve off live-free shrinks it exactly when memory is
+    tightest. Live probes owe the pool total's reserve regardless of load."""
+    assert (hw._uma_budget(24 * GIB, 128 * GIB).usable_vram_bytes
+            == 24 * GIB - hw._uma_reserve_bytes(128 * GIB))
+
+
 # ── _unified_pool_bytes: the classification gate ─────────────
 
 
@@ -108,7 +130,7 @@ def test_budget_unified_pool_planning(monkeypatch):
     assert b.uma is True
     assert b.ram_available_bytes == 0
     assert b.total_device_bytes == UMA_POOL
-    assert b.usable_vram_bytes == int(UMA_POOL * (1 - hw._UMA_HEADROOM_FRACTION))
+    assert b.usable_vram_bytes == UMA_POOL - hw._uma_reserve_bytes(UMA_POOL)
     # The whole point: the budget must dwarf the carve-out.
     assert b.usable_vram_bytes > 2 * UMA_SMI_TOTAL
 
@@ -120,8 +142,9 @@ def test_budget_unified_pool_live_counts_dedicated_free_plus_os_available(monkey
     b = hw.probe_budget(planning=False)
     assert b.uma is True
     live = (14848 << 20) + 32 * GIB
-    assert b.usable_vram_bytes == int(min(UMA_POOL, live)
-                                      * (1 - hw._UMA_HEADROOM_FRACTION))
+    # Reserve is sized from the pool's physical extent, not from the live
+    # figure: what the OS is owed does not shrink because memory got tight.
+    assert b.usable_vram_bytes == min(UMA_POOL, live) - hw._uma_reserve_bytes(UMA_POOL)
 
 
 def test_budget_unified_no_smi_still_classifies(monkeypatch):
@@ -135,10 +158,12 @@ def test_budget_unified_no_smi_still_classifies(monkeypatch):
     planning = hw.probe_budget(planning=True)
     assert planning.uma is True
     assert planning.total_device_bytes == UMA_POOL
-    assert planning.usable_vram_bytes == int(
-        UMA_POOL * (1 - hw._UMA_HEADROOM_FRACTION))
+    assert planning.usable_vram_bytes == UMA_POOL - hw._uma_reserve_bytes(UMA_POOL)
     live = hw.probe_budget(planning=False)
-    assert live.usable_vram_bytes == int(32 * GIB * (1 - hw._UMA_HEADROOM_FRACTION))
+    # Reserve is owed off the pool TOTAL even in live probes — the old code
+    # took 20% of FREE ram, so the reserve shrank precisely as the machine
+    # ran out of memory (the 'Too big' verdict drifted with unrelated load).
+    assert live.usable_vram_bytes == 32 * GIB - hw._uma_reserve_bytes(UMA_POOL)
 
 
 def test_budget_discrete_unchanged_when_probe_says_discrete(monkeypatch):


### PR DESCRIPTION
## What Problem This Solves
Fixes #102619 — [Bug]: 'Too big for this machine' tag applied to models that fit easily on unified-memory Macs (Qwen3.8 27B on 128 GB M5 Max). Minimal diff, single shared guard, no new deps.

## Evidence
- Repro: local repro shows before→after.
- Related suites pass (see worktree 102619).

Closes #102619