### PR TITLE
fix(cli): keep exhausted-pool providers visible in the main /model picker

### DIFF
--- a/hermes_cli/cli_model_switch_mixin.py
+++ b/hermes_cli/cli_model_switch_mixin.py
@@ -192,6 +192,10 @@ def _show_model_picker(cli, ctx, force_refresh: bool) -> None:
         providers = build_models_payload(
             ctx, probe_custom_providers=force_refresh,
             probe_current_custom_provider=not force_refresh,
+            # Keep providers whose pool is entirely in cooldown visible: limits are
+            # per-model for many providers, so another model may work (#103829) —
+            # same contract as the gateway picker (#66584) and aux pickers (#66624).
+            for_picker=True,
         )["providers"]
     except Exception:
         providers = []

--- a/tests/hermes_cli/test_show_model_picker_exhausted_pool.py
+++ b/tests/hermes_cli/test_show_model_picker_exhausted_pool.py
@@ -1,0 +1,52 @@
+"""Regression test for #103829: the interactive CLI's main ``/model`` picker
+(``/model`` with no args) must request exhausted-pool visibility.
+
+``_show_model_picker`` feeds ``cli._open_model_picker`` from
+``build_models_payload`` but never forwarded ``for_picker`` — a provider whose
+credential pool was entirely rate-limited (entries present, none usable until
+``last_error_reset_at``) was treated as "not authenticated" and its row
+vanished from the main picker until the cooldown elapsed or the user ran
+``hermes auth reset``. The gateway interactive picker (#66584) and the aux
+pickers (#66624) already forward the flag; this is the same contract for the
+CLI's main picker surface.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from hermes_cli.cli_model_switch_mixin import _show_model_picker
+
+
+def _run_picker(payload_providers):
+    captured: dict = {}
+
+    def _fake_build(_ctx, **kwargs):
+        captured.update(kwargs)
+        return {"providers": payload_providers}
+
+    cli = SimpleNamespace(model="some-model", provider="", _open_model_picker=MagicMock())
+    ctx = SimpleNamespace(user_providers={}, custom_providers=[])
+    with patch("hermes_cli.inventory.build_models_payload", side_effect=_fake_build):
+        _show_model_picker(cli, ctx, force_refresh=False)
+    return captured, cli
+
+
+def test_show_model_picker_requests_for_picker():
+    """The main CLI picker must pass for_picker=True so exhausted-pool providers stay visible."""
+    providers = [{"slug": "openai-codex", "models": ["gpt-5.6-sol"]}]
+    captured, cli = _run_picker(providers)
+
+    assert captured.get("for_picker") is True, (
+        "_show_model_picker must forward for_picker=True so providers whose credential "
+        "pool is entirely in cooldown remain selectable from the main picker (#103829)"
+    )
+    cli._open_model_picker.assert_called_once()
+    assert cli._open_model_picker.call_args[0][0] is providers
+
+
+def test_show_model_picker_usage_fallback_still_works():
+    """Empty provider list keeps printing usage instead of opening the picker."""
+    captured, cli = _run_picker([])
+
+    assert captured.get("for_picker") is True
+    cli._open_model_picker.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

`/model` with no args in an interactive CLI session opens the main model picker via `_show_model_picker`, which feeds `build_models_payload` **without** `for_picker=True`. A provider whose credential-pool entries are all marked `exhausted` (HTTP 429, `last_error_reset_at` set) therefore fails the `has_creds` gate in `_overlay_has_creds` and its row disappears from the main picker as if the provider were not authenticated — the exact symptom in #103829.

The visibility branch already exists and is gated on the flag: with `for_picker=True`, `load_pool(slug).has_credentials()` keeps the row visible so the user can pick a different model under the same provider (limits are per-model for many providers). The gateway interactive picker forwards it (#66584) and the aux-task/vision pickers forward it (#66624); the CLI main picker surface was simply never wired to the same contract. This PR forwards `for_picker=True` from `_show_model_picker` — no filter logic is duplicated or moved.

## Related Issue

Fixes #103829

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/cli_model_switch_mixin.py`: `_show_model_picker` now passes `for_picker=True` to `build_models_payload` (+4 lines incl. rationale comment).
- `tests/hermes_cli/test_show_model_picker_exhausted_pool.py`: new regression tests asserting the flag is forwarded and the picker open/usage-fallback paths are unchanged.

## How to Test

1. `pytest tests/hermes_cli/test_show_model_picker_exhausted_pool.py -v` — 2 passed (should pass).
2. `pytest tests/hermes_cli/test_authenticated_providers_exhausted_pool.py tests/hermes_cli/test_aux_picker_inventory.py tests/hermes_cli/test_25106_global_switch_persists_base_url_api_mode.py tests/hermes_cli/test_apply_model_switch_result_context.py tests/hermes_cli/test_model_switch_context_offload.py tests/hermes_cli/test_user_providers_model_switch.py -q` — 27 passed, no regressions (Observed result: 27 passed on Python 3.11.15).
3. Manual repro of the issue: exhaust a pool-based provider (e.g. `openai-codex` device-code auth hitting HTTP 429), run `/model` in an interactive session — the provider row should now stay visible instead of vanishing until `last_error_reset_at` elapses or `hermes auth reset <provider>` is run.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — not a skill.

## Screenshots / Logs

Not applicable — behavior verified via the regression tests above; the underlying visibility branch is already covered end-to-end by `tests/hermes_cli/test_authenticated_providers_exhausted_pool.py::test_picker_shows_exhausted_pool_provider`.