### PR TITLE
feat(webhook): gate GitHub issue-worker events before agent runs

### DIFF
--- a/gateway/platforms/github_issue_gate.py
+++ b/gateway/platforms/github_issue_gate.py
@@ -1,0 +1,177 @@
+"""Local GitHub issue/PR webhook gate for agent-triggering routes.
+
+The generic webhook adapter already validates HMAC signatures and can wake an
+agent for accepted events.  GitHub issue-worker routes need one more guardrail:
+cheaply decide whether an event is worth an LLM run before the prompt reaches
+the agent.  This module is deliberately pure Python / payload-only so it can be
+unit tested without a gateway, network, GitHub API, or model provider.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+_RELEVANT_ISSUE_ACTIONS = frozenset(
+    {"opened", "edited", "closed", "reopened", "labeled", "unlabeled"}
+)
+_RELEVANT_COMMENT_ACTIONS = frozenset({"created", "edited"})
+_RELEVANT_PR_ACTIONS = frozenset(
+    {"opened", "edited", "closed", "reopened", "synchronize", "labeled", "unlabeled"}
+)
+
+
+@dataclass(frozen=True)
+class GitHubIssueGateDecision:
+    keep: bool
+    reason: str
+    repo: str
+    number: int | None
+    action: str
+    event_type: str
+    llm_reason: str = ""
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple | set):
+        return list(value)
+    return [value]
+
+
+def _string_set(value: Any) -> set[str]:
+    return {str(item).strip() for item in _as_list(value) if str(item).strip()}
+
+
+def _labels_from(item: Any) -> set[str]:
+    labels: set[str] = set()
+    if not isinstance(item, dict):
+        return labels
+    for raw in _as_list(item.get("labels")):
+        if isinstance(raw, dict):
+            name = raw.get("name")
+        else:
+            name = raw
+        if name is not None and str(name).strip():
+            labels.add(str(name).strip())
+    label = item.get("label")
+    if isinstance(label, dict) and label.get("name"):
+        labels.add(str(label["name"]).strip())
+    return labels
+
+
+def _repo_name(payload: dict[str, Any]) -> str:
+    repo = payload.get("repository")
+    return str(repo.get("full_name") or "") if isinstance(repo, dict) else ""
+
+
+def _sender_login(payload: dict[str, Any]) -> str:
+    sender = payload.get("sender")
+    return str(sender.get("login") or "") if isinstance(sender, dict) else ""
+
+
+def _body_text(payload: dict[str, Any]) -> str:
+    parts: list[str] = []
+    for key in ("comment", "issue", "pull_request"):
+        item = payload.get(key)
+        if isinstance(item, dict):
+            body = item.get("body")
+            if body:
+                parts.append(str(body))
+    return "\n".join(parts)
+
+
+def _subject(payload: dict[str, Any], event_type: str) -> tuple[dict[str, Any] | None, bool]:
+    if event_type == "issue_comment":
+        issue = payload.get("issue")
+        return (issue, bool(isinstance(issue, dict) and issue.get("pull_request")))
+    if event_type == "issues":
+        issue = payload.get("issue")
+        return (issue, False)
+    if event_type == "pull_request":
+        return (payload.get("pull_request"), True)
+    return (None, False)
+
+
+def evaluate_github_issue_gate(
+    config: dict[str, Any] | None,
+    payload: dict[str, Any],
+    event_type: str,
+) -> GitHubIssueGateDecision:
+    """Return whether a GitHub webhook event should wake an agent.
+
+    Supported route config under ``github_issue_gate``:
+      - repositories: optional list of ``owner/repo`` names
+      - labels_all / labels_any: labels required on the issue/PR
+      - self_users: GitHub logins whose events are ignored
+      - self_markers: body markers whose events are ignored
+      - include_pull_requests / include_pushes: opt into PR/push events
+    """
+
+    cfg = config or {}
+    repo = _repo_name(payload)
+    action = str(payload.get("action") or "")
+    subject, is_pr_subject = _subject(payload, event_type)
+    number = None
+    if isinstance(subject, dict):
+        try:
+            number = int(subject.get("number") or payload.get("number"))
+        except (TypeError, ValueError):
+            number = None
+
+    repositories = _string_set(cfg.get("repositories"))
+    if repositories and repo not in repositories:
+        return GitHubIssueGateDecision(False, "repository_not_configured", repo, number, action, event_type)
+
+    if _sender_login(payload) in _string_set(cfg.get("self_users")):
+        return GitHubIssueGateDecision(False, "self_sender", repo, number, action, event_type)
+
+    body = _body_text(payload)
+    for marker in _string_set(cfg.get("self_markers")):
+        if marker and marker in body:
+            return GitHubIssueGateDecision(False, "self_marker", repo, number, action, event_type)
+
+    if event_type == "issues":
+        if action not in _RELEVANT_ISSUE_ACTIONS:
+            return GitHubIssueGateDecision(False, "irrelevant_issue_action", repo, number, action, event_type)
+    elif event_type == "issue_comment":
+        if action not in _RELEVANT_COMMENT_ACTIONS:
+            return GitHubIssueGateDecision(False, "irrelevant_comment_action", repo, number, action, event_type)
+        if is_pr_subject and not bool(cfg.get("include_pull_requests", False)):
+            return GitHubIssueGateDecision(False, "pull_request_comment_disabled", repo, number, action, event_type)
+    elif event_type == "pull_request":
+        if not bool(cfg.get("include_pull_requests", False)):
+            return GitHubIssueGateDecision(False, "pull_request_disabled", repo, number, action, event_type)
+        if action not in _RELEVANT_PR_ACTIONS:
+            return GitHubIssueGateDecision(False, "irrelevant_pull_request_action", repo, number, action, event_type)
+    elif event_type == "push":
+        if not bool(cfg.get("include_pushes", False)):
+            return GitHubIssueGateDecision(False, "push_disabled", repo, number, action, event_type)
+    else:
+        return GitHubIssueGateDecision(False, "unsupported_event", repo, number, action, event_type)
+
+    if subject is None and event_type != "push":
+        return GitHubIssueGateDecision(False, "missing_subject", repo, number, action, event_type)
+
+    labels = _labels_from(subject or {}) | _labels_from(payload)
+    labels_all = _string_set(cfg.get("labels_all"))
+    if labels_all and not labels_all.issubset(labels):
+        return GitHubIssueGateDecision(False, "missing_required_labels", repo, number, action, event_type)
+
+    labels_any = _string_set(cfg.get("labels_any"))
+    if labels_any and not (labels & labels_any):
+        return GitHubIssueGateDecision(False, "missing_any_label", repo, number, action, event_type)
+
+    if event_type == "push":
+        llm_reason = "configured push event may change issue-worker code or status"
+    elif event_type == "pull_request":
+        llm_reason = f"pull request {action} matched configured GitHub issue gate"
+    elif event_type == "issue_comment":
+        llm_reason = f"issue comment {action} matched configured labels"
+    else:
+        llm_reason = f"issue {action} matched configured labels"
+    return GitHubIssueGateDecision(True, "matched", repo, number, action, event_type, llm_reason)

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -31,6 +31,7 @@ except ImportError:
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.platforms.github_issue_gate import evaluate_github_issue_gate
 from gateway.platforms.webhook_filters import DEFAULT_SCRIPT_TIMEOUT_SECONDS, WebhookRouteProcessor
 from gateway.response_filters import is_autonomous_silence_response
 
@@ -446,6 +447,62 @@ class WebhookAdapter(BasePlatformAdapter):
             except Exception:
                 return _UNPARSEABLE
 
+    @staticmethod
+    def _delivery_id_from_headers(headers: Any) -> str:
+        return headers.get("X-GitHub-Delivery", headers.get(
+            "svix-id", headers.get("X-Request-ID", str(int(time.time() * 1000)))))
+
+    @staticmethod
+    def _attach_webhook_metadata(payload: Any, *, route_name: str, event_type: str, delivery_id: str) -> Any:
+        """Expose cheap routing metadata to route scripts/templates without trusting model prompts.
+
+        Scripts run before any agent dispatch and are the intended place for local filters, dedupe
+        stores, and self-trigger guards.  GitHub's delivery id lives in a header, not the JSON body;
+        copying it into a reserved metadata object lets scripts make idempotent decisions without
+        widening their interface or receiving raw request headers.
+        """
+        if not isinstance(payload, dict):
+            return payload
+        annotated = dict(payload)
+        annotated.setdefault("__hermes_webhook", {})
+        if isinstance(annotated["__hermes_webhook"], dict):
+            annotated["__hermes_webhook"] = {
+                **annotated["__hermes_webhook"],
+                "route": route_name,
+                "event_type": event_type,
+                "delivery_id": delivery_id,
+            }
+        return annotated
+
+    def _apply_github_issue_gate(self, route_config: dict, payload: Any, event_type: str) -> Optional["web.Response"]:
+        gate_config = route_config.get("github_issue_gate")
+        if not gate_config:
+            return None
+        if not isinstance(payload, dict):
+            logger.info("[webhook] github_issue_gate discarded event=%s repo= number= action= reason=payload_not_object llm_call=false",
+                        event_type)
+            return web.json_response({"status": "ignored", "reason": "payload_not_object"})
+        decision = evaluate_github_issue_gate(gate_config, payload, event_type)
+        logger.info(
+            "[webhook] github_issue_gate event=%s repo=%s number=%s action=%s discarded=%s llm_call=%s reason=%s llm_reason=%s",
+            decision.event_type,
+            decision.repo,
+            decision.number or "",
+            decision.action,
+            not decision.keep,
+            decision.keep,
+            decision.reason,
+            decision.llm_reason,
+        )
+        if decision.keep:
+            gate_meta = payload.setdefault("__hermes_github_gate", {})
+            if not isinstance(gate_meta, dict):
+                gate_meta = {}
+                payload["__hermes_github_gate"] = gate_meta
+            gate_meta["llm_reason"] = decision.llm_reason
+            return None
+        return web.json_response({"status": "ignored", "reason": decision.reason})
+
     async def _handle_deliver_only(self, prompt: str, payload: Any, route_config: dict, route_name: str,
                                    event_type: str, delivery_id: str) -> "web.Response":
         """deliver_only: the rendered prompt IS the message — skip the agent, reuse the same
@@ -523,13 +580,23 @@ class WebhookAdapter(BasePlatformAdapter):
         headers = request.headers
         event_type = (headers.get("X-GitHub-Event", "") or headers.get("X-GitLab-Event", "")
                       or payload.get("event_type", "") or payload.get("type", "") or "unknown")
+        delivery_id = self._delivery_id_from_headers(headers)
+        payload = self._attach_webhook_metadata(
+            payload,
+            route_name=route_name,
+            event_type=event_type,
+            delivery_id=delivery_id,
+        )
         allowed_events = route_config.get("events", [])
         if allowed_events and event_type not in allowed_events:
-            logger.debug("[webhook] Ignoring event %s for route %s (allowed: %s)", event_type, route_name,
-                         allowed_events)
+            logger.info("[webhook] ignored event=%s route=%s discarded=true llm_call=false reason=event_not_allowed",
+                        event_type, route_name)
             return web.json_response({"status": "ignored", "event": event_type})
+        if response := self._apply_github_issue_gate(route_config, payload, event_type):
+            return response
         if not self._route_processor.route_filters_match(route_config, payload, event_type, request.headers):
-            logger.info("[webhook] filtered event=%s route=%s", event_type, route_name)
+            logger.info("[webhook] filtered event=%s route=%s discarded=true llm_call=false reason=filter",
+                        event_type, route_name)
             return web.json_response({"status": "ignored", "reason": "filter", "route": route_name})
         # Script, prompt render and skill lookup read the profile's home (skills/, config); the runner
         # only enters the routed profile's scope later around handle_message, so enter it here.
@@ -542,17 +609,17 @@ class WebhookAdapter(BasePlatformAdapter):
                 keep, transformed_payload = await asyncio.to_thread(
                     self._route_processor.run_route_script, script, payload)
                 if not keep:
-                    logger.info("[webhook] script ignored event=%s route=%s", event_type, route_name)
+                    logger.info("[webhook] script ignored event=%s route=%s discarded=true llm_call=false reason=script",
+                                event_type, route_name)
                     return web.json_response({"status": "ignored", "reason": "script", "route": route_name})
                 payload = transformed_payload or payload
             prompt = self._render_prompt(route_config.get("prompt", ""), payload, event_type, route_name)
             if skills := route_config.get("skills", []):
                 prompt = self._apply_skills(prompt, skills)
-        delivery_id = headers.get("X-GitHub-Delivery", headers.get(
-            "svix-id", headers.get("X-Request-ID", str(int(time.time() * 1000)))))
         now = time.time()  # idempotency: skip duplicate deliveries (webhook retries)
         if not self._record_delivery_id(delivery_id, now):
-            logger.info("[webhook] Skipping duplicate delivery %s", delivery_id)
+            logger.info("[webhook] Skipping duplicate delivery %s discarded=true llm_call=false reason=duplicate",
+                        delivery_id)
             return web.json_response({"status": "duplicate", "delivery_id": delivery_id}, status=200)
         if route_config.get("deliver_only"):
             return await self._handle_deliver_only(prompt, payload, route_config, route_name, event_type, delivery_id)

--- a/tests/gateway/test_github_issue_gate.py
+++ b/tests/gateway/test_github_issue_gate.py
@@ -1,0 +1,211 @@
+import hashlib
+import hmac
+import json
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.github_issue_gate import evaluate_github_issue_gate
+from gateway.platforms.webhook import WebhookAdapter
+
+
+SECRET = "github-secret"
+
+
+def _signature(body: bytes) -> str:
+    return "sha256=" + hmac.new(SECRET.encode(), body, hashlib.sha256).hexdigest()
+
+
+def _adapter(route):
+    return WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"host": "127.0.0.1", "port": 0, "routes": {"github-issue-worker": route}},
+        )
+    )
+
+
+def _app(adapter):
+    app = web.Application()
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+    return app
+
+
+def _issue_payload(**overrides):
+    payload = {
+        "action": "opened",
+        "repository": {"full_name": "ozwicked/trading_bot"},
+        "sender": {"login": "human-user"},
+        "issue": {
+            "number": 47,
+            "title": "Fix trade trail exits",
+            "body": "Please fix this.",
+            "labels": [{"name": "bot-ready"}, {"name": "trading-bot"}],
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _route(**gate_overrides):
+    gate = {
+        "repositories": ["ozwicked/trading_bot", "ozwicked/grow-journal-pro"],
+        "labels_all": ["bot-ready"],
+        "labels_any": ["trading-bot", "growpro"],
+        "self_users": ["ozwicked", "github-actions[bot]"],
+        "self_markers": ["<!-- hermes:automation -->"],
+    }
+    gate.update(gate_overrides)
+    return {
+        "secret": SECRET,
+        "events": ["issues", "issue_comment", "pull_request", "push"],
+        "github_issue_gate": gate,
+        "prompt": "Process {repository.full_name} #{issue.number}: {issue.title}",
+        "deliver": "log",
+    }
+
+
+class TestGitHubIssueGate:
+    def test_accepts_relevant_labeled_issue(self):
+        decision = evaluate_github_issue_gate(_route()["github_issue_gate"], _issue_payload(), "issues")
+        assert decision.keep is True
+        assert decision.reason == "matched"
+        assert decision.repo == "ozwicked/trading_bot"
+        assert decision.number == 47
+        assert "issue opened" in decision.llm_reason
+
+    def test_rejects_issue_without_required_labels_before_llm(self):
+        payload = _issue_payload(issue={"number": 48, "labels": [{"name": "bug"}]})
+        decision = evaluate_github_issue_gate(_route()["github_issue_gate"], payload, "issues")
+        assert decision.keep is False
+        assert decision.reason == "missing_required_labels"
+
+    def test_rejects_self_sender(self):
+        decision = evaluate_github_issue_gate(
+            _route()["github_issue_gate"],
+            _issue_payload(sender={"login": "ozwicked"}),
+            "issues",
+        )
+        assert decision.keep is False
+        assert decision.reason == "self_sender"
+
+    def test_rejects_internal_marker_to_prevent_self_trigger_loops(self):
+        payload = _issue_payload(
+            issue={
+                "number": 47,
+                "body": "<!-- hermes:automation -->\nPR opened by automation.",
+                "labels": [{"name": "bot-ready"}, {"name": "trading-bot"}],
+            }
+        )
+        decision = evaluate_github_issue_gate(_route()["github_issue_gate"], payload, "issues")
+        assert decision.keep is False
+        assert decision.reason == "self_marker"
+
+    @pytest.mark.asyncio
+    async def test_signature_gate_accepts_valid_github_signature_and_dispatches_once(self):
+        adapter = _adapter(_route())
+        captured = []
+
+        async def _capture(event):
+            captured.append(event)
+
+        adapter.handle_message = _capture
+        body = json.dumps(_issue_payload()).encode()
+        async with TestClient(TestServer(_app(adapter))) as cli:
+            resp = await cli.post(
+                "/webhooks/github-issue-worker",
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-1",
+                    "X-Hub-Signature-256": _signature(body),
+                },
+            )
+            assert resp.status == 202
+            assert (await resp.json())["status"] == "accepted"
+
+        assert len(captured) == 1
+        event = captured[0]
+        assert event.message_id == "delivery-1"
+        assert event.raw_message["__hermes_webhook"]["delivery_id"] == "delivery-1"
+        assert event.raw_message["__hermes_github_gate"]["llm_reason"]
+
+    @pytest.mark.asyncio
+    async def test_irrelevant_event_is_filtered_before_agent_dispatch(self):
+        adapter = _adapter(_route())
+        captured = []
+
+        async def _capture(event):
+            captured.append(event)
+
+        adapter.handle_message = _capture
+        payload = _issue_payload(issue={"number": 49, "labels": [{"name": "bug"}]})
+        body = json.dumps(payload).encode()
+        async with TestClient(TestServer(_app(adapter))) as cli:
+            resp = await cli.post(
+                "/webhooks/github-issue-worker",
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-filtered",
+                    "X-Hub-Signature-256": _signature(body),
+                },
+            )
+            assert resp.status == 200
+            assert await resp.json() == {"status": "ignored", "reason": "missing_required_labels"}
+
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_duplicate_delivery_does_not_dispatch_second_agent_run(self):
+        adapter = _adapter(_route())
+        captured = []
+
+        async def _capture(event):
+            captured.append(event)
+
+        adapter.handle_message = _capture
+        body = json.dumps(_issue_payload()).encode()
+        headers = {
+            "Content-Type": "application/json",
+            "X-GitHub-Event": "issues",
+            "X-GitHub-Delivery": "same-delivery",
+            "X-Hub-Signature-256": _signature(body),
+        }
+        async with TestClient(TestServer(_app(adapter))) as cli:
+            first = await cli.post("/webhooks/github-issue-worker", data=body, headers=headers)
+            second = await cli.post("/webhooks/github-issue-worker", data=body, headers=headers)
+            assert first.status == 202
+            assert second.status == 200
+            assert (await second.json())["status"] == "duplicate"
+
+        assert len(captured) == 1
+
+    @pytest.mark.asyncio
+    async def test_bad_signature_rejected_before_filter_or_agent(self):
+        adapter = _adapter(_route())
+        captured = []
+
+        async def _capture(event):
+            captured.append(event)
+
+        adapter.handle_message = _capture
+        body = json.dumps(_issue_payload()).encode()
+        async with TestClient(TestServer(_app(adapter))) as cli:
+            resp = await cli.post(
+                "/webhooks/github-issue-worker",
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "bad-sig",
+                    "X-Hub-Signature-256": "sha256=bad",
+                },
+            )
+            assert resp.status == 401
+
+        assert captured == []

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -397,6 +397,60 @@ hermes webhook subscribe antenna-matches \
 
 ---
 
+## GitHub issue-worker gate {#github-issue-worker-gate}
+
+GitHub issue automation should not wake an LLM just to discover that nothing relevant changed. Add
+`github_issue_gate` to a route to apply a local, payload-only decision before prompt rendering and
+before any agent run. The route still uses the normal GitHub `X-Hub-Signature-256` HMAC validation,
+rate limiting, and delivery-id dedupe.
+
+```yaml
+platforms:
+  webhook:
+    enabled: true
+    extra:
+      routes:
+        github-issue-worker:
+          # Store the real value in config/secrets management; do not hardcode it in code.
+          secret: "${GITHUB_WEBHOOK_SECRET}"
+          events: [issues, issue_comment, pull_request, push]
+          github_issue_gate:
+            repositories:
+              - ozwicked/grow-journal-pro
+              - ozwicked/trading_bot
+            labels_all: [bot-ready]
+            labels_any: [growpro, trading-bot]
+            self_users: [ozwicked, github-actions[bot]]
+            self_markers: ["<!-- hermes:automation -->"]
+            include_pull_requests: true
+            include_pushes: false
+          prompt: |
+            GitHub event matched the local issue-worker gate.
+            Repo: {repository.full_name}
+            Event: {event_type} / {action}
+            Issue: #{issue.number} {issue.title}
+            LLM reason: {__hermes_github_gate.llm_reason}
+
+            Process this issue using the existing bot-ready issue-worker flow.
+          toolsets: ["terminal", "file", "code_execution", "web"]
+```
+
+The gate wakes the agent only when all configured conditions match. It discards unsupported events,
+irrelevant actions, events from configured self users, payloads containing configured self markers,
+repository mismatches, and label mismatches. Discarded events return `200 OK` with `status=ignored`
+and never call the model.
+
+Every gate decision is logged with the event type, repository, issue/PR number, action, whether it
+was discarded, whether an LLM run will be triggered, and the reason. GitHub delivery metadata is
+also copied into `__hermes_webhook` so optional route scripts can do persistent dedupe or additional
+local filtering before any LLM call.
+
+Use this gate to replace cron jobs whose only purpose is polling GitHub issues. Keep a periodic
+fallback only if you need outage recovery; make it script-only (`no_agent=true`) or use a monitor so
+unchanged GitHub state skips the agent.
+
+---
+
 ## Dynamic Subscriptions (CLI) {#dynamic-subscriptions}
 
 In addition to static routes in `config.yaml`, you can create webhook subscriptions dynamically using the `hermes webhook` CLI command. This is especially useful when the agent itself needs to set up event-driven triggers.


### PR DESCRIPTION
## Summary
- add a local GitHub issue-worker gate for webhook routes so irrelevant issue events are discarded before agent dispatch
- annotate payloads with webhook delivery metadata for route scripts and idempotent filters
- document replacing GitHub issue polling cron jobs with signed webhook routes

## Local deployment note
- Paused the existing GrowPro and Trading-Bot bot-ready polling cron jobs because they were failing on provider rate limits and only polling GitHub.
- Configured a local `github-bot-ready-issues` webhook subscription with a script prefilter in the active Hermes profile. A gateway restart from outside the running gateway process is still required before port 8644 is live.

## Tests
- `PYTHONPATH=$PWD /home/hermes/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_github_issue_gate.py tests/gateway/test_webhook_signature_rate_limit.py tests/gateway/test_webhook_integration.py tests/gateway/test_webhook_route_toolsets.py -q -o 'addopts='`
- `git diff --check`
