### PR TITLE
fix(cli): strip repeated degraded bracketed-paste wrappers

### DIFF
--- a/hermes_cli/input_sanitize.py
+++ b/hermes_cli/input_sanitize.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 import re
 
 # Degraded visible bracketed-paste forms, matched only at boundaries so embedded literals stay intact.
+# Each form is quantified so a run of them is consumed by one match: the boundary character is part
+# of the opening matches and is re-emitted, so after a single-marker substitution the next marker is
+# preceded by the previous one's "~" rather than a boundary and would never match again.
 _BOUNDARY_SUBS = (
-    (re.compile(r"(^|[\s\n>:\]\)])\[200~"), r"\1"),
-    (re.compile(r"\[201~(?=$|[\s\n<\[\(\):;.,!?])"), ""),
-    (re.compile(r"(^|[\s\n>:\]\)])00~"), r"\1"),
-    (re.compile(r"01~(?=$|[\s\n<\[\(\):;.,!?])"), ""),
+    (re.compile(r"(^|[\s\n>:\]\)])(?:\[200~)+"), r"\1"),
+    (re.compile(r"(?:\[201~)+(?=$|[\s\n<\[\(\):;.,!?])"), ""),
+    (re.compile(r"(^|[\s\n>:\]\)])(?:00~)+"), r"\1"),
+    (re.compile(r"(?:01~)+(?=$|[\s\n<\[\(\):;.,!?])"), ""),
 )
 
 # Corruption signature from desktop bracketed-paste leaks (#62557).

--- a/tests/hermes_cli/test_input_sanitize.py
+++ b/tests/hermes_cli/test_input_sanitize.py
@@ -17,6 +17,33 @@ class TestStripLeakedBracketedPasteWrappers:
         text = "literal[200~tag and literal[201~tag should stay"
         assert strip_leaked_bracketed_paste_wrappers(text) == text
 
+    def test_strips_a_repeated_degraded_opening_wrapper(self):
+        """A leak that emits the marker twice left one behind.
+
+        The boundary character is consumed and re-emitted by the substitution, so on the
+        second marker the preceding character is the first marker's "~" rather than a
+        boundary, and it never matched again.
+        """
+        assert strip_leaked_bracketed_paste_wrappers("[200~[200~hello") == "hello"
+        assert strip_leaked_bracketed_paste_wrappers("[200~[200~[200~hello") == "hello"
+        assert strip_leaked_bracketed_paste_wrappers("prefix [200~[200~hello") == "prefix hello"
+
+    def test_strips_repeated_degraded_wrapper_fragments(self):
+        assert strip_leaked_bracketed_paste_wrappers("00~00~hello") == "hello"
+        assert strip_leaked_bracketed_paste_wrappers("hello01~01~") == "hello"
+        assert (
+            strip_leaked_bracketed_paste_wrappers("00~00~00~hello world01~01~01~")
+            == "hello world"
+        )
+
+    def test_strips_a_repeated_wrapper_pair(self):
+        assert strip_leaked_bracketed_paste_wrappers("[200~[200~hello[201~[201~") == "hello"
+
+    def test_repeats_do_not_widen_the_boundary_rule(self):
+        """Repetition must not make an embedded literal strippable."""
+        text = "literal[200~[200~tag should stay"
+        assert strip_leaked_bracketed_paste_wrappers(text) == text
+
 
 class TestCollapseRepeatedInputArtifacts:
     def test_issue_62557_corruption_tail(self):


### PR DESCRIPTION
## What does this PR do?

`strip_leaked_bracketed_paste_wrappers` only removed the **first** of a repeated degraded wrapper. A leak that emitted the marker twice left one behind, and it was then persisted and sent to the model — the thing this module exists to prevent.

```
[200~[200~hello              ->  [200~hello
[200~[200~[200~hello         ->  [200~[200~hello
00~00~hello                  ->  00~hello
hello01~01~                  ->  hello01~
[200~[200~hello[201~[201~    ->  [200~hello
```

The canonical `\x1b[200~` / `^[[200~` forms were fine — those go through `str.replace`, which is global. Only the degraded visible forms in `_BOUNDARY_SUBS` were affected.

### Why

The opening patterns capture the boundary character and re-emit it:

```python
(re.compile(r"(^|[\s\n>:\]\)])\[200~"), r"\1"),
```

`re.sub` resumes scanning after the consumed text, so on the second marker the preceding character is the first marker's `~`, which is not a boundary, and it never matches again. The closing forms fail differently: `[201~[201~` happened to work because `[` is in the lookahead set, while `01~01~` did not, because `0` is not.

That repetition is not hypothetical for this bug class — #62557 is the same leak observed at 200+ repeats, which is why `collapse_repeated_input_artifacts` already exists beside it.

### The fix

Quantify each form so a run is consumed by one match:

```python
(re.compile(r"(^|[\s\n>:\]\)])(?:\[200~)+"), r"\1"),
(re.compile(r"(?:\[201~)+(?=$|[\s\n<\[\(\):;.,!?])"), ""),
(re.compile(r"(^|[\s\n>:\]\)])(?:00~)+"), r"\1"),
(re.compile(r"(?:01~)+(?=$|[\s\n<\[\(\):;.,!?])"), ""),
```

The boundary rule itself is untouched, so embedded literals still survive — `literal[200~tag` as before, and `literal[200~[200~tag` too. That second case is a new test: repetition must not become a way around the boundary check.

`cli._strip_leaked_bracketed_paste_wrappers` is a lazy shim over this function, so both call sites are covered by the one change.

## Related Issue

None open. Same family as #62557 (closed), which is what `_DESKTOP_PASTE_ARTIFACT` and `collapse_repeated_input_artifacts` were added for.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/input_sanitize.py` — quantified the four `_BOUNDARY_SUBS` patterns, plus a comment recording why a single-marker pattern cannot work here.
- `tests/hermes_cli/test_input_sanitize.py` — four tests: repeated opening wrapper, repeated fragments, a repeated wrapper pair, and the boundary-rule guard.

## How to Test

```
pytest tests/hermes_cli/test_input_sanitize.py tests/cli/test_cli_bracketed_paste_sanitizer.py -q
```

Reverting only `input_sanitize.py` and keeping the tests fails exactly three of the four new tests:

```
FAILED ...::test_strips_a_repeated_degraded_opening_wrapper
FAILED ...::test_strips_repeated_degraded_wrapper_fragments
FAILED ...::test_strips_a_repeated_wrapper_pair
3 failed, 12 passed
```

The fourth, `test_repeats_do_not_widen_the_boundary_rule`, passes either way — it is there to catch the fix over-reaching, not to catch the bug.

With the fix, 15 passed. All 11 pre-existing tests across both files pass before and after.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **see note below**
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.6), Python 3.12

**Note on the full suite:** I ran the two test files that cover this module, not `pytest tests/ -q`. Cloning this repo fails on my connection — repeated `early EOF` on the pack, and the tarball moved at roughly 35 KB/s against 866 MB — so I ran these two files against the patched module in isolation instead. The change is four regex literals in a module whose only imports are `re` and `__future__`, and nothing else in the tree imports `_BOUNDARY_SUBS`, so the blast radius is those two files. Happy to be told otherwise if CI disagrees.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — the comment above `_BOUNDARY_SUBS` now records the constraint
- [x] `cli-config.yaml.example` — N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture change
- [x] Cross-platform impact — N/A, pure string handling with no platform branches
- [x] Tool descriptions/schemas — N/A
