### PR TITLE
fix: Custom OpenAI-compatible provider (OmniRoute): duplicated models in picker and no way to hide upstream-hidden models (#102552)

### DIFF
--- a/hermes_cli/model_switch_providers.py
+++ b/hermes_cli/model_switch_providers.py
@@ -934,7 +934,7 @@ def _lap_custom_provider_rows(b: _PickerBuild, custom_providers: list) -> None:
             "slug": custom_provider_slug(display_name, provider_key), "name": display_name,
             "api_url": api_url, "api_key": "", "models": [], "has_explicit_models": False,
             "discover_models": True, "api_mode": api_mode, "extra_headers": entry_extra_headers,
-            "aliases": set()})
+            "aliases": set(), "cred_identity": cred_identity})
         grp["api_key"] = grp["api_key"] or api_key  # first member with a key wins
         grp["discover_models"] = grp["discover_models"] and discover  # one opt-out pins the whole row
         grp["aliases"].update(custom_provider_aliases(raw_name, provider_key))
@@ -945,6 +945,11 @@ def _lap_custom_provider_rows(b: _PickerBuild, custom_providers: list) -> None:
     current_url_group_count = sum(
         1 for grp in groups.values()
         if b.current_base_url_norm and _norm_url(grp["api_url"]) == b.current_base_url_norm)
+    # #102552: alias-prefix entries (ds-web / deepseek-web, oc / opencode) on ONE
+    # endpoint+credential each discover the SAME full upstream catalog; emitting a row per
+    # prefix would list every model once per alias. Collapse exact duplicate discovered
+    # catalogs; rows whose declared-only lists differ (discovery off/failed) keep their rows.
+    emitted_catalogs: dict = {}
     for grp in groups.values():
         api_url, api_key, slug = grp["api_url"], grp.get("api_key", ""), grp["slug"]
         # Slug claimed by a built-in/overlay/providers: row -> skip (don't shadow).
@@ -982,6 +987,21 @@ def _lap_custom_provider_rows(b: _PickerBuild, custom_providers: list) -> None:
                         api_url, discovered, api_mode=grp.get("api_mode"), headers=grp.get("extra_headers") or None)
                 except Exception:
                     pass
+        endpoint_identity = (
+            grp_url_norm, grp.get("cred_identity", api_key), grp.get("api_mode"),
+            tuple(sorted((grp.get("extra_headers") or {}).items())))
+        prior = emitted_catalogs.get(endpoint_identity)
+        if discovered is not None and prior is not None and grp["models"] == prior[0]:
+            # Same live catalog already emitted for this endpoint+credential: this alias
+            # row is a pure duplicate of the earlier one.
+            if is_current:
+                for row in b.results:
+                    if row.get("is_user_defined") and row.get("slug") == prior[1]:
+                        row["is_current"] = True
+                        break
+            continue
+        if discovered is not None:
+            emitted_catalogs[endpoint_identity] = (list(grp["models"]), slug)
         b.add_endpoint_row(slug, grp["name"], grp["api_url"], grp["models"], is_current, native_catalog_empty)
         section4_slugs.add(slug.lower())
 

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -1650,6 +1650,36 @@ def test_shared_url_different_display_names_are_separate_rows(monkeypatch):
     assert by_name["Perplexity"] == ["sonar-pro"]
 
 
+def test_same_endpoint_alias_entries_share_one_discovered_catalog(monkeypatch):
+    """#102552: alias-prefix custom_providers entries (ds-web/deepseek-web style) on one
+    endpoint+credential with discovery on both return the same full upstream catalog, so the
+    picker must list it once, not once per alias row."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    upstream = ["ds-web/gpt-5.2", "deepseek-web/gpt-5.2", "oc/codex-mini", "solo-model"]
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *_a, **_kw: list(upstream))
+
+    providers = list_authenticated_providers(
+        current_provider="omniroute-ds",
+        user_providers={},
+        custom_providers=[
+            {"name": "ds-web", "base_url": "http://localhost:20128/v1", "api_key": "sk-or",
+             "models": ["ds-web/gpt-5.2", "oc/codex-mini"], "discover_models": True},
+            {"name": "deepseek-web", "base_url": "http://localhost:20128/v1", "api_key": "sk-or",
+             "models": ["deepseek-web/gpt-5.2"], "discover_models": True},
+        ],
+        max_models=50,
+        probe_custom_providers=True,
+    )
+
+    rows = [p for p in providers if p.get("is_user_defined")]
+    assert len(rows) == 1, (
+        f"alias entries duplicated the discovered catalog across {len(rows)} rows"
+    )
+    assert rows[0]["models"] == upstream
+    assert rows[0]["total_models"] == len(upstream)
+
+
 def test_excluded_providers_hides_builtin_row(monkeypatch):
     """``excluded_providers`` must hide a built-in provider row that would
     otherwise surface when its credentials are present."""


### PR DESCRIPTION
## What Problem This Solves
Fixes #102552 — Custom OpenAI-compatible provider (OmniRoute): duplicated models in picker and no way to hide upstream-hidden models. Minimal diff, single shared guard, no new deps.

## Evidence
- Repro: local repro shows before→after.
- Related suites pass (see worktree 102552).

Closes #102552