### PR TITLE
fix(agent): render batch skill review details instead of Skill ?

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -545,10 +545,31 @@ def _verbose_skill_line(data: Dict, detail: Dict, message: str) -> str:
     if action == "patch" and (old_string or new_string):
         old_preview, new_preview = (_preview(t, 80).replace("\n", " ") for t in (old_string, new_string))
         return f"📝 Skill '{skill_name}' patched: \"{old_preview}\" → \"{new_preview}\""
+    file_path = detail.get("file_path", "")
+    if action == "write_file" and file_path:
+        return f"📝 Skill '{skill_name}' wrote file '{file_path}'"
+    if action == "remove_file" and file_path:
+        return f"📝 Skill '{skill_name}' removed file '{file_path}'"
     verb = {"create": "created", "edit": "rewritten"}.get(action)
     if verb and change.get("description"):
         return f"📝 Skill '{skill_name}' {verb}: {change['description']}"
-    return f"📝 {message}" if message else f"Skill {action}"
+    if verb and skill_name:
+        return f"📝 Skill '{skill_name}' {verb}"
+    return f"📝 {message}" if message else "Skill updated"
+
+
+def _verbose_skill_lines(data: Dict, detail: Dict, message: str) -> List[str]:
+    """Render a single skill operation or each operation in a batch."""
+    operations = detail.get("operations")
+    if isinstance(operations, list) and operations:
+        lines = [
+            _verbose_skill_line({}, op, "")
+            for op in operations
+            if isinstance(op, dict)
+        ]
+        if lines:
+            return lines
+    return [_verbose_skill_line(data, detail, message)]
 
 
 def _verbose_memory_lines(label: str, detail: Dict) -> List[str]:
@@ -562,8 +583,8 @@ def _verbose_memory_lines(label: str, detail: Dict) -> List[str]:
 
 # Tool-call argument fields surfaced in action summaries, with their defaults.
 _CALL_DETAIL_DEFAULTS = (
-    ("action", "?"), ("target", "memory"), ("content", ""), ("old_text", ""), ("name", ""),
-    ("old_string", ""), ("new_string", ""),
+    ("action", ""), ("target", "memory"), ("content", ""), ("old_text", ""), ("name", ""),
+    ("old_string", ""), ("new_string", ""), ("file_path", ""),
 )
 
 
@@ -622,7 +643,7 @@ def _action_lines(data: Dict, detail: Dict, verbose: bool) -> List[str]:
         return []
     label = "Skill" if is_skill else {"memory": "Memory", "user": "User profile"}.get(target, target)
     if verbose:
-        return [_verbose_skill_line(data, detail, message)] if is_skill else _verbose_memory_lines(label, detail)
+        return _verbose_skill_lines(data, detail, message) if is_skill else _verbose_memory_lines(label, detail)
     hit = any(k in lower for k in ("added", "replaced", "removed", "applied")) or (target and "add" in lower)
     return [f"{label} updated"] if hit else []
 

--- a/tests/run_agent/test_background_review_summary.py
+++ b/tests/run_agent/test_background_review_summary.py
@@ -7,6 +7,7 @@ history before the review started (e.g. an earlier "Cron job '...' created.").
 
 import json
 
+from agent.background_review import summarize_background_review_actions
 from run_agent import AIAgent
 
 
@@ -92,6 +93,71 @@ def test_empty_inputs():
     assert _summarize(None, None) == []
 
 
+
+
+def _skill_batch_review():
+    """Batch skill_manage call: operations list, no top-level action."""
+    return [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_skill_batch",
+                    "function": {
+                        "name": "skill_manage",
+                        "arguments": json.dumps(
+                            {
+                                "operations": [
+                                    {
+                                        "action": "create",
+                                        "name": "alpha",
+                                        "content": "A new skill body",
+                                    },
+                                    {
+                                        "action": "patch",
+                                        "name": "beta",
+                                        "old_string": "old text",
+                                        "new_string": "new text",
+                                    },
+                                    {
+                                        "action": "write_file",
+                                        "name": "alpha",
+                                        "file_path": "references/x.md",
+                                        "file_content": "data",
+                                    },
+                                ]
+                            }
+                        ),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_skill_batch",
+            "content": json.dumps(
+                {
+                    "success": True,
+                    "message": "batch(3 ops: create, patch, write_file) on alpha, beta",
+                }
+            ),
+        },
+    ]
+
+
+def test_skill_batch_renders_per_op_lines():
+    """Issue #102853: a batch skill_manage call must render per-op previews,
+    never the empty-action "Skill " line."""
+    verbose = summarize_background_review_actions(
+        _skill_batch_review(), [], notification_mode="verbose"
+    )
+    assert verbose, "expected at least one rendered line"
+    joined = "\n".join(verbose)
+    assert "Skill 'alpha' created" in joined
+    assert "Skill 'beta' patched" in joined
+    assert "Skill 'alpha' wrote file" in joined
+    assert not any(line == "Skill " or line.rstrip() == "Skill" for line in verbose), verbose
+    assert not any("Skill ?" in line for line in verbose), verbose
 
 
 def test_removed_or_replaced_relabels_by_target():


### PR DESCRIPTION
## Summary

Fix verbose self-improvement notifications for batch `skill_manage` calls. Batch calls carry `action`, `name`, and `file_path` inside `operations[]`, while the summary formatter only read top-level fields and therefore rendered the literal fallback `Skill ?`.

This ports and updates #102867 onto current `main`, where that PR is now conflicting after the `background_review.py` decomposition. The original author's commit authorship is preserved.

Fixes #102853.

## RED proof

On current `origin/main` (`9dd6634c56`), the production-shaped batch payload reproduced the screenshot:

```text
$ /root/.hermes/hermes-agent/venv/bin/python <reproduction>
['Skill ?']
AssertionError
```

After the fix, the same payload returns:

```text
["📝 Skill 'plfy-deployment' wrote file 'references/release.md'"]
```

The regression test covers `create`, `patch`, and `write_file` in one batch and rejects any `Skill ?` result.

## Code path trace

1. Symptom: Desktop shows `Self-improvement review — Skill ?` after a successful skill update.
2. Intermediate: `summarize_background_review_actions()` recognizes `skill_manage`, but `_verbose_skill_line()` receives the top-level defaults rather than each batch operation.
3. Root cause: `skill_manage(operations=[...])` stores action metadata per operation; `_collect_review_call_details()` retained the list but `_action_lines()` never iterated it, while `_CALL_DETAIL_DEFAULTS` supplied the user-visible `?`.

## Widening audit

- Batch skill `create`: affected → renders the skill name and action.
- Batch skill `patch`: affected → renders the existing old/new preview.
- Batch skill `write_file` / `remove_file`: affected → renders skill name and relative file path without leaking file content.
- Single-operation skill calls: existing behavior preserved; unknown metadata now falls back to `Skill updated`, never `Skill ?`.
- Batch memory operations: not affected; already iterate `operations[]` through `_verbose_memory_lines()`.
- Desktop/TUI/gateway surfaces: no separate fix needed; all consume the same backend review summary.

## Verification

```text
scripts/run_tests.sh tests/run_agent/test_background_review.py tests/run_agent/test_background_review_summary.py tests/test_background_review_list_shapes.py tests/test_background_review_session_isolation.py tests/run_agent/test_background_review_cache_parity.py tests/run_agent/test_background_review_cost_controls.py tests/run_agent/test_background_review_toolset_restriction.py tests/run_agent/test_review_prompt_class_first.py
64 passed, 0 failed

ruff check agent/background_review.py tests/run_agent/test_background_review_summary.py
All checks passed!

python -m py_compile agent/background_review.py tests/run_agent/test_background_review_summary.py
OK

git diff --check
OK
```
