### PR TITLE
fix(copilot): preserve Astra reasoning effort

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1391,7 +1391,7 @@ class _CodexCompletionsAdapter:
             # ``enabled: False`` leaves reasoning/include unset (Codex still thinks by default).
             if isinstance(reasoning_cfg, dict) and reasoning_cfg.get("enabled") is not False:
                 # Truthy-only: Codex 400s on e.g. {"effort": null}, so falsy → default. Shared
-                # per-model clamp with the main transport ("max" is gpt-5.6-only; "minimal"/"ultra" rejected).
+                # per-model clamp with the main transport ("minimal"/"ultra" require wire translation).
                 from agent.reasoning_effort import clamp_effort, codex_supported_efforts
                 effort = clamp_effort(reasoning_cfg.get("effort") or "medium", codex_supported_efforts(model))
                 resp_kwargs["reasoning"] = {"effort": effort, "summary": "auto"}

--- a/agent/reasoning_effort.py
+++ b/agent/reasoning_effort.py
@@ -27,8 +27,8 @@ EFFORT_LADDER: tuple[str, ...] = ("none", "minimal", "low", "medium", "high", "x
 #: Widest OpenAI-compatible wire vocabulary (OpenRouter, Nous Portal).
 OPENAI_COMPAT_WIRE_EFFORTS: tuple[str, ...] = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
 
-#: OpenAI/Codex Responses per model generation (live-verified): ``minimal`` is rejected by
-#: both (clamps to low); ``max`` is gpt-5.6-only.
+#: OpenAI/Codex Responses per model generation; ``minimal`` clamps to low.
+CODEX_ASTRA_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh", "max")
 CODEX_GPT56_EFFORTS: tuple[str, ...] = ("none", "low", "medium", "high", "xhigh", "max")
 CODEX_LEGACY_EFFORTS: tuple[str, ...] = ("none", "low", "medium", "high", "xhigh")
 
@@ -80,6 +80,8 @@ META_AI_EFFORTS: tuple[str, ...] = ("minimal", "low", "medium", "high", "xhigh")
 
 def codex_supported_efforts(model: Optional[str]) -> tuple[str, ...]:
     """Supported effort set for an OpenAI/Codex Responses model."""
+    if "gpt-6-astra" in (model or "").lower():
+        return CODEX_ASTRA_EFFORTS
     return CODEX_GPT56_EFFORTS if "gpt-5.6" in (model or "").lower() else CODEX_LEGACY_EFFORTS
 
 

--- a/agent/reasoning_params.py
+++ b/agent/reasoning_params.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 from agent.lazy_forward import forward as _forward, forward_static as _forward_static
 from agent.message_sanitization import matches_reasoning_echo_family
+from agent.reasoning_effort import clamp_effort
 from utils import base_url_host_matches
 
 # Static OpenRouter fallback when the live /v1/models capability cache is cold.
@@ -120,9 +121,9 @@ class ReasoningParamsMixin:
         effort = str(cfg.get("effort", "medium")).strip().lower()
 
         if effort not in supported:
-            # Nearest-neighbour fallbacks: xhigh→high, minimal→low, else medium, else the first published level.
-            nearest = {"xhigh": "high", "minimal": "low"}.get(effort)
-            effort = nearest if nearest in supported else "medium" if "medium" in supported else supported[0]
+            effort = clamp_effort(effort, supported)
+            if effort not in supported:
+                effort = "medium" if "medium" in supported else supported[0]
         return {"effort": effort}
 
     _build_assistant_message = _forward("agent.chat_completion_helpers", "build_assistant_message")

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -13,7 +13,7 @@ from typing import Any, Callable, Optional
 from agent.reasoning_effort import (
     ACTUAL_RELAY_EFFORTS, XAI_GROK46_EFFORTS, XAI_LEGACY_EFFORTS, clamp_effort,
     # Same declared vocabulary + shared clamp as the main Codex transport (agent.reasoning_effort):
-    # per-model — "max" is gpt-5.6-only, "minimal"/"ultra" always rejected (live-verified, #68365).
+    # per-model — "max" availability varies; "minimal"/"ultra" require wire translation.
     codex_supported_efforts,
 )
 from agent.transports.base import ProviderTransport

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1846,6 +1846,10 @@ def _github_reasoning_efforts_for_model_id(model_id: str) -> list[str]:
     if raw.startswith(("openai/o1", "openai/o3", "openai/o4", "o1", "o3", "o4")):
         return list(COPILOT_REASONING_EFFORTS_O_SERIES)
     normalized = normalize_copilot_model_id(model_id).lower()
+    if normalized.startswith("gpt-6-astra"):
+        from agent.reasoning_effort import CODEX_ASTRA_EFFORTS
+
+        return list(CODEX_ASTRA_EFFORTS)
     if normalized.startswith("gpt-5"):
         return list(COPILOT_REASONING_EFFORTS_GPT5)
     return []

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -39,6 +39,45 @@ class TestCodexTransportBasic:
 
 class TestCodexBuildKwargs:
 
+    @pytest.mark.parametrize("model", ["gpt-6-astra", "openai/gpt-6-astra"])
+    @pytest.mark.parametrize("effort, expected", [
+        ("low", "low"), ("medium", "medium"), ("high", "high"),
+        ("xhigh", "xhigh"), ("max", "max"), ("ultra", "max"),
+        ("minimal", "low"), ("none", None),
+    ])
+    def test_astra_copilot_forwards_configured_reasoning(self, transport, model, effort, expected):
+        from agent.reasoning_params import ReasoningParamsMixin
+        from hermes_cli.config import get_config_path, load_config
+        from hermes_constants import resolve_reasoning_config
+
+        get_config_path().write_text(json.dumps({
+            "model": {"default": model}, "agent": {"reasoning_effort": effort},
+        }), encoding="utf-8")
+        reasoning = resolve_reasoning_config(load_config(), model)
+        agent = SimpleNamespace(model=model, reasoning_config=reasoning)
+        kw = transport.build_kwargs(
+            model=model, messages=[{"role": "user", "content": "Hi"}],
+            provider="github-copilot", is_github_responses=True,
+            reasoning_config=reasoning,
+            github_reasoning_extra=ReasoningParamsMixin._github_models_reasoning_extra_body(agent),
+        )
+        assert kw.get("reasoning") == ({"effort": expected} if expected else None)
+
+    @pytest.mark.parametrize("model", ["gpt-6-astra", "openai/gpt-6-astra"])
+    @pytest.mark.parametrize("effort, expected", [("max", "max"), ("ultra", "max"), ("minimal", "low")])
+    def test_astra_main_and_auxiliary_responses_preserve_effort(self, transport, model, effort, expected):
+        from agent.auxiliary_client import _CodexCompletionsAdapter
+
+        messages = [{"role": "user", "content": "Hi"}]
+        reasoning = {"enabled": True, "effort": effort}
+        main = transport.build_kwargs(model=model, messages=messages, reasoning_config=reasoning)
+        adapter = _CodexCompletionsAdapter(SimpleNamespace(base_url="https://api.openai.com/v1"), model)
+        auxiliary, _, _ = adapter._build_responses_kwargs({
+            "messages": messages, "extra_body": {"reasoning": reasoning},
+        })
+        assert main["reasoning"]["effort"] == expected
+        assert auxiliary["reasoning"]["effort"] == expected
+
     def test_900k_context_variant_suffix_stripped_on_wire(self, transport):
         """``-900k`` large-context picker variants are Hermes-side aliases —
         the Codex backend only knows the base slug, so build_kwargs must


### PR DESCRIPTION
## What does this PR do?

Native GitHub Copilot requests dropped GPT-6 Astra's configured reasoning level, while the shared Responses path reduced `max` to `xhigh`. This change preserves Astra's supported effort levels in main and auxiliary requests.

## Changes Made

- Share Astra's published `low` through `max` vocabulary between Responses and Copilot capability detection.
- Use the existing clamp for native Copilot requests so Hermes's internal `ultra` effort resolves to `max`, preserving the existing fallback for unknown effort names.
- Add two parameterized request-level regression tests covering configuration loading, qualified model names, disabled reasoning, and main/auxiliary parity.
- Correct stale comments about which model families accept `max`.

## Related Issue

Related to #103556, #103570, and #103696. The existing PRs address the OpenAI/Codex clamp; this change also fixes the native Copilot path that omitted the reasoning payload entirely.

Model reference: https://developers.openai.com/api/docs/models/gpt-6-astra

## Type of Change

- [x] Bug fix

## Validation

- The new regression cases produced 18 expected failures before the fix; all 22 cases pass with the fix.
- 317 tests passed: six complete affected test files plus 26 reasoning/Copilot cases from the two larger files.
- Ruff, explicit-file bytecode compilation, the repository compatibility-pointer check, and the shared reasoning module's type check passed.
- Read-only diff review found no actionable regressions.
- Verification limits: full runs of `test_auxiliary_client.py` and `test_run_agent.py` exceeded the runner's 300-second file budget without reporting assertion failures. Their relevant cases passed separately with one worker and a 900-second budget. Type checking all changed behavior files was terminated with exit 137 before diagnostics, including with one worker. The repository-wide suite was not run.
- Tested on macOS with Python 3.12.
