### PR TITLE
fix(bot-mode): match scoped bot selection in reset guard

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.mentions.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.mentions.test.ts
@@ -21,6 +21,8 @@
 
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { RosterRow } from './types'
+
 interface MentionCompletionItem {
   display: string
   insert: string
@@ -58,7 +60,7 @@ const ROSTER = {
 }
 
 const { cache, hostMock, live } = vi.hoisted(() => {
-  const live = { focused: 'default', profile: 'default' }
+  const live = { focused: 'default', profile: 'default', stored: null as string | null }
 
   return {
     cache: new Map<string, { key: unknown[]; value: unknown }>(),
@@ -69,7 +71,7 @@ const { cache, hostMock, live } = vi.hoisted(() => {
       state: {
         connectionId: { get: () => 'local', listen: () => () => undefined },
         focusedSessionProfile: { get: () => live.focused, listen: () => () => undefined },
-        focusedStoredSessionId: { get: () => null, listen: () => () => undefined },
+        focusedStoredSessionId: { get: () => live.stored, listen: () => () => undefined },
         gateway: { get: () => null, listen: () => () => undefined },
         profile: { get: () => live.profile, listen: () => () => undefined }
       }
@@ -173,6 +175,54 @@ beforeEach(() => {
   vi.clearAllMocks()
   live.focused = 'default'
   live.profile = 'default'
+  live.stored = null
+})
+
+describe('Bot Chat reset guard', () => {
+  it.each([
+    { connectionId: 'local', sourceScoped: true },
+    { connectionId: 'remote', remoteSource: true, sourceScoped: true },
+    {}
+  ])('compacts only the selected bot canonical chat: %j', async source => {
+    const { handler } = await contributions()
+    const { $lastRoster } = await import('./data')
+    const { saveSelectedRosterBot } = await import('./bot-state')
+
+    const selected: RosterRow = {
+      ...source,
+      name: 'writer',
+      canonical_session: { id: 'bot-root', resolved_id: 'bot-tip' }
+    }
+
+    // An identically named bot on another connection must not win the lookup.
+    $lastRoster.set([
+      { name: 'writer', connectionId: 'other', sourceScoped: true, canonical_session: { id: 'other-chat' } },
+      selected
+    ])
+    saveSelectedRosterBot(selected)
+
+    for (const stored of ['bot-root', 'bot-tip']) {
+      live.stored = stored
+
+      for (const text of ['/new', '/reset']) {
+        hostMock.notify.mockClear()
+        expect(await handler({ text })).toEqual({ text: '/compact' })
+        expect(hostMock.notify).toHaveBeenCalledOnce()
+        expect(hostMock.notify).toHaveBeenCalledWith(expect.objectContaining({ title: 'This chat never resets' }))
+      }
+    }
+
+    for (const stored of ['scratch-chat', 'other-chat', null]) {
+      live.stored = stored
+
+      for (const text of ['/new', '/reset']) {
+        hostMock.notify.mockClear()
+        const draft = { text }
+        expect(await handler(draft)).toBe(draft)
+        expect(hostMock.notify).not.toHaveBeenCalled()
+      }
+    }
+  })
 })
 
 describe('@-mention completions', () => {

--- a/apps/desktop/src/plugins/hermes-bots/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.tsx
@@ -37,6 +37,7 @@ import {
   $lastRoster,
   botHandle,
   botMentionTag,
+  botSelectionKey,
   cachedUnionRoster,
   isActiveRosterBot,
   migrateBotMeta,
@@ -665,7 +666,7 @@ export default {
             // server-side by name), matching either the durable row id or
             // the compression-lineage tip currently on screen.
             const roster = $lastRoster.get()
-            const row = Array.isArray(roster) ? roster.find(bot => bot?.name === activeBot) : null
+            const row = Array.isArray(roster) ? roster.find(bot => botSelectionKey(bot) === activeBot) : null
 
             // The STORED id, which is the id space canonical_session is keyed
             // in. `host.state.activeSessionId` is the runtime id and could


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop Bot Chat `/new` and `/reset` guard looking up the selected bot by bare profile name instead of its selection key.

`saveSelectedRosterBot()` stores `botSelectionKey(bot)` in `$selectedBot`. For source-scoped roster rows, that is a connection-qualified value such as `local::writer`, including profiles on the active local connection. The composer middleware compared that value with `bot.name`, found no matching row, and silently let `/new` create a scratch conversation instead of compacting the canonical Bot Chat. The existing explanatory notice was also skipped.

Use the same identity helper on both sides of the lookup. The existing canonical-session/root-or-tip check still decides whether to compact. Ordinary side chats retain `/new` and `/reset` behavior, and a same-named bot on another connection cannot win the lookup.

This restores the existing Bot Chat contract. It does not change session visibility, recover earlier scratch conversations, or claim that persisted chat data was deleted.

## Related Issue

No GitHub issue. Reproduced through the registered composer middleware against current main, `9dd6634c5635321cf38840cc30e9b51226689128`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.tsx`: match the selected roster row with `botSelectionKey`, already used when storing the selection.
- `apps/desktop/src/plugins/hermes-bots/plugin.mentions.test.ts`: extend the existing registered-plugin harness to exercise the reset guard using the real selection setter, roster atom, identity helper, and canonical-session matcher. Cover local/remote/legacy selection, duplicate profile names, root and compression-tip IDs, and ordinary side chats. Existing pure matcher tests did not exercise the broken roster lookup.

## How to Test

From `apps/desktop`:

```sh
npx vitest run --project ui --maxWorkers 2 src/plugins/hermes-bots/plugin.mentions.test.ts src/plugins/hermes-bots/new-compact-guard.test.ts
```

1. With only the regression tests applied to the base commit, the new cases fail because the middleware returns `/new` rather than `/compact` (3 failed, 16 passed).
2. With the lookup fixed, both focused files pass: 24 tests. The existing host/query-cache harness is mocked; selection state, identity resolution, and the registered middleware are real imports. No live backend, provider, or customer data is used.
3. Manual Desktop check: open a bot's canonical Bot Chat and submit `/new` or `/reset`. Expect the existing "This chat never resets" notice and compaction in the same conversation. In an ordinary Sessions-mode side chat, expect the commands to retain their normal new-session behavior. Manual packaged-app verification has not been run for this PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows, focused Vitest regressions and file-scoped ESLint/Prettier checks. No packaged-app manual test. Full-suite coverage is left to CI.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A: restores existing behavior
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility): platform-independent renderer lookup
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

```text
Base + regression tests:
  Expected { text: '/compact' }
  Received { text: '/new' }
  3 failed | 16 passed

With fix:
  Test Files  2 passed (2)
       Tests  24 passed (24)
```
