### PR TITLE
fix(agent): emit recovered response before stream close on empty recovery (#31449)

### DIFF
--- a/agent/turn_empty_response.py
+++ b/agent/turn_empty_response.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List, Optional
 
 from agent import empty_response_guard as _empty_guard
 from agent.message_metadata import append_message
-from agent.turn_recovery import interruptible_backoff_sleep
+from agent.turn_recovery import emit_terminal_stream_response, interruptible_backoff_sleep
 
 logger = logging.getLogger("agent.conversation_loop")
 
@@ -174,6 +174,7 @@ def recover_empty_response(
         # A streamed fragment isn't a confirmed preview: gateway fallback delivery
         # sends the text plus the abnormal-turn explanation.
         agent._response_was_previewed = False
+        emit_terminal_stream_response(agent, final_response)
         return _verdict("break")
 
     # Prior turn had real content + ONLY housekeeping tools: model is done, reuse it.
@@ -190,6 +191,7 @@ def recover_empty_response(
         # Do NOT modify the assistant message content (injected text poisoned history).
         final_response = agent._strip_think_blocks(fallback).strip()
         agent._response_was_previewed = True
+        emit_terminal_stream_response(agent, final_response)
         return _verdict("break")
 
     # Post-tool-call empty (no prior content, or only mid-task narration): nudge once.

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -45,12 +45,16 @@ def emit_terminal_stream_response(
     if not final_response:
         return
     if safe_print and hasattr(agent, "_safe_print"):
-        with suppress(Exception):
+        try:
             agent._safe_print(f"\n{final_response}\n")
+        except Exception as exc:
+            logger.debug("emit_terminal_stream_response safe_print failed: %s", exc)
     if getattr(agent, "stream_delta_callback", None):
-        with suppress(Exception):
+        try:
             agent.stream_delta_callback(final_response)
             agent.stream_delta_callback(None)
+        except Exception as exc:
+            logger.debug("emit_terminal_stream_response callback failed: %s", exc)
 
 
 def _vlines(agent: Any, *lines: str) -> None:

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -9,6 +9,7 @@ mutate ``agent`` / ``messages`` / ``api_messages`` in place. Logger name stays
 
 from __future__ import annotations
 
+from contextlib import suppress
 import logging
 import re
 import time
@@ -30,6 +31,26 @@ from agent.turn_retry_state import TurnRetryState
 from utils import base_url_host_matches
 
 logger = logging.getLogger("agent.conversation_loop")
+
+
+def emit_terminal_stream_response(
+    agent: Any, final_response: str, *, safe_print: bool = True
+) -> None:
+    """Emit a synthesized/recovered response to SSE/TUI streams before loop exit.
+
+    Prevents silent stream closes on abnormal exits (guardrail halt, partial stream recovery,
+    prior turn content fallback) where the client would otherwise receive zero content delta
+    and render an empty bubble (#31448, #31449).
+    """
+    if not final_response:
+        return
+    if safe_print and hasattr(agent, "_safe_print"):
+        with suppress(Exception):
+            agent._safe_print(f"\n{final_response}\n")
+    if getattr(agent, "stream_delta_callback", None):
+        with suppress(Exception):
+            agent.stream_delta_callback(final_response)
+            agent.stream_delta_callback(None)
 
 
 def _vlines(agent: Any, *lines: str) -> None:

--- a/agent/turn_tool_round.py
+++ b/agent/turn_tool_round.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, Optional, Tuple
 from agent.message_metadata import append_message
 from agent.message_sanitization import coalesce_tool_call_id
 from agent.turn_preflight import compress_after_tool_results
+from agent.turn_recovery import emit_terminal_stream_response
 from agent.turn_tool_validation import validate_tool_calls
 
 logger = logging.getLogger("agent.conversation_loop")
@@ -167,12 +168,7 @@ def run_tool_round(
         append_message(messages, {"role": "assistant", "content": final_response})
         # Emit the halt so it isn't mistaken for a crash; the stream callback is still
         # alive, so SSE/TUI clients see the explanation.
-        if final_response:
-            agent._safe_print(f"\n{final_response}\n")
-            if agent.stream_delta_callback:
-                with suppress(Exception):
-                    agent.stream_delta_callback(final_response)
-                    agent.stream_delta_callback(None)
+        emit_terminal_stream_response(agent, final_response)
         return _verdict("break")
 
     # Reset per-turn retry counters so one truncation can't poison the turn.

--- a/tests/run_agent/test_empty_response_stream_delivery.py
+++ b/tests/run_agent/test_empty_response_stream_delivery.py
@@ -1,0 +1,115 @@
+﻿"""Tests for stream emission during abnormal turn recoveries (#31448, #31449).
+
+Verifies that when a turn completes via:
+1. Guardrail halt
+2. Partial stream recovery
+3. Prior turn content fallback
+
+The synthesized or recovered final response is delivered through ``stream_delta_callback``
+before loop break, so SSE/TUI clients receive the explanation rather than a silent stream
+close with zero content delta (indistinguishable from a crash).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from agent.turn_empty_response import recover_empty_response
+from agent.turn_recovery import emit_terminal_stream_response
+
+
+def test_emit_terminal_stream_response_delivers_text_and_eof():
+    agent = SimpleNamespace()
+    deltas = []
+    agent.stream_delta_callback = lambda d: deltas.append(d)
+
+    emit_terminal_stream_response(agent, "Test response", safe_print=False)
+
+    assert deltas == ["Test response", None]
+
+
+def test_emit_terminal_stream_response_noop_on_empty_text():
+    agent = SimpleNamespace()
+    deltas = []
+    agent.stream_delta_callback = lambda d: deltas.append(d)
+
+    emit_terminal_stream_response(agent, "", safe_print=False)
+    emit_terminal_stream_response(agent, None, safe_print=False)
+
+    assert deltas == []
+
+
+def test_emit_terminal_stream_response_swallows_callback_exception():
+    agent = SimpleNamespace()
+
+    def buggy_callback(d):
+        raise RuntimeError("stream broken")
+
+    agent.stream_delta_callback = buggy_callback
+    # Should not raise
+    emit_terminal_stream_response(agent, "Test response", safe_print=False)
+
+
+def test_partial_stream_recovery_emits_through_stream_delta_callback():
+    """Regression test for #31449: partial_stream_recovery must push recovered
+    text through stream_delta_callback before breaking out of the turn loop."""
+    agent = MagicMock()
+    agent._current_streamed_assistant_text = "<think>pondering</think>Recovered partial stream"
+    agent._has_content_after_think_block = lambda text: "Recovered" in text
+    agent._strip_think_blocks = lambda text: "Recovered partial stream"
+
+    deltas = []
+    agent.stream_delta_callback = lambda d: deltas.append(d)
+
+    verdict = recover_empty_response(
+        agent,
+        assistant_message=SimpleNamespace(content=""),
+        response=None,
+        finish_reason="stop",
+        final_response="",
+        messages=[],
+        api_messages=[],
+        conversation_history=[],
+        active_system_prompt="",
+        api_call_count=1,
+        turn_exit_reason=None,
+        preflight_compression_blocked=False,
+    )
+
+    assert verdict.action == "break"
+    assert verdict.turn_exit_reason == "partial_stream_recovery"
+    assert verdict.final_response == "Recovered partial stream"
+    assert deltas == ["Recovered partial stream", None]
+
+
+def test_fallback_prior_turn_content_emits_through_stream_delta_callback():
+    """Regression test for #31449: fallback_prior_turn_content must push prior
+    turn content through stream_delta_callback before breaking out of the turn loop."""
+    agent = MagicMock()
+    agent._current_streamed_assistant_text = ""
+    agent._has_content_after_think_block = lambda text: bool(text)
+    agent._strip_think_blocks = lambda text: text
+    agent._last_content_with_tools = "Previous answer after housekeeping tools"
+    agent._last_content_tools_all_housekeeping = True
+
+    deltas = []
+    agent.stream_delta_callback = lambda d: deltas.append(d)
+
+    verdict = recover_empty_response(
+        agent,
+        assistant_message=SimpleNamespace(content=""),
+        response=None,
+        finish_reason="stop",
+        final_response="",
+        messages=[],
+        api_messages=[],
+        conversation_history=[],
+        active_system_prompt="",
+        api_call_count=1,
+        turn_exit_reason=None,
+        preflight_compression_blocked=False,
+    )
+
+    assert verdict.action == "break"
+    assert verdict.turn_exit_reason == "fallback_prior_turn_content"
+    assert verdict.final_response == "Previous answer after housekeeping tools"
+    assert deltas == ["Previous answer after housekeeping tools", None]


### PR DESCRIPTION
## Summary
Follow-up to #31448 (which fixed guardrail-halt stream emission). Synthesized and recovered responses from empty-response recovery paths (`partial_stream_recovery` and `fallback_prior_turn_content`) are now emitted through `stream_delta_callback` before breaking out of the turn loop, preventing silent stream closures where SSE/TUI clients see an empty finish chunk with zero content delta (fixing #31449).

## Root cause
When a turn ends via:
1. `partial_stream_recovery`: A streaming connection died and `_strip_think_blocks(_partial_streamed)` is used as `final_response`.
2. `fallback_prior_turn_content`: Model choke after housekeeping tools reuses `_last_content_with_tools` from the prior turn as `final_response`.

Both sites assign `final_response` to text that was not fully streamed during the current turn, and immediately return `_verdict("break")`. Because `stream_delta_callback` was not fired with the recovered text before the stream closed, SSE/TUI writers drained an empty queue and sent a finish chunk with 0 content delta, creating a blank response bubble in Open WebUI / Desktop (indistinguishable from a crash).

## Fix
1. Extracted `emit_terminal_stream_response(agent, final_response, *, safe_print=True)` into `agent/turn_recovery.py` to deduplicate terminal/recovery stream emission across abnormal exit sites.
2. Updated `agent/turn_tool_round.py` (guardrail halt) to use the shared helper.
3. Updated `agent/turn_empty_response.py` at both `partial_stream_recovery` and `fallback_prior_turn_content` to invoke `emit_terminal_stream_response(agent, final_response)`.
4. Added unit test coverage in `tests/run_agent/test_empty_response_stream_delivery.py` validating delivery of text and EOF `None`, no-op on empty, exception suppression, and both recovery paths.

Fixes #31449.