### PR TITLE
Fix gateway task continuity after compression and restart

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -787,10 +787,12 @@ def _synthetic_user_row(content: str) -> bool:
 
 def _build_verbatim_user_section(turns: List[Dict[str, Any]]) -> str:
     """Compacted region's REAL user messages verbatim, newest-first under a char budget (straddler truncated); "" if none."""
+    from agent.conversation_compression import _is_real_user_message
+
     collected: list[str] = []
     used = 0
     for msg in reversed(turns):
-        if msg.get("role") != "user":
+        if not _is_real_user_message(msg):
             continue
         content = _content_text_for_contains(msg.get("content"))
         if _synthetic_user_row(content):
@@ -3564,12 +3566,15 @@ Write only the summary body. Do not include any preamble or prefix."""
 
     @classmethod
     def _is_synthetic_compression_user_turn(cls, message: Any) -> bool:
-        """Recognize internal user-role rows by content marker (SessionDB drops metadata)."""
+        """Recognize operational rows by durable provenance, with markers for older transcripts."""
         if not isinstance(message, dict) or message.get("role") != "user":
             return False
-        if cls._is_context_summary_message(message):
+        if message.get("display_kind") or cls._is_context_summary_message(message):
             return True
         text = _content_text_for_contains(message.get("content")).strip()
+        from agent.replay_cleanup import is_auto_continue_noise, strip_auto_continue_noise
+        if is_auto_continue_noise(text) and not strip_auto_continue_noise(text):
+            return True
         # Recovery nudges are scaffolding, not human turns; lazy import avoids an import cycle.
         from agent.conversation_loop import (
             _CODEX_ACK_CONTINUATION_NUDGE, _CODEX_INCOMPLETE_NUDGE, _DROPPED_TOOLCALL_NUDGE_CONTENT,

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -4214,18 +4214,35 @@ Write only the summary body. Do not include any preamble or prefix."""
         if cut_idx <= head_end:
             cut_idx = max(fallback_cut, head_end + 1)
         cut_idx = self._align_boundary_backward(messages, cut_idx)
-        # Latest user message must stay in the tail (active task). Latest assistant reply must stay too;
-        # anchors only walk backward, so chaining is monotonic.
-        # Ensure the most recent user message is always in the tail so the active task is never lost to
-        # compression (fixes #10896).
-        cut_idx = self._ensure_last_user_message_in_tail(messages, cut_idx, head_end)
-        cut_idx = self._ensure_last_assistant_message_in_tail(messages, cut_idx, head_end)
+        # Completed exchanges and short tool runs keep the latest user and visible assistant reply verbatim.
+        # In a long unfinished tool loop those anchors retain the ENTIRE active turn, making every compression a
+        # no-op after a restart or prior handoff. The finalizer already re-appends the exact in-flight task after
+        # the summary; the ordinary token walk and tool-group alignment keep the newest working set structurally
+        # intact. Letting the cut cross only the older part of a long human turn makes sustained coding
+        # compressible without changing short-turn UI continuity or treating synthetic event rows as tasks.
+        inflight_task = self._find_inflight_user_task(messages)
+        inflight_task_idx = next(
+            (i for i, message in enumerate(messages) if message is inflight_task), -1
+        )
+        inflight_tool_rounds = sum(
+            1
+            for message in messages[inflight_task_idx + 1:]
+            if message.get("role") == "assistant" and message.get("tool_calls")
+        )
+        long_human_tool_loop = (
+            inflight_task_idx >= 0
+            and not _synthetic_user_row(_content_text_for_contains(inflight_task.get("content")))
+            and inflight_tool_rounds > _LEAN_TAIL_KEEP_TOOL_ROUNDS
+        )
+        if not long_human_tool_loop:
+            cut_idx = self._ensure_last_user_message_in_tail(messages, cut_idx, head_end)
+            cut_idx = self._ensure_last_assistant_message_in_tail(messages, cut_idx, head_end)
 
-        # Optional multi-user anchor; n<=1 is gated here (not delegated): re-running the single-user anchor after
-        # the assistant anchor could re-trigger its forward turn-pair push. getattr: __new__ doubles skip __init__.
-        _min_tail_users = getattr(self, "min_tail_user_messages", 1)
-        if isinstance(_min_tail_users, int) and not isinstance(_min_tail_users, bool) and _min_tail_users > 1:
-            cut_idx = self._ensure_last_n_user_messages_in_tail(messages, cut_idx, head_end, _min_tail_users)
+            # Optional multi-user anchor; n<=1 is gated here (not delegated): re-running the single-user anchor after
+            # the assistant anchor could re-trigger its forward turn-pair push. getattr: __new__ doubles skip __init__.
+            _min_tail_users = getattr(self, "min_tail_user_messages", 1)
+            if isinstance(_min_tail_users, int) and not isinstance(_min_tail_users, bool) and _min_tail_users > 1:
+                cut_idx = self._ensure_last_n_user_messages_in_tail(messages, cut_idx, head_end, _min_tail_users)
 
         # Floor guarantees progress (>= 1 message claimed); re-align FORWARD only so a raised cut
         # can't split a tool group (backward would give the floor's message back).

--- a/agent/replay_cleanup.py
+++ b/agent/replay_cleanup.py
@@ -15,6 +15,30 @@ from agent.turn_context import drop_stale_api_content
 
 logger = logging.getLogger(__name__)
 
+RESUME_RECOVERY_NOTE_PREFIX = "[System note: The previous turn was interrupted by"
+_AUTO_CONTINUE_NOTE_PREFIXES = (
+    "[System note: Your previous turn", "[System note: A new message", RESUME_RECOVERY_NOTE_PREFIX,
+)
+
+
+def is_auto_continue_noise(content: Any) -> bool:
+    """Recognize persisted gateway recovery wrappers across their historical wordings."""
+    return isinstance(content, str) and content.startswith(_AUTO_CONTINUE_NOTE_PREFIXES)
+
+
+def strip_auto_continue_noise(content: Any) -> Any:
+    """Remove replay-only recovery wrappers, retaining any trailing human request."""
+    if not is_auto_continue_noise(content):
+        return content
+    text = content
+    while is_auto_continue_noise(text):
+        end = text.find("]")
+        if end < 0:
+            return ""
+        text = text[end + 1:].lstrip()
+    return text
+
+
 # Orphan-recovery notices: (side-effecting, read-only) for an interrupted block vs a dangling tail.
 _INTERRUPTED_NOTICES = (
     "[Orphan recovery: interrupted side-effecting tool may have executed; its effect is UNKNOWN. Inspect state before retrying.]",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -977,16 +977,13 @@ def build_resume_recovery_note(
         else "a gateway shutdown" if reason == "shutdown_timeout" else "a gateway interruption")
     if message:
         resume_guidance = (
-            "Address the user's NEW message below FIRST and focus on what the user is asking now.")
+            "Address the user's NEW message below FIRST and focus on what the user is asking now. "
+            "If it explicitly asks to resume or finish the interrupted task, continue that task from "
+            "the next unfinished step using the recorded results. Status or reporting requests must report from "
+            "recorded history without resuming work. Otherwise do not revive unrelated unfinished work.")
         tail_guidance = (
-            "Do NOT re-execute old tool calls — skip any unfinished work from the conversation history."
-        )
-    elif interactive:
-        resume_guidance = (
-            "Report to the user that the session was restored "
-            "successfully and ask what they would like to do next.")
-        tail_guidance = (
-            "Do NOT re-execute old tool calls — skip any unfinished work from the conversation history."
+            "Do NOT repeat successful tool calls merely to recreate completed work. "
+            "A failed or incomplete result may require a retry after checking the cause and current state."
         )
     else:
         resume_guidance = (
@@ -995,13 +992,17 @@ def build_resume_recovery_note(
             "or ask questions. Review the conversation history and "
             "CONTINUE the interrupted task to completion.")
         tail_guidance = (
-            "Do NOT re-run tool calls whose results already "
-            "appear in the history — resume from the first step that has no recorded result.")
+            "Use recorded results to identify the next unfinished step; do NOT repeat successful calls "
+            "merely to recreate completed work. Retry failed or incomplete work only after checking "
+            "the cause and current state.")
     return (
-        f"[System note: The previous turn was interrupted by "
+        f"{RESUME_RECOVERY_NOTE_PREFIX} "
         f"{reason_phrase}; the gateway is now back online. "
-        f"Any restart/shutdown command in the history has already "
-        f"run — do NOT re-execute or verify it. {resume_guidance} {tail_guidance}]"
+        f"Do NOT repeat a restart/shutdown command simply because its response was interrupted. "
+        f"Use recorded tool results as evidence. If a tool's effect is UNKNOWN, inspect current state "
+        f"with read-only checks before deciding whether any unfinished action is still needed. "
+        f"Read-only verification of the running revision or task outcome is allowed when required "
+        f"by the active request. {resume_guidance} {tail_guidance}]"
         + (f"\n\n{message}" if message else ""))
 
 
@@ -1059,6 +1060,11 @@ def _build_replay_entry(
     providers.
     """
     entry: Dict[str, Any] = {"role": role, "content": content}
+    # Runtime notices remain runtime notices after a reload. Compaction uses this
+    # provenance to avoid turning a background/recovery event into the human task.
+    for key in ("display_kind", "display_metadata"):
+        if msg.get(key):
+            entry[key] = msg[key]
     # api_content sidecar keeps the request prefix byte-stable — ONLY if this pipeline did not rewrite content.
     _sidecar = msg.get("api_content")
     if (
@@ -1164,6 +1170,12 @@ def _build_gateway_agent_history(
             continue
 
         content = msg.get("content")
+        # Recognize runtime wrappers before timestamp decoration hides their prefix.
+        # Real follow-up text survives; standalone recovery instructions never replay.
+        if role == "user":
+            content = _strip_auto_continue_noise(content)
+            if not content:
+                continue
         if inject_timestamps and role == "user" and isinstance(content, str):
             content = _render_msg_ts(content, msg.get("timestamp"), tz=_msg_tz)
         if separate_observed_context and msg.get("observed") and role == "user" and content:
@@ -1175,11 +1187,6 @@ def _build_gateway_agent_history(
             clean_msg = {k: v for k, v in msg.items() if k not in {"timestamp", "observed"}}
             agent_history.append(clean_msg)
         elif content:
-            # Strip persisted auto-continue notes: keep the real user text, never replay the recovery note.
-            if role == "user":
-                content = _strip_auto_continue_noise(content)
-                if not content:
-                    continue
             if msg.get("mirror"):
                 mirror_src = msg.get("mirror_source", "another session")
                 content = f"[Delivered from {mirror_src}] {content}"
@@ -1273,30 +1280,11 @@ _AUTO_APPEND_MEDIA_TOOL_NAMES = {"text_to_speech", "text_to_speech_tool", "image
 
 # Replay-tail sanitization lives in agent/replay_cleanup.py so every resume surface shares one implementation.
 from agent.replay_cleanup import (  # noqa: E402
+    RESUME_RECOVERY_NOTE_PREFIX,
+    is_auto_continue_noise as _is_auto_continue_noise,
+    strip_auto_continue_noise as _strip_auto_continue_noise,
     strip_interrupted_tool_tails, strip_dangling_tool_call_tail, strip_stale_dangerous_confirmations)
 
-
-_AUTO_CONTINUE_NOTE_PREFIX = "[System note: Your previous turn"
-_AUTO_CONTINUE_FALLBACK_PREFIX = "[System note: A new message"
-
-
-def _is_auto_continue_noise(content: Any) -> bool:
-    """Return True if this user-message content is a gateway-injected auto-continue note (never replay it)."""
-    return isinstance(content, str) and content.startswith(
-        (_AUTO_CONTINUE_NOTE_PREFIX, _AUTO_CONTINUE_FALLBACK_PREFIX))
-
-
-def _strip_auto_continue_noise(content: Any) -> Any:
-    """Strip leading persisted auto-continue notes from user text; the trailing real question is preserved."""
-    if not _is_auto_continue_noise(content):
-        return content
-    text = str(content)
-    while _is_auto_continue_noise(text):
-        end = text.find("]")
-        if end < 0:
-            return ""
-        text = text[end + 1 :].lstrip()
-    return text
 
 # Tools whose deliverable is a JSON payload with a local-file path field rather than a literal ``MEDIA:`` tag.
 _JSON_MEDIA_TOOL_PATH_FIELDS = ("host_image", "image", "agent_visible_image")

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1344,11 +1344,15 @@ class TurnRunner:
         """
         from gateway.run import (
             _auto_continue_freshness_window, _is_fresh_gateway_interruption,
-            _last_transcript_timestamp, _prepare_resume_pending_message, build_resume_recovery_note,
+            _last_transcript_timestamp, _prepare_resume_pending_message,
         )
         ctx = self._ctx
         persist_override: Optional[Any] = ctx.persist_user_message
-        self._prepend_pending_note("_pending_model_notes")
+        blank_turn = ctx.message is None or (isinstance(ctx.message, str) and not ctx.message.strip())
+        # Native images can have no caption. Only an internal empty event is a
+        # synthesized continuation; an empty human caption remains new input.
+        synthetic_resume = blank_turn and ctx.persist_user_display_kind == "internal_notification"
+        recovery_input = not blank_turn or synthetic_resume
         # Auto-continue: history ending with a tool result means the previous turn was cut off
         # (restart, crash, SIGTERM). Session-level resume_pending (drain-timeout shutdown) uses
         # stronger reason-aware wording that subsumes this case. Both gate on the age of
@@ -1367,26 +1371,25 @@ class TurnRunner:
         mark_is_fresh = resume_pending and _is_fresh_gateway_interruption(
             getattr(entry, "last_resume_marked_at", None), window_secs=window,
         )
-        if resume_pending and (interruption_is_fresh or mark_is_fresh):
-            # Empty message = the startup auto-resume turn; there is no NEW user message.
+        if recovery_input and resume_pending and (interruption_is_fresh or mark_is_fresh):
             ctx.message, persist_override = _prepare_resume_pending_message(
                 resume_reason, ctx.message, interactive=self._resume_note_interactive(),
             )
-        elif agent_history and agent_history[-1].get("role") == "tool" and interruption_is_fresh:
-            persist_override = ctx.message
-            ctx.message = (
-                "[System note: A new message has arrived. The conversation "
-                "history contains pending tool outputs from an interrupted turn. "
-                "IGNORE those pending results. Address the user's NEW message "
-                "below FIRST. Do NOT re-execute old tool calls from the history.]\n\n"
-                + ctx.message
+        elif recovery_input and agent_history and agent_history[-1].get("role") == "tool" and interruption_is_fresh:
+            ctx.message, persist_override = _prepare_resume_pending_message(
+                None, ctx.message, interactive=self._resume_note_interactive(),
             )
-        self._prepend_pending_note("_pending_skills_reload_notes")
         # Safety net: a startup auto-resume event carries empty text; if the resume_pending branch
         # did not fire (freshness signals disagreed, marker cleared) we must NOT hand the model a blank
         # user turn. Restricted to resume_pending sessions so caption-less image turns are untouched.
-        if isinstance(ctx.message, str) and not ctx.message.strip() and resume_pending:
-            ctx.message = build_resume_recovery_note(resume_reason, "", interactive=self._resume_note_interactive())
+        if synthetic_resume and isinstance(ctx.message, str) and not ctx.message.strip() and resume_pending:
+            ctx.message, persist_override = _prepare_resume_pending_message(
+                resume_reason, "", interactive=self._resume_note_interactive(),
+            )
+        # Classify the human input before adding operational notices: a model
+        # switch must not turn an empty startup-resume event into a NEW request.
+        self._prepend_pending_note("_pending_model_notes")
+        self._prepend_pending_note("_pending_skills_reload_notes")
         return persist_override, ctx.persist_user_timestamp
 
     def _native_image_run_message(self):

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -42,59 +42,66 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # (HERMES_PYTHON is exported by the devShell hook and ships [dev] extras:
 # pytest, pytest-asyncio, pytest-timeout, ruff, ty).
 #
-# A candidate must have pytest INSTALLED, not merely exist. The release venv
-# at ~/.hermes/hermes-agent/venv has bin/activate but no pytest, so an
-# existence-only probe selected it in checkouts/worktrees without a local
-# .venv — every file then died with "No module named pytest" and the run
-# reported "0 tests passed" (which reads green at a glance even though the
-# exit code is 1). Skip such a venv and keep probing instead.
+# A candidate needs both test dependencies declared in the dev extra. A
+# release venv with pytest but no pytest-asyncio cannot collect or execute
+# async tests; skip it before compilation or test dispatch, just as we skip
+# an environment without pytest. Optional plugins are not required here.
+has_test_dependencies() {
+  local missing
+  if missing=$("$1" -c '
+import importlib
+import sys
+
+missing = []
+for module in ("pytest", "pytest_asyncio"):
+    try:
+        importlib.import_module(module)
+    except Exception:
+        missing.append(module)
+print(", ".join(missing))
+sys.exit(bool(missing))
+' 2>/dev/null); then
+    return 0
+  fi
+  echo "▶ skipping test interpreter $1: cannot import ${missing:-test dependencies}" >&2
+  return 1
+}
+
 VENV=""
 VENV_PYTHON=""
-SKIPPED_VENVS=""
 for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv"; do
   if [ -f "$candidate/bin/activate" ]; then
-    if "$candidate/bin/python" -c 'import pytest' 2>/dev/null; then
+    if has_test_dependencies "$candidate/bin/python"; then
       VENV="$candidate"
       VENV_PYTHON="$candidate/bin/python"
       break
     fi
-    SKIPPED_VENVS="$SKIPPED_VENVS $candidate"
   fi
   # Native Windows venv layout: python.exe and activate live under
   # Scripts/, and there is no bin/. Anyone running this script from
   # Git Bash / MSYS with a `python -m venv`- or uv-created venv hits
   # this branch — without it the canonical runner refuses to start.
   if [ -f "$candidate/Scripts/activate" ]; then
-    if "$candidate/Scripts/python.exe" -c 'import pytest' 2>/dev/null; then
+    if has_test_dependencies "$candidate/Scripts/python.exe"; then
       VENV="$candidate"
       VENV_PYTHON="$candidate/Scripts/python.exe"
       break
     fi
-    SKIPPED_VENVS="$SKIPPED_VENVS $candidate"
   fi
 done
-
-if [ -n "$SKIPPED_VENVS" ]; then
-  for skipped in $SKIPPED_VENVS; do
-    echo "▶ skipping venv without pytest: $skipped" >&2
-  done
-fi
 
 if [ -n "$VENV" ]; then
   PYTHON="$VENV_PYTHON"
 elif [ -n "${HERMES_PYTHON:-}" ] && [ -x "$HERMES_PYTHON" ] \
-    && "$HERMES_PYTHON" -c 'import pytest' 2>/dev/null; then
+    && has_test_dependencies "$HERMES_PYTHON"; then
   # Guard with an import check: HERMES_PYTHON may point at the RELEASE
-  # venv (no pytest) when inherited from a wrapped `hermes` binary rather
+  # venv (incomplete test dependencies) when inherited from a wrapped `hermes` binary rather
   # than the devShell hook.
   PYTHON="$HERMES_PYTHON"
   echo "▶ no local venv — using Nix dev venv via HERMES_PYTHON: $PYTHON"
 else
-  echo "error: no virtualenv with pytest found in $REPO_ROOT/.venv or $REPO_ROOT/venv," >&2
-  echo "       and HERMES_PYTHON is not a python with pytest (enter the Nix devShell or create a venv)" >&2
-  if [ -n "$SKIPPED_VENVS" ]; then
-    echo "       (skipped for missing pytest:$SKIPPED_VENVS — install dev extras there, or create $REPO_ROOT/.venv)" >&2
-  fi
+  echo "error: no interpreter with pytest and pytest_asyncio found in the local or release venvs," >&2
+  echo "       or via HERMES_PYTHON (install dev extras in a local venv or enter the Nix devShell)" >&2
   exit 1
 fi
 

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -998,6 +998,15 @@ def main() -> int:
         else:
             roots = [repo_root / p for p in _split_pathspec(args.paths)]
 
+    # Validate the whole requested selection before discovery, CI matrix
+    # generation, or execution. Silently dropping one mistyped path can make
+    # a partial verification run look complete when the remaining tests pass.
+    requested = files if args.files else roots
+    missing = [str(path) for path in requested if not path.exists()]
+    if missing:
+        parser.error("requested test path does not exist: " + ", ".join(missing))
+
+    if not args.files:
         if args.include_integration:
             # Caller takes responsibility — typically used via explicit -k filter.
             global _SKIP_PARTS  # noqa: PLW0603 — config knob

--- a/tests/agent/test_context_compressor_inflight_tail.py
+++ b/tests/agent/test_context_compressor_inflight_tail.py
@@ -1,0 +1,135 @@
+"""Behavioral coverage for compaction inside a long, unfinished tool loop."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from agent.context_compressor import (
+    COMPRESSED_SUMMARY_METADATA_KEY,
+    SUMMARY_PREFIX,
+    ContextCompressor,
+    _SUMMARY_END_MARKER,
+)
+
+
+TASK = "Implement the reservation-aware stock summary and verify it."
+
+
+def _compressor() -> ContextCompressor:
+    with patch(
+        "agent.context_compressor.get_model_context_length", return_value=100_000
+    ):
+        compressor = ContextCompressor(
+            model="test",
+            quiet_mode=True,
+            protect_first_n=3,
+            protect_last_n=2,
+        )
+    compressor.compression_count = 1
+    compressor.tail_token_budget = 500
+    return compressor
+
+
+def _tool_pairs(count: int) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for index in range(count):
+        call_id = f"call-{index}"
+        rows.extend(
+            [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": call_id,
+                            "function": {
+                                "name": "terminal",
+                                "arguments": '{"cmd":"read-only probe"}',
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": call_id,
+                    "content": ("synthetic output " * 200) + str(index),
+                },
+            ]
+        )
+    return rows
+
+
+def _resumed_inflight_transcript() -> list[dict[str, Any]]:
+    return [
+        {
+            "role": "user",
+            "content": SUMMARY_PREFIX + "\nEarlier work.\n" + _SUMMARY_END_MARKER,
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+        },
+        {"role": "assistant", "content": "Continuing."},
+        {"role": "user", "content": TASK},
+        *_tool_pairs(30),
+    ]
+
+
+def test_tail_cut_can_cross_inflight_user_after_a_prior_handoff():
+    compressor = _compressor()
+    messages = _resumed_inflight_transcript()
+    head_end = compressor._protect_head_size(messages)
+
+    cut = compressor._find_tail_cut_by_tokens(messages, head_end)
+
+    assert cut > 2, (
+        "the latest in-flight user turn anchored the entire tool loop, leaving "
+        "nothing useful for compression"
+    )
+    assert messages[cut]["role"] == "assistant"
+    assert messages[cut].get("tool_calls"), "the retained tool group must stay intact"
+
+
+def test_compress_rolls_up_old_inflight_steps_and_replays_exact_task():
+    compressor = _compressor()
+    messages = _resumed_inflight_transcript()
+    summary = SUMMARY_PREFIX + "\n## Summary\nEarlier synthetic steps completed."
+
+    with patch.object(compressor, "_generate_summary", return_value=summary):
+        result = compressor.compress(messages, current_tokens=30_000, force=True)
+
+    assert len(result) < len(messages) // 2
+    handoff_index = next(
+        index
+        for index, message in enumerate(result)
+        if message.get(COMPRESSED_SUMMARY_METADATA_KEY)
+    )
+    after_handoff = result[handoff_index:]
+    assert any(
+        TASK in str(message.get("content")) for message in after_handoff
+    ), "the exact unfinished task must remain actionable after the handoff"
+
+    retained_calls = {
+        call["id"]
+        for message in result
+        for call in message.get("tool_calls", [])
+    }
+    retained_results = {
+        str(message.get("tool_call_id"))
+        for message in result
+        if message.get("role") == "tool"
+    }
+    assert retained_calls == retained_results
+    assert "call-29" in retained_calls
+
+
+def test_completed_turn_keeps_the_existing_user_anchor():
+    compressor = _compressor()
+    messages = [
+        *_resumed_inflight_transcript(),
+        {"role": "assistant", "content": "Completed and verified."},
+    ]
+    head_end = compressor._protect_head_size(messages)
+
+    cut = compressor._find_tail_cut_by_tokens(messages, head_end)
+
+    assert cut <= 2
+    assert TASK in [str(message.get("content")) for message in messages[cut:]]

--- a/tests/agent/test_context_compressor_zero_user_provenance.py
+++ b/tests/agent/test_context_compressor_zero_user_provenance.py
@@ -238,6 +238,70 @@ def test_real_task_wins_over_trailing_max_iterations_nudge(compressor):
     assert messages[idx]["content"] == human["content"]
 
 
+@pytest.mark.parametrize("display_kind", ["internal_notification", None])
+def test_restart_notification_cannot_replace_persisted_human_task(tmp_path, display_kind):
+    """A restart followed by compaction must retain the job, not promote its recovery notice."""
+    human = "Fix the parser and verify the malformed-input regression."
+    notification = (
+        "[System note: The previous turn was interrupted by a gateway shutdown; "
+        "the gateway is now back online. CONTINUE the interrupted task to completion.]"
+    )
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("restart-provenance", source="telegram", model="test/model")
+        db.append_message("restart-provenance", "user", human)
+        db.append_message("restart-provenance", "assistant", "Inspecting the parser.", tool_calls=[
+            {"id": "inspect-parser", "type": "function", "function": {
+                "name": "read_file", "arguments": '{"path":"parser.py"}'}}
+        ])
+        db.append_message("restart-provenance", "tool", "Parser contents inspected.",
+                          tool_call_id="inspect-parser", tool_name="read_file")
+        db.append_message("restart-provenance", "user", notification, display_kind=display_kind)
+        replayed = db.get_messages_as_conversation("restart-provenance")
+
+        snapshot = ContextCompressor._latest_user_task_snapshot(replayed)
+        assert human in snapshot
+        assert notification not in snapshot
+        assert not ContextCompressor._transcript_has_real_user_turn([replayed[-1]])
+        assert ContextCompressor._find_inflight_user_task(replayed)["content"] == human
+        from agent.context_compressor import _build_verbatim_user_section
+        user_section = _build_verbatim_user_section(replayed)
+        assert human in user_section
+        assert notification not in user_section
+    finally:
+        db.close()
+
+
+def test_internal_notifications_do_not_hide_a_later_human_change_of_task():
+    """Operational wording may vary; durable provenance wins, but a new human instruction still wins."""
+    messages = [
+        {"role": "user", "content": "Implement the parser change."},
+        {"role": "assistant", "content": "Working.", "tool_calls": [
+            {"id": "inspect", "function": {"name": "read_file", "arguments": "{}"}}
+        ]},
+        {"role": "tool", "tool_call_id": "inspect", "content": "Inspection complete."},
+        {"role": "user", "content": "Background reviewer is available.",
+         "display_kind": "internal_notification", "display_metadata": {"reason": "review_complete"}},
+    ]
+    assert "Implement the parser change." in ContextCompressor._latest_user_task_snapshot(messages)
+    assert not ContextCompressor._transcript_has_real_user_turn([messages[-1]])
+    new_request = {"role": "user", "content": "Stop implementing. Report the findings only."}
+    messages.append(new_request)
+    assert new_request["content"] in ContextCompressor._latest_user_task_snapshot(messages)
+    assert ContextCompressor._find_inflight_user_task(messages) == new_request
+
+
+def test_captionless_human_image_preserves_user_provenance():
+    """An image is human input even when it supplies no text for a verbatim excerpt."""
+    image = {"role": "user", "content": [
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,dGVzdA=="}}
+    ]}
+    notice = {"role": "user", "content": "Gateway restarted.",
+              "display_kind": "internal_notification"}
+    assert ContextCompressor._transcript_has_real_user_turn([image, notice])
+    assert not ContextCompressor._transcript_has_real_user_turn([notice])
+
+
 @pytest.mark.parametrize(
     "event",
     [
@@ -445,8 +509,6 @@ def test_compress_context_todo_snapshot_stays_synthetic_across_two_boundaries(
     assert "Second boundary" in handoff["content"]
     assert "User asked:" not in handoff["content"]
     db.close()
-
-
 
 
 

--- a/tests/gateway/test_auto_continue.py
+++ b/tests/gateway/test_auto_continue.py
@@ -8,22 +8,18 @@ does not re-execute stale interrupted tool calls before addressing new input.
 
 
 def _simulate_auto_continue(agent_history: list, user_message: str) -> str:
-    """Reproduce the auto-continue injection logic from _run_agent().
+    """Exercise production recovery without starting a gateway or a model."""
+    from types import SimpleNamespace
+    from gateway.run_turn_runner import TurnRunner
+    from gateway.turn_context import TurnContext
 
-    This mirrors the exact code in gateway/run.py so we can test the
-    detection and message transformation without spinning up a full
-    gateway runner.
-    """
-    message = user_message
-    if agent_history and agent_history[-1].get("role") == "tool":
-        message = (
-            "[System note: A new message has arrived. The conversation "
-            "history contains pending tool outputs from an interrupted turn. "
-            "IGNORE those pending results. Address the user's NEW message "
-            "below FIRST. Do NOT re-execute old tool calls from the history.]\n\n"
-            + message
-        )
-    return message
+    runner = SimpleNamespace(
+        session_store=SimpleNamespace(_entries={}),
+        _adapter_for_source=lambda source: None,
+    )
+    ctx = TurnContext(message=user_message, history=agent_history, session_key="fixture")
+    TurnRunner(runner, ctx)._prepare_turn_message(agent_history)
+    return ctx.message
 
 
 class TestAutoDetection:
@@ -41,7 +37,8 @@ class TestAutoDetection:
         assert "[System note:" in result
         assert "interrupted" in result
         assert "NEW message" in result
-        assert "Do NOT re-execute" in result
+        assert "Do NOT repeat successful tool calls" in result
+        assert "failed or incomplete result may require a retry after checking" in result
         assert "what happened?" in result
 
 

--- a/tests/gateway/test_recovery_context_continuity.py
+++ b/tests/gateway/test_recovery_context_continuity.py
@@ -1,0 +1,167 @@
+"""Recovery scaffolding must not replace the human task on replay or compaction."""
+
+from copy import deepcopy
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+import time
+
+import pytest
+
+from agent.context_compressor import ContextCompressor
+from gateway.run import _build_gateway_agent_history, build_resume_recovery_note
+from gateway.run_turn_runner import TurnRunner
+from gateway.turn_context import TurnContext
+
+
+@pytest.mark.parametrize("reason", ["restart_timeout", "shutdown_timeout", "restart_interrupted"])
+@pytest.mark.parametrize("timestamps", [False, True])
+def test_restart_replay_keeps_human_task_as_compaction_anchor(reason, timestamps):
+    task = "Implement the parser fix and validate its output."
+    history = [
+        {"role": "user", "content": task},
+        {"role": "assistant", "content": "Implementation is underway."},
+        {"role": "user", "content": build_resume_recovery_note(reason), "timestamp": time.time()},
+        {"role": "assistant", "content": "Continuing validation."},
+    ]
+    original = deepcopy(history)
+
+    replay, _ = _build_gateway_agent_history(history, inject_timestamps=timestamps)
+    snapshot = ContextCompressor._latest_user_task_snapshot(replay)
+
+    assert snapshot is not None and task in snapshot
+    assert "gateway is now back online" not in snapshot
+    assert history == original  # Clean the API replay, never the durable transcript.
+
+
+def test_replay_strips_stacked_recovery_notes_but_keeps_real_followup():
+    task = "Stop implementation; report what changed."
+    wrapped = build_resume_recovery_note(
+        "restart_timeout", build_resume_recovery_note("shutdown_timeout", task)
+    )
+    replay, _ = _build_gateway_agent_history([
+        {"role": "user", "content": wrapped, "api_content": wrapped + "\nold context"},
+    ])
+
+    assert replay == [{"role": "user", "content": task}]
+
+
+def test_replay_preserves_notification_provenance_before_compaction():
+    task = "Finish the parser fix."
+    notice = {
+        "role": "user", "content": "Background validation completed.",
+        "display_kind": "internal_notification",
+        "display_metadata": {"process_id": "fixture-process"},
+    }
+    replay, _ = _build_gateway_agent_history([
+        {"role": "user", "content": task}, notice,
+    ])
+
+    assert replay[-1] == notice
+    assert ContextCompressor._find_inflight_user_task(replay)["content"] == task
+
+
+@pytest.mark.parametrize("message", [
+    "Continue the interrupted work.",
+    "Stop; do not make further changes.",
+    "What has finished? Report only.",
+    "Start a new task: explain the parser API.",
+])
+def test_tool_tail_recovery_uses_same_policy_and_evidence_as_marked_restart(message):
+    history = [
+        {"role": "user", "content": "Implement and validate the parser."},
+        {"role": "assistant", "tool_calls": [{
+            "id": "verified", "function": {"name": "terminal", "arguments": "{}"},
+        }]},
+        {"role": "tool", "tool_call_id": "verified", "content": "Validation passed.",
+         "timestamp": time.time()},
+    ]
+    replay, _ = _build_gateway_agent_history(history)
+    runner = SimpleNamespace(
+        session_store=SimpleNamespace(_entries={}),
+        _adapter_for_source=lambda source: None,
+    )
+    ctx = TurnContext(message=message, history=history, session_key="fixture")
+    persist, _ = TurnRunner(runner, ctx)._prepare_turn_message(replay)
+
+    assert persist == message
+    assert ctx.message == build_resume_recovery_note(None, message)
+    assert "IGNORE those pending results" not in ctx.message
+    assert replay[-1]["content"] == "Validation passed."
+
+
+def test_restart_recovery_allows_verification_without_repeating_side_effects():
+    note = build_resume_recovery_note("restart_timeout", "Verify the deployed revision.")
+
+    assert "do NOT re-execute or verify it" not in note
+    assert "read-only" in note
+    assert "UNKNOWN" in note
+
+
+@pytest.mark.parametrize("age_seconds", [0, 7200])
+def test_pending_model_notice_does_not_turn_auto_resume_into_a_new_human_request(age_seconds):
+    now = datetime.now() - timedelta(seconds=age_seconds)
+    runner = SimpleNamespace(
+        session_store=SimpleNamespace(_entries={"fixture": SimpleNamespace(
+            resume_pending=True, resume_reason="restart_timeout", last_resume_marked_at=now,
+        )}),
+        _pending_model_notes={"fixture": "[The model changed.]"},
+        _adapter_for_source=lambda source: None,
+    )
+    history = [{"role": "assistant", "content": "Working.", "timestamp": time.time() - age_seconds}]
+    ctx = TurnContext(
+        message="", history=history, session_key="fixture", persist_user_display_kind="internal_notification",
+    )
+    persist, _ = TurnRunner(runner, ctx)._prepare_turn_message([])
+
+    assert "CONTINUE the interrupted task" in ctx.message
+    assert "NEW message below" not in ctx.message
+    assert "[The model changed.]" in ctx.message
+    assert persist == build_resume_recovery_note("restart_timeout")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("resume_pending", [False, True])
+async def test_captionless_image_after_interruption_remains_new_input(tmp_path, resume_pending):
+    """Native preprocessing keeps an empty caption; recovery must still honor the image."""
+    import base64
+    from gateway.config import Platform
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+
+    image = tmp_path / "fixture.png"
+    image.write_bytes(base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jF9kAAAAASUVORK5CYII="
+    ))
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="fixture", user_id="fixture")
+    event = MessageEvent(
+        text="", source=source, message_type=MessageType.PHOTO,
+        media_urls=[str(image)], media_types=["image/png"],
+    )
+    state = SimpleNamespace(persistent=SimpleNamespace(native_image_paths=[]))
+    entry = SimpleNamespace(
+        resume_pending=resume_pending, resume_reason="restart_timeout", last_resume_marked_at=datetime.now(),
+    )
+    runner = SimpleNamespace(
+        session_store=SimpleNamespace(_entries={"fixture": entry}),
+        _adapter_for_source=lambda source: None,
+        _session_state=lambda key: state,
+        _decide_image_input_mode=lambda **kwargs: "native",
+        _consume_pending_native_image_paths=lambda key: state.persistent.native_image_paths,
+    )
+    caption = await GatewayRunner._enrich_inbound_images(runner, source, "fixture", event.text, event.media_urls)
+    history = [{"role": "tool", "content": "Earlier validation completed.", "timestamp": time.time()}]
+    ctx = TurnContext(
+        message=caption, history=history, session_key="fixture",
+        persist_user_display_kind="internal_notification" if event.internal else None,
+    )
+    turn = TurnRunner(runner, ctx)
+    persist, _ = turn._prepare_turn_message(history)
+    api_message = turn._native_image_run_message()
+
+    assert caption == "" and ctx.message == ""
+    assert persist is None  # Do not persist operational guidance as the human's caption.
+    assert any(part["type"] == "image_url" for part in api_message)
+    text = "\n".join(part.get("text", "") for part in api_message)
+    assert "No new user message" not in text
+    assert "CONTINUE the interrupted task" not in text

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -82,28 +82,9 @@ def _make_store(tmp_path):
 
 
 def _build_agent_history(history: list) -> list:
-    """Mirror gateway/run.py's ``history → agent_history`` conversion.
-
-    This is the transformation that strips ``timestamp`` off tool/tool_call
-    rows before the agent sees them.  Tests that check the freshness gate
-    must go through this conversion so they exercise the *real* data the
-    note-injection code sees.
-    """
-    agent_history: list = []
-    for msg in history:
-        role = msg.get("role")
-        if not role or role in {"session_meta", "system"}:
-            continue
-        has_tool_calls = "tool_calls" in msg
-        has_tool_call_id = "tool_call_id" in msg
-        is_tool_message = role == "tool"
-        if has_tool_calls or has_tool_call_id or is_tool_message:
-            agent_history.append({k: v for k, v in msg.items() if k != "timestamp"})
-        else:
-            content = msg.get("content")
-            if content:
-                agent_history.append({"role": role, "content": content})
-    return agent_history
+    """Exercise the production replay filtering used before recovery."""
+    from gateway.run import _build_gateway_agent_history
+    return _build_gateway_agent_history(history)[0]
 
 
 def _simulate_note_injection(
@@ -114,69 +95,27 @@ def _simulate_note_injection(
     agent_history: list | None = None,
     window_secs: float | None = None,
 ) -> str:
-    """Mirror the note-injection logic in gateway/run.py _run_agent().
+    """Call the real turn preparation with a controlled session and freshness window."""
+    from types import SimpleNamespace
+    from gateway.run_turn_runner import TurnRunner
+    from gateway.turn_context import TurnContext
 
-    The freshness signal reads ``history[-1].timestamp`` (the raw transcript
-    row), NOT ``agent_history[-1].timestamp`` (which has been stripped).
-    Tests pass the raw ``history`` — ``agent_history`` is derived from it
-    via the real conversion if not supplied explicitly.
-    """
     if agent_history is None:
         agent_history = _build_agent_history(history)
-
-    window = (
-        float(window_secs)
-        if window_secs is not None
-        else _auto_continue_freshness_window()
+    key = resume_entry.session_key if resume_entry else "fixture"
+    entries = {key: resume_entry} if resume_entry else {}
+    runner = SimpleNamespace(
+        session_store=SimpleNamespace(_entries=entries),
+        _adapter_for_source=lambda source: None,
     )
-    interruption_is_fresh = _is_fresh_gateway_interruption(
-        _last_transcript_timestamp(history),
-        window_secs=window,
+    ctx = TurnContext(
+        message=user_message, history=history, session_key=key,
+        persist_user_display_kind="internal_notification" if not user_message.strip() and resume_entry else None,
     )
-
-    message = user_message
-    resume_mark_is_fresh = False
-    if resume_entry is not None and getattr(resume_entry, "resume_pending", False):
-        resume_mark_is_fresh = _is_fresh_gateway_interruption(
-            getattr(resume_entry, "last_resume_marked_at", None),
-            window_secs=window,
-        )
-    is_resume_pending = bool(
-        resume_entry is not None
-        and getattr(resume_entry, "resume_pending", False)
-        and (interruption_is_fresh or resume_mark_is_fresh)
-    )
-    has_fresh_tool_tail = bool(
-        agent_history
-        and agent_history[-1].get("role") == "tool"
-        and interruption_is_fresh
-    )
-
-    if is_resume_pending:
-        reason = getattr(resume_entry, "resume_reason", None) or "restart_timeout"
-        # Real production note builder — extracted to module scope in
-        # gateway/run.py so tests exercise the actual strings.
-        message = build_resume_recovery_note(reason, message)
-    elif has_fresh_tool_tail:
-        message = (
-            "[System note: A new message has arrived. The conversation "
-            "history contains pending tool outputs from an interrupted turn. "
-            "IGNORE those pending results. Address the user's NEW message "
-            "below FIRST. Do NOT re-execute old tool calls from the history.]\n\n"
-            + message
-        )
-
-    # Empty-turn safety net: mirrors gateway/run.py — a blank
-    # auto-resume turn on a resume_pending session must never reach the model.
-    if (
-        isinstance(message, str)
-        and not message.strip()
-        and resume_entry is not None
-        and getattr(resume_entry, "resume_pending", False)
-    ):
-        sn_reason = getattr(resume_entry, "resume_reason", None) or "restart_timeout"
-        message = build_resume_recovery_note(sn_reason, "")
-    return message
+    window = float(window_secs) if window_secs is not None else _auto_continue_freshness_window()
+    with patch("gateway.run._auto_continue_freshness_window", return_value=window):
+        TurnRunner(runner, ctx)._prepare_turn_message(agent_history)
+    return ctx.message
 
 
 # ---------------------------------------------------------------------------
@@ -312,7 +251,8 @@ class TestResumePendingSystemNote:
         # Must not tell the model to skip the unfinished work it should finish.
         assert "skip any unfinished work" not in note
         # But still guards against re-running already-recorded tool calls.
-        assert "already appear in the history" in note
+        assert "do NOT repeat successful calls" in note
+        assert "Retry failed or incomplete work only after checking" in note
 
 
     def test_resume_note_is_persisted_instead_of_original_empty_message(self):
@@ -366,7 +306,7 @@ class TestResumePendingSystemNote:
 
 
     def test_no_resume_pending_preserves_tool_tail_note(self):
-        """Regression: the old PR #9934 tool-tail behaviour is unchanged."""
+        """Tool-tail recovery follows the same evidence-preserving policy without a marker."""
         history = [
             {"role": "assistant", "content": None, "tool_calls": [
                 {"id": "c1", "function": {"name": "x", "arguments": "{}"}},
@@ -376,8 +316,9 @@ class TestResumePendingSystemNote:
         ]
         result = _simulate_note_injection(history, "ping", resume_entry=None)
         assert "[System note:" in result
-        assert "pending tool outputs" in result
-        assert "Do NOT re-execute" in result
+        assert "Use recorded tool results as evidence" in result
+        assert "Do NOT repeat successful tool calls" in result
+        assert "failed or incomplete result may require a retry after checking" in result
 
     def test_stale_resume_pending_does_not_inject_restart_note(self):
         """Old restart markers must not revive an unrelated stale task.
@@ -491,8 +432,9 @@ class TestResumePendingSystemNote:
             history, "ping", resume_entry=None, window_secs=0,
         )
         assert "[System note:" in result
-        assert "pending tool outputs" in result
-        assert "Do NOT re-execute" in result
+        assert "Use recorded tool results as evidence" in result
+        assert "Do NOT repeat successful tool calls" in result
+        assert "failed or incomplete result may require a retry after checking" in result
 
     def test_legacy_history_without_timestamps_still_injects(self):
         """Transcripts predating timestamp persistence must keep the old
@@ -505,8 +447,9 @@ class TestResumePendingSystemNote:
         ]
         result = _simulate_note_injection(history, "ping", resume_entry=None)
         assert "[System note:" in result
-        assert "pending tool outputs" in result
-        assert "Do NOT re-execute" in result
+        assert "Use recorded tool results as evidence" in result
+        assert "Do NOT repeat successful tool calls" in result
+        assert "failed or incomplete result may require a retry after checking" in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_run_tests_interpreter.py
+++ b/tests/test_run_tests_interpreter.py
@@ -1,0 +1,129 @@
+"""The canonical runner must reject environments unable to run async tests."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt" or shutil.which("bash") is None,
+    reason="Controlled interpreter fixtures require POSIX executable scripts and bash",
+)
+
+
+@pytest.fixture
+def runner_tree(tmp_path):
+    repo = tmp_path / "checkout"
+    scripts = repo / "scripts"
+    scripts.mkdir(parents=True)
+    shutil.copyfile(
+        Path(__file__).resolve().parents[1] / "scripts" / "run_tests.sh",
+        scripts / "run_tests.sh",
+    )
+    home = tmp_path / "home"
+    home.mkdir()
+    commands = tmp_path / "commands"
+    commands.mkdir()
+    git = commands / "git"
+    git.write_text("#!/bin/sh\nexit 0\n")
+    git.chmod(0o755)
+    return repo, home, commands
+
+
+def _interpreter(venv: Path, *, complete: bool, layout: str = "bin") -> Path:
+    """Execute real import probes with isolated stub packages, never host packages."""
+    binaries = venv / layout
+    binaries.mkdir(parents=True)
+    (binaries / "activate").touch()
+    modules = venv / "modules"
+    modules.mkdir()
+    (modules / "pytest.py").touch()
+    if complete:
+        (modules / "pytest_asyncio.py").touch()
+    python = binaries / ("python.exe" if layout == "Scripts" else "python")
+    python.write_text(
+        f"#!{sys.executable}\n"
+        "import os, subprocess, sys\n"
+        "if sys.argv[1:2] == ['-c']:\n"
+        f"    env = dict(os.environ, PYTHONPATH={str(modules)!r})\n"
+        "    raise SystemExit(subprocess.call([sys.executable, '-S', *sys.argv[1:]], env=env))\n"
+        f"print('SELECTED:' + {json.dumps(str(python))} + ':' + ' '.join(sys.argv[1:]))\n"
+    )
+    python.chmod(0o755)
+    return python
+
+
+def _run(tree, *, explicit_python: Path | None = None):
+    repo, home, commands = tree
+    env = {
+        "HOME": str(home),
+        "PATH": str(commands) + os.pathsep + os.defpath,
+    }
+    if explicit_python is not None:
+        env["HERMES_PYTHON"] = str(explicit_python)
+    return subprocess.run(
+        ["bash", str(repo / "scripts" / "run_tests.sh"), "tests/test_example.py"],
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=15,
+    )
+
+
+@pytest.mark.parametrize("layout", ["bin", "Scripts"])
+def test_incomplete_local_venv_does_not_hide_usable_test_environment(runner_tree, layout):
+    repo, _, _ = runner_tree
+    rejected = _interpreter(repo / ".venv", complete=False, layout=layout)
+    selected = _interpreter(repo / "venv", complete=True, layout=layout)
+
+    result = _run(runner_tree)
+
+    assert result.returncode == 0, result.stderr
+    assert f"SELECTED:{selected}:" in result.stdout
+    assert f"SELECTED:{rejected}:" not in result.stdout
+    assert "run_tests_parallel.py tests/test_example.py" in result.stdout
+    assert "pytest_asyncio" in result.stderr
+
+
+def test_incomplete_release_venv_falls_back_to_explicit_dev_interpreter(runner_tree):
+    repo, home, _ = runner_tree
+    rejected = _interpreter(home / ".hermes" / "hermes-agent" / "venv", complete=False)
+    selected = _interpreter(repo / "external-dev", complete=True)
+
+    result = _run(runner_tree, explicit_python=selected)
+
+    assert result.returncode == 0, result.stderr
+    assert f"SELECTED:{selected}:" in result.stdout
+    assert f"SELECTED:{rejected}:" not in result.stdout
+    assert "pytest_asyncio" in result.stderr
+
+
+def test_missing_async_plugin_fails_before_compilation_or_test_dispatch(runner_tree):
+    repo, home, _ = runner_tree
+    _interpreter(home / ".hermes" / "hermes-agent" / "venv", complete=False)
+    explicit = _interpreter(repo / "external-dev", complete=False)
+
+    result = _run(runner_tree, explicit_python=explicit)
+
+    assert result.returncode != 0
+    assert "SELECTED:" not in result.stdout
+    assert "pytest_asyncio" in result.stderr
+
+
+def test_complete_local_environment_needs_no_optional_test_plugins(runner_tree):
+    repo, home, _ = runner_tree
+    selected = _interpreter(repo / ".venv", complete=True)
+    unused = _interpreter(home / ".hermes" / "hermes-agent" / "venv", complete=True)
+
+    result = _run(runner_tree)
+
+    assert result.returncode == 0, result.stderr
+    assert f"SELECTED:{selected}:" in result.stdout
+    assert f"SELECTED:{unused}:" not in result.stdout

--- a/tests/test_run_tests_paths.py
+++ b/tests/test_run_tests_paths.py
@@ -1,0 +1,48 @@
+"""Explicit test inputs must never disappear from an apparently passing run."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize("input_mode", ["positional", "--paths", "--files"])
+@pytest.mark.parametrize("generate_slices", [False, True])
+def test_missing_input_rejects_entire_run_before_any_tests_start(
+    tmp_path, input_mode, generate_slices
+):
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    runner = scripts / "run_tests_parallel.py"
+    shutil.copyfile(
+        Path(__file__).resolve().parents[1] / "scripts" / runner.name, runner
+    )
+    marker = tmp_path / "test-was-run"
+    valid = tmp_path / "test_valid.py"
+    valid.write_text(
+        "from pathlib import Path\n"
+        f"def test_passes():\n    Path({str(marker)!r}).touch()\n"
+    )
+    missing = tmp_path / "test_mistyped.py"
+    paths = [str(valid), str(missing)]
+    selection = paths if input_mode == "positional" else [input_mode, os.pathsep.join(paths)]
+    args = ["--generate-slices", "1"] if generate_slices else ["-j", "1", "-q"]
+
+    result = subprocess.run(
+        [sys.executable, str(runner), *selection, *args],
+        cwd=tmp_path,
+        capture_output=True,
+        encoding="utf-8",
+        timeout=30,
+    )
+
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert str(missing) in result.stderr
+    assert "does not exist" in result.stderr
+    assert not marker.exists(), "A partial selection must not execute before input validation"
+    assert '"slice":' not in result.stdout, "CI must not publish an incomplete test matrix"


### PR DESCRIPTION
Gateway recovery could replace the user's persisted coding request with a terse synthetic continuation message after compression or restart. That made resumed work drift, repeat discovery, or stop because paths and acceptance criteria were no longer present.

This change reconstructs the latest human task context from persisted messages, carries it through replay cleanup and auto-continue, and keeps the recovery envelope as metadata instead of treating it as the task. Long unfinished human tool loops can now compact their older steps while retaining the newest six tool rounds and replaying the exact task after the handoff; this prevents the user and assistant anchors from making post-restart compression a no-op. It also makes the repository test launchers fail clearly when the selected interpreter lacks pytest and validates requested test paths before spawning workers.

Validation:

- 676 compression and compaction tests passed, including new long in-flight loop behavior coverage
- 90 focused recovery, gateway, and test-runner tests passed
- `git diff --check` passed
- A fresh-process synthetic coding canary resumed after compression and interruption without the task being restated, completed the implementation, and passed an independent holdout
