### PR TITLE
fix(web/exa): web_extract requests fresh content instead of Exa's index snapshot

### DIFF
--- a/plugins/web/exa/provider.py
+++ b/plugins/web/exa/provider.py
@@ -56,7 +56,10 @@ class ExaWebSearchProvider(BaseWebSearchProvider):
             if use_keyless("exa", provider_env("EXA_API_KEY")):
                 return keyless_extract("Exa", "exa", urls, logger)
             logger.info("Exa extract: %d URL(s)", len(urls))
-            response = _get_exa_client().get_contents(urls, text=True)
+            # Exa serves its index snapshot by default (observed 10 days stale for a
+            # news front page). max_age_hours=0 = always fetch fresh; Exa deprecates
+            # `livecrawl` in favour of this knob.
+            response = _get_exa_client().get_contents(urls, text=True, max_age_hours=0)
             return [document(r.url or "", r.title or "", r.text or "") for r in response.results or []]
 
         return run_extract("Exa", logger, urls, _body, sdk=True)

--- a/tests/tools/test_web_providers_exa_freshness.py
+++ b/tests/tools/test_web_providers_exa_freshness.py
@@ -1,0 +1,63 @@
+"""Exa web provider — keyed extract() must request fresh content.
+
+Exa's ``/contents`` endpoint serves its index snapshot of a page unless told
+otherwise; for a news front page that snapshot was observed 10 days stale.
+``max_age_hours=0`` is Exa's documented "always fetch fresh" setting (the older
+``livecrawl`` flag is deprecated in favour of it). These tests pin the contract
+that the keyed extract path never lets Exa fall back to an aged snapshot, and
+that the returned documents keep the shared ``document()`` shape.
+
+The real provider is imported and only the SDK client is stubbed, so the
+``_common`` glue and the extract body run together.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from plugins.web.exa.provider import ExaWebSearchProvider
+
+
+def _result(url: str, title: str = "T", text: str = "body") -> MagicMock:
+    r = MagicMock()
+    r.url = url
+    r.title = title
+    r.text = text
+    return r
+
+
+def _run_extract(urls, results):
+    """Call the keyed extract path with a stubbed SDK client; return (docs, client)."""
+    client = MagicMock()
+    client.get_contents.return_value = MagicMock(results=results, statuses=[])
+    with patch("plugins.web.exa.provider._get_exa_client", return_value=client), \
+         patch("plugins.web.exa.provider.use_keyless", return_value=False):
+        docs = ExaWebSearchProvider().extract(urls)
+    return docs, client
+
+
+class TestExaExtractRequestsFreshContent:
+    def test_get_contents_is_asked_for_fresh_content(self) -> None:
+        urls = ["https://news.example/", "https://blog.example/post"]
+        _, client = _run_extract(urls, [_result(u) for u in urls])
+
+        client.get_contents.assert_called_once()
+        args, kwargs = client.get_contents.call_args
+        assert list(args[0]) == urls
+        assert kwargs.get("text") is True
+        # 0 = always fetch fresh. Omitting it (or any positive value) lets Exa
+        # serve a cached snapshot that can be days old.
+        assert kwargs.get("max_age_hours") == 0
+
+    def test_documents_keep_shared_shape(self) -> None:
+        url = "https://news.example/"
+        docs, _ = _run_extract([url], [_result(url, title="Front page", text="today's stories")])
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert "error" not in doc
+        assert doc["url"] == url
+        assert doc["title"] == "Front page"
+        assert doc["content"] == "today's stories"
+        assert doc["raw_content"] == doc["content"]
+        assert doc["metadata"] == {"sourceURL": url, "title": "Front page"}

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -313,6 +313,8 @@ EXA_API_KEY=your-exa-key-here
 
 Get a key at [exa.ai](https://exa.ai). The free tier includes 1 000 searches/month.
 
+`web_extract` always asks Exa for a fresh crawl of each page (`maxAgeHours: 0`). Exa's default would otherwise return its index snapshot of the page, which can be days old for frequently changing pages such as news front pages.
+
 ---
 
 ### Parallel


### PR DESCRIPTION
## What does this PR do?

`web_extract` on the keyed Exa backend returned Exa's cached **index snapshot** of a page instead of the live page. The provider called `get_contents(urls, text=True)` with no freshness option, and Exa's default for `/contents` is to serve whatever it has indexed. For a news front page that snapshot was ~10 days old, and nothing in the result signalled it.

The fix passes `max_age_hours=0`, Exa's documented "always fetch fresh content" setting. Exa's API reference now marks the older `livecrawl` flag as **deprecated** in favour of `maxAgeHours`, so this uses the supported knob rather than `livecrawl="always"` (both were verified to return the live page).

Why always-fresh rather than a heuristic: Hermes already defines the freshness contract at its own layer, the 20-minute extract cache (`web.cache_ttl_minutes`), and the docs tell users to lower the TTL or disable the cache for live data. With Exa that advice was silently a no-op because Exa's own snapshot was stale regardless. Requesting fresh content restores the documented contract without adding a config knob.

**Reproduction on current `main`** (2026-09-05, `exa-py==2.10.2` as pinned), `plugins/web/exa/provider.py:59`:

| `get_contents(["https://news.ycombinator.com/"], ...)` | Result |
|---|---|
| `text=True` (current code) | Aug 25–26 snapshot: "Critical CVE issued for hallucinated SQLite vulnerability", "Don't be a meat proxy", "Qwen3.8-Max" |
| `text=True, max_age_hours=0` (this PR) | Live front page, top five stories identical to `curl -s https://news.ycombinator.com/` |
| `text=True, livecrawl="always"` (deprecated) | Identical live front page |

**Trade-offs, stated plainly:** a live crawl adds latency (Exa's `livecrawlTimeout` default is 10 s). A page whose live crawl fails no longer gets a stale copy; it surfaces as missing/error, and the existing one-shot keyless rescue then tries the ring.

**Out of scope:** the keyless `mcp.exa.ai` `web_fetch_exa` tool accepts only `urls`/`maxCharacters`, so the free-tier path has no freshness option to set. `search()`'s `contents={"highlights": True}` is index-backed by design and is unchanged.

**Related open PR:** #102397 edits the same `get_contents` line to surface per-URL failures from `response.statuses`. The two changes are independent and rebase trivially in either order; the test file here is named distinctly so it never add/add-conflicts with that PR's `test_web_providers_exa.py`.

## Related Issue

No existing issue or PR mentions `livecrawl`, `maxAgeHours`, or stale Exa extracts (searched open and closed).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/web/exa/provider.py`: pass `max_age_hours=0` to `get_contents` in the keyed `extract()` path, with a comment explaining why.
- `tests/tools/test_web_providers_exa_freshness.py` (new): imports the real `ExaWebSearchProvider`, stubs only the SDK client, and pins (a) `get_contents` is called with the URL list, `text=True`, `max_age_hours=0`, and (b) the returned docs keep the shared `document()` shape. The freshness assertion fails on the unpatched provider and passes with the fix.
- `website/docs/user-guide/features/web-search.md`: one sentence in the Exa section documenting the fresh-crawl behaviour.

## How to Test

1. With `EXA_API_KEY` set, on `main`: `python -c "from plugins.web.exa.provider import ExaWebSearchProvider as P; print(P().extract(['https://news.ycombinator.com/'])[0]['content'][:600])"` and compare the story titles with `curl -s https://news.ycombinator.com/`. They differ (stale snapshot).
2. Check out this branch and repeat step 1. The titles match the live page.
3. `scripts/run_tests.sh tests/tools/test_web_providers_exa_freshness.py tests/tools/test_web_keyless_fallback.py tests/tools/test_web_providers.py -q` → 56 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the targeted suites above via `scripts/run_tests.sh` and `ruff check` on the changed files; all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.6.0), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A (one SDK kwarg)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (tool schema unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7rSrXPUYkaarB1UVkTdTx
