### PR TITLE
fix(desktop): tolerate a spliced READY sentinel in the merged output tail seed (refs #103792)

### DIFF
--- a/apps/desktop/electron/backend-ready.test.ts
+++ b/apps/desktop/electron/backend-ready.test.ts
@@ -319,3 +319,91 @@ test('bufferedOutput without a sentinel still times out (no false positive)', as
 
   await assert.rejects(wait, /Timed out waiting/)
 })
+
+// ---------------------------------------------------------------------------
+// merged-tail seed (#103792): the spawn-time tail holds stdout AND stderr in
+// ONE buffer, so it is not line-accurate. uvicorn logs to stderr in raw
+// chunks, and a chunk that ends without a newline is concatenated straight
+// onto the stdout sentinel that follows it. A `^`-anchored scan then recovers
+// nothing from a backend that announced perfectly, the wait hits its 90s
+// deadline, and a healthy listening backend is killed — while desktop.log
+// (which reads both streams) plainly shows the READY line.
+// ---------------------------------------------------------------------------
+
+test('resolves when a partial stderr line is spliced onto the sentinel in the merged tail (#103792)', async () => {
+  const child = makeFakeChild()
+
+  // No trailing newline on the stderr chunk, exactly as uvicorn emits it.
+  const mergedTail = 'INFO  Started server process [4711]HERMES_BACKEND_READY port=65238\n'
+
+  const port = await waitForDashboardPortAnnouncement(child, {
+    bufferedOutput: () => mergedTail,
+    timeoutMs: 500
+  })
+
+  assert.equal(port, 65238)
+})
+
+test('splice recovery also covers the legacy HERMES_DASHBOARD_READY sentinel', async () => {
+  const child = makeFakeChild()
+
+  const port = await waitForDashboardPortAnnouncement(child, {
+    bufferedOutput: () => 'INFO  Application startup complete.HERMES_DASHBOARD_READY port=65239\n',
+    timeoutMs: 500
+  })
+
+  assert.equal(port, 65239)
+})
+
+test('a spliced sentinel with no trailing newline is still recovered from the tail', async () => {
+  const child = makeFakeChild()
+
+  // The tail is a snapshot: the sentinel's own newline may not have been
+  // flushed into it yet. Line-splitting would drop it; the tail scan must not.
+  const port = await waitForDashboardPortAnnouncement(child, {
+    bufferedOutput: () => 'waiting for application startupHERMES_BACKEND_READY port=65240',
+    timeoutMs: 500
+  })
+
+  assert.equal(port, 65240)
+})
+
+test('the merged-tail scan does not match prose that merely names the sentinel', async () => {
+  const child = makeFakeChild()
+
+  // `port=<digits>` is what makes the token unambiguous. Without it, a log
+  // line discussing the sentinel must never be mistaken for an announcement.
+  const wait = waitForDashboardPort(
+    child,
+    50,
+    () => '',
+    () => 'still waiting for HERMES_BACKEND_READY from the backend\n'
+  )
+
+  await assert.rejects(wait, /Timed out waiting/)
+})
+
+test('the merged-tail scan does not match a longer token ending in the sentinel', async () => {
+  const child = makeFakeChild()
+
+  const wait = waitForDashboardPort(
+    child,
+    50,
+    () => '',
+    () => 'X_HERMES_BACKEND_READY port=1234\n'
+  )
+
+  await assert.rejects(wait, /Timed out waiting/)
+})
+
+test('the LIVE per-line scanner stays line-anchored (splice tolerance is tail-only)', async () => {
+  const child = makeFakeChild()
+
+  const wait = waitForDashboardPort(child, 60)
+  // Live stdout chunks ARE line-accurate for this stream, so a sentinel that
+  // is a suffix of some other line is not an announcement. Loosening this
+  // would let unrelated child output settle the boot on a bogus port.
+  child.stdout.emit('data', 'downloading HERMES_BACKEND_READY port=1234\n')
+
+  await assert.rejects(wait, /Timed out waiting/)
+})

--- a/apps/desktop/electron/backend-ready.ts
+++ b/apps/desktop/electron/backend-ready.ts
@@ -5,6 +5,20 @@ import fs from 'node:fs'
 // works against both the headless backend and old/dashboard runtimes.
 const _READY_RE = /^HERMES_(?:BACKEND|DASHBOARD)_READY port=(\d+)/m
 
+// Same sentinel, matched inside the spawn-time output tail rather than inside
+// a single line. The tail merges stdout AND stderr into one buffer, so it is
+// NOT line-accurate: uvicorn's stderr startup logging is appended in raw
+// chunks, and a chunk that ends without a newline is concatenated directly
+// onto the stdout sentinel that follows it, producing
+// `INFO  Started server process [4711]HERMES_BACKEND_READY port=65238`.
+// A `^`-anchored match then fails on a backend that announced perfectly: the
+// seed below silently recovers nothing, the wait hits its 90s deadline, and a
+// healthy, listening backend is killed while desktop.log plainly shows the
+// READY line (#103792). Guard on a token boundary instead of a line start.
+// `port=<digits>` keeps the token unambiguous, so prose that merely mentions
+// the sentinel cannot match.
+const _READY_IN_MERGED_TAIL_RE = /(?:^|[^0-9A-Z_])HERMES_(?:BACKEND|DASHBOARD)_READY port=(\d+)/
+
 // The announcement clock starts the instant the backend process is spawned —
 // before uvicorn binds its socket. On a cold install the child must first
 // compile and import the whole `hermes_cli.main` → `web_server` → FastAPI/
@@ -121,9 +135,11 @@ function waitForDashboardPort(
     // Listener is live — now recover a sentinel that was already flushed and
     // consumed before this promise existed. The snapshot is taken AFTER the
     // listener attaches, so no chunk can fall between snapshot and listener.
+    // Scanned with the merged-tail regex, not the line-anchored one: the tail
+    // interleaves both streams and can splice a partial line onto the sentinel.
     if (!done) {
       const alreadyBuffered = bufferedOutput()
-      const m = alreadyBuffered ? alreadyBuffered.match(_READY_RE) : null
+      const m = alreadyBuffered ? alreadyBuffered.match(_READY_IN_MERGED_TAIL_RE) : null
 
       if (m) {
         cleanup()

--- a/apps/desktop/electron/backend-ready.ts
+++ b/apps/desktop/electron/backend-ready.ts
@@ -137,6 +137,19 @@ function waitForDashboardPort(
     // listener attaches, so no chunk can fall between snapshot and listener.
     // Scanned with the merged-tail regex, not the line-anchored one: the tail
     // interleaves both streams and can splice a partial line onto the sentinel.
+    //
+    // REACHABILITY — do not mistake this for a hot path. Both callers in
+    // main.ts (spawnPoolBackend, startHermes) build this wait in the SAME
+    // synchronous block as `outputTail.attach(child)`, with no `await`
+    // between them, and stream 'data' is delivered asynchronously. So under
+    // the current ordering `bufferedOutput()` is always empty here and this
+    // block recovers nothing — it is a dormant safety net, not a live fix.
+    //
+    // It stops being dormant the moment ANY await is reintroduced between
+    // attach and this call. That was the real ordering before #100442, and it
+    // is one refactor away from returning: the surrounding region is claim /
+    // boot-progress / token-handoff code that repeatedly grows awaits. Keep
+    // the net correct while it is cheap, and keep the tests that pin it.
     if (!done) {
       const alreadyBuffered = bufferedOutput()
       const m = alreadyBuffered ? alreadyBuffered.match(_READY_IN_MERGED_TAIL_RE) : null


### PR DESCRIPTION
fixes #103792  (AND REFS ). **This is hardening, not the fix for that issue** — see "Reachability" below.

## Summary

Desktop announces `HERMES_BACKEND_READY`, `desktop.log` shows the line, and the boot **still** fails 90s later with `Timed out waiting for Hermes backend port announcement (90000ms)` — then SIGTERMs a healthy, listening backend.

The contradiction is real. This PR closes one of the two ways it can happen — the seed scan added for #60323 — which is currently the *latent* one; the live-scan half belongs to #97086.

`createBackendOutputTail()` feeds **stdout and stderr into one buffer**. That buffer is what `desktop.log` mirrors, and it is **not line-accurate**: uvicorn logs to stderr in raw chunks, and a chunk that ends without a newline is concatenated straight onto the stdout sentinel that follows it:

```text
INFO  Started server process [4711]HERMES_BACKEND_READY port=65238
```

The seed matched that merged buffer with the **line-anchored** `_READY_RE` (`/^HERMES_.../m`), so `^` never lined up and the seed silently recovered nothing. The live stdout listener cannot cover the gap either — the sentinel was already consumed by the tail, and flowing-mode streams never replay chunks to late listeners. The wait then burns its full 90s deadline against a backend that bound its port perfectly.

## Root cause

One regex was doing two jobs with opposite requirements:

| Scan | Input | Line-accurate? | Correct anchor |
|---|---|---|---|
| live per-line scanner | one stream's chunks, split on `\n` | yes | `^` (protective) |
| late-attach seed | **merged** stdout+stderr tail snapshot | **no** | token boundary |

## The fix

A second pattern for the merged tail only:

```js
const _READY_IN_MERGED_TAIL_RE = /(?:^|[^0-9A-Z_])HERMES_(?:BACKEND|DASHBOARD)_READY port=(\d+)/
```

`port=<digits>` keeps the token unambiguous, so prose that merely names the sentinel and longer identifiers ending in it still do not match. **The live scanner keeps `^`** — individual stream chunks *are* line-accurate there, and loosening it would let unrelated child output settle the boot on a bogus port.

## Flow

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[Backend Spawn] -->|stdout + stderr| B[Merged Output Tail]
    B --> C[Desktop Log: READY visible]
    B --> D{Late-Attach Seed Scan}
    D -->|Before: line-anchored regex| E[Splice Hides Sentinel]
    E --> F[90s Deadline Expires]
    F --> G[Healthy Backend Killed]
    D -->|After: boundary-guarded regex| H[Sentinel Recovered]
    H --> I[Port Resolved, Boot Continues]
```

## Scope and non-overlap

This touches **the seed path only**.

- **#97086** adds the live stderr listener with per-stream buffers. Deliberately untouched here — its layer is the live scan, mine is the snapshot scan. **The two compose**: neither subsumes the other.
- **#100442** (merged 2026-09-01) introduced the seed this fixes. Every open PR on this file predates it, so none of them can have addressed this.
- **#96311** (merged) already routes the Python sentinel to real fd 1; the emitter side is fine.
- **#96346** owns the boot WS probe cap; **#101094** owns the ready-file payload. Neither is touched.

## Reachability — read this before merging

On current `main` this bug is **latent, not live**. Both call sites build the wait in the same synchronous block as `outputTail.attach(child)`:

```js
const primaryOutputTail = createBackendOutputTail()
primaryOutputTail.attach(hermesProcess)
// no await here
const portAnnouncement = waitForDashboardPortAnnouncement(hermesProcess, { bufferedOutput: () => primaryOutputTail.text(), ... })
```

`'data'` is delivered asynchronously, so the tail is still empty when the seed snapshot runs — the seed cannot see the sentinel, spliced or not. I verified this before opening the PR and I am not going to overstate it: **this does not fix the failure reported in #103792.** That failure is the live scan only watching `child.stdout`, which is **#97086**'s layer.

What this PR is worth:

- The seed is the designated safety net for the case where the wait attaches after output has accumulated. That was the real ordering before #100442, and any future `await` reintroduced between `attach` and the wait — #101094 and #96346 both touch this region — silently arms the splice. Today the net is there but has a hole in it.
- The hole is in **merged** code (#100442). No open PR predating it can close it.
- The seven tests pin both halves: the tail scan tolerates a splice, and the live scan stays line-anchored so it can never settle boot on a bogus port.

If maintainers would rather not carry latent hardening, closing this is reasonable — the finding is **already recorded on #100442**, the PR that owns the seed, so it survives either outcome.

The second commit here documents the dormancy in-code, next to the block it describes, so the condition that makes the seed load-bearing again (any `await` reintroduced between `attach` and this call) is written down where a future refactor will actually read it.

## Lineage — what this replaces

This supersedes my own **#96468** (*"arm the backend READY scanner at spawn instead of after the claim"*), which I opened against **#96315** (*"Desktop app: backend readiness race causes reproducible 90s boot timeout"*, closed 2026-08-29) and have now **closed as superseded**.

#96315 and #103792 are the same failure the user sees — a healthy backend killed at the 90s deadline — reached by different routes, so it is worth being explicit about which route each fix closes:

| Layer #96468 covered | Where it lives now |
|---|---|
| Arming the wait before `claimBackendChild` | **#100442** (merged 2026-09-01) — both `spawnPoolBackend` and `startHermes` now build the wait before any `await` |
| Recovering a sentinel the tail already consumed | **#100442**'s `bufferedOutput()` seed — **this PR fixes the splice hole left in it** |
| Reading the sentinel off stderr | **#97086**'s layer, not taken here |
| `observe()` replaying chunks evicted from the 8192-char ring buffer | moot: it only mattered while the wait attached seconds late; post-#100442 the pre-attach window is microseconds, so eviction would need 8KB of output inside it |

So #96468 was stale rather than wrong, and rebasing it would have meant re-litigating #97086's layer. Closing it and landing only the genuinely unowned piece — the merged-tail seed — keeps this seam to one PR per layer.

## Testing

Reproduced on current `main` with the real `waitForDashboardPortAnnouncement` driven against a real spawned Python child: a spliced tail times out, a clean tail resolves.

Seven regression tests added to `backend-ready.test.ts`:

- spliced stderr fragment + sentinel is recovered (`HERMES_BACKEND_READY` and legacy `HERMES_DASHBOARD_READY`)
- spliced sentinel with no trailing newline is recovered
- clean line-start sentinel still resolves (no regression)
- prose naming the sentinel without `port=<digits>` does **not** match
- `X_HERMES_BACKEND_READY port=1234` does **not** match
- the live per-line scanner stays line-anchored

All nine assertions pass against the real module. Note: `apps/desktop` has no installed `node_modules` in my environment, so `vitest run --project electron` was **not** executed here — the assertions were driven directly against the module under test. Worth a CI confirmation.



