### PR TITLE
fix(agent): a JSON-object tool result is judged by its top-level shape, not by a substring scan

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -924,6 +924,10 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
         err = data.get("error") or data.get("message")
         if err and (failed or "error" in data):
             return True, f" [{_trim_error(str(err))}]"
+        # A JSON object is judged by its top-level shape only. An ``error`` key nested
+        # inside a success payload is data the tool read (a page's own validation
+        # message inside browser_cdp's ``result``), not a failure of the call.
+        return False, ""
     # Multimodal results (dicts) are successes; failures arrive as JSON-encoded strings.
     if isinstance(result, str) and (
         '"error"' in result[:500].lower() or '"failed"' in result[:500].lower() or result.startswith("Error")

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -214,10 +214,15 @@ def classify_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str
         exit_code = data.get("exit_code") if isinstance(data, dict) else None
         return (True, f" [exit {exit_code}]") if exit_code is not None and exit_code != 0 else (False, "")
 
-    if tool_name == "memory":
-        data = safe_json_loads(result)
-        if isinstance(data, dict) and data.get("success") is False and "exceed the limit" in data.get("error", ""):
+    data = safe_json_loads(result)
+    if isinstance(data, dict):
+        failed = data.get("success") is False
+        if tool_name == "memory" and failed and "exceed the limit" in data.get("error", ""):
             return True, " [full]"
+        # Same rule as _detect_tool_failure: a JSON object is judged by its top-level
+        # shape, never by a substring scan of its nested content.
+        err = data.get("error") or data.get("message")
+        return (True, " [error]") if err and (failed or "error" in data) else (False, "")
     lower = result[:500].lower()
     return (True, " [error]") if '"error"' in lower or '"failed"' in lower or result.startswith("Error") else (False, "")
 

--- a/tests/agent/test_display_tool_failure.py
+++ b/tests/agent/test_display_tool_failure.py
@@ -98,6 +98,35 @@ class TestDetectToolFailureStructured:
 
 
 
+    def test_nested_error_inside_a_success_object_is_not_a_failure(self):
+        # browser_cdp wraps a raw CDP result as {"success": True, "method", "result"}.
+        # A Runtime.evaluate that reads a page's own validation object puts that
+        # object's "error" key inside "result": data the tool read, not a failure.
+        result = json.dumps({
+            "success": True,
+            "method": "Runtime.evaluate",
+            "result": {"result": {"type": "object",
+                                  "value": {"error": ["Vul een geldig telefoonnummer in."]}}},
+        })
+        assert _detect_tool_failure("browser_cdp", result) == (False, "")
+
+    def test_success_object_with_error_word_in_a_nested_string_is_not_a_failure(self):
+        result = json.dumps({"success": True, "rows": [{"ok": False, "error": "matched 0 elements"}]})
+        assert _detect_tool_failure("browser_fill_form", result) == (False, "")
+
+    def test_top_level_error_without_success_flag_is_still_a_failure(self):
+        result = json.dumps({"error": "CDP call timed out after 30.0s", "method": "Runtime.evaluate"})
+        is_failure, suffix = _detect_tool_failure("browser_cdp", result)
+        assert is_failure is True
+        assert "timed out" in suffix
+
+    def test_plain_text_failures_still_trip_the_substring_scan(self):
+        # The substring scan is for results that are not a JSON object.
+        assert _detect_tool_failure("web_search", "Error executing tool 'web_search': boom") == (True, " [error]")
+        assert _detect_tool_failure("web_search", 'request "failed" upstream') == (True, " [error]")
+        assert _detect_tool_failure("web_search", "all good") == (False, "")
+
+
 class TestGetCuteToolMessageFailureSuffix:
     """End-to-end: failure suffix is appended by get_cute_tool_message."""
 

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -376,3 +376,26 @@ def test_supervised_task_platforms_keep_warning_only_default():
     for platform in ("telegram", "discord", "cron", "kanban"):
         cfg = ToolCallGuardrailConfig.from_mapping({}, platform=platform)
         assert cfg.hard_stop_enabled is True, platform
+
+
+def test_classify_tool_failure_judges_a_json_object_by_its_top_level_shape():
+    # Mirrors agent.display._detect_tool_failure: an "error" key nested inside a
+    # success payload (browser_cdp's wrapped Runtime.evaluate result) is not a failure.
+    nested = json.dumps({
+        "success": True,
+        "method": "Runtime.evaluate",
+        "result": {"result": {"type": "object", "value": {"error": ["Vul een geldig telefoonnummer in."]}}},
+    })
+    assert classify_tool_failure("browser_cdp", nested) == (False, "")
+    assert classify_tool_failure("browser_cdp", json.dumps({"error": "CDP call timed out"})) == (True, " [error]")
+    assert classify_tool_failure("read_file", json.dumps({"success": False, "error": "File not found"})) == (True, " [error]")
+    assert classify_tool_failure("memory", json.dumps({"success": False, "error": "would exceed the limit"})) == (True, " [full]")
+    assert classify_tool_failure("web_search", json.dumps({"success": True, "data": "hello"})) == (False, "")
+
+
+def test_classify_tool_failure_keeps_the_substring_scan_for_plain_text():
+    assert classify_tool_failure("web_search", "Error executing tool 'web_search': boom") == (True, " [error]")
+    assert classify_tool_failure("web_search", 'request "failed" upstream') == (True, " [error]")
+    assert classify_tool_failure("web_search", "all good") == (False, "")
+    assert classify_tool_failure("terminal", json.dumps({"output": "x", "exit_code": 2})) == (True, " [exit 2]")
+    assert classify_tool_failure("terminal", json.dumps({"output": "x", "exit_code": 0})) == (False, "")


### PR DESCRIPTION
## What does this PR do?

`agent.display._detect_tool_failure` judges a JSON-object tool result by its top-level `error`/`message` key, and then still scans the first 500 characters of the string for the words `"error"` or `"failed"`. A success payload that *contains* an `error` key nested inside its data is therefore scored as a failure.

Concrete case: `browser_cdp` wraps every CDP result as `{"success": true, "method": ..., "result": ...}`. A `Runtime.evaluate` that reads a page's own validation object (for example `{"error": ["Vul een geldig telefoonnummer in."]}` from a government form) puts that object inside `result`. The call succeeded and read exactly what the page said, but the heuristic returns `(True, " [error]")`. The executor then logs "Tool browser_cdp returned error" and passes `failed=True` into the tool-call guardrail, which counts it as a same-tool failure; three in one turn inject the "this looks like a loop" recovery hint into the model's context while the tool is working. The `post_tool_call` observer status (`_tool_result_observer_fields`) also falls back to the same heuristic, so plugins receive `status="error"` for a successful read.

The fix: **a result that parses to a JSON object is judged by its top-level shape only.** The substring scan applies only to a result that did not parse to an object (plain text such as `Error executing tool ...`). `classify_tool_failure` in `agent/tool_guardrails.py` gets the same object branch, so the fallback classifier agrees with the display one as its docstring promises. `_tool_result_observer_fields` already judged objects by their top-level `error`, so the three classifiers now agree.

## Related Issue

No issue filed; the case was found operating `browser_cdp` against a form whose validation payload carries an `error` key.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/display.py` — `_detect_tool_failure`: after the structured (top-level) branch, a JSON object returns `(False, "")` instead of falling through to the substring scan.
- `agent/tool_guardrails.py` — `classify_tool_failure`: the same object branch (top-level `error`/`message` with `success: false` or an `error` key → failure; any other object → not a failure) before the substring scan. The `memory` store-full case moves inside that branch unchanged.
- `tests/agent/test_display_tool_failure.py` — four tests: the nested `browser_cdp` case is not a failure; a success object with `error` in a nested row is not a failure; a top-level `error` without `success` is still a failure; plain-text failures still trip the scan.
- `tests/agent/test_tool_guardrails.py` — two parity tests for `classify_tool_failure` (object shapes, plain text, `terminal` exit codes, `memory` full).

## How to Test

1. `scripts/run_tests.sh tests/agent/test_display_tool_failure.py tests/agent/test_tool_guardrails.py` — 36 passed.
2. `scripts/run_tests.sh tests/agent/` — 6295 passed, 13 failed in 10 files. The same 13 tests fail on clean `main` in this environment (provider-client and relay wiring tests that need credentials or network: `test_auxiliary_named_custom_providers`, `test_auxiliary_transport_autodetect`, `test_command_token_source`, `test_nous_portal_anthropic_wire`, `test_relay_llm`, `test_relay_nested_execution`, `test_relay_runtime_plugins`, `test_relay_tools`, `test_set_runtime_main_custom_provider`, `test_vision_routing_31179`); the set is identical with and without this change.
3. Reproduce the bug on `main` before the change: `python -c 'import json; from agent.display import _detect_tool_failure; print(_detect_tool_failure("browser_cdp", json.dumps({"success": True, "method": "Runtime.evaluate", "result": {"result": {"type": "object", "value": {"error": ["x"]}}}})))'` prints `(True, ' [error]')`; with the change it prints `(False, '')`.

## Checklist

- [x] Tests added for the changed behaviour and the behaviour that must not change
- [x] No behaviour change for plain-text results, `terminal`, or `memory`
