### PR TITLE
fix(cron): tick named-profile host store under multiplex

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1565,6 +1565,38 @@ def _multiplex_profile_homes(config: object) -> list[tuple[str, "Path"]]:
         multiplex=True, profile_allowlist=getattr(config, "multiplex_profile_allowlist", None)))
 
 
+def _with_active_profile_home(
+    homes: list[tuple[str, "Path"]],
+) -> list[tuple[str, "Path"]]:
+    """Union the process-active profile into a multiplex home list.
+
+    ``profiles_to_serve(multiplex=True)`` always starts with the *default*
+    profile (``~/.hermes``) plus the allowlist. A named-profile gateway
+    (``--profile <name>``) is therefore omitted unless it is allowlisted —
+    and allowlisting it would also start secondary adapters on the same
+    bot token.
+
+    Adapter startup already skips ``active`` and prepends it to
+    ``served_profiles``. Cron must visit that store too, or host jobs sit
+    ``scheduled`` forever while default + allowlist tick empty rooms.
+    """
+    from hermes_cli.profiles import get_active_profile_name, get_profile_dir
+
+    active = get_active_profile_name() or "default"
+    if any(name == active for name, _home in homes):
+        return list(homes)
+    try:
+        active_home = get_profile_dir(active)
+    except Exception:
+        return list(homes)
+    return list(homes) + [(active, active_home)]
+
+
+def _cron_tick_profile_homes(config: object) -> list[tuple[str, "Path"]]:
+    """Profile homes the in-process ticker must visit under multiplex."""
+    return _with_active_profile_home(_multiplex_profile_homes(config))
+
+
 def _enable_multiplex_log_routing(config: object) -> bool:
     """Route agent.log/errors.log/gateway.log records to their owning profile (inert single-profile).
     ``setup_logging(mode="gateway")`` binds file handlers to the launch home, so under multiplexing
@@ -5032,10 +5064,13 @@ def _start_gateway_start_cron_and_housekeeping(runner):
         resolve_cron_scheduler(), multiplex_profiles=multiplex_cron)
     cron_start_kwargs: Dict[str, Any] = {"adapters": runner.adapters, "loop": asyncio.get_running_loop()}
 
-    # Multiplex: tell the ticker which profile homes to tick, else secondary profiles' jobs never run.
+    # Multiplex: tick secondary profiles (#69377) *and* the named-profile host
+    # store. profiles_to_serve() starts at default plus the allowlist; a
+    # gateway running as --profile <name> would otherwise never visit its own
+    # cron dir. Adapter serve-set stays allowlist-only.
     if isinstance(cron_provider, InProcessCronScheduler) and multiplex_cron:
         try:
-            profile_homes = _multiplex_profile_homes(runner.config)
+            profile_homes = _cron_tick_profile_homes(runner.config)
             if profile_homes:
                 cron_start_kwargs["profile_homes"] = profile_homes
                 # Per-profile adapters so each profile's cron output goes via its own bot, not the default's.

--- a/tests/gateway/test_multiplex_lifecycle.py
+++ b/tests/gateway/test_multiplex_lifecycle.py
@@ -41,6 +41,34 @@ def test_cron_profile_homes_follow_allowlist(tmp_path, monkeypatch):
     assert [name for name, _home in homes] == ["default", "worker"]
 
 
+def test_cron_tick_homes_include_active_named_host(tmp_path, monkeypatch):
+    """Named-profile gateway + allowlist must still tick the host store.
+
+    Adapter homes stay allowlist-only so the host is not started a second
+    time as a secondary (same bot token). Cron unions the active profile.
+    """
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    default_home = tmp_path / ".hermes"
+    for name in ("host", "worker"):
+        (default_home / "profiles" / name).mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(default_home / "profiles" / "host"))
+
+    import gateway.run as gateway_run
+
+    cfg = GatewayConfig(
+        multiplex_profiles=True,
+        multiplex_profile_allowlist=["worker"],
+    )
+    adapter_names = [name for name, _home in gateway_run._multiplex_profile_homes(cfg)]
+    cron_homes = gateway_run._cron_tick_profile_homes(cfg)
+    cron_names = [name for name, _home in cron_homes]
+    cron_by_name = dict(cron_homes)
+
+    assert adapter_names == ["default", "worker"]
+    assert cron_names == ["default", "worker", "host"]
+    assert cron_by_name["host"] == default_home / "profiles" / "host"
+
+
 class TestNamedProfileMultiplexerGuard:
     """_guard_named_profile_under_multiplexer is inert unless all conditions hold."""
 


### PR DESCRIPTION
## Bug Description

A gateway started with `--profile <name>` and `multiplex_profiles: true` never ticks that profile's cron store unless the name is also in `multiplex_profile_allowlist`. Jobs sit `scheduled` with a past `next_run_at`, `last_status: ok` stays stale, and only default + allowlist heartbeats stay fresh.

Allowlisting the host is the wrong fix: it starts a second messaging adapter on the same bot token.

## Root Cause

`profiles_to_serve(multiplex=True)` always returns **default** (`~/.hermes`) plus the allowlist. Adapter startup already skips `active` and prepends it to `served_profiles`. The in-process cron ticker used the allowlist-only set (`_multiplex_profile_homes`), so a named-profile host was omitted.

Follow-on hole after #54913 (cross-profile tick for secondaries).

## Fix

- Add `_cron_tick_profile_homes` / `_with_active_profile_home` to union the process-active store into the ticker home list.
- Cron start uses that helper. Adapter serve-set stays allowlist-only.

## How to Verify

1. `hermes --profile host gateway run` with `multiplex_profiles: true` and allowlist `["worker"]` (host not listed).
2. Log should read: `Cron scheduler will tick … ['default', 'worker', 'host']`.
3. Host `cron/ticker_heartbeat` stays seconds-old. Adapter set still does not start a second host adapter.

## Test Plan

- [x] Added regression test `test_cron_tick_homes_include_active_named_host`
- [x] Existing allowlist test still passes
- [x] Manual verification on a named-profile multiplex gateway (host heartbeat resumed; log included the host)

## Risk Assessment

Low — ticker home list only. Adapter multiplex set is unchanged, so no second bot-token adapter.