### PR TITLE
stt: retry Windows mid-transcribe CUDA dlopen on CPU

### DIFF
--- a/tests/tools/test_stt_windows_cuda_fallback.py
+++ b/tests/tools/test_stt_windows_cuda_fallback.py
@@ -1,0 +1,158 @@
+"""Regression tests for #103793: Windows STT fails with
+"Library cublas64_12.dll is not found or cannot be loaded".
+
+Two gaps let a first-use CUDA dlopen failure kill local STT with no CPU retry:
+
+1. ``_CUDA_LIB_ERROR_MARKERS`` only listed POSIX library names (``libcublas``…).
+   Windows DLLs carry no ``lib`` prefix, so ``cublas64_12.dll`` matched only by
+   luck via the generic "cannot be loaded" phrasing.
+2. faster-whisper's ``model.transcribe()`` is LAZY: it returns a generator and
+   the decode — where the dlopen-on-first-use actually fires — happens while
+   iterating segments. The mid-transcribe CUDA retry only wrapped the
+   ``transcribe()`` call, so the error escaped the guard during iteration.
+"""
+
+from unittest.mock import MagicMock, patch
+from importlib.machinery import ModuleSpec
+import sys
+import types
+
+import pytest
+
+# Stub faster_whisper when absent (same pattern as tests/tools/test_transcription_tools.py):
+# patch("faster_whisper.WhisperModel", ...) needs an importable module, and CI
+# does not install the STT extra.
+if "faster_whisper" not in sys.modules:
+    faster_whisper_stub = types.ModuleType("faster_whisper")
+    faster_whisper_stub.WhisperModel = MagicMock(name="WhisperModel")
+    # find_spec() raises when __spec__ is None on a sys.modules stub.
+    faster_whisper_stub.__spec__ = ModuleSpec("faster_whisper", loader=None)
+    sys.modules["faster_whisper"] = faster_whisper_stub
+
+
+class _FakeInfo:
+    language = "en"
+    duration = 1.0
+
+
+class _Segments:
+    """Iterable whose iteration itself fails — mirrors faster-whisper's lazy decode."""
+
+    def __init__(self, exc):
+        self._exc = exc
+
+    def __iter__(self):
+        raise self._exc
+        yield  # pragma: no cover
+
+
+# ===========================================================================
+# Marker coverage: Windows DLL spellings must count as missing-CUDA-lib errors
+# ===========================================================================
+
+class TestWindowsCudaLibMarkers:
+    @pytest.mark.parametrize("message", [
+        "Library cublas64_12.dll is not found or cannot be loaded",
+        "Library cublasLt64_12.dll is not found or cannot be loaded",
+        "Library cudnn64_9.dll is not found or cannot be loaded",
+        "Library cudart64_12.dll is not found or cannot be loaded",
+    ])
+    def test_windows_dll_names_are_cuda_lib_errors(self, message):
+        from tools.transcription_local import _looks_like_cuda_lib_error
+        assert _looks_like_cuda_lib_error(RuntimeError(message)) is True
+
+    def test_posix_names_still_match(self):
+        from tools.transcription_local import _looks_like_cuda_lib_error
+        assert _looks_like_cuda_lib_error(
+            RuntimeError("libcublas.so.12: cannot open shared object file")) is True
+
+    def test_oom_still_not_a_missing_lib(self):
+        from tools.transcription_local import _looks_like_cuda_lib_error
+        assert _looks_like_cuda_lib_error(RuntimeError("CUDA out of memory")) is False
+
+
+# ===========================================================================
+# Mid-transcribe (iteration-time) dlopen failure retries on CPU
+# ===========================================================================
+
+class TestMidTranscribeDlopenFallback:
+    def test_iteration_time_cuda_dlopen_retries_on_cpu(self, tmp_path):
+        """The decode runs during segment ITERATION, not the transcribe() call:
+        a first-use cuBLAS load failure there must evict the cached model and
+        retry on CPU, not surface as a hard failure (#103793)."""
+        audio = tmp_path / "test.ogg"
+        audio.write_bytes(b"fake")
+
+        # First (CUDA) model: transcribe() succeeds, iteration raises the Windows
+        # dlopen error. CPU model: fully succeeds.
+        cuda_model = MagicMock()
+        cuda_model.transcribe.return_value = (
+            _Segments(RuntimeError("Library cublas64_12.dll is not found or cannot be loaded")),
+            _FakeInfo(),
+        )
+        cpu_model = MagicMock()
+        cpu_model.transcribe.return_value = (iter([]), _FakeInfo())
+
+        mock_cls = MagicMock(side_effect=[cuda_model, cpu_model])
+
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("faster_whisper.WhisperModel", mock_cls), \
+             patch("tools.transcription_tools._local_model", None), \
+             patch("tools.transcription_tools._local_model_name", None):
+            from tools.transcription_tools import _transcribe_local
+            result = _transcribe_local(str(audio), "base")
+
+        assert result["success"] is True, result.get("error")
+        # First load (CUDA) + CPU retry.
+        assert mock_cls.call_count == 2
+        # The retry must pin CPU + int8.
+        retry_kwargs = mock_cls.call_args_list[1].kwargs
+        assert retry_kwargs.get("device") == "cpu"
+        assert retry_kwargs.get("compute_type") == "int8"
+
+    def test_call_time_dlopen_still_retries_on_cpu(self, tmp_path):
+        """The pre-existing shape — transcribe() itself raising the dlopen error —
+        keeps working after the guard moves to cover iteration."""
+        audio = tmp_path / "test.ogg"
+        audio.write_bytes(b"fake")
+
+        cuda_model = MagicMock()
+        cuda_model.transcribe.side_effect = RuntimeError(
+            "libcublas.so.12: cannot open shared object file")
+        cpu_model = MagicMock()
+        cpu_model.transcribe.return_value = (iter([]), _FakeInfo())
+
+        mock_cls = MagicMock(side_effect=[cuda_model, cpu_model])
+
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("faster_whisper.WhisperModel", mock_cls), \
+             patch("tools.transcription_tools._local_model", None), \
+             patch("tools.transcription_tools._local_model_name", None):
+            from tools.transcription_tools import _transcribe_local
+            result = _transcribe_local(str(audio), "base")
+
+        assert result["success"] is True, result.get("error")
+        assert mock_cls.call_count == 2
+        assert mock_cls.call_args_list[1].kwargs.get("device") == "cpu"
+
+    def test_iteration_time_oom_surfaces_as_error(self, tmp_path):
+        """A real runtime failure during iteration must NOT trigger the CPU retry."""
+        audio = tmp_path / "test.ogg"
+        audio.write_bytes(b"fake")
+
+        cuda_model = MagicMock()
+        cuda_model.transcribe.return_value = (_Segments(RuntimeError("CUDA out of memory")), _FakeInfo())
+
+        mock_cls = MagicMock(return_value=cuda_model)
+
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("faster_whisper.WhisperModel", mock_cls), \
+             patch("tools.transcription_tools._local_model", None), \
+             patch("tools.transcription_tools._local_model_name", None):
+            from tools.transcription_tools import _transcribe_local
+            result = _transcribe_local(str(audio), "base")
+
+        assert result["success"] is False
+        assert "CUDA out of memory" in result["error"]
+        # No CPU retry for a non-missing-lib failure.
+        assert mock_cls.call_count == 1

--- a/tools/transcription_local.py
+++ b/tools/transcription_local.py
@@ -81,9 +81,12 @@ def _try_lazy_install_stt() -> bool:
 # Substrings identifying a missing/unloadable CUDA runtime library: the "auto" device
 # picker has already committed to CUDA, so we fall back to CPU and reload. Deliberately
 # narrow (library names + dlopen phrasing) so legitimate runtime failures like "CUDA
-# out of memory" surface to the user instead of silently running on CPU.
+# out of memory" surface to the user instead of silently running on CPU. Windows DLL
+# names carry no "lib" prefix (cublas64_12.dll, cudnn64_9.dll, cudart64_12.dll), so
+# both POSIX and Windows spellings are listed (#103793).
 _CUDA_LIB_ERROR_MARKERS = (
-    "libcublas", "libcudnn", "libcudart", "cannot be loaded", "cannot open shared object",
+    "libcublas", "libcudnn", "libcudart", "cublas64_", "cudnn64_", "cudart64_",
+    "cannot be loaded", "cannot open shared object",
     "no kernel image is available", "CUBLAS_STATUS_NOT_SUPPORTED", "no CUDA-capable device",
     "CUDA driver version is insufficient")
 

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -370,6 +370,12 @@ def _transcribe_local(
                                   if v})
         try:
             segments, info = model.transcribe(file_path, **transcribe_kwargs)
+            # faster-whisper's transcribe() is lazy: the decode (and with it the
+            # dlopen-on-first-use of the CUDA runtime on Windows) happens while
+            # ITERATING segments, after this call has already returned (#103793).
+            # Consume inside the guard so a first-use cuBLAS/cuDNN load failure
+            # retries on CPU exactly like a load-time failure does.
+            segments = list(segments)
         except Exception as exc:
             # CUDA libs can fail at dlopen-on-first-use, AFTER loading: evict the poisoned
             # cached model, reload on CPU and retry once, else every later message fails.
@@ -379,6 +385,7 @@ def _transcribe_local(
                            "evicting cached model and retrying on CPU (int8).", exc)
             model = _replace_cached_model_on_cpu(model_name)
             segments, info = model.transcribe(file_path, **transcribe_kwargs)
+            segments = list(segments)
         transcript = _join_confident_segments(segments, local_cfg)
         logger.info("Transcribed %s via local whisper (%s, lang=%s, %.1fs audio)",
                     Path(file_path).name, model_name, info.language, info.duration)


### PR DESCRIPTION
Fixes #103793

## Root cause

The suggested improvement in the issue ("catch mid-transcribe `dlopen` failures, not just load-time") is half-implemented on main — and the half that exists cannot catch the reported error:

**1. The markers don't know Windows DLL names.** `_CUDA_LIB_ERROR_MARKERS` (`tools/transcription_local.py`) listed only POSIX spellings (`libcublas`, `libcudnn`, `libcudart`). Windows DLLs carry no `lib` prefix — `cublas64_12.dll`, `cudnn64_9.dll`, `cudart64_12.dll` — so the reporter's exact message matched only via the generic `"cannot be loaded"` substring.

**2. The mid-transcribe retry guards a call that can't raise.** `_transcribe_local` (`tools/transcription_tools.py:371`) wraps `model.transcribe(...)` in a CUDA→CPU retry — but faster-whisper's `transcribe()` is **lazy**: it returns a `(segments, info)` generator pair immediately, and the actual decode — where dlopen-on-first-use of the CUDA runtime fires on Windows — happens while **iterating segments** at `_join_confident_segments`, outside the guard. That's why the reporter's log shows the error surfacing from the outer `Local transcription failed` handler with no retry attempted.

## Change

- `tools/transcription_local.py`: add `cublas64_`, `cudnn64_`, `cudart64_` (covers `cublasLt64_12.dll` too) to `_CUDA_LIB_ERROR_MARKERS`, with a comment noting both spellings.
- `tools/transcription_tools.py`: consume `segments = list(segments)` inside the existing guarded `try`, so a first-use cuBLAS/cuDNN load failure during iteration takes the same evict-cached-model → reload-CPU-int8 → retry-once path as a load-time failure. The retry line gets the same consumption.

Deliberately unchanged: `CUDA out of memory` and other real runtime failures still surface to the user (the markers stay narrow — library names + dlopen phrasing only).

## Tests

9 new cases in `tests/tools/test_stt_windows_cuda_fallback.py`:

- marker coverage: each Windows DLL message from the issue (`cublas64_12.dll`, `cublasLt64_12.dll`, `cudnn64_9.dll`, `cudart64_12.dll`) classified as a missing-lib error; POSIX names still match; `CUDA out of memory` still does **not**
- iteration-time dlopen failure (transcribe succeeds, segment iteration raises the reporter's exact message) → retries on CPU, pins `device="cpu"`/`compute_type="int8"`, succeeds
- call-time dlopen failure (the pre-existing shape) still retries after the guard moved
- iteration-time OOM → no CPU retry, hard error

## Verification

- `tests/tools/test_stt_windows_cuda_fallback.py`: 9/9 pass
- Full transcription suites (`test_transcription_tools.py`, `test_stt_cloud_trim.py`, `test_stt_silence_hallucinations.py`, `test_stt_idle_unload.py` + new file): 112 passed, 2 skipped, 1 failed
- The 1 failure (`test_stderr_progress_extends_beyond_timeout`) is a 0.1s idle-timeout subprocess race that fails on **unmodified main** on this Windows machine too — verified via stash/re-run — and is unrelated to this change.

Note for reviewers: the issue's Solutions A/B (installing CUDA wheels into the venv / pinning `device: cpu`) remain valid *user-side* workarounds; this PR only makes the auto-fallback work as #9088's design intended, so an unmodified Windows install degrades to CPU with one clear warning instead of hard-failing.