### PR TITLE
fix(kanban): render the drawer's stored PATCH error so failed Ready transitions are visible

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -3689,7 +3689,11 @@
         loading ? h("div", { className: "p-4 text-sm text-muted-foreground" },
           tx(t, "loadingDetail", "Loading…")) :
         err ? h("div", { className: "p-4 text-sm text-destructive" }, err) :
-        data ? h(TaskDetail, {
+        patchErr ? h("div", {
+          className: "px-4 pt-2 text-sm text-destructive",
+          role: "alert",
+        }, patchErr) : null,
+        !loading && !err && data ? h(TaskDetail, {
           data, editing, setEditing,
           renderMarkdown: props.renderMarkdown,
           allTasks: props.allTasks,

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -849,6 +849,10 @@ def test_dashboard_surfaces_ready_blocked_error_inline():
     assert "const [patchErr, setPatchErr] = useState(null);" in bundle
     assert "setPatchErr(parseApiErrorMessage(e))" in bundle
     assert "setPatchErr(null)" in bundle
+    # The stored error must actually be rendered — wiring-only assertions
+    # stay green when the render hunk is missing (the exact gap #26744
+    # reported: state written, never read).
+    assert "}, patchErr) : null," in bundle
 
 
 def test_dashboard_dependency_selects_use_value_change_handler():


### PR DESCRIPTION
## What does this PR do?

Restores the missing render half of the drawer PATCH-error surface. #28481 wired `setPatchErr` into the task drawer (declaration + writes on clear/failure), but the render tree never reads `patchErr` back — so when the backend rejects a status transition (409 "parent not done"), the Ready/Block/Unblock buttons silently revert with no visible error, which is exactly the no-op UX #26744 reports. This PR restores #26777's render hunk: a `role="alert"` div for `patchErr` between the `err` branch and `TaskDetail`, and strengthens the regression test to assert the render itself.

## Related Issue

Fixes #26744

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/kanban/dashboard/dist/index.js`: render `patchErr` as a destructive `role="alert"` div before `TaskDetail` (restores the render hunk from #26777 that #28481 dropped; `TaskDetail` now also gated on `!loading && !err`)
- `tests/plugins/test_kanban_dashboard_plugin.py`: add a render assertion (`assert "}, patchErr) : null," in bundle`) to `test_dashboard_surfaces_ready_blocked_error_inline` — the existing wiring-only substring assertions stay green when the render hunk is missing, which is how this gap survived two re-lands

## How to Test

1. Create task A and leave it in a non-`done` status; create task B with A as a parent dependency.
2. Open B's drawer in the Kanban dashboard and click **Ready** (or drag B to the Ready swimlane and then use the drawer action row).
3. Observed result before: the drawer buttons appear to do nothing — `patchErr` is written by `doPatch`'s `.catch` but never rendered.
4. Observed result after: an inline destructive alert appears in the drawer showing the parsed API detail, e.g. "Cannot move to 'ready': blocked by parent(s) not done", and it clears on the next successful patch/refresh.
5. `pytest tests/plugins/test_kanban_dashboard_plugin.py -q` — 38 passed (the new render assertion fails on `main`'s bundle, confirming it guards the exact gap).
6. `node --check plugins/kanban/dashboard/dist/index.js` — syntax OK.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — full plugin test module: 38 passed
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (browser-side JS, no platform API)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A