### PR TITLE
fix: [Bug]: post-hoc kanban block (--kind capability, sticky-blocked event) auto-unblocked after gateway restart with no attributed caller (#102545)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2910,7 +2910,18 @@ def block_task(
 ) -> bool:
     """``running``/``ready`` -> ``blocked`` (or ``todo`` / ``triage``, see
     :func:`_route_block`). ``transient`` still counts toward the loop breaker
-    so a forever-flaky task escalates. True on any transition."""
+    so a forever-flaky task escalates. True on any transition.
+
+    A post-hoc explicit block (operator CLI / dashboard, or a worker on its
+    own card) may also PIN a card the dispatcher already parked: breaker /
+    crash auto-blocks sit in ``blocked`` behind only a ``gave_up`` event (NOT
+    sticky, so they auto-recover) and dependency waits sit in ``todo`` —
+    refusing those left the operator's gate unrecorded, and the next
+    ``recompute_ready`` (first tick after a gateway restart) auto-released the
+    card with no explicit unblock (#102545). Human kinds (``None`` included)
+    re-block from ``blocked``/``todo`` so the gate lands as a sticky
+    ``blocked`` event; ``dependency`` still routes only from ``running``/
+    ``ready`` — a worker must not silently demote an operator's gate."""
     if kind is not None and kind not in VALID_BLOCK_KINDS:
         raise ValueError(f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None")
     with write_txn(conn):
@@ -2924,6 +2935,11 @@ def block_task(
             kind, reason, source_status, prev_kind=_row_get(cur_row, "block_kind"),
             prev_recurrences=int(_row_get(cur_row, "block_recurrences") or 0),
         )
+        if kind == "dependency":
+            source_statuses = ("running", "ready")
+        else:
+            source_statuses = ("running", "ready", "blocked", "todo")
+        in_list = ", ".join("'" + s + "'" for s in source_statuses)
         sql = f"""
                 UPDATE tasks
                    SET status        = '{new_status}',
@@ -2932,7 +2948,7 @@ def block_task(
                        worker_pid    = NULL,
                        {set_sql}
                  WHERE id = ?
-                   AND status IN ('running', 'ready')
+                   AND status IN ({in_list})
                 """
         params = (*params, task_id)
         if expected_run_id is not None:

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -77,6 +77,41 @@ def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path)
             assert kb.get_task(conn, tid).status == "blocked"
 
 
+def test_post_hoc_explicit_block_pins_a_dispatcher_parked_card(kanban_home: Path) -> None:
+    """#102545: an explicit post-hoc block (operator ``kanban block
+    --kind capability``) must pin a card the dispatcher already parked —
+    breaker/crash auto-blocks sit in ``blocked`` behind only a ``gave_up``
+    event (NOT sticky) and dependency waits sit in ``todo``. Before the fix
+    ``block_task`` refused both, so the operator's gate was never recorded
+    and the next ``recompute_ready`` (first tick after a gateway restart)
+    auto-released the card with no explicit unblock."""
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="gate across restart")
+        # Simulate the breaker after a restart crash wave: status='blocked',
+        # only a gave_up event -> auto-recoverable, NOT sticky.
+        conn.execute(
+            "UPDATE tasks SET status = 'blocked', consecutive_failures = 0 "
+            "WHERE id = ?", (tid,),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'gave_up', NULL, ?)", (tid, int(time.time())),
+        )
+        conn.commit()
+
+        # Operator's post-hoc explicit gate must land as a sticky blocked event.
+        assert kb.block_task(conn, tid, reason="hold until merge lands", kind="capability")
+        assert kb.get_task(conn, tid).status == "blocked"
+
+        # First dispatcher tick after the restart must not release the gate.
+        for _ in range(3):
+            assert kb.recompute_ready(conn) == 0
+            assert kb.get_task(conn, tid).status == "blocked"
+
+        kinds = [e.kind for e in kb.list_events(conn, tid)]
+        assert kinds[-1] == "blocked"
+
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What Problem This Solves
Fixes #102545 — [Bug]: post-hoc kanban block (--kind capability, sticky-blocked event) auto-unblocked after gateway restart with no attributed caller. Minimal diff, single shared guard, no new deps.

## Evidence
- Repro: local repro shows before→after.
- Related suites pass (see worktree 102545).

Closes #102545